### PR TITLE
FIX `roc_auc_score` now uses `y_prob` instead of `y_pred`

### DIFF
--- a/examples/calibration/plot_calibration_curve.py
+++ b/examples/calibration/plot_calibration_curve.py
@@ -155,15 +155,18 @@ for i, (clf, name) in enumerate(clf_list):
     y_pred = clf.predict(X_test)
     scores["Classifier"].append(name)
 
-    for metric in [brier_score_loss, log_loss]:
+    for metric in [brier_score_loss, log_loss, roc_auc_score]:
         score_name = metric.__name__.replace("_", " ").replace("score", "").capitalize()
         scores[score_name].append(metric(y_test, y_prob[:, 1]))
 
-    for metric in [precision_score, recall_score, f1_score, roc_auc_score]:
+    for metric in [precision_score, recall_score, f1_score]:
         score_name = metric.__name__.replace("_", " ").replace("score", "").capitalize()
         scores[score_name].append(metric(y_test, y_pred))
 
     score_df = pd.DataFrame(scores).set_index("Classifier")
+    score_df = score_df[
+        ["Brier  loss", "Log loss", "Precision ", "Recall ", "F1 ", "Roc auc "]
+    ]
     score_df.round(decimals=3)
 
 score_df
@@ -300,15 +303,18 @@ for i, (clf, name) in enumerate(clf_list):
     y_pred = clf.predict(X_test)
     scores["Classifier"].append(name)
 
-    for metric in [brier_score_loss, log_loss]:
+    for metric in [brier_score_loss, log_loss, roc_auc_score]:
         score_name = metric.__name__.replace("_", " ").replace("score", "").capitalize()
         scores[score_name].append(metric(y_test, y_prob[:, 1]))
 
-    for metric in [precision_score, recall_score, f1_score, roc_auc_score]:
+    for metric in [precision_score, recall_score, f1_score]:
         score_name = metric.__name__.replace("_", " ").replace("score", "").capitalize()
         scores[score_name].append(metric(y_test, y_pred))
 
     score_df = pd.DataFrame(scores).set_index("Classifier")
+    score_df = score_df[
+        ["Brier  loss", "Log loss", "Precision ", "Recall ", "F1 ", "Roc auc "]
+    ]
     score_df.round(decimals=3)
 
 score_df

--- a/examples/calibration/plot_calibration_curve.py
+++ b/examples/calibration/plot_calibration_curve.py
@@ -164,9 +164,6 @@ for i, (clf, name) in enumerate(clf_list):
         scores[score_name].append(metric(y_test, y_pred))
 
     score_df = pd.DataFrame(scores).set_index("Classifier")
-    score_df = score_df[
-        ["Brier  loss", "Log loss", "Precision ", "Recall ", "F1 ", "Roc auc "]
-    ]
     score_df.round(decimals=3)
 
 score_df
@@ -312,9 +309,6 @@ for i, (clf, name) in enumerate(clf_list):
         scores[score_name].append(metric(y_test, y_pred))
 
     score_df = pd.DataFrame(scores).set_index("Classifier")
-    score_df = score_df[
-        ["Brier  loss", "Log loss", "Precision ", "Recall ", "F1 ", "Roc auc "]
-    ]
     score_df.round(decimals=3)
 
 score_df


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #25571

#### What does this implement/fix? Explain your changes.
`roc_auc_score` now uses `y_prob` instead of `y_pred` for `plot_calibration_curve.py`

#### Any other comments?