### PR TITLE
DOC Update daal4py -> scikit-learn-intelex reference

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -279,10 +279,11 @@ and in the `main`, `conda-forge` and `intel` conda channels:
 
   conda install scikit-learn-intelex
 
-This package can accelerate an existing installation of scikit-learn and comes 
-with alternative solvers for some common estimators. Those solvers come 
-from the oneDAL C++ library and are optimized for the x86_64 architecture, 
-and are optimized for multi-core Intel CPUs.
+This package has an Intel optimized version of many estimators. Whenever 
+an alternative implementation doesn't exist, scikit-learn implementation 
+is used as a fallback. Those optimized solvers come from the oneDAL 
+C++ library and are optimized for the x86_64 architecture, and are 
+optimized for multi-core Intel CPUs.
 
 Note that those solvers are not enabled by default, please refer to the
 `scikit-learn-intelex <https://intel.github.io/scikit-learn-intelex/what-is-patching.html>`_ 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -272,7 +272,7 @@ Anaconda offers scikit-learn as part of its free distribution.
 Intel Extension for Scikit-learn
 -------------------
 
-Intel maintains an optimized x86 package, avaialbe in PyPi, conda main 
+Intel maintains an optimized x86 package, avaialbe in PyPi, conda 
 and conda-forge:
 
 .. prompt:: bash $
@@ -295,7 +295,9 @@ documentation for more details on usage scenarious.
 
 Compatibility with the standard scikit-learn solvers is checked by running the
 full scikit-learn test suite via automated continuous integration as reported
-on https://github.com/intel/scikit-learn-intelex.
+on https://github.com/intel/scikit-learn-intelex. If you observe any issues
+with `scikit-learn-intelex`, please report the issue on their
+`issue tracker <https://github.com/intel/scikit-learn-intelex/issues>`__.
 
 
 WinPython for Windows

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -269,26 +269,33 @@ python library for Windows, Mac OSX and Linux.
 Anaconda offers scikit-learn as part of its free distribution.
 
 
-Intel conda channel
+Intel Extension for Scikit-learn
 -------------------
 
-Intel maintains a dedicated conda channel that ships scikit-learn:
+Intel maintains an optimized x86 package, avaialbe in PyPi, conda main 
+and conda-forge:
 
 .. prompt:: bash $
 
-  conda install -c intel scikit-learn
+  conda install scikit-learn-intelex
 
-This version of scikit-learn comes with alternative solvers for some common
-estimators. Those solvers come from the DAAL C++ library and are optimized for
-multi-core Intel CPUs.
+This pacage can accelerate existing intalation of scikit-learn and comes 
+with alternative solvers for some common estimators. Those solvers come 
+from the oneDAL C++ library and are optimized for x86 architeture, 
+delivering most of performance for multi-core Intel CPUs.
 
 Note that those solvers are not enabled by default, please refer to the
-`daal4py <https://intelpython.github.io/daal4py/sklearn.html>`_ documentation
-for more details.
+`scikit-learn-intelex <https://intel.github.io/scikit-learn-intelex/what-is-patching.html>`_ 
+documentation for more details on usage scenarious.
+
+.. prompt:: bash $
+
+  from sklearnex import patch_sklearn
+  patch_sklearn()
 
 Compatibility with the standard scikit-learn solvers is checked by running the
 full scikit-learn test suite via automated continuous integration as reported
-on https://github.com/IntelPython/daal4py.
+on https://github.com/intel/scikit-learn-intelex.
 
 
 WinPython for Windows

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -270,23 +270,23 @@ Anaconda offers scikit-learn as part of its free distribution.
 
 
 Intel Extension for Scikit-learn
--------------------
+--------------------------------
 
-Intel maintains an optimized x86 package, avaialbe in PyPi, conda 
-and conda-forge:
+Intel maintains an optimized x86_64 package, available in PyPI (via `pip`),
+and in the `main`, `conda-forge` and `intel` conda channels:
 
 .. prompt:: bash $
 
   conda install scikit-learn-intelex
 
-This pacage can accelerate existing intalation of scikit-learn and comes 
+This package can accelerate an existing installation of scikit-learn and comes 
 with alternative solvers for some common estimators. Those solvers come 
-from the oneDAL C++ library and are optimized for x86 architeture, 
-delivering most of performance for multi-core Intel CPUs.
+from the oneDAL C++ library and are optimized for the x86_64 architecture, 
+and are optimized for multi-core Intel CPUs.
 
 Note that those solvers are not enabled by default, please refer to the
 `scikit-learn-intelex <https://intel.github.io/scikit-learn-intelex/what-is-patching.html>`_ 
-documentation for more details on usage scenarious.
+documentation for more details on usage scenarios.
 
 .. prompt:: bash $
 
@@ -295,7 +295,7 @@ documentation for more details on usage scenarious.
 
 Compatibility with the standard scikit-learn solvers is checked by running the
 full scikit-learn test suite via automated continuous integration as reported
-on https://github.com/intel/scikit-learn-intelex. If you observe any issues
+on https://github.com/intel/scikit-learn-intelex. If you observe any issue
 with `scikit-learn-intelex`, please report the issue on their
 `issue tracker <https://github.com/intel/scikit-learn-intelex/issues>`__.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -286,12 +286,11 @@ and are optimized for multi-core Intel CPUs.
 
 Note that those solvers are not enabled by default, please refer to the
 `scikit-learn-intelex <https://intel.github.io/scikit-learn-intelex/what-is-patching.html>`_ 
-documentation for more details on usage scenarios.
+documentation for more details on usage scenarios. Direct export example:
 
 .. prompt:: bash $
 
-  from sklearnex import patch_sklearn
-  patch_sklearn()
+  from sklearnex.neighbors import NearestNeighbors
 
 Compatibility with the standard scikit-learn solvers is checked by running the
 full scikit-learn test suite via automated continuous integration as reported


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### What does this implement/fix? Explain your changes.
This change replace daal4py mention with relevant scikit-learn-intelex as well as updating links

Also would love to discuss any ongoing issues with package and fact it's being used on top of scikit-learn itself. One of the problems i've heard was defects submission against scikit-learn instead of scikit-learn-intelex
