### PR TITLE
DOC add links to cca examples

### DIFF
--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -780,6 +780,9 @@ class PLSCanonical(_PLS):
 class CCA(_PLS):
     """Canonical Correlation Analysis, also known as "Mode B" PLS.
 
+    For an example on usage, see
+    :ref:`sphx_glr_auto_examples_cross_decomposition_plot_compare_cross_decomposition.py`.
+
     Read more in the :ref:`User Guide <cross_decomposition>`.
 
     Parameters


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Adds links to `CCA` examples as mentioned in #26927

#### What does this implement/fix? Explain your changes.
Adds links to the auto-generated examples for classes `CCA`

Classes linked with examples
1. `CCA` in `sklearn/cross_decomposition/_pls.py`