### PR TITLE
FIX make CalibratedClassifierCV not enforce sample alignment for fit_params

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -107,6 +107,12 @@ Changelog
 - |Feature| A `__sklearn_clone__` protocol is now available to override the
   default behavior of :func:`base.clone`. :pr:`24568` by `Thomas Fan`_.
 
+:mod:`sklearn.calibration`
+..........................
+
+- |Fix| :class:`calibration.CalibratedClassifierCV` now does not enforce sample
+  alignment on `fit_params`. :pr:`25805` by `Adrin Jalali`_.
+
 :mod:`sklearn.cluster`
 ......................
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -308,9 +308,6 @@ class CalibratedClassifierCV(ClassifierMixin, MetaEstimatorMixin, BaseEstimator)
         if sample_weight is not None:
             sample_weight = _check_sample_weight(sample_weight, X)
 
-        for sample_aligned_params in fit_params.values():
-            check_consistent_length(y, sample_aligned_params)
-
         # TODO(1.4): Remove when base_estimator is removed
         if self.base_estimator != "deprecated":
             if self.estimator is not None:

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -974,23 +974,6 @@ def test_calibration_without_sample_weight_base_estimator(data):
         pc_clf.fit(X, y, sample_weight=sample_weight)
 
 
-def test_calibration_with_fit_params_inconsistent_length(data):
-    """fit_params having different length than data should raise the
-    correct error message.
-    """
-    X, y = data
-    fit_params = {"a": y[:5]}
-    clf = CheckingClassifier(expected_fit_params=fit_params)
-    pc_clf = CalibratedClassifierCV(clf)
-
-    msg = (
-        r"Found input variables with inconsistent numbers of "
-        r"samples: \[" + str(N_SAMPLES) + r", 5\]"
-    )
-    with pytest.raises(ValueError, match=msg):
-        pc_clf.fit(X, y, **fit_params)
-
-
 @pytest.mark.parametrize("method", ["sigmoid", "isotonic"])
 @pytest.mark.parametrize("ensemble", [True, False])
 def test_calibrated_classifier_cv_zeros_sample_weights_equivalence(method, ensemble):
@@ -1054,3 +1037,16 @@ def test_calibrated_classifier_deprecation_base_estimator(data):
     warn_msg = "`base_estimator` was renamed to `estimator`"
     with pytest.warns(FutureWarning, match=warn_msg):
         calibrated_classifier.fit(*data)
+
+
+def test_calibration_with_non_sample_aligned_fit_param(data):
+    """Check that CalibratedClassifierCV does not enforce sample alignment
+    for fit parameters."""
+
+    class TestClassifier(LogisticRegression):
+        def fit(self, X, y, sample_weight=None, fit_param=None):
+            return super().fit(X, y, sample_weight=sample_weight)
+
+    CalibratedClassifierCV(estimator=TestClassifier()).fit(
+        *data, fit_param=np.ones(len(data[1]) + 1)
+    )

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -1045,6 +1045,7 @@ def test_calibration_with_non_sample_aligned_fit_param(data):
 
     class TestClassifier(LogisticRegression):
         def fit(self, X, y, sample_weight=None, fit_param=None):
+            assert fit_param is not None
             return super().fit(X, y, sample_weight=sample_weight)
 
     CalibratedClassifierCV(estimator=TestClassifier()).fit(


### PR DESCRIPTION
Fixes #25696

This PR removes the enforcement of sample alignment for `fit_params` in `CalibratedClassifierCV`, which makes it the same as other estimators we have.

It also removes the old test which was ensuring the enforcement, and introduces a new test to make sure non-sample-aligned data is accepted and passed along.