### PR TITLE
MNT clean up old scipy sparse.linalg.cg fallback code

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -119,14 +119,9 @@ def _solve_sparse_cg(
             C = sp_linalg.LinearOperator(
                 (n_features, n_features), matvec=mv, dtype=X.dtype
             )
-            # FIXME atol
-            try:
-                coefs[i], info = sp_linalg.cg(
-                    C, y_column, maxiter=max_iter, tol=tol, atol="legacy"
-                )
-            except TypeError:
-                # old scipy
-                coefs[i], info = sp_linalg.cg(C, y_column, maxiter=max_iter, tol=tol)
+            coefs[i], info = sp_linalg.cg(
+                C, y_column, maxiter=max_iter, tol=tol, atol="legacy"
+            )
 
         if info < 0:
             raise ValueError("Failed with error code %d" % info)

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -105,12 +105,7 @@ def _solve_sparse_cg(
             C = sp_linalg.LinearOperator(
                 (n_samples, n_samples), matvec=mv, dtype=X.dtype
             )
-            # FIXME atol
-            try:
-                coef, info = sp_linalg.cg(C, y_column, tol=tol, atol="legacy")
-            except TypeError:
-                # old scipy
-                coef, info = sp_linalg.cg(C, y_column, tol=tol)
+            coef, info = sp_linalg.cg(C, y_column, tol=tol, atol="legacy")
             coefs[i] = X1.rmatvec(coef)
         else:
             # linear ridge


### PR DESCRIPTION
atol parameter exists since scipy 1.1 https://docs.scipy.org/doc/scipy-1.1.0/reference/generated/scipy.sparse.linalg.cg.html and our min supported version is scipy 1.5.