### PR TITLE
FIX Raise an error when min_samples_split=1 in trees

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -79,6 +79,15 @@ Changelog
   `encoded_missing_value` or `unknown_value` set to a categories' cardinality
   when there is missing values in the training data. :pr:`25704` by `Thomas Fan`_.
 
+:mod:`sklearn.tree`
+...................
+
+- |Fix| Fixed a regression in :class:`tree.DecisionTreeClassifier`,
+  :class:`tree.DecisionTreeRegressor`, :class:`tree.ExtraTreeClassifier` and
+  :class:`tree.ExtraTreeRegressor` where an error was no longer raised in version
+  1.2 when `min_sample_split=1`.
+  :pr:`25744` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
 :mod:`sklearn.utils`
 ....................
 

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -99,16 +99,16 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         "max_depth": [Interval(Integral, 1, None, closed="left"), None],
         "min_samples_split": [
             Interval(Integral, 2, None, closed="left"),
-            Interval(Real, 0.0, 1.0, closed="right"),
+            Interval("real_not_int", 0.0, 1.0, closed="right"),
         ],
         "min_samples_leaf": [
             Interval(Integral, 1, None, closed="left"),
-            Interval(Real, 0.0, 1.0, closed="neither"),
+            Interval("real_not_int", 0.0, 1.0, closed="neither"),
         ],
         "min_weight_fraction_leaf": [Interval(Real, 0.0, 0.5, closed="both")],
         "max_features": [
             Interval(Integral, 1, None, closed="left"),
-            Interval(Real, 0.0, 1.0, closed="right"),
+            Interval("real_not_int", 0.0, 1.0, closed="right"),
             StrOptions({"auto", "sqrt", "log2"}, deprecated={"auto"}),
             None,
         ],

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2425,3 +2425,25 @@ def test_tree_deserialization_from_read_only_buffer(tmpdir):
         clf.tree_,
         "The trees of the original and loaded classifiers are not equal.",
     )
+
+
+@pytest.mark.parametrize("Tree", ALL_TREES.values())
+def test_min_sample_split_1_error(Tree):
+    """Check that an error is raised when min_sample_split=1.
+
+    non-regression test for issue gh-25481.
+    """
+    X = np.array([[0, 0], [1, 1]])
+    y = np.array([0, 1])
+
+    # min_samples_split=1.0 is valid
+    Tree(min_samples_split=1.0).fit(X, y)
+
+    # min_samples_split=1 is invalid
+    tree = Tree(min_samples_split=1)
+    msg = (
+        r"'min_samples_split' .* must be an int in the range \[2, inf\) "
+        r"or a float in the range \(0.0, 1.0\]"
+    )
+    with pytest.raises(ValueError, match=msg):
+        tree.fit(X, y)

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -431,6 +431,11 @@ class Interval(_Constraint):
                 raise ValueError(
                     f"right can't be None when closed == {self.closed} {suffix}"
                 )
+        else:
+            if self.left is not None and not isinstance(self.left, Real):
+                raise TypeError(f"Expecting left to be a real number.")
+            if self.right is not None and not isinstance(self.right, Real):
+                raise TypeError(f"Expecting right to be a real number.")
 
         if self.right is not None and self.left is not None and self.right <= self.left:
             raise ValueError(

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -433,9 +433,9 @@ class Interval(_Constraint):
                 )
         else:
             if self.left is not None and not isinstance(self.left, Real):
-                raise TypeError(f"Expecting left to be a real number.")
+                raise TypeError("Expecting left to be a real number.")
             if self.right is not None and not isinstance(self.right, Real):
-                raise TypeError(f"Expecting right to be a real number.")
+                raise TypeError("Expecting right to be a real number.")
 
         if self.right is not None and self.left is not None and self.right <= self.left:
             raise ValueError(

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -367,6 +367,9 @@ class Interval(_Constraint):
     type : {numbers.Integral, numbers.Real, "real_not_int"}
         The set of numbers in which to set the interval.
 
+        If "real_not_int", only reals that don't have the integer type
+        are allowed. For example 1.0 is allowed but 1 is not.
+
     left : float or int or None
         The left bound of the interval. None means left bound is -∞.
 

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -662,3 +662,10 @@ def test_third_party_estimator():
     # does not raise, even though "b" is not in the constraints dict and "a" is not
     # a parameter of the estimator.
     ThirdPartyEstimator(b=0).fit()
+
+
+def test_interval_real_not_int():
+    """Check for the type "real_not_int" in the Interval constraint."""
+    constraint = Interval("real_not_int", 0, 1, closed="both")
+    assert constraint.is_satisfied_by(1.0)
+    assert not constraint.is_satisfied_by(1)


### PR DESCRIPTION
Fixes #25481 

Fixes a regression introduced by the new param validations. This PR introduces a new type for the Interval constraint: "real_not_int". It's useful when parameters have a behavior depending on whether the param is an int or a float.

@thomasjpfan I didn't follow exactly your suggestion from https://github.com/scikit-learn/scikit-learn/issues/25481#issuecomment-1421888785 because there can only be 1 situation where invalid_type is meaningful, i.e real but not int (int but not real is already excluded by definition). I felt that making it a third type option was more natural. Let me know what you think.

I think we should use this type wherever a parameter has 2 Interval constraints, one for ints and one for reals. It would make constraints more disjoints and would prevent more situations like this one. I plan to do that in a separate PR though.