### PR TITLE
MAINT Parameters validation for sklearn.metrics.davies_bouldin_score 

### DIFF
--- a/sklearn/metrics/cluster/_unsupervised.py
+++ b/sklearn/metrics/cluster/_unsupervised.py
@@ -352,6 +352,12 @@ def calinski_harabasz_score(X, labels):
     )
 
 
+@validate_params(
+    {
+        "X": ["array-like"],
+        "labels": ["array-like"],
+    }
+)
 def davies_bouldin_score(X, labels):
     """Compute the Davies-Bouldin score.
 

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -180,6 +180,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.d2_absolute_error_score",
     "sklearn.metrics.d2_pinball_score",
     "sklearn.metrics.d2_tweedie_score",
+    "sklearn.metrics.davies_bouldin_score",
     "sklearn.metrics.dcg_score",
     "sklearn.metrics.det_curve",
     "sklearn.metrics.explained_variance_score",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards https://github.com/scikit-learn/scikit-learn/issues/24862

#### What does this implement/fix? Explain your changes.
Add automatic parameter validation for [klearn.metrics.davies_bouldin_score](https://github.com/scikit-learn/scikit-learn/blob/c3bfe86b4/sklearn/metrics/cluster/_unsupervised.py#L332)

#### Any other comments?
X, labels = check_X_y(X, labels) can not be deleted,
as it is necessary to check X is 2 dimensional and the label is 1 dimensional

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
