### PR TITLE
MAINT Clean-up deprecations in FastICA for 1.3

### DIFF
--- a/sklearn/decomposition/_fastica.py
+++ b/sklearn/decomposition/_fastica.py
@@ -19,7 +19,7 @@ from ..base import BaseEstimator, TransformerMixin, ClassNamePrefixFeaturesOutMi
 from ..exceptions import ConvergenceWarning
 from ..utils import check_array, as_float_array, check_random_state
 from ..utils.validation import check_is_fitted
-from ..utils._param_validation import Hidden, Interval, StrOptions, validate_params
+from ..utils._param_validation import Interval, StrOptions, Options, validate_params
 
 __all__ = ["fastica", "FastICA"]
 
@@ -169,7 +169,7 @@ def fastica(
     n_components=None,
     *,
     algorithm="parallel",
-    whiten="warn",
+    whiten="unit-variance",
     fun="logcosh",
     fun_args=None,
     max_iter=200,
@@ -199,20 +199,18 @@ def fastica(
     algorithm : {'parallel', 'deflation'}, default='parallel'
         Specify which algorithm to use for FastICA.
 
-    whiten : str or bool, default="warn"
+    whiten : str or bool, default='unit-variance'
         Specify the whitening strategy to use.
 
-        - If 'arbitrary-variance' (default), a whitening with variance
+        - If 'arbitrary-variance', a whitening with variance
           arbitrary is used.
         - If 'unit-variance', the whitening matrix is rescaled to ensure that
           each recovered source has unit variance.
         - If False, the data is already considered to be whitened, and no
           whitening is performed.
 
-        .. deprecated:: 1.1
-            Starting in v1.3, `whiten='unit-variance'` will be used by default.
-            `whiten=True` is deprecated from 1.1 and will raise ValueError in 1.3.
-            Use `whiten=arbitrary-variance` instead.
+        .. versionchanged:: 1.3
+            The default value of `whiten` changed to 'unit-variance' in 1.3.
 
     fun : {'logcosh', 'exp', 'cube'} or callable, default='logcosh'
         The functional form of the G function used in the
@@ -332,7 +330,7 @@ def fastica(
     est._validate_params()
     S = est._fit_transform(X, compute_sources=compute_sources)
 
-    if est._whiten in ["unit-variance", "arbitrary-variance"]:
+    if est.whiten in ["unit-variance", "arbitrary-variance"]:
         K = est.whitening_
         X_mean = est.mean_
     else:
@@ -363,20 +361,18 @@ class FastICA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
     algorithm : {'parallel', 'deflation'}, default='parallel'
         Specify which algorithm to use for FastICA.
 
-    whiten : str or bool, default="warn"
+    whiten : str or bool, default='unit-variance'
         Specify the whitening strategy to use.
 
-        - If 'arbitrary-variance' (default), a whitening with variance
+        - If 'arbitrary-variance', a whitening with variance
           arbitrary is used.
         - If 'unit-variance', the whitening matrix is rescaled to ensure that
           each recovered source has unit variance.
         - If False, the data is already considered to be whitened, and no
           whitening is performed.
 
-        .. deprecated:: 1.1
-            Starting in v1.3, `whiten='unit-variance'` will be used by default.
-            `whiten=True` is deprecated from 1.1 and will raise ValueError in 1.3.
-            Use `whiten=arbitrary-variance` instead.
+        .. versionchanged:: 1.3
+            The default value of `whiten` changed to 'unit-variance' in 1.3.
 
     fun : {'logcosh', 'exp', 'cube'} or callable, default='logcosh'
         The functional form of the G function used in the
@@ -490,9 +486,8 @@ class FastICA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         "n_components": [Interval(Integral, 1, None, closed="left"), None],
         "algorithm": [StrOptions({"parallel", "deflation"})],
         "whiten": [
-            Hidden(StrOptions({"warn"})),
             StrOptions({"arbitrary-variance", "unit-variance"}),
-            "boolean",
+            Options(bool, {False}),
         ],
         "fun": [StrOptions({"logcosh", "exp", "cube"}), callable],
         "fun_args": [dict, None],
@@ -508,7 +503,7 @@ class FastICA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         n_components=None,
         *,
         algorithm="parallel",
-        whiten="warn",
+        whiten="unit-variance",
         fun="logcosh",
         fun_args=None,
         max_iter=200,
@@ -547,29 +542,8 @@ class FastICA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         S : ndarray of shape (n_samples, n_components) or None
             Sources matrix. `None` if `compute_sources` is `False`.
         """
-        self._whiten = self.whiten
-
-        if self._whiten == "warn":
-            warnings.warn(
-                "Starting in v1.3, whiten='unit-variance' will be used by default.",
-                FutureWarning,
-            )
-            self._whiten = "arbitrary-variance"
-
-        if self._whiten is True:
-            warnings.warn(
-                (
-                    "Starting in v1.3, whiten=True should be specified as "
-                    "whiten='arbitrary-variance' (its current behaviour). This "
-                    "behavior is deprecated in 1.1 and will raise ValueError in 1.3."
-                ),
-                FutureWarning,
-                stacklevel=2,
-            )
-            self._whiten = "arbitrary-variance"
-
         XT = self._validate_data(
-            X, copy=self._whiten, dtype=[np.float64, np.float32], ensure_min_samples=2
+            X, copy=self.whiten, dtype=[np.float64, np.float32], ensure_min_samples=2
         ).T
         fun_args = {} if self.fun_args is None else self.fun_args
         random_state = check_random_state(self.random_state)
@@ -591,7 +565,7 @@ class FastICA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
 
         n_features, n_samples = XT.shape
         n_components = self.n_components
-        if not self._whiten and n_components is not None:
+        if not self.whiten and n_components is not None:
             n_components = None
             warnings.warn("Ignoring n_components with whiten=False.")
 
@@ -603,7 +577,7 @@ class FastICA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
                 "n_components is too large: it will be set to %s" % n_components
             )
 
-        if self._whiten:
+        if self.whiten:
             # Centering the features of X
             X_mean = XT.mean(axis=-1)
             XT -= X_mean[:, np.newaxis]
@@ -672,15 +646,15 @@ class FastICA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         self.n_iter_ = n_iter
 
         if compute_sources:
-            if self._whiten:
+            if self.whiten:
                 S = np.linalg.multi_dot([W, K, XT]).T
             else:
                 S = np.dot(W, XT).T
         else:
             S = None
 
-        if self._whiten:
-            if self._whiten == "unit-variance":
+        if self.whiten:
+            if self.whiten == "unit-variance":
                 if not compute_sources:
                     S = np.linalg.multi_dot([W, K, XT]).T
                 S_std = np.std(S, axis=0, keepdims=True)
@@ -763,9 +737,9 @@ class FastICA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         check_is_fitted(self)
 
         X = self._validate_data(
-            X, copy=(copy and self._whiten), dtype=[np.float64, np.float32], reset=False
+            X, copy=(copy and self.whiten), dtype=[np.float64, np.float32], reset=False
         )
-        if self._whiten:
+        if self.whiten:
             X -= self.mean_
 
         return np.dot(X, self.components_.T)
@@ -788,9 +762,9 @@ class FastICA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         """
         check_is_fitted(self)
 
-        X = check_array(X, copy=(copy and self._whiten), dtype=[np.float64, np.float32])
+        X = check_array(X, copy=(copy and self.whiten), dtype=[np.float64, np.float32])
         X = np.dot(X, self.mixing_.T)
-        if self._whiten:
+        if self.whiten:
             X += self.mean_
 
         return X

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -9,7 +9,6 @@ import os
 import numpy as np
 from scipy import stats
 
-from sklearn.utils._testing import assert_array_equal
 from sklearn.utils._testing import assert_allclose
 
 from sklearn.decomposition import FastICA, fastica, PCA
@@ -70,10 +69,6 @@ def test_fastica_return_dtypes(global_dtype):
     assert s_.dtype == global_dtype
 
 
-# FIXME remove filter in 1.3
-@pytest.mark.filterwarnings(
-    "ignore:Starting in v1.3, whiten='unit-variance' will be used by default."
-)
 @pytest.mark.parametrize("add_noise", [True, False])
 def test_fastica_simple(add_noise, global_random_seed, global_dtype):
     if (
@@ -362,10 +357,6 @@ def test_inverse_transform(
         assert_allclose(X, X2, atol=atol)
 
 
-# FIXME remove filter in 1.3
-@pytest.mark.filterwarnings(
-    "ignore:Starting in v1.3, whiten='unit-variance' will be used by default."
-)
 def test_fastica_errors():
     n_features = 3
     n_samples = 10
@@ -392,58 +383,6 @@ def test_fastica_whiten_unit_variance():
     Xt = ica.fit_transform(X)
 
     assert np.var(Xt) == pytest.approx(1.0)
-
-
-@pytest.mark.parametrize("ica", [FastICA(), FastICA(whiten=True)])
-def test_fastica_whiten_default_value_deprecation(ica):
-    """Test FastICA whiten default value deprecation.
-
-    Regression test for #19490
-    """
-    rng = np.random.RandomState(0)
-    X = rng.random_sample((100, 10))
-    with pytest.warns(FutureWarning, match=r"Starting in v1.3, whiten="):
-        ica.fit(X)
-        assert ica._whiten == "arbitrary-variance"
-
-
-def test_fastica_whiten_backwards_compatibility():
-    """Test previous behavior for FastICA whitening (whiten=True)
-
-    Regression test for #19490
-    """
-    rng = np.random.RandomState(0)
-    X = rng.random_sample((100, 10))
-    n_components = X.shape[1]
-
-    default_ica = FastICA(n_components=n_components, random_state=0)
-    with pytest.warns(FutureWarning):
-        Xt_on_default = default_ica.fit_transform(X)
-
-    ica = FastICA(n_components=n_components, whiten=True, random_state=0)
-    with pytest.warns(FutureWarning):
-        Xt = ica.fit_transform(X)
-
-    # No warning must be raised in this case.
-    av_ica = FastICA(
-        n_components=n_components,
-        whiten="arbitrary-variance",
-        random_state=0,
-        whiten_solver="svd",
-    )
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", FutureWarning)
-        Xt_av = av_ica.fit_transform(X)
-
-    # The whitening strategy must be "arbitrary-variance" in all the cases.
-    assert default_ica._whiten == "arbitrary-variance"
-    assert ica._whiten == "arbitrary-variance"
-    assert av_ica._whiten == "arbitrary-variance"
-
-    assert_array_equal(Xt, Xt_on_default)
-    assert_array_equal(Xt, Xt_av)
-
-    assert np.var(Xt) == pytest.approx(1.0 / 100)
 
 
 @pytest.mark.parametrize("whiten", ["arbitrary-variance", "unit-variance", False])


### PR DESCRIPTION
The default value changes in 1.3 and `whiten=True` is no longer valid.