### PR TITLE
MNT Use fixed version of Pyodide

### DIFF
--- a/doc/jupyter-lite.json
+++ b/doc/jupyter-lite.json
@@ -1,0 +1,10 @@
+{
+  "jupyter-lite-schema-version": 0,
+  "jupyter-config-data": {
+    "litePluginSettings": {
+      "@jupyterlite/pyodide-kernel-extension:kernel": {
+        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.23.1/full/pyodide.js"
+      }
+    }
+  }
+} 


### PR DESCRIPTION
#### Reference Issues/PRs

Follow up of #25887.

#### What does this implement/fix? Explain your changes.

This uses a fixed version of Pyodide as mentioned in https://github.com/scikit-learn/scikit-learn/pull/25887#issuecomment-1514714120.

When we start building a scikit-learn wheel in our CI this will make it easier to make sure that the emscripten version we use to build the scikit-learn wheel is the same as the one that was used to build the Pyodide we are using inside JupyterLite.