### PR TITLE
MNT Use `curl` instead of `wget` to avoid occasional `SSL` error on Cirrus CI

### DIFF
--- a/build_tools/cirrus/build_test_arm.sh
+++ b/build_tools/cirrus/build_test_arm.sh
@@ -25,7 +25,7 @@ setup_ccache() {
 MAMBAFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-aarch64.sh"
 
 # Install Mambaforge
-curl $MAMBAFORGE_URL -o mambaforge.sh
+curl -L $MAMBAFORGE_URL -o mambaforge.sh
 MAMBAFORGE_PATH=$HOME/mambaforge
 bash ./mambaforge.sh -b -p $MAMBAFORGE_PATH
 export PATH=$MAMBAFORGE_PATH/bin:$PATH

--- a/build_tools/cirrus/build_test_arm.sh
+++ b/build_tools/cirrus/build_test_arm.sh
@@ -25,7 +25,7 @@ setup_ccache() {
 MAMBAFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-aarch64.sh"
 
 # Install Mambaforge
-wget $MAMBAFORGE_URL -O mambaforge.sh
+curl $MAMBAFORGE_URL -o mambaforge.sh
 MAMBAFORGE_PATH=$HOME/mambaforge
 bash ./mambaforge.sh -b -p $MAMBAFORGE_PATH
 export PATH=$MAMBAFORGE_PATH/bin:$PATH


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
Replaces the use of `wget` with `curl` instead to avoid known(?) bug.

#### Any other comments?
cc: @jeremiedbb 