### PR TITLE
MNT Adds black commit to git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -25,3 +25,6 @@
 
 # PR 22983: Update to Black 22.3.0
 d4aad64b1eb2e42e76f49db2ccfbe4b4660d092b
+
+# PR 26110: Update black to 23.3.0
+893d5accaf9d16f447645e704f85a216187564f7


### PR DESCRIPTION
Follow up to #26110 

This PR adds https://github.com/scikit-learn/scikit-learn/commit/893d5accaf9d16f447645e704f85a216187564f7 to `.git-blame-ignore-revs`