### PR TITLE
CI Adjust atol for conda-forge to pass

### DIFF
--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -874,7 +874,7 @@ def test_linear_regression_sample_weight_consistency(
         # ::test_linear_regression_sample_weight_consistency
         pass
     else:
-        assert_allclose(reg.coef_, coef_0, rtol=1e-6)
+        assert_allclose(reg.coef_, coef_0, rtol=1e-5)
         if fit_intercept:
             assert_allclose(reg.intercept_, intercept_0)
 


### PR DESCRIPTION
Conda-forge is [failing with CPython](https://github.com/conda-forge/scikit-learn-feedstock/pull/222) tests, because of the strictness of the `test_linear_regression_sample_weight_consistency` test. [Here](https://dev.azure.com/conda-forge/84710dde-1620-425b-80d0-4cf5baca359d/_apis/build/builds/725120/logs/260) is an example of a failing test.

@jeremiedbb

