### PR TITLE
MNT Fix Pyodide build errors due to incompatible function pointer types

### DIFF
--- a/sklearn/svm/_liblinear.pxi
+++ b/sklearn/svm/_liblinear.pxi
@@ -1,8 +1,8 @@
 cdef extern from "_cython_blas_helpers.h":
-    ctypedef double (*dot_func)(int, double*, int, double*, int)
-    ctypedef void (*axpy_func)(int, double, double*, int, double*, int)
-    ctypedef void (*scal_func)(int, double, double*, int)
-    ctypedef double (*nrm2_func)(int, double*, int)
+    ctypedef double (*dot_func)(int, const double*, int, const double*, int)
+    ctypedef void (*axpy_func)(int, double, const double*, int, double*, int)
+    ctypedef void (*scal_func)(int, double, const double*, int)
+    ctypedef double (*nrm2_func)(int, const double*, int)
     cdef struct BlasFunctions:
         dot_func dot
         axpy_func axpy

--- a/sklearn/svm/_libsvm.pxi
+++ b/sklearn/svm/_libsvm.pxi
@@ -1,7 +1,7 @@
 ################################################################################
 # Includes
 cdef extern from "_svm_cython_blas_helpers.h":
-    ctypedef double (*dot_func)(int, double*, int, double*, int)
+    ctypedef double (*dot_func)(int, const double*, int, const double*, int)
     cdef struct BlasFunctions:
         dot_func dot
 

--- a/sklearn/svm/_libsvm_sparse.pyx
+++ b/sklearn/svm/_libsvm_sparse.pyx
@@ -11,7 +11,7 @@ cdef extern from *:
 # Includes
 
 cdef extern from "_svm_cython_blas_helpers.h":
-    ctypedef double (*dot_func)(int, double*, int, double*, int)
+    ctypedef double (*dot_func)(int, const double*, int, const double*, int)
     cdef struct BlasFunctions:
         dot_func dot
 

--- a/sklearn/svm/src/liblinear/_cython_blas_helpers.h
+++ b/sklearn/svm/src/liblinear/_cython_blas_helpers.h
@@ -1,10 +1,10 @@
 #ifndef _CYTHON_BLAS_HELPERS_H
 #define _CYTHON_BLAS_HELPERS_H
 
-typedef double (*dot_func)(int, double*, int, double*, int);
-typedef void (*axpy_func)(int, double, double*, int, double*, int);
-typedef void (*scal_func)(int, double, double*, int);
-typedef double (*nrm2_func)(int, double*, int);
+typedef double (*dot_func)(int, const double*, int, const double*, int);
+typedef void (*axpy_func)(int, double, const double*, int, double*, int);
+typedef void (*scal_func)(int, double, const double*, int);
+typedef double (*nrm2_func)(int, const double*, int);
 
 typedef struct BlasFunctions{
     dot_func dot;

--- a/sklearn/svm/src/libsvm/_svm_cython_blas_helpers.h
+++ b/sklearn/svm/src/libsvm/_svm_cython_blas_helpers.h
@@ -1,7 +1,7 @@
 #ifndef _SVM_CYTHON_BLAS_HELPERS_H
 #define _SVM_CYTHON_BLAS_HELPERS_H
 
-typedef double (*dot_func)(int, double*, int, double*, int);
+typedef double (*dot_func)(int, const double*, int, const double*, int);
 typedef struct BlasFunctions{
     dot_func dot;
 } BlasFunctions;


### PR DESCRIPTION
#### Reference Issues/PRs

The Pyodide build of the scikit-learn development version started failing a few days ago with errors like these:

```
sklearn/svm/_libsvm.c:5709:30: error: incompatible function pointer types       
assigning to 'dot_func' (aka 'double (*)(int, double *, int, double *, int)')   
from 'double (*)(int, const double *, int, const double *, int)'                
[-Wincompatible-function-pointer-types]                                         
  __pyx_v_blas_functions.dot =                                                  
__pyx_fuse_1__pyx_f_7sklearn_5utils_12_cython_blas__dot;                        
```

See https://github.com/lesteve/scipy-tests-pyodide/actions/runs/4400682262/jobs/7706203301 for the full build log.

The problem was very likely introduced by https://github.com/scikit-learn/scikit-learn/pull/25791. It seems like the emscripten compiler builds by default with `-Wincompatible-function-pointer-types` which is not the case for our build. cc @jjerphan @jeremiedbb @OmarManzoor.

#### What does this implement/fix? Explain your changes.

With these changes I can build locally the scikit-learn development version with `pyodide build`.
