### PR TITLE
MNT Mention pytest version in error message when pytest version is too old

### DIFF
--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -27,8 +27,8 @@ from sklearn.tests import random_seed
 
 if parse_version(pytest.__version__) < parse_version(PYTEST_MIN_VERSION):
     raise ImportError(
-        "Your version of pytest is too old, you should have "
-        "at least pytest >= {} installed.".format(PYTEST_MIN_VERSION)
+        f"Your version of pytest is too old. Got version {pytest.__version__}, you"
+        f" should have pytest >= {PYTEST_MIN_VERSION} installed."
     )
 
 scipy_datasets_require_network = sp_version >= parse_version("1.10")


### PR DESCRIPTION
#### Reference Issues/PRs

See in https://github.com/scikit-learn/scikit-learn/issues/26377 build log, the pytest version is not mentioned.

#### What does this implement/fix? Explain your changes.

Add pytest version and tweak error message
