### PR TITLE
CI Fix circleci artifact redirector action

### DIFF
--- a/.github/workflows/artifact-redirector.yml
+++ b/.github/workflows/artifact-redirector.yml
@@ -18,6 +18,7 @@ jobs:
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.CIRCLECI_TOKEN }}
           artifact-path: 0/doc/_changed.html
           circleci-jobs: doc
           job-title: Check the rendered docs here!


### PR DESCRIPTION
It's been failing for a while. Following instructions here https://github.com/larsoner/circleci-artifacts-redirector-action/issues/40#issuecomment-1505543564, I created a circle-ci token and added it to scikit-learn on github. What's left to do is to refence it in the action's yaml.