### PR TITLE
MNT SLEP006: prepare sample-props to be merged into main

### DIFF
--- a/doc/metadata_routing.rst
+++ b/doc/metadata_routing.rst
@@ -8,9 +8,10 @@ Metadata Routing
 
 .. note::
   This feature, default metadata routing, and the API related to it are **all
-  experimental**, and might change without the usual deprecation cycle. By
-  default this feature is not enabled. You can enable this feature  by setting
-  the ``enable_metadata_routing`` flag to ``True``:
+  experimental** and many of them are **not implemented** yet, and might change
+  without the usual deprecation cycle. By default this feature is not enabled.
+  You can enable this feature  by setting the ``enable_metadata_routing`` flag
+  to ``True``:
 
     >>> import sklearn
     >>> sklearn.set_config(enable_metadata_routing=True)

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -231,7 +231,8 @@ the following two rules:
 - Advanced: If it requires extra metadata to be passed to it, it should expose
   a ``get_metadata_routing`` method returning the requested metadata. The user
   should be able to set the requested metadata via a ``set_score_request``
-  method. Please see :ref:`User Guide <metadata_routing>` for more details.
+  method. Please see :ref:`User Guide <metadata_routing>` and :ref:`Developer
+  Guide <sphx_glr_auto_examples_plot_metadata_routing.py>` for more details.
 
 
 .. note:: **Using custom scorers in functions where n_jobs > 1**

--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -27,8 +27,16 @@ User Guide
    visualizations.rst
    data_transforms.rst
    datasets.rst
-   metadata_routing.rst
    computing.rst
    model_persistence.rst
    common_pitfalls.rst
    dispatching.rst
+
+Under Development
+-----------------
+
+.. toctree::
+   :numbered:
+   :maxdepth: 1
+
+   metadata_routing.rst

--- a/examples/plot_metadata_routing.py
+++ b/examples/plot_metadata_routing.py
@@ -622,9 +622,16 @@ except Exception as e:
 # Third Party Development and scikit-learn Dependency
 # ---------------------------------------------------
 #
-# As seen above, information is communicated between classes using a dictionary
-# representation as the output of ``get_metadata_routing``. Therefore it is
-# possible for a third party library to not have a hard dependency on
-# scikit-learn, and internally (re)implement or vendor the functionality
-# required to present the dictionary representation of the routing data to
-# other classes inside and outside scikit-learn.
+# As seen above, information is communicated between classes using
+# :class:`~utils.metadata_routing.MetadataRequest` and
+# :class:`~utils.metadata_routing.MetadataRouter`. It is strongly not advised,
+# but possible to vendor the tools related to metadata-routing if you strictly
+# want to have a scikit-learn compatible estimator, without depending on the
+# scikit-learn package. If the following conditions are met, you do NOT need to
+# modify your code at all:
+#  - your estimator inherits from :class:`~base.BaseEstimator`
+#  - the parameters consumed by your estimator's methods, e.g. ``fit``, are
+#    explicitly defined in the method's signature, as opposed to being
+#    ``*args`` or ``*kwargs``.
+#  - you do not route any metadata to the underlying objects, i.e. you're not a
+#    *router*.

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -146,7 +146,7 @@ def set_config(
         - `False`: Metadata routing is disabled, use the old syntax.
         - `None`: Configuration is unchanged
 
-        .. versionadded:: 1.4
+        .. versionadded:: 1.3
 
     See Also
     --------
@@ -276,7 +276,7 @@ def config_context(
         - `False`: Metadata routing is disabled, use the old syntax.
         - `None`: Configuration is unchanged
 
-        .. versionadded:: 1.4
+        .. versionadded:: 1.3
 
     Yields
     ------

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -7,9 +7,9 @@
 #
 # License: BSD 3 clause
 
-from inspect import signature
 from numbers import Integral
 import warnings
+from inspect import signature
 from functools import partial
 
 from math import log

--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -21,7 +21,7 @@ class UnsetMetadataPassedError(ValueError):
     """Exception class to raise if a metadata is passed which is not explicitly \
         requested.
 
-    .. versionadded:: 2.0
+    .. versionadded:: 1.3
 
     Parameters
     ----------

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -18,14 +18,14 @@ ground truth labeling (or ``None`` in the case of unsupervised models).
 #          Arnaud Joly <arnaud.v.joly@gmail.com>
 # License: Simplified BSD
 
-import copy
-import warnings
 from collections.abc import Iterable
 from functools import partial
 from collections import Counter
 from traceback import format_exc
 
 import numpy as np
+import copy
+import warnings
 
 from . import (
     r2_score,
@@ -178,6 +178,8 @@ class _MultimetricScorer:
         Please check :ref:`User Guide <metadata_routing>` on how the routing
         mechanism works.
 
+        .. versionadded:: 1.3
+
         Returns
         -------
         routing : MetadataRouter
@@ -266,7 +268,7 @@ class _BaseScorer(_MetadataRequester):
             Only available if `enable_metadata_routing=True`. See the
             :ref:`User Guide <metadata_routing>`.
 
-            .. versionadded:: 1.4
+            .. versionadded:: 1.3
 
         Returns
         -------
@@ -307,7 +309,7 @@ class _BaseScorer(_MetadataRequester):
         Please see :ref:`User Guide <metadata_routing>` on how the routing
         mechanism works.
 
-        .. versionadded:: 1.4
+        .. versionadded:: 1.3
 
         Parameters
         ----------
@@ -355,7 +357,7 @@ class _PredictScorer(_BaseScorer):
             Other parameters passed to the scorer, e.g. sample_weight.
             Refer to :func:`set_score_request` for more details.
 
-            .. versionadded:: 1.4
+            .. versionadded:: 1.3
 
         Returns
         -------
@@ -400,7 +402,7 @@ class _ProbaScorer(_BaseScorer):
             Other parameters passed to the scorer, e.g. sample_weight.
             Refer to :func:`set_score_request` for more details.
 
-            .. versionadded:: 1.4
+            .. versionadded:: 1.3
 
         Returns
         -------
@@ -467,7 +469,7 @@ class _ThresholdScorer(_BaseScorer):
             Other parameters passed to the scorer, e.g. sample_weight.
             Refer to :func:`set_score_request` for more details.
 
-            .. versionadded:: 1.4
+            .. versionadded:: 1.3
 
         Returns
         -------
@@ -582,7 +584,10 @@ class _PassthroughScorer:
     def get_metadata_routing(self):
         """Get requested data properties.
 
-        .. versionadded:: 1.4
+        Please check :ref:`User Guide <metadata_routing>` on how the routing
+        mechanism works.
+
+        .. versionadded:: 1.3
 
         Returns
         -------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -60,7 +60,7 @@ class GroupsConsumerMixin(_MetadataRequester):
     This Mixin makes the object to request ``groups`` by default as
     ``REQUESTED``.
 
-    .. versionadded:: 2.0
+    .. versionadded:: 1.3
     """
 
     __metadata_request__split = {"groups": RequestType.REQUESTED}

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -132,7 +132,7 @@ class _MultiOutputEstimator(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta
             Only available if `enable_metadata_routing=True`. See the
             :ref:`User Guide <metadata_routing>`.
 
-            .. versionadded:: 1.4
+            .. versionadded:: 1.3
 
         Returns
         -------
@@ -309,6 +309,8 @@ class _MultiOutputEstimator(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta
         Please check :ref:`User Guide <metadata_routing>` on how the routing
         mechanism works.
 
+        .. versionadded:: 1.3
+
         Returns
         -------
         routing : MetadataRouter
@@ -417,7 +419,7 @@ class MultiOutputRegressor(RegressorMixin, _MultiOutputEstimator):
             Only available if `enable_metadata_routing=True`. See the
             :ref:`User Guide <metadata_routing>`.
 
-            .. versionadded:: 1.4
+            .. versionadded:: 1.3
 
         Returns
         -------
@@ -895,7 +897,10 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
         **fit_params : dict of string -> object
             Parameters passed to the `fit` method of each step.
 
-            .. versionadded:: 1.4
+            Only available if `enable_metadata_routing=True`. See the
+            :ref:`User Guide <metadata_routing>`.
+
+            .. versionadded:: 1.3
 
         Returns
         -------
@@ -985,6 +990,8 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
 
         Please check :ref:`User Guide <metadata_routing>` on how the routing
         mechanism works.
+
+        .. versionadded:: 1.3
 
         Returns
         -------
@@ -1130,6 +1137,8 @@ class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
 
         Please check :ref:`User Guide <metadata_routing>` on how the routing
         mechanism works.
+
+        .. versionadded:: 1.3
 
         Returns
         -------

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -29,7 +29,7 @@ MethodPair = namedtuple("MethodPair", ["callee", "caller"])
 def _routing_enabled():
     """Return whether metadata routing is enabled.
 
-    .. versionadded:: 1.4
+    .. versionadded:: 1.3
 
     Returns
     -------
@@ -43,7 +43,7 @@ def _routing_enabled():
 class RequestType(Enum):
     """A metadata is requested either with a string alias or this enum.
 
-    .. versionadded:: 2.0
+    .. versionadded:: 1.3
     """
 
     # Metadata is not requested. It will not be routed to the object having the
@@ -136,7 +136,7 @@ REQUESTER_DOC = """        Request metadata passed to the ``{method}`` method.
         Please see :ref:`User Guide <metadata_routing>` on how the routing
         mechanism works.
 
-        .. versionadded:: 2.0
+        .. versionadded:: 1.3
 
         Parameters
         ----------
@@ -176,7 +176,7 @@ class MethodMetadataRequest:
 
     Refer to :class:`MetadataRequest` for how this class is used.
 
-    .. versionadded:: 2.0
+    .. versionadded:: 1.3
 
     Parameters
     ----------
@@ -368,7 +368,7 @@ class MetadataRequest:
     Consumer-only classes such as simple estimators return a serialized
     version of this class as the output of `get_metadata_routing()`.
 
-    .. versionadded:: 2.0
+    .. versionadded:: 1.3
 
     Parameters
     ----------
@@ -488,7 +488,7 @@ class MethodMapping:
     Iterating through an instance of this class will yield named
     ``MethodPair(callee, caller)`` tuples.
 
-    .. versionadded:: 2.0
+    .. versionadded:: 1.3
     """
 
     def __init__(self):
@@ -585,7 +585,7 @@ class MetadataRouter:
     :class:`~utils.metadata_requests.MetadataRequest` or a
     :class:`~utils.metadata_requests.MetadataRouter` instance.
 
-    .. versionadded:: 2.0
+    .. versionadded:: 1.3
 
     Parameters
     ----------
@@ -892,7 +892,7 @@ def get_routing_for_object(obj=None):
     intput, such that changing the output of this function will not change the
     original object.
 
-    .. versionadded:: 2.0
+    .. versionadded:: 1.3
 
     Parameters
     ----------
@@ -930,7 +930,7 @@ class RequestMethod:
     """
     A descriptor for request methods.
 
-    .. versionadded:: 2.0
+    .. versionadded:: 1.3
 
     Parameters
     ----------
@@ -1025,7 +1025,7 @@ class RequestMethod:
 class _MetadataRequester:
     """Mixin class for adding metadata request functionality.
 
-    .. versionadded:: 2.0
+    .. versionadded:: 1.3
     """
 
     def __init_subclass__(cls, **kwargs):
@@ -1197,7 +1197,7 @@ def process_routing(obj, method, other_params, **kwargs):
     a call to this function would be:
     ``process_routing(self, fit_params, sample_weight=sample_weight)``.
 
-    .. versionadded:: 2.0
+    .. versionadded:: 1.3
 
     Parameters
     ----------


### PR DESCRIPTION
This PR does the final touches to prepare `sample-props` branch to be merged into `main`, and in some cases (like moving imports) reduce the diff with `main`.

Once this merged, we can move to a final review on https://github.com/scikit-learn/scikit-learn/pull/24027 before merging it.