### PR TITLE
MAINT remove unecessary check covered by parameter validation framework

### DIFF
--- a/sklearn/mixture/_base.py
+++ b/sklearn/mixture/_base.py
@@ -137,10 +137,6 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
                 random_state=random_state,
             )
             resp[indices, np.arange(self.n_components)] = 1
-        else:
-            raise ValueError(
-                "Unimplemented initialization method '%s'" % self.init_params
-            )
 
         self._initialize(X, resp)
 


### PR DESCRIPTION
This line should never be executed because the parameter validation should take care of it.