### PR TITLE
TST add global_random_seed fixture to sklearn/datasets/tests/test_covtype.py

### DIFF
--- a/sklearn/datasets/tests/test_covtype.py
+++ b/sklearn/datasets/tests/test_covtype.py
@@ -6,9 +6,9 @@ import pytest
 from sklearn.datasets.tests.test_common import check_return_X_y
 
 
-def test_fetch(fetch_covtype_fxt):
-    data1 = fetch_covtype_fxt(shuffle=True, random_state=42)
-    data2 = fetch_covtype_fxt(shuffle=True, random_state=37)
+def test_fetch(fetch_covtype_fxt, global_random_seed):
+    data1 = fetch_covtype_fxt(shuffle=True, random_state=global_random_seed)
+    data2 = fetch_covtype_fxt(shuffle=True, random_state=global_random_seed)
 
     X1, X2 = data1["data"], data2["data"]
     assert (581012, 54) == X1.shape

--- a/sklearn/datasets/tests/test_covtype.py
+++ b/sklearn/datasets/tests/test_covtype.py
@@ -8,7 +8,7 @@ from sklearn.datasets.tests.test_common import check_return_X_y
 
 def test_fetch(fetch_covtype_fxt, global_random_seed):
     data1 = fetch_covtype_fxt(shuffle=True, random_state=global_random_seed)
-    data2 = fetch_covtype_fxt(shuffle=True, random_state=global_random_seed)
+    data2 = fetch_covtype_fxt(shuffle=True, random_state=global_random_seed + 1)
 
     X1, X2 = data1["data"], data2["data"]
     assert (581012, 54) == X1.shape


### PR DESCRIPTION
#### Reference Issues/PRs
towards #22827


#### What does this implement/fix? Explain your changes.
Adds the global random seed fixture to the test `test_fetch` in `sklearn/datasets/tests/test_covtype.py`

#### Any other comments?
I enabled the test locally by setting `environ.get("SKLEARN_SKIP_NETWORK_TESTS", "0") == "0"` here: 
https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/conftest.py#L117