### PR TITLE
FIX make sure to have a CSR matrix

### DIFF
--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -1145,7 +1145,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
                     " of scipy `>=1.9.2` or alter the `SplineTransformer`"
                     " transformer to produce fewer than 2^31 output features"
                 )
-            XBS = sparse.hstack(output_list)
+            XBS = sparse.hstack(output_list, format="csr")
         elif self.sparse_output:
             # TODO: Remove ones scipy 1.10 is the minimum version. See comments above.
             XBS = sparse.csr_matrix(XBS)


### PR DESCRIPTION
This should fix the issue with the COO matrix. I am not able to reproduce the issue with the `hstack` on a single array. I am not sure what is the reason for this change in SciPy.

In the other part of the code, we do the same conversion when using `hstack`.