### PR TITLE
CLN Make _NumPyAPIWrapper naming consistent to _ArrayAPIWrapper

### DIFF
--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -49,7 +49,7 @@ class _ArrayAPIWrapper:
         return self._namespace.stack(selected, axis=axis)
 
 
-class _NumPyApiWrapper:
+class _NumPyAPIWrapper:
     """Array API compat wrapper for any numpy version
 
     NumPy < 1.22 does not expose the numpy.array_api namespace. This
@@ -98,7 +98,7 @@ def get_namespace(*arrays):
     See: https://numpy.org/neps/nep-0047-array-api-standard.html
 
     If `arrays` are regular numpy arrays, an instance of the
-    `_NumPyApiWrapper` compatibility wrapper is returned instead.
+    `_NumPyAPIWrapper` compatibility wrapper is returned instead.
 
     Namespace support is not enabled by default. To enabled it
     call:
@@ -110,7 +110,7 @@ def get_namespace(*arrays):
       with sklearn.config_context(array_api_dispatch=True):
           # your code here
 
-    Otherwise an instance of the `_NumPyApiWrapper`
+    Otherwise an instance of the `_NumPyAPIWrapper`
     compatibility wrapper is always returned irrespective of
     the fact that arrays implement the `__array_namespace__`
     protocol or not.
@@ -133,7 +133,7 @@ def get_namespace(*arrays):
     # Returns a tuple: (array_namespace, is_array_api)
 
     if not get_config()["array_api_dispatch"]:
-        return _NumPyApiWrapper(), False
+        return _NumPyAPIWrapper(), False
 
     namespaces = {
         x.__array_namespace__() if hasattr(x, "__array_namespace__") else None
@@ -152,7 +152,7 @@ def get_namespace(*arrays):
     (xp,) = namespaces
     if xp is None:
         # Use numpy as default
-        return _NumPyApiWrapper(), False
+        return _NumPyAPIWrapper(), False
 
     return _ArrayAPIWrapper(xp), True
 

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -4,7 +4,7 @@ import pytest
 
 from sklearn.base import BaseEstimator
 from sklearn.utils._array_api import get_namespace
-from sklearn.utils._array_api import _NumPyApiWrapper
+from sklearn.utils._array_api import _NumPyAPIWrapper
 from sklearn.utils._array_api import _ArrayAPIWrapper
 from sklearn.utils._array_api import _asarray_with_order
 from sklearn.utils._array_api import _convert_to_numpy
@@ -27,7 +27,7 @@ def test_get_namespace_ndarray():
         with config_context(array_api_dispatch=array_api_dispatch):
             xp_out, is_array_api = get_namespace(X_np)
             assert not is_array_api
-            assert isinstance(xp_out, _NumPyApiWrapper)
+            assert isinstance(xp_out, _NumPyAPIWrapper)
 
 
 def test_get_namespace_array_api():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/scikit-learn/scikit-learn/pull/26029#discussion_r1154254602

#### What does this implement/fix? Explain your changes.
This PR renames `_NumPyApiWrapper` to have the same casting as `_ArrayAPIWrapper`.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
