### PR TITLE
MAINT Parameters validation for manhattan_distances

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -35,6 +35,7 @@ from ..utils._param_validation import (
     Real,
     Hidden,
     MissingValues,
+    StrOptions,
 )
 
 from ._pairwise_distances_reduction import ArgKmin
@@ -904,6 +905,13 @@ def haversine_distances(X, Y=None):
     return DistanceMetric.get_metric("haversine").pairwise(X, Y)
 
 
+@validate_params(
+    {
+        "X": ["array-like", "sparse matrix"],
+        "Y": ["array-like", "sparse matrix", None],
+        "sum_over_features": ["boolean", Hidden(StrOptions({"deprecated"}))],
+    }
+)
 def manhattan_distances(X, Y=None, *, sum_over_features="deprecated"):
     """Compute the L1 distances between the vectors in X and Y.
 

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -242,6 +242,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.tree.export_text",
     "sklearn.tree.plot_tree",
     "sklearn.utils.gen_batches",
+    "sklearn.metrics.pairwise.manhattan_distances",
 ]
 
 


### PR DESCRIPTION

#### Reference Issues/PRs
Towards #24862

#### What does this implement/fix? Explain your changes.
Add automatic parameter validation for "sklearn.metrics.pairwise.manhattan_distances".
