### PR TITLE
MAINT remove deprecated call to resources.content

### DIFF
--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1216,7 +1216,8 @@ def load_sample_images():
     descr = load_descr("README.txt", descr_module=IMAGES_MODULE)
 
     filenames, images = [], []
-    for filename in sorted(resources.contents(IMAGES_MODULE)):
+    content = [path.name for path in resources.files(IMAGES_MODULE).iterdir()]
+    for filename in sorted(content):
         if filename.endswith(".jpg"):
             filenames.append(filename)
             with _open_binary(IMAGES_MODULE, filename) as image_file:

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -14,14 +14,13 @@ from collections import namedtuple
 import os
 from os import environ, listdir, makedirs
 from os.path import expanduser, isdir, join, splitext
-from importlib import resources
 from pathlib import Path
 
 from ..preprocessing import scale
 from ..utils import Bunch
 from ..utils import check_random_state
 from ..utils import check_pandas_support
-from ..utils.fixes import _open_binary, _open_text, _read_text
+from ..utils.fixes import _open_binary, _open_text, _read_text, _contents
 
 import numpy as np
 
@@ -1216,8 +1215,7 @@ def load_sample_images():
     descr = load_descr("README.txt", descr_module=IMAGES_MODULE)
 
     filenames, images = [], []
-    content = [path.name for path in resources.files(IMAGES_MODULE).iterdir()]
-    for filename in sorted(content):
+    for filename in sorted(_contents(IMAGES_MODULE)):
         if filename.endswith(".jpg"):
             filenames.append(filename)
             with _open_binary(IMAGES_MODULE, filename) as image_file:

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -215,3 +215,14 @@ def _is_resource(data_module, data_file_name):
         return resources.files(data_module).joinpath(data_file_name).is_file()
     else:
         return resources.is_resource(data_module, data_file_name)
+
+
+def _contents(data_module):
+    if sys.version_info >= (3, 9):
+        return (
+            resource.name
+            for resource in resources.files(data_module).iterdir()
+            if resource.is_file()
+        )
+    else:
+        return resources.contents(data_module)


### PR DESCRIPTION
closes #25949 

Remove the call to `resources.content` that is deprecated in favour of `resources.files()`.