### PR TITLE
Allow Self Training classifier fit to accept kwargs

### DIFF
--- a/sklearn/semi_supervised/_self_training.py
+++ b/sklearn/semi_supervised/_self_training.py
@@ -175,7 +175,7 @@ class SelfTrainingClassifier(MetaEstimatorMixin, BaseEstimator):
         # SelfTrainingClassifier.base_estimator is not validated yet
         prefer_skip_nested_validation=False
     )
-    def fit(self, X, y):
+    def fit(self, X, y,**kwargs):
         """
         Fit self-training classifier using `X`, `y` as training data.
 
@@ -236,7 +236,7 @@ class SelfTrainingClassifier(MetaEstimatorMixin, BaseEstimator):
         ):
             self.n_iter_ += 1
             self.base_estimator_.fit(
-                X[safe_mask(X, has_label)], self.transduction_[has_label]
+                X[safe_mask(X, has_label)], self.transduction_[has_label],**kwargs
             )
 
             # Predict on the unlabeled samples
@@ -280,7 +280,7 @@ class SelfTrainingClassifier(MetaEstimatorMixin, BaseEstimator):
             self.termination_condition_ = "all_labeled"
 
         self.base_estimator_.fit(
-            X[safe_mask(X, has_label)], self.transduction_[has_label]
+            X[safe_mask(X, has_label)], self.transduction_[has_label],**kwargs
         )
         self.classes_ = self.base_estimator_.classes_
         return self

--- a/sklearn/semi_supervised/_self_training.py
+++ b/sklearn/semi_supervised/_self_training.py
@@ -175,7 +175,7 @@ class SelfTrainingClassifier(MetaEstimatorMixin, BaseEstimator):
         # SelfTrainingClassifier.base_estimator is not validated yet
         prefer_skip_nested_validation=False
     )
-    def fit(self, X, y,**kwargs):
+    def fit(self, X, y, **kwargs):
         """
         Fit self-training classifier using `X`, `y` as training data.
 
@@ -236,7 +236,7 @@ class SelfTrainingClassifier(MetaEstimatorMixin, BaseEstimator):
         ):
             self.n_iter_ += 1
             self.base_estimator_.fit(
-                X[safe_mask(X, has_label)], self.transduction_[has_label],**kwargs
+                X[safe_mask(X, has_label)], self.transduction_[has_label], **kwargs
             )
 
             # Predict on the unlabeled samples
@@ -280,7 +280,7 @@ class SelfTrainingClassifier(MetaEstimatorMixin, BaseEstimator):
             self.termination_condition_ = "all_labeled"
 
         self.base_estimator_.fit(
-            X[safe_mask(X, has_label)], self.transduction_[has_label],**kwargs
+            X[safe_mask(X, has_label)], self.transduction_[has_label], **kwargs
         )
         self.classes_ = self.base_estimator_.classes_
         return self

--- a/sklearn/semi_supervised/_self_training.py
+++ b/sklearn/semi_supervised/_self_training.py
@@ -188,6 +188,9 @@ class SelfTrainingClassifier(MetaEstimatorMixin, BaseEstimator):
             Array representing the labels. Unlabeled samples should have the
             label -1.
 
+        **kwargs : list of keyword arguments to be passed to the `fit` method of the
+            `base_estimator`.
+
         Returns
         -------
         self : object


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Problem
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
We have observed that Sklearn models typically only accept X and y as parameters for the fit method. However, several libraries, such as [Catboost, allow passing additional parameters to the fit method](https://catboost.ai/en/docs/concepts/python-reference_catboost_fit). By enabling kwargs in the fit method, we can make the Self Training classifier wrapper more versatile and compatible with such libraries.
It basically means that we can use Self Training Classifier to train catboost models in a semi-supervised way, without compromising any feature of either library
#### What does this implement/fix? Explain your changes.
The proposed modification enables the passing of any kwargs to the fit method of models.

#### Any other comments?
None

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
