### PR TITLE
Include informative error message when checking classification target is of a non-regression type

### DIFF
--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -216,9 +216,9 @@ def check_classification_targets(y):
         "multilabel-sequences",
     ]:
         raise ValueError(
-            "Unknown label type: %r"
-            "Maybe you are trying to fit a classifier for discrete classes"
-            "on a regression target with continuous values" % y_type
+            f"Unknown label type: {y_type}. Maybe you are trying to fit a "
+            "classifier which expects discrete classes as output on a "
+            "regression target having continuous values."
         )
 
 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -217,8 +217,8 @@ def check_classification_targets(y):
     ]:
         raise ValueError(
             f"Unknown label type: {y_type}. Maybe you are trying to fit a "
-            "classifier which expects discrete classes as output on a "
-            "regression target having continuous values."
+            "classifier, which expects discrete classes on a "
+            "regression target with continuous values."
         )
 
 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -215,7 +215,11 @@ def check_classification_targets(y):
         "multilabel-indicator",
         "multilabel-sequences",
     ]:
-        raise ValueError("Unknown label type: %r" % y_type)
+        raise ValueError(
+            "Unknown label type: %r"
+            "Maybe you are trying to fit a classifier for discrete classes"
+            "on a regression target with continuous values" % y_type
+        )
 
 
 def type_of_target(y, input_name=""):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #26270

#### What does this implement/fix? Explain your changes.
This includes an informative error message when checking  a classification target in `multiclass.py` . This provides a helpful error message to the user when a classifier is fit on a regression type/outcome.

#### Any other comments?
The error message will offer more insight for a user to get back on track.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
