### PR TITLE
MNT use api.openml.org URLs for fetch_openml

### DIFF
--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -22,7 +22,7 @@ from ..utils import check_pandas_support  # noqa
 
 __all__ = ["fetch_openml"]
 
-_OPENML_PREFIX = "https://openml.org/"
+_OPENML_PREFIX = "https://api.openml.org/"
 _SEARCH_NAME = "api/v1/json/data/list/data_name/{}/limit/2"
 _DATA_INFO = "api/v1/json/data/{}"
 _DATA_FEATURES = "api/v1/json/data/features/{}"

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -73,10 +73,10 @@ def _monkey_patch_webbased_functions(context, data_id, gzip_response):
     # monkey patches the urlopen function. Important note: Do NOT use this
     # in combination with a regular cache directory, as the files that are
     # stored as cache should not be mixed up with real openml datasets
-    url_prefix_data_description = "https://openml.org/api/v1/json/data/"
-    url_prefix_data_features = "https://openml.org/api/v1/json/data/features/"
-    url_prefix_download_data = "https://openml.org/data/v1/"
-    url_prefix_data_list = "https://openml.org/api/v1/json/data/list/"
+    url_prefix_data_description = "https://api.openml.org/api/v1/json/data/"
+    url_prefix_data_features = "https://api.openml.org/api/v1/json/data/features/"
+    url_prefix_download_data = "https://api.openml.org/data/v1/"
+    url_prefix_data_list = "https://api.openml.org/api/v1/json/data/list/"
 
     path_suffix = ".gz"
     read_fn = gzip.open
@@ -85,7 +85,9 @@ def _monkey_patch_webbased_functions(context, data_id, gzip_response):
 
     def _file_name(url, suffix):
         output = (
-            re.sub(r"\W", "-", url[len("https://openml.org/") :]) + suffix + path_suffix
+            re.sub(r"\W", "-", url[len("https://api.openml.org/") :])
+            + suffix
+            + path_suffix
         )
         # Shorten the filenames to have better compatibility with windows 10
         # and filenames > 260 characters


### PR DESCRIPTION
#### Reference Issues/PRs

According to https://github.com/openml/OpenML/issues/1135#issuecomment-1504114194, this is the preferred URL.

#### What does this implement/fix? Explain your changes.

This uses `api.openml.org` rather than `openml.org` in `fetch_openml`. This adapts the tests as well.

To take the example of a single URL, [`https://openml.org/api/v1/json/data/list/data_name/titanic/limit/2/data_version/1`](https://openml.org/api/v1/json/data/list/data_name/titanic/limit/2/data_version/1) redirects to [`https://www.openml.org/api/v1/json/data/list/data_name/titanic/limit/2/data_version/1`](https://www.openml.org/api/v1/json/data/list/data_name/titanic/limit/2/data_version/1) (`openml.org` -> `www.openml.org`) which redirects to [`https://api.openml.org/api/v1/json/data/list/data_name/titanic/limit/2/data_version/1`](https://api.openml.org/api/v1/json/data/list/data_name/titanic/limit/2/data_version/1) (`www.openml.org` -> `api.openml.org`)

#### Any other comments

I have added the "no changelog needed" label, let me know it you think a changelog entry is needed
