### PR TITLE
FIX use correct template name for displays

### DIFF
--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1122,7 +1122,7 @@ See the :ref:`visualizations` section of the user guide for further details.
 
 .. autosummary::
    :toctree: generated/
-   :template: display.rst
+   :template: display_all_class_methods.rst
 
    metrics.ConfusionMatrixDisplay
    metrics.DetCurveDisplay


### PR DESCRIPTION
I think that one file was renamed in #25994 before the merge but the `modules/classes.rst` was not changed accordingly.