### PR TITLE
TST Speed-up common tests of DictionaryLearning

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -676,7 +676,7 @@ def _set_checking_parameters(estimator):
             estimator.set_params(max_iter=500)
         # DictionaryLearning
         if name == "DictionaryLearning":
-            estimator.set_params(max_iter=200, transform_algorithm="lasso_lars")
+            estimator.set_params(max_iter=20, transform_algorithm="lasso_lars")
         # MiniBatchNMF
         if estimator.__class__.__name__ == "MiniBatchNMF":
             estimator.set_params(max_iter=20, fresh_restarts=True)


### PR DESCRIPTION
by reducing `max_iter`. Locally the duration of all common tests for DictionaryLearning decrease from ~50s to ~15s.
I tried to tweak the parameters to further reduce the duration without success (at least without breaking some tests :) )
ref https://github.com/scikit-learn/scikit-learn/issues/23211