### PR TITLE
Fix minor typo

### DIFF
--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -85,7 +85,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
             - If float, then draw `max(1, int(max_features * n_features_in_))` features.
 
         Note: using a float number less than 1.0 or integer less than number of
-        features will enable feature subsampling and leads to a longerr runtime.
+        features will enable feature subsampling and leads to a longer runtime.
 
     bootstrap : bool, default=False
         If True, individual trees are fit on random subsets of the training


### PR DESCRIPTION
Fixed a small typo I found in the docstring for IsolationForest