### PR TITLE
MNT (SLEP6) remove other_params from provess_routing

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -66,6 +66,11 @@ Changelog
 - |Enhancement| :func:`base.clone` now supports `dict` as input and creates a
   copy. :pr:`26786` by `Adrin Jalali`_.
 
+- |API|:func:`~utils.metadata_routing.process_routing` now has a different
+  signature. The first two (the object and the method) are positional only,
+  and all metadata are passed as keyword arguments. :pr:`26909` by `Adrin
+  Jalali`_.
+
 :mod:`sklearn.cross_decomposition`
 ..................................
 

--- a/examples/miscellaneous/plot_metadata_routing.py
+++ b/examples/miscellaneous/plot_metadata_routing.py
@@ -447,7 +447,7 @@ class SimplePipeline(ClassifierMixin, BaseEstimator):
         return router
 
     def fit(self, X, y, **fit_params):
-        params = process_routing(self, "fit", fit_params)
+        params = process_routing(self, "fit", **fit_params)
 
         self.transformer_ = clone(self.transformer).fit(X, y, **params.transformer.fit)
         X_transformed = self.transformer_.transform(X, **params.transformer.transform)
@@ -458,7 +458,7 @@ class SimplePipeline(ClassifierMixin, BaseEstimator):
         return self
 
     def predict(self, X, **predict_params):
-        params = process_routing(self, "predict", predict_params)
+        params = process_routing(self, "predict", **predict_params)
 
         X_transformed = self.transformer_.transform(X, **params.transformer.transform)
         return self.classifier_.predict(X_transformed, **params.classifier.predict)
@@ -543,7 +543,7 @@ class MetaRegressor(MetaEstimatorMixin, RegressorMixin, BaseEstimator):
         self.estimator = estimator
 
     def fit(self, X, y, **fit_params):
-        params = process_routing(self, "fit", fit_params)
+        params = process_routing(self, "fit", **fit_params)
         self.estimator_ = clone(self.estimator).fit(X, y, **params.estimator.fit)
 
     def get_metadata_routing(self):
@@ -572,7 +572,7 @@ class WeightedMetaRegressor(MetaEstimatorMixin, RegressorMixin, BaseEstimator):
         self.estimator = estimator
 
     def fit(self, X, y, sample_weight=None, **fit_params):
-        params = process_routing(self, "fit", fit_params, sample_weight=sample_weight)
+        params = process_routing(self, "fit", sample_weight=sample_weight, **fit_params)
         check_metadata(self, sample_weight=sample_weight)
         self.estimator_ = clone(self.estimator).fit(X, y, **params.estimator.fit)
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -378,10 +378,10 @@ class CalibratedClassifierCV(ClassifierMixin, MetaEstimatorMixin, BaseEstimator)
 
             if _routing_enabled():
                 routed_params = process_routing(
-                    obj=self,
-                    method="fit",
+                    self,
+                    "fit",
                     sample_weight=sample_weight,
-                    other_params=fit_params,
+                    **fit_params,
                 )
             else:
                 # sample_weight checks

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1859,10 +1859,10 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
 
         if _routing_enabled():
             routed_params = process_routing(
-                obj=self,
-                method="fit",
+                self,
+                "fit",
                 sample_weight=sample_weight,
-                other_params=params,
+                **params,
             )
         else:
             routed_params = Bunch()
@@ -2150,10 +2150,10 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
         scoring = self._get_scorer()
         if _routing_enabled():
             routed_params = process_routing(
-                obj=self,
-                method="score",
+                self,
+                "score",
                 sample_weight=sample_weight,
-                other_params=score_params,
+                **score_params,
             )
         else:
             routed_params = Bunch()

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -124,7 +124,7 @@ class _MultimetricScorer:
         cached_call = partial(_cached_call, cache)
 
         if _routing_enabled():
-            routed_params = process_routing(self, "score", kwargs)
+            routed_params = process_routing(self, "score", **kwargs)
         else:
             # they all get the same args, and they all get them all
             routed_params = Bunch(

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -163,10 +163,10 @@ class _MultiOutputEstimator(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta
 
         if _routing_enabled():
             routed_params = process_routing(
-                obj=self,
-                method="partial_fit",
-                other_params=partial_fit_params,
+                self,
+                "partial_fit",
                 sample_weight=sample_weight,
+                **partial_fit_params,
             )
         else:
             if sample_weight is not None and not has_fit_parameter(
@@ -249,10 +249,10 @@ class _MultiOutputEstimator(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta
 
         if _routing_enabled():
             routed_params = process_routing(
-                obj=self,
-                method="fit",
-                other_params=fit_params,
+                self,
+                "fit",
                 sample_weight=sample_weight,
+                **fit_params,
             )
         else:
             if sample_weight is not None and not has_fit_parameter(
@@ -706,9 +706,7 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
         del Y_pred_chain
 
         if _routing_enabled():
-            routed_params = process_routing(
-                obj=self, method="fit", other_params=fit_params
-            )
+            routed_params = process_routing(self, "fit", **fit_params)
         else:
             routed_params = Bunch(estimator=Bunch(fit=fit_params))
 

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -334,9 +334,7 @@ class Pipeline(_BaseComposition):
 
     def _check_method_params(self, method, props, **kwargs):
         if _routing_enabled():
-            routed_params = process_routing(
-                self, method=method, other_params=props, **kwargs
-            )
+            routed_params = process_routing(self, method, **props, **kwargs)
             return routed_params
         else:
             fit_params_steps = Bunch(
@@ -586,7 +584,7 @@ class Pipeline(_BaseComposition):
             return self.steps[-1][1].predict(Xt, **params)
 
         # metadata routing enabled
-        routed_params = process_routing(self, "predict", other_params=params)
+        routed_params = process_routing(self, "predict", **params)
         for _, name, transform in self._iter(with_final=False):
             Xt = transform.transform(Xt, **routed_params[name].transform)
         return self.steps[-1][1].predict(Xt, **routed_params[self.steps[-1][0]].predict)
@@ -706,7 +704,7 @@ class Pipeline(_BaseComposition):
             return self.steps[-1][1].predict_proba(Xt, **params)
 
         # metadata routing enabled
-        routed_params = process_routing(self, "predict_proba", other_params=params)
+        routed_params = process_routing(self, "predict_proba", **params)
         for _, name, transform in self._iter(with_final=False):
             Xt = transform.transform(Xt, **routed_params[name].transform)
         return self.steps[-1][1].predict_proba(
@@ -747,7 +745,7 @@ class Pipeline(_BaseComposition):
 
         # not branching here since params is only available if
         # enable_metadata_routing=True
-        routed_params = process_routing(self, "decision_function", other_params=params)
+        routed_params = process_routing(self, "decision_function", **params)
 
         Xt = X
         for _, name, transform in self._iter(with_final=False):
@@ -833,7 +831,7 @@ class Pipeline(_BaseComposition):
             return self.steps[-1][1].predict_log_proba(Xt, **params)
 
         # metadata routing enabled
-        routed_params = process_routing(self, "predict_log_proba", other_params=params)
+        routed_params = process_routing(self, "predict_log_proba", **params)
         for _, name, transform in self._iter(with_final=False):
             Xt = transform.transform(Xt, **routed_params[name].transform)
         return self.steps[-1][1].predict_log_proba(
@@ -882,7 +880,7 @@ class Pipeline(_BaseComposition):
 
         # not branching here since params is only available if
         # enable_metadata_routing=True
-        routed_params = process_routing(self, "transform", other_params=params)
+        routed_params = process_routing(self, "transform", **params)
         Xt = X
         for _, name, transform in self._iter():
             Xt = transform.transform(Xt, **routed_params[name].transform)
@@ -925,7 +923,7 @@ class Pipeline(_BaseComposition):
 
         # we don't have to branch here, since params is only non-empty if
         # enable_metadata_routing=True.
-        routed_params = process_routing(self, "inverse_transform", other_params=params)
+        routed_params = process_routing(self, "inverse_transform", **params)
         reverse_iter = reversed(list(self._iter()))
         for _, name, transform in reverse_iter:
             Xt = transform.inverse_transform(
@@ -981,7 +979,7 @@ class Pipeline(_BaseComposition):
 
         # metadata routing is enabled.
         routed_params = process_routing(
-            self, "score", sample_weight=sample_weight, other_params=params
+            self, "score", sample_weight=sample_weight, **params
         )
 
         Xt = X

--- a/sklearn/tests/metadata_routing_common.py
+++ b/sklearn/tests/metadata_routing_common.py
@@ -323,7 +323,7 @@ class MetaRegressor(MetaEstimatorMixin, RegressorMixin, BaseEstimator):
         self.estimator = estimator
 
     def fit(self, X, y, **fit_params):
-        params = process_routing(self, "fit", fit_params)
+        params = process_routing(self, "fit", **fit_params)
         self.estimator_ = clone(self.estimator).fit(X, y, **params.estimator.fit)
 
     def get_metadata_routing(self):
@@ -345,12 +345,12 @@ class WeightedMetaRegressor(MetaEstimatorMixin, RegressorMixin, BaseEstimator):
             self.registry.append(self)
 
         record_metadata(self, "fit", sample_weight=sample_weight)
-        params = process_routing(self, "fit", fit_params, sample_weight=sample_weight)
+        params = process_routing(self, "fit", sample_weight=sample_weight, **fit_params)
         self.estimator_ = clone(self.estimator).fit(X, y, **params.estimator.fit)
         return self
 
     def predict(self, X, **predict_params):
-        params = process_routing(self, "predict", predict_params)
+        params = process_routing(self, "predict", **predict_params)
         return self.estimator_.predict(X, **params.estimator.predict)
 
     def get_metadata_routing(self):
@@ -374,7 +374,7 @@ class WeightedMetaClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator)
             self.registry.append(self)
 
         record_metadata(self, "fit", sample_weight=sample_weight)
-        params = process_routing(self, "fit", kwargs, sample_weight=sample_weight)
+        params = process_routing(self, "fit", sample_weight=sample_weight, **kwargs)
         self.estimator_ = clone(self.estimator).fit(X, y, **params.estimator.fit)
         return self
 
@@ -394,12 +394,12 @@ class MetaTransformer(MetaEstimatorMixin, TransformerMixin, BaseEstimator):
         self.transformer = transformer
 
     def fit(self, X, y=None, **fit_params):
-        params = process_routing(self, "fit", fit_params)
+        params = process_routing(self, "fit", **fit_params)
         self.transformer_ = clone(self.transformer).fit(X, y, **params.transformer.fit)
         return self
 
     def transform(self, X, y=None, **transform_params):
-        params = process_routing(self, "transform", transform_params)
+        params = process_routing(self, "transform", **transform_params)
         return self.transformer_.transform(X, **params.transformer.transform)
 
     def get_metadata_routing(self):

--- a/sklearn/tests/test_metadata_routing.py
+++ b/sklearn/tests/test_metadata_routing.py
@@ -74,7 +74,7 @@ class SimplePipeline(BaseEstimator):
 
     def fit(self, X, y, **fit_params):
         self.steps_ = []
-        params = process_routing(self, "fit", fit_params)
+        params = process_routing(self, "fit", **fit_params)
         X_transformed = X
         for i, step in enumerate(self.steps[:-1]):
             transformer = clone(step).fit(
@@ -93,7 +93,7 @@ class SimplePipeline(BaseEstimator):
     def predict(self, X, **predict_params):
         check_is_fitted(self)
         X_transformed = X
-        params = process_routing(self, "predict", predict_params)
+        params = process_routing(self, "predict", **predict_params)
         for i, step in enumerate(self.steps_[:-1]):
             X_transformed = step.transform(X, **params.get(f"step_{i}").transform)
 
@@ -230,7 +230,7 @@ def test_default_requests():
 
 def test_process_routing_invalid_method():
     with pytest.raises(TypeError, match="Can only route and process input"):
-        process_routing(ConsumingClassifier(), "invalid_method", {})
+        process_routing(ConsumingClassifier(), "invalid_method", **{})
 
 
 def test_process_routing_invalid_object():
@@ -238,7 +238,7 @@ def test_process_routing_invalid_object():
         pass
 
     with pytest.raises(AttributeError, match="has not implemented the routing"):
-        process_routing(InvalidObject(), "fit", {})
+        process_routing(InvalidObject(), "fit", **{})
 
 
 def test_simple_metadata_routing():

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -1412,6 +1412,10 @@ class _MetadataRequester:
 # given metadata. This is to minimize the boilerplate required in routers.
 
 
+# Here the first two arguments are positional only which makes everything
+# passed as keyword argument a metadata. The first two args also have an `_`
+# prefix to reduce the chances of name collisions with the passed metadata, and
+# since they're positional only, users will never type those underscores.
 def process_routing(_obj, _method, /, **kwargs):
     """Validate and route input parameters.
 
@@ -1420,7 +1424,7 @@ def process_routing(_obj, _method, /, **kwargs):
 
     Assuming this signature: ``fit(self, X, y, sample_weight=None, **fit_params)``,
     a call to this function would be:
-    ``process_routing(self, fit_params, sample_weight=sample_weight)``.
+    ``process_routing(self, sample_weight=sample_weight, **fit_params)``.
 
     .. versionadded:: 1.3
 

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -1412,7 +1412,7 @@ class _MetadataRequester:
 # given metadata. This is to minimize the boilerplate required in routers.
 
 
-def process_routing(obj, method, other_params, **kwargs):
+def process_routing(_obj, _method, /, **kwargs):
     """Validate and route input parameters.
 
     This function is used inside a router's method, e.g. :term:`fit`,
@@ -1426,20 +1426,15 @@ def process_routing(obj, method, other_params, **kwargs):
 
     Parameters
     ----------
-    obj : object
+    _obj : object
         An object implementing ``get_metadata_routing``. Typically a
         meta-estimator.
 
-    method : str
+    _method : str
         The name of the router's method in which this function is called.
 
-    other_params : dict
-        A dictionary of extra parameters passed to the router's method,
-        e.g. ``**fit_params`` passed to a meta-estimator's :term:`fit`.
-
     **kwargs : dict
-        Parameters explicitly accepted and included in the router's method
-        signature.
+        Metadata to be routed.
 
     Returns
     -------
@@ -1449,27 +1444,19 @@ def process_routing(obj, method, other_params, **kwargs):
         corresponding methods or corresponding child objects. The object names
         are those defined in `obj.get_metadata_routing()`.
     """
-    if not hasattr(obj, "get_metadata_routing"):
+    if not hasattr(_obj, "get_metadata_routing"):
         raise AttributeError(
-            f"This {repr(obj.__class__.__name__)} has not implemented the routing"
+            f"This {repr(_obj.__class__.__name__)} has not implemented the routing"
             " method `get_metadata_routing`."
         )
-    if method not in METHODS:
+    if _method not in METHODS:
         raise TypeError(
             f"Can only route and process input on these methods: {METHODS}, "
-            f"while the passed method is: {method}."
+            f"while the passed method is: {_method}."
         )
 
-    # We take the extra params (**fit_params) which is passed as `other_params`
-    # and add the explicitly passed parameters (passed as **kwargs) to it. This
-    # is equivalent to a code such as this in a router:
-    # if sample_weight is not None:
-    #     fit_params["sample_weight"] = sample_weight
-    all_params = other_params if other_params is not None else dict()
-    all_params.update(kwargs)
-
-    request_routing = get_routing_for_object(obj)
-    request_routing.validate_metadata(params=all_params, method=method)
-    routed_params = request_routing.route_params(params=all_params, caller=method)
+    request_routing = get_routing_for_object(_obj)
+    request_routing.validate_metadata(params=kwargs, method=_method)
+    routed_params = request_routing.route_params(params=kwargs, caller=_method)
 
     return routed_params


### PR DESCRIPTION
This PR removes the `other_params` from `process_routing`, since they can be passed as `**kwarg` anyway. There used to be some difference between args passed explicitly and the ones passed as kwargs to methods such as `fit`, but later with the introduction of a more rich `MetadataRouter` the need for that distinction was removed.

This also renames `obj` to `_obj` and `method` to `_method` as arguments and makes them positional only. This also reflects quite a bit from Python's API. The rename helps with avoiding collisions between metadata and `obj` and `method` as metadata names.

cc @thomasjpfan @OmarManzoor 