### PR TITLE
CI disable coverage on Windows to keep CI times reasonable

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -277,6 +277,11 @@ jobs:
         DISTRIB: 'conda'
         LOCK_FILE: ./build_tools/azure/py38_conda_forge_mkl_win-64_conda.lock
         CHECK_WARNINGS: 'true'
-        COVERAGE: 'true'
+        # The Azure Windows runner is typically much slower than other CI
+        # runners due to the lack of compiler cache. Running the tests with
+        # coverage enabled make them run extra slower. Since very few parts of
+        # code should have windows-specific code branches, it should be enable
+        # to restrict the code coverage collection to the non-windows runners.
+        COVERAGE: 'false'
         SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES: '1'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '7'  # non-default seed

--- a/build_tools/azure/combine_coverage_reports.sh
+++ b/build_tools/azure/combine_coverage_reports.sh
@@ -11,7 +11,8 @@ activate_environment
 # such as pytest-xdist and joblib/loky:
 pushd $TEST_DIR
 coverage combine --append
+coverage xml
 popd
 
 # Copy the combined coverage file to the root of the repository:
-cp $TEST_DIR/.coverage $BUILD_REPOSITORY_LOCALPATH
+cp $TEST_DIR/coverage.xml $BUILD_REPOSITORY_LOCALPATH

--- a/build_tools/azure/upload_codecov.sh
+++ b/build_tools/azure/upload_codecov.sh
@@ -32,12 +32,6 @@ if [[ ! -f "$COVERAGE_XML" ]]; then
     exit 1
 fi
 
-# Check the content of the coverage.xml file:
-echo "Content of $COVERAGE_XML:"
-head -n 10 $COVERAGE_XML
-echo "..."
-tail -n 10 $COVERAGE_XML
-
 if [[ $OSTYPE == *"linux"* ]]; then
     curl -Os "$CODECOV_BASE_URL/linux/codecov"
     SHA256SUM="32cb14b5f3aaacd67f4c1ff55d82f037d3cd10c8e7b69c051f27391d2e66e15c  codecov"

--- a/build_tools/azure/upload_codecov.sh
+++ b/build_tools/azure/upload_codecov.sh
@@ -29,6 +29,13 @@ if [[ ! -f "$BUILD_REPOSITORY_LOCALPATH/.coverage" ]]; then
     echo "Could not find the combined coverage file at $BUILD_REPOSITORY_LOCALPATH/.coverage"
     exit 1
 fi
+
+# Check the content of the .coverage file:
+echo "Content of $BUILD_REPOSITORY_LOCALPATH/.coverage:"
+head -n 10 $BUILD_REPOSITORY_LOCALPATH/.coverage
+echo "..."
+tail -n 10 $BUILD_REPOSITORY_LOCALPATH/.coverage
+
 if [[ $OSTYPE == *"linux"* ]]; then
     curl -Os "$CODECOV_BASE_URL/linux/codecov"
     SHA256SUM="32cb14b5f3aaacd67f4c1ff55d82f037d3cd10c8e7b69c051f27391d2e66e15c  codecov"

--- a/build_tools/azure/upload_codecov.sh
+++ b/build_tools/azure/upload_codecov.sh
@@ -24,33 +24,35 @@ if [[ ! -d "$BUILD_REPOSITORY_LOCALPATH/.git" ]]; then
     echo "Could not find the git checkout at $BUILD_REPOSITORY_LOCALPATH"
     exit 1
 fi
+
 # Check that the combined coverage file exists at the expected location:
-if [[ ! -f "$BUILD_REPOSITORY_LOCALPATH/.coverage" ]]; then
-    echo "Could not find the combined coverage file at $BUILD_REPOSITORY_LOCALPATH/.coverage"
+export COVERAGE_XML="$BUILD_REPOSITORY_LOCALPATH/coverage.xml"
+if [[ ! -f "$COVERAGE_XML" ]]; then
+    echo "Could not find the combined coverage file at $COVERAGE_XML"
     exit 1
 fi
 
-# Check the content of the .coverage file:
-echo "Content of $BUILD_REPOSITORY_LOCALPATH/.coverage:"
-head -n 10 $BUILD_REPOSITORY_LOCALPATH/.coverage
+# Check the content of the coverage.xml file:
+echo "Content of $COVERAGE_XML:"
+head -n 10 $COVERAGE_XML
 echo "..."
-tail -n 10 $BUILD_REPOSITORY_LOCALPATH/.coverage
+tail -n 10 $COVERAGE_XML
 
 if [[ $OSTYPE == *"linux"* ]]; then
     curl -Os "$CODECOV_BASE_URL/linux/codecov"
     SHA256SUM="32cb14b5f3aaacd67f4c1ff55d82f037d3cd10c8e7b69c051f27391d2e66e15c  codecov"
     echo "$SHA256SUM" | shasum -a256 -c
     chmod +x codecov
-    ./codecov -t ${CODECOV_TOKEN} -R $BUILD_REPOSITORY_LOCALPATH -f .coverage -Z
+    ./codecov -t ${CODECOV_TOKEN} -R $BUILD_REPOSITORY_LOCALPATH -f coverage.xml -Z
 elif [[ $OSTYPE == *"darwin"* ]]; then
     curl -Os "$CODECOV_BASE_URL/macos/codecov"
     SHA256SUM="4ab0f06f06e9c4d25464f155b0aff36bfc1e8dbcdb19bfffd586beed1269f3af  codecov"
     echo "$SHA256SUM" | shasum -a256 -c
     chmod +x codecov
-    ./codecov -t ${CODECOV_TOKEN} -R $BUILD_REPOSITORY_LOCALPATH -f .coverage -Z
+    ./codecov -t ${CODECOV_TOKEN} -R $BUILD_REPOSITORY_LOCALPATH -f coverage.xml -Z
 else
     curl -Os "$CODECOV_BASE_URL/windows/codecov.exe"
     SHA256SUM="e0cda212aeaebe695509ce8fa2d608760ff70bc932003f544f1ad368ac5450a8 codecov.exe"
     echo "$SHA256SUM" | sha256sum -c
-    ./codecov.exe -t ${CODECOV_TOKEN} -R $BUILD_REPOSITORY_LOCALPATH -f .coverage -Z
+    ./codecov.exe -t ${CODECOV_TOKEN} -R $BUILD_REPOSITORY_LOCALPATH -f coverage.xml -Z
 fi


### PR DESCRIPTION
Now that codecov has correctly collected coverage data on `main` after the merge of #26027, let see if we can speed-up the Windows CI by disabling coverage collection for this platform without degrading the test coverage statistics since very few code branches should depend on the windows platform in scikit-learn:

```
git grep sys.platform sklearn
sklearn/_build_utils/openmp_helpers.py:    if sys.platform == "win32":
sklearn/_build_utils/openmp_helpers.py:    elif sys.platform == "darwin" and "openmp" in os.getenv("CPPFLAGS", ""):
sklearn/conftest.py:    elif sys.platform.startswith("win32"):
sklearn/decomposition/tests/test_sparse_pca.py:    if sys.platform == "win32":  # fake parallelism for win32
sklearn/utils/_testing.py:        sys.platform == "darwin", reason="Possible multi-process bug with some BLAS"
```