### PR TITLE
FIX GroupShuffleSplit raises a ValueError for NaN

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -359,6 +359,9 @@ Changelog
   `return_indices` to return the train-test indices of each cv split.
   :pr:`25659` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- |Fix| :class:`model_selection.GroupShuffleSplit` raises an error if the
+  input contains `pd.NA`. :pr:`26094` by :user:`Rahil Parikh <rprkh>`.
+
 :mod:`sklearn.naive_bayes`
 ..........................
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -21,7 +21,6 @@ from abc import ABCMeta, abstractmethod
 from inspect import signature
 
 import numpy as np
-import pandas as pd
 from scipy.special import comb
 
 from ..utils import indexable, check_random_state, _safe_indexing
@@ -1933,10 +1932,6 @@ class GroupShuffleSplit(ShuffleSplit):
     def _iter_indices(self, X, y, groups):
         if groups is None:
             raise ValueError("The 'groups' parameter should not be None.")
-
-        if pd.Series(groups).isna().sum() != 0:
-            raise ValueError("Input groups contain NaN.")
-
         groups = check_array(groups, input_name="groups", ensure_2d=False, dtype=None)
         classes, group_indices = np.unique(groups, return_inverse=True)
         for group_train, group_test in super()._iter_indices(X=classes):

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1936,7 +1936,7 @@ class GroupShuffleSplit(ShuffleSplit):
 
         if pd.Series(groups).isna().sum() != 0:
             raise ValueError("Input groups contain NaN.")
-            
+
         groups = check_array(groups, input_name="groups", ensure_2d=False, dtype=None)
         classes, group_indices = np.unique(groups, return_inverse=True)
         for group_train, group_test in super()._iter_indices(X=classes):

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -21,6 +21,7 @@ from abc import ABCMeta, abstractmethod
 from inspect import signature
 
 import numpy as np
+import pandas as pd
 from scipy.special import comb
 
 from ..utils import indexable, check_random_state, _safe_indexing
@@ -1932,6 +1933,10 @@ class GroupShuffleSplit(ShuffleSplit):
     def _iter_indices(self, X, y, groups):
         if groups is None:
             raise ValueError("The 'groups' parameter should not be None.")
+
+        if pd.Series(groups).isna().sum() != 0:
+            raise ValueError("Input groups contain NaN.")
+            
         groups = check_array(groups, input_name="groups", ensure_2d=False, dtype=None)
         classes, group_indices = np.unique(groups, return_inverse=True)
         for group_train, group_test in super()._iter_indices(X=classes):

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1,5 +1,6 @@
 """Test the split module"""
 import warnings
+import pandas as pd
 import pytest
 import re
 import numpy as np
@@ -716,6 +717,19 @@ def test_group_shuffle_split_default_test_size(train_size, exp_train, exp_test):
 
     assert len(X_train) == exp_train
     assert len(X_test) == exp_test
+
+
+def test_group_shuffle_split_nan_values():
+    data = pd.DataFrame({"clusters": [1, 2, 3, pd.NA, np.nan], "x": [0, 1, 2, 3, 4]})
+
+    splitter = GroupShuffleSplit(test_size=0.2, n_splits=2, random_state=7)
+
+    error_message = "Input groups contain NaN."
+
+    # raises a value error if the data contains pd.NA or np.nan
+    with pytest.raises(ValueError, match=re.escape(error_message)):
+        split = splitter.split(data, groups=data["clusters"])
+        train_inds, test_inds = next(split)
 
 
 @ignore_warnings

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -719,6 +719,10 @@ def test_group_shuffle_split_default_test_size(train_size, exp_train, exp_test):
 
 
 def test_group_shuffle_split_nan_values():
+    """Check error is raised with pandas NA value.
+
+    Non-regression for gh-24486.
+    """
     pd = pytest.importorskip("pandas")
     data = pd.DataFrame({"clusters": [1, 2, 3, pd.NA, np.nan], "x": [0, 1, 2, 3, 4]})
 

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -725,7 +725,7 @@ def test_group_shuffle_split_nan_values():
     splitter = GroupShuffleSplit(test_size=0.2, n_splits=2, random_state=7)
     split = splitter.split(data, groups=data["clusters"])
 
-    error_message = "Input groups contain NaN."
+    error_message = "Input groups contains NaN."
 
     # raises a value error if the data contains pd.NA or np.nan
     with pytest.raises(ValueError, match=error_message):

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1,6 +1,5 @@
 """Test the split module"""
 import warnings
-import pandas as pd
 import pytest
 import re
 import numpy as np
@@ -720,16 +719,17 @@ def test_group_shuffle_split_default_test_size(train_size, exp_train, exp_test):
 
 
 def test_group_shuffle_split_nan_values():
+    pd = pytest.importorskip("pandas")
     data = pd.DataFrame({"clusters": [1, 2, 3, pd.NA, np.nan], "x": [0, 1, 2, 3, 4]})
 
     splitter = GroupShuffleSplit(test_size=0.2, n_splits=2, random_state=7)
+    split = splitter.split(data, groups=data["clusters"])
 
     error_message = "Input groups contain NaN."
 
     # raises a value error if the data contains pd.NA or np.nan
-    with pytest.raises(ValueError, match=re.escape(error_message)):
-        split = splitter.split(data, groups=data["clusters"])
-        train_inds, test_inds = next(split)
+    with pytest.raises(ValueError, match=error_message):
+        next(split)
 
 
 @ignore_warnings

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -24,7 +24,6 @@ import joblib
 
 from contextlib import suppress
 
-from .fixes import _object_dtype_isnan
 from .. import get_config as _get_config
 from ..exceptions import PositiveSpectrumWarning
 from ..exceptions import NotFittedError
@@ -123,7 +122,7 @@ def _assert_all_finite(
     if X.dtype == np.dtype("object") and not allow_nan:
         if _object_dtype_any_isnan(X):
             padded_input_name = input_name + " " if input_name else ""
-            raise ValueError(f"Input {padded_input_name}contain NaN.")
+            raise ValueError(f"Input {padded_input_name}contains NaN.")
 
     # We need only consider float arrays, hence can early return for all else.
     if not xp.isdtype(X.dtype, ("real floating", "complex floating")):

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -94,6 +94,19 @@ def _deprecate_positional_args(func=None, *, version="1.3"):
     return _inner_deprecate_positional_args
 
 
+def _object_dtype_any_isnan(X):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        try:
+            return (X != X).any()
+        except (DeprecationWarning, TypeError):
+            # Deprecation warning happens because pd.NA uses three-valued logic
+            # returning a pd.NA when comparing pd.NA with anything.
+            # Here we assume that if any comparisons fails, it is due to three-valued
+            # logic. The TypeError is raised by pandas when considering bool(pd.NA).
+            return True
+
+
 def _assert_all_finite(
     X, allow_nan=False, msg_dtype=None, estimator_name=None, input_name=""
 ):
@@ -108,8 +121,9 @@ def _assert_all_finite(
 
     # for object dtype data, we only check for NaNs (GH-13254)
     if X.dtype == np.dtype("object") and not allow_nan:
-        if _object_dtype_isnan(X).any():
-            raise ValueError("Input contains NaN")
+        if _object_dtype_any_isnan(X):
+            padded_input_name = input_name + " " if input_name else ""
+            raise ValueError(f"Input {padded_input_name}contain NaN.")
 
     # We need only consider float arrays, hence can early return for all else.
     if not xp.isdtype(X.dtype, ("real floating", "complex floating")):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #24486

#### What does this implement/fix? Explain your changes.
A ValueError is raised if the input to GroupShuffleSplit contains a `pd.NA` or `np.nan`:

```
import sklearn
import pandas as pd
import numpy as np
from sklearn.model_selection import GroupShuffleSplit

data = pd.DataFrame({"clusters": [1, 2, 3, pd.NA, np.nan],
                    "x" : [0,1,2,3,4]})

splitter = GroupShuffleSplit(test_size=.2, n_splits=2, random_state = 7)
split = splitter.split(data, groups=data['clusters'])
train_inds, test_inds = next(split)
```

Output:
```
ValueError: Input groups contain NaN.
```

#### Any other comments?
The errors for the failing tests seem to be due to [pandas not being found](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=53933&view=logs&j=689a1c8f-ff4e-5689-1a1a-6fa551ae9eba&t=0b7e60d2-0e3c-59af-8129-1150b3e7bf0c&l=211910) on some builds.


