### PR TITLE
MAINT Use `scipy.sparse.isspmatrix_*`

### DIFF
--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -3,7 +3,12 @@ import warnings
 import pytest
 import re
 import numpy as np
-from scipy.sparse import coo_matrix, csc_matrix, csr_matrix
+from scipy.sparse import (
+    coo_matrix,
+    csc_matrix,
+    csr_matrix,
+    isspmatrix_csr,
+)
 from scipy import stats
 from scipy.special import comb
 from itertools import combinations
@@ -1327,8 +1332,8 @@ def test_train_test_split_sparse():
     for InputFeatureType in sparse_types:
         X_s = InputFeatureType(X)
         X_train, X_test = train_test_split(X_s)
-        assert isinstance(X_train, csr_matrix)
-        assert isinstance(X_test, csr_matrix)
+        assert isspmatrix_csr(X_train)
+        assert isspmatrix_csr(X_test)
 
 
 def test_train_test_split_mock_pandas():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1851,7 +1851,7 @@ def test_normalizer_l1():
         X_norm = normalizer = Normalizer(norm="l2", copy=False).transform(X)
 
         assert X_norm is not X
-        assert isinstance(X_norm, sparse.csr_matrix)
+        assert sparse.isspmatrix_csr(X_norm)
 
         X_norm = toarray(X_norm)
         for i in range(3):
@@ -1898,7 +1898,7 @@ def test_normalizer_l2():
         X_norm = normalizer = Normalizer(norm="l2", copy=False).transform(X)
 
         assert X_norm is not X
-        assert isinstance(X_norm, sparse.csr_matrix)
+        assert sparse.isspmatrix_csr(X_norm)
 
         X_norm = toarray(X_norm)
         for i in range(3):
@@ -1946,7 +1946,7 @@ def test_normalizer_max():
         X_norm = normalizer = Normalizer(norm="l2", copy=False).transform(X)
 
         assert X_norm is not X
-        assert isinstance(X_norm, sparse.csr_matrix)
+        assert sparse.isspmatrix_csr(X_norm)
 
         X_norm = toarray(X_norm)
         for i in range(3):

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -625,7 +625,7 @@ def test_polynomial_features_csc_X(deg, include_bias, interaction_only, dtype):
     Xt_csc = est.fit_transform(X_csc.astype(dtype))
     Xt_dense = est.fit_transform(X.astype(dtype))
 
-    assert isinstance(Xt_csc, sparse.csc_matrix)
+    assert sparse.isspmatrix_csc(Xt_csc)
     assert Xt_csc.dtype == Xt_dense.dtype
     assert_array_almost_equal(Xt_csc.A, Xt_dense)
 
@@ -652,7 +652,7 @@ def test_polynomial_features_csr_X(deg, include_bias, interaction_only, dtype):
     Xt_csr = est.fit_transform(X_csr.astype(dtype))
     Xt_dense = est.fit_transform(X.astype(dtype, copy=False))
 
-    assert isinstance(Xt_csr, sparse.csr_matrix)
+    assert sparse.isspmatrix_csr(Xt_csr)
     assert Xt_csr.dtype == Xt_dense.dtype
     assert_array_almost_equal(Xt_csr.A, Xt_dense)
 
@@ -711,7 +711,7 @@ def test_polynomial_features_csr_X_floats(deg, include_bias, interaction_only, d
     Xt_csr = est.fit_transform(X_csr.astype(dtype))
     Xt_dense = est.fit_transform(X.astype(dtype))
 
-    assert isinstance(Xt_csr, sparse.csr_matrix)
+    assert sparse.isspmatrix_csr(Xt_csr)
     assert Xt_csr.dtype == Xt_dense.dtype
     assert_array_almost_equal(Xt_csr.A, Xt_dense)
 
@@ -742,7 +742,7 @@ def test_polynomial_features_csr_X_zero_row(zero_row_index, deg, interaction_onl
     Xt_csr = est.fit_transform(X_csr)
     Xt_dense = est.fit_transform(X)
 
-    assert isinstance(Xt_csr, sparse.csr_matrix)
+    assert sparse.isspmatrix_csr(Xt_csr)
     assert Xt_csr.dtype == Xt_dense.dtype
     assert_array_almost_equal(Xt_csr.A, Xt_dense)
 
@@ -763,7 +763,7 @@ def test_polynomial_features_csr_X_degree_4(include_bias, interaction_only):
     Xt_csr = est.fit_transform(X_csr)
     Xt_dense = est.fit_transform(X)
 
-    assert isinstance(Xt_csr, sparse.csr_matrix)
+    assert sparse.isspmatrix_csr(X_csr)
     assert Xt_csr.dtype == Xt_dense.dtype
     assert_array_almost_equal(Xt_csr.A, Xt_dense)
 
@@ -791,7 +791,7 @@ def test_polynomial_features_csr_X_dim_edges(deg, dim, interaction_only):
     Xt_csr = est.fit_transform(X_csr)
     Xt_dense = est.fit_transform(X)
 
-    assert isinstance(Xt_csr, sparse.csr_matrix)
+    assert sparse.isspmatrix_csr(Xt_csr)
     assert Xt_csr.dtype == Xt_dense.dtype
     assert_array_almost_equal(Xt_csr.A, Xt_dense)
 

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -20,7 +20,7 @@ from cython cimport final
 
 import numpy as np
 
-from scipy.sparse import csc_matrix
+from scipy.sparse import isspmatrix_csc
 
 from ._utils cimport log
 from ._utils cimport rand_int
@@ -1041,7 +1041,7 @@ cdef class SparsePartitioner:
         DTYPE_t[::1] feature_values,
         const unsigned char[::1] feature_has_missing,
     ):
-        if not isinstance(X, csc_matrix):
+        if not isspmatrix_csc(X):
             raise ValueError("X should be in csc format")
 
         self.samples = samples

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -32,6 +32,7 @@ cnp.import_array()
 
 from scipy.sparse import issparse
 from scipy.sparse import csr_matrix
+from scipy.sparse import isspmatrix_csr
 
 from ._utils cimport safe_realloc
 from ._utils cimport sizet_ptr_to_ndarray
@@ -876,7 +877,7 @@ cdef class Tree:
         """Finds the terminal region (=leaf node) for each sample in sparse X.
         """
         # Check input
-        if not isinstance(X, csr_matrix):
+        if not isspmatrix_csr(X):
             raise ValueError("X should be in csr_matrix format, got %s"
                              % type(X))
 
@@ -952,7 +953,7 @@ cdef class Tree:
         """Finds the decision path (=node) for each sample in X."""
 
         # Check input
-        if not isinstance(X, np.ndarray):
+        if not isspmatrix_csr(X):
             raise ValueError("X should be in np.ndarray format, got %s"
                              % type(X))
 
@@ -1004,7 +1005,7 @@ cdef class Tree:
         """Finds the decision path (=node) for each sample in X."""
 
         # Check input
-        if not isinstance(X, csr_matrix):
+        if not isinstance(X, np.ndarray):
             raise ValueError("X should be in csr_matrix format, got %s"
                              % type(X))
 

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -953,7 +953,7 @@ cdef class Tree:
         """Finds the decision path (=node) for each sample in X."""
 
         # Check input
-        if not isspmatrix_csr(X):
+        if not isinstance(X, np.ndarray):
             raise ValueError("X should be in np.ndarray format, got %s"
                              % type(X))
 
@@ -1005,7 +1005,7 @@ cdef class Tree:
         """Finds the decision path (=node) for each sample in X."""
 
         # Check input
-        if not isinstance(X, np.ndarray):
+        if not isspmatrix_csr(X):
             raise ValueError("X should be in csr_matrix format, got %s"
                              % type(X))
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -72,7 +72,7 @@ def row_norms(X, squared=False):
         The row-wise (squared) Euclidean norm of X.
     """
     if sparse.issparse(X):
-        if not isinstance(X, sparse.csr_matrix):
+        if not sparse.isspmatrix_csr(X):
             X = sparse.csr_matrix(X)
         norms = csr_row_norms(X)
     else:
@@ -425,7 +425,7 @@ def randomized_svd(
     >>> U.shape, s.shape, Vh.shape
     ((3, 2), (2,), (2, 4))
     """
-    if isinstance(M, (sparse.lil_matrix, sparse.dok_matrix)):
+    if sparse.isspmatrix_lil(M) or sparse.isspmatrix_dok(M):
         warnings.warn(
             "Calculating SVD of a {} is expensive. "
             "csr_matrix is more efficient.".format(type(M).__name__),

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -11,8 +11,8 @@ from itertools import chain
 import warnings
 
 from scipy.sparse import issparse
-from scipy.sparse import dok_matrix
-from scipy.sparse import lil_matrix
+from scipy.sparse import isspmatrix_dok
+from scipy.sparse import isspmatrix_lil
 
 import numpy as np
 
@@ -179,7 +179,7 @@ def is_multilabel(y):
         return False
 
     if issparse(y):
-        if isinstance(y, (dok_matrix, lil_matrix)):
+        if isspmatrix_dok(y) or isspmatrix_lil(y):
             y = y.tocsr()
         labels = xp.unique_values(y.data)
         return (

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -103,7 +103,7 @@ def mean_variance_axis(X, axis, weights=None, return_sum_weights=False):
     """
     _raise_error_wrong_axis(axis)
 
-    if isinstance(X, sp.csr_matrix):
+    if sp.isspmatrix_csr(X):
         if axis == 0:
             return _csr_mean_var_axis0(
                 X, weights=weights, return_sum_weights=return_sum_weights
@@ -112,7 +112,7 @@ def mean_variance_axis(X, axis, weights=None, return_sum_weights=False):
             return _csc_mean_var_axis0(
                 X.T, weights=weights, return_sum_weights=return_sum_weights
             )
-    elif isinstance(X, sp.csc_matrix):
+    elif sp.isspmatrix_csc(X):
         if axis == 0:
             return _csc_mean_var_axis0(
                 X, weights=weights, return_sum_weights=return_sum_weights
@@ -187,7 +187,7 @@ def incr_mean_variance_axis(X, *, axis, last_mean, last_var, last_n, weights=Non
     """
     _raise_error_wrong_axis(axis)
 
-    if not isinstance(X, (sp.csr_matrix, sp.csc_matrix)):
+    if not (sp.isspmatrix_csr(X) or sp.isspmatrix_csc(X)):
         _raise_typeerror(X)
 
     if np.size(last_n) == 1:
@@ -234,9 +234,9 @@ def inplace_column_scale(X, scale):
     scale : ndarray of shape (n_features,), dtype={np.float32, np.float64}
         Array of precomputed feature-wise values to use for scaling.
     """
-    if isinstance(X, sp.csc_matrix):
+    if sp.isspmatrix_csc(X):
         inplace_csr_row_scale(X.T, scale)
-    elif isinstance(X, sp.csr_matrix):
+    elif sp.isspmatrix_csr(X):
         inplace_csr_column_scale(X, scale)
     else:
         _raise_typeerror(X)
@@ -256,9 +256,9 @@ def inplace_row_scale(X, scale):
     scale : ndarray of shape (n_features,), dtype={np.float32, np.float64}
         Array of precomputed sample-wise values to use for scaling.
     """
-    if isinstance(X, sp.csc_matrix):
+    if sp.isspmatrix_csc(X):
         inplace_csr_column_scale(X.T, scale)
-    elif isinstance(X, sp.csr_matrix):
+    elif sp.isspmatrix_csr(X):
         inplace_csr_row_scale(X, scale)
     else:
         _raise_typeerror(X)
@@ -372,9 +372,9 @@ def inplace_swap_row(X, m, n):
     n : int
         Index of the row of X to be swapped.
     """
-    if isinstance(X, sp.csc_matrix):
+    if sp.isspmatrix_csc(X):
         inplace_swap_row_csc(X, m, n)
-    elif isinstance(X, sp.csr_matrix):
+    elif sp.isspmatrix_csr(X):
         inplace_swap_row_csr(X, m, n)
     else:
         _raise_typeerror(X)
@@ -400,9 +400,9 @@ def inplace_swap_column(X, m, n):
         m += X.shape[1]
     if n < 0:
         n += X.shape[1]
-    if isinstance(X, sp.csc_matrix):
+    if sp.isspmatrix_csc(X):
         inplace_swap_row_csr(X, m, n)
-    elif isinstance(X, sp.csr_matrix):
+    elif sp.isspmatrix_csr(X):
         inplace_swap_row_csc(X, m, n)
     else:
         _raise_typeerror(X)
@@ -501,7 +501,7 @@ def min_max_axis(X, axis, ignore_nan=False):
     maxs : ndarray of shape (n_features,), dtype={np.float32, np.float64}
         Feature-wise maxima.
     """
-    if isinstance(X, (sp.csr_matrix, sp.csc_matrix)):
+    if sp.isspmatrix_csr(X) or sp.isspmatrix_csc(X):
         if ignore_nan:
             return _sparse_nan_min_max(X, axis=axis)
         else:
@@ -610,7 +610,7 @@ def csc_median_axis_0(X):
     median : ndarray of shape (n_features,)
         Median.
     """
-    if not isinstance(X, sp.csc_matrix):
+    if not sp.isspmatrix_csc(X):
         raise TypeError("Expected matrix of CSC format, got %s" % X.format)
 
     indptr = X.indptr


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Towards resolving https://github.com/scikit-learn/scikit-learn/issues/26418.


#### What does this implement/fix? Explain your changes.

Contrary to what names suggest, `scipy.sparse.isspmatrix_*` not only check for sparse matrices' instances but also sparse arrays'.

This PR proposes replacing all occurrences of checks using `isinstance(X, *_matrix)` by checks calling to `scipy.sparse.isspmatrix_*`.

#### Any other comments?

Later, when $n$-dimensional arrays are implemented (with $n > 2$) in SciPy, we will need to add extra checks on $n$.

cc @ivirshup