### PR TITLE
DOC improve section folding behaviour

### DIFF
--- a/doc/themes/scikit-learn-modern/javascript.html
+++ b/doc/themes/scikit-learn-modern/javascript.html
@@ -49,7 +49,7 @@ $(document).ready(function() {
 });
 
 function toggleDetails() {
-    /* Expand and hide all <details> sections on a page.*/
+    /* Expand and hide all <details> sections on a page. */
     var btn = document.getElementById("sk-btn-details");
     var sections = document.querySelectorAll("details");
 

--- a/doc/themes/scikit-learn-modern/javascript.html
+++ b/doc/themes/scikit-learn-modern/javascript.html
@@ -48,6 +48,21 @@ $(document).ready(function() {
 	});
 });
 
+function toggleDetails() {
+    /* Expand and hide all <details> sections on a page.*/
+    var btn = document.getElementById("sk-btn-details");
+    var sections = document.querySelectorAll("details");
+
+    if (btn.value == "Expand Details") {
+        for (s of sections) s.setAttribute("open", "");
+        btn.value = "Hide Details";
+    }
+    else {
+        for (s of sections) s.removeAttribute("open");
+        btn.value = "Expand Details";
+    }
+}
+
 </script>
 {%- if pagename != 'index' and pagename != 'documentation' %}
     {% if theme_mathjax_path %}

--- a/doc/themes/scikit-learn-modern/layout.html
+++ b/doc/themes/scikit-learn-modern/layout.html
@@ -43,7 +43,10 @@
 {%- block content %}
 <div class="d-flex" id="sk-doc-wrapper">
     <input type="checkbox" name="sk-toggle-checkbox" id="sk-toggle-checkbox">
-    <label id="sk-sidemenu-toggle" class="sk-btn-toggle-toc btn sk-btn-primary" for="sk-toggle-checkbox">Toggle Menu</label>
+    <div class="sk-btns-sk-btn-toggle-wrapper">
+      <label id="sk-sidemenu-toggle" class="sk-btn-toggle btn sk-btn-primary" for="sk-toggle-checkbox">Toggle Menu</label>
+      <input onclick="toggleDetails()" type="button" class="sk-btn-toggle btn sk-btn-primary" value="Expand Details" id="sk-btn-details"></input>
+    </div>
     <div id="sk-sidebar-wrapper" class="border-right">
       <div class="sk-sidebar-toc-wrapper">
         <div class="btn-group w-100 mb-2" role="group" aria-label="rellinks">

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -501,7 +501,7 @@ div.section h6 {
   border-top-right-radius: 0.5rem;
   border-top-left-radius: 0.5rem;
   width: 115px;
-  font-size: x-small;
+  font-size: small;
   cursor: pointer;
 }
 

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -157,7 +157,7 @@ div.sk-page-content details[open] summary ~ * {
   animation: fadein .35s ease-in-out;
 }
 
-@keyframes fatein {
+@keyframes fadein {
   0%    {opacity: 0; margin-top: -10px}
   100%  {opacity: 1; margin-top: 0px}
 }

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -153,6 +153,15 @@ div.sk-page-content details {
     margin: 4ex 0pt;
 }
 
+div.sk-page-content details[open] summary ~ * {
+  animation: fadein .35s ease-in-out;
+}
+
+@keyframes fatein {
+  0%    {opacity: 0; margin-top: -10px}
+  100%  {opacity: 1; margin-top: 0px}
+}
+
 div.sk-page-content summary.btn {
     display: list-item;
     padding: 6px 20px;
@@ -160,8 +169,7 @@ div.sk-page-content summary.btn {
 }
 
 div.sk-page-content details div.card {
-    padding: 0pt .5ex;
-    margin: 1ex 0pt;
+    padding: 1.25rem;
     border: 1px solid #e9ecef;
     border-left-width: .25rem;
     border-radius: .25rem;

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -478,13 +478,22 @@ div.section h6 {
   margin-top: 1rem;
 }
 
-.sk-btn-toggle-toc {
+.sk-btns-sk-btn-toggle-wrapper {
   position: fixed;
+  bottom: 0;
+  margin: 0;
+  z-index: 3;
+}
+
+.sk-btn-toggle {
+  position: relative;
   bottom: 0;
   margin: 0;
   border-radius: 0;
   border-top-right-radius: 0.5rem;
-  z-index: 3;
+  border-top-left-radius: 0.5rem;
+  width: 115px;
+  font-size: x-small;
   cursor: pointer;
 }
 
@@ -493,12 +502,12 @@ div.sk-page-content {
 }
 
 @media screen and (min-width: 1400px) {
-  .sk-btn-toggle-toc {
+  .sk-btn-toggle {
     border-top-left-radius: 0.5rem;
   }
 }
 
-.sk-btn-toggle-toc:hover {
+.sk-btn-toggle:hover {
   color: white;
   background-color: #297ca7;
 }


### PR DESCRIPTION
Bring some improvements to the new foldable sections:

- [x] Use larger padding as in Bootstrap
- [x] Use a small animation to expand details
- [x] Add an additional option to expand all details at once

I did not want to change the `<details>`/`<summary>` pattern since the find-in-page already works with Chrome and Edge. We can expect this feature to land on Firefox at some point.