### PR TITLE
MAINT Parameters validation for sklearn.metrics.mean_poisson_deviance

### DIFF
--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1172,6 +1172,13 @@ def mean_tweedie_deviance(y_true, y_pred, *, sample_weight=None, power=0):
     )
 
 
+@validate_params(
+    {
+        "y_true": ["array-like"],
+        "y_pred": ["array-like"],
+        "sample_weight": ["array-like", None],
+    }
+)
 def mean_poisson_deviance(y_true, y_pred, *, sample_weight=None):
     """Mean Poisson deviance regression loss.
 

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -199,6 +199,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.mean_absolute_percentage_error",
     "sklearn.metrics.mean_gamma_deviance",
     "sklearn.metrics.mean_pinball_loss",
+    "sklearn.metrics.mean_poisson_deviance",
     "sklearn.metrics.mean_squared_error",
     "sklearn.metrics.mean_squared_log_error",
     "sklearn.metrics.mean_tweedie_deviance",


### PR DESCRIPTION

#### Reference Issues/PRs
Towards #24862

#### What does this implement/fix? Explain your changes.
Adding validating parameters decorator to metrics.mean_poisson_deviance.
