### PR TITLE
API Deprecate data_transposed in make_sparse_coded_signal

### DIFF
--- a/benchmarks/bench_plot_omp_lars.py
+++ b/benchmarks/bench_plot_omp_lars.py
@@ -27,7 +27,7 @@ def compute_bench(samples_range, features_range):
     for i_s, n_samples in enumerate(samples_range):
         for i_f, n_features in enumerate(features_range):
             it += 1
-            n_informative = n_features / 10
+            n_informative = n_features // 10
             print("====================")
             print("Iteration %03d of %03d" % (it, max_it))
             print("====================")
@@ -46,12 +46,11 @@ def compute_bench(samples_range, features_range):
                 "n_features": n_samples,
                 "n_nonzero_coefs": n_informative,
                 "random_state": 0,
-                "data_transposed": True,
             }
             print("n_samples: %d" % n_samples)
             print("n_features: %d" % n_features)
             y, X, _ = make_sparse_coded_signal(**dataset_kwargs)
-            X = np.asfortranarray(X)
+            X = np.asfortranarray(X.T)
 
             gc.collect()
             print("benchmarking lars_path (with Gram):", end="")

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -110,6 +110,13 @@ Changelog
   is now deprecated and will be removed in v1.5.
   :pr:`25251` by :user:`Gleb Levitski <glevv>`.
 
+:mod:`sklearn.datasets`
+.......................
+
+- |API| The `data_transposed` argument of :func:`datasets.make_sparse_coded_signal`
+  is deprecated and will be removed in v1.5.
+  :pr:`25781` by :user:`Jérémie du Boisberranger`.
+
 :mod:`sklearn.decomposition`
 ............................
 

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -115,7 +115,7 @@ Changelog
 
 - |API| The `data_transposed` argument of :func:`datasets.make_sparse_coded_signal`
   is deprecated and will be removed in v1.5.
-  :pr:`25781` by :user:`Jérémie du Boisberranger`.
+  :pr:`25784` by :user:`Jérémie du Boisberranger`.
 
 :mod:`sklearn.decomposition`
 ............................

--- a/examples/linear_model/plot_omp.py
+++ b/examples/linear_model/plot_omp.py
@@ -28,8 +28,8 @@ y, X, w = make_sparse_coded_signal(
     n_features=n_features,
     n_nonzero_coefs=n_nonzero_coefs,
     random_state=0,
-    data_transposed=True,
 )
+X = X.T
 
 (idx,) = w.nonzero()
 

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1278,10 +1278,6 @@ def make_low_rank_matrix(
     return np.dot(np.dot(u, s), v.T)
 
 
-# TODO(1.3): Change argument `data_transposed` default from True to False.
-# TODO(1.3): Deprecate data_transposed, always return data not transposed.
-
-
 @validate_params(
     {
         "n_samples": [Interval(Integral, 1, None, closed="left")],
@@ -1289,7 +1285,7 @@ def make_low_rank_matrix(
         "n_features": [Interval(Integral, 1, None, closed="left")],
         "n_nonzero_coefs": [Interval(Integral, 1, None, closed="left")],
         "random_state": ["random_state"],
-        "data_transposed": ["boolean", Hidden(StrOptions({"warn"}))],
+        "data_transposed": ["boolean", Hidden(StrOptions({"deprecated"}))],
     }
 )
 def make_sparse_coded_signal(
@@ -1299,7 +1295,7 @@ def make_sparse_coded_signal(
     n_features,
     n_nonzero_coefs,
     random_state=None,
-    data_transposed="warn",
+    data_transposed="deprecated",
 ):
     """Generate a signal as a sparse combination of dictionary elements.
 
@@ -1328,10 +1324,16 @@ def make_sparse_coded_signal(
         for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
-    data_transposed : bool, default=True
-        By default, Y, D and X are transposed.
+    data_transposed : bool, default=False
+        By default, Y, D and X are not transposed.
 
         .. versionadded:: 1.1
+
+        .. versionchanged:: 1.3
+            Default value changed from True to False.
+
+        .. deprecated:: 1.3
+            `data_transposed` is deprecated and will be removed in 1.5.
 
     Returns
     -------
@@ -1367,14 +1369,15 @@ def make_sparse_coded_signal(
     # encode signal
     Y = np.dot(D, X)
 
+    # TODO(1.5) remove data_transposed
     # raise warning if data_transposed is not passed explicitly
-    if data_transposed == "warn":
-        data_transposed = True
+    if data_transposed != "deprecated":
         warnings.warn(
-            "The default value of data_transposed will change from True to False in"
-            " version 1.3",
+            "data_transposed was deprecated in version 1.3 and will be removed in 1.5.",
             FutureWarning,
         )
+    else:
+        data_transposed = False
 
     # transpose if needed
     if not data_transposed:

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -10,6 +10,7 @@ from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_array_almost_equal
 from sklearn.utils._testing import assert_allclose
+from sklearn.utils._testing import ignore_warnings
 
 from sklearn.datasets import make_classification
 from sklearn.datasets import make_multilabel_classification
@@ -497,7 +498,6 @@ def test_make_sparse_coded_signal():
         n_features=10,
         n_nonzero_coefs=3,
         random_state=0,
-        data_transposed=False,
     )
     assert Y.shape == (5, 10), "Y shape mismatch"
     assert D.shape == (8, 10), "D shape mismatch"
@@ -508,6 +508,8 @@ def test_make_sparse_coded_signal():
     assert_allclose(np.sqrt((D**2).sum(axis=1)), np.ones(D.shape[0]))
 
 
+# TODO(1.5): remove
+@ignore_warnings(category=FutureWarning)
 def test_make_sparse_coded_signal_transposed():
     Y, D, X = make_sparse_coded_signal(
         n_samples=5,
@@ -526,13 +528,18 @@ def test_make_sparse_coded_signal_transposed():
     assert_allclose(np.sqrt((D**2).sum(axis=0)), np.ones(D.shape[1]))
 
 
-# TODO(1.3): remove
-def test_make_sparse_code_signal_warning():
+# TODO(1.5): remove
+def test_make_sparse_code_signal_deprecation_warning():
     """Check the message for future deprecation."""
-    warn_msg = "The default value of data_transposed will change from True to False"
+    warn_msg = "data_transposed was deprecated in version 1.3"
     with pytest.warns(FutureWarning, match=warn_msg):
         make_sparse_coded_signal(
-            n_samples=1, n_components=1, n_features=1, n_nonzero_coefs=1, random_state=0
+            n_samples=1,
+            n_components=1,
+            n_features=1,
+            n_nonzero_coefs=1,
+            random_state=0,
+            data_transposed=True,
         )
 
 

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1687,7 +1687,7 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
     >>> from sklearn.decomposition import DictionaryLearning
     >>> X, dictionary, code = make_sparse_coded_signal(
     ...     n_samples=100, n_components=15, n_features=20, n_nonzero_coefs=10,
-    ...     random_state=42, data_transposed=False
+    ...     random_state=42,
     ... )
     >>> dict_learner = DictionaryLearning(
     ...     n_components=15, transform_algorithm='lasso_lars', transform_alpha=0.1,
@@ -2059,7 +2059,7 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
     >>> from sklearn.decomposition import MiniBatchDictionaryLearning
     >>> X, dictionary, code = make_sparse_coded_signal(
     ...     n_samples=100, n_components=15, n_features=20, n_nonzero_coefs=10,
-    ...     random_state=42, data_transposed=False)
+    ...     random_state=42)
     >>> dict_learner = MiniBatchDictionaryLearning(
     ...     n_components=15, batch_size=3, transform_algorithm='lasso_lars',
     ...     transform_alpha=0.1, random_state=42)

--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -28,8 +28,8 @@ y, X, gamma = make_sparse_coded_signal(
     n_features=n_samples,
     n_nonzero_coefs=n_nonzero_coefs,
     random_state=0,
-    data_transposed=True,
 )
+y, X, gamma = y.T, X.T, gamma.T
 # Make X not of norm 1 for testing
 X *= 10
 y *= 10


### PR DESCRIPTION
Continuation of the deprecation cycle: change the default from True to False and deprecate the parameter.