### PR TITLE
DOC Fix description of roc_auc_score for average=None

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -440,7 +440,7 @@ def roc_auc_score(
         Otherwise, this determines the type of averaging performed on the data.
         Note: multiclass ROC AUC currently only handles the 'macro' and
         'weighted' averages. For multiclass targets, `average=None` is only
-        implemented for `multi_class='ovo'` and `average='micro'` is only
+        implemented for `multi_class='ovr'` and `average='micro'` is only
         implemented for `multi_class='ovr'`.
 
         ``'micro'``:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #25773


#### What does this implement/fix? Explain your changes.
Fixes documentation of `sklearn.metrics.roc_auc_score` for `average=None` parameter because it falsely stated that it only works with `multi_class="ovo"`. In reality, a `NotImplementedError` is thrown when `average=None` and `multi_class="ovo"` ([lines 681-684](https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/metrics/_ranking.py#L681-L684)) but it works flawlessly with `multi_class="ovr"`. Therefore, `ovo` should be changed to `ovr` in the docs.

#### Any other comments?
I wasted some time trying to use `roc_auc_score` according to documentation with `average=None` and `multi_class="ovo"` so I hope this fix saves somebody else's time.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
