### PR TITLE
TST Fix failing fastica tests

### DIFF
--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -167,7 +167,7 @@ def test_fastica_simple(add_noise, global_random_seed, global_dtype):
     assert_allclose(sources_fun, sources)
     # Set atol to account for the different magnitudes of the elements in sources
     # (from 1e-4 to 1e1).
-    atol = np.max(np.abs(sources)) * 1e-7
+    atol = np.max(np.abs(sources)) * (1e-5 if global_dtype == np.float32 else 1e-7)
     assert_allclose(sources, ica.transform(m.T), atol=atol)
 
     assert ica.mixing_.shape == (2, 2)

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -165,8 +165,9 @@ def test_fastica_simple(add_noise, global_random_seed, global_dtype):
     assert sources.shape == (1000, 2)
 
     assert_allclose(sources_fun, sources)
-    # the debian 32 bit build with global dtype float32 needs an atol to pass
-    atol = 1e-7 if global_dtype == np.float32 else 0
+    # Set atol to account for the different magnitudes of the elements in sources
+    # (from 1e-4 to 1e1).
+    atol = np.max(np.abs(sources)) * 1e-7
     assert_allclose(sources, ica.transform(m.T), atol=atol)
 
     assert ica.mixing_.shape == (2, 2)


### PR DESCRIPTION
Fixes #26538
Fixes https://github.com/scikit-learn/scikit-learn/issues/26499
Fixes https://github.com/scikit-learn/scikit-learn/issues/26500
Fixes https://github.com/scikit-learn/scikit-learn/issues/26523

This PR deals with `test_fastica_simple`. We're comparing arrays with elements of very different magnitude, from 1e-4 to 1e1. I don't find it surprising that it fails in float32 for some arbitrary atol. It's typically the kind of situation where I think setting atol based on the magnitude of the largest element of the array is more appropriate. (side note, I've been thinking for a while that it should be our standard way to compare arrays, this is convincing me even more)

In these issues there's a failure for the test `test_fastica_eigh_low_rank_warning`. However it doesn't fail anymore, running for all seeds. This is kind of weird, but let's ignore this test for now and investigate later if it starts failing again.
