### PR TITLE
CI Disable network when SciPy requires it

### DIFF
--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -33,6 +33,7 @@ scipy_datasets_require_network = sp_version >= parse_version("1.10")
 
 
 def raccoon_face_or_skip():
+    # SciPy >= 1.10 requires network to access to get data
     if scipy_datasets_require_network:
         run_network_tests = environ.get("SKLEARN_SKIP_NETWORK_TESTS", "1") == "0"
         from scipy.datasets import face

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -11,7 +11,7 @@ from _pytest.doctest import DoctestItem
 from sklearn.utils import _IS_32BIT
 from sklearn.utils._openmp_helpers import _openmp_effective_n_threads
 from sklearn._min_dependencies import PYTEST_MIN_VERSION
-from sklearn.utils.fixes import sp_base_version
+from sklearn.utils.fixes import sp_version
 from sklearn.utils.fixes import parse_version
 from sklearn.datasets import fetch_20newsgroups
 from sklearn.datasets import fetch_20newsgroups_vectorized
@@ -29,7 +29,7 @@ if parse_version(pytest.__version__) < parse_version(PYTEST_MIN_VERSION):
         "at least pytest >= {} installed.".format(PYTEST_MIN_VERSION)
     )
 
-scipy_datasets_require_network = sp_base_version >= parse_version("1.10")
+scipy_datasets_require_network = sp_version >= parse_version("1.10")
 
 
 def raccoon_face_or_skip():

--- a/sklearn/feature_extraction/tests/test_image.py
+++ b/sklearn/feature_extraction/tests/test_image.py
@@ -7,7 +7,6 @@ from scipy import ndimage
 from scipy.sparse.csgraph import connected_components
 import pytest
 
-from sklearn.utils.fixes import sp_version, parse_version
 from sklearn.feature_extraction.image import (
     img_to_graph,
     grid_to_graph,
@@ -16,17 +15,6 @@ from sklearn.feature_extraction.image import (
     PatchExtractor,
     _extract_patches,
 )
-
-
-@pytest.fixture(scope="module")
-def raccoon_face():
-    if sp_version.release >= parse_version("1.10").release:
-        pytest.importorskip("pooch")
-        from scipy.datasets import face
-    else:
-        from scipy.misc import face
-
-    return face(gray=True)
 
 
 def test_img_to_graph():
@@ -93,8 +81,8 @@ def test_grid_to_graph():
     assert A.dtype == np.float64
 
 
-def test_connect_regions(raccoon_face):
-    face = raccoon_face.copy()
+def test_connect_regions(raccoon_face_fxt):
+    face = raccoon_face_fxt
     # subsample by 4 to reduce run time
     face = face[::4, ::4]
     for thr in (50, 150):
@@ -103,8 +91,8 @@ def test_connect_regions(raccoon_face):
         assert ndimage.label(mask)[1] == connected_components(graph)[0]
 
 
-def test_connect_regions_with_grid(raccoon_face):
-    face = raccoon_face.copy()
+def test_connect_regions_with_grid(raccoon_face_fxt):
+    face = raccoon_face_fxt
 
     # subsample by 4 to reduce run time
     face = face[::4, ::4]
@@ -118,15 +106,9 @@ def test_connect_regions_with_grid(raccoon_face):
     assert ndimage.label(mask)[1] == connected_components(graph)[0]
 
 
-def _downsampled_face():
-    if sp_version.release >= parse_version("1.10").release:
-        pytest.importorskip("pooch")
-        from scipy.datasets import face as raccoon_face
-    else:
-        from scipy.misc import face as raccoon_face
-
-    face = raccoon_face(gray=True)
-    face = face.astype(np.float32)
+@pytest.fixture
+def downsampled_face(raccoon_face_fxt):
+    face = raccoon_face_fxt
     face = face[::2, ::2] + face[1::2, ::2] + face[::2, 1::2] + face[1::2, 1::2]
     face = face[::2, ::2] + face[1::2, ::2] + face[::2, 1::2] + face[1::2, 1::2]
     face = face.astype(np.float32)
@@ -134,8 +116,9 @@ def _downsampled_face():
     return face
 
 
-def _orange_face(face=None):
-    face = _downsampled_face() if face is None else face
+@pytest.fixture
+def orange_face(downsampled_face):
+    face = downsampled_face
     face_color = np.zeros(face.shape + (3,))
     face_color[:, :, 0] = 256 - face
     face_color[:, :, 1] = 256 - face / 2
@@ -143,8 +126,7 @@ def _orange_face(face=None):
     return face_color
 
 
-def _make_images(face=None):
-    face = _downsampled_face() if face is None else face
+def _make_images(face):
     # make a collection of faces
     images = np.zeros((3,) + face.shape)
     images[0] = face
@@ -153,12 +135,12 @@ def _make_images(face=None):
     return images
 
 
-downsampled_face = _downsampled_face()
-orange_face = _orange_face(downsampled_face)
-face_collection = _make_images(downsampled_face)
+@pytest.fixture
+def downsampled_face_collection(downsampled_face):
+    return _make_images(downsampled_face)
 
 
-def test_extract_patches_all():
+def test_extract_patches_all(downsampled_face):
     face = downsampled_face
     i_h, i_w = face.shape
     p_h, p_w = 16, 16
@@ -167,7 +149,7 @@ def test_extract_patches_all():
     assert patches.shape == (expected_n_patches, p_h, p_w)
 
 
-def test_extract_patches_all_color():
+def test_extract_patches_all_color(orange_face):
     face = orange_face
     i_h, i_w = face.shape[:2]
     p_h, p_w = 16, 16
@@ -176,7 +158,7 @@ def test_extract_patches_all_color():
     assert patches.shape == (expected_n_patches, p_h, p_w, 3)
 
 
-def test_extract_patches_all_rect():
+def test_extract_patches_all_rect(downsampled_face):
     face = downsampled_face
     face = face[:, 32:97]
     i_h, i_w = face.shape
@@ -187,7 +169,7 @@ def test_extract_patches_all_rect():
     assert patches.shape == (expected_n_patches, p_h, p_w)
 
 
-def test_extract_patches_max_patches():
+def test_extract_patches_max_patches(downsampled_face):
     face = downsampled_face
     i_h, i_w = face.shape
     p_h, p_w = 16, 16
@@ -205,7 +187,7 @@ def test_extract_patches_max_patches():
         extract_patches_2d(face, (p_h, p_w), max_patches=-1.0)
 
 
-def test_extract_patch_same_size_image():
+def test_extract_patch_same_size_image(downsampled_face):
     face = downsampled_face
     # Request patches of the same size as image
     # Should return just the single patch a.k.a. the image
@@ -213,7 +195,7 @@ def test_extract_patch_same_size_image():
     assert patches.shape[0] == 1
 
 
-def test_extract_patches_less_than_max_patches():
+def test_extract_patches_less_than_max_patches(downsampled_face):
     face = downsampled_face
     i_h, i_w = face.shape
     p_h, p_w = 3 * i_h // 4, 3 * i_w // 4
@@ -224,7 +206,7 @@ def test_extract_patches_less_than_max_patches():
     assert patches.shape == (expected_n_patches, p_h, p_w)
 
 
-def test_reconstruct_patches_perfect():
+def test_reconstruct_patches_perfect(downsampled_face):
     face = downsampled_face
     p_h, p_w = 16, 16
 
@@ -233,7 +215,7 @@ def test_reconstruct_patches_perfect():
     np.testing.assert_array_almost_equal(face, face_reconstructed)
 
 
-def test_reconstruct_patches_perfect_color():
+def test_reconstruct_patches_perfect_color(orange_face):
     face = orange_face
     p_h, p_w = 16, 16
 
@@ -242,14 +224,14 @@ def test_reconstruct_patches_perfect_color():
     np.testing.assert_array_almost_equal(face, face_reconstructed)
 
 
-def test_patch_extractor_fit():
-    faces = face_collection
+def test_patch_extractor_fit(downsampled_face_collection):
+    faces = downsampled_face_collection
     extr = PatchExtractor(patch_size=(8, 8), max_patches=100, random_state=0)
     assert extr == extr.fit(faces)
 
 
-def test_patch_extractor_max_patches():
-    faces = face_collection
+def test_patch_extractor_max_patches(downsampled_face_collection):
+    faces = downsampled_face_collection
     i_h, i_w = faces.shape[1:3]
     p_h, p_w = 8, 8
 
@@ -272,15 +254,15 @@ def test_patch_extractor_max_patches():
     assert patches.shape == (expected_n_patches, p_h, p_w)
 
 
-def test_patch_extractor_max_patches_default():
-    faces = face_collection
+def test_patch_extractor_max_patches_default(downsampled_face_collection):
+    faces = downsampled_face_collection
     extr = PatchExtractor(max_patches=100, random_state=0)
     patches = extr.transform(faces)
     assert patches.shape == (len(faces) * 100, 19, 25)
 
 
-def test_patch_extractor_all_patches():
-    faces = face_collection
+def test_patch_extractor_all_patches(downsampled_face_collection):
+    faces = downsampled_face_collection
     i_h, i_w = faces.shape[1:3]
     p_h, p_w = 8, 8
     expected_n_patches = len(faces) * (i_h - p_h + 1) * (i_w - p_w + 1)
@@ -289,7 +271,7 @@ def test_patch_extractor_all_patches():
     assert patches.shape == (expected_n_patches, p_h, p_w)
 
 
-def test_patch_extractor_color():
+def test_patch_extractor_color(orange_face):
     faces = _make_images(orange_face)
     i_h, i_w = faces.shape[1:3]
     p_h, p_w = 8, 8
@@ -347,7 +329,7 @@ def test_extract_patches_strided():
         ).all()
 
 
-def test_extract_patches_square():
+def test_extract_patches_square(downsampled_face):
     # test same patch size for all dimensions
     face = downsampled_face
     i_h, i_w = face.shape
@@ -366,7 +348,7 @@ def test_width_patch():
         extract_patches_2d(x, (1, 4))
 
 
-def test_patch_extractor_wrong_input():
+def test_patch_extractor_wrong_input(orange_face):
     """Check that an informative error is raised if the patch_size is not valid."""
     faces = _make_images(orange_face)
     err_msg = "patch_size must be a tuple of two integers"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Observed in https://github.com/conda-forge/scikit-learn-feedstock/pull/212: [CI link](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=655196&view=logs&jobId=00f5923e-fdef-5026-5091-0d5a0b3d5a2c&j=00f5923e-fdef-5026-5091-0d5a0b3d5a2c&t=3cc4a9ed-60e1-5810-6eb3-5f9cd4a26dba)
Observed in #25677 [CI link](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=52451&view=logs&jobId=5b4df9b9-567d-5cb5-f730-68ee56e1ba5c&j=0238e32a-2fbb-5be1-f782-cfff4ef2924e&t=7a1155ea-f171-542f-2ca6-f7f6ff076f10&s=96ac2280-8cb4-5df5-99de-dd2da759617d)

#### What does this implement/fix? Explain your changes.
With SciPy 1.10, the network is required to get `scipy.datasets.face`. This PR allows `SKLEARN_SKIP_NETWORK_TESTS` to configure the download. Here is the behavior

1. SciPy < 1.10, nothing changes, `test_image.py` always runs.
2. SciPy >= 1.10, `test_image.py` only runs when `SKLEARN_SKIP_NETWORK_TESTS=0`.

#### Any other comments?
The failing test comes from multiple `pytest-xdist` processes trying to download `face` at the same time. This PR hooks up `face` with the same mechanism we use to control the `fetch_*` downloads.

I'm placing this on `1.2.2` because it can cause the CI on `conda-forge` to fail randomly as seen in https://github.com/conda-forge/scikit-learn-feedstock/pull/212.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
