### PR TITLE
Fix PowerTransformer leaves constant feature unchanged

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -630,7 +630,7 @@ Changelog
 
 - |Fix| :class:`preprocessing.PowerTransformer` with `method="yeo-johnson"` now leaves
   constant features unchanged.
-  :pr:`` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+  :pr:`26566` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 :mod:`sklearn.svm`
 ..................

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -628,6 +628,10 @@ Changelog
   The `sample_interval_` attribute is deprecated and will be removed in 1.5.
   :pr:`25190` by :user:`Vincent Maladière <Vincent-Maladiere>`.
 
+- |Fix| :class:`preprocessing.PowerTransformer` with `method="yeo-johnson"` now leaves
+  constant features unchanged.
+  :pr:`` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
 :mod:`sklearn.svm`
 ..................
 

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -629,7 +629,8 @@ Changelog
   :pr:`25190` by :user:`Vincent Maladière <Vincent-Maladiere>`.
 
 - |Fix| :class:`preprocessing.PowerTransformer` with `method="yeo-johnson"` now leaves
-  constant features unchanged.
+  constant features unchanged instead of transforming with an arbitrary value for
+  the `lambdas_` fitted parameter.
   :pr:`26566` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 :mod:`sklearn.svm`

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -3158,7 +3158,7 @@ class PowerTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
             self.lambdas_ = np.empty(X.shape[1], dtype=X.dtype)
             for i, col in enumerate(X.T):
                 # For yeo-johnson, leave constant features unchanged
-                # in the yeo-johnson transformation, lambda = 1 corresponds to the identity
+                # the yeo-johnson transformation, lambda=1 corresponds to the identity
                 is_constant_feature = _is_constant_feature(var[i], mean[i], n_samples)
                 if self.method == "yeo-johnson" and is_constant_feature:
                     self.lambdas_[i] = 1.0

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2654,3 +2654,20 @@ def test_kernel_centerer_feature_names_out():
     names_out = centerer.get_feature_names_out()
     samples_out2 = X_pairwise.shape[1]
     assert_array_equal(names_out, [f"kernelcenterer{i}" for i in range(samples_out2)])
+
+
+@pytest.mark.parametrize("method", ["yeo-johnson", "box-cox"])
+@pytest.mark.parametrize("standardize", [True, False])
+def test_power_transformer_constant_feature(method, standardize):
+    """Check that PowerTransfomer leaves constant features unchanged."""
+    X = [[2], [2], [2]]
+
+    pt = PowerTransformer(method=method, standardize=standardize)
+    Xt = pt.fit(X).transform(X)
+
+    assert_allclose(pt.lambdas_, 1)
+    
+    if standardize:
+        assert_allclose(Xt, np.zeros_like(X))
+    else:
+        assert_allclose(Xt, X)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2656,18 +2656,20 @@ def test_kernel_centerer_feature_names_out():
     assert_array_equal(names_out, [f"kernelcenterer{i}" for i in range(samples_out2)])
 
 
-@pytest.mark.parametrize("method", ["yeo-johnson", "box-cox"])
 @pytest.mark.parametrize("standardize", [True, False])
-def test_power_transformer_constant_feature(method, standardize):
+def test_power_transformer_constant_feature(standardize):
     """Check that PowerTransfomer leaves constant features unchanged."""
-    X = [[2], [2], [2]]
+    X = [[-2, 0, 2], [-2, 0, 2], [-2, 0, 2]]
 
-    pt = PowerTransformer(method=method, standardize=standardize)
-    Xt = pt.fit(X).transform(X)
+    pt = PowerTransformer(method="yeo-johnson", standardize=standardize).fit(X)
 
-    assert_allclose(pt.lambdas_, 1)
-    
-    if standardize:
-        assert_allclose(Xt, np.zeros_like(X))
-    else:
-        assert_allclose(Xt, X)
+    assert_allclose(pt.lambdas_, [1, 1, 1])
+
+    Xft = pt.fit_transform(X)
+    Xt = pt.transform(X)
+
+    for Xt_ in [Xft, Xt]:
+        if standardize:
+            assert_allclose(Xt_, np.zeros_like(X))
+        else:
+            assert_allclose(Xt_, X)


### PR DESCRIPTION
When a feature is constant, ``Powertransformer`` with ``method="yeo-johnson"`` sets an unmeaningful lambda which arbitrarily scales the feature. I think it should be left unchanged in that case, and lambda should be set to 1 because the yeo-johnson transformation with lambda=1 correponds to the identity transformation.

This also fixes a couple of failing tests in the scipy-dev job because scipy now raises an error when the optimisation of lambda failed (https://github.com/scipy/scipy/pull/17704), which is the case for constant features.

(Note: this is irrelevant for method="boxcox" because it does not support constant features from the start and scipy already used to raise an informative error message)

Partial fix for #26154.