### PR TITLE
ENH Allow to extract and reconstruct patches using a specific stride

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.feature_extraction/26353.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.feature_extraction/26353.enhancement.rst
@@ -1,0 +1,4 @@
+- :class:`feature_extraction.image.extract_patches_2d` and
+  :class:`feature_extraction.image.reconstruct_from_patches_2d` now can manage
+  extracted patches at different strides with the `stride` parameter.
+  By :user:`Victor Martin <REDVM>`.


### PR DESCRIPTION
### Added stride parameter to `extract_patches_2d` and `reconstruct_from_patches_2d` functions.

In sklearn.feature_extraction.image, current `extract_patches_2d` function extract patches with stride forced to 1. This function use another function `_extract_patches` that can manage different strides with the parameter `extraction_step`.
This change adds the `stride` parameter in `extract_patches_2d` and `reconstruct_from_patches_2d`.

### Notes
#### 1. The way overlapping parts of patches are managed has changed
Executing this code:
```python
import numpy as np
from sklearn.feature_extraction.image import extract_patches_2d, reconstruct_from_patches_2d
for img_size, patch_size, stride in [(128, (5, 5), 1), (1500, (64, 64), 32)]:
    img = np.random.rand(img_size, img_size)
    print(f"{img_size}x{img_size} image, {patch_size[0]}x{patch_size[1]} patches, stride {stride}")
    p = extract_patches_2d(img, patch_size, stride=stride)
    print("Reconstruction from p:", p.shape)
    %time r = reconstruct_from_patches_2d(p, img.shape, stride=stride)
    print()
```
##### With the current sklearn implementation
```
128x128 image, 5x5 patches, stride 1
Reconstruction from p: (15376, 5, 5)
CPU times: user 35.2 ms, sys: 3.6 ms, total: 38.8 ms
Wall time: 38.6 ms

1500x1500 image, 64x64 patches, stride 32
Reconstruction from p: (2025, 64, 64)
CPU times: user 1.22 s, sys: 7.86 ms, total: 1.23 s
Wall time: 1.23 s
```
##### With the implementation from this pull request
```
128x128 image, 5x5 patches, stride 1
Reconstruction from p: (15376, 5, 5)
CPU times: user 64.6 ms, sys: 1.07 ms, total: 65.7 ms
Wall time: 65.5 ms

1500x1500 image, 64x64 patches, stride 32
Reconstruction from p: (2025, 64, 64)
CPU times: user 24.7 ms, sys: 16.5 ms, total: 41.3 ms
Wall time: 41.3 ms
```

With stride=1, the new implementation is 2x slower.
With stride=32, the new implementation is 30x faster.

#### 2. Reconstruction is perfect depending on stride value
However, we could `np.pad` image in `extract_patches_2d` so that all parts in image are extracted, and remove the padding in `reconstruct_from_patches_2d` given `image_size`.
