### PR TITLE
MAINT Parameters validation for sklearn.datasets.get_data_home

### DIFF
--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -24,6 +24,7 @@ from ..utils import check_pandas_support
 from ..utils.fixes import _open_binary, _open_text, _read_text, _contents
 from ..utils._param_validation import validate_params, Interval
 
+
 import numpy as np
 
 from urllib.request import urlretrieve
@@ -35,6 +36,11 @@ IMAGES_MODULE = "sklearn.datasets.images"
 RemoteFileMetadata = namedtuple("RemoteFileMetadata", ["filename", "url", "checksum"])
 
 
+@validate_params(
+    {
+        "data_home": [str, os.PathLike, None],
+    }
+)
 def get_data_home(data_home=None) -> str:
     """Return the path of the scikit-learn data directory.
 

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -24,7 +24,6 @@ from ..utils import check_pandas_support
 from ..utils.fixes import _open_binary, _open_text, _read_text, _contents
 from ..utils._param_validation import validate_params, Interval
 
-
 import numpy as np
 
 from urllib.request import urlretrieve
@@ -64,7 +63,7 @@ def get_data_home(data_home=None) -> str:
 
     Returns
     -------
-    data_home: str
+    data_home: str or path-like, default=None
         The path to scikit-learn data directory.
     """
     if data_home is None:

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -903,7 +903,7 @@ def fetch_openml(
         data_home = None
     else:
         data_home = get_data_home(data_home=data_home)
-        data_home = join(data_home, "openml")
+        data_home = join(str(data_home), "openml")
 
     # check valid function arguments. data_id XOR (name, version) should be
     # provided

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -903,7 +903,7 @@ def fetch_openml(
         data_home = None
     else:
         data_home = get_data_home(data_home=data_home)
-        data_home = join(str(data_home), "openml")
+        data_home = join(data_home, "openml")
 
     # check valid function arguments. data_id XOR (name, version) should be
     # provided

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -130,6 +130,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.datasets.fetch_olivetti_faces",
     "sklearn.datasets.fetch_rcv1",
     "sklearn.datasets.fetch_species_distributions",
+    "sklearn.datasets.get_data_home",
     "sklearn.datasets.load_breast_cancer",
     "sklearn.datasets.load_diabetes",
     "sklearn.datasets.load_digits",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #24862

#### What does this implement/fix? Explain your changes.
Parameters validation for [sklearn.datasets.get_data_home](https://github.com/scikit-learn/scikit-learn/blob/c3bfe86b4/sklearn/datasets/_base.py#L36)

#### Any other comments?
if data_home is not converted to `str`, `Optional[str]` will raise static check error

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
