### PR TITLE
DOC fix rendering of download note in example

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -1019,13 +1019,12 @@ div.sphx-glr-thumbcontainer {
   padding: 0;
 }
 
-
 @media screen and (min-width: 1540px) {
-  .sphx-glr-download-link-note {
-    position: absolute;
+  div.sphx-glr-download-link-note.admonition.note {
     position: absolute;
     left: 98%;
     width: 20ex;
+    margin-top: calc(max(5.5rem, 1vh));
   }
 }
 

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -1024,7 +1024,7 @@ div.sphx-glr-thumbcontainer {
     position: absolute;
     left: 98%;
     width: 20ex;
-    margin-top: calc(max(5.5rem, 1vh));
+    margin-top: calc(max(5.75rem, 1vh));
   }
 }
 


### PR DESCRIPTION
Fix the rendering of the note placed on the top-right corner of the examples in the gallery:

### In `main`:

![image](https://github.com/scikit-learn/scikit-learn/assets/7454015/e19bb0ec-5e6c-4486-9346-a66fdf524a81)

### In this branch:

![image](https://github.com/scikit-learn/scikit-learn/assets/7454015/260c981f-0384-4132-9fcb-d0921dce8dff)
