### PR TITLE
FIX Adds requires_y tag to TargetEncoder

### DIFF
--- a/sklearn/preprocessing/_target_encoder.py
+++ b/sklearn/preprocessing/_target_encoder.py
@@ -339,3 +339,6 @@ class TargetEncoder(OneToOneFeatureMixin, _BaseEncoder):
         for f_idx, encoding in enumerate(encodings):
             X_out[indices, f_idx] = encoding[X_ordinal[indices, f_idx]]
             X_out[X_unknown_mask[:, f_idx], f_idx] = y_mean
+
+    def _more_tags(self):
+        return {"requires_y": True}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to #25334

#### What does this implement/fix? Explain your changes.
As noted in https://github.com/scikit-learn/scikit-learn/pull/25334#issuecomment-1476013120, TargetEncoder requires y, and thus the tag.

#### Any other comments?
Thank you @BenjaminBossan for noticing this.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
