### PR TITLE
MNT Bump Pyodide version to 0.23.4

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,9 +127,9 @@ jobs:
     vmImage: ubuntu-22.04
   variables:
     # Need to match Python version and Emscripten version for the correct
-    # Pyodide version. For Pyodide version 0.23.2, see
-    # https://github.com/pyodide/pyodide/blob/0.23.2/Makefile.envs
-    PYODIDE_VERSION: '0.23.2'
+    # Pyodide version. For example, for Pyodide version 0.23.4, see
+    # https://github.com/pyodide/pyodide/blob/0.23.4/Makefile.envs
+    PYODIDE_VERSION: '0.23.4'
     EMSCRIPTEN_VERSION: '3.1.32'
     PYTHON_VERSION: '3.11.2'
 

--- a/doc/jupyter-lite.json
+++ b/doc/jupyter-lite.json
@@ -3,8 +3,8 @@
   "jupyter-config-data": {
     "litePluginSettings": {
       "@jupyterlite/pyodide-kernel-extension:kernel": {
-        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.23.1/full/pyodide.js"
+        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.23.4/full/pyodide.js"
       }
     }
   }
-} 
+}


### PR DESCRIPTION
Currently the nightly Pyodide build has been failing for some time, bumping to pyodide-build latest release version (0.23.4 released July 7 2023) should fix this. The underlying issue is that pyodide-build needs pydantic<2.

Also used the opportunity to bump the Pyodide version used by JupyterLite.