### PR TITLE
FIX seed in test_ridge_sample_weight_consistency [all random seeds]

### DIFF
--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1978,7 +1978,9 @@ def test_lbfgs_solver_error():
 @pytest.mark.parametrize("sparseX", [False, True])
 @pytest.mark.parametrize("data", ["tall", "wide"])
 @pytest.mark.parametrize("solver", SOLVERS + ["lbfgs"])
-def test_ridge_sample_weight_consistency(fit_intercept, sparseX, data, solver):
+def test_ridge_sample_weight_consistency(
+    fit_intercept, sparseX, data, solver, global_random_seed
+):
     """Test that the impact of sample_weight is consistent.
 
     Note that this test is stricter than the common test
@@ -1989,6 +1991,9 @@ def test_ridge_sample_weight_consistency(fit_intercept, sparseX, data, solver):
         if solver == "svd" or (solver in ("cholesky", "saga") and fit_intercept):
             pytest.skip("unsupported configuration")
 
+    # XXX: this test is quite sensitive to the seed used to generate the data:
+    # ideally we would like to pass for any global_random_seed but this is not
+    # the case at the moment.
     rng = np.random.RandomState(42)
     n_samples = 12
     if data == "tall":
@@ -2005,6 +2010,7 @@ def test_ridge_sample_weight_consistency(fit_intercept, sparseX, data, solver):
         alpha=1.0,
         solver=solver,
         positive=(solver == "lbfgs"),
+        random_state=global_random_seed,  # for sag/saga
         tol=1e-12,
     )
 

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1992,7 +1992,7 @@ def test_ridge_sample_weight_consistency(
             pytest.skip("unsupported configuration")
 
     # XXX: this test is quite sensitive to the seed used to generate the data:
-    # ideally we would like to pass for any global_random_seed but this is not
+    # ideally we would like the test to pass for any global_random_seed but this is not
     # the case at the moment.
     rng = np.random.RandomState(42)
     n_samples = 12


### PR DESCRIPTION
Fix a random failure in `test_ridge_sample_weight_consistency` while ensuring that the saga solver is not too seed sensitive.

The failure was first observed in the unrelated #26464.

Note that the data used in this test still uses a fixed `42` seed. I tried to change it to `global_random_seed` but that would make the test fail for other (deterministic) solvers such as lbfgs for some seed values so I decided to keep this PR focused on seeding SAG and SAGA.