### PR TITLE
MAINT Remove soon-to-be deprecated scipy.sparse functions

### DIFF
--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -90,11 +90,12 @@ def _fix_connectivity(X, connectivity, affinity):
     connectivity = connectivity + connectivity.T
 
     # Convert connectivity matrix to LIL
-    if not sparse.isspmatrix_lil(connectivity):
-        if not sparse.isspmatrix(connectivity):
-            connectivity = sparse.lil_matrix(connectivity)
-        else:
-            connectivity = connectivity.tolil()
+    if not sparse.issparse(connectivity):
+        connectivity = sparse.lil_matrix(connectivity)
+
+    # `connectivity` is a sparse matrix at this point
+    if connectivity.format != "lil":
+        connectivity = connectivity.tolil()
 
     # Compute the number of nodes
     n_connected_components, labels = connected_components(connectivity)

--- a/sklearn/datasets/tests/test_20news.py
+++ b/sklearn/datasets/tests/test_20news.py
@@ -64,7 +64,7 @@ def test_20news_length_consistency(fetch_20newsgroups_fxt):
 def test_20news_vectorized(fetch_20newsgroups_vectorized_fxt):
     # test subset = train
     bunch = fetch_20newsgroups_vectorized_fxt(subset="train")
-    assert sp.isspmatrix_csr(bunch.data)
+    assert sp.issparse(bunch.data) and bunch.data.format == "csr"
     assert bunch.data.shape == (11314, 130107)
     assert bunch.target.shape[0] == 11314
     assert bunch.data.dtype == np.float64
@@ -72,7 +72,7 @@ def test_20news_vectorized(fetch_20newsgroups_vectorized_fxt):
 
     # test subset = test
     bunch = fetch_20newsgroups_vectorized_fxt(subset="test")
-    assert sp.isspmatrix_csr(bunch.data)
+    assert sp.issparse(bunch.data) and bunch.data.format == "csr"
     assert bunch.data.shape == (7532, 130107)
     assert bunch.target.shape[0] == 7532
     assert bunch.data.dtype == np.float64
@@ -84,7 +84,7 @@ def test_20news_vectorized(fetch_20newsgroups_vectorized_fxt):
 
     # test subset = all
     bunch = fetch_20newsgroups_vectorized_fxt(subset="all")
-    assert sp.isspmatrix_csr(bunch.data)
+    assert sp.issparse(bunch.data) and bunch.data.format == "csr"
     assert bunch.data.shape == (11314 + 7532, 130107)
     assert bunch.target.shape[0] == 11314 + 7532
     assert bunch.data.dtype == np.float64

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -917,7 +917,7 @@ class HashingVectorizer(
 
 def _document_frequency(X):
     """Count the number of non-zero values for each feature in sparse X."""
-    if sp.isspmatrix_csr(X):
+    if sp.issparse(X) and X.format == "csr":
         return np.bincount(X.indices, minlength=X.shape[1])
     else:
         return np.diff(X.indptr)

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -363,7 +363,7 @@ class RBFSampler(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimato
         X = self._validate_data(X, accept_sparse="csr")
         random_state = check_random_state(self.random_state)
         n_features = X.shape[1]
-        sparse = sp.isspmatrix(X)
+        sparse = sp.issparse(X)
         if self.gamma == "scale":
             # var = E[X^2] - E[X]^2 if sparse
             X_var = (X.multiply(X)).mean() - (X.mean()) ** 2 if sparse else X.var()

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -839,7 +839,7 @@ def _pre_fit(
     """
     n_samples, n_features = X.shape
 
-    if sparse.isspmatrix(X):
+    if sparse.issparse(X):
         # copy is not needed here as X is not modified inplace when X is sparse
         precompute = False
         X, y, X_offset, y_offset, X_scale = _preprocess_data(

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -137,7 +137,7 @@ def _alpha_grid(
 
     sparse_center = False
     if Xy is None:
-        X_sparse = sparse.isspmatrix(X)
+        X_sparse = sparse.issparse(X)
         sparse_center = X_sparse and fit_intercept
         X = check_array(
             X, accept_sparse="csc", copy=(copy_X and fit_intercept and not X_sparse)
@@ -560,7 +560,7 @@ def enet_path(
         raise ValueError("positive=True is not allowed for multi-output (y.ndim != 1)")
 
     # MultiTaskElasticNet does not support sparse matrices
-    if not multi_output and sparse.isspmatrix(X):
+    if not multi_output and sparse.issparse(X):
         if X_offset_param is not None:
             # As sparse matrices are not actually centered we need this to be passed to
             # the CD solver.
@@ -621,7 +621,7 @@ def enet_path(
         # account for n_samples scaling in objectives between here and cd_fast
         l1_reg = alpha * l1_ratio * n_samples
         l2_reg = alpha * (1.0 - l1_ratio) * n_samples
-        if not multi_output and sparse.isspmatrix(X):
+        if not multi_output and sparse.issparse(X):
             model = cd_fast.sparse_enet_coordinate_descent(
                 w=coef_,
                 alpha=l1_reg,
@@ -1101,7 +1101,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
             The predicted decision function.
         """
         check_is_fitted(self)
-        if sparse.isspmatrix(X):
+        if sparse.issparse(X):
             return safe_sparse_dot(X, self.coef_.T, dense_output=True) + self.intercept_
         else:
             return super()._decision_function(X)
@@ -1546,7 +1546,7 @@ class LinearModelCV(MultiOutputMixin, LinearModel, ABC):
         check_y_params = dict(
             copy=False, dtype=[np.float64, np.float32], ensure_2d=False
         )
-        if isinstance(X, np.ndarray) or sparse.isspmatrix(X):
+        if isinstance(X, np.ndarray) or sparse.issparse(X):
             # Keep a reference to X
             reference_to_old_X = X
             # Let us not impose fortran ordering so far: it is
@@ -1563,7 +1563,7 @@ class LinearModelCV(MultiOutputMixin, LinearModel, ABC):
             X, y = self._validate_data(
                 X, y, validate_separately=(check_X_params, check_y_params)
             )
-            if sparse.isspmatrix(X):
+            if sparse.issparse(X):
                 if hasattr(reference_to_old_X, "data") and not np.may_share_memory(
                     reference_to_old_X.data, X.data
                 ):
@@ -1598,7 +1598,7 @@ class LinearModelCV(MultiOutputMixin, LinearModel, ABC):
                 )
             y = column_or_1d(y, warn=True)
         else:
-            if sparse.isspmatrix(X):
+            if sparse.issparse(X):
                 raise TypeError("X should be dense but a sparse matrix waspassed")
             elif y.ndim == 1:
                 raise ValueError(

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -84,12 +84,10 @@ def test_set_order_sparse(order, input_order):
     X = X.asformat(sparse_format)
     y = X.asformat(sparse_format)
     X2, y2 = _set_order(X, y, order=order)
-    if order == "C":
-        assert sparse.isspmatrix_csr(X2)
-        assert sparse.isspmatrix_csr(y2)
-    elif order == "F":
-        assert sparse.isspmatrix_csc(X2)
-        assert sparse.isspmatrix_csc(y2)
+
+    format = "csc" if order == "F" else "csr"
+    assert sparse.issparse(X2) and X2.format == format
+    assert sparse.issparse(y2) and y2.format == format
 
 
 def test_lasso_zero():

--- a/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_sparse_coordinate_descent.py
@@ -19,7 +19,7 @@ def test_sparse_coef():
     clf = ElasticNet()
     clf.coef_ = [1, 2, 3]
 
-    assert sp.isspmatrix(clf.sparse_coef_)
+    assert sp.issparse(clf.sparse_coef_)
     assert clf.sparse_coef_.toarray().tolist()[0] == clf.coef_
 
 

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -85,7 +85,7 @@ def _graph_is_connected(graph):
     is_connected : bool
         True means the graph is fully connected and False means not.
     """
-    if sparse.isspmatrix(graph):
+    if sparse.issparse(graph):
         # sparse graph, find all the connected components
         n_connected_components, _ = connected_components(graph)
         return n_connected_components == 1
@@ -118,7 +118,7 @@ def _set_diag(laplacian, value, norm_laplacian):
     """
     n_nodes = laplacian.shape[0]
     # We need all entries in the diagonal to values
-    if not sparse.isspmatrix(laplacian):
+    if not sparse.issparse(laplacian):
         if norm_laplacian:
             laplacian.flat[:: n_nodes + 1] = value
     else:
@@ -280,7 +280,7 @@ def spectral_embedding(
     if (
         eigen_solver == "arpack"
         or eigen_solver != "lobpcg"
-        and (not sparse.isspmatrix(laplacian) or n_nodes < 5 * n_components)
+        and (not sparse.issparse(laplacian) or n_nodes < 5 * n_components)
     ):
         # lobpcg used with eigen_solver='amg' has bugs for low number of nodes
         # for details see the source code in scipy:
@@ -371,7 +371,7 @@ def spectral_embedding(
             # see note above under arpack why lobpcg has problems with small
             # number of nodes
             # lobpcg will fallback to eigh, so we short circuit it
-            if sparse.isspmatrix(laplacian):
+            if sparse.issparse(laplacian):
                 laplacian = laplacian.toarray()
             _, diffusion_map = eigh(laplacian, check_finite=False)
             embedding = diffusion_map.T[:n_components]

--- a/sklearn/metrics/_pairwise_distances_reduction/_dispatcher.py
+++ b/sklearn/metrics/_pairwise_distances_reduction/_dispatcher.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 from typing import List
 
 import numpy as np
-from scipy.sparse import issparse, isspmatrix_csr
+from scipy.sparse import issparse
 
 from ... import get_config
 from .._dist_metrics import BOOL_METRICS, METRIC_MAPPING64
@@ -100,7 +100,8 @@ class BaseDistancesReductionDispatcher:
 
         def is_valid_sparse_matrix(X):
             return (
-                isspmatrix_csr(X)
+                issparse(X)
+                and X.format == "csr"
                 and
                 # TODO: support CSR matrices without non-zeros elements
                 X.nnz > 0

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -10,7 +10,7 @@ from scipy.sparse import (
     coo_matrix,
     csc_matrix,
     csr_matrix,
-    isspmatrix_csr,
+    issparse,
 )
 from scipy.special import comb
 
@@ -1355,8 +1355,8 @@ def test_train_test_split_sparse():
     for InputFeatureType in sparse_types:
         X_s = InputFeatureType(X)
         X_train, X_test = train_test_split(X_s)
-        assert isspmatrix_csr(X_train)
-        assert isspmatrix_csr(X_test)
+        assert issparse(X_train) and X_train.format == "csr"
+        assert issparse(X_test) and X_test.format == "csr"
 
 
 def test_train_test_split_mock_pandas():

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2393,7 +2393,7 @@ def add_dummy_feature(X, value=1.0):
     n_samples, n_features = X.shape
     shape = (n_samples, n_features + 1)
     if sparse.issparse(X):
-        if sparse.isspmatrix_coo(X):
+        if X.format == "coo":
             # Shift columns to the right.
             col = X.col + 1
             # Column indices of dummy feature are 0 everywhere.
@@ -2403,7 +2403,7 @@ def add_dummy_feature(X, value=1.0):
             # Prepend the dummy feature n_samples times.
             data = np.concatenate((np.full(n_samples, value), X.data))
             return sparse.coo_matrix((data, (row, col)), shape)
-        elif sparse.isspmatrix_csc(X):
+        elif X.format == "csc":
             # Shift index pointers since we need to add n_samples elements.
             indptr = X.indptr + n_samples
             # indptr[0] must be 0.

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -435,7 +435,7 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
 
         n_samples, n_features = X.shape
         max_int32 = np.iinfo(np.int32).max
-        if sparse.isspmatrix_csr(X):
+        if sparse.issparse(X) and X.format == "csr":
             if self._max_degree > 3:
                 return self.transform(X.tocsc()).tocsr()
             to_stack = []
@@ -480,9 +480,9 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
                         " transformer to produce fewer than 2^31 output features"
                     )
                 XP = sparse.hstack(to_stack, dtype=X.dtype, format="csr")
-        elif sparse.isspmatrix_csc(X) and self._max_degree < 4:
+        elif sparse.issparse(X) and X.format == "csc" and self._max_degree < 4:
             return self.transform(X.tocsr()).tocsc()
-        elif sparse.isspmatrix(X):
+        elif sparse.issparse(X):
             combinations = self._combinations(
                 n_features=n_features,
                 min_degree=self._min_degree,
@@ -1119,8 +1119,7 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
                             XBS[mask, i * n_splines + k] = linear_extr
 
             if use_sparse:
-                if not sparse.isspmatrix_csr(XBS_sparse):
-                    XBS_sparse = XBS_sparse.tocsr()
+                XBS_sparse = XBS_sparse.tocsr()
                 output_list.append(XBS_sparse)
 
         if use_sparse:

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1846,7 +1846,7 @@ def test_normalizer_l1():
         X_norm = normalizer = Normalizer(norm="l2", copy=False).transform(X)
 
         assert X_norm is not X
-        assert sparse.isspmatrix_csr(X_norm)
+        assert sparse.issparse(X_norm) and X_norm.format == "csr"
 
         X_norm = toarray(X_norm)
         for i in range(3):
@@ -1893,7 +1893,7 @@ def test_normalizer_l2():
         X_norm = normalizer = Normalizer(norm="l2", copy=False).transform(X)
 
         assert X_norm is not X
-        assert sparse.isspmatrix_csr(X_norm)
+        assert sparse.issparse(X_norm) and X_norm.format == "csr"
 
         X_norm = toarray(X_norm)
         for i in range(3):
@@ -1941,7 +1941,7 @@ def test_normalizer_max():
         X_norm = normalizer = Normalizer(norm="l2", copy=False).transform(X)
 
         assert X_norm is not X
-        assert sparse.isspmatrix_csr(X_norm)
+        assert sparse.issparse(X_norm) and X_norm.format == "csr"
 
         X_norm = toarray(X_norm)
         for i in range(3):
@@ -2205,21 +2205,21 @@ def test_add_dummy_feature():
 def test_add_dummy_feature_coo():
     X = sparse.coo_matrix([[1, 0], [0, 1], [0, 1]])
     X = add_dummy_feature(X)
-    assert sparse.isspmatrix_coo(X), X
+    assert sparse.issparse(X) and X.format == "coo", X
     assert_array_equal(X.toarray(), [[1, 1, 0], [1, 0, 1], [1, 0, 1]])
 
 
 def test_add_dummy_feature_csc():
     X = sparse.csc_matrix([[1, 0], [0, 1], [0, 1]])
     X = add_dummy_feature(X)
-    assert sparse.isspmatrix_csc(X), X
+    assert sparse.issparse(X) and X.format == "csc", X
     assert_array_equal(X.toarray(), [[1, 1, 0], [1, 0, 1], [1, 0, 1]])
 
 
 def test_add_dummy_feature_csr():
     X = sparse.csr_matrix([[1, 0], [0, 1], [0, 1]])
     X = add_dummy_feature(X)
-    assert sparse.isspmatrix_csr(X), X
+    assert sparse.issparse(X) and X.format == "csr", X
     assert_array_equal(X.toarray(), [[1, 1, 0], [1, 0, 1], [1, 0, 1]])
 
 

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -240,7 +240,7 @@ def check_categorical_onehot(X):
 
     assert_allclose(Xtr1.toarray(), Xtr2)
 
-    assert sparse.isspmatrix_csr(Xtr1)
+    assert sparse.issparse(Xtr1) and Xtr1.format == "csr"
     return Xtr1.toarray()
 
 

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -423,8 +423,10 @@ def test_spline_transformer_sparse_output(
     splt_dense.fit(X)
     splt_sparse.fit(X)
 
-    assert sparse.isspmatrix_csr(splt_sparse.transform(X))
-    assert_allclose(splt_dense.transform(X), splt_sparse.transform(X).toarray())
+    X_trans_sparse = splt_sparse.transform(X)
+    X_trans_dense = splt_dense.transform(X)
+    assert sparse.issparse(X_trans_sparse) and X_trans_sparse.format == "csr"
+    assert_allclose(X_trans_dense, X_trans_sparse.toarray())
 
     # extrapolation regime
     X_min = np.amin(X, axis=0)
@@ -721,7 +723,7 @@ def test_polynomial_features_csc_X(deg, include_bias, interaction_only, dtype):
     Xt_csc = est.fit_transform(X_csc.astype(dtype))
     Xt_dense = est.fit_transform(X.astype(dtype))
 
-    assert sparse.isspmatrix_csc(Xt_csc)
+    assert sparse.issparse(Xt_csc) and Xt_csc.format == "csc"
     assert Xt_csc.dtype == Xt_dense.dtype
     assert_array_almost_equal(Xt_csc.A, Xt_dense)
 
@@ -748,7 +750,7 @@ def test_polynomial_features_csr_X(deg, include_bias, interaction_only, dtype):
     Xt_csr = est.fit_transform(X_csr.astype(dtype))
     Xt_dense = est.fit_transform(X.astype(dtype, copy=False))
 
-    assert sparse.isspmatrix_csr(Xt_csr)
+    assert sparse.issparse(Xt_csr) and Xt_csr.format == "csr"
     assert Xt_csr.dtype == Xt_dense.dtype
     assert_array_almost_equal(Xt_csr.A, Xt_dense)
 
@@ -807,7 +809,7 @@ def test_polynomial_features_csr_X_floats(deg, include_bias, interaction_only, d
     Xt_csr = est.fit_transform(X_csr.astype(dtype))
     Xt_dense = est.fit_transform(X.astype(dtype))
 
-    assert sparse.isspmatrix_csr(Xt_csr)
+    assert sparse.issparse(Xt_csr) and Xt_csr.format == "csr"
     assert Xt_csr.dtype == Xt_dense.dtype
     assert_array_almost_equal(Xt_csr.A, Xt_dense)
 
@@ -838,7 +840,7 @@ def test_polynomial_features_csr_X_zero_row(zero_row_index, deg, interaction_onl
     Xt_csr = est.fit_transform(X_csr)
     Xt_dense = est.fit_transform(X)
 
-    assert sparse.isspmatrix_csr(Xt_csr)
+    assert sparse.issparse(Xt_csr) and Xt_csr.format == "csr"
     assert Xt_csr.dtype == Xt_dense.dtype
     assert_array_almost_equal(Xt_csr.A, Xt_dense)
 
@@ -859,7 +861,7 @@ def test_polynomial_features_csr_X_degree_4(include_bias, interaction_only):
     Xt_csr = est.fit_transform(X_csr)
     Xt_dense = est.fit_transform(X)
 
-    assert sparse.isspmatrix_csr(X_csr)
+    assert sparse.issparse(Xt_csr) and Xt_csr.format == "csr"
     assert Xt_csr.dtype == Xt_dense.dtype
     assert_array_almost_equal(Xt_csr.A, Xt_dense)
 
@@ -887,7 +889,7 @@ def test_polynomial_features_csr_X_dim_edges(deg, dim, interaction_only):
     Xt_csr = est.fit_transform(X_csr)
     Xt_dense = est.fit_transform(X)
 
-    assert sparse.isspmatrix_csr(Xt_csr)
+    assert sparse.issparse(Xt_csr) and Xt_csr.format == "csr"
     assert Xt_csr.dtype == Xt_dense.dtype
     assert_array_almost_equal(Xt_csr.A, Xt_dense)
 

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -294,7 +294,7 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
         l_previous = np.zeros((self.X_.shape[0], n_classes))
 
         unlabeled = unlabeled[:, np.newaxis]
-        if sparse.isspmatrix(graph_matrix):
+        if sparse.issparse(graph_matrix):
             graph_matrix = graph_matrix.tocsr()
 
         for self.n_iter_ in range(self.max_iter):
@@ -456,7 +456,7 @@ class LabelPropagation(BaseLabelPropagation):
             self.nn_fit = None
         affinity_matrix = self._get_kernel(self.X_)
         normalizer = affinity_matrix.sum(axis=0)
-        if sparse.isspmatrix(affinity_matrix):
+        if sparse.issparse(affinity_matrix):
             affinity_matrix.data /= np.diag(np.array(normalizer))
         else:
             affinity_matrix /= normalizer[:, np.newaxis]
@@ -616,7 +616,7 @@ class LabelSpreading(BaseLabelPropagation):
         affinity_matrix = self._get_kernel(self.X_)
         laplacian = csgraph.laplacian(affinity_matrix, normed=True)
         laplacian = -laplacian
-        if sparse.isspmatrix(laplacian):
+        if sparse.issparse(laplacian):
             diag_mask = laplacian.row == laplacian.col
             laplacian.data[diag_mask] = 0.0
         else:

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -179,7 +179,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
         """
         rnd = check_random_state(self.random_state)
 
-        sparse = sp.isspmatrix(X)
+        sparse = sp.issparse(X)
         if sparse and self.kernel == "precomputed":
             raise TypeError("Sparse precomputed kernels are not supported.")
         self._sparse = sparse and not callable(self.kernel)
@@ -617,7 +617,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
                 reset=False,
             )
 
-        if self._sparse and not sp.isspmatrix(X):
+        if self._sparse and not sp.issparse(X):
             X = sp.csr_matrix(X)
         if self._sparse:
             X.sort_indices()
@@ -1222,7 +1222,7 @@ def _fit_liblinear(
     raw_coef_, n_iter_ = liblinear.train_wrap(
         X,
         y_ind,
-        sp.isspmatrix(X),
+        sp.issparse(X),
         solver_type,
         tol,
         bias,

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -45,7 +45,7 @@ iris.data = sparse.csr_matrix(iris.data)
 
 def check_svm_model_equal(dense_svm, sparse_svm, X_train, y_train, X_test):
     dense_svm.fit(X_train.toarray(), y_train)
-    if sparse.isspmatrix(X_test):
+    if sparse.issparse(X_test):
         X_test_dense = X_test.toarray()
     else:
         X_test_dense = X_test
@@ -77,7 +77,7 @@ def check_svm_model_equal(dense_svm, sparse_svm, X_train, y_train, X_test):
             dense_svm.predict_proba(X_test_dense), sparse_svm.predict_proba(X_test), 4
         )
         msg = "cannot use sparse input in 'SVC' trained on dense data"
-    if sparse.isspmatrix(X_test):
+    if sparse.issparse(X_test):
         with pytest.raises(ValueError, match=msg):
             dense_svm.predict(X_test)
 

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -22,7 +22,7 @@ from cython cimport final
 
 import numpy as np
 
-from scipy.sparse import isspmatrix_csc
+from scipy.sparse import issparse
 
 from ._utils cimport log
 from ._utils cimport rand_int
@@ -1100,7 +1100,7 @@ cdef class SparsePartitioner:
         DTYPE_t[::1] feature_values,
         const unsigned char[::1] missing_values_in_feature_mask,
     ):
-        if not isspmatrix_csc(X):
+        if not (issparse(X) and X.format == "csc"):
             raise ValueError("X should be in csc format")
 
         self.samples = samples

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -32,7 +32,6 @@ cnp.import_array()
 
 from scipy.sparse import issparse
 from scipy.sparse import csr_matrix
-from scipy.sparse import isspmatrix_csr
 
 from ._utils cimport safe_realloc
 from ._utils cimport sizet_ptr_to_ndarray
@@ -1018,7 +1017,7 @@ cdef class Tree:
         """Finds the terminal region (=leaf node) for each sample in sparse X.
         """
         # Check input
-        if not isspmatrix_csr(X):
+        if not (issparse(X) and X.format == 'csr'):
             raise ValueError("X should be in csr_matrix format, got %s"
                              % type(X))
 
@@ -1146,7 +1145,7 @@ cdef class Tree:
         """Finds the decision path (=node) for each sample in X."""
 
         # Check input
-        if not isspmatrix_csr(X):
+        if not (issparse(X) and X.format == "csr"):
             raise ValueError("X should be in csr_matrix format, got %s"
                              % type(X))
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -74,8 +74,7 @@ def row_norms(X, squared=False):
         The row-wise (squared) Euclidean norm of X.
     """
     if sparse.issparse(X):
-        if not sparse.isspmatrix_csr(X):
-            X = sparse.csr_matrix(X)
+        X = X.tocsr()
         norms = csr_row_norms(X)
     else:
         norms = np.einsum("ij,ij->i", X, X)
@@ -441,7 +440,7 @@ def randomized_svd(
     >>> U.shape, s.shape, Vh.shape
     ((3, 2), (2,), (2, 4))
     """
-    if sparse.isspmatrix_lil(M) or sparse.isspmatrix_dok(M):
+    if sparse.issparse(M) and M.format in ("lil", "dok"):
         warnings.warn(
             "Calculating SVD of a {} is expensive. "
             "csr_matrix is more efficient.".format(type(M).__name__),

--- a/sklearn/utils/graph.py
+++ b/sklearn/utils/graph.py
@@ -63,7 +63,7 @@ def single_source_shortest_path_length(graph, source, *, cutoff=None):
     >>> sorted(single_source_shortest_path_length(graph, 2).items())
     [(0, 1), (1, 1), (2, 0), (3, 1), (4, 1), (5, 1)]
     """
-    if sparse.isspmatrix(graph):
+    if sparse.issparse(graph):
         graph = graph.tolil()
     else:
         graph = sparse.lil_matrix(graph)

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -11,7 +11,7 @@ from collections.abc import Sequence
 from itertools import chain
 
 import numpy as np
-from scipy.sparse import issparse, isspmatrix_dok, isspmatrix_lil
+from scipy.sparse import issparse
 
 from ..utils._array_api import get_namespace
 from .validation import _assert_all_finite, check_array
@@ -176,7 +176,7 @@ def is_multilabel(y):
         return False
 
     if issparse(y):
-        if isspmatrix_dok(y) or isspmatrix_lil(y):
+        if y.format in ("dok", "lil"):
             y = y.tocsr()
         labels = xp.unique_values(y.data)
         return (

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -107,7 +107,7 @@ def mean_variance_axis(X, axis, weights=None, return_sum_weights=False):
     """
     _raise_error_wrong_axis(axis)
 
-    if sp.isspmatrix_csr(X):
+    if sp.issparse(X) and X.format == "csr":
         if axis == 0:
             return _csr_mean_var_axis0(
                 X, weights=weights, return_sum_weights=return_sum_weights
@@ -116,7 +116,7 @@ def mean_variance_axis(X, axis, weights=None, return_sum_weights=False):
             return _csc_mean_var_axis0(
                 X.T, weights=weights, return_sum_weights=return_sum_weights
             )
-    elif sp.isspmatrix_csc(X):
+    elif sp.issparse(X) and X.format == "csc":
         if axis == 0:
             return _csc_mean_var_axis0(
                 X, weights=weights, return_sum_weights=return_sum_weights
@@ -191,7 +191,7 @@ def incr_mean_variance_axis(X, *, axis, last_mean, last_var, last_n, weights=Non
     """
     _raise_error_wrong_axis(axis)
 
-    if not (sp.isspmatrix_csr(X) or sp.isspmatrix_csc(X)):
+    if not (sp.issparse(X) and X.format in ("csc", "csr")):
         _raise_typeerror(X)
 
     if np.size(last_n) == 1:
@@ -238,9 +238,9 @@ def inplace_column_scale(X, scale):
     scale : ndarray of shape (n_features,), dtype={np.float32, np.float64}
         Array of precomputed feature-wise values to use for scaling.
     """
-    if sp.isspmatrix_csc(X):
+    if sp.issparse(X) and X.format == "csc":
         inplace_csr_row_scale(X.T, scale)
-    elif sp.isspmatrix_csr(X):
+    elif sp.issparse(X) and X.format == "csr":
         inplace_csr_column_scale(X, scale)
     else:
         _raise_typeerror(X)
@@ -260,9 +260,9 @@ def inplace_row_scale(X, scale):
     scale : ndarray of shape (n_features,), dtype={np.float32, np.float64}
         Array of precomputed sample-wise values to use for scaling.
     """
-    if sp.isspmatrix_csc(X):
+    if sp.issparse(X) and X.format == "csc":
         inplace_csr_column_scale(X.T, scale)
-    elif sp.isspmatrix_csr(X):
+    elif sp.issparse(X) and X.format == "csr":
         inplace_csr_row_scale(X, scale)
     else:
         _raise_typeerror(X)
@@ -376,9 +376,9 @@ def inplace_swap_row(X, m, n):
     n : int
         Index of the row of X to be swapped.
     """
-    if sp.isspmatrix_csc(X):
+    if sp.issparse(X) and X.format == "csc":
         inplace_swap_row_csc(X, m, n)
-    elif sp.isspmatrix_csr(X):
+    elif sp.issparse(X) and X.format == "csr":
         inplace_swap_row_csr(X, m, n)
     else:
         _raise_typeerror(X)
@@ -404,9 +404,9 @@ def inplace_swap_column(X, m, n):
         m += X.shape[1]
     if n < 0:
         n += X.shape[1]
-    if sp.isspmatrix_csc(X):
+    if sp.issparse(X) and X.format == "csc":
         inplace_swap_row_csr(X, m, n)
-    elif sp.isspmatrix_csr(X):
+    elif sp.issparse(X) and X.format == "csr":
         inplace_swap_row_csc(X, m, n)
     else:
         _raise_typeerror(X)
@@ -505,7 +505,7 @@ def min_max_axis(X, axis, ignore_nan=False):
     maxs : ndarray of shape (n_features,), dtype={np.float32, np.float64}
         Feature-wise maxima.
     """
-    if sp.isspmatrix_csr(X) or sp.isspmatrix_csc(X):
+    if sp.issparse(X) and X.format in ("csr", "csc"):
         if ignore_nan:
             return _sparse_nan_min_max(X, axis=axis)
         else:
@@ -614,7 +614,7 @@ def csc_median_axis_0(X):
     median : ndarray of shape (n_features,)
         Median.
     """
-    if not sp.isspmatrix_csc(X):
+    if not (sp.issparse(X) and X.format == "csc"):
         raise TypeError("Expected matrix of CSC format, got %s" % X.format)
 
     indptr = X.indptr


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #26418.

#### What does this implement/fix? Explain your changes.

With the deprecation of SciPy sparse matrices, those functions will also be removed.

Note that those changes extend the support of SciPy sparse matrices to SciPy sparse arrays.

#### Any other comments?

