### PR TITLE
MAINT | ENH Change default value of subsample + allow for all strategies in KBinsDiscretizer

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -536,7 +536,7 @@ Changelog
   :pr:`26424` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 - |API| The default value of the `subsample` parameter of
-  :class:`preprocessing.KBinsDiscretizer` will change from `None` to `200000` in
+  :class:`preprocessing.KBinsDiscretizer` will change from `None` to `200_000` in
   version 1.5 when `strategy="kmeans"` or `strategy="uniform"`.
   :pr:`26424` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -531,6 +531,10 @@ Changelog
   is enabled by specifying how to select infrequent categories with
   `min_frequency` or `max_categories`. :pr:`25677` by `Thomas Fan`_.
 
+- |Enhancement| Subsampling through the `subsample` parameter can now be used in
+  :class:`preprocessing.KBinsDiscretizer` regardless of the strategy used.
+  :pr:`` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
 - |Fix| :class:`AdditiveChi2Sampler` is now stateless.
   The `sample_interval_` attribute is deprecated and will be removed in 1.5.
   :pr:`25190` by :user:`Vincent Maladière <Vincent-Maladiere>`.

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -533,7 +533,7 @@ Changelog
 
 - |Enhancement| Subsampling through the `subsample` parameter can now be used in
   :class:`preprocessing.KBinsDiscretizer` regardless of the strategy used.
-  :pr:`` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+  :pr:`26424` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 - |Fix| :class:`AdditiveChi2Sampler` is now stateless.
   The `sample_interval_` attribute is deprecated and will be removed in 1.5.

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -535,6 +535,11 @@ Changelog
   :class:`preprocessing.KBinsDiscretizer` regardless of the strategy used.
   :pr:`26424` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+- |API| The default value of the `subsample` parameter of
+  :class:`preprocessing.KBinsDiscretizer` will change from `None` to `200000` in
+  version 1.5 when `strategy="kmeans"` or `strategy="uniform"`.
+  :pr:`26424` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
 - |Fix| :class:`AdditiveChi2Sampler` is now stateless.
   The `sample_interval_` attribute is deprecated and will be removed in 1.5.
   :pr:`25190` by :user:`Vincent Maladière <Vincent-Maladiere>`.

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -62,7 +62,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
     subsample : int or None, default='warn'
         Maximum number of samples, used to fit the model, for computational
-        efficiency. Defaults to 200000 when `strategy='quantile'` and to `None`
+        efficiency. Defaults to 200_000 when `strategy='quantile'` and to `None`
         when `strategy='uniform'` or `strategy='kmeans'`.
         `subsample=None` means that all the training samples are used when
         computing the quantiles that determine the binning thresholds.
@@ -72,11 +72,11 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         very large number of samples.
 
         .. versionchanged:: 1.3
-            The default value of `subsample` changed from `None` to 200_000 when
+            The default value of `subsample` changed from `None` to `200_000` when
             `strategy="quantile"`.
 
         .. versionchanged:: 1.5
-            The default value of `subsample` changed from `None` to 200_000 when
+            The default value of `subsample` changed from `None` to `200_000` when
             `strategy="uniform"` or `strategy="kmeans"`.
 
     random_state : int, RandomState instance or None, default=None

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -136,7 +136,9 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
     ...      [-1, 2, -3, -0.5],
     ...      [ 0, 3, -2,  0.5],
     ...      [ 1, 4, -1,    2]]
-    >>> est = KBinsDiscretizer(n_bins=3, encode='ordinal', strategy='uniform')
+    >>> est = KBinsDiscretizer(
+    ...     n_bins=3, encode='ordinal', strategy='uniform', subsample=None
+    ... )
     >>> est.fit(X)
     KBinsDiscretizer(...)
     >>> Xt = est.transform(X)

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -11,7 +11,7 @@ import warnings
 from . import OneHotEncoder
 
 from ..base import BaseEstimator, TransformerMixin
-from ..utils._param_validation import Interval, StrOptions, Options
+from ..utils._param_validation import Hidden, Interval, StrOptions, Options
 from ..utils.validation import check_array
 from ..utils.validation import check_is_fitted
 from ..utils.validation import check_random_state
@@ -60,9 +60,10 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
         .. versionadded:: 0.24
 
-    subsample : int or None, default=200_000
+    subsample : int or None, default='warn'
         Maximum number of samples, used to fit the model, for computational
-        efficiency. Used when `strategy="quantile"`.
+        efficiency. Defaults to 200000 when `strategy='quantile'` and to `None`
+        when `strategy='uniform'` or `strategy='kmeans'`.
         `subsample=None` means that all the training samples are used when
         computing the quantiles that determine the binning thresholds.
         Since quantile computation relies on sorting each column of `X` and
@@ -71,7 +72,12 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         very large number of samples.
 
         .. versionchanged:: 1.3
-           In version 1.3 and onwards, `subsample=200_000` will be the default.
+            The default value of `subsample` changed from `None` to 200_000 when
+            `strategy="quantile"`.
+
+        .. versionchanged:: 1.5
+            The default value of `subsample` changed from `None` to 200_000 when
+            `strategy="uniform"` or `strategy="kmeans"`.
 
     random_state : int, RandomState instance or None, default=None
         Determines random number generation for subsampling.
@@ -159,7 +165,11 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         "encode": [StrOptions({"onehot", "onehot-dense", "ordinal"})],
         "strategy": [StrOptions({"uniform", "quantile", "kmeans"})],
         "dtype": [Options(type, {np.float64, np.float32}), None],
-        "subsample": [Interval(Integral, 1, None, closed="left"), None],
+        "subsample": [
+            Interval(Integral, 1, None, closed="left"),
+            None,
+            Hidden(StrOptions({"warn"})),
+        ],
         "random_state": ["random_state"],
     }
 
@@ -170,7 +180,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         encode="onehot",
         strategy="quantile",
         dtype=None,
-        subsample=200000,
+        subsample="warn",
         random_state=None,
     ):
         self.n_bins = n_bins
@@ -221,13 +231,24 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
                 f"{self.strategy!r} instead."
             )
 
-        if self.subsample is not None:
+        if self.strategy in ("uniform", "kmeans") and self.subsample == "warn":
+            warnings.warn(
+                (
+                    "In version 1.5 onwards, subsample=200_000 "
+                    "will be used by default. Set subsample explicitly to "
+                    "silence this warning in the mean time. Set "
+                    "subsample=None to disable subsampling explicitly."
+                ),
+                FutureWarning,
+            )
+
+        subsample = self.subsample
+        if subsample == "warn":
+            subsample = 200000 if self.strategy == "quantile" else None
+        if subsample is not None and n_samples > subsample:
             rng = check_random_state(self.random_state)
-            if n_samples > self.subsample:
-                subsample_idx = rng.choice(
-                    n_samples, size=self.subsample, replace=False
-                )
-                X = _safe_indexing(X, subsample_idx)
+            subsample_idx = rng.choice(n_samples, size=subsample, replace=False)
+            X = _safe_indexing(X, subsample_idx)
 
         n_features = X.shape[1]
         n_bins = self._validate_n_bins(n_features)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -404,60 +404,21 @@ def test_32_equal_64(input_dtype, encode):
     assert_allclose_dense_sparse(Xt_32, Xt_64)
 
 
-# FIXME: remove the `filterwarnings` in 1.3
-@pytest.mark.filterwarnings("ignore:In version 1.3 onwards, subsample=2e5")
-@pytest.mark.parametrize("subsample", [None, "warn"])
-def test_kbinsdiscretizer_subsample_default(subsample):
+def test_kbinsdiscretizer_subsample_default():
     # Since the size of X is small (< 2e5), subsampling will not take place.
     X = np.array([-2, 1.5, -4, -1]).reshape(-1, 1)
     kbd_default = KBinsDiscretizer(n_bins=10, encode="ordinal", strategy="quantile")
     kbd_default.fit(X)
 
-    kbd_with_subsampling = clone(kbd_default)
-    kbd_with_subsampling.set_params(subsample=subsample)
-    kbd_with_subsampling.fit(X)
+    kbd_without_subsampling = clone(kbd_default)
+    kbd_without_subsampling.set_params(subsample=None)
+    kbd_without_subsampling.fit(X)
 
     for bin_kbd_default, bin_kbd_with_subsampling in zip(
-        kbd_default.bin_edges_[0], kbd_with_subsampling.bin_edges_[0]
+        kbd_default.bin_edges_[0], kbd_without_subsampling.bin_edges_[0]
     ):
         np.testing.assert_allclose(bin_kbd_default, bin_kbd_with_subsampling)
-    assert kbd_default.bin_edges_.shape == kbd_with_subsampling.bin_edges_.shape
-
-
-def test_kbinsdiscretizer_subsample_invalid_strategy():
-    X = np.array([-2, 1.5, -4, -1]).reshape(-1, 1)
-    kbd = KBinsDiscretizer(n_bins=10, encode="ordinal", strategy="uniform", subsample=3)
-
-    err_msg = '`subsample` must be used with `strategy="quantile"`.'
-    with pytest.raises(ValueError, match=err_msg):
-        kbd.fit(X)
-
-
-# TODO: Remove in 1.3
-def test_kbinsdiscretizer_subsample_warn():
-    X = np.random.rand(200001, 1).reshape(-1, 1)
-    kbd = KBinsDiscretizer(n_bins=100, encode="ordinal", strategy="quantile")
-
-    msg = "In version 1.3 onwards, subsample=2e5 will be used by default."
-    with pytest.warns(FutureWarning, match=msg):
-        kbd.fit(X)
-
-
-# TODO(1.3) remove
-def test_kbinsdiscretizer_subsample_values():
-    X = np.random.rand(220000, 1).reshape(-1, 1)
-    kbd_default = KBinsDiscretizer(n_bins=10, encode="ordinal", strategy="quantile")
-
-    kbd_with_subsampling = clone(kbd_default)
-    kbd_with_subsampling.set_params(subsample=int(2e5))
-
-    msg = "In version 1.3 onwards, subsample=2e5 will be used by default."
-    with pytest.warns(FutureWarning, match=msg):
-        kbd_default.fit(X)
-
-    kbd_with_subsampling.fit(X)
-    assert not np.all(kbd_default.bin_edges_[0] == kbd_with_subsampling.bin_edges_[0])
-    assert kbd_default.bin_edges_.shape == kbd_with_subsampling.bin_edges_.shape
+    assert kbd_default.bin_edges_.shape == kbd_without_subsampling.bin_edges_.shape
 
 
 @pytest.mark.parametrize(
@@ -496,3 +457,24 @@ def test_kbinsdiscrtizer_get_feature_names_out(encode, expected_names):
     assert Xt.shape[1] == output_names.shape[0]
 
     assert_array_equal(output_names, expected_names)
+
+
+@pytest.mark.parametrize("strategy", ["uniform", "kmeans", "quantile"])
+def test_kbinsdiscretizer_subsample(strategy, global_random_seed):
+    # Check that the bin edges are almost the same when subsampling is used.
+    X = np.random.RandomState(global_random_seed).random_sample((100000, 1)) + 1
+
+    kbd_subsampling = KBinsDiscretizer(
+        strategy=strategy, subsample=50000, random_state=global_random_seed
+    )
+    kbd_subsampling.fit(X)
+
+    kbd_no_subsampling = clone(kbd_subsampling)
+    kbd_no_subsampling.set_params(subsample=None)
+    kbd_no_subsampling.fit(X)
+
+    # We use a large tolerance because we can't expect the bin edges to be exactely the
+    # same when subsampling is used.
+    assert_allclose(
+        kbd_subsampling.bin_edges_[0], kbd_no_subsampling.bin_edges_[0], rtol=1e-2
+    )

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -49,6 +49,8 @@ X = [[-2, 1.5, -4, -1], [-1, 2.5, -3, -0.5], [0, 3.5, -2, 0.5], [1, 4.5, -1, 2]]
         ),
     ],
 )
+# FIXME: remove the `filterwarnings` in 1.5
+@pytest.mark.filterwarnings("ignore:In version 1.5 onwards, subsample=200_000")
 def test_fit_transform(strategy, expected, sample_weight):
     est = KBinsDiscretizer(n_bins=3, encode="ordinal", strategy=strategy)
     est.fit(X, sample_weight=sample_weight)
@@ -147,6 +149,8 @@ def test_invalid_n_bins_array():
         ),
     ],
 )
+# FIXME: remove the `filterwarnings` in 1.5
+@pytest.mark.filterwarnings("ignore:In version 1.5 onwards, subsample=200_000")
 def test_fit_transform_n_bins_array(strategy, expected, sample_weight):
     est = KBinsDiscretizer(
         n_bins=[2, 3, 3, 3], encode="ordinal", strategy=strategy
@@ -172,6 +176,8 @@ def test_kbinsdiscretizer_effect_sample_weight():
     assert_allclose(est.transform(X), [[0.0], [1.0], [2.0], [2.0], [2.0], [2.0]])
 
 
+# FIXME: remove the `filterwarnings` in 1.5
+@pytest.mark.filterwarnings("ignore:In version 1.5 onwards, subsample=200_000")
 @pytest.mark.parametrize("strategy", ["kmeans", "quantile"])
 def test_kbinsdiscretizer_no_mutating_sample_weight(strategy):
     """Make sure that `sample_weight` is not changed in place."""
@@ -252,6 +258,8 @@ def test_encode_options():
         ("quantile", [0, 0, 0, 1, 1, 1], [0, 0, 1, 1, 2, 2], [0, 1, 2, 3, 4, 4]),
     ],
 )
+# FIXME: remove the `filterwarnings` in 1.5
+@pytest.mark.filterwarnings("ignore:In version 1.5 onwards, subsample=200_000")
 def test_nonuniform_strategies(
     strategy, expected_2bins, expected_3bins, expected_5bins
 ):
@@ -305,6 +313,8 @@ def test_nonuniform_strategies(
         ),
     ],
 )
+# FIXME: remove the `filterwarnings` in 1.5
+@pytest.mark.filterwarnings("ignore:In version 1.5 onwards, subsample=200_000")
 @pytest.mark.parametrize("encode", ["ordinal", "onehot", "onehot-dense"])
 def test_inverse_transform(strategy, encode, expected_inv):
     kbd = KBinsDiscretizer(n_bins=3, strategy=strategy, encode=encode)
@@ -313,6 +323,8 @@ def test_inverse_transform(strategy, encode, expected_inv):
     assert_array_almost_equal(expected_inv, Xinv)
 
 
+# FIXME: remove the `filterwarnings` in 1.5
+@pytest.mark.filterwarnings("ignore:In version 1.5 onwards, subsample=200_000")
 @pytest.mark.parametrize("strategy", ["uniform", "kmeans", "quantile"])
 def test_transform_outside_fit_range(strategy):
     X = np.array([0, 1, 2, 3])[:, None]
@@ -478,3 +490,14 @@ def test_kbinsdiscretizer_subsample(strategy, global_random_seed):
     assert_allclose(
         kbd_subsampling.bin_edges_[0], kbd_no_subsampling.bin_edges_[0], rtol=1e-2
     )
+
+
+# TODO(1.5) remove this test
+@pytest.mark.parametrize("strategy", ["uniform", "kmeans"])
+def test_kbd_subsample_warning(strategy):
+    # Check the future warning for the change of default of subsample
+    X = np.random.RandomState(0).random_sample((100, 1))
+
+    kbd = KBinsDiscretizer(strategy=strategy, random_state=0)
+    with pytest.warns(FutureWarning, match="subsample=200_000 will be used by default"):
+        kbd.fit(X)

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -49,7 +49,7 @@ X = [[-2, 1.5, -4, -1], [-1, 2.5, -3, -0.5], [0, 3.5, -2, 0.5], [1, 4.5, -1, 2]]
         ),
     ],
 )
-# FIXME: remove the `filterwarnings` in 1.5
+# TODO(1.5) remove warning filter when kbd's subsample default is changed
 @pytest.mark.filterwarnings("ignore:In version 1.5 onwards, subsample=200_000")
 def test_fit_transform(strategy, expected, sample_weight):
     est = KBinsDiscretizer(n_bins=3, encode="ordinal", strategy=strategy)
@@ -149,7 +149,7 @@ def test_invalid_n_bins_array():
         ),
     ],
 )
-# FIXME: remove the `filterwarnings` in 1.5
+# TODO(1.5) remove warning filter when kbd's subsample default is changed
 @pytest.mark.filterwarnings("ignore:In version 1.5 onwards, subsample=200_000")
 def test_fit_transform_n_bins_array(strategy, expected, sample_weight):
     est = KBinsDiscretizer(
@@ -176,7 +176,7 @@ def test_kbinsdiscretizer_effect_sample_weight():
     assert_allclose(est.transform(X), [[0.0], [1.0], [2.0], [2.0], [2.0], [2.0]])
 
 
-# FIXME: remove the `filterwarnings` in 1.5
+# TODO(1.5) remove warning filter when kbd's subsample default is changed
 @pytest.mark.filterwarnings("ignore:In version 1.5 onwards, subsample=200_000")
 @pytest.mark.parametrize("strategy", ["kmeans", "quantile"])
 def test_kbinsdiscretizer_no_mutating_sample_weight(strategy):
@@ -258,7 +258,7 @@ def test_encode_options():
         ("quantile", [0, 0, 0, 1, 1, 1], [0, 0, 1, 1, 2, 2], [0, 1, 2, 3, 4, 4]),
     ],
 )
-# FIXME: remove the `filterwarnings` in 1.5
+# TODO(1.5) remove warning filter when kbd's subsample default is changed
 @pytest.mark.filterwarnings("ignore:In version 1.5 onwards, subsample=200_000")
 def test_nonuniform_strategies(
     strategy, expected_2bins, expected_3bins, expected_5bins
@@ -313,7 +313,7 @@ def test_nonuniform_strategies(
         ),
     ],
 )
-# FIXME: remove the `filterwarnings` in 1.5
+# TODO(1.5) remove warning filter when kbd's subsample default is changed
 @pytest.mark.filterwarnings("ignore:In version 1.5 onwards, subsample=200_000")
 @pytest.mark.parametrize("encode", ["ordinal", "onehot", "onehot-dense"])
 def test_inverse_transform(strategy, encode, expected_inv):
@@ -323,7 +323,7 @@ def test_inverse_transform(strategy, encode, expected_inv):
     assert_array_almost_equal(expected_inv, Xinv)
 
 
-# FIXME: remove the `filterwarnings` in 1.5
+# TODO(1.5) remove warning filter when kbd's subsample default is changed
 @pytest.mark.filterwarnings("ignore:In version 1.5 onwards, subsample=200_000")
 @pytest.mark.parametrize("strategy", ["uniform", "kmeans", "quantile"])
 def test_transform_outside_fit_range(strategy):

--- a/sklearn/preprocessing/tests/test_target_encoder.py
+++ b/sklearn/preprocessing/tests/test_target_encoder.py
@@ -434,6 +434,8 @@ def test_invariance_of_encoding_under_label_permutation(smooth, global_random_se
     assert_allclose(X_test_encoded, X_test_permuted_encoded)
 
 
+# TODO(1.5) remove warning filter when kbd's subsample default is changed
+@pytest.mark.filterwarnings("ignore:In version 1.5 onwards, subsample=200_000")
 @pytest.mark.parametrize("smooth", [0.0, "auto"])
 def test_target_encoding_for_linear_regression(smooth, global_random_seed):
     # Check some expected statistical properties when fitting a linear


### PR DESCRIPTION
The value is meant to change to 20000 for the 1.3 release.
When implementing the change I faced an error because we used to not support subsampling for other strategies than "quantile". This is an issue because we are setting the default to use subsampling.

Looking at this, I don't see any reason not to support subsampling for the "kmeans" and "uniform" strategies, especially since we set the default value very high. Note that there was no test for the behavior of subsampling, so I added a simple one to check that the bin edges a somewhat close the the ones obtained without subsampling. I propose to now support subsampling for all strategies.