### PR TITLE
MAINT DOC HGBT leave updated if loss is not smooth

### DIFF
--- a/sklearn/_loss/loss.py
+++ b/sklearn/_loss/loss.py
@@ -111,7 +111,7 @@ class BaseLoss:
         Indicates whether n_classes > 2 is allowed.
     """
 
-    # For decision trees:
+    # For gradient boosted decision trees:
     # This variable indicates whether the loss requires the leaves values to
     # be updated once the tree has been trained. The trees are trained to
     # predict a Newton-Raphson step (see grower._finalize_leaf()). But for
@@ -120,8 +120,8 @@ class BaseLoss:
     # procedure. See the original paper Greedy Function Approximation: A
     # Gradient Boosting Machine by Friedman
     # (https://statweb.stanford.edu/~jhf/ftp/trebst.pdf) for the theory.
-    need_update_leaves_values = False
     differentiable = True
+    need_update_leaves_values = False
     is_multiclass = False
 
     def __init__(self, closs, link, n_classes=None):

--- a/sklearn/_loss/loss.py
+++ b/sklearn/_loss/loss.py
@@ -541,6 +541,10 @@ class AbsoluteError(BaseLoss):
     For a given sample x_i, the absolute error is defined as::
 
         loss(x_i) = |y_true_i - raw_prediction_i|
+
+    Note that the exact hessian = 0 almost everywhere (except at one point, therefore
+    differentiable = False). Optimization routines like in HGBT, however, need a
+    hessian > 0. Therefore, we assign 1.
     """
 
     differentiable = False
@@ -582,6 +586,10 @@ class PinballLoss(BaseLoss):
                              u * quantile       if u >= 0
 
     Note: 2 * PinballLoss(quantile=0.5) equals AbsoluteError().
+
+    Note that the exact hessian = 0 almost everywhere (except at one point, therefore
+    differentiable = False). Optimization routines like in HGBT, however, need a
+    hessian > 0. Therefore, we assign 1.
 
     Additional Attributes
     ---------------------

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -63,12 +63,15 @@ def _update_leaves_values(loss, grower, y_true, raw_prediction, sample_weight):
       - PinballLoss: quantile(y_true - raw_prediction).
 
     More background:
-    For the standard gradient descent method in "Greedy Function Approximation: A
-    Gradient Boosting Machine" by Friedman, all loss functions but the squared loss
-    need a line search step. But BaseHistGradientBoosting implements a so called Newton
-    boosting where the trees are fitted to a 2nd order approximations of the loss in
-    terms of gradients and hessians. In this case, the line search step is only
-    necessary if the loss is not smooth, i.e. not differentiable.
+    For the standard gradient descent method according to "Greedy Function
+    Approximation: A Gradient Boosting Machine" by Friedman, all loss functions but the
+    squared loss need a line search step. BaseHistGradientBoosting, however, implements
+    a so called Newton boosting where the trees are fitted to a 2nd order
+    approximations of the loss in terms of gradients and hessians. In this case, the
+    line search step is only necessary if the loss is not smooth, i.e. not
+    differentiable, which renders the 2nd order approximation invalid. In fact,
+    non-smooth losses arbitrarily set hessians to 1 and effectively use the standard
+    gradient descent method with line search.
     """
     # TODO: Ideally this should be computed in parallel over the leaves using something
     # similar to _update_raw_predictions(), but this requires a cython version of

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -55,13 +55,20 @@ def _update_leaves_values(loss, grower, y_true, raw_prediction, sample_weight):
     Update equals:
         loss.fit_intercept_only(y_true - raw_prediction)
 
-    This is only applied if loss.need_update_leaves_values is True.
+    This is only applied if loss.differentiable is False.
     Note: It only works, if the loss is a function of the residual, as is the
     case for AbsoluteError and PinballLoss. Otherwise, one would need to get
     the minimum of loss(y_true, raw_prediction + x) in x. A few examples:
       - AbsoluteError: median(y_true - raw_prediction).
       - PinballLoss: quantile(y_true - raw_prediction).
-    See also notes about need_update_leaves_values in BaseLoss.
+
+    More background:
+    For the standard gradient descent method in "Greedy Function Approximation: A
+    Gradient Boosting Machine" by Friedman, all loss functions but the squared loss
+    need a line search step. But BaseHistGradientBoosting implements a so called Newton
+    boosting where the trees are fitted to a 2nd order approximations of the loss in
+    terms of gradients and hessians. In this case, the line search step is only
+    necessary if the loss is not smooth, i.e. not differentiable.
     """
     # TODO: Ideally this should be computed in parallel over the leaves using something
     # similar to _update_raw_predictions(), but this requires a cython version of
@@ -696,7 +703,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                 acc_find_split_time += grower.total_find_split_time
                 acc_compute_hist_time += grower.total_compute_hist_time
 
-                if self._loss.need_update_leaves_values:
+                if not self._loss.differentiable:
                     _update_leaves_values(
                         loss=self._loss,
                         grower=grower,


### PR DESCRIPTION
#### Reference Issues/PRs
Popped up while working on #25964.

#### What does this implement/fix? Explain your changes.
HGBT leave updates now rely on `loss.differentiable` and the reasons and differences to the standard gradient boosting algo are explained.

#### Any other comments?
It is hard to find a reference for gradient boosting with 2nd order loss approximation (using hessians) and non-smooth losses.
Edit: https://arxiv.org/abs/1808.03064 explicitly considers the different boosting schemes and mentions the problem of non-smooth loss functions with Newton boosting.