### PR TITLE
DOC document that last step is never cached in pipeline

### DIFF
--- a/doc/modules/compose.rst
+++ b/doc/modules/compose.rst
@@ -198,7 +198,8 @@ after calling ``fit``.
 This feature is used to avoid computing the fit transformers within a pipeline
 if the parameters and input data are identical. A typical example is the case of
 a grid search in which the transformers can be fitted only once and reused for
-each configuration.
+each configuration. Currently, the last step will never be cached. This might
+change in the future.
 
 The parameter ``memory`` is needed in order to cache the transformers.
 ``memory`` can be either a string containing the directory where to cache the

--- a/doc/modules/compose.rst
+++ b/doc/modules/compose.rst
@@ -198,8 +198,7 @@ after calling ``fit``.
 This feature is used to avoid computing the fit transformers within a pipeline
 if the parameters and input data are identical. A typical example is the case of
 a grid search in which the transformers can be fitted only once and reused for
-each configuration. Currently, the last step will never be cached. This might
-change in the future.
+each configuration. Currently, the last step will never be cached.
 
 The parameter ``memory`` is needed in order to cache the transformers.
 ``memory`` can be either a string containing the directory where to cache the

--- a/doc/modules/compose.rst
+++ b/doc/modules/compose.rst
@@ -198,7 +198,7 @@ after calling ``fit``.
 This feature is used to avoid computing the fit transformers within a pipeline
 if the parameters and input data are identical. A typical example is the case of
 a grid search in which the transformers can be fitted only once and reused for
-each configuration. Currently, the last step will never be cached.
+each configuration. The last step will never be cached, even if it is a transformer.
 
 The parameter ``memory`` is needed in order to cache the transformers.
 ``memory`` can be either a string containing the directory where to cache the

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -80,11 +80,11 @@ class Pipeline(_BaseComposition):
         estimator.
 
     memory : str or object with the joblib.Memory interface, default=None
-        Used to cache the fitted transformers of the pipeline. By default,
-        no caching is performed. If a string is given, it is the path to
-        the caching directory. Enabling caching triggers a clone of
-        the transformers before fitting. Therefore, the transformer
-        instance given to the pipeline cannot be inspected
+        Used to cache the fitted transformers of the pipeline. Currently,
+        the last step will never be cached. By default, no caching is performed.
+        If a string is given, it is the path to the caching directory. Enabling
+        caching triggers a clone of the transformers before fitting. Therefore,
+        the transformer instance given to the pipeline cannot be inspected
         directly. Use the attribute ``named_steps`` or ``steps`` to
         inspect estimators within the pipeline. Caching the
         transformers is advantageous when fitting is time consuming.
@@ -858,11 +858,11 @@ def make_pipeline(*steps, memory=None, verbose=False):
         List of the scikit-learn estimators that are chained together.
 
     memory : str or object with the joblib.Memory interface, default=None
-        Used to cache the fitted transformers of the pipeline. By default,
-        no caching is performed. If a string is given, it is the path to
-        the caching directory. Enabling caching triggers a clone of
-        the transformers before fitting. Therefore, the transformer
-        instance given to the pipeline cannot be inspected
+        Used to cache the fitted transformers of the pipeline. Currently,
+        the last step will never be cached. By default, no caching is performed.
+        If a string is given, it is the path to the caching directory. Enabling
+        caching triggers a clone of the transformers before fitting. Therefore,
+        the transformer instance given to the pipeline cannot be inspected
         directly. Use the attribute ``named_steps`` or ``steps`` to
         inspect estimators within the pipeline. Caching the
         transformers is advantageous when fitting is time consuming.

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -80,13 +80,13 @@ class Pipeline(_BaseComposition):
         estimator.
 
     memory : str or object with the joblib.Memory interface, default=None
-        Used to cache the fitted transformers of the pipeline. Currently,
-        the last step will never be cached. By default, no caching is performed.
-        If a string is given, it is the path to the caching directory. Enabling
-        caching triggers a clone of the transformers before fitting. Therefore,
-        the transformer instance given to the pipeline cannot be inspected
-        directly. Use the attribute ``named_steps`` or ``steps`` to
-        inspect estimators within the pipeline. Caching the
+        Used to cache the fitted transformers of the pipeline. The last step
+        will never be cached, even if it is a transformer. By default, no
+        caching is performed. If a string is given, it is the path to the
+        caching directory. Enabling caching triggers a clone of the transformers
+        before fitting. Therefore, the transformer instance given to the
+        pipeline cannot be inspected directly. Use the attribute ``named_steps``
+        or ``steps`` to inspect estimators within the pipeline. Caching the
         transformers is advantageous when fitting is time consuming.
 
     verbose : bool, default=False
@@ -858,13 +858,13 @@ def make_pipeline(*steps, memory=None, verbose=False):
         List of the scikit-learn estimators that are chained together.
 
     memory : str or object with the joblib.Memory interface, default=None
-        Used to cache the fitted transformers of the pipeline. Currently,
-        the last step will never be cached. By default, no caching is performed.
-        If a string is given, it is the path to the caching directory. Enabling
-        caching triggers a clone of the transformers before fitting. Therefore,
-        the transformer instance given to the pipeline cannot be inspected
-        directly. Use the attribute ``named_steps`` or ``steps`` to
-        inspect estimators within the pipeline. Caching the
+        Used to cache the fitted transformers of the pipeline. The last step
+        will never be cached, even if it is a transformer. By default, no
+        caching is performed. If a string is given, it is the path to the
+        caching directory. Enabling caching triggers a clone of the transformers
+        before fitting. Therefore, the transformer instance given to the
+        pipeline cannot be inspected directly. Use the attribute ``named_steps``
+        or ``steps`` to inspect estimators within the pipeline. Caching the
         transformers is advantageous when fitting is time consuming.
 
     verbose : bool, default=False


### PR DESCRIPTION
In compose.rst and pipeline.py there are three places where pipeline caching is explained. An extra sentence was added that currently, the last step will never be cached. In one place it is mentioned that this might change in the future.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Improves #23112. This just improves documentation regarding the current state. There might be more activity on the Issue in order to change the behavior of scikit-learn to extend caching functionality. 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

In `compose.rst` and `pipeline.py`, there are three places where pipeline caching is explained. An extra sentence was added explaining that currently, the last step will never be cached. In one place it is mentioned that this might change in the future.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
