### PR TITLE
MNT Fix regression in lock file update script when using --select-build

### DIFF
--- a/build_tools/update_environments_and_lock_files.py
+++ b/build_tools/update_environments_and_lock_files.py
@@ -574,7 +574,11 @@ def remove_unnecessary_package_from_lock_file(build_metadata_list, build_name, p
             build_metadata = metadata
             break
     if build_metadata is None:
-        raise ValueError(f"Could not find build metadata for {build_name}")
+        logger.warning(
+            f"Could not find {build_name} in build_metadata_list. This may be expected"
+            " if --select-build is used"
+        )
+        return
     folder_path = Path(build_metadata["folder"])
     platform = build_metadata["platform"]
     lock_file_basename = build_name


### PR DESCRIPTION
Noticed this with @ArturoAmorQ and @glemaitre which is a regression from #26184

On main:
```
❯ python build_tools/update_environments_and_lock_files.py --select-build doc_min
Writing conda environments
Writing conda lock files
doc_min_dependencies
Traceback (most recent call last):
  File "/home/lesteve/dev/scikit-learn/build_tools/update_environments_and_lock_files.py", line 651, in <module>
    main()
  File "/home/lesteve/miniconda3/envs/conda-lock/lib/python3.10/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/lesteve/miniconda3/envs/conda-lock/lib/python3.10/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/lesteve/miniconda3/envs/conda-lock/lib/python3.10/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/lesteve/miniconda3/envs/conda-lock/lib/python3.10/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/lesteve/dev/scikit-learn/build_tools/update_environments_and_lock_files.py", line 635, in main
    remove_unnecessary_package_from_lock_file(
  File "/home/lesteve/dev/scikit-learn/build_tools/update_environments_and_lock_files.py", line 577, in remove_unnecessary_package_from_lock_file
    raise ValueError(f"Could not find build metadata for {build_name}")
ValueError: Could not find build metadata for doc
```

This is because we always expect that `doc` will be in the build metadata list, which is not the case when using `--select-build`.

I went for a simple fix, i.e. a warning, since (hopefully) there will be a conda-lock release in the not too distant future and we can get rid of `remove_unnecessary_package_from_lock_file`

