### PR TITLE
TST add global_random_seed fixture to sklearn/datasets/tests/test_rcv1.py

### DIFF
--- a/sklearn/datasets/tests/test_rcv1.py
+++ b/sklearn/datasets/tests/test_rcv1.py
@@ -42,7 +42,9 @@ def test_fetch_rcv1(fetch_rcv1_fxt, global_random_seed):
         assert num == Y1[:, j].data.size
 
     # test shuffling and subset
-    data2 = fetch_rcv1_fxt(shuffle=True, subset="train", random_state=global_random_seed)
+    data2 = fetch_rcv1_fxt(
+        shuffle=True, subset="train", random_state=global_random_seed
+    )
     X2, Y2 = data2.data, data2.target
     s2 = data2.sample_id
 

--- a/sklearn/datasets/tests/test_rcv1.py
+++ b/sklearn/datasets/tests/test_rcv1.py
@@ -10,7 +10,7 @@ from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_array_equal
 
 
-def test_fetch_rcv1(fetch_rcv1_fxt):
+def test_fetch_rcv1(fetch_rcv1_fxt, global_random_seed):
     data1 = fetch_rcv1_fxt(shuffle=False)
     X1, Y1 = data1.data, data1.target
     cat_list, s1 = data1.target_names.tolist(), data1.sample_id
@@ -42,7 +42,7 @@ def test_fetch_rcv1(fetch_rcv1_fxt):
         assert num == Y1[:, j].data.size
 
     # test shuffling and subset
-    data2 = fetch_rcv1_fxt(shuffle=True, subset="train", random_state=77)
+    data2 = fetch_rcv1_fxt(shuffle=True, subset="train", random_state=global_random_seed)
     X2, Y2 = data2.data, data2.target
     s2 = data2.sample_id
 


### PR DESCRIPTION
#### Reference Issues/PRs
#22827 


#### What does this implement/fix? Explain your changes.
Adds the global random seed fixture to the test `test_fetch_rcv1` in `sklearn/datasets/tests/test_rcv1.py`

#### Any other comments?
I enabled the test locally by setting environ.get("SKLEARN_SKIP_NETWORK_TESTS", "0") == "0" here:
https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/conftest.py#L117