### PR TITLE
ENH Supports DataFrame API for polars in ColumnTransformer

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -48,7 +48,7 @@ Changes impacting all modules
 
 - |Feature| Adds polars input support to :class:`compose.ColumnTransformer` through the
   `DataFrame API specification <https://data-apis.org/dataframe-api/draft/index.html>`__.
-  :pr:`xxxxx` by `Thomas Fan`_.
+  :pr:`26669` by `Thomas Fan`_.
 
 Code and Documentation Contributors
 -----------------------------------

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -43,6 +43,13 @@ Changes impacting all modules
   to work with our estimators and functions.
   :pr:`26464` by `Thomas Fan`_.
 
+:mod:`sklearn.compose`
+......................
+
+- |Feature| Adds polars input support to :class:`compose.ColumnTransformer` through the
+  `DataFrame API specification <https://data-apis.org/dataframe-api/draft/index.html>`__.
+  :pr:`xxxxx` by `Thomas Fan`_.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -620,7 +620,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             name for name, _, _, _ in self._iter(fitted=True, replace_strings=True)
         ]
         for Xs, name in zip(result, names):
-            if not getattr(Xs, "ndim", 0) == 2:
+            if not getattr(Xs, "ndim", 0) == 2 and not hasattr(Xs, "__dataframe__"):
                 raise ValueError(
                     "The output of the '{0}' transformer should be 2D (scipy "
                     "matrix, array, or pandas DataFrame).".format(name)

--- a/sklearn/externals/_dataframe_api/LICENSE
+++ b/sklearn/externals/_dataframe_api/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023, Marco Gorelli
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sklearn/externals/_dataframe_api/README.md
+++ b/sklearn/externals/_dataframe_api/README.md
@@ -1,0 +1,1 @@
+The files in this folder is vendoered from https://github.com/MarcoGorelli/impl-dataframe-api

--- a/sklearn/externals/_dataframe_api/__init__.py
+++ b/sklearn/externals/_dataframe_api/__init__.py
@@ -1,0 +1,25 @@
+from ...utils.validation import _is_pandas_df
+from ...utils.validation import _is_polars_df
+
+__all__ = ["get_dataframe_standard", "has_supported_dataframe_standards"]
+
+
+def get_dataframe_standard(df):
+    if hasattr(df, "__dataframe_standard__"):
+        return df.__dataframe_standard__()
+    elif _is_pandas_df(df):
+        from .pandas_standard import dataframe_standard as pandas_dataframe_standard
+
+        return pandas_dataframe_standard(df)
+    elif _is_polars_df(df):
+        from .polars_standard import dataframe_standard as polars_dataframe_standard
+
+        return polars_dataframe_standard(df)
+    else:
+        raise ValueError("Only pandas and polars DataFrames are supported.")
+
+
+def has_supported_dataframe_standards(df):
+    return (
+        hasattr(df, "__dataframe_standard__") or _is_pandas_df(df) or _is_polars_df(df)
+    )

--- a/sklearn/externals/_dataframe_api/pandas_standard.py
+++ b/sklearn/externals/_dataframe_api/pandas_standard.py
@@ -1,0 +1,502 @@
+# The files in this folder is vendoered from
+# https://github.com/MarcoGorelli/impl-dataframe-api
+
+from __future__ import annotations
+import numpy as np
+
+import pandas as pd
+from pandas.api.types import is_extension_array_dtype
+import collections
+from typing import Any, Sequence, Mapping, NoReturn, cast
+
+import pandas
+
+
+def dataframe_standard(df: pd.DataFrame) -> PandasDataFrame:
+    return PandasDataFrame(df)
+
+
+class PandasNamespace:
+    @classmethod
+    def concat(cls, dataframes: Sequence[PandasDataFrame]) -> PandasDataFrame:
+        dtypes = dataframes[0].dataframe.dtypes
+        dfs = []
+        for _df in dataframes:
+            try:
+                pd.testing.assert_series_equal(_df.dataframe.dtypes, dtypes)
+            except Exception as exc:
+                raise ValueError("Expected matching columns") from exc
+            else:
+                dfs.append(_df.dataframe)
+        return PandasDataFrame(
+            pd.concat(
+                dfs,
+                axis=0,
+                ignore_index=True,
+            )
+        )
+
+    @classmethod
+    def column_from_sequence(
+        cls, sequence: Sequence[object], dtype: str
+    ) -> PandasColumn:
+        return PandasColumn(pd.Series(sequence, dtype=dtype))
+
+    @classmethod
+    def dataframe_from_dict(cls, data: dict[str, PandasColumn]) -> PandasDataFrame:
+        return PandasDataFrame(
+            pd.DataFrame({label: column._series for label, column in data.items()})
+        )
+
+
+class PandasColumn:
+    # private, not technically part of the standard
+    def __init__(self, column: pd.Series) -> None:  # type: ignore[type-arg]
+        if (
+            isinstance(column.index, pd.RangeIndex)
+            and column.index.start == 0  # type: ignore[comparison-overlap]
+            and column.index.step == 1  # type: ignore[comparison-overlap]
+            and (column.index.stop == len(column))  # type: ignore[comparison-overlap]
+        ):
+            self._series = column
+        else:
+            self._series = column.reset_index(drop=True)
+
+    # In the standard
+    def __column_namespace__(self, *, api_version: str | None = None) -> Any:
+        return PandasNamespace
+
+    def __len__(self) -> int:
+        return len(self._series)
+
+    def __iter__(self) -> NoReturn:
+        raise NotImplementedError()
+
+    @property
+    def dtype(self) -> object:
+        return self._series.dtype
+
+    def get_rows(self, indices: PandasColumn) -> PandasColumn:
+        return PandasColumn(self._series.iloc[indices._series.to_numpy()])
+
+    def __getitem__(self, row: int) -> object:
+        return self._series.iloc[row]
+
+    def sorted_indices(self) -> PandasColumn:
+        return PandasColumn(pd.Series(self._series.argsort()))
+
+    def is_in(self, values: PandasColumn) -> PandasColumn:
+        if values.dtype != self.dtype:
+            raise ValueError(f"`value` has dtype {values.dtype}, expected {self.dtype}")
+        return PandasColumn(self._series.isin(values._series))
+
+    def unique(self) -> PandasColumn:
+        return PandasColumn(pd.Series(self._series.unique()))
+
+    def mean(self) -> float:
+        return self._series.mean()
+
+    def std(self) -> float:
+        return self._series.std()
+
+    def isnull(self) -> PandasColumn:
+        if is_extension_array_dtype(self._series.dtype):
+            return PandasColumn(self._series.isnull())
+        else:
+            return PandasColumn(pd.Series(np.array([False] * len(self))))
+
+    def isnan(self) -> PandasColumn:
+        return PandasColumn(self._series.isna())
+
+    def any(self) -> bool:
+        return self._series.any()
+
+    def all(self) -> bool:
+        return self._series.all()
+
+    def __eq__(  # type: ignore[override]
+        self, other: PandasColumn | object
+    ) -> PandasColumn:
+        if isinstance(other, PandasColumn):
+            return PandasColumn(self._series == other._series)
+        return PandasColumn(self._series == other)
+
+    def __ne__(self, other: PandasColumn) -> PandasColumn:  # type: ignore[override]
+        if isinstance(other, PandasColumn):
+            return PandasColumn(self._series != other._series)
+        return PandasColumn(self._series != other)
+
+    def __ge__(self, other: PandasColumn) -> PandasColumn:
+        if isinstance(other, PandasColumn):
+            return PandasColumn(self._series >= other._series)
+        return PandasColumn(self._series >= other)
+
+    def __gt__(self, other: PandasColumn) -> PandasColumn:
+        if isinstance(other, PandasColumn):
+            return PandasColumn(self._series > other._series)
+        return PandasColumn(self._series > other)
+
+    def __le__(self, other: PandasColumn) -> PandasColumn:
+        if isinstance(other, PandasColumn):
+            return PandasColumn(self._series <= other._series)
+        return PandasColumn(self._series <= other)
+
+    def __lt__(self, other: PandasColumn) -> PandasColumn:
+        if isinstance(other, PandasColumn):
+            return PandasColumn(self._series < other._series)
+        return PandasColumn(self._series < other)
+
+    def __add__(self, other: PandasColumn) -> PandasColumn:
+        if isinstance(other, PandasColumn):
+            return PandasColumn(self._series + other._series)
+        return PandasColumn(self._series + other)
+
+    def __sub__(self, other: PandasColumn) -> PandasColumn:
+        if isinstance(other, PandasColumn):
+            return PandasColumn(self._series - other._series)
+        return PandasColumn(self._series - other)
+
+    def __mul__(self, other: PandasColumn) -> PandasColumn:
+        if isinstance(other, PandasColumn):
+            return PandasColumn(self._series * other._series)
+        return PandasColumn(self._series * other)
+
+    def __truediv__(self, other: PandasColumn) -> PandasColumn:
+        if isinstance(other, PandasColumn):
+            return PandasColumn(self._series / other._series)
+        return PandasColumn(self._series / other)
+
+    def __floordiv__(self, other: PandasColumn) -> PandasColumn:
+        if isinstance(other, PandasColumn):
+            return PandasColumn(self._series // other._series)
+        return PandasColumn(self._series // other)
+
+    def __pow__(self, other: PandasColumn) -> PandasColumn:
+        if isinstance(other, PandasColumn):
+            return PandasColumn(self._series**other._series)
+        return PandasColumn(self._series**other)
+
+    def __mod__(self, other: PandasColumn) -> PandasColumn:
+        if isinstance(other, PandasColumn):
+            return PandasColumn(self._series % other._series)
+        return PandasColumn(self._series % other)
+
+    def __invert__(self) -> PandasColumn:
+        return PandasColumn(~self._series)
+
+    def __and__(self, other: PandasColumn) -> PandasColumn:
+        return PandasColumn(self._series & other._series)
+
+    def max(self) -> object:
+        return self._series.max()
+
+    def fill_nan(
+        self, value: float | pd.NAType  # type: ignore[name-defined]
+    ) -> PandasColumn:
+        ser = self._series.copy()
+        ser[cast("pd.Series[bool]", np.isnan(ser)).fillna(False).to_numpy(bool)] = value
+        return PandasColumn(ser)
+
+
+class PandasGroupBy:
+    def __init__(self, df: pd.DataFrame, keys: Sequence[str]) -> None:
+        self.df = df
+        self.grouped = df.groupby(list(keys), sort=False, as_index=False)
+        self.keys = list(keys)
+
+    def _validate_result(self, result: pd.DataFrame) -> None:
+        failed_columns = self.df.columns.difference(result.columns)
+        if len(failed_columns) > 0:
+            # defensive check
+            raise AssertionError(
+                "Groupby operation could not be performed on columns "
+                f"{failed_columns}. Please drop them before calling groupby."
+            )
+
+    def size(self) -> PandasDataFrame:
+        # pandas-stubs is wrong
+        return PandasDataFrame(self.grouped.size())  # type: ignore[arg-type]
+
+    def any(self, skipna: bool = True) -> PandasDataFrame:
+        if not (self.df.drop(columns=self.keys).dtypes == "bool").all():
+            raise ValueError("Expected boolean types")
+        result = self.grouped.any()
+        self._validate_result(result)
+        return PandasDataFrame(result)
+
+    def all(self, skipna: bool = True) -> PandasDataFrame:
+        if not (self.df.drop(columns=self.keys).dtypes == "bool").all():
+            raise ValueError("Expected boolean types")
+        result = self.grouped.all()
+        self._validate_result(result)
+        return PandasDataFrame(result)
+
+    def min(self, skipna: bool = True) -> PandasDataFrame:
+        result = self.grouped.min()
+        self._validate_result(result)
+        return PandasDataFrame(result)
+
+    def max(self, skipna: bool = True) -> PandasDataFrame:
+        result = self.grouped.max()
+        self._validate_result(result)
+        return PandasDataFrame(result)
+
+    def sum(self, skipna: bool = True) -> PandasDataFrame:
+        result = self.grouped.sum()
+        self._validate_result(result)
+        return PandasDataFrame(result)
+
+    def prod(self, skipna: bool = True) -> PandasDataFrame:
+        result = self.grouped.prod()
+        self._validate_result(result)
+        return PandasDataFrame(result)
+
+    def median(self, skipna: bool = True) -> PandasDataFrame:
+        result = self.grouped.median()
+        self._validate_result(result)
+        return PandasDataFrame(result)
+
+    def mean(self, skipna: bool = True) -> PandasDataFrame:
+        result = self.grouped.mean()
+        self._validate_result(result)
+        return PandasDataFrame(result)
+
+    def std(self, skipna: bool = True) -> PandasDataFrame:
+        result = self.grouped.std()
+        self._validate_result(result)
+        return PandasDataFrame(result)
+
+    def var(self, skipna: bool = True) -> PandasDataFrame:
+        result = self.grouped.var()
+        self._validate_result(result)
+        return PandasDataFrame(result)
+
+
+class PandasDataFrame:
+    # Not technically part of the standard
+
+    def __init__(self, dataframe: pd.DataFrame) -> None:
+        self._validate_columns(dataframe.columns)  # type: ignore[arg-type]
+        if (
+            isinstance(dataframe.index, pd.RangeIndex)
+            and dataframe.index.start == 0  # type: ignore[comparison-overlap]
+            and dataframe.index.step == 1  # type: ignore[comparison-overlap]
+            and (
+                dataframe.index.stop == len(dataframe)  # type: ignore[comparison-overlap]
+            )
+        ):
+            self._dataframe = dataframe
+        else:
+            self._dataframe = dataframe.reset_index(drop=True)
+
+    def __len__(self) -> int:
+        return self.shape()[0]
+
+    def _validate_columns(self, columns: Sequence[str]) -> None:
+        counter = collections.Counter(columns)
+        for col, count in counter.items():
+            if count > 1:
+                raise ValueError(
+                    f"Expected unique column names, got {col} {count} time(s)"
+                )
+        for col in columns:
+            if not isinstance(col, str):
+                raise TypeError(
+                    f"Expected column names to be of type str, got {col} "
+                    f"of type {type(col)}"
+                )
+
+    def _validate_index(self, index: pd.Index) -> None:
+        pd.testing.assert_index_equal(self.dataframe.index, index)
+
+    def _validate_comparand(self, other: PandasDataFrame) -> None:
+        if isinstance(other, PandasDataFrame) and not (
+            self.dataframe.index.equals(other.dataframe.index)
+            and self.dataframe.shape == other.dataframe.shape
+            and self.dataframe.columns.equals(other.dataframe.columns)
+        ):
+            raise ValueError(
+                "Expected DataFrame with same length, matching columns, "
+                "and matching index."
+            )
+
+    def _validate_booleanness(self) -> None:
+        if not (self.dataframe.dtypes == "bool").all():
+            raise NotImplementedError(
+                "'any' can only be called on DataFrame where all dtypes are 'bool'"
+            )
+
+    # In the standard
+    def __dataframe_namespace__(self, *, api_version: str | None = None) -> Any:
+        return PandasNamespace
+
+    @property
+    def dataframe(self) -> pd.DataFrame:
+        return self._dataframe
+
+    def shape(self) -> tuple[int, int]:
+        return self.dataframe.shape
+
+    def groupby(self, keys: Sequence[str]) -> PandasGroupBy:
+        if not isinstance(keys, collections.abc.Sequence):
+            raise TypeError(f"Expected sequence of strings, got: {type(keys)}")
+        if isinstance(keys, str):
+            raise TypeError("Expected sequence of strings, got: str")
+        for key in keys:
+            if key not in self.get_column_names():
+                raise KeyError(f"key {key} not present in DataFrame's columns")
+        return PandasGroupBy(self.dataframe, keys)
+
+    def get_column_by_name(self, name: str) -> PandasColumn:
+        if not isinstance(name, str):
+            raise ValueError(f"Expected str, got: {type(name)}")
+        return PandasColumn(self.dataframe.loc[:, name])
+
+    def get_columns_by_name(self, names: Sequence[str]) -> PandasDataFrame:
+        if isinstance(names, str):
+            raise TypeError(f"Expected sequence of str, got {type(names)}")
+        self._validate_columns(names)
+        return PandasDataFrame(self.dataframe.loc[:, list(names)])
+
+    def get_rows(self, indices: PandasColumn) -> PandasDataFrame:
+        return PandasDataFrame(self.dataframe.iloc[indices._series, :])
+
+    def slice_rows(self, start: int, stop: int, step: int) -> PandasDataFrame:
+        return PandasDataFrame(self.dataframe.iloc[start:stop:step])
+
+    def get_rows_by_mask(self, mask: PandasColumn) -> PandasDataFrame:
+        series = mask._series
+        self._validate_index(series.index)
+        return PandasDataFrame(self.dataframe.loc[series, :])
+
+    def insert(self, loc: int, label: str, value: PandasColumn) -> PandasDataFrame:
+        series = value._series
+        self._validate_index(series.index)
+        before = self.dataframe.iloc[:, :loc]
+        after = self.dataframe.iloc[:, loc:]
+        to_insert = value._series.rename(label)
+        return PandasDataFrame(pd.concat([before, to_insert, after], axis=1))
+
+    def drop_column(self, label: str) -> PandasDataFrame:
+        if not isinstance(label, str):
+            raise TypeError(f"Expected str, got: {type(label)}")
+        return PandasDataFrame(self.dataframe.drop(label, axis=1))
+
+    def rename_columns(self, mapping: Mapping[str, str]) -> PandasDataFrame:
+        if not isinstance(mapping, collections.abc.Mapping):
+            raise TypeError(f"Expected Mapping, got: {type(mapping)}")
+        return PandasDataFrame(self.dataframe.rename(columns=mapping))
+
+    def get_column_names(self) -> Sequence[str]:
+        return self.dataframe.columns.tolist()
+
+    def __iter__(self) -> NoReturn:
+        raise NotImplementedError()
+
+    def __eq__(self, other: PandasDataFrame) -> PandasDataFrame:  # type: ignore[override]
+        self._validate_comparand(other)
+        return PandasDataFrame(self.dataframe.__eq__(other.dataframe))
+
+    def __ne__(self, other: PandasDataFrame) -> PandasDataFrame:  # type: ignore[override]
+        self._validate_comparand(other)
+        return PandasDataFrame((self.dataframe.__ne__(other.dataframe)))
+
+    def __ge__(self, other: PandasDataFrame) -> PandasDataFrame:
+        self._validate_comparand(other)
+        return PandasDataFrame((self.dataframe.__ge__(other.dataframe)))
+
+    def __gt__(self, other: PandasDataFrame) -> PandasDataFrame:
+        self._validate_comparand(other)
+        return PandasDataFrame((self.dataframe.__gt__(other.dataframe)))
+
+    def __le__(self, other: PandasDataFrame) -> PandasDataFrame:
+        self._validate_comparand(other)
+        return PandasDataFrame((self.dataframe.__le__(other.dataframe)))
+
+    def __lt__(self, other: PandasDataFrame) -> PandasDataFrame:
+        self._validate_comparand(other)
+        return PandasDataFrame((self.dataframe.__lt__(other.dataframe)))
+
+    def __add__(self, other: PandasDataFrame) -> PandasDataFrame:
+        self._validate_comparand(other)
+        return PandasDataFrame((self.dataframe.__add__(other.dataframe)))
+
+    def __sub__(self, other: PandasDataFrame) -> PandasDataFrame:
+        self._validate_comparand(other)
+        return PandasDataFrame((self.dataframe.__sub__(other.dataframe)))
+
+    def __mul__(self, other: PandasDataFrame) -> PandasDataFrame:
+        self._validate_comparand(other)
+        return PandasDataFrame((self.dataframe.__mul__(other.dataframe)))
+
+    def __truediv__(self, other: PandasDataFrame) -> PandasDataFrame:
+        self._validate_comparand(other)
+        return PandasDataFrame((self.dataframe.__truediv__(other.dataframe)))
+
+    def __floordiv__(self, other: PandasDataFrame) -> PandasDataFrame:
+        self._validate_comparand(other)
+        return PandasDataFrame((self.dataframe.__floordiv__(other.dataframe)))
+
+    def __pow__(self, other: PandasDataFrame) -> PandasDataFrame:
+        self._validate_comparand(other)
+        return PandasDataFrame((self.dataframe.__pow__(other.dataframe)))
+
+    def __mod__(self, other: PandasDataFrame) -> PandasDataFrame:
+        self._validate_comparand(other)
+        return PandasDataFrame((self.dataframe.__mod__(other.dataframe)))
+
+    def __divmod__(
+        self, other: PandasDataFrame
+    ) -> tuple[PandasDataFrame, PandasDataFrame]:
+        self._validate_comparand(other)
+        quotient, remainder = self.dataframe.__divmod__(other.dataframe)
+        return PandasDataFrame(quotient), PandasDataFrame(remainder)
+
+    def any(self) -> PandasDataFrame:
+        self._validate_booleanness()
+        return PandasDataFrame(self.dataframe.any().to_frame().T)
+
+    def all(self) -> PandasDataFrame:
+        self._validate_booleanness()
+        return PandasDataFrame(self.dataframe.all().to_frame().T)
+
+    def any_rowwise(self) -> PandasColumn:
+        self._validate_booleanness()
+        return PandasColumn(self.dataframe.any(axis=1))
+
+    def all_rowwise(self) -> PandasColumn:
+        self._validate_booleanness()
+        return PandasColumn(self.dataframe.all(axis=1))
+
+    def isnull(self) -> PandasDataFrame:
+        result = []
+        for column in self.dataframe.columns:
+            if is_extension_array_dtype(self.dataframe[column].dtype):
+                result.append(self.dataframe[column].isnull())
+            else:
+                result.append(
+                    pd.Series(np.array([False] * self.shape()[0]), name=column)
+                )
+        return PandasDataFrame(pd.concat(result, axis=1))
+
+    def isnan(self) -> PandasDataFrame:
+        result = []
+        for column in self.dataframe.columns:
+            if is_extension_array_dtype(self.dataframe[column].dtype):
+                result.append(
+                    np.isnan(self.dataframe[column]).replace(pd.NA, False).astype(bool)
+                )
+            else:
+                result.append(self.dataframe[column].isna())
+        return PandasDataFrame(pd.concat(result, axis=1))
+
+    def sorted_indices(self, keys: Sequence[str]) -> PandasColumn:
+        df = self.dataframe.loc[:, list(keys)]
+        return PandasColumn(df.sort_values(keys).index.to_series())
+
+    def fill_nan(
+        self, value: float | pd.NAType  # type: ignore[name-defined]
+    ) -> PandasDataFrame:
+        df = self.dataframe.copy()
+        df[cast(pd.DataFrame, np.isnan(df)).fillna(False).to_numpy(bool)] = value
+        return PandasDataFrame(df)

--- a/sklearn/externals/_dataframe_api/polars_standard.py
+++ b/sklearn/externals/_dataframe_api/polars_standard.py
@@ -1,0 +1,383 @@
+# The files in this folder is vendoered from
+# https://github.com/MarcoGorelli/impl-dataframe-api
+
+from __future__ import annotations
+import collections
+
+from typing import Sequence, NoReturn, Any, Mapping
+import polars as pl
+import polars
+
+
+def dataframe_standard(df: pl.DataFrame) -> PolarsDataFrame:
+    return PolarsDataFrame(df)
+
+
+DTYPE_MAPPING = {  # todo, expand
+    "bool": pl.Boolean,
+    "int64": pl.Int64,
+    "float64": pl.Float64,
+}
+
+
+class PolarsNamespace:
+    @classmethod
+    def concat(cls, dataframes: Sequence[PolarsDataFrame]) -> PolarsDataFrame:
+        dfs = []
+        for _df in dataframes:
+            dfs.append(_df.dataframe)
+        return PolarsDataFrame(pl.concat(dfs))
+
+    @classmethod
+    def dataframe_from_dict(cls, data: dict[str, PolarsColumn]) -> PolarsDataFrame:
+        return PolarsDataFrame(
+            pl.DataFrame({label: column._series for label, column in data.items()})
+        )
+
+    @classmethod
+    def column_from_sequence(
+        cls, sequence: Sequence[object], dtype: str
+    ) -> PolarsColumn:
+        return PolarsColumn(pl.Series(sequence, dtype=DTYPE_MAPPING[dtype]))
+
+
+class PolarsColumn:
+    def __init__(self, column: pl.Series) -> None:
+        self._series = column
+
+    # In the standard
+    def __column_namespace__(self, *, api_version: str | None = None) -> Any:
+        return PolarsNamespace
+
+    def __len__(self) -> int:
+        return len(self._series)
+
+    @property
+    def dtype(self) -> object:
+        # todo change
+        return self._series.dtype
+
+    def get_rows(self, indices: PolarsColumn) -> PolarsColumn:
+        return PolarsColumn(self._series.take(indices._series))
+
+    def __getitem__(self, row: int) -> object:
+        return self._series[row]
+
+    def __iter__(self) -> NoReturn:
+        raise NotImplementedError()
+
+    def is_in(self, values: PolarsColumn) -> PolarsColumn:
+        if values.dtype != self.dtype:
+            raise ValueError(f"`value` has dtype {values.dtype}, expected {self.dtype}")
+        return PolarsColumn(self._series.is_in(values._series))
+
+    def unique(self) -> PolarsColumn:
+        return PolarsColumn(self._series.unique())
+
+    def mean(self) -> object:
+        return self._series.mean()
+
+    def isnull(self) -> PolarsColumn:
+        return PolarsColumn(self._series.is_null())
+
+    def isnan(self) -> PolarsColumn:
+        return PolarsColumn(self._series.is_nan())
+
+    def any(self) -> bool:
+        return self._series.any()
+
+    def all(self) -> bool:
+        return self._series.all()
+
+    def __eq__(  # type: ignore[override]
+        self, other: PolarsColumn | object
+    ) -> PolarsColumn:
+        if isinstance(other, PolarsColumn):
+            return PolarsColumn(self._series == other._series)
+        return PolarsColumn(self._series == other)
+
+    def __ne__(  # type: ignore[override]
+        self, other: PolarsColumn | object
+    ) -> PolarsColumn:
+        if isinstance(other, PolarsColumn):
+            return PolarsColumn(self._series != other._series)
+        return PolarsColumn(self._series != other)
+
+    def __ge__(self, other: PolarsColumn | object) -> PolarsColumn:
+        if isinstance(other, PolarsColumn):
+            return PolarsColumn(self._series >= other._series)
+        return PolarsColumn(self._series >= other)
+
+    def __gt__(self, other: PolarsColumn | object) -> PolarsColumn:
+        if isinstance(other, PolarsColumn):
+            return PolarsColumn(self._series > other._series)
+        return PolarsColumn(self._series > other)
+
+    def __le__(self, other: PolarsColumn | object) -> PolarsColumn:
+        if isinstance(other, PolarsColumn):
+            return PolarsColumn(self._series <= other._series)
+        return PolarsColumn(self._series <= other)
+
+    def __lt__(self, other: PolarsColumn | object) -> PolarsColumn:
+        if isinstance(other, PolarsColumn):
+            return PolarsColumn(self._series < other._series)
+        return PolarsColumn(self._series < other)
+
+    def __mul__(self, other: PolarsColumn | object) -> PolarsColumn:
+        if isinstance(other, PolarsColumn):
+            return PolarsColumn(self._series * other._series)
+        return PolarsColumn(self._series * other)
+
+    def __floordiv__(self, other: PolarsColumn | object) -> PolarsColumn:
+        if isinstance(other, PolarsColumn):
+            return PolarsColumn(self._series // other._series)
+        return PolarsColumn(self._series // other)
+
+    def __truediv__(self, other: PolarsColumn | object) -> PolarsColumn:
+        if isinstance(other, PolarsColumn):
+            return PolarsColumn(self._series / other._series)
+        return PolarsColumn(self._series / other)
+
+    def __pow__(self, other: PolarsColumn | float) -> PolarsColumn:
+        if isinstance(other, PolarsColumn):
+            return PolarsColumn(self._series.pow(other._series))
+        return PolarsColumn(self._series.pow(other))
+
+    def __mod__(self, other: PolarsColumn | object) -> PolarsColumn:
+        if isinstance(other, PolarsColumn):
+            return PolarsColumn(self._series % other._series)
+        return PolarsColumn(self._series % other)
+
+    def __and__(self, other: PolarsColumn | object) -> PolarsColumn:
+        if isinstance(other, PolarsColumn):
+            return PolarsColumn(self._series & other._series)
+        return PolarsColumn(self._series & other)  # type: ignore[operator]
+
+    def __invert__(self) -> PolarsColumn:
+        return PolarsColumn(~self._series)
+
+    def max(self) -> object:
+        return self._series.max()
+
+    def std(self) -> object:
+        return self._series.std()
+
+    def __add__(self, other: PolarsColumn) -> PolarsColumn:
+        if isinstance(other, PolarsColumn):
+            return PolarsColumn(self._series + other._series)
+        return PolarsColumn(self._series + other)
+
+    def __sub__(self, other: PolarsColumn) -> PolarsColumn:
+        if isinstance(other, PolarsColumn):
+            return PolarsColumn(self._series - other._series)
+        return PolarsColumn(self._series - other)
+
+    def sorted_indices(self) -> PolarsColumn:
+        df = self._series.to_frame()
+        keys = df.columns
+        return PolarsColumn(df.with_row_count().sort(keys, descending=False)["row_nr"])
+
+    def fill_nan(self, value: float) -> PolarsColumn:
+        return PolarsColumn(self._series.fill_nan(value))
+
+
+class PolarsGroupBy:
+    def __init__(self, df: pl.DataFrame, keys: Sequence[str]) -> None:
+        for key in keys:
+            if key not in df.columns:
+                raise KeyError(f"key {key} not present in DataFrame's columns")
+        self.df = df
+        self.keys = keys
+
+    def size(self) -> PolarsDataFrame:
+        result = self.df.groupby(self.keys).count().rename({"count": "size"})
+        return PolarsDataFrame(result)
+
+    def any(self, skipna: bool = True) -> PolarsDataFrame:
+        result = self.df.groupby(self.keys).agg(pl.col("*").any())
+        return PolarsDataFrame(result)
+
+    def all(self, skipna: bool = True) -> PolarsDataFrame:
+        result = self.df.groupby(self.keys).agg(pl.col("*").all())
+        return PolarsDataFrame(result)
+
+    def min(self, skipna: bool = True) -> PolarsDataFrame:
+        result = self.df.groupby(self.keys).agg(pl.col("*").min())
+        return PolarsDataFrame(result)
+
+    def max(self, skipna: bool = True) -> PolarsDataFrame:
+        result = self.df.groupby(self.keys).agg(pl.col("*").max())
+        return PolarsDataFrame(result)
+
+    def sum(self, skipna: bool = True) -> PolarsDataFrame:
+        result = self.df.groupby(self.keys).agg(pl.col("*").sum())
+        return PolarsDataFrame(result)
+
+    def prod(self, skipna: bool = True) -> PolarsDataFrame:
+        result = self.df.groupby(self.keys).agg(pl.col("*").product())
+        return PolarsDataFrame(result)
+
+    def median(self, skipna: bool = True) -> PolarsDataFrame:
+        result = self.df.groupby(self.keys).agg(pl.col("*").median())
+        return PolarsDataFrame(result)
+
+    def mean(self, skipna: bool = True) -> PolarsDataFrame:
+        result = self.df.groupby(self.keys).agg(pl.col("*").mean())
+        return PolarsDataFrame(result)
+
+    def std(self, skipna: bool = True) -> PolarsDataFrame:
+        result = self.df.groupby(self.keys).agg(pl.col("*").std())
+        return PolarsDataFrame(result)
+
+    def var(self, skipna: bool = True) -> PolarsDataFrame:
+        result = self.df.groupby(self.keys).agg(pl.col("*").var())
+        return PolarsDataFrame(result)
+
+
+class PolarsDataFrame:
+    def __init__(self, df: pl.DataFrame) -> None:
+        # columns already have to be strings, and duplicates aren't
+        # allowed, so no validation required
+        self.df = df
+
+    def __dataframe_namespace__(self, *, api_version: str | None = None) -> Any:
+        return PolarsNamespace
+
+    def __len__(self) -> int:
+        return len(self.df)
+
+    @property
+    def dataframe(self) -> pl.DataFrame:
+        return self.df
+
+    def shape(self) -> tuple[int, int]:
+        return self.df.shape
+
+    def groupby(self, keys: Sequence[str]) -> PolarsGroupBy:
+        return PolarsGroupBy(self.df, keys)
+
+    def get_column_by_name(self, name: str) -> PolarsColumn:
+        return PolarsColumn(self.df[name])
+
+    def get_columns_by_name(self, names: Sequence[str]) -> PolarsDataFrame:
+        if isinstance(names, str):
+            raise TypeError(f"Expected sequence of str, got {type(names)}")
+        return PolarsDataFrame(self.df.select(names))
+
+    def get_rows(self, indices: PolarsColumn) -> PolarsDataFrame:
+        return PolarsDataFrame(self.df[indices._series])
+
+    def slice_rows(self, start: int, stop: int, step: int) -> PolarsDataFrame:
+        return PolarsDataFrame(
+            self.df.with_row_count("idx")
+            .filter(pl.col("idx").is_in(range(start, stop, step)))
+            .drop("idx")
+        )
+
+    def get_rows_by_mask(self, mask: PolarsColumn) -> PolarsDataFrame:
+        return PolarsDataFrame(self.df.filter(mask._series))
+
+    def insert(self, loc: int, label: str, value: PolarsColumn) -> PolarsDataFrame:
+        df = self.df.clone()
+        if len(df) > 0:
+            df.insert_at_idx(loc, pl.Series(label, value._series))
+            return PolarsDataFrame(df)
+        return PolarsDataFrame(pl.DataFrame({label: value._series}))
+
+    def drop_column(self, label: str) -> PolarsDataFrame:
+        if not isinstance(label, str):
+            raise TypeError(f"Expected str, got: {type(label)}")
+        return PolarsDataFrame(self.dataframe.drop(label))
+
+    def rename_columns(self, mapping: Mapping[str, str]) -> PolarsDataFrame:
+        if not isinstance(mapping, collections.abc.Mapping):
+            raise TypeError(f"Expected Mapping, got: {type(mapping)}")
+        return PolarsDataFrame(self.dataframe.rename(dict(mapping)))
+
+    def get_column_names(self) -> Sequence[str]:
+        return self.dataframe.columns
+
+    def __eq__(self, other: PolarsDataFrame) -> PolarsDataFrame:  # type: ignore[override]
+        return PolarsDataFrame(self.dataframe.__eq__(other.dataframe))
+
+    def __ne__(self, other: PolarsDataFrame) -> PolarsDataFrame:  # type: ignore[override]
+        return PolarsDataFrame(self.dataframe.__ne__(other.dataframe))
+
+    def __ge__(self, other: PolarsDataFrame) -> PolarsDataFrame:
+        return PolarsDataFrame(self.dataframe.__ge__(other.dataframe))
+
+    def __gt__(self, other: PolarsDataFrame) -> PolarsDataFrame:
+        return PolarsDataFrame(self.dataframe.__gt__(other.dataframe))
+
+    def __le__(self, other: PolarsDataFrame) -> PolarsDataFrame:
+        return PolarsDataFrame(self.dataframe.__le__(other.dataframe))
+
+    def __lt__(self, other: PolarsDataFrame) -> PolarsDataFrame:
+        return PolarsDataFrame(self.dataframe.__lt__(other.dataframe))
+
+    def __add__(self, other: PolarsDataFrame) -> PolarsDataFrame:
+        return PolarsDataFrame(self.dataframe.__add__(other.dataframe))
+
+    def __sub__(self, other: PolarsDataFrame) -> PolarsDataFrame:
+        return PolarsDataFrame(self.dataframe.__sub__(other.dataframe))
+
+    def __mul__(self, other: PolarsDataFrame) -> PolarsDataFrame:
+        return PolarsDataFrame(self.dataframe.__mul__(other.dataframe))
+
+    def __truediv__(self, other: PolarsDataFrame) -> PolarsDataFrame:
+        return PolarsDataFrame(self.dataframe.__truediv__(other.dataframe))
+
+    def __floordiv__(self, other: PolarsDataFrame) -> PolarsDataFrame:
+        return PolarsDataFrame(self.dataframe.__floordiv__(other.dataframe))
+
+    def __pow__(self, other: PolarsDataFrame) -> PolarsDataFrame:
+        return PolarsDataFrame(
+            self.dataframe.select(
+                [
+                    pl.col(col).pow(other.dataframe[col])
+                    for col in self.get_column_names()
+                ]
+            )
+        )
+
+    def __mod__(self, other: PolarsDataFrame) -> PolarsDataFrame:
+        return PolarsDataFrame(self.dataframe.__mod__(other.dataframe))
+
+    def __divmod__(
+        self,
+        other: PolarsDataFrame,
+    ) -> tuple[PolarsDataFrame, PolarsDataFrame]:
+        quotient = self // other
+        remainder = self - quotient * other
+        return quotient, remainder
+
+    def isnull(self) -> PolarsDataFrame:
+        result = {}
+        for column in self.dataframe.columns:
+            result[column] = self.dataframe[column].is_null()
+        return PolarsDataFrame(pl.DataFrame(result))
+
+    def isnan(self) -> PolarsDataFrame:
+        result = {}
+        for column in self.dataframe.columns:
+            result[column] = self.dataframe[column].is_nan()
+        return PolarsDataFrame(pl.DataFrame(result))
+
+    def any(self) -> PolarsDataFrame:
+        return PolarsDataFrame(self.dataframe.select(pl.col("*").any()))
+
+    def all(self) -> PolarsDataFrame:
+        return PolarsDataFrame(self.dataframe.select(pl.col("*").all()))
+
+    def any_rowwise(self) -> PolarsColumn:
+        return PolarsColumn(self.dataframe.select(pl.any(pl.col("*")))["any"])
+
+    def all_rowwise(self) -> PolarsColumn:
+        return PolarsColumn(self.dataframe.select(pl.all(pl.col("*")))["all"])
+
+    def sorted_indices(self, keys: Sequence[str]) -> PolarsColumn:
+        df = self.dataframe.select(keys)
+        return PolarsColumn(df.with_row_count().sort(keys, descending=False)["row_nr"])
+
+    def fill_nan(self, value: float) -> PolarsDataFrame:
+        return PolarsDataFrame(self.dataframe.fill_nan(value))

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1998,6 +1998,18 @@ def _is_pandas_df(X):
     return False
 
 
+def _is_polars_df(X):
+    """Return True if the X is a polars dataframe."""
+    if hasattr(X, "columns") and hasattr(X, "schema"):
+        # Likely a polars DataFrame, we explicitly check the type to confirm.
+        try:
+            pl = sys.modules["polars"]
+        except KeyError:
+            return False
+        return isinstance(X, pl.DataFrame)
+    return False
+
+
 def _get_feature_names(X):
     """Get feature names from X.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards https://github.com/scikit-learn/scikit-learn/issues/25896
Supersedes https://github.com/scikit-learn/scikit-learn/pull/26115

#### What does this implement/fix? Explain your changes.
As a first step, this PR adds polars support to `ColumnTransformer` using the DataFrame API Spec. The `ColumnTransformer` will slice the DataFrame on the column axis and pass it as Polars DataFrames to the inner transformers.

#### Any other comments?
This PR only adds polars input to `ColumnTransformer`. Polars output is not in scope for this PR.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
