### PR TITLE
FIX sklearn.tree: fix validation of class_names argument for plot_tree

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -23,6 +23,12 @@ Changelog
   :attr:`sklearn.neighbors.KDTree.valid_metrics` as public class attributes.
   :pr:`26754` by :user:`Julien Jerphanion <jjerphan>`.
 
+:mod:`sklearn.tree`
+...................
+
+- |Fix| :func:`tree.plot_tree` now accepts `class_names=True` as documented.
+  :pr:`26903` by :user:`Thomas Roehr <2maz>`
+
 .. _changes_1_3:
 
 Version 1.3.0
@@ -757,9 +763,6 @@ Changelog
 - |Fix| :func:`tree.export_graphviz` and :func:`tree.export_text` now accepts
   `feature_names` and `class_names` as array-like rather than lists.
   :pr:`26289` by :user:`Yao Xiao <Charlie-XIAO>`
-
-- |Fix| :func:`tree.plot_tree` now accepts `class_names=True` as documented.
-  :pr:`26903` by :user:`Thomas Roehr <2maz>`
 
 :mod:`sklearn.utils`
 ....................

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -758,6 +758,9 @@ Changelog
   `feature_names` and `class_names` as array-like rather than lists.
   :pr:`26289` by :user:`Yao Xiao <Charlie-XIAO>`
 
+- |Fix| :func:`tree.plot_tree` now accepts `class_names=True` as documented.
+  :pr:`26903` by :user:`Thomas Roehr <2maz>`
+
 :mod:`sklearn.utils`
 ....................
 

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -134,7 +134,7 @@ def plot_tree(
         Names of each of the features.
         If None, generic names will be used ("x[0]", "x[1]", ...).
 
-    class_names : list of str or bool, default=None
+    class_names : array-like of str or True, default=None
         Names of each of the target classes in ascending numerical order.
         Only relevant for classification and not supported for multi-output.
         If ``True``, shows a symbolic representation of the class name.

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -79,7 +79,7 @@ SENTINEL = Sentinel()
         "decision_tree": [DecisionTreeClassifier, DecisionTreeRegressor],
         "max_depth": [Interval(Integral, 0, None, closed="left"), None],
         "feature_names": [list, None],
-        "class_names": [list, None],
+        "class_names": ["array-like", "boolean", None],
         "label": [StrOptions({"all", "root", "none"})],
         "filled": ["boolean"],
         "impurity": ["boolean"],


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
In sklearn.tree.plot_tree: allow documented use of 'class_names' arguments, i.e. setting class_names=True

Currently this raises:
```
 sklearn.utils._param_validation.InvalidParameterError: The 'class_names' parameter of plot_tree must be an instance of 'list' or None. Got True instead.
```

Replicate with:
```
from sklearn.datasets import load_iris
from sklearn import tree

clf = tree.DecisionTreeClassifier(random_state=0)
iris = load_iris()

clf = clf.fit(iris.data, iris.target)

# Plotting class_names=True will raise
tree.plot_tree(clf, class_names=True)
```

#### Any other comments?

Reproducible with the above code snippet

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
