### PR TITLE
CLN clean up some repeated code related to SLEP006

### DIFF
--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -38,6 +38,7 @@ from ..utils.extmath import row_norms, softmax
 from ..utils.metadata_routing import (
     MetadataRouter,
     MethodMapping,
+    _raise_for_params,
     _routing_enabled,
     process_routing,
 )
@@ -1791,11 +1792,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
         self : object
             Fitted LogisticRegressionCV estimator.
         """
-        if params and not _routing_enabled():
-            raise ValueError(
-                "params is only supported if enable_metadata_routing=True."
-                " See the User Guide for more information."
-            )
+        _raise_for_params(params, self, "fit")
 
         solver = _check_solver(self.solver, self.penalty, self.dual)
 
@@ -2146,12 +2143,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
         score : float
             Score of self.predict(X) w.r.t. y.
         """
-        if score_params and not _routing_enabled():
-            raise ValueError(
-                "score_params is only supported if enable_metadata_routing=True."
-                " See the User Guide for more information."
-                " https://scikit-learn.org/stable/metadata_routing.html"
-            )
+        _raise_for_params(score_params, self, "score")
 
         scoring = self._get_scorer()
         if _routing_enabled():

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -2167,7 +2167,7 @@ def test_passing_params_without_enabling_metadata_routing():
     are passed while not supported when `enable_metadata_routing=False`."""
     X, y = make_classification(n_samples=10, random_state=0)
     lr_cv = LogisticRegressionCV()
-    msg = "params is only supported if enable_metadata_routing=True"
+    msg = "is only supported if enable_metadata_routing=True"
 
     with config_context(enable_metadata_routing=False):
         params = {"extra_param": 1.0}

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -35,6 +35,7 @@ from ..utils.metadata_routing import (
     MetadataRequest,
     MetadataRouter,
     _MetadataRequester,
+    _raise_for_params,
     _routing_enabled,
     get_routing_for_object,
     process_routing,
@@ -253,11 +254,7 @@ class _BaseScorer(_MetadataRequester):
         score : float
             Score function applied to prediction of estimator on X.
         """
-        if kwargs and not _routing_enabled():
-            raise ValueError(
-                "kwargs is only supported if enable_metadata_routing=True. See"
-                " the User Guide for more information."
-            )
+        _raise_for_params(kwargs, self, None)
 
         _kwargs = copy.deepcopy(kwargs)
         if sample_weight is not None:

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1197,6 +1197,7 @@ def test_scorer_no_op_multiclass_select_proba():
     scorer(lr, X_test, y_test)
 
 
+@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize("name", get_scorer_names(), ids=get_scorer_names())
 def test_scorer_metadata_request(name):
     """Testing metadata requests for scorers.
@@ -1204,90 +1205,87 @@ def test_scorer_metadata_request(name):
     This test checks many small things in a large test, to reduce the
     boilerplate required for each section.
     """
-    with config_context(enable_metadata_routing=True):
-        # Make sure they expose the routing methods.
-        scorer = get_scorer(name)
-        assert hasattr(scorer, "set_score_request")
-        assert hasattr(scorer, "get_metadata_routing")
+    # Make sure they expose the routing methods.
+    scorer = get_scorer(name)
+    assert hasattr(scorer, "set_score_request")
+    assert hasattr(scorer, "get_metadata_routing")
 
-        # Check that by default no metadata is requested.
-        assert_request_is_empty(scorer.get_metadata_routing())
+    # Check that by default no metadata is requested.
+    assert_request_is_empty(scorer.get_metadata_routing())
 
-        weighted_scorer = scorer.set_score_request(sample_weight=True)
-        # set_score_request should mutate the instance, rather than returning a
-        # new instance
-        assert weighted_scorer is scorer
+    weighted_scorer = scorer.set_score_request(sample_weight=True)
+    # set_score_request should mutate the instance, rather than returning a
+    # new instance
+    assert weighted_scorer is scorer
 
-        # make sure the scorer doesn't request anything on methods other than
-        # `score`, and that the requested value on `score` is correct.
-        assert_request_is_empty(weighted_scorer.get_metadata_routing(), exclude="score")
-        assert (
-            weighted_scorer.get_metadata_routing().score.requests["sample_weight"]
-            is True
-        )
+    # make sure the scorer doesn't request anything on methods other than
+    # `score`, and that the requested value on `score` is correct.
+    assert_request_is_empty(weighted_scorer.get_metadata_routing(), exclude="score")
+    assert (
+        weighted_scorer.get_metadata_routing().score.requests["sample_weight"] is True
+    )
 
-        # make sure putting the scorer in a router doesn't request anything by
-        # default
-        router = MetadataRouter(owner="test").add(
-            method_mapping="score", scorer=get_scorer(name)
-        )
-        # make sure `sample_weight` is refused if passed.
-        with pytest.raises(TypeError, match="got unexpected argument"):
-            router.validate_metadata(params={"sample_weight": 1}, method="score")
-        # make sure `sample_weight` is not routed even if passed.
-        routed_params = router.route_params(params={"sample_weight": 1}, caller="score")
-        assert not routed_params.scorer.score
-
-        # make sure putting weighted_scorer in a router requests sample_weight
-        router = MetadataRouter(owner="test").add(
-            scorer=weighted_scorer, method_mapping="score"
-        )
+    # make sure putting the scorer in a router doesn't request anything by
+    # default
+    router = MetadataRouter(owner="test").add(
+        method_mapping="score", scorer=get_scorer(name)
+    )
+    # make sure `sample_weight` is refused if passed.
+    with pytest.raises(TypeError, match="got unexpected argument"):
         router.validate_metadata(params={"sample_weight": 1}, method="score")
-        routed_params = router.route_params(params={"sample_weight": 1}, caller="score")
-        assert list(routed_params.scorer.score.keys()) == ["sample_weight"]
+    # make sure `sample_weight` is not routed even if passed.
+    routed_params = router.route_params(params={"sample_weight": 1}, caller="score")
+    assert not routed_params.scorer.score
+
+    # make sure putting weighted_scorer in a router requests sample_weight
+    router = MetadataRouter(owner="test").add(
+        scorer=weighted_scorer, method_mapping="score"
+    )
+    router.validate_metadata(params={"sample_weight": 1}, method="score")
+    routed_params = router.route_params(params={"sample_weight": 1}, caller="score")
+    assert list(routed_params.scorer.score.keys()) == ["sample_weight"]
 
 
+@pytest.mark.usefixtures("enable_slep006")
 def test_metadata_kwarg_conflict():
     """This test makes sure the right warning is raised if the user passes
     some metadata both as a constructor to make_scorer, and during __call__.
     """
-    with config_context(enable_metadata_routing=True):
-        X, y = make_classification(
-            n_classes=3, n_informative=3, n_samples=20, random_state=0
-        )
-        lr = LogisticRegression().fit(X, y)
+    X, y = make_classification(
+        n_classes=3, n_informative=3, n_samples=20, random_state=0
+    )
+    lr = LogisticRegression().fit(X, y)
 
-        scorer = make_scorer(
-            roc_auc_score,
-            needs_proba=True,
-            multi_class="ovo",
-            labels=lr.classes_,
-        )
-        with pytest.warns(UserWarning, match="already set as kwargs"):
-            scorer.set_score_request(labels=True)
+    scorer = make_scorer(
+        roc_auc_score,
+        needs_proba=True,
+        multi_class="ovo",
+        labels=lr.classes_,
+    )
+    with pytest.warns(UserWarning, match="already set as kwargs"):
+        scorer.set_score_request(labels=True)
 
-        with config_context(enable_metadata_routing=True):
-            with pytest.warns(UserWarning, match="There is an overlap"):
-                scorer(lr, X, y, labels=lr.classes_)
+    with pytest.warns(UserWarning, match="There is an overlap"):
+        scorer(lr, X, y, labels=lr.classes_)
 
 
+@pytest.mark.usefixtures("enable_slep006")
 def test_PassthroughScorer_metadata_request():
     """Test that _PassthroughScorer properly routes metadata.
 
     _PassthroughScorer should behave like a consumer, mirroring whatever is the
     underlying score method.
     """
-    with config_context(enable_metadata_routing=True):
-        scorer = _PassthroughScorer(
-            estimator=LinearSVC()
-            .set_score_request(sample_weight="alias")
-            .set_fit_request(sample_weight=True)
-        )
-        # test that _PassthroughScorer leaves everything other than `score` empty
-        assert_request_is_empty(scorer.get_metadata_routing(), exclude="score")
-        # test that _PassthroughScorer doesn't behave like a router and leaves
-        # the request as is.
-        assert scorer.get_metadata_routing().score.requests["sample_weight"] == "alias"
+    scorer = _PassthroughScorer(
+        estimator=LinearSVC()
+        .set_score_request(sample_weight="alias")
+        .set_fit_request(sample_weight=True)
+    )
+    # test that _PassthroughScorer leaves everything other than `score` empty
+    assert_request_is_empty(scorer.get_metadata_routing(), exclude="score")
+    # test that _PassthroughScorer doesn't behave like a router and leaves
+    # the request as is.
+    assert scorer.get_metadata_routing().score.requests["sample_weight"] == "alias"
 
 
 def test_multimetric_scoring_metadata_routing():
@@ -1344,5 +1342,7 @@ def test_kwargs_without_metadata_routing_error():
     clf = DecisionTreeClassifier().fit(X, y)
     scorer = make_scorer(score)
     with config_context(enable_metadata_routing=False):
-        with pytest.raises(ValueError, match="kwargs is only supported if"):
+        with pytest.raises(
+            ValueError, match="is only supported if enable_metadata_routing=True"
+        ):
             scorer(clf, X, y, param="blah")

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -36,6 +36,7 @@ from .utils._param_validation import HasMethods, StrOptions
 from .utils.metadata_routing import (
     MetadataRouter,
     MethodMapping,
+    _raise_for_params,
     _routing_enabled,
     process_routing,
 )
@@ -148,11 +149,7 @@ class _MultiOutputEstimator(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta
         self : object
             Returns a fitted instance.
         """
-        if partial_fit_params and not _routing_enabled():
-            raise ValueError(
-                "partial_fit_params is only supported if enable_metadata_routing=True."
-                " See the User Guide for more information."
-            )
+        _raise_for_params(partial_fit_params, self, "partial_fit")
 
         first_time = not hasattr(self, "estimators_")
 
@@ -919,11 +916,7 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
         self : object
             Class instance.
         """
-        if fit_params and not _routing_enabled():
-            raise ValueError(
-                "fit_params is only supported if enable_metadata_routing=True. "
-                "See the User Guide for more information."
-            )
+        _raise_for_params(fit_params, self, "fit")
 
         super().fit(X, Y, **fit_params)
         self.classes_ = [

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -27,6 +27,7 @@ from .utils._tags import _safe_tags
 from .utils.metadata_routing import (
     MetadataRouter,
     MethodMapping,
+    _raise_for_params,
     _routing_enabled,
     process_routing,
 )
@@ -742,11 +743,7 @@ class Pipeline(_BaseComposition):
         y_score : ndarray of shape (n_samples, n_classes)
             Result of calling `decision_function` on the final estimator.
         """
-        if params and not _routing_enabled():
-            raise ValueError(
-                "params is only supported if enable_metadata_routing=True."
-                " See the User Guide for more information."
-            )
+        _raise_for_params(params, self, "decision_function")
 
         # not branching here since params is only available if
         # enable_metadata_routing=True
@@ -881,11 +878,7 @@ class Pipeline(_BaseComposition):
         Xt : ndarray of shape (n_samples, n_transformed_features)
             Transformed data.
         """
-        if not _routing_enabled() and params:
-            raise ValueError(
-                "params is only supported if enable_metadata_routing=True."
-                " See the User Guide for more information."
-            )
+        _raise_for_params(params, self, "transform")
 
         # not branching here since params is only available if
         # enable_metadata_routing=True
@@ -928,11 +921,7 @@ class Pipeline(_BaseComposition):
             Inverse transformed data, that is, data in the original feature
             space.
         """
-        if not _routing_enabled() and params:
-            raise ValueError(
-                "params is only supported if enable_metadata_routing=True. See"
-                " the User Guide for more information."
-            )
+        _raise_for_params(params, self, "inverse_transform")
 
         # we don't have to branch here, since params is only non-empty if
         # enable_metadata_routing=True.

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -127,6 +127,40 @@ def _routing_enabled():
     return get_config().get("enable_metadata_routing", False)
 
 
+def _raise_for_params(params, owner, method):
+    """Raise an error if metadata routing is not enabled and params are passed.
+
+    .. versionadded:: 1.4
+
+    Parameters
+    ----------
+    params : dict
+        The metadata passed to a method.
+
+    owner : object
+        The object to which the method belongs.
+
+    method : str
+        The name of the method, e.g. "fit".
+
+    Raises
+    ------
+    ValueError
+        If metadata routing is not enabled and params are passed.
+    """
+    caller = (
+        f"{owner.__class__.__name__}.{method}" if method else owner.__class__.__name__
+    )
+    if not _routing_enabled() and params:
+        raise ValueError(
+            f"Passing extra keyword arguments to {caller} is only supported if"
+            " enable_metadata_routing=True, which you can set using"
+            " `sklearn.set_config`. See the User Guide"
+            " <https://scikit-learn.org/stable/metadata_routing.html> for more"
+            " details."
+        )
+
+
 # Request values
 # ==============
 # Each request value needs to be one of the following values, or an alias.

--- a/sklearn/utils/metadata_routing.py
+++ b/sklearn/utils/metadata_routing.py
@@ -16,3 +16,4 @@ from ._metadata_requests import MethodMapping  # noqa
 from ._metadata_requests import process_routing  # noqa
 from ._metadata_requests import _MetadataRequester  # noqa
 from ._metadata_requests import _routing_enabled  # noqa
+from ._metadata_requests import _raise_for_params  # noqa


### PR DESCRIPTION
This creates a `_raise_for_params` to move the raise statement and the message to one place, which we're gonna have in more places than what's already in `main`.

Also uses the fixture to enable metadata routing in tests when appropriate, instead of directly using the context manager.

cc @OmarManzoor @glemaitre 