### PR TITLE
ENH Improves memory usage and runtime for gradient boosting

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -111,6 +111,11 @@ Changelog
   :pr:`13649` by :user:`Samuel Ronsin <samronsin>`,
   initiated by :user:`Patrick O'Reilly <pat-oreilly>`.
 
+- |Efficiency| Improves runtime and memory usage for
+  :class:`ensemble.GradientBoostingClassifier` and
+  :class:`ensemble.GradientBoostingRegressor` when trained on sparse data.
+  :pr:`xxxxx` by `Thomas Fan`_.
+
 :mod:`sklearn.feature_selection`
 ................................
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -114,7 +114,7 @@ Changelog
 - |Efficiency| Improves runtime and memory usage for
   :class:`ensemble.GradientBoostingClassifier` and
   :class:`ensemble.GradientBoostingRegressor` when trained on sparse data.
-  :pr:`xxxxx` by `Thomas Fan`_.
+  :pr:`26957` by `Thomas Fan`_.
 
 :mod:`sklearn.feature_selection`
 ................................

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -242,13 +242,14 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                 # no inplace multiplication!
                 sample_weight = sample_weight * sample_mask.astype(np.float64)
 
-            X = X_csr if X_csr is not None else X
+            X = X_csc if X_csc is not None else X
             tree.fit(X, residual, sample_weight=sample_weight, check_input=False)
 
             # update tree leaves
+            X_for_tree_update = X_csr if X_csr is not None else X
             loss.update_terminal_regions(
                 tree.tree_,
-                X,
+                X_for_tree_update,
                 y,
                 residual,
                 raw_predictions,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Found this when reviewing https://github.com/scikit-learn/scikit-learn/pull/26278

#### What does this implement/fix? Explain your changes.
On `main`, a CSR matrix is passed to `fit`, which the tree will convert to a csc matrix here:

https://github.com/scikit-learn/scikit-learn/blob/405a5a09503a7f2cd241f8a5b1a1d2368dcc2676/sklearn/tree/_tree.pyx#L109-L110

This PR makes use of the `X_csc` matrix when fitting, so the tree no longer needs to make the copy. Here is a quick memory profiler benchmark:

```python
from scipy.sparse import csc_matrix

from sklearn.datasets import make_regression
from sklearn.ensemble import GradientBoostingRegressor

X, y = make_regression(10_000, 100, random_state=0)
X_csc = csc_matrix(X)

gb = GradientBoostingRegressor(random_state=0)

gb.fit(X_csc, y)
```

## main

![Figure_1](https://github.com/scikit-learn/scikit-learn/assets/5402633/91bba538-1dbb-4be0-b01b-de38307d68c6)

## PR

![Figure_2](https://github.com/scikit-learn/scikit-learn/assets/5402633/3149280c-a137-4e67-9b97-c1d2b7214271)

We can see that the PR runs faster and uses less memory overall.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
