### PR TITLE
CLN Cleaned `TreeUnionFind` in `_hdbscan/_tree.pyx`

### DIFF
--- a/sklearn/cluster/_hdbscan/_tree.pyx
+++ b/sklearn/cluster/_hdbscan/_tree.pyx
@@ -288,10 +288,10 @@ cdef class TreeUnionFind:
     cdef cnp.uint8_t[::1] is_component
 
     def __init__(self, size):
-        cdef cnp.ndarray[cnp.intp_t, ndim=2] data_arr
-        data_arr = np.zeros((size, 2), dtype=np.intp)
-        data_arr.T[0] = np.arange(size)
-        self.data = data_arr
+        cdef cnp.intp_t idx
+        self.data = np.zeros((size, 2), dtype=np.intp)
+        for idx in range(size):
+            self.data[idx, 0] = idx
         self.is_component = np.ones(size, dtype=bool)
 
     @cython.final

--- a/sklearn/cluster/_hdbscan/_tree.pyx
+++ b/sklearn/cluster/_hdbscan/_tree.pyx
@@ -282,7 +282,7 @@ cdef max_lambdas(cnp.ndarray hierarchy):
     return deaths
 
 
-cdef class TreeUnionFind (object):
+cdef class TreeUnionFind:
 
     cdef cnp.intp_t[:, ::1] data
     cdef cnp.uint8_t[::1] is_component

--- a/sklearn/cluster/_hdbscan/_tree.pyx
+++ b/sklearn/cluster/_hdbscan/_tree.pyx
@@ -293,9 +293,8 @@ cdef class TreeUnionFind:
         self.data = np.zeros((size, 2), dtype=np.intp)
         for idx in range(size):
             self.data[idx, 0] = idx
-        self.is_component = np.ones(size, dtype=bool)
+        self.is_component = np.ones(size, dtype=np.uint8_t)
 
-    @cython.final
     cdef void union(self, cnp.intp_t x, cnp.intp_t y):
         cdef cnp.intp_t x_root = self.find(x)
         cdef cnp.intp_t y_root = self.find(y)
@@ -309,7 +308,6 @@ cdef class TreeUnionFind:
             self.data[x_root, 1] += 1
         return
 
-    @cython.final
     cdef cnp.intp_t find(self, cnp.intp_t x):
         if self.data[x, 0] != x:
             self.data[x, 0] = self.find(self.data[x, 0])

--- a/sklearn/cluster/_hdbscan/_tree.pyx
+++ b/sklearn/cluster/_hdbscan/_tree.pyx
@@ -282,7 +282,7 @@ cdef max_lambdas(cnp.ndarray hierarchy):
     return deaths
 
 
-@final
+@cython.final
 cdef class TreeUnionFind:
 
     cdef cnp.intp_t[:, ::1] data

--- a/sklearn/cluster/_hdbscan/_tree.pyx
+++ b/sklearn/cluster/_hdbscan/_tree.pyx
@@ -293,7 +293,7 @@ cdef class TreeUnionFind:
         self.data = np.zeros((size, 2), dtype=np.intp)
         for idx in range(size):
             self.data[idx, 0] = idx
-        self.is_component = np.ones(size, dtype=np.uint8_t)
+        self.is_component = np.ones(size, dtype=np.uint8)
 
     cdef void union(self, cnp.intp_t x, cnp.intp_t y):
         cdef cnp.intp_t x_root = self.find(x)

--- a/sklearn/cluster/_hdbscan/_tree.pyx
+++ b/sklearn/cluster/_hdbscan/_tree.pyx
@@ -282,6 +282,7 @@ cdef max_lambdas(cnp.ndarray hierarchy):
     return deaths
 
 
+@final
 cdef class TreeUnionFind:
 
     cdef cnp.intp_t[:, ::1] data
@@ -292,7 +293,7 @@ cdef class TreeUnionFind:
         data_arr = np.zeros((size, 2), dtype=np.intp)
         data_arr.T[0] = np.arange(size)
         self.data = data_arr
-        self.is_component = np.ones(size, dtype=bool)
+        self.is_component = np.ones(size, dtype=np.uint8)
 
     @cython.final
     cdef void union(self, cnp.intp_t x, cnp.intp_t y):


### PR DESCRIPTION
#### Reference Issues/PRs
Towards https://github.com/scikit-learn/scikit-learn/issues/24686

#### What does this implement/fix? Explain your changes.
1. Updated data arrays to utilize memoryviews
2. Improved removed trailing underscore
3. Trimmed extraneous method

#### Any other comments?
