### PR TITLE
TST Speed-up test_dbscan_optics_parity

### DIFF
--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -300,7 +300,7 @@ def test_dbscan_optics_parity(eps, min_samples, metric, is_sparse, global_dtype)
 
     centers = [[1, 1], [-1, -1], [1, -1]]
     X, labels_true = make_blobs(
-        n_samples=750, centers=centers, cluster_std=0.4, random_state=0
+        n_samples=150, centers=centers, cluster_std=0.4, random_state=0
     )
     X = sparse.csr_matrix(X) if is_sparse else X
 


### PR DESCRIPTION
by reducing the size of the dataset. Locally the test duration decreases from ~30s to ~10s.
Note that it's the `sparse` parametrization that is especially slow, but I'm not sure there's something we can do about that.
https://github.com/scikit-learn/scikit-learn/issues/23211