### PR TITLE
[MRG] LogReg: Check if l1_ratio is None when using elasticnet

### DIFF
--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1168,6 +1168,9 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
                 "(penalty={})".format(self.penalty)
             )
 
+        if self.penalty == "elasticnet" and self.l1_ratio is None:
+            raise ValueError("l1_ratio must be specified when penalty is elasticnet.")
+
         # TODO(1.4): Remove "none" option
         if self.penalty == "none":
             warnings.warn(

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -226,6 +226,7 @@ def test_check_solver_option(LR):
         with pytest.raises(ValueError, match=msg):
             lr.fit(X, y)
 
+
 @pytest.mark.parametrize("LR", [LogisticRegression, LogisticRegressionCV])
 def test_elasticnet_l1_ratio_none_err_helpful(LR):
     """Test that the error that occurs when l1_ratio=None and penalty='elasticnet' 

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -231,8 +231,8 @@ def test_check_solver_option(LR):
 def test_elasticnet_l1_ratio_err_helpful(LR):
     # Check that an informative error message is raised when penalty="elasticnet"
     # but l1_ratio is not specified.
-    model = LR(penalty="elasticnet")
-    with pytest.raises(Exception, match="l1_ratio must be specified"):
+    model = LR(penalty="elasticnet", solver="saga")
+    with pytest.raises(ValueError, match=r".*l1_ratio.*"):
         model.fit(np.array([[1, 2], [3, 4]]), np.array([0, 1]))
 
 

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -226,6 +226,16 @@ def test_check_solver_option(LR):
         with pytest.raises(ValueError, match=msg):
             lr.fit(X, y)
 
+@pytest.mark.parametrize("LR", [LogisticRegression, LogisticRegressionCV])
+def test_elasticnet_l1_ratio_none_err_helpful(LR):
+    """Test that the error that occurs when l1_ratio=None and penalty='elasticnet' 
+    is helpful, meaning it contains the word 'l1_ratio'."""
+    # Check that the error message contains the word 'l1_ratio'.
+    with pytest.raises(Exception, match=r".*l1_ratio.*"):
+        # Perform a simple LogisticRegression to trigger the error.
+        model = LR(penalty="elasticnet", l1_ratio=None, solver="saga")
+        model.fit(np.array([[1, 2], [3, 4]]), np.array([0, 1]))
+
 
 @pytest.mark.parametrize("solver", ["lbfgs", "newton-cg", "sag", "saga"])
 def test_multinomial_binary(solver):

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -228,9 +228,7 @@ def test_check_solver_option(LR):
 
 
 @pytest.mark.parametrize("LR", [LogisticRegression, LogisticRegressionCV])
-def test_elasticnet_l1_ratio_none_err_helpful(LR):
-    """Test that the error that occurs when l1_ratio=None and penalty='elasticnet' 
-    is helpful, meaning it contains the word 'l1_ratio'."""
+def test_elasticnet_l1_ratio_err_helpful(LR):
     # Check that the error message contains the word 'l1_ratio'.
     with pytest.raises(Exception, match=r".*l1_ratio.*"):
         # Perform a simple LogisticRegression to trigger the error.

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -229,10 +229,10 @@ def test_check_solver_option(LR):
 
 @pytest.mark.parametrize("LR", [LogisticRegression, LogisticRegressionCV])
 def test_elasticnet_l1_ratio_err_helpful(LR):
-    # Check that the error message contains the word 'l1_ratio'.
-    with pytest.raises(Exception, match=r".*l1_ratio.*"):
-        # Perform a simple LogisticRegression to trigger the error.
-        model = LR(penalty="elasticnet", l1_ratio=None, solver="saga")
+    # Check that an informative error message is raised when penalty="elasticnet"
+    # but l1_ratio is not specified.
+    model = LR(penalty="elasticnet")
+    with pytest.raises(Exception, match="l1_ratio must be specified"):
         model.fit(np.array([[1, 2], [3, 4]]), np.array([0, 1]))
 
 


### PR DESCRIPTION
LogisticRegression with `penalty='elasticnet'` requires the user specify the `l1_ratio` between the L1 and L2 penalties, but the code currently does not check for this. The default value for `l1_ratio` is `None`.

Currently, calling `fit()` with the default value for `l1_ratio` will result in an unhelpful error stating `unsupported operand type(s) for -: 'int' and 'NoneType'`. This unhelpful error message is raised in `fit()` on the line:

```python
fold_coefs_ = Parallel(n_jobs=self.n_jobs, verbose=self.verbose, prefer=prefer)(
```

With the proposed change, it will now be clear to the user that the error was not specifying `l1_ratio`.

#### Reference Issues/PRs
N/A