### PR TITLE
CI Disable sphinx parallelism in CircleCI doc build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,8 @@ jobs:
       - OPENBLAS_NUM_THREADS: 2
       - CONDA_ENV_NAME: testenv
       - LOCK_FILE: build_tools/circle/doc_linux-64_conda.lock
+      # Disable sphinx parallelism to avoid EOFError or job stalling in CircleCI
+      - SPHINX_NUMJOBS: 1
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -8,12 +8,10 @@ PAPER         =
 BUILDDIR      = _build
 
 # Disable multiple jobs on OSX
-# FIXME: disable completely the parallel build to investigate the EOFError and
-# OSError observe in CircleCI
 ifeq ($(shell uname), Darwin)
 	SPHINX_NUMJOBS ?= 1
 else
-	SPHINX_NUMJOBS ?= 1
+	SPHINX_NUMJOBS ?= auto
 endif
 
 ifneq ($(EXAMPLES_PATTERN),)


### PR DESCRIPTION
#### Reference Issues/PRs

#25809 actually did not disable sphinx parallelism as you can see from the `-j2` in the [build log](https://app.circleci.com/pipelines/github/scikit-learn/scikit-learn/44402/workflows/e47ba226-2d5a-404d-8b0b-d085e755516b/jobs/228473):
```
sphinx-build -b html -T -d _build/doctrees  -T -j2  . _build/html/stable
```

I think this is because we do `export SPHINX_NUMJOBS=2` in build_tools/circle/build_doc.sh and in the Makefile `SPHINX_NUMJOBS ?= 1` only happens if `SPHINX_NUMJOBS` is not already defined ...

#### What does this implement/fix? Explain your changes.

This is another attempt at disabling sphinx parallelism and see if it gets rid of the timeout and EOFError in CircleCI which seems to happen quite consistently recently, see https://app.circleci.com/pipelines/github/scikit-learn/scikit-learn?branch=main.

cc @glemaitre 
