### PR TITLE
MAINT parameter validation for d2_absolute_error_score

### DIFF
--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1499,7 +1499,17 @@ def d2_pinball_score(
 
     return np.average(output_scores, weights=avg_weights)
 
-
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_pred": ["array-like"],
+        "sample_weight": ["array-like", None],
+        "multioutput": [
+            StrOptions({"raw_values", "uniform_average"}),
+            "array-like",
+        ],
+    }
+)
 def d2_absolute_error_score(
     y_true, y_pred, *, sample_weight=None, multioutput="uniform_average"
 ):

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1499,6 +1499,7 @@ def d2_pinball_score(
 
     return np.average(output_scores, weights=avg_weights)
 
+
 @validate_params(
     {
         "y_true": ["array-like"],
@@ -1514,8 +1515,7 @@ def d2_absolute_error_score(
     y_true, y_pred, *, sample_weight=None, multioutput="uniform_average"
 ):
     """
-    :math:`D^2` regression score function, \
-    fraction of absolute error explained.
+    :math:`D^2` regression score function, fraction of absolute error explained.
 
     Best possible score is 1.0 and it can be negative (because the model can be
     arbitrarily worse). A model that always uses the empirical median of `y_true`
@@ -1534,7 +1534,7 @@ def d2_absolute_error_score(
     y_pred : array-like of shape (n_samples,) or (n_samples, n_outputs)
         Estimated target values.
 
-    sample_weight : array-like of shape (n_samples,), optional
+    sample_weight : array-like of shape (n_samples,), default=None
         Sample weights.
 
     multioutput : {'raw_values', 'uniform_average'} or array-like of shape \

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -176,6 +176,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.cohen_kappa_score",
     "sklearn.metrics.confusion_matrix",
     "sklearn.metrics.coverage_error",
+    "sklearn.metrics.d2_absolute_error_score",
     "sklearn.metrics.d2_pinball_score",
     "sklearn.metrics.d2_tweedie_score",
     "sklearn.metrics.dcg_score",


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bd7dfcc</samp>

Added parameter validation to the `d2_absolute_error_score` function and updated the corresponding test module. This improves the robustness and consistency of the regression metrics in scikit-learn.