### PR TITLE
TST Adaboost: Fixed ValueError in test_multidimensional_X

### DIFF
--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -475,9 +475,9 @@ def test_multidimensional_X():
     """
     rng = np.random.RandomState(0)
 
-    X = rng.randn(50, 3, 3)
-    yc = rng.choice([0, 1], 50)
-    yr = rng.randn(50)
+    X = rng.randn(51, 3, 3)
+    yc = rng.choice([0, 1], 51)
+    yr = rng.randn(51)
 
     boost = AdaBoostClassifier(DummyClassifier(strategy="most_frequent"))
     boost.fit(X, yc)


### PR DESCRIPTION
Dataset creation with `RandomState(0)`, in `def test_multidimensional_X()`  resulted in an evenly distributed number of classes on my machine. Thus, the DummyClassifier with `strategy="most_frequent"` couldn't  have better results than random guessing. And the test would fail raising: `ValueError: BaseClassifier in AdaBoostClassifier ensemble is worse than random, ensemble can not be fit.`

I propose to fix this by creating a dataset with an odd number of samples.