### PR TITLE
fix: add cython max version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 requires = [
     "setuptools",
     "wheel",
-    "Cython>=0.28.5",
+    "Cython >=0.28.5, <3.0.0",
 
     # PyPy needs numpy >= 1.14.0
     # platform_python_implementation!='CPython' not needed >= Python 3.7 which is numpy 1.14.5

--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -29,7 +29,10 @@ def _check_cython_version():
         # Re-raise with more informative error message instead:
         raise ModuleNotFoundError(message) from e
 
-    if LooseVersion(Cython.__version__) < CYTHON_MIN_VERSION or LooseVersion(Cython.__version__) >= CYTHON_MAX_VERSION:
+    if (
+        LooseVersion(Cython.__version__) < CYTHON_MIN_VERSION
+        or LooseVersion(Cython.__version__) >= CYTHON_MAX_VERSION
+    ):
         message += (' The current version of Cython is {} installed in {}.'
                     .format(Cython.__version__, Cython.__path__))
         raise ValueError(message)

--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -13,23 +13,23 @@ from distutils.version import LooseVersion
 
 from .pre_build_helpers import basic_check_build
 from .openmp_helpers import check_openmp_support
-from .._min_dependencies import CYTHON_MIN_VERSION
+from .._min_dependencies import CYTHON_MIN_VERSION, CYTHON_MAX_VERSION
 
 
 DEFAULT_ROOT = 'sklearn'
 
 
 def _check_cython_version():
-    message = ('Please install Cython with a version >= {0} in order '
+    message = ('Please install Cython with a version >= {0} < {1} in order '
                'to build a scikit-learn from source.').format(
-                    CYTHON_MIN_VERSION)
+                    CYTHON_MIN_VERSION, CYTHON_MAX_VERSION)
     try:
         import Cython
     except ModuleNotFoundError as e:
         # Re-raise with more informative error message instead:
         raise ModuleNotFoundError(message) from e
 
-    if LooseVersion(Cython.__version__) < CYTHON_MIN_VERSION:
+    if LooseVersion(Cython.__version__) < CYTHON_MIN_VERSION or LooseVersion(Cython.__version__) >= CYTHON_MAX_VERSION:
         message += (' The current version of Cython is {} installed in {}.'
                     .format(Cython.__version__, Cython.__path__))
         raise ValueError(message)

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -15,7 +15,7 @@ JOBLIB_MIN_VERSION = '0.11'
 THREADPOOLCTL_MIN_VERSION = '2.0.0'
 PYTEST_MIN_VERSION = '5.0.1'
 CYTHON_MIN_VERSION = '0.28.5'
-CYTHON_MAX_VERSION = '1.0.0'
+CYTHON_MAX_VERSION = '3.0.0'
 
 
 # 'build' and 'install' is included to have structured metadata for CI.

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -15,6 +15,7 @@ JOBLIB_MIN_VERSION = '0.11'
 THREADPOOLCTL_MIN_VERSION = '2.0.0'
 PYTEST_MIN_VERSION = '5.0.1'
 CYTHON_MIN_VERSION = '0.28.5'
+CYTHON_MAX_VERSION = '1.0.0'
 
 
 # 'build' and 'install' is included to have structured metadata for CI.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #26850

#### What does this implement/fix? Explain your changes.
- Set a upper limit on the Cython version required for build tools (`Cython < 3.0.0`) in addition to the minimum version.
- Add a `CYTHON_MAX_VERSION` constant in addition to `CYTHON_MIN_VERSION` and update
  `sklearn._build_utils._check_cython_version` to also check against this version

#### Any other comments?
None

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
