### PR TITLE
MNT Improve robustness of sparse test in `HDBSCAN`

### DIFF
--- a/sklearn/cluster/_hdbscan/hdbscan.py
+++ b/sklearn/cluster/_hdbscan/hdbscan.py
@@ -732,6 +732,7 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
                 X = X[finite_index]
         elif issparse(X):
             # Handle sparse precomputed distance matrices separately
+            print(f"\nDEBUG *** {X.data=}")
             X = self._validate_data(
                 X,
                 accept_sparse=["csr", "lil"],

--- a/sklearn/cluster/_hdbscan/hdbscan.py
+++ b/sklearn/cluster/_hdbscan/hdbscan.py
@@ -732,7 +732,6 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
                 X = X[finite_index]
         elif issparse(X):
             # Handle sparse precomputed distance matrices separately
-            print(f"\nDEBUG *** {X.data=}")
             X = self._validate_data(
                 X,
                 accept_sparse=["csr", "lil"],

--- a/sklearn/cluster/tests/test_hdbscan.py
+++ b/sklearn/cluster/tests/test_hdbscan.py
@@ -287,29 +287,33 @@ def test_hdbscan_precomputed_non_brute(tree):
 def test_hdbscan_sparse():
     """
     Tests that HDBSCAN works correctly when passing sparse feature data.
+    Evaluates correctness by comparing against the same data passed as a dense
+    array.
     """
 
     dense_labels = HDBSCAN().fit(X).labels_
     n_clusters = len(set(dense_labels) - OUTLIER_SET)
     assert n_clusters == 3
 
-    X_sparse = sparse.csr_matrix(X)
+    _X_sparse = sparse.csr_matrix(X)
+    X_sparse = _X_sparse.copy()
     sparse_labels = HDBSCAN().fit(X_sparse).labels_
     n_clusters = len(set(sparse_labels) - OUTLIER_SET)
     assert n_clusters == 3
     assert_array_equal(dense_labels, sparse_labels)
 
+    # Compare that the sparse and dense non-precomputed routines return the same labels
     for outlier_val, outlier_type in zip((np.inf, np.nan), ("infinite", "missing")):
-        _X = X.copy()
-        _X[0, 0] = outlier_val
-        dense_labels = HDBSCAN().fit(_X).labels_
+        X_dense = X.copy()
+        X_dense[0, 0] = outlier_val
+        dense_labels = HDBSCAN().fit(X_dense).labels_
         n_clusters = len(set(dense_labels) - OUTLIER_SET)
         assert n_clusters == 3
         assert dense_labels[0] == _OUTLIER_ENCODING[outlier_type]["label"]
 
-        _X_sparse = X_sparse.copy()
-        _X_sparse[0, 0] = outlier_val
-        sparse_labels = HDBSCAN().fit(_X_sparse).labels_
+        X_sparse = _X_sparse.copy()
+        X_sparse[0, 0] = outlier_val
+        sparse_labels = HDBSCAN().fit(X_sparse).labels_
         n_clusters = len(set(sparse_labels) - OUTLIER_SET)
         assert n_clusters == 3
         assert sparse_labels[0] == _OUTLIER_ENCODING[outlier_type]["label"]

--- a/sklearn/cluster/tests/test_hdbscan.py
+++ b/sklearn/cluster/tests/test_hdbscan.py
@@ -298,12 +298,10 @@ def test_hdbscan_sparse():
     _X_sparse = sparse.csr_matrix(X)
     X_sparse = _X_sparse.copy()
     sparse_labels = HDBSCAN().fit(X_sparse).labels_
-    n_clusters = len(set(sparse_labels) - OUTLIER_SET)
-    assert n_clusters == 3
     assert_array_equal(dense_labels, sparse_labels)
 
     # Compare that the sparse and dense non-precomputed routines return the same labels
-    for outlier_val, outlier_type in zip((np.inf, np.nan), ("infinite", "missing")):
+    for outlier_val, outlier_type in ((np.inf, "infinite"), (np.nan, "missing")):
         X_dense = X.copy()
         X_dense[0, 0] = outlier_val
         dense_labels = HDBSCAN().fit(X_dense).labels_
@@ -314,9 +312,6 @@ def test_hdbscan_sparse():
         X_sparse = _X_sparse.copy()
         X_sparse[0, 0] = outlier_val
         sparse_labels = HDBSCAN().fit(X_sparse).labels_
-        n_clusters = len(set(sparse_labels) - OUTLIER_SET)
-        assert n_clusters == 3
-        assert sparse_labels[0] == _OUTLIER_ENCODING[outlier_type]["label"]
         assert_array_equal(dense_labels, sparse_labels)
 
     msg = "Sparse data matrices only support algorithm `brute`."

--- a/sklearn/cluster/tests/test_hdbscan.py
+++ b/sklearn/cluster/tests/test_hdbscan.py
@@ -288,21 +288,36 @@ def test_hdbscan_sparse():
     """
     Tests that HDBSCAN works correctly when passing sparse feature data.
     """
-    sparse_X = sparse.csr_matrix(X)
 
-    labels = HDBSCAN().fit(sparse_X).labels_
-    n_clusters = len(set(labels) - OUTLIER_SET)
+    dense_labels = HDBSCAN().fit(X).labels_
+    n_clusters = len(set(dense_labels) - OUTLIER_SET)
     assert n_clusters == 3
 
-    sparse_X_nan = sparse_X.copy()
-    sparse_X_nan[0, 0] = np.nan
-    labels = HDBSCAN().fit(sparse_X_nan).labels_
-    n_clusters = len(set(labels) - OUTLIER_SET)
+    X_sparse = sparse.csr_matrix(X)
+    sparse_labels = HDBSCAN().fit(X_sparse).labels_
+    n_clusters = len(set(sparse_labels) - OUTLIER_SET)
     assert n_clusters == 3
+    assert_array_equal(dense_labels, sparse_labels)
+
+    for outlier_val, outlier_type in zip((np.inf, np.nan), ("infinite", "missing")):
+        _X = X.copy()
+        _X[0, 0] = outlier_val
+        dense_labels = HDBSCAN().fit(_X).labels_
+        n_clusters = len(set(dense_labels) - OUTLIER_SET)
+        assert n_clusters == 3
+        assert dense_labels[0] == _OUTLIER_ENCODING[outlier_type]["label"]
+
+        _X_sparse = X_sparse.copy()
+        _X_sparse[0, 0] = outlier_val
+        sparse_labels = HDBSCAN().fit(_X_sparse).labels_
+        n_clusters = len(set(sparse_labels) - OUTLIER_SET)
+        assert n_clusters == 3
+        assert sparse_labels[0] == _OUTLIER_ENCODING[outlier_type]["label"]
+        assert_array_equal(dense_labels, sparse_labels)
 
     msg = "Sparse data matrices only support algorithm `brute`."
     with pytest.raises(ValueError, match=msg):
-        HDBSCAN(metric="euclidean", algorithm="balltree").fit(sparse_X)
+        HDBSCAN(metric="euclidean", algorithm="balltree").fit(_X_sparse)
 
 
 @pytest.mark.parametrize("algorithm", ALGORITHMS)

--- a/sklearn/cluster/tests/test_hdbscan.py
+++ b/sklearn/cluster/tests/test_hdbscan.py
@@ -303,6 +303,7 @@ def test_hdbscan_sparse():
     assert_array_equal(dense_labels, sparse_labels)
 
     # Compare that the sparse and dense non-precomputed routines return the same labels
+    # where the 0th observation contains the outlier.
     for outlier_val, outlier_type in zip((np.inf, np.nan), ("infinite", "missing")):
         X_dense = X.copy()
         X_dense[0, 0] = outlier_val

--- a/sklearn/cluster/tests/test_hdbscan.py
+++ b/sklearn/cluster/tests/test_hdbscan.py
@@ -317,7 +317,7 @@ def test_hdbscan_sparse():
 
     msg = "Sparse data matrices only support algorithm `brute`."
     with pytest.raises(ValueError, match=msg):
-        HDBSCAN(metric="euclidean", algorithm="balltree").fit(_X_sparse)
+        HDBSCAN(metric="euclidean", algorithm="balltree").fit(X_sparse)
 
 
 @pytest.mark.parametrize("algorithm", ALGORITHMS)


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #26801 

#### What does this implement/fix? Explain your changes.
In pursuit of another feature enhancement, I noticed that the tests were missing certain cases and could be made more robust

#### Any other comments?