### PR TITLE
MAINT Fix readonly to read-only where necessary

### DIFF
--- a/benchmarks/bench_covertype.py
+++ b/benchmarks/bench_covertype.py
@@ -61,8 +61,8 @@ from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.metrics import zero_one_loss
 from sklearn.utils import check_array
 
-# Memoize the data extraction and memory map the resulting
-# train / test splits in readonly mode
+# Memorize the data extraction and memory map the resulting
+# train / test splits in read-only mode.
 memory = Memory(
     os.path.join(get_data_home(), "covertype_benchmark_data"), mmap_mode="r"
 )

--- a/benchmarks/bench_mnist.py
+++ b/benchmarks/bench_mnist.py
@@ -51,8 +51,8 @@ from sklearn.utils import check_array
 from sklearn.linear_model import LogisticRegression
 from sklearn.neural_network import MLPClassifier
 
-# Memoize the data extraction and memory map the resulting
-# train / test splits in readonly mode
+# Memorize the data extraction and memory map the resulting
+# train / test splits in read-only mode.
 memory = Memory(os.path.join(get_data_home(), "mnist_benchmark_data"), mmap_mode="r")
 
 

--- a/sklearn/_loss/tests/test_loss.py
+++ b/sklearn/_loss/tests/test_loss.py
@@ -272,12 +272,12 @@ def test_loss_on_specific_values(loss, y_true, raw_prediction, loss_true):
 def test_loss_dtype(
     loss, readonly_memmap, dtype_in, dtype_out, sample_weight, out1, out2, n_threads
 ):
-    """Test acceptance of dtypes, readonly and writeable arrays in loss functions.
+    """Test acceptance of dtypes, read-only and writeable arrays in loss functions.
 
     Check that loss accepts if all input arrays are either all float32 or all
     float64, and all output arrays are either all float32 or all float64.
 
-    Also check that input arrays can be readonly, e.g. memory mapped.
+    Also check that input arrays can be read-only, e.g., memory mapped.
     """
     loss = loss()
     # generate a y_true and raw_prediction in valid range

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -1271,7 +1271,7 @@ def test_predict_does_not_change_cluster_centers(is_sparse):
 
     kmeans = KMeans()
     y_pred1 = kmeans.fit_predict(X)
-    # Make cluster_centers readonly
+    # Make cluster_centers read-only
     kmeans.cluster_centers_ = create_memmap_backed_data(kmeans.cluster_centers_)
     kmeans.labels_ = create_memmap_backed_data(kmeans.labels_)
 

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1762,7 +1762,7 @@ def test_base_estimator_property_deprecated(name):
 
 
 def test_read_only_buffer(monkeypatch):
-    """RandomForestClassifier must work on readonly sparse data.
+    """RandomForestClassifier must work on read-only sparse data.
 
     Non-regression test for: https://github.com/scikit-learn/scikit-learn/issues/25333
     """

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -35,7 +35,7 @@ def _calculate_permutation_scores(
     # Work on a copy of X to ensure thread-safety in case of threading based
     # parallelism. Furthermore, making a copy is also useful when the joblib
     # backend is 'loky' (default) or the old 'multiprocessing': in those cases,
-    # if X is large it will be automatically be backed by a readonly memory map
+    # if X is large it will automatically be backed by a read-only memory map
     # (memmap). X.copy() on the other hand is always guaranteed to return a
     # writable data-structure whose columns can be shuffled inplace.
     if max_samples < X.shape[0]:

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -2036,7 +2036,7 @@ def test_SGDClassifier_fit_for_all_backends(backend):
     # We further test a case where memmapping would have been used if
     # SGDClassifier.fit was called from a loky or multiprocessing backend. In
     # this specific case, in-place modification of clf.coef_ would have caused
-    # a segmentation fault when trying to write in a readonly memory mapped
+    # a segmentation fault when trying to write in a read-only memory mapped
     # buffer.
 
     random_state = np.random.RandomState(42)

--- a/sklearn/metrics/tests/test_dist_metrics.py
+++ b/sklearn/metrics/tests/test_dist_metrics.py
@@ -398,7 +398,7 @@ def test_readonly_kwargs():
     weights.setflags(write=False)
     VI.setflags(write=False)
 
-    # Those distances metrics have to support readonly buffers.
+    # Those distance metrics have to support read-only buffers.
     DistanceMetric.get_metric("seuclidean", V=weights)
     DistanceMetric.get_metric("wminkowski", p=1, w=weights)
     DistanceMetric.get_metric("mahalanobis", VI=VI)

--- a/sklearn/neighbors/tests/test_kd_tree.py
+++ b/sklearn/neighbors/tests/test_kd_tree.py
@@ -24,7 +24,7 @@ def test_kdtree_picklable_with_joblib():
     X = rng.random_sample((10, 3))
     tree = KDTree(X, leaf_size=2)
 
-    # Call Parallel with max_nbytes=1 to trigger readonly memory mapping that
+    # Call Parallel with max_nbytes=1 to trigger read-only memory mapping that
     # use to raise "ValueError: buffer source array is read-only" in a previous
     # version of the Cython code.
     Parallel(n_jobs=2, max_nbytes=1)(delayed(tree.query)(data) for data in 2 * [X])

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -106,7 +106,7 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
         Weights assigned to the features (coefficients in the primal
         problem).
 
-        ``coef_`` is a readonly property derived from ``raw_coef_`` that
+        ``coef_`` is a read-only property derived from ``raw_coef_`` that
         follows the internal memory layout of liblinear.
 
     intercept_ : ndarray of shape (1,) if n_classes == 2 else (n_classes,)
@@ -386,7 +386,7 @@ class LinearSVR(RegressorMixin, LinearModel):
         Weights assigned to the features (coefficients in the primal
         problem).
 
-        `coef_` is a readonly property derived from `raw_coef_` that
+        `coef_` is a read-only property derived from `raw_coef_` that
         follows the internal memory layout of liblinear.
 
     intercept_ : ndarray of shape (1) if n_classes == 2 else (n_classes)
@@ -682,7 +682,7 @@ class SVC(BaseSVC):
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of a linear kernel.
 
-        `coef_` is a readonly property derived from `dual_coef_` and
+        `coef_` is a read-only property derived from `dual_coef_` and
         `support_vectors_`.
 
     dual_coef_ : ndarray of shape (n_classes -1, n_SV)
@@ -944,7 +944,7 @@ class NuSVC(BaseSVC):
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of a linear kernel.
 
-        `coef_` is readonly property derived from `dual_coef_` and
+        `coef_` is a read-only property derived from `dual_coef_` and
         `support_vectors_`.
 
     dual_coef_ : ndarray of shape (n_classes - 1, n_SV)
@@ -1185,7 +1185,7 @@ class SVR(RegressorMixin, BaseLibSVM):
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of a linear kernel.
 
-        `coef_` is readonly property derived from `dual_coef_` and
+        `coef_` is a read-only property derived from `dual_coef_` and
         `support_vectors_`.
 
     dual_coef_ : ndarray of shape (1, n_SV)
@@ -1394,7 +1394,7 @@ class NuSVR(RegressorMixin, BaseLibSVM):
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of a linear kernel.
 
-        `coef_` is readonly property derived from `dual_coef_` and
+        `coef_` is a read-only property derived from `dual_coef_` and
         `support_vectors_`.
 
     dual_coef_ : ndarray of shape (1, n_SV)
@@ -1599,7 +1599,7 @@ class OneClassSVM(OutlierMixin, BaseLibSVM):
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of a linear kernel.
 
-        `coef_` is readonly property derived from `dual_coef_` and
+        `coef_` is a read-only property derived from `dual_coef_` and
         `support_vectors_`.
 
     dual_coef_ : ndarray of shape (1, n_SV)


### PR DESCRIPTION
#### Reference Issues/PRs
No issues in existence.
An issue is not needed for typo fixes.

#### What does this implement/fix? Explain your changes.
In several files in comments and docstrings the word read-only is written as readonly.
Although readonly is often a name of variables etc. the right version in a text is with a hyphen.
I collected all of them in one PR.

#### Any other comments?
