### PR TITLE
DOC Update contributor experience team

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -73,6 +73,13 @@ past, but no longer have communication responsibilities:
 
 .. include:: communication_team_emeritus.rst
 
+Emeritus Contributor Experience Team
+------------------------------------
+
+The following people have been active in the contributor experience team in the
+past:
+
+.. include:: contributor_experience_team_emeritus.rst
 
 .. _citing-scikit-learn:
 

--- a/doc/contributor_experience_team_emeritus.rst
+++ b/doc/contributor_experience_team_emeritus.rst
@@ -1,0 +1,1 @@
+- Chiara Marmo


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Dear maintainers as discussed off-line with some of you, this pull request updates the status of the contributor experience team, introducing emeritus members.
The team is up to date on github but I don´t have the rights to update the team itself in the doc (the page is generated automatically from github).

Thanks for your attention.
