### PR TITLE
TST Fix test_clone_sparse_matrices on scipy dev

### DIFF
--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -188,7 +188,9 @@ def test_clone_nan():
 
 def test_clone_sparse_matrices():
     sparse_matrix_classes = [
-        getattr(sp, name) for name in dir(sp) if name.endswith("_matrix")
+        cls
+        for name in dir(sp)
+        if name.endswith("_matrix") and type(cls := getattr(sp, name)) is type
     ]
 
     for cls in sparse_matrix_classes:


### PR DESCRIPTION
The discovery of sparse matrix classes done by this test is no longer valid because there's a new module ``sparse._matrix``.