### PR TITLE
ENH Improve ROC curves visualization and add option to plot chance level

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -319,7 +319,8 @@ Changelog
   :pr:`24668` by :user:`dberenbaum`.
 
 - |Enhancement| :class:`RocCurveDisplay` now plots the ROC curve with both axes
-  limited to [0, 1] and a loosely dotted frame.
+  limited to [0, 1] and a loosely dotted frame. There is also an additional
+  parameter `plot_chance_level` to determine whether to plot the chance level.
   :pr:`25972` by :user:`Yao Xiao <Charlie-XIAO>`.
 
 - |Fix| :func:`log_loss` raises a warning if the values of the parameter `y_pred` are

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -318,6 +318,10 @@ Changelog
   curves.
   :pr:`24668` by :user:`dberenbaum`.
 
+- |Enhancement| :class:`RocCurveDisplay` now plots the ROC curve with both axes
+  limited to [0, 1] and a loosely dotted frame.
+  :pr:`25972` by :user:`Yao Xiao <Charlie-XIAO>`.
+
 - |Fix| :func:`log_loss` raises a warning if the values of the parameter `y_pred` are
   not normalized, instead of actually normalizing them in the metric. Starting from
   1.5 this will raise an error. :pr:`25299` by :user:`Omar Salman <OmarManzoor`.

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -123,6 +123,17 @@ class RocCurveDisplay:
         if ax is None:
             fig, ax = plt.subplots()
 
+        # Set limits of axes to [0, 1] and fix aspect ratio to squared
+        ax.set_xlim((0, 1))
+        ax.set_ylim((0, 1))
+        ax.set_aspect(1)
+
+        # Plot the frame in dotted line, so that the curve can be
+        # seen better when values are close to 0 or 1
+        for s in ["right", "left", "top", "bottom"]:
+            ax.spines[s].set_linestyle((0, (1, 5)))
+            ax.spines[s].set_linewidth(0.5)
+
         (self.line_,) = ax.plot(self.fpr, self.tpr, **line_kwargs)
         info_pos_label = (
             f" (Positive label: {self.pos_label})" if self.pos_label is not None else ""

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -43,6 +43,9 @@ class RocCurveDisplay:
     line_ : matplotlib Artist
         ROC Curve.
 
+    chance_level_ : matplotlib Artist
+        The chance level line or None if the chance level is not plotted.
+
     ax_ : matplotlib Axes
         Axes with ROC Curve.
 
@@ -81,7 +84,7 @@ class RocCurveDisplay:
         self.roc_auc = roc_auc
         self.pos_label = pos_label
 
-    def plot(self, ax=None, *, name=None, **kwargs):
+    def plot(self, ax=None, *, name=None, plot_chance_level=True, **kwargs):
         """Plot visualization.
 
         Extra keyword arguments will be passed to matplotlib's ``plot``.
@@ -95,6 +98,9 @@ class RocCurveDisplay:
         name : str, default=None
             Name of ROC Curve for labeling. If `None`, use `estimator_name` if
             not `None`, otherwise no labeling is shown.
+
+        plot_chance_level : bool, default=True
+            Whether to plot the chance level.
 
         **kwargs : dict
             Keyword arguments to be passed to matplotlib's `plot`.
@@ -134,6 +140,13 @@ class RocCurveDisplay:
             ax.spines[s].set_linestyle((0, (1, 5)))
             ax.spines[s].set_linewidth(0.5)
 
+        if plot_chance_level:
+            (self.chance_level_,) = ax.plot(
+                (0, 1), (0, 1), linestyle="dotted", label="Chance level"
+            )
+        else:
+            self.chance_level_ = None
+
         (self.line_,) = ax.plot(self.fpr, self.tpr, **line_kwargs)
         info_pos_label = (
             f" (Positive label: {self.pos_label})" if self.pos_label is not None else ""
@@ -163,6 +176,7 @@ class RocCurveDisplay:
         pos_label=None,
         name=None,
         ax=None,
+        plot_chance_level=True,
         **kwargs,
     ):
         """Create a ROC Curve display from an estimator.
@@ -205,6 +219,9 @@ class RocCurveDisplay:
 
         ax : matplotlib axes, default=None
             Axes object to plot on. If `None`, a new figure and axes is created.
+
+        plot_chance_level : bool, default=True
+            Whether to plot the chance level.
 
         **kwargs : dict
             Keyword arguments to be passed to matplotlib's `plot`.
@@ -256,6 +273,7 @@ class RocCurveDisplay:
             name=name,
             ax=ax,
             pos_label=pos_label,
+            plot_chance_level=plot_chance_level,
             **kwargs,
         )
 
@@ -270,6 +288,7 @@ class RocCurveDisplay:
         pos_label=None,
         name=None,
         ax=None,
+        plot_chance_level=True,
         **kwargs,
     ):
         """Plot ROC curve given the true and predicted values.
@@ -308,6 +327,9 @@ class RocCurveDisplay:
         ax : matplotlib axes, default=None
             Axes object to plot on. If `None`, a new figure and axes is
             created.
+
+        plot_chance_level : bool, default=True
+            Whether to plot the chance level.
 
         **kwargs : dict
             Additional keywords arguments passed to matplotlib `plot` function.
@@ -359,4 +381,4 @@ class RocCurveDisplay:
             fpr=fpr, tpr=tpr, roc_auc=roc_auc, estimator_name=name, pos_label=pos_label
         )
 
-        return viz.plot(ax=ax, name=name, **kwargs)
+        return viz.plot(ax=ax, name=name, plot_chance_level=plot_chance_level, **kwargs)

--- a/sklearn/metrics/_plot/tests/test_roc_curve_display.py
+++ b/sklearn/metrics/_plot/tests/test_roc_curve_display.py
@@ -36,6 +36,7 @@ def data_binary(data):
 @pytest.mark.parametrize("with_sample_weight", [True, False])
 @pytest.mark.parametrize("drop_intermediate", [True, False])
 @pytest.mark.parametrize("with_strings", [True, False])
+@pytest.mark.parametrize("plot_chance_level", [True, False])
 @pytest.mark.parametrize(
     "constructor_name, default_name",
     [
@@ -50,6 +51,7 @@ def test_roc_curve_display_plotting(
     with_sample_weight,
     drop_intermediate,
     with_strings,
+    plot_chance_level,
     constructor_name,
     default_name,
 ):
@@ -82,6 +84,7 @@ def test_roc_curve_display_plotting(
             drop_intermediate=drop_intermediate,
             pos_label=pos_label,
             alpha=0.8,
+            plot_chance_level=plot_chance_level,
         )
     else:
         display = RocCurveDisplay.from_predictions(
@@ -91,6 +94,7 @@ def test_roc_curve_display_plotting(
             drop_intermediate=drop_intermediate,
             pos_label=pos_label,
             alpha=0.8,
+            plot_chance_level=plot_chance_level,
         )
 
     fpr, tpr, _ = roc_curve(
@@ -113,6 +117,13 @@ def test_roc_curve_display_plotting(
     assert display.line_.get_alpha() == 0.8
     assert isinstance(display.ax_, mpl.axes.Axes)
     assert isinstance(display.figure_, mpl.figure.Figure)
+
+    if plot_chance_level:
+        assert isinstance(display.chance_level_, mpl.lines.Line2D)
+        assert tuple(display.chance_level_.get_xdata()) == (0, 1)
+        assert tuple(display.chance_level_.get_ydata()) == (0, 1)
+    else:
+        assert display.chance_level_ is None
 
     expected_label = f"{default_name} (AUC = {display.roc_auc:.2f})"
     assert display.line_.get_label() == expected_label

--- a/sklearn/metrics/_plot/tests/test_roc_curve_display.py
+++ b/sklearn/metrics/_plot/tests/test_roc_curve_display.py
@@ -124,6 +124,15 @@ def test_roc_curve_display_plotting(
     assert display.ax_.get_ylabel() == expected_ylabel
     assert display.ax_.get_xlabel() == expected_xlabel
 
+    assert display.ax_.get_xlim() == (0, 1)
+    assert display.ax_.get_ylim() == (0, 1)
+    assert display.ax_.get_aspect() == 1
+
+    # Check frame styles
+    for s in ["right", "left", "top", "bottom"]:
+        assert display.ax_.spines[s].get_linestyle() == (0, (1, 5))
+        assert display.ax_.spines[s].get_linewidth() <= 0.5
+
 
 @pytest.mark.parametrize(
     "clf",


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #25929.

#### What does this implement/fix? Explain your changes.

This implements the following visual improvements:
- Set the limits of both x- and y-axis to [0, 1].
- Change the plotting frame into loosely dotted lines so that the values near 0 or 1 can be seen clearly.
- Fix aspect ratio to squared (i.e., y/x=1).
- Add an option `plot_chance_level` to indicate whether to plot the chance level. This option is available via `RocCurveDisplay.plot`, `RocCurveDisplay.from_estimator`, and `RocCurveDisplay.from_predictions`.
- Add an attribute `chance_level_` to the `RocCurveDisplay`. If the chance level is plotted, the attribute would be the Matplotlib 2D line object of the chance level line. Otherwise, it would be None.

#### Any other comments?

I may have misunderstood what @glemaitre asked me to do in Issue #25929. If I'm doing wrong, please tell me and I will close this issue and open new ones ASAP.

Also, I'm aware that reviewers may not have permission to directly modify this PR, because I'm making this PR from my course repo according to the course policy. However, I will make changes ASAP when the reviewer makes a comment. Sorry for the inconvenience I may have caused you.
