### PR TITLE
MNT Bump Github Action labeler version to use newer Node

### DIFF
--- a/.github/workflows/labeler-module.yml
+++ b/.github/workflows/labeler-module.yml
@@ -14,7 +14,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: thomasjpfan/labeler@v2.5.0
+    - uses: thomasjpfan/labeler@v2.5.1
       continue-on-error: true
       if: github.repository == 'scikit-learn/scikit-learn'
       with:
@@ -25,7 +25,7 @@ jobs:
   triage_file_extensions:
     runs-on: ubuntu-latest
     steps:
-    - uses: thomasjpfan/labeler@v2.5.0
+    - uses: thomasjpfan/labeler@v2.5.1
       continue-on-error: true
       if: github.repository == 'scikit-learn/scikit-learn'
       with:


### PR DESCRIPTION
On the CI, the labeler action has been issuing [deprecation warnings](https://github.com/scikit-learn/scikit-learn/actions/runs/4840051286) because it is using an old node version. This PR updates the action to `v2.5.1`, which updates node to v16.

I tested the `v2.5.1` release [with a PR to my fork](https://github.com/thomasjpfan/scikit-learn/pull/120) to make sure the labeler works as expected. [Here](https://github.com/thomasjpfan/scikit-learn/actions/runs/4840960598/jobs/8626923820?pr=120) is a link to the run which shows that it used `v2.5.1`.

Note that we use a fork, because I added a [max-labels feature](https://github.com/thomasjpfan/labeler/tree/releases/v2.5.1#change-in-this-fork) which disables the labeling if there are too many labels.