### PR TITLE
MAINT do not use nitpicks for sphinx build

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -nT
+SPHINXOPTS    = -T
 SPHINXBUILD  ?= sphinx-build
 PAPER         =
 BUILDDIR      = _build


### PR DESCRIPTION
This setting throws too many warnings for the moment.

https://github.com/scikit-learn/scikit-learn/pull/26779 is intended to remove most of them but we should disable the option in meanwhile.