### PR TITLE
Fix for Multiclass SVC.fit fails if sample_weight zeros out a class

### DIFF
--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -550,6 +550,24 @@ def test_svm_equivalence_sample_weight_C():
     assert_allclose(dual_coef_no_weight, clf.dual_coef_)
 
 
+def test_svm_multiclass_zero_sample_weights():
+    # test that class with zero sample weight has no effect
+    # on the model trained params with and without the class
+    X = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+    y = [0, 1, 2]
+    w = [0.0, 1.0, 1.0]
+    clf = svm.SVC().fit(X, y, w)
+    n_support_zero = clf.n_support_
+    support_vectors_zero = clf.support_vectors_
+    X = np.array([[1.0, 0.0], [0.0, 1.0]])
+    y = [1, 2]
+    w = [1.0, 1.0]
+    clf = svm.SVC().fit(X, y, w)
+
+    assert_allclose(n_support_zero, clf.n_support_)
+    assert_allclose(support_vectors_zero, clf.support_vectors_)
+
+
 @pytest.mark.parametrize(
     "Estimator, err_msg",
     [


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #25380 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Fix for multiclass SVM when weights of a class are zero

Now it removes the class with zero weights from X, y, and sample_weight
Trains the model and skips zero classes

Also, a test to assert model params when it is trained with or without the class

A new warning for removing the weights has been added

#### Any other comments?
The labels of y remain unchanged

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
