### PR TITLE
SLEP006: remove RequestType enum

### DIFF
--- a/doc/metadata_routing.rst
+++ b/doc/metadata_routing.rst
@@ -49,7 +49,6 @@ in this section require the following imports and data::
   >>> from sklearn.linear_model import LogisticRegressionCV, LogisticRegression
   >>> from sklearn.model_selection import cross_validate, GridSearchCV, GroupKFold
   >>> from sklearn.feature_selection import SelectKBest
-  >>> from sklearn.utils.metadata_requests import RequestType
   >>> from sklearn.pipeline import make_pipeline
   >>> n_samples, n_features = 100, 4
   >>> rng = np.random.RandomState(42)
@@ -94,7 +93,7 @@ Weighted scoring and unweighted fitting
 
 When passing metadata such as ``sample_weight`` around, all scikit-learn
 estimators require weights to be either explicitly requested or not requested
-(i.e. ``UNREQUESTED``) when used in another router such as a
+(i.e. ``True`` or ``False``) when used in another router such as a
 :class:`~pipeline.Pipeline` or a ``*GridSearchCV``. To perform an unweighted
 fit, we need to configure :class:`~linear_model.LogisticRegressionCV` to not
 request sample weights, so that :func:`~model_selection.cross_validate` does
@@ -105,7 +104,7 @@ not pass the weights along::
   ... )
   >>> lr = LogisticRegressionCV(
   ...     cv=GroupKFold(), scoring=weighted_acc,
-  ... ).set_fit_request(sample_weight=RequestType.UNREQUESTED)
+  ... ).set_fit_request(sample_weight=False)
   >>> cv_results = cross_validate(
   ...     lr,
   ...     X,
@@ -114,10 +113,6 @@ not pass the weights along::
   ...     props={"sample_weight": my_weights, "groups": my_groups},
   ...     scoring=weighted_acc,
   ... )
-
-Note the usage of :class:`~utils.metadata_routing.RequestType` which in this
-case is equivalent to ``False``; the type is explained further at the end of
-this document.
 
 If :meth:`linear_model.LogisticRegressionCV.set_fit_request` has not
 been called, :func:`~model_selection.cross_validate` will raise an
@@ -195,16 +190,13 @@ supports ``sample_weight`` in ``fit`` and ``score``, it exposes
 ``estimator.set_fit_request(sample_weight=value)`` and
 ``estimator.set_score_request(sample_weight=value)``. Here ``value`` can be:
 
-- ``RequestType.REQUESTED`` or ``True``: method requests a ``sample_weight``.
-  This means if the metadata is provided, it will be used, otherwise no error
-  is raised.
-- ``RequestType.UNREQUESTED`` or ``False``: method does not request a
-  ``sample_weight``.
-- ``RequestType.ERROR_IF_PASSED`` or ``None``: router will raise an error if
-  ``sample_weight`` is passed. This is in almost all cases the default value
-  when an object is instantiated and ensures the user sets the metadata
-  requests explicitly when a metadata is passed. The only exception are
-  ``Group*Fold`` splitters.
+- ``True``: method requests a ``sample_weight``. This means if the metadata is
+  provided, it will be used, otherwise no error is raised.
+- ``False``: method does not request a ``sample_weight``.
+- ``None``: router will raise an error if ``sample_weight`` is passed. This is
+  in almost all cases the default value when an object is instantiated and
+  ensures the user sets the metadata requests explicitly when a metadata is
+  passed. The only exception are ``Group*Fold`` splitters.
 - ``"param_name"``: if this estimator is used in a meta-estimator, the
   meta-estimator should forward ``"param_name"`` as ``sample_weight`` to this
   estimator. This means the mapping between the metadata required by the

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -1652,7 +1652,6 @@ Plotting
    utils.validation.check_symmetric
    utils.validation.column_or_1d
    utils.validation.has_fit_parameter
-   utils.metadata_routing.RequestType
    utils.metadata_routing.get_routing_for_object
    utils.metadata_routing.MetadataRouter
    utils.metadata_routing.MetadataRequest

--- a/examples/plot_metadata_routing.py
+++ b/examples/plot_metadata_routing.py
@@ -32,7 +32,7 @@ from sklearn.base import RegressorMixin
 from sklearn.base import MetaEstimatorMixin
 from sklearn.base import TransformerMixin
 from sklearn.base import clone
-from sklearn.utils.metadata_routing import RequestType
+from sklearn.utils import metadata_routing
 from sklearn.utils.metadata_routing import get_routing_for_object
 from sklearn.utils.metadata_routing import MetadataRouter
 from sklearn.utils.metadata_routing import MethodMapping
@@ -121,19 +121,6 @@ est = (
     .set_fit_request(sample_weight=False)
     .set_predict_request(groups=True)
     .set_score_request(sample_weight=False)
-)
-print_routing(est)
-
-# %%
-# As you can see, the metadata have now explicit request values, one is
-# requested and one is not. Instead of ``True`` and ``False``, we could also
-# use the :class:`~sklearn.utils.metadata_routing.RequestType` values.
-
-est = (
-    ExampleClassifier()
-    .set_fit_request(sample_weight=RequestType.UNREQUESTED)
-    .set_predict_request(groups=RequestType.REQUESTED)
-    .set_score_request(sample_weight=RequestType.UNREQUESTED)
 )
 print_routing(est)
 
@@ -563,7 +550,7 @@ reg.fit(X, y, sample_weight=my_weights)
 
 
 class WeightedMetaRegressor(MetaEstimatorMixin, RegressorMixin, BaseEstimator):
-    __metadata_request__fit = {"sample_weight": RequestType.WARN}
+    __metadata_request__fit = {"sample_weight": metadata_routing.WARN}
 
     def __init__(self, estimator):
         self.estimator = estimator
@@ -601,7 +588,7 @@ for w in record:
 
 
 class ExampleRegressor(RegressorMixin, BaseEstimator):
-    __metadata_request__fit = {"sample_weight": RequestType.WARN}
+    __metadata_request__fit = {"sample_weight": metadata_routing.WARN}
 
     def fit(self, X, y, sample_weight=None):
         check_metadata(self, sample_weight=sample_weight)

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -292,8 +292,7 @@ class _BaseScorer(_MetadataRequester):
         ----------
         kwargs : dict
             Arguments should be of the form ``param_name=alias``, and `alias`
-            can be either one of ``{True, False, None, str}`` or an instance of
-            RequestType.
+            can be one of ``{True, False, None, str}``.
         """
         self._warn_overlap(
             message=(

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -16,7 +16,7 @@ from sklearn import config_context
 from sklearn.utils._testing import assert_almost_equal
 from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import ignore_warnings
-from sklearn.utils.metadata_routing import MetadataRouter, RequestType
+from sklearn.utils.metadata_routing import MetadataRouter
 from sklearn.tests.test_metadata_routing import assert_request_is_empty
 
 from sklearn.base import BaseEstimator
@@ -1219,7 +1219,7 @@ def test_scorer_metadata_request(name):
         assert_request_is_empty(weighted_scorer.get_metadata_routing(), exclude="score")
         assert (
             weighted_scorer.get_metadata_routing().score.requests["sample_weight"]
-            == RequestType.REQUESTED
+            is True
         )
 
         # make sure putting the scorer in a router doesn't request anything by

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -28,7 +28,7 @@ from ..utils import _approximate_mode
 from ..utils.validation import _num_samples, column_or_1d
 from ..utils.validation import check_array
 from ..utils.multiclass import type_of_target
-from ..utils.metadata_routing import RequestType
+from ..utils import metadata_routing
 from ..utils.metadata_routing import _MetadataRequester
 from ..utils._param_validation import validate_params, Interval
 from ..utils._param_validation import RealNotInt
@@ -57,13 +57,12 @@ __all__ = [
 class GroupsConsumerMixin(_MetadataRequester):
     """A Mixin to ``groups`` by default.
 
-    This Mixin makes the object to request ``groups`` by default as
-    ``REQUESTED``.
+    This Mixin makes the object to request ``groups`` by default as ``True``.
 
     .. versionadded:: 1.3
     """
 
-    __metadata_request__split = {"groups": RequestType.REQUESTED}
+    __metadata_request__split = {"groups": True}
 
 
 class BaseCrossValidator(_MetadataRequester, metaclass=ABCMeta):
@@ -76,7 +75,7 @@ class BaseCrossValidator(_MetadataRequester, metaclass=ABCMeta):
     # unless indicated by inheriting from ``GroupsConsumerMixin``.
     # This also prevents ``set_split_request`` to be generated for splitters
     # which don't support ``groups``.
-    __metadata_request__split = {"groups": RequestType.UNUSED}
+    __metadata_request__split = {"groups": metadata_routing.UNUSED}
 
     def split(self, X, y=None, groups=None):
         """Generate indices to split data into training and test set.
@@ -1457,7 +1456,7 @@ class _RepeatedSplits(_MetadataRequester, metaclass=ABCMeta):
     # unless indicated by inheriting from ``GroupsConsumerMixin``.
     # This also prevents ``set_split_request`` to be generated for splitters
     # which don't support ``groups``.
-    __metadata_request__split = {"groups": RequestType.UNUSED}
+    __metadata_request__split = {"groups": metadata_routing.UNUSED}
 
     def __init__(self, cv, *, n_repeats=10, random_state=None, **cvargs):
         if not isinstance(n_repeats, numbers.Integral):
@@ -1680,7 +1679,7 @@ class BaseShuffleSplit(_MetadataRequester, metaclass=ABCMeta):
     # unless indicated by inheriting from ``GroupsConsumerMixin``.
     # This also prevents ``set_split_request`` to be generated for splitters
     # which don't support ``groups``.
-    __metadata_request__split = {"groups": RequestType.UNUSED}
+    __metadata_request__split = {"groups": metadata_routing.UNUSED}
 
     def __init__(
         self, n_splits=10, *, test_size=None, train_size=None, random_state=None

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -48,7 +48,6 @@ from sklearn.datasets import make_classification
 
 from sklearn.svm import SVC
 
-from sklearn.utils.metadata_routing import RequestType
 from sklearn.tests.test_metadata_routing import assert_request_is_empty
 
 NO_GROUP_SPLITTERS = [
@@ -1932,7 +1931,7 @@ def test_splitter_get_metadata_routing(cv):
     assert hasattr(cv, "get_metadata_routing")
     metadata = cv.get_metadata_routing()
     if cv in GROUP_SPLITTERS:
-        assert metadata.split.requests["groups"] == RequestType.REQUESTED
+        assert metadata.split.requests["groups"] is True
     elif cv in NO_GROUP_SPLITTERS:
         assert not metadata.split.requests
 

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -8,7 +8,6 @@ Metadata Routing Utility
 import inspect
 from collections import namedtuple
 from copy import deepcopy
-from enum import Enum
 from typing import Optional, Union
 from warnings import warn
 
@@ -40,78 +39,66 @@ def _routing_enabled():
     return get_config().get("enable_metadata_routing", False)
 
 
-class RequestType(Enum):
-    """A metadata is requested either with a string alias or this enum.
+# ============================
+# Request values:
+# Each request value needs to be one of the following values, or an alias.
 
-    .. versionadded:: 1.3
-    """
+# this is used in `__metadata_request__*` attributes to indicate that a
+# metadata is not present even though it may be present in the
+# corresponding method's signature.
+UNUSED = "$UNUSED$"
 
-    # Metadata is not requested. It will not be routed to the object having the
-    # request value as UNREQUESTED.
-    UNREQUESTED = False
-    # Metadata is requested, and will be routed to the requesting object. There
-    # will be no error if the metadata is not provided.
-    REQUESTED = True
-    # Default metadata request configuration. It should not be passed, and if
-    # present, an error is raised for the user to explicitly set the request
-    # value.
-    ERROR_IF_PASSED = None
-    # this is used in `__metadata_request__*` attributes to indicate that a
-    # metadata is not present even though it may be present in the
-    # corresponding method's signature.
-    UNUSED = "$UNUSED$"
-    # this is used whenever a default value is changed, and therefore the user
-    # should explicitly set the value, otherwise a warning is shown. An example
-    # is when a meta-estimator is only a router, but then becomes also a
-    # consumer in a new release.
-    WARN = "$WARN$"
+# this is used whenever a default value is changed, and therefore the user
+# should explicitly set the value, otherwise a warning is shown. An example
+# is when a meta-estimator is only a router, but then becomes also a
+# consumer in a new release.
+WARN = "$WARN$"
 
-    @classmethod
-    def is_alias(cls, item):
-        """Check if an item is a valid alias.
-
-        Parameters
-        ----------
-        item : object
-            The given item to be checked if it can be an alias.
-
-        Returns
-        -------
-        result : bool
-            Whether the given item is a valid alias.
-        """
-        try:
-            cls(item)
-        except ValueError:
-            # item is only an alias if it's a valid identifier
-            return isinstance(item, str) and item.isidentifier()
-        else:
-            return False
-
-    @classmethod
-    def is_valid(cls, item):
-        """Check if an item is a valid RequestType (and not an alias).
-
-        Parameters
-        ----------
-        item : object
-            The given item to be checked.
-
-        Returns
-        -------
-        result : bool
-            Whether the given item is valid.
-        """
-        try:
-            cls(item)
-            return True
-        except ValueError:
-            return False
-
-
-# this is the default used in `set_{method}_request` methods to indicate no change
-# requested by the user.
+# this is the default used in `set_{method}_request` methods to indicate no
+# change requested by the user.
 UNCHANGED = "$UNCHANGED$"
+
+VALID_REQUEST_VALUES = [False, True, None, UNUSED, WARN]
+
+
+def request_is_alias(item):
+    """Check if an item is a valid alias.
+
+    Parameters
+    ----------
+    item : object
+        The given item to be checked if it can be an alias.
+
+    Returns
+    -------
+    result : bool
+        Whether the given item is a valid alias.
+    """
+    if item in VALID_REQUEST_VALUES:
+        return False
+
+    # item is only an alias if it's a valid identifier
+    return isinstance(item, str) and item.isidentifier()
+
+
+def request_is_valid(item):
+    """Check if an item is a valid request value (and not an alias).
+
+    Parameters
+    ----------
+    item : object
+        The given item to be checked.
+
+    Returns
+    -------
+    result : bool
+        Whether the given item is valid.
+    """
+    return item in VALID_REQUEST_VALUES
+
+
+# End of request values
+# ===============================
 
 # Only the following methods are supported in the routing mechanism. Adding new
 # methods at the moment involves monkeypatching this list.
@@ -153,8 +140,9 @@ will raise an error if the user provides it.
         - ``str``: metadata should be passed to the meta-estimator with \
 this given alias instead of the original name.
 
-        The default (``UNCHANGED``) retains the existing request. This allows
-        you to change the request for some parameters and not others.
+        The default (``sklearn.utils.metadata_routing.UNCHANGED``) retains the
+        existing request. This allows you to change the request for some
+        parameters and not others.
 
         .. versionadded:: 1.3
 
@@ -165,8 +153,8 @@ this given alias instead of the original name.
         Parameters
         ----------
 """
-REQUESTER_DOC_PARAM = """        {metadata} : RequestType, str, True, False, or None, \
-                    default=UNCHANGED
+REQUESTER_DOC_PARAM = """        {metadata} : str, True, False, or None, \
+                    default=sklearn.utils.metadata_routing.UNCHANGED
             Metadata routing for ``{metadata}`` parameter in ``{method}``.
 
 """
@@ -217,33 +205,31 @@ class MethodMetadataRequest:
         param : str
             The property for which a request is set.
 
-        alias : str, RequestType, or {True, False, None}
+        alias : str, or {True, False, None}
             Specifies which metadata should be routed to `param`
 
             - str: the name (or alias) of metadata given to a meta-estimator that
               should be routed to this parameter.
 
-            - True or RequestType.REQUESTED: requested
+            - True: requested
 
-            - False or RequestType.UNREQUESTED: not requested
+            - False: not requested
 
-            - None or RequestType.ERROR_IF_PASSED: error if passed
+            - None: error if passed
         """
-        if RequestType.is_valid(alias):
-            alias = RequestType(alias)
-        elif not RequestType.is_alias(alias):
+        if not request_is_alias(alias) and not request_is_valid(alias):
             raise ValueError(
                 "alias should be either a valid identifier or one of "
-                "{None, True, False}, or a RequestType."
+                "{None, True, False}."
             )
 
         if alias != self._requests.get(param, None):
             self.router._is_default_request = False
 
         if alias == param:
-            alias = RequestType.REQUESTED
+            alias = True
 
-        if alias == RequestType.UNUSED and param in self._requests:
+        if alias == UNUSED and param in self._requests:
             del self._requests[param]
         else:
             self._requests[param] = alias
@@ -253,7 +239,7 @@ class MethodMetadataRequest:
     def _get_param_names(self, return_alias):
         """Get names of all metadata that can be consumed or routed by this method.
 
-        This method returns the names of all metadata, even the UNREQUESTED
+        This method returns the names of all metadata, even the ``False``
         ones.
 
         Parameters
@@ -268,10 +254,9 @@ class MethodMetadataRequest:
             A set of strings with the names of all parameters.
         """
         return set(
-            alias if return_alias and not RequestType.is_valid(alias) else prop
+            alias if return_alias and not request_is_valid(alias) else prop
             for prop, alias in self._requests.items()
-            if not RequestType.is_valid(alias)
-            or RequestType(alias) != RequestType.UNREQUESTED
+            if not request_is_valid(alias) or alias is not False
         )
 
     def _check_warnings(self, *, params):
@@ -288,15 +273,14 @@ class MethodMetadataRequest:
         warn_params = {
             prop
             for prop, alias in self._requests.items()
-            if alias == RequestType.WARN and prop in params
+            if alias == WARN and prop in params
         }
         for param in warn_params:
             warn(
                 f"Support for {param} has recently been added to this class. "
                 "To maintain backward compatibility, it is ignored now. "
-                "You can set the request value to RequestType.UNREQUESTED "
-                "to silence this warning, or to RequestType.REQUESTED to "
-                "consume and use the metadata."
+                "You can set the request value to False to silence this "
+                "warning, or to True to consume and use the metadata."
             )
 
     def _route_params(self, params=None):
@@ -322,14 +306,11 @@ class MethodMetadataRequest:
         args = {arg: value for arg, value in params.items() if value is not None}
         res = Bunch()
         for prop, alias in self._requests.items():
-            if RequestType.is_valid(alias):
-                alias = RequestType(alias)
-
-            if alias == RequestType.UNREQUESTED or alias == RequestType.WARN:
+            if alias is False or alias == WARN:
                 continue
-            elif alias == RequestType.REQUESTED and prop in args:
+            elif alias is True and prop in args:
                 res[prop] = args[prop]
-            elif alias == RequestType.ERROR_IF_PASSED and prop in args:
+            elif alias is None and prop in args:
                 unrequested[prop] = args[prop]
             elif alias in args:
                 res[prop] = args[alias]
@@ -354,7 +335,7 @@ class MethodMetadataRequest:
             A serialized version of the instance in the form of a dictionary.
         """
         return {
-            prop: RequestType(alias) if RequestType.is_valid(alias) else alias
+            prop: alias if request_is_valid(alias) else alias
             for prop, alias in self._requests.items()
         }
 
@@ -401,7 +382,7 @@ class MetadataRequest:
         """Get names of all metadata that can be consumed or routed by specified \
             method.
 
-        This method returns the names of all metadata, even the UNREQUESTED
+        This method returns the names of all metadata, even the ``False``
         ones.
 
         Parameters
@@ -694,7 +675,7 @@ class MetadataRouter:
         """Get names of all metadata that can be consumed or routed by specified \
             method.
 
-        This method returns the names of all metadata, even the UNREQUESTED
+        This method returns the names of all metadata, even the ``False``
         ones.
 
         Parameters
@@ -1018,7 +999,7 @@ class RequestMethod:
                     k,
                     inspect.Parameter.KEYWORD_ONLY,
                     default=UNCHANGED,
-                    annotation=Optional[Union[RequestType, str]],
+                    annotation=Optional[Union[bool, None, str]],
                 )
                 for k in self.keys
             ]
@@ -1052,7 +1033,7 @@ class _MetadataRequester:
         The ``__metadata_request__*`` class attributes are used when a method
         does not explicitly accept a metadata through its arguments or if the
         developer would like to specify a request value for those metadata
-        which are different from the default ``RequestType.ERROR_IF_PASSED``.
+        which are different from the default ``None``.
 
         References
         ----------
@@ -1084,8 +1065,8 @@ class _MetadataRequester:
         """Build the `MethodMetadataRequest` for a method using its signature.
 
         This method takes all arguments from the method signature and uses
-        ``RequestType.ERROR_IF_PASSED`` as their default request value, except
-        ``X``, ``y``, ``*args``, and ``**kwargs``.
+        ``None`` as their default request value, except ``X``, ``y``,
+        ``*args``, and ``**kwargs``.
 
         Parameters
         ----------
@@ -1113,7 +1094,7 @@ class _MetadataRequester:
                 continue
             mmr.add_request(
                 param=pname,
-                alias=RequestType.ERROR_IF_PASSED,
+                alias=None,
             )
         return mmr
 

--- a/sklearn/utils/metadata_routing.py
+++ b/sklearn/utils/metadata_routing.py
@@ -8,7 +8,7 @@ circular import issue.
 # Author: Adrin Jalali <adrin.jalali@gmail.com>
 # License: BSD 3 clause
 
-from ._metadata_requests import RequestType  # noqa
+from ._metadata_requests import WARN, UNUSED, UNCHANGED  # noqa
 from ._metadata_requests import get_routing_for_object  # noqa
 from ._metadata_requests import MetadataRouter  # noqa
 from ._metadata_requests import MetadataRequest  # noqa


### PR DESCRIPTION
This is an alternative to having `RequestType` class/enum. As it is, it removes REQUESTED, UNREQUESTED, and ERROR_IF_PASSED.

An alternative to this would be to keep those constants, and refer to them as `sklearn.utils.metadata_routing.REQUESTED/...` (kinda like `logging.DEBUG/...`).

I'm not sure if we prefer this or not, so I created a separate PR.

cc @thomasjpfan @glemaitre 