### PR TITLE
CLN `v1.4.rst` entries are not sorted

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -19,6 +19,16 @@ parameters, may produce different models from the previous version. This often
 occurs due to changes in the modelling logic (bug fixes or enhancements), or in
 random sampling procedures.
 
+Changes impacting all modules
+-----------------------------
+
+- |Enhancement| All estimators now recognizes the column names from any dataframe
+  that adopts the
+  `DataFrame Interchange Protocol <https://data-apis.org/dataframe-protocol/latest/purpose_and_scope.html>`__.
+  Dataframes that return a correct representation through `np.asarray(df)` is expected
+  to work with our estimators and functions.
+  :pr:`26464` by `Thomas Fan`_.
+
 Changelog
 ---------
 
@@ -33,24 +43,6 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123456 is the *pull request* number, not the issue number.
 
-Changes impacting all modules
------------------------------
-
-- |Enhancement| All estimators now recognizes the column names from any dataframe
-  that adopts the
-  `DataFrame Interchange Protocol <https://data-apis.org/dataframe-protocol/latest/purpose_and_scope.html>`__.
-  Dataframes that return a correct representation through `np.asarray(df)` is expected
-  to work with our estimators and functions.
-  :pr:`26464` by `Thomas Fan`_.
-
-Code and Documentation Contributors
------------------------------------
-
-Thanks to everyone who has contributed to the maintenance and improvement of
-the project since version 1.3, including:
-
-TODO: update at the time of the release.
-
 :mod:`sklearn.base`
 ...................
 
@@ -59,6 +51,15 @@ TODO: update at the time of the release.
   passed to the ``fit`` method of the the estimator. :pr:`26506` by `Adrin
   Jalali`_.
 
+:mod:`sklearn.decomposition`
+............................
+
+- |Enhancement| An "auto" option was added to the `n_components` parameter of
+  :func:`decomposition.non_negative_factorization`, :class:`decomposition.NMF` and
+  :class:`decomposition.MiniBatchNMF` to automatically infer the number of components from W or H shapes
+  when using a custom initialization. The default value of this parameter will change
+  from `None` to `auto` in version 1.6.
+  :pr:`26634` by :user:`Alexandre Landeau <AlexL>` and :user:`Alexandre Vigny <avigny>`.
 
 :mod:`sklearn.ensemble`
 .......................
@@ -71,6 +72,11 @@ TODO: update at the time of the release.
   :pr:`13649` by :user:`Samuel Ronsin <samronsin>`,
   initiated by :user:`Patrick O'Reilly <pat-oreilly>`.
 
+:mod:`sklearn.feature_selection`
+................................
+
+- |Fix| :func:`feature_selection.mutual_info_regression` now correctly computes the
+  result when `X` is of integer dtype. :pr:`26748` by :user:`Yao Xiao <Charlie-XIAO>`.
 
 :mod:`sklearn.tree`
 ...................
@@ -83,20 +89,10 @@ TODO: update at the time of the release.
   :pr:`13649` by :user:`Samuel Ronsin <samronsin>`, initiated by
   :user:`Patrick O'Reilly <pat-oreilly>`.
 
+Code and Documentation Contributors
+-----------------------------------
 
-:mod:`sklearn.decomposition`
-............................
+Thanks to everyone who has contributed to the maintenance and improvement of
+the project since version 1.3, including:
 
-- |Enhancement| An "auto" option was added to the `n_components` parameter of
-  :func:`decomposition.non_negative_factorization`, :class:`decomposition.NMF` and
-  :class:`decomposition.MiniBatchNMF` to automatically infer the number of components from W or H shapes
-  when using a custom initialization. The default value of this parameter will change
-  from `None` to `auto` in version 1.6.
-  :pr:`26634` by :user:`Alexandre Landeau <AlexL>` and :user:`Alexandre Vigny <avigny>`.
-
-
-:mod:`sklearn.feature_selection`
-................................
-
-- |Fix| :func:`feature_selection.mutual_info_regression` now correctly computes the
-  result when `X` is of integer dtype. :pr:`26748` by :user:`Yao Xiao <Charlie-XIAO>`.
+TODO: update at the time of the release.


### PR DESCRIPTION
#### Reference Issues/PRs

xref https://github.com/scikit-learn/scikit-learn/pull/26748#pullrequestreview-1510597599

#### What does this implement/fix? Explain your changes.

This PR sorts the modules in alphabetical order (according to the guide), and reorders the sections (according to `v1.3.rst`).
