### PR TITLE
TST add test_binomial_vs_alternative_formulation

### DIFF
--- a/sklearn/_loss/tests/test_loss.py
+++ b/sklearn/_loss/tests/test_loss.py
@@ -1003,18 +1003,20 @@ def test_binomial_vs_alternative_formulation():
 
     bin_loss = HalfBinomialLoss()
 
-    test_data = product(
-        (np.array([0.0, 0, 0]), np.array([1.0, 1, 1])),
-        (np.array([-5.0, -5, -5]), np.array([3.0, 3, 3])),
+    test_data = list(
+        product(
+            (np.array([0.0, 0, 0]), np.array([1.0, 1, 1])),
+            (np.array([-5.0, -5, -5]), np.array([3.0, 3, 3])),
+        )
     )
 
     for datum in test_data:
         assert bin_loss(*datum) == approx(alt_loss(*datum))
 
-    # check the negative gradient against alternative formula from ESLII
+    # check the gradient against alternative formula from ESLII
     def alt_gradient(y, raw_pred):
         z = 2 * y - 1
-        return z / (1 + np.exp(z * raw_pred))
+        return -z / (1 + np.exp(z * raw_pred))
 
     for datum in test_data:
         assert bin_loss.gradient(*datum) == approx(alt_gradient(*datum))

--- a/sklearn/_loss/tests/test_loss.py
+++ b/sklearn/_loss/tests/test_loss.py
@@ -1,4 +1,3 @@
-from itertools import product
 import pickle
 
 import numpy as np
@@ -982,7 +981,9 @@ def test_binomial_and_multinomial_loss(global_random_seed):
     )
 
 
-def test_binomial_vs_alternative_formulation():
+@pytest.mark.parametrize("y_true", (np.array([0.0, 0, 0]), np.array([1.0, 1, 1])))
+@pytest.mark.parametrize("y_pred", (np.array([-5.0, -5, -5]), np.array([3.0, 3, 3])))
+def test_binomial_vs_alternative_formulation(y_true, y_pred, global_dtype):
     """Test that both formulations of the binomial deviance agree.
 
     Often, the binomial deviance or log loss is written in terms of a variable
@@ -1008,14 +1009,12 @@ def test_binomial_vs_alternative_formulation():
 
     bin_loss = HalfBinomialLoss()
 
-    test_data = product(
-        (np.array([0.0, 0, 0]), np.array([1.0, 1, 1])),
-        (np.array([-5.0, -5, -5]), np.array([3.0, 3, 3])),
-    )
+    y_true = y_true.astype(global_dtype)
+    y_pred = y_pred.astype(global_dtype)
+    datum = (y_true, y_pred)
 
-    for datum in test_data:
-        assert bin_loss(*datum) == approx(alt_loss(*datum))
-        assert_allclose(bin_loss.gradient(*datum), alt_gradient(*datum))
+    assert bin_loss(*datum) == approx(alt_loss(*datum))
+    assert_allclose(bin_loss.gradient(*datum), alt_gradient(*datum))
 
 
 @pytest.mark.parametrize("loss", LOSS_INSTANCES, ids=loss_instance_name)

--- a/sklearn/_loss/tests/test_loss.py
+++ b/sklearn/_loss/tests/test_loss.py
@@ -1,3 +1,4 @@
+from itertools import product
 import pickle
 
 import numpy as np
@@ -979,6 +980,44 @@ def test_binomial_and_multinomial_loss(global_random_seed):
         binom.loss(y_true=y_train, raw_prediction=raw_prediction),
         multinom.loss(y_true=y_train, raw_prediction=raw_multinom),
     )
+
+
+def test_binomial_vs_alternative_formulation():
+    """Test that both formulations of the binomial deviance agree.
+
+    Often, the binomial deviance or log loss is written in terms of a variable
+    z in {-1, +1}, but we use y in {0, 1}, hence z = 2 * y - 1.
+    ESL II Eq. (10.18):
+
+        -loglike(z, f) = log(1 + exp(-2 * z * f))
+
+    Note:
+        - ESL 2*f = raw_prediction, hence the factor 2 of ESL disappears.
+        - Deviance = -2*loglike + .., but HalfBinomialLoss is half of the
+          deviance, hence the factor of 2 cancels in the comparison.
+    """
+
+    def alt_loss(y, raw_pred):
+        z = 2 * y - 1
+        return np.mean(np.log(1 + np.exp(-z * raw_pred)))
+
+    bin_loss = HalfBinomialLoss()
+
+    test_data = product(
+        (np.array([0.0, 0, 0]), np.array([1.0, 1, 1])),
+        (np.array([-5.0, -5, -5]), np.array([3.0, 3, 3])),
+    )
+
+    for datum in test_data:
+        assert bin_loss(*datum) == approx(alt_loss(*datum))
+
+    # check the negative gradient against alternative formula from ESLII
+    def alt_gradient(y, raw_pred):
+        z = 2 * y - 1
+        return z / (1 + np.exp(z * raw_pred))
+
+    for datum in test_data:
+        assert bin_loss.gradient(*datum) == approx(alt_gradient(*datum))
 
 
 @pytest.mark.parametrize("loss", LOSS_INSTANCES, ids=loss_instance_name)

--- a/sklearn/_loss/tests/test_loss.py
+++ b/sklearn/_loss/tests/test_loss.py
@@ -1019,7 +1019,7 @@ def test_binomial_vs_alternative_formulation():
         return -z / (1 + np.exp(z * raw_pred))
 
     for datum in test_data:
-        assert bin_loss.gradient(*datum) == approx(alt_gradient(*datum))
+        assert_allclose(bin_loss.gradient(*datum), alt_gradient(*datum))
 
 
 @pytest.mark.parametrize("loss", LOSS_INSTANCES, ids=loss_instance_name)

--- a/sklearn/_loss/tests/test_loss.py
+++ b/sklearn/_loss/tests/test_loss.py
@@ -1001,24 +1001,20 @@ def test_binomial_vs_alternative_formulation():
         z = 2 * y - 1
         return np.mean(np.log(1 + np.exp(-z * raw_pred)))
 
+    def alt_gradient(y, raw_pred):
+        # alternative gradient formula according to ESL
+        z = 2 * y - 1
+        return -z / (1 + np.exp(z * raw_pred))
+
     bin_loss = HalfBinomialLoss()
 
-    test_data = list(
-        product(
-            (np.array([0.0, 0, 0]), np.array([1.0, 1, 1])),
-            (np.array([-5.0, -5, -5]), np.array([3.0, 3, 3])),
-        )
+    test_data = product(
+        (np.array([0.0, 0, 0]), np.array([1.0, 1, 1])),
+        (np.array([-5.0, -5, -5]), np.array([3.0, 3, 3])),
     )
 
     for datum in test_data:
         assert bin_loss(*datum) == approx(alt_loss(*datum))
-
-    # check the gradient against alternative formula from ESLII
-    def alt_gradient(y, raw_pred):
-        z = 2 * y - 1
-        return -z / (1 + np.exp(z * raw_pred))
-
-    for datum in test_data:
         assert_allclose(bin_loss.gradient(*datum), alt_gradient(*datum))
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Makes #26278 smaller

#### What does this implement/fix? Explain your changes.
It adds a test for the binomial loss function that compares with an alternative formulation. This test is taken from `sklearn.ensemble.test.test_gradient_boosting_loss_functions.py`, `test_binomial_deviance` (which will be removed with #26278).

#### Any other comments?
