### PR TITLE
Add tests for train_test_split with Array API input

### DIFF
--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -83,17 +83,26 @@ the tensors directly::
     >>> X_trans.device.type
     'cuda'
 
-.. _array_api_estimators:
+.. _array_api_supported:
 
-Estimators with support for `Array API`-compatible inputs
-=========================================================
+Support for `Array API`-compatible inputs
+=========================================
+
+Estimators and other tools in scikit-learn that support Array API compatible inputs.
+
+Estimators
+----------
 
 - :class:`decomposition.PCA` (with `svd_solver="full"`,
   `svd_solver="randomized"` and `power_iteration_normalizer="QR"`)
 - :class:`discriminant_analysis.LinearDiscriminantAnalysis` (with `solver="svd"`)
 
-Coverage for more estimators is expected to grow over time. Please follow the
-dedicated `meta-issue on GitHub
+Tools
+-----
+
+- :func:`model_selection.train_test_split`
+
+Coverage is expected to grow over time. Please follow the dedicated `meta-issue on GitHub
 <https://github.com/scikit-learn/scikit-learn/issues/22352>`_ to track progress.
 
 Common estimator checks

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -171,6 +171,9 @@ Changelog
   when `sparse_output=True` and the output is configured to be pandas.
   :pr:`26931` by `Thomas Fan`_.
 
+- |Enhancement| :func:`sklearn.model_selection.train_test_split` now supports
+  Array API compatible inputs. :pr:`26855` by `Tim Head`_.
+
 :mod:`sklearn.tree`
 ...................
 

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1295,7 +1295,7 @@ def test_array_api_train_test_split(shuffle, stratify, array_namepsace, device, 
     y_np = y.astype(dtype)
     y_xp = xp.asarray(y_np, device=device)
 
-    np_X_train, np_X_test, np_y_train, np_y_test = train_test_split(
+    X_train_np, X_test_np, y_train_np, y_test_np = train_test_split(
         X_np, y, random_state=0, shuffle=shuffle, stratify=stratify
     )
     with config_context(array_api_dispatch=True):
@@ -1303,37 +1303,35 @@ def test_array_api_train_test_split(shuffle, stratify, array_namepsace, device, 
             stratify_xp = xp.asarray(stratify)
         else:
             stratify_xp = stratify
-        xp_X_train, xp_X_test, xp_y_train, xp_y_test = train_test_split(
+        X_train_xp, X_test_xp, y_train_xp, y_test_xp = train_test_split(
             X_xp, y_xp, shuffle=shuffle, stratify=stratify_xp, random_state=0
         )
 
         # Check that namespace is preserved, has to happen with
         # array_api_dispatch enabled.
-        assert get_namespace(xp_X_train)[0] == get_namespace(X_xp)[0]
-        assert get_namespace(xp_X_test)[0] == get_namespace(X_xp)[0]
-        assert get_namespace(xp_y_train)[0] == get_namespace(y_xp)[0]
-        assert get_namespace(xp_y_test)[0] == get_namespace(y_xp)[0]
-
-        print("namespace", get_namespace(xp_y_test)[0])
+        assert get_namespace(X_train_xp)[0] == get_namespace(X_xp)[0]
+        assert get_namespace(X_test_xp)[0] == get_namespace(X_xp)[0]
+        assert get_namespace(y_train_xp)[0] == get_namespace(y_xp)[0]
+        assert get_namespace(y_test_xp)[0] == get_namespace(y_xp)[0]
 
     # Check device and dtype is preserved on output
-    assert array_api_device(xp_X_train) == array_api_device(X_xp)
-    assert array_api_device(xp_y_train) == array_api_device(y_xp)
-    assert array_api_device(xp_X_test) == array_api_device(X_xp)
-    assert array_api_device(xp_y_test) == array_api_device(y_xp)
+    assert array_api_device(X_train_xp) == array_api_device(X_xp)
+    assert array_api_device(y_train_xp) == array_api_device(y_xp)
+    assert array_api_device(X_test_xp) == array_api_device(X_xp)
+    assert array_api_device(y_test_xp) == array_api_device(y_xp)
 
-    assert xp_X_train.dtype == X_xp.dtype
-    assert xp_y_train.dtype == y_xp.dtype
-    assert xp_X_test.dtype == X_xp.dtype
-    assert xp_y_test.dtype == y_xp.dtype
+    assert X_train_xp.dtype == X_xp.dtype
+    assert y_train_xp.dtype == y_xp.dtype
+    assert X_test_xp.dtype == X_xp.dtype
+    assert y_test_xp.dtype == y_xp.dtype
 
     assert_allclose(
-        _convert_to_numpy(xp_X_train, xp=xp),
-        np_X_train,
+        _convert_to_numpy(X_train_xp, xp=xp),
+        X_train_np,
     )
     assert_allclose(
-        _convert_to_numpy(xp_X_test, xp=xp),
-        np_X_test,
+        _convert_to_numpy(X_test_xp, xp=xp),
+        X_test_np,
     )
 
 

--- a/sklearn/preprocessing/tests/test_function_transformer.py
+++ b/sklearn/preprocessing/tests/test_function_transformer.py
@@ -6,7 +6,6 @@ from scipy import sparse
 
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import FunctionTransformer
-from sklearn.utils import _safe_indexing
 from sklearn.utils._testing import (
     _convert_container,
     assert_allclose_dense_sparse,
@@ -196,9 +195,7 @@ def test_function_transformer_raise_error_with_mixed_dtype(X_type):
     data = _convert_container(data, X_type, columns_name=["value"], dtype=dtype)
 
     def func(X):
-        return np.array(
-            [mapping[_safe_indexing(X, i)] for i in range(X.size)], dtype=object
-        )
+        return np.array([mapping[X[i]] for i in range(X.size)], dtype=object)
 
     def inverse_func(X):
         return _convert_container(

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -188,7 +188,7 @@ def _array_indexing(array, key, key_dtype, axis):
         key = np.asarray(key)
     if isinstance(key, tuple):
         key = list(key)
-    return array[key] if axis == 0 else array[:, key]
+    return array[key, ...] if axis == 0 else array[:, key]
 
 
 def _pandas_indexing(X, key, key_dtype, axis):

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -186,6 +186,9 @@ class _ArrayAPIWrapper:
     def __getattr__(self, name):
         return getattr(self._namespace, name)
 
+    def __eq__(self, other):
+        return self._namespace == other._namespace
+
     def take(self, X, indices, *, axis=0):
         # When array_api supports `take` we can use this directly
         # https://github.com/data-apis/array-api/issues/177


### PR DESCRIPTION
#### Reference Issues/PRs
(need to find one)

#### What does this implement/fix? Explain your changes.
This mostly adds some tests that use `train_test_split` with Array API input and compare to using a pure Numpy array as input.

#### Any other comments?

First attempt of seeing what happens when you feed cupy/pytorch/array api arrays to `train_test_split`. Need to explore more of the different parameters to see if they all "just work".

* [x] add a changelog entry
