### PR TITLE
DOC Fix wrong ref in RandomForestClassifier docstring

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1336,7 +1336,7 @@ class RandomForestClassifier(ForestClassifier):
     sklearn.tree.DecisionTreeClassifier : A decision tree classifier.
     sklearn.ensemble.ExtraTreesClassifier : Ensemble of extremely randomized
         tree classifiers.
-    sklearn.ensemble.HistGradientBoostingRegressor : A Histogram-based Gradient
+    sklearn.ensemble.HistGradientBoostingClassifier : A Histogram-based Gradient
         Boosting Classification Tree, very fast for big datasets (n_samples >=
         10_000).
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Follows #26319.

#### What does this implement/fix? Explain your changes.

I made a mistake in #26319 and cross-linked the HGDT regressor instead of the classifer in the `RandomForestClassifier` docstring. This PR fixes it.

#### Any other comments?

Sorry!

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
