### PR TITLE
DOC Remove reference to CharNGramAnalyzer

### DIFF
--- a/doc/tutorial/text_analytics/working_with_text_data.rst
+++ b/doc/tutorial/text_analytics/working_with_text_data.rst
@@ -520,7 +520,7 @@ Exercise 1: Language identification
 -----------------------------------
 
 - Write a text classification pipeline using a custom preprocessor and
-  ``CharNGramAnalyzer`` using data from Wikipedia articles as training set.
+  ``CountVectorizer`` set up to use character based n-grams, using data from Wikipedia articles as the training set.
 
 - Evaluate the performance on some held out test set.
 

--- a/doc/tutorial/text_analytics/working_with_text_data.rst
+++ b/doc/tutorial/text_analytics/working_with_text_data.rst
@@ -520,7 +520,7 @@ Exercise 1: Language identification
 -----------------------------------
 
 - Write a text classification pipeline using a custom preprocessor and
-  ``CountVectorizer`` set up to use character based n-grams, using data from Wikipedia articles as the training set.
+  ``TfidfVectorizer`` set up to use character based n-grams, using data from Wikipedia articles as the training set.
 
 - Evaluate the performance on some held out test set.
 


### PR DESCRIPTION
As CharNGramAnalyzer was removed in 2012, this commit replaces the reference to it in the tutorial with a reference to CountVectorizer set up to use character based n-grams.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: 
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #26843

#### What does this implement/fix? Explain your changes.
It removes the reference to CharNGramAnalyzer, replacing it with CountVectorizer.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
