### PR TITLE
MAINT Parameters validation for sklearn.metrics.cluster._supervised.check_clusterings

### DIFF
--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -30,6 +30,12 @@ from ...utils._param_validation import validate_params
 from ...utils._param_validation import Interval, StrOptions
 
 
+@validate_params(
+    {
+        "labels_true": ["array-like"],
+        "labels_pred": ["array-like"],
+    }
+)
 def check_clusterings(labels_true, labels_pred):
     """Check that the labels arrays are 1D and of same dimension.
 

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -187,6 +187,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.completeness_score",
     "sklearn.metrics.class_likelihood_ratios",
     "sklearn.metrics.classification_report",
+    "sklearn.metrics.cluster._supervised.check_clusterings",
     "sklearn.metrics.cluster.adjusted_mutual_info_score",
     "sklearn.metrics.cluster.contingency_matrix",
     "sklearn.metrics.cluster.entropy",


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #24862

#### What does this implement/fix? Explain your changes.
This PR implements automatic parameters validation for `sklearn.metrics.cluster._supervised.check_clusterings`.
This one is missing in module `sklearn.metrics.cluster._supervised.py`.

#### Any other comments?
