### PR TITLE
CI Add Pyodide wheel build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -121,6 +121,37 @@ jobs:
         DISTRIB: 'conda-pypy3'
         LOCK_FILE: './build_tools/azure/pypy3_linux-64_conda.lock'
 
+
+- job: Linux_Nightly_Pyodide
+  pool:
+    vmImage: ubuntu-22.04
+  variables:
+    # Need to match Python version and Emscripten version for the correct
+    # Pyodide version. For Pyodide version 0.23.2, see
+    # https://github.com/pyodide/pyodide/blob/0.23.2/Makefile.envs
+    PYODIDE_VERSION: '0.23.2'
+    EMSCRIPTEN_VERSION: '3.1.32'
+    PYTHON_VERSION: '3.11.2'
+
+  dependsOn: [git_commit, linting]
+  condition: |
+    and(
+      succeeded(),
+      not(contains(dependencies['git_commit']['outputs']['commit.message'], '[ci skip]')),
+      or(eq(variables['Build.Reason'], 'Schedule'),
+         contains(dependencies['git_commit']['outputs']['commit.message'], '[pyodide]'
+        )
+      )
+    )
+  steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: ${{ PYTHON_VERSION }}
+        addToPath: true
+
+    - bash: bash build_tools/azure/build_pyodide_wheel.sh
+      displayName: Build Pyodide wheel
+
 # Will run all the time regardless of linting outcome.
 - template: build_tools/azure/posix.yml
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -149,8 +149,11 @@ jobs:
         versionSpec: $(PYTHON_VERSION)
         addToPath: true
 
-    - bash: bash build_tools/azure/build_pyodide_wheel.sh
-      displayName: Build Pyodide wheel
+    - bash: bash build_tools/azure/install_pyodide.sh
+      displayName: Build Pyodide wheel and install it in a Pyodide venv
+
+    - bash: bash build_tools/azure/test_script_pyodide.sh
+      displayName: Test Pyodide wheel
 
 # Will run all the time regardless of linting outcome.
 - template: build_tools/azure/posix.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,7 +146,7 @@ jobs:
   steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: ${{ PYTHON_VERSION }}
+        versionSpec: $(PYTHON_VERSION)
         addToPath: true
 
     - bash: bash build_tools/azure/build_pyodide_wheel.sh

--- a/build_tools/azure/build_pyodide_wheel.sh
+++ b/build_tools/azure/build_pyodide_wheel.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# git clone https://github.com/emscripten-core/emsdk.git
+cd emsdk
+./emsdk install $EMSCRIPTEN_VERSION
+./emsdk activate $EMSCRIPTEN_VERSION
+source emsdk_env.sh
+cd -
+
+pip install pyodide-build==$PYODIDE_VERSION
+
+pyodide build
+
+ls -ltrh dist

--- a/build_tools/azure/build_pyodide_wheel.sh
+++ b/build_tools/azure/build_pyodide_wheel.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-# git clone https://github.com/emscripten-core/emsdk.git
+git clone https://github.com/emscripten-core/emsdk.git
 cd emsdk
 ./emsdk install $EMSCRIPTEN_VERSION
 ./emsdk activate $EMSCRIPTEN_VERSION

--- a/build_tools/azure/install_pyodide.sh
+++ b/build_tools/azure/install_pyodide.sh
@@ -9,8 +9,13 @@ cd emsdk
 source emsdk_env.sh
 cd -
 
-pip install pyodide-build==$PYODIDE_VERSION
+pip install pyodide-build==$PYODIDE_VERSION pyodide-cli
 
 pyodide build
 
 ls -ltrh dist
+
+pyodide venv pyodide-venv
+source pyodide-venv/bin/activate
+
+pip install dist/*.whl

--- a/build_tools/azure/install_pyodide.sh
+++ b/build_tools/azure/install_pyodide.sh
@@ -19,3 +19,4 @@ pyodide venv pyodide-venv
 source pyodide-venv/bin/activate
 
 pip install dist/*.whl
+pip list

--- a/build_tools/azure/test_script_pyodide.sh
+++ b/build_tools/azure/test_script_pyodide.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+source pyodide-venv/bin/activate
+
+pip list
 # TODO for now only testing sklearn import to make sure the wheel is not badly
 # broken. When Pyodide 0.24 is released we should run the full test suite and
 # xfail tests that fail due to Pyodide limitations

--- a/build_tools/azure/test_script_pyodide.sh
+++ b/build_tools/azure/test_script_pyodide.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+# TODO for now only testing sklearn import to make sure the wheel is not badly
+# broken. When Pyodide 0.24 is released we should run the full test suite and
+# xfail tests that fail due to Pyodide limitations
+python -c 'import sklearn'

--- a/build_tools/azure/test_script_pyodide.sh
+++ b/build_tools/azure/test_script_pyodide.sh
@@ -5,6 +5,10 @@ set -e
 source pyodide-venv/bin/activate
 
 pip list
+
+# Need to be outside of the git clone otherwise finds non build sklearn folder
+cd /tmp
+
 # TODO for now only testing sklearn import to make sure the wheel is not badly
 # broken. When Pyodide 0.24 is released we should run the full test suite and
 # xfail tests that fail due to Pyodide limitations

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -551,6 +551,7 @@ message, the following actions are taken.
     [scipy-dev]            Build & test with our dependencies (numpy, scipy, etc.) development builds
     [nogil]                Build & test with the nogil experimental branches of CPython, Cython, NumPy, SciPy, ...
     [pypy]                 Build & test with PyPy
+    [pyodide]              Build & test with Pyodide
     [azure parallel]       Run Azure CI jobs in parallel
     [float32]              Run float32 tests by setting `SKLEARN_RUN_FLOAT32_TESTS=1`. See :ref:`environment_variable` for more details
     [doc skip]             Docs are not built


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This adds a CI build that build a Pyodide wheel:
- in `[pyodide]` is in the commit message
- in the scheduled nightly build

I am not planning to run the scikit-learn tests in this PR. This is already useful to make sure the Pyodide wheel builds fine. There was at least one issue in the past where some changes broke the Pyodide build, see #25831. 

Right now the scikit-learn test suite pass on the Pyodide development version (but not on the latest released version namely 0.23.2 at the time of writing) so probably I will wait for the next Pyodide release before running tests. I could also add something simple like making sure that `import sklearn` works or run the test suite for some submodules that are known to work, let me know!

For more details about scikit-learn test suite status in Pyodide see https://github.com/lesteve/scikit-learn-tests-pyodide.

**Edit:** the [Pyodide build](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=55054&view=logs&jobId=6fac3219-cc32-5595-eb73-7f086a643b12&j=6fac3219-cc32-5595-eb73-7f086a643b12&t=876d6681-fe58-5468-c827-6de6cb86009f) seems to work fine.