### PR TITLE
FIX: cython 3.0 is stricter about checking except / noexcept status

### DIFF
--- a/sklearn/cluster/_hierarchical_fast.pyx
+++ b/sklearn/cluster/_hierarchical_fast.pyx
@@ -328,7 +328,7 @@ cdef class UnionFind(object):
         self.size = np.hstack((np.ones(N, dtype=np.intp),
                                np.zeros(N - 1, dtype=np.intp)))
 
-    cdef void union(self, intp_t m, intp_t n):
+    cdef void union(self, intp_t m, intp_t n) noexcept:
         self.parent[m] = self.next_label
         self.parent[n] = self.next_label
         self.size[self.next_label] = self.size[m] + self.size[n]
@@ -336,7 +336,7 @@ cdef class UnionFind(object):
         return
 
     @cython.wraparound(True)
-    cdef intp_t fast_find(self, intp_t n):
+    cdef intp_t fast_find(self, intp_t n) noexcept:
         cdef intp_t p
         p = n
         # find the highest node in the linkage graph so far


### PR DESCRIPTION
This patch is required to cythonize with the current default branch of cython.

Trusted the pxd over the pyx.



#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Fixes cythonization / compilation with the cython default branch.

Believe (but have not bisected to be sure) that this is fallout from https://github.com/cython/cython/pull/5386

#### Any other comments?


