### PR TITLE
FIX Disable set_output for label encoder

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -23,6 +23,12 @@ Changelog
   :attr:`sklearn.neighbors.KDTree.valid_metrics` as public class attributes.
   :pr:`26754` by :user:`Julien Jerphanion <jjerphan>`.
 
+:mod:`sklearn.preprocessing`
+............................
+
+- |Fix| :class:`preprocessing.LabelEncoder` correctly accepts `y` as a keyword
+  argument. :pr:`xxxxx` by `Thomas Fan`_.
+
 :mod:`sklearn.tree`
 ...................
 

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -27,7 +27,7 @@ Changelog
 ............................
 
 - |Fix| :class:`preprocessing.LabelEncoder` correctly accepts `y` as a keyword
-  argument. :pr:`xxxxx` by `Thomas Fan`_.
+  argument. :pr:`26940` by `Thomas Fan`_.
 
 :mod:`sklearn.tree`
 ...................

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -31,7 +31,7 @@ __all__ = [
 ]
 
 
-class LabelEncoder(TransformerMixin, BaseEstimator):
+class LabelEncoder(TransformerMixin, BaseEstimator, auto_wrap_output_keys=None):
     """Encode target labels with value between 0 and n_classes-1.
 
     This transformer should be used to encode target values, *i.e.* `y`, and
@@ -165,7 +165,7 @@ class LabelEncoder(TransformerMixin, BaseEstimator):
         return {"X_types": ["1dlabels"]}
 
 
-class LabelBinarizer(TransformerMixin, BaseEstimator):
+class LabelBinarizer(TransformerMixin, BaseEstimator, auto_wrap_output_keys=None):
     """Binarize labels in a one-vs-all fashion.
 
     Several regression and binary classification algorithms are
@@ -685,7 +685,7 @@ def _inverse_binarize_thresholding(y, output_type, classes, threshold):
         raise ValueError("{0} format is not supported".format(output_type))
 
 
-class MultiLabelBinarizer(TransformerMixin, BaseEstimator):
+class MultiLabelBinarizer(TransformerMixin, BaseEstimator, auto_wrap_output_keys=None):
     """Transform between iterable of iterables and a multilabel format.
 
     Although a list of sets or tuples is a very intuitive format for multilabel

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -678,7 +678,7 @@ def test_nan_label_encoder():
     "encoder", [LabelEncoder(), LabelBinarizer(), MultiLabelBinarizer()]
 )
 def test_label_encoders_do_not_have_set_output(encoder):
-    """Check that label encoders does not define set_output and works with y as a kwarg.
+    """Check that label encoders do not define set_output and work with y as a kwarg.
 
     Non-regression test for #26854.
     """

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -672,3 +672,17 @@ def test_nan_label_encoder():
 
     y_trans = le.transform([np.nan])
     assert_array_equal(y_trans, [2])
+
+
+@pytest.mark.parametrize(
+    "encoder", [LabelEncoder(), LabelBinarizer(), MultiLabelBinarizer()]
+)
+def test_label_encoders_do_not_have_set_output(encoder):
+    """Check that label encoders does not define set_output and works with y as a kwarg.
+
+    Non-regression test for #26854.
+    """
+    assert not hasattr(encoder, "set_output")
+    y_encoded_with_kwarg = encoder.fit_transform(y=["a", "b", "c"])
+    y_encoded_positional = encoder.fit_transform(["a", "b", "c"])
+    assert_array_equal(y_encoded_with_kwarg, y_encoded_positional)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/26854

#### What does this implement/fix? Explain your changes.
This PR uses `auto_wrap_output_keys=None` to fully disable `set_output` for the label encoders and any wrapping. The set output API was not designed to transform `y`.

#### Any other comments?
Even with this PR, Sphinx still picks up `set_output` and adds it as a method in the API docs. Given that this PR fixes the functionality, I think we can merge and follow up with the documentation fix.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
