### PR TITLE
[MRG] GaussianRandomProjection documentation error

### DIFF
--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -164,7 +164,7 @@ def _gaussian_random_matrix(n_components, n_features, random_state=None):
 
     The components of the random matrix are drawn from
 
-        N(0, 1.0 / n_components).
+        N(0, 1.0 / sqrt(n_components)).
 
     Read more in the :ref:`User Guide <gaussian_random_matrix>`.
 
@@ -462,7 +462,7 @@ class BaseRandomProjection(
 class GaussianRandomProjection(BaseRandomProjection):
     """Reduce dimensionality through Gaussian random projection.
 
-    The components of the random matrix are drawn from N(0, 1 / n_components).
+    The components of the random matrix are drawn from N(0, 1 / sqrt(n_components)).
 
     Read more in the :ref:`User Guide <gaussian_random_matrix>`.
 


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Fixed documentation to take the square root of n_component as done in the code on lines: 196-198

components = rng.normal(
        loc=0.0, scale=1.0 / np.sqrt(n_components), size=(n_components, n_features)
    )


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
