### PR TITLE
Fix confusion_matrix to autodetect number of classes

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -238,7 +238,7 @@ def accuracy_score(y_true, y_pred, *, normalize=True, sample_weight=None):
     }
 )
 def confusion_matrix(
-    y_true, y_pred, *, labels=None, sample_weight=None, normalize=None
+    y_true, y_pred, *, num_classes=None, labels=None, sample_weight=None, normalize=None
 ):
     """Compute confusion matrix to evaluate the accuracy of a classification.
 
@@ -327,7 +327,10 @@ def confusion_matrix(
         raise ValueError("%s is not supported" % y_type)
 
     if labels is None:
-        labels = unique_labels(y_true, y_pred)
+        if num_classes is None:
+            labels = unique_labels(y_true, y_pred)
+        else:
+            labels = np.arange(num_classes)
     else:
         labels = np.asarray(labels)
         n_labels = labels.size


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Fixes #26158. 
-->

Related to discussion in issue #26158.

#### What does this implement/fix? Explain your changes.

This PR updates the `confusion_matrix` function in `sklearn/metrics/_classification.py` to automatically detect the number of classes in the input data via the use of a keyword argument, even if some classes are not present in the predictions or ground truth labels. This change ensures that the confusion matrix will always have the expected dimensions, even when the model predicts all samples as a single class.

#### Any other comments?

This change will prevent undesired behaviour and errors. Typically, users will expect an NxN matrix to be produced, and this fix will ensure this happens.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
