### PR TITLE
MAINT Parameters validation for metrics.fbeta_score

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1227,6 +1227,24 @@ def f1_score(
     )
 
 
+@validate_params(
+    {
+        "y_true": ["array-like", "sparse matrix"],
+        "y_pred": ["array-like", "sparse matrix"],
+        "beta": [Interval(Real, 0.0, None, closed="both")],
+        "labels": ["array-like", None],
+        "pos_label": [Real, str, "boolean", None],
+        "average": [
+            StrOptions({"micro", "macro", "samples", "weighted", "binary"}),
+            None,
+        ],
+        "sample_weight": ["array-like", None],
+        "zero_division": [
+            Options(Real, {0, 1}),
+            StrOptions({"warn"}),
+        ],
+    }
+)
 def fbeta_score(
     y_true,
     y_pred,

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -137,6 +137,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.dcg_score",
     "sklearn.metrics.det_curve",
     "sklearn.metrics.f1_score",
+    "sklearn.metrics.fbeta_score",
     "sklearn.metrics.get_scorer",
     "sklearn.metrics.hamming_loss",
     "sklearn.metrics.jaccard_score",


### PR DESCRIPTION
Reference Issues/PRs

Towards https://github.com/scikit-learn/scikit-learn/issues/24862

What does this implement/fix? Explain your changes.

This PR implements parameter validation for `metrics.fbeta_score`

Any other comments?

Might be redundant with existing validation on `metrics.precision_recall_fscore_support` (as seen discussed in a similar PR https://github.com/scikit-learn/scikit-learn/pull/25816#issue-161966437) yet wanted to give it a go as a good first issue !