### PR TITLE
CI Cross compile wheel macos wheels on github actions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -103,6 +103,18 @@ jobs:
             python: 311
             platform_id: macosx_x86_64
 
+          # MacOS arm64
+          # The latest macos arm64 Python build is on Cirrus CI
+          - os: macos-latest
+            python: 38
+            platform_id: macosx_arm64
+          - os: macos-latest
+            python: 39
+            platform_id: macosx_arm64
+          - os: macos-latest
+            python: 310
+            platform_id: macosx_arm64
+
     steps:
       - name: Checkout scikit-learn
         uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -104,7 +104,7 @@ jobs:
             platform_id: macosx_x86_64
 
           # MacOS arm64
-          # The latest macos arm64 Python build is on Cirrus CI
+          # The latest Python version is built and tested on CirrusCI
           - os: macos-latest
             python: 38
             platform_id: macosx_arm64

--- a/build_tools/cirrus/arm_wheel.yml
+++ b/build_tools/cirrus/arm_wheel.yml
@@ -16,12 +16,8 @@ macos_arm64_wheel_task:
     # See `maint_tools/update_tracking_issue.py` for details on the permissions the token requires.
     BOT_GITHUB_TOKEN: ENCRYPTED[9b50205e2693f9e4ce9a3f0fcb897a259289062fda2f5a3b8aaa6c56d839e0854a15872f894a70fca337dd4787274e0f]
   matrix:
-    - env:
-        CIBW_BUILD: cp38-macosx_arm64
-    - env:
-        CIBW_BUILD: cp39-macosx_arm64
-    - env:
-        CIBW_BUILD: cp310-macosx_arm64
+    # Only the latest Python version is built and tested on CirrusCI, the other
+    # macos arm64 builds are on GitHub Actions
     - env:
         CIBW_BUILD: cp311-macosx_arm64
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards https://github.com/scikit-learn/scikit-learn/issues/26879


#### What does this implement/fix? Explain your changes.
On CirrusCI, macOS uses 4 times more credits then Linux credits. This PR moves the macos arm64 builds to GitHub Actions.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
