### PR TITLE
FIX Raises an erorr in vectorizers when output is pandas

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -297,6 +297,11 @@ Changelog
   Parameter validation only happens at `fit` time.
   :pr:`24230` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- |FIX| :class:`feature_extraction.text.CountVectorizer`,
+  :class:`feature_extraction.text.TfidfVectorizer`, and
+  :class:`feature_extraction.text.HashingVectorizer` now correctly raises an error
+  when the global output is configured to be pandas. :pr:`xxxxx` by `Thomas Fan`_.
+
 :mod:`sklearn.feature_selection`
 ................................
 

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -300,7 +300,7 @@ Changelog
 - |FIX| :class:`feature_extraction.text.CountVectorizer`,
   :class:`feature_extraction.text.TfidfVectorizer`, and
   :class:`feature_extraction.text.HashingVectorizer` now correctly raises an error
-  when the global output is configured to be pandas. :pr:`xxxxx` by `Thomas Fan`_.
+  when the global output is configured to be pandas. :pr:`26253` by `Thomas Fan`_.
 
 :mod:`sklearn.feature_selection`
 ................................

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -5,6 +5,7 @@ import pytest
 import warnings
 from scipy import sparse
 
+import sklearn
 from sklearn.feature_extraction.text import strip_tags
 from sklearn.feature_extraction.text import strip_accents_unicode
 from sklearn.feature_extraction.text import strip_accents_ascii
@@ -1646,3 +1647,21 @@ def test_vectorizers_do_not_have_set_output(Estimator):
     """Check that vectorizers do not define set_output."""
     est = Estimator()
     assert not hasattr(est, "set_output")
+
+
+@pytest.mark.parametrize(
+    "Vectorizer", [CountVectorizer, TfidfVectorizer, HashingVectorizer]
+)
+def test_vectorizer_errors_with_pandas_output_configuration(Vectorizer):
+    """Raise error for vectorizers because sparse dataframes are not supported."""
+
+    pytest.importorskip("pandas")
+    error_msg = "Pandas output does not support sparse data"
+
+    vec = Vectorizer().fit(JUNK_FOOD_DOCS)
+    with sklearn.config_context(transform_output="pandas"):
+        with pytest.raises(ValueError, match=error_msg):
+            vec.transform(JUNK_FOOD_DOCS)
+
+        with pytest.raises(ValueError, match=error_msg):
+            vec.fit_transform(JUNK_FOOD_DOCS)

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -33,6 +33,7 @@ from ..utils import _IS_32BIT
 from ..exceptions import NotFittedError
 from ..utils._param_validation import StrOptions, Interval, HasMethods
 from ..utils._param_validation import RealNotInt
+from ..utils._set_output import _get_output_config
 
 
 __all__ = [
@@ -512,6 +513,11 @@ class _VectorizerMixin:
         if len(self.vocabulary_) == 0:
             raise ValueError("Vocabulary is empty")
 
+    def _check_transform_output_config(self):
+        output_config = _get_output_config("transform", estimator=self)["dense"]
+        if output_config == "pandas":
+            raise ValueError("Pandas output does not support sparse data.")
+
     def _validate_ngram_range(self):
         """Check validity of ngram_range parameter"""
         min_n, max_m = self.ngram_range
@@ -877,6 +883,7 @@ class HashingVectorizer(
                 "Iterable over raw text documents expected, string object received."
             )
 
+        self._check_transform_output_config()
         self._validate_ngram_range()
 
         analyzer = self.build_analyzer()
@@ -1364,6 +1371,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
             raise ValueError(
                 "Iterable over raw text documents expected, string object received."
             )
+        self._check_transform_output_config()
 
         self._validate_params()
         self._validate_ngram_range()
@@ -1426,6 +1434,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
             raise ValueError(
                 "Iterable over raw text documents expected, string object received."
             )
+        self._check_transform_output_config()
         self._check_vocabulary()
 
         # use the same matrix-building strategy as fit_transform


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to #26210

#### What does this implement/fix? Explain your changes.
This PR has the Vectorizers raise an error when the global configuration sets the output to pandas.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
