### PR TITLE
MNT speed-up html-noplot build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,6 @@ jobs:
       - OPENBLAS_NUM_THREADS: 2
       - CONDA_ENV_NAME: testenv
       - LOCK_FILE: build_tools/circle/doc_min_dependencies_linux-64_conda.lock
-      # Sphinx race condition in doc-min-dependencies is causing job to stall
-      # Here we run the job serially
-      - SPHINX_NUMJOBS: 1
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh
@@ -61,8 +58,6 @@ jobs:
       - OPENBLAS_NUM_THREADS: 2
       - CONDA_ENV_NAME: testenv
       - LOCK_FILE: build_tools/circle/doc_linux-64_conda.lock
-      # Disable sphinx parallelism to avoid EOFError or job stalling in CircleCI
-      - SPHINX_NUMJOBS: 1
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -13,6 +13,8 @@ endif
 
 ifeq ($(CI), true)
     SPHINX_NUMJOBS_NOPLOT_DEFAULT=2
+else ($(shell uname), Darwin)
+    SPHINX_NUMJOBS_NOPLOT_DEFAULT=1
 else
     SPHINX_NUMJOBS_NOPLOT_DEFAULT=auto
 endif

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,18 +7,21 @@ SPHINXBUILD  ?= sphinx-build
 PAPER         =
 BUILDDIR      = _build
 
-# Run sequential by default, unless SPHINX_NUMJOBS is set.
-SPHINX_NUMJOBS ?= 1
-
 ifneq ($(EXAMPLES_PATTERN),)
     EXAMPLES_PATTERN_OPTS := -D sphinx_gallery_conf.filename_pattern="$(EXAMPLES_PATTERN)"
+endif
+
+ifeq ($(CI), true)
+    SPHINX_NUMJOBS_NOPLOT_DEFAULT=2
+else
+    SPHINX_NUMJOBS_NOPLOT_DEFAULT=auto
 endif
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -T -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS)\
-    -j$(SPHINX_NUMJOBS) $(EXAMPLES_PATTERN_OPTS) .
+    $(EXAMPLES_PATTERN_OPTS) .
 
 
 .PHONY: help clean html dirhtml ziphtml pickle json latex latexpdf changes linkcheck doctest optipng
@@ -44,17 +47,27 @@ clean:
 	-rm -rf generated/*
 	-rm -rf modules/generated/
 
+# Default to SPHINX_NUMJOBS=1 for full documentation build. Using
+# SPHINX_NUMJOBS!=1 may actually slow down the build, or cause weird issues in
+# the CI (job stalling or EOFError), see
+# https://github.com/scikit-learn/scikit-learn/pull/25836 or
+# https://github.com/scikit-learn/scikit-learn/pull/25809
+html: SPHINX_NUMJOBS ?= 1
 html:
 	# These two lines make the build a bit more lengthy, and the
 	# the embedding of images more robust
 	rm -rf $(BUILDDIR)/html/_images
 	#rm -rf _build/doctrees/
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html/stable
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) -j$(SPHINX_NUMJOBS) $(BUILDDIR)/html/stable
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html/stable"
 
+# Default to SPHINX_NUMJOBS=auto locally and SPHINX_NUMJOBS=2 in CI, since this
+# makes html-noplot build faster
+html-noplot: SPHINX_NUMJOBS ?= $(SPHINX_NUMJOBS_NOPLOT_DEFAULT)
 html-noplot:
-	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html/stable
+	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) -j$(SPHINX_NUMJOBS) \
+    $(BUILDDIR)/html/stable
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html/stable."
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -12,8 +12,10 @@ ifneq ($(EXAMPLES_PATTERN),)
 endif
 
 ifeq ($(CI), true)
-    SPHINX_NUMJOBS_NOPLOT_DEFAULT=2
+    # On CircleCI using -j2 does not seem to speed up the html-noplot build
+    SPHINX_NUMJOBS_NOPLOT_DEFAULT=1
 else ($(shell uname), Darwin)
+    # Avoid stalling issues on MacOS
     SPHINX_NUMJOBS_NOPLOT_DEFAULT=1
 else
     SPHINX_NUMJOBS_NOPLOT_DEFAULT=auto
@@ -64,8 +66,8 @@ html:
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html/stable"
 
-# Default to SPHINX_NUMJOBS=auto locally and SPHINX_NUMJOBS=2 in CI, since this
-# makes html-noplot build faster
+# Default to SPHINX_NUMJOBS=auto (except on MacOS and CI) since this makes
+# html-noplot build faster
 html-noplot: SPHINX_NUMJOBS ?= $(SPHINX_NUMJOBS_NOPLOT_DEFAULT)
 html-noplot:
 	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) -j$(SPHINX_NUMJOBS) \


### PR DESCRIPTION
#### Reference Issues/PRs

This was an improvement mentioned in
https://github.com/scikit-learn/scikit-learn/pull/25836#issuecomment-1468227529

#### What does this implement/fix? Explain your changes.

Using parallel build for `html-noplot` does speed things up locally see https://github.com/scikit-learn/scikit-learn/pull/25836#issuecomment-1466378341.

This use Makefile target-specific variables to set SPHINX_NUMJOBS to different values depending on the target, see https://www.gnu.org/software/make/manual/html_node/Target_002dspecific.html

On the CI I fixed SPHINX_NUMJOBS=2 for html-noplot to avoid issues. I used the `CI` environment variable which should be defined in the CI e.g. [GHA](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) and [CircleCI](https://circleci.com/docs/variables/)

You can test this locally by using `make -n` and checking the `-j` e.g. this is what I get locally:

html-noplot defaults to `-jauto`
```
❯ make -n html-noplot
sphinx-build -D plot_gallery=0 -b html -T -d _build/doctrees    . -jauto \
    _build/html/stable
echo
echo "Build finished. The HTML pages are in _build/html/stable."
```

CI=true and `html-noplot` defaults to `-j2`
```
❯ CI=true make -n html-noplot
sphinx-build -D plot_gallery=0 -b html -T -d _build/doctrees    . -j2 \
    _build/html/stable
echo
echo "Build finished. The HTML pages are in _build/html/stable."
```

`html` defaults to `-j1`
```
base ❯ make -n html        
# These two lines make the build a bit more lengthy, and the
# the embedding of images more robust
rm -rf _build/html/_images
#rm -rf _build/doctrees/
sphinx-build -b html -T -d _build/doctrees    . -j1 _build/html/stable
echo
echo "Build finished. The HTML pages are in _build/html/stable"
```