### PR TITLE
Add concept of "soft deprecation" to development tools

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1356,7 +1356,7 @@ The main difference between a "soft" and a (regular) "hard" deprecation is that 
 soft deprecation does not imply scheduling the removal of the deprecated API.
 
 Another difference is that a soft deprecation does not issue a warning: it's only mentioned
-in the documentation, whereas usually a "hard" deprecation issues a ``DeprecationWarning``
+in the documentation, whereas usually a "hard" deprecation issues a ``FutureWarning``
 warning at runtime. The documentation of a soft deprecation should explain why the API
 should be avoided, and if possible propose a replacement.
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1345,6 +1345,27 @@ not in other cases. The warning should be caught in all other tests
 (using e.g., ``@pytest.mark.filterwarnings``), and there should be no warning
 in the examples.
 
+Soft Deprecation
+----------------
+
+A soft deprecation can be used to indicate that a particular API should no longer be
+used when writing new code, but that it is safe to continue using it in existing code.
+The API remains documentated and tested, but will not be developerd further.
+
+The main difference between a "soft" and a (regular) "hard" deprecation is that the
+soft deprecation does not imply scheduling the removal of the deprecated API.
+
+Another difference is that a soft deprecation does not issue a warning: it's only mentioned
+in the documentation, whereas usually a "hard" deprecation issues a ``DeprecationWarning``
+warning at runtime. The documentation of a soft deprecation should explain why the API
+should be avoided, and if possible propose a replacement.
+
+If the decision is made to deprecate (in the regular sense) a feature that is currently
+soft deprecated, the deprecation must follow the :term:`backwards compatibility` rules
+(i.e., there is no exception because the feature is already soft deprecated).
+
+This policy and text is taken from `PEP387 <https://peps.python.org/pep-0387/#soft-deprecation>`_.
+
 .. currentmodule:: sklearn
 
 .. _code_review:

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -242,6 +242,7 @@ General Concepts
         instance.
 
         See the :ref:`Contributors' Guide <contributing_deprecation>`.
+        See also :term:`soft deprecation`.
 
     dimensionality
         May be used to refer to the number of :term:`features` (i.e.
@@ -729,6 +730,13 @@ General Concepts
         available for some samples provided as training data when
         :term:`fitting` the model.  We conventionally apply the label ``-1``
         to :term:`unlabeled` samples in semi-supervised classification.
+
+    soft deprecation
+        A soft deprecation can be used to indicate that a particular API should no longer be
+        used when writing new code, but that it is safe to continue using it in existing code.
+
+        See the :ref:`Contributors' Guide <contributing_deprecation>`.
+        See also :term:`deprecation`.
 
     sparse matrix
     sparse graph


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This adds the concept of "soft deprecation" from https://peps.python.org/pep-0387/#soft-deprecation.

The idea of this PR is to find out what other core devs think of this concept and idea.

TL;DR: is used in core Python to indicate that part of the API should not be used for new code, but won't be removed (so you can keep using it in existing code).

When I saw this I thought it could be an interesting tool to use to deal with having "too much stuff" in scikit-learn. Two examples for "soft deprecation" are the MLP code and the Passive Aggressive Classifier.

Questions:
* is this useful? Too complicated? Impractical?
* how do we deal with the text being taken verbatim from the PEP?