### PR TITLE
DOC Consistent param type for pos_label

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -928,7 +928,7 @@ def calibration_curve(
     y_prob : array-like of shape (n_samples,)
         Probabilities of the positive class.
 
-    pos_label : int or str, default=None
+    pos_label : int, float, bool or str, default=None
         The label of the positive class.
 
         .. versionadded:: 1.1
@@ -1042,7 +1042,7 @@ class CalibrationDisplay(_BinaryClassifierCurveDisplayMixin):
     estimator_name : str, default=None
         Name of estimator. If None, the estimator name is not shown.
 
-    pos_label : str or int, default=None
+    pos_label : int, float, bool or str, default=None
         The positive class when computing the calibration curve.
         By default, `estimators.classes_[1]` is considered as the
         positive class.
@@ -1208,7 +1208,7 @@ class CalibrationDisplay(_BinaryClassifierCurveDisplayMixin):
             - `'quantile'`: The bins have the same number of samples and depend
               on predicted probabilities.
 
-        pos_label : str or int, default=None
+        pos_label : int, float, bool or str, default=None
             The positive class when computing the calibration curve.
             By default, `estimators.classes_[1]` is considered as the
             positive class.
@@ -1326,7 +1326,7 @@ class CalibrationDisplay(_BinaryClassifierCurveDisplayMixin):
             - `'quantile'`: The bins have the same number of samples and depend
               on predicted probabilities.
 
-        pos_label : str or int, default=None
+        pos_label : int, float, bool or str, default=None
             The positive class when computing the calibration curve.
             By default, `estimators.classes_[1]` is considered as the
             positive class.

--- a/sklearn/metrics/_plot/det_curve.py
+++ b/sklearn/metrics/_plot/det_curve.py
@@ -26,7 +26,7 @@ class DetCurveDisplay(_BinaryClassifierCurveDisplayMixin):
     estimator_name : str, default=None
         Name of estimator. If None, the estimator name is not shown.
 
-    pos_label : str or int, default=None
+    pos_label : int, float, bool or str, default=None
         The label of the positive class.
 
     Attributes
@@ -117,7 +117,7 @@ class DetCurveDisplay(_BinaryClassifierCurveDisplayMixin):
             to 'auto', :term:`predict_proba` is tried first and if it does not
             exist :term:`decision_function` is tried next.
 
-        pos_label : str or int, default=None
+        pos_label : int, float, bool or str, default=None
             The label of the positive class. When `pos_label=None`, if `y_true`
             is in {-1, 1} or {0, 1}, `pos_label` is set to 1, otherwise an
             error will be raised.
@@ -210,7 +210,7 @@ class DetCurveDisplay(_BinaryClassifierCurveDisplayMixin):
         sample_weight : array-like of shape (n_samples,), default=None
             Sample weights.
 
-        pos_label : str or int, default=None
+        pos_label : int, float, bool or str, default=None
             The label of the positive class. When `pos_label=None`, if `y_true`
             is in {-1, 1} or {0, 1}, `pos_label` is set to 1, otherwise an
             error will be raised.

--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -28,7 +28,7 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
     estimator_name : str, default=None
         Name of estimator. If None, then the estimator name is not shown.
 
-    pos_label : str or int, default=None
+    pos_label : int, float, bool or str, default=None
         The class considered as the positive class. If None, the class will not
         be shown in the legend.
 
@@ -194,7 +194,7 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
         sample_weight : array-like of shape (n_samples,), default=None
             Sample weights.
 
-        pos_label : str or int, default=None
+        pos_label : int, float, bool or str, default=None
             The class considered as the positive class when computing the
             precision and recall metrics. By default, `estimators.classes_[1]`
             is considered as the positive class.
@@ -306,7 +306,7 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
         sample_weight : array-like of shape (n_samples,), default=None
             Sample weights.
 
-        pos_label : str or int, default=None
+        pos_label : int, float, bool or str, default=None
             The class considered as the positive class when computing the
             precision and recall metrics.
 

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -28,7 +28,7 @@ class RocCurveDisplay(_BinaryClassifierCurveDisplayMixin):
     estimator_name : str, default=None
         Name of estimator. If None, the estimator name is not shown.
 
-    pos_label : str or int, default=None
+    pos_label : int, float, bool or str, default=None
         The class considered as the positive class when computing the roc auc
         metrics. By default, `estimators.classes_[1]` is considered
         as the positive class.
@@ -213,7 +213,7 @@ class RocCurveDisplay(_BinaryClassifierCurveDisplayMixin):
             :term:`predict_proba` is tried first and if it does not exist
             :term:`decision_function` is tried next.
 
-        pos_label : str or int, default=None
+        pos_label : int, float, bool or str, default=None
             The class considered as the positive class when computing the roc auc
             metrics. By default, `estimators.classes_[1]` is considered
             as the positive class.
@@ -328,7 +328,7 @@ class RocCurveDisplay(_BinaryClassifierCurveDisplayMixin):
             on a plotted ROC curve. This is useful in order to create lighter
             ROC curves.
 
-        pos_label : str or int, default=None
+        pos_label : int, float, bool or str, default=None
             The label of the positive class. When `pos_label=None`, if `y_true`
             is in {-1, 1} or {0, 1}, `pos_label` is set to 1, otherwise an
             error will be raised.

--- a/sklearn/utils/_response.py
+++ b/sklearn/utils/_response.py
@@ -47,7 +47,7 @@ def _get_response_values(
           preference. The method returned corresponds to the first method in
           the list and which is implemented by `estimator`.
 
-    pos_label : str or int, default=None
+    pos_label : int, float, bool or str, default=None
         The class considered as the positive class when computing
         the metrics. By default, `estimators.classes_[1]` is
         considered as the positive class.
@@ -58,7 +58,7 @@ def _get_response_values(
         Target scores calculated from the provided response_method
         and `pos_label`.
 
-    pos_label : str, int or None
+    pos_label : int, float, bool, str or None
         The class considered as the positive class when computing
         the metrics. Returns `None` if `estimator` is a regressor.
 
@@ -133,24 +133,24 @@ def _get_response_values_binary(estimator, X, response_method, pos_label=None):
     X : {array-like, sparse matrix} of shape (n_samples, n_features)
         Input values.
 
-    response_method: {'auto', 'predict_proba', 'decision_function'}
+    response_method : {'auto', 'predict_proba', 'decision_function'}
         Specifies whether to use :term:`predict_proba` or
         :term:`decision_function` as the target response. If set to 'auto',
         :term:`predict_proba` is tried first and if it does not exist
         :term:`decision_function` is tried next.
 
-    pos_label : str or int, default=None
+    pos_label : int, float, bool or str, default=None
         The class considered as the positive class when computing
         the metrics. By default, `estimators.classes_[1]` is
         considered as the positive class.
 
     Returns
     -------
-    y_pred: ndarray of shape (n_samples,)
+    y_pred : ndarray of shape (n_samples,)
         Target scores calculated from the provided response_method
         and pos_label.
 
-    pos_label: str or int
+    pos_label : int, float, bool or str
         The class considered as the positive class when computing
         the metrics.
     """

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -2162,14 +2162,14 @@ def _check_pos_label_consistency(pos_label, y_true):
 
     Parameters
     ----------
-    pos_label : int, str or None
+    pos_label : int, float, bool, str or None
         The positive label.
     y_true : ndarray of shape (n_samples,)
         The target vector.
 
     Returns
     -------
-    pos_label : int
+    pos_label : int, float, bool or str
         If `pos_label` can be inferred, it will be returned.
 
     Raises


### PR DESCRIPTION
Follow-up of https://github.com/scikit-learn/scikit-learn/pull/25317
Updated the remaining docstrings involving ``pos_label``