### PR TITLE
CI Only run arm tests nightly

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -26,10 +26,12 @@ def main(ctx):
     response = http.get(url).json()
     commit_msg = response["message"]
 
+    jobs_to_run = []
+
     if "[cd build]" in commit_msg or "[cd build cirrus]" in commit_msg:
-        return fs.read(arm_wheel_yaml)
+        jobs_to_run.append(fs.read(arm_wheel_yaml))
 
     if "[cirrus arm]" in commit_msg:
-        return fs.read(arm_tests_yaml)
+        jobs_to_run.append(fs.read(arm_tests_yaml))
 
-    return []
+    return jobs_to_run

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -29,4 +29,7 @@ def main(ctx):
     if "[cd build]" in commit_msg or "[cd build cirrus]" in commit_msg:
         return fs.read(arm_wheel_yaml)
 
+    if "[cirrus arm]" in commit_msg:
+        return fs.read(arm_tests_yaml)
+
     return []

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -14,7 +14,7 @@ def main(ctx):
 
     # Nightly jobs always run
     if env.get("CIRRUS_CRON", "") == "nightly":
-        return fs.read(arm_wheel_yaml)
+        return fs.read(arm_wheel_yaml) + fs.read(arm_tests_yaml)
 
     # Get commit message for event. We can not use `git` here because there is
     # no command line access in starlark. Thus we need to query the GitHub API
@@ -26,10 +26,7 @@ def main(ctx):
     response = http.get(url).json()
     commit_msg = response["message"]
 
-    if "[skip ci]" in commit_msg:
-        return []
-
     if "[cd build]" in commit_msg or "[cd build cirrus]" in commit_msg:
-        return fs.read(arm_wheel_yaml) + fs.read(arm_tests_yaml)
+        return fs.read(arm_wheel_yaml)
 
-    return fs.read(arm_tests_yaml)
+    return []

--- a/.cirrus.star
+++ b/.cirrus.star
@@ -26,12 +26,12 @@ def main(ctx):
     response = http.get(url).json()
     commit_msg = response["message"]
 
-    jobs_to_run = []
+    jobs_to_run = ""
 
     if "[cd build]" in commit_msg or "[cd build cirrus]" in commit_msg:
-        jobs_to_run.append(fs.read(arm_wheel_yaml))
+        jobs_to_run += fs.read(arm_wheel_yaml)
 
     if "[cirrus arm]" in commit_msg:
-        jobs_to_run.append(fs.read(arm_tests_yaml))
+        jobs_to_run += fs.read(arm_tests_yaml)
 
     return jobs_to_run

--- a/build_tools/cirrus/arm_tests.yml
+++ b/build_tools/cirrus/arm_tests.yml
@@ -17,4 +17,10 @@ linux_aarch64_test_task:
     folder: /root/.conda/pkgs
     fingerprint_script: cat build_tools/cirrus/py39_conda_forge_linux-aarch64_conda.lock
 
-  test_script: bash build_tools/cirrus/build_test_arm.sh
+  test_script: |
+    bash build_tools/cirrus/build_test_arm.sh
+    bash build_tools/cirrus/update_tracking_issue.sh true
+
+  on_failure:
+    update_tracker_script:
+      - bash build_tools/cirrus/update_tracking_issue.sh false

--- a/build_tools/cirrus/arm_tests.yml
+++ b/build_tools/cirrus/arm_tests.yml
@@ -19,6 +19,7 @@ linux_aarch64_test_task:
 
   test_script: |
     bash build_tools/cirrus/build_test_arm.sh
+    # On success, this script is run updating the issue.
     bash build_tools/cirrus/update_tracking_issue.sh true
 
   on_failure:

--- a/build_tools/cirrus/arm_tests.yml
+++ b/build_tools/cirrus/arm_tests.yml
@@ -22,5 +22,4 @@ linux_aarch64_test_task:
     bash build_tools/cirrus/update_tracking_issue.sh true
 
   on_failure:
-    update_tracker_script:
-      - bash build_tools/cirrus/update_tracking_issue.sh false
+    update_tracker_script: bash build_tools/cirrus/update_tracking_issue.sh false

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -542,6 +542,7 @@ message, the following actions are taken.
     [pypy]                 Build & test with PyPy
     [pyodide]              Build & test with Pyodide
     [azure parallel]       Run Azure CI jobs in parallel
+    [cirrus arm]           Run Cirrus CI ARM test
     [float32]              Run float32 tests by setting `SKLEARN_RUN_FLOAT32_TESTS=1`. See :ref:`environment_variable` for more details
     [doc skip]             Docs are not built
     [doc quick]            Docs built, but excludes example gallery plots


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes https://github.com/scikit-learn/scikit-learn/issues/26879


#### What does this implement/fix? Explain your changes.
This PR makes the ARM test run nightly. This PR also adds a `[cirrus arm]` commit tag to run the arm tests on CI if they are needed.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
