### PR TITLE
MAINT Ensure disjoint interval constraints

### DIFF
--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -233,7 +233,7 @@ class OPTICS(ClusterMixin, BaseEstimator):
     _parameter_constraints: dict = {
         "min_samples": [
             Interval(Integral, 2, None, closed="left"),
-            Interval(Real, 0, 1, closed="both"),
+            Interval("real_not_int", 0, 1, closed="both"),
         ],
         "max_eps": [Interval(Real, 0, None, closed="both")],
         "metric": [StrOptions(set(_VALID_METRICS) | {"precomputed"}), callable],
@@ -245,7 +245,7 @@ class OPTICS(ClusterMixin, BaseEstimator):
         "predecessor_correction": ["boolean"],
         "min_cluster_size": [
             Interval(Integral, 2, None, closed="left"),
-            Interval(Real, 0, 1, closed="right"),
+            Interval("real_not_int", 0, 1, closed="right"),
             None,
         ],
         "algorithm": [StrOptions({"auto", "brute", "ball_tree", "kd_tree"})],
@@ -431,7 +431,7 @@ def _compute_core_distances_(X, neighbors, min_samples, working_memory):
         "X": [np.ndarray, "sparse matrix"],
         "min_samples": [
             Interval(Integral, 2, None, closed="left"),
-            Interval(Real, 0, 1, closed="both"),
+            Interval("real_not_int", 0, 1, closed="both"),
         ],
         "max_eps": [Interval(Real, 0, None, closed="both")],
         "metric": [StrOptions(set(_VALID_METRICS) | {"precomputed"}), callable],
@@ -723,12 +723,12 @@ def cluster_optics_dbscan(*, reachability, core_distances, ordering, eps):
         "predecessor": [np.ndarray],
         "ordering": [np.ndarray],
         "min_samples": [
-            Interval(Integral, 1, None, closed="neither"),
-            Interval(Real, 0, 1, closed="both"),
+            Interval(Integral, 2, None, closed="left"),
+            Interval("real_not_int", 0, 1, closed="both"),
         ],
         "min_cluster_size": [
-            Interval(Integral, 1, None, closed="neither"),
-            Interval(Real, 0, 1, closed="both"),
+            Interval(Integral, 2, None, closed="left"),
+            Interval("real_not_int", 0, 1, closed="both"),
             None,
         ],
         "xi": [Interval(Real, 0, 1, closed="both")],

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -20,6 +20,7 @@ from ..metrics.pairwise import PAIRWISE_BOOLEAN_FUNCTIONS
 from ..metrics.pairwise import _VALID_METRICS
 from ..utils import gen_batches, get_chunk_n_rows
 from ..utils._param_validation import Interval, HasMethods, StrOptions, validate_params
+from ..utils._param_validation import RealNotInt
 from ..utils.validation import check_memory
 from ..neighbors import NearestNeighbors
 from ..base import BaseEstimator, ClusterMixin
@@ -233,7 +234,7 @@ class OPTICS(ClusterMixin, BaseEstimator):
     _parameter_constraints: dict = {
         "min_samples": [
             Interval(Integral, 2, None, closed="left"),
-            Interval("real_not_int", 0, 1, closed="both"),
+            Interval(RealNotInt, 0, 1, closed="both"),
         ],
         "max_eps": [Interval(Real, 0, None, closed="both")],
         "metric": [StrOptions(set(_VALID_METRICS) | {"precomputed"}), callable],
@@ -245,7 +246,7 @@ class OPTICS(ClusterMixin, BaseEstimator):
         "predecessor_correction": ["boolean"],
         "min_cluster_size": [
             Interval(Integral, 2, None, closed="left"),
-            Interval("real_not_int", 0, 1, closed="right"),
+            Interval(RealNotInt, 0, 1, closed="right"),
             None,
         ],
         "algorithm": [StrOptions({"auto", "brute", "ball_tree", "kd_tree"})],
@@ -431,7 +432,7 @@ def _compute_core_distances_(X, neighbors, min_samples, working_memory):
         "X": [np.ndarray, "sparse matrix"],
         "min_samples": [
             Interval(Integral, 2, None, closed="left"),
-            Interval("real_not_int", 0, 1, closed="both"),
+            Interval(RealNotInt, 0, 1, closed="both"),
         ],
         "max_eps": [Interval(Real, 0, None, closed="both")],
         "metric": [StrOptions(set(_VALID_METRICS) | {"precomputed"}), callable],
@@ -724,11 +725,11 @@ def cluster_optics_dbscan(*, reachability, core_distances, ordering, eps):
         "ordering": [np.ndarray],
         "min_samples": [
             Interval(Integral, 2, None, closed="left"),
-            Interval("real_not_int", 0, 1, closed="both"),
+            Interval(RealNotInt, 0, 1, closed="both"),
         ],
         "min_cluster_size": [
             Interval(Integral, 2, None, closed="left"),
-            Interval("real_not_int", 0, 1, closed="both"),
+            Interval(RealNotInt, 0, 1, closed="both"),
             None,
         ],
         "xi": [Interval(Real, 0, 1, closed="both")],

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -197,7 +197,7 @@ def test_minimum_number_of_sample_check():
 
     # Compute OPTICS
     X = [[1, 1]]
-    clust = OPTICS(max_eps=5.0 * 0.3, min_samples=10, min_cluster_size=1)
+    clust = OPTICS(max_eps=5.0 * 0.3, min_samples=10, min_cluster_size=1.0)
 
     # Run the fit
     with pytest.raises(ValueError, match=msg):

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -363,7 +363,7 @@ class PCA(_BasePCA):
     _parameter_constraints: dict = {
         "n_components": [
             Interval(Integral, 0, None, closed="left"),
-            Interval(Real, 0, 1, closed="neither"),
+            Interval("real_not_int", 0, 1, closed="neither"),
             StrOptions({"mle"}),
             None,
         ],

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -27,6 +27,7 @@ from ..utils.extmath import fast_logdet, randomized_svd, svd_flip
 from ..utils.extmath import stable_cumsum
 from ..utils.validation import check_is_fitted
 from ..utils._param_validation import Interval, StrOptions
+from ..utils._param_validation import RealNotInt
 
 
 def _assess_dimension(spectrum, rank, n_samples):
@@ -363,7 +364,7 @@ class PCA(_BasePCA):
     _parameter_constraints: dict = {
         "n_components": [
             Interval(Integral, 0, None, closed="left"),
-            Interval("real_not_int", 0, 1, closed="neither"),
+            Interval(RealNotInt, 0, 1, closed="neither"),
             StrOptions({"mle"}),
             None,
         ],

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -8,7 +8,7 @@ import itertools
 import numbers
 import numpy as np
 from abc import ABCMeta, abstractmethod
-from numbers import Integral, Real
+from numbers import Integral
 from warnings import warn
 from functools import partial
 
@@ -248,11 +248,11 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
         "n_estimators": [Interval(Integral, 1, None, closed="left")],
         "max_samples": [
             Interval(Integral, 1, None, closed="left"),
-            Interval(Real, 0, 1, closed="right"),
+            Interval("real_not_int", 0, 1, closed="right"),
         ],
         "max_features": [
             Interval(Integral, 1, None, closed="left"),
-            Interval(Real, 0, 1, closed="right"),
+            Interval("real_not_int", 0, 1, closed="right"),
         ],
         "bootstrap": ["boolean"],
         "bootstrap_features": ["boolean"],

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -22,6 +22,7 @@ from ..utils.metaestimators import available_if
 from ..utils.multiclass import check_classification_targets
 from ..utils.random import sample_without_replacement
 from ..utils._param_validation import Interval, HasMethods, StrOptions
+from ..utils._param_validation import RealNotInt
 from ..utils.validation import has_fit_parameter, check_is_fitted, _check_sample_weight
 from ..utils._tags import _safe_tags
 from ..utils.parallel import delayed, Parallel
@@ -248,11 +249,11 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
         "n_estimators": [Interval(Integral, 1, None, closed="left")],
         "max_samples": [
             Interval(Integral, 1, None, closed="left"),
-            Interval("real_not_int", 0, 1, closed="right"),
+            Interval(RealNotInt, 0, 1, closed="right"),
         ],
         "max_features": [
             Interval(Integral, 1, None, closed="left"),
-            Interval("real_not_int", 0, 1, closed="right"),
+            Interval(RealNotInt, 0, 1, closed="right"),
         ],
         "bootstrap": ["boolean"],
         "bootstrap_features": ["boolean"],

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -74,6 +74,7 @@ from ..utils.validation import (
 )
 from ..utils.validation import _num_samples
 from ..utils._param_validation import Interval, StrOptions
+from ..utils._param_validation import RealNotInt
 
 
 __all__ = [
@@ -206,7 +207,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         "warm_start": ["boolean"],
         "max_samples": [
             None,
-            Interval("real_not_int", 0.0, 1.0, closed="right"),
+            Interval(RealNotInt, 0.0, 1.0, closed="right"),
             Interval(Integral, 1, None, closed="left"),
         ],
     }

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -206,7 +206,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         "warm_start": ["boolean"],
         "max_samples": [
             None,
-            Interval(Real, 0.0, 1.0, closed="right"),
+            Interval("real_not_int", 0.0, 1.0, closed="right"),
             Interval(Integral, 1, None, closed="left"),
         ],
     }

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -103,7 +103,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         ],
         "n_iter_no_change": [Interval(Integral, 1, None, closed="left")],
         "validation_fraction": [
-            Interval(Real, 0, 1, closed="neither"),
+            Interval("real_not_int", 0, 1, closed="neither"),
             Interval(Integral, 1, None, closed="left"),
             None,
         ],

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -27,6 +27,7 @@ from ...utils.validation import (
     _check_monotonic_cst,
 )
 from ...utils._param_validation import Interval, StrOptions
+from ...utils._param_validation import RealNotInt
 from ...utils._openmp_helpers import _openmp_effective_n_threads
 from ...utils.multiclass import check_classification_targets
 from ...metrics import check_scoring
@@ -103,7 +104,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         ],
         "n_iter_no_change": [Interval(Integral, 1, None, closed="left")],
         "validation_fraction": [
-            Interval("real_not_int", 0, 1, closed="neither"),
+            Interval(RealNotInt, 0, 1, closed="neither"),
             Interval(Integral, 1, None, closed="left"),
             None,
         ],

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -17,6 +17,7 @@ from ..utils import (
     get_chunk_n_rows,
 )
 from ..utils._param_validation import Interval, StrOptions
+from ..utils._param_validation import RealNotInt
 from ..utils.validation import check_is_fitted, _num_samples
 from ..base import OutlierMixin
 
@@ -206,7 +207,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
         "max_samples": [
             StrOptions({"auto"}),
             Interval(Integral, 1, None, closed="left"),
-            Interval("real_not_int", 0, 1, closed="right"),
+            Interval(RealNotInt, 0, 1, closed="right"),
         ],
         "contamination": [
             StrOptions({"auto"}),

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -206,7 +206,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
         "max_samples": [
             StrOptions({"auto"}),
             Interval(Integral, 1, None, closed="left"),
-            Interval(Real, 0, 1, closed="right"),
+            Interval("real_not_int", 0, 1, closed="right"),
         ],
         "contamination": [
             StrOptions({"auto"}),

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -18,6 +18,7 @@ from numpy.lib.stride_tricks import as_strided
 from ..base import BaseEstimator, TransformerMixin
 from ..utils import check_array, check_random_state
 from ..utils._param_validation import Hidden, Interval, validate_params
+from ..utils._param_validation import RealNotInt
 
 __all__ = [
     "PatchExtractor",
@@ -343,7 +344,7 @@ def _extract_patches(arr, patch_shape=8, extraction_step=1):
         "image": [np.ndarray],
         "patch_size": [tuple, list],
         "max_patches": [
-            Interval("real_not_int", 0, 1, closed="neither"),
+            Interval(RealNotInt, 0, 1, closed="neither"),
             Interval(Integral, 1, None, closed="left"),
             None,
         ],
@@ -542,7 +543,7 @@ class PatchExtractor(TransformerMixin, BaseEstimator):
         "patch_size": [tuple, None],
         "max_patches": [
             None,
-            Interval("real_not_int", 0, 1, closed="neither"),
+            Interval(RealNotInt, 0, 1, closed="neither"),
             Interval(Integral, 1, None, closed="left"),
         ],
         "random_state": ["random_state"],

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -343,8 +343,8 @@ def _extract_patches(arr, patch_shape=8, extraction_step=1):
         "image": [np.ndarray],
         "patch_size": [tuple, list],
         "max_patches": [
-            Interval(Real, left=0, right=1, closed="neither"),
-            Interval(Integral, left=1, right=None, closed="left"),
+            Interval("real_not_int", 0, 1, closed="neither"),
+            Interval(Integral, 1, None, closed="left"),
             None,
         ],
         "random_state": ["random_state"],
@@ -542,7 +542,7 @@ class PatchExtractor(TransformerMixin, BaseEstimator):
         "patch_size": [tuple, None],
         "max_patches": [
             None,
-            Interval(Real, 0, 1, closed="neither"),
+            Interval("real_not_int", 0, 1, closed="neither"),
             Interval(Integral, 1, None, closed="left"),
         ],
         "random_state": ["random_state"],

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -32,6 +32,7 @@ from ..utils.validation import check_is_fitted, check_array, FLOAT_DTYPES
 from ..utils import _IS_32BIT
 from ..exceptions import NotFittedError
 from ..utils._param_validation import StrOptions, Interval, HasMethods
+from ..utils._param_validation import RealNotInt
 
 
 __all__ = [
@@ -1148,11 +1149,11 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         "ngram_range": [tuple],
         "analyzer": [StrOptions({"word", "char", "char_wb"}), callable],
         "max_df": [
-            Interval("real_not_int", 0, 1, closed="both"),
+            Interval(RealNotInt, 0, 1, closed="both"),
             Interval(Integral, 1, None, closed="left"),
         ],
         "min_df": [
-            Interval("real_not_int", 0, 1, closed="both"),
+            Interval(RealNotInt, 0, 1, closed="both"),
             Interval(Integral, 1, None, closed="left"),
         ],
         "max_features": [Interval(Integral, 1, None, closed="left"), None],

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -15,7 +15,7 @@ import array
 from collections import defaultdict
 from collections.abc import Mapping
 from functools import partial
-from numbers import Integral, Real
+from numbers import Integral
 from operator import itemgetter
 import re
 import unicodedata
@@ -1148,11 +1148,11 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         "ngram_range": [tuple],
         "analyzer": [StrOptions({"word", "char", "char_wb"}), callable],
         "max_df": [
-            Interval(Real, 0, 1, closed="both"),
+            Interval("real_not_int", 0, 1, closed="both"),
             Interval(Integral, 1, None, closed="left"),
         ],
         "min_df": [
-            Interval(Real, 0, 1, closed="both"),
+            Interval("real_not_int", 0, 1, closed="both"),
             Interval(Integral, 1, None, closed="left"),
         ],
         "max_features": [Interval(Integral, 1, None, closed="left"), None],

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -7,7 +7,7 @@
 """Recursive feature elimination for feature ranking"""
 
 import numpy as np
-from numbers import Integral, Real
+from numbers import Integral
 from joblib import effective_n_jobs
 
 
@@ -187,12 +187,12 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         "estimator": [HasMethods(["fit"])],
         "n_features_to_select": [
             None,
-            Interval(Real, 0, 1, closed="right"),
+            Interval("real_not_int", 0, 1, closed="right"),
             Interval(Integral, 0, None, closed="neither"),
         ],
         "step": [
             Interval(Integral, 0, None, closed="neither"),
-            Interval(Real, 0, 1, closed="neither"),
+            Interval("real_not_int", 0, 1, closed="neither"),
         ],
         "verbose": ["verbose"],
         "importance_getter": [str, callable],

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -14,6 +14,7 @@ from joblib import effective_n_jobs
 from ..utils.metaestimators import available_if
 from ..utils.metaestimators import _safe_split
 from ..utils._param_validation import HasMethods, Interval
+from ..utils._param_validation import RealNotInt
 from ..utils._tags import _safe_tags
 from ..utils.validation import check_is_fitted
 from ..utils.parallel import delayed, Parallel
@@ -187,12 +188,12 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         "estimator": [HasMethods(["fit"])],
         "n_features_to_select": [
             None,
-            Interval("real_not_int", 0, 1, closed="right"),
+            Interval(RealNotInt, 0, 1, closed="right"),
             Interval(Integral, 0, None, closed="neither"),
         ],
         "step": [
             Interval(Integral, 0, None, closed="neither"),
-            Interval("real_not_int", 0, 1, closed="neither"),
+            Interval(RealNotInt, 0, 1, closed="neither"),
         ],
         "verbose": ["verbose"],
         "importance_getter": [str, callable],

--- a/sklearn/feature_selection/_sequential.py
+++ b/sklearn/feature_selection/_sequential.py
@@ -154,7 +154,7 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
         "estimator": [HasMethods(["fit"])],
         "n_features_to_select": [
             StrOptions({"auto", "warn"}, deprecated={"warn"}),
-            Interval(Real, 0, 1, closed="right"),
+            Interval("real_not_int", 0, 1, closed="right"),
             Interval(Integral, 0, None, closed="neither"),
             Hidden(None),
         ],

--- a/sklearn/feature_selection/_sequential.py
+++ b/sklearn/feature_selection/_sequential.py
@@ -10,6 +10,7 @@ import warnings
 from ._base import SelectorMixin
 from ..base import BaseEstimator, MetaEstimatorMixin, clone
 from ..utils._param_validation import HasMethods, Hidden, Interval, StrOptions
+from ..utils._param_validation import RealNotInt
 from ..utils._tags import _safe_tags
 from ..utils.validation import check_is_fitted
 from ..model_selection import cross_val_score
@@ -154,7 +155,7 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
         "estimator": [HasMethods(["fit"])],
         "n_features_to_select": [
             StrOptions({"auto", "warn"}, deprecated={"warn"}),
-            Interval("real_not_int", 0, 1, closed="right"),
+            Interval(RealNotInt, 0, 1, closed="right"),
             Interval(Integral, 0, None, closed="neither"),
             Hidden(None),
         ],

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -15,6 +15,7 @@ from ..utils.validation import check_is_fitted, _check_sample_weight
 from ._base import LinearRegression
 from ..utils.validation import has_fit_parameter
 from ..utils._param_validation import Interval, Options, StrOptions, HasMethods, Hidden
+from ..utils._param_validation import RealNotInt
 from ..exceptions import ConvergenceWarning
 
 _EPSILON = np.spacing(1)
@@ -236,7 +237,7 @@ class RANSACRegressor(
         "estimator": [HasMethods(["fit", "score", "predict"]), None],
         "min_samples": [
             Interval(Integral, 1, None, closed="left"),
-            Interval("real_not_int", 0, 1, closed="both"),
+            Interval(RealNotInt, 0, 1, closed="both"),
             None,
         ],
         "residual_threshold": [Interval(Real, 0, None, closed="left"), None],

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -236,7 +236,7 @@ class RANSACRegressor(
         "estimator": [HasMethods(["fit", "score", "predict"]), None],
         "min_samples": [
             Interval(Integral, 1, None, closed="left"),
-            Interval(Real, 0, 1, closed="both"),
+            Interval("real_not_int", 0, 1, closed="both"),
             None,
         ],
         "residual_threshold": [Interval(Real, 0, None, closed="left"), None],

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2464,12 +2464,12 @@ def check_cv(cv=5, y=None, *, classifier=False):
 @validate_params(
     {
         "test_size": [
-            Interval(numbers.Real, 0, 1, closed="neither"),
+            Interval("real_not_int", 0, 1, closed="neither"),
             Interval(numbers.Integral, 1, None, closed="left"),
             None,
         ],
         "train_size": [
-            Interval(numbers.Real, 0, 1, closed="neither"),
+            Interval("real_not_int", 0, 1, closed="neither"),
             Interval(numbers.Integral, 1, None, closed="left"),
             None,
         ],

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -29,6 +29,7 @@ from ..utils.validation import _num_samples, column_or_1d
 from ..utils.validation import check_array
 from ..utils.multiclass import type_of_target
 from ..utils._param_validation import validate_params, Interval
+from ..utils._param_validation import RealNotInt
 
 __all__ = [
     "BaseCrossValidator",
@@ -2464,12 +2465,12 @@ def check_cv(cv=5, y=None, *, classifier=False):
 @validate_params(
     {
         "test_size": [
-            Interval("real_not_int", 0, 1, closed="neither"),
+            Interval(RealNotInt, 0, 1, closed="neither"),
             Interval(numbers.Integral, 1, None, closed="left"),
             None,
         ],
         "train_size": [
-            Interval("real_not_int", 0, 1, closed="neither"),
+            Interval(RealNotInt, 0, 1, closed="neither"),
             Interval(numbers.Integral, 1, None, closed="left"),
             None,
         ],

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -14,6 +14,7 @@ from ..utils import check_array, is_scalar_nan, _safe_indexing
 from ..utils.validation import check_is_fitted
 from ..utils.validation import _check_feature_names_in
 from ..utils._param_validation import Interval, StrOptions, Hidden
+from ..utils._param_validation import RealNotInt
 from ..utils._mask import _get_mask
 
 from ..utils._encode import _encode, _check_unknown, _unique, _get_counts
@@ -493,7 +494,7 @@ class OneHotEncoder(_BaseEncoder):
         "max_categories": [Interval(Integral, 1, None, closed="left"), None],
         "min_frequency": [
             Interval(Integral, 1, None, closed="left"),
-            Interval("real_not_int", 0, 1, closed="neither"),
+            Interval(RealNotInt, 0, 1, closed="neither"),
             None,
         ],
         "sparse": [Hidden(StrOptions({"deprecated"})), "boolean"],  # deprecated

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -3,7 +3,7 @@
 # License: BSD 3 clause
 
 import numbers
-from numbers import Integral, Real
+from numbers import Integral
 import warnings
 
 import numpy as np
@@ -493,7 +493,7 @@ class OneHotEncoder(_BaseEncoder):
         "max_categories": [Interval(Integral, 1, None, closed="left"), None],
         "min_frequency": [
             Interval(Integral, 1, None, closed="left"),
-            Interval(Real, 0, 1, closed="neither"),
+            Interval("real_not_int", 0, 1, closed="neither"),
             None,
         ],
         "sparse": [Hidden(StrOptions({"deprecated"})), "boolean"],  # deprecated

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -1,5 +1,6 @@
 from importlib import import_module
 from inspect import signature
+from numbers import Integral, Real
 
 import pytest
 
@@ -7,6 +8,7 @@ from sklearn.utils._param_validation import generate_invalid_param_val
 from sklearn.utils._param_validation import generate_valid_param
 from sklearn.utils._param_validation import make_constraint
 from sklearn.utils._param_validation import InvalidParameterError
+from sklearn.utils._param_validation import Interval
 
 
 def _get_func_info(func_module):
@@ -70,6 +72,20 @@ def _check_function_param_validation(
             # This parameter is not validated
             continue
 
+        # Mixing an interval of reals and an interval of integers must be avoided.
+        if any(
+            isinstance(constraint, Interval) and constraint.type == Integral
+            for constraint in constraints
+        ) and any(
+            isinstance(constraint, Interval) and constraint.type == Real
+            for constraint in constraints
+        ):
+            raise ValueError(
+                f"The constraint for parameter {param_name} of {func_name} can't have a"
+                " mix of intervals of Integral and Real types. Use the type"
+                " 'real_not_int' instead of Real."
+            )
+
         match = (
             rf"The '{param_name}' parameter of {func_name} must be .* Got .* instead."
         )
@@ -85,7 +101,7 @@ def _check_function_param_validation(
 
         for constraint in constraints:
             try:
-                bad_value = generate_invalid_param_val(constraint, constraints)
+                bad_value = generate_invalid_param_val(constraint)
             except NotImplementedError:
                 continue
 

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -83,7 +83,7 @@ def _check_function_param_validation(
             raise ValueError(
                 f"The constraint for parameter {param_name} of {func_name} can't have a"
                 " mix of intervals of Integral and Real types. Use the type"
-                " 'real_not_int' instead of Real."
+                " RealNotInt instead of Real."
             )
 
         match = (

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -38,6 +38,7 @@ from ..utils import compute_sample_weight
 from ..utils.multiclass import check_classification_targets
 from ..utils.validation import check_is_fitted
 from ..utils._param_validation import Hidden, Interval, StrOptions
+from ..utils._param_validation import RealNotInt
 
 from ._criterion import Criterion
 from ._splitter import Splitter
@@ -99,16 +100,16 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         "max_depth": [Interval(Integral, 1, None, closed="left"), None],
         "min_samples_split": [
             Interval(Integral, 2, None, closed="left"),
-            Interval("real_not_int", 0.0, 1.0, closed="right"),
+            Interval(RealNotInt, 0.0, 1.0, closed="right"),
         ],
         "min_samples_leaf": [
             Interval(Integral, 1, None, closed="left"),
-            Interval("real_not_int", 0.0, 1.0, closed="neither"),
+            Interval(RealNotInt, 0.0, 1.0, closed="neither"),
         ],
         "min_weight_fraction_leaf": [Interval(Real, 0.0, 0.5, closed="both")],
         "max_features": [
             Interval(Integral, 1, None, closed="left"),
-            Interval("real_not_int", 0.0, 1.0, closed="right"),
+            Interval(RealNotInt, 0.0, 1.0, closed="right"),
             StrOptions({"auto", "sqrt", "log2"}, deprecated={"auto"}),
             None,
         ],

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -476,6 +476,13 @@ class Interval(_Constraint):
         left_bound = "-inf" if self.left is None else self.left
         right_bound = "inf" if self.right is None else self.right
         right_bracket = "]" if self.closed in ("right", "both") else ")"
+
+        # better repr if the bounds were given as integers
+        if not self.type == Integral and isinstance(self.left, Real):
+            left_bound = float(left_bound)
+        if not self.type == Integral and isinstance(self.right, Real):
+            right_bound = float(right_bound)
+
         return (
             f"{type_str} in the range "
             f"{left_bracket}{left_bound}, {right_bound}{right_bracket}"
@@ -718,7 +725,7 @@ class Hidden:
         self.constraint = constraint
 
 
-def generate_invalid_param_val(constraint, constraints=None):
+def generate_invalid_param_val(constraint):
     """Return a value that does not satisfy the constraint.
 
     Raises a NotImplementedError if there exists no invalid value for this constraint.
@@ -729,10 +736,6 @@ def generate_invalid_param_val(constraint, constraints=None):
     ----------
     constraint : _Constraint instance
         The constraint to generate a value for.
-
-    constraints : list of _Constraint instances or None, default=None
-        The list of all constraints for this parameter. If None, the list only
-        containing `constraint` is used.
 
     Returns
     -------
@@ -757,116 +760,31 @@ def generate_invalid_param_val(constraint, constraints=None):
     if isinstance(constraint, _CVObjects):
         return "not a cv object"
 
-    if not isinstance(constraint, Interval):
+    if isinstance(constraint, Interval) and constraint.type is Integral:
+        if constraint.left is not None:
+            return constraint.left - 1
+        if constraint.right is not None:
+            return constraint.right + 1
+
+        # There's no integer outside (-inf, +inf)
         raise NotImplementedError
 
-    # constraint is an interval
-    constraints = [constraint] if constraints is None else constraints
-    return _generate_invalid_param_val_interval(constraint, constraints)
+    if isinstance(constraint, Interval) and constraint.type in (Real, "real_not_int"):
+        if constraint.left is not None:
+            return constraint.left - 1e-6
+        if constraint.right is not None:
+            return constraint.right + 1e-6
 
+        # bounds are -inf, +inf
+        if constraint.closed in ("right", "neither"):
+            return -np.inf
+        if constraint.closed in ("left", "neither"):
+            return np.inf
 
-def _generate_invalid_param_val_interval(interval, constraints):
-    """Return a value that does not satisfy an interval constraint.
+        # interval is [-inf, +inf]
+        return np.nan
 
-    Generating an invalid value for an integer interval depends on the other constraints
-    since an int is a real, meaning that it can be valid for a real interval.
-    Assumes that there can be at most 2 interval constraints: one integer interval
-    and/or one real interval.
-
-    This is only useful for testing purpose.
-
-    Parameters
-    ----------
-    interval : Interval instance
-        The interval to generate a value for.
-
-    constraints : list of _Constraint instances
-        The list of all constraints for this parameter.
-
-    Returns
-    -------
-    val : object
-        A value that does not satisfy the interval constraint.
-    """
-    if interval.type is Real:
-        # generate a non-integer value such that it can't be valid even if there's also
-        # an integer interval constraint.
-        if interval.left is None and interval.right is None:
-            if interval.closed in ("left", "neither"):
-                return np.inf
-            elif interval.closed in ("right", "neither"):
-                return -np.inf
-            else:
-                raise NotImplementedError
-
-        if interval.left is not None:
-            return np.floor(interval.left) - 0.5
-        else:  # right is not None
-            return np.ceil(interval.right) + 0.5
-
-    else:  # interval.type is Integral
-        if interval.left is None and interval.right is None:
-            raise NotImplementedError
-
-        # We need to check if there's also a real interval constraint to generate a
-        # value that is not valid for any of the 2 interval constraints.
-        real_intervals = [
-            i for i in constraints if isinstance(i, Interval) and i.type is Real
-        ]
-        real_interval = real_intervals[0] if real_intervals else None
-
-        if real_interval is None:
-            # Only the integer interval constraint -> easy
-            if interval.left is not None:
-                return interval.left - 1
-            else:  # interval.right is not None
-                return interval.right + 1
-
-        # There's also a real interval constraint. Try to find a value left to both or
-        # right to both or in between them.
-
-        # redefine left and right bounds to be smallest and largest valid integers in
-        # both intervals.
-        int_left = interval.left
-        if int_left is not None and interval.closed in ("right", "neither"):
-            int_left = int_left + 1
-
-        int_right = interval.right
-        if int_right is not None and interval.closed in ("left", "neither"):
-            int_right = int_right - 1
-
-        real_left = real_interval.left
-        if real_interval.left is not None:
-            real_left = int(np.ceil(real_interval.left))
-            if real_interval.closed in ("right", "neither"):
-                real_left = real_left + 1
-
-        real_right = real_interval.right
-        if real_interval.right is not None:
-            real_right = int(np.floor(real_interval.right))
-            if real_interval.closed in ("left", "neither"):
-                real_right = real_right - 1
-
-        if int_left is not None and real_left is not None:
-            # there exists an int left to both intervals
-            return min(int_left, real_left) - 1
-
-        if int_right is not None and real_right is not None:
-            # there exists an int right to both intervals
-            return max(int_right, real_right) + 1
-
-        if int_left is not None:
-            if real_right is not None and int_left - real_right >= 2:
-                # there exists an int between the 2 intervals
-                return int_left - 1
-            else:
-                raise NotImplementedError
-        else:  # int_right is not None
-            if real_left is not None and real_left - int_right >= 2:
-                # there exists an int between the 2 intervals
-                return int_right + 1
-            else:
-                raise NotImplementedError
+    raise NotImplementedError
 
 
 def generate_valid_param(constraint):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -4165,7 +4165,7 @@ def check_param_validation(name, estimator_orig):
         ):
             raise ValueError(
                 f"The constraint for parameter {param_name} of {name} can't have a mix"
-                " of intervals of Integral and Real types. Use the type 'real_not_int'"
+                " of intervals of Integral and Real types. Use the type RealNotInt"
                 " instead of Real."
             )
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -4,7 +4,7 @@ import re
 from copy import deepcopy
 from functools import partial, wraps
 from inspect import signature
-from numbers import Real
+from numbers import Real, Integral
 
 import numpy as np
 from scipy import sparse
@@ -1434,7 +1434,7 @@ def check_fit2d_1sample(name, estimator_orig):
 
     # min_cluster_size cannot be less than the data size for OPTICS.
     if name == "OPTICS":
-        estimator.set_params(min_samples=1)
+        estimator.set_params(min_samples=1.0)
 
     # perplexity cannot be more than the number of samples for TSNE.
     if name == "TSNE":
@@ -4155,6 +4155,20 @@ def check_param_validation(name, estimator_orig):
             # This parameter is not validated
             continue
 
+        # Mixing an interval of reals and an interval of integers must be avoided.
+        if any(
+            isinstance(constraint, Interval) and constraint.type == Integral
+            for constraint in constraints
+        ) and any(
+            isinstance(constraint, Interval) and constraint.type == Real
+            for constraint in constraints
+        ):
+            raise ValueError(
+                f"The constraint for parameter {param_name} of {name} can't have a mix"
+                " of intervals of Integral and Real types. Use the type 'real_not_int'"
+                " instead of Real."
+            )
+
         match = rf"The '{param_name}' parameter of {name} must be .* Got .* instead."
         err_msg = (
             f"{name} does not raise an informative error message when the "
@@ -4188,7 +4202,7 @@ def check_param_validation(name, estimator_orig):
 
         for constraint in constraints:
             try:
-                bad_value = generate_invalid_param_val(constraint, constraints)
+                bad_value = generate_invalid_param_val(constraint)
             except NotImplementedError:
                 continue
 

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -662,3 +662,11 @@ def test_interval_real_not_int():
     constraint = Interval(RealNotInt, 0, 1, closed="both")
     assert constraint.is_satisfied_by(1.0)
     assert not constraint.is_satisfied_by(1)
+
+
+def test_real_not_int():
+    """Check for the RealNotInt type."""
+    assert isinstance(1.0, RealNotInt)
+    assert not isinstance(1, RealNotInt)
+    assert isinstance(np.float64(1), RealNotInt)
+    assert not isinstance(np.int64(1), RealNotInt)

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -219,75 +219,75 @@ def test_generate_invalid_param_val(constraint):
     [
         (
             Interval(Integral, None, 3, closed="right"),
-            Interval(Real, -5, 5, closed="both"),
+            Interval("real_not_int", -5, 5, closed="both"),
         ),
         (
             Interval(Integral, None, 3, closed="right"),
-            Interval(Real, -5, 5, closed="neither"),
+            Interval("real_not_int", -5, 5, closed="neither"),
         ),
         (
             Interval(Integral, None, 3, closed="right"),
-            Interval(Real, 4, 5, closed="both"),
+            Interval("real_not_int", 4, 5, closed="both"),
         ),
         (
             Interval(Integral, None, 3, closed="right"),
-            Interval(Real, 5, None, closed="left"),
+            Interval("real_not_int", 5, None, closed="left"),
         ),
         (
             Interval(Integral, None, 3, closed="right"),
-            Interval(Real, 4, None, closed="neither"),
+            Interval("real_not_int", 4, None, closed="neither"),
         ),
         (
             Interval(Integral, 3, None, closed="left"),
-            Interval(Real, -5, 5, closed="both"),
+            Interval("real_not_int", -5, 5, closed="both"),
         ),
         (
             Interval(Integral, 3, None, closed="left"),
-            Interval(Real, -5, 5, closed="neither"),
+            Interval("real_not_int", -5, 5, closed="neither"),
         ),
         (
             Interval(Integral, 3, None, closed="left"),
-            Interval(Real, 1, 2, closed="both"),
+            Interval("real_not_int", 1, 2, closed="both"),
         ),
         (
             Interval(Integral, 3, None, closed="left"),
-            Interval(Real, None, -5, closed="left"),
+            Interval("real_not_int", None, -5, closed="left"),
         ),
         (
             Interval(Integral, 3, None, closed="left"),
-            Interval(Real, None, -4, closed="neither"),
+            Interval("real_not_int", None, -4, closed="neither"),
         ),
         (
             Interval(Integral, -5, 5, closed="both"),
-            Interval(Real, None, 1, closed="right"),
+            Interval("real_not_int", None, 1, closed="right"),
         ),
         (
             Interval(Integral, -5, 5, closed="both"),
-            Interval(Real, 1, None, closed="left"),
+            Interval("real_not_int", 1, None, closed="left"),
         ),
         (
             Interval(Integral, -5, 5, closed="both"),
-            Interval(Real, -10, -4, closed="neither"),
+            Interval("real_not_int", -10, -4, closed="neither"),
         ),
         (
             Interval(Integral, -5, 5, closed="both"),
-            Interval(Real, -10, -4, closed="right"),
+            Interval("real_not_int", -10, -4, closed="right"),
         ),
         (
             Interval(Integral, -5, 5, closed="neither"),
-            Interval(Real, 6, 10, closed="neither"),
+            Interval("real_not_int", 6, 10, closed="neither"),
         ),
         (
             Interval(Integral, -5, 5, closed="neither"),
-            Interval(Real, 6, 10, closed="left"),
+            Interval("real_not_int", 6, 10, closed="left"),
         ),
         (
             Interval(Integral, 2, None, closed="left"),
-            Interval(Real, 0, 1, closed="both"),
+            Interval("real_not_int", 0, 1, closed="both"),
         ),
         (
             Interval(Integral, 1, None, closed="left"),
-            Interval(Real, 0, 1, closed="both"),
+            Interval("real_not_int", 0, 1, closed="both"),
         ),
     ],
 )
@@ -295,15 +295,11 @@ def test_generate_invalid_param_val_2_intervals(integer_interval, real_interval)
     """Check that the value generated for an interval constraint does not satisfy any of
     the interval constraints.
     """
-    bad_value = generate_invalid_param_val(
-        real_interval, constraints=[real_interval, integer_interval]
-    )
+    bad_value = generate_invalid_param_val(constraint=real_interval)
     assert not real_interval.is_satisfied_by(bad_value)
     assert not integer_interval.is_satisfied_by(bad_value)
 
-    bad_value = generate_invalid_param_val(
-        integer_interval, constraints=[real_interval, integer_interval]
-    )
+    bad_value = generate_invalid_param_val(constraint=integer_interval)
     assert not real_interval.is_satisfied_by(bad_value)
     assert not integer_interval.is_satisfied_by(bad_value)
 
@@ -318,11 +314,7 @@ def test_generate_invalid_param_val_2_intervals(integer_interval, real_interval)
         [_RandomStates()],
         [_SparseMatrices()],
         [_Booleans()],
-        [Interval(Real, None, None, closed="both")],
-        [
-            Interval(Integral, 0, None, closed="left"),
-            Interval(Real, None, 0, closed="neither"),
-        ],
+        [Interval(Integral, None, None, closed="neither")],
     ],
 )
 def test_generate_invalid_param_val_all_valid(constraints):
@@ -330,7 +322,7 @@ def test_generate_invalid_param_val_all_valid(constraints):
     for the constraint.
     """
     with pytest.raises(NotImplementedError):
-        generate_invalid_param_val(constraints[0], constraints=constraints)
+        generate_invalid_param_val(constraints[0])
 
 
 @pytest.mark.parametrize(

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -306,24 +306,24 @@ def test_generate_invalid_param_val_2_intervals(integer_interval, real_interval)
 
 
 @pytest.mark.parametrize(
-    "constraints",
+    "constraint",
     [
-        [_ArrayLikes()],
-        [_InstancesOf(list)],
-        [_Callables()],
-        [_NoneConstraint()],
-        [_RandomStates()],
-        [_SparseMatrices()],
-        [_Booleans()],
-        [Interval(Integral, None, None, closed="neither")],
+        _ArrayLikes(),
+        _InstancesOf(list),
+        _Callables(),
+        _NoneConstraint(),
+        _RandomStates(),
+        _SparseMatrices(),
+        _Booleans(),
+        Interval(Integral, None, None, closed="neither"),
     ],
 )
-def test_generate_invalid_param_val_all_valid(constraints):
+def test_generate_invalid_param_val_all_valid(constraint):
     """Check that the function raises NotImplementedError when there's no invalid value
     for the constraint.
     """
     with pytest.raises(NotImplementedError):
-        generate_invalid_param_val(constraints[0])
+        generate_invalid_param_val(constraint)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -29,6 +29,7 @@ from sklearn.utils._param_validation import generate_invalid_param_val
 from sklearn.utils._param_validation import generate_valid_param
 from sklearn.utils._param_validation import validate_params
 from sklearn.utils._param_validation import InvalidParameterError
+from sklearn.utils._param_validation import RealNotInt
 
 
 # Some helpers for the tests
@@ -219,75 +220,75 @@ def test_generate_invalid_param_val(constraint):
     [
         (
             Interval(Integral, None, 3, closed="right"),
-            Interval("real_not_int", -5, 5, closed="both"),
+            Interval(RealNotInt, -5, 5, closed="both"),
         ),
         (
             Interval(Integral, None, 3, closed="right"),
-            Interval("real_not_int", -5, 5, closed="neither"),
+            Interval(RealNotInt, -5, 5, closed="neither"),
         ),
         (
             Interval(Integral, None, 3, closed="right"),
-            Interval("real_not_int", 4, 5, closed="both"),
+            Interval(RealNotInt, 4, 5, closed="both"),
         ),
         (
             Interval(Integral, None, 3, closed="right"),
-            Interval("real_not_int", 5, None, closed="left"),
+            Interval(RealNotInt, 5, None, closed="left"),
         ),
         (
             Interval(Integral, None, 3, closed="right"),
-            Interval("real_not_int", 4, None, closed="neither"),
+            Interval(RealNotInt, 4, None, closed="neither"),
         ),
         (
             Interval(Integral, 3, None, closed="left"),
-            Interval("real_not_int", -5, 5, closed="both"),
+            Interval(RealNotInt, -5, 5, closed="both"),
         ),
         (
             Interval(Integral, 3, None, closed="left"),
-            Interval("real_not_int", -5, 5, closed="neither"),
+            Interval(RealNotInt, -5, 5, closed="neither"),
         ),
         (
             Interval(Integral, 3, None, closed="left"),
-            Interval("real_not_int", 1, 2, closed="both"),
+            Interval(RealNotInt, 1, 2, closed="both"),
         ),
         (
             Interval(Integral, 3, None, closed="left"),
-            Interval("real_not_int", None, -5, closed="left"),
+            Interval(RealNotInt, None, -5, closed="left"),
         ),
         (
             Interval(Integral, 3, None, closed="left"),
-            Interval("real_not_int", None, -4, closed="neither"),
+            Interval(RealNotInt, None, -4, closed="neither"),
         ),
         (
             Interval(Integral, -5, 5, closed="both"),
-            Interval("real_not_int", None, 1, closed="right"),
+            Interval(RealNotInt, None, 1, closed="right"),
         ),
         (
             Interval(Integral, -5, 5, closed="both"),
-            Interval("real_not_int", 1, None, closed="left"),
+            Interval(RealNotInt, 1, None, closed="left"),
         ),
         (
             Interval(Integral, -5, 5, closed="both"),
-            Interval("real_not_int", -10, -4, closed="neither"),
+            Interval(RealNotInt, -10, -4, closed="neither"),
         ),
         (
             Interval(Integral, -5, 5, closed="both"),
-            Interval("real_not_int", -10, -4, closed="right"),
+            Interval(RealNotInt, -10, -4, closed="right"),
         ),
         (
             Interval(Integral, -5, 5, closed="neither"),
-            Interval("real_not_int", 6, 10, closed="neither"),
+            Interval(RealNotInt, 6, 10, closed="neither"),
         ),
         (
             Interval(Integral, -5, 5, closed="neither"),
-            Interval("real_not_int", 6, 10, closed="left"),
+            Interval(RealNotInt, 6, 10, closed="left"),
         ),
         (
             Interval(Integral, 2, None, closed="left"),
-            Interval("real_not_int", 0, 1, closed="both"),
+            Interval(RealNotInt, 0, 1, closed="both"),
         ),
         (
             Interval(Integral, 1, None, closed="left"),
-            Interval("real_not_int", 0, 1, closed="both"),
+            Interval(RealNotInt, 0, 1, closed="both"),
         ),
     ],
 )
@@ -657,7 +658,7 @@ def test_third_party_estimator():
 
 
 def test_interval_real_not_int():
-    """Check for the type "real_not_int" in the Interval constraint."""
-    constraint = Interval("real_not_int", 0, 1, closed="both")
+    """Check for the type RealNotInt in the Interval constraint."""
+    constraint = Interval(RealNotInt, 0, 1, closed="both")
     assert constraint.is_satisfied_by(1.0)
     assert not constraint.is_satisfied_by(1)


### PR DESCRIPTION
Follow up of #25744

#25744 introduced "real_not_int" as possible type for an interval. It's useful when a parameter accepts ints and floats that have different meanings, to have more disjoint constraints. This PR proposes to use it wherever a parameter has one interval of Real and one interval of Integral as constraint.

I also added a test to ensure that we can't have an interval of Integral and an interval of Real as constraint. I think it's better to ensure that even if having both would not be a problem in many situations (like the ones changed in this PR), because first it prevents new bugs like in #25744 and then it simplifies a lot the testing tools (see the diff).