### PR TITLE
FIX add missing prefer_skip_nested_validation in missing paired_distances

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1234,7 +1234,8 @@ PAIRED_DISTANCES = {
         "X": ["array-like"],
         "Y": ["array-like"],
         "metric": [StrOptions(set(PAIRED_DISTANCES)), callable],
-    }
+    },
+    prefer_skip_nested_validation=True,
 )
 def paired_distances(X, Y, *, metric="euclidean", **kwds):
     """


### PR DESCRIPTION
Follow-up of #26495

I forgot to rerun the CIs and we merged parameter validation for the `paired_distances` function that did not have yet `prefer_skip_nested_validation`.