### PR TITLE
MAINT ignore commit that sorts all import statements with ruff in blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -28,3 +28,6 @@ d4aad64b1eb2e42e76f49db2ccfbe4b4660d092b
 
 # PR 26110: Update black to 23.3.0
 893d5accaf9d16f447645e704f85a216187564f7
+
+# PR 26649: Add isort and ruff rules
+42173fdb34b5aded79664e045cada719dfbe39dc


### PR DESCRIPTION
Follow up of #26649

Ignore the commit introducing changes due to adoption of `isort` and `ruff` packages.

Ignores: 42173fdb34b5aded79664e045cada719dfbe39dc.