### PR TITLE
MAINT applies black formatting to libsvm

### DIFF
--- a/sklearn/svm/_libsvm.pxi
+++ b/sklearn/svm/_libsvm.pxi
@@ -36,38 +36,100 @@ cdef extern from "svm.h":
         svm_node *x
         double *W # instance weights
 
-    char *svm_check_parameter(svm_problem *, svm_parameter *)
-    svm_model *svm_train(svm_problem *, svm_parameter *, int *, BlasFunctions *) nogil
+    char *svm_check_parameter(svm_problem *prob, svm_parameter *param)
+    svm_model *svm_train(
+        svm_problem *prob,
+        svm_parameter *param,
+        int *status,
+        BlasFunctions *blas_functions,
+    ) nogil
     void svm_free_and_destroy_model(svm_model** model_ptr_ptr)
-    void svm_cross_validation(svm_problem *, svm_parameter *, int nr_fold, double *target, BlasFunctions *) nogil
+    void svm_cross_validation(
+        svm_problem *prob,
+        svm_parameter *param,
+        int nr_fold,
+        double *target,
+        BlasFunctions *blas_functions,
+    ) nogil
 
 
 cdef extern from "libsvm_helper.c":
     # this file contains methods for accessing libsvm 'hidden' fields
-    svm_node **dense_to_sparse (char *, cnp.npy_intp *)
-    void set_parameter (svm_parameter *, int , int , int , double, double ,
-                                  double , double , double , double,
-                                  double, int, int, int, char *, char *, int,
-                                  int)
-    void set_problem (svm_problem *, char *, char *, char *, cnp.npy_intp *, int)
-
-    svm_model *set_model (svm_parameter *, int, char *, cnp.npy_intp *,
-                         char *, cnp.npy_intp *, cnp.npy_intp *, char *,
-                         char *, char *, char *, char *)
-
-    void copy_sv_coef   (char *, svm_model *)
-    void copy_n_iter  (char *, svm_model *)
-    void copy_intercept (char *, svm_model *, cnp.npy_intp *)
-    void copy_SV        (char *, svm_model *, cnp.npy_intp *)
-    int copy_support (char *data, svm_model *model)
-    int copy_predict (char *, svm_model *, cnp.npy_intp *, char *, BlasFunctions *) nogil
-    int copy_predict_proba (char *, svm_model *, cnp.npy_intp *, char *, BlasFunctions *) nogil
-    int copy_predict_values(char *, svm_model *, cnp.npy_intp *, char *, int, BlasFunctions *) nogil
-    void copy_nSV     (char *, svm_model *)
-    void copy_probA   (char *, svm_model *, cnp.npy_intp *)
-    void copy_probB   (char *, svm_model *, cnp.npy_intp *)
-    cnp.npy_intp  get_l  (svm_model *)
-    cnp.npy_intp  get_nr (svm_model *)
-    int  free_problem   (svm_problem *)
-    int  free_model     (svm_model *)
+    svm_node **dense_to_sparse(char *, cnp.npy_intp *)
+    void set_parameter(
+        svm_parameter *param,
+        int svm_type,
+        int kernel_type,
+        int degree,
+        double gamma,
+        double coef0,
+        double nu,
+        double cache_size,
+        double C,
+        double eps,
+        double p,
+        int shrinking,
+        int probability,
+        int nr_weight,
+        char *weight_label,
+        char *weight,
+        int max_iter,
+        int random_seed,
+    )
+    void set_problem(
+        svm_problem *problem,
+        char *X,
+        char *Y,
+        char *sample_weight,
+        cnp.npy_intp *dims,
+        int kernel_type,
+    )
+    svm_model *set_model(
+        svm_parameter *param,
+        int nr_class,
+        char *SV,
+        cnp.npy_intp *SV_dims,
+        char *support,
+        cnp.npy_intp *support_dims,
+        cnp.npy_intp *sv_coef_strides,
+        char *sv_coef,
+        char *rho,
+        char *nSV,
+        char *probA,
+        char *probB,
+    )
+    void copy_sv_coef(char *data, svm_model *model)
+    void copy_n_iter(char *data, svm_model *model)
+    void copy_intercept(char *data, svm_model *model, cnp.npy_intp *dims)
+    void copy_SV(char *data, svm_model *model, cnp.npy_intp *dims)
+    int copy_support(char *data, svm_model *model)
+    int copy_predict(
+        char *predict,
+        svm_model *model,
+        cnp.npy_intp *predict_dims,
+        char *dec_values,
+        BlasFunctions *blas_functions,
+    ) nogil
+    int copy_predict_proba(
+        char *predict,
+        svm_model *model,
+        cnp.npy_intp *predict_dims,
+        char *dec_values,
+        BlasFunctions *blas_functions,
+    ) nogil
+    int copy_predict_values(
+        char *predict,
+        svm_model *model,
+        cnp.npy_intp *predict_dims,
+        char *dec_values,
+        int nr_class,
+        BlasFunctions *blas_functions,
+    ) nogil
+    void copy_nSV(char *data, svm_model *model)
+    void copy_probA(char *data, svm_model *model, cnp.npy_intp *dims)
+    void copy_probB(char *data, svm_model *model, cnp.npy_intp *dims)
+    cnp.npy_intp get_l(svm_model *model)
+    cnp.npy_intp get_nr(svm_model *model)
+    int free_problem(svm_problem *)
+    int free_model(svm_model *model)
     void set_verbosity(int)

--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -462,18 +462,18 @@ def predict(
         weight=<char*> &class_weight[0] if class_weight.size > 0 else NULL,
     )
     model = set_model(
-        &param,
-        <int> nSV.shape[0],
-        <char*> &SV[0, 0] if SV.size > 0 else NULL,
-        <cnp.npy_intp*> SV.shape,
-        <char*> &support[0] if support.size > 0 else NULL,
-        <cnp.npy_intp*> support.shape,
-        <cnp.npy_intp*> sv_coef.strides,
-        <char*> &sv_coef[0, 0] if sv_coef.size > 0 else NULL,
-        <char*> &intercept[0],
-        <char*> &nSV[0],
-        <char*> &probA[0] if probA.size > 0 else NULL,
-        <char*> &probB[0] if probB.size > 0 else NULL,
+        param=&param,
+        nr_class=<int> nSV.shape[0],
+        SV=<char*> &SV[0, 0] if SV.size > 0 else NULL,
+        SV_dims=<cnp.npy_intp*> SV.shape,
+        support=<char*> &support[0] if support.size > 0 else NULL,
+        support_dims=<cnp.npy_intp*> support.shape,
+        sv_coef_strides=<cnp.npy_intp*> sv_coef.strides,
+        sv_coef=<char*> &sv_coef[0, 0] if sv_coef.size > 0 else NULL,
+        rho=<char*> &intercept[0],
+        nSV=<char*> &nSV[0],
+        probA=<char*> &probA[0] if probA.size > 0 else NULL,
+        probB=<char*> &probB[0] if probB.size > 0 else NULL,
     )
     cdef BlasFunctions blas_functions
     blas_functions.dot = _dot[double]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
None

#### What does this implement/fix? Explain your changes.
- Applies black formatting in relevant areas to _libsvm.pyx and _libsvm.pxi

#### Any other comments?
A follow up PR can be used to apply black formatting to _libsvm_sparse similarly.
CC: @jjerphan 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
