### PR TITLE
MAINT create y before enforcing X using tags

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1389,9 +1389,9 @@ def check_dict_unchanged(name, estimator_orig):
     else:
         X = 2 * rnd.uniform(size=(20, 3))
 
+    y = X[:, 0].astype(int)
     X = _enforce_estimator_tags_X(estimator_orig, X)
 
-    y = X[:, 0].astype(int)
     estimator = clone(estimator_orig)
     y = _enforce_estimator_tags_y(estimator, y)
     if hasattr(estimator, "n_components"):
@@ -1428,8 +1428,8 @@ def check_dont_overwrite_parameters(name, estimator_orig):
     estimator = clone(estimator_orig)
     rnd = np.random.RandomState(0)
     X = 3 * rnd.uniform(size=(20, 3))
-    X = _enforce_estimator_tags_X(estimator_orig, X)
     y = X[:, 0].astype(int)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
     y = _enforce_estimator_tags_y(estimator, y)
 
     if hasattr(estimator, "n_components"):
@@ -1483,8 +1483,8 @@ def check_fit2d_predict1d(name, estimator_orig):
     # check by fitting a 2d array and predicting with a 1d array
     rnd = np.random.RandomState(0)
     X = 3 * rnd.uniform(size=(20, 3))
-    X = _enforce_estimator_tags_X(estimator_orig, X)
     y = X[:, 0].astype(int)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
     estimator = clone(estimator_orig)
     y = _enforce_estimator_tags_y(estimator, y)
 
@@ -1527,8 +1527,8 @@ def check_methods_subset_invariance(name, estimator_orig):
     # on mini batches or the whole set
     rnd = np.random.RandomState(0)
     X = 3 * rnd.uniform(size=(20, 3))
-    X = _enforce_estimator_tags_X(estimator_orig, X)
     y = X[:, 0].astype(int)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
     estimator = clone(estimator_orig)
     y = _enforce_estimator_tags_y(estimator, y)
 
@@ -1564,8 +1564,8 @@ def check_methods_sample_order_invariance(name, estimator_orig):
     # on a subset with different sample order
     rnd = np.random.RandomState(0)
     X = 3 * rnd.uniform(size=(20, 3))
-    X = _enforce_estimator_tags_X(estimator_orig, X)
     y = X[:, 0].astype(np.int64)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
     if _safe_tags(estimator_orig, key="binary_only"):
         y[y == 2] = 1
     estimator = clone(estimator_orig)
@@ -1609,9 +1609,9 @@ def check_fit2d_1sample(name, estimator_orig):
     # the number of samples or the number of classes.
     rnd = np.random.RandomState(0)
     X = 3 * rnd.uniform(size=(1, 10))
-    X = _enforce_estimator_tags_X(estimator_orig, X)
-
     y = X[:, 0].astype(int)
+
+    X = _enforce_estimator_tags_X(estimator_orig, X)
     estimator = clone(estimator_orig)
     y = _enforce_estimator_tags_y(estimator, y)
 
@@ -1649,8 +1649,8 @@ def check_fit2d_1feature(name, estimator_orig):
     # informative message
     rnd = np.random.RandomState(0)
     X = 3 * rnd.uniform(size=(10, 1))
-    X = _enforce_estimator_tags_X(estimator_orig, X)
     y = X[:, 0].astype(int)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
     estimator = clone(estimator_orig)
     y = _enforce_estimator_tags_y(estimator, y)
 
@@ -1919,11 +1919,11 @@ def check_fit_score_takes_y(name, estimator_orig):
 def check_estimators_dtypes(name, estimator_orig):
     rnd = np.random.RandomState(0)
     X_train_32 = 3 * rnd.uniform(size=(20, 5)).astype(np.float32)
+    y = X_train_32[:, 0].astype(np.int64)
     X_train_32 = _enforce_estimator_tags_X(estimator_orig, X_train_32)
     X_train_64 = X_train_32.astype(np.float64)
     X_train_int_64 = X_train_32.astype(np.int64)
     X_train_int_32 = X_train_32.astype(np.int32)
-    y = X_train_int_64[:, 0]
     y = _enforce_estimator_tags_y(estimator_orig, y)
 
     methods = ["predict", "transform", "decision_function", "predict_proba"]

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1331,10 +1331,11 @@ def check_sample_weights_not_overwritten(name, estimator_orig):
 def check_dtype_object(name, estimator_orig):
     # check that estimators treat dtype object as numeric if possible
     rng = np.random.RandomState(0)
-    X = _enforce_estimator_tags_X(estimator_orig, rng.uniform(size=(40, 10)))
+    X = rng.uniform(size=(40, 10))
+    y = (X[:, 0] * 4).astype(int)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
     X = X.astype(object)
     tags = _safe_tags(estimator_orig)
-    y = (X[:, 0] * 4).astype(int)
     estimator = clone(estimator_orig)
     y = _enforce_estimator_tags_y(estimator, y)
 


### PR DESCRIPTION
We should create `y` before enforcing rules on `X`. This could be problematic for third-party libraries. I got issues in `skrub` where `X` was enforced to have `string` only and create `y` after the enforcement does not work.