### PR TITLE
DOC add dropdown header permalink

### DIFF
--- a/doc/themes/scikit-learn-modern/layout.html
+++ b/doc/themes/scikit-learn-modern/layout.html
@@ -36,6 +36,8 @@
   <link rel="stylesheet" href="{{ pathto('_static/' + styles[0], 1) }}" type="text/css" />
 <script id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
 <script src="{{ pathto('_static/js/vendor/jquery-3.6.3.slim.min.js', 1) }}"></script>
+<script src="{{ pathto('_static/js/dropdown-permalink.js', 1) }}"></script>
+
 {%- block extrahead %} {% endblock %}
 </head>
 <body>

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -58,6 +58,7 @@ h3:hover a.headerlink,
 h4:hover a.headerlink,
 h5:hover a.headerlink,
 h6:hover a.headerlink,
+strong:hover a.headerlink,
 dt:hover a.headerlink {
   visibility: visible;
 }

--- a/doc/themes/scikit-learn-modern/static/js/dropdown-permalink.js
+++ b/doc/themes/scikit-learn-modern/static/js/dropdown-permalink.js
@@ -9,6 +9,22 @@ document.addEventListener("DOMContentLoaded", function () {
                 const summaryText = strongElement.textContent.trim();
                 const id = summaryText.replace(/\s+/g, "-").toLowerCase();
                 detailsElement.setAttribute("id", id);
+
+                // Create the <a> element and set its attributes
+                const anchorElement = document.createElement("a");
+                anchorElement.setAttribute("class", "headerlink");
+                anchorElement.setAttribute("href", `#${id}`);
+                anchorElement.setAttribute("title", summaryText);
+                anchorElement.textContent = "¶"
+
+                // Insert the <a> element after the text inside the <strong> tag
+                strongElement.appendChild(anchorElement);
+
+                // Add event listener to the anchor element to toggle the 'open' attribute
+                anchorElement.addEventListener("click", function (event) {
+                    // event.preventDefault();
+                    detailsElement.open = true;
+                });
             }
         }
     });

--- a/doc/themes/scikit-learn-modern/static/js/dropdown-permalink.js
+++ b/doc/themes/scikit-learn-modern/static/js/dropdown-permalink.js
@@ -1,0 +1,26 @@
+// JavaScript for dynamically setting the id attribute
+document.addEventListener("DOMContentLoaded", function () {
+    const detailsElements = document.querySelectorAll("details");
+    detailsElements.forEach((detailsElement) => {
+        const summaryElement = detailsElement.querySelector("summary");
+        if (summaryElement) {
+            const strongElement = summaryElement.querySelector("strong");
+            if (strongElement) {
+                const summaryText = strongElement.textContent.trim();
+                const id = summaryText.replace(/\s+/g, "-").toLowerCase();
+                detailsElement.setAttribute("id", id);
+            }
+        }
+    });
+
+    const url = new URL(window.location.href);
+    const fragment = url.hash.slice(1); // Get the URL fragment (without the '#' symbol)
+
+    if (fragment) {
+        const targetDetailsElement = document.getElementById(fragment);
+        if (targetDetailsElement) {
+            targetDetailsElement.open = true;
+        }
+    }
+});
+  


### PR DESCRIPTION
as discussed in #26617
- It will inject an `id="xxx"` in the `<details>` tag
- if url have `.html#xxx` then it will add `open` to `<details id="xxx">` tag

example:
#### it will change from:
````
<details>
  <summary class="btn btn-light">
    <strong>Custom Kernels</strong>
````
#### to:
```
<details id="custom-kernels" open>
  <summary class="btn btn-light">
    <strong>Custom Kernels<a class="headerlink" href="#custom-kernels" title="Custom Kernels">¶</a></strong>  
```
#### result:
![dropdown result](https://raw.githubusercontent.com/greyisbetter/images/main/Screenshot%202023-07-21%20110745.png)

cc @lucyleeow 
cc @glemaitre @GaelVaroquaux