### PR TITLE
remove obvious comment

### DIFF
--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -307,7 +307,6 @@ class KernelPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator
 
     def _fit_transform(self, K):
         """Fit's using kernel K"""
-        # center kernel
         K = self._centerer.fit_transform(K)
 
         # adjust n_components according to user inputs


### PR DESCRIPTION
This PR removes an obvious comment (i.e. comment that restates what the code does in an obvious manner). The code itself is understandable that the kernel is being centered.