### PR TITLE
MAINT Update link to Tim's homepage

### DIFF
--- a/doc/whats_new/_contributors.rst
+++ b/doc/whats_new/_contributors.rst
@@ -177,3 +177,5 @@
 .. _Nicolas Hug: https://github.com/NicolasHug
 
 .. _Guillaume Lemaitre: https://github.com/glemaitre
+
+.. _Tim Head: https://betatim.github.io/


### PR DESCRIPTION
Prefer linking to Tim's homepage over his GitHub profile
