### PR TITLE
CI small cleanup of Cirrus CI test script

### DIFF
--- a/build_tools/cirrus/build_test_arm.sh
+++ b/build_tools/cirrus/build_test_arm.sh
@@ -22,13 +22,13 @@ setup_ccache() {
     ccache -M 0
 }
 
-MINICONDA_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-aarch64.sh"
+MAMBAFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-aarch64.sh"
 
 # Install Mambaforge
-wget $MINICONDA_URL -O mambaforge.sh
-MINICONDA_PATH=$HOME/miniconda
-chmod +x mambaforge.sh && ./mambaforge.sh -b -p $MINICONDA_PATH
-export PATH=$MINICONDA_PATH/bin:$PATH
+wget $MAMBAFORGE_URL -O mambaforge.sh
+MAMBAFORGE_PATH=$HOME/mambaforge
+bash ./mambaforge.sh -b -p $MAMBAFORGE_PATH
+export PATH=$MAMBAFORGE_PATH/bin:$PATH
 mamba init --all --verbose
 mamba update --yes mamba
 mamba update --yes conda


### PR DESCRIPTION
E.g. as observed in:

- https://github.com/scikit-learn/scikit-learn/pull/26160/checks?check_run_id=12690369061

Note that I could not reproduce the failure locally in a docker container (although I have not tried exactly the same image / env variables as the one used on Cirrus CI).

This PR currently has only what I think are cosmetic changes, not the actual fix.