### PR TITLE
ENH xlim and ylim to axes of RocCurveDisplay and PrecisionRecallDisplay

### DIFF
--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -156,6 +156,8 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
         xlabel = "Recall" + info_pos_label
         ylabel = "Precision" + info_pos_label
         self.ax_.set(xlabel=xlabel, ylabel=ylabel)
+        self.ax_.set_xlim([-0.001, 1.001])
+        self.ax_.set_ylim([-0.001, 1.001])
 
         if "label" in line_kwargs:
             self.ax_.legend(loc="lower left")

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -154,6 +154,8 @@ class RocCurveDisplay(_BinaryClassifierCurveDisplayMixin):
         xlabel = "False Positive Rate" + info_pos_label
         ylabel = "True Positive Rate" + info_pos_label
         self.ax_.set(xlabel=xlabel, ylabel=ylabel)
+        self.ax_.set_xlim([-0.001, 1.001])
+        self.ax_.set_ylim([-0.001, 1.001])
 
         if plot_chance_level:
             (self.chance_level_,) = self.ax_.plot(

--- a/sklearn/metrics/_plot/tests/test_precision_recall_display.py
+++ b/sklearn/metrics/_plot/tests/test_precision_recall_display.py
@@ -69,6 +69,8 @@ def test_precision_recall_display_plotting(
 
     assert display.ax_.get_xlabel() == "Recall (Positive label: 1)"
     assert display.ax_.get_ylabel() == "Precision (Positive label: 1)"
+    assert display.ax_.get_xlim() == (-0.001, 1.001)
+    assert display.ax_.get_ylim() == (-0.001, 1.001)
 
     # plotting passing some new parameters
     display.plot(alpha=0.8, name="MySpecialEstimator")


### PR DESCRIPTION
Related to #25929 

Adding xlim and ylim of (-0.001, 1.001) to the axes