### PR TITLE
MAINT fix cython 3 compilation errors

### DIFF
--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -32,7 +32,9 @@ cdef enum:
     # Max value for our rand_r replacement (near the bottom).
     # We don't use RAND_MAX because it's different across platforms and
     # particularly tiny on Windows/MSVC.
-    RAND_R_MAX = 0x7FFFFFFF
+    # It corresponds to the maximum representable value for
+    # 32-bit signed integers (i.e. 2^31 - 1).
+    RAND_R_MAX = 2147483647
 
 
 cdef inline UINT32_t rand_int(UINT32_t end, UINT32_t* random_state) noexcept nogil:

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -236,7 +236,7 @@ cdef class Criterion:
         double upper_bound,
         double value_left,
         double value_right,
-    ) nogil:
+    ) noexcept nogil:
         cdef:
             bint check_lower_bound = (
                 (value_left >= lower_bound) &

--- a/sklearn/tree/_utils.pxd
+++ b/sklearn/tree/_utils.pxd
@@ -23,7 +23,9 @@ cdef enum:
     # Max value for our rand_r replacement (near the bottom).
     # We don't use RAND_MAX because it's different across platforms and
     # particularly tiny on Windows/MSVC.
-    RAND_R_MAX = 0x7FFFFFFF
+    # It corresponds to the maximum representable value for
+    # 32-bit signed integers (i.e. 2^31 - 1).
+    RAND_R_MAX = 2147483647
 
 
 # safe_realloc(&p, n) resizes the allocation of p to n * sizeof(*p) bytes or

--- a/sklearn/utils/_random.pxd
+++ b/sklearn/utils/_random.pxd
@@ -14,7 +14,7 @@ cdef enum:
     # particularly tiny on Windows/MSVC.
     # It corresponds to the maximum representable value for
     # 32-bit signed integers (i.e. 2^31 - 1).
-    RAND_R_MAX = 0x7FFFFFFF
+    RAND_R_MAX = 2147483647
 
 cpdef sample_without_replacement(cnp.int_t n_population,
                                  cnp.int_t n_samples,


### PR DESCRIPTION
Cython compilation errors seen in scipy dev build with cython 3.0.0rc1.dev0.

- enum with non base 10 int
```
cdef enum:
    # Max value for our rand_r replacement (near the bottom).
    # We don't use RAND_MAX because it's different across platforms and
    # particularly tiny on Windows/MSVC.
    RAND_R_MAX = 0x7FFFFFFF
    ^
------------------------------------------------------------

sklearn/tree/_utils.pxd:26:4: Compiler crash in AnalyseDeclarationsTransform

File 'ModuleNode.py', line 203, in analyse_declarations: ModuleNode(_utils.pxd:1:0,
    full_module_name = 'sklearn.tree._utils',
    is_pxd = True)
File 'Nodes.py', line 393, in analyse_declarations: StatListNode(_utils.pxd:11:0)
File 'Nodes.py', line 393, in analyse_declarations: StatListNode(_utils.pxd:22:5)
File 'Nodes.py', line 1728, in analyse_declarations: CEnumDefNode(_utils.pxd:22:5,
    in_pxd = True,
    visibility = 'private')
File 'Nodes.py', line 1786, in analyse_enum_declarations: CEnumDefItemNode(_utils.pxd:26:4,
    name = 'RAND_R_MAX')

Compiler crash traceback from this point on:
  File "/usr/share/miniconda/envs/testvenv/lib/python3.11/site-packages/Cython/Compiler/Nodes.py", line 1786, in analyse_enum_declarations
    enum_value = int(self.value.value)
                 ^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '0x7FFFFFFF'
```
- non matching function declaration
```
Error compiling Cython file:
------------------------------------------------------------
...
        double lower_bound,
        double upper_bound,
    ) noexcept nogil:
        pass

    cdef inline bint _check_monotonicity(
         ^
------------------------------------------------------------

sklearn/tree/_criterion.pyx:232:9: Signature not compatible with previous declaration

Error compiling Cython file:
------------------------------------------------------------
...
            self,
            cnp.int8_t monotonic_cst,
            double lower_bound,
            double upper_bound,
    ) noexcept nogil
    cdef inline bint _check_monotonicity(
                                        ^
------------------------------------------------------------

sklearn/tree/_criterion.pxd:92:40: Previous declaration is here
```
