### PR TITLE
BUG Fixes sample weights when there are missing values in DecisionTrees

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -409,7 +409,7 @@ Changelog
 
 - |API| The `eps` parameter of the :func:`log_loss` has been deprecated and will be
   removed in 1.5. :pr:`25299` by :user:`Omar Salman <OmarManzoor>`.
-
+  
 - |Feature| :func:`metrics.average_precision_score` now supports the
   multiclass case.
   :pr:`17388` by :user:`Geoffrey Bolmier <gbolmier>` and

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -516,7 +516,7 @@ Changelog
   :class:`tree.DecisionTreeClassifier` support missing values when
   `splitter='best'` and criterion is `gini`, `entropy`, or `log_loss`,
   for classification or `squared_error`, `friedman_mse`, or `poisson`
-  for regression. :pr:`23595` by `Thomas Fan`_.
+  for regression. :pr:`23595`, :pr:`xxxxx` by `Thomas Fan`_.
 
 - |Enhancement| Adds a `class_names` parameter to
   :func:`tree.export_text`. This allows specifying the parameter `class_names`

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -409,7 +409,7 @@ Changelog
 
 - |API| The `eps` parameter of the :func:`log_loss` has been deprecated and will be
   removed in 1.5. :pr:`25299` by :user:`Omar Salman <OmarManzoor>`.
-  
+
 - |Feature| :func:`metrics.average_precision_score` now supports the
   multiclass case.
   :pr:`17388` by :user:`Geoffrey Bolmier <gbolmier>` and
@@ -516,7 +516,7 @@ Changelog
   :class:`tree.DecisionTreeClassifier` support missing values when
   `splitter='best'` and criterion is `gini`, `entropy`, or `log_loss`,
   for classification or `squared_error`, `friedman_mse`, or `poisson`
-  for regression. :pr:`23595`, :pr:`xxxxx` by `Thomas Fan`_.
+  for regression. :pr:`23595`, :pr:`26376` by `Thomas Fan`_.
 
 - |Enhancement| Adds a `class_names` parameter to
   :func:`tree.export_text`. This allows specifying the parameter `class_names`

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -838,7 +838,9 @@ cdef class RegressionCriterion(Criterion):
         self.sample_indices[-n_missing:]
         """
         cdef SIZE_t i, p, k
-        cdef DOUBLE_t w = 0.0
+        cdef DOUBLE_t y_ik
+        cdef DOUBLE_t w_y_ik
+        cdef DOUBLE_t w = 1.0
 
         self.n_missing = n_missing
         if n_missing == 0:
@@ -855,7 +857,9 @@ cdef class RegressionCriterion(Criterion):
                 w = self.sample_weight[i]
 
             for k in range(self.n_outputs):
-                self.sum_missing[k] += w
+                y_ik = self.y[i, k]
+                w_y_ik = w * y_ik
+                self.sum_missing[k] += w_y_ik
 
             self.weighted_n_missing += w
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2556,6 +2556,7 @@ def test_missing_values_is_resilience(make_data, Tree, sample_weight_train):
     rng = np.random.RandomState(0)
     n_samples, n_features = 1000, 50
     X, y = make_data(n_samples=n_samples, n_features=n_features, random_state=rng)
+
     # Create dataset with missing values
     X_missing = X.copy()
     X_missing[rng.choice([False, True], size=X.shape, p=[0.9, 0.1])] = np.nan

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2623,10 +2623,10 @@ def test_sample_weight_non_uniform(make_data, Tree):
     # Create dataset with missing values
     X[rng.choice([False, True], size=X.shape, p=[0.9, 0.1])] = np.nan
 
+    # Zero sample weight is the same as removing the sample
     sample_weight = np.ones(X.shape[0])
     sample_weight[::2] = 0.0
 
-    # Train tree with missing values
     tree_with_sw = Tree(random_state=0)
     tree_with_sw.fit(X, y, sample_weight=sample_weight)
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2617,7 +2617,7 @@ def test_missing_value_is_predictive():
 def test_sample_weight_non_uniform(make_data, Tree):
     """Check sample weight is correctly handled with missing values."""
     rng = np.random.RandomState(0)
-    n_samples, n_features = 1000, 50
+    n_samples, n_features = 1000, 10
     X, y = make_data(n_samples=n_samples, n_features=n_features, random_state=rng)
 
     # Create dataset with missing values

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2549,7 +2549,7 @@ def test_missing_values_poisson():
         (datasets.make_classification, DecisionTreeClassifier),
     ],
 )
-@pytest.mark.parametrize("sample_weight_train", [None, "ones"])
+@pytest.mark.parametrize("sample_weight_train", [None, "ones", "one_and_two"])
 def test_missing_values_is_resilience(make_data, Tree, sample_weight_train):
     """Check that trees can deal with missing values and have decent performance."""
 
@@ -2566,6 +2566,9 @@ def test_missing_values_is_resilience(make_data, Tree, sample_weight_train):
 
     if sample_weight_train == "ones":
         sample_weight_train = np.ones(X_missing_train.shape[0])
+    elif sample_weight_train == "one_and_two":
+        sample_weight_train = np.ones(X_missing_train.shape[0])
+        sample_weight_train[::2] = 2
 
     # Train tree with missing values
     tree_with_missing = Tree(random_state=rng)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to #23595

#### What does this implement/fix? Explain your changes.
On `main`, the `weighted_n_missing` was incorrectly computed. This PR fixes it. For reference the computation is exactly the same as `sum_total`:

https://github.com/scikit-learn/scikit-learn/blob/6be774b9a00ed347c8c633006b962c027003562e/sklearn/tree/_criterion.pyx#L818-L824


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
