### PR TITLE
DOC update documentation on re-building Cython extensions

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -90,7 +90,7 @@ feature, code or documentation improvement).
 
    .. prompt:: bash $
 
-     pip install --verbose --no-build-isolation --editable .
+     pip install --verbose --no-use-pep517 --no-build-isolation --editable .
 
 #. Check that the installed scikit-learn has a version number ending with
    `.dev0`:
@@ -104,10 +104,11 @@ feature, code or documentation improvement).
 
 .. note::
 
-    You will have to run the ``pip install --no-build-isolation --editable .``
+    You will have to run the ``pip install -v --no-use-pep517 --no-build-isolation -e .``
     command every time the source code of a Cython file is updated
-    (ending in `.pyx` or `.pxd`). Use the ``--no-build-isolation`` flag to
-    avoid compiling the whole project each time, only the files you have
+    (ending in `.pyx` or `.pxd`). This can happen when you edit them or when you
+    use certain git commands such as `git pull`. Use the ``--no-build-isolation`` flag
+    to avoid compiling the whole project each time, only the files you have
     modified.
 
 Dependencies
@@ -179,8 +180,8 @@ Editable mode
 
 If you run the development version, it is cumbersome to reinstall the package
 each time you update the sources. Therefore it is recommended that you install
-in with the ``pip install --no-build-isolation --editable .`` command, which
-allows you to edit the code in-place. This builds the extension in place and
+in with the ``pip install -v --no-use-pep517 --no-build-isolation -e .`` command,
+which allows you to edit the code in-place. This builds the extension in place and
 creates a link to the development directory (see `the pip docs
 <https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs>`_).
 
@@ -241,7 +242,7 @@ Finally, build scikit-learn from this command prompt:
 
 .. prompt:: bash $
 
-    pip install --verbose --no-build-isolation --editable .
+    pip install --verbose --no-use-pep517 --no-build-isolation --editable .
 
 .. _compiler_macos:
 
@@ -283,7 +284,7 @@ scikit-learn from source:
         joblib threadpoolctl pytest compilers llvm-openmp
     conda activate sklearn-dev
     make clean
-    pip install --verbose --no-build-isolation --editable .
+    pip install --verbose --no-use-pep517 --no-build-isolation --editable .
 
 .. note::
 
@@ -363,7 +364,7 @@ Finally, build scikit-learn in verbose mode (to check for the presence of the
 .. prompt:: bash $
 
     make clean
-    pip install --verbose --no-build-isolation --editable .
+    pip install --verbose --no-use-pep517 --no-build-isolation --editable .
 
 .. _compiler_linux:
 
@@ -423,7 +424,7 @@ in the user folder using conda:
     conda create -n sklearn-dev -c conda-forge python numpy scipy cython \
         joblib threadpoolctl pytest compilers
     conda activate sklearn-dev
-    pip install --verbose --no-build-isolation --editable .
+    pip install --verbose --no-use-pep517 --no-build-isolation --editable .
 
 .. _compiler_freebsd:
 
@@ -452,7 +453,7 @@ Finally, build the package using the standard command:
 
 .. prompt:: bash $
 
-    pip install --verbose --no-build-isolation --editable .
+    pip install --verbose --no-use-pep517 --no-build-isolation --editable .
 
 For the upcoming FreeBSD 12.1 and 11.3 versions, OpenMP will be included in
 the base system and these steps will not be necessary.
@@ -513,7 +514,7 @@ and environment variable as follows before calling the ``pip install`` or
 ``python setup.py build_ext`` commands::
 
     export SKLEARN_BUILD_PARALLEL=3
-    pip install --verbose --no-build-isolation --editable .
+    pip install --verbose --no-use-pep517 --no-build-isolation --editable .
 
 On a machine with 2 CPU cores, it can be beneficial to use a parallelism level
 of 3 to overlap IO bound tasks (reading and writing files on disk) with CPU

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -336,7 +336,7 @@ modifying code and submitting a PR:
 
     .. prompt:: bash $
 
-        pip install --no-build-isolation -e .
+        pip install -v --no-use-pep517 --no-build-isolation -e .
 
     Use the ``--no-build-isolation`` flag to avoid compiling the whole project
     each time, only the files you have modified.


### PR DESCRIPTION
#### Reference Issues/PRs
towards #25985 


#### What does this implement/fix? Explain your changes.
Updates the documentation on re-building Cython extensions to provide better guidance for new contributors. I also updated the `pip install -v --no-build-isolation -e .` command to `pip install -v --no-use-pep517 --no-build-isolation -e .` in the documentation to prevent potential errors during the installation process. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
