### PR TITLE
FIX Fixes memory regression for inspecting extension arrays

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -452,7 +452,7 @@ Changelog
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 - |FIX| Fixes :func:`utils.validation.check_array` to properly convert pandas
-  extension arrays. :pr:`25813` by `Thomas Fan`_.
+  extension arrays. :pr:`25813` :pr:`xxxxx` by `Thomas Fan`_.
 
 - |Fix| :func:`utils.validation.check_array` now suports pandas DataFrames with
   extension arrays and object dtypes by return an ndarray with object dtype.

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -452,7 +452,7 @@ Changelog
   :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 - |FIX| Fixes :func:`utils.validation.check_array` to properly convert pandas
-  extension arrays. :pr:`25813` :pr:`xxxxx` by `Thomas Fan`_.
+  extension arrays. :pr:`25813` and :pr:`26106` by `Thomas Fan`_.
 
 - |Fix| :func:`utils.validation.check_array` now suports pandas DataFrames with
   extension arrays and object dtypes by return an ndarray with object dtype.

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -628,12 +628,8 @@ def _pandas_dtype_needs_early_conversion(pd_dtype):
 
 
 def _is_extension_array_dtype(array):
-    try:
-        from pandas.api.types import is_extension_array_dtype
-
-        return is_extension_array_dtype(array)
-    except ImportError:
-        return False
+    # Pandas extension arrays have a dtype with an na_value
+    return hasattr(array, "dtype") and hasattr(array.dtype, "na_value")
 
 
 def check_array(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/26098

#### What does this implement/fix? Explain your changes.
The pandas import is increasing the memory usage. This PR uses the interface for panda's [ExtensionDtype](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.api.extensions.ExtensionDtype.html), so that we do not need to import pandas to perform the check.

For reference, https://github.com/scikit-learn/scikit-learn/commit/18af5508013d8497b0449c059b9a794c9643735a added this import and it already includes a test to make sure the code in this PR works.

#### Any other comments?
I confirmed that this PR fixed the regression by running `asv run -b KNeighborsClassifierBenchmark.peakmem_fit HEAD^!`, which resulted in:

#### This PR

```bash
[100.00%] ··· =========== ========= ==========
              --           dimension / n_jobs
              ----------- --------------------
               algorithm   low / 1   high / 1
              =========== ========= ==========
                 brute       104M      107M
                kd_tree      107M      116M
               ball_tree     106M      114M
              =========== ========= ==========
```

#### On Main

```bash
[100.00%] ··· =========== ========= ==========
              --           dimension / n_jobs
              ----------- --------------------
               algorithm   low / 1   high / 1
              =========== ========= ==========
                 brute       129M      131M
                kd_tree      130M      140M
               ball_tree     129M      140M
              =========== ========= ==========
```

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
