### PR TITLE
ENH Remove unnecessary OOB computation when n_more_estimators == 0

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -287,6 +287,10 @@ Changelog
   scikit-learn 1.3: retraining with scikit-learn 1.3 is required.
   :pr:`25186` by :user:`Felipe Breve Siola <fsiola>`.
 
+- |Efficiency| :class:`ensemble.BaseForest` now only recomputes out-of-bag scores
+  if `n_more_estimators > 0` in subsequent `fit` calls.
+  :pr:`26318` by :user:`Joshua Choo Yun Keat <choo8>`.
+
 - |Enhancement| :class:`ensemble.BaggingClassifier` and
   :class:`ensemble.BaggingRegressor` expose the `allow_nan` tag from the
   underlying estimator. :pr:`25506` by `Thomas Fan`_.

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -287,8 +287,10 @@ Changelog
   scikit-learn 1.3: retraining with scikit-learn 1.3 is required.
   :pr:`25186` by :user:`Felipe Breve Siola <fsiola>`.
 
-- |Efficiency| :class:`ensemble.BaseForest` now only recomputes out-of-bag scores
-  if `n_more_estimators > 0` in subsequent `fit` calls.
+- |Efficiency| :class:`ensemble.RandomForestClassifier` and 
+  :class:`ensemble.RandomForestRegressor` with `warm_start=True` now only
+  recomputes out-of-bag scores when there are actually more `n_estimators`
+  in subsequent `fit` calls.
   :pr:`26318` by :user:`Joshua Choo Yun Keat <choo8>`.
 
 - |Enhancement| :class:`ensemble.BaggingClassifier` and

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -287,7 +287,7 @@ Changelog
   scikit-learn 1.3: retraining with scikit-learn 1.3 is required.
   :pr:`25186` by :user:`Felipe Breve Siola <fsiola>`.
 
-- |Efficiency| :class:`ensemble.RandomForestClassifier` and 
+- |Efficiency| :class:`ensemble.RandomForestClassifier` and
   :class:`ensemble.RandomForestRegressor` with `warm_start=True` now only
   recomputes out-of-bag scores when there are actually more `n_estimators`
   in subsequent `fit` calls.

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -472,7 +472,11 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
             # Collect newly grown trees
             self.estimators_.extend(trees)
 
-        if self.oob_score:
+        # Only perform OOB computation again if there are newly grown trees or
+        # if it was not previously calculated due to oob_score parameter being False
+        if self.oob_score and (
+            n_more_estimators > 0 or not hasattr(self, "oob_score_")
+        ):
             y_type = type_of_target(y)
             if y_type in ("multiclass-multioutput", "unknown"):
                 # FIXME: we could consider to support multiclass-multioutput if

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -472,11 +472,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
             # Collect newly grown trees
             self.estimators_.extend(trees)
 
-        # Only perform OOB computation again if there are newly grown trees or
-        # if it was not previously calculated due to oob_score parameter being False
-        if self.oob_score and (
-            n_more_estimators > 0 or not hasattr(self, "oob_score_")
-        ):
+        if self.oob_score:
             y_type = type_of_target(y)
             if y_type in ("multiclass-multioutput", "unknown"):
                 # FIXME: we could consider to support multiclass-multioutput if

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -357,9 +357,11 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         y = np.atleast_1d(y)
         if y.ndim == 2 and y.shape[1] == 1:
             warn(
-                "A column-vector y was passed when a 1d array was"
-                " expected. Please change the shape of y to "
-                "(n_samples,), for example using ravel().",
+                (
+                    "A column-vector y was passed when a 1d array was"
+                    " expected. Please change the shape of y to "
+                    "(n_samples,), for example using ravel()."
+                ),
                 DataConversionWarning,
                 stacklevel=2,
             )
@@ -574,9 +576,11 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         for k in range(n_outputs):
             if (n_oob_pred == 0).any():
                 warn(
-                    "Some inputs do not have OOB scores. This probably means "
-                    "too few trees were used to compute any reliable OOB "
-                    "estimates.",
+                    (
+                        "Some inputs do not have OOB scores. This probably means "
+                        "too few trees were used to compute any reliable OOB "
+                        "estimates."
+                    ),
                     UserWarning,
                 )
                 n_oob_pred[n_oob_pred == 0] = 1

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -474,7 +474,11 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
             # Collect newly grown trees
             self.estimators_.extend(trees)
 
-        if self.oob_score:
+        # Only perform OOB computation again if there are newly grown trees or
+        # if it was not previously calculated due to oob_score parameter being False
+        if self.oob_score and (
+            n_more_estimators > 0 or not hasattr(self, "oob_score_")
+        ):
             y_type = type_of_target(y)
             if y_type in ("multiclass-multioutput", "unknown"):
                 # FIXME: we could consider to support multiclass-multioutput if

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -474,11 +474,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
             # Collect newly grown trees
             self.estimators_.extend(trees)
 
-        # Only perform OOB computation again if there are newly grown trees or
-        # if it was not previously calculated due to oob_score parameter being False
-        if self.oob_score and (
-            n_more_estimators > 0 or not hasattr(self, "oob_score_")
-        ):
+        if self.oob_score:
             y_type = type_of_target(y)
             if y_type in ("multiclass-multioutput", "unknown"):
                 # FIXME: we could consider to support multiclass-multioutput if

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -357,11 +357,9 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         y = np.atleast_1d(y)
         if y.ndim == 2 and y.shape[1] == 1:
             warn(
-                (
-                    "A column-vector y was passed when a 1d array was"
-                    " expected. Please change the shape of y to "
-                    "(n_samples,), for example using ravel()."
-                ),
+                "A column-vector y was passed when a 1d array was"
+                " expected. Please change the shape of y to "
+                "(n_samples,), for example using ravel().",
                 DataConversionWarning,
                 stacklevel=2,
             )
@@ -576,11 +574,9 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         for k in range(n_outputs):
             if (n_oob_pred == 0).any():
                 warn(
-                    (
-                        "Some inputs do not have OOB scores. This probably means "
-                        "too few trees were used to compute any reliable OOB "
-                        "estimates."
-                    ),
+                    "Some inputs do not have OOB scores. This probably means "
+                    "too few trees were used to compute any reliable OOB "
+                    "estimates.",
                     UserWarning,
                 )
                 n_oob_pred[n_oob_pred == 0] = 1

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -474,8 +474,6 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
             # Collect newly grown trees
             self.estimators_.extend(trees)
 
-        # Only perform OOB computation again if there are newly grown trees or
-        # if it was not previously calculated due to oob_score parameter being False
         if self.oob_score and (
             n_more_estimators > 0 or not hasattr(self, "oob_score_")
         ):

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1476,7 +1476,9 @@ def check_oob_not_computed_twice(name):
     X, y = hastie_X, hastie_y
     ForestEstimator = FOREST_ESTIMATORS[name]
 
-    est = ForestEstimator(n_estimators=10, warm_start=True, bootstrap=True, oob_score=True)
+    est = ForestEstimator(
+        n_estimators=10, warm_start=True, bootstrap=True, oob_score=True
+    )
 
     with patch.object(
         est, "_set_oob_score_and_attributes", wraps=est._set_oob_score_and_attributes

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1467,6 +1467,11 @@ def check_warm_start_oob(name):
 
 
 @pytest.mark.parametrize("name", FOREST_CLASSIFIERS_REGRESSORS)
+def test_warm_start_oob(name):
+    check_warm_start_oob(name)
+
+
+@pytest.mark.parametrize("name", FOREST_CLASSIFIERS_REGRESSORS)
 def test_oob_not_computed_twice(name):
     # Check that oob_score is not computed twice when warm_start=True.
     X, y = hastie_X, hastie_y
@@ -1485,11 +1490,6 @@ def test_oob_not_computed_twice(name):
             est.fit(X, y)
 
         mock_set_oob_score_and_attributes.assert_called_once()
-
-
-@pytest.mark.parametrize("name", FOREST_CLASSIFIERS_REGRESSORS)
-def test_oob_not_computed_twice(name):
-    check_oob_not_computed_twice(name)
 
 
 def test_dtype_convert(n_classes=15):

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1467,11 +1467,7 @@ def check_warm_start_oob(name):
 
 
 @pytest.mark.parametrize("name", FOREST_CLASSIFIERS_REGRESSORS)
-def test_warm_start_oob(name):
-    check_warm_start_oob(name)
-
-
-def check_oob_not_computed_twice(name):
+def test_oob_not_computed_twice(name):
     # Check that oob_score is not computed twice when warm_start=True.
     X, y = hastie_X, hastie_y
     ForestEstimator = FOREST_ESTIMATORS[name]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #20435, based on the comments by @NicolasHug (https://github.com/scikit-learn/scikit-learn/issues/20435#issuecomment-872835169)

#### What does this implement/fix? Explain your changes.
Removes unnecessary OOB computation when n_more_estimators == 0

#### Any other comments?
I understand from our previous conversation (https://github.com/scikit-learn/scikit-learn/pull/24579#discussion_r1012729686) that @glemaitre would like some unit tests for this change.

I noticed that the unit test below will check for the case where oob_score is toggled from `False` to `True`
https://github.com/scikit-learn/scikit-learn/blob/c5f10c8b51003caa1feb90b1c6cdd3f73615e45f/sklearn/ensemble/tests/test_forest.py#L1418-L1465

However, I am not sure how I should go about checking that OOB computation (call to `self._set_oob_score_and_attributes()` at https://github.com/scikit-learn/scikit-learn/blob/c5f10c8b51003caa1feb90b1c6cdd3f73615e45f/sklearn/ensemble/_forest.py#L492-L494 or https://github.com/scikit-learn/scikit-learn/blob/c5f10c8b51003caa1feb90b1c6cdd3f73615e45f/sklearn/ensemble/_forest.py#L496) is not called when `n_more_estimators == 0`.

I thought of checking on some object attribute that might be changed by `self._set_oob_score_and_attributes()` but I couldn't find any candidates. I did some research online and it seems like others create a mock function if they want to check for functions being called in runtime.

Do you have any suggestions on how I can go about writing the test for this?
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
