### PR TITLE
CI Fixes tests when matplotlib is not installed

### DIFF
--- a/sklearn/model_selection/tests/test_plot.py
+++ b/sklearn/model_selection/tests/test_plot.py
@@ -525,7 +525,7 @@ def test_curve_display_plot_kwargs(pyplot, data, CurveDisplay, specific_params):
 
 
 # TODO(1.5): to be removed
-def test_learning_curve_display_deprecate_log_scale(data):
+def test_learning_curve_display_deprecate_log_scale(data, pyplot):
     """Check that we warn for the deprecated parameter `log_scale`."""
     X, y = data
     estimator = DecisionTreeClassifier(random_state=0)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #26583
Fixes https://github.com/scikit-learn/scikit-learn/issues/26581
Fixes https://github.com/scikit-learn/scikit-learn/issues/26582

#### What does this implement/fix? Explain your changes.
This PR adds the `pyplot` fixture that will skip the test if matplotlib is not installed.

#### Any other comments?
Looks like all our CI jobs that run on PRs have matplotlib installed, so we did not catch this during development.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
