### PR TITLE
CI ignore more non-library Python files in codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -28,4 +28,7 @@ codecov:
 ignore:
 - "sklearn/externals"
 - "sklearn/_build_utils"
+- "sklearn/__check_build"
+- "sklearn/_min_dependencies.py"
 - "**/setup.py"
+- "**/conftest.py"


### PR DESCRIPTION
To make it easier to spot modules that actually lack test coverage:

https://app.codecov.io/gh/scikit-learn/scikit-learn/tree/main/