### PR TITLE
MNT Reset transform_output default in example to fix doc build build

### DIFF
--- a/examples/preprocessing/plot_target_encoder_cross_val.py
+++ b/examples/preprocessing/plot_target_encoder_cross_val.py
@@ -158,3 +158,8 @@ _ = coefs_no_cv.plot(kind="barh")
 # :class:`TargetEncoder` is a part of a :class:`~sklearn.pipeline.Pipeline` and the
 # pipeline is fitted, the pipeline will correctly call
 # :meth:`TargetEncoder.fit_transform` and pass the encoding along.
+
+# %%
+# This resets `transform_output` to its default value to avoid impacting other
+# examples when generating the scikit-learn documentation
+sklearn.set_config(transform_output="default")


### PR DESCRIPTION
#### Reference Issues/PRs

The doc build on `main` fails since #26185 has been merged.

sphinx-gallery runs all the examples in the same process, so you need to reset stuff at the end of each example otherwise there will be a side-effect of other examples, also https://github.com/scikit-learn/scikit-learn/pull/24654#discussion_r994744202

This kind of things already happened before, see #24654. This is hard to notice before merging, because only the example is run in the PR so you can not notice side-effects unless you run the full doc build.
