### PR TITLE
DOC search link to sphinx version

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -763,7 +763,7 @@ To build the PDF manual, run:
    versions of Sphinx as possible, the different versions tend to
    behave slightly differently. To get the best results, you should
    use the same version as the one we used on CircleCI. Look at this
-   `github search <https://github.com/search?utf8=%E2%9C%93&q=sphinx+repo%3Ascikit-learn%2Fscikit-learn+extension%3Ash+path%3Abuild_tools%2Fcircle&type=Code>`_
+   `GitHub search <https://github.com/search?q=%5C%22sphinx%5C%22+repo%3Ascikit-learn%2Fscikit-learn+path%3Asklearn%2F_min_dependencies.py&type=code>`_
    to know the exact version.
 
 Guidelines for writing documentation

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -763,7 +763,7 @@ To build the PDF manual, run:
    versions of Sphinx as possible, the different versions tend to
    behave slightly differently. To get the best results, you should
    use the same version as the one we used on CircleCI. Look at this
-   `GitHub search <https://github.com/search?q=%5C%22sphinx%5C%22+repo%3Ascikit-learn%2Fscikit-learn+path%3Asklearn%2F_min_dependencies.py&type=code>`_
+   `GitHub search <https://github.com/search?q=repo%3Ascikit-learn%2Fscikit-learn+path%3Abuild_tools%2Fcircle%2F*.yml+sphinx&type=code>`_
    to know the exact version.
 
 Guidelines for writing documentation


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #26598.

#### What does this implement/fix? Explain your changes.

The *github search* link on the bottom of [this section](https://scikit-learn.org/dev/developers/contributing.html#building-the-documentation) is broken. This PR currently uses

![image](https://github.com/scikit-learn/scikit-learn/assets/108576690/d069e04c-ab99-47d3-b512-7b28f7c90f8b)

Alternatively we may use

![image](https://github.com/scikit-learn/scikit-learn/assets/108576690/0c95384d-0599-4a63-814d-dbc3d8cbbdaf)

or any other link that maintainers prefer.
