### PR TITLE
MNT Always reset sckit-learn global config in examples

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -475,6 +475,14 @@ def notebook_modification_function(notebook_content, notebook_filename):
     )
 
 
+default_global_config = sklearn.get_config()
+
+
+def reset_sklearn_config(gallery_conf, fname):
+    """Reset sklearn config to default values."""
+    sklearn.set_config(**default_global_config)
+
+
 sphinx_gallery_conf = {
     "doc_module": "sklearn",
     "backreferences_dir": os.path.join("modules", "generated"),
@@ -497,6 +505,7 @@ sphinx_gallery_conf = {
     "inspect_global_variables": False,
     "remove_config_comments": True,
     "plot_gallery": "True",
+    "reset_modules": ("matplotlib", "seaborn", reset_sklearn_config),
 }
 
 

--- a/examples/preprocessing/plot_target_encoder_cross_val.py
+++ b/examples/preprocessing/plot_target_encoder_cross_val.py
@@ -158,8 +158,3 @@ _ = coefs_no_cv.plot(kind="barh")
 # :class:`TargetEncoder` is a part of a :class:`~sklearn.pipeline.Pipeline` and the
 # pipeline is fitted, the pipeline will correctly call
 # :meth:`TargetEncoder.fit_transform` and pass the encoding along.
-
-# %%
-# This resets `transform_output` to its default value to avoid impacting other
-# examples when generating the scikit-learn documentation
-sklearn.set_config(transform_output="default")


### PR DESCRIPTION
This PR uses sphinx-gallery's [reset_modules](https://sphinx-gallery.github.io/stable/configuration.html#resetting-modules) to reset the global config. This way we do not need to manually reset the global config at the end of every example.

CC @lesteve 