### PR TITLE
CI make it possible to cancel running Azure jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -153,7 +153,8 @@ jobs:
     dependsOn: [git_commit, linting]
     condition: |
       and(
-        succeeded(),
+        # Runs when dependencies succeeded or skipped
+        not(or(failed(), canceled())
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     commitMessage: dependencies['git_commit']['outputs']['commit.message']
@@ -171,8 +172,8 @@ jobs:
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
     condition: |
       and(
-        succeeded(),
-        in(dependencies['Ubuntu_Jammy_Jellyfish']['result'], 'Succeeded', 'Skipped'),
+        # Runs when dependencies succeeded or skipped
+        not(or(failed(), canceled())
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     matrix:
@@ -207,8 +208,8 @@ jobs:
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
     condition: |
       and(
-        succeeded(),
-        in(dependencies['Ubuntu_Jammy_Jellyfish']['result'], 'Succeeded', 'Skipped'),
+        # Runs when dependencies succeeded or skipped
+        not(or(failed(), canceled())
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     matrix:
@@ -227,8 +228,8 @@ jobs:
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
     condition: |
       and(
-        succeeded(),
-        in(dependencies['Ubuntu_Jammy_Jellyfish']['result'], 'Succeeded', 'Skipped'),
+        # Runs when dependencies succeeded or skipped
+        not(or(failed(), canceled())
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     matrix:
@@ -250,8 +251,8 @@ jobs:
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
     condition: |
       and(
-        succeeded(),
-        in(dependencies['Ubuntu_Jammy_Jellyfish']['result'], 'Succeeded', 'Skipped'),
+        # Runs when dependencies succeeded or skipped
+        not(or(failed(), canceled())
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     matrix:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,7 +172,7 @@ jobs:
     # Runs when dependencies succeeded or skipped
     condition: |
       and(
-        not(or(failed(), canceled()),
+        not(or(failed(), canceled())),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     matrix:
@@ -208,7 +208,7 @@ jobs:
     # Runs when dependencies succeeded or skipped
     condition: |
       and(
-        not(or(failed(), canceled()),
+        not(or(failed(), canceled())),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     matrix:
@@ -228,7 +228,7 @@ jobs:
     # Runs when dependencies succeeded or skipped
     condition: |
       and(
-        not(or(failed(), canceled()),
+        not(or(failed(), canceled())),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     matrix:
@@ -251,7 +251,7 @@ jobs:
     # Runs when dependencies succeeded or skipped
     condition: |
       and(
-        not(or(failed(), canceled()),
+        not(or(failed(), canceled())),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     matrix:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,6 +171,7 @@ jobs:
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
     condition: |
       and(
+        succeeded(),
         in(dependencies['Ubuntu_Jammy_Jellyfish']['result'], 'Succeeded', 'Skipped'),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
@@ -206,6 +207,7 @@ jobs:
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
     condition: |
       and(
+        succeeded(),
         in(dependencies['Ubuntu_Jammy_Jellyfish']['result'], 'Succeeded', 'Skipped'),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
@@ -225,6 +227,7 @@ jobs:
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
     condition: |
       and(
+        succeeded(),
         in(dependencies['Ubuntu_Jammy_Jellyfish']['result'], 'Succeeded', 'Skipped'),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
@@ -247,6 +250,7 @@ jobs:
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
     condition: |
       and(
+        succeeded(),
         in(dependencies['Ubuntu_Jammy_Jellyfish']['result'], 'Succeeded', 'Skipped'),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -169,9 +169,9 @@ jobs:
     name: Linux
     vmImage: ubuntu-20.04
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
+    # Runs when dependencies succeeded or skipped
     condition: |
       and(
-        # Runs when dependencies succeeded or skipped
         not(or(failed(), canceled()),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
@@ -205,9 +205,9 @@ jobs:
     name: Linux_Docker
     vmImage: ubuntu-20.04
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
+    # Runs when dependencies succeeded or skipped
     condition: |
       and(
-        # Runs when dependencies succeeded or skipped
         not(or(failed(), canceled()),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
@@ -225,9 +225,9 @@ jobs:
     name: macOS
     vmImage: macOS-11
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
+    # Runs when dependencies succeeded or skipped
     condition: |
       and(
-        # Runs when dependencies succeeded or skipped
         not(or(failed(), canceled()),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
@@ -248,9 +248,9 @@ jobs:
     name: Windows
     vmImage: windows-latest
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
+    # Runs when dependencies succeeded or skipped
     condition: |
       and(
-        # Runs when dependencies succeeded or skipped
         not(or(failed(), canceled()),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -154,7 +154,7 @@ jobs:
     condition: |
       and(
         # Runs when dependencies succeeded or skipped
-        not(or(failed(), canceled())
+        not(or(failed(), canceled()),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     commitMessage: dependencies['git_commit']['outputs']['commit.message']
@@ -173,7 +173,7 @@ jobs:
     condition: |
       and(
         # Runs when dependencies succeeded or skipped
-        not(or(failed(), canceled())
+        not(or(failed(), canceled()),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     matrix:
@@ -209,7 +209,7 @@ jobs:
     condition: |
       and(
         # Runs when dependencies succeeded or skipped
-        not(or(failed(), canceled())
+        not(or(failed(), canceled()),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     matrix:
@@ -229,7 +229,7 @@ jobs:
     condition: |
       and(
         # Runs when dependencies succeeded or skipped
-        not(or(failed(), canceled())
+        not(or(failed(), canceled()),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     matrix:
@@ -252,7 +252,7 @@ jobs:
     condition: |
       and(
         # Runs when dependencies succeeded or skipped
-        not(or(failed(), canceled())
+        not(or(failed(), canceled()),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     matrix:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -153,8 +153,7 @@ jobs:
     dependsOn: [git_commit, linting]
     condition: |
       and(
-        # Runs when dependencies succeeded or skipped
-        not(or(failed(), canceled()),
+        succeeded(),
         not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]'))
       )
     commitMessage: dependencies['git_commit']['outputs']['commit.message']

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -63,11 +63,12 @@ jobs:
     - script: |
         build_tools/azure/test_docs.sh
       displayName: 'Test Docs'
-      condition: eq(variables['SELECTED_TESTS'], '')
+      condition: and(succeeded(), eq(variables['SELECTED_TESTS'], ''))
     - script: |
         build_tools/azure/test_pytest_soft_dependency.sh
       displayName: 'Test Soft Dependency'
-      condition: and(eq(variables['CHECK_PYTEST_SOFT_DEPENDENCY'], 'true'),
+      condition: and(succeeded(),
+                     eq(variables['CHECK_PYTEST_SOFT_DEPENDENCY'], 'true'),
                      eq(variables['SELECTED_TESTS'], ''))
     - task: PublishTestResults@2
       inputs:

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -37,13 +37,14 @@ jobs:
         addToPath: true
         architecture: 'x86'
       displayName: Use 32 bit System Python
-      condition: eq(variables['PYTHON_ARCH'], '32')
+      condition: and(succeeded(), eq(variables['PYTHON_ARCH'], '32'))
     - bash: ./build_tools/azure/install_win.sh
       displayName: 'Install'
     - bash: ./build_tools/azure/test_script.sh
       displayName: 'Test Library'
     - bash: ./build_tools/azure/upload_codecov.sh
-      condition: and(succeeded(), eq(variables['COVERAGE'], 'true'),
+      condition: and(succeeded(),
+                     eq(variables['COVERAGE'], 'true'),
                      eq(variables['SELECTED_TESTS'], ''))
       displayName: 'Upload To Codecov'
       env:


### PR DESCRIPTION
We recently noticed that pushing new commits to the same PR would no longer interrupt previously started and running jobs even if they are marked "canceled".

I suspect this is because of our use of custom conditions:

- https://developercommunity.visualstudio.com/t/cant-cancel-build-job-from-within-a-multi-stage-pi/732570

Let's see if pushing several times to this branch fixes the problem.