### PR TITLE
MAINT add const qualifications to required places in cython_blas and cd_fast

### DIFF
--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -55,7 +55,7 @@ cdef inline floating fsign(floating f) noexcept nogil:
         return -1.0
 
 
-cdef floating abs_max(int n, floating* a) noexcept nogil:
+cdef floating abs_max(int n, const floating* a) noexcept nogil:
     """np.max(np.abs(a))"""
     cdef int i
     cdef floating m = fabs(a[0])
@@ -79,7 +79,7 @@ cdef floating max(int n, floating* a) noexcept nogil:
     return m
 
 
-cdef floating diff_abs_max(int n, floating* a, floating* b) noexcept nogil:
+cdef floating diff_abs_max(int n, const floating* a, floating* b) noexcept nogil:
     """np.max(np.abs(a - b))"""
     cdef int i
     cdef floating m = fabs(a[0] - b[0])

--- a/sklearn/utils/_cython_blas.pxd
+++ b/sklearn/utils/_cython_blas.pxd
@@ -12,24 +12,24 @@ cpdef enum BLAS_Trans:
 
 
 # BLAS Level 1 ################################################################
-cdef floating _dot(int, floating*, int, floating*, int) noexcept nogil
+cdef floating _dot(int, const floating*, int, const floating*, int) noexcept nogil
 
 cdef floating _asum(int, floating*, int) noexcept nogil
 
-cdef void _axpy(int, floating, floating*, int, floating*, int) noexcept nogil
+cdef void _axpy(int, floating, const floating*, int, floating*, int) noexcept nogil
 
-cdef floating _nrm2(int, floating*, int) noexcept nogil
+cdef floating _nrm2(int, const floating*, int) noexcept nogil
 
-cdef void _copy(int, floating*, int, floating*, int) noexcept nogil
+cdef void _copy(int, const floating*, int, const floating*, int) noexcept nogil
 
-cdef void _scal(int, floating, floating*, int) noexcept nogil
+cdef void _scal(int, floating, const floating*, int) noexcept nogil
 
 cdef void _rotg(floating*, floating*, floating*, floating*) noexcept nogil
 
 cdef void _rot(int, floating*, int, floating*, int, floating, floating) noexcept nogil
 
 # BLAS Level 2 ################################################################
-cdef void _gemv(BLAS_Order, BLAS_Trans, int, int, floating, floating*, int,
+cdef void _gemv(BLAS_Order, BLAS_Trans, int, int, floating, const floating*, int,
                 floating*, int, floating, floating*, int) noexcept nogil
 
 cdef void _ger(BLAS_Order, int, int, floating, floating*, int, floating*, int,

--- a/sklearn/utils/_cython_blas.pxd
+++ b/sklearn/utils/_cython_blas.pxd
@@ -14,7 +14,7 @@ cpdef enum BLAS_Trans:
 # BLAS Level 1 ################################################################
 cdef floating _dot(int, const floating*, int, const floating*, int) noexcept nogil
 
-cdef floating _asum(int, floating*, int) noexcept nogil
+cdef floating _asum(int, const floating*, int) noexcept nogil
 
 cdef void _axpy(int, floating, const floating*, int, floating*, int) noexcept nogil
 
@@ -30,10 +30,10 @@ cdef void _rot(int, floating*, int, floating*, int, floating, floating) noexcept
 
 # BLAS Level 2 ################################################################
 cdef void _gemv(BLAS_Order, BLAS_Trans, int, int, floating, const floating*, int,
-                floating*, int, floating, floating*, int) noexcept nogil
+                const floating*, int, floating, floating*, int) noexcept nogil
 
-cdef void _ger(BLAS_Order, int, int, floating, floating*, int, floating*, int,
-               floating*, int) noexcept nogil
+cdef void _ger(BLAS_Order, int, int, floating, const floating*, int, const floating*,
+               int, floating*, int) noexcept nogil
 
 # BLASLevel 3 ################################################################
 cdef void _gemm(BLAS_Order, BLAS_Trans, BLAS_Trans, int, int, int, floating,

--- a/sklearn/utils/_cython_blas.pyx
+++ b/sklearn/utils/_cython_blas.pyx
@@ -30,15 +30,15 @@ cpdef _dot_memview(const floating[::1] x, const floating[::1] y):
     return _dot(x.shape[0], &x[0], 1, &y[0], 1)
 
 
-cdef floating _asum(int n, floating *x, int incx) noexcept nogil:
+cdef floating _asum(int n, const floating *x, int incx) noexcept nogil:
     """sum(|x_i|)"""
     if floating is float:
-        return sasum(&n, x, &incx)
+        return sasum(&n, <float *> x, &incx)
     else:
-        return dasum(&n, x, &incx)
+        return dasum(&n, <double *> x, &incx)
 
 
-cpdef _asum_memview(floating[::1] x):
+cpdef _asum_memview(const floating[::1] x):
     return _asum(x.shape[0], &x[0], 1)
 
 
@@ -122,33 +122,29 @@ cpdef _rot_memview(floating[::1] x, floating[::1] y, floating c, floating s):
 ################
 
 cdef void _gemv(BLAS_Order order, BLAS_Trans ta, int m, int n, floating alpha,
-                const floating *A, int lda, floating *x, int incx,
+                const floating *A, int lda, const floating *x, int incx,
                 floating beta, floating *y, int incy) noexcept nogil:
     """y := alpha * op(A).x + beta * y"""
     cdef char ta_ = ta
     if order == RowMajor:
         ta_ = NoTrans if ta == Trans else Trans
         if floating is float:
-            sgemv(
-                &ta_, &n, &m, &alpha, <float *> A, &lda, x, &incx, &beta, y, &incy
-            )
+            sgemv(&ta_, &n, &m, &alpha, <float *> A, &lda, <float *> x,
+                  &incx, &beta, y, &incy)
         else:
-            dgemv(
-                &ta_, &n, &m, &alpha, <double *> A, &lda, x, &incx, &beta, y, &incy
-            )
+            dgemv(&ta_, &n, &m, &alpha, <double *> A, &lda, <double *> x,
+                  &incx, &beta, y, &incy)
     else:
         if floating is float:
-            sgemv(
-                &ta_, &m, &n, &alpha, <float *> A, &lda, x, &incx, &beta, y, &incy
-            )
+            sgemv(&ta_, &m, &n, &alpha, <float *> A, &lda, <float *> x,
+                  &incx, &beta, y, &incy)
         else:
-            dgemv(
-                &ta_, &m, &n, &alpha, <double *> A, &lda, x, &incx, &beta, y, &incy
-            )
+            dgemv(&ta_, &m, &n, &alpha, <double *> A, &lda, <double *> x,
+                  &incx, &beta, y, &incy)
 
 
 cpdef _gemv_memview(BLAS_Trans ta, floating alpha, const floating[:, :] A,
-                    floating[::1] x, floating beta, floating[::1] y):
+                    const floating[::1] x, floating beta, floating[::1] y):
     cdef:
         int m = A.shape[0]
         int n = A.shape[1]
@@ -158,23 +154,24 @@ cpdef _gemv_memview(BLAS_Trans ta, floating alpha, const floating[:, :] A,
     _gemv(order, ta, m, n, alpha, &A[0, 0], lda, &x[0], 1, beta, &y[0], 1)
 
 
-cdef void _ger(BLAS_Order order, int m, int n, floating alpha, floating *x,
-               int incx, floating *y, int incy, floating *A, int lda) noexcept nogil:
+cdef void _ger(BLAS_Order order, int m, int n, floating alpha,
+               const floating *x, int incx, const floating *y,
+               int incy, floating *A, int lda) noexcept nogil:
     """A := alpha * x.y.T + A"""
     if order == RowMajor:
         if floating is float:
-            sger(&n, &m, &alpha, y, &incy, x, &incx, A, &lda)
+            sger(&n, &m, &alpha, <float *> y, &incy, <float *> x, &incx, A, &lda)
         else:
-            dger(&n, &m, &alpha, y, &incy, x, &incx, A, &lda)
+            dger(&n, &m, &alpha, <double *> y, &incy, <double *> x, &incx, A, &lda)
     else:
         if floating is float:
-            sger(&m, &n, &alpha, x, &incx, y, &incy, A, &lda)
+            sger(&m, &n, &alpha, <float *> x, &incx,<float *> y, &incy, A, &lda)
         else:
-            dger(&m, &n, &alpha, x, &incx, y, &incy, A, &lda)
+            dger(&m, &n, &alpha, <double *> x, &incx, <double *> y, &incy, A, &lda)
 
 
-cpdef _ger_memview(floating alpha, floating[::1] x, floating[::1] y,
-                   floating[:, :] A):
+cpdef _ger_memview(floating alpha, const floating[::1] x,
+                   const floating[::1] y, floating[:, :] A):
     cdef:
         int m = A.shape[0]
         int n = A.shape[1]

--- a/sklearn/utils/_cython_blas.pyx
+++ b/sklearn/utils/_cython_blas.pyx
@@ -17,16 +17,16 @@ from scipy.linalg.cython_blas cimport sgemm, dgemm
 # BLAS Level 1 #
 ################
 
-cdef floating _dot(int n, floating *x, int incx,
-                   floating *y, int incy) noexcept nogil:
+cdef floating _dot(int n, const floating *x, int incx,
+                   const floating *y, int incy) noexcept nogil:
     """x.T.y"""
     if floating is float:
-        return sdot(&n, x, &incx, y, &incy)
+        return sdot(&n, <float *> x, &incx, <float *> y, &incy)
     else:
-        return ddot(&n, x, &incx, y, &incy)
+        return ddot(&n, <double *> x, &incx, <double *> y, &incy)
 
 
-cpdef _dot_memview(floating[::1] x, floating[::1] y):
+cpdef _dot_memview(const floating[::1] x, const floating[::1] y):
     return _dot(x.shape[0], &x[0], 1, &y[0], 1)
 
 
@@ -42,52 +42,52 @@ cpdef _asum_memview(floating[::1] x):
     return _asum(x.shape[0], &x[0], 1)
 
 
-cdef void _axpy(int n, floating alpha, floating *x, int incx,
+cdef void _axpy(int n, floating alpha, const floating *x, int incx,
                 floating *y, int incy) noexcept nogil:
     """y := alpha * x + y"""
     if floating is float:
-        saxpy(&n, &alpha, x, &incx, y, &incy)
+        saxpy(&n, &alpha, <float *> x, &incx, y, &incy)
     else:
-        daxpy(&n, &alpha, x, &incx, y, &incy)
+        daxpy(&n, &alpha, <double *> x, &incx, y, &incy)
 
 
-cpdef _axpy_memview(floating alpha, floating[::1] x, floating[::1] y):
+cpdef _axpy_memview(floating alpha, const floating[::1] x, floating[::1] y):
     _axpy(x.shape[0], alpha, &x[0], 1, &y[0], 1)
 
 
-cdef floating _nrm2(int n, floating *x, int incx) noexcept nogil:
+cdef floating _nrm2(int n, const floating *x, int incx) noexcept nogil:
     """sqrt(sum((x_i)^2))"""
     if floating is float:
-        return snrm2(&n, x, &incx)
+        return snrm2(&n, <float *> x, &incx)
     else:
-        return dnrm2(&n, x, &incx)
+        return dnrm2(&n, <double *> x, &incx)
 
 
-cpdef _nrm2_memview(floating[::1] x):
+cpdef _nrm2_memview(const floating[::1] x):
     return _nrm2(x.shape[0], &x[0], 1)
 
 
-cdef void _copy(int n, floating *x, int incx, floating *y, int incy) noexcept nogil:
+cdef void _copy(int n, const floating *x, int incx, const floating *y, int incy) noexcept nogil:
     """y := x"""
     if floating is float:
-        scopy(&n, x, &incx, y, &incy)
+        scopy(&n, <float *> x, &incx, <float *> y, &incy)
     else:
-        dcopy(&n, x, &incx, y, &incy)
+        dcopy(&n, <double *> x, &incx, <double *> y, &incy)
 
 
-cpdef _copy_memview(floating[::1] x, floating[::1] y):
+cpdef _copy_memview(const floating[::1] x, const floating[::1] y):
     _copy(x.shape[0], &x[0], 1, &y[0], 1)
 
 
-cdef void _scal(int n, floating alpha, floating *x, int incx) noexcept nogil:
+cdef void _scal(int n, floating alpha, const floating *x, int incx) noexcept nogil:
     """x := alpha * x"""
     if floating is float:
-        sscal(&n, &alpha, x, &incx)
+        sscal(&n, &alpha, <float *> x, &incx)
     else:
-        dscal(&n, &alpha, x, &incx)
+        dscal(&n, &alpha, <double *> x, &incx)
 
 
-cpdef _scal_memview(floating alpha, floating[::1] x):
+cpdef _scal_memview(floating alpha, const floating[::1] x):
     _scal(x.shape[0], alpha, &x[0], 1)
 
 
@@ -122,24 +122,32 @@ cpdef _rot_memview(floating[::1] x, floating[::1] y, floating c, floating s):
 ################
 
 cdef void _gemv(BLAS_Order order, BLAS_Trans ta, int m, int n, floating alpha,
-                floating *A, int lda, floating *x, int incx,
+                const floating *A, int lda, floating *x, int incx,
                 floating beta, floating *y, int incy) noexcept nogil:
     """y := alpha * op(A).x + beta * y"""
     cdef char ta_ = ta
     if order == RowMajor:
         ta_ = NoTrans if ta == Trans else Trans
         if floating is float:
-            sgemv(&ta_, &n, &m, &alpha, A, &lda, x, &incx, &beta, y, &incy)
+            sgemv(
+                &ta_, &n, &m, &alpha, <float *> A, &lda, x, &incx, &beta, y, &incy
+            )
         else:
-            dgemv(&ta_, &n, &m, &alpha, A, &lda, x, &incx, &beta, y, &incy)
+            dgemv(
+                &ta_, &n, &m, &alpha, <double *> A, &lda, x, &incx, &beta, y, &incy
+            )
     else:
         if floating is float:
-            sgemv(&ta_, &m, &n, &alpha, A, &lda, x, &incx, &beta, y, &incy)
+            sgemv(
+                &ta_, &m, &n, &alpha, <float *> A, &lda, x, &incx, &beta, y, &incy
+            )
         else:
-            dgemv(&ta_, &m, &n, &alpha, A, &lda, x, &incx, &beta, y, &incy)
+            dgemv(
+                &ta_, &m, &n, &alpha, <double *> A, &lda, x, &incx, &beta, y, &incy
+            )
 
 
-cpdef _gemv_memview(BLAS_Trans ta, floating alpha, floating[:, :] A,
+cpdef _gemv_memview(BLAS_Trans ta, floating alpha, const floating[:, :] A,
                     floating[::1] x, floating beta, floating[::1] y):
     cdef:
         int m = A.shape[0]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up of #25775

#### What does this implement/fix? Explain your changes.
- Specifies const definition for the required pointer parameters in relevant _cython_blas functions.
- Specifies const definition for required pointer parameters in _cd_fast functions abs_max and diff_abs_max
- Removes the [-Wincompatible-pointer-types-discards-qualifiers] warnings that were raised as a result of #25775

#### Any other comments?
CC @jjerphan @jeremiedbb 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
