### PR TITLE
CI Use Trusted Publishers for uploading wheels to PyPI

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
@@ -35,15 +38,10 @@ jobs:
       run: |
         python build_tools/github/check_wheels.py
     - name: Publish package to TestPyPI
-      uses: pypa/gh-action-pypi-publish@v1.4.1
+      uses: pypa/gh-action-pypi-publish@v1.8.5
       with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
       if: ${{ github.event.inputs.pypi_repo == 'testpypi' }}
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.4.1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_TOKEN }}
+      uses: pypa/gh-action-pypi-publish@v1.8.5
       if: ${{ github.event.inputs.pypi_repo == 'pypi' }}


### PR DESCRIPTION
PyPI now has [Trusted Publishers](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/), which means we can use OpenID Connect to configure PyPI tor trust a given GitHub repo and workflow. This means we no longer need the API keys anymore.

This PR adjusts the workflow to make use of this OpenID system. I already made the interface of PyPI live and PyPI test servers such that they trust this specific workflow.