### PR TITLE
ENH simplify alpha_grid expression for ElasticNetCV

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -168,9 +168,7 @@ def _alpha_grid(
         alphas.fill(np.finfo(float).resolution)
         return alphas
 
-    return np.logspace(np.log10(alpha_max * eps), np.log10(alpha_max), num=n_alphas)[
-        ::-1
-    ]
+    return np.geomspace(alpha_max, alpha_max * eps, num=n_alphas)
 
 
 def lasso_path(


### PR DESCRIPTION
Simpler formulation for the construction of geometrically space grid of alphas for LassoCV/ElasticNetCV
- the sequence can directly be constructed in decreasing order by reversing bounds
- applying  logspace to log values of bound is like applying geomspace
 
 
Check that both formulations are equivalent:
```
import numpy as np
alpha_max = 7.3
eps = 0.00145
n_alphas = 57

choice1 = np.logspace(np.log10(alpha_max * eps), np.log10(alpha_max), num=n_alphas)[::-1]
choice2 = np.geomspace(alpha_max, alpha_max * eps, num=n_alphas)

np.testing.assert_allclose(choice1, choice2)
```
