### PR TITLE
ENH add verbose option for gpr

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -253,6 +253,16 @@ Changelog
   Parameter validation only happens at `fit` time.
   :pr:`24230` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+:mod:`sklearn.gaussian_process`
+...............................
+
+- |Enhancement| :class:`_gpr.GaussianProcessRegressor` Add parameter `verbose`
+  to check whether user wants to track theta and corresponding log margimal
+  likelihood. In `_constrained_optimization`, if verbose >= 1, then an array
+  self.explored_theta that tracks explored theta and self.explored_theta_log
+  that tracks coresponding log marginal likelihood would be defined.
+  :pr:`26012` by :user:`Yuchen Zhou <ROMEEZHOU>`
+
 :mod:`sklearn.impute`
 .....................
 

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -263,6 +263,24 @@ Changelog
   that tracks coresponding log marginal likelihood would be defined.
   :pr:`26012` by :user:`Yuchen Zhou <ROMEEZHOU>`
 
+:mod:`sklearn.gaussian_process`
+...............................
+
+- |Enhancement| :class:`_gpr.GaussianProcessRegressor` Add attribute
+  `explored_theta`, a nparray to store the explored theta
+  :pr:`26012` by :user:`Yuchen Zhou <ROMEEZHOU>`
+
+:mod:`sklearn.impute`
+.....................
+
+:mod:`sklearn.gaussian_process`
+...............................
+
+- |Enhancement| :class:`_gpr.GaussianProcessRegressor` Add attribute
+  `explored_theta_log`, a nparray to store the corresponding value of
+  log marginal likelihood of explored theta
+  :pr:`26012` by :user:`Yuchen Zhou <ROMEEZHOU>`
+
 :mod:`sklearn.impute`
 .....................
 

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -625,9 +625,11 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             if self.verbose >= 1:
                 self.explored_theta = []
                 self.explored_theta_log = []
+
                 def func_callback(theta):
                     self.explored_theta.append(theta)
                     self.explored_theta_log.append(self.log_marginal_likelihood(theta))
+
                 opt_res = scipy.optimize.minimize(
                     obj_func,
                     initial_theta,
@@ -650,9 +652,16 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                 theta_opt, func_min = opt_res.x, opt_res.fun
         elif callable(self.optimizer):
             if self.verbose >= 1:
-                theta_opt, func_min, self.explored_theta, self.explored_theta_log = self.optimizer(obj_func, initial_theta, bounds=bounds)
+                (
+                    theta_opt,
+                    func_min,
+                    self.explored_theta,
+                    self.explored_theta_log,
+                ) = self.optimizer(obj_func, initial_theta, bounds=bounds)
             else:
-                theta_opt, func_min = self.optimizer(obj_func, initial_theta, bounds=bounds)
+                theta_opt, func_min = self.optimizer(
+                    obj_func, initial_theta, bounds=bounds
+                )
         else:
             raise ValueError(f"Unknown optimizer {self.optimizer}.")
 

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -66,8 +66,8 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
     optimizer : "fmin_l_bfgs_b", callable or None, default="fmin_l_bfgs_b"
         Can either be one of the internally supported optimizers for optimizing
         the kernel's parameters, specified by a string, or an externally
-        defined optimizer passed as a callable. If a callable is passed, it
-        must have the signature::
+        defined optimizer passed as a callable. If a callable is passed when
+        `verbose=0`, it must have the signature::
 
             def optimizer(obj_func, initial_theta, bounds):
                 # * 'obj_func': the objective function to be minimized, which
@@ -81,6 +81,24 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                 # Returned are the best found hyperparameters theta and
                 # the corresponding value of the target function.
                 return theta_opt, func_min
+
+        If a callable is passed when `verbose>=1`, it must have the signature::
+
+            def optimizer(obj_func, initial_theta, bounds):
+                # * 'obj_func': the objective function to be minimized, which
+                #   takes the hyperparameters theta as a parameter and an
+                #   optional flag eval_gradient, which determines if the
+                #   gradient is returned additionally to the function value
+                # * 'initial_theta': the initial value for theta, which can be
+                #   used by local optimizers
+                # * 'bounds': the bounds on the values of theta
+                ....
+                # Returned are the best found hyperparameters theta,
+                # the corresponding value of the target function,
+                # an array of explored theta,
+                # and an array of log marginal likelihood of the corresponding
+                # theta
+                return theta_opt, func_min, explored_theta, explored_theta_log
 
         Per default, the L-BFGS-B algorithm from `scipy.optimize.minimize`
         is used. If None is passed, the kernel's parameters are kept fixed.
@@ -114,6 +132,12 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         Determines random number generation used to initialize the centers.
         Pass an int for reproducible results across multiple function calls.
         See :term:`Glossary <random_state>`.
+
+    verbose : int, default=0
+        Enable verbose output. Tracks the theta explored and the corresponding
+        log marginal likelihood in the regression process.
+
+        .. versionadded:: 1.3
 
     Attributes
     ----------

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -172,6 +172,16 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
         .. versionadded:: 1.0
 
+    explored_theta : ndarray of explored theta
+        Defined only when `verbose>=1`
+
+        .. versionadded:: 1.3
+
+    explored_theta_log : ndarray of the log marginal likelihood corresponding
+        to explored theta values. Defined only when `verbose>=1`
+
+        ..versionadded:: 1.3
+
     See Also
     --------
     GaussianProcessClassifier : Gaussian process classification (GPC)

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -19,7 +19,7 @@ from sklearn.gaussian_process.kernels import (
     ConstantKernel as C,
     WhiteKernel,
 )
-from sklearn.gaussian_process.kernels import DotProduct, ExpSineSquared, WhiteKernel
+from sklearn.gaussian_process.kernels import DotProduct, ExpSineSquared
 from sklearn.gaussian_process.tests._mini_sequence_kernel import MiniSeqKernel
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils._testing import (
@@ -775,11 +775,11 @@ def test_sample_y_shapes(normalize_y, n_targets):
 
 @pytest.mark.parametrize("verbose", [1, 2])
 def test_verbose(verbose):
-    kernel = kernel = 1.0 * ExpSineSquared(1.0, 5.0, periodicity_bounds=(1e-2, 1e1)) + WhiteKernel(
-    1e-1
-    )
-    gpr = GaussianProcessRegressor(kernel=kernel,verbose=2)
-    res = gpr.fit(X,y)
+    kernel = kernel = 1.0 * ExpSineSquared(
+        1.0, 5.0, periodicity_bounds=(1e-2, 1e1)
+    ) + WhiteKernel(1e-1)
+    gpr = GaussianProcessRegressor(kernel=kernel, verbose=2)
+    res = gpr.fit(X, y)
     assert len(res.explored_theta) == len(res.explored_theta_log)
     assert res.explored_theta[-1].all() == res.kernel_.theta.all()
 

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -778,7 +778,23 @@ def test_verbose(verbose):
     kernel = kernel = 1.0 * ExpSineSquared(
         1.0, 5.0, periodicity_bounds=(1e-2, 1e1)
     ) + WhiteKernel(1e-1)
-    gpr = GaussianProcessRegressor(kernel=kernel, verbose=2)
+    gpr = GaussianProcessRegressor(kernel=kernel, verbose=verbose)
+    res = gpr.fit(X, y)
+    assert len(res.explored_theta) == len(res.explored_theta_log)
+    assert res.explored_theta[-1].all() == res.kernel_.theta.all()
+
+
+def my_optimizer(obj_func, theta, bounds):
+    theta_array = np.array([1, 1, 1, 1])
+    return theta_array, 0, [theta_array], [0]
+
+
+@pytest.mark.parametrize("optimizer", [my_optimizer])
+def test_verbose_optimizer(optimizer):
+    kernel = kernel = 1.0 * ExpSineSquared(
+        1.0, 5.0, periodicity_bounds=(1e-2, 1e1)
+    ) + WhiteKernel(1e-1)
+    gpr = GaussianProcessRegressor(kernel=kernel, optimizer=my_optimizer, verbose=2)
     res = gpr.fit(X, y)
     assert len(res.explored_theta) == len(res.explored_theta_log)
     assert res.explored_theta[-1].all() == res.kernel_.theta.all()

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -19,7 +19,7 @@ from sklearn.gaussian_process.kernels import (
     ConstantKernel as C,
     WhiteKernel,
 )
-from sklearn.gaussian_process.kernels import DotProduct, ExpSineSquared
+from sklearn.gaussian_process.kernels import DotProduct, ExpSineSquared, WhiteKernel
 from sklearn.gaussian_process.tests._mini_sequence_kernel import MiniSeqKernel
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils._testing import (
@@ -771,6 +771,17 @@ def test_sample_y_shapes(normalize_y, n_targets):
 
     y_samples = model.sample_y(X_test, n_samples=n_samples_y_test)
     assert y_samples.shape == y_test_shape
+
+
+@pytest.mark.parametrize("verbose", [1, 2])
+def test_verbose(verbose):
+    kernel = kernel = 1.0 * ExpSineSquared(1.0, 5.0, periodicity_bounds=(1e-2, 1e1)) + WhiteKernel(
+    1e-1
+    )
+    gpr = GaussianProcessRegressor(kernel=kernel,verbose=2)
+    res = gpr.fit(X,y)
+    assert len(res.explored_theta) == len(res.explored_theta_log)
+    assert res.explored_theta[-1].all() == res.kernel_.theta.all()
 
 
 class CustomKernel(C):


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #25740

#### What does this implement/fix? Explain your changes.
In sklearn/gaussian_process/_gpr.py, added a verbose parameter. The default value is 0. If verbose >= 1, define a list  self.explored_theta to track all tested theta in the regression process, and define another list self.explored_theta_log to track the corresponding log_marginal_likelihood. If the user is passing self-defined optimizer and let verbose >= 1, then this self-defined optimizer should return corresponding array of explored theta and log marginal likelihood itself.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
