### PR TITLE
Fix PLSR n_components documentation.

### DIFF
--- a/doc/modules/cross_decomposition.rst
+++ b/doc/modules/cross_decomposition.rst
@@ -158,7 +158,7 @@ These two modifications affect the output of `predict` and `transform`,
 which are not the same as for :class:`PLSCanonical`. Also, while the number
 of components is limited by `min(n_samples, n_features, n_targets)` in
 :class:`PLSCanonical`, here the limit is the rank of :math:`X^TX`, i.e.
-`min(n_samples, n_features)`.
+`n_features`.
 
 :class:`PLSRegression` is also known as PLS1 (single targets) and PLS2
 (multiple targets). Much like :class:`~sklearn.linear_model.Lasso`,

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -531,8 +531,7 @@ class PLSRegression(_PLS):
     Parameters
     ----------
     n_components : int, default=2
-        Number of components to keep. Should be in `[1, min(n_samples,
-        n_features, n_targets)]`.
+        Number of components to keep. Should be in `[1, n_features]`.
 
     scale : bool, default=True
         Whether to scale `X` and `Y`.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes incorrect restriction on n_components in PLSRegression docstring.

#### What does this implement/fix? Explain your changes.
The PLSRegression class docstring incorrectly states that n_components is upper-bounded by n_targets, but this is only the case for PLSCanonical. This fix removes that restriction from the docstring, so that it now aligns with the description for PLSRegression in the User Guide.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
