### PR TITLE
AdaBoost: allow base_estimator=None

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -281,6 +281,10 @@ Changelog
   pandas' conventions.
   :pr:`25629` by `Thomas Fan`_.
 
+- |Fix| Fix deprecation of `base_estimator__` in :class:`ensemble.AdaBoostClassifier`
+  and :class:`ensemble.AdaBoostRegressor` that was introduced in :pr:`23819`.
+  :pr:`26242` by :user:`Marko Toplak <markotoplak>`.
+
 :mod:`sklearn.exception`
 ........................
 - |Feature| Added :class:`exception.InconsistentVersionWarning` which is raised

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -281,7 +281,7 @@ Changelog
   pandas' conventions.
   :pr:`25629` by `Thomas Fan`_.
 
-- |Fix| Fix deprecation of `base_estimator__` in :class:`ensemble.AdaBoostClassifier`
+- |Fix| Fix deprecation of `base_estimator` in :class:`ensemble.AdaBoostClassifier`
   and :class:`ensemble.AdaBoostRegressor` that was introduced in :pr:`23819`.
   :pr:`26242` by :user:`Marko Toplak <markotoplak>`.
 

--- a/sklearn/ensemble/_base.py
+++ b/sklearn/ensemble/_base.py
@@ -157,7 +157,7 @@ class BaseEnsemble(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
 
         if self.estimator is not None:
             self.estimator_ = self.estimator
-        elif self.base_estimator not in [None, "deprecated"]:
+        elif self.base_estimator != "deprecated":
             warnings.warn(
                 (
                     "`base_estimator` was renamed to `estimator` in version 1.2 and "
@@ -165,7 +165,10 @@ class BaseEnsemble(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
                 ),
                 FutureWarning,
             )
-            self.estimator_ = self.base_estimator
+            if self.base_estimator is not None:
+                self.estimator_ = self.base_estimator
+            else:
+                self.estimator_ = default
         else:
             self.estimator_ = default
 

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -64,7 +64,11 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         "n_estimators": [Interval(Integral, 1, None, closed="left")],
         "learning_rate": [Interval(Real, 0, None, closed="neither")],
         "random_state": ["random_state"],
-        "base_estimator": [HasMethods(["fit", "predict"]), StrOptions({"deprecated"}), None],
+        "base_estimator": [
+            HasMethods(["fit", "predict"]),
+            StrOptions({"deprecated"}),
+            None,
+        ],
     }
 
     @abstractmethod

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -64,7 +64,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         "n_estimators": [Interval(Integral, 1, None, closed="left")],
         "learning_rate": [Interval(Real, 0, None, closed="neither")],
         "random_state": ["random_state"],
-        "base_estimator": [HasMethods(["fit", "predict"]), StrOptions({"deprecated"})],
+        "base_estimator": [HasMethods(["fit", "predict"]), StrOptions({"deprecated"}), None],
     }
 
     @abstractmethod

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -616,6 +616,27 @@ def test_base_estimator_argument_deprecated(AdaBoost, Estimator):
 # TODO(1.4): remove in 1.4
 @pytest.mark.parametrize(
     "AdaBoost",
+    [
+        AdaBoostClassifier,
+        AdaBoostRegressor,
+    ],
+)
+def test_base_estimator_argument_deprecated_none(AdaBoost):
+    X = np.array([[1, 2], [3, 4]])
+    y = np.array([1, 0])
+    model = AdaBoost(base_estimator=None)
+
+    warn_msg = (
+        "`base_estimator` was renamed to `estimator` in version 1.2 and "
+        "will be removed in 1.4."
+    )
+    with pytest.warns(FutureWarning, match=warn_msg):
+        model.fit(X, y)
+
+
+# TODO(1.4): remove in 1.4
+@pytest.mark.parametrize(
+    "AdaBoost",
     [AdaBoostClassifier, AdaBoostRegressor],
 )
 def test_base_estimator_property_deprecated(AdaBoost):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #26241. 


#### What does this implement/fix? Explain your changes.
To ensure that the (deprecated) explicit `base_estimator=None` doesn't stop working, add a (likely forgotten) `None` to a list allowed values in _parameter_constraints. Everything else already seems to be setup properly.