### PR TITLE
MNT use a single job by default with sphinx build

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -189,11 +189,6 @@ ccache -s
 
 export OMP_NUM_THREADS=1
 
-# Avoid CI job getting killed because it uses too much memory
-if [[ -z $SPHINX_NUMJOBS ]]; then
-    export SPHINX_NUMJOBS=2
-fi
-
 if [[ "$CIRCLE_BRANCH" =~ ^main$ && -z "$CI_PULL_REQUEST" ]]
 then
     # List available documentation versions if on main

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,12 +7,8 @@ SPHINXBUILD  ?= sphinx-build
 PAPER         =
 BUILDDIR      = _build
 
-# Disable multiple jobs on OSX
-ifeq ($(shell uname), Darwin)
-	SPHINX_NUMJOBS ?= 1
-else
-	SPHINX_NUMJOBS ?= auto
-endif
+# Run sequential by default, unless SPHINX_NUMJOBS is set.
+SPHINX_NUMJOBS ?= 1
 
 ifneq ($(EXAMPLES_PATTERN),)
     EXAMPLES_PATTERN_OPTS := -D sphinx_gallery_conf.filename_pattern="$(EXAMPLES_PATTERN)"


### PR DESCRIPTION
I don't think in most cases parallel run is going to be faster, at least for me the difference is about 6 minutes, sequencial run being faster:

```
# auto
4765.77user 2308.57system 27:44.35elapsed 425%CPU (0avgtext+0avgdata 3165084maxresident)k
14448inputs+2382992outputs (198major+9639491minor)pagefaults 0swaps

# 1
3799.71user 1916.26system 21:54.21elapsed 434%CPU (0avgtext+0avgdata 3157024maxresident)k
22064inputs+764960outputs (69major+4528302minor)pagefaults 0swaps
```

This PR makes sequencial run the default for sphinx.

cc @lesteve @glemaitre 