### PR TITLE
MAINT Parameter validation for sklearn.utils.validation.check_array

### DIFF
--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -275,6 +275,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.tree.export_graphviz",
     "sklearn.tree.export_text",
     "sklearn.tree.plot_tree",
+    "sklearn.utils.check_array",
     "sklearn.utils.gen_batches",
     "sklearn.utils.resample",
 ]

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -15,7 +15,6 @@ from scipy.sparse import issparse
 from scipy.sparse import csr_matrix
 
 from .._config import get_config, config_context
-from .validation import _is_arraylike_not_scalar
 
 
 class InvalidParameterError(ValueError, TypeError):
@@ -522,6 +521,9 @@ class _ArrayLikes(_Constraint):
     """Constraint representing array-likes"""
 
     def is_satisfied_by(self, val):
+        # having the import here to avoid a circular import issue
+        from .validation import _is_arraylike_not_scalar
+
         return _is_arraylike_not_scalar(val)
 
     def __str__(self):

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -188,9 +188,20 @@ def test_check_array_force_all_finite_valid(value, force_all_finite, retype):
             np.nan,
             "",
             "allow-inf",
-            'force_all_finite should be a bool or "allow-nan"',
+            (
+                "The 'force_all_finite' parameter of check_array must be an instance of"
+                " 'bool'"
+            ),
         ),
-        (np.nan, "", 1, "Input contains NaN"),
+        (
+            np.nan,
+            "",
+            1,
+            (
+                "The 'force_all_finite' parameter of check_array must be an instance of"
+                " 'bool'"
+            ),
+        ),
     ],
 )
 @pytest.mark.parametrize("retype", [np.asarray, sp.csr_matrix])
@@ -304,11 +315,13 @@ def test_check_array():
     X_array = check_array([0, 1, 2], ensure_2d=False)
     assert X_array.ndim == 1
     # ensure_2d=True with 1d array
-    with pytest.raises(ValueError, match="Expected 2D array, got 1D array instead"):
+    with pytest.raises(ValueError, match="Expected 2D array, got 1D array instead:"):
         check_array([0, 1, 2], ensure_2d=True)
 
     # ensure_2d=True with scalar array
-    with pytest.raises(ValueError, match="Expected 2D array, got scalar array instead"):
+    with pytest.raises(
+        ValueError, match="The 'array' parameter of check_array must be an array-like."
+    ):
         check_array(10, ensure_2d=True)
 
     # don't allow ndim > 3
@@ -586,10 +599,7 @@ def test_check_array_accept_sparse_type_exception():
     with pytest.raises(TypeError, match=msg):
         check_array(X_csr, accept_sparse=False)
 
-    msg = (
-        "Parameter 'accept_sparse' should be a string, "
-        "boolean or list of strings. You provided 'accept_sparse=.*'."
-    )
+    msg = "The 'accept_sparse' parameter of check_array must be an instance of"
     with pytest.raises(ValueError, match=msg):
         check_array(X_csr, accept_sparse=invalid_type)
 
@@ -652,7 +662,7 @@ def test_check_array_min_samples_and_features_messages():
         check_array([], ensure_2d=False)
 
     # Invalid edge case when checking the default minimum sample of a scalar
-    msg = r"Singleton array array\(42\) cannot be considered a valid" " collection."
+    msg = r"The 'array' parameter of check_array must be an array-like. Got 42 instead."
     with pytest.raises(TypeError, match=msg):
         check_array(42, ensure_2d=False)
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -32,6 +32,7 @@ from ..exceptions import DataConversionWarning
 from ..utils._array_api import get_namespace
 from ..utils._array_api import _asarray_with_order
 from ..utils._array_api import _is_numpy_namespace
+from ..utils._param_validation import Integral, Interval, StrOptions, validate_params
 from ._isfinite import cy_isfinite, FiniteStatus
 
 FLOAT_DTYPES = (np.float64, np.float32, np.float16)
@@ -648,6 +649,32 @@ def _is_extension_array_dtype(array):
     return hasattr(array, "dtype") and hasattr(array.dtype, "na_value")
 
 
+@validate_params(
+    {
+        "array": ["array-like"],
+        "accept_sparse": [
+            bool,
+            StrOptions({"csc", "csr", "coo", "dok", "bsr", "lil", "dia"}),
+            list,
+            tuple,
+        ],  # list or tuple should be specified to list or tuple with any
+        # combination of 'csc', 'csr', 'coo', 'dok', 'bsr', 'lil', 'dia'
+        "accept_large_sparse": [bool],
+        "dtype": [StrOptions({"numeric"}), np.dtype, type, set, list, tuple, None],
+        # list shold be modified to list of type
+        "order": [StrOptions({"F", "C"}), None],
+        "copy": [bool],
+        "force_all_finite": [bool, StrOptions({"allow-nan"})],
+        "ensure_2d": [bool],
+        "allow_nd": [bool],
+        "ensure_min_samples": [Interval(Integral, 0, None, closed="left")],
+        "ensure_min_features": [Interval(Integral, 0, None, closed="left")],
+        "estimator": [str, object, None],  # object should be specified to be of
+        # type estimator
+        "input_name": [str],
+    },
+    prefer_skip_nested_validation=True,
+)
 def check_array(
     array,
     accept_sparse=False,


### PR DESCRIPTION
#### Reference Issues/PRs
#24862 

#### What does this implement/fix? Explain your changes.
added the validate_params decorator to sklearn.utils.validation.check_array

#### Any other comments?

I'm opening this PR as a draft and there are a few issues:

There's a pytest test failing, where it tests `check_array` with `array = array([1, 2, 3]), accept_sparse = False` and then  stumbles over `if array.ndim == 1: raise ValueError`.

I think this happens because the default value for `ensure_2d` is `True`. This way it unintentionally checks two values that depend on each other: `array` (which here has only one dimension) and `ensure_2d` (which is here set to True).

If the input generated by _param_validation could be somehow changed from `array = array([1, 2, 3]), accept_sparse = False` to `array = array([1, 2, 3]), accept_sparse = False, ensure_2d=False`, then I think it should work. But I didn't try and not sure if this is the right way to fix that.


Also, within the decorator dictionary, I didn't know how to express some of the types expected by the function:

```
        "accept_sparse": [
            bool,
            StrOptions({"csc", "csr", "coo", "dok", "bsr", "lil", "dia"}),
            list,
            tuple,
        ],  
```
Instead of `list` or `tuple` I assume it should be specified to list or tuple with any combination of 'csc', 'csr', 'coo', 'dok', 'bsr', 'lil', 'dia', and the docstring needs to be changes, so it becomes clearer.
  

```
        "dtype": [StrOptions({"numeric"}), np.dtype, type, set, list, tuple, None],
```
`list` should represent `list of type` according to docstring
   
```
        "estimator": [str, object, None], 
```
`object` should instead be `estimator` or something similar


Last thing, I think this check from `validation.py` isn't needed anymore, is it?

```
                if array.ndim == 0:
                    raise ValueError(
                        "Expected 2D array, got scalar array instead:\narray={}.\n"
                        "Reshape your data either using array.reshape(-1, 1) if "
                        "your data has a single feature or array.reshape(1, -1) "
                        "if it contains a single sample.".format(array)
```
After implementing the constraint `"array": ["array-like"],` it just stepped over it, because array-likes cannot have a dimension of 0.