### PR TITLE
BLD Clean command removes generated from cython templates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,17 +79,20 @@ class CleanCommand(Command):
             shutil.rmtree("build")
         for dirpath, dirnames, filenames in os.walk("sklearn"):
             for filename in filenames:
-                if any(
-                    filename.endswith(suffix)
-                    for suffix in (".so", ".pyd", ".dll", ".pyc")
-                ):
+                root, extension = os.path.splitext(filename)
+
+                if extension in [".so", ".pyd", ".dll", ".pyc"]:
                     os.unlink(os.path.join(dirpath, filename))
-                    continue
-                extension = os.path.splitext(filename)[1]
+
                 if remove_c_files and extension in [".c", ".cpp"]:
                     pyx_file = str.replace(filename, extension, ".pyx")
                     if os.path.exists(os.path.join(dirpath, pyx_file)):
                         os.unlink(os.path.join(dirpath, filename))
+
+                if remove_c_files and extension == ".tp":
+                    if os.path.exists(os.path.join(dirpath, root)):
+                        os.unlink(os.path.join(dirpath, root))
+
             for dirname in dirnames:
                 if dirname == "__pycache__":
                     shutil.rmtree(os.path.join(dirpath, dirname))


### PR DESCRIPTION
I think that the ``clean`` command (``python setup.py clean``) should also remove the cython files generated from templates (``.pyx.tp``, ``.pxd.tp``).

It doesn't change much since compilation will regenerate them if the template was modified, but I was surprised to see that the files were still here after I ran the clean command.