### PR TITLE
DOC add `pip install  sphinx_copybutton` to contribution guide

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -920,7 +920,7 @@ Building the documentation requires installing some additional packages:
 
     pip install sphinx sphinx-gallery numpydoc matplotlib Pillow pandas \
                 scikit-image packaging seaborn sphinx-prompt \
-                sphinxext-opengraph plotly pooch
+                sphinxext-opengraph sphinx-copybutton plotly pooch
 
 To build the documentation, you need to be in the ``doc`` folder:
 


### PR DESCRIPTION
#### Reference Issues/PRs
#26666

#### What does this implement/fix? Explain your changes.
PR #26666 has introduced the `sphinx-copybutton` package. This PR adds it to the developer's guide to be pip installed manually to build the docs.