### PR TITLE
FIX Add additional prompts for sphinx-copybutton

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,7 +66,8 @@ extensions = [
 ]
 
 # Specify how to identify the prompt when copying code snippets
-copybutton_prompt_text = ">>> "
+copybutton_prompt_text = r">>> |\.\.\. "
+copybutton_prompt_is_regexp = True
 
 try:
     import jupyterlite_sphinx  # noqa: F401


### PR DESCRIPTION
With this regex both lines starting with `>>> ` and `... ` are recognised as lines that should be copied by the copy button.

Follow up to #26666

cc @ArturoAmorQ 