### PR TITLE
MAINT: remove `from numpy.math cimport` statements

### DIFF
--- a/sklearn/decomposition/_online_lda_fast.pyx
+++ b/sklearn/decomposition/_online_lda_fast.pyx
@@ -6,7 +6,6 @@ import numpy as np
 cnp.import_array()
 
 from libc.math cimport exp, fabs, log
-from numpy.math cimport EULER
 
 
 def mean_change(const floating[:] arr_1, const floating[:] arr_2):
@@ -91,6 +90,7 @@ def _dirichlet_expectation_2d(const floating[:, :] arr):
 # After: J. Bernardo (1976). Algorithm AS 103: Psi (Digamma) Function.
 # https://www.uv.es/~bernardo/1976AppStatist.pdf
 cdef floating psi(floating x) noexcept nogil:
+    cdef double EULER = 0.577215664901532860606512090082402431
     if x <= 1e-6:
         # psi(x) = -EULER - 1/x + O(x)
         return -EULER - 1. / x

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -10,9 +10,9 @@
 cimport cython
 from cython.parallel import prange
 import numpy as np
+from libc.math cimport INFINITY
 from libc.stdlib cimport malloc, free, qsort
 from libc.string cimport memcpy
-from numpy.math cimport INFINITY
 
 from .common cimport X_BINNED_DTYPE_C
 from .common cimport Y_DTYPE_C

--- a/sklearn/linear_model/_sgd_fast.pyx.tp
+++ b/sklearn/linear_model/_sgd_fast.pyx.tp
@@ -30,9 +30,8 @@ from cython cimport floating
 import numpy as np
 from time import time
 
-from libc.math cimport exp, log, pow, fabs
+from libc.math cimport exp, log, pow, fabs, INFINITY
 cimport numpy as cnp
-from numpy.math cimport INFINITY
 cdef extern from "_sgd_fast_helpers.h":
     bint skl_isfinite32(float) nogil
     bint skl_isfinite64(double) nogil

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -14,13 +14,12 @@
 
 from libc.string cimport memcpy
 from libc.string cimport memset
-from libc.math cimport fabs
+from libc.math cimport fabs, INFINITY
 
 import numpy as np
 cimport numpy as cnp
 cnp.import_array()
 
-from numpy.math cimport INFINITY
 from scipy.special.cython_special cimport xlogy
 
 from ._utils cimport log

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -8,12 +8,11 @@
 
 #!python
 
-from libc.math cimport fabs, sqrt
+from libc.math cimport fabs, sqrt, isnan
 cimport numpy as cnp
 import numpy as np
 from cython cimport floating
 from cython.parallel cimport prange
-from numpy.math cimport isnan
 
 from sklearn.utils._openmp_helpers import _openmp_effective_n_threads
 


### PR DESCRIPTION
All C99 constants and functions are available from Cython's `libc`, which is cleaner. NumPy would like to get rid of shipping libnpymath, and has also deprecated the (unrelated) `numpy.math` in the Python API. Finally, numpy is shipping its own `__init__.pxd` now, but not `math.pxd` - so the latter should be considered legacy at this point. Therefore, best to not use Cython's `numpy.math` at all.