### PR TITLE
MAINT replace cnp.ndarray with memory views in _fast_dict

### DIFF
--- a/sklearn/utils/_fast_dict.pyx
+++ b/sklearn/utils/_fast_dict.pyx
@@ -75,23 +75,6 @@ cdef class IntFloatDict:
             value = values[idx]
             yield key, value
 
-    def to_arrays(self):
-        """Return the key, value representation of the IntFloatDict
-           object.
-
-           Returns
-           =======
-           keys : ndarray, shape (n_items, ), dtype=int
-                The indices of the data points
-           values : ndarray, shape (n_items, ), dtype=float
-                The values of the data points
-        """
-        cdef int size = self.my_map.size()
-        cdef ITYPE_t[:] keys = np.empty(size, dtype=np.intp)
-        cdef DTYPE_t[:] values = np.empty(size, dtype=np.float64)
-        self._to_arrays(keys, values)
-        return keys, values
-
     cdef _to_arrays(self, ITYPE_t [:] keys, DTYPE_t [:] values):
         # Internal version of to_arrays that takes already-initialized arrays
         cdef cpp_map[ITYPE_t, DTYPE_t].iterator it = self.my_map.begin()

--- a/sklearn/utils/_fast_dict.pyx
+++ b/sklearn/utils/_fast_dict.pyx
@@ -12,13 +12,6 @@ from libcpp.map cimport map as cpp_map
 
 import numpy as np
 
-# Import the C-level symbols of numpy
-cimport numpy as cnp
-
-# Numpy must be initialized. When using numpy from C or Cython you must
-# _always_ do that, or you will have segfaults
-cnp.import_array()
-
 #DTYPE = np.float64
 #ctypedef cnp.float64_t DTYPE_t
 
@@ -35,8 +28,11 @@ cnp.import_array()
 
 cdef class IntFloatDict:
 
-    def __init__(self, cnp.ndarray[ITYPE_t, ndim=1] keys,
-                       cnp.ndarray[DTYPE_t, ndim=1] values):
+    def __init__(
+        self,
+        ITYPE_t[:] keys,
+        DTYPE_t[:] values,
+    ):
         cdef int i
         cdef int size = values.size
         # Should check that sizes for keys and values are equal, and
@@ -91,10 +87,8 @@ cdef class IntFloatDict:
                 The values of the data points
         """
         cdef int size = self.my_map.size()
-        cdef cnp.ndarray[ITYPE_t, ndim=1] keys = np.empty(size,
-                                                         dtype=np.intp)
-        cdef cnp.ndarray[DTYPE_t, ndim=1] values = np.empty(size,
-                                                           dtype=np.float64)
+        cdef ITYPE_t[:] keys = np.empty(size, dtype=np.intp)
+        cdef DTYPE_t[:] values = np.empty(size, dtype=np.float64)
         self._to_arrays(keys, values)
         return keys, values
 

--- a/sklearn/utils/_fast_dict.pyx
+++ b/sklearn/utils/_fast_dict.pyx
@@ -75,6 +75,23 @@ cdef class IntFloatDict:
             value = values[idx]
             yield key, value
 
+    def to_arrays(self):
+        """Return the key, value representation of the IntFloatDict
+           object.
+
+           Returns
+           =======
+           keys : ndarray, shape (n_items, ), dtype=int
+                The indices of the data points
+           values : ndarray, shape (n_items, ), dtype=float
+                The values of the data points
+        """
+        cdef int size = self.my_map.size()
+        cdef ITYPE_t[:] keys = np.empty(size, dtype=np.intp)
+        cdef DTYPE_t[:] values = np.empty(size, dtype=np.float64)
+        self._to_arrays(keys, values)
+        return np.asarray(keys), np.asarray(values)
+
     cdef _to_arrays(self, ITYPE_t [:] keys, DTYPE_t [:] values):
         # Internal version of to_arrays that takes already-initialized arrays
         cdef cpp_map[ITYPE_t, DTYPE_t].iterator it = self.my_map.begin()

--- a/sklearn/utils/_fast_dict.pyx
+++ b/sklearn/utils/_fast_dict.pyx
@@ -87,10 +87,10 @@ cdef class IntFloatDict:
                 The values of the data points
         """
         cdef int size = self.my_map.size()
-        cdef ITYPE_t[:] keys = np.empty(size, dtype=np.intp)
-        cdef DTYPE_t[:] values = np.empty(size, dtype=np.float64)
+        keys = np.empty(size, dtype=np.intp)
+        values = np.empty(size, dtype=np.float64)
         self._to_arrays(keys, values)
-        return np.asarray(keys), np.asarray(values)
+        return keys, values
 
     cdef _to_arrays(self, ITYPE_t [:] keys, DTYPE_t [:] values):
         # Internal version of to_arrays that takes already-initialized arrays

--- a/sklearn/utils/tests/test_fast_dict.py
+++ b/sklearn/utils/tests/test_fast_dict.py
@@ -33,6 +33,8 @@ def test_int_float_dict_argmin():
 
 
 def test_to_arrays():
+    # Test that an IntFloatDict is converted into arrays
+    # of keys and values correctly
     keys_in = np.array([1, 2, 3], dtype=np.intp)
     values_in = np.array([4, 5, 6], dtype=np.float64)
 

--- a/sklearn/utils/tests/test_fast_dict.py
+++ b/sklearn/utils/tests/test_fast_dict.py
@@ -1,6 +1,7 @@
 """ Test fast_dict.
 """
 import numpy as np
+from numpy.testing import assert_array_equal, assert_allclose
 
 from sklearn.utils._fast_dict import IntFloatDict, argmin
 
@@ -29,3 +30,16 @@ def test_int_float_dict_argmin():
     values = np.arange(100, dtype=np.float64)
     d = IntFloatDict(keys, values)
     assert argmin(d) == (0, 0)
+
+
+def test_to_arrays():
+    keys_in = np.array([1, 2, 3], dtype=np.intp)
+    values_in = np.array([4, 5, 6], dtype=np.float64)
+
+    d = IntFloatDict(keys_in, values_in)
+    keys_out, values_out = d.to_arrays()
+
+    assert keys_out.dtype == keys_in.dtype
+    assert values_in.dtype == values_out.dtype
+    assert_array_equal(keys_out, keys_in)
+    assert_allclose(values_out, values_in)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #25484

#### What does this implement/fix? Explain your changes.
- Replaced cnp.ndarray instances with memory views in _fast_dict.

#### Any other comments?
CC: @jjerphan @Vincent-Maladiere @adam2392 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
