### PR TITLE
DOC Highlight differerence between SVC/R and LinearSVC/R

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -66,10 +66,10 @@ section :ref:`svm_mathematical_formulation`). On the other hand,
 :class:`LinearSVC` is another (faster) implementation of Support Vector
 Classification for the case of a linear kernel. It also
 lacks some of the attributes of :class:`SVC` and :class:`NuSVC`, like
-``support_``. :class:`LinearSVC` uses ``squared_hinge`` loss and due to its
+`support_`. :class:`LinearSVC` uses `squared_hinge` loss and due to its
 implementation in `liblinear` it also regularizes the intercept, if considered.
 This effect can however be reduced by carefully fine tuning its
-``intercept_scaling`` parameter, which allows the intercept term to have a
+`intercept_scaling` parameter, which allows the intercept term to have a
 different regularization behavior compared to the other features. The
 classification results and score can therefore differ from the other two
 classifiers.
@@ -318,16 +318,16 @@ because the cost function ignores samples whose prediction is close to their
 target.
 
 There are three different implementations of Support Vector Regression:
-:class:`SVR`, :class:`NuSVR` and :class:`LinearSVR`. :class:`LinearSVR` provides
-a faster implementation than :class:`SVR` but only considers the linear kernel,
-while :class:`NuSVR` implements a slightly different formulation than
-:class:`SVR` and :class:`LinearSVR`. Due to its implementation in `liblinear`
-:class:`LinearSVR` also regularizes the intercept, if considered. This effect
-can however be reduced by carefully fine tuning its ``intercept_scaling``
-parameter, which allows the intercept term to have a different regularization
-behavior compared to the other features. The classification results and score
-can therefore differ from the other two classifiers. See
-:ref:`svm_implementation_details` for further details.
+:class:`SVR`, :class:`NuSVR` and :class:`LinearSVR`. :class:`LinearSVR`
+provides a faster implementation than :class:`SVR` but only considers the
+linear kernel, while :class:`NuSVR` implements a slightly different formulation
+than :class:`SVR` and :class:`LinearSVR`. Due to its implementation in
+`liblinear` :class:`LinearSVR` also regularizes the intercept, if considered.
+This effect can however be reduced by carefully fine tuning its
+`intercept_scaling` parameter, which allows the intercept term to have a
+different regularization behavior compared to the other features. The
+classification results and score can therefore differ from the other two
+classifiers. See :ref:`svm_implementation_details` for further details.
 
 As with classification classes, the fit method will take as
 argument vectors X, y, only that in this case y is expected to have

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -60,14 +60,19 @@ capable of performing binary and multi-class classification on a dataset.
    :align: center
 
 
-:class:`SVC` and :class:`NuSVC` are similar methods, but accept
-slightly different sets of parameters and have different mathematical
-formulations (see section :ref:`svm_mathematical_formulation`). On the
-other hand, :class:`LinearSVC` is another (faster) implementation of Support
-Vector Classification for the case of a linear kernel. Note that
-:class:`LinearSVC` does not accept parameter ``kernel``, as this is
-assumed to be linear. It also lacks some of the attributes of
-:class:`SVC` and :class:`NuSVC`, like ``support_``.
+:class:`SVC` and :class:`NuSVC` are similar methods, but accept slightly
+different sets of parameters and have different mathematical formulations (see
+section :ref:`svm_mathematical_formulation`). On the other hand,
+:class:`LinearSVC` is another (faster) implementation of Support Vector
+Classification for the case of a linear kernel. It also
+lacks some of the attributes of :class:`SVC` and :class:`NuSVC`, like
+``support_``. :class:`LinearSVC` uses ``squared_hinge`` loss and due to its
+implementation in `liblinear` it also regularizes the intercept, if considered.
+This effect can however be reduced by carefully fine tuning its
+``intercept_scaling`` parameter, which allows the intercept term to have a
+different regularization behavior compared to the other features. The
+classification results and score can therefore differ from the other two
+classifiers.
 
 As other classifiers, :class:`SVC`, :class:`NuSVC` and
 :class:`LinearSVC` take as input two arrays: an array `X` of shape
@@ -313,10 +318,15 @@ because the cost function ignores samples whose prediction is close to their
 target.
 
 There are three different implementations of Support Vector Regression:
-:class:`SVR`, :class:`NuSVR` and :class:`LinearSVR`. :class:`LinearSVR`
-provides a faster implementation than :class:`SVR` but only considers
-the linear kernel, while :class:`NuSVR` implements a slightly different
-formulation than :class:`SVR` and :class:`LinearSVR`. See
+:class:`SVR`, :class:`NuSVR` and :class:`LinearSVR`. :class:`LinearSVR` provides
+a faster implementation than :class:`SVR` but only considers the linear kernel,
+while :class:`NuSVR` implements a slightly different formulation than
+:class:`SVR` and :class:`LinearSVR`. Due to its implementation in `liblinear`
+:class:`LinearSVR` also regularizes the intercept, if considered. This effect
+can however be reduced by carefully fine tuning its ``intercept_scaling``
+parameter, which allows the intercept term to have a different regularization
+behavior compared to the other features. The classification results and score
+can therefore differ from the other two classifiers. See
 :ref:`svm_implementation_details` for further details.
 
 As with classification classes, the fit method will take as

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -1100,17 +1100,19 @@ def _fit_liblinear(
 
     fit_intercept : bool
         Whether or not to fit an intercept. If set to True, the feature vector
-        is extended to include an intercept term: [x_1, ..., x_n, 1].
+        is extended to include an intercept term: ``[x_1, ..., x_n, 1]``, where
+        1 corresponds to the intercept. If set to False, no intercept will be
+        used in calculations (i.e. data is expected to be already centered).
 
     intercept_scaling : float
-        LibLinear internally penalizes the intercept, treating it like any other
+        Liblinear internally penalizes the intercept, treating it like any other
         term in the feature vector. To reduce the impact of the regularization
         on the intercept, the `intercept_scaling` parameter can be set to a
         value greater than 1. Then, the weights become `[w_x_1, ..., w_x_n,
-        1*intercept_scaling]`, where `w_x_1, ..., w_x_n` represent the feature
-        weights and the intercept term is scaled by `intercept_scaling`. This
-        scaling allows the intercept term to have a different regularization
-        behavior compared to the other features.
+        w_intercept*intercept_scaling]`, where `w_x_1, ..., w_x_n` represent the
+        feature weights and the intercept weight is scaled by
+        `intercept_scaling`. This scaling allows the intercept term to have a
+        different regularization behavior compared to the other features.
 
     class_weight : dict or 'balanced', default=None
         Weights associated with classes in the form ``{class_label: weight}``.

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -825,7 +825,7 @@ class BaseSVC(ClassifierMixin, BaseLibSVM, metaclass=ABCMeta):
     def _check_proba(self):
         if not self.probability:
             raise AttributeError(
-                "predict_proba is not available when  probability=False"
+                "predict_proba is not available when probability=False"
             )
         if self._impl not in ("c_svc", "nu_svc"):
             raise AttributeError("predict_proba only implemented for SVC and NuSVC")
@@ -835,7 +835,7 @@ class BaseSVC(ClassifierMixin, BaseLibSVM, metaclass=ABCMeta):
     def predict_proba(self, X):
         """Compute probabilities of possible outcomes for samples in X.
 
-        The model need to have probability information computed at training
+        The model needs to have probability information computed at training
         time: fit with attribute `probability` set to True.
 
         Parameters
@@ -1095,18 +1095,22 @@ def _fit_liblinear(
         Target vector relative to X
 
     C : float
-        Inverse of cross-validation parameter. Lower the C, the more
+        Inverse of cross-validation parameter. The lower the C, the higher
         the penalization.
 
     fit_intercept : bool
-        Whether or not to fit the intercept, that is to add a intercept
-        term to the decision function.
+        Whether or not to fit an intercept. If set to True, the feature vector
+        is extended to include an intercept term: [x_1, ..., x_n, 1].
 
     intercept_scaling : float
-        LibLinear internally penalizes the intercept and this term is subject
-        to regularization just like the other terms of the feature vector.
-        In order to avoid this, one should increase the intercept_scaling.
-        such that the feature vector becomes [x, intercept_scaling].
+        LibLinear internally penalizes the intercept, treating it like any other
+        term in the feature vector. To reduce the impact of the regularization
+        on the intercept, the `intercept_scaling` parameter can be set to a
+        value greater than 1. Then, the weights become `[w_x_1, ..., w_x_n,
+        1*intercept_scaling]`, where `w_x_1, ..., w_x_n` represent the feature
+        weights and the intercept term is scaled by `intercept_scaling`. This
+        scaling allows the intercept term to have a different regularization
+        behavior compared to the other features.
 
     class_weight : dict or 'balanced', default=None
         Weights associated with classes in the form ``{class_label: weight}``.

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -1105,12 +1105,14 @@ def _fit_liblinear(
         used in calculations (i.e. data is expected to be already centered).
 
     intercept_scaling : float
-        Liblinear internally penalizes the intercept, treating it like any other
-        term in the feature vector. To reduce the impact of the regularization
-        on the intercept, the `intercept_scaling` parameter can be set to a
-        value greater than 1. Then, the weights become `[w_x_1, ..., w_x_n,
-        w_intercept*intercept_scaling]`, where `w_x_1, ..., w_x_n` represent the
-        feature weights and the intercept weight is scaled by
+        Liblinear internally penalizes the intercept, treating it like any
+        other term in the feature vector. To reduce the impact of the
+        regularization on the intercept, the ``intercept_scaling`` parameter
+        can be set to a value greater than 1; the higher the value of
+        ``intercept_scaling``, the lower the impact of regularization on it.
+        Then, the weights become `[w_x_1, ..., w_x_n,
+        w_intercept*intercept_scaling]`, where `w_x_1, ..., w_x_n` represent
+        the feature weights and the intercept weight is scaled by
         `intercept_scaling`. This scaling allows the intercept term to have a
         different regularization behavior compared to the other features.
 

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -1107,9 +1107,9 @@ def _fit_liblinear(
     intercept_scaling : float
         Liblinear internally penalizes the intercept, treating it like any
         other term in the feature vector. To reduce the impact of the
-        regularization on the intercept, the ``intercept_scaling`` parameter
-        can be set to a value greater than 1; the higher the value of
-        ``intercept_scaling``, the lower the impact of regularization on it.
+        regularization on the intercept, the `intercept_scaling` parameter can
+        be set to a value greater than 1; the higher the value of
+        `intercept_scaling`, the lower the impact of regularization on it.
         Then, the weights become `[w_x_1, ..., w_x_n,
         w_intercept*intercept_scaling]`, where `w_x_1, ..., w_x_n` represent
         the feature weights and the intercept weight is scaled by

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -49,9 +49,9 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
     penalties and loss functions and should scale better to large numbers of
     samples.
 
-    The main differences between LinearSVC and SVC lie in the loss function used
-    by default, and in the handling of intercept regularization between those
-    two implementations.
+    The main differences between LinearSVC and SVC lie in the loss function
+    used by default, and in the handling of intercept regularization between
+    those two implementations.
 
     This class supports both dense and sparse input and the multiclass support
     is handled according to a one-vs-the-rest scheme.
@@ -108,18 +108,19 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
         used in calculations (i.e. data is expected to be already centered).
 
     intercept_scaling : float, default=1.0
-        When `fit_intercept` is True, the instance vector x becomes ``[x_1, ...,
-        x_n, intercept_scaling]``, i.e. a "synthetic" feature with a constant
-        value equal to `intercept_scaling` is appended to the instance vector.
-        The intercept becomes intercept_scaling * synthetic feature weight. Use
-        case: Liblinear internally penalizes the intercept, treating it like any
-        other term in the feature vector. To reduce the impact of the
-        regularization on the intercept, the `intercept_scaling` parameter can
-        be set to a value greater than 1. Then, the weights become `[w_x_1, ...,
-        w_x_n, w_intercept*intercept_scaling]`, where `w_x_1, ..., w_x_n`
-        represent the feature weights and the intercept weight is scaled by
-        `intercept_scaling`. This scaling allows the intercept term to have a
-        different regularization behavior compared to the other features.
+        When `fit_intercept` is True, the instance vector x becomes ``[x_1,
+        ..., x_n, intercept_scaling]``, i.e. a "synthetic" feature with a
+        constant value equal to `intercept_scaling` is appended to the instance
+        vector. The intercept becomes intercept_scaling * synthetic feature
+        weight. Note that liblinear internally penalizes the intercept,
+        treating it like any other term in the feature vector. To reduce the
+        impact of the regularization on the intercept, the `intercept_scaling`
+        parameter can be set to a value greater than 1. Then, the weights
+        become `[w_x_1, ..., w_x_n, w_intercept*intercept_scaling]`, where
+        `w_x_1, ..., w_x_n` represent the feature weights and the intercept
+        weight is scaled by `intercept_scaling`. This scaling allows the
+        intercept term to have a different regularization behavior compared to
+        the other features.
 
     class_weight : dict or 'balanced', default=None
         Set the parameter C of class i to ``class_weight[i]*C`` for
@@ -406,18 +407,19 @@ class LinearSVR(RegressorMixin, LinearModel):
         used in calculations (i.e. data is expected to be already centered).
 
     intercept_scaling : float, default=1.0
-        When `fit_intercept` is True, the instance vector x becomes ``[x_1, ...,
-        x_n, intercept_scaling]``, i.e. a "synthetic" feature with a constant
-        value equal to `intercept_scaling` is appended to the instance vector.
-        The intercept becomes intercept_scaling * synthetic feature weight. Use
-        case: Liblinear internally penalizes the intercept, treating it like any
-        other term in the feature vector. To reduce the impact of the
-        regularization on the intercept, the `intercept_scaling` parameter can
-        be set to a value greater than 1. Then, the weights become `[w_x_1, ...,
-        w_x_n, w_intercept*intercept_scaling]`, where `w_x_1, ..., w_x_n`
-        represent the feature weights and the intercept weight is scaled by
-        `intercept_scaling`. This scaling allows the intercept term to have a
-        different regularization behavior compared to the other features.
+        When `fit_intercept` is True, the instance vector x becomes ``[x_1,
+        ..., x_n, intercept_scaling]``, i.e. a "synthetic" feature with a
+        constant value equal to `intercept_scaling` is appended to the instance
+        vector. The intercept becomes intercept_scaling * synthetic feature
+        weight. Note that liblinear internally penalizes the intercept,
+        treating it like any other term in the feature vector. To reduce the
+        impact of the regularization on the intercept, the `intercept_scaling`
+        parameter can be set to a value greater than 1. Then, the weights
+        become `[w_x_1, ..., w_x_n, w_intercept*intercept_scaling]`, where
+        `w_x_1, ..., w_x_n` represent the feature weights and the intercept
+        weight is scaled by `intercept_scaling`. This scaling allows the
+        intercept term to have a different regularization behavior compared to
+        the other features.
 
     dual : "auto" or bool, default=True
         Select the algorithm to either solve the dual or primal

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -49,6 +49,10 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
     penalties and loss functions and should scale better to large numbers of
     samples.
 
+    The main differences between LinearSVC and SVC lie in the loss function used
+    by default, and in the handling of intercept regularization between those
+    two implementations.
+
     This class supports both dense and sparse input and the multiclass support
     is handled according to a one-vs-the-rest scheme.
 
@@ -98,20 +102,24 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
         will be ignored.
 
     fit_intercept : bool, default=True
-        Whether to calculate the intercept for this model. If set
-        to false, no intercept will be used in calculations
-        (i.e. data is expected to be already centered).
+        Whether or not to fit an intercept. If set to True, the feature vector
+        is extended to include an intercept term: ``[x_1, ..., x_n, 1]``, where
+        1 corresponds to the intercept. If set to False, no intercept will be
+        used in calculations (i.e. data is expected to be already centered).
 
     intercept_scaling : float, default=1.0
-        When self.fit_intercept is True, instance vector x becomes
-        ``[x, self.intercept_scaling]``,
-        i.e. a "synthetic" feature with constant value equals to
-        intercept_scaling is appended to the instance vector.
-        The intercept becomes intercept_scaling * synthetic feature weight
-        Note! the synthetic feature weight is subject to l1/l2 regularization
-        as all other features.
-        To lessen the effect of regularization on synthetic feature weight
-        (and therefore on the intercept) intercept_scaling has to be increased.
+        When `fit_intercept` is True, the instance vector x becomes ``[x_1, ...,
+        x_n, intercept_scaling]``, i.e. a "synthetic" feature with a constant
+        value equal to `intercept_scaling` is appended to the instance vector.
+        The intercept becomes intercept_scaling * synthetic feature weight. Use
+        case: Liblinear internally penalizes the intercept, treating it like any
+        other term in the feature vector. To reduce the impact of the
+        regularization on the intercept, the `intercept_scaling` parameter can
+        be set to a value greater than 1. Then, the weights become `[w_x_1, ...,
+        w_x_n, w_intercept*intercept_scaling]`, where `w_x_1, ..., w_x_n`
+        represent the feature weights and the intercept weight is scaled by
+        `intercept_scaling`. This scaling allows the intercept term to have a
+        different regularization behavior compared to the other features.
 
     class_weight : dict or 'balanced', default=None
         Set the parameter C of class i to ``class_weight[i]*C`` for
@@ -361,6 +369,10 @@ class LinearSVR(RegressorMixin, LinearModel):
     penalties and loss functions and should scale better to large numbers of
     samples.
 
+    The main differences between LinearSVR and SVR lie in the loss function used
+    by default, and in the handling of intercept regularization between those
+    two implementations.
+
     This class supports both dense and sparse input.
 
     Read more in the :ref:`User Guide <svm_regression>`.
@@ -388,20 +400,24 @@ class LinearSVR(RegressorMixin, LinearModel):
         loss ('squared_epsilon_insensitive') is the L2 loss.
 
     fit_intercept : bool, default=True
-        Whether to calculate the intercept for this model. If set
-        to false, no intercept will be used in calculations
-        (i.e. data is expected to be already centered).
+        Whether or not to fit an intercept. If set to True, the feature vector
+        is extended to include an intercept term: ``[x_1, ..., x_n, 1]``, where
+        1 corresponds to the intercept. If set to False, no intercept will be
+        used in calculations (i.e. data is expected to be already centered).
 
     intercept_scaling : float, default=1.0
-        When self.fit_intercept is True, instance vector x becomes
-        [x, self.intercept_scaling],
-        i.e. a "synthetic" feature with constant value equals to
-        intercept_scaling is appended to the instance vector.
-        The intercept becomes intercept_scaling * synthetic feature weight
-        Note! the synthetic feature weight is subject to l1/l2 regularization
-        as all other features.
-        To lessen the effect of regularization on synthetic feature weight
-        (and therefore on the intercept) intercept_scaling has to be increased.
+        When `fit_intercept` is True, the instance vector x becomes ``[x_1, ...,
+        x_n, intercept_scaling]``, i.e. a "synthetic" feature with a constant
+        value equal to `intercept_scaling` is appended to the instance vector.
+        The intercept becomes intercept_scaling * synthetic feature weight. Use
+        case: Liblinear internally penalizes the intercept, treating it like any
+        other term in the feature vector. To reduce the impact of the
+        regularization on the intercept, the `intercept_scaling` parameter can
+        be set to a value greater than 1. Then, the weights become `[w_x_1, ...,
+        w_x_n, w_intercept*intercept_scaling]`, where `w_x_1, ..., w_x_n`
+        represent the feature weights and the intercept weight is scaled by
+        `intercept_scaling`. This scaling allows the intercept term to have a
+        different regularization behavior compared to the other features.
 
     dual : "auto" or bool, default=True
         Select the algorithm to either solve the dual or primal
@@ -461,7 +477,7 @@ class LinearSVR(RegressorMixin, LinearModel):
 
     SVR : Implementation of Support Vector Machine regression using libsvm:
         the kernel can be non-linear but its SMO algorithm does not
-        scale to large number of samples as LinearSVC does.
+        scale to large number of samples as LinearSVR does.
 
     sklearn.linear_model.SGDRegressor : SGDRegressor can optimize the same cost
         function as LinearSVR

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -49,9 +49,9 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
     penalties and loss functions and should scale better to large numbers of
     samples.
 
-    The main differences between LinearSVC and SVC lie in the loss function
-    used by default, and in the handling of intercept regularization between
-    those two implementations.
+    The main differences between :class:`~sklearn.svm.LinearSVC` and
+    :class:`~sklearn.svm.SVC` lie in the loss function used by default, and in
+    the handling of intercept regularization between those two implementations.
 
     This class supports both dense and sparse input and the multiclass support
     is handled according to a one-vs-the-rest scheme.
@@ -103,7 +103,7 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
 
     fit_intercept : bool, default=True
         Whether or not to fit an intercept. If set to True, the feature vector
-        is extended to include an intercept term: ``[x_1, ..., x_n, 1]``, where
+        is extended to include an intercept term: `[x_1, ..., x_n, 1]`, where
         1 corresponds to the intercept. If set to False, no intercept will be
         used in calculations (i.e. data is expected to be already centered).
 
@@ -114,10 +114,10 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
         vector. The intercept becomes intercept_scaling * synthetic feature
         weight. Note that liblinear internally penalizes the intercept,
         treating it like any other term in the feature vector. To reduce the
-        impact of the regularization on the intercept, the
-        ``intercept_scaling`` parameter can be set to a value greater than 1;
-        the higher the value of ``intercept_scaling``, the lower the impact of
-        regularization on it. Then, the weights become `[w_x_1, ..., w_x_n,
+        impact of the regularization on the intercept, the `intercept_scaling`
+        parameter can be set to a value greater than 1; the higher the value of
+        `intercept_scaling`, the lower the impact of regularization on it.
+        Then, the weights become `[w_x_1, ..., w_x_n,
         w_intercept*intercept_scaling]`, where `w_x_1, ..., w_x_n` represent
         the feature weights and the intercept weight is scaled by
         `intercept_scaling`. This scaling allows the intercept term to have a
@@ -371,9 +371,9 @@ class LinearSVR(RegressorMixin, LinearModel):
     penalties and loss functions and should scale better to large numbers of
     samples.
 
-    The main differences between LinearSVR and SVR lie in the loss function used
-    by default, and in the handling of intercept regularization between those
-    two implementations.
+    The main differences between :class:`~sklearn.svm.LinearSVR` and
+    :class:`~sklearn.svm.SVR` lie in the loss function used by default, and in
+    the handling of intercept regularization between those two implementations.
 
     This class supports both dense and sparse input.
 
@@ -403,21 +403,21 @@ class LinearSVR(RegressorMixin, LinearModel):
 
     fit_intercept : bool, default=True
         Whether or not to fit an intercept. If set to True, the feature vector
-        is extended to include an intercept term: ``[x_1, ..., x_n, 1]``, where
+        is extended to include an intercept term: `[x_1, ..., x_n, 1]`, where
         1 corresponds to the intercept. If set to False, no intercept will be
         used in calculations (i.e. data is expected to be already centered).
 
     intercept_scaling : float, default=1.0
-        When `fit_intercept` is True, the instance vector x becomes ``[x_1,
-        ..., x_n, intercept_scaling]``, i.e. a "synthetic" feature with a
-        constant value equal to `intercept_scaling` is appended to the instance
-        vector. The intercept becomes intercept_scaling * synthetic feature
-        weight. Note that liblinear internally penalizes the intercept,
-        treating it like any other term in the feature vector. To reduce the
-        impact of the regularization on the intercept, the
-        ``intercept_scaling`` parameter can be set to a value greater than 1;
-        the higher the value of ``intercept_scaling``, the lower the impact of
-        regularization on it. Then, the weights become `[w_x_1, ..., w_x_n,
+        When `fit_intercept` is True, the instance vector x becomes `[x_1, ...,
+        x_n, intercept_scaling]`, i.e. a "synthetic" feature with a constant
+        value equal to `intercept_scaling` is appended to the instance vector.
+        The intercept becomes intercept_scaling * synthetic feature weight.
+        Note that liblinear internally penalizes the intercept, treating it
+        like any other term in the feature vector. To reduce the impact of the
+        regularization on the intercept, the `intercept_scaling` parameter can
+        be set to a value greater than 1; the higher the value of
+        `intercept_scaling`, the lower the impact of regularization on it.
+        Then, the weights become `[w_x_1, ..., w_x_n,
         w_intercept*intercept_scaling]`, where `w_x_1, ..., w_x_n` represent
         the feature weights and the intercept weight is scaled by
         `intercept_scaling`. This scaling allows the intercept term to have a
@@ -480,8 +480,8 @@ class LinearSVR(RegressorMixin, LinearModel):
         same library as this class (liblinear).
 
     SVR : Implementation of Support Vector Machine regression using libsvm:
-        the kernel can be non-linear but its SMO algorithm does not
-        scale to large number of samples as LinearSVR does.
+        the kernel can be non-linear but its SMO algorithm does not scale to
+        large number of samples as :class:`~sklearn.svm.LinearSVR` does.
 
     sklearn.linear_model.SGDRegressor : SGDRegressor can optimize the same cost
         function as LinearSVR

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -114,13 +114,14 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
         vector. The intercept becomes intercept_scaling * synthetic feature
         weight. Note that liblinear internally penalizes the intercept,
         treating it like any other term in the feature vector. To reduce the
-        impact of the regularization on the intercept, the `intercept_scaling`
-        parameter can be set to a value greater than 1. Then, the weights
-        become `[w_x_1, ..., w_x_n, w_intercept*intercept_scaling]`, where
-        `w_x_1, ..., w_x_n` represent the feature weights and the intercept
-        weight is scaled by `intercept_scaling`. This scaling allows the
-        intercept term to have a different regularization behavior compared to
-        the other features.
+        impact of the regularization on the intercept, the
+        ``intercept_scaling`` parameter can be set to a value greater than 1;
+        the higher the value of ``intercept_scaling``, the lower the impact of
+        regularization on it. Then, the weights become `[w_x_1, ..., w_x_n,
+        w_intercept*intercept_scaling]`, where `w_x_1, ..., w_x_n` represent
+        the feature weights and the intercept weight is scaled by
+        `intercept_scaling`. This scaling allows the intercept term to have a
+        different regularization behavior compared to the other features.
 
     class_weight : dict or 'balanced', default=None
         Set the parameter C of class i to ``class_weight[i]*C`` for
@@ -413,13 +414,14 @@ class LinearSVR(RegressorMixin, LinearModel):
         vector. The intercept becomes intercept_scaling * synthetic feature
         weight. Note that liblinear internally penalizes the intercept,
         treating it like any other term in the feature vector. To reduce the
-        impact of the regularization on the intercept, the `intercept_scaling`
-        parameter can be set to a value greater than 1. Then, the weights
-        become `[w_x_1, ..., w_x_n, w_intercept*intercept_scaling]`, where
-        `w_x_1, ..., w_x_n` represent the feature weights and the intercept
-        weight is scaled by `intercept_scaling`. This scaling allows the
-        intercept term to have a different regularization behavior compared to
-        the other features.
+        impact of the regularization on the intercept, the
+        ``intercept_scaling`` parameter can be set to a value greater than 1;
+        the higher the value of ``intercept_scaling``, the lower the impact of
+        regularization on it. Then, the weights become `[w_x_1, ..., w_x_n,
+        w_intercept*intercept_scaling]`, where `w_x_1, ..., w_x_n` represent
+        the feature weights and the intercept weight is scaled by
+        `intercept_scaling`. This scaling allows the intercept term to have a
+        different regularization behavior compared to the other features.
 
     dual : "auto" or bool, default=True
         Select the algorithm to either solve the dual or primal


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #26812

#### What does this implement/fix? Explain your changes.
This PR suggests a way to prevent confusion about similarities and differences between SVC / SCR and LinearSCV / LinearSCR, especially regarding the regularization of an intercept (that is implemented differently in the underlying libraries).
