### PR TITLE
MAINT Parameters validation for sklearn.datasets.fetch_species_distributions

### DIFF
--- a/sklearn/datasets/_species_distributions.py
+++ b/sklearn/datasets/_species_distributions.py
@@ -51,6 +51,7 @@ from ._base import _fetch_remote
 from ._base import RemoteFileMetadata
 from ..utils import Bunch
 from ._base import _pkl_filepath
+from ..utils._param_validation import validate_params
 
 # The original data can be found at:
 # https://biodiversityinformatics.amnh.org/open_source/maxent/samples.zip
@@ -137,6 +138,7 @@ def construct_grids(batch):
     return (xgrid, ygrid)
 
 
+@validate_params({"data_home": [str, None], "download_if_missing": ["boolean"]})
 def fetch_species_distributions(*, data_home=None, download_if_missing=True):
     """Loader for species distribution dataset from Phillips et. al. (2006).
 

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -128,6 +128,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.datasets.fetch_lfw_people",
     "sklearn.datasets.fetch_olivetti_faces",
     "sklearn.datasets.fetch_rcv1",
+    "sklearn.datasets.fetch_species_distributions",
     "sklearn.datasets.load_svmlight_file",
     "sklearn.datasets.load_svmlight_files",
     "sklearn.datasets.make_biclusters",


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #24862.

#### What does this implement/fix? Explain your changes.

Automatic parameters validation for [sklearn.datasets.fetch_species_distributions](https://github.com/scikit-learn/scikit-learn/blob/c3bfe86b4/sklearn/datasets/_species_distributions.py#L140)

#### Any other comments?

I'm failing `pytest -vl sklearn/tests/test_public_functions.py` even with the main branch. I think it might be due to this commit: [`cf3573e`](https://github.com/scikit-learn/scikit-learn/commit/cf3573ee90c541c82d22b80d57c9dec7d99fc58d). Not sure if it is my local issue.

*Update: no problem now, fixed after locally running `pip install --no-build-isolation --editable .`*