### PR TITLE
MAINT Replace cnp.ndarray with memory views in _hashing_fast.pyx

### DIFF
--- a/sklearn/feature_extraction/_hashing_fast.pyx
+++ b/sklearn/feature_extraction/_hashing_fast.pyx
@@ -35,7 +35,7 @@ def transform(raw_X, Py_ssize_t n_features, dtype,
     # and values arrays ourselves. Use a Py_ssize_t capacity for safety.
     cdef Py_ssize_t capacity = 8192     # arbitrary
     cdef cnp.int64_t size = 0
-    cdef cnp.ndarray values = np.empty(capacity, dtype=dtype)
+    cdef cnp.dtype values = np.empty(capacity, dtype=dtype)
 
     for x in raw_X:
         for f, v in x:


### PR DESCRIPTION
#### Reference Issues/PRs

Towards https://github.com/scikit-learn/scikit-learn/issues/25484


#### What does this implement/fix? Explain your changes.


#### Any other comments?

In this case I am not sure in how to make the change because the dtype is dynamical and it is in python format