### PR TITLE
MAINT Replaces cnp.ndarray with memory views in _cd_fast

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ USE_NEWEST_NUMPY_C_API = (
     "sklearn.ensemble._hist_gradient_boosting.common",
     "sklearn.ensemble._hist_gradient_boosting.utils",
     "sklearn.feature_extraction._hashing_fast",
+    "sklearn.linear_model._cd_fast",
     "sklearn.linear_model._sag_fast",
     "sklearn.linear_model._sgd_fast",
     "sklearn.manifold._barnes_hut_tsne",

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -24,8 +24,6 @@ from ..utils._random cimport our_rand_r
 ctypedef cnp.float64_t DOUBLE
 ctypedef cnp.uint32_t UINT32_t
 
-cnp.import_array()
-
 # The following two functions are shamelessly copied from the tree code.
 
 cdef enum:

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -24,6 +24,8 @@ from ..utils._random cimport our_rand_r
 ctypedef cnp.float64_t DOUBLE
 ctypedef cnp.uint32_t UINT32_t
 
+cnp.import_array()
+
 # The following two functions are shamelessly copied from the tree code.
 
 cdef enum:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #25484
Towards #24875 

#### What does this implement/fix? Explain your changes.
- Replace cnp.ndarray with const memory views in _cd_fast.
- Remove the -Wcpp warning when compiling _cd_fast.

#### Any other comments?
CC: @thomasjpfan @jjerphan  

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
