### PR TITLE
CI Add summary about failures and errors in most builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,7 +171,7 @@ jobs:
         DISTRIB: 'conda'
         LOCK_FILE: './build_tools/azure/pylatest_conda_forge_mkl_linux-64_conda.lock'
         COVERAGE: 'true'
-        SHOW_SHORT_SUMMARY: 'true'
+        SHOW_LONG_SUMMARY: 'true'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '42'  # default global random seed
 
 # Check compilation with Ubuntu 22.04 LTS (Jammy Jellyfish) and scipy from conda-forge

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,7 +171,6 @@ jobs:
         DISTRIB: 'conda'
         LOCK_FILE: './build_tools/azure/pylatest_conda_forge_mkl_linux-64_conda.lock'
         COVERAGE: 'true'
-        SHOW_LONG_SUMMARY: 'true'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '42'  # default global random seed
 
 # Check compilation with Ubuntu 22.04 LTS (Jammy Jellyfish) and scipy from conda-forge

--- a/build_tools/azure/posix-docker.yml
+++ b/build_tools/azure/posix-docker.yml
@@ -22,7 +22,6 @@ jobs:
     # Set in azure-pipelines.yml
     DISTRIB: ''
     DOCKER_CONTAINER: ''
-    SHOW_LONG_SUMMARY: 'false'
     CREATE_ISSUE_ON_TRACKER: 'true'
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
     CCACHE_COMPRESS: '1'

--- a/build_tools/azure/posix-docker.yml
+++ b/build_tools/azure/posix-docker.yml
@@ -22,7 +22,7 @@ jobs:
     # Set in azure-pipelines.yml
     DISTRIB: ''
     DOCKER_CONTAINER: ''
-    SHOW_SHORT_SUMMARY: 'false'
+    SHOW_LONG_SUMMARY: 'false'
     CREATE_ISSUE_ON_TRACKER: 'true'
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
     CCACHE_COMPRESS: '1'

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -22,7 +22,7 @@ jobs:
     PYTEST_XDIST_VERSION: 'latest'
     COVERAGE: 'true'
     CREATE_ISSUE_ON_TRACKER: 'true'
-    SHOW_SHORT_SUMMARY: 'false'
+    SHOW_LONG_SUMMARY: 'false'
   strategy:
     matrix:
       ${{ insert }}: ${{ parameters.matrix }}

--- a/build_tools/azure/posix.yml
+++ b/build_tools/azure/posix.yml
@@ -22,7 +22,6 @@ jobs:
     PYTEST_XDIST_VERSION: 'latest'
     COVERAGE: 'true'
     CREATE_ISSUE_ON_TRACKER: 'true'
-    SHOW_LONG_SUMMARY: 'false'
   strategy:
     matrix:
       ${{ insert }}: ${{ parameters.matrix }}

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -75,10 +75,6 @@ if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
     TEST_CMD="$TEST_CMD -n$XDIST_WORKERS"
 fi
 
-if [[ "$SHOW_LONG_SUMMARY" == "true" ]]; then
-    TEST_CMD="$TEST_CMD -ra"
-fi
-
 if [[ -n "$SELECTED_TESTS" ]]; then
     TEST_CMD="$TEST_CMD -k $SELECTED_TESTS"
 

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -75,7 +75,7 @@ if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
     TEST_CMD="$TEST_CMD -n$XDIST_WORKERS"
 fi
 
-if [[ "$SHOW_SHORT_SUMMARY" == "true" ]]; then
+if [[ "$SHOW_LONG_SUMMARY" == "true" ]]; then
     TEST_CMD="$TEST_CMD -ra"
 fi
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ addopts =
     # correctly on the CI when running `pytest --pyargs sklearn` from the
     # source folder.
     -p sklearn.tests.random_seed
-    -rN
 
 filterwarnings =
     ignore:the matrix subclass:PendingDeprecationWarning


### PR DESCRIPTION
I would find it very useful to have the default pytest summary for failures and errors. This allows to go to the end of the CI log and have at a quick glance an idea where things are broken and whether the same root cause is causing all the errors (although the limit is width is not that helpful sometimes oh well ...). Right now if I want to have an idea of which test are broken, I tend to look `test_` in the CI log which is not very efficient given CI log verbosity.

Maybe I am biased because I have looked at broken scipy-dev builds recently, where there are 100+ errors currently. I think it would be useful generally speaking.

The `-rN` was added in https://github.com/scikit-learn/scikit-learn/pull/21554, I guess because `-ra` was too long which makes sense but having "errors + failures" feels like a better default.

I also renamed SHOW_SHORT_SUMMARY => SHOW_LONG_SUMMARY, since `-ra` is all except passed and is a lot more than the default summary "errors + failures"
