### PR TITLE
CI Do not auto close issue when cirrus ci arm build fails

### DIFF
--- a/build_tools/cirrus/update_tracking_issue.sh
+++ b/build_tools/cirrus/update_tracking_issue.sh
@@ -18,4 +18,5 @@ python maint_tools/update_tracking_issue.py \
     $CIRRUS_TASK_NAME \
     $CIRRUS_REPO_FULL_NAME \
     $LINK_TO_RUN \
-    --tests-passed $TEST_PASSED
+    --tests-passed $TEST_PASSED \
+    --auto-close false


### PR DESCRIPTION
This PR configures the cirrus CI to **not** auto close a tracking issue if the job starts to succeed.

I noticed that the ARM wheel has been failing and passing for the [past week](https://github.com/scikit-learn/scikit-learn/issues?q=is%3Aissue+sort%3Aupdated-desc+author%3Ascikit-learn-bot+is%3Aclosed+linux_arm64_wheel). Here is the latest issue opened by the bot: https://github.com/scikit-learn/scikit-learn/issues/26429. I think it's better to keep the original issue open.