### PR TITLE
DOC update doc building for jupyterlite

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -920,7 +920,7 @@ Building the documentation requires installing some additional packages:
 
     pip install sphinx sphinx-gallery numpydoc matplotlib Pillow pandas \
                 scikit-image packaging seaborn sphinx-prompt \
-                sphinxext-opengraph plotly pooch
+                sphinxext-opengraph plotly pooch jupyterlite jupyterlite-sphinx
 
 To build the documentation, you need to be in the ``doc`` folder:
 


### PR DESCRIPTION
While trying to build locally, I am getting an error if `jupyterlite` is not installed.
I assume that we should advice installing `jupyterlite` and `jupyterlite-sphinx`.

An alternative is to make our `conf.py` more flexible by only adding `jupyterlite` if it is installed.

@lesteve What do you think is the more appropriate.