### PR TITLE
PERF speed up confusion matrix calculation

### DIFF
--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -219,7 +219,7 @@ def check_classification_targets(y):
         )
 
 
-def type_of_target(y, input_name=""):
+def type_of_target(y, input_name="", n_classes=None):
     """Determine the type of data indicated by the target.
 
     Note that this type is the most specific type that can be inferred.
@@ -241,6 +241,11 @@ def type_of_target(y, input_name=""):
         The data name used to construct the error message.
 
         .. versionadded:: 1.1.0
+
+    n_classes : int, default=None
+        Number of classes. Will be inferred from the data if not provided.
+
+        .. versionadded:: 1.4
 
     Returns
     -------
@@ -383,8 +388,9 @@ def type_of_target(y, input_name=""):
             return "continuous" + suffix
 
     # Check multiclass
+    n_classes = n_classes or xp.unique_values(y).shape[0]
     first_row = y[0] if not issparse(y) else y.getrow(0).data
-    if xp.unique_values(y).shape[0] > 2 or (y.ndim == 2 and len(first_row) > 1):
+    if n_classes > 2 or (y.ndim == 2 and len(first_row) > 1):
         # [1, 2, 3] or [[1., 2., 3]] or [[1, 2]]
         return "multiclass" + suffix
     else:


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/26808

Speed up `confusion_matrix` calculation.

This achieves the speedup by calculating the unique values on `y_true` and `y_pred` only once, and adds the required args along the way to the inner methods.

Not sure about the names of the added args on public functions, and might need to refactor to hide them if necessary.

Also this needs to add the same for some other functions to make the tests pass, but for now this works, and brings the time from about 15s to 5s on my machine.

```py
import numpy as np

from sklearn.metrics import classification_report

y_true = np.random.randint(0, 2, size=2**23)
y_pred = y_true.copy()
np.random.shuffle(y_pred[2**20 : 2**21])

print(
    classification_report(
        y_true=y_true,
        y_pred=y_pred,
        digits=10,
        output_dict=False,
        zero_division=0,
    )
)
```