### PR TITLE
FIX raise a better error in partial_dependence with mixed type categories

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -70,7 +70,7 @@ Changelog
   when dealing with mixed data type categories that cannot be sorted by
   :func:`numpy.unique`. This problem usually happen when categories are `str` and
   missing values are present using `np.nan`.
-  :pr:`xxxxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`25774` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.isotonic`
 .......................

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -64,6 +64,14 @@ Changelog
   :class:`feature_selection.SequentialFeatureSelector`.
   :pr:`25664` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+:mod:`sklearn.inspection`
+.........................
+- |Fix| Raise a more informative error message in :func:`inspection.partial_dependence`
+  when dealing with mixed data type categories that cannot be sorted by
+  :func:`numpy.unique`. This problem usually happen when categories are `str` and
+  missing values are present using `np.nan`.
+  :pr:`xxxxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.isotonic`
 .......................
 

--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -66,6 +66,7 @@ Changelog
 
 :mod:`sklearn.inspection`
 .........................
+
 - |Fix| Raise a more informative error message in :func:`inspection.partial_dependence`
   when dealing with mixed data type categories that cannot be sorted by
   :func:`numpy.unique`. This problem usually happen when categories are `str` and

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -96,7 +96,7 @@ def _grid_from_X(X, percentiles, is_categorical, grid_resolution):
             # `np.unique` will fail in the presence of `np.nan` and `str` categories
             # due to sorting. Temporary, we reraise an error explaining the problem.
             raise ValueError(
-                f"The column #{feature} contains mixed data type. Finding unique "
+                f"The column #{feature} contains mixed data types. Finding unique "
                 "categories fail due to sorting. It usually means that the column "
                 "contains `np.nan` values together with `str` categories. Such use "
                 "case is not yet supported in scikit-learn."

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -87,8 +87,20 @@ def _grid_from_X(X, percentiles, is_categorical, grid_resolution):
         raise ValueError("'grid_resolution' must be strictly greater than 1.")
 
     values = []
+    # TODO: we should handle missing values (i.e. `np.nan`) specifically and store them
+    # in a different Bunch attribute.
     for feature, is_cat in enumerate(is_categorical):
-        uniques = np.unique(_safe_indexing(X, feature, axis=1))
+        try:
+            uniques = np.unique(_safe_indexing(X, feature, axis=1))
+        except TypeError as exc:
+            # `np.unique` will fail in the presence of `np.nan` and `str` categories
+            # due to sorting. Temporary, we reraise an error explaining the problem.
+            raise ValueError(
+                f"The column #{feature} contains mixed data type. Finding unique "
+                "categories fail due to sorting. It usually means that the column "
+                "contains `np.nan` values together with `str` categories. Such use "
+                "case is not yet supported in scikit-learn."
+            ) from exc
         if is_cat or uniques.shape[0] < grid_resolution:
             # Use the unique values either because:
             # - feature has low resolution use unique values

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -871,18 +871,13 @@ def test_mixed_type_categorical():
     """Check that we raise a proper error when a column has mixed types and
     the sorting of `np.unique` will fail."""
     X = np.array(["A", "B", "C", np.nan], dtype=object).reshape(-1, 1)
+    y = np.array([0, 1, 0, 1])
 
-    percentiles, is_categorical, grid_resolution = (
-        (0.05, 0.95),
-        [
-            True,
-        ],
-        30,
-    )
-    with pytest.raises(ValueError, match="The column #0 contains mixed data type"):
-        _grid_from_X(
-            X,
-            percentiles=percentiles,
-            is_categorical=is_categorical,
-            grid_resolution=grid_resolution,
-        )
+    from sklearn.preprocessing import OrdinalEncoder
+
+    clf = make_pipeline(
+        OrdinalEncoder(encoded_missing_value=-1),
+        LogisticRegression(),
+    ).fit(X, y)
+    with pytest.raises(ValueError, match="The column #0 contains mixed data types"):
+        partial_dependence(clf, X, features=[0])

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -865,3 +865,24 @@ def test_partial_dependence_bunch_values_deprecated():
 
     # "values" and "grid_values" are the same object
     assert values is grid_values
+
+
+def test_mixed_type_categorical():
+    """Check that we raise a proper error when a column has mixed types and
+    the sorting of `np.unique` will fail."""
+    X = np.array(["A", "B", "C", np.nan], dtype=object).reshape(-1, 1)
+
+    percentiles, is_categorical, grid_resolution = (
+        (0.05, 0.95),
+        [
+            True,
+        ],
+        30,
+    )
+    with pytest.raises(ValueError, match="The column #0 contains mixed data type"):
+        _grid_from_X(
+            X,
+            percentiles=percentiles,
+            is_categorical=is_categorical,
+            grid_resolution=grid_resolution,
+        )


### PR DESCRIPTION
closes #25401 
closes #25407 
Alternative at #25407 

The error is raised when getting a column of mixed types where the sorting intended by `np.unique` will fail. It is typically happening in the presence of `np.nan` and `str` categories.

In a subsequent PR, we should handle this sorting problem using our `_unique` implementation and have a change of API to deal specifically with the `np.nan` by isolating them when returning the `Bunch` object.

