### PR TITLE
Pass optional column names to parallel tree function in using the self.feature_names_in attribute.

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -348,10 +348,6 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         if issparse(y):
             raise ValueError("sparse multilabel-indicator for y is not supported.")
 
-        feature_names_in_ = []
-        if hasattr(X, "columns"):
-            feature_names_in_ = X.columns.to_list()
-
         X, y = self._validate_data(
             X,
             y,
@@ -481,7 +477,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
                     verbose=self.verbose,
                     class_weight=self.class_weight,
                     n_samples_bootstrap=n_samples_bootstrap,
-                    feature_names_in_=feature_names_in_,
+                    feature_names_in_=getattr(self, "feature_names_in_", None),
                 )
                 for i, t in enumerate(trees)
             )

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -46,7 +46,6 @@ import threading
 
 from abc import ABCMeta, abstractmethod
 import numpy as np
-import pandas as pd
 from scipy.sparse import issparse
 from scipy.sparse import hstack as sparse_hstack
 
@@ -349,8 +348,8 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         if issparse(y):
             raise ValueError("sparse multilabel-indicator for y is not supported.")
 
-        feature_names_in_ = None
-        if isinstance(X, pd.DataFrame):
+        feature_names_in_ = []
+        if hasattr(X, "columns"):
             feature_names_in_ = X.columns.to_list()
 
         X, y = self._validate_data(

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -23,7 +23,6 @@ from math import ceil
 from numbers import Integral, Real
 
 import numpy as np
-import pandas as pd
 from scipy.sparse import issparse
 
 from ..base import BaseEstimator
@@ -886,9 +885,6 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
         self : DecisionTreeClassifier
             Fitted estimator.
         """
-        if isinstance(X, pd.DataFrame):
-            self.feature_names_in_ = X.columns.to_list()
-
         super().fit(
             X,
             y,

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -23,6 +23,7 @@ from math import ceil
 from numbers import Integral, Real
 
 import numpy as np
+import pandas as pd
 from scipy.sparse import issparse
 
 from ..base import BaseEstimator
@@ -885,6 +886,8 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
         self : DecisionTreeClassifier
             Fitted estimator.
         """
+        if isinstance(X, pd.DataFrame):
+            self.feature_names_in_ = X.columns.to_list()
 
         super().fit(
             X,


### PR DESCRIPTION
#### Reference Issues/PRs
Example: Fixes #26140 

#### What does this implement/fix? Explain your changes.
In case of using a pandas DataFrame as the X variable type, every tree inside the forest will set its `feature_names_in_` attribute equal the list of the columns of set pandas DataFrame 

#### Any other comments?

