### PR TITLE
CLN EnvironmentError, IOError, WindowsError → OSError

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -323,7 +323,7 @@ size limit of Windows if Python is installed in a nested location such as the
     Collecting scikit-learn
     ...
     Installing collected packages: scikit-learn
-    ERROR: Could not install packages due to an EnvironmentError: [Errno 2] No such file or directory: 'C:\\Users\\username\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.7_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python37\\site-packages\\sklearn\\datasets\\tests\\data\\openml\\292\\api-v1-json-data-list-data_name-australian-limit-2-data_version-1-status-deactivated.json.gz'
+    ERROR: Could not install packages due to an OSError: [Errno 2] No such file or directory: 'C:\\Users\\username\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.7_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python37\\site-packages\\sklearn\\datasets\\tests\\data\\openml\\292\\api-v1-json-data-list-data_name-australian-limit-2-data_version-1-status-deactivated.json.gz'
 
 In this case it is possible to lift that limit in the Windows registry by
 using the ``regedit`` tool:

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -630,6 +630,13 @@ Changelog
   accepts sparse metrics.
   :pr:`19664` by :user:`Kaushik Amar Das <cozek>`.
 
+Miscellaneous
+.............
+
+- |Enhancement| Replace obsolete exceptions EnvironmentError, IOError and
+  WindowsError.
+  :pr:`26466` by :user:`Dimitri Papadopoulos ORfanos <DimitriPapadopoulos>`.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -87,7 +87,7 @@ def _fetch_fixture(f):
         kwargs["download_if_missing"] = download_if_missing
         try:
             return f(*args, **kwargs)
-        except IOError as e:
+        except OSError as e:
             if str(e) != "Data not found and `download_if_missing` is False":
                 raise
             pytest.skip("test is enabled when SKLEARN_SKIP_NETWORK_TESTS=0")

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1377,7 +1377,7 @@ def _fetch_remote(remote, dirname=None):
     urlretrieve(remote.url, file_path)
     checksum = _sha256(file_path)
     if remote.checksum != checksum:
-        raise IOError(
+        raise OSError(
             "{} has an SHA256 checksum ({}) "
             "differing from expected ({}), "
             "file may be corrupted.".format(file_path, checksum, remote.checksum)

--- a/sklearn/datasets/_california_housing.py
+++ b/sklearn/datasets/_california_housing.py
@@ -80,7 +80,7 @@ def fetch_california_housing(
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 
     download_if_missing : bool, default=True
-        If False, raise a IOError if the data is not locally available
+        If False, raise an OSError if the data is not locally available
         instead of trying to download the data from the source site.
 
     return_X_y : bool, default=False
@@ -138,7 +138,7 @@ def fetch_california_housing(
     filepath = _pkl_filepath(data_home, "cal_housing.pkz")
     if not exists(filepath):
         if not download_if_missing:
-            raise IOError("Data not found and `download_if_missing` is False")
+            raise OSError("Data not found and `download_if_missing` is False")
 
         logger.info(
             "Downloading Cal. housing from {} to {}".format(ARCHIVE.url, data_home)

--- a/sklearn/datasets/_covtype.py
+++ b/sklearn/datasets/_covtype.py
@@ -101,7 +101,7 @@ def fetch_covtype(
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 
     download_if_missing : bool, default=True
-        If False, raise a IOError if the data is not locally available
+        If False, raise an OSError if the data is not locally available
         instead of trying to download the data from the source site.
 
     random_state : int, RandomState instance or None, default=None
@@ -184,7 +184,7 @@ def fetch_covtype(
             os.rename(targets_tmp_path, targets_path)
 
     elif not available and not download_if_missing:
-        raise IOError("Data not found and `download_if_missing` is False")
+        raise OSError("Data not found and `download_if_missing` is False")
     try:
         X, y
     except NameError:

--- a/sklearn/datasets/_kddcup99.py
+++ b/sklearn/datasets/_kddcup99.py
@@ -110,7 +110,7 @@ def fetch_kddcup99(
         Whether to load only 10 percent of the data.
 
     download_if_missing : bool, default=True
-        If False, raise a IOError if the data is not locally available
+        If False, raise an OSError if the data is not locally available
         instead of trying to download the data from the source site.
 
     return_X_y : bool, default=False
@@ -252,7 +252,7 @@ def _fetch_brute_kddcup99(data_home=None, download_if_missing=True, percent10=Tr
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 
     download_if_missing : bool, default=True
-        If False, raise a IOError if the data is not locally available
+        If False, raise an OSError if the data is not locally available
         instead of trying to download the data from the source site.
 
     percent10 : bool, default=True
@@ -345,7 +345,7 @@ def _fetch_brute_kddcup99(data_home=None, download_if_missing=True, percent10=Tr
             X = joblib.load(samples_path)
             y = joblib.load(targets_path)
         except Exception as e:
-            raise IOError(
+            raise OSError(
                 "The cache for fetch_kddcup99 is invalid, please delete "
                 f"{str(kddcup_dir)} and run the fetch_kddcup99 again"
             ) from e
@@ -379,7 +379,7 @@ def _fetch_brute_kddcup99(data_home=None, download_if_missing=True, percent10=Tr
         joblib.dump(X, samples_path, compress=0)
         joblib.dump(y, targets_path, compress=0)
     else:
-        raise IOError("Data not found and `download_if_missing` is False")
+        raise OSError("Data not found and `download_if_missing` is False")
 
     return Bunch(
         data=X,

--- a/sklearn/datasets/_lfw.py
+++ b/sklearn/datasets/_lfw.py
@@ -88,7 +88,7 @@ def _check_fetch_lfw(data_home=None, funneled=True, download_if_missing=True):
                 logger.info("Downloading LFW metadata: %s", target.url)
                 _fetch_remote(target, dirname=lfw_home)
             else:
-                raise IOError("%s is missing" % target_filepath)
+                raise OSError("%s is missing" % target_filepath)
 
     if funneled:
         data_folder_path = join(lfw_home, "lfw_funneled")
@@ -104,7 +104,7 @@ def _check_fetch_lfw(data_home=None, funneled=True, download_if_missing=True):
                 logger.info("Downloading LFW data (~200MB): %s", archive.url)
                 _fetch_remote(archive, dirname=lfw_home)
             else:
-                raise IOError("%s is missing" % archive_path)
+                raise OSError("%s is missing" % archive_path)
 
         import tarfile
 
@@ -297,7 +297,7 @@ def fetch_lfw_people(
         correlation from the background.
 
     download_if_missing : bool, default=True
-        If False, raise a IOError if the data is not locally available
+        If False, raise an OSError if the data is not locally available
         instead of trying to download the data from the source site.
 
     return_X_y : bool, default=False
@@ -500,7 +500,7 @@ def fetch_lfw_pairs(
         correlation from the background.
 
     download_if_missing : bool, default=True
-        If False, raise a IOError if the data is not locally available
+        If False, raise an OSError if the data is not locally available
         instead of trying to download the data from the source site.
 
     Returns

--- a/sklearn/datasets/_olivetti_faces.py
+++ b/sklearn/datasets/_olivetti_faces.py
@@ -83,7 +83,7 @@ def fetch_olivetti_faces(
         See :term:`Glossary <random_state>`.
 
     download_if_missing : bool, default=True
-        If False, raise a IOError if the data is not locally available
+        If False, raise an OSError if the data is not locally available
         instead of trying to download the data from the source site.
 
     return_X_y : bool, default=False
@@ -121,7 +121,7 @@ def fetch_olivetti_faces(
     filepath = _pkl_filepath(data_home, "olivetti.pkz")
     if not exists(filepath):
         if not download_if_missing:
-            raise IOError("Data not found and `download_if_missing` is False")
+            raise OSError("Data not found and `download_if_missing` is False")
 
         print("downloading Olivetti faces from %s to %s" % (FACES.url, data_home))
         mat_path = _fetch_remote(FACES, dirname=data_home)

--- a/sklearn/datasets/_rcv1.py
+++ b/sklearn/datasets/_rcv1.py
@@ -126,7 +126,7 @@ def fetch_rcv1(
         This follows the official LYRL2004 chronological split.
 
     download_if_missing : bool, default=True
-        If False, raise a IOError if the data is not locally available
+        If False, raise an OSError if the data is not locally available
         instead of trying to download the data from the source site.
 
     random_state : int, RandomState instance or None, default=None

--- a/sklearn/datasets/_species_distributions.py
+++ b/sklearn/datasets/_species_distributions.py
@@ -151,7 +151,7 @@ def fetch_species_distributions(*, data_home=None, download_if_missing=True):
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 
     download_if_missing : bool, default=True
-        If False, raise a IOError if the data is not locally available
+        If False, raise an OSError if the data is not locally available
         instead of trying to download the data from the source site.
 
     Returns
@@ -228,7 +228,7 @@ def fetch_species_distributions(*, data_home=None, download_if_missing=True):
 
     if not exists(archive_path):
         if not download_if_missing:
-            raise IOError("Data not found and `download_if_missing` is False")
+            raise OSError("Data not found and `download_if_missing` is False")
         logger.info("Downloading species data from %s to %s" % (SAMPLES.url, data_home))
         samples_path = _fetch_remote(SAMPLES, dirname=data_home)
         with np.load(samples_path) as X:  # samples.zip is a valid npz

--- a/sklearn/datasets/_twenty_newsgroups.py
+++ b/sklearn/datasets/_twenty_newsgroups.py
@@ -226,7 +226,7 @@ def fetch_20newsgroups(
         correct.
 
     download_if_missing : bool, default=True
-        If False, raise an IOError if the data is not locally available
+        If False, raise an OSError if the data is not locally available
         instead of trying to download the data from the source site.
 
     return_X_y : bool, default=False
@@ -283,7 +283,7 @@ def fetch_20newsgroups(
                 target_dir=twenty_home, cache_path=cache_path
             )
         else:
-            raise IOError("20Newsgroups dataset not found")
+            raise OSError("20Newsgroups dataset not found")
 
     if subset in ("train", "test"):
         data = cache[subset]
@@ -413,7 +413,7 @@ def fetch_20newsgroups_vectorized(
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 
     download_if_missing : bool, default=True
-        If False, raise an IOError if the data is not locally available
+        If False, raise an OSError if the data is not locally available
         instead of trying to download the data from the source site.
 
     return_X_y : bool, default=False

--- a/sklearn/datasets/tests/test_kddcup99.py
+++ b/sklearn/datasets/tests/test_kddcup99.py
@@ -82,5 +82,5 @@ def test_corrupted_file_error_message(fetch_kddcup99_fxt, tmp_path):
         f"delete {str(kddcup99_dir)} and run the fetch_kddcup99 again"
     )
 
-    with pytest.raises(IOError, match=msg):
+    with pytest.raises(OSError, match=msg):
         fetch_kddcup99_fxt(data_home=str(tmp_path))

--- a/sklearn/datasets/tests/test_lfw.py
+++ b/sklearn/datasets/tests/test_lfw.py
@@ -109,7 +109,7 @@ def teardown_module():
 
 
 def test_load_empty_lfw_people():
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         fetch_lfw_people(data_home=SCIKIT_LEARN_EMPTY_DATA, download_if_missing=False)
 
 
@@ -181,7 +181,7 @@ def test_load_fake_lfw_people_too_restrictive():
 
 
 def test_load_empty_lfw_pairs():
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         fetch_lfw_pairs(data_home=SCIKIT_LEARN_EMPTY_DATA, download_if_missing=False)
 
 

--- a/sklearn/datasets/tests/test_svmlight_format.py
+++ b/sklearn/datasets/tests/test_svmlight_format.py
@@ -249,7 +249,7 @@ def test_not_a_filename():
 
 
 def test_invalid_filename():
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         load_svmlight_file("trou pic nic douille")
 
 

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -79,12 +79,6 @@ from sklearn.model_selection.tests.common import OneTimeSplitter
 from sklearn.model_selection import GridSearchCV
 
 
-try:
-    WindowsError  # type: ignore
-except NameError:
-    WindowsError = None
-
-
 class MockImprovingEstimator(BaseEstimator):
     """Dummy classifier to test the learning curve"""
 
@@ -2064,7 +2058,7 @@ def test_score_memmap():
             try:
                 os.unlink(tf.name)
                 break
-            except WindowsError:
+            except OSError:
                 sleep(1.0)
 
 

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -33,12 +33,6 @@ import atexit
 import unittest
 from unittest import TestCase
 
-# WindowsError only exist on Windows
-try:
-    WindowsError  # type: ignore
-except NameError:
-    WindowsError = None
-
 from numpy.testing import assert_allclose as np_assert_allclose
 from numpy.testing import assert_almost_equal
 from numpy.testing import assert_approx_equal
@@ -453,7 +447,7 @@ def _delete_folder(folder_path, warn=False):
             # This can fail under windows,
             #  but will succeed when called by atexit
             shutil.rmtree(folder_path)
-    except WindowsError:
+    except OSError:
         if warn:
             warnings.warn("Could not delete temporary folder %s" % folder_path)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Starting from Python 3.3, `EnvironmentError`, `IOError` and `WindowsError` are aliases of `OSError`:
https://docs.python.org/3/library/exceptions.html#IOError

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
