### PR TITLE
CI fix CircleCI failures by making it run sequencially

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -8,10 +8,12 @@ PAPER         =
 BUILDDIR      = _build
 
 # Disable multiple jobs on OSX
+# FIXME: disable completely the parallel build to investigate the EOFError and
+# OSError observe in CircleCI
 ifeq ($(shell uname), Darwin)
 	SPHINX_NUMJOBS ?= 1
 else
-	SPHINX_NUMJOBS ?= auto
+	SPHINX_NUMJOBS ?= 1
 endif
 
 ifneq ($(EXAMPLES_PATTERN),)


### PR DESCRIPTION
Investigate the CircleCI failure (i.e. `EOFError` and `OSError`) that could be linked to some hardware limitation (i.e. memory).

The first thing to try is to limit the number of jobs to build the documentation. This could limit memory consumption.