### PR TITLE
FIX `mutual_info_regression` when `X` is of integer dtype

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -19,18 +19,6 @@ parameters, may produce different models from the previous version. This often
 occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
-
-Changes impacting all modules
------------------------------
-
-- |Enhancement| All estimators now recognizes the column names from any dataframe
-  that adopts the
-  `DataFrame Interchange Protocol <https://data-apis.org/dataframe-protocol/latest/purpose_and_scope.html>`__.
-  Dataframes that return a correct representation through `np.asarray(df)` is expected
-  to work with our estimators and functions.
-  :pr:`26464` by `Thomas Fan`_.
-
-
 Changelog
 ---------
 
@@ -45,6 +33,23 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
+Changes impacting all modules
+-----------------------------
+
+- |Enhancement| All estimators now recognizes the column names from any dataframe
+  that adopts the
+  `DataFrame Interchange Protocol <https://data-apis.org/dataframe-protocol/latest/purpose_and_scope.html>`__.
+  Dataframes that return a correct representation through `np.asarray(df)` is expected
+  to work with our estimators and functions.
+  :pr:`26464` by `Thomas Fan`_.
+
+Code and Documentation Contributors
+-----------------------------------
+
+Thanks to everyone who has contributed to the maintenance and improvement of
+the project since version 1.3, including:
+
+TODO: update at the time of the release.
 
 :mod:`sklearn.base`
 ...................
@@ -53,17 +58,6 @@ Changelog
   :meth:`base.OutlierMixin.fit_predict` now accept ``**kwargs`` which are
   passed to the ``fit`` method of the the estimator. :pr:`26506` by `Adrin
   Jalali`_.
-
-
-:mod:`sklearn.decomposition`
-............................
-
-- |Enhancement| An "auto" option was added to the `n_components` parameter of
-  :func:`decomposition.non_negative_factorization`, :class:`decomposition.NMF` and
-  :class:`decomposition.MiniBatchNMF` to automatically infer the number of components from W or H shapes
-  when using a custom initialization. The default value of this parameter will change
-  from `None` to `auto` in version 1.6.
-  :pr:`26634` by :user:`Alexandre Landeau <AlexL>` and :user:`Alexandre Vigny <avigny>`.
 
 
 :mod:`sklearn.ensemble`
@@ -78,13 +72,6 @@ Changelog
   initiated by :user:`Patrick O'Reilly <pat-oreilly>`.
 
 
-:mod:`sklearn.feature_selection`
-................................
-
-- |Fix| :func:`feature_selection.mutual_info_regression` now correctly computes the
-  result when `X` is of integer dtype. :pr:`26748` by :user:`Yao Xiao <Charlie-XIAO>`.
-
-
 :mod:`sklearn.tree`
 ...................
 
@@ -97,10 +84,19 @@ Changelog
   :user:`Patrick O'Reilly <pat-oreilly>`.
 
 
-Code and Documentation Contributors
------------------------------------
+:mod:`sklearn.decomposition`
+............................
 
-Thanks to everyone who has contributed to the maintenance and improvement of
-the project since version 1.3, including:
+- |Enhancement| An "auto" option was added to the `n_components` parameter of
+  :func:`decomposition.non_negative_factorization`, :class:`decomposition.NMF` and
+  :class:`decomposition.MiniBatchNMF` to automatically infer the number of components from W or H shapes
+  when using a custom initialization. The default value of this parameter will change
+  from `None` to `auto` in version 1.6.
+  :pr:`26634` by :user:`Alexandre Landeau <AlexL>` and :user:`Alexandre Vigny <avigny>`.
 
-TODO: update at the time of the release.
+
+:mod:`sklearn.feature_selection`
+................................
+
+- |Fix| :func:`feature_selection.mutual_info_regression` now correctly computes the
+  result when `X` is of integer dtype. :pr:`26748` by :user:`Yao Xiao <Charlie-XIAO>`.

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -19,6 +19,18 @@ parameters, may produce different models from the previous version. This often
 occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
+
+Changes impacting all modules
+-----------------------------
+
+- |Enhancement| All estimators now recognizes the column names from any dataframe
+  that adopts the
+  `DataFrame Interchange Protocol <https://data-apis.org/dataframe-protocol/latest/purpose_and_scope.html>`__.
+  Dataframes that return a correct representation through `np.asarray(df)` is expected
+  to work with our estimators and functions.
+  :pr:`26464` by `Thomas Fan`_.
+
+
 Changelog
 ---------
 
@@ -33,23 +45,6 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
-Changes impacting all modules
------------------------------
-
-- |Enhancement| All estimators now recognizes the column names from any dataframe
-  that adopts the
-  `DataFrame Interchange Protocol <https://data-apis.org/dataframe-protocol/latest/purpose_and_scope.html>`__.
-  Dataframes that return a correct representation through `np.asarray(df)` is expected
-  to work with our estimators and functions.
-  :pr:`26464` by `Thomas Fan`_.
-
-Code and Documentation Contributors
------------------------------------
-
-Thanks to everyone who has contributed to the maintenance and improvement of
-the project since version 1.3, including:
-
-TODO: update at the time of the release.
 
 :mod:`sklearn.base`
 ...................
@@ -58,6 +53,17 @@ TODO: update at the time of the release.
   :meth:`base.OutlierMixin.fit_predict` now accept ``**kwargs`` which are
   passed to the ``fit`` method of the the estimator. :pr:`26506` by `Adrin
   Jalali`_.
+
+
+:mod:`sklearn.decomposition`
+............................
+
+- |Enhancement| An "auto" option was added to the `n_components` parameter of
+  :func:`decomposition.non_negative_factorization`, :class:`decomposition.NMF` and
+  :class:`decomposition.MiniBatchNMF` to automatically infer the number of components from W or H shapes
+  when using a custom initialization. The default value of this parameter will change
+  from `None` to `auto` in version 1.6.
+  :pr:`26634` by :user:`Alexandre Landeau <AlexL>` and :user:`Alexandre Vigny <avigny>`.
 
 
 :mod:`sklearn.ensemble`
@@ -72,6 +78,13 @@ TODO: update at the time of the release.
   initiated by :user:`Patrick O'Reilly <pat-oreilly>`.
 
 
+:mod:`sklearn.feature_selection`
+................................
+
+- |Fix| :func:`feature_selection.mutual_info_regression` now correctly computes the
+  result when `X` is of integer dtype. :pr:`26748` by :user:`Yao Xiao <Charlie-XIAO>`.
+
+
 :mod:`sklearn.tree`
 ...................
 
@@ -84,12 +97,10 @@ TODO: update at the time of the release.
   :user:`Patrick O'Reilly <pat-oreilly>`.
 
 
-:mod:`sklearn.decomposition`
-............................
+Code and Documentation Contributors
+-----------------------------------
 
-- |Enhancement| An "auto" option was added to the `n_components` parameter of
-  :func:`decomposition.non_negative_factorization`, :class:`decomposition.NMF` and
-  :class:`decomposition.MiniBatchNMF` to automatically infer the number of components from W or H shapes
-  when using a custom initialization. The default value of this parameter will change
-  from `None` to `auto` in version 1.6.
-  :pr:`26634` by :user:`Alexandre Landeau <AlexL>` and :user:`Alexandre Vigny <avigny>`.
+Thanks to everyone who has contributed to the maintenance and improvement of
+the project since version 1.3, including:
+
+TODO: update at the time of the release.

--- a/sklearn/feature_selection/_mutual_info.py
+++ b/sklearn/feature_selection/_mutual_info.py
@@ -280,15 +280,12 @@ def _estimate_mi(
 
     rng = check_random_state(random_state)
     if np.any(continuous_mask):
-        if copy:
-            X = X.copy()
-
+        X = X.astype(np.float64, copy=copy)
         X[:, continuous_mask] = scale(
             X[:, continuous_mask], with_mean=False, copy=False
         )
 
         # Add small noise to continuous features as advised in Kraskov et. al.
-        X = X.astype(np.float64, copy=False)
         means = np.maximum(1, np.mean(np.abs(X[:, continuous_mask]), axis=0))
         X[:, continuous_mask] += (
             1e-10

--- a/sklearn/feature_selection/tests/test_mutual_info.py
+++ b/sklearn/feature_selection/tests/test_mutual_info.py
@@ -236,3 +236,18 @@ def test_mutual_information_symmetry_classif_regression(correlated, global_rando
     )
 
     assert mi_classif == pytest.approx(mi_regression)
+
+
+def test_mutual_info_regression_X_int_dtype(global_random_seed):
+    """Check that results agree when X is integer dtype and float dtype.
+
+    Non-regression test for Issue #26696.
+    """
+    rng = np.random.RandomState(global_random_seed)
+    X = rng.randint(100, size=(100, 10))
+    X_float = X.astype(np.float64, copy=True)
+    y = rng.randint(100, size=100)
+
+    expected = mutual_info_regression(X_float, y, random_state=global_random_seed)
+    result = mutual_info_regression(X, y, random_state=global_random_seed)
+    assert_allclose(result, expected)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #26696.

#### What does this implement/fix? Explain your changes.

This PR converts `X` to `float64` dtype before calling `scale` to avoid rounding to integers.

*Btw I reordered the changelog sections according to the 1.3 version and alphabetical order. If not desired I can revert.*