### PR TITLE
FIX Backwards `SequentialFeatureSelector` always drops one feature

### DIFF
--- a/sklearn/feature_selection/_sequential.py
+++ b/sklearn/feature_selection/_sequential.py
@@ -257,8 +257,11 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
         elif isinstance(self.n_features_to_select, Real):
             self.n_features_to_select_ = int(n_features * self.n_features_to_select)
 
-        if self.tol is not None and self.tol < 0 and self.direction == "forward":
-            raise ValueError("tol must be positive when doing forward selection")
+        if self.tol is not None:
+            if self.tol < 0 and self.direction == "forward":
+                raise ValueError("tol must be positive when doing forward selection")
+            if self.tol > 0 and self.direction == "backward":
+                raise ValueError("tol must be negative when doing backward selection")
 
         cv = check_cv(self.cv, y, classifier=is_classifier(self.estimator))
 

--- a/sklearn/feature_selection/_sequential.py
+++ b/sklearn/feature_selection/_sequential.py
@@ -292,12 +292,11 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
                 cloned_estimator, X, y, cv, current_mask
             )
 
-            if is_auto_select:
-                if (new_score - old_score) < self.tol:
-                    # The score has not improved enough by adding the latest feature,
-                    # so we stop. Or, the score has decreased too much by removing the
-                    # latest feature, so we stop
-                    break
+            if is_auto_select and ((new_score - old_score) < self.tol):
+                # The score has not improved enough by adding the latest feature,
+                # so we stop. Or, the score has decreased too much by removing the
+                # latest feature, so we stop
+                break
 
             old_score = new_score
             current_mask[new_feature_idx] = True

--- a/sklearn/feature_selection/tests/test_sequential.py
+++ b/sklearn/feature_selection/tests/test_sequential.py
@@ -340,21 +340,23 @@ def test_cv_generator_support():
 def test_backwards_doesnt_remove_feature():
     """All features should be kept.
 
-    This is a somewhat artificial setup because the tolerance is very large, but
-    it is
-
     Non regression test for #26369
     """
-    expected_selected_features = 3
+    expected_selected_features = [
+        0,
+        1,
+    ]
     rng = np.random.RandomState(0)
-    n_samples = 100
-    X = rng.randn(n_samples, 3)
-    y = 3 * X[:, 0] - 10 * X[:, 2]
+    n_samples = 500
+    X = rng.randn(n_samples, 2)
+    y = 3 * X[:, 0] - 10 * X[:, 1]
 
     sfs = SequentialFeatureSelector(
         LinearRegression(),
         direction="backward",
         cv=2,
+        n_features_to_select="auto",
+        tol=-0.01,
     )
     sfs.fit(X, y)
     assert_array_equal(sfs.get_support(indices=True), expected_selected_features)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes #26369 

#### What does this implement/fix? Explain your changes.

This is an attempt at closing the issue. It uses the "all features selected" cross val score as the starting value instead of `-inf` for backwards selection. ~~I also changed the forward selection starting value to `0`, I think scores have to be between zero and one?!~~

I also had to update the tests after this change, so I am not sure the changes are correct. (Maybe the test was wrong, but maybe not?)

This is just a draft/way to store this work in progress somewhere and lets others see it. Maybe someone wants to take on this PR.

#### Any other comments?

There is code to reproduce the problem in the original issue. It could be a good starting point for making a non-regression test.
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
