### PR TITLE
DOC Add 2 related projects for microcontroller export

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -136,6 +136,14 @@ enhance the functionality of scikit-learn's estimators.
   Compiles tree-based ensemble models into C code for minimizing prediction
   latency.
 
+- `micromlgen <https://github.com/eloquentarduino/micromlgen>`_
+  MicroML brings Machine Learning algorithms to microcontrollers.
+  Supports several scikit-learn classifiers by transpiles them to C code.
+
+- `emlearn <https://emlearn.org>`_
+  Implements scikit-learn estimators in C99 for embedded devices and microcontrollers.
+  Supports several classifier, regression and outlier detection models.
+
 **Model throughput**
 
 - `Intel(R) Extension for scikit-learn <https://github.com/intel/scikit-learn-intelex>`_

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -138,7 +138,7 @@ enhance the functionality of scikit-learn's estimators.
 
 - `micromlgen <https://github.com/eloquentarduino/micromlgen>`_
   MicroML brings Machine Learning algorithms to microcontrollers.
-  Supports several scikit-learn classifiers by transpiles them to C code.
+  Supports several scikit-learn classifiers by transpiling them to C code.
 
 - `emlearn <https://emlearn.org>`_
   Implements scikit-learn estimators in C99 for embedded devices and microcontrollers.


### PR DESCRIPTION
#### What does this implement/fix?
Documentation only change.
Added a couple of projects to "related projects" under "Model export for production".
These are similar to other tools that are already present, like m2cgen, sklearn-porter and sklearn-onnx - but are focused/specialized for microcontrollers/embedded (think Arduino).
Both have existed for several years, have a reasonable amount of visbility on Github. They are also both referenced in several academic papers within this niche.

#### Any other comments?
Disclaimer: I am the maintainer of emlearn, which was added. No affiliation with micromlgen, the other project

First pull request. Have attempted to follow the contribution guidelines as best as I could. Will happily adjust to feedback