### PR TITLE
MAINT add missing space in error message in SVM

### DIFF
--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -268,9 +268,9 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
         dual_coef_finiteness = np.isfinite(dual_coef).all()
         if not (intercept_finiteness and dual_coef_finiteness):
             raise ValueError(
-                "The dual coefficients or intercepts are not finite. "
-                "The input data may contain large values and need to be"
-                "preprocessed."
+                "The dual coefficients or intercepts are not finite."
+                " The input data may contain large values and need to be"
+                " preprocessed."
             )
 
         # Since, in the case of SVC and NuSVC, the number of models optimized by


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
N/A

#### What does this implement/fix? Explain your changes.

Tiny change to simply add a space between “to be“ and “processed” in the following ValueError message:
```py
File ~/miniconda3/lib/python3.9/site-packages/sklearn/svm/_base.py:269, in BaseLibSVM.fit(self, X, y, sample_weight)
    267 dual_coef_finiteness = np.isfinite(dual_coef).all()
    268 if not (intercept_finiteness and dual_coef_finiteness):
--> 269     raise ValueError(
    270         "The dual coefficients or intercepts are not finite. "
    271         "The input data may contain large values and need to be"
    272         "preprocessed."
    273     )
    275 # Since, in the case of SVC and NuSVC, the number of models optimized by
    276 # libSVM could be greater than one (depending on the input), `n_iter_`
    277 # stores an ndarray.
    278 # For the other sub-classes (SVR, NuSVR, and OneClassSVM), the number of
    279 # models optimized by libSVM is always one, so `n_iter_` stores an
    280 # integer.
    281 if self._impl in ["c_svc", "nu_svc"]:

ValueError: The dual coefficients or intercepts are not finite. The input data may contain large values and need to bepreprocessed.
```

#### Any other comments?

It seems like the most common approach for handling spaces in multi-line strings in svm/_base.py is to start the new line with a space so that's the style I used.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
