### PR TITLE
MNT Use enable_slep006 fixture directly

### DIFF
--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -2076,8 +2076,7 @@ def test_liblinear_not_stuck():
         clf.fit(X_prep, y)
 
 
-@pytest.mark.usefixtures("enable_slep006")
-def test_lr_cv_scores_differ_when_sample_weight_is_requested():
+def test_lr_cv_scores_differ_when_sample_weight_is_requested(enable_slep006):
     """Test that `sample_weight` is correctly passed to the scorer in
     `LogisticRegressionCV.fit` and `LogisticRegressionCV.score` by
     checking the difference in scores with the case when `sample_weight`

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1206,9 +1206,8 @@ def test_scorer_set_score_request_raises(name):
         scorer.set_score_request()
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize("name", get_scorer_names(), ids=get_scorer_names())
-def test_scorer_metadata_request(name):
+def test_scorer_metadata_request(enable_slep006, name):
     """Testing metadata requests for scorers.
 
     This test checks many small things in a large test, to reduce the
@@ -1255,8 +1254,7 @@ def test_scorer_metadata_request(name):
     assert list(routed_params.scorer.score.keys()) == ["sample_weight"]
 
 
-@pytest.mark.usefixtures("enable_slep006")
-def test_metadata_kwarg_conflict():
+def test_metadata_kwarg_conflict(enable_slep006):
     """This test makes sure the right warning is raised if the user passes
     some metadata both as a constructor to make_scorer, and during __call__.
     """
@@ -1278,8 +1276,7 @@ def test_metadata_kwarg_conflict():
         scorer(lr, X, y, labels=lr.classes_)
 
 
-@pytest.mark.usefixtures("enable_slep006")
-def test_PassthroughScorer_metadata_request():
+def test_PassthroughScorer_metadata_request(enable_slep006):
     """Test that _PassthroughScorer properly routes metadata.
 
     _PassthroughScorer should behave like a consumer, mirroring whatever is the
@@ -1297,8 +1294,7 @@ def test_PassthroughScorer_metadata_request():
     assert scorer.get_metadata_routing().score.requests["sample_weight"] == "alias"
 
 
-@pytest.mark.usefixtures("enable_slep006")
-def test_multimetric_scoring_metadata_routing():
+def test_multimetric_scoring_metadata_routing(enable_slep006):
     # Test that _MultimetricScorer properly routes metadata.
     def score1(y_true, y_pred):
         return 1

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -869,8 +869,7 @@ def test_dataframe_protocol(constructor_name, minversion):
         no_op.transform(df_bad)
 
 
-@pytest.mark.usefixtures("enable_slep006")
-def test_transformer_fit_transform_with_metadata_in_transform():
+def test_transformer_fit_transform_with_metadata_in_transform(enable_slep006):
     """Test that having a transformer with metadata for transform raises a
     warning when calling fit_transform."""
 
@@ -895,8 +894,7 @@ def test_transformer_fit_transform_with_metadata_in_transform():
         assert len(record) == 0
 
 
-@pytest.mark.usefixtures("enable_slep006")
-def test_outlier_mixin_fit_predict_with_metadata_in_predict():
+def test_outlier_mixin_fit_predict_with_metadata_in_predict(enable_slep006):
     """Test that having an OutlierMixin with metadata for predict raises a
     warning when calling fit_predict."""
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -1761,8 +1761,7 @@ class SimpleTransformer(BaseEstimator, TransformerMixin):
         return X
 
 
-@pytest.mark.usefixtures("enable_slep006")
-def test_metadata_routing_for_pipeline():
+def test_metadata_routing_for_pipeline(enable_slep006):
     """Test that metadata is routed correctly for pipelines."""
 
     def set_request(est, method, **kwarg):
@@ -1832,8 +1831,7 @@ def test_routing_passed_metadata_not_supported(method):
         getattr(pipe, method)([[1]], sample_weight=[1], prop="a")
 
 
-@pytest.mark.usefixtures("enable_slep006")
-def test_pipeline_with_estimator_with_len():
+def test_pipeline_with_estimator_with_len(enable_slep006):
     """Test that pipeline works with estimators that have a `__len__` method."""
     pipe = Pipeline(
         [("trs", RandomTreesEmbedding()), ("estimator", RandomForestClassifier())]
@@ -1842,9 +1840,8 @@ def test_pipeline_with_estimator_with_len():
     pipe.predict([[1]])
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize("last_step", [None, "passthrough"])
-def test_pipeline_with_no_last_step(last_step):
+def test_pipeline_with_no_last_step(enable_slep006, last_step):
     """Test that the pipeline works when there is not last step.
 
     It should just ignore and pass through the data on transform.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Noticed this when reviewing #26964


#### What does this implement/fix? Explain your changes.
Although the decorator works, I usually see the fixtures placed directly in the test signature.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
