### PR TITLE
DOC Allows section links to be visible when linked

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -395,7 +395,7 @@ a.sk-footer-funding-link:hover {
   width: 100%;
 }
 
-/* Enables section links to be visible when linked */
+/* Enables section links to be visible when anchor-linked */
 section[id]::before {
   display: block;
   height: 52px;

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -395,6 +395,15 @@ a.sk-footer-funding-link:hover {
   width: 100%;
 }
 
+/* Enables section links to be visible when linked */
+section[id]::before {
+  display: block;
+  height: 52px;
+  margin-top: -52px;
+  visibility: hidden;
+  content: "";
+}
+
 div.sk-page-content {
   background-color: white;
   position: relative;


### PR DESCRIPTION
This PR allows anchor links to appear directly under the navbar. For example, this link to the [cluster example](https://scikit-learn.org/dev/auto_examples/index.html#clustering) navigates to shows the following. With this PR, the "Clustering" header is actually visible.

### main

![Screenshot 2023-03-08 at 1 24 06 PM](https://user-images.githubusercontent.com/5402633/223801054-e2cdc602-6f17-494c-b5f3-20cf9e9e43b6.jpg)

### This PR

![Screenshot 2023-03-08 at 1 24 59 PM](https://user-images.githubusercontent.com/5402633/223801502-69d0122d-6374-438d-a190-17ef6234cca6.jpg)

