### PR TITLE
DOC add links to cross decomposition examples

### DIFF
--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -789,8 +789,8 @@ class PLSCanonical(_PLS):
 class CCA(_PLS):
     """Canonical Correlation Analysis, also known as "Mode B" PLS.
 
-    For a comparison between other cross decomposition algorithms,
-    see :ref:`sphx_glr_auto_examples_cross_decomposition_plot_compare_cross_decomposition.py`.
+    For a comparison between other cross decomposition algorithms, see
+    :ref:`sphx_glr_auto_examples_cross_decomposition_plot_compare_cross_decomposition.py`.
 
     Read more in the :ref:`User Guide <cross_decomposition>`.
 

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -505,7 +505,7 @@ class PLSRegression(_PLS):
     PLSRegression is also known as PLS2 or PLS1, depending on the number of
     targets.
 
-    For an example on usage, see
+    For a comparison between other cross decomposition algorithms, see
     :ref:`sphx_glr_auto_examples_cross_decomposition_plot_compare_cross_decomposition.py`.
 
     Read more in the :ref:`User Guide <cross_decomposition>`.
@@ -656,7 +656,7 @@ class PLSRegression(_PLS):
 class PLSCanonical(_PLS):
     """Partial Least Squares transformer and regressor.
 
-    For an example on usage, see
+    For a comparison between other cross decomposition algorithms, see
     :ref:`sphx_glr_auto_examples_cross_decomposition_plot_compare_cross_decomposition.py`.
 
     Read more in the :ref:`User Guide <cross_decomposition>`.

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -508,9 +508,6 @@ class PLSRegression(_PLS):
     For an example on usage, see
     :ref:`sphx_glr_auto_examples_cross_decomposition_plot_compare_cross_decomposition.py`.
 
-    For comparison between PLS Regression and PCR, see
-    :ref:`sphx_glr_auto_examples_cross_decomposition_plot_pcr_vs_pls.py`.
-
     Read more in the :ref:`User Guide <cross_decomposition>`.
 
     .. versionadded:: 0.8
@@ -592,6 +589,9 @@ class PLSRegression(_PLS):
     See Also
     --------
     PLSCanonical : Partial Least Squares transformer and regressor.
+
+    For a comparison between PLS Regression and :class:`~sklearn.decomposition.PCA`, see
+    :ref:`sphx_glr_auto_examples_cross_decomposition_plot_pcr_vs_pls.py`.
 
     Examples
     --------

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -789,9 +789,6 @@ class PLSCanonical(_PLS):
 class CCA(_PLS):
     """Canonical Correlation Analysis, also known as "Mode B" PLS.
 
-    For an example on usage, see
-    :ref:`sphx_glr_auto_examples_cross_decomposition_plot_compare_cross_decomposition.py`.
-
     Read more in the :ref:`User Guide <cross_decomposition>`.
 
     Parameters

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -590,9 +590,6 @@ class PLSRegression(_PLS):
     --------
     PLSCanonical : Partial Least Squares transformer and regressor.
 
-    For a comparison between PLS Regression and :class:`~sklearn.decomposition.PCA`, see
-    :ref:`sphx_glr_auto_examples_cross_decomposition_plot_pcr_vs_pls.py`.
-
     Examples
     --------
     >>> from sklearn.cross_decomposition import PLSRegression
@@ -602,6 +599,9 @@ class PLSRegression(_PLS):
     >>> pls2.fit(X, Y)
     PLSRegression()
     >>> Y_pred = pls2.predict(X)
+
+    For a comparison between PLS Regression and :class:`~sklearn.decomposition.PCA`, see
+    :ref:`sphx_glr_auto_examples_cross_decomposition_plot_pcr_vs_pls.py`.
     """
 
     _parameter_constraints: dict = {**_PLS._parameter_constraints}

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -505,6 +505,12 @@ class PLSRegression(_PLS):
     PLSRegression is also known as PLS2 or PLS1, depending on the number of
     targets.
 
+    For an example on usage, see
+    :ref:`sphx_glr_auto_examples_cross_decomposition_plot_compare_cross_decomposition.py`.
+
+    For comparison between PLS Regression and PCR, see
+    :ref:`sphx_glr_auto_examples_cross_decomposition_plot_pcr_vs_pls.py`.
+
     Read more in the :ref:`User Guide <cross_decomposition>`.
 
     .. versionadded:: 0.8
@@ -650,6 +656,9 @@ class PLSRegression(_PLS):
 class PLSCanonical(_PLS):
     """Partial Least Squares transformer and regressor.
 
+    For an example on usage, see
+    :ref:`sphx_glr_auto_examples_cross_decomposition_plot_compare_cross_decomposition.py`.
+
     Read more in the :ref:`User Guide <cross_decomposition>`.
 
     .. versionadded:: 0.8
@@ -779,6 +788,9 @@ class PLSCanonical(_PLS):
 
 class CCA(_PLS):
     """Canonical Correlation Analysis, also known as "Mode B" PLS.
+
+    For an example on usage, see
+    :ref:`sphx_glr_auto_examples_cross_decomposition_plot_compare_cross_decomposition.py`.
 
     Read more in the :ref:`User Guide <cross_decomposition>`.
 

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -789,6 +789,9 @@ class PLSCanonical(_PLS):
 class CCA(_PLS):
     """Canonical Correlation Analysis, also known as "Mode B" PLS.
 
+    For a comparison between other cross decomposition algorithms,
+    see :ref:`sphx_glr_auto_examples_cross_decomposition_plot_compare_cross_decomposition.py`.
+
     Read more in the :ref:`User Guide <cross_decomposition>`.
 
     Parameters


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Adds links to `cross-decomposition` examples as mentioned in #26927

#### What does this implement/fix? Explain your changes.
Adds links to the auto-generated examples for classes `PLSRegression` and `PLSCanonical`. The diff also adds link to the example comparing `PLSRegression` and `PCR`

Classes linked with examples
1. `PLSRegression` in `sklearn/cross_decomposition/_pls.py`
2. `PLSCanonical` in `sklearn/cross_decomposition/_pls.py`