### PR TITLE
 FIX workaround sphinx limitation with rst_prolog

### DIFF
--- a/doc/templates/class.rst
+++ b/doc/templates/class.rst
@@ -1,3 +1,4 @@
+
 :mod:`{{module}}`.{{objname}}
 {{ underline }}==============
 

--- a/doc/templates/class.rst
+++ b/doc/templates/class.rst
@@ -1,3 +1,7 @@
+..
+    The empty line below should not be removed. It is added such that the `rst_prolog`
+    is added before the :mod: directive. Otherwise, the rendering will show as a
+    paragraph instead of a header.
 
 :mod:`{{module}}`.{{objname}}
 {{ underline }}==============

--- a/doc/templates/class_with_call.rst
+++ b/doc/templates/class_with_call.rst
@@ -1,3 +1,7 @@
+..
+    The empty line below should not be removed. It is added such that the `rst_prolog`
+    is added before the :mod: directive. Otherwise, the rendering will show as a
+    paragraph instead of a header.
 
 :mod:`{{module}}`.{{objname}}
 {{ underline }}===============

--- a/doc/templates/class_with_call.rst
+++ b/doc/templates/class_with_call.rst
@@ -1,3 +1,4 @@
+
 :mod:`{{module}}`.{{objname}}
 {{ underline }}===============
 

--- a/doc/templates/deprecated_class.rst
+++ b/doc/templates/deprecated_class.rst
@@ -1,3 +1,4 @@
+
 :mod:`{{module}}`.{{objname}}
 {{ underline }}==============
 

--- a/doc/templates/deprecated_class.rst
+++ b/doc/templates/deprecated_class.rst
@@ -1,3 +1,7 @@
+..
+    The empty line below should not be removed. It is added such that the `rst_prolog`
+    is added before the :mod: directive. Otherwise, the rendering will show as a
+    paragraph instead of a header.
 
 :mod:`{{module}}`.{{objname}}
 {{ underline }}==============

--- a/doc/templates/deprecated_class_with_call.rst
+++ b/doc/templates/deprecated_class_with_call.rst
@@ -1,3 +1,7 @@
+..
+    The empty line below should not be removed. It is added such that the `rst_prolog`
+    is added before the :mod: directive. Otherwise, the rendering will show as a
+    paragraph instead of a header.
 
 :mod:`{{module}}`.{{objname}}
 {{ underline }}===============

--- a/doc/templates/deprecated_class_with_call.rst
+++ b/doc/templates/deprecated_class_with_call.rst
@@ -1,3 +1,4 @@
+
 :mod:`{{module}}`.{{objname}}
 {{ underline }}===============
 

--- a/doc/templates/deprecated_class_without_init.rst
+++ b/doc/templates/deprecated_class_without_init.rst
@@ -1,3 +1,4 @@
+
 :mod:`{{module}}`.{{objname}}
 {{ underline }}==============
 

--- a/doc/templates/deprecated_class_without_init.rst
+++ b/doc/templates/deprecated_class_without_init.rst
@@ -1,3 +1,7 @@
+..
+    The empty line below should not be removed. It is added such that the `rst_prolog`
+    is added before the :mod: directive. Otherwise, the rendering will show as a
+    paragraph instead of a header.
 
 :mod:`{{module}}`.{{objname}}
 {{ underline }}==============

--- a/doc/templates/deprecated_function.rst
+++ b/doc/templates/deprecated_function.rst
@@ -1,3 +1,7 @@
+..
+    The empty line below should not be removed. It is added such that the `rst_prolog`
+    is added before the :mod: directive. Otherwise, the rendering will show as a
+    paragraph instead of a header.
 
 :mod:`{{module}}`.{{objname}}
 {{ underline }}====================

--- a/doc/templates/deprecated_function.rst
+++ b/doc/templates/deprecated_function.rst
@@ -1,3 +1,4 @@
+
 :mod:`{{module}}`.{{objname}}
 {{ underline }}====================
 

--- a/doc/templates/display_all_class_methods.rst
+++ b/doc/templates/display_all_class_methods.rst
@@ -1,3 +1,4 @@
+
 :mod:`{{module}}`.{{objname}}
 {{ underline }}==============
 

--- a/doc/templates/display_all_class_methods.rst
+++ b/doc/templates/display_all_class_methods.rst
@@ -1,3 +1,7 @@
+..
+    The empty line below should not be removed. It is added such that the `rst_prolog`
+    is added before the :mod: directive. Otherwise, the rendering will show as a
+    paragraph instead of a header.
 
 :mod:`{{module}}`.{{objname}}
 {{ underline }}==============

--- a/doc/templates/display_only_from_estimator.rst
+++ b/doc/templates/display_only_from_estimator.rst
@@ -1,3 +1,4 @@
+
 :mod:`{{module}}`.{{objname}}
 {{ underline }}==============
 

--- a/doc/templates/display_only_from_estimator.rst
+++ b/doc/templates/display_only_from_estimator.rst
@@ -1,3 +1,7 @@
+..
+    The empty line below should not be removed. It is added such that the `rst_prolog`
+    is added before the :mod: directive. Otherwise, the rendering will show as a
+    paragraph instead of a header.
 
 :mod:`{{module}}`.{{objname}}
 {{ underline }}==============

--- a/doc/templates/function.rst
+++ b/doc/templates/function.rst
@@ -1,3 +1,7 @@
+..
+    The empty line below should not be removed. It is added such that the `rst_prolog`
+    is added before the :mod: directive. Otherwise, the rendering will show as a
+    paragraph instead of a header.
 
 :mod:`{{module}}`.{{objname}}
 {{ underline }}====================

--- a/doc/templates/function.rst
+++ b/doc/templates/function.rst
@@ -1,3 +1,4 @@
+
 :mod:`{{module}}`.{{objname}}
 {{ underline }}====================
 


### PR DESCRIPTION
closes #26679 

Workaround to be sure that the `rst_prolog` is added on top of the RST files.
I added an empty line first as a workaround as discussed in https://github.com/sphinx-doc/sphinx/issues/11437

If the bug fix is merged, we could think of reverting this change but I don't think that it would be an issue.