### PR TITLE
DOC use notebook style in Spectral Biclustering example

### DIFF
--- a/examples/bicluster/plot_spectral_biclustering.py
+++ b/examples/bicluster/plot_spectral_biclustering.py
@@ -17,8 +17,9 @@ plot the biclusters found by the algorithm.
 # %%
 # Generate sample data
 # --------------------
-# We generate the sample data using the `make_checkerboard` function. Each pixel
-# within `shape=(300, 300)` represents with it's color a value from a uniform
+# We generate the sample data using the
+# :func:`~sklearn.datasets.make_checkerboard` function. Each pixel within
+# `shape=(300, 300)` represents with it's color a value from a uniform
 # distribution. The noise is added from a normal distribution, where the value
 # chosen for `noise` is the standard deviation.
 #
@@ -30,7 +31,7 @@ from matplotlib import pyplot as plt
 
 n_clusters = (4, 3)
 data, rows, columns = make_checkerboard(
-    shape=(300, 300), n_clusters=n_clusters, noise=10, shuffle=False, random_state=1
+    shape=(300, 300), n_clusters=n_clusters, noise=10, shuffle=False, random_state=42
 )
 
 plt.matshow(data, cmap=plt.cm.Blues)
@@ -82,9 +83,10 @@ print("consensus score: {:.1f}".format(score))
 # Plotting results
 # ----------------
 # Now, we rearrange the data based on the row and column labels assigned by the
-# `SpectralBiclustering` model in ascending order and plot again. The
-# `row_labels_` range from 0 to 3, while the `column_labels_` range from 0 to 2,
-# representing a total of 4 clusters per row and 3 clusters per column.
+# :class:`~sklearn.cluster.SpectralBiclustering` model in ascending order and
+# plot again. The `row_labels_` range from 0 to 3, while the `column_labels_`
+# range from 0 to 2, representing a total of 4 clusters per row and 3 clusters
+# per column.
 
 fit_data = data[np.argsort(model.row_labels_)]
 fit_data = fit_data[:, np.argsort(model.column_labels_)]

--- a/examples/bicluster/plot_spectral_biclustering.py
+++ b/examples/bicluster/plot_spectral_biclustering.py
@@ -3,63 +3,111 @@
 A demo of the Spectral Biclustering algorithm
 =============================================
 
-This example demonstrates how to generate a checkerboard dataset and
-bicluster it using the Spectral Biclustering algorithm.
+This example demonstrates how to generate a checkerboard dataset and bicluster
+it using the Spectral Biclustering algorithm.
 
-The data is generated with the ``make_checkerboard`` function, then
-shuffled and passed to the Spectral Biclustering algorithm. The rows
-and columns of the shuffled matrix are rearranged to show the
-biclusters found by the algorithm.
-
-The outer product of the row and column label vectors shows a
-representation of the checkerboard structure.
-
+The data is generated, then shuffled and passed to the Spectral Biclustering
+algorithm. The rows and columns of the shuffled matrix are then rearranged to
+plot the biclusters found by the algorithm.
 """
 
 # Author: Kemal Eren <kemal@kemaleren.com>
 # License: BSD 3 clause
 
-import numpy as np
-from matplotlib import pyplot as plt
+# %%
+# Generate sample data
+# --------------------
+# We generate the sample data using the `make_checkerboard` function. Each pixel
+# within `shape=(300, 300)` represents with it's color a value from a uniform
+# distribution. The noise is added from a normal distribution, where the value
+# chosen for `noise` is the standard deviation.
+#
+# As you can see, the data is distributed over 12 cluster cells and is
+# relatively well distinguishable.
 
 from sklearn.datasets import make_checkerboard
-from sklearn.cluster import SpectralBiclustering
-from sklearn.metrics import consensus_score
-
+from matplotlib import pyplot as plt
 
 n_clusters = (4, 3)
 data, rows, columns = make_checkerboard(
-    shape=(300, 300), n_clusters=n_clusters, noise=10, shuffle=False, random_state=0
+    shape=(300, 300), n_clusters=n_clusters, noise=10, shuffle=False, random_state=1
 )
 
 plt.matshow(data, cmap=plt.cm.Blues)
 plt.title("Original dataset")
+plt.show()
 
-# shuffle clusters
+# %%
+# We're now going to shuffle the data. The goal is to reconstruct it afterwards
+# using `SpectralBiclustering`.
+
+import numpy as np
+
+# Creating lists of shuffled row and column indices
 rng = np.random.RandomState(0)
 row_idx = rng.permutation(data.shape[0])
 col_idx = rng.permutation(data.shape[1])
+
+# %%
+# We will redefine the shuffled data and plot it.
 data = data[row_idx][:, col_idx]
 
 plt.matshow(data, cmap=plt.cm.Blues)
 plt.title("Shuffled dataset")
+plt.show()
+
+# %%
+# Fitting SpectralBiclustering
+# ----------------------------
+# We fit the model and compare the obtained clusters with the ground truth
+# biclusters (our artifical dataset). Note that when instanciating the
+# model we specify the same number of clusters we used to create the dataset
+# (`n_clusters = (4, 3)`), which will contribute to good results.
+
+from sklearn.cluster import SpectralBiclustering
+from sklearn.metrics import consensus_score
 
 model = SpectralBiclustering(n_clusters=n_clusters, method="log", random_state=0)
 model.fit(data)
-score = consensus_score(model.biclusters_, (rows[:, row_idx], columns[:, col_idx]))
 
+# Calculating the similarity of two sets of biclusters
+score = consensus_score(model.biclusters_, (rows[:, row_idx], columns[:, col_idx]))
 print("consensus score: {:.1f}".format(score))
+
+# %%
+# The score is between 0 and 1. It shows the quality of the biclustering
+# results.
+
+# %%
+# Plotting results
+# ----------------
+# Now, we rearrange the data based on the row and column labels assigned by the
+# `SpectralBiclustering` model in ascending order and plot again. The
+# `row_labels_` range from 0 to 3, while the `column_labels_` range from 0 to 2,
+# representing a total of 4 clusters per row and 3 clusters per column.
 
 fit_data = data[np.argsort(model.row_labels_)]
 fit_data = fit_data[:, np.argsort(model.column_labels_)]
 
 plt.matshow(fit_data, cmap=plt.cm.Blues)
 plt.title("After biclustering; rearranged to show biclusters")
+plt.show()
+
+
+# %%
+# As a last step, we want to demonstrate the relationships between the row
+# and column labels assigned by the model. Therefore, we create a grid with
+# `np.outer()`, which takes the sorted `row_labels_` and `column_labels_` and
+# adds 1 to each to ensure that the labels start from 1 instead of 0 for better
+# visualization.
+#
+# The outer product of the row and column label vectors show a representation
+# of the checkerboard structure, where different combinations of row and column
+# labels are represented by different shades of blue.
 
 plt.matshow(
     np.outer(np.sort(model.row_labels_) + 1, np.sort(model.column_labels_) + 1),
     cmap=plt.cm.Blues,
 )
 plt.title("Checkerboard structure of rearranged data")
-
 plt.show()

--- a/examples/bicluster/plot_spectral_biclustering.py
+++ b/examples/bicluster/plot_spectral_biclustering.py
@@ -13,7 +13,7 @@ data. This makes spectral biclustering particularly well-suited for datasets
 where the order or arrangement of features is fixed, such as in images, time
 series, or genomes.
 
-The data is generated, then shuffled and passed to the Spectral Biclustering
+The data is generated, then shuffled and passed to the spectral biclustering
 algorithm. The rows and columns of the shuffled matrix are then rearranged to
 plot the biclusters found.
 """

--- a/examples/bicluster/plot_spectral_biclustering.py
+++ b/examples/bicluster/plot_spectral_biclustering.py
@@ -4,13 +4,14 @@ A demo of the Spectral Biclustering algorithm
 =============================================
 
 This example demonstrates how to generate a checkerboard dataset and bicluster
-it using the `SpectralBiclustering` algorithm. The Spectral Biclustering
-algorithm is specifically designed to cluster data by simultaneously considering
-both the rows (samples) and columns (features) of a matrix. It aims to identify
-patterns not only between samples but also within subsets of samples, allowing
-for the detection of localized structure within the data. This makes spectral
-biclustering particularly well-suited for datasets where the order or
-arrangement of features is fixed, such as in images, time series, or genomes.
+it using the :class:`~sklearn.cluster.SpectralBiclustering` algorithm. The
+spectral biclustering algorithm is specifically designed to cluster data by
+simultaneously considering both the rows (samples) and columns (features) of a
+matrix. It aims to identify patterns not only between samples but also within
+subsets of samples, allowing for the detection of localized structure within the
+data. This makes spectral biclustering particularly well-suited for datasets
+where the order or arrangement of features is fixed, such as in images, time
+series, or genomes.
 
 The data is generated, then shuffled and passed to the Spectral Biclustering
 algorithm. The rows and columns of the shuffled matrix are then rearranged to
@@ -41,7 +42,7 @@ data, rows, columns = make_checkerboard(
 
 plt.matshow(data, cmap=plt.cm.Blues)
 plt.title("Original dataset")
-plt.show()
+_ = plt.show()
 
 # %%
 # We shuffle the data and the goal is to reconstruct it afterwards using
@@ -54,16 +55,17 @@ row_idx_shuffled = rng.permutation(data.shape[0])
 col_idx_shuffled = rng.permutation(data.shape[1])
 
 # %%
-# We will redefine the shuffled data and plot it. We observe that we lost the
+# We redefine the shuffled data and plot it. We observe that we lost the
 # strucuture of original data matrix.
 data = data[row_idx_shuffled][:, col_idx_shuffled]
 
 plt.matshow(data, cmap=plt.cm.Blues)
 plt.title("Shuffled dataset")
+_ = plt.show()
 
 # %%
 # Fitting `SpectralBiclustering`
-# -----------------------------
+# ------------------------------
 # We fit the model and compare the obtained clusters with the ground truth. Note
 # that when creating the model we specify the same number of clusters that we
 # used to create the dataset (`n_clusters = (4, 3)`), which will contribute to
@@ -99,13 +101,14 @@ reordered_data = reordered_rows[:, np.argsort(model.column_labels_)]
 
 plt.matshow(reordered_data, cmap=plt.cm.Blues)
 plt.title("After biclustering; rearranged to show biclusters")
+_ = plt.show()
 
 # %%
 # As a last step, we want to demonstrate the relationships between the row
 # and column labels assigned by the model. Therefore, we create a grid with
-# :func:`numpy.outer`, which takes the sorted `row_labels_` and `column_labels_` and
-# adds 1 to each to ensure that the labels start from 1 instead of 0 for better
-# visualization.
+# :func:`numpy.outer`, which takes the sorted `row_labels_` and `column_labels_`
+# and adds 1 to each to ensure that the labels start from 1 instead of 0 for
+# better visualization.
 plt.matshow(
     np.outer(np.sort(model.row_labels_) + 1, np.sort(model.column_labels_) + 1),
     cmap=plt.cm.Blues,

--- a/examples/bicluster/plot_spectral_biclustering.py
+++ b/examples/bicluster/plot_spectral_biclustering.py
@@ -4,11 +4,17 @@ A demo of the Spectral Biclustering algorithm
 =============================================
 
 This example demonstrates how to generate a checkerboard dataset and bicluster
-it using the Spectral Biclustering algorithm.
+it using the `SpectralBiclustering` algorithm. The Spectral Biclustering
+algorithm is specifically designed to cluster data by simultaneously considering
+both the rows (samples) and columns (features) of a matrix. It aims to identify
+patterns not only between samples but also within subsets of samples, allowing
+for the detection of localized structure within the data. This makes spectral
+biclustering particularly well-suited for datasets where the order or
+arrangement of features is fixed, such as in images, time series, or genomes.
 
 The data is generated, then shuffled and passed to the Spectral Biclustering
 algorithm. The rows and columns of the shuffled matrix are then rearranged to
-plot the biclusters found by the algorithm.
+plot the biclusters found.
 """
 
 # Author: Kemal Eren <kemal@kemaleren.com>
@@ -25,7 +31,6 @@ plot the biclusters found by the algorithm.
 #
 # As you can see, the data is distributed over 12 cluster cells and is
 # relatively well distinguishable.
-
 from sklearn.datasets import make_checkerboard
 from matplotlib import pyplot as plt
 
@@ -39,45 +44,45 @@ plt.title("Original dataset")
 plt.show()
 
 # %%
-# We're now going to shuffle the data. The goal is to reconstruct it afterwards
-# using `SpectralBiclustering`.
-
+# We shuffle the data and the goal is to reconstruct it afterwards using
+# :class:`~sklearn.bicluster.SpectralBiclustering`.
 import numpy as np
 
 # Creating lists of shuffled row and column indices
 rng = np.random.RandomState(0)
-row_idx = rng.permutation(data.shape[0])
-col_idx = rng.permutation(data.shape[1])
+row_idx_shuffled = rng.permutation(data.shape[0])
+col_idx_shuffled = rng.permutation(data.shape[1])
 
 # %%
-# We will redefine the shuffled data and plot it.
-data = data[row_idx][:, col_idx]
+# We will redefine the shuffled data and plot it. We observe that we lost the
+# strucuture of original data matrix.
+data = data[row_idx_shuffled][:, col_idx_shuffled]
 
 plt.matshow(data, cmap=plt.cm.Blues)
 plt.title("Shuffled dataset")
-plt.show()
 
 # %%
-# Fitting SpectralBiclustering
-# ----------------------------
-# We fit the model and compare the obtained clusters with the ground truth
-# biclusters (our artifical dataset). Note that when instanciating the
-# model we specify the same number of clusters we used to create the dataset
-# (`n_clusters = (4, 3)`), which will contribute to good results.
-
+# Fitting `SpectralBiclustering`
+# -----------------------------
+# We fit the model and compare the obtained clusters with the ground truth. Note
+# that when creating the model we specify the same number of clusters that we
+# used to create the dataset (`n_clusters = (4, 3)`), which will contribute to
+# obtain a good result.
 from sklearn.cluster import SpectralBiclustering
 from sklearn.metrics import consensus_score
 
 model = SpectralBiclustering(n_clusters=n_clusters, method="log", random_state=0)
 model.fit(data)
 
-# Calculating the similarity of two sets of biclusters
-score = consensus_score(model.biclusters_, (rows[:, row_idx], columns[:, col_idx]))
-print("consensus score: {:.1f}".format(score))
+# Compute the similarity of two sets of biclusters
+score = consensus_score(
+    model.biclusters_, (rows[:, row_idx_shuffled], columns[:, col_idx_shuffled])
+)
+print(f"consensus score: {score:.1f}")
 
 # %%
-# The score is between 0 and 1. It shows the quality of the biclustering
-# results.
+# The score is between 0 and 1, where 1 corresponds to a perfect matching. It
+# shows the quality of the biclustering.
 
 # %%
 # Plotting results
@@ -88,28 +93,27 @@ print("consensus score: {:.1f}".format(score))
 # range from 0 to 2, representing a total of 4 clusters per row and 3 clusters
 # per column.
 
-fit_data = data[np.argsort(model.row_labels_)]
-fit_data = fit_data[:, np.argsort(model.column_labels_)]
+# Reordering first the rows and then the columns.
+reordered_rows = data[np.argsort(model.row_labels_)]
+reordered_data = reordered_rows[:, np.argsort(model.column_labels_)]
 
-plt.matshow(fit_data, cmap=plt.cm.Blues)
+plt.matshow(reordered_data, cmap=plt.cm.Blues)
 plt.title("After biclustering; rearranged to show biclusters")
-plt.show()
-
 
 # %%
 # As a last step, we want to demonstrate the relationships between the row
 # and column labels assigned by the model. Therefore, we create a grid with
-# `np.outer()`, which takes the sorted `row_labels_` and `column_labels_` and
+# :func:`numpy.outer`, which takes the sorted `row_labels_` and `column_labels_` and
 # adds 1 to each to ensure that the labels start from 1 instead of 0 for better
 # visualization.
-#
-# The outer product of the row and column label vectors show a representation
-# of the checkerboard structure, where different combinations of row and column
-# labels are represented by different shades of blue.
-
 plt.matshow(
     np.outer(np.sort(model.row_labels_) + 1, np.sort(model.column_labels_) + 1),
     cmap=plt.cm.Blues,
 )
 plt.title("Checkerboard structure of rearranged data")
 plt.show()
+
+# %%
+# The outer product of the row and column label vectors shows a representation
+# of the checkerboard structure, where different combinations of row and column
+# labels are represented by different shades of blue.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR suggests to introduce notebook style in the demo of the [Spectral Biclustering](https://scikit-learn.org/stable/auto_examples/bicluster/plot_spectral_biclustering.html#sphx-glr-auto-examples-bicluster-plot-spectral-biclustering-py).
I've also added some descriptive text.