### PR TITLE
FIX Remove spurious feature names warning in IsolationForest

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -232,8 +232,9 @@ Changelog
   when `max_samples` is a float and `round(n_samples * max_samples) < 1`.
   :pr:`25601` by :user:`Jan Fidor <JanFidor>`.
 
-- |Fix| :meth:`ensemble.IsolationForest.fit` no longer removes feature names
-  or gives warnings when called with `contamination` not `"auto"`.
+- |Fix| :meth:`ensemble.IsolationForest.fit` no longer warns about missing
+  feature names when called with `contamination` not `"auto"` on a pandas
+  dataframe.
   :pr:`25931` by :user:`Yao Xiao <Charlie-XIAO>`.
 
 :mod:`sklearn.exception`

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -232,6 +232,10 @@ Changelog
   when `max_samples` is a float and `round(n_samples * max_samples) < 1`.
   :pr:`25601` by :user:`Jan Fidor <JanFidor>`.
 
+- |Fix| :meth:`ensemble.IsolationForest.fit` no longer removes feature names
+  or gives warnings when called with `contamination` not `"auto"`.
+  :pr:`25931` by :user:`Yao Xiao <Charlie-XIAO>`.
+
 :mod:`sklearn.exception`
 ........................
 - |Feature| Added :class:`exception.InconsistentVersionWarning` which is raised

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -434,10 +434,10 @@ class IsolationForest(OutlierMixin, BaseBagging):
         X = self._validate_data(X, accept_sparse="csr", dtype=np.float32, reset=False)
 
         return self._score_samples(X)
-    
+
     def _score_samples(self, X):
         """Private version of score_samples without input validation.
-        
+
         Input validation would remove feature names, so we disable it.
         """
         # Code structure from ForestClassifier/predict_proba

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -345,8 +345,8 @@ class IsolationForest(OutlierMixin, BaseBagging):
             return self
 
         # Else, define offset_ wrt contamination parameter
-        # Input validation would remove feature names, so we call private version
-        # of score_sample that does not perform input validation
+        # To avoid performing input validation a second time we call
+        # _score_samples rather than score_samples
         self.offset_ = np.percentile(self._score_samples(X), 100.0 * self.contamination)
 
         return self

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -344,8 +344,10 @@ class IsolationForest(OutlierMixin, BaseBagging):
             self.offset_ = -0.5
             return self
 
-        # else, define offset_ wrt contamination parameter
-        self.offset_ = np.percentile(self.score_samples(X), 100.0 * self.contamination)
+        # Else, define offset_ wrt contamination parameter
+        # Input validation would remove feature names, so we call private version
+        # of score_sample that does not perform input validation
+        self.offset_ = np.percentile(self._score_samples(X), 100.0 * self.contamination)
 
         return self
 
@@ -428,15 +430,21 @@ class IsolationForest(OutlierMixin, BaseBagging):
             The anomaly score of the input samples.
             The lower, the more abnormal.
         """
-        # code structure from ForestClassifier/predict_proba
-
-        check_is_fitted(self)
-
         # Check data
         X = self._validate_data(X, accept_sparse="csr", dtype=np.float32, reset=False)
 
-        # Take the opposite of the scores as bigger is better (here less
-        # abnormal)
+        return self._score_samples(X)
+    
+    def _score_samples(self, X):
+        """Private version of score_samples without input validation.
+        
+        Input validation would remove feature names, so we disable it.
+        """
+        # Code structure from ForestClassifier/predict_proba
+
+        check_is_fitted(self)
+
+        # Take the opposite of the scores as bigger is better (here less abnormal)
         return -self._compute_chunked_score_samples(X)
 
     def _compute_chunked_score_samples(self, X):

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -339,3 +339,20 @@ def test_base_estimator_property_deprecated():
     )
     with pytest.warns(FutureWarning, match=warn_msg):
         model.base_estimator_
+    
+def test_iforest_preserve_feature_names():
+    """Check that feature names are preserved when contamination is not "auto".
+
+    Feature names are required for consistency checks during scoring.
+    
+    Non-regression test for Issue #25844
+    """
+    pd = pytest.importorskip("pandas")
+    rng = np.random.RandomState(0)
+
+    X = pd.DataFrame(data=rng.randn(4), columns=["a"])
+    model = IsolationForest(random_state=0, contamination=0.05)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        model.fit(X)

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -339,12 +339,13 @@ def test_base_estimator_property_deprecated():
     )
     with pytest.warns(FutureWarning, match=warn_msg):
         model.base_estimator_
-    
+
+
 def test_iforest_preserve_feature_names():
     """Check that feature names are preserved when contamination is not "auto".
 
     Feature names are required for consistency checks during scoring.
-    
+
     Non-regression test for Issue #25844
     """
     pd = pytest.importorskip("pandas")


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #25844.

#### What does this implement/fix? Explain your changes.

This fix adds a private method `_scores_sample` method without input validation. The original method `scores_sample` calls validates input data and then calls this private method, so essentially it is does not get affected at all. Now instead of calling `scores_sample` at the end of the `fit` method, we call `_scores_sample` because input validation would remove feature names and throw warnings.

#### Any other comments?

Thanks for the detailed explantion in Issue #25844. This pull requests also refers to the structure of PR #24873.
