### PR TITLE
CI Retry codecov upload when it fails

### DIFF
--- a/build_tools/azure/posix-docker.yml
+++ b/build_tools/azure/posix-docker.yml
@@ -129,5 +129,6 @@ jobs:
       condition: and(succeeded(), eq(variables['COVERAGE'], 'true'),
                      eq(variables['SELECTED_TESTS'], ''))
       displayName: 'Upload To Codecov'
+      retryCountOnTaskFailure: 5
       env:
         CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -107,5 +107,6 @@ jobs:
       condition: and(succeeded(), eq(variables['COVERAGE'], 'true'),
                      eq(variables['SELECTED_TESTS'], ''))
       displayName: 'Upload To Codecov'
+      retryCountOnTaskFailure: 5
       env:
         CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/build_tools/azure/windows.yml
+++ b/build_tools/azure/windows.yml
@@ -80,5 +80,6 @@ jobs:
                      eq(variables['COVERAGE'], 'true'),
                      eq(variables['SELECTED_TESTS'], ''))
       displayName: 'Upload To Codecov'
+      retryCountOnTaskFailure: 5
       env:
         CODECOV_TOKEN: $(CODECOV_TOKEN)


### PR DESCRIPTION
Recently, I have noticed that the codecov upload fail randomly. This PR configures azure to retry the the codecov upload task if it fails.