### PR TITLE
MNT reduce JupyterLite build size

### DIFF
--- a/doc/jupyter_lite_config.json
+++ b/doc/jupyter_lite_config.json
@@ -1,0 +1,5 @@
+{
+  "LiteBuildConfig": {
+    "no_sourcemaps": true
+  }
+}


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

I realised that the JupyterLite output is ~39MB this is added on each push in our scikit-learn.github.io so this is likely to grow ...

Removing sourcemaps, following the [JuyterLite doc](https://jupyterlite.readthedocs.io/en/latest/howto/configure/advanced/optimizations.html#removing-source-maps), reduces the JupyterLite output to ~15MB.

