### PR TITLE
MAINT Parameters validation for metrics.top_k_accuracy_score

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1733,6 +1733,16 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
     return np.average(gain, weights=sample_weight)
 
 
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_score": ["array-like"],
+        "k": [Integral],
+        "normalize": ["boolean"],
+        "sample_weight": ["array-like", None],
+        "labels": ["array-like", None],
+    }
+)
 def top_k_accuracy_score(
     y_true, y_score, *, k=2, normalize=True, sample_weight=None, labels=None
 ):

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1737,7 +1737,7 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
     {
         "y_true": ["array-like"],
         "y_score": ["array-like"],
-        "k": [Integral],
+        "k": [Interval(Integral, 1, None, closed="left")],
         "normalize": ["boolean"],
         "sample_weight": ["array-like", None],
         "labels": ["array-like", None],

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -158,6 +158,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.precision_score",
     "sklearn.metrics.r2_score",
     "sklearn.metrics.roc_curve",
+    "sklearn.metrics.top_k_accuracy_score",
     "sklearn.metrics.zero_one_loss",
     "sklearn.model_selection.train_test_split",
     "sklearn.random_projection.johnson_lindenstrauss_min_dim",


### PR DESCRIPTION
Towards #24862

* Added parameter validation for `metrics.top_k_accuracy_score`
* Added test for `metrics.top_k_accuracy_score` in `test_public_functions.py`

Note: the `k` parameter also works for integers `k <= 0`, which may not be its intended use case. 

