### PR TITLE
DOC Fix y-axis plot labels in permutation test score example

### DIFF
--- a/examples/model_selection/plot_permutation_tests_for_classification.py
+++ b/examples/model_selection/plot_permutation_tests_for_classification.py
@@ -95,7 +95,7 @@ ax.axvline(score_iris, ls="--", color="r")
 score_label = f"Score on original\ndata: {score_iris:.2f}\n(p-value: {pvalue_iris:.3f})"
 ax.text(0.7, 10, score_label, fontsize=12)
 ax.set_xlabel("Accuracy score")
-_ = ax.set_ylabel("Probability")
+_ = ax.set_ylabel("Probability density")
 
 # %%
 # Random data
@@ -116,7 +116,7 @@ ax.axvline(score_rand, ls="--", color="r")
 score_label = f"Score on original\ndata: {score_rand:.2f}\n(p-value: {pvalue_rand:.3f})"
 ax.text(0.14, 7.5, score_label, fontsize=12)
 ax.set_xlabel("Accuracy score")
-ax.set_ylabel("Probability")
+ax.set_ylabel("Probability density")
 plt.show()
 
 # %%


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
The example incorrectly labels the plots of probability density function (PDF) as "probability", which is, however, incorrect. That would be the case for probability mass function (PMF). In this case, it should be 'probability density' as the range of y values goes from 0 to above 1.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
