### PR TITLE
TST mark test as xfail due to bug fix in pandas-dev

### DIFF
--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -925,7 +925,19 @@ def datasets_missing_values():
         # with casting it will be transformed to either float or Int64
         (40966, "pandas", 1, 77, 0),
         # titanic
-        (40945, "liac-arff", 3, 5, 0),
+        pytest.param(
+            40945,
+            "liac-arff",
+            3,
+            6,
+            0,
+            marks=pytest.mark.xfail(
+                reason=(
+                    "Type inference with missing values works differently in new pandas"
+                    " versions: https://github.com/pandas-dev/pandas/pull/52542"
+                )
+            ),
+        ),
         (40945, "pandas", 3, 3, 3),
     ],
 )


### PR DESCRIPTION
Partially address https://github.com/scikit-learn/scikit-learn/issues/26154

Solving the issue pointed out here: https://github.com/scikit-learn/scikit-learn/issues/26154#issuecomment-1505233045

In short, `pandas` will better infer type during `DataFrame` concatenation with missing values. Previously, due to the way we read by chunk in the `liac-arff` parser, we could end up with `None` and `np.nan` in the same column. The new version of pandas will identify both values are missing values.

Since the new behaviour is what one would expect but we cannot make a backport, a way is to mark the test as `xfail`.