### PR TITLE
Corrected the weights to use sum instead of number of samples

### DIFF
--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -715,7 +715,7 @@ class GaussianMixture(BaseMixture):
         weights, means, covariances = _estimate_gaussian_parameters(
             X, resp, self.reg_covar, self.covariance_type
         )
-        weights /= n_samples
+        weights /= weights.sum()
 
         self.weights_ = weights if self.weights_init is None else self.weights_init
         self.means_ = means if self.means_init is None else self.means_init


### PR DESCRIPTION
File sklearn/mixture/_gaussian_mixture.py (line 718):

```python
- weights /= n_samples
+ weights/= weights.sum()
```
Fixes: https://github.com/scikit-learn/scikit-learn/issues/24085
