### PR TITLE
Fix the misleading `confusion_matrix()` outputs

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -639,8 +639,8 @@ false negatives and true positives as follows::
 
   >>> y_true = [0, 0, 0, 1, 1, 1, 1, 1]
   >>> y_pred = [0, 1, 0, 1, 0, 1, 0, 1]
-  >>> tn, fp, fn, tp = confusion_matrix(y_true, y_pred).ravel()
-  >>> tn, fp, fn, tp
+  >>> tp, fn, fp, tn = confusion_matrix(y_true, y_pred).ravel()
+  >>> tp, fn, fp, tn
   (2, 1, 2, 3)
 
 .. topic:: Example:

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -318,8 +318,8 @@ def confusion_matrix(
 
     In the binary case, we can extract true positives, etc. as follows:
 
-    >>> tn, fp, fn, tp = confusion_matrix([0, 1, 0, 1], [1, 1, 1, 0]).ravel()
-    >>> (tn, fp, fn, tp)
+    >>> tp, fn, fp, tn = confusion_matrix([0, 1, 0, 1], [1, 1, 1, 0]).ravel()
+    >>> (tp, fn, fp, tn)
     (0, 2, 1, 1)
     """
     y_type, y_true, y_pred = _check_targets(y_true, y_pred)
@@ -1921,7 +1921,7 @@ def class_likelihood_ratios(
         positive_likelihood_ratio = np.nan
         negative_likelihood_ratio = np.nan
     else:
-        tn, fp, fn, tp = cm.ravel()
+        tp, fn, fp, tn = cm.ravel()
         support_pos = tp + fn
         support_neg = tn + fp
         pos_num = tp * support_neg

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -428,9 +428,9 @@ def adjusted_rand_score(labels_true, labels_pred):
       >>> adjusted_rand_score([0, 0, 1, 1], [0, 1, 0, 1])
       -0.5
     """
-    (tn, fp), (fn, tp) = pair_confusion_matrix(labels_true, labels_pred)
+    (tp, fn), (fp, tn) = pair_confusion_matrix(labels_true, labels_pred)
     # convert to Python integer types, to avoid overflow or underflow
-    tn, fp, fn, tp = int(tn), int(fp), int(fn), int(tp)
+    tp, fn, fp, tn = int(tp), int(fn), int(fp), int(tn)
 
     # Special cases: empty data or full agreement
     if fn == 0 and fp == 0:


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Resolves the misleading outputs from the `confusion_matrix()` function.

Closes: #26446