### PR TITLE
DOC Use Scientific Python Plausible instance for stable doc analytics

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -171,7 +171,8 @@ html_theme = "scikit-learn-modern"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "google_analytics": True,
+    "legacy_google_analytics": True,
+    "analytics": True,
     "mathjax_path": mathjax_path,
     "link_to_live_contributing_page": not parsed_version.is_devrelease,
 }

--- a/doc/themes/scikit-learn-modern/javascript.html
+++ b/doc/themes/scikit-learn-modern/javascript.html
@@ -1,4 +1,4 @@
-{% if theme_google_analytics|tobool %}
+{% if theme_legacy_google_analytics|tobool %}
 <script>
     window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
     ga('create', 'UA-22606712-2', 'auto');
@@ -6,6 +6,11 @@
     ga('send', 'pageview');
 </script>
 <script async src='https://www.google-analytics.com/analytics.js'></script>
+{% endif %}
+
+{% if theme_analytics|tobool %}
+<script defer data-domain="scikit-learn.org" src="https://views.scientific-python.org/js/script.js">
+</script>
 {% endif %}
 
 <script>

--- a/doc/themes/scikit-learn-modern/theme.conf
+++ b/doc/themes/scikit-learn-modern/theme.conf
@@ -4,6 +4,7 @@ pygments_style = default
 stylesheet = css/theme.css
 
 [options]
-google_analytics = true
+legacy_google_analytics = true
+analytics = true
 link_to_live_contributing_page = false
 mathjax_path =


### PR DESCRIPTION
#### Reference Issues/PRs

This is a backport of https://github.com/scikit-learn/scikit-learn/pull/25547 targetting the `1.2.X` branch.

#### What does this implement/fix? Explain your changes.

This adds the Scientific Python Plausible instance. A quick comparison on the dev doc seems to indicate Google Analytics and Plausible are in the same ball park see https://github.com/scikit-learn/scikit-learn/pull/25547#issuecomment-1504902376.
