### PR TITLE
MAINT Clean-up deprecated wminkowski distance metric for 1.3

### DIFF
--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -142,7 +142,7 @@ of valid metrics use :meth:`KDTree.valid_metrics` and :meth:`BallTree.valid_metr
     >>> KDTree.valid_metrics()
     ['euclidean', 'l2', 'minkowski', 'p', 'manhattan', 'cityblock', 'l1', 'chebyshev', 'infinity']
     >>> BallTree.valid_metrics()
-    ['euclidean', 'l2', 'minkowski', 'p', 'manhattan', 'cityblock', 'l1', 'chebyshev', 'infinity', 'seuclidean', 'mahalanobis', 'wminkowski', 'hamming', 'canberra', 'braycurtis', 'jaccard', 'dice', 'rogerstanimoto', 'russellrao', 'sokalmichener', 'sokalsneath', 'haversine', 'pyfunc']
+    ['euclidean', 'l2', 'minkowski', 'p', 'manhattan', 'cityblock', 'l1', 'chebyshev', 'infinity', 'seuclidean', 'mahalanobis', 'hamming', 'canberra', 'braycurtis', 'jaccard', 'dice', 'rogerstanimoto', 'russellrao', 'sokalmichener', 'sokalsneath', 'haversine', 'pyfunc']
 
 .. _classification:
 

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -395,8 +395,6 @@ def test_vector_scikit_single_vs_scipy_single(global_random_seed):
     assess_same_labelling(cut, cut_scipy)
 
 
-# TODO: Remove filterwarnings in 1.3 when wminkowski is removed
-@pytest.mark.filterwarnings("ignore:WMinkowskiDistance:FutureWarning:sklearn")
 @pytest.mark.parametrize("metric_param_grid", METRICS_DEFAULT_PARAMS)
 def test_mst_linkage_core_memory_mapped(metric_param_grid):
     """The MST-LINKAGE-CORE algorithm must work on mem-mapped dataset.

--- a/sklearn/metrics/_dist_metrics.pyx.tp
+++ b/sklearn/metrics/_dist_metrics.pyx.tp
@@ -94,7 +94,6 @@ METRIC_MAPPING{{name_suffix}} = {
     'infinity': ChebyshevDistance{{name_suffix}},
     'seuclidean': SEuclideanDistance{{name_suffix}},
     'mahalanobis': MahalanobisDistance{{name_suffix}},
-    'wminkowski': WMinkowskiDistance{{name_suffix}},
     'hamming': HammingDistance{{name_suffix}},
     'canberra': CanberraDistance{{name_suffix}},
     'braycurtis': BrayCurtisDistance{{name_suffix}},
@@ -157,17 +156,9 @@ cdef class DistanceMetric{{name_suffix}}:
     "manhattan"     ManhattanDistance     -         ``sum(|x - y|)``
     "chebyshev"     ChebyshevDistance     -         ``max(|x - y|)``
     "minkowski"     MinkowskiDistance     p, w      ``sum(w * |x - y|^p)^(1/p)``
-    "wminkowski"    WMinkowskiDistance    p, w      ``sum(|w * (x - y)|^p)^(1/p)``
     "seuclidean"    SEuclideanDistance    V         ``sqrt(sum((x - y)^2 / V))``
     "mahalanobis"   MahalanobisDistance   V or VI   ``sqrt((x - y)' V^-1 (x - y))``
     ==============  ====================  ========  ===============================
-
-    .. deprecated:: 1.1
-        `WMinkowskiDistance` is deprecated in version 1.1 and will be removed in version 1.3.
-        Use `MinkowskiDistance` instead. Note that in `MinkowskiDistance`, the weights are
-        applied to the absolute differences already raised to the p power. This is different from
-        `WMinkowskiDistance` where weights are applied to the absolute differences before raising
-        to the p power. The deprecation aims to remain consistent with SciPy 1.8 convention.
 
     **Metrics intended for two-dimensional vector spaces:**  Note that the haversine
     distance metric requires data in the form of [latitude, longitude] and both
@@ -1417,160 +1408,6 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
                     i1 = i1 + 1
 
             return d
-
-    cdef inline float64_t dist_csr(
-        self,
-        const {{INPUT_DTYPE_t}}* x1_data,
-        const int32_t[:] x1_indices,
-        const {{INPUT_DTYPE_t}}* x2_data,
-        const int32_t[:] x2_indices,
-        const int32_t x1_start,
-        const int32_t x1_end,
-        const int32_t x2_start,
-        const int32_t x2_end,
-        const intp_t size,
-    ) except -1 nogil:
-        return pow(
-            self.rdist_csr(
-                x1_data,
-                x1_indices,
-                x2_data,
-                x2_indices,
-                x1_start,
-                x1_end,
-                x2_start,
-                x2_end,
-                size,
-            ),
-            1 / self.p
-        )
-
-#------------------------------------------------------------
-# TODO: Remove in 1.3 - WMinkowskiDistance class
-# W-Minkowski Distance
-cdef class WMinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
-    r"""Weighted Minkowski Distance
-
-    .. math::
-       D(x, y) = [\sum_i |w_i * (x_i - y_i)|^p] ^ (1/p)
-
-    Weighted Minkowski Distance requires p >= 1 and finite.
-
-    Parameters
-    ----------
-    p : int
-        The order of the norm of the difference :math:`{||u-v||}_p`.
-    w : (N,) array-like
-        The weight vector.
-
-    """
-    def __init__(self, p, w):
-        from warnings import warn
-        warn("WMinkowskiDistance is deprecated in version 1.1 and will be "
-            "removed in version 1.3. Use MinkowskiDistance instead. Note "
-            "that in MinkowskiDistance, the weights are applied to the "
-            "absolute differences raised to the p power. This is different "
-            "from WMinkowskiDistance where weights are applied to the "
-            "absolute differences before raising to the p power. "
-            "The deprecation aims to remain consistent with SciPy 1.8 "
-            "convention.", FutureWarning)
-
-        if p < 1:
-            raise ValueError("p must be greater than 1")
-        elif np.isinf(p):
-            raise ValueError("WMinkowskiDistance requires finite p. "
-                             "For p=inf, use ChebyshevDistance.")
-        self.p = p
-        self.vec = np.asarray(w, dtype=np.float64)
-        self.size = self.vec.shape[0]
-
-    def _validate_data(self, X):
-        if X.shape[1] != self.size:
-            raise ValueError('WMinkowskiDistance dist: '
-                             'size of w does not match')
-
-    cdef inline float64_t rdist(
-        self,
-        const {{INPUT_DTYPE_t}}* x1,
-        const {{INPUT_DTYPE_t}}* x2,
-        intp_t size,
-    ) except -1 nogil:
-
-        cdef float64_t d = 0
-        cdef intp_t j
-        for j in range(size):
-            d += (pow(self.vec[j] * fabs(x1[j] - x2[j]), self.p))
-        return d
-
-    cdef inline float64_t dist(
-        self,
-        const {{INPUT_DTYPE_t}}* x1,
-        const {{INPUT_DTYPE_t}}* x2,
-        intp_t size,
-    ) except -1 nogil:
-        return pow(self.rdist(x1, x2, size), 1. / self.p)
-
-    cdef inline float64_t _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
-        return pow(rdist, 1. / self.p)
-
-    cdef inline float64_t _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
-        return pow(dist, self.p)
-
-    def rdist_to_dist(self, rdist):
-        return rdist ** (1. / self.p)
-
-    def dist_to_rdist(self, dist):
-        return dist ** self.p
-
-    cdef inline float64_t rdist_csr(
-        self,
-        const {{INPUT_DTYPE_t}}* x1_data,
-        const int32_t[:] x1_indices,
-        const {{INPUT_DTYPE_t}}* x2_data,
-        const int32_t[:] x2_indices,
-        const int32_t x1_start,
-        const int32_t x1_end,
-        const int32_t x2_start,
-        const int32_t x2_end,
-        const intp_t size,
-    ) except -1 nogil:
-
-        cdef:
-            intp_t ix1, ix2
-            intp_t i1 = x1_start
-            intp_t i2 = x2_start
-
-            float64_t d = 0.0
-
-        while i1 < x1_end and i2 < x2_end:
-            ix1 = x1_indices[i1]
-            ix2 = x2_indices[i2]
-
-            if ix1 == ix2:
-                d = d + pow(self.vec[ix1] * fabs(
-                    x1_data[i1] - x2_data[i2]
-                ), self.p)
-                i1 = i1 + 1
-                i2 = i2 + 1
-            elif ix1 < ix2:
-                d = d + pow(self.vec[ix1] * fabs(x1_data[i1]), self.p)
-                i1 = i1 + 1
-            else:
-                d = d + pow(self.vec[ix2] * fabs(x2_data[i2]), self.p)
-                i2 = i2 + 1
-
-        if i1 == x1_end:
-            while i2 < x2_end:
-                ix2 = x2_indices[i2]
-                d = d + pow(self.vec[ix2] * fabs(x2_data[i2]), self.p)
-                i2 = i2 + 1
-        else:
-            while i1 < x1_end:
-                ix1 = x1_indices[i1]
-                d = d + pow(self.vec[ix1] * fabs(x1_data[i1]), self.p)
-                i1 = i1 + 1
-
-        return d
 
     cdef inline float64_t dist_csr(
         self,

--- a/sklearn/metrics/tests/test_dist_metrics.py
+++ b/sklearn/metrics/tests/test_dist_metrics.py
@@ -17,7 +17,6 @@ from sklearn.metrics._dist_metrics import (
 
 from sklearn.utils import check_random_state
 from sklearn.utils._testing import assert_allclose, create_memmap_backed_data
-from sklearn.utils.fixes import sp_version, parse_version
 
 
 def dist_func(x1, x2, p):

--- a/sklearn/metrics/tests/test_dist_metrics.py
+++ b/sklearn/metrics/tests/test_dist_metrics.py
@@ -56,23 +56,10 @@ METRICS_DEFAULT_PARAMS = [
     ("hamming", {}),
     ("canberra", {}),
     ("braycurtis", {}),
+    ("minkowski", dict(p=(1, 1.5, 3), w=(rng.random_sample(d),))),
 ]
-if sp_version >= parse_version("1.8.0.dev0"):
-    # Starting from scipy 1.8.0.dev0, minkowski now accepts w, the weighting
-    # parameter directly and using it is preferred over using wminkowski.
-    METRICS_DEFAULT_PARAMS.append(
-        ("minkowski", dict(p=(1, 1.5, 3), w=(rng.random_sample(d),))),
-    )
-else:
-    # For previous versions of scipy, this was possible through a dedicated
-    # metric (deprecated in 1.6 and removed in 1.8).
-    METRICS_DEFAULT_PARAMS.append(
-        ("wminkowski", dict(p=(1, 1.5, 3), w=(rng.random_sample(d),))),
-    )
 
 
-# TODO: Remove filterwarnings in 1.3 when wminkowski is removed
-@pytest.mark.filterwarnings("ignore:WMinkowskiDistance:FutureWarning:sklearn")
 @pytest.mark.parametrize(
     "metric_param_grid", METRICS_DEFAULT_PARAMS, ids=lambda params: params[0]
 )
@@ -95,15 +82,7 @@ def test_cdist(metric_param_grid, X, Y):
             # with scipy
             rtol_dict = {"rtol": 1e-6}
 
-        if metric == "wminkowski":
-            # wminkoski is deprecated in SciPy 1.6.0 and removed in 1.8.0
-            WarningToExpect = None
-            if sp_version >= parse_version("1.6.0"):
-                WarningToExpect = DeprecationWarning
-            with pytest.warns(WarningToExpect):
-                D_scipy_cdist = cdist(X, Y, metric, **kwargs)
-        else:
-            D_scipy_cdist = cdist(X, Y, metric, **kwargs)
+        D_scipy_cdist = cdist(X, Y, metric, **kwargs)
 
         dm = DistanceMetricInterface.get_metric(metric, **kwargs)
 
@@ -158,8 +137,6 @@ def test_cdist_bool_metric(metric, X_bool, Y_bool):
     assert_allclose(D_sklearn, D_scipy_cdist)
 
 
-# TODO: Remove filterwarnings in 1.3 when wminkowski is removed
-@pytest.mark.filterwarnings("ignore:WMinkowskiDistance:FutureWarning:sklearn")
 @pytest.mark.parametrize(
     "metric_param_grid", METRICS_DEFAULT_PARAMS, ids=lambda params: params[0]
 )
@@ -182,18 +159,7 @@ def test_pdist(metric_param_grid, X):
             # with scipy
             rtol_dict = {"rtol": 1e-6}
 
-        if metric == "wminkowski":
-            if sp_version >= parse_version("1.8.0"):
-                pytest.skip("wminkowski will be removed in SciPy 1.8.0")
-
-            # wminkoski is deprecated in SciPy 1.6.0 and removed in 1.8.0
-            ExceptionToAssert = None
-            if sp_version >= parse_version("1.6.0"):
-                ExceptionToAssert = DeprecationWarning
-            with pytest.warns(ExceptionToAssert):
-                D_scipy_pdist = cdist(X, X, metric, **kwargs)
-        else:
-            D_scipy_pdist = cdist(X, X, metric, **kwargs)
+        D_scipy_pdist = cdist(X, X, metric, **kwargs)
 
         dm = DistanceMetricInterface.get_metric(metric, **kwargs)
         D_sklearn = dm.pairwise(X)
@@ -209,8 +175,6 @@ def test_pdist(metric_param_grid, X):
         assert_allclose(D_sklearn_csr, D_scipy_pdist, **rtol_dict)
 
 
-# TODO: Remove filterwarnings in 1.3 when wminkowski is removed
-@pytest.mark.filterwarnings("ignore:WMinkowskiDistance:FutureWarning:sklearn")
 @pytest.mark.parametrize(
     "metric_param_grid", METRICS_DEFAULT_PARAMS, ids=lambda params: params[0]
 )
@@ -261,8 +225,6 @@ def test_pdist_bool_metrics(metric, X_bool):
     assert_allclose(D_sklearn, D_scipy_pdist)
 
 
-# TODO: Remove filterwarnings in 1.3 when wminkowski is removed
-@pytest.mark.filterwarnings("ignore:WMinkowskiDistance:FutureWarning:sklearn")
 @pytest.mark.parametrize("writable_kwargs", [True, False])
 @pytest.mark.parametrize(
     "metric_param_grid", METRICS_DEFAULT_PARAMS, ids=lambda params: params[0]
@@ -288,8 +250,6 @@ def test_pickle(writable_kwargs, metric_param_grid, X):
         assert_allclose(D1, D2)
 
 
-# TODO: Remove filterwarnings in 1.3 when wminkowski is removed
-@pytest.mark.filterwarnings("ignore:WMinkowskiDistance:FutureWarning:sklearn")
 @pytest.mark.parametrize("metric", BOOL_METRICS)
 @pytest.mark.parametrize("X_bool", [X_bool, X_bool_mmap])
 def test_pickle_bool_metrics(metric, X_bool):
@@ -385,8 +345,6 @@ def test_input_data_size():
     assert_allclose(pyfunc.pairwise(X), eucl.pairwise(X) ** 2)
 
 
-# TODO: Remove filterwarnings in 1.3 when wminkowski is removed
-@pytest.mark.filterwarnings("ignore:WMinkowskiDistance:FutureWarning:sklearn")
 def test_readonly_kwargs():
     # Non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/21685
@@ -400,7 +358,6 @@ def test_readonly_kwargs():
 
     # Those distances metrics have to support readonly buffers.
     DistanceMetric.get_metric("seuclidean", V=weights)
-    DistanceMetric.get_metric("wminkowski", p=1, w=weights)
     DistanceMetric.get_metric("mahalanobis", VI=VI)
 
 
@@ -433,24 +390,3 @@ def test_minkowski_metric_validate_weights_size():
     )
     with pytest.raises(ValueError, match=msg):
         dm.pairwise(X64, Y64)
-
-
-# TODO: Remove in 1.3 when wminkowski is removed
-def test_wminkowski_deprecated():
-    w = rng.random_sample(d)
-    msg = "WMinkowskiDistance is deprecated in version 1.1"
-    with pytest.warns(FutureWarning, match=msg):
-        DistanceMetric.get_metric("wminkowski", p=3, w=w)
-
-
-# TODO: Remove in 1.3 when wminkowski is removed
-@pytest.mark.filterwarnings("ignore:WMinkowskiDistance:FutureWarning:sklearn")
-@pytest.mark.parametrize("p", [1, 1.5, 3])
-def test_wminkowski_minkowski_equivalence(p):
-    w = rng.random_sample(d)
-    # Weights are rescaled for consistency w.r.t scipy 1.8 refactoring of 'minkowski'
-    dm_wmks = DistanceMetric.get_metric("wminkowski", p=p, w=(w) ** (1 / p))
-    dm_mks = DistanceMetric.get_metric("minkowski", p=p, w=w)
-    D_wmks = dm_wmks.pairwise(X64, Y64)
-    D_mks = dm_mks.pairwise(X64, Y64)
-    assert_allclose(D_wmks, D_mks)

--- a/sklearn/metrics/tests/test_pairwise_distances_reduction.py
+++ b/sklearn/metrics/tests/test_pairwise_distances_reduction.py
@@ -18,7 +18,6 @@ from sklearn.metrics._pairwise_distances_reduction import (
     sqeuclidean_row_norms,
 )
 from sklearn.metrics import euclidean_distances
-from sklearn.utils.fixes import sp_version, parse_version
 from sklearn.utils._testing import (
     assert_array_equal,
     assert_allclose,
@@ -49,7 +48,11 @@ def _get_metric_params_list(metric: str, n_features: int, seed: int = 1):
 
     if metric == "minkowski":
         minkowski_kwargs = [
-            dict(p=1.5), dict(p=2), dict(p=3), dict(p=np.inf), dict(p=3, w=rng.rand(n_features))
+            dict(p=1.5),
+            dict(p=2),
+            dict(p=3),
+            dict(p=np.inf),
+            dict(p=3, w=rng.rand(n_features)),
         ]
 
         return minkowski_kwargs

--- a/sklearn/metrics/tests/test_pairwise_distances_reduction.py
+++ b/sklearn/metrics/tests/test_pairwise_distances_reduction.py
@@ -48,25 +48,11 @@ def _get_metric_params_list(metric: str, n_features: int, seed: int = 1):
     rng = np.random.RandomState(seed)
 
     if metric == "minkowski":
-        minkowski_kwargs = [dict(p=1.5), dict(p=2), dict(p=3), dict(p=np.inf)]
-        if sp_version >= parse_version("1.8.0.dev0"):
-            # TODO: remove the test once we no longer support scipy < 1.8.0.
-            # Recent scipy versions accept weights in the Minkowski metric directly:
-            # type: ignore
-            minkowski_kwargs.append(dict(p=3, w=rng.rand(n_features)))
+        minkowski_kwargs = [
+            dict(p=1.5), dict(p=2), dict(p=3), dict(p=np.inf), dict(p=3, w=rng.rand(n_features))
+        ]
 
         return minkowski_kwargs
-
-    # TODO: remove this case for "wminkowski" once we no longer support scipy < 1.8.0.
-    if metric == "wminkowski":
-        weights = rng.random_sample(n_features)
-        weights /= weights.sum()
-        wminkowski_kwargs = [dict(p=1.5, w=weights)]
-        if sp_version < parse_version("1.8.0.dev0"):
-            # wminkowski was removed in scipy 1.8.0 but should work for previous
-            # versions.
-            wminkowski_kwargs.append(dict(p=3, w=rng.rand(n_features)))
-        return wminkowski_kwargs
 
     if metric == "seuclidean":
         return [dict(V=rng.rand(n_features))]
@@ -1116,8 +1102,6 @@ def test_strategies_consistency(
 # "Concrete Dispatchers"-specific tests
 
 
-# TODO: Remove filterwarnings in 1.3 when wminkowski is removed
-@pytest.mark.filterwarnings("ignore:WMinkowskiDistance:FutureWarning:sklearn")
 @pytest.mark.parametrize("n_features", [50, 500])
 @pytest.mark.parametrize("translation", [0, 1e6])
 @pytest.mark.parametrize("metric", CDIST_PAIRWISE_DISTANCES_REDUCTION_COMMON_METRICS)
@@ -1192,8 +1176,6 @@ def test_pairwise_distances_argkmin(
         )
 
 
-# TODO: Remove filterwarnings in 1.3 when wminkowski is removed
-@pytest.mark.filterwarnings("ignore:WMinkowskiDistance:FutureWarning:sklearn")
 @pytest.mark.parametrize("n_features", [50, 500])
 @pytest.mark.parametrize("translation", [0, 1e6])
 @pytest.mark.parametrize("metric", CDIST_PAIRWISE_DISTANCES_REDUCTION_COMMON_METRICS)

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -38,7 +38,7 @@ from ..utils.validation import check_is_fitted
 from ..utils.validation import check_non_negative
 from ..utils._param_validation import Interval, StrOptions, validate_params
 from ..utils.parallel import delayed, Parallel
-from ..utils.fixes import parse_version, sp_base_version, sp_version
+from ..utils.fixes import parse_version, sp_base_version
 from ..exceptions import DataConversionWarning, EfficiencyWarning
 
 SCIPY_METRICS = [
@@ -621,7 +621,7 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
                     self._fit_method = "brute"
 
         if (
-            self.effective_metric_== "minkowski"
+            self.effective_metric_ == "minkowski"
             and self.effective_metric_params_["p"] < 1
         ):
             # For 0 < p < 1 Minkowski distances aren't valid distance

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -75,12 +75,6 @@ VALID_METRICS = dict(
     brute=sorted(set(PAIRWISE_DISTANCE_FUNCTIONS).union(SCIPY_METRICS)),
 )
 
-# TODO: Remove filterwarnings in 1.3 when wminkowski is removed
-if sp_version < parse_version("1.8.0.dev0"):
-    # Before scipy 1.8.0.dev0, wminkowski was the key to use
-    # the weighted minkowski metric.
-    VALID_METRICS["brute"].append("wminkowski")
-
 VALID_METRICS_SPARSE = dict(
     ball_tree=[],
     kd_tree=[],
@@ -512,7 +506,7 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             self.effective_metric_params_ = self.metric_params.copy()
 
         effective_p = self.effective_metric_params_.get("p", self.p)
-        if self.metric in ["wminkowski", "minkowski"]:
+        if self.metric == "minkowski":
             self.effective_metric_params_["p"] = effective_p
 
         self.effective_metric_ = self.metric
@@ -605,8 +599,7 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
                 self._fit_method = "brute"
             else:
                 if (
-                    # TODO(1.3): remove "wminkowski"
-                    self.effective_metric_ in ("wminkowski", "minkowski")
+                    self.effective_metric_ == "minkowski"
                     and self.effective_metric_params_["p"] < 1
                 ):
                     self._fit_method = "brute"
@@ -614,15 +607,8 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
                     self.effective_metric_ == "minkowski"
                     and self.effective_metric_params_.get("w") is not None
                 ):
-                    # Be consistent with scipy 1.8 conventions: in scipy 1.8,
-                    # 'wminkowski' was removed in favor of passing a
-                    # weight vector directly to 'minkowski'.
-                    #
-                    # 'wminkowski' is not part of valid metrics for KDTree but
-                    # the 'minkowski' without weights is.
-                    #
-                    # Hence, we detect this case and choose BallTree
-                    # which supports 'wminkowski'.
+                    # 'minkowski' with weights is not supported by KDTree but is
+                    # supported byBallTree.
                     self._fit_method = "ball_tree"
                 elif self.effective_metric_ in VALID_METRICS["kd_tree"]:
                     self._fit_method = "kd_tree"
@@ -635,8 +621,7 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
                     self._fit_method = "brute"
 
         if (
-            # TODO(1.3): remove "wminkowski"
-            self.effective_metric_ in ("wminkowski", "minkowski")
+            self.effective_metric_== "minkowski"
             and self.effective_metric_params_["p"] < 1
         ):
             # For 0 < p < 1 Minkowski distances aren't valid distance

--- a/sklearn/neighbors/tests/test_ball_tree.py
+++ b/sklearn/neighbors/tests/test_ball_tree.py
@@ -14,16 +14,6 @@ V_mahalanobis = np.dot(V_mahalanobis, V_mahalanobis.T)
 
 DIMENSION = 3
 
-METRICS = {
-    "euclidean": {},
-    "manhattan": {},
-    "minkowski": dict(p=3),
-    "chebyshev": {},
-    "seuclidean": dict(V=rng.random_sample(DIMENSION)),
-    "wminkowski": dict(p=3, w=rng.random_sample(DIMENSION)),
-    "mahalanobis": dict(V=V_mahalanobis),
-}
-
 DISCRETE_METRICS = ["hamming", "canberra", "braycurtis"]
 
 BOOLEAN_METRICS = [

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1,5 +1,4 @@
 from itertools import product
-from contextlib import nullcontext
 import warnings
 
 import pytest
@@ -87,7 +86,6 @@ def _generate_test_params_for(metric: str, n_features: int):
 
     # Distinguishing on cases not to compute unneeded datastructures.
     rng = np.random.RandomState(1)
-    weights = rng.random_sample(n_features)
 
     if metric == "minkowski":
         minkowski_kwargs = [dict(p=1.5), dict(p=2), dict(p=3), dict(p=np.inf)]

--- a/sklearn/neighbors/tests/test_neighbors_tree.py
+++ b/sklearn/neighbors/tests/test_neighbors_tree.py
@@ -36,7 +36,6 @@ METRICS = {
     "minkowski": dict(p=3),
     "chebyshev": {},
     "seuclidean": dict(V=rng.random_sample(DIMENSION)),
-    "wminkowski": dict(p=3, w=rng.random_sample(DIMENSION)),
     "mahalanobis": dict(V=V_mahalanobis),
 }
 
@@ -231,8 +230,6 @@ def test_gaussian_kde(Cls, n_samples=1000):
         assert_array_almost_equal(dens_tree, dens_gkde, decimal=3)
 
 
-# TODO: Remove filterwarnings in 1.3 when wminkowski is removed
-@pytest.mark.filterwarnings("ignore:WMinkowskiDistance:FutureWarning:sklearn")
 @pytest.mark.parametrize(
     "Cls, metric",
     itertools.chain(


### PR DESCRIPTION
The `WMinkowskiDistance` class was deprecated in 1.1.

KNN classes didn't properly deprecate `metric="wminkowski"` but there was the future warning for WMinkowskiDistance being deprecated so it's fine to just remove it.

However, `metric="wminkowski"` was not deprecated at all for `pairwise_distances` and co because it directly relies on the scipy function. That is, if you have an old version of scipy, `metric="wminkowski"` works, and if you have a recent version of scipy it doesn't. I left it as is. We could decide to deprecate it properly but I'd just let it and it'll settle automatically when we drop support for scipy < 1.8. 