### PR TITLE
PERF revert openmp use in csr_row_norms

### DIFF
--- a/sklearn/metrics/_pairwise_distances_reduction/_base.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_base.pyx.tp
@@ -5,7 +5,7 @@ from libcpp.vector cimport vector
 
 from ...utils._cython_blas cimport _dot
 from ...utils._openmp_helpers cimport omp_get_thread_num
-from ...utils._typedefs cimport intp_t, float32_t, float64_t
+from ...utils._typedefs cimport intp_t, float32_t, float64_t, int32_t
 
 import numpy as np
 
@@ -14,7 +14,6 @@ from numbers import Integral
 from sklearn import get_config
 from sklearn.utils import check_scalar
 from ...utils._openmp_helpers import _openmp_effective_n_threads
-from ...utils.sparsefuncs_fast import _sqeuclidean_row_norms_sparse
 
 #####################
 
@@ -84,6 +83,23 @@ cdef float64_t[::1] _sqeuclidean_row_norms32_dense(
     return squared_row_norms
 
 
+cdef float64_t[::1] _sqeuclidean_row_norms64_sparse(
+    const float64_t[:] X_data,
+    const int32_t[:] X_indptr,
+    intp_t num_threads,
+):
+    cdef:
+        intp_t n = X_indptr.shape[0] - 1
+        int32_t X_i_ptr, idx = 0
+        float64_t[::1] squared_row_norms = np.zeros(n, dtype=np.float64)
+
+    for idx in prange(n, schedule='static', nogil=True, num_threads=num_threads):
+        for X_i_ptr in range(X_indptr[idx], X_indptr[idx+1]):
+            squared_row_norms[idx] += X_data[X_i_ptr] * X_data[X_i_ptr]
+
+    return squared_row_norms
+
+
 {{for name_suffix in ["64", "32"]}}
 
 from ._datasets_pair cimport DatasetsPair{{name_suffix}}
@@ -98,7 +114,7 @@ cpdef float64_t[::1] _sqeuclidean_row_norms{{name_suffix}}(
         # by moving squared row norms computations in MiddleTermComputer.
         X_data = np.asarray(X.data, dtype=np.float64)
         X_indptr = np.asarray(X.indptr, dtype=np.int32)
-        return _sqeuclidean_row_norms_sparse(X_data, X_indptr, num_threads)
+        return _sqeuclidean_row_norms64_sparse(X_data, X_indptr, num_threads)
     else:
         return _sqeuclidean_row_norms{{name_suffix}}_dense(X, num_threads)
 


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/26097
Fixes https://github.com/scikit-learn/scikit-learn/issues/26100

The introduction of openmp in ``csr_row_norms`` done in https://github.com/scikit-learn/scikit-learn/pull/25598 in order to factor some code in https://github.com/scikit-learn/scikit-learn/pull/25731 caused a performance regression identified in https://github.com/scikit-learn/scikit-learn/issues/26097 and https://github.com/scikit-learn/scikit-learn/issues/26100 (explanations here https://github.com/scikit-learn/scikit-learn/issues/26097#issuecomment-1517844849)

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b8ee2be</samp>

> _We crush the matrices with our mighty norms_
> _We spare no mercy for the sparse and slow_
> _We simplify the code and break the norms_
> _We `_sqeuclidean_row_norms64_sparse` and go_