### PR TITLE
FIX tol in SGDRegressorBenchmark

### DIFF
--- a/asv_benchmarks/benchmarks/common.py
+++ b/asv_benchmarks/benchmarks/common.py
@@ -9,9 +9,6 @@ from multiprocessing import cpu_count
 
 import numpy as np
 
-from sklearn.exceptions import ConvergenceWarning
-from sklearn.utils._testing import ignore_warnings
-
 
 def get_from_config():
     """Get benchmarks configuration from the config.json file"""
@@ -181,8 +178,7 @@ class Estimator(ABC):
         self.make_scorers()
 
     def time_fit(self, *args):
-        with ignore_warnings(category=ConvergenceWarning):
-            self.estimator.fit(self.X, self.y)
+        self.estimator.fit(self.X, self.y)
 
     def peakmem_fit(self, *args):
         self.estimator.fit(self.X, self.y)

--- a/asv_benchmarks/benchmarks/common.py
+++ b/asv_benchmarks/benchmarks/common.py
@@ -9,6 +9,9 @@ from multiprocessing import cpu_count
 
 import numpy as np
 
+from sklearn.exceptions import ConvergenceWarning
+from sklearn.utils._testing import ignore_warnings
+
 
 def get_from_config():
     """Get benchmarks configuration from the config.json file"""
@@ -178,7 +181,8 @@ class Estimator(ABC):
         self.make_scorers()
 
     def time_fit(self, *args):
-        self.estimator.fit(self.X, self.y)
+        with ignore_warnings(category=ConvergenceWarning):
+            self.estimator.fit(self.X, self.y)
 
     def peakmem_fit(self, *args):
         self.estimator.fit(self.X, self.y)

--- a/asv_benchmarks/benchmarks/linear_model.py
+++ b/asv_benchmarks/benchmarks/linear_model.py
@@ -1,3 +1,4 @@
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import (
     LogisticRegression,
     Ridge,
@@ -6,6 +7,7 @@ from sklearn.linear_model import (
     LinearRegression,
     SGDRegressor,
 )
+from sklearn.utils._testing import ignore_warnings
 
 from .common import Benchmark, Estimator, Predictor
 from .datasets import (
@@ -164,12 +166,18 @@ class SGDRegressorBenchmark(Predictor, Estimator, Benchmark):
         return data
 
     def make_estimator(self, params):
-        estimator = SGDRegressor(max_iter=1000, tol=1e-16, random_state=0)
+        estimator = SGDRegressor(max_iter=1000, tol=None, random_state=0)
 
         return estimator
 
     def make_scorers(self):
         make_gen_reg_scorers(self)
+
+    def time_fit(self, *args):
+        with ignore_warnings(category=ConvergenceWarning):
+            self.estimator.fit(self.X, self.y)
+
+        assert self.estimator.n_iter_ == self.estimator.max_iter
 
 
 class ElasticNetBenchmark(Predictor, Estimator, Benchmark):

--- a/asv_benchmarks/benchmarks/linear_model.py
+++ b/asv_benchmarks/benchmarks/linear_model.py
@@ -1,4 +1,3 @@
-from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import (
     LogisticRegression,
     Ridge,
@@ -7,7 +6,6 @@ from sklearn.linear_model import (
     LinearRegression,
     SGDRegressor,
 )
-from sklearn.utils._testing import ignore_warnings
 
 from .common import Benchmark, Estimator, Predictor
 from .datasets import (
@@ -166,18 +164,14 @@ class SGDRegressorBenchmark(Predictor, Estimator, Benchmark):
         return data
 
     def make_estimator(self, params):
-        estimator = SGDRegressor(max_iter=1000, tol=None, random_state=0)
+        (representation,) = params
+        max_iter = 60 if representation == "dense" else 300
+        estimator = SGDRegressor(max_iter=max_iter, tol=None, random_state=0)
 
         return estimator
 
     def make_scorers(self):
         make_gen_reg_scorers(self)
-
-    def time_fit(self, *args):
-        with ignore_warnings(category=ConvergenceWarning):
-            self.estimator.fit(self.X, self.y)
-
-        assert self.estimator.n_iter_ == self.estimator.max_iter
 
 
 class ElasticNetBenchmark(Predictor, Estimator, Benchmark):

--- a/asv_benchmarks/benchmarks/linear_model.py
+++ b/asv_benchmarks/benchmarks/linear_model.py
@@ -165,7 +165,9 @@ class SGDRegressorBenchmark(Predictor, Estimator, Benchmark):
 
     def make_estimator(self, params):
         (representation,) = params
+
         max_iter = 60 if representation == "dense" else 300
+
         estimator = SGDRegressor(max_iter=max_iter, tol=None, random_state=0)
 
         return estimator


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #26095

#### What does this implement/fix? Explain your changes.
- Sets the value of tol to None for SGDRegressorBenchmark
- Catches the ConvergenceWarning and assets that the n_iter_ is equal to max_iter to clarify that the benchmark runs for max_iters.

#### Any other comments?
CC: @ogrisel @jeremiedbb @glemaitre 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
