### PR TITLE
MAINT remove deprecated is_categorical_dtype

### DIFF
--- a/sklearn/datasets/_arff_parser.py
+++ b/sklearn/datasets/_arff_parser.py
@@ -427,7 +427,7 @@ def _pandas_arff_parser(
     categorical_columns = [
         name
         for name, dtype in frame.dtypes.items()
-        if pd.api.types.is_categorical_dtype(dtype)
+        if isinstance(dtype, pd.CategoricalDtype)
     ]
     for col in categorical_columns:
         frame[col] = frame[col].cat.rename_categories(strip_single_quotes)
@@ -442,7 +442,7 @@ def _pandas_arff_parser(
     categories = {
         name: dtype.categories.tolist()
         for name, dtype in frame.dtypes.items()
-        if pd.api.types.is_categorical_dtype(dtype)
+        if isinstance(dtype, pd.CategoricalDtype)
     }
     return X, y, None, categories
 

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -376,7 +376,7 @@ def test_fetch_openml_consistency_parser(monkeypatch, data_id):
         pandas_series = frame_pandas[series.name]
         if pd.api.types.is_numeric_dtype(pandas_series):
             return series.astype(pandas_series.dtype)
-        elif pd.api.types.is_categorical_dtype(pandas_series):
+        elif isinstance(pandas_series.dtype, pd.CategoricalDtype):
             # Compare categorical features by converting categorical liac uses
             # strings to denote the categories, we rename the categories to make
             # them comparable to the pandas parser. Fixing this behavior in


### PR DESCRIPTION
Avoid using `is_categorical_dtype` due to deprecation: xref https://github.com/pandas-dev/pandas/pull/52527/

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6263051</samp>

### Summary
🛠️🚨🧹

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate the change to the `convert_numerical_and_categorical_dtypes` function, which is a helper function for testing and debugging.
2.  🚨 - This emoji represents a warning or an alert, and can be used to indicate the change to avoid the deprecation warning from pandas, which could cause future issues or errors if not addressed.
3.  🧹 - This emoji represents a broom or a cleanup, and can be used to indicate the change to improve code consistency and readability, which makes the code more maintainable and easier to understand.
-->
This pull request fixes a deprecation warning from pandas by using `isinstance` to check for categorical dtypes in the ARFF parser and the corresponding test. It also improves code consistency in `sklearn/datasets/_arff_parser.py` and `sklearn/datasets/tests/test_openml.py`.

> _Sing, O Muse, of the skillful code reviewers_
> _Who spotted the warning from the wise pandas_
> _And urged the swift coder to change his function_
> _That converts the types of the data columns_

### Walkthrough
*  Replace `pd.api.types.is_categorical_dtype` with `isinstance(dtype, pd.CategoricalDtype)` to check for categorical columns and avoid deprecation warning from pandas ([link](https://github.com/scikit-learn/scikit-learn/pull/26156/files?diff=unified&w=0#diff-b59ff32eec21d8678252097d53678f443a4ccd5759717a195dd30fff12dc5ed2L430-R430), [link](https://github.com/scikit-learn/scikit-learn/pull/26156/files?diff=unified&w=0#diff-b59ff32eec21d8678252097d53678f443a4ccd5759717a195dd30fff12dc5ed2L445-R445), [link](https://github.com/scikit-learn/scikit-learn/pull/26156/files?diff=unified&w=0#diff-100fa77e7a4ebdf96d3ed58771fea073f25ca409d33d0b31d012c46b6ba0b26eL379-R379))
*  Update `test_fetch_openml_consistency_parser` to use the same dtype check as the main code in `sklearn/datasets/_arff_parser.py` ([link](https://github.com/scikit-learn/scikit-learn/pull/26156/files?diff=unified&w=0#diff-100fa77e7a4ebdf96d3ed58771fea073f25ca409d33d0b31d012c46b6ba0b26eL379-R379))

