### PR TITLE
DOC Update model_persistence.rst to fix skops example

### DIFF
--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -126,7 +126,7 @@ trusted by you. You can get existing unknown types in a dumped object / file
 using :func:`skops.io.get_untrusted_types`, and after checking its contents,
 pass it to the load function::
 
-    unknown_types = sio.get_untrusted_types(obj)
+    unknown_types = sio.get_untrusted_types(data=obj)
     clf = sio.loads(obj, trusted=unknown_types)
 
 If you trust the source of the file / object, you can pass ``trusted=True``::


### PR DESCRIPTION
Fix example of skops.io.get_untrusted_types. With this fix, the code snippet fails with the following error:

```
In [9]: unknown_types = sio.get_untrusted_types(obj)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[9], line 1
----> 1 unknown_types = sio.get_untrusted_types(obj)

TypeError: get_untrusted_types() takes 0 positional arguments but 1 was given
```

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
