### PR TITLE
FIX Keeps namedtuple's class when transform returns a tuple

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -166,6 +166,9 @@ Changelog
 - |Feature| A `__sklearn_clone__` protocol is now available to override the
   default behavior of :func:`base.clone`. :pr:`24568` by `Thomas Fan`_.
 
+- |Fix| :class:`base.TransformerMixin` now currently keeps a namedtuple's class
+  if `transform` returns a namedtuple. :pr:`xxxxx` by `Thomas Fan`_.
+
 :mod:`sklearn.calibration`
 ..........................
 

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -167,7 +167,7 @@ Changelog
   default behavior of :func:`base.clone`. :pr:`24568` by `Thomas Fan`_.
 
 - |Fix| :class:`base.TransformerMixin` now currently keeps a namedtuple's class
-  if `transform` returns a namedtuple. :pr:`xxxxx` by `Thomas Fan`_.
+  if `transform` returns a namedtuple. :pr:`26121` by `Thomas Fan`_.
 
 :mod:`sklearn.calibration`
 ..........................

--- a/sklearn/utils/_set_output.py
+++ b/sklearn/utils/_set_output.py
@@ -144,7 +144,7 @@ def _wrap_method_output(f, method):
                 _wrap_data_with_container(method, data_to_wrap[0], X, self),
                 *data_to_wrap[1:],
             )
-            # `_make` is a documented API for named tuples:
+            # Support for namedtuples `_make` is a documented API for namedtuples:
             # https://docs.python.org/3/library/collections.html#collections.somenamedtuple._make
             if hasattr(type(data_to_wrap), "_make"):
                 return type(data_to_wrap)._make(return_tuple)

--- a/sklearn/utils/_set_output.py
+++ b/sklearn/utils/_set_output.py
@@ -140,10 +140,15 @@ def _wrap_method_output(f, method):
         data_to_wrap = f(self, X, *args, **kwargs)
         if isinstance(data_to_wrap, tuple):
             # only wrap the first output for cross decomposition
-            return type(data_to_wrap)(
+            return_tuple = (
                 _wrap_data_with_container(method, data_to_wrap[0], X, self),
                 *data_to_wrap[1:],
             )
+            # `_make` is a documented API for named tuples:
+            # https://docs.python.org/3/library/collections.html#collections.somenamedtuple._make
+            if hasattr(type(data_to_wrap), "_make"):
+                return type(data_to_wrap)._make(return_tuple)
+            return return_tuple
 
         return _wrap_data_with_container(method, data_to_wrap, X, self)
 

--- a/sklearn/utils/_set_output.py
+++ b/sklearn/utils/_set_output.py
@@ -140,7 +140,7 @@ def _wrap_method_output(f, method):
         data_to_wrap = f(self, X, *args, **kwargs)
         if isinstance(data_to_wrap, tuple):
             # only wrap the first output for cross decomposition
-            return (
+            return type(data_to_wrap)(
                 _wrap_data_with_container(method, data_to_wrap[0], X, self),
                 *data_to_wrap[1:],
             )

--- a/sklearn/utils/tests/test_set_output.py
+++ b/sklearn/utils/tests/test_set_output.py
@@ -1,4 +1,5 @@
 import pytest
+from collections import namedtuple
 
 import numpy as np
 from scipy.sparse import csr_matrix
@@ -292,3 +293,21 @@ def test_set_output_pandas_keep_index():
 
     X_trans = est.transform(X)
     assert_array_equal(X_trans.index, ["s0", "s1"])
+
+
+class EstimatorReturnTuple(_SetOutputMixin):
+    def __init__(self, OutputTuple):
+        self.OutputTuple = OutputTuple
+
+    def transform(self, X, y=None):
+        return self.OutputTuple(X, 2 * X)
+
+
+def test_set_output_named_tuple_out():
+    """Check that namedtuples are kept by default."""
+    Output = namedtuple("Output", "X, y")
+    X = np.asarray([[1, 2, 3]])
+    est = EstimatorReturnTuple(OutputTuple=Output)
+    X_trans = est.transform(X)
+
+    assert isinstance(X_trans, Output)

--- a/sklearn/utils/tests/test_set_output.py
+++ b/sklearn/utils/tests/test_set_output.py
@@ -305,9 +305,11 @@ class EstimatorReturnTuple(_SetOutputMixin):
 
 def test_set_output_named_tuple_out():
     """Check that namedtuples are kept by default."""
-    Output = namedtuple("Output", "X, y")
+    Output = namedtuple("Output", "X, Y")
     X = np.asarray([[1, 2, 3]])
     est = EstimatorReturnTuple(OutputTuple=Output)
     X_trans = est.transform(X)
 
     assert isinstance(X_trans, Output)
+    assert_array_equal(X_trans.X, X)
+    assert_array_equal(X_trans.Y, 2 * X)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/scikit-learn/scikit-learn/issues/4143#issuecomment-1462597795

#### What does this implement/fix? Explain your changes.
This PR allows a namedtuple's class to be retained in `transform`. Although we do not used namedtuples in the library, I think the fix is simple enough to include.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
