### PR TITLE
MAINT Parameters validation for sklearn.inspection.partial_dependence

### DIFF
--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -237,13 +237,13 @@ def _partial_dependence_brute(est, grid, features, X, response_method):
             HasMethods(["fit", "predict_proba"]),
             HasMethods(["fit", "decision_function"]),
         ],
-        "X": ["array-like"],
+        "X": ["array-like", "sparse matrix"],
         "features": ["array-like", Integral, str],
         "categorical_features": ["array-like", None],
         "feature_names": ["array-like", None],
         "response_method": [StrOptions({"auto", "predict_proba", "decision_function"})],
         "percentiles": [tuple],
-        "grid_resolution": [Interval(Integral, 1, None, closed="neither")],
+        "grid_resolution": [Interval(Integral, 1, None, closed="left")],
         "method": [StrOptions({"auto", "recursion", "brute"})],
         "kind": [StrOptions({"average", "individual", "both"})],
     }
@@ -293,7 +293,7 @@ def partial_dependence(
         :term:`predict_proba`, or :term:`decision_function`.
         Multioutput-multiclass classifiers are not supported.
 
-    X : {array-like or dataframe} of shape (n_samples, n_features)
+    X : {array-like, sparse matrix or dataframe} of shape (n_samples, n_features)
         ``X`` is used to generate a grid of values for the target
         ``features`` (where the partial dependence will be evaluated), and
         also to generate values for the complement features when the

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -22,6 +22,13 @@ from ..utils import _determine_key_type
 from ..utils import _get_column_indices
 from ..utils.validation import check_is_fitted
 from ..utils import Bunch
+from ..utils._param_validation import (
+    HasMethods,
+    Integral,
+    Interval,
+    StrOptions,
+    validate_params,
+)
 from ..tree import DecisionTreeRegressor
 from ..ensemble import RandomForestRegressor
 from ..exceptions import NotFittedError
@@ -223,6 +230,24 @@ def _partial_dependence_brute(est, grid, features, X, response_method):
     return averaged_predictions, predictions
 
 
+@validate_params(
+    {
+        "estimator": [
+            HasMethods(["fit", "predict"]),
+            HasMethods(["fit", "predict_proba"]),
+            HasMethods(["fit", "decision_function"]),
+        ],
+        "X": ["array-like"],
+        "features": ["array-like", Integral, str],
+        "categorical_features": ["array-like", None],
+        "feature_names": ["array-like", None],
+        "response_method": [StrOptions({"auto", "predict_proba", "decision_function"})],
+        "percentiles": [tuple],
+        "grid_resolution": [Interval(Integral, 1, None, closed="neither")],
+        "method": [StrOptions({"auto", "recursion", "brute"})],
+        "kind": [StrOptions({"average", "individual", "both"})],
+    }
+)
 def partial_dependence(
     estimator,
     X,
@@ -274,7 +299,7 @@ def partial_dependence(
         also to generate values for the complement features when the
         `method` is 'brute'.
 
-    features : array-like of {int, str}
+    features : array-like of {int, str, bool} or int or str
         The feature (e.g. `[0]`) or pair of interacting features
         (e.g. `[(0, 1)]`) for which the partial dependency should be computed.
 
@@ -425,25 +450,10 @@ def partial_dependence(
     if not (hasattr(X, "__array__") or sparse.issparse(X)):
         X = check_array(X, force_all_finite="allow-nan", dtype=object)
 
-    accepted_responses = ("auto", "predict_proba", "decision_function")
-    if response_method not in accepted_responses:
-        raise ValueError(
-            "response_method {} is invalid. Accepted response_method names "
-            "are {}.".format(response_method, ", ".join(accepted_responses))
-        )
-
     if is_regressor(estimator) and response_method != "auto":
         raise ValueError(
             "The response_method parameter is ignored for regressors and "
             "must be 'auto'."
-        )
-
-    accepted_methods = ("brute", "recursion", "auto")
-    if method not in accepted_methods:
-        raise ValueError(
-            "method {} is invalid. Accepted method names are {}.".format(
-                method, ", ".join(accepted_methods)
-            )
         )
 
     if kind != "average":

--- a/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
@@ -611,16 +611,6 @@ dummy_classification_data = make_classification(random_state=0)
             {"features": [1], "categorical_features": [1], "kind": "individual"},
             "It is not possible to display individual effects",
         ),
-        (
-            dummy_classification_data,
-            {"features": [1], "kind": "foo"},
-            "Values provided to `kind` must be one of",
-        ),
-        (
-            dummy_classification_data,
-            {"features": [0, 1], "kind": ["foo", "individual"]},
-            "Values provided to `kind` must be one of",
-        ),
     ],
 )
 def test_plot_partial_dependence_error(pyplot, data, params, err_msg):

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -511,31 +511,6 @@ class NoPredictProbaNoDecisionFunction(ClassifierMixin, BaseEstimator):
             "'recursion' method, the response_method must be 'decision_function'",
         ),
         (
-            GradientBoostingClassifier(random_state=0),
-            {"features": [0], "response_method": "blahblah"},
-            "response_method blahblah is invalid. Accepted response_method",
-        ),
-        (
-            NoPredictProbaNoDecisionFunction(),
-            {"features": [0], "response_method": "auto"},
-            "The estimator has no predict_proba and no decision_function method",
-        ),
-        (
-            NoPredictProbaNoDecisionFunction(),
-            {"features": [0], "response_method": "predict_proba"},
-            "The estimator has no predict_proba method.",
-        ),
-        (
-            NoPredictProbaNoDecisionFunction(),
-            {"features": [0], "response_method": "decision_function"},
-            "The estimator has no decision_function method.",
-        ),
-        (
-            LinearRegression(),
-            {"features": [0], "method": "blahblah"},
-            "blahblah is invalid. Accepted method names are brute, recursion, auto",
-        ),
-        (
             LinearRegression(),
             {"features": [0], "method": "recursion", "kind": "individual"},
             "The 'recursion' method only applies when 'kind' is set to 'average'",
@@ -558,24 +533,6 @@ def test_partial_dependence_error(estimator, params, err_msg):
 
     with pytest.raises(ValueError, match=err_msg):
         partial_dependence(estimator, X, **params)
-
-
-@pytest.mark.parametrize(
-    "with_dataframe, err_msg",
-    [
-        (True, "Only array-like or scalar are supported"),
-        (False, "Only array-like or scalar are supported"),
-    ],
-)
-def test_partial_dependence_slice_error(with_dataframe, err_msg):
-    X, y = make_classification(random_state=0)
-    if with_dataframe:
-        pd = pytest.importorskip("pandas")
-        X = pd.DataFrame(X)
-    estimator = LogisticRegression().fit(X, y)
-
-    with pytest.raises(TypeError, match=err_msg):
-        partial_dependence(estimator, X, features=slice(0, 2, 1))
 
 
 @pytest.mark.parametrize(

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -165,6 +165,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.feature_selection.mutual_info_classif",
     "sklearn.feature_selection.mutual_info_regression",
     "sklearn.feature_selection.r_regression",
+    "sklearn.inspection.partial_dependence",
     "sklearn.inspection.permutation_importance",
     "sklearn.linear_model.orthogonal_mp",
     "sklearn.metrics.accuracy_score",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #24862.

#### What does this implement/fix? Explain your changes.
Add automatic parameter validation for `sklearn.inspection.partial_dependence` and remove unnecessary tests.

According to [test](https://github.com/yuanx749/scikit-learn/blob/d94497d3116da642a55350f1a4c39f254e30141a/sklearn/inspection/tests/test_partial_dependence.py#L740), `features` type can be ["scalar-int", "scalar-str", "list-int", "list-str", "mask"].

`PartialDependenceDisplay.from_estimator` calls `partial_dependence` and its validation on the parameter `kind` raises conflicting error messages. So I also remove the tests in test_plot_partial_dependence.py. Not sure if it is a right solution.
#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
