### PR TITLE
MAINT Parameters validation for sklearn.inspection.permutation_importance

### DIFF
--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -10,6 +10,13 @@ from ..utils import Bunch, _safe_indexing
 from ..utils import check_random_state
 from ..utils import check_array
 from ..utils.parallel import delayed, Parallel
+from ..utils._param_validation import (
+    HasMethods,
+    Integral,
+    Interval,
+    RealNotInt,
+    validate_params,
+)
 
 
 def _weights_scorer(scorer, estimator, X, y, sample_weight):
@@ -99,6 +106,22 @@ def _create_importances_bunch(baseline_score, permuted_score):
     )
 
 
+@validate_params(
+    {
+        "estimator": [HasMethods(["fit"])],
+        "X": ["array-like"],
+        "y": ["array-like", None],
+        "scoring": [str, callable, list, tuple, dict, None],
+        "n_repeats": [Interval(Integral, 1, None, closed="left")],
+        "n_jobs": [Integral, None],
+        "random_state": ["random_state"],
+        "sample_weight": ["array-like", None],
+        "max_samples": [
+            Interval(Integral, 1, None, closed="left"),
+            Interval(RealNotInt, 0, 1, closed="right"),
+        ],
+    }
+)
 def permutation_importance(
     estimator,
     X,
@@ -242,7 +265,7 @@ def permutation_importance(
 
     if not isinstance(max_samples, numbers.Integral):
         max_samples = int(max_samples * X.shape[0])
-    elif not (0 < max_samples <= X.shape[0]):
+    elif max_samples > X.shape[0]:
         raise ValueError("max_samples must be in (0, n_samples]")
 
     if callable(scoring):

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -266,7 +266,7 @@ def permutation_importance(
     if not isinstance(max_samples, numbers.Integral):
         max_samples = int(max_samples * X.shape[0])
     elif max_samples > X.shape[0]:
-        raise ValueError("max_samples must be in (0, n_samples]")
+        raise ValueError("max_samples must be <= n_samples")
 
     if callable(scoring):
         scorer = scoring

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -3,7 +3,7 @@ import numbers
 import numpy as np
 
 from ..ensemble._bagging import _generate_indices
-from ..metrics import check_scoring
+from ..metrics import check_scoring, get_scorer_names
 from ..metrics._scorer import _check_multimetric_scoring, _MultimetricScorer
 from ..model_selection._validation import _aggregate_score_dicts
 from ..utils import Bunch, _safe_indexing
@@ -15,6 +15,7 @@ from ..utils._param_validation import (
     Integral,
     Interval,
     RealNotInt,
+    StrOptions,
     validate_params,
 )
 
@@ -111,7 +112,14 @@ def _create_importances_bunch(baseline_score, permuted_score):
         "estimator": [HasMethods(["fit"])],
         "X": ["array-like"],
         "y": ["array-like", None],
-        "scoring": [str, callable, list, tuple, dict, None],
+        "scoring": [
+            StrOptions(set(get_scorer_names())),
+            callable,
+            list,
+            tuple,
+            dict,
+            None,
+        ],
         "n_repeats": [Interval(Integral, 1, None, closed="left")],
         "n_jobs": [Integral, None],
         "random_state": ["random_state"],

--- a/sklearn/inspection/tests/test_permutation_importance.py
+++ b/sklearn/inspection/tests/test_permutation_importance.py
@@ -535,7 +535,7 @@ def test_permutation_importance_max_samples_error():
     clf = LogisticRegression()
     clf.fit(X, y)
 
-    err_msg = r"max_samples must be in \(0, n_samples\]"
+    err_msg = r"max_samples must be <= n_samples"
 
     with pytest.raises(ValueError, match=err_msg):
         permutation_importance(clf, X, y, max_samples=5)

--- a/sklearn/inspection/tests/test_permutation_importance.py
+++ b/sklearn/inspection/tests/test_permutation_importance.py
@@ -525,8 +525,7 @@ def test_permutation_importance_multi_metric(list_single_scorer, multi_scorer):
         assert_allclose(multi_result.importances, single_result.importances)
 
 
-@pytest.mark.parametrize("max_samples", [-1, 5])
-def test_permutation_importance_max_samples_error(max_samples):
+def test_permutation_importance_max_samples_error():
     """Check that a proper error message is raised when `max_samples` is not
     set to a valid input value.
     """
@@ -539,4 +538,4 @@ def test_permutation_importance_max_samples_error(max_samples):
     err_msg = r"max_samples must be in \(0, n_samples\]"
 
     with pytest.raises(ValueError, match=err_msg):
-        permutation_importance(clf, X, y, max_samples=max_samples)
+        permutation_importance(clf, X, y, max_samples=5)

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -160,6 +160,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.feature_selection.mutual_info_classif",
     "sklearn.feature_selection.mutual_info_regression",
     "sklearn.feature_selection.r_regression",
+    "sklearn.inspection.permutation_importance",
     "sklearn.linear_model.orthogonal_mp",
     "sklearn.metrics.accuracy_score",
     "sklearn.metrics.auc",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #24862.


#### What does this implement/fix? Explain your changes.
Add automatic parameter validation for sklearn.inspection.permutation_importance.

#### Any other comments?
Currently `max_samples` can only be in (0, X.shape[0]], and a specific ValueError will be raised if it is out of the range.

Do you think it is better to set `max_sample=X.shape[0]` when users specify a `max_sample` larger than X.shape[0]? In this case the test that checks this error message can also be removed.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
