### PR TITLE
DOC: add dropdowns to module 1.9 Naive Bayes

### DIFF
--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -147,8 +147,13 @@ that is particularly suited for imbalanced data sets. Specifically, CNB uses
 statistics from the *complement* of each class to compute the model's weights.
 The inventors of CNB show empirically that the parameter estimates for CNB are
 more stable than those for MNB. Further, CNB regularly outperforms MNB (often
-by a considerable margin) on text classification tasks. The procedure for
-calculating the weights is as follows:
+by a considerable margin) on text classification tasks. 
+
+|details-start|
+**Weights forecalculation**
+|details-split|
+
+The procedure forcalculating the weights is as follows:
 
 .. math::
 
@@ -172,6 +177,8 @@ classification rule is:
 
 i.e., a document is assigned to the class that is the *poorest* complement
 match.
+
+|details-end|
 
 .. topic:: References:
 
@@ -239,6 +246,10 @@ For each feature :math:`i` in the training set :math:`X`,
 of X conditioned on the class y. The index set of the samples is defined as
 :math:`J = \{ 1, \dots, m \}`, with :math:`m` as the number of samples.
 
+|details-start|
+**Probability calculation**
+|details-split|
+
 The probability of category :math:`t` in feature :math:`i` given class
 :math:`c` is estimated as:
 
@@ -252,6 +263,8 @@ of times category :math:`t` appears in the samples :math:`x_{i}`, which belong
 to class :math:`c`, :math:`N_{c} = |\{ j \in J\mid y_j = c\}|` is the number
 of samples with class c, :math:`\alpha` is a smoothing parameter and
 :math:`n_i` is the number of available categories of feature :math:`i`.
+
+|details-end|
 
 :class:`CategoricalNB` assumes that the sample matrix :math:`X` is encoded
 (for instance with the help of :class:`OrdinalEncoder`) such that all


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
add dropdowns to the module 1.9 Naive Bayes from Issue #26617 

#### What does this implement/fix? Explain your changes.
Folded:
- Weights forecalculation details in 1.9.3
- Probability calculation details in 1.9.5

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
