### PR TITLE
ENH `_hdbscan` `HIERARCHY` data type introduction

### DIFF
--- a/sklearn/cluster/_hdbscan/_linkage.pyx
+++ b/sklearn/cluster/_hdbscan/_linkage.pyx
@@ -215,8 +215,8 @@ cpdef cnp.ndarray[HIERARCHY_t, ndim=1, mode="c"] make_single_linkage(const MST_e
 
         # Note mst.shape[0] is one fewer than the number of samples
         cnp.int64_t n_samples = mst.shape[0] + 1
-        cnp.int64_t current_node, next_node, index
         cnp.intp_t current_node_cluster, next_node_cluster
+        cnp.int64_t current_node, next_node, index
         cnp.float64_t distance
         UnionFind U = UnionFind(n_samples)
 

--- a/sklearn/cluster/_hdbscan/_linkage.pyx
+++ b/sklearn/cluster/_hdbscan/_linkage.pyx
@@ -231,8 +231,6 @@ cpdef cnp.ndarray[HIERARCHY_t, ndim=1, mode="c"] make_single_linkage(const MST_e
         current_node_cluster = U.fast_find(current_node)
         next_node_cluster = U.fast_find(next_node)
 
-        # TODO: Update this to an array of structs (AoS).
-        # Should be done simultaneously in _tree.pyx to ensure compatability.
         single_linkage[i].left_node = current_node_cluster
         single_linkage[i].right_node = next_node_cluster
         single_linkage[i].value = distance

--- a/sklearn/cluster/_hdbscan/_linkage.pyx
+++ b/sklearn/cluster/_hdbscan/_linkage.pyx
@@ -10,6 +10,8 @@ from libc.float cimport DBL_MAX
 import numpy as np
 from ...metrics._dist_metrics cimport DistanceMetric
 from ...cluster._hierarchical_fast cimport UnionFind
+from ...cluster._hdbscan._tree cimport HIERARCHY_t
+from ...cluster._hdbscan._tree import HIERARCHY_dtype
 from ...utils._typedefs cimport ITYPE_t, DTYPE_t
 from ...utils._typedefs import ITYPE, DTYPE
 
@@ -188,7 +190,7 @@ cpdef cnp.ndarray[MST_edge_t, ndim=1, mode='c'] mst_from_data_matrix(
 
     return mst
 
-cpdef cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] make_single_linkage(const MST_edge_t[::1] mst):
+cpdef cnp.ndarray[HIERARCHY_t, ndim=1] make_single_linkage(const MST_edge_t[::1] mst):
     """Construct a single-linkage tree from an MST.
 
     Parameters
@@ -209,16 +211,16 @@ cpdef cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] make_single_linkage(const MST
         - new cluster size
     """
     cdef:
-        cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] single_linkage
+        cnp.ndarray[HIERARCHY_t, ndim=1] single_linkage
 
         # Note mst.shape[0] is one fewer than the number of samples
         cnp.int64_t n_samples = mst.shape[0] + 1
-        cnp.int64_t current_node_cluster, next_node_cluster
         cnp.int64_t current_node, next_node, index
+        cnp.intp_t current_node_cluster, next_node_cluster
         cnp.float64_t distance
         UnionFind U = UnionFind(n_samples)
 
-    single_linkage = np.zeros((n_samples - 1, 4), dtype=np.float64)
+    single_linkage = np.zeros(n_samples - 1, dtype=HIERARCHY_dtype)
 
     for i in range(n_samples - 1):
 
@@ -231,10 +233,10 @@ cpdef cnp.ndarray[cnp.float64_t, ndim=2, mode='c'] make_single_linkage(const MST
 
         # TODO: Update this to an array of structs (AoS).
         # Should be done simultaneously in _tree.pyx to ensure compatability.
-        single_linkage[i][0] = <cnp.float64_t> current_node_cluster
-        single_linkage[i][1] = <cnp.float64_t> next_node_cluster
-        single_linkage[i][2] = distance
-        single_linkage[i][3] = U.size[current_node_cluster] + U.size[next_node_cluster]
+        single_linkage[i].left_node = current_node_cluster
+        single_linkage[i].right_node = next_node_cluster
+        single_linkage[i].value = distance
+        single_linkage[i].cluster_size = U.size[current_node_cluster] + U.size[next_node_cluster]
 
         U.union(current_node_cluster, next_node_cluster)
 

--- a/sklearn/cluster/_hdbscan/_linkage.pyx
+++ b/sklearn/cluster/_hdbscan/_linkage.pyx
@@ -190,7 +190,7 @@ cpdef cnp.ndarray[MST_edge_t, ndim=1, mode='c'] mst_from_data_matrix(
 
     return mst
 
-cpdef cnp.ndarray[HIERARCHY_t, ndim=1] make_single_linkage(const MST_edge_t[::1] mst):
+cpdef cnp.ndarray[HIERARCHY_t, ndim=1, mode="c"] make_single_linkage(const MST_edge_t[::1] mst):
     """Construct a single-linkage tree from an MST.
 
     Parameters

--- a/sklearn/cluster/_hdbscan/_linkage.pyx
+++ b/sklearn/cluster/_hdbscan/_linkage.pyx
@@ -211,7 +211,7 @@ cpdef cnp.ndarray[HIERARCHY_t, ndim=1, mode="c"] make_single_linkage(const MST_e
         - new cluster size
     """
     cdef:
-        cnp.ndarray[HIERARCHY_t, ndim=1] single_linkage
+        cnp.ndarray[HIERARCHY_t, ndim=1, mode="c"] single_linkage
 
         # Note mst.shape[0] is one fewer than the number of samples
         cnp.int64_t n_samples = mst.shape[0] + 1

--- a/sklearn/cluster/_hdbscan/_tree.pxd
+++ b/sklearn/cluster/_hdbscan/_tree.pxd
@@ -7,6 +7,8 @@ ctypedef packed struct HIERARCHY_t:
     cnp.float64_t value
     cnp.intp_t cluster_size
 
+# Effectively an edgelist encoding a parent/child pair, along with a value and
+# the corresponding cluster_size in each row providing a tree structure.
 ctypedef packed struct CONDENSED_t:
     cnp.intp_t parent
     cnp.intp_t child

--- a/sklearn/cluster/_hdbscan/_tree.pxd
+++ b/sklearn/cluster/_hdbscan/_tree.pxd
@@ -1,5 +1,4 @@
 cimport numpy as cnp
-import numpy as np
 
 # This corresponds to the scipy.cluster.hierarchy format
 ctypedef packed struct HIERARCHY_t:

--- a/sklearn/cluster/_hdbscan/_tree.pxd
+++ b/sklearn/cluster/_hdbscan/_tree.pxd
@@ -1,0 +1,9 @@
+cimport numpy as cnp
+import numpy as np
+
+
+ctypedef packed struct HIERARCHY_t:
+    cnp.intp_t left_node
+    cnp.intp_t right_node
+    cnp.float64_t value
+    cnp.intp_t cluster_size

--- a/sklearn/cluster/_hdbscan/_tree.pxd
+++ b/sklearn/cluster/_hdbscan/_tree.pxd
@@ -1,9 +1,15 @@
 cimport numpy as cnp
 import numpy as np
 
-
+# This corresponds to the scipy.cluster.hierarchy format
 ctypedef packed struct HIERARCHY_t:
     cnp.intp_t left_node
     cnp.intp_t right_node
+    cnp.float64_t value
+    cnp.intp_t cluster_size
+
+ctypedef packed struct CONDENSED_t:
+    cnp.intp_t parent
+    cnp.intp_t child
     cnp.float64_t value
     cnp.intp_t cluster_size

--- a/sklearn/cluster/_hdbscan/_tree.pyx
+++ b/sklearn/cluster/_hdbscan/_tree.pyx
@@ -108,9 +108,10 @@ cdef cnp.ndarray[CONDENSED_t, ndim=1, mode='c'] _condense_tree(
 
     Returns
     -------
-    condensed_tree : ndarray of shape (n_samples,), dtype=HIERARCHY_dtype
-        Effectively an edgelist with a parent, child, lambda_val
-        and cluster_size in each row providing a tree structure.
+    condensed_tree : ndarray of shape (n_samples,), dtype=CONDENSED_dtype
+        Effectively an edgelist encoding a parent/child pair, along with a
+        value and the corresponding cluster_size in each row providing a tree
+        structure.
     """
 
     cdef:
@@ -626,8 +627,10 @@ cdef tuple _get_clusters(
 
     Parameters
     ----------
-    condensed_tree : numpy recarray
-        The condensed tree to extract flat clusters from
+    condensed_tree : ndarray of shape (n_samples,), dtype=CONDENSED_dtype
+        Effectively an edgelist encoding a parent/child pair, along with a
+        value and the corresponding cluster_size in each row providing a tree
+        structure.
 
     stability : dict
         A dictionary mapping cluster_ids to stability values

--- a/sklearn/cluster/_hdbscan/_tree.pyx
+++ b/sklearn/cluster/_hdbscan/_tree.pyx
@@ -5,7 +5,7 @@
 
 cimport numpy as cnp
 from libc.math cimport isinf
-from cython import wraparound
+import cython
 
 import numpy as np
 
@@ -580,7 +580,7 @@ cdef set epsilon_search(
 
     return set(selected_clusters)
 
-@wraparound(True)
+@cython.wraparound(True)
 cpdef tuple get_clusters(
     cnp.ndarray[HIERARCHY_t, ndim=1, mode='c'] hierarchy,
     dict stability,

--- a/sklearn/cluster/_hdbscan/hdbscan.py
+++ b/sklearn/cluster/_hdbscan/hdbscan.py
@@ -29,6 +29,7 @@ from ._linkage import (
     MST_edge_dtype,
 )
 from ._tree import compute_stability, condense_tree, get_clusters, labelling_at_cut
+from ._tree import HIERARCHY_dtype
 
 FAST_METRICS = KDTree.valid_metrics + BallTree.valid_metrics
 
@@ -223,22 +224,24 @@ def remap_single_linkage_tree(tree, internal_to_raw, non_finite):
     outlier_count = len(non_finite)
     for i, (left, right, *_) in enumerate(tree):
         if left < finite_count:
-            tree[i, 0] = internal_to_raw[left]
+            tree[i]["left_node"] = internal_to_raw[left]
         else:
-            tree[i, 0] = left + outlier_count
+            tree[i]["left_node"] = left + outlier_count
         if right < finite_count:
-            tree[i, 1] = internal_to_raw[right]
+            tree[i]["right_node"] = internal_to_raw[right]
         else:
-            tree[i, 1] = right + outlier_count
+            tree[i]["right_node"] = right + outlier_count
 
-    outlier_tree = np.zeros((len(non_finite), 4))
-    last_cluster_id = tree[tree.shape[0] - 1][0:2].max()
-    last_cluster_size = tree[tree.shape[0] - 1][3]
+    outlier_tree = np.zeros(len(non_finite), dtype=HIERARCHY_dtype)
+    last_cluster_id = max(
+        tree[tree.shape[0] - 1]["left_node"], tree[tree.shape[0] - 1]["right_node"]
+    )
+    last_cluster_size = tree[tree.shape[0] - 1]["value"]
     for i, outlier in enumerate(non_finite):
         outlier_tree[i] = (outlier, last_cluster_id + 1, np.inf, last_cluster_size + 1)
         last_cluster_id += 1
         last_cluster_size += 1
-    tree = np.vstack([tree, outlier_tree])
+    tree = np.concatenate([tree, outlier_tree])
     return tree
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Towards https://github.com/scikit-learn/scikit-learn/issues/24686

#### What does this implement/fix? Explain your changes.
1. Creates new `HIERARCHY` `dtype` and `c-type`
2. Replaces current 2D `float64_t` arrays with `HIERARCHY` where appropriate
3. Minor code refactor reflecting new dtype usage

#### Any other comments?
This is a blocker for more sweeping algorithm refactors and simplifications which rely on the structure of the dtype