### PR TITLE
[WIP] FIX Add tests for pyarrow dtypes in pandas Dataframes

### DIFF
--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -292,7 +292,9 @@ def test_column_transformer_dataframe(use_pyarrow_dtypes):
     ids=["list", "bool", "bool_int"],
 )
 @pytest.mark.parametrize("callable_column", [False, True])
-def test_column_transformer_empty_columns(use_pyarrow_dtypes, pandas, column_selection, callable_column):
+def test_column_transformer_empty_columns(
+    use_pyarrow_dtypes, pandas, column_selection, callable_column
+):
     # test case that ensures that the column transformer does also work when
     # a given transformer doesn't have any columns to work on
     X_array = np.array([[0, 1, 2], [2, 4, 6]]).T
@@ -1202,6 +1204,7 @@ def test_column_transformer_callable_specifier():
     assert callable(ct.transformers[0][2])
     assert ct.transformers_[0][2] == [0]
 
+
 @pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 def test_column_transformer_callable_specifier_dataframe(use_pyarrow_dtypes):
     # assert that function gets the full dataframe
@@ -1282,7 +1285,9 @@ def test_n_features_in():
         (["col_int", "col_float", "col_str"], None, [np.number, object], None),
     ],
 )
-def test_make_column_selector_with_select_dtypes(use_pyarrow_dtypes, cols, pattern, include, exclude):
+def test_make_column_selector_with_select_dtypes(
+    use_pyarrow_dtypes, cols, pattern, include, exclude
+):
     pd = pytest.importorskip("pandas")
     if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
@@ -1303,6 +1308,7 @@ def test_make_column_selector_with_select_dtypes(use_pyarrow_dtypes, cols, patte
     )
 
     assert_array_equal(selector(X_df), cols)
+
 
 @pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 def test_column_transformer_with_make_column_selector(use_pyarrow_dtypes):
@@ -1459,6 +1465,7 @@ def test_sk_visual_block_remainder_drop():
     assert visual_block.name_details == (["col1", "col2"],)
     assert visual_block.estimators == (ohe,)
 
+
 @pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("remainder", ["passthrough", StandardScaler()])
 def test_sk_visual_block_remainder_fitted_pandas(use_pyarrow_dtypes, remainder):
@@ -1546,6 +1553,7 @@ def test_column_transformer_reordered_column_names_remainder(
         with pytest.raises(ValueError, match=err_msg):
             tf.transform(X_array)
 
+
 @pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 def test_feature_name_validation_missing_columns_drop_passthough(use_pyarrow_dtypes):
     """Test the interaction between {'drop', 'passthrough'} and
@@ -1585,6 +1593,7 @@ def test_feature_name_validation_missing_columns_drop_passthough(use_pyarrow_dty
     df_dropped_trans = tf.transform(df_dropped)
     df_fit_trans = tf.transform(df)
     assert_allclose(df_dropped_trans, df_fit_trans)
+
 
 @pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 def test_feature_names_in_(use_pyarrow_dtypes):
@@ -1742,7 +1751,9 @@ class TransWithNames(Trans):
         ),
     ],
 )
-def test_verbose_feature_names_out_true(use_pyarrow_dtypes, transformers, remainder, expected_names):
+def test_verbose_feature_names_out_true(
+    use_pyarrow_dtypes, transformers, remainder, expected_names
+):
     """Check feature_names_out for verbose_feature_names_out=True (default)"""
     pd = pytest.importorskip("pandas")
     if use_pyarrow_dtypes:
@@ -1760,6 +1771,7 @@ def test_verbose_feature_names_out_true(use_pyarrow_dtypes, transformers, remain
     assert isinstance(names, np.ndarray)
     assert names.dtype == object
     assert_array_equal(names, expected_names)
+
 
 @pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize(
@@ -1877,7 +1889,9 @@ def test_verbose_feature_names_out_true(use_pyarrow_dtypes, transformers, remain
         ),
     ],
 )
-def test_verbose_feature_names_out_false(use_pyarrow_dtypes, transformers, remainder, expected_names):
+def test_verbose_feature_names_out_false(
+    use_pyarrow_dtypes, transformers, remainder, expected_names
+):
     """Check feature_names_out for verbose_feature_names_out=False"""
     pd = pytest.importorskip("pandas")
     if use_pyarrow_dtypes:
@@ -2033,7 +2047,9 @@ def test_verbose_feature_names_out_false_errors(
 @pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("verbose_feature_names_out", [True, False])
 @pytest.mark.parametrize("remainder", ["drop", "passthrough"])
-def test_column_transformer_set_output(use_pyarrow_dtypes, verbose_feature_names_out, remainder):
+def test_column_transformer_set_output(
+    use_pyarrow_dtypes, verbose_feature_names_out, remainder
+):
     """Check column transformer behavior with set_output."""
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame([[1, 2, 3, 4]], columns=["a", "b", "c", "d"], index=[10])
@@ -2064,7 +2080,9 @@ def test_column_transformer_set_output(use_pyarrow_dtypes, verbose_feature_names
 @pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("remainder", ["drop", "passthrough"])
 @pytest.mark.parametrize("fit_transform", [True, False])
-def test_column_transform_set_output_mixed(use_pyarrow_dtypes, remainder, fit_transform):
+def test_column_transform_set_output_mixed(
+    use_pyarrow_dtypes, remainder, fit_transform
+):
     """Check ColumnTransformer outputs mixed types correctly."""
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame(

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -155,15 +155,15 @@ def test_column_transformer_tuple_transformers_parameter():
     )
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_column_transformer_dataframe(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_column_transformer_dataframe(use_pyarrow_dtypes):
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
     X_array = np.array([[0, 1, 2], [2, 4, 6]]).T
     X_df = pd.DataFrame(X_array, columns=["first", "second"])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         X_df.convert_dtypes(dtype_backend="pyarrow")
 
     X_res_first = np.array([0, 1, 2]).reshape(-1, 1)
@@ -284,7 +284,7 @@ def test_column_transformer_dataframe(with_pyarrow):
     assert_array_equal(ct.transformers_[-1][2], [1])
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("pandas", [True, False], ids=["pandas", "numpy"])
 @pytest.mark.parametrize(
     "column_selection",
@@ -292,7 +292,7 @@ def test_column_transformer_dataframe(with_pyarrow):
     ids=["list", "bool", "bool_int"],
 )
 @pytest.mark.parametrize("callable_column", [False, True])
-def test_column_transformer_empty_columns(with_pyarrow, pandas, column_selection, callable_column):
+def test_column_transformer_empty_columns(use_pyarrow_dtypes, pandas, column_selection, callable_column):
     # test case that ensures that the column transformer does also work when
     # a given transformer doesn't have any columns to work on
     X_array = np.array([[0, 1, 2], [2, 4, 6]]).T
@@ -301,7 +301,7 @@ def test_column_transformer_empty_columns(with_pyarrow, pandas, column_selection
     if pandas:
         pd = pytest.importorskip("pandas")
         X = pd.DataFrame(X_array, columns=["first", "second"])
-        if with_pyarrow:
+        if use_pyarrow_dtypes:
             X.convert_dtypes(dtype_backend="pyarrow")
     else:
         X = X_array
@@ -384,15 +384,15 @@ def test_column_transformer_output_indices():
     assert_array_equal(X_trans[:, [0, 1]], X_trans[:, ct.output_indices_["remainder"]])
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_column_transformer_output_indices_df(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_column_transformer_output_indices_df(use_pyarrow_dtypes):
     # Checks for the output_indices_ attribute with data frames
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
     X_df = pd.DataFrame(np.arange(6).reshape(3, 2), columns=["first", "second"])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         X_df.convert_dtypes(dtype_backend="pyarrow")
 
     ct = ColumnTransformer(
@@ -593,15 +593,15 @@ def test_2D_transformer_output():
         ct.fit(X_array)
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_2D_transformer_output_pandas(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_2D_transformer_output_pandas(use_pyarrow_dtypes):
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
     X_array = np.array([[0, 1, 2], [2, 4, 6]]).T
     X_df = pd.DataFrame(X_array, columns=["col1", "col2"])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         X_df.convert_dtypes(dtype_backend="pyarrow")
 
     # if one transformer is dropped, test that name is still correct
@@ -675,14 +675,14 @@ def test_make_column_transformer():
     assert columns == ("first", ["second"])
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_make_column_transformer_pandas(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_make_column_transformer_pandas(use_pyarrow_dtypes):
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
     X_array = np.array([[0, 1, 2], [2, 4, 6]]).T
     X_df = pd.DataFrame(X_array, columns=["first", "second"])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         X_df.convert_dtypes(dtype_backend="pyarrow")
     norm = Normalizer()
     ct1 = ColumnTransformer([("norm", Normalizer(), X_df.columns)])
@@ -918,7 +918,7 @@ def test_column_transformer_remainder_numpy(key):
     assert_array_equal(ct.transformers_[-1][2], [1])
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize(
     "key",
     [
@@ -933,10 +933,10 @@ def test_column_transformer_remainder_numpy(key):
         slice("first", "first"),
     ],
 )
-def test_column_transformer_remainder_pandas(with_pyarrow, key):
+def test_column_transformer_remainder_pandas(use_pyarrow_dtypes, key):
     # test different ways that columns are specified with passthrough
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
     if isinstance(key, str) and key == "pd-index":
         key = pd.Index(["first"])
@@ -944,7 +944,7 @@ def test_column_transformer_remainder_pandas(with_pyarrow, key):
     X_array = np.array([[0, 1, 2], [2, 4, 6]]).T
     X_df = pd.DataFrame(X_array, columns=["first", "second"])
     X_res_both = X_array
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         X_df.convert_dtypes(dtype_backend="pyarrow")
 
     ct = ColumnTransformer([("trans1", Trans(), key)], remainder="passthrough")
@@ -1202,17 +1202,17 @@ def test_column_transformer_callable_specifier():
     assert callable(ct.transformers[0][2])
     assert ct.transformers_[0][2] == [0]
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_column_transformer_callable_specifier_dataframe(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_column_transformer_callable_specifier_dataframe(use_pyarrow_dtypes):
     # assert that function gets the full dataframe
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
     X_array = np.array([[0, 1, 2], [2, 4, 6]]).T
     X_res_first = np.array([[0, 1, 2]]).T
 
     X_df = pd.DataFrame(X_array, columns=["first", "second"])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         X_df.convert_dtypes(dtype_backend="pyarrow")
 
     def func(X):
@@ -1263,7 +1263,7 @@ def test_n_features_in():
     assert ct.n_features_in_ == 2
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize(
     "cols, pattern, include, exclude",
     [
@@ -1282,9 +1282,9 @@ def test_n_features_in():
         (["col_int", "col_float", "col_str"], None, [np.number, object], None),
     ],
 )
-def test_make_column_selector_with_select_dtypes(with_pyarrow, cols, pattern, include, exclude):
+def test_make_column_selector_with_select_dtypes(use_pyarrow_dtypes, cols, pattern, include, exclude):
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
     X_df = pd.DataFrame(
@@ -1295,7 +1295,7 @@ def test_make_column_selector_with_select_dtypes(with_pyarrow, cols, pattern, in
         },
         columns=["col_int", "col_float", "col_str"],
     )
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         X_df.convert_dtypes(dtype_backend="pyarrow")
 
     selector = make_column_selector(
@@ -1304,11 +1304,11 @@ def test_make_column_selector_with_select_dtypes(with_pyarrow, cols, pattern, in
 
     assert_array_equal(selector(X_df), cols)
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_column_transformer_with_make_column_selector(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_column_transformer_with_make_column_selector(use_pyarrow_dtypes):
     # Functional test for column transformer + column selector
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
     X_df = pd.DataFrame(
         {
@@ -1320,7 +1320,7 @@ def test_column_transformer_with_make_column_selector(with_pyarrow):
         columns=["col_int", "col_float", "col_cat", "col_str"],
     )
     X_df["col_str"] = X_df["col_str"].astype("category")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         X_df.convert_dtypes(dtype_backend="pyarrow")
 
     cat_selector = make_column_selector(dtype_include=["category", object])
@@ -1348,10 +1348,10 @@ def test_make_column_selector_error():
         selector(X)
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_make_column_selector_pickle(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_make_column_selector_pickle(use_pyarrow_dtypes):
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
     X_df = pd.DataFrame(
@@ -1362,7 +1362,7 @@ def test_make_column_selector_pickle(with_pyarrow):
         },
         columns=["col_int", "col_float", "col_str"],
     )
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         X_df.convert_dtypes(dtype_backend="pyarrow")
 
     selector = make_column_selector(dtype_include=[object])
@@ -1371,19 +1371,19 @@ def test_make_column_selector_pickle(with_pyarrow):
     assert_array_equal(selector(X_df), selector_picked(X_df))
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize(
     "empty_col",
     [[], np.array([], dtype=int), lambda x: []],
     ids=["list", "array", "callable"],
 )
-def test_feature_names_empty_columns(with_pyarrow, empty_col):
+def test_feature_names_empty_columns(use_pyarrow_dtypes, empty_col):
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
     df = pd.DataFrame({"col1": ["a", "a", "b"], "col2": ["z", "z", "z"]})
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         df.convert_dtypes(dtype_backend="pyarrow")
 
     ct = ColumnTransformer(
@@ -1399,7 +1399,7 @@ def test_feature_names_empty_columns(with_pyarrow, empty_col):
     )
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize(
     "selector",
     [
@@ -1411,13 +1411,13 @@ def test_feature_names_empty_columns(with_pyarrow, empty_col):
         lambda x: [False, True],
     ],
 )
-def test_feature_names_out_pandas(with_pyarrow, selector):
+def test_feature_names_out_pandas(use_pyarrow_dtypes, selector):
     """Checks name when selecting only the second column"""
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
     df = pd.DataFrame({"col1": ["a", "a", "b"], "col2": ["z", "z", "z"]})
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         df.convert_dtypes(dtype_backend="pyarrow")
     ct = ColumnTransformer([("ohe", OneHotEncoder(), selector)])
     ct.fit(df)
@@ -1459,12 +1459,12 @@ def test_sk_visual_block_remainder_drop():
     assert visual_block.name_details == (["col1", "col2"],)
     assert visual_block.estimators == (ohe,)
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("remainder", ["passthrough", StandardScaler()])
-def test_sk_visual_block_remainder_fitted_pandas(with_pyarrow, remainder):
+def test_sk_visual_block_remainder_fitted_pandas(use_pyarrow_dtypes, remainder):
     # Remainder shows the columns after fitting
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
     ohe = OneHotEncoder()
     ct = ColumnTransformer(
@@ -1478,7 +1478,7 @@ def test_sk_visual_block_remainder_fitted_pandas(with_pyarrow, remainder):
             "col4": [3, 4, 5],
         }
     )
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         df.convert_dtypes(dtype_backend="pyarrow")
     ct.fit(df)
     visual_block = ct._sk_visual_block_()
@@ -1502,15 +1502,15 @@ def test_sk_visual_block_remainder_fitted_numpy(remainder):
     assert visual_block.estimators == (scaler, remainder)
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("explicit_colname", ["first", "second", 0, 1])
 @pytest.mark.parametrize("remainder", [Trans(), "passthrough", "drop"])
 def test_column_transformer_reordered_column_names_remainder(
-    with_pyarrow, explicit_colname, remainder
+    use_pyarrow_dtypes, explicit_colname, remainder
 ):
     """Test the interaction between remainder and column transformer"""
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
     X_fit_array = np.array([[0, 1, 2], [2, 4, 6]]).T
@@ -1519,7 +1519,7 @@ def test_column_transformer_reordered_column_names_remainder(
     X_trans_array = np.array([[2, 4, 6], [0, 1, 2]]).T
     X_trans_df = pd.DataFrame(X_trans_array, columns=["second", "first"])
 
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         X_fit_df.convert_dtypes(dtype_backend="pyarrow")
         X_trans_df.convert_dtypes(dtype_backend="pyarrow")
 
@@ -1546,12 +1546,12 @@ def test_column_transformer_reordered_column_names_remainder(
         with pytest.raises(ValueError, match=err_msg):
             tf.transform(X_array)
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_feature_name_validation_missing_columns_drop_passthough(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_feature_name_validation_missing_columns_drop_passthough(use_pyarrow_dtypes):
     """Test the interaction between {'drop', 'passthrough'} and
     missing column names."""
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
     X = np.ones(shape=(3, 4))
@@ -1559,7 +1559,7 @@ def test_feature_name_validation_missing_columns_drop_passthough(with_pyarrow):
 
     df_dropped = df.drop("c", axis=1)
 
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         df.convert_dtypes(dtype_backend="pyarrow")
         df_dropped.convert_dtypes(dtype_backend="pyarrow")
 
@@ -1586,8 +1586,8 @@ def test_feature_name_validation_missing_columns_drop_passthough(with_pyarrow):
     df_fit_trans = tf.transform(df)
     assert_allclose(df_dropped_trans, df_fit_trans)
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_feature_names_in_(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_feature_names_in_(use_pyarrow_dtypes):
     """Feature names are stored in column transformer.
 
     Column transformer deliberately does not check for column name consistency.
@@ -1596,12 +1596,12 @@ def test_feature_names_in_(with_pyarrow):
     `test_feature_name_validation_missing_columns_drop_passthough`"""
 
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
     feature_names = ["a", "c", "d"]
     df = pd.DataFrame([[1, 2, 3]], columns=feature_names)
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         df.convert_dtypes(dtype_backend="pyarrow")
     ct = ColumnTransformer([("bycol", Trans(), ["a", "d"])], remainder="passthrough")
 
@@ -1621,7 +1621,7 @@ class TransWithNames(Trans):
         return input_features
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize(
     "transformers, remainder, expected_names",
     [
@@ -1742,13 +1742,13 @@ class TransWithNames(Trans):
         ),
     ],
 )
-def test_verbose_feature_names_out_true(with_pyarrow, transformers, remainder, expected_names):
+def test_verbose_feature_names_out_true(use_pyarrow_dtypes, transformers, remainder, expected_names):
     """Check feature_names_out for verbose_feature_names_out=True (default)"""
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
     df = pd.DataFrame([[1, 2, 3, 4]], columns=["a", "b", "c", "d"])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         df.convert_dtypes(dtype_backend="pyarrow")
     ct = ColumnTransformer(
         transformers,
@@ -1761,7 +1761,7 @@ def test_verbose_feature_names_out_true(with_pyarrow, transformers, remainder, e
     assert names.dtype == object
     assert_array_equal(names, expected_names)
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize(
     "transformers, remainder, expected_names",
     [
@@ -1877,13 +1877,13 @@ def test_verbose_feature_names_out_true(with_pyarrow, transformers, remainder, e
         ),
     ],
 )
-def test_verbose_feature_names_out_false(with_pyarrow, transformers, remainder, expected_names):
+def test_verbose_feature_names_out_false(use_pyarrow_dtypes, transformers, remainder, expected_names):
     """Check feature_names_out for verbose_feature_names_out=False"""
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
     df = pd.DataFrame([[1, 2, 3, 4]], columns=["a", "b", "c", "d"])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         df.convert_dtypes(dtype_backend="pyarrow")
     ct = ColumnTransformer(
         transformers,
@@ -1898,7 +1898,7 @@ def test_verbose_feature_names_out_false(with_pyarrow, transformers, remainder, 
     assert_array_equal(names, expected_names)
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize(
     "transformers, remainder, colliding_columns",
     [
@@ -2007,12 +2007,12 @@ def test_verbose_feature_names_out_false(with_pyarrow, transformers, remainder, 
     ],
 )
 def test_verbose_feature_names_out_false_errors(
-    with_pyarrow, transformers, remainder, colliding_columns
+    use_pyarrow_dtypes, transformers, remainder, colliding_columns
 ):
     """Check feature_names_out for verbose_feature_names_out=False"""
 
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
     df = pd.DataFrame([[1, 2, 3, 4]], columns=["a", "b", "c", "d"])
     ct = ColumnTransformer(
@@ -2030,14 +2030,14 @@ def test_verbose_feature_names_out_false_errors(
         ct.get_feature_names_out()
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("verbose_feature_names_out", [True, False])
 @pytest.mark.parametrize("remainder", ["drop", "passthrough"])
-def test_column_transformer_set_output(with_pyarrow, verbose_feature_names_out, remainder):
+def test_column_transformer_set_output(use_pyarrow_dtypes, verbose_feature_names_out, remainder):
     """Check column transformer behavior with set_output."""
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame([[1, 2, 3, 4]], columns=["a", "b", "c", "d"], index=[10])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df.convert_dtypes(dtype_backend="pyarrow")
     ct = ColumnTransformer(
@@ -2051,7 +2051,7 @@ def test_column_transformer_set_output(with_pyarrow, verbose_feature_names_out, 
     ct.set_output(transform="pandas")
 
     df_test = pd.DataFrame([[1, 2, 3, 4]], columns=df.columns, index=[20])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         df_test.convert_dtypes(dtype_backend="pyarrow")
     X_trans = ct.transform(df_test)
     assert isinstance(X_trans, pd.DataFrame)
@@ -2061,10 +2061,10 @@ def test_column_transformer_set_output(with_pyarrow, verbose_feature_names_out, 
     assert_array_equal(X_trans.index, df_test.index)
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("remainder", ["drop", "passthrough"])
 @pytest.mark.parametrize("fit_transform", [True, False])
-def test_column_transform_set_output_mixed(with_pyarrow, remainder, fit_transform):
+def test_column_transform_set_output_mixed(use_pyarrow_dtypes, remainder, fit_transform):
     """Check ColumnTransformer outputs mixed types correctly."""
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame(
@@ -2076,7 +2076,7 @@ def test_column_transform_set_output_mixed(with_pyarrow, remainder, fit_transfor
             "distance": pd.Series([20, pd.NA, 100], dtype="Int32"),
         }
     )
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df.convert_dtypes(dtype_backend="pyarrow")
     ct = ColumnTransformer(
@@ -2112,9 +2112,9 @@ def test_column_transform_set_output_mixed(with_pyarrow, remainder, fit_transfor
         assert dtype == expected_dtypes[col]
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("remainder", ["drop", "passthrough"])
-def test_column_transform_set_output_after_fitting(with_pyarrow, remainder):
+def test_column_transform_set_output_after_fitting(use_pyarrow_dtypes, remainder):
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame(
         {
@@ -2123,7 +2123,7 @@ def test_column_transform_set_output_after_fitting(with_pyarrow, remainder):
             "height": [20, 40, 10],
         }
     )
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df.convert_dtypes(dtype_backend="pyarrow")
     ct = ColumnTransformer(
@@ -2179,7 +2179,7 @@ class PandasOutTransformer(BaseEstimator):
         return self
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize(
     "trans_1, expected_verbose_names, expected_non_verbose_names",
     [
@@ -2201,7 +2201,7 @@ class PandasOutTransformer(BaseEstimator):
     ],
 )
 def test_transformers_with_pandas_out_but_not_feature_names_out(
-    with_pyarrow, trans_1, expected_verbose_names, expected_non_verbose_names
+    use_pyarrow_dtypes, trans_1, expected_verbose_names, expected_non_verbose_names
 ):
     """Check that set_config(transform="pandas") is compatible with more transformers.
 
@@ -2210,7 +2210,7 @@ def test_transformers_with_pandas_out_but_not_feature_names_out(
     """
     pd = pytest.importorskip("pandas")
     X_df = pd.DataFrame({"feat0": [1.0, 2.0, 3.0], "feat1": [2.0, 3.0, 4.0]})
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X_df.convert_dtypes(dtype_backend="pyarrow")
     ct = ColumnTransformer(
@@ -2237,20 +2237,20 @@ def test_transformers_with_pandas_out_but_not_feature_names_out(
     assert_array_equal(X_trans_df1.columns, expected_non_verbose_names)
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize(
     "empty_selection",
     [[], np.array([False, False]), [False, False]],
     ids=["list", "bool", "bool_int"],
 )
-def test_empty_selection_pandas_output(with_pyarrow, empty_selection):
+def test_empty_selection_pandas_output(use_pyarrow_dtypes, empty_selection):
     """Check that pandas output works when there is an empty selection.
 
     Non-regression test for gh-25487
     """
     pd = pytest.importorskip("pandas")
     X = pd.DataFrame([[1.0, 2.2], [3.0, 1.0]], columns=["a", "b"])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X.convert_dtypes(dtype_backend="pyarrow")
 
@@ -2270,15 +2270,15 @@ def test_empty_selection_pandas_output(with_pyarrow, empty_selection):
     assert_array_equal(X_out.columns, ["a", "b"])
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_raise_error_if_index_not_aligned(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_raise_error_if_index_not_aligned(use_pyarrow_dtypes):
     """Check column transformer raises error if indices are not aligned.
 
     Non-regression test for gh-26210.
     """
     pd = pytest.importorskip("pandas")
     X = pd.DataFrame([[1.0, 2.2], [3.0, 1.0]], columns=["a", "b"], index=[8, 3])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X.convert_dtypes(dtype_backend="pyarrow")
     reset_index_transformer = FunctionTransformer(
@@ -2301,8 +2301,8 @@ def test_raise_error_if_index_not_aligned(with_pyarrow):
         ct.fit_transform(X)
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_remainder_set_output(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_remainder_set_output(use_pyarrow_dtypes):
     """Check that the output is set for the remainder.
 
     Non-regression test for #26306.
@@ -2310,7 +2310,7 @@ def test_remainder_set_output(with_pyarrow):
 
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame({"a": [True, False, True], "b": [1, 2, 3]})
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df.convert_dtypes(dtype_backend="pyarrow")
 

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -611,11 +611,16 @@ def test_pls_feature_names_out(Klass):
     assert_array_equal(names_out, expected_names_out)
 
 
+@pytest.mark.parametrize("with_pyarrow", [True, False])
 @pytest.mark.parametrize("Klass", [CCA, PLSSVD, PLSRegression, PLSCanonical])
-def test_pls_set_output(Klass):
+def test_pls_set_output(with_pyarrow, Klass):
     """Check `set_output` in cross_decomposition module."""
     pd = pytest.importorskip("pandas")
     X, Y = load_linnerud(return_X_y=True, as_frame=True)
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
+        X.convert_dtypes(dtype_backend="pyarrow")
+        Y.convert_dtypes(dtype_backend="pyarrow")
 
     est = Klass().set_output(transform="pandas").fit(X, Y)
     X_trans, y_trans = est.transform(X, Y)

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -611,13 +611,13 @@ def test_pls_feature_names_out(Klass):
     assert_array_equal(names_out, expected_names_out)
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("Klass", [CCA, PLSSVD, PLSRegression, PLSCanonical])
-def test_pls_set_output(with_pyarrow, Klass):
+def test_pls_set_output(use_pyarrow_dtypes, Klass):
     """Check `set_output` in cross_decomposition module."""
     pd = pytest.importorskip("pandas")
     X, Y = load_linnerud(return_X_y=True, as_frame=True)
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X.convert_dtypes(dtype_backend="pyarrow")
         Y.convert_dtypes(dtype_backend="pyarrow")

--- a/sklearn/datasets/tests/test_arff_parser.py
+++ b/sklearn/datasets/tests/test_arff_parser.py
@@ -11,6 +11,7 @@ from sklearn.datasets._arff_parser import (
 )
 
 
+@pytest.mark.parametrize("with_pyarrow", [True, False])
 @pytest.mark.parametrize(
     "feature_names, target_names",
     [
@@ -43,7 +44,7 @@ from sklearn.datasets._arff_parser import (
         ),
     ],
 )
-def test_post_process_frame(feature_names, target_names):
+def test_post_process_frame(with_pyarrow, feature_names, target_names):
     """Check the behaviour of the post-processing function for splitting a dataframe."""
     pd = pytest.importorskip("pandas")
 
@@ -57,6 +58,9 @@ def test_post_process_frame(feature_names, target_names):
             "col_string": ["a", "b", "c"],
         }
     )
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
+        X_original.convert_dtypes(dtype_backend="pyarrow")
 
     X, y = _post_process_frame(X_original, feature_names, target_names)
     assert isinstance(X, pd.DataFrame)

--- a/sklearn/datasets/tests/test_arff_parser.py
+++ b/sklearn/datasets/tests/test_arff_parser.py
@@ -11,7 +11,7 @@ from sklearn.datasets._arff_parser import (
 )
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize(
     "feature_names, target_names",
     [
@@ -44,7 +44,7 @@ from sklearn.datasets._arff_parser import (
         ),
     ],
 )
-def test_post_process_frame(with_pyarrow, feature_names, target_names):
+def test_post_process_frame(use_pyarrow_dtypes, feature_names, target_names):
     """Check the behaviour of the post-processing function for splitting a dataframe."""
     pd = pytest.importorskip("pandas")
 
@@ -58,7 +58,7 @@ def test_post_process_frame(with_pyarrow, feature_names, target_names):
             "col_string": ["a", "b", "c"],
         }
     )
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X_original.convert_dtypes(dtype_backend="pyarrow")
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -1113,11 +1113,11 @@ def test_categorical_spec_errors(
         est.fit(X, y)
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize(
     "Est", (HistGradientBoostingClassifier, HistGradientBoostingRegressor)
 )
-def test_categorical_spec_errors_with_feature_names(with_pyarrow, Est):
+def test_categorical_spec_errors_with_feature_names(use_pyarrow_dtypes, Est):
     pd = pytest.importorskip("pandas")
     n_samples = 10
     X = pd.DataFrame(
@@ -1128,7 +1128,7 @@ def test_categorical_spec_errors_with_feature_names(with_pyarrow, Est):
         }
     )
     y = [0, 1] * (n_samples // 2)
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X.convert_dtypes(dtype_backend="pyarrow")
 
@@ -1166,14 +1166,14 @@ def test_categorical_spec_no_categories(Est, categorical_features, as_array):
     assert est.is_categorical_ is None
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize(
     "Est", (HistGradientBoostingClassifier, HistGradientBoostingRegressor)
 )
 @pytest.mark.parametrize(
     "use_pandas, feature_name", [(False, "at index 0"), (True, "'f0'")]
 )
-def test_categorical_bad_encoding_errors(with_pyarrow, Est, use_pandas, feature_name):
+def test_categorical_bad_encoding_errors(use_pyarrow_dtypes, Est, use_pandas, feature_name):
     # Test errors when categories are encoded incorrectly
 
     gb = Est(categorical_features=[True], max_bins=2)
@@ -1181,7 +1181,7 @@ def test_categorical_bad_encoding_errors(with_pyarrow, Est, use_pandas, feature_
     if use_pandas:
         pd = pytest.importorskip("pandas")
         X = pd.DataFrame({"f0": [0, 1, 2]})
-        if with_pyarrow:
+        if use_pyarrow_dtypes:
             pytest.importorskip("pyarrow")
             X.convert_dtypes(dtype_backend="pyarrow")
     else:
@@ -1196,7 +1196,7 @@ def test_categorical_bad_encoding_errors(with_pyarrow, Est, use_pandas, feature_
 
     if use_pandas:
         X = pd.DataFrame({"f0": [0, 2]})
-        if with_pyarrow:
+        if use_pyarrow_dtypes:
             X.convert_dtypes(dtype_backend="pyarrow")
     else:
         X = np.array([[0, 2]]).T
@@ -1303,8 +1303,8 @@ def test_interaction_cst_numerically():
     )
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_no_user_warning_with_scoring(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_no_user_warning_with_scoring(use_pyarrow_dtypes):
     """Check that no UserWarning is raised when scoring is set.
 
     Non-regression test for #22907.
@@ -1312,7 +1312,7 @@ def test_no_user_warning_with_scoring(with_pyarrow):
     pd = pytest.importorskip("pandas")
     X, y = make_regression(n_samples=50, random_state=0)
     X_df = pd.DataFrame(X, columns=[f"col{i}" for i in range(X.shape[1])])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X_df.convert_dtypes(dtype_backend="pyarrow")
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -1113,10 +1113,11 @@ def test_categorical_spec_errors(
         est.fit(X, y)
 
 
+@pytest.mark.parametrize("with_pyarrow", [True, False])
 @pytest.mark.parametrize(
     "Est", (HistGradientBoostingClassifier, HistGradientBoostingRegressor)
 )
-def test_categorical_spec_errors_with_feature_names(Est):
+def test_categorical_spec_errors_with_feature_names(with_pyarrow, Est):
     pd = pytest.importorskip("pandas")
     n_samples = 10
     X = pd.DataFrame(
@@ -1127,6 +1128,9 @@ def test_categorical_spec_errors_with_feature_names(Est):
         }
     )
     y = [0, 1] * (n_samples // 2)
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
+        X.convert_dtypes(dtype_backend="pyarrow")
 
     est = Est(categorical_features=["f0", "f1", "f3"])
     expected_msg = re.escape(
@@ -1162,13 +1166,14 @@ def test_categorical_spec_no_categories(Est, categorical_features, as_array):
     assert est.is_categorical_ is None
 
 
+@pytest.mark.parametrize("with_pyarrow", [True, False])
 @pytest.mark.parametrize(
     "Est", (HistGradientBoostingClassifier, HistGradientBoostingRegressor)
 )
 @pytest.mark.parametrize(
     "use_pandas, feature_name", [(False, "at index 0"), (True, "'f0'")]
 )
-def test_categorical_bad_encoding_errors(Est, use_pandas, feature_name):
+def test_categorical_bad_encoding_errors(with_pyarrow, Est, use_pandas, feature_name):
     # Test errors when categories are encoded incorrectly
 
     gb = Est(categorical_features=[True], max_bins=2)
@@ -1176,6 +1181,9 @@ def test_categorical_bad_encoding_errors(Est, use_pandas, feature_name):
     if use_pandas:
         pd = pytest.importorskip("pandas")
         X = pd.DataFrame({"f0": [0, 1, 2]})
+        if with_pyarrow:
+            pytest.importorskip("pyarrow")
+            X.convert_dtypes(dtype_backend="pyarrow")
     else:
         X = np.array([[0, 1, 2]]).T
     y = np.arange(3)
@@ -1188,6 +1196,8 @@ def test_categorical_bad_encoding_errors(Est, use_pandas, feature_name):
 
     if use_pandas:
         X = pd.DataFrame({"f0": [0, 2]})
+        if with_pyarrow:
+            X.convert_dtypes(dtype_backend="pyarrow")
     else:
         X = np.array([[0, 2]]).T
     y = np.arange(2)
@@ -1293,7 +1303,8 @@ def test_interaction_cst_numerically():
     )
 
 
-def test_no_user_warning_with_scoring():
+@pytest.mark.parametrize("with_pyarrow", [True, False])
+def test_no_user_warning_with_scoring(with_pyarrow):
     """Check that no UserWarning is raised when scoring is set.
 
     Non-regression test for #22907.
@@ -1301,6 +1312,9 @@ def test_no_user_warning_with_scoring():
     pd = pytest.importorskip("pandas")
     X, y = make_regression(n_samples=50, random_state=0)
     X_df = pd.DataFrame(X, columns=[f"col{i}" for i in range(X.shape[1])])
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
+        X_df.convert_dtypes(dtype_backend="pyarrow")
 
     est = HistGradientBoostingRegressor(
         random_state=0, scoring="neg_mean_absolute_error", early_stopping=True

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -1173,7 +1173,9 @@ def test_categorical_spec_no_categories(Est, categorical_features, as_array):
 @pytest.mark.parametrize(
     "use_pandas, feature_name", [(False, "at index 0"), (True, "'f0'")]
 )
-def test_categorical_bad_encoding_errors(use_pyarrow_dtypes, Est, use_pandas, feature_name):
+def test_categorical_bad_encoding_errors(
+    use_pyarrow_dtypes, Est, use_pandas, feature_name
+):
     # Test errors when categories are encoded incorrectly
 
     gb = Est(categorical_features=[True], max_bins=2)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -301,7 +301,6 @@ def test_input_error_related_to_feature_names(use_pyarrow_dtypes):
     if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X.convert_dtypes(dtype_backend="pyarrow")
-        y.convert_dtypes(dtype_backend="pyarrow")
 
     monotonic_cst = {"d": 1, "a": 1, "c": -1}
     gbdt = HistGradientBoostingRegressor(monotonic_cst=monotonic_cst)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -293,12 +293,12 @@ def test_input_error():
         gbdt.fit(X, y)
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_input_error_related_to_feature_names(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_input_error_related_to_feature_names(use_pyarrow_dtypes):
     pd = pytest.importorskip("pandas")
     X = pd.DataFrame({"a": [0, 1, 2], "b": [0, 1, 2]})
     y = np.array([0, 1, 0])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X.convert_dtypes(dtype_backend="pyarrow")
         y.convert_dtypes(dtype_backend="pyarrow")

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -293,10 +293,15 @@ def test_input_error():
         gbdt.fit(X, y)
 
 
-def test_input_error_related_to_feature_names():
+@pytest.mark.parametrize("with_pyarrow", [True, False])
+def test_input_error_related_to_feature_names(with_pyarrow):
     pd = pytest.importorskip("pandas")
     X = pd.DataFrame({"a": [0, 1, 2], "b": [0, 1, 2]})
     y = np.array([0, 1, 0])
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
+        X.convert_dtypes(dtype_backend="pyarrow")
+        y.convert_dtypes(dtype_backend="pyarrow")
 
     monotonic_cst = {"d": 1, "a": 1, "c": -1}
     gbdt = HistGradientBoostingRegressor(monotonic_cst=monotonic_cst)

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -341,7 +341,8 @@ def test_base_estimator_property_deprecated():
         model.base_estimator_
 
 
-def test_iforest_preserve_feature_names():
+@pytest.mark.parametrize("with_pyarrow", [True, False])
+def test_iforest_preserve_feature_names(with_pyarrow):
     """Check that feature names are preserved when contamination is not "auto".
 
     Feature names are required for consistency checks during scoring.
@@ -352,6 +353,10 @@ def test_iforest_preserve_feature_names():
     rng = np.random.RandomState(0)
 
     X = pd.DataFrame(data=rng.randn(4), columns=["a"])
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
+        X.convert_dtypes(dtype_backend="pyarrow")
+
     model = IsolationForest(random_state=0, contamination=0.05)
 
     with warnings.catch_warnings():

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -341,8 +341,8 @@ def test_base_estimator_property_deprecated():
         model.base_estimator_
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_iforest_preserve_feature_names(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_iforest_preserve_feature_names(use_pyarrow_dtypes):
     """Check that feature names are preserved when contamination is not "auto".
 
     Feature names are required for consistency checks during scoring.
@@ -353,7 +353,7 @@ def test_iforest_preserve_feature_names(with_pyarrow):
     rng = np.random.RandomState(0)
 
     X = pd.DataFrame(data=rng.randn(4), columns=["a"])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X.convert_dtypes(dtype_backend="pyarrow")
 

--- a/sklearn/feature_selection/tests/test_base.py
+++ b/sklearn/feature_selection/tests/test_base.py
@@ -118,7 +118,8 @@ def test_get_support():
     assert_array_equal(support_inds, sel.get_support(indices=True))
 
 
-def test_output_dataframe():
+@pytest.mark.parametrize("with_pyarrow", [True, False])
+def test_output_dataframe(with_pyarrow):
     """Check output dtypes for dataframes is consistent with the input dtypes."""
     pd = pytest.importorskip("pandas")
 
@@ -130,6 +131,9 @@ def test_output_dataframe():
             "d": pd.Series([3.0, 2.4, 1.2], dtype=np.float64),
         }
     )
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
+        X.convert_dtypes(dtype_backend="pyarrow")
 
     for step in [2, 3]:
         sel = StepSelector(step=step).set_output(transform="pandas")

--- a/sklearn/feature_selection/tests/test_base.py
+++ b/sklearn/feature_selection/tests/test_base.py
@@ -118,8 +118,8 @@ def test_get_support():
     assert_array_equal(support_inds, sel.get_support(indices=True))
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_output_dataframe(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_output_dataframe(use_pyarrow_dtypes):
     """Check output dtypes for dataframes is consistent with the input dtypes."""
     pd = pytest.importorskip("pandas")
 
@@ -131,7 +131,7 @@ def test_output_dataframe(with_pyarrow):
             "d": pd.Series([3.0, 2.4, 1.2], dtype=np.float64),
         }
     )
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X.convert_dtypes(dtype_backend="pyarrow")
 

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -946,12 +946,15 @@ def test_mutual_info_regression():
     assert_array_equal(support, gtruth)
 
 
-def test_dataframe_output_dtypes():
-    """Check that the output datafarme dtypes are the same as the input.
+@pytest.mark.parametrize("with_pyarrow", [True, False])
+def test_dataframe_output_dtypes(with_pyarrow):
+    """Check that the output dataframe dtypes are the same as the input.
 
     Non-regression test for gh-24860.
     """
     pd = pytest.importorskip("pandas")
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
 
     X, y = load_iris(return_X_y=True, as_frame=True)
     X = X.astype(
@@ -960,6 +963,9 @@ def test_dataframe_output_dtypes():
             "petal width (cm)": np.float64,
         }
     )
+    if with_pyarrow:
+        X.convert_dtypes(dtype_backend="pyarrow")
+
     X["petal_width_binned"] = pd.cut(X["petal width (cm)"], bins=10)
 
     column_order = X.columns

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -946,14 +946,14 @@ def test_mutual_info_regression():
     assert_array_equal(support, gtruth)
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_dataframe_output_dtypes(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_dataframe_output_dtypes(use_pyarrow_dtypes):
     """Check that the output dataframe dtypes are the same as the input.
 
     Non-regression test for gh-24860.
     """
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
     X, y = load_iris(return_X_y=True, as_frame=True)
@@ -963,7 +963,7 @@ def test_dataframe_output_dtypes(with_pyarrow):
             "petal width (cm)": np.float64,
         }
     )
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         X.convert_dtypes(dtype_backend="pyarrow")
 
     X["petal_width_binned"] = pd.cut(X["petal width (cm)"], bins=10)

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -597,13 +597,21 @@ def test_select_from_model_pls(PLSEstimator):
     assert model.score(X, y) > 0.5
 
 
-def test_estimator_does_not_support_feature_names():
+@pytest.mark.parametrize("with_pyarrow", [True, False])
+def test_estimator_does_not_support_feature_names(with_pyarrow):
     """SelectFromModel works with estimators that do not support feature_names_in_.
 
     Non-regression test for #21949.
     """
     pytest.importorskip("pandas")
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
+
     X, y = datasets.load_iris(as_frame=True, return_X_y=True)
+    if with_pyarrow:
+        X.convert_dtypes(dtype_backend="pyarrow")
+        y.convert_dtypes(dtype_backend="pyarrow")
+
     all_feature_names = set(X.columns)
 
     def importance_getter(estimator):
@@ -645,12 +653,17 @@ def test_partial_fit_validate_max_features(error, err_msg, max_features):
             estimator=SGDClassifier(), max_features=max_features
         ).partial_fit(X, y, classes=[0, 1])
 
-
+@pytest.mark.parametrize("with_pyarrow", [True, False])
 @pytest.mark.parametrize("as_frame", [True, False])
-def test_partial_fit_validate_feature_names(as_frame):
+def test_partial_fit_validate_feature_names(with_pyarrow, as_frame):
     """Test that partial_fit from SelectFromModel validates `feature_names_in_`."""
     pytest.importorskip("pandas")
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
     X, y = datasets.load_iris(as_frame=as_frame, return_X_y=True)
+    if with_pyarrow and as_frame is True:
+        X.convert_dtypes(dtype_backend="pyarrow")
+        y.convert_dtypes(dtype_backend="pyarrow")
 
     selector = SelectFromModel(estimator=SGDClassifier(), max_features=4).partial_fit(
         X, y, classes=[0, 1, 2]

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -653,6 +653,7 @@ def test_partial_fit_validate_max_features(error, err_msg, max_features):
             estimator=SGDClassifier(), max_features=max_features
         ).partial_fit(X, y, classes=[0, 1])
 
+
 @pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("as_frame", [True, False])
 def test_partial_fit_validate_feature_names(use_pyarrow_dtypes, as_frame):

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -597,18 +597,18 @@ def test_select_from_model_pls(PLSEstimator):
     assert model.score(X, y) > 0.5
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_estimator_does_not_support_feature_names(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_estimator_does_not_support_feature_names(use_pyarrow_dtypes):
     """SelectFromModel works with estimators that do not support feature_names_in_.
 
     Non-regression test for #21949.
     """
     pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
     X, y = datasets.load_iris(as_frame=True, return_X_y=True)
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         X.convert_dtypes(dtype_backend="pyarrow")
         y.convert_dtypes(dtype_backend="pyarrow")
 
@@ -653,15 +653,15 @@ def test_partial_fit_validate_max_features(error, err_msg, max_features):
             estimator=SGDClassifier(), max_features=max_features
         ).partial_fit(X, y, classes=[0, 1])
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("as_frame", [True, False])
-def test_partial_fit_validate_feature_names(with_pyarrow, as_frame):
+def test_partial_fit_validate_feature_names(use_pyarrow_dtypes, as_frame):
     """Test that partial_fit from SelectFromModel validates `feature_names_in_`."""
     pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
     X, y = datasets.load_iris(as_frame=as_frame, return_X_y=True)
-    if with_pyarrow and as_frame is True:
+    if use_pyarrow_dtypes and as_frame is True:
         X.convert_dtypes(dtype_backend="pyarrow")
         y.convert_dtypes(dtype_backend="pyarrow")
 

--- a/sklearn/impute/tests/test_common.py
+++ b/sklearn/impute/tests/test_common.py
@@ -105,7 +105,9 @@ def test_imputers_add_indicator_sparse(imputer, marker):
 @pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("imputer", imputers(), ids=lambda x: x.__class__.__name__)
 @pytest.mark.parametrize("add_indicator", [True, False])
-def test_imputers_pandas_na_integer_array_support(use_pyarrow_dtypes, imputer, add_indicator):
+def test_imputers_pandas_na_integer_array_support(
+    use_pyarrow_dtypes, imputer, add_indicator
+):
     # Test pandas IntegerArray with pd.NA
     pd = pytest.importorskip("pandas")
     if use_pyarrow_dtypes:
@@ -134,6 +136,7 @@ def test_imputers_pandas_na_integer_array_support(use_pyarrow_dtypes, imputer, a
     X_trans = imputer.fit_transform(X_df)
 
     assert_allclose(X_trans_expected, X_trans)
+
 
 @pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("imputer", imputers(), ids=lambda x: x.__class__.__name__)

--- a/sklearn/impute/tests/test_common.py
+++ b/sklearn/impute/tests/test_common.py
@@ -102,11 +102,15 @@ def test_imputers_add_indicator_sparse(imputer, marker):
 
 # ConvergenceWarning will be raised by the IterativeImputer
 @pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
+@pytest.mark.parametrize("with_pyarrow", [True, False])
 @pytest.mark.parametrize("imputer", imputers(), ids=lambda x: x.__class__.__name__)
 @pytest.mark.parametrize("add_indicator", [True, False])
-def test_imputers_pandas_na_integer_array_support(imputer, add_indicator):
+def test_imputers_pandas_na_integer_array_support(with_pyarrow, imputer, add_indicator):
     # Test pandas IntegerArray with pd.NA
     pd = pytest.importorskip("pandas")
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
+
     marker = np.nan
     imputer = imputer.set_params(add_indicator=add_indicator, missing_values=marker)
 
@@ -123,18 +127,23 @@ def test_imputers_pandas_na_integer_array_support(imputer, add_indicator):
 
     # Creates dataframe with IntegerArrays with pd.NA
     X_df = pd.DataFrame(X, dtype="Int16", columns=["a", "b", "c", "d", "e"])
+    if with_pyarrow:
+        X_df.convert_dtypes(dtype_backend="pyarrow")
 
     # fit on pandas dataframe with IntegerArrays
     X_trans = imputer.fit_transform(X_df)
 
     assert_allclose(X_trans_expected, X_trans)
 
-
+@pytest.mark.parametrize("with_pyarrow", [True, False])
 @pytest.mark.parametrize("imputer", imputers(), ids=lambda x: x.__class__.__name__)
 @pytest.mark.parametrize("add_indicator", [True, False])
-def test_imputers_feature_names_out_pandas(imputer, add_indicator):
+def test_imputers_feature_names_out_pandas(with_pyarrow, imputer, add_indicator):
     """Check feature names out for imputers."""
     pd = pytest.importorskip("pandas")
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
+
     marker = np.nan
     imputer = imputer.set_params(add_indicator=add_indicator, missing_values=marker)
 
@@ -147,6 +156,8 @@ def test_imputers_feature_names_out_pandas(imputer, add_indicator):
         ]
     )
     X_df = pd.DataFrame(X, columns=["a", "b", "c", "d", "e", "f"])
+    if with_pyarrow:
+        X_df.convert_dtypes(dtype_backend="pyarrow")
     imputer.fit(X_df)
 
     names = imputer.get_feature_names_out()

--- a/sklearn/impute/tests/test_common.py
+++ b/sklearn/impute/tests/test_common.py
@@ -102,13 +102,13 @@ def test_imputers_add_indicator_sparse(imputer, marker):
 
 # ConvergenceWarning will be raised by the IterativeImputer
 @pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("imputer", imputers(), ids=lambda x: x.__class__.__name__)
 @pytest.mark.parametrize("add_indicator", [True, False])
-def test_imputers_pandas_na_integer_array_support(with_pyarrow, imputer, add_indicator):
+def test_imputers_pandas_na_integer_array_support(use_pyarrow_dtypes, imputer, add_indicator):
     # Test pandas IntegerArray with pd.NA
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
     marker = np.nan
@@ -127,7 +127,7 @@ def test_imputers_pandas_na_integer_array_support(with_pyarrow, imputer, add_ind
 
     # Creates dataframe with IntegerArrays with pd.NA
     X_df = pd.DataFrame(X, dtype="Int16", columns=["a", "b", "c", "d", "e"])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         X_df.convert_dtypes(dtype_backend="pyarrow")
 
     # fit on pandas dataframe with IntegerArrays
@@ -135,13 +135,13 @@ def test_imputers_pandas_na_integer_array_support(with_pyarrow, imputer, add_ind
 
     assert_allclose(X_trans_expected, X_trans)
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("imputer", imputers(), ids=lambda x: x.__class__.__name__)
 @pytest.mark.parametrize("add_indicator", [True, False])
-def test_imputers_feature_names_out_pandas(with_pyarrow, imputer, add_indicator):
+def test_imputers_feature_names_out_pandas(use_pyarrow_dtypes, imputer, add_indicator):
     """Check feature names out for imputers."""
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
     marker = np.nan
@@ -156,7 +156,7 @@ def test_imputers_feature_names_out_pandas(with_pyarrow, imputer, add_indicator)
         ]
     )
     X_df = pd.DataFrame(X, columns=["a", "b", "c", "d", "e", "f"])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         X_df.convert_dtypes(dtype_backend="pyarrow")
     imputer.fit(X_df)
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -104,9 +104,12 @@ def test_imputation_deletion_warning(strategy):
         imputer.transform(X)
 
 
+@pytest.mark.parametrize("with_pyarrow", [True, False])
 @pytest.mark.parametrize("strategy", ["mean", "median", "most_frequent"])
-def test_imputation_deletion_warning_feature_names(strategy):
+def test_imputation_deletion_warning_feature_names(with_pyarrow, strategy):
     pd = pytest.importorskip("pandas")
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
 
     missing_values = np.nan
     feature_names = np.array(["a", "b", "c", "d"], dtype=object)
@@ -117,6 +120,8 @@ def test_imputation_deletion_warning_feature_names(strategy):
         ],
         columns=feature_names,
     )
+    if with_pyarrow:
+        X.convert_dtypes(dtype_backend="pyarrow")
 
     imputer = SimpleImputer(strategy=strategy).fit(X)
 
@@ -267,12 +272,16 @@ def test_imputation_mean_median_error_invalid_type(strategy, dtype):
         imputer.fit_transform(X)
 
 
+@pytest.mark.parametrize("with_pyarrow", [True, False])
 @pytest.mark.parametrize("strategy", ["mean", "median"])
 @pytest.mark.parametrize("type", ["list", "dataframe"])
-def test_imputation_mean_median_error_invalid_type_list_pandas(strategy, type):
+def test_imputation_mean_median_error_invalid_type_list_pandas(with_pyarrow, strategy, type):
     X = [["a", "b", 3], [4, "e", 6], ["g", "h", 9]]
     if type == "dataframe":
         pd = pytest.importorskip("pandas")
+        if with_pyarrow:
+            pytest.importorskip("pyarrow")
+
         X = pd.DataFrame(X)
     msg = "non-numeric data:\ncould not convert string to float: '"
     with pytest.raises(ValueError, match=msg):
@@ -357,10 +366,14 @@ def test_imputation_most_frequent_objects(marker):
     assert_array_equal(X_trans, X_true)
 
 
+@pytest.mark.parametrize("with_pyarrow", [True, False])
 @pytest.mark.parametrize("dtype", [object, "category"])
-def test_imputation_most_frequent_pandas(dtype):
+def test_imputation_most_frequent_pandas(with_pyarrow, dtype):
     # Test imputation using the most frequent strategy on pandas df
     pd = pytest.importorskip("pandas")
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
+
 
     f = io.StringIO("Cat1,Cat2,Cat3,Cat4\n,i,x,\na,,y,\na,j,,\nb,j,x,")
 
@@ -459,10 +472,13 @@ def test_imputation_constant_object(marker):
     assert_array_equal(X_trans, X_true)
 
 
+@pytest.mark.parametrize("with_pyarrow", [True, False])
 @pytest.mark.parametrize("dtype", [object, "category"])
-def test_imputation_constant_pandas(dtype):
+def test_imputation_constant_pandas(with_pyarrow, dtype):
     # Test imputation using the constant strategy on pandas df
     pd = pytest.importorskip("pandas")
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
 
     f = io.StringIO("Cat1,Cat2,Cat3,Cat4\n,i,x,\na,,y,\na,j,,\nb,j,x,")
 
@@ -1546,11 +1562,16 @@ def test_knn_imputer_keep_empty_features(keep_empty_features):
             assert X_imputed.shape == (X.shape[0], X.shape[1] - 1)
 
 
-def test_simple_impute_pd_na():
+@pytest.mark.parametrize("with_pyarrow", [True, False])
+def test_simple_impute_pd_na(with_pyarrow):
     pd = pytest.importorskip("pandas")
+    if with_pyarrow:
+       pytest.importorskip("pyarrow")
 
     # Impute pandas array of string types.
     df = pd.DataFrame({"feature": pd.Series(["abc", None, "de"], dtype="string")})
+    if with_pyarrow:
+        df.convert_dtypes(dtype_backend="pyarrow")
     imputer = SimpleImputer(missing_values=pd.NA, strategy="constant", fill_value="na")
     _assert_array_equal_and_same_dtype(
         imputer.fit_transform(df), np.array([["abc"], ["na"], ["de"]], dtype=object)
@@ -1558,6 +1579,8 @@ def test_simple_impute_pd_na():
 
     # Impute pandas array of string types without any missing values.
     df = pd.DataFrame({"feature": pd.Series(["abc", "de", "fgh"], dtype="string")})
+    if with_pyarrow:
+        df.convert_dtypes(dtype_backend="pyarrow")
     imputer = SimpleImputer(fill_value="ok", strategy="constant")
     _assert_array_equal_and_same_dtype(
         imputer.fit_transform(df), np.array([["abc"], ["de"], ["fgh"]], dtype=object)
@@ -1565,6 +1588,8 @@ def test_simple_impute_pd_na():
 
     # Impute pandas array of integer types.
     df = pd.DataFrame({"feature": pd.Series([1, None, 3], dtype="Int64")})
+    if with_pyarrow:
+        df.convert_dtypes(dtype_backend="pyarrow")
     imputer = SimpleImputer(missing_values=pd.NA, strategy="constant", fill_value=-1)
     _assert_allclose_and_same_dtype(
         imputer.fit_transform(df), np.array([[1], [-1], [3]], dtype="float64")
@@ -1578,6 +1603,8 @@ def test_simple_impute_pd_na():
 
     # Impute pandas array of integer types with 'median' strategy.
     df = pd.DataFrame({"feature": pd.Series([1, None, 2, 3], dtype="Int64")})
+    if with_pyarrow:
+        df.convert_dtypes(dtype_backend="pyarrow")
     imputer = SimpleImputer(missing_values=pd.NA, strategy="median")
     _assert_allclose_and_same_dtype(
         imputer.fit_transform(df), np.array([[1], [2], [2], [3]], dtype="float64")
@@ -1585,6 +1612,8 @@ def test_simple_impute_pd_na():
 
     # Impute pandas array of integer types with 'mean' strategy.
     df = pd.DataFrame({"feature": pd.Series([1, None, 2], dtype="Int64")})
+    if with_pyarrow:
+        df.convert_dtypes(dtype_backend="pyarrow")
     imputer = SimpleImputer(missing_values=pd.NA, strategy="mean")
     _assert_allclose_and_same_dtype(
         imputer.fit_transform(df), np.array([[1], [1.5], [2]], dtype="float64")
@@ -1592,6 +1621,8 @@ def test_simple_impute_pd_na():
 
     # Impute pandas array of float types.
     df = pd.DataFrame({"feature": pd.Series([1.0, None, 3.0], dtype="float64")})
+    if with_pyarrow:
+        df.convert_dtypes(dtype_backend="pyarrow")
     imputer = SimpleImputer(missing_values=pd.NA, strategy="constant", fill_value=-2.0)
     _assert_allclose_and_same_dtype(
         imputer.fit_transform(df), np.array([[1.0], [-2.0], [3.0]], dtype="float64")
@@ -1599,6 +1630,8 @@ def test_simple_impute_pd_na():
 
     # Impute pandas array of float types with 'median' strategy.
     df = pd.DataFrame({"feature": pd.Series([1.0, None, 2.0, 3.0], dtype="float64")})
+    if with_pyarrow:
+        df.convert_dtypes(dtype_backend="pyarrow")
     imputer = SimpleImputer(missing_values=pd.NA, strategy="median")
     _assert_allclose_and_same_dtype(
         imputer.fit_transform(df),
@@ -1606,9 +1639,12 @@ def test_simple_impute_pd_na():
     )
 
 
-def test_missing_indicator_feature_names_out():
+@pytest.mark.parametrize("with_pyarrow", [True, False])
+def test_missing_indicator_feature_names_out(with_pyarrow):
     """Check that missing indicator return the feature names with a prefix."""
     pd = pytest.importorskip("pandas")
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
 
     missing_values = np.nan
     X = pd.DataFrame(
@@ -1618,6 +1654,9 @@ def test_missing_indicator_feature_names_out():
         ],
         columns=["a", "b", "c", "d"],
     )
+
+    if with_pyarrow:
+        X.convert_dtypes(dtype_backend="pyarrow")
 
     indicator = MissingIndicator(missing_values=missing_values).fit(X)
     feature_names = indicator.get_feature_names_out()

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -104,11 +104,11 @@ def test_imputation_deletion_warning(strategy):
         imputer.transform(X)
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("strategy", ["mean", "median", "most_frequent"])
-def test_imputation_deletion_warning_feature_names(with_pyarrow, strategy):
+def test_imputation_deletion_warning_feature_names(use_pyarrow_dtypes, strategy):
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
     missing_values = np.nan
@@ -120,7 +120,7 @@ def test_imputation_deletion_warning_feature_names(with_pyarrow, strategy):
         ],
         columns=feature_names,
     )
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         X.convert_dtypes(dtype_backend="pyarrow")
 
     imputer = SimpleImputer(strategy=strategy).fit(X)
@@ -272,14 +272,14 @@ def test_imputation_mean_median_error_invalid_type(strategy, dtype):
         imputer.fit_transform(X)
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("strategy", ["mean", "median"])
 @pytest.mark.parametrize("type", ["list", "dataframe"])
-def test_imputation_mean_median_error_invalid_type_list_pandas(with_pyarrow, strategy, type):
+def test_imputation_mean_median_error_invalid_type_list_pandas(use_pyarrow_dtypes, strategy, type):
     X = [["a", "b", 3], [4, "e", 6], ["g", "h", 9]]
     if type == "dataframe":
         pd = pytest.importorskip("pandas")
-        if with_pyarrow:
+        if use_pyarrow_dtypes:
             pytest.importorskip("pyarrow")
 
         X = pd.DataFrame(X)
@@ -366,12 +366,12 @@ def test_imputation_most_frequent_objects(marker):
     assert_array_equal(X_trans, X_true)
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("dtype", [object, "category"])
-def test_imputation_most_frequent_pandas(with_pyarrow, dtype):
+def test_imputation_most_frequent_pandas(use_pyarrow_dtypes, dtype):
     # Test imputation using the most frequent strategy on pandas df
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
 
@@ -472,12 +472,12 @@ def test_imputation_constant_object(marker):
     assert_array_equal(X_trans, X_true)
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("dtype", [object, "category"])
-def test_imputation_constant_pandas(with_pyarrow, dtype):
+def test_imputation_constant_pandas(use_pyarrow_dtypes, dtype):
     # Test imputation using the constant strategy on pandas df
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
     f = io.StringIO("Cat1,Cat2,Cat3,Cat4\n,i,x,\na,,y,\na,j,,\nb,j,x,")
@@ -1562,15 +1562,15 @@ def test_knn_imputer_keep_empty_features(keep_empty_features):
             assert X_imputed.shape == (X.shape[0], X.shape[1] - 1)
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_simple_impute_pd_na(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_simple_impute_pd_na(use_pyarrow_dtypes):
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
        pytest.importorskip("pyarrow")
 
     # Impute pandas array of string types.
     df = pd.DataFrame({"feature": pd.Series(["abc", None, "de"], dtype="string")})
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         df.convert_dtypes(dtype_backend="pyarrow")
     imputer = SimpleImputer(missing_values=pd.NA, strategy="constant", fill_value="na")
     _assert_array_equal_and_same_dtype(
@@ -1579,7 +1579,7 @@ def test_simple_impute_pd_na(with_pyarrow):
 
     # Impute pandas array of string types without any missing values.
     df = pd.DataFrame({"feature": pd.Series(["abc", "de", "fgh"], dtype="string")})
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         df.convert_dtypes(dtype_backend="pyarrow")
     imputer = SimpleImputer(fill_value="ok", strategy="constant")
     _assert_array_equal_and_same_dtype(
@@ -1588,7 +1588,7 @@ def test_simple_impute_pd_na(with_pyarrow):
 
     # Impute pandas array of integer types.
     df = pd.DataFrame({"feature": pd.Series([1, None, 3], dtype="Int64")})
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         df.convert_dtypes(dtype_backend="pyarrow")
     imputer = SimpleImputer(missing_values=pd.NA, strategy="constant", fill_value=-1)
     _assert_allclose_and_same_dtype(
@@ -1603,7 +1603,7 @@ def test_simple_impute_pd_na(with_pyarrow):
 
     # Impute pandas array of integer types with 'median' strategy.
     df = pd.DataFrame({"feature": pd.Series([1, None, 2, 3], dtype="Int64")})
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         df.convert_dtypes(dtype_backend="pyarrow")
     imputer = SimpleImputer(missing_values=pd.NA, strategy="median")
     _assert_allclose_and_same_dtype(
@@ -1612,7 +1612,7 @@ def test_simple_impute_pd_na(with_pyarrow):
 
     # Impute pandas array of integer types with 'mean' strategy.
     df = pd.DataFrame({"feature": pd.Series([1, None, 2], dtype="Int64")})
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         df.convert_dtypes(dtype_backend="pyarrow")
     imputer = SimpleImputer(missing_values=pd.NA, strategy="mean")
     _assert_allclose_and_same_dtype(
@@ -1621,7 +1621,7 @@ def test_simple_impute_pd_na(with_pyarrow):
 
     # Impute pandas array of float types.
     df = pd.DataFrame({"feature": pd.Series([1.0, None, 3.0], dtype="float64")})
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         df.convert_dtypes(dtype_backend="pyarrow")
     imputer = SimpleImputer(missing_values=pd.NA, strategy="constant", fill_value=-2.0)
     _assert_allclose_and_same_dtype(
@@ -1630,7 +1630,7 @@ def test_simple_impute_pd_na(with_pyarrow):
 
     # Impute pandas array of float types with 'median' strategy.
     df = pd.DataFrame({"feature": pd.Series([1.0, None, 2.0, 3.0], dtype="float64")})
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         df.convert_dtypes(dtype_backend="pyarrow")
     imputer = SimpleImputer(missing_values=pd.NA, strategy="median")
     _assert_allclose_and_same_dtype(
@@ -1639,11 +1639,11 @@ def test_simple_impute_pd_na(with_pyarrow):
     )
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_missing_indicator_feature_names_out(with_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_missing_indicator_feature_names_out(use_pyarrow_dtypes):
     """Check that missing indicator return the feature names with a prefix."""
     pd = pytest.importorskip("pandas")
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
     missing_values = np.nan
@@ -1655,7 +1655,7 @@ def test_missing_indicator_feature_names_out(with_pyarrow):
         columns=["a", "b", "c", "d"],
     )
 
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         X.convert_dtypes(dtype_backend="pyarrow")
 
     indicator = MissingIndicator(missing_values=missing_values).fit(X)

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -275,7 +275,9 @@ def test_imputation_mean_median_error_invalid_type(strategy, dtype):
 @pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.parametrize("strategy", ["mean", "median"])
 @pytest.mark.parametrize("type", ["list", "dataframe"])
-def test_imputation_mean_median_error_invalid_type_list_pandas(use_pyarrow_dtypes, strategy, type):
+def test_imputation_mean_median_error_invalid_type_list_pandas(
+    use_pyarrow_dtypes, strategy, type
+):
     X = [["a", "b", 3], [4, "e", 6], ["g", "h", 9]]
     if type == "dataframe":
         pd = pytest.importorskip("pandas")
@@ -373,7 +375,6 @@ def test_imputation_most_frequent_pandas(use_pyarrow_dtypes, dtype):
     pd = pytest.importorskip("pandas")
     if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
-
 
     f = io.StringIO("Cat1,Cat2,Cat3,Cat4\n,i,x,\na,,y,\na,j,,\nb,j,x,")
 
@@ -1566,7 +1567,7 @@ def test_knn_imputer_keep_empty_features(keep_empty_features):
 def test_simple_impute_pd_na(use_pyarrow_dtypes):
     pd = pytest.importorskip("pandas")
     if use_pyarrow_dtypes:
-       pytest.importorskip("pyarrow")
+        pytest.importorskip("pyarrow")
 
     # Impute pandas array of string types.
     df = pd.DataFrame({"feature": pd.Series(["abc", None, "de"], dtype="string")})

--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -279,17 +279,17 @@ def test_multioutput_regressor_error(pyplot):
         DecisionBoundaryDisplay.from_estimator(tree, X)
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 @pytest.mark.filterwarnings(
     # We expect to raise the following warning because the classifier is fit on a
     # NumPy array
     "ignore:X has feature names, but LogisticRegression was fitted without"
 )
-def test_dataframe_labels_used(with_pyarrow, pyplot, fitted_clf):
+def test_dataframe_labels_used(use_pyarrow_dtypes, pyplot, fitted_clf):
     """Check that column names are used for pandas."""
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame(X, columns=["col_x", "col_y"])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X.convert_dtypes(dtype_backend="pyarrow")
 
@@ -344,8 +344,8 @@ def test_string_target(pyplot):
     )
 
 
-@pytest.mark.parametrize("with_pyarrow", [True, False])
-def test_dataframe_support(with_pyarrow, pyplot):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_dataframe_support(use_pyarrow_dtypes, pyplot):
     """Check that passing a dataframe at fit and to the Display does not
     raise warnings.
 
@@ -354,7 +354,7 @@ def test_dataframe_support(with_pyarrow, pyplot):
     """
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame(X, columns=["col_x", "col_y"])
-    if with_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X.convert_dtypes(dtype_backend="pyarrow")
     estimator = LogisticRegression().fit(df, y)

--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -279,15 +279,19 @@ def test_multioutput_regressor_error(pyplot):
         DecisionBoundaryDisplay.from_estimator(tree, X)
 
 
+@pytest.mark.parametrize("with_pyarrow", [True, False])
 @pytest.mark.filterwarnings(
     # We expect to raise the following warning because the classifier is fit on a
     # NumPy array
     "ignore:X has feature names, but LogisticRegression was fitted without"
 )
-def test_dataframe_labels_used(pyplot, fitted_clf):
+def test_dataframe_labels_used(with_pyarrow, pyplot, fitted_clf):
     """Check that column names are used for pandas."""
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame(X, columns=["col_x", "col_y"])
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
+        X.convert_dtypes(dtype_backend="pyarrow")
 
     # pandas column names are used by default
     _, ax = pyplot.subplots()
@@ -340,7 +344,8 @@ def test_string_target(pyplot):
     )
 
 
-def test_dataframe_support(pyplot):
+@pytest.mark.parametrize("with_pyarrow", [True, False])
+def test_dataframe_support(with_pyarrow, pyplot):
     """Check that passing a dataframe at fit and to the Display does not
     raise warnings.
 
@@ -349,6 +354,9 @@ def test_dataframe_support(pyplot):
     """
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame(X, columns=["col_x", "col_y"])
+    if with_pyarrow:
+        pytest.importorskip("pyarrow")
+        X.convert_dtypes(dtype_backend="pyarrow")
     estimator = LogisticRegression().fit(df, y)
 
     with warnings.catch_warnings():

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -371,21 +371,17 @@ def test_inplace_data_preprocessing(sparse_X, use_sw, global_random_seed):
         assert_allclose(sample_weight, orginal_sw_data)
 
 
-def test_linear_regression_pd_sparse_dataframe_warning(use_pyarrow_dtypes):
+def test_linear_regression_pd_sparse_dataframe_warning():
     pd = pytest.importorskip("pandas")
 
     # Warning is raised only when some of the columns is sparse
-    if not use_pyarrow_dtypes:
-        df = pd.DataFrame({"0": np.random.randn(10)})
-    else:
-        df = pd.DataFrame({"0": np.random.randn(10)})
+    df = pd.DataFrame({"0": np.random.randn(10)})
     for col in range(1, 4):
         arr = np.random.randn(10)
         arr[:8] = 0
         # all columns but the first column is sparse
         if col != 0:
             arr = pd.arrays.SparseArray(arr, fill_value=0)
-            arr = arr.astype(arr.dtype + "[pyarrow]")
         df[str(col)] = arr
 
     msg = "pandas.DataFrame with sparse columns found."

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -371,11 +371,11 @@ def test_inplace_data_preprocessing(sparse_X, use_sw, global_random_seed):
         assert_allclose(sample_weight, orginal_sw_data)
 
 
-def test_linear_regression_pd_sparse_dataframe_warning(use_pyarrow):
+def test_linear_regression_pd_sparse_dataframe_warning(use_pyarrow_dtypes):
     pd = pytest.importorskip("pandas")
 
     # Warning is raised only when some of the columns is sparse
-    if not use_pyarrow:
+    if not use_pyarrow_dtypes:
         df = pd.DataFrame({"0": np.random.randn(10)})
     else:
         df = pd.DataFrame({"0": np.random.randn(10)})

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -371,17 +371,21 @@ def test_inplace_data_preprocessing(sparse_X, use_sw, global_random_seed):
         assert_allclose(sample_weight, orginal_sw_data)
 
 
-def test_linear_regression_pd_sparse_dataframe_warning():
+def test_linear_regression_pd_sparse_dataframe_warning(use_pyarrow):
     pd = pytest.importorskip("pandas")
 
     # Warning is raised only when some of the columns is sparse
-    df = pd.DataFrame({"0": np.random.randn(10)})
+    if not use_pyarrow:
+        df = pd.DataFrame({"0": np.random.randn(10)})
+    else:
+        df = pd.DataFrame({"0": np.random.randn(10)})
     for col in range(1, 4):
         arr = np.random.randn(10)
         arr[:8] = 0
         # all columns but the first column is sparse
         if col != 0:
             arr = pd.arrays.SparseArray(arr, fill_value=0)
+            arr = arr.astype(arr.dtype + "[pyarrow]")
         df[str(col)] = arr
 
     msg = "pandas.DataFrame with sparse columns found."

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1163,12 +1163,16 @@ def test_confusion_matrix_dtype():
 
 
 @pytest.mark.parametrize("dtype", ["Int64", "Float64", "boolean"])
-def test_confusion_matrix_pandas_nullable(dtype):
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_confusion_matrix_pandas_nullable(dtype, use_pyarrow):
     """Checks that confusion_matrix works with pandas nullable dtypes.
 
     Non-regression test for gh-25635.
     """
     pd = pytest.importorskip("pandas")
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        dtype = dtype + "[pyarrow]"
 
     y_ndarray = np.array([1, 0, 0, 1, 0, 1, 1, 0, 1])
     y_true = pd.Series(y_ndarray, dtype=dtype)

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1163,14 +1163,14 @@ def test_confusion_matrix_dtype():
 
 
 @pytest.mark.parametrize("dtype", ["Int64", "Float64", "boolean"])
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_confusion_matrix_pandas_nullable(dtype, use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_confusion_matrix_pandas_nullable(dtype, use_pyarrow_dtypes):
     """Checks that confusion_matrix works with pandas nullable dtypes.
 
     Non-regression test for gh-25635.
     """
     pd = pytest.importorskip("pandas")
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         dtype = dtype + "[pyarrow]"
 

--- a/sklearn/model_selection/tests/test_successive_halving.py
+++ b/sklearn/model_selection/tests/test_successive_halving.py
@@ -548,7 +548,7 @@ def test_top_k(k, itr, expected):
 
 
 @pytest.mark.parametrize("Est", (HalvingRandomSearchCV, HalvingGridSearchCV))
-def test_cv_results(Est):
+def test_cv_results(Est, use_pyarrow):
     # test that the cv_results_ matches correctly the logic of the
     # tournament: in particular that the candidates continued in each
     # successive iteration are those that were best in the previous iteration

--- a/sklearn/model_selection/tests/test_successive_halving.py
+++ b/sklearn/model_selection/tests/test_successive_halving.py
@@ -548,7 +548,7 @@ def test_top_k(k, itr, expected):
 
 
 @pytest.mark.parametrize("Est", (HalvingRandomSearchCV, HalvingGridSearchCV))
-def test_cv_results(Est, use_pyarrow_dtypes):
+def test_cv_results(Est):
     # test that the cv_results_ matches correctly the logic of the
     # tournament: in particular that the candidates continued in each
     # successive iteration are those that were best in the previous iteration

--- a/sklearn/model_selection/tests/test_successive_halving.py
+++ b/sklearn/model_selection/tests/test_successive_halving.py
@@ -548,7 +548,7 @@ def test_top_k(k, itr, expected):
 
 
 @pytest.mark.parametrize("Est", (HalvingRandomSearchCV, HalvingGridSearchCV))
-def test_cv_results(Est, use_pyarrow):
+def test_cv_results(Est, use_pyarrow_dtypes):
     # test that the cv_results_ matches correctly the logic of the
     # tournament: in particular that the candidates continued in each
     # successive iteration are those that were best in the previous iteration

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -895,7 +895,8 @@ def test_mlp_loading_from_joblib_partial_fit(tmp_path):
 
 
 @pytest.mark.parametrize("Estimator", [MLPClassifier, MLPRegressor])
-def test_preserve_feature_names(Estimator):
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_preserve_feature_names(Estimator, use_pyarrow):
     """Check that feature names are preserved when early stopping is enabled.
 
     Feature names are required for consistency checks during scoring.
@@ -907,6 +908,11 @@ def test_preserve_feature_names(Estimator):
 
     X = pd.DataFrame(data=rng.randn(10, 2), columns=["colname_a", "colname_b"])
     y = pd.Series(data=np.full(10, 1), name="colname_y")
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        X = X.convert_dtypes(dtype_backend="pyarrow")
+        y = y.convert_dtypes(dtype_backend="pyarrow")
 
     model = Estimator(early_stopping=True, validation_fraction=0.2)
 

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -895,8 +895,8 @@ def test_mlp_loading_from_joblib_partial_fit(tmp_path):
 
 
 @pytest.mark.parametrize("Estimator", [MLPClassifier, MLPRegressor])
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_preserve_feature_names(Estimator, use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_preserve_feature_names(Estimator, use_pyarrow_dtypes):
     """Check that feature names are preserved when early stopping is enabled.
 
     Feature names are required for consistency checks during scoring.
@@ -909,7 +909,7 @@ def test_preserve_feature_names(Estimator, use_pyarrow):
     X = pd.DataFrame(data=rng.randn(10, 2), columns=["colname_a", "colname_b"])
     y = pd.Series(data=np.full(10, 1), name="colname_y")
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X = X.convert_dtypes(dtype_backend="pyarrow")
         y = y.convert_dtypes(dtype_backend="pyarrow")

--- a/sklearn/preprocessing/tests/test_common.py
+++ b/sklearn/preprocessing/tests/test_common.py
@@ -161,7 +161,8 @@ def test_missing_value_handling(
         (RobustScaler(with_centering=False), robust_scale),
     ],
 )
-def test_missing_value_pandas_na_support(est, func):
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_missing_value_pandas_na_support(est, func, use_pyarrow):
     # Test pandas IntegerArray with pd.NA
     pd = pytest.importorskip("pandas")
 
@@ -176,6 +177,10 @@ def test_missing_value_pandas_na_support(est, func):
     # Creates dataframe with IntegerArrays with pd.NA
     X_df = pd.DataFrame(X, dtype="Int16", columns=["a", "b", "c"])
     X_df["c"] = X_df["c"].astype("int")
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        X_df = X_df.convert_dtypes(dtype_backend="pyarrow")
 
     X_trans = est.fit_transform(X)
     X_df_trans = est.fit_transform(X_df)

--- a/sklearn/preprocessing/tests/test_common.py
+++ b/sklearn/preprocessing/tests/test_common.py
@@ -161,8 +161,8 @@ def test_missing_value_handling(
         (RobustScaler(with_centering=False), robust_scale),
     ],
 )
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_missing_value_pandas_na_support(est, func, use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_missing_value_pandas_na_support(est, func, use_pyarrow_dtypes):
     # Test pandas IntegerArray with pd.NA
     pd = pytest.importorskip("pandas")
 
@@ -178,7 +178,7 @@ def test_missing_value_pandas_na_support(est, func, use_pyarrow):
     X_df = pd.DataFrame(X, dtype="Int16", columns=["a", "b", "c"])
     X_df["c"] = X_df["c"].astype("int")
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X_df = X_df.convert_dtypes(dtype_backend="pyarrow")
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2639,13 +2639,13 @@ def test_one_to_one_features(Transformer):
         Binarizer,
     ],
 )
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_one_to_one_features_pandas(Transformer, use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_one_to_one_features_pandas(Transformer, use_pyarrow_dtypes):
     """Check one-to-one transformers give correct feature names."""
     pd = pytest.importorskip("pandas")
 
     df = pd.DataFrame(iris.data, columns=iris.feature_names)
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df = df.convert_dtypes(dtype_backend="pyarrow")
     tr = Transformer().fit(df)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2639,11 +2639,15 @@ def test_one_to_one_features(Transformer):
         Binarizer,
     ],
 )
-def test_one_to_one_features_pandas(Transformer):
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_one_to_one_features_pandas(Transformer, use_pyarrow):
     """Check one-to-one transformers give correct feature names."""
     pd = pytest.importorskip("pandas")
 
     df = pd.DataFrame(iris.data, columns=iris.feature_names)
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        df = df.convert_dtypes(dtype_backend="pyarrow")
     tr = Transformer().fit(df)
 
     names_out_df_default = tr.get_feature_names_out()

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -108,12 +108,12 @@ def test_one_hot_encoder_dtype(input_dtype, output_dtype):
 
 
 @pytest.mark.parametrize("output_dtype", [np.int32, np.float32, np.float64])
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_one_hot_encoder_dtype_pandas(output_dtype, use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_one_hot_encoder_dtype_pandas(output_dtype, use_pyarrow_dtypes):
     pd = pytest.importorskip("pandas")
 
     X_df = pd.DataFrame({"A": ["a", "b"], "B": [1, 2]})
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X_df = X_df.convert_dtypes(dtype_backend="pyarrow")
     X_expected = np.array([[1, 0, 1, 0], [0, 1, 0, 1]], dtype=output_dtype)
@@ -397,11 +397,11 @@ def test_X_is_not_1D(X, method):
 
 
 @pytest.mark.parametrize("method", ["fit", "fit_transform"])
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_X_is_not_1D_pandas(method, use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_X_is_not_1D_pandas(method, use_pyarrow_dtypes):
     pd = pytest.importorskip("pandas")
     X = pd.Series([6, 3, 4, 6])
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X = X.convert_dtypes(dtype_backend="pyarrow")
     oh = OneHotEncoder()
@@ -575,12 +575,12 @@ def test_one_hot_encoder_specified_categories_mixed_columns():
     assert np.issubdtype(enc.categories_[1].dtype, np.object_)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_one_hot_encoder_pandas(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_one_hot_encoder_pandas(use_pyarrow_dtypes):
     pd = pytest.importorskip("pandas")
 
     X_df = pd.DataFrame({"A": ["a", "b"], "B": [1, 2]})
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X_df = X_df.convert_dtypes(dtype_backend="pyarrow")
 
@@ -793,8 +793,8 @@ def test_encoder_dtypes():
     assert_array_equal(enc.transform(X).toarray(), exp)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_encoder_dtypes_pandas(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_encoder_dtypes_pandas(use_pyarrow_dtypes):
     # check dtype (similar to test_categorical_encoder_dtypes for dataframes)
     pd = pytest.importorskip("pandas")
 
@@ -805,7 +805,7 @@ def test_encoder_dtypes_pandas(use_pyarrow):
     )
 
     X = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]}, dtype="int64")
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X = X.convert_dtypes(dtype_backend="pyarrow")
     enc.fit(X)
@@ -813,7 +813,7 @@ def test_encoder_dtypes_pandas(use_pyarrow):
     assert_array_equal(enc.transform(X).toarray(), exp)
 
     X = pd.DataFrame({"A": [1, 2], "B": ["a", "b"], "C": [3.0, 4.0]})
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         X = X.convert_dtypes(dtype_backend="pyarrow")
     X_type = [X["A"].dtype, X["B"].dtype, X["C"].dtype]
     enc.fit(X)
@@ -1283,8 +1283,8 @@ def test_ohe_infrequent_multiple_categories():
     assert_array_equal(expected_inv, X_inv)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_ohe_infrequent_multiple_categories_dtypes(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_ohe_infrequent_multiple_categories_dtypes(use_pyarrow_dtypes):
     """Test infrequent categories with a pandas dataframe with multiple dtypes."""
 
     pd = pytest.importorskip("pandas")
@@ -1295,7 +1295,7 @@ def test_ohe_infrequent_multiple_categories_dtypes(use_pyarrow):
         },
         columns=["str", "int"],
     )
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X = X.convert_dtypes(dtype_backend="pyarrow")
 
@@ -1327,7 +1327,7 @@ def test_ohe_infrequent_multiple_categories_dtypes(use_pyarrow):
     assert_allclose(expected, X_trans)
 
     X_test = pd.DataFrame({"str": ["b", "f"], "int": [14, 12]}, columns=["str", "int"])
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         X_test = X_test.convert_dtypes(dtype_backend="pyarrow")
 
     expected = [[0, 0, 1, 0, 0, 1], [0, 1, 0, 0, 0, 1]]
@@ -1343,7 +1343,7 @@ def test_ohe_infrequent_multiple_categories_dtypes(use_pyarrow):
 
     # only infrequent or known categories
     X_test = pd.DataFrame({"str": ["c", "b"], "int": [12, 5]}, columns=["str", "int"])
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         X_test = X_test.convert_dtypes(dtype_backend="pyarrow")
     X_test_trans = ohe.transform(X_test).toarray()
     expected = [[1, 0, 0, 0, 0, 1], [0, 0, 1, 1, 0, 0]]
@@ -1457,8 +1457,8 @@ def test_ohe_missing_values_get_feature_names(missing_value):
     assert_array_equal(names, ["x0_a", "x0_b", f"x0_{missing_value}"])
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_ohe_missing_value_support_pandas(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_ohe_missing_value_support_pandas(use_pyarrow_dtypes):
     # check support for pandas with mixed dtypes and missing values
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame(
@@ -1468,7 +1468,7 @@ def test_ohe_missing_value_support_pandas(use_pyarrow):
         },
         columns=["col1", "col2"],
     )
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df = df.convert_dtypes(dtype_backend="pyarrow")
     expected_df_trans = np.array(
@@ -1486,9 +1486,9 @@ def test_ohe_missing_value_support_pandas(use_pyarrow):
 
 @pytest.mark.parametrize("handle_unknown", ["infrequent_if_exist", "ignore"])
 @pytest.mark.parametrize("pd_nan_type", ["pd.NA", "np.nan"])
-@pytest.mark.parametrize("use_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 def test_ohe_missing_value_support_pandas_categorical(
-    pd_nan_type, handle_unknown, use_pyarrow
+    pd_nan_type, handle_unknown, use_pyarrow_dtypes
 ):
     # checks pandas dataframe with categorical features
     pd = pytest.importorskip("pandas")
@@ -1500,7 +1500,7 @@ def test_ohe_missing_value_support_pandas_categorical(
             "col1": pd.Series(["c", "a", pd_missing_value, "b", "a"], dtype="category"),
         }
     )
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df = df.convert_dtypes(dtype_backend="pyarrow")
     expected_df_trans = np.array(
@@ -1658,9 +1658,9 @@ def test_ordinal_encoder_passthrough_missing_values_float(encoded_missing_value)
 
 @pytest.mark.parametrize("pd_nan_type", ["pd.NA", "np.nan"])
 @pytest.mark.parametrize("encoded_missing_value", [np.nan, -2])
-@pytest.mark.parametrize("use_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 def test_ordinal_encoder_missing_value_support_pandas_categorical(
-    pd_nan_type, encoded_missing_value, use_pyarrow
+    pd_nan_type, encoded_missing_value, use_pyarrow_dtypes
 ):
     """Check ordinal encoder is compatible with pandas."""
     # checks pandas dataframe with categorical features
@@ -1673,7 +1673,7 @@ def test_ordinal_encoder_missing_value_support_pandas_categorical(
             "col1": pd.Series(["c", "a", pd_missing_value, "b", "a"], dtype="category"),
         }
     )
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df = df.convert_dtypes(dtype_backend="pyarrow")
 
@@ -1868,14 +1868,14 @@ def test_ordinal_encoder_python_integer():
     assert_array_equal(X_trans, [[0], [3], [2], [1]])
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_ordinal_encoder_features_names_out_pandas(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_ordinal_encoder_features_names_out_pandas(use_pyarrow_dtypes):
     """Check feature names out is same as the input."""
     pd = pytest.importorskip("pandas")
 
     names = ["b", "c", "a"]
     X = pd.DataFrame([[1, 2, 3]], columns=names)
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X = X.convert_dtypes(dtype_backend="pyarrow")
     enc = OrdinalEncoder().fit(X)
@@ -1915,8 +1915,8 @@ def test_ordinal_encoder_unknown_missing_interaction():
 
 
 @pytest.mark.parametrize("with_pandas", [True, False])
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_ordinal_encoder_encoded_missing_value_error(with_pandas, use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_ordinal_encoder_encoded_missing_value_error(with_pandas, use_pyarrow_dtypes):
     """Check OrdinalEncoder errors when encoded_missing_value is used by
     an known category."""
     X = np.array([["a", "dog"], ["b", "cat"], ["c", np.nan]], dtype=object)
@@ -1932,7 +1932,7 @@ def test_ordinal_encoder_encoded_missing_value_error(with_pandas, use_pyarrow):
         pd = pytest.importorskip("pandas")
         X = pd.DataFrame(X, columns=["letter", "pet"])
         error_msg = error_msg + r"\['pet'\]"
-        if use_pyarrow:
+        if use_pyarrow_dtypes:
             pytest.importorskip("pyarrow")
             X = X.convert_dtypes(dtype_backend="pyarrow")
     else:
@@ -1996,13 +1996,13 @@ def test_ordinal_encoder_unknown_missing_interaction_both_nan(
             assert val == expected_val
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_one_hot_encoder_set_output(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_one_hot_encoder_set_output(use_pyarrow_dtypes):
     """Check OneHotEncoder works with set_output."""
     pd = pytest.importorskip("pandas")
 
     X_df = pd.DataFrame({"A": ["a", "b"], "B": [1, 2]})
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X_df = X_df.convert_dtypes(dtype_backend="pyarrow")
     ohe = OneHotEncoder()
@@ -2023,14 +2023,14 @@ def test_one_hot_encoder_set_output(use_pyarrow):
     assert_array_equal(ohe_pandas.get_feature_names_out(), X_pandas.columns)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_ordinal_set_output(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_ordinal_set_output(use_pyarrow_dtypes):
     """Check OrdinalEncoder works with set_output."""
     pd = pytest.importorskip("pandas")
 
     X_df = pd.DataFrame({"A": ["a", "b"], "B": [1, 2]})
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X_df = X_df.convert_dtypes(dtype_backend="pyarrow")
 
@@ -2205,8 +2205,8 @@ def test_ordinal_encoder_infrequent_mixed():
     assert_array_equal(X_inverse, expected_inverse)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_ordinal_encoder_infrequent_multiple_categories_dtypes(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_ordinal_encoder_infrequent_multiple_categories_dtypes(use_pyarrow_dtypes):
     """Test infrequent categories with a pandas DataFrame with multiple dtypes."""
 
     pd = pytest.importorskip("pandas")
@@ -2222,7 +2222,7 @@ def test_ordinal_encoder_infrequent_multiple_categories_dtypes(use_pyarrow):
         },
         columns=["str", "int", "categorical"],
     )
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X = X.convert_dtypes(dtype_backend="pyarrow")
 
@@ -2251,7 +2251,7 @@ def test_ordinal_encoder_infrequent_multiple_categories_dtypes(use_pyarrow):
         },
         columns=["str", "int", "categorical"],
     )
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         X_test = X_test.convert_dtypes(dtype_backend="pyarrow")
     expected_trans = [[2, 2, 0], [2, 2, 2], [1, 1, 2], [0, 0, 1]]
 

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -793,8 +793,7 @@ def test_encoder_dtypes():
     assert_array_equal(enc.transform(X).toarray(), exp)
 
 
-@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
-def test_encoder_dtypes_pandas(use_pyarrow_dtypes):
+def test_encoder_dtypes_pandas():
     # check dtype (similar to test_categorical_encoder_dtypes for dataframes)
     pd = pytest.importorskip("pandas")
 
@@ -805,16 +804,11 @@ def test_encoder_dtypes_pandas(use_pyarrow_dtypes):
     )
 
     X = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]}, dtype="int64")
-    if use_pyarrow_dtypes:
-        pytest.importorskip("pyarrow")
-        X = X.convert_dtypes(dtype_backend="pyarrow")
     enc.fit(X)
     assert all([enc.categories_[i].dtype == "int64" for i in range(2)])
     assert_array_equal(enc.transform(X).toarray(), exp)
 
     X = pd.DataFrame({"A": [1, 2], "B": ["a", "b"], "C": [3.0, 4.0]})
-    if use_pyarrow_dtypes:
-        X = X.convert_dtypes(dtype_backend="pyarrow")
     X_type = [X["A"].dtype, X["B"].dtype, X["C"].dtype]
     enc.fit(X)
     assert all([enc.categories_[i].dtype == X_type[i] for i in range(3)])

--- a/sklearn/preprocessing/tests/test_function_transformer.py
+++ b/sklearn/preprocessing/tests/test_function_transformer.py
@@ -177,11 +177,11 @@ def test_check_inverse():
         trans.fit(X_dense)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_function_transformer_frame(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_function_transformer_frame(use_pyarrow_dtypes):
     pd = pytest.importorskip("pandas")
     X_df = pd.DataFrame(np.random.randn(100, 10))
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X_df = X_df.convert_dtypes(dtype_backend="pyarrow")
     transformer = FunctionTransformer()
@@ -221,15 +221,15 @@ def test_function_transformer_raise_error_with_mixed_dtype(X_type):
         transformer.fit(data)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 def test_function_transformer_support_all_nummerical_dataframes_check_inverse_True(
-    use_pyarrow,
+    use_pyarrow_dtypes,
 ):
     """Check support for dataframes with only numerical values."""
     pd = pytest.importorskip("pandas")
 
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df = df.convert_dtypes(dtype_backend="pyarrow")
     transformer = FunctionTransformer(
@@ -241,8 +241,8 @@ def test_function_transformer_support_all_nummerical_dataframes_check_inverse_Tr
     assert_allclose_dense_sparse(df_out, df + 2)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_function_transformer_with_dataframe_and_check_inverse_True(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_function_transformer_with_dataframe_and_check_inverse_True(use_pyarrow_dtypes):
     """Check error is raised when check_inverse=True.
 
     Non-regresion test for gh-25261.
@@ -253,7 +253,7 @@ def test_function_transformer_with_dataframe_and_check_inverse_True(use_pyarrow)
     )
 
     df_mixed = pd.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df_mixed = df_mixed.convert_dtypes(dtype_backend="pyarrow")
     msg = "'check_inverse' is only supported when all the elements in `X` is numerical."
@@ -337,14 +337,14 @@ def test_function_transformer_with_dataframe_and_check_inverse_True(use_pyarrow)
     ],
 )
 @pytest.mark.parametrize("validate", [True, False])
-@pytest.mark.parametrize("use_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 def test_function_transformer_get_feature_names_out(
-    X, feature_names_out, input_features, expected, validate, use_pyarrow
+    X, feature_names_out, input_features, expected, validate, use_pyarrow_dtypes
 ):
     if isinstance(X, dict):
         pd = pytest.importorskip("pandas")
         X = pd.DataFrame(X)
-        if use_pyarrow:
+        if use_pyarrow_dtypes:
             pytest.importorskip("pyarrow")
             X = X.convert_dtypes(dtype_backend="pyarrow")
 
@@ -379,8 +379,8 @@ def test_function_transformer_feature_names_out_is_None():
         transformer.get_feature_names_out()
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_function_transformer_feature_names_out_uses_estimator(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_function_transformer_feature_names_out_uses_estimator(use_pyarrow_dtypes):
     def add_n_random_features(X, n):
         return np.concatenate([X, np.random.rand(len(X), n)], axis=1)
 
@@ -396,7 +396,7 @@ def test_function_transformer_feature_names_out_uses_estimator(use_pyarrow):
     )
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame({"a": np.random.rand(100), "b": np.random.rand(100)})
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df = df.convert_dtypes(dtype_backend="pyarrow")
     transformer.fit_transform(df)
@@ -439,14 +439,14 @@ def test_function_transformer_validate_inverse():
     ],
 )
 @pytest.mark.parametrize("in_pipeline", [True, False])
-@pytest.mark.parametrize("use_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 def test_get_feature_names_out_dataframe_with_string_data(
-    feature_names_out, expected, in_pipeline, use_pyarrow
+    feature_names_out, expected, in_pipeline, use_pyarrow_dtypes
 ):
     """Check that get_feature_names_out works with DataFrames with string data."""
     pd = pytest.importorskip("pandas")
     X = pd.DataFrame({"pet": ["dog", "cat"], "color": ["red", "green"]})
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X = X.convert_dtypes(dtype_backend="pyarrow")
 
@@ -463,13 +463,13 @@ def test_get_feature_names_out_dataframe_with_string_data(
     assert_array_equal(names, expected)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_set_output_func(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_set_output_func(use_pyarrow_dtypes):
     """Check behavior of set_output with different settings."""
     pd = pytest.importorskip("pandas")
 
     X = pd.DataFrame({"a": [1, 2, 3], "b": [10, 20, 100]})
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X = X.convert_dtypes(dtype_backend="pyarrow")
 

--- a/sklearn/preprocessing/tests/test_function_transformer.py
+++ b/sklearn/preprocessing/tests/test_function_transformer.py
@@ -177,9 +177,13 @@ def test_check_inverse():
         trans.fit(X_dense)
 
 
-def test_function_transformer_frame():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_function_transformer_frame(use_pyarrow):
     pd = pytest.importorskip("pandas")
     X_df = pd.DataFrame(np.random.randn(100, 10))
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        X_df = X_df.convert_dtypes(dtype_backend="pyarrow")
     transformer = FunctionTransformer()
     X_df_trans = transformer.fit_transform(X_df)
     assert hasattr(X_df_trans, "loc")
@@ -217,11 +221,17 @@ def test_function_transformer_raise_error_with_mixed_dtype(X_type):
         transformer.fit(data)
 
 
-def test_function_transformer_support_all_nummerical_dataframes_check_inverse_True():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_function_transformer_support_all_nummerical_dataframes_check_inverse_True(
+    use_pyarrow,
+):
     """Check support for dataframes with only numerical values."""
     pd = pytest.importorskip("pandas")
 
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        df = df.convert_dtypes(dtype_backend="pyarrow")
     transformer = FunctionTransformer(
         func=lambda x: x + 2, inverse_func=lambda x: x - 2, check_inverse=True
     )
@@ -231,7 +241,8 @@ def test_function_transformer_support_all_nummerical_dataframes_check_inverse_Tr
     assert_allclose_dense_sparse(df_out, df + 2)
 
 
-def test_function_transformer_with_dataframe_and_check_inverse_True():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_function_transformer_with_dataframe_and_check_inverse_True(use_pyarrow):
     """Check error is raised when check_inverse=True.
 
     Non-regresion test for gh-25261.
@@ -242,6 +253,9 @@ def test_function_transformer_with_dataframe_and_check_inverse_True():
     )
 
     df_mixed = pd.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        df_mixed = df_mixed.convert_dtypes(dtype_backend="pyarrow")
     msg = "'check_inverse' is only supported when all the elements in `X` is numerical."
     with pytest.raises(ValueError, match=msg):
         transformer.fit(df_mixed)
@@ -323,12 +337,16 @@ def test_function_transformer_with_dataframe_and_check_inverse_True():
     ],
 )
 @pytest.mark.parametrize("validate", [True, False])
+@pytest.mark.parametrize("use_pyarrow", [True, False])
 def test_function_transformer_get_feature_names_out(
-    X, feature_names_out, input_features, expected, validate
+    X, feature_names_out, input_features, expected, validate, use_pyarrow
 ):
     if isinstance(X, dict):
         pd = pytest.importorskip("pandas")
         X = pd.DataFrame(X)
+        if use_pyarrow:
+            pytest.importorskip("pyarrow")
+            X = X.convert_dtypes(dtype_backend="pyarrow")
 
     transformer = FunctionTransformer(
         feature_names_out=feature_names_out, validate=validate
@@ -361,7 +379,8 @@ def test_function_transformer_feature_names_out_is_None():
         transformer.get_feature_names_out()
 
 
-def test_function_transformer_feature_names_out_uses_estimator():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_function_transformer_feature_names_out_uses_estimator(use_pyarrow):
     def add_n_random_features(X, n):
         return np.concatenate([X, np.random.rand(len(X), n)], axis=1)
 
@@ -377,6 +396,9 @@ def test_function_transformer_feature_names_out_uses_estimator():
     )
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame({"a": np.random.rand(100), "b": np.random.rand(100)})
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        df = df.convert_dtypes(dtype_backend="pyarrow")
     transformer.fit_transform(df)
     names = transformer.get_feature_names_out()
 
@@ -417,12 +439,16 @@ def test_function_transformer_validate_inverse():
     ],
 )
 @pytest.mark.parametrize("in_pipeline", [True, False])
+@pytest.mark.parametrize("use_pyarrow", [True, False])
 def test_get_feature_names_out_dataframe_with_string_data(
-    feature_names_out, expected, in_pipeline
+    feature_names_out, expected, in_pipeline, use_pyarrow
 ):
     """Check that get_feature_names_out works with DataFrames with string data."""
     pd = pytest.importorskip("pandas")
     X = pd.DataFrame({"pet": ["dog", "cat"], "color": ["red", "green"]})
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        X = X.convert_dtypes(dtype_backend="pyarrow")
 
     transformer = FunctionTransformer(feature_names_out=feature_names_out)
     if in_pipeline:
@@ -437,11 +463,15 @@ def test_get_feature_names_out_dataframe_with_string_data(
     assert_array_equal(names, expected)
 
 
-def test_set_output_func():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_set_output_func(use_pyarrow):
     """Check behavior of set_output with different settings."""
     pd = pytest.importorskip("pandas")
 
     X = pd.DataFrame({"a": [1, 2, 3], "b": [10, 20, 100]})
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        X = X.convert_dtypes(dtype_backend="pyarrow")
 
     ft = FunctionTransformer(np.log, feature_names_out="one-to-one")
 

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -119,7 +119,8 @@ def test_label_binarizer_set_label_encoding():
 
 @pytest.mark.parametrize("dtype", ["Int64", "Float64", "boolean"])
 @pytest.mark.parametrize("unique_first", [True, False])
-def test_label_binarizer_pandas_nullable(dtype, unique_first):
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_label_binarizer_pandas_nullable(dtype, unique_first, use_pyarrow):
     """Checks that LabelBinarizer works with pandas nullable dtypes.
 
     Non-regression test for gh-25637.
@@ -127,6 +128,9 @@ def test_label_binarizer_pandas_nullable(dtype, unique_first):
     pd = pytest.importorskip("pandas")
 
     y_true = pd.Series([1, 0, 0, 1, 0, 1, 1, 0, 1], dtype=dtype)
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        y_true = y_true.convert_dtypes(dtype_backend="pyarrow")
     if unique_first:
         # Calling unique creates a pandas array which has a different interface
         # compared to a pandas Series. Specifically, pandas arrays do not have "iloc".

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -119,8 +119,8 @@ def test_label_binarizer_set_label_encoding():
 
 @pytest.mark.parametrize("dtype", ["Int64", "Float64", "boolean"])
 @pytest.mark.parametrize("unique_first", [True, False])
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_label_binarizer_pandas_nullable(dtype, unique_first, use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_label_binarizer_pandas_nullable(dtype, unique_first, use_pyarrow_dtypes):
     """Checks that LabelBinarizer works with pandas nullable dtypes.
 
     Non-regression test for gh-25637.
@@ -128,7 +128,7 @@ def test_label_binarizer_pandas_nullable(dtype, unique_first, use_pyarrow):
     pd = pytest.importorskip("pandas")
 
     y_true = pd.Series([1, 0, 0, 1, 0, 1, 1, 0, 1], dtype=dtype)
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         y_true = y_true.convert_dtypes(dtype_backend="pyarrow")
     if unique_first:

--- a/sklearn/preprocessing/tests/test_target_encoder.py
+++ b/sklearn/preprocessing/tests/test_target_encoder.py
@@ -204,13 +204,13 @@ def test_use_regression_target():
     assert enc.target_type_ == "continuous"
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_feature_names_out_set_output(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_feature_names_out_set_output(use_pyarrow_dtypes):
     """Check TargetEncoder works with set_output."""
     pd = pytest.importorskip("pandas")
 
     X_df = pd.DataFrame({"A": ["a", "b"] * 10, "B": [1, 2] * 10})
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X_df = X_df.convert_dtypes(dtype_backend="pyarrow")
     y = [1, 2] * 10
@@ -231,8 +231,8 @@ def test_feature_names_out_set_output(use_pyarrow):
 @pytest.mark.parametrize("to_pandas", [True, False])
 @pytest.mark.parametrize("smooth", [1.0, "auto"])
 @pytest.mark.parametrize("target_type", ["binary-ints", "binary-str", "continuous"])
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_multiple_features_quick(to_pandas, smooth, target_type, use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_multiple_features_quick(to_pandas, smooth, target_type, use_pyarrow_dtypes):
     """Check target encoder with multiple features."""
     X_ordinal = np.array(
         [[1, 1], [0, 1], [1, 1], [2, 1], [1, 0], [0, 1], [1, 0], [0, 0]], dtype=np.int64
@@ -272,7 +272,7 @@ def test_multiple_features_quick(to_pandas, smooth, target_type, use_pyarrow):
         )
         # "snake" is unknown
         X_test = pd.DataFrame({"feat0": X_test[:, 0], "feat1": ["dog", "cat", "snake"]})
-        if use_pyarrow:
+        if use_pyarrow_dtypes:
             pytest.importorskip("pyarrow")
             X_train = X_train.convert_dtypes(dtype_backend="pyarrow")
             X_test = X_test.convert_dtypes(dtype_backend="pyarrow")

--- a/sklearn/preprocessing/tests/test_target_encoder.py
+++ b/sklearn/preprocessing/tests/test_target_encoder.py
@@ -204,11 +204,15 @@ def test_use_regression_target():
     assert enc.target_type_ == "continuous"
 
 
-def test_feature_names_out_set_output():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_feature_names_out_set_output(use_pyarrow):
     """Check TargetEncoder works with set_output."""
     pd = pytest.importorskip("pandas")
 
     X_df = pd.DataFrame({"A": ["a", "b"] * 10, "B": [1, 2] * 10})
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        X_df = X_df.convert_dtypes(dtype_backend="pyarrow")
     y = [1, 2] * 10
 
     enc_default = TargetEncoder(cv=2, smooth=3.0, random_state=0)
@@ -227,7 +231,8 @@ def test_feature_names_out_set_output():
 @pytest.mark.parametrize("to_pandas", [True, False])
 @pytest.mark.parametrize("smooth", [1.0, "auto"])
 @pytest.mark.parametrize("target_type", ["binary-ints", "binary-str", "continuous"])
-def test_multiple_features_quick(to_pandas, smooth, target_type):
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_multiple_features_quick(to_pandas, smooth, target_type, use_pyarrow):
     """Check target encoder with multiple features."""
     X_ordinal = np.array(
         [[1, 1], [0, 1], [1, 1], [2, 1], [1, 0], [0, 1], [1, 0], [0, 0]], dtype=np.int64
@@ -267,6 +272,10 @@ def test_multiple_features_quick(to_pandas, smooth, target_type):
         )
         # "snake" is unknown
         X_test = pd.DataFrame({"feat0": X_test[:, 0], "feat1": ["dog", "cat", "snake"]})
+        if use_pyarrow:
+            pytest.importorskip("pyarrow")
+            X_train = X_train.convert_dtypes(dtype_backend="pyarrow")
+            X_test = X_test.convert_dtypes(dtype_backend="pyarrow")
     else:
         X_train = X_ordinal
 

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -643,14 +643,14 @@ def test_n_features_in_no_validation():
     est._check_n_features("invalid X", reset=False)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_feature_names_in(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_feature_names_in(use_pyarrow_dtypes):
     """Check that feature_name_in are recorded by `_validate_data`"""
     pd = pytest.importorskip("pandas")
     iris = datasets.load_iris()
     X_np = iris.data
     df = pd.DataFrame(X_np, columns=iris.feature_names)
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df = df.convert_dtypes(dtype_backend="pyarrow")
 
@@ -674,7 +674,7 @@ def test_feature_names_in(use_pyarrow):
     trans.fit(df)
     msg = "The feature names should match those that were passed"
     df_bad = pd.DataFrame(X_np, columns=iris.feature_names[::-1])
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df_bad = df_bad.convert_dtypes(dtype_backend="pyarrow")
     with pytest.raises(ValueError, match=msg):
@@ -696,7 +696,7 @@ def test_feature_names_in(use_pyarrow):
 
     # fit on dataframe with all integer feature names works without warning
     df_int_names = pd.DataFrame(X_np)
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df_int_names = df_int_names.convert_dtypes(dtype_backend="pyarrow")
     trans = NoOpTransformer()
@@ -714,7 +714,7 @@ def test_feature_names_in(use_pyarrow):
 
     # fit on dataframe with feature names that are mixed raises an error:
     df_mixed = pd.DataFrame(X_np, columns=["a", "b", 1, 2])
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df_mixed = df_mixed.convert_dtypes(dtype_backend="pyarrow")
     trans = NoOpTransformer()
@@ -734,15 +734,15 @@ def test_feature_names_in(use_pyarrow):
         trans.transform(df_mixed)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_validate_data_cast_to_ndarray(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_validate_data_cast_to_ndarray(use_pyarrow_dtypes):
     """Check cast_to_ndarray option of _validate_data."""
 
     pd = pytest.importorskip("pandas")
     iris = datasets.load_iris()
     df = pd.DataFrame(iris.data, columns=iris.feature_names)
     y = pd.Series(iris.target)
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df = df.convert_dtypes(dtype_backend="pyarrow")
         y = y.convert_dtypes(dtype_backend="pyarrow")

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -1589,14 +1589,14 @@ def test_pipeline_get_feature_names_out_passes_names_through():
     assert_array_equal(feature_names_out, [f"my_prefix_{name}" for name in input_names])
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_pipeline_set_output_integration(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_pipeline_set_output_integration(use_pyarrow_dtypes):
     """Test pipeline's set_output with feature names."""
     pytest.importorskip("pandas")
 
     X, y = load_iris(as_frame=True, return_X_y=True)
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X = X.convert_dtypes(dtype_backend="pyarrow")
         y = y.convert_dtypes(dtype_backend="pyarrow")
@@ -1611,15 +1611,15 @@ def test_pipeline_set_output_integration(use_pyarrow):
     assert_array_equal(feature_names_in_, log_reg_feature_names)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_feature_union_set_output(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_feature_union_set_output(use_pyarrow_dtypes):
     """Test feature union with set_output API."""
     pd = pytest.importorskip("pandas")
 
     X, _ = load_iris(as_frame=True, return_X_y=True)
     X_train, X_test = train_test_split(X, random_state=0)
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X_train = X_train.convert_dtypes(dtype_backend="pyarrow")
         X_test = X_test.convert_dtypes(dtype_backend="pyarrow")
@@ -1663,8 +1663,8 @@ def test_feature_union_getitem_error(key):
         union[key]
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_feature_union_feature_names_in_(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_feature_union_feature_names_in_(use_pyarrow_dtypes):
     """Ensure feature union has `.feature_names_in_` attribute if `X` has a
     `columns` attribute.
 
@@ -1674,7 +1674,7 @@ def test_feature_union_feature_names_in_(use_pyarrow):
 
     X, _ = load_iris(as_frame=True, return_X_y=True)
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X = X.convert_dtypes(dtype_backend="pyarrow")
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -1589,11 +1589,17 @@ def test_pipeline_get_feature_names_out_passes_names_through():
     assert_array_equal(feature_names_out, [f"my_prefix_{name}" for name in input_names])
 
 
-def test_pipeline_set_output_integration():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_pipeline_set_output_integration(use_pyarrow):
     """Test pipeline's set_output with feature names."""
     pytest.importorskip("pandas")
 
     X, y = load_iris(as_frame=True, return_X_y=True)
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        X = X.convert_dtypes(dtype_backend="pyarrow")
+        y = y.convert_dtypes(dtype_backend="pyarrow")
 
     pipe = make_pipeline(StandardScaler(), LogisticRegression())
     pipe.set_output(transform="pandas")
@@ -1605,12 +1611,19 @@ def test_pipeline_set_output_integration():
     assert_array_equal(feature_names_in_, log_reg_feature_names)
 
 
-def test_feature_union_set_output():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_feature_union_set_output(use_pyarrow):
     """Test feature union with set_output API."""
     pd = pytest.importorskip("pandas")
 
     X, _ = load_iris(as_frame=True, return_X_y=True)
     X_train, X_test = train_test_split(X, random_state=0)
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        X_train = X_train.convert_dtypes(dtype_backend="pyarrow")
+        X_test = X_test.convert_dtypes(dtype_backend="pyarrow")
+
     union = FeatureUnion([("scalar", StandardScaler()), ("pca", PCA())])
     union.set_output(transform="pandas")
     union.fit(X_train)
@@ -1650,7 +1663,8 @@ def test_feature_union_getitem_error(key):
         union[key]
 
 
-def test_feature_union_feature_names_in_():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_feature_union_feature_names_in_(use_pyarrow):
     """Ensure feature union has `.feature_names_in_` attribute if `X` has a
     `columns` attribute.
 
@@ -1659,6 +1673,10 @@ def test_feature_union_feature_names_in_():
     pytest.importorskip("pandas")
 
     X, _ = load_iris(as_frame=True, return_X_y=True)
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        X = X.convert_dtypes(dtype_backend="pyarrow")
 
     # FeatureUnion should have the feature_names_in_ attribute if the
     # first transformer also has it

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -346,44 +346,44 @@ def test_type_of_target_pandas_sparse():
         type_of_target(y)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_type_of_target_pandas_nullable(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_type_of_target_pandas_nullable(use_pyarrow_dtypes):
     """Check that type_of_target works with pandas nullable dtypes."""
     pd = pytest.importorskip("pandas")
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
 
     for dtype in ["Int32", "Float32"]:
         y_true = pd.Series([1, 0, 2, 3, 4], dtype=dtype)
-        if use_pyarrow:
+        if use_pyarrow_dtypes:
             y_true = y_true.convert_dtypes(dtype_backend="pyarrow")
         assert type_of_target(y_true) == "multiclass"
 
         y_true = pd.Series([1, 0, 1, 0], dtype=dtype)
-        if use_pyarrow:
+        if use_pyarrow_dtypes:
             y_true = y_true.convert_dtypes(dtype_backend="pyarrow")
         assert type_of_target(y_true) == "binary"
 
     y_true = pd.DataFrame([[1.4, 3.1], [3.1, 1.4]], dtype="Float32")
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         y_true = y_true.convert_dtypes(dtype_backend="pyarrow")
     assert type_of_target(y_true) == "continuous-multioutput"
 
     y_true = pd.DataFrame([[0, 1], [1, 1]], dtype="Int32")
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         y_true = y_true.convert_dtypes(dtype_backend="pyarrow")
     assert type_of_target(y_true) == "multilabel-indicator"
 
     y_true = pd.DataFrame([[1, 2], [3, 1]], dtype="Int32")
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         y_true = y_true.convert_dtypes(dtype_backend="pyarrow")
     assert type_of_target(y_true) == "multiclass-multioutput"
 
 
 @pytest.mark.parametrize("dtype", ["Int64", "Float64", "boolean"])
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_unique_labels_pandas_nullable(dtype, use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_unique_labels_pandas_nullable(dtype, use_pyarrow_dtypes):
     """Checks that unique_labels work with pandas nullable dtypes and pyarrow.
 
     Non-regression test for gh-25634.
@@ -393,7 +393,7 @@ def test_unique_labels_pandas_nullable(dtype, use_pyarrow):
     y_true = pd.Series([1, 0, 0, 1, 0, 1, 1, 0, 1], dtype=dtype)
     y_predicted = pd.Series([0, 0, 1, 1, 0, 1, 1, 1, 1], dtype="int64")
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         y_true = y_true.convert_dtypes(dtype_backend="pyarrow")
         y_predicted = y_predicted.convert_dtypes(dtype_backend="pyarrow")

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -346,30 +346,45 @@ def test_type_of_target_pandas_sparse():
         type_of_target(y)
 
 
-def test_type_of_target_pandas_nullable():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_type_of_target_pandas_nullable(use_pyarrow):
     """Check that type_of_target works with pandas nullable dtypes."""
     pd = pytest.importorskip("pandas")
 
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+
     for dtype in ["Int32", "Float32"]:
         y_true = pd.Series([1, 0, 2, 3, 4], dtype=dtype)
+        if use_pyarrow:
+            y_true = y_true.convert_dtypes(dtype_backend="pyarrow")
         assert type_of_target(y_true) == "multiclass"
 
         y_true = pd.Series([1, 0, 1, 0], dtype=dtype)
+        if use_pyarrow:
+            y_true = y_true.convert_dtypes(dtype_backend="pyarrow")
         assert type_of_target(y_true) == "binary"
 
     y_true = pd.DataFrame([[1.4, 3.1], [3.1, 1.4]], dtype="Float32")
+    if use_pyarrow:
+        y_true = y_true.convert_dtypes(dtype_backend="pyarrow")
     assert type_of_target(y_true) == "continuous-multioutput"
 
     y_true = pd.DataFrame([[0, 1], [1, 1]], dtype="Int32")
+    if use_pyarrow:
+        y_true = y_true.convert_dtypes(dtype_backend="pyarrow")
     assert type_of_target(y_true) == "multilabel-indicator"
 
     y_true = pd.DataFrame([[1, 2], [3, 1]], dtype="Int32")
+    if use_pyarrow:
+        y_true = y_true.convert_dtypes(dtype_backend="pyarrow")
     assert type_of_target(y_true) == "multiclass-multioutput"
 
 
 @pytest.mark.parametrize("dtype", ["Int64", "Float64", "boolean"])
-def test_unique_labels_pandas_nullable(dtype):
-    """Checks that unique_labels work with pandas nullable dtypes.
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_unique_labels_pandas_nullable(dtype, use_pyarrow):
+    """Checks that unique_labels work with pandas nullable dtypes and pyarrow.
 
     Non-regression test for gh-25634.
     """
@@ -377,6 +392,11 @@ def test_unique_labels_pandas_nullable(dtype):
 
     y_true = pd.Series([1, 0, 0, 1, 0, 1, 1, 0, 1], dtype=dtype)
     y_predicted = pd.Series([0, 0, 1, 1, 0, 1, 1, 1, 1], dtype="int64")
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        y_true = y_true.convert_dtypes(dtype_backend="pyarrow")
+        y_predicted = y_predicted.convert_dtypes(dtype_backend="pyarrow")
 
     labels = unique_labels(y_true, y_predicted)
     assert_array_equal(labels, [0, 1])

--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -54,7 +54,8 @@ def test_parallel_delayed_warnings():
 
 
 @pytest.mark.parametrize("n_jobs", [1, 2])
-def test_dispatch_config_parallel(n_jobs):
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_dispatch_config_parallel(n_jobs, use_pyarrow):
     """Check that we properly dispatch the configuration in parallel processing.
 
     Non-regression test for:
@@ -62,6 +63,9 @@ def test_dispatch_config_parallel(n_jobs):
     """
     pd = pytest.importorskip("pandas")
     iris = load_iris(as_frame=True)
+
+    if use_pyarrow:
+        iris.data = iris.data.convert_dtypes(dtype_backend="pyarrow")
 
     class TransformerRequiredDataFrame(StandardScaler):
         def fit(self, X, y=None):

--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -54,8 +54,8 @@ def test_parallel_delayed_warnings():
 
 
 @pytest.mark.parametrize("n_jobs", [1, 2])
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_dispatch_config_parallel(n_jobs, use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_dispatch_config_parallel(n_jobs, use_pyarrow_dtypes):
     """Check that we properly dispatch the configuration in parallel processing.
 
     Non-regression test for:
@@ -64,7 +64,7 @@ def test_dispatch_config_parallel(n_jobs, use_pyarrow):
     pd = pytest.importorskip("pandas")
     iris = load_iris(as_frame=True)
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         iris.data = iris.data.convert_dtypes(dtype_backend="pyarrow")
 
     class TransformerRequiredDataFrame(StandardScaler):

--- a/sklearn/utils/tests/test_set_output.py
+++ b/sklearn/utils/tests/test_set_output.py
@@ -25,10 +25,17 @@ def test__wrap_in_pandas_container_dense():
     assert_array_equal(dense_named.index, index)
 
 
-def test__wrap_in_pandas_container_dense_update_columns_and_index():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test__wrap_in_pandas_container_dense_update_columns_and_index(use_pyarrow):
     """Check that _wrap_in_pandas_container overrides columns and index."""
     pd = pytest.importorskip("pandas")
+
     X_df = pd.DataFrame([[1, 0, 3], [0, 0, 1]], columns=["a", "b", "c"])
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        X_df = X_df.convert_dtypes(dtype_backend="pyarrow")
+
     new_columns = np.asarray(["f0", "f1", "f2"], dtype=object)
     new_index = [10, 12]
 
@@ -225,7 +232,8 @@ def test_set_output_mixin_custom_mixin():
     assert hasattr(est, "set_output")
 
 
-def test__wrap_in_pandas_container_column_errors():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test__wrap_in_pandas_container_column_errors(use_pyarrow):
     """If a callable `columns` errors, it has the same semantics as columns=None."""
     pd = pytest.importorskip("pandas")
 
@@ -233,6 +241,10 @@ def test__wrap_in_pandas_container_column_errors():
         raise ValueError("No feature names defined")
 
     X_df = pd.DataFrame({"feat1": [1, 2, 3], "feat2": [3, 4, 5]})
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        X_df = X_df.convert_dtypes(dtype_backend="pyarrow")
 
     X_wrapped = _wrap_in_pandas_container(X_df, columns=get_columns)
     assert_array_equal(X_wrapped.columns, X_df.columns)
@@ -280,7 +292,8 @@ class EstimatorWithSetOutputIndex(_SetOutputMixin):
         return np.asarray([f"X{i}" for i in range(self.n_features_in_)], dtype=object)
 
 
-def test_set_output_pandas_keep_index():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_set_output_pandas_keep_index(use_pyarrow):
     """Check that set_output does not override index.
 
     Non-regression test for gh-25730.
@@ -288,6 +301,11 @@ def test_set_output_pandas_keep_index():
     pd = pytest.importorskip("pandas")
 
     X = pd.DataFrame([[1, 2, 3], [4, 5, 6]], index=[0, 1])
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        X = X.convert_dtypes(dtype_backend="pyarrow")
+
     est = EstimatorWithSetOutputIndex().set_output(transform="pandas")
     est.fit(X)
 

--- a/sklearn/utils/tests/test_set_output.py
+++ b/sklearn/utils/tests/test_set_output.py
@@ -25,14 +25,14 @@ def test__wrap_in_pandas_container_dense():
     assert_array_equal(dense_named.index, index)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test__wrap_in_pandas_container_dense_update_columns_and_index(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test__wrap_in_pandas_container_dense_update_columns_and_index(use_pyarrow_dtypes):
     """Check that _wrap_in_pandas_container overrides columns and index."""
     pd = pytest.importorskip("pandas")
 
     X_df = pd.DataFrame([[1, 0, 3], [0, 0, 1]], columns=["a", "b", "c"])
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X_df = X_df.convert_dtypes(dtype_backend="pyarrow")
 
@@ -232,8 +232,8 @@ def test_set_output_mixin_custom_mixin():
     assert hasattr(est, "set_output")
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test__wrap_in_pandas_container_column_errors(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test__wrap_in_pandas_container_column_errors(use_pyarrow_dtypes):
     """If a callable `columns` errors, it has the same semantics as columns=None."""
     pd = pytest.importorskip("pandas")
 
@@ -242,7 +242,7 @@ def test__wrap_in_pandas_container_column_errors(use_pyarrow):
 
     X_df = pd.DataFrame({"feat1": [1, 2, 3], "feat2": [3, 4, 5]})
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X_df = X_df.convert_dtypes(dtype_backend="pyarrow")
 
@@ -292,8 +292,8 @@ class EstimatorWithSetOutputIndex(_SetOutputMixin):
         return np.asarray([f"X{i}" for i in range(self.n_features_in_)], dtype=object)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_set_output_pandas_keep_index(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_set_output_pandas_keep_index(use_pyarrow_dtypes):
     """Check that set_output does not override index.
 
     Non-regression test for gh-25730.
@@ -302,7 +302,7 @@ def test_set_output_pandas_keep_index(use_pyarrow):
 
     X = pd.DataFrame([[1, 2, 3], [4, 5, 6]], index=[0, 1])
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X = X.convert_dtypes(dtype_backend="pyarrow")
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -428,7 +428,8 @@ def test_check_array_numeric_error(X):
         ("numeric", np.float64),
     ],
 )
-def test_check_array_pandas_na_support(pd_dtype, dtype, expected_dtype):
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_check_array_pandas_na_support(use_pyarrow, pd_dtype, dtype, expected_dtype):
     # Test pandas numerical extension arrays with pd.NA
     pd = pytest.importorskip("pandas")
 
@@ -442,6 +443,11 @@ def test_check_array_pandas_na_support(pd_dtype, dtype, expected_dtype):
 
     # Creates dataframe with numerical extension arrays with pd.NA
     X = pd.DataFrame(X_np, dtype=pd_dtype, columns=["a", "b", "c"])
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        X = X.convert_dtypes(dtype_backend="pyarrow")
+
     # column c has no nans
     X["c"] = X["c"].astype("float")
     X_checked = check_array(X, force_all_finite="allow-nan", dtype=dtype)
@@ -457,11 +463,16 @@ def test_check_array_pandas_na_support(pd_dtype, dtype, expected_dtype):
         check_array(X, force_all_finite=True)
 
 
-def test_check_array_panadas_na_support_series():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_check_array_panadas_na_support_series(use_pyarrow):
     """Check check_array is correct with pd.NA in a series."""
     pd = pytest.importorskip("pandas")
 
     X_int64 = pd.Series([1, 2, pd.NA], dtype="Int64")
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        X_int64 = X_int64.convert_dtypes(dtype_backend="pyarrow")
 
     msg = "Input contains NaN"
     with pytest.raises(ValueError, match=msg):
@@ -478,11 +489,17 @@ def test_check_array_panadas_na_support_series():
     assert X_out.dtype == np.float32
 
 
-def test_check_array_pandas_dtype_casting():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_check_array_pandas_dtype_casting(use_pyarrow):
     # test that data-frames with homogeneous dtype are not upcast
     pd = pytest.importorskip("pandas")
     X = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.float32)
     X_df = pd.DataFrame(X)
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        X_df = X_df.convert_dtypes(dtype_backend="pyarrow")
+
     assert check_array(X_df).dtype == np.float32
     assert check_array(X_df, dtype=FLOAT_DTYPES).dtype == np.float32
 
@@ -511,6 +528,10 @@ def test_check_array_pandas_dtype_casting():
     # this is actually tricky because we can't really know that this
     # should be integer ahead of converting it.
     cat_df = pd.DataFrame({"cat_col": pd.Categorical([1, 2, 3])})
+
+    if use_pyarrow:
+        cat_df = cat_df.convert_dtypes(dtype_backend="pyarrow")
+
     assert check_array(cat_df).dtype == np.int64
     assert check_array(cat_df, dtype=FLOAT_DTYPES).dtype == np.float64
 
@@ -940,14 +961,25 @@ def test_suppress_validation():
         assert_all_finite(X)
 
 
-def test_check_array_series():
-    # regression test that check_array works on pandas Series
-    pd = importorskip("pandas")
-    res = check_array(pd.Series([1, 2, 3]), ensure_2d=False)
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_check_array_series(use_pyarrow):
+    """Regression test that check_array works on pandas Series."""
+    pd = pytest.importorskip("pandas")
+
+    X = pd.Series([1, 2, 3])
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        X = X.convert_dtypes(dtype_backend="pyarrow")
+
+    res = check_array(X, ensure_2d=False)
     assert_array_equal(res, np.array([1, 2, 3]))
 
     # with categorical dtype (not a numpy dtype) (GH12699)
     s = pd.Series(["a", "b", "c"]).astype("category")
+    if use_pyarrow:
+        s = s.convert_dtypes(dtype_backend="pyarrow")
+
     res = check_array(s, dtype=None, ensure_2d=False)
     assert_array_equal(res, np.array(["a", "b", "c"], dtype=object))
 
@@ -956,18 +988,20 @@ def test_check_array_series():
     "dtype", ((np.float64, np.float32), np.float64, None, "numeric")
 )
 @pytest.mark.parametrize("bool_dtype", ("bool", "boolean"))
-def test_check_dataframe_mixed_float_dtypes(dtype, bool_dtype):
-    # pandas dataframe will coerce a boolean into a object, this is a mismatch
-    # with np.result_type which will return a float
-    # check_array needs to explicitly check for bool dtype in a dataframe for
-    # this situation
-    # https://github.com/scikit-learn/scikit-learn/issues/15787
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_check_dataframe_mixed_float_dtypes(dtype, bool_dtype, use_pyarrow):
+    """Check array type conversion with mixed float dtypes in pandas DataFrame.
 
+    Pandas dataframe will coerce a boolean into an object, this is a mismatch
+    with np.result_type which will return a float. check_array needs to
+    explicitly check for bool dtype in a dataframe for this situation.
+    https://github.com/scikit-learn/scikit-learn/issues/15787
+    """
     if bool_dtype == "boolean":
-        # boolean extension arrays was introduced in 1.0
-        pd = importorskip("pandas", minversion="1.0")
+        # boolean extension arrays were introduced in pandas 1.0
+        pd = pytest.importorskip("pandas", minversion="1.0")
     else:
-        pd = importorskip("pandas")
+        pd = pytest.importorskip("pandas")
 
     df = pd.DataFrame(
         {
@@ -978,6 +1012,10 @@ def test_check_dataframe_mixed_float_dtypes(dtype, bool_dtype):
         columns=["int", "float", "bool"],
     )
 
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        df = df.convert_dtypes(dtype_backend="pyarrow")
+
     array = check_array(df, dtype=dtype)
     assert array.dtype == np.float64
     expected_array = np.array(
@@ -986,10 +1024,15 @@ def test_check_dataframe_mixed_float_dtypes(dtype, bool_dtype):
     assert_allclose_dense_sparse(array, expected_array)
 
 
-def test_check_dataframe_with_only_bool():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_check_dataframe_with_only_bool(use_pyarrow):
     """Check that dataframe with bool return a boolean arrays."""
     pd = importorskip("pandas")
     df = pd.DataFrame({"bool": [True, False, True]})
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        df = df.convert_dtypes(dtype_backend="pyarrow")
 
     array = check_array(df, dtype=None)
     assert array.dtype == np.bool_
@@ -1000,15 +1043,24 @@ def test_check_dataframe_with_only_bool():
         {"bool": [True, False, True], "int": [1, 2, 3]},
         columns=["bool", "int"],
     )
+
+    if use_pyarrow:
+        df = df.convert_dtypes(dtype_backend="pyarrow")
+
     array = check_array(df, dtype="numeric")
     assert array.dtype == np.int64
     assert_array_equal(array, [[1, 1], [0, 2], [1, 3]])
 
 
-def test_check_dataframe_with_only_boolean():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_check_dataframe_with_only_boolean(use_pyarrow):
     """Check that dataframe with boolean return a float array with dtype=None"""
     pd = importorskip("pandas", minversion="1.0")
     df = pd.DataFrame({"bool": pd.Series([True, False, True], dtype="boolean")})
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        df = df.convert_dtypes(dtype_backend="pyarrow")
 
     array = check_array(df, dtype=None)
     assert array.dtype == np.float64
@@ -1524,13 +1576,19 @@ def test_check_fit_params(indices):
 
 
 @pytest.mark.parametrize("sp_format", [True, "csr", "csc", "coo", "bsr"])
-def test_check_sparse_pandas_sp_format(sp_format):
-    # check_array converts pandas dataframe with only sparse arrays into
-    # sparse matrix
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_check_sparse_pandas_sp_format(sp_format, use_pyarrow):
+    """Check conversion from sparse pandas dataframe to sparse matrix."""
     pd = pytest.importorskip("pandas")
+
     sp_mat = _sparse_random_matrix(10, 3)
 
     sdf = pd.DataFrame.sparse.from_spmatrix(sp_mat)
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        sdf = sdf.sparse.convert_dtypes(dtype_backend="pyarrow")
+
     result = check_array(sdf, accept_sparse=sp_format)
 
     if sp_format is True:
@@ -1556,7 +1614,8 @@ def test_check_sparse_pandas_sp_format(sp_format):
         ("uint8", "int8"),
     ],
 )
-def test_check_pandas_sparse_invalid(ntype1, ntype2):
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_check_pandas_sparse_invalid(ntype1, ntype2, use_pyarrow):
     """check that we raise an error with dataframe having
     sparse extension arrays with unsupported mixed dtype
     and pandas version below 1.1. pandas versions 1.1 and
@@ -1568,6 +1627,10 @@ def test_check_pandas_sparse_invalid(ntype1, ntype2):
             "col2": pd.arrays.SparseArray([1, 0, 1], dtype=ntype2, fill_value=0),
         }
     )
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        df = df.convert_dtypes(dtype_backend="pyarrow")
 
     if parse_version(pd.__version__) < parse_version("1.1"):
         err_msg = "Pandas DataFrame with mixed sparse extension arrays"
@@ -1600,7 +1663,8 @@ def test_check_pandas_sparse_invalid(ntype1, ntype2):
         ("uintp", "ulonglong", np.unsignedinteger),
     ],
 )
-def test_check_pandas_sparse_valid(ntype1, ntype2, expected_subtype):
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_check_pandas_sparse_valid(ntype1, ntype2, expected_subtype, use_pyarrow):
     # check that we support the conversion of sparse dataframe with mixed
     # type which can be converted safely.
     pd = pytest.importorskip("pandas")
@@ -1610,6 +1674,11 @@ def test_check_pandas_sparse_valid(ntype1, ntype2, expected_subtype):
             "col2": pd.arrays.SparseArray([1, 0, 1], dtype=ntype2, fill_value=0),
         }
     )
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        df = df.convert_dtypes(dtype_backend="pyarrow")
+
     arr = check_array(df, accept_sparse=["csr", "csc"])
     assert np.issubdtype(arr.dtype, expected_subtype)
 
@@ -1821,10 +1890,17 @@ def test_check_response_method_list_str():
     assert method_name_predicting == "predict"
 
 
-def test_boolean_series_remains_boolean():
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_boolean_series_remains_boolean(use_pyarrow):
     """Regression test for gh-25145"""
     pd = importorskip("pandas")
-    res = check_array(pd.Series([True, False]), ensure_2d=False)
+    series = pd.Series([True, False])
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        series = series.convert_dtypes(dtype_backend="pyarrow")
+
+    res = check_array(series, ensure_2d=False)
     expected = np.array([True, False])
 
     assert res.dtype == expected.dtype
@@ -1832,13 +1908,21 @@ def test_boolean_series_remains_boolean():
 
 
 @pytest.mark.parametrize("input_values", [[0, 1, 0, 1, 0, np.nan], [0, 1, 0, 1, 0, 1]])
-def test_pandas_array_returns_ndarray(input_values):
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_pandas_array_returns_ndarray(input_values, use_pyarrow):
     """Check pandas array with extensions dtypes returns a numeric ndarray.
 
     Non-regression test for gh-25637.
     """
     pd = importorskip("pandas")
     input_series = pd.array(input_values, dtype="Int32")
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        input_series = (
+            pd.Series(input_series).convert_dtypes(dtype_backend="pyarrow").array
+        )
+
     result = check_array(
         input_series,
         dtype=None,
@@ -1877,8 +1961,9 @@ def test_check_array_array_api_has_non_finite(array_namespace):
     ],
 )
 @pytest.mark.parametrize("include_object", [True, False])
+@pytest.mark.parametrize("use_pyarrow", [True, False])
 def test_check_array_multiple_extensions(
-    extension_dtype, regular_dtype, include_object
+    extension_dtype, regular_dtype, include_object, use_pyarrow
 ):
     """Check pandas extension arrays give the same result as non-extension arrays."""
     pd = pytest.importorskip("pandas")
@@ -1892,6 +1977,10 @@ def test_check_array_multiple_extensions(
         X_regular["b"] = pd.Series(["a", "b", "c", "d"], dtype="object")
 
     X_extension = X_regular.assign(a=X_regular["a"].astype(extension_dtype))
+
+    if use_pyarrow:
+        pytest.importorskip("pyarrow")
+        X_extension = X_extension.convert_dtypes(dtype_backend="pyarrow")
 
     X_regular_checked = check_array(X_regular, dtype=None)
     X_extension_checked = check_array(X_extension, dtype=None)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -428,8 +428,8 @@ def test_check_array_numeric_error(X):
         ("numeric", np.float64),
     ],
 )
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_check_array_pandas_na_support(use_pyarrow, pd_dtype, dtype, expected_dtype):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_check_array_pandas_na_support(use_pyarrow_dtypes, pd_dtype, dtype, expected_dtype):
     # Test pandas numerical extension arrays with pd.NA
     pd = pytest.importorskip("pandas")
 
@@ -444,7 +444,7 @@ def test_check_array_pandas_na_support(use_pyarrow, pd_dtype, dtype, expected_dt
     # Creates dataframe with numerical extension arrays with pd.NA
     X = pd.DataFrame(X_np, dtype=pd_dtype, columns=["a", "b", "c"])
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X = X.convert_dtypes(dtype_backend="pyarrow")
 
@@ -463,14 +463,14 @@ def test_check_array_pandas_na_support(use_pyarrow, pd_dtype, dtype, expected_dt
         check_array(X, force_all_finite=True)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_check_array_panadas_na_support_series(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_check_array_panadas_na_support_series(use_pyarrow_dtypes):
     """Check check_array is correct with pd.NA in a series."""
     pd = pytest.importorskip("pandas")
 
     X_int64 = pd.Series([1, 2, pd.NA], dtype="Int64")
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X_int64 = X_int64.convert_dtypes(dtype_backend="pyarrow")
 
@@ -489,14 +489,14 @@ def test_check_array_panadas_na_support_series(use_pyarrow):
     assert X_out.dtype == np.float32
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_check_array_pandas_dtype_casting(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_check_array_pandas_dtype_casting(use_pyarrow_dtypes):
     # test that data-frames with homogeneous dtype are not upcast
     pd = pytest.importorskip("pandas")
     X = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.float32)
     X_df = pd.DataFrame(X)
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X_df = X_df.convert_dtypes(dtype_backend="pyarrow")
 
@@ -529,7 +529,7 @@ def test_check_array_pandas_dtype_casting(use_pyarrow):
     # should be integer ahead of converting it.
     cat_df = pd.DataFrame({"cat_col": pd.Categorical([1, 2, 3])})
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         cat_df = cat_df.convert_dtypes(dtype_backend="pyarrow")
 
     assert check_array(cat_df).dtype == np.int64
@@ -961,14 +961,14 @@ def test_suppress_validation():
         assert_all_finite(X)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_check_array_series(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_check_array_series(use_pyarrow_dtypes):
     """Regression test that check_array works on pandas Series."""
     pd = pytest.importorskip("pandas")
 
     X = pd.Series([1, 2, 3])
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X = X.convert_dtypes(dtype_backend="pyarrow")
 
@@ -977,7 +977,7 @@ def test_check_array_series(use_pyarrow):
 
     # with categorical dtype (not a numpy dtype) (GH12699)
     s = pd.Series(["a", "b", "c"]).astype("category")
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         s = s.convert_dtypes(dtype_backend="pyarrow")
 
     res = check_array(s, dtype=None, ensure_2d=False)
@@ -988,8 +988,8 @@ def test_check_array_series(use_pyarrow):
     "dtype", ((np.float64, np.float32), np.float64, None, "numeric")
 )
 @pytest.mark.parametrize("bool_dtype", ("bool", "boolean"))
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_check_dataframe_mixed_float_dtypes(dtype, bool_dtype, use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_check_dataframe_mixed_float_dtypes(dtype, bool_dtype, use_pyarrow_dtypes):
     """Check array type conversion with mixed float dtypes in pandas DataFrame.
 
     Pandas dataframe will coerce a boolean into an object, this is a mismatch
@@ -1012,7 +1012,7 @@ def test_check_dataframe_mixed_float_dtypes(dtype, bool_dtype, use_pyarrow):
         columns=["int", "float", "bool"],
     )
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df = df.convert_dtypes(dtype_backend="pyarrow")
 
@@ -1024,13 +1024,13 @@ def test_check_dataframe_mixed_float_dtypes(dtype, bool_dtype, use_pyarrow):
     assert_allclose_dense_sparse(array, expected_array)
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_check_dataframe_with_only_bool(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_check_dataframe_with_only_bool(use_pyarrow_dtypes):
     """Check that dataframe with bool return a boolean arrays."""
     pd = importorskip("pandas")
     df = pd.DataFrame({"bool": [True, False, True]})
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df = df.convert_dtypes(dtype_backend="pyarrow")
 
@@ -1044,7 +1044,7 @@ def test_check_dataframe_with_only_bool(use_pyarrow):
         columns=["bool", "int"],
     )
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         df = df.convert_dtypes(dtype_backend="pyarrow")
 
     array = check_array(df, dtype="numeric")
@@ -1052,13 +1052,13 @@ def test_check_dataframe_with_only_bool(use_pyarrow):
     assert_array_equal(array, [[1, 1], [0, 2], [1, 3]])
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_check_dataframe_with_only_boolean(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_check_dataframe_with_only_boolean(use_pyarrow_dtypes):
     """Check that dataframe with boolean return a float array with dtype=None"""
     pd = importorskip("pandas", minversion="1.0")
     df = pd.DataFrame({"bool": pd.Series([True, False, True], dtype="boolean")})
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df = df.convert_dtypes(dtype_backend="pyarrow")
 
@@ -1576,8 +1576,8 @@ def test_check_fit_params(indices):
 
 
 @pytest.mark.parametrize("sp_format", [True, "csr", "csc", "coo", "bsr"])
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_check_sparse_pandas_sp_format(sp_format, use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_check_sparse_pandas_sp_format(sp_format, use_pyarrow_dtypes):
     """Check conversion from sparse pandas dataframe to sparse matrix."""
     pd = pytest.importorskip("pandas")
 
@@ -1585,7 +1585,7 @@ def test_check_sparse_pandas_sp_format(sp_format, use_pyarrow):
 
     sdf = pd.DataFrame.sparse.from_spmatrix(sp_mat)
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         sdf = sdf.sparse.convert_dtypes(dtype_backend="pyarrow")
 
@@ -1614,8 +1614,8 @@ def test_check_sparse_pandas_sp_format(sp_format, use_pyarrow):
         ("uint8", "int8"),
     ],
 )
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_check_pandas_sparse_invalid(ntype1, ntype2, use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_check_pandas_sparse_invalid(ntype1, ntype2, use_pyarrow_dtypes):
     """check that we raise an error with dataframe having
     sparse extension arrays with unsupported mixed dtype
     and pandas version below 1.1. pandas versions 1.1 and
@@ -1628,7 +1628,7 @@ def test_check_pandas_sparse_invalid(ntype1, ntype2, use_pyarrow):
         }
     )
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df = df.convert_dtypes(dtype_backend="pyarrow")
 
@@ -1663,8 +1663,8 @@ def test_check_pandas_sparse_invalid(ntype1, ntype2, use_pyarrow):
         ("uintp", "ulonglong", np.unsignedinteger),
     ],
 )
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_check_pandas_sparse_valid(ntype1, ntype2, expected_subtype, use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_check_pandas_sparse_valid(ntype1, ntype2, expected_subtype, use_pyarrow_dtypes):
     # check that we support the conversion of sparse dataframe with mixed
     # type which can be converted safely.
     pd = pytest.importorskip("pandas")
@@ -1675,7 +1675,7 @@ def test_check_pandas_sparse_valid(ntype1, ntype2, expected_subtype, use_pyarrow
         }
     )
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         df = df.convert_dtypes(dtype_backend="pyarrow")
 
@@ -1890,13 +1890,13 @@ def test_check_response_method_list_str():
     assert method_name_predicting == "predict"
 
 
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_boolean_series_remains_boolean(use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_boolean_series_remains_boolean(use_pyarrow_dtypes):
     """Regression test for gh-25145"""
     pd = importorskip("pandas")
     series = pd.Series([True, False])
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         series = series.convert_dtypes(dtype_backend="pyarrow")
 
@@ -1908,8 +1908,8 @@ def test_boolean_series_remains_boolean(use_pyarrow):
 
 
 @pytest.mark.parametrize("input_values", [[0, 1, 0, 1, 0, np.nan], [0, 1, 0, 1, 0, 1]])
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_pandas_array_returns_ndarray(input_values, use_pyarrow):
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
+def test_pandas_array_returns_ndarray(input_values, use_pyarrow_dtypes):
     """Check pandas array with extensions dtypes returns a numeric ndarray.
 
     Non-regression test for gh-25637.
@@ -1917,7 +1917,7 @@ def test_pandas_array_returns_ndarray(input_values, use_pyarrow):
     pd = importorskip("pandas")
     input_series = pd.array(input_values, dtype="Int32")
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         input_series = (
             pd.Series(input_series).convert_dtypes(dtype_backend="pyarrow").array
@@ -1961,9 +1961,9 @@ def test_check_array_array_api_has_non_finite(array_namespace):
     ],
 )
 @pytest.mark.parametrize("include_object", [True, False])
-@pytest.mark.parametrize("use_pyarrow", [True, False])
+@pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
 def test_check_array_multiple_extensions(
-    extension_dtype, regular_dtype, include_object, use_pyarrow
+    extension_dtype, regular_dtype, include_object, use_pyarrow_dtypes
 ):
     """Check pandas extension arrays give the same result as non-extension arrays."""
     pd = pytest.importorskip("pandas")
@@ -1978,7 +1978,7 @@ def test_check_array_multiple_extensions(
 
     X_extension = X_regular.assign(a=X_regular["a"].astype(extension_dtype))
 
-    if use_pyarrow:
+    if use_pyarrow_dtypes:
         pytest.importorskip("pyarrow")
         X_extension = X_extension.convert_dtypes(dtype_backend="pyarrow")
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -429,7 +429,9 @@ def test_check_array_numeric_error(X):
     ],
 )
 @pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
-def test_check_array_pandas_na_support(use_pyarrow_dtypes, pd_dtype, dtype, expected_dtype):
+def test_check_array_pandas_na_support(
+    use_pyarrow_dtypes, pd_dtype, dtype, expected_dtype
+):
     # Test pandas numerical extension arrays with pd.NA
     pd = pytest.importorskip("pandas")
 
@@ -1664,7 +1666,9 @@ def test_check_pandas_sparse_invalid(ntype1, ntype2, use_pyarrow_dtypes):
     ],
 )
 @pytest.mark.parametrize("use_pyarrow_dtypes", [True, False])
-def test_check_pandas_sparse_valid(ntype1, ntype2, expected_subtype, use_pyarrow_dtypes):
+def test_check_pandas_sparse_valid(
+    ntype1, ntype2, expected_subtype, use_pyarrow_dtypes
+):
     # check that we support the conversion of sparse dataframe with mixed
     # type which can be converted safely.
     pd = pytest.importorskip("pandas")


### PR DESCRIPTION
Co-authored-by: @LeoGrin

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes partly #25896, see also #26464

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Adds tests when using the Arrow backend with pandas, for dataframes with arrow dtypes [(added with Pandas 2.0)](https://pandas.pydata.org/pandas-docs/version/2.0/user_guide/pyarrow.html)

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
