### PR TITLE
fixing overlapping plot y axis text which makes bench_sample_without_replacement.py hard to interpret

### DIFF
--- a/benchmarks/bench_sample_without_replacement.py
+++ b/benchmarks/bench_sample_without_replacement.py
@@ -208,7 +208,7 @@ if __name__ == "__main__":
     print("")
 
     fig = plt.figure("scikit-learn sample w/o replacement benchmark results")
-    plt.title("n_population = %s, n_times = %s" % (opts.n_population, opts.n_times))
+    fig.suptitle("n_population = %s, n_times = %s" % (opts.n_population, opts.n_times))
     ax = fig.add_subplot(111)
     for name in sampling_algorithm:
         ax.plot(ratio, time[name], label=name)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

The x and y axis for bench_sample_without_replacement.py is displayed incorrectly. This fixes the printed axis to be printed once as it should.

The current output is


![main-scikit-learn_sample_w:o_replacement_benchmark_results](https://user-images.githubusercontent.com/29247195/225508985-65ec6644-a437-46e5-a5ca-4149894bb314.png)

The PR's output is


![fix-scikit-learn_sample_w:o_replacement_benchmark_results](https://user-images.githubusercontent.com/29247195/225509181-63fc7f7e-ea66-4c5e-9d83-f215265d0ab3.png)

Here is my versions output

System:
    python: 3.9.6 (default, Aug  5 2022, 15:21:02)  [Clang 14.0.0 (clang-1400.0.29.102)]
executable: /Users/rockstar/gitrepos/scikit-learn/sklearn-env/bin/python
   machine: macOS-12.5.1-arm64-arm-64bit

Python dependencies:
      sklearn: 1.3.dev0
          pip: 21.2.4
   setuptools: 58.0.4
        numpy: 1.24.2
        scipy: 1.10.1
       Cython: 0.29.33
       pandas: 1.5.3
   matplotlib: 3.7.1
       joblib: 1.2.0
threadpoolctl: 3.1.0

Built with OpenMP: False

threadpoolctl info:
       user_api: blas
   internal_api: openblas
         prefix: libopenblas
       filepath: /Users/rockstar/gitrepos/scikit-learn/sklearn-env/lib/python3.9/site-packages/numpy/.dylibs/libopenblas64_.0.dylib
        version: 0.3.21
threading_layer: pthreads
   architecture: armv8
    num_threads: 10

       user_api: blas
   internal_api: openblas
         prefix: libopenblas
       filepath: /Users/rockstar/gitrepos/scikit-learn/sklearn-env/lib/python3.9/site-packages/scipy/.dylibs/libopenblas.0.dylib
        version: 0.3.18
threading_layer: pthreads
   architecture: armv8
    num_threads: 10

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
