### PR TITLE
PERF fix overhead of _rescale_data in LinearRegression

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -294,8 +294,9 @@ Changelog
 :mod:`sklearn.linear_model`
 ...........................
 
-- |Efficiency| Avoid uncessary data scaling and conversion to sparse data
-  structures in :class:`linear_model.LinearRegression` when not necessary.
+- |Efficiency| Avoid data scaling when `sample_weight=None` and other
+  unnecessary data copies and unexpected dense to sparse data conversion in
+  :class:`linear_model.LinearRegression`.
   :pr:`26207` by :user:`Olivier Grisel <ogrisel>`.
 
 - |Enhancement| :class:`linear_model.SGDClassifier`,

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -267,7 +267,7 @@ Changelog
   meaning that it is note required to call `fit` before calling `transform`.
   Parameter validation only happens at `fit` time.
   :pr:`24230` by :user:`Guillaume Lemaitre <glemaitre>`.
-  
+
 :mod:`sklearn.feature_selection`
 ................................
 
@@ -294,6 +294,10 @@ Changelog
 :mod:`sklearn.linear_model`
 ...........................
 
+- |Efficiency| Avoid uncessary data scaling and conversion to sparse data
+  structures in :class:`linear_model.LinearRegression` when not necessary.
+  :pr:`26207` by :user:`Olivier Grisel <ogrisel>`.
+
 - |Enhancement| :class:`linear_model.SGDClassifier`,
   :class:`linear_model.SGDRegressor` and :class:`linear_model.SGDOneClassSVM`
   now preserve dtype for `numpy.float32`.
@@ -309,7 +313,7 @@ Changelog
   :class:`linear_model.ARDRegression` to expose the actual number of iterations
   required to reach the stopping criterion.
   :pr:`25697` by :user:`John Pangas <jpangas>`.
-  
+
 - |Fix| Use a more robust criterion to detect convergence of
   :class:`linear_model.LogisticRegression(penalty="l1", solver="liblinear")`
   on linearly separable problems.

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -324,6 +324,7 @@ def _rescale_data(X, y, sample_weight):
         sw_matrix = sparse.dia_matrix(
             (sample_weight_sqrt, 0), shape=(n_samples, n_samples)
         )
+
     if sp.issparse(X):
         X = safe_sparse_dot(sw_matrix, X)
     else:

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -187,6 +187,7 @@ def _preprocess_data(
     fit_intercept,
     normalize=False,
     copy=True,
+    copy_y=True,
     sample_weight=None,
     check_input=True,
 ):
@@ -230,13 +231,14 @@ def _preprocess_data(
 
     if check_input:
         X = check_array(X, copy=copy, accept_sparse=["csr", "csc"], dtype=FLOAT_DTYPES)
-    elif copy:
-        if sp.issparse(X):
-            X = X.copy()
-        else:
-            X = X.copy(order="K")
-
-    y = np.asarray(y, dtype=X.dtype)
+        y = check_array(y, dtype=X.dtype, copy=copy_y, ensure_2d=False)
+    else:
+        y = y.astype(X.dtype, copy=copy_y)
+        if copy:
+            if sp.issparse(X):
+                X = X.copy()
+            else:
+                X = X.copy(order="K")
 
     if fit_intercept:
         if sp.issparse(X):
@@ -276,7 +278,7 @@ def _preprocess_data(
             X_scale = np.ones(X.shape[1], dtype=X.dtype)
 
         y_offset = np.average(y, axis=0, weights=sample_weight)
-        y = y - y_offset
+        y -= y_offset
     else:
         X_offset = np.zeros(X.shape[1], dtype=X.dtype)
         X_scale = np.ones(X.shape[1], dtype=X.dtype)
@@ -293,7 +295,7 @@ def _preprocess_data(
 # sample_weight makes the refactoring tricky.
 
 
-def _rescale_data(X, y, sample_weight):
+def _rescale_data(X, y, sample_weight, inplace=False):
     """Rescale data sample-wise by square root of sample_weight.
 
     For many linear models, this enables easy support for sample_weight because
@@ -328,18 +330,24 @@ def _rescale_data(X, y, sample_weight):
     if sp.issparse(X):
         X = safe_sparse_dot(sw_matrix, X)
     else:
-        # XXX: we do not do inplace multiplication on X for consistency
-        # with the sparse case and because the _rescale_data currently
-        # does not make it explicit if it's ok to do it or not.
-        X = X * sample_weight_sqrt[:, np.newaxis]
+        if inplace:
+            X *= sample_weight_sqrt[:, np.newaxis]
+        else:
+            X = X * sample_weight_sqrt[:, np.newaxis]
 
     if sp.issparse(y):
         y = safe_sparse_dot(sw_matrix, y)
     else:
-        if y.ndim == 1:
-            y = y * sample_weight_sqrt
+        if inplace:
+            if y.ndim == 1:
+                y *= sample_weight_sqrt
+            else:
+                y *= sample_weight_sqrt[:, np.newaxis]
         else:
-            y = y * sample_weight_sqrt[:, np.newaxis]
+            if y.ndim == 1:
+                y = y * sample_weight_sqrt
+            else:
+                y = y * sample_weight_sqrt[:, np.newaxis]
     return X, y, sample_weight_sqrt
 
 
@@ -674,17 +682,26 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
                 sample_weight, X, dtype=X.dtype, only_non_negative=True
             )
 
+        # Note that neither _rescale_data nor the rest of the fit method of
+        # LinearRegression can benefit from in-place operations when X is a
+        # sparse matrix. Therefore, let's not copy X when it is sparse.
+        copy_X_in_preprocess_data = self.copy_X and not sp.issparse(X)
+
         X, y, X_offset, y_offset, X_scale = _preprocess_data(
             X,
             y,
             fit_intercept=self.fit_intercept,
-            copy=self.copy_X,
+            copy=copy_X_in_preprocess_data,
             sample_weight=sample_weight,
         )
 
-        # Sample weight can be implemented via a simple rescaling.
         if has_sw:
-            X, y, sample_weight_sqrt = _rescale_data(X, y, sample_weight)
+            # Sample weight can be implemented via a simple rescaling. Note
+            # that we safely do inplace rescaling when _preprocess_data has
+            # already made a copy if requested.
+            X, y, sample_weight_sqrt = _rescale_data(
+                X, y, sample_weight, inplace=copy_X_in_preprocess_data
+            )
 
         if self.positive:
             if y.ndim < 2:

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -331,6 +331,7 @@ def _rescale_data(X, y, sample_weight):
         # with the sparse case and because the _rescale_data currently
         # does not make it explicit if it's ok to do it or not.
         X = X * sample_weight_sqrt[:, np.newaxis]
+
     if sp.issparse(y):
         y = safe_sparse_dot(sw_matrix, y)
     else:

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -315,13 +315,9 @@ def _rescale_data(X, y, sample_weight):
 
     y_rescaled : {array-like, sparse matrix}
     """
+    # Assume that _validate_data and _check_sample_weight have been called by
+    # the caller.
     n_samples = X.shape[0]
-    sample_weight = np.asarray(sample_weight)
-
-    if sample_weight.ndim == 0:
-        # XXX: compat for scalar weight: do we really need to support this?
-        sample_weight = np.full(n_samples, sample_weight, dtype=sample_weight.dtype)
-
     sample_weight_sqrt = np.sqrt(sample_weight)
 
     if sp.issparse(X) or sp.issparse(y):


### PR DESCRIPTION
This is a partial fix for #22855.

It only focuses on removing the `_rescale_data` overhead observed in:

- https://github.com/scikit-learn/scikit-learn/issues/22855#issuecomment-1463934731

There are three main changes in this PR:

- do not use `scipy.sparse` operations (and conversion to CSR) when training data is all dense.
- do not call `_rescale_data` when calling `LinearRegression().fit(X, y, sample_weight=None)` which is the default.
- avoid duplicated data copies as much as possible (taking `copy_X` into account).

<del>I believe we don't need any new tests as the existing tests should cover all the branches.</del> Let's check if this is really the case once codecov has run on this PR.

Note: to properly fix #22855 we should also select a better default solver or at least offer alternative solvers as constructor parameters such as cholesky and lsqr (potentially by factorizing common code with `Ridge`) but this is a more intrusive refactoring hence this first PR which should already be a net improvement.

TODO:

- [x] document change in the changelog
- [x] check that all branches are covered by the existing tests in codecov report
   - [x] codecov found that the sparse y case is not properly covered. Need to add a test.
- [x] profile with dense data without weights
- [x] profile with dense data with weights
- [x] profile with sparse data without weights
- [x] profile with sparse data with weights
- [x] check if we can avoid some data copies when not needed (e.g. for sparse data with our without sample weights).