### PR TITLE
MAINT make it explicit that additive_chi2_kernel does not accept sparse matrix

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1555,7 +1555,7 @@ def additive_chi2_kernel(X, Y=None):
       International Journal of Computer Vision 2007
       https://hal.archives-ouvertes.fr/hal-00171412/document
     """
-    X, Y = check_pairwise_arrays(X, Y)
+    X, Y = check_pairwise_arrays(X, Y, accept_sparse=False)
     if (X < 0).any():
         raise ValueError("X contains negative values.")
     if Y is not X and (Y < 0).any():


### PR DESCRIPTION
related to https://github.com/scikit-learn/scikit-learn/pull/26153

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 85d7eda</samp>

Fixed input validation for additive chi-squared kernel in `sklearn/metrics/pairwise.py` by explicitly disallowing sparse matrices.