### PR TITLE
[MRG] fix: avoid overflow in Yeo-Johnson power transform

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -483,6 +483,10 @@ Changelog
   The `sample_interval_` attribute is deprecated and will be removed in 1.5.
   :pr:`25190` by :user:`Vincent Maladière <Vincent-Maladiere>`.
 
+- |Fix| :class:`PowerTransformer` no longer causes overflow for certain input data when
+  fitting with the Yeo-Johnson method.
+  :pr:`26188` by :user:`Laurent Sorber <lsorber>`.
+
 :mod:`sklearn.tree`
 ...................
 

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -3342,7 +3342,7 @@ class PowerTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
 
             # Regularize the exponents to avoid blowing them up for a marginal gain in
             # log likelihood
-            x_trans_exp = np.log(np.abs(x_trans))
+            x_trans_exp = np.log(np.abs(x_trans[x_trans != 0]))
             loglike -= 1e-3 * np.sum(np.abs(x_trans_exp[np.isfinite(x_trans_exp)]))
 
             return -loglike


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes https://github.com/scikit-learn/scikit-learn/issues/23319

#### What does this implement/fix? Explain your changes.

This PR fixes two sources of overflow in the Yeo-Johnson power transform:
1. RuntimeWarning: overflow encountered in multiply from `x_trans_var = x_trans.var()`
2. RuntimeWarning: overflow encountered in power from `out[pos] = (np.power(x[pos] + 1, lmbda) - 1) / lmbda`

The first type of overflow is caused by `np.power`. This PR mitigates this type of overflow by replacing all instances of `np.power` with a numerically more robust formulation based on `np.exp`.

The second type of overflow occurs when the exponents blow up for a marginal gain in log likelihood. This PR mitigates this type of overflow by adding a small regularization term on the exponents.

Non-regression tests for both types of overflow have been added.