### PR TITLE
DOC Note missing value support as advantage of decision trees

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -28,7 +28,7 @@ Some advantages of decision trees are:
     - Requires little data preparation. Other techniques often require data
       normalization, dummy variables need to be created and blank values to
       be removed. Some tree and algorithm combinations even support 
-      :ref:`missing values <_tree_missing_value_support>`.
+      :ref:`missing values <tree_missing_value_support>`.
 
     - The cost of using the tree (i.e., predicting data) is logarithmic in the
       number of data points used to train the tree.

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -27,8 +27,8 @@ Some advantages of decision trees are:
 
     - Requires little data preparation. Other techniques often require data
       normalization, dummy variables need to be created and blank values to
-      be removed. Note however that this module does not support missing
-      values.
+      be removed. Some tree and algorithm combinations even support 
+      :ref:`missing values <_tree_missing_value_support>`.
 
     - The cost of using the tree (i.e., predicting data) is logarithmic in the
       number of data points used to train the tree.

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -27,7 +27,7 @@ Some advantages of decision trees are:
 
     - Requires little data preparation. Other techniques often require data
       normalization, dummy variables need to be created and blank values to
-      be removed. Some tree and algorithm combinations even support 
+      be removed. Some tree and algorithm combinations support 
       :ref:`missing values <tree_missing_value_support>`.
 
     - The cost of using the tree (i.e., predicting data) is logarithmic in the


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #26925.

#### What does this implement/fix? Explain your changes.

Replaces the previous note of decision trees not supporting missing values with a note and link to the missing value support section in the same document. Missing value support was added in v1.3 of scikit-learn.
