### PR TITLE
DOC fix docstring dtype parameter in OrdinalEncoder

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -1182,7 +1182,7 @@ class OrdinalEncoder(OneToOneFeatureMixin, _BaseEncoder):
 
         The used categories can be found in the ``categories_`` attribute.
 
-    dtype : number type, default np.float64
+    dtype : number type, default=np.float64
         Desired dtype of output.
 
     handle_unknown : {'error', 'use_encoded_value'}, default='error'


### PR DESCRIPTION
A very small fix for documentation consistency.
ping @jeremiedbb 