### PR TITLE
DOC Fixed a typo error in plot_kernel_pca.py

### DIFF
--- a/examples/decomposition/plot_kernel_pca.py
+++ b/examples/decomposition/plot_kernel_pca.py
@@ -4,7 +4,7 @@ Kernel PCA
 ==========
 
 This example shows the difference between the Principal Components Analysis
-(:class:`~sklearn.decomposition.PCA`) and its kernalized version
+(:class:`~sklearn.decomposition.PCA`) and its kernelized version
 (:class:`~sklearn.decomposition.KernelPCA`).
 
 On the one hand, we show that :class:`~sklearn.decomposition.KernelPCA` is able

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -2301,7 +2301,7 @@ def kernel_metrics():
 
     Returns
     -------
-    kernal_metrics : dict
+    kernel_metrics : dict
         Returns valid metrics for pairwise_kernels.
     """
     return PAIRWISE_KERNEL_FUNCTIONS


### PR DESCRIPTION

fixed a typo error in the file. changed the spelling from "kernalized" to "kernelized".