### PR TITLE
TST Speed-up test_partial_dependence.test_output_shape

### DIFF
--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -94,7 +94,7 @@ def test_output_shape(Estimator, method, data, grid_resolution, features, kind):
 
     est = Estimator()
     if hasattr(est, "n_estimators"):
-        est.set_params(n_estimators=5)  # speed-up computations
+        est.set_params(n_estimators=2)  # speed-up computations
 
     # n_target corresponds to the number of classes (1 for binary classif) or
     # the number of tasks / outputs in multi task settings. It's equal to 1 for

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -94,7 +94,7 @@ def test_output_shape(Estimator, method, data, grid_resolution, features, kind):
 
     est = Estimator()
     if hasattr(est, "n_estimators"):
-        est.set_params(n_estimators=5)  # speed-up computations
+        est.set_params(n_estimators=5)  # speed-up computations
 
     # n_target corresponds to the number of classes (1 for binary classif) or
     # the number of tasks / outputs in multi task settings. It's equal to 1 for

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -93,6 +93,8 @@ def test_output_shape(Estimator, method, data, grid_resolution, features, kind):
     # - multi-task regressors
 
     est = Estimator()
+    if hasattr(est, "n_estimators"):
+        est.set_params(n_estimators=5)  # speed-up computations
 
     # n_target corresponds to the number of classes (1 for binary classif) or
     # the number of tasks / outputs in multi task settings. It's equal to 1 for


### PR DESCRIPTION
by reducing the number of trees for gradient boosting estimators. Locally the test duration decreases from ~17s to ~5s.
We don't care about achieving good quality fit since the test is just about checking shapes.
ref https://github.com/scikit-learn/scikit-learn/issues/23211