### PR TITLE
[MRG] DOC GPs: log_marginal_likelihood() log(theta) input

### DIFF
--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -84,9 +84,15 @@ the API of standard scikit-learn estimators, :class:`GaussianProcessRegressor`:
 * provides an additional method ``sample_y(X)``, which evaluates samples
   drawn from the GPR (prior or posterior) at given inputs
 
-* exposes a method ``log_marginal_likelihood(theta)``, which can be used
-  externally for other ways of selecting hyperparameters, e.g., via
+* exposes a method ``log_marginal_likelihood(log(theta))``, which can be used
+  externally for other ways of selecting hyperparameters ``theta``, e.g., via
   Markov chain Monte Carlo.
+
+  .. note:: This method expects ``log(theta)`` as argument and the internal
+     optimizer calls ``log_marginal_likelihood(log(theta))`` automatically. If
+     you call ``GaussianProcessRegressor.log_marginal_likelihood()``, then make
+     sure to pass in ``log(theta)``.
+
 
 .. topic:: Examples
 

--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -340,9 +340,9 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
         Parameters
         ----------
         theta : array-like of shape (n_kernel_params,), default=None
-            Kernel hyperparameters for which the log-marginal likelihood is
-            evaluated. If None, the precomputed log_marginal_likelihood
-            of ``self.kernel_.theta`` is returned.
+            Log-transformed kernel hyperparameters for which the log-marginal
+            likelihood is evaluated. If None, the precomputed
+            log_marginal_likelihood of ``self.kernel_.theta`` is returned.
 
         eval_gradient : bool, default=False
             If True, the gradient of the log-marginal likelihood with respect
@@ -827,12 +827,12 @@ class GaussianProcessClassifier(ClassifierMixin, BaseEstimator):
         Parameters
         ----------
         theta : array-like of shape (n_kernel_params,), default=None
-            Kernel hyperparameters for which the log-marginal likelihood is
-            evaluated. In the case of multi-class classification, theta may
-            be the  hyperparameters of the compound kernel or of an individual
-            kernel. In the latter case, all individual kernel get assigned the
-            same theta values. If None, the precomputed log_marginal_likelihood
-            of ``self.kernel_.theta`` is returned.
+            Log-transformed kernel hyperparameters for which the log-marginal
+            likelihood is evaluated. In the case of multi-class classification,
+            theta may be the  hyperparameters of the compound kernel or of an
+            individual kernel. In the latter case, all individual kernel get
+            assigned the same theta values. If None, the precomputed
+            log_marginal_likelihood of ``self.kernel_.theta`` is returned.
 
         eval_gradient : bool, default=False
             If True, the gradient of the log-marginal likelihood with respect

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -34,9 +34,9 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
        * allows prediction without prior fitting (based on the GP prior)
        * provides an additional method `sample_y(X)`, which evaluates samples
          drawn from the GPR (prior or posterior) at given inputs
-       * exposes a method `log_marginal_likelihood(theta)`, which can be used
-         externally for other ways of selecting hyperparameters, e.g., via
-         Markov chain Monte Carlo.
+       * exposes a method `log_marginal_likelihood(log(theta))`, which can be
+         used externally for other ways of selecting hyperparameters ``theta``,
+         e.g., via Markov chain Monte Carlo.
 
     To learn the difference between a point-estimate approach vs. a more
     Bayesian modelling approach, refer to the example entitled
@@ -542,9 +542,9 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         Parameters
         ----------
         theta : array-like of shape (n_kernel_params,) default=None
-            Kernel hyperparameters for which the log-marginal likelihood is
-            evaluated. If None, the precomputed log_marginal_likelihood
-            of ``self.kernel_.theta`` is returned.
+            Log-transformed kernel hyperparameters for which the log-marginal
+            likelihood is evaluated. If None, the precomputed
+            log_marginal_likelihood of ``self.kernel_.theta`` is returned.
 
         eval_gradient : bool, default=False
             If True, the gradient of the log-marginal likelihood with respect

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -118,6 +118,26 @@ def test_lml_gradient(kernel):
     assert_almost_equal(lml_gradient, lml_gradient_approx, 3)
 
 
+@pytest.mark.parametrize("kernel", non_fixed_kernels)
+def test_lml_log_theta_input(kernel):
+    """Show that log_marginal_likelihood() expects log(theta) as argument."""
+
+    # Use non_fixed_kernels because len(gp.kernel_.theta) = 0 for fixed_kernel (no
+    # optimization done).
+
+    gp = GaussianProcessClassifier(kernel=kernel).fit(X, y)
+
+    log_theta = gp.kernel_.theta
+    theta_dct = gp.kernel_.get_params()
+    theta = np.array([theta_dct[hp.name] for hp in gp.kernel_.hyperparameters])
+
+    assert_almost_equal(
+        gp.log_marginal_likelihood(log_theta),
+        gp.log_marginal_likelihood_value_,
+    )
+    assert_almost_equal(np.exp(log_theta), theta)
+
+
 def test_random_starts(global_random_seed):
     # Test that an increasing number of random-starts of GP fitting only
     # increases the log marginal likelihood of the chosen theta.

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -154,6 +154,26 @@ def test_lml_gradient(kernel):
     assert_almost_equal(lml_gradient, lml_gradient_approx, 3)
 
 
+@pytest.mark.parametrize("kernel", non_fixed_kernels)
+def test_lml_log_theta_input(kernel):
+    """Show that log_marginal_likelihood() expects log(theta) as argument."""
+
+    # Use non_fixed_kernels because len(gp.kernel_.theta) = 0 for fixed_kernel (no
+    # optimization done).
+
+    gp = GaussianProcessRegressor(kernel=kernel).fit(X, y)
+
+    log_theta = gp.kernel_.theta
+    theta_dct = gp.kernel_.get_params()
+    theta = np.array([theta_dct[hp.name] for hp in gp.kernel_.hyperparameters])
+
+    assert_almost_equal(
+        gp.log_marginal_likelihood(log_theta),
+        gp.log_marginal_likelihood_value_,
+    )
+    assert_almost_equal(np.exp(log_theta), theta)
+
+
 @pytest.mark.parametrize("kernel", kernels)
 def test_prior(kernel):
     # Test that GP prior has mean 0 and identical variances.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #24786

#### What does this implement/fix? Explain your changes.

Document the fact that the input argument `theta` to GaussianProcess{Regressor,Classifier}'s `log_marginal_likelihood()` method is actually expected to be `log(theta)`, as this is used in the optimizer code path when `self.kernel_.theta` is passed and where the latter triggers a getter that returns `log(theta)`. This is now consistent with other doc strings where "log-transformed theta" is mentioned.

In the method doc strings, only add "log-transformed". In the GPR user guide add an extra note.

Add two tests, one for GPR and GPC.

#### Any other comments?

No changelog needed. This change is small and only corrects documentation and adds two tests.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
