### PR TITLE
DOC Fix warnings in auto_examples

### DIFF
--- a/examples/miscellaneous/plot_metadata_routing.py
+++ b/examples/miscellaneous/plot_metadata_routing.py
@@ -402,8 +402,8 @@ est.fit(X, y, sample_weight=my_weights, clf_sample_weight=my_other_weights)
 
 # %%
 # - Alias only on the sub-estimator. This is useful if we don't want the
-# meta-estimator to use the metadata, and we only want the metadata to be used
-# by the sub-estimator.
+#   meta-estimator to use the metadata, and we only want the metadata to be used
+#   by the sub-estimator.
 est = RouterConsumerClassifier(
     estimator=ExampleClassifier().set_fit_request(sample_weight="aliased_sample_weight")
 ).set_fit_request(sample_weight=True)
@@ -615,9 +615,10 @@ for w in record:
 # want to have a scikit-learn compatible estimator, without depending on the
 # scikit-learn package. If the following conditions are met, you do NOT need to
 # modify your code at all:
-#  - your estimator inherits from :class:`~base.BaseEstimator`
-#  - the parameters consumed by your estimator's methods, e.g. ``fit``, are
-#    explicitly defined in the method's signature, as opposed to being
-#    ``*args`` or ``*kwargs``.
-#  - you do not route any metadata to the underlying objects, i.e. you're not a
-#    *router*.
+#
+# - your estimator inherits from :class:`~base.BaseEstimator`
+# - the parameters consumed by your estimator's methods, e.g. ``fit``, are
+#   explicitly defined in the method's signature, as opposed to being 
+#   ``*args`` or ``*kwargs``.
+# - you do not route any metadata to the underlying objects, i.e. you're not a 
+#   *router*.

--- a/examples/miscellaneous/plot_metadata_routing.py
+++ b/examples/miscellaneous/plot_metadata_routing.py
@@ -618,7 +618,7 @@ for w in record:
 #
 # - your estimator inherits from :class:`~base.BaseEstimator`
 # - the parameters consumed by your estimator's methods, e.g. ``fit``, are
-#   explicitly defined in the method's signature, as opposed to being 
+#   explicitly defined in the method's signature, as opposed to being
 #   ``*args`` or ``*kwargs``.
-# - you do not route any metadata to the underlying objects, i.e. you're not a 
+# - you do not route any metadata to the underlying objects, i.e. you're not a
 #   *router*.


### PR DESCRIPTION
Fix two warnings in the example plot_metadata_routing documentation:
`/scikit-learn/doc/auto_examples/miscellaneous/plot_metadata_routing.rst:592: WARNING: Bullet list ends without a blank line; unexpected unindent.`
`/scikit-learn/doc/auto_examples/miscellaneous/plot_metadata_routing.rst:868: ERROR: Unexpected indentation.`
