### PR TITLE
MNT replace flake8 with ruff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           command: |
             source build_tools/shared.sh
             # Include pytest compatibility with mypy
-            pip install pytest flake8 $(get_dep mypy min) $(get_dep black min) cython-lint
+            pip install pytest ruff $(get_dep mypy min) $(get_dep black min) cython-lint
       - run:
           name: linting
           command: ./build_tools/linting.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           source build_tools/shared.sh
           # Include pytest compatibility with mypy
-          pip install pytest flake8 $(get_dep mypy min) $(get_dep black min) cython-lint
+          pip install pytest ruff $(get_dep mypy min) $(get_dep black min) cython-lint
 
       - name: Run linting
         run: ./build_tools/linting.sh &> /tmp/linting_output.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,11 @@ repos:
     rev: 23.3.0
     hooks:
     -   id: black
--   repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.0.272
     hooks:
-    -   id: flake8
-        types: [file, python]
+    -   id: ruff
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.961
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -61,5 +61,4 @@ doc-noplot: inplace
 	$(MAKE) -C doc html-noplot
 
 code-analysis:
-	flake8 sklearn | grep -v __init__ | grep -v external
-	pylint -E -i y sklearn/ -d E1103,E0611,E1101
+	build_tools/linting.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
     - bash: |
         source build_tools/shared.sh
         # Include pytest compatibility with mypy
-        pip install pytest flake8 $(get_dep mypy min) $(get_dep black min) cython-lint
+        pip install pytest ruff $(get_dep mypy min) $(get_dep black min) cython-lint
       displayName: Install linters
     - bash: |
         ./build_tools/linting.sh

--- a/build_tools/linting.sh
+++ b/build_tools/linting.sh
@@ -7,8 +7,8 @@ set -o pipefail
 black --check --diff .
 echo -e "No problem detected by black\n"
 
-flake8 --show-source .
-echo -e "No problem detected by flake8\n"
+ruff check --show-source .
+echo -e "No problem detected by ruff\n"
 
 mypy sklearn/
 echo -e "No problem detected by mypy\n"

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -254,7 +254,7 @@ how to set up your git repository:
 
    .. prompt:: bash $
 
-        pip install pytest pytest-cov flake8 mypy numpydoc black==23.3.0
+        pip install pytest pytest-cov ruff mypy numpydoc black==23.3.0
 
 .. _upstream:
 
@@ -425,30 +425,15 @@ complies with the following rules before marking a PR as ``[MRG]``. The
    non-regression tests should fail for the code base in the ``main`` branch
    and pass for the PR code.
 
-5. Run `black` to auto-format your code.
 
-   .. prompt:: bash $
-
-        black .
-
-   See black's
-   `editor integration documentation <https://black.readthedocs.io/en/stable/integrations/editors.html>`_
-   to configure your editor to run `black`.
-
-6. Run `flake8` to make sure you followed the project coding conventions.
-
-   .. prompt:: bash $
-
-        flake8 .
-
-7. Follow the :ref:`coding-guidelines`.
+5. Follow the :ref:`coding-guidelines`.
 
 
-8. When applicable, use the validation tools and scripts in the
+6. When applicable, use the validation tools and scripts in the
    ``sklearn.utils`` submodule.  A list of utility routines available
    for developers can be found in the :ref:`developers-utils` page.
 
-9. Often pull requests resolve one or more other issues (or pull requests).
+7. Often pull requests resolve one or more other issues (or pull requests).
    If merging your pull request means that some other issues/PRs should
    be closed, you should `use keywords to create link to them
    <https://github.com/blog/1506-closing-issues-via-pull-requests/>`_
@@ -458,7 +443,7 @@ complies with the following rules before marking a PR as ``[MRG]``. The
    related to some other issues/PRs, create a link to them without using
    the keywords (e.g., ``See also #1234``).
 
-10. PRs should often substantiate the change, through benchmarks of
+8. PRs should often substantiate the change, through benchmarks of
     performance and efficiency (see :ref:`monitoring_performances`) or through
     examples of usage. Examples also illustrate the features and intricacies of
     the library to users. Have a look at other examples in the `examples/
@@ -467,14 +452,14 @@ complies with the following rules before marking a PR as ``[MRG]``. The
     functionality is useful in practice and, if possible, compare it to other
     methods available in scikit-learn.
 
-11. New features have some maintenance overhead. We expect PR authors
+9. New features have some maintenance overhead. We expect PR authors
     to take part in the maintenance for the code they submit, at least
     initially. New features need to be illustrated with narrative
     documentation in the user guide, with small code snippets.
     If relevant, please also add references in the literature, with PDF links
     when possible.
 
-12. The user guide should also include expected time and space complexity
+10. The user guide should also include expected time and space complexity
     of the algorithm and scalability, e.g. "this algorithm can scale to a
     large number of samples > 100000, but does not scale in dimensionality:
     n_features is expected to be lower than 100".
@@ -534,8 +519,10 @@ Continuous Integration (CI)
 
 * Azure pipelines are used for testing scikit-learn on Linux, Mac and Windows,
   with different dependencies and settings.
-* CircleCI is used to build the docs for viewing, for linting with flake8, and
-  for testing with ARM64 / aarch64 on Linux
+* CircleCI is used to build the docs for viewing.
+* Github Actions are used for various tasks, including building wheels and
+  source distributions.
+* Cirrus CI is used to build on ARM.
 
 Please note that if one of the following markers appear in the latest commit
 message, the following actions are taken.

--- a/examples/feature_selection/plot_select_from_model_diabetes.py
+++ b/examples/feature_selection/plot_select_from_model_diabetes.py
@@ -43,7 +43,7 @@ print(diabetes.DESCR)
 # were already standardized.
 # For a more complete example on the interpretations of the coefficients of
 # linear models, you may refer to
-# :ref:`sphx_glr_auto_examples_inspection_plot_linear_model_coefficient_interpretation.py`.
+# :ref:`sphx_glr_auto_examples_inspection_plot_linear_model_coefficient_interpretation.py`.  # noqa: E501
 import matplotlib.pyplot as plt
 import numpy as np
 from sklearn.linear_model import RidgeCV

--- a/examples/text/plot_document_classification_20newsgroups.py
+++ b/examples/text/plot_document_classification_20newsgroups.py
@@ -358,7 +358,7 @@ def benchmark(clf, custom_name=False):
 # Notice that the most important hyperparameters values were tuned using a grid
 # search procedure not shown in this notebook for the sake of simplicity. See
 # the example script
-# :ref:`sphx_glr_auto_examples_model_selection_plot_grid_search_text_feature_extraction.py`
+# :ref:`sphx_glr_auto_examples_model_selection_plot_grid_search_text_feature_extraction.py`  # noqa: E501
 # for a demo on how such tuning can be done.
 
 from sklearn.linear_model import LogisticRegression

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,6 @@ ignore=[
     "E731",
     # do not use variables named 'l', 'O', or 'I'
     "E741",
-    # line break before binary operator
-    # "W503",
-    # line break after binary operator
-    # "W504"
 ]
 
 exclude=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,47 @@ exclude = '''
 )/
 '''
 
+[tool.ruff]
+# max line length for black
+line-length = 88
+target-version = "py38"
+
+ignore=[
+    # space before : (needed for how black formats slicing)
+    "E203",
+    # do not assign a lambda expression, use a def
+    "E731",
+    # do not use variables named 'l', 'O', or 'I'
+    "E741",
+    # line break before binary operator
+    # "W503",
+    # line break after binary operator
+    # "W504"
+]
+
+exclude=[
+    ".git",
+    "__pycache__",
+    "dist",
+    "sklearn/externals",
+    "doc/_build",
+    "doc/auto_examples",
+    "doc/tutorial",
+    "build",
+    "asv_benchmarks/env",
+    "asv_benchmarks/html",
+    "asv_benchmarks/results",
+    "asv_benchmarks/benchmarks/cache",
+]
+
+[tool.ruff.per-file-ignores]
+# It's fine not to put the import at the top of the file in the examples
+# folder.
+"examples/*"=["E402"]
+"doc/conf.py"=["E402"]
+
 [tool.cython-lint]
-# Ignore the same error codes as flake8
+# Ignore the same error codes as ruff
 # + E501 (line too long) because keeping it < 88 in cython
 # often makes code less readable.
 ignore = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,44 +25,6 @@ addopts =
 filterwarnings =
     ignore:the matrix subclass:PendingDeprecationWarning
 
-[flake8]
-# max line length for black
-max-line-length = 88
-target-version = ['py37']
-# Default flake8 3.5 ignored flags
-ignore=
-    # check ignored by default in flake8. Meaning unclear.
-    E24,
-    # space before : (needed for how black formats slicing)
-    E203,
-    # do not assign a lambda expression, use a def
-    E731,
-    # do not use variables named 'l', 'O', or 'I'
-    E741,
-    # line break before binary operator
-    W503,
-    # line break after binary operator
-    W504
-exclude=
-    .git,
-    __pycache__,
-    dist,
-    sklearn/externals,
-    doc/_build,
-    doc/auto_examples,
-    doc/tutorial,
-    build,
-    asv_benchmarks/env,
-    asv_benchmarks/html,
-    asv_benchmarks/results,
-    asv_benchmarks/benchmarks/cache
-
-# It's fine not to put the import at the top of the file in the examples
-# folder.
-per-file-ignores =
-    examples/*: E402
-    doc/conf.py: E402
-
 [mypy]
 ignore_missing_imports = True
 allow_redefinition = True

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -37,7 +37,7 @@ dependent_packages = {
     "memory_profiler": ("0.57.0", "benchmark, docs"),
     "pytest": (PYTEST_MIN_VERSION, "tests"),
     "pytest-cov": ("2.9.0", "tests"),
-    "flake8": ("3.8.2", "tests"),
+    "ruff": ("0.0.272", "tests"),
     "black": ("23.3.0", "tests"),
     "mypy": ("0.961", "tests"),
     "pyamg": ("4.0.0", "tests"),

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1029,6 +1029,7 @@ class OutlierMixin:
             1 for inliers, -1 for outliers.
         """
         # override for transductive outlier detectors like LocalOulierFactor
+
         return self.fit(X).predict(X)
 
 

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1029,7 +1029,6 @@ class OutlierMixin:
             1 for inliers, -1 for outliers.
         """
         # override for transductive outlier detectors like LocalOulierFactor
-
         return self.fit(X).predict(X)
 
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -229,7 +229,7 @@ def test_pipeline_invalid_parameters():
 
     # Test clone
     pipe2 = clone(pipe)
-    assert not pipe.named_steps["svc"] is pipe2.named_steps["svc"]
+    assert pipe.named_steps["svc"] is not pipe2.named_steps["svc"]
 
     # Check that apart from estimators, the parameters are the same
     params = pipe.get_params(deep=True)


### PR DESCRIPTION
This replaces `flake8` with `ruff` (https://github.com/astral-sh/ruff), which is significantly faster than `flake8`, and can also fix many of the reported issues automatically (in `pre-commit` hooks).

Once this is merged, we can then introduce import sorting (instead of using `isort`) through `ruff` as well (and more linting).

cc @thomasjpfan @ogrisel 