### PR TITLE
MAINT Use memoryviews in _random.pyx

### DIFF
--- a/sklearn/utils/_random.pyx
+++ b/sklearn/utils/_random.pyx
@@ -12,6 +12,7 @@ The module contains:
 """
 import numpy as np
 cimport numpy as cnp
+cnp.import_array()
 
 from . import check_random_state
 

--- a/sklearn/utils/_random.pyx
+++ b/sklearn/utils/_random.pyx
@@ -78,7 +78,7 @@ cpdef _sample_without_replacement_with_tracking_selection(
 
     cdef cnp.int_t i
     cdef cnp.int_t j
-    cdef cnp.ndarray[cnp.int_t, ndim=1] out = np.empty((n_samples, ), dtype=int)
+    cdef cnp.int_t[:] out = np.empty((n_samples, ), dtype=np.int_)
 
     rng = check_random_state(random_state)
     rng_randint = rng.randint
@@ -94,7 +94,7 @@ cpdef _sample_without_replacement_with_tracking_selection(
         selected.add(j)
         out[i] = j
 
-    return out
+    return np.asarray(out)
 
 
 cpdef _sample_without_replacement_with_pool(cnp.int_t n_population,
@@ -133,9 +133,9 @@ cpdef _sample_without_replacement_with_pool(cnp.int_t n_population,
 
     cdef cnp.int_t i
     cdef cnp.int_t j
-    cdef cnp.ndarray[cnp.int_t, ndim=1] out = np.empty((n_samples, ), dtype=int)
+    cdef cnp.int_t[:] out = np.empty((n_samples, ), dtype=np.int_)
 
-    cdef cnp.ndarray[cnp.int_t, ndim=1] pool = np.empty((n_population, ),
+    cdef cnp.int_t[:] pool = np.empty((n_population, ),
                                                       dtype=int)
 
     rng = check_random_state(random_state)
@@ -153,7 +153,7 @@ cpdef _sample_without_replacement_with_pool(cnp.int_t n_population,
         pool[j] = pool[n_population - i - 1]  # move non-selected item into
                                               # vacancy
 
-    return out
+    return np.asarray(out)
 
 
 cpdef _sample_without_replacement_with_reservoir_sampling(
@@ -195,7 +195,7 @@ cpdef _sample_without_replacement_with_reservoir_sampling(
 
     cdef cnp.int_t i
     cdef cnp.int_t j
-    cdef cnp.ndarray[cnp.int_t, ndim=1] out = np.empty((n_samples, ), dtype=int)
+    cdef cnp.int_t[:] out = np.empty((n_samples, ), dtype=np.int_)
 
     rng = check_random_state(random_state)
     rng_randint = rng.randint
@@ -212,7 +212,7 @@ cpdef _sample_without_replacement_with_reservoir_sampling(
         if j < n_samples:
             out[j] = i
 
-    return out
+    return np.asarray(out)
 
 
 cpdef sample_without_replacement(cnp.int_t n_population,

--- a/sklearn/utils/_random.pyx
+++ b/sklearn/utils/_random.pyx
@@ -12,7 +12,6 @@ The module contains:
 """
 import numpy as np
 cimport numpy as cnp
-cnp.import_array()
 
 from . import check_random_state
 

--- a/sklearn/utils/_random.pyx
+++ b/sklearn/utils/_random.pyx
@@ -78,7 +78,7 @@ cpdef _sample_without_replacement_with_tracking_selection(
 
     cdef cnp.int_t i
     cdef cnp.int_t j
-    cdef cnp.int_t[:] out = np.empty((n_samples, ), dtype=np.int_)
+    cdef cnp.int_t[:] out = np.empty((n_samples, ), dtype=int)
 
     rng = check_random_state(random_state)
     rng_randint = rng.randint
@@ -133,7 +133,7 @@ cpdef _sample_without_replacement_with_pool(cnp.int_t n_population,
 
     cdef cnp.int_t i
     cdef cnp.int_t j
-    cdef cnp.int_t[:] out = np.empty((n_samples, ), dtype=np.int_)
+    cdef cnp.int_t[:] out = np.empty((n_samples, ), dtype=int)
 
     cdef cnp.int_t[:] pool = np.empty((n_population, ),
                                                       dtype=int)
@@ -195,7 +195,7 @@ cpdef _sample_without_replacement_with_reservoir_sampling(
 
     cdef cnp.int_t i
     cdef cnp.int_t j
-    cdef cnp.int_t[:] out = np.empty((n_samples, ), dtype=np.int_)
+    cdef cnp.int_t[:] out = np.empty((n_samples, ), dtype=int)
 
     rng = check_random_state(random_state)
     rng_randint = rng.randint


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes sklearn/utils/_random.pyx from #[25484](https://github.com/scikit-learn/scikit-learn/issues/25484)


#### What does this implement/fix? Explain your changes.

- Replaces cnp.ndarray with memory views in sklearn/utils/_random.pyx


#### Any other comments?

The output needed to be casted to an numpy array as tests (for example test_svm.py) call .astype on the return of the modified functions.

I also tried to reason as to why cnp.int_t and int are the types as values are intuitively indices. The indices can be between 0<= index < inf. Should we be using an unsigned long maybe? So, a cnp.uint64_t and np.uint64 or maybe a uint32.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
