### PR TITLE
MAINT Parameters validation for metrics.label_ranking_average_precision_score

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1074,6 +1074,13 @@ def roc_curve(
     return fpr, tpr, thresholds
 
 
+@validate_params(
+    {
+        "y_true": ["array-like", "sparse matrix"],
+        "y_score": ["array-like"],
+        "sample_weight": ["array-like", None],
+    }
+)
 def label_ranking_average_precision_score(y_true, y_score, *, sample_weight=None):
     """Compute ranking-based average precision.
 
@@ -1091,10 +1098,10 @@ def label_ranking_average_precision_score(y_true, y_score, *, sample_weight=None
 
     Parameters
     ----------
-    y_true : {ndarray, sparse matrix} of shape (n_samples, n_labels)
+    y_true : {array-like, sparse matrix} of shape (n_samples, n_labels)
         True binary labels in binary indicator format.
 
-    y_score : ndarray of shape (n_samples, n_labels)
+    y_score : array-like of shape (n_samples, n_labels)
         Target scores, can either be probability estimates of the positive
         class, confidence values, or non-thresholded measure of decisions
         (as returned by "decision_function" on some classifiers).

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -136,6 +136,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.get_scorer",
     "sklearn.metrics.hamming_loss",
     "sklearn.metrics.jaccard_score",
+    "sklearn.metrics.label_ranking_average_precision_score",
     "sklearn.metrics.label_ranking_loss",
     "sklearn.metrics.log_loss",
     "sklearn.metrics.make_scorer",


### PR DESCRIPTION
Towards #24862

* Added parameter validation for `metrics.label_ranking_average_precision_score`
* Added test for `metrics.label_ranking_average_precision_score` in `test_public_functions.py`
* Changed `ndarray` to `array-like` in docstring

