### PR TITLE
ENH RocCurveDisplay add option to plot chance level

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -319,7 +319,8 @@ Changelog
   :pr:`24668` by :user:`dberenbaum`.
 
 - |Enhancement| :class:`RocCurveDisplay` now plots the ROC curve with both axes
-  limited to [0, 1] and a loosely dotted frame.
+  limited to [0, 1] and a loosely dotted frame. There is also an additional
+  parameter `plot_chance_level` to determine whether to plot the chance level.
   :pr:`25972` by :user:`Yao Xiao <Charlie-XIAO>`.
 
 - |Fix| :func:`log_loss` raises a warning if the values of the parameter `y_pred` are

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -318,10 +318,10 @@ Changelog
   curves.
   :pr:`24668` by :user:`dberenbaum`.
 
-- |Enhancement| :class:`RocCurveDisplay` now plots the ROC curve with both axes
-  limited to [0, 1] and a loosely dotted frame. There is also an additional
-  parameter `plot_chance_level` to determine whether to plot the chance level.
-  :pr:`25972` by :user:`Yao Xiao <Charlie-XIAO>`.
+- |Enhancement| :class:`RocCurveDisplay` now has a new attribute `chance_level_`
+  and supports plotting the chance level line via `plot_chance_level` and
+  altering its style via `chance_level_kwargs`.
+  :pr:`25987` by :user:`Yao Xiao <Charlie-XIAO>`.
 
 - |Fix| :func:`log_loss` raises a warning if the values of the parameter `y_pred` are
   not normalized, instead of actually normalizing them in the metric. Starting from

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -318,6 +318,10 @@ Changelog
   curves.
   :pr:`24668` by :user:`dberenbaum`.
 
+- |Enhancement| :class:`RocCurveDisplay` now plots the ROC curve with both axes
+  limited to [0, 1] and a loosely dotted frame.
+  :pr:`25972` by :user:`Yao Xiao <Charlie-XIAO>`.
+
 - |Fix| :func:`log_loss` raises a warning if the values of the parameter `y_pred` are
   not normalized, instead of actually normalizing them in the metric. Starting from
   1.5 this will raise an error. :pr:`25299` by :user:`Omar Salman <OmarManzoor`.

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -320,7 +320,7 @@ Changelog
 
 - |Enhancement| :meth:`metrics.RocCurveDisplay.from_estimator` and
   :meth:`metrics.RocCurveDisplay.from_predictions` now accept two new keywords,
-  `plot_chance_level` and `chance_level_kwargs` to plot the baseline chance
+  `plot_chance_level` and `chance_level_kw` to plot the baseline chance
   level. This line is exposed in the `chance_level_` attribute.
   :pr:`25987` by :user:`Yao Xiao <Charlie-XIAO>`.
 

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -318,8 +318,8 @@ Changelog
   curves.
   :pr:`24668` by :user:`dberenbaum`.
 
-- |Enhancement| :meth:`metrics.RocCurveDisplay.from_estiamtor` and
-  :meth:`metrics.ocCurveDisplay.from_predictions` now accept two new keywords,
+- |Enhancement| :meth:`metrics.RocCurveDisplay.from_estimator` and
+  :meth:`metrics.RocCurveDisplay.from_predictions` now accept two new keywords,
   `plot_chance_level` and `chance_level_kwargs` to plot the baseline chance
   level. This line is exposed in the `chance_level_` attribute.
   :pr:`25987` by :user:`Yao Xiao <Charlie-XIAO>`.

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -318,9 +318,10 @@ Changelog
   curves.
   :pr:`24668` by :user:`dberenbaum`.
 
-- |Enhancement| :class:`RocCurveDisplay` now has a new attribute `chance_level_`
-  and supports plotting the chance level line via `plot_chance_level` and
-  altering its style via `chance_level_kwargs`.
+- |Enhancement| :meth:`metrics.RocCurveDisplay.from_estiamtor` and
+  :meth:`metrics.ocCurveDisplay.from_predictions` now accept two new keywords,
+  `plot_chance_level` and `chance_level_kwargs` to plot the baseline chance
+  level. This line is exposed in the `chance_level_` attribute.
   :pr:`25987` by :user:`Yao Xiao <Charlie-XIAO>`.
 
 - |Fix| :func:`log_loss` raises a warning if the values of the parameter `y_pred` are

--- a/examples/miscellaneous/plot_outlier_detection_bench.py
+++ b/examples/miscellaneous/plot_outlier_detection_bench.py
@@ -172,12 +172,12 @@ linewidth = 1
 pos_label = 0  # mean 0 belongs to positive class
 rows = math.ceil(len(datasets_name) / cols)
 
-fig, axs = plt.subplots(rows, cols, figsize=(10, rows * 3))
+fig, axs = plt.subplots(rows, cols, figsize=(10, rows * 3), sharex=True, sharey=True)
 
 for i, dataset_name in enumerate(datasets_name):
     (X, y) = preprocess_dataset(dataset_name=dataset_name)
 
-    for model_name in models_name:
+    for model_idx, model_name in enumerate(models_name):
         y_pred = compute_prediction(X, model_name=model_name)
         display = RocCurveDisplay.from_predictions(
             y,
@@ -186,16 +186,14 @@ for i, dataset_name in enumerate(datasets_name):
             name=model_name,
             linewidth=linewidth,
             ax=axs[i // cols, i % cols],
-            plot_chance_level=True,
+            plot_chance_level=(model_idx == len(models_name) - 1),
             chance_level_kwargs={
                 "linewidth": linewidth,
                 "linestyle": ":",
-                "color": "g",
-                "label": "",
             },
         )
     axs[i // cols, i % cols].set_title(dataset_name)
-    axs[i // cols, i % cols].set_xlabel("False Positive Rate")
-    axs[i // cols, i % cols].set_ylabel("True Positive Rate")
 plt.tight_layout(pad=2.0)  # spacing between subplots
 plt.show()
+
+# %%

--- a/examples/miscellaneous/plot_outlier_detection_bench.py
+++ b/examples/miscellaneous/plot_outlier_detection_bench.py
@@ -186,8 +186,14 @@ for i, dataset_name in enumerate(datasets_name):
             name=model_name,
             linewidth=linewidth,
             ax=axs[i // cols, i % cols],
+            plot_chance_level=True,
+            chance_level_kwargs={
+                "linewidth": linewidth,
+                "linestyle": ":",
+                "color": "g",
+                "label": "",
+            },
         )
-    axs[i // cols, i % cols].plot([0, 1], [0, 1], linewidth=linewidth, linestyle=":")
     axs[i // cols, i % cols].set_title(dataset_name)
     axs[i // cols, i % cols].set_xlabel("False Positive Rate")
     axs[i // cols, i % cols].set_ylabel("True Positive Rate")

--- a/examples/miscellaneous/plot_outlier_detection_bench.py
+++ b/examples/miscellaneous/plot_outlier_detection_bench.py
@@ -187,7 +187,7 @@ for i, dataset_name in enumerate(datasets_name):
             linewidth=linewidth,
             ax=axs[i // cols, i % cols],
             plot_chance_level=(model_idx == len(models_name) - 1),
-            chance_level_kwargs={
+            chance_level_kw={
                 "linewidth": linewidth,
                 "linestyle": ":",
             },

--- a/examples/miscellaneous/plot_outlier_detection_bench.py
+++ b/examples/miscellaneous/plot_outlier_detection_bench.py
@@ -195,5 +195,3 @@ for i, dataset_name in enumerate(datasets_name):
     axs[i // cols, i % cols].set_title(dataset_name)
 plt.tight_layout(pad=2.0)  # spacing between subplots
 plt.show()
-
-# %%

--- a/examples/model_selection/plot_roc.py
+++ b/examples/model_selection/plot_roc.py
@@ -281,7 +281,7 @@ for class_id, color in zip(range(n_classes), colors):
         name=f"ROC curve for {target_names[class_id]}",
         color=color,
         ax=ax,
-        plot_chance_level=True,
+        plot_chance_level=(class_id == 0),
     )
 
 plt.axis("square")

--- a/examples/model_selection/plot_roc.py
+++ b/examples/model_selection/plot_roc.py
@@ -281,7 +281,7 @@ for class_id, color in zip(range(n_classes), colors):
         name=f"ROC curve for {target_names[class_id]}",
         color=color,
         ax=ax,
-        plot_chance_level=(class_id == 0),
+        plot_chance_level=(class_id == 2),
     )
 
 plt.axis("square")
@@ -358,13 +358,13 @@ for ix, (label_a, label_b) in enumerate(pair_list):
         y_score[ab_mask, idx_a],
         ax=ax,
         name=f"{label_a} as positive class",
-        plot_chance_level=True,
     )
     RocCurveDisplay.from_predictions(
         b_true,
         y_score[ab_mask, idx_b],
         ax=ax,
         name=f"{label_b} as positive class",
+        plot_chance_level=True,
     )
     plt.axis("square")
     plt.xlabel("False Positive Rate")

--- a/examples/model_selection/plot_roc.py
+++ b/examples/model_selection/plot_roc.py
@@ -125,8 +125,8 @@ RocCurveDisplay.from_predictions(
     y_score[:, class_id],
     name=f"{class_of_interest} vs the rest",
     color="darkorange",
+    plot_chance_level=True,
 )
-plt.plot([0, 1], [0, 1], "k--", label="chance level (AUC = 0.5)")
 plt.axis("square")
 plt.xlabel("False Positive Rate")
 plt.ylabel("True Positive Rate")
@@ -161,8 +161,8 @@ RocCurveDisplay.from_predictions(
     y_score.ravel(),
     name="micro-average OvR",
     color="darkorange",
+    plot_chance_level=True,
 )
-plt.plot([0, 1], [0, 1], "k--", label="chance level (AUC = 0.5)")
 plt.axis("square")
 plt.xlabel("False Positive Rate")
 plt.ylabel("True Positive Rate")
@@ -281,9 +281,9 @@ for class_id, color in zip(range(n_classes), colors):
         name=f"ROC curve for {target_names[class_id]}",
         color=color,
         ax=ax,
+        plot_chance_level=True,
     )
 
-plt.plot([0, 1], [0, 1], "k--", label="ROC curve for chance level (AUC = 0.5)")
 plt.axis("square")
 plt.xlabel("False Positive Rate")
 plt.ylabel("True Positive Rate")
@@ -358,6 +358,7 @@ for ix, (label_a, label_b) in enumerate(pair_list):
         y_score[ab_mask, idx_a],
         ax=ax,
         name=f"{label_a} as positive class",
+        plot_chance_level=True,
     )
     RocCurveDisplay.from_predictions(
         b_true,
@@ -365,7 +366,6 @@ for ix, (label_a, label_b) in enumerate(pair_list):
         ax=ax,
         name=f"{label_b} as positive class",
     )
-    plt.plot([0, 1], [0, 1], "k--", label="chance level (AUC = 0.5)")
     plt.axis("square")
     plt.xlabel("False Positive Rate")
     plt.ylabel("True Positive Rate")
@@ -413,7 +413,7 @@ plt.plot(
     linestyle=":",
     linewidth=4,
 )
-plt.plot([0, 1], [0, 1], "k--", label="chance level (AUC = 0.5)")
+plt.plot([0, 1], [0, 1], "k--", label="Chance level (AUC = 0.5)")
 plt.axis("square")
 plt.xlabel("False Positive Rate")
 plt.ylabel("True Positive Rate")

--- a/examples/model_selection/plot_roc_crossval.py
+++ b/examples/model_selection/plot_roc_crossval.py
@@ -70,7 +70,8 @@ from sklearn.metrics import auc
 from sklearn.metrics import RocCurveDisplay
 from sklearn.model_selection import StratifiedKFold
 
-cv = StratifiedKFold(n_splits=6)
+n_splits = 6
+cv = StratifiedKFold(n_splits=n_splits)
 classifier = svm.SVC(kernel="linear", probability=True, random_state=random_state)
 
 tprs = []
@@ -88,7 +89,7 @@ for fold, (train, test) in enumerate(cv.split(X, y)):
         alpha=0.3,
         lw=1,
         ax=ax,
-        plot_chance_level=(fold == 0),
+        plot_chance_level=(fold == n_splits - 1),
     )
     interp_tpr = np.interp(mean_fpr, viz.fpr, viz.tpr)
     interp_tpr[0] = 0.0

--- a/examples/model_selection/plot_roc_crossval.py
+++ b/examples/model_selection/plot_roc_crossval.py
@@ -88,7 +88,7 @@ for fold, (train, test) in enumerate(cv.split(X, y)):
         alpha=0.3,
         lw=1,
         ax=ax,
-        plot_chance_level=True,
+        plot_chance_level=(fold == 0),
     )
     interp_tpr = np.interp(mean_fpr, viz.fpr, viz.tpr)
     interp_tpr[0] = 0.0

--- a/examples/model_selection/plot_roc_crossval.py
+++ b/examples/model_selection/plot_roc_crossval.py
@@ -88,12 +88,12 @@ for fold, (train, test) in enumerate(cv.split(X, y)):
         alpha=0.3,
         lw=1,
         ax=ax,
+        plot_chance_level=True,
     )
     interp_tpr = np.interp(mean_fpr, viz.fpr, viz.tpr)
     interp_tpr[0] = 0.0
     tprs.append(interp_tpr)
     aucs.append(viz.roc_auc)
-ax.plot([0, 1], [0, 1], "k--", label="chance level (AUC = 0.5)")
 
 mean_tpr = np.mean(tprs, axis=0)
 mean_tpr[-1] = 1.0

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -92,7 +92,7 @@ class RocCurveDisplay:
         *,
         name=None,
         plot_chance_level=False,
-        chance_level_kwargs={},
+        chance_level_kwargs=None,
         **kwargs,
     ):
         """Plot visualization.
@@ -114,7 +114,7 @@ class RocCurveDisplay:
 
             .. versionadded:: 1.3
 
-        chance_level_kwargs : dict, default={}
+        chance_level_kwargs : dict, default=None
             Keyword arguments to be passed to matplotlib's `plot` for rendering
             the chance level line.
 
@@ -148,7 +148,8 @@ class RocCurveDisplay:
             "linestyle": "--",
         }
 
-        chance_level_line_kwargs.update(**chance_level_kwargs)
+        if chance_level_kwargs is not None:
+            chance_level_line_kwargs.update(**chance_level_kwargs)
 
         import matplotlib.pyplot as plt
 
@@ -203,7 +204,7 @@ class RocCurveDisplay:
         name=None,
         ax=None,
         plot_chance_level=False,
-        chance_level_kwargs={},
+        chance_level_kwargs=None,
         **kwargs,
     ):
         """Create a ROC Curve display from an estimator.
@@ -252,7 +253,7 @@ class RocCurveDisplay:
 
             .. versionadded:: 1.3
 
-        chance_level_kwargs : dict, default={}
+        chance_level_kwargs : dict, default=None
             Keyword arguments to be passed to matplotlib's `plot` for rendering
             the chance level line.
 
@@ -325,7 +326,7 @@ class RocCurveDisplay:
         name=None,
         ax=None,
         plot_chance_level=False,
-        chance_level_kwargs={},
+        chance_level_kwargs=None,
         **kwargs,
     ):
         """Plot ROC curve given the true and predicted values.
@@ -370,7 +371,7 @@ class RocCurveDisplay:
 
             .. versionadded:: 1.3
 
-        chance_level_kwargs : dict, default={}
+        chance_level_kwargs : dict, default=None
             Keyword arguments to be passed to matplotlib's `plot` for rendering
             the chance level line.
 

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -155,10 +155,23 @@ class RocCurveDisplay:
         if ax is None:
             fig, ax = plt.subplots()
 
+        # Make sure that the chance level line is not plotted multiple times
+        chance_level_line = None
+        if plot_chance_level:
+            for line in ax.get_lines():
+                if (
+                    len(line.get_xdata()) == 2
+                    and tuple(line.get_xdata()) == (0, 1)
+                    and tuple(line.get_ydata()) == (0, 1)
+                ):
+                    chance_level_line = line
+                    plot_chance_level = False
+                    break
+
         if plot_chance_level:
             (self.chance_level_,) = ax.plot((0, 1), (0, 1), **chance_level_line_kwargs)
         else:
-            self.chance_level_ = None
+            self.chance_level_ = chance_level_line
 
         (self.line_,) = ax.plot(self.fpr, self.tpr, **line_kwargs)
         info_pos_label = (

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -92,7 +92,7 @@ class RocCurveDisplay:
         *,
         name=None,
         plot_chance_level=False,
-        chance_level_kwargs=None,
+        chance_level_kw=None,
         **kwargs,
     ):
         """Plot visualization.
@@ -114,7 +114,7 @@ class RocCurveDisplay:
 
             .. versionadded:: 1.3
 
-        chance_level_kwargs : dict, default=None
+        chance_level_kw : dict, default=None
             Keyword arguments to be passed to matplotlib's `plot` for rendering
             the chance level line.
 
@@ -142,14 +142,14 @@ class RocCurveDisplay:
 
         line_kwargs.update(**kwargs)
 
-        chance_level_line_kwargs = {
+        chance_level_line_kw = {
             "label": "Chance level (AUC = 0.5)",
             "color": "k",
             "linestyle": "--",
         }
 
-        if chance_level_kwargs is not None:
-            chance_level_line_kwargs.update(**chance_level_kwargs)
+        if chance_level_kw is not None:
+            chance_level_line_kw.update(**chance_level_kw)
 
         import matplotlib.pyplot as plt
 
@@ -166,7 +166,7 @@ class RocCurveDisplay:
         ax.set(xlabel=xlabel, ylabel=ylabel)
 
         if plot_chance_level:
-            (self.chance_level_,) = ax.plot((0, 1), (0, 1), **chance_level_line_kwargs)
+            (self.chance_level_,) = ax.plot((0, 1), (0, 1), **chance_level_line_kw)
         else:
             self.chance_level_ = None
 
@@ -191,7 +191,7 @@ class RocCurveDisplay:
         name=None,
         ax=None,
         plot_chance_level=False,
-        chance_level_kwargs=None,
+        chance_level_kw=None,
         **kwargs,
     ):
         """Create a ROC Curve display from an estimator.
@@ -240,7 +240,7 @@ class RocCurveDisplay:
 
             .. versionadded:: 1.3
 
-        chance_level_kwargs : dict, default=None
+        chance_level_kw : dict, default=None
             Keyword arguments to be passed to matplotlib's `plot` for rendering
             the chance level line.
 
@@ -297,7 +297,7 @@ class RocCurveDisplay:
             ax=ax,
             pos_label=pos_label,
             plot_chance_level=plot_chance_level,
-            chance_level_kwargs=chance_level_kwargs,
+            chance_level_kw=chance_level_kw,
             **kwargs,
         )
 
@@ -313,7 +313,7 @@ class RocCurveDisplay:
         name=None,
         ax=None,
         plot_chance_level=False,
-        chance_level_kwargs=None,
+        chance_level_kw=None,
         **kwargs,
     ):
         """Plot ROC curve given the true and predicted values.
@@ -358,7 +358,7 @@ class RocCurveDisplay:
 
             .. versionadded:: 1.3
 
-        chance_level_kwargs : dict, default=None
+        chance_level_kw : dict, default=None
             Keyword arguments to be passed to matplotlib's `plot` for rendering
             the chance level line.
 
@@ -418,6 +418,6 @@ class RocCurveDisplay:
             ax=ax,
             name=name,
             plot_chance_level=plot_chance_level,
-            chance_level_kwargs=chance_level_kwargs,
+            chance_level_kw=chance_level_kw,
             **kwargs,
         )

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -123,6 +123,17 @@ class RocCurveDisplay:
         if ax is None:
             fig, ax = plt.subplots()
 
+        # Set limits of axes to [0, 1] and fix aspect ratio to squared
+        ax.set_xlim((0, 1))
+        ax.set_ylim((0, 1))
+        ax.set_aspect(1)
+
+        # Plot the frame in dotted line, so that the curve can be
+        # seen better when values are close to 0 or 1
+        for s in ["right", "left", "top", "bottom"]:
+            ax.spines[s].set_linestyle((0, (1, 5)))
+            ax.spines[s].set_linewidth(0.5)
+
         (self.line_,) = ax.plot(self.fpr, self.tpr, **line_kwargs)
         info_pos_label = (
             f" (Positive label: {self.pos_label})" if self.pos_label is not None else ""

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -43,8 +43,10 @@ class RocCurveDisplay:
     line_ : matplotlib Artist
         ROC Curve.
 
-    chance_level_ : matplotlib Artist
-        The chance level line or None if the chance level is not plotted.
+    chance_level_ : matplotlib Artist or None
+        The chance level line. It is `None` if the chance level is not plotted.
+
+        .. versionadded:: 1.3
 
     ax_ : matplotlib Axes
         Axes with ROC Curve.
@@ -84,7 +86,15 @@ class RocCurveDisplay:
         self.roc_auc = roc_auc
         self.pos_label = pos_label
 
-    def plot(self, ax=None, *, name=None, plot_chance_level=True, **kwargs):
+    def plot(
+        self,
+        ax=None,
+        *,
+        name=None,
+        plot_chance_level=False,
+        chance_level_kwargs={},
+        **kwargs,
+    ):
         """Plot visualization.
 
         Extra keyword arguments will be passed to matplotlib's ``plot``.
@@ -99,8 +109,16 @@ class RocCurveDisplay:
             Name of ROC Curve for labeling. If `None`, use `estimator_name` if
             not `None`, otherwise no labeling is shown.
 
-        plot_chance_level : bool, default=True
+        plot_chance_level : bool, default=False
             Whether to plot the chance level.
+
+        .. versionadded:: 1.3
+
+        chance_level_kwargs : dict, default={}
+            Keyword arguments to be passed to matplotlib's `plot` for rendering
+            the chance level line.
+
+        .. versionadded:: 1.3
 
         **kwargs : dict
             Keyword arguments to be passed to matplotlib's `plot`.
@@ -124,26 +142,20 @@ class RocCurveDisplay:
 
         line_kwargs.update(**kwargs)
 
+        chance_level_line_kwargs = {
+            "label": "Chance level",
+            "linestyle": "dotted",
+        }
+
+        chance_level_line_kwargs.update(**chance_level_kwargs)
+
         import matplotlib.pyplot as plt
 
         if ax is None:
             fig, ax = plt.subplots()
 
-        # Set limits of axes to [0, 1] and fix aspect ratio to squared
-        ax.set_xlim((0, 1))
-        ax.set_ylim((0, 1))
-        ax.set_aspect(1)
-
-        # Plot the frame in dotted line, so that the curve can be
-        # seen better when values are close to 0 or 1
-        for s in ["right", "left", "top", "bottom"]:
-            ax.spines[s].set_linestyle((0, (1, 5)))
-            ax.spines[s].set_linewidth(0.5)
-
         if plot_chance_level:
-            (self.chance_level_,) = ax.plot(
-                (0, 1), (0, 1), linestyle="dotted", label="Chance level"
-            )
+            (self.chance_level_,) = ax.plot((0, 1), (0, 1), **chance_level_line_kwargs)
         else:
             self.chance_level_ = None
 
@@ -176,7 +188,8 @@ class RocCurveDisplay:
         pos_label=None,
         name=None,
         ax=None,
-        plot_chance_level=True,
+        plot_chance_level=False,
+        chance_level_kwargs={},
         **kwargs,
     ):
         """Create a ROC Curve display from an estimator.
@@ -220,8 +233,16 @@ class RocCurveDisplay:
         ax : matplotlib axes, default=None
             Axes object to plot on. If `None`, a new figure and axes is created.
 
-        plot_chance_level : bool, default=True
+        plot_chance_level : bool, default=False
             Whether to plot the chance level.
+
+        .. versionadded:: 1.3
+
+        chance_level_kwargs : dict, default={}
+            Keyword arguments to be passed to matplotlib's `plot` for rendering
+            the chance level line.
+
+        .. versionadded:: 1.3
 
         **kwargs : dict
             Keyword arguments to be passed to matplotlib's `plot`.
@@ -274,6 +295,7 @@ class RocCurveDisplay:
             ax=ax,
             pos_label=pos_label,
             plot_chance_level=plot_chance_level,
+            chance_level_kwargs=chance_level_kwargs,
             **kwargs,
         )
 
@@ -288,7 +310,8 @@ class RocCurveDisplay:
         pos_label=None,
         name=None,
         ax=None,
-        plot_chance_level=True,
+        plot_chance_level=False,
+        chance_level_kwargs={},
         **kwargs,
     ):
         """Plot ROC curve given the true and predicted values.
@@ -328,8 +351,16 @@ class RocCurveDisplay:
             Axes object to plot on. If `None`, a new figure and axes is
             created.
 
-        plot_chance_level : bool, default=True
+        plot_chance_level : bool, default=False
             Whether to plot the chance level.
+
+        .. versionadded:: 1.3
+
+        chance_level_kwargs : dict, default={}
+            Keyword arguments to be passed to matplotlib's `plot` for rendering
+            the chance level line.
+
+        .. versionadded:: 1.3
 
         **kwargs : dict
             Additional keywords arguments passed to matplotlib `plot` function.
@@ -381,4 +412,10 @@ class RocCurveDisplay:
             fpr=fpr, tpr=tpr, roc_auc=roc_auc, estimator_name=name, pos_label=pos_label
         )
 
-        return viz.plot(ax=ax, name=name, plot_chance_level=plot_chance_level, **kwargs)
+        return viz.plot(
+            ax=ax,
+            name=name,
+            plot_chance_level=plot_chance_level,
+            chance_level_kwargs=chance_level_kwargs,
+            **kwargs,
+        )

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -144,7 +144,7 @@ class RocCurveDisplay:
 
         chance_level_line_kwargs = {
             "label": "Chance level",
-            "linestyle": "dotted",
+            "linestyle": ":",
         }
 
         chance_level_line_kwargs.update(**chance_level_kwargs)

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -43,6 +43,9 @@ class RocCurveDisplay:
     line_ : matplotlib Artist
         ROC Curve.
 
+    chance_level_ : matplotlib Artist
+        The chance level line or None if the chance level is not plotted.
+
     ax_ : matplotlib Axes
         Axes with ROC Curve.
 
@@ -81,7 +84,7 @@ class RocCurveDisplay:
         self.roc_auc = roc_auc
         self.pos_label = pos_label
 
-    def plot(self, ax=None, *, name=None, **kwargs):
+    def plot(self, ax=None, *, name=None, plot_chance_level=True, **kwargs):
         """Plot visualization.
 
         Extra keyword arguments will be passed to matplotlib's ``plot``.
@@ -95,6 +98,9 @@ class RocCurveDisplay:
         name : str, default=None
             Name of ROC Curve for labeling. If `None`, use `estimator_name` if
             not `None`, otherwise no labeling is shown.
+
+        plot_chance_level : bool, default=True
+            Whether to plot the chance level.
 
         **kwargs : dict
             Keyword arguments to be passed to matplotlib's `plot`.
@@ -134,6 +140,13 @@ class RocCurveDisplay:
             ax.spines[s].set_linestyle((0, (1, 5)))
             ax.spines[s].set_linewidth(0.5)
 
+        if plot_chance_level:
+            (self.chance_level_,) = ax.plot(
+                (0, 1), (0, 1), linestyle="dotted", label="Chance level"
+            )
+        else:
+            self.chance_level_ = None
+
         (self.line_,) = ax.plot(self.fpr, self.tpr, **line_kwargs)
         info_pos_label = (
             f" (Positive label: {self.pos_label})" if self.pos_label is not None else ""
@@ -163,6 +176,7 @@ class RocCurveDisplay:
         pos_label=None,
         name=None,
         ax=None,
+        plot_chance_level=True,
         **kwargs,
     ):
         """Create a ROC Curve display from an estimator.
@@ -205,6 +219,9 @@ class RocCurveDisplay:
 
         ax : matplotlib axes, default=None
             Axes object to plot on. If `None`, a new figure and axes is created.
+
+        plot_chance_level : bool, default=True
+            Whether to plot the chance level.
 
         **kwargs : dict
             Keyword arguments to be passed to matplotlib's `plot`.
@@ -256,6 +273,7 @@ class RocCurveDisplay:
             name=name,
             ax=ax,
             pos_label=pos_label,
+            plot_chance_level=plot_chance_level,
             **kwargs,
         )
 
@@ -270,6 +288,7 @@ class RocCurveDisplay:
         pos_label=None,
         name=None,
         ax=None,
+        plot_chance_level=True,
         **kwargs,
     ):
         """Plot ROC curve given the true and predicted values.
@@ -308,6 +327,9 @@ class RocCurveDisplay:
         ax : matplotlib axes, default=None
             Axes object to plot on. If `None`, a new figure and axes is
             created.
+
+        plot_chance_level : bool, default=True
+            Whether to plot the chance level.
 
         **kwargs : dict
             Additional keywords arguments passed to matplotlib `plot` function.
@@ -359,4 +381,4 @@ class RocCurveDisplay:
             fpr=fpr, tpr=tpr, roc_auc=roc_auc, estimator_name=name, pos_label=pos_label
         )
 
-        return viz.plot(ax=ax, name=name, **kwargs)
+        return viz.plot(ax=ax, name=name, plot_chance_level=plot_chance_level, **kwargs)

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -156,11 +156,6 @@ class RocCurveDisplay:
         if ax is None:
             fig, ax = plt.subplots()
 
-        if plot_chance_level:
-            (self.chance_level_,) = ax.plot((0, 1), (0, 1), **chance_level_line_kwargs)
-        else:
-            self.chance_level_ = None
-
         (self.line_,) = ax.plot(self.fpr, self.tpr, **line_kwargs)
         info_pos_label = (
             f" (Positive label: {self.pos_label})" if self.pos_label is not None else ""
@@ -169,6 +164,11 @@ class RocCurveDisplay:
         xlabel = "False Positive Rate" + info_pos_label
         ylabel = "True Positive Rate" + info_pos_label
         ax.set(xlabel=xlabel, ylabel=ylabel)
+
+        if plot_chance_level:
+            (self.chance_level_,) = ax.plot((0, 1), (0, 1), **chance_level_line_kwargs)
+        else:
+            self.chance_level_ = None
 
         if "label" in line_kwargs:
             ax.legend(loc="lower right")

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -112,13 +112,13 @@ class RocCurveDisplay:
         plot_chance_level : bool, default=False
             Whether to plot the chance level.
 
-        .. versionadded:: 1.3
+            .. versionadded:: 1.3
 
         chance_level_kwargs : dict, default={}
             Keyword arguments to be passed to matplotlib's `plot` for rendering
             the chance level line.
 
-        .. versionadded:: 1.3
+            .. versionadded:: 1.3
 
         **kwargs : dict
             Keyword arguments to be passed to matplotlib's `plot`.
@@ -250,13 +250,13 @@ class RocCurveDisplay:
         plot_chance_level : bool, default=False
             Whether to plot the chance level.
 
-        .. versionadded:: 1.3
+            .. versionadded:: 1.3
 
         chance_level_kwargs : dict, default={}
             Keyword arguments to be passed to matplotlib's `plot` for rendering
             the chance level line.
 
-        .. versionadded:: 1.3
+            .. versionadded:: 1.3
 
         **kwargs : dict
             Keyword arguments to be passed to matplotlib's `plot`.
@@ -368,13 +368,13 @@ class RocCurveDisplay:
         plot_chance_level : bool, default=False
             Whether to plot the chance level.
 
-        .. versionadded:: 1.3
+            .. versionadded:: 1.3
 
         chance_level_kwargs : dict, default={}
             Keyword arguments to be passed to matplotlib's `plot` for rendering
             the chance level line.
 
-        .. versionadded:: 1.3
+            .. versionadded:: 1.3
 
         **kwargs : dict
             Additional keywords arguments passed to matplotlib `plot` function.

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -143,8 +143,9 @@ class RocCurveDisplay:
         line_kwargs.update(**kwargs)
 
         chance_level_line_kwargs = {
-            "label": "Chance level",
-            "linestyle": ":",
+            "label": "chance level (AUC = 0.5)",
+            "color": "k",
+            "linestyle": "--",
         }
 
         chance_level_line_kwargs.update(**chance_level_kwargs)

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -143,7 +143,7 @@ class RocCurveDisplay:
         line_kwargs.update(**kwargs)
 
         chance_level_line_kwargs = {
-            "label": "chance level (AUC = 0.5)",
+            "label": "Chance level (AUC = 0.5)",
             "color": "k",
             "linestyle": "--",
         }

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -156,23 +156,10 @@ class RocCurveDisplay:
         if ax is None:
             fig, ax = plt.subplots()
 
-        # Make sure that the chance level line is not plotted multiple times
-        chance_level_line = None
-        if plot_chance_level:
-            for line in ax.get_lines():
-                if (
-                    len(line.get_xdata()) == 2
-                    and tuple(line.get_xdata()) == (0, 1)
-                    and tuple(line.get_ydata()) == (0, 1)
-                ):
-                    chance_level_line = line
-                    plot_chance_level = False
-                    break
-
         if plot_chance_level:
             (self.chance_level_,) = ax.plot((0, 1), (0, 1), **chance_level_line_kwargs)
         else:
-            self.chance_level_ = chance_level_line
+            self.chance_level_ = None
 
         (self.line_,) = ax.plot(self.fpr, self.tpr, **line_kwargs)
         info_pos_label = (

--- a/sklearn/metrics/_plot/tests/test_roc_curve_display.py
+++ b/sklearn/metrics/_plot/tests/test_roc_curve_display.py
@@ -36,6 +36,7 @@ def data_binary(data):
 @pytest.mark.parametrize("with_sample_weight", [True, False])
 @pytest.mark.parametrize("drop_intermediate", [True, False])
 @pytest.mark.parametrize("with_strings", [True, False])
+@pytest.mark.parametrize("plot_chance_level", [True, False])
 @pytest.mark.parametrize(
     "constructor_name, default_name",
     [
@@ -50,6 +51,7 @@ def test_roc_curve_display_plotting(
     with_sample_weight,
     drop_intermediate,
     with_strings,
+    plot_chance_level,
     constructor_name,
     default_name,
 ):
@@ -82,6 +84,7 @@ def test_roc_curve_display_plotting(
             drop_intermediate=drop_intermediate,
             pos_label=pos_label,
             alpha=0.8,
+            plot_chance_level=plot_chance_level,
         )
     else:
         display = RocCurveDisplay.from_predictions(
@@ -91,6 +94,7 @@ def test_roc_curve_display_plotting(
             drop_intermediate=drop_intermediate,
             pos_label=pos_label,
             alpha=0.8,
+            plot_chance_level=plot_chance_level,
         )
 
     fpr, tpr, _ = roc_curve(
@@ -113,6 +117,13 @@ def test_roc_curve_display_plotting(
     assert display.line_.get_alpha() == 0.8
     assert isinstance(display.ax_, mpl.axes.Axes)
     assert isinstance(display.figure_, mpl.figure.Figure)
+
+    if plot_chance_level:
+        assert isinstance(display.chance_level_, mpl.lines.Line2D)
+        assert tuple(display.chance_level_.get_xdata()) == (0, 1)
+        assert tuple(display.chance_level_.get_ydata()) == (0, 1)
+    else:
+        assert display.chance_level_ is None
 
     expected_label = f"{default_name} (AUC = {display.roc_auc:.2f})"
     assert display.line_.get_label() == expected_label

--- a/sklearn/metrics/_plot/tests/test_roc_curve_display.py
+++ b/sklearn/metrics/_plot/tests/test_roc_curve_display.py
@@ -139,7 +139,7 @@ def test_roc_curve_display_plotting(
         if "linestyle" not in chance_level_kwargs:
             assert display.chance_level_.get_linestyle() == "--"
         if "label" not in chance_level_kwargs:
-            assert display.chance_level_.get_label() == "chance level (AUC = 0.5)"
+            assert display.chance_level_.get_label() == "Chance level (AUC = 0.5)"
 
         for k, v in chance_level_kwargs.items():
             assert getattr(display.chance_level_, "get_" + k)() == v

--- a/sklearn/metrics/_plot/tests/test_roc_curve_display.py
+++ b/sklearn/metrics/_plot/tests/test_roc_curve_display.py
@@ -42,7 +42,7 @@ def data_binary(data):
     [
         {"color": "r", "linewidth": 1},
         {"color": "b", "linewidth": 0.6, "label": "DummyEstimator"},
-        {"color": "g", "linewidth": 0.3, "linestyle": "-."},
+        {"color": "g", "linewidth": 0.3, "linestyle": ":"},
     ],
 )
 @pytest.mark.parametrize(
@@ -134,10 +134,12 @@ def test_roc_curve_display_plotting(
         assert tuple(display.chance_level_.get_xdata()) == (0, 1)
         assert tuple(display.chance_level_.get_ydata()) == (0, 1)
 
+        if "color" not in chance_level_kwargs:
+            assert display.chance_level_.get_color() == "k"
         if "linestyle" not in chance_level_kwargs:
-            assert display.chance_level_.get_linestyle() == ":"
+            assert display.chance_level_.get_linestyle() == "--"
         if "label" not in chance_level_kwargs:
-            assert display.chance_level_.get_label() == "Chance level"
+            assert display.chance_level_.get_label() == "chance level (AUC = 0.5)"
 
         for k, v in chance_level_kwargs.items():
             assert getattr(display.chance_level_, "get_" + k)() == v

--- a/sklearn/metrics/_plot/tests/test_roc_curve_display.py
+++ b/sklearn/metrics/_plot/tests/test_roc_curve_display.py
@@ -7,8 +7,6 @@ from sklearn.compose import make_column_transformer
 from sklearn.datasets import load_iris
 
 from sklearn.datasets import load_breast_cancer
-from sklearn.datasets import make_classification
-from sklearn.ensemble import RandomForestClassifier
 from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import roc_curve
@@ -18,7 +16,6 @@ from sklearn.model_selection import train_test_split
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils import shuffle
-from sklearn.svm import SVC
 
 
 from sklearn.metrics import RocCurveDisplay
@@ -285,45 +282,3 @@ def test_plot_roc_curve_pos_label(pyplot, response_method, constructor_name):
 
     assert display.roc_auc == pytest.approx(roc_auc_limit)
     assert np.trapz(display.tpr, display.fpr) == pytest.approx(roc_auc_limit)
-
-
-@pytest.mark.parametrize("constructor_name", ["from_estimator", "from_predictions"])
-def test_plot_roc_curve_multiple_chance_levels(pyplot, constructor_name):
-    # check that no matter how many times `plot_chance_level=True` is called,
-    # we only plot the chance level line once
-    # this can happen especially when using a loop
-    X, y = make_classification(random_state=0)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
-
-    svc = SVC(random_state=42)
-    svc.fit(X_train, y_train)
-    rfc = RandomForestClassifier(random_state=42)
-    rfc.fit(X_train, y_train)
-
-    svc_disp = RocCurveDisplay.from_estimator(
-        svc,
-        X_test,
-        y_test,
-        plot_chance_level=True,
-    )
-    rfc_disp = RocCurveDisplay.from_estimator(
-        rfc,
-        X_test,
-        y_test,
-        ax=svc_disp.ax_,
-        plot_chance_level=True,
-    )
-
-    chance_level_line_count = 0
-    for line in rfc_disp.ax_.get_lines():
-        if (
-            len(line.get_xdata()) == 2
-            and tuple(line.get_xdata()) == (0, 1)
-            and tuple(line.get_ydata()) == (0, 1)
-        ):
-            chance_level_line_count += 1
-            assert chance_level_line_count <= 1
-    assert chance_level_line_count == 1
-
-    assert tuple(rfc_disp.chance_level_.get_xdata()) == (0, 1)
-    assert tuple(rfc_disp.chance_level_.get_ydata()) == (0, 1)

--- a/sklearn/metrics/_plot/tests/test_roc_curve_display.py
+++ b/sklearn/metrics/_plot/tests/test_roc_curve_display.py
@@ -43,9 +43,9 @@ def data_binary(data):
 @pytest.mark.parametrize(
     "chance_level_kwargs",
     [
-        {"color": "r", "linewidth": 1},
-        {"color": "b", "linewidth": 0.6, "label": "DummyEstimator"},
-        {"color": "g", "linewidth": 0.3, "linestyle": ":"},
+        {"linewidth": 1},
+        {"color": "b", "label": "DummyEstimator"},
+        {"color": "g", "linestyle": ":"},
     ],
 )
 @pytest.mark.parametrize(

--- a/sklearn/metrics/_plot/tests/test_roc_curve_display.py
+++ b/sklearn/metrics/_plot/tests/test_roc_curve_display.py
@@ -128,11 +128,7 @@ def test_roc_curve_display_plotting(
 @pytest.mark.parametrize("plot_chance_level", [True, False])
 @pytest.mark.parametrize(
     "chance_level_kwargs",
-    [
-        {"linewidth": 1},
-        {"color": "b", "label": "DummyEstimator"},
-        {"color": "g", "linestyle": ":"},
-    ],
+    [None, {"linewidth": 1, "color": "red", "label": "DummyEstimator"}],
 )
 @pytest.mark.parametrize(
     "constructor_name",
@@ -184,16 +180,15 @@ def test_roc_curve_chance_level_line(
         assert tuple(display.chance_level_.get_xdata()) == (0, 1)
         assert tuple(display.chance_level_.get_ydata()) == (0, 1)
 
-        if "color" not in chance_level_kwargs:
-            assert display.chance_level_.get_color() == "k"
-        if "linestyle" not in chance_level_kwargs:
-            assert display.chance_level_.get_linestyle() == "--"
-        if "label" not in chance_level_kwargs:
-            assert display.chance_level_.get_label() == "Chance level (AUC = 0.5)"
-
+    # Checking for chance level line styles
+    if plot_chance_level and chance_level_kwargs is None:
+        assert display.chance_level_.get_color() == "k"
+        assert display.chance_level_.get_linestyle() == "--"
+        assert display.chance_level_.get_label() == "Chance level (AUC = 0.5)"
+    elif plot_chance_level:
         for k, v in chance_level_kwargs.items():
-            assert getattr(display.chance_level_, "get_" + k)() == v
-
+            if hasattr(display.chance_level_, "get_" + k):
+                assert getattr(display.chance_level_, "get_" + k)() == v
     else:
         assert display.chance_level_ is None
 

--- a/sklearn/metrics/_plot/tests/test_roc_curve_display.py
+++ b/sklearn/metrics/_plot/tests/test_roc_curve_display.py
@@ -168,7 +168,7 @@ def test_roc_curve_chance_level_line(
             chance_level_kw=chance_level_kw,
         )
 
-    import matplotlib as mpl  # noqal
+    import matplotlib as mpl  # noqa
 
     assert isinstance(display.line_, mpl.lines.Line2D)
     assert display.line_.get_alpha() == 0.8

--- a/sklearn/metrics/_plot/tests/test_roc_curve_display.py
+++ b/sklearn/metrics/_plot/tests/test_roc_curve_display.py
@@ -124,6 +124,15 @@ def test_roc_curve_display_plotting(
     assert display.ax_.get_ylabel() == expected_ylabel
     assert display.ax_.get_xlabel() == expected_xlabel
 
+    assert display.ax_.get_xlim() == (0, 1)
+    assert display.ax_.get_ylim() == (0, 1)
+    assert display.ax_.get_aspect() == 1
+
+    # Check frame styles
+    for s in ["right", "left", "top", "bottom"]:
+        assert display.ax_.spines[s].get_linestyle() == (0, (1, 5))
+        assert display.ax_.spines[s].get_linewidth() <= 0.5
+
 
 @pytest.mark.parametrize(
     "clf",

--- a/sklearn/metrics/_plot/tests/test_roc_curve_display.py
+++ b/sklearn/metrics/_plot/tests/test_roc_curve_display.py
@@ -38,6 +38,14 @@ def data_binary(data):
 @pytest.mark.parametrize("with_strings", [True, False])
 @pytest.mark.parametrize("plot_chance_level", [True, False])
 @pytest.mark.parametrize(
+    "chance_level_kwargs",
+    [
+        {"color": "r", "linewidth": 1},
+        {"color": "b", "linewidth": 0.6, "label": "DummyEstimator"},
+        {"color": "g", "linewidth": 0.3, "linestyle": "-."},
+    ],
+)
+@pytest.mark.parametrize(
     "constructor_name, default_name",
     [
         ("from_estimator", "LogisticRegression"),
@@ -52,6 +60,7 @@ def test_roc_curve_display_plotting(
     drop_intermediate,
     with_strings,
     plot_chance_level,
+    chance_level_kwargs,
     constructor_name,
     default_name,
 ):
@@ -85,6 +94,7 @@ def test_roc_curve_display_plotting(
             pos_label=pos_label,
             alpha=0.8,
             plot_chance_level=plot_chance_level,
+            chance_level_kwargs=chance_level_kwargs,
         )
     else:
         display = RocCurveDisplay.from_predictions(
@@ -95,6 +105,7 @@ def test_roc_curve_display_plotting(
             pos_label=pos_label,
             alpha=0.8,
             plot_chance_level=plot_chance_level,
+            chance_level_kwargs=chance_level_kwargs,
         )
 
     fpr, tpr, _ = roc_curve(
@@ -122,6 +133,15 @@ def test_roc_curve_display_plotting(
         assert isinstance(display.chance_level_, mpl.lines.Line2D)
         assert tuple(display.chance_level_.get_xdata()) == (0, 1)
         assert tuple(display.chance_level_.get_ydata()) == (0, 1)
+
+        if "linestyle" not in chance_level_kwargs:
+            assert display.chance_level_.get_linestyle() == ":"
+        if "label" not in chance_level_kwargs:
+            assert display.chance_level_.get_label() == "Chance level"
+
+        for k, v in chance_level_kwargs.items():
+            assert getattr(display.chance_level_, "get_" + k)() == v
+
     else:
         assert display.chance_level_ is None
 
@@ -134,15 +154,6 @@ def test_roc_curve_display_plotting(
 
     assert display.ax_.get_ylabel() == expected_ylabel
     assert display.ax_.get_xlabel() == expected_xlabel
-
-    assert display.ax_.get_xlim() == (0, 1)
-    assert display.ax_.get_ylim() == (0, 1)
-    assert display.ax_.get_aspect() == 1
-
-    # Check frame styles
-    for s in ["right", "left", "top", "bottom"]:
-        assert display.ax_.spines[s].get_linestyle() == (0, (1, 5))
-        assert display.ax_.spines[s].get_linewidth() <= 0.5
 
 
 @pytest.mark.parametrize(

--- a/sklearn/metrics/_plot/tests/test_roc_curve_display.py
+++ b/sklearn/metrics/_plot/tests/test_roc_curve_display.py
@@ -127,7 +127,7 @@ def test_roc_curve_display_plotting(
 
 @pytest.mark.parametrize("plot_chance_level", [True, False])
 @pytest.mark.parametrize(
-    "chance_level_kwargs",
+    "chance_level_kw",
     [None, {"linewidth": 1, "color": "red", "label": "DummyEstimator"}],
 )
 @pytest.mark.parametrize(
@@ -138,7 +138,7 @@ def test_roc_curve_chance_level_line(
     pyplot,
     data_binary,
     plot_chance_level,
-    chance_level_kwargs,
+    chance_level_kw,
     constructor_name,
 ):
     """Check the chance leve line plotting behaviour."""
@@ -157,7 +157,7 @@ def test_roc_curve_chance_level_line(
             y,
             alpha=0.8,
             plot_chance_level=plot_chance_level,
-            chance_level_kwargs=chance_level_kwargs,
+            chance_level_kw=chance_level_kw,
         )
     else:
         display = RocCurveDisplay.from_predictions(
@@ -165,7 +165,7 @@ def test_roc_curve_chance_level_line(
             y_pred,
             alpha=0.8,
             plot_chance_level=plot_chance_level,
-            chance_level_kwargs=chance_level_kwargs,
+            chance_level_kw=chance_level_kw,
         )
 
     import matplotlib as mpl  # noqal
@@ -179,18 +179,18 @@ def test_roc_curve_chance_level_line(
         assert isinstance(display.chance_level_, mpl.lines.Line2D)
         assert tuple(display.chance_level_.get_xdata()) == (0, 1)
         assert tuple(display.chance_level_.get_ydata()) == (0, 1)
+    else:
+        assert display.chance_level_ is None
 
     # Checking for chance level line styles
-    if plot_chance_level and chance_level_kwargs is None:
+    if plot_chance_level and chance_level_kw is None:
         assert display.chance_level_.get_color() == "k"
         assert display.chance_level_.get_linestyle() == "--"
         assert display.chance_level_.get_label() == "Chance level (AUC = 0.5)"
     elif plot_chance_level:
-        for k, v in chance_level_kwargs.items():
-            if hasattr(display.chance_level_, "get_" + k):
-                assert getattr(display.chance_level_, "get_" + k)() == v
-    else:
-        assert display.chance_level_ is None
+        assert display.chance_level_.get_label() == chance_level_kw["label"]
+        assert display.chance_level_.get_color() == chance_level_kw["color"]
+        assert display.chance_level_.get_linewidth() == chance_level_kw["linewidth"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference Issues/PRs

towards #25929. Relevant PR: #25972.

#### What does this implement/fix? Explain your changes.

This PR implements the following:
- Add attribute chance_level_ to `RocCurveDisplay` class
- Add option to plot the chance level line, and supports passing a dict to alter its style
- Will not plot the chance level line multiple times
- Update examples where `RocCurveDisplay` is used. Remove the part we were plotting the chance level by hand and instead use the new feature.

#### Any other comments?

The previous pull request is [#25972](https://github.com/scikit-learn/scikit-learn/pull/25972), but it was from another repo so reviewers do not have permission to directly modify it. Therefore I closed that issue and moved the changes here, meanwhile adopting the suggestions by @glemaitre.