### PR TITLE
MAINT Parameters validation for sklearn.metrics.pairwise.paired_manhattan_distances

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1048,6 +1048,9 @@ def paired_euclidean_distances(X, Y):
     return row_norms(X - Y)
 
 
+@validate_params(
+    {"X": ["array-like", "sparse matrix"], "Y": ["array-like", "sparse matrix"]}
+)
 def paired_manhattan_distances(X, Y):
     """Compute the paired L1 distances between X and Y.
 
@@ -1058,10 +1061,10 @@ def paired_manhattan_distances(X, Y):
 
     Parameters
     ----------
-    X : array-like of shape (n_samples, n_features)
+    X : {array-like, sparse matrix} of shape (n_samples, n_features)
         An array-like where each row is a sample and each column is a feature.
 
-    Y : array-like of shape (n_samples, n_features)
+    Y : {array-like, sparse matrix} of shape (n_samples, n_features)
         An array-like where each row is a sample and each column is a feature.
 
     Returns

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -209,6 +209,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.pairwise.haversine_distances",
     "sklearn.metrics.pairwise.laplacian_kernel",
     "sklearn.metrics.pairwise.linear_kernel",
+    "sklearn.metrics.pairwise.paired_manhattan_distances",
     "sklearn.metrics.precision_recall_curve",
     "sklearn.metrics.precision_recall_fscore_support",
     "sklearn.metrics.precision_score",


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #24862.


#### What does this implement/fix? Explain your changes.

Automatic parameters validation for [sklearn.metrics.pairwise.paired_manhattan_distances](https://github.com/scikit-learn/scikit-learn/blob/c3bfe86b4/sklearn/metrics/pairwise.py#L1042)