### PR TITLE
FIX samples average computation for multi-label classification

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1717,11 +1717,29 @@ def precision_recall_fscore_support(
      array([0., 0., 1.]), array([0. , 0. , 0.8]),
      array([2, 2, 2]))
     """
+    # Calculate tp_sum, pred_sum, true_sum ###
+    samplewise = average == "samples"
+    if average == "samples":
+        # Check if both rows are zero vectors
+        zero_rows = np.logical_and(y_true.sum(axis=1) == 0, y_pred.sum(axis=1) == 0)
+
+        # Append extra values based on the condition
+        extra_value = np.where(zero_rows, 1, 0)
+
+        # Create a new array with the modified values
+        if isinstance(y_true, csr_matrix):
+            y_true = y_true.toarray()
+        y_true = np.column_stack((y_true, extra_value))
+        if isinstance(y_pred, csr_matrix):
+            y_pred = y_pred.toarray()
+        y_pred = np.column_stack((y_pred, extra_value))
+
+        if labels is not None:
+            labels = np.append(labels, max(labels) + 1)
+
     zero_division_value = _check_zero_division(zero_division)
     labels = _check_set_wise_labels(y_true, y_pred, average, labels, pos_label)
 
-    # Calculate tp_sum, pred_sum, true_sum ###
-    samplewise = average == "samples"
     MCM = multilabel_confusion_matrix(
         y_true,
         y_pred,
@@ -2535,7 +2553,6 @@ def classification_report(
     weighted avg       1.00      0.67      0.80         3
     <BLANKLINE>
     """
-
     y_type, y_true, y_pred = _check_targets(y_true, y_pred)
 
     if labels is None:

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -14,13 +14,17 @@ from sklearn.metrics import (
     accuracy_score,
     auc,
     average_precision_score,
+    classification_report,
     coverage_error,
     dcg_score,
     det_curve,
+    f1_score,
     label_ranking_average_precision_score,
     label_ranking_loss,
     ndcg_score,
     precision_recall_curve,
+    precision_score,
+    recall_score,
     roc_auc_score,
     roc_curve,
     top_k_accuracy_score,
@@ -2240,3 +2244,105 @@ def test_roc_curve_with_probablity_estimates(global_random_seed):
     y_score = rng.rand(10)
     _, _, thresholds = roc_curve(y_true, y_score)
     assert np.isinf(thresholds[0])
+
+
+def test_multilabel_samples_average():
+    y_true = np.array([[0, 0, 0]])
+    y_pred = np.array([[0, 0, 0]])
+    assert precision_score(y_true, y_pred, average="samples") == 1
+    assert recall_score(y_true, y_pred, average="samples") == 1
+    assert f1_score(y_true, y_pred, average="samples") == 1
+    assert (
+        classification_report(y_true, y_pred)[-53:]
+        == "samples avg       1.00      1.00      1.00         0\n"
+    )
+
+    y_true = np.array(
+        [
+            [0, 1, 0],
+            [0, 1, 1],
+            [1, 0, 1],
+        ]
+    )
+    y_pred = np.array(
+        [
+            [0, 1, 1],
+            [0, 1, 1],
+            [0, 1, 0],
+        ]
+    )
+    assert precision_score(y_true, y_pred, average="samples") == np.mean([1 / 2, 1, 0])
+    assert recall_score(y_true, y_pred, average="samples") == pytest.approx(
+        np.mean([1, 1, 0])
+    )
+    assert f1_score(y_true, y_pred, average="samples") == pytest.approx(
+        np.mean([2 / 3, 1, 0])
+    )
+    assert (
+        classification_report(y_true, y_pred)[-53:]
+        == "samples avg       0.50      0.67      0.56         5\n"
+    )
+
+    y_true = np.array(
+        [
+            [0, 1, 0],
+            [0, 1, 1],
+            [1, 0, 1],
+            [0, 0, 1],
+            [0, 0, 0],
+        ]
+    )
+    y_pred = np.array(
+        [
+            [0, 1, 1],
+            [0, 1, 1],
+            [0, 1, 0],
+            [0, 0, 0],
+            [1, 0, 0],
+        ]
+    )
+    assert precision_score(y_true, y_pred, average="samples") == np.mean(
+        [1 / 2, 1, 0, 0, 0]
+    )
+    assert recall_score(y_true, y_pred, average="samples") == np.mean([1, 1, 0, 0, 0])
+    assert f1_score(y_true, y_pred, average="samples") == pytest.approx(
+        np.mean([2 / 3, 1, 0, 0, 0])
+    )
+    assert (
+        classification_report(y_true, y_pred)[-53:]
+        == "samples avg       0.30      0.40      0.33         6\n"
+    )
+
+    y_true = np.array(
+        [
+            [0, 1, 0],
+            [0, 1, 1],
+            [1, 0, 1],
+            [0, 0, 1],
+            [0, 0, 0],
+            [0, 0, 0],
+        ]
+    )
+    y_pred = np.array(
+        [
+            [0, 1, 1],
+            [0, 1, 1],
+            [0, 1, 0],
+            [0, 0, 0],
+            [1, 0, 0],
+            [0, 0, 0],
+        ]
+    )
+    assert precision_score(y_true, y_pred, average="samples") == pytest.approx(
+        np.mean([1 / 2, 1, 0, 0, 0, 1])
+    )
+    assert recall_score(y_true, y_pred, average="samples") == np.mean(
+        [1, 1, 0, 0, 0, 1]
+    )
+    assert f1_score(y_true, y_pred, average="samples") == pytest.approx(
+        np.mean([2 / 3, 1, 0, 0, 0, 1])
+    )
+    assert (
+        classification_report(y_true, y_pred)[-53:]
+        == "samples avg       0.42      0.50      0.44         6\n"
+    )


### PR DESCRIPTION
FIX samples average computation for multi-label classification when the label of a test instance and the ground truth label are both all zeros.

#### What does this implement/fix? Explain your changes.

In multi-label classification, it is possible for an instance to have zero labels. When a model predicted the exact zero label for such instances, the original implementation incorrectly returned 0 for precision_score, recall_score, and f1_score.

To address this issue, the new implementation introduces the following changes:

1. When the average parameter is set to "samples".
2. If some rows in y_true (ground truth labels) are zero vectors.
3. And if the corresponding rows of y_pred (predicted labels) are also zero vectors.

In such cases, a boolean column vector 'v' is appended to the end of both y_true and y_pred. The value of v[i] is 1 if y_true[i,] == y_pred[i,] == a zero vector; otherwise, it is set to 0.

Additionally, test cases have been added to the 'tests/test_ranking.py' file to verify the correctness of the changes.