### PR TITLE
CI Only update tracker to succes when all jobs pass on CirrusCI

### DIFF
--- a/build_tools/cirrus/arm_wheel.yml
+++ b/build_tools/cirrus/arm_wheel.yml
@@ -31,7 +31,6 @@ macos_arm64_wheel_task:
 
   cibuildwheel_script:
     - bash build_tools/wheels/build_wheels.sh
-    - bash build_tools/cirrus/update_tracking_issue.sh true
 
   on_failure:
     update_tracker_script:
@@ -73,7 +72,6 @@ linux_arm64_wheel_task:
   cibuildwheel_script:
     - apt install -y python3 python-is-python3
     - bash build_tools/wheels/build_wheels.sh
-    - bash build_tools/cirrus/update_tracking_issue.sh true
 
   on_failure:
     update_tracker_script:
@@ -82,6 +80,17 @@ linux_arm64_wheel_task:
   wheels_artifacts:
     path: "wheelhouse/*"
 
+# Update tracker when all jobs are successful
+update_tracker_success:
+  depends_on:
+    - macos_arm64_wheel
+    - linux_arm64_wheel
+  container:
+    image: python:3.11
+  # Only update tracker for nightly builds
+  only_if: $CIRRUS_CRON == "nightly"
+  update_script:
+    - bash build_tools/cirrus/update_tracking_issue.sh true
 
 wheels_upload_task:
   depends_on:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes CI issue observed in https://github.com/scikit-learn/scikit-learn/issues/26745


#### What does this implement/fix? Explain your changes.
On `main`, each wheel build is updating the tracker independently for success. This means that if a build failed early, but a later build succeeded, the issue tracker will say that everything passed.

With this PR, if any of the builds fail, they will update the tracker for failure. Only when **all** the wheels pass does the tracker gets update to success.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
