### PR TITLE
MNT Put nogil at the end of function signature

### DIFF
--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -230,7 +230,7 @@ cdef class Splitter:
         SIZE_t* n_constant_features,
         double lower_bound,
         double upper_bound,
-    ) nogil except -1:
+    ) except -1 nogil:
 
         """Find the best split on node samples[start:end].
 

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -598,7 +598,7 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
         double lower_bound,
         double upper_bound,
         FrontierRecord* res
-    ) nogil except -1:
+    ) except -1 nogil:
         """Adds node w/ partition ``[start, end)`` to the frontier. """
         cdef SplitRecord split
         cdef SIZE_t node_id


### PR DESCRIPTION
This fixes two warnings with the Cython development version:
```
warning: sklearn/tree/_tree.pyx:601:21: The keyword 'nogil' should appear at the end of the function signature line. Placing it before 'except' or 'noexcept' will be disallowed in a future version of Cython.
warning: sklearn/tree/_splitter.pyx:233:21: The keyword 'nogil' should appear at the end of the function signature line. Placing it before 'except' or 'noexcept' will be disallowed in a future version of Cython.
```