### PR TITLE
FIX possible UnboundLocalError in fetch_openml

### DIFF
--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -519,19 +519,21 @@ def _load_arff_response(
             url, data_home, n_retries, delay, arff_params
         )
     except Exception as exc:
-        if parser == "pandas":
-            from pandas.errors import ParserError
+        if parser != "pandas":
+            raise
 
-            if isinstance(exc, ParserError):
-                # A parsing error could come from providing the wrong quotechar
-                # to pandas. By default, we use a double quote. Thus, we retry
-                # with a single quote before to raise the error.
-                arff_params["read_csv_kwargs"] = {"quotechar": "'"}
-                X, y, frame, categories = _open_url_and_load_gzip_file(
-                    url, data_home, n_retries, delay, arff_params
-                )
-            else:
-                raise
+        from pandas.errors import ParserError
+
+        if not isinstance(exc, ParserError):
+            raise
+
+        # A parsing error could come from providing the wrong quotechar
+        # to pandas. By default, we use a double quote. Thus, we retry
+        # with a single quote before to raise the error.
+        arff_params["read_csv_kwargs"] = {"quotechar": "'"}
+        X, y, frame, categories = _open_url_and_load_gzip_file(
+            url, data_home, n_retries, delay, arff_params
+        )
 
     return X, y, frame, categories
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The previous code looked like this:
```py
try:
    X, y, frame, categories = _open_url_and_load_gzip_file(
        url, data_home, n_retries, delay, arff_params
    )
except Exception as exc:
    if parser == "pandas":
        from pandas.errors import ParserError

        if isinstance(exc, ParserError):
            # A parsing error could come from providing the wrong quotechar
            # to pandas. By default, we use a double quote. Thus, we retry
            # with a single quote before to raise the error.
            arff_params["read_csv_kwargs"] = {"quotechar": "'"}
            X, y, frame, categories = _open_url_and_load_gzip_file(
                url, data_home, n_retries, delay, arff_params
            )
        else:
            raise

return X, y, frame, categories
```

So if the first `_open_url_and_load_gzip_file` fails and `parser != "pandas"` we don't raise again in the `except` and we reach the return with `X, y, frame, categories` undefined causing an `UnboundLocalError`.

This was seen in a [nightly build](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=54407&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=ef785ae2-496b-5b02-9f0e-07a6c3ab3081&l=788).

#### Any other comments?

I have not added a test for this, but let me know if you think this is necessary and I'll try to see how easy this is.
