### PR TITLE
DOC remove sphinx warnings related to if_delegate_has_method

### DIFF
--- a/doc/whats_new/v1.0.rst
+++ b/doc/whats_new/v1.0.rst
@@ -262,7 +262,7 @@ Fixed models
   :pr:`20880` by :user:`Guillaume Lemaitre <glemaitre>`
   and :user:`András Simon <simonandras>`.
 
-- |Fix| Solve a bug in :func:`~sklearn.utils.metaestimators.if_delegate_has_method`
+- |Fix| Solve a bug in ``sklearn.utils.metaestimators.if_delegate_has_method``
   where the underlying check for an attribute did not work with NumPy arrays.
   :pr:`21145` by :user:`Zahlii <Zahlii>`.
 

--- a/doc/whats_new/v1.1.rst
+++ b/doc/whats_new/v1.1.rst
@@ -1331,7 +1331,7 @@ Changelog
   `estimator` (previous name was `Estimator`). :pr:`22188` by
   :user:`Mathurin Massias <mathurinm>`.
 
-- |API| :func:`utils.metaestimators.if_delegate_has_method` is deprecated and will be
+- |API| ``utils.metaestimators.if_delegate_has_method`` is deprecated and will be
   removed in version 1.3. Use :func:`utils.metaestimators.available_if` instead.
   :pr:`22830` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 


### PR DESCRIPTION
`if_delegate_has_method` no longer exists, and therefore `sphinx` gives a warning whenever it's referenced. This PR changes those old references to verbatim format.