### PR TITLE
FIX Updated hdbscan stability calculation to avoid implicit casting

### DIFF
--- a/sklearn/cluster/_hdbscan/_tree.pyx
+++ b/sklearn/cluster/_hdbscan/_tree.pyx
@@ -240,13 +240,13 @@ cdef dict _compute_stability(
         cnp.float64_t[::1] result, births
         cnp.intp_t[:] parents = condensed_tree['parent']
 
-        cnp.intp_t parent, cluster_size, result_index
+        cnp.intp_t parent, cluster_size, result_index, idx
         cnp.float64_t lambda_val
         CONDENSED_t condensed_node
-        cnp.float64_t[:, :] result_pre_dict
         cnp.intp_t largest_child = condensed_tree['child'].max()
         cnp.intp_t smallest_cluster = np.min(parents)
         cnp.intp_t num_clusters = np.max(parents) - smallest_cluster + 1
+        dict stability_dict = {}
 
     largest_child = max(largest_child, smallest_cluster)
     births = np.full(largest_child + 1, np.nan, dtype=np.float64)
@@ -266,14 +266,10 @@ cdef dict _compute_stability(
         result_index = parent - smallest_cluster
         result[result_index] += (lambda_val - births[parent]) * cluster_size
 
-    result_pre_dict = np.vstack(
-        (
-            np.arange(smallest_cluster, np.max(parents) + 1),
-            result
-        )
-    ).T
+    for idx in range(num_clusters):
+        stability_dict[idx + smallest_cluster] = result[idx]
 
-    return dict(result_pre_dict)
+    return stability_dict
 
 
 cdef list bfs_from_cluster_tree(


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #26535

#### What does this implement/fix? Explain your changes.
Updates the construction of the final stability dict to avoid implicit casting

#### Any other comments?
I'm not sure what exactly led to the change in behavior but most likely some update in Cython escalated the implicit cast to an error.

cc: @jeremiedbb @lesteve