### PR TITLE
MNT Fix scipy sparse matrix test for scipy development version

### DIFF
--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -188,8 +188,9 @@ def test_clone_nan():
 
 def test_clone_sparse_matrices():
     sparse_matrix_classes = [
-        cls for name in dir(sp) if name.endswith("_matrix")
-        and type(cls := getattr(sp, name)) == type
+        cls
+        for name in dir(sp)
+        if name.endswith("_matrix") and type(cls := getattr(sp, name)) == type
     ]
 
     for cls in sparse_matrix_classes:

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -188,7 +188,8 @@ def test_clone_nan():
 
 def test_clone_sparse_matrices():
     sparse_matrix_classes = [
-        getattr(sp, name) for name in dir(sp) if name.endswith("_matrix")
+        cls for name in dir(sp) if name.endswith("_matrix")
+        and type(cls := getattr(sp, name)) == type
     ]
 
     for cls in sparse_matrix_classes:


### PR DESCRIPTION
See in scipy-dev build [build](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=55743&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=ef785ae2-496b-5b02-9f0e-07a6c3ab3081&l=1046), in scipy development vesion `scipy.sparse._matrix` is a module so the test breaks.

I used the walrus operator `:=` since it has been added in Python 3.8 and we suport Python 3.8+. Let me know if you feel strongly about this!

