### PR TITLE
STY Do not make whole space white in html repr

### DIFF
--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -191,7 +191,6 @@ def _write_estimator_html(
 _STYLE = """
 #$id {
   color: black;
-  background-color: white;
 }
 #$id pre{
   padding: 0;


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to https://github.com/scikit-learn/scikit-learn/issues/26364

#### What does this implement/fix? Explain your changes.
Before this PR, with VScode notebooks the HTML repr will make the whole cell white:

![Screenshot 2023-06-01 at 9 35 56 AM](https://github.com/scikit-learn/scikit-learn/assets/5402633/ff8f6563-80c5-4fdb-898e-0c57ff3797a4)


With this PR only the HTML repr is white:

![Screenshot 2023-06-01 at 9 35 43 AM](https://github.com/scikit-learn/scikit-learn/assets/5402633/1cdb8740-a91e-4310-957b-73b717c787c8)

#### Any other comments?
I'm still thinking about how to enable dark mode based on OS preferences. According to https://github.com/jupyterlab/jupyterlab/issues/8777, Jupyter does not currently support the `prefers-color-scheme` CSS media query.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
