### PR TITLE
DOC add links to neural network examples

### DIFF
--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -146,7 +146,8 @@ See the examples below and the docstring of
 .. topic:: Examples:
 
  * :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_training_curves.py`
- * :ref:`sphx_glr_auto_examples_neural_networks_plot_mnist_filters.py`
+ * See :ref:`sphx_glr_auto_examples_neural_networks_plot_mnist_filters.py` for
+   visualization of varying regularization in MLP.
 
 Regression
 ==========

--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -147,7 +147,7 @@ See the examples below and the docstring of
 
  * :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_training_curves.py`
  * See :ref:`sphx_glr_auto_examples_neural_networks_plot_mnist_filters.py` for
-   visualization of varying regularization in MLP.
+   visualized representation of trained weights.
 
 Regression
 ==========

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -1161,7 +1161,7 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
         y : ndarray, shape (n_samples,) or (n_samples, n_classes)
             The predicted classes.
         """
-        check_is_fitted(selfo
+        check_is_fitted(self)
         return self._predict(X)
 
     def _predict(self, X, check_input=True):

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -800,7 +800,7 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
         - 'adam' refers to a stochastic gradient-based optimizer proposed
           by Kingma, Diederik, and Jimmy Ba
 
-        For example usage and comparison with Adam optimizer, see
+        For a comparison between Adam optimizer and SGD, see
         :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_training_curves.py`
 
         Note: The default solver 'adam' works pretty well on relatively
@@ -1299,7 +1299,7 @@ class MLPRegressor(RegressorMixin, BaseMultilayerPerceptron):
         - 'adam' refers to a stochastic gradient-based optimizer proposed by
           Kingma, Diederik, and Jimmy Ba
 
-        For example usage and comparison with Adam optimizer, see
+        For a comparison between Adam optimizer and SGD, see
         :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_training_curves.py`
 
         Note: The default solver 'adam' works pretty well on relatively

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -767,6 +767,12 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
     This model optimizes the log-loss function using LBFGS or stochastic
     gradient descent.
 
+    For an example usage and visualization of varying regularization, see
+    :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_alpha.py`
+
+    For an example usage and visualization of the MLP weights on MNIST, see
+    :ref:`sphx_glr_auto_examples_neural_networks_plot_mnist_filters.py`
+
     .. versionadded:: 0.18
 
     Parameters

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -801,7 +801,7 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
           by Kingma, Diederik, and Jimmy Ba
 
         For a comparison between Adam optimizer and SGD, see
-        :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_training_curves.py`
+        :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_training_curves.py`.
 
         Note: The default solver 'adam' works pretty well on relatively
         large datasets (with thousands of training samples or more) in terms of
@@ -814,7 +814,7 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
         is divided by the sample size when added to the loss.
 
         For an example usage and visualization of varying regularization, see
-        :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_alpha.py`
+        :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_alpha.py`.
 
     batch_size : int, default='auto'
         Size of minibatches for stochastic optimizers.
@@ -1300,7 +1300,7 @@ class MLPRegressor(RegressorMixin, BaseMultilayerPerceptron):
           Kingma, Diederik, and Jimmy Ba
 
         For a comparison between Adam optimizer and SGD, see
-        :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_training_curves.py`
+        :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_training_curves.py`.
 
         Note: The default solver 'adam' works pretty well on relatively
         large datasets (with thousands of training samples or more) in terms of

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -767,9 +767,6 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
     This model optimizes the log-loss function using LBFGS or stochastic
     gradient descent.
 
-    For an example usage and visualization of varying regularization, see
-    :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_alpha.py`
-
     .. versionadded:: 0.18
 
     Parameters
@@ -803,6 +800,9 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
         - 'adam' refers to a stochastic gradient-based optimizer proposed
           by Kingma, Diederik, and Jimmy Ba
 
+        For example usage and comparison with Adam optimizer, see
+        :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_training_curves.py`
+
         Note: The default solver 'adam' works pretty well on relatively
         large datasets (with thousands of training samples or more) in terms of
         both training time and validation score.
@@ -812,6 +812,9 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
     alpha : float, default=0.0001
         Strength of the L2 regularization term. The L2 regularization term
         is divided by the sample size when added to the loss.
+
+        For an example usage and visualization of varying regularization, see
+        :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_alpha.py`
 
     batch_size : int, default='auto'
         Size of minibatches for stochastic optimizers.
@@ -1158,7 +1161,7 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
         y : ndarray, shape (n_samples,) or (n_samples, n_classes)
             The predicted classes.
         """
-        check_is_fitted(self)
+        check_is_fitted(selfo
         return self._predict(X)
 
     def _predict(self, X, check_input=True):
@@ -1295,6 +1298,9 @@ class MLPRegressor(RegressorMixin, BaseMultilayerPerceptron):
 
         - 'adam' refers to a stochastic gradient-based optimizer proposed by
           Kingma, Diederik, and Jimmy Ba
+
+        For example usage and comparison with Adam optimizer, see
+        :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_training_curves.py`
 
         Note: The default solver 'adam' works pretty well on relatively
         large datasets (with thousands of training samples or more) in terms of

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -770,9 +770,6 @@ class MLPClassifier(ClassifierMixin, BaseMultilayerPerceptron):
     For an example usage and visualization of varying regularization, see
     :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_alpha.py`
 
-    For an example usage and visualization of the MLP weights on MNIST, see
-    :ref:`sphx_glr_auto_examples_neural_networks_plot_mnist_filters.py`
-
     .. versionadded:: 0.18
 
     Parameters

--- a/sklearn/neural_network/_rbm.py
+++ b/sklearn/neural_network/_rbm.py
@@ -37,6 +37,9 @@ class BernoulliRBM(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstima
     The time complexity of this implementation is ``O(d ** 2)`` assuming
     d ~ n_features ~ n_components.
 
+    For an example usage, see
+    :ref:`sphx_glr_auto_examples_neural_networks_plot_rbm_logistic_classification.py`.
+
     Read more in the :ref:`User Guide <rbm>`.
 
     Parameters

--- a/sklearn/neural_network/_rbm.py
+++ b/sklearn/neural_network/_rbm.py
@@ -37,9 +37,6 @@ class BernoulliRBM(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstima
     The time complexity of this implementation is ``O(d ** 2)`` assuming
     d ~ n_features ~ n_components.
 
-    For an example usage, see
-    :ref:`sphx_glr_auto_examples_neural_networks_plot_rbm_logistic_classification.py`.
-
     Read more in the :ref:`User Guide <rbm>`.
 
     Parameters
@@ -130,6 +127,9 @@ class BernoulliRBM(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstima
     >>> model = BernoulliRBM(n_components=2)
     >>> model.fit(X)
     BernoulliRBM(n_components=2)
+
+    For an example usage, see
+    :ref:`sphx_glr_auto_examples_neural_networks_plot_rbm_logistic_classification.py`.
     """
 
     _parameter_constraints: dict = {

--- a/sklearn/neural_network/_rbm.py
+++ b/sklearn/neural_network/_rbm.py
@@ -128,7 +128,7 @@ class BernoulliRBM(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstima
     >>> model.fit(X)
     BernoulliRBM(n_components=2)
 
-    For an example usage, see
+    For a more detailed example usage, see
     :ref:`sphx_glr_auto_examples_neural_networks_plot_rbm_logistic_classification.py`.
     """
 

--- a/sklearn/neural_network/_stochastic_optimizers.py
+++ b/sklearn/neural_network/_stochastic_optimizers.py
@@ -73,6 +73,9 @@ class BaseOptimizer:
 class SGDOptimizer(BaseOptimizer):
     """Stochastic gradient descent optimizer with momentum
 
+    For example usage and comparison with Adam optimizer, see
+    :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_training_curves.py`
+
     Parameters
     ----------
     params : list, length = len(coefs_) + len(intercepts_)
@@ -197,6 +200,9 @@ class SGDOptimizer(BaseOptimizer):
 
 class AdamOptimizer(BaseOptimizer):
     """Stochastic gradient descent optimizer with Adam
+
+    For example usage and comparison with SGD optimizer, see
+    :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_training_curves.py`
 
     Note: All default values are from the original Adam paper
 

--- a/sklearn/neural_network/_stochastic_optimizers.py
+++ b/sklearn/neural_network/_stochastic_optimizers.py
@@ -73,9 +73,6 @@ class BaseOptimizer:
 class SGDOptimizer(BaseOptimizer):
     """Stochastic gradient descent optimizer with momentum
 
-    For example usage and comparison with Adam optimizer, see
-    :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_training_curves.py`
-
     Parameters
     ----------
     params : list, length = len(coefs_) + len(intercepts_)
@@ -200,9 +197,6 @@ class SGDOptimizer(BaseOptimizer):
 
 class AdamOptimizer(BaseOptimizer):
     """Stochastic gradient descent optimizer with Adam
-
-    For example usage and comparison with SGD optimizer, see
-    :ref:`sphx_glr_auto_examples_neural_networks_plot_mlp_training_curves.py`
 
     Note: All default values are from the original Adam paper
 


### PR DESCRIPTION

#### Reference Issues/PRs
Adds links to `neural-networks` examples as mentioned in #26927 


#### What does this implement/fix? Explain your changes.
Adds links to auto-generated examples for classes `MLPClassifier`, `BernoulliRBM`, `SGDOptimizer` and `AdamOptimizer`

Classes and files updated with examples link
1. `MLPClassifier` (`sklearn/neural_network/_multilayer_perceptron.py`)
2. `BernoulliRBM` (`sklearn/neural_network/_rbm.py`)
3. `SGDOptimizer` (`sklearn/neural_network/_stochastic_optimizers.py`)
4. `AdamOptimizer` (`sklearn/neural_network/_stochastic_optimizers.py`)