### PR TITLE
MAINT Fix C warning in Cython module splitting.pyx

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -569,15 +569,15 @@ cdef class Splitter:
         free(split_infos)
         return out
 
-    cdef unsigned int _find_best_feature_to_split_helper(
+    cdef int _find_best_feature_to_split_helper(
         self,
         split_info_struct * split_infos,  # IN
         int n_allowed_features,
     ) noexcept nogil:
         """Return the index of split_infos with the best feature split."""
         cdef:
-            unsigned int split_info_idx
-            unsigned int best_split_info_idx = 0
+            int split_info_idx
+            int best_split_info_idx = 0
 
         for split_info_idx in range(1, n_allowed_features):
             if (split_infos[split_info_idx].gain > split_infos[best_split_info_idx].gain):


### PR DESCRIPTION
#### Reference Issues/PRs
No issues in existence.

#### What does this implement/fix? Explain your changes.
While compiling sklearn, we get the following warning:

```
sklearn/ensemble/_hist_gradient_boosting/splitting.c:6363:33: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]
 6363 |   for (__pyx_t_3 = 1; __pyx_t_3 < __pyx_t_2; __pyx_t_3+=1) {
      |                                 ^
```

The C code generated by Cython generates a type mismatch.
Reason:
In `sklearn/ensemble/_hist_gradient_boosting/splitting.pyx` at line 575 the variable `n_allowed_features` was defined as `int`
and was used in a loop with a loop var defined as `unsigned int`.

Solution:
Convert the variable `n_allowed_features` to an `unsigned int` before using it in the loop.
This way Cython generates the right types.
Since the variable `n_allowed_features` was used this way `range(1, n_allowed_features)` it is assumed that `n_allowed_features` must be >= 1.
Thus, converting to an `unsigned int` is possible.

#### Any other comments?
