### PR TITLE
FIX do not allow for p=None in NN-based algorithm

### DIFF
--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -442,7 +442,7 @@ def _compute_core_distances_(X, neighbors, min_samples, working_memory):
         ],
         "max_eps": [Interval(Real, 0, None, closed="both")],
         "metric": [StrOptions(set(_VALID_METRICS) | {"precomputed"}), callable],
-        "p": [Interval(Real, 0, None, closed="right"), None],
+        "p": [Interval(Real, 0, None, closed="right")],
         "metric_params": [dict, None],
         "algorithm": [StrOptions({"auto", "brute", "ball_tree", "kd_tree"})],
         "leaf_size": [Interval(Integral, 1, None, closed="left")],

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -383,7 +383,7 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         "radius": [Interval(Real, 0, None, closed="both"), None],
         "algorithm": [StrOptions({"auto", "ball_tree", "kd_tree", "brute"})],
         "leaf_size": [Interval(Integral, 1, None, closed="left")],
-        "p": [Interval(Real, 0, None, closed="right"), None],
+        "p": [Interval(Real, 0, None, closed="right")],
         "metric": [StrOptions(set(itertools.chain(*VALID_METRICS.values()))), callable],
         "metric_params": [dict, None],
         "n_jobs": [Integral, None],


### PR DESCRIPTION
From the discussion in https://github.com/scikit-learn/scikit-learn/pull/26568/files#r1246511365, it seems that we should not accept `p=None` because it raises an error:

```pytb
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```

with the minimal reproducer:

```python
import numpy as np
from sklearn.neighbors import NearestNeighbors
samples = [[0, 0, 2], [1, 0, 0], [0, 0, 1]]
neigh = NearestNeighbors(n_neighbors=2, radius=0.4, p=None)
neigh.fit(samples)
```

Let's see if we break something somewhere else depending on some combination of parameters.