### PR TITLE
API Set random_state=0 for TargetEncoder

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -361,7 +361,7 @@ Changelog
 
 - |MajorFeature| Introduces :class:`preprocessing.TargetEncoder` which is a
   categorical encoding based on target mean conditioned on the value of the
-  category. :pr:`25334` by `Thomas Fan`_.
+  category. :pr:`25334`, :pr:`25927` by `Thomas Fan`_.
 
 - |Enhancement| Adds a `feature_name_combiner` parameter to
   :class:`preprocessing.OneHotEncoder`. This specifies a custom callable to create

--- a/sklearn/preprocessing/_target_encoder.py
+++ b/sklearn/preprocessing/_target_encoder.py
@@ -76,7 +76,7 @@ class TargetEncoder(OneToOneFeatureMixin, _BaseEncoder):
         Whether to shuffle the data in :meth:`fit_transform` before splitting into
         batches. Note that the samples within each split will not be shuffled.
 
-    random_state : int, RandomState instance or None, default=None
+    random_state : int, RandomState instance or None, default=0
         When `shuffle` is True, `random_state` affects the ordering of the
         indices, which controls the randomness of each fold. Otherwise, this
         parameter has no effect.
@@ -167,7 +167,7 @@ class TargetEncoder(OneToOneFeatureMixin, _BaseEncoder):
         smooth="auto",
         cv=5,
         shuffle=True,
-        random_state=None,
+        random_state=0,
     ):
         self.categories = categories
         self.smooth = smooth
@@ -222,14 +222,16 @@ class TargetEncoder(OneToOneFeatureMixin, _BaseEncoder):
         self._validate_params()
         X_ordinal, X_known_mask, y, n_categories = self._fit_encodings_all(X, y)
 
+        random_state = self.random_state if self.shuffle else None
+
         # The cv splitter is voluntarily restricted to *KFold to enforce non
         # overlapping validation folds, otherwise the fit_transform output will
         # not be well-specified.
         if self.target_type_ == "continuous":
-            cv = KFold(self.cv, shuffle=self.shuffle, random_state=self.random_state)
+            cv = KFold(self.cv, shuffle=self.shuffle, random_state=random_state)
         else:
             cv = StratifiedKFold(
-                self.cv, shuffle=self.shuffle, random_state=self.random_state
+                self.cv, shuffle=self.shuffle, random_state=random_state
             )
 
         X_out = np.empty_like(X_ordinal, dtype=np.float64)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to #25334

#### What does this implement/fix? Explain your changes.
I think setting the `random_state=0` is better to prevent target leakage when there are multiple `TargetEnocders`. If `random_state=None`, then the following example would combine target information from overlapping splits:

```python
ct = ColumnTransformer([
    ("smooth_1", TargetEncoder(smooth=1), ["a", "b"]),
    ("smooth_2", TargetEncoder(smooth=2), ["c", "d"]),
])
```

With `random_state=0`, the CV in each target encoder would use the same splits during `fit_transform`.

#### Any other comments?
CC @ogrisel 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
