### PR TITLE
MNT make type checkers happy with set_{method}_request methods

### DIFF
--- a/examples/feature_selection/plot_select_from_model_diabetes.py
+++ b/examples/feature_selection/plot_select_from_model_diabetes.py
@@ -153,8 +153,9 @@ print(f"Done in {toc_bwd - tic_bwd:.3f}s")
 #
 # We begin by loading the Breast Cancer dataset, consisting of 30 different
 # features and 569 samples.
-from sklearn.datasets import load_breast_cancer
 import numpy as np
+
+from sklearn.datasets import load_breast_cancer
 
 breast_cancer_data = load_breast_cancer()
 X, y = breast_cancer_data.data, breast_cancer_data.target
@@ -166,9 +167,9 @@ print(breast_cancer_data.DESCR)
 # estimator with :class:`~sklearn.feature_selection.SequentialFeatureSelector`
 # to perform the feature selection.
 from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
-from sklearn.metrics import roc_auc_score
 
 for tol in [-1e-2, -1e-3, -1e-4]:
     start = time()

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -1254,55 +1254,26 @@ class _MetadataRequester:
     .. versionadded:: 1.3
     """
 
-    if TYPE_CHECKING:
+    if TYPE_CHECKING:  # pragma: no cover
         # This code is never run in runtime, but it's here for type checking.
         # Type checkers fail to understand that the `set_{method}_request`
         # methods are dynamically generated, and they complain that they are
         # not defined. We define them here to make type checkers happy.
         # During type checking analyzers assume this to be True.
         # The following list of defined methods mirrors the list of methods
-        # in this list:
-        # SIMPLE_METHODS = [
-        #     "fit",
-        #     "partial_fit",
-        #     "predict",
-        #     "predict_proba",
-        #     "predict_log_proba",
-        #     "decision_function",
-        #     "score",
-        #     "split",
-        #     "transform",
-        #     "inverse_transform",
-        # ]
-        def set_fit_request(self, **kwargs):
-            pass  # pragma: no cover
-
-        def set_partial_fit_request(self, **kwargs):
-            pass  # pragma: no cover
-
-        def set_predict_request(self, **kwargs):
-            pass  # pragma: no cover
-
-        def set_predict_proba_request(self, **kwargs):
-            pass  # pragma: no cover
-
-        def set_predict_log_proba_request(self, **kwargs):
-            pass  # pragma: no cover
-
-        def set_decision_function_request(self, **kwargs):
-            pass  # pragma: no cover
-
-        def set_score_request(self, **kwargs):
-            pass  # pragma: no cover
-
-        def set_split_request(self, **kwargs):
-            pass  # pragma: no cover
-
-        def set_transform_request(self, **kwargs):
-            pass  # pragma: no cover
-
-        def set_inverse_transform_request(self, **kwargs):
-            pass  # pragma: no cover
+        # in SIMPLE_METHODS.
+        # fmt: off
+        def set_fit_request(self, **kwargs): pass
+        def set_partial_fit_request(self, **kwargs): pass
+        def set_predict_request(self, **kwargs): pass
+        def set_predict_proba_request(self, **kwargs): pass
+        def set_predict_log_proba_request(self, **kwargs): pass
+        def set_decision_function_request(self, **kwargs): pass
+        def set_score_request(self, **kwargs): pass
+        def set_split_request(self, **kwargs): pass
+        def set_transform_request(self, **kwargs): pass
+        def set_inverse_transform_request(self, **kwargs): pass
+        # fmt: on
 
     def __init_subclass__(cls, **kwargs):
         """Set the ``set_{method}_request`` methods.

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -80,7 +80,7 @@ need to override, but it works for simple consumers as is.
 import inspect
 from collections import namedtuple
 from copy import deepcopy
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 from warnings import warn
 
 from .. import get_config
@@ -89,6 +89,9 @@ from ._bunch import Bunch
 
 # Only the following methods are supported in the routing mechanism. Adding new
 # methods at the moment involves monkeypatching this list.
+# Note that if this list is changed or monkeypatched, the corresponding method
+# needs to be added under a TYPE_CHECKING condition like the one done here in
+# _MetadataRequester
 SIMPLE_METHODS = [
     "fit",
     "partial_fit",
@@ -1250,6 +1253,56 @@ class _MetadataRequester:
 
     .. versionadded:: 1.3
     """
+
+    if TYPE_CHECKING:
+        # This code is never run in runtime, but it's here for type checking.
+        # Type checkers fail to understand that the `set_{method}_request`
+        # methods are dynamically generated, and they complain that they are
+        # not defined. We define them here to make type checkers happy.
+        # During type checking analyzers assume this to be True.
+        # The following list of defined methods mirrors the list of methods
+        # in this list:
+        # SIMPLE_METHODS = [
+        #     "fit",
+        #     "partial_fit",
+        #     "predict",
+        #     "predict_proba",
+        #     "predict_log_proba",
+        #     "decision_function",
+        #     "score",
+        #     "split",
+        #     "transform",
+        #     "inverse_transform",
+        # ]
+        def set_fit_request(self, **kwargs):
+            pass  # pragma: no cover
+
+        def set_partial_fit_request(self, **kwargs):
+            pass  # pragma: no cover
+
+        def set_predict_request(self, **kwargs):
+            pass  # pragma: no cover
+
+        def set_predict_proba_request(self, **kwargs):
+            pass  # pragma: no cover
+
+        def set_predict_log_proba_request(self, **kwargs):
+            pass  # pragma: no cover
+
+        def set_decision_function_request(self, **kwargs):
+            pass  # pragma: no cover
+
+        def set_score_request(self, **kwargs):
+            pass  # pragma: no cover
+
+        def set_split_request(self, **kwargs):
+            pass  # pragma: no cover
+
+        def set_transform_request(self, **kwargs):
+            pass  # pragma: no cover
+
+        def set_inverse_transform_request(self, **kwargs):
+            pass  # pragma: no cover
 
     def __init_subclass__(cls, **kwargs):
         """Set the ``set_{method}_request`` methods.


### PR DESCRIPTION
This makes `mypy` (and other type checkers) happy by hard coding potentially generated methods to the parent class.

This code is never run in runtime, and is only there for type checkers since `TYPE_CHECKING` is `False` during runetime.

Right now, `mypy` would complain with the code:

```python
from sklearn.linear_model import LogisticRegression

LogisticRegression().set_fit_request(sample_weight=True)
```

and say:

```
error: "LogisticRegression" has no attribute "set_fit_request"  [attr-defined]
Found 1 error in 1 file (checked 1 source file)
```

with this PR, the above errors are gone. It's still not idea, since we're telling mypy methods exist even if they don't, and we don't tell it about their signature.	

cc @thomasjpfan @glemaitre @rth 