### PR TITLE
ENH Introduce dtype preservation semantics in `DistanceMetric` objects.

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -199,6 +199,11 @@ Changelog
   for CSR × CSR,  Dense × CSR, and CSR × Dense datasets is now 1.5x faster.
   :pr:`26765` by :user:`Meekail Zain <micky774>`
 
+- |Efficiency| Computing distances via :class:`metrics.DistanceMetric`
+  for CSR × CSR,  Dense × CSR, and CSR × Dense now use ~50% less memory, output
+  distances in the same dtype as the provided data.
+  :pr:`27006` by :user:`Meekail Zain <micky774>`
+
 :mod:`sklearn.utils`
 ....................
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -200,8 +200,8 @@ Changelog
   :pr:`26765` by :user:`Meekail Zain <micky774>`
 
 - |Efficiency| Computing distances via :class:`metrics.DistanceMetric`
-  for CSR × CSR,  Dense × CSR, and CSR × Dense now use ~50% less memory, output
-  distances in the same dtype as the provided data.
+  for CSR × CSR, Dense × CSR, and CSR × Dense now uses ~50% less memory,
+  and outputs distances in the same dtype as the provided data.
   :pr:`27006` by :user:`Meekail Zain <micky774>`
 
 :mod:`sklearn.utils`

--- a/sklearn/metrics/_dist_metrics.pxd.tp
+++ b/sklearn/metrics/_dist_metrics.pxd.tp
@@ -49,11 +49,11 @@ cdef inline float64_t euclidean_rdist{{name_suffix}}(
     return d
 
 
-cdef inline float64_t euclidean_dist_to_rdist{{name_suffix}}(const {{INPUT_DTYPE_t}} dist) except -1 nogil:
+cdef inline float64_t euclidean_dist_to_rdist{{name_suffix}}(const float64_t dist) except -1 nogil:
     return dist * dist
 
 
-cdef inline float64_t euclidean_rdist_to_dist{{name_suffix}}(const {{INPUT_DTYPE_t}} dist) except -1 nogil:
+cdef inline float64_t euclidean_rdist_to_dist{{name_suffix}}(const float64_t dist) except -1 nogil:
     return sqrt(dist)
 
 
@@ -71,21 +71,21 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
     cdef object func
     cdef object kwargs
 
-    cdef {{INPUT_DTYPE_t}} dist(
+    cdef float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
     ) except -1 nogil
 
-    cdef {{INPUT_DTYPE_t}} rdist(
+    cdef float64_t rdist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
     ) except -1 nogil
 
-    cdef {{INPUT_DTYPE_t}} dist_csr(
+    cdef float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -98,7 +98,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         const intp_t size,
     ) except -1 nogil
 
-    cdef {{INPUT_DTYPE_t}} rdist_csr(
+    cdef float64_t rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -145,8 +145,8 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         {{INPUT_DTYPE_t}}[:, ::1] D,
     ) except -1 nogil
 
-    cdef {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil
+    cdef float64_t _rdist_to_dist(self, float64_t rdist) except -1 nogil
 
-    cdef {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil
+    cdef float64_t _dist_to_rdist(self, float64_t dist) except -1 nogil
 
 {{endfor}}

--- a/sklearn/metrics/_dist_metrics.pxd.tp
+++ b/sklearn/metrics/_dist_metrics.pxd.tp
@@ -65,27 +65,27 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
     # Because we don't expect to instantiate a lot of these objects, the
     # extra memory overhead of this setup should not be an issue.
     cdef float64_t p
-    cdef const float64_t[::1] vec
-    cdef const float64_t[:, ::1] mat
+    cdef const {{INPUT_DTYPE_t}}[::1] vec
+    cdef const {{INPUT_DTYPE_t}}[:, ::1] mat
     cdef intp_t size
     cdef object func
     cdef object kwargs
 
-    cdef float64_t dist(
+    cdef {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
     ) except -1 nogil
 
-    cdef float64_t rdist(
+    cdef {{INPUT_DTYPE_t}} rdist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
     ) except -1 nogil
 
-    cdef float64_t dist_csr(
+    cdef {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -98,7 +98,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         const intp_t size,
     ) except -1 nogil
 
-    cdef float64_t rdist_csr(
+    cdef {{INPUT_DTYPE_t}} rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -114,14 +114,14 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
     cdef int pdist(
         self,
         const {{INPUT_DTYPE_t}}[:, ::1] X,
-        float64_t[:, ::1] D,
+        {{INPUT_DTYPE_t}}[:, ::1] D,
     ) except -1
 
     cdef int cdist(
         self,
         const {{INPUT_DTYPE_t}}[:, ::1] X,
         const {{INPUT_DTYPE_t}}[:, ::1] Y,
-        float64_t[:, ::1] D,
+        {{INPUT_DTYPE_t}}[:, ::1] D,
     ) except -1
 
     cdef int pdist_csr(
@@ -130,7 +130,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         const int32_t[::1] x1_indices,
         const int32_t[::1] x1_indptr,
         const intp_t size,
-        float64_t[:, ::1] D,
+        {{INPUT_DTYPE_t}}[:, ::1] D,
     ) except -1 nogil
 
     cdef int cdist_csr(
@@ -142,11 +142,11 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         const int32_t[::1] x2_indices,
         const int32_t[::1] x2_indptr,
         const intp_t size,
-        float64_t[:, ::1] D,
+        {{INPUT_DTYPE_t}}[:, ::1] D,
     ) except -1 nogil
 
-    cdef float64_t _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil
+    cdef {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil
 
-    cdef float64_t _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil
+    cdef {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil
 
 {{endfor}}

--- a/sklearn/metrics/_dist_metrics.pxd.tp
+++ b/sklearn/metrics/_dist_metrics.pxd.tp
@@ -65,8 +65,8 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
     # Because we don't expect to instantiate a lot of these objects, the
     # extra memory overhead of this setup should not be an issue.
     cdef float64_t p
-    cdef const {{INPUT_DTYPE_t}}[::1] vec
-    cdef const {{INPUT_DTYPE_t}}[:, ::1] mat
+    cdef const float64_t[::1] vec
+    cdef const float64_t[:, ::1] mat
     cdef intp_t size
     cdef object func
     cdef object kwargs

--- a/sklearn/metrics/_dist_metrics.pxd.tp
+++ b/sklearn/metrics/_dist_metrics.pxd.tp
@@ -49,11 +49,11 @@ cdef inline float64_t euclidean_rdist{{name_suffix}}(
     return d
 
 
-cdef inline float64_t euclidean_dist_to_rdist{{name_suffix}}(const float64_t dist) except -1 nogil:
+cdef inline float64_t euclidean_dist_to_rdist{{name_suffix}}(const {{INPUT_DTYPE_t}} dist) except -1 nogil:
     return dist * dist
 
 
-cdef inline float64_t euclidean_rdist_to_dist{{name_suffix}}(const float64_t dist) except -1 nogil:
+cdef inline float64_t euclidean_rdist_to_dist{{name_suffix}}(const {{INPUT_DTYPE_t}} dist) except -1 nogil:
     return sqrt(dist)
 
 
@@ -71,21 +71,21 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
     cdef object func
     cdef object kwargs
 
-    cdef float64_t dist(
+    cdef {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
     ) except -1 nogil
 
-    cdef float64_t rdist(
+    cdef {{INPUT_DTYPE_t}} rdist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
     ) except -1 nogil
 
-    cdef float64_t dist_csr(
+    cdef {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -98,7 +98,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         const intp_t size,
     ) except -1 nogil
 
-    cdef float64_t rdist_csr(
+    cdef {{INPUT_DTYPE_t}} rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -145,8 +145,8 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         {{INPUT_DTYPE_t}}[:, ::1] D,
     ) except -1 nogil
 
-    cdef float64_t _rdist_to_dist(self, float64_t rdist) except -1 nogil
+    cdef {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil
 
-    cdef float64_t _dist_to_rdist(self, float64_t dist) except -1 nogil
+    cdef {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil
 
 {{endfor}}

--- a/sklearn/metrics/_dist_metrics.pyx.tp
+++ b/sklearn/metrics/_dist_metrics.pyx.tp
@@ -372,8 +372,8 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
     """
     def __cinit__(self):
         self.p = 2
-        self.vec = np.zeros(1, dtype=np.float64, order='C')
-        self.mat = np.zeros((1, 1), dtype=np.float64, order='C')
+        self.vec = np.zeros(1, dtype={{INPUT_DTYPE}}, order='C')
+        self.mat = np.zeros((1, 1), dtype={{INPUT_DTYPE}}, order='C')
         self.size = 1
 
     def __reduce__(self):
@@ -457,7 +457,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         """
         return
 
-    cdef float64_t dist(
+    cdef {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -469,7 +469,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         """
         return -999
 
-    cdef float64_t rdist(
+    cdef {{INPUT_DTYPE_t}} rdist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -489,7 +489,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
     cdef int pdist(
         self,
         const {{INPUT_DTYPE_t}}[:, ::1] X,
-        float64_t[:, ::1] D,
+        {{INPUT_DTYPE_t}}[:, ::1] D,
     ) except -1:
         """Compute the pairwise distances between points in X"""
         cdef intp_t i1, i2
@@ -504,7 +504,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         self,
         const {{INPUT_DTYPE_t}}[:, ::1] X,
         const {{INPUT_DTYPE_t}}[:, ::1] Y,
-        float64_t[:, ::1] D,
+        {{INPUT_DTYPE_t}}[:, ::1] D,
     ) except -1:
         """Compute the cross-pairwise distances between arrays X and Y"""
         cdef intp_t i1, i2
@@ -515,7 +515,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
                 D[i1, i2] = self.dist(&X[i1, 0], &Y[i2, 0], X.shape[1])
         return 0
 
-    cdef float64_t dist_csr(
+    cdef {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -545,7 +545,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
 
         2. An alternative signature would be:
 
-            cdef float64_t dist_csr(
+            cdef {{INPUT_DTYPE_t}} dist_csr(
                 self,
                 const {{INPUT_DTYPE_t}}* x1_data,
                 const int32_t* x1_indices,
@@ -581,7 +581,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         """
         return -999
 
-    cdef float64_t rdist_csr(
+    cdef {{INPUT_DTYPE_t}} rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -628,7 +628,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         const int32_t[::1] x1_indices,
         const int32_t[::1] x1_indptr,
         const intp_t size,
-        float64_t[:, ::1] D,
+        {{INPUT_DTYPE_t}}[:, ::1] D,
     ) except -1 nogil:
         """Pairwise distances between rows in CSR matrix X.
 
@@ -668,7 +668,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         const int32_t[::1] x2_indices,
         const int32_t[::1] x2_indptr,
         const intp_t size,
-        float64_t[:, ::1] D,
+        {{INPUT_DTYPE_t}}[:, ::1] D,
     ) except -1 nogil:
         """Compute the cross-pairwise distances between arrays X and Y
         represented in the CSR format."""
@@ -698,11 +698,11 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
                 )
         return 0
 
-    cdef float64_t _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
+    cdef {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
         """Convert the rank-preserving surrogate distance to the distance"""
         return rdist
 
-    cdef float64_t _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
+    cdef {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
         """Convert the distance to the rank-preserving surrogate distance"""
         return dist
 
@@ -749,17 +749,17 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
     def _pairwise_dense_dense(self, X, Y):
         cdef const {{INPUT_DTYPE_t}}[:, ::1] Xarr
         cdef const {{INPUT_DTYPE_t}}[:, ::1] Yarr
-        cdef float64_t[:, ::1] Darr
+        cdef {{INPUT_DTYPE_t}}[:, ::1] Darr
 
         Xarr = np.asarray(X, dtype={{INPUT_DTYPE}}, order='C')
         self._validate_data(Xarr)
         if X is Y:
-            Darr = np.empty((Xarr.shape[0], Xarr.shape[0]), dtype=np.float64, order='C')
+            Darr = np.empty((Xarr.shape[0], Xarr.shape[0]), dtype={{INPUT_DTYPE}}, order='C')
             self.pdist(Xarr, Darr)
         else:
             Yarr = np.asarray(Y, dtype={{INPUT_DTYPE}}, order='C')
             self._validate_data(Yarr)
-            Darr = np.empty((Xarr.shape[0], Yarr.shape[0]), dtype=np.float64, order='C')
+            Darr = np.empty((Xarr.shape[0], Yarr.shape[0]), dtype={{INPUT_DTYPE}}, order='C')
             self.cdist(Xarr, Yarr, Darr)
         return np.asarray(Darr)
 
@@ -775,7 +775,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
             const int32_t[::1] Y_indices
             const int32_t[::1] Y_indptr
 
-            float64_t[:, ::1] Darr
+            {{INPUT_DTYPE_t}}[:, ::1] Darr
 
         X_csr = X.tocsr()
         n_X, n_features = X_csr.shape
@@ -783,7 +783,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         X_indices = np.asarray(X_csr.indices, dtype=np.int32)
         X_indptr = np.asarray(X_csr.indptr, dtype=np.int32)
         if X is Y:
-            Darr = np.empty((n_X, n_X), dtype=np.float64, order='C')
+            Darr = np.empty((n_X, n_X), dtype={{INPUT_DTYPE}}, order='C')
             self.pdist_csr(
                 x1_data=&X_data[0],
                 x1_indices=X_indices,
@@ -798,7 +798,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
             Y_indices = np.asarray(Y_csr.indices, dtype=np.int32)
             Y_indptr = np.asarray(Y_csr.indptr, dtype=np.int32)
 
-            Darr = np.empty((n_X, n_Y), dtype=np.float64, order='C')
+            Darr = np.empty((n_X, n_Y), dtype={{INPUT_DTYPE}}, order='C')
             self.cdist_csr(
                 x1_data=&X_data[0],
                 x1_indices=X_indices,
@@ -833,7 +833,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
                 np.arange(n_features, dtype=np.int32)
             )
 
-            float64_t[:, ::1] Darr = np.empty((n_X, n_Y), dtype=np.float64, order='C')
+            {{INPUT_DTYPE_t}}[:, ::1] Darr = np.empty((n_X, n_Y), dtype={{INPUT_DTYPE}}, order='C')
 
             intp_t i1, i2
             intp_t x1_start, x1_end
@@ -898,7 +898,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
                 Y.indptr, dtype=np.int32,
             )
 
-            float64_t[:, ::1] Darr = np.empty((n_X, n_Y), dtype=np.float64, order='C')
+            {{INPUT_DTYPE_t}}[:, ::1] Darr = np.empty((n_X, n_Y), dtype={{INPUT_DTYPE}}, order='C')
 
             intp_t i1, i2
             {{INPUT_DTYPE_t}} * x1_data
@@ -992,24 +992,24 @@ cdef class EuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def __init__(self):
         self.p = 2
 
-    cdef inline float64_t dist(self,
+    cdef inline {{INPUT_DTYPE_t}} dist(self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
     ) except -1 nogil:
         return euclidean_dist{{name_suffix}}(x1, x2, size)
 
-    cdef inline float64_t rdist(self,
+    cdef inline {{INPUT_DTYPE_t}} rdist(self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
     ) except -1 nogil:
         return euclidean_rdist{{name_suffix}}(x1, x2, size)
 
-    cdef inline float64_t _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
         return sqrt(rdist)
 
-    cdef inline float64_t _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
         return dist * dist
 
     def rdist_to_dist(self, rdist):
@@ -1018,7 +1018,7 @@ cdef class EuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def dist_to_rdist(self, dist):
         return dist ** 2
 
-    cdef inline float64_t rdist_csr(
+    cdef inline {{INPUT_DTYPE_t}} rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1070,7 +1070,7 @@ cdef class EuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         return d
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1105,7 +1105,7 @@ cdef class SEuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
        D(x, y) = \sqrt{ \sum_i \frac{ (x_i - y_i) ^ 2}{V_i} }
     """
     def __init__(self, V):
-        self.vec = np.asarray(V, dtype=np.float64)
+        self.vec = np.asarray(V, dtype={{INPUT_DTYPE}})
         self.size = self.vec.shape[0]
         self.p = 2
 
@@ -1113,7 +1113,7 @@ cdef class SEuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         if X.shape[1] != self.size:
             raise ValueError('SEuclidean dist: size of V does not match')
 
-    cdef inline float64_t rdist(
+    cdef inline {{INPUT_DTYPE_t}} rdist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1126,7 +1126,7 @@ cdef class SEuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             d += (tmp * tmp / self.vec[j])
         return d
 
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1134,10 +1134,10 @@ cdef class SEuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     ) except -1 nogil:
         return sqrt(self.rdist(x1, x2, size))
 
-    cdef inline float64_t _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
         return sqrt(rdist)
 
-    cdef inline float64_t _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
         return dist * dist
 
     def rdist_to_dist(self, rdist):
@@ -1146,7 +1146,7 @@ cdef class SEuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def dist_to_rdist(self, dist):
         return dist ** 2
 
-    cdef inline float64_t rdist_csr(
+    cdef inline {{INPUT_DTYPE_t}} rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1199,7 +1199,7 @@ cdef class SEuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
                 i1 = i1 + 1
         return d
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1236,7 +1236,7 @@ cdef class ManhattanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def __init__(self):
         self.p = 1
 
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1248,7 +1248,7 @@ cdef class ManhattanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             d += fabs(x1[j] - x2[j])
         return d
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1319,7 +1319,7 @@ cdef class ChebyshevDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def __init__(self):
         self.p = INF{{name_suffix}}
 
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1332,7 +1332,7 @@ cdef class ChebyshevDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         return d
 
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1424,14 +1424,14 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         self.p = p
         if w is not None:
             w_array = check_array(
-                w, ensure_2d=False, dtype=np.float64, input_name="w"
+                w, ensure_2d=False, dtype={{INPUT_DTYPE}}, input_name="w"
             )
             if (w_array < 0).any():
                 raise ValueError("w cannot contain negative weights")
             self.vec = w_array
             self.size = self.vec.shape[0]
         else:
-            self.vec = np.asarray([], dtype=np.float64)
+            self.vec = np.asarray([], dtype={{INPUT_DTYPE}})
             self.size = 0
 
     def _validate_data(self, X):
@@ -1440,7 +1440,7 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
                              f"the number of features ({X.shape[1]}). "
                              f"Currently len(w)={self.size}.")
 
-    cdef inline float64_t rdist(
+    cdef inline {{INPUT_DTYPE_t}} rdist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1457,7 +1457,7 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
                 d += (pow(fabs(x1[j] - x2[j]), self.p))
         return d
 
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1465,10 +1465,10 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     ) except -1 nogil:
         return pow(self.rdist(x1, x2, size), 1. / self.p)
 
-    cdef inline float64_t _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
         return pow(rdist, 1. / self.p)
 
-    cdef inline float64_t _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
         return pow(dist, self.p)
 
     def rdist_to_dist(self, rdist):
@@ -1477,7 +1477,7 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def dist_to_rdist(self, dist):
         return dist ** self.p
 
-    cdef inline float64_t rdist_csr(
+    cdef inline {{INPUT_DTYPE_t}} rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1557,7 +1557,7 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
             return d
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1613,7 +1613,7 @@ cdef class MahalanobisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         if VI.ndim != 2 or VI.shape[0] != VI.shape[1]:
             raise ValueError("V/VI must be square")
 
-        self.mat = np.asarray(VI, dtype=np.float64, order='C')
+        self.mat = np.asarray(VI, dtype={{INPUT_DTYPE}}, order='C')
 
         self.size = self.mat.shape[0]
 
@@ -1629,7 +1629,7 @@ cdef class MahalanobisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         if X.shape[1] != self.size:
             raise ValueError('Mahalanobis dist: size of V does not match')
 
-    cdef inline float64_t rdist(
+    cdef inline {{INPUT_DTYPE_t}} rdist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1649,7 +1649,7 @@ cdef class MahalanobisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             d += tmp * self.buffer[i]
         return d
 
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1657,10 +1657,10 @@ cdef class MahalanobisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     ) except -1 nogil:
         return sqrt(self.rdist(x1, x2, size))
 
-    cdef inline float64_t _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
         return sqrt(rdist)
 
-    cdef inline float64_t _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
         return dist * dist
 
     def rdist_to_dist(self, rdist):
@@ -1669,7 +1669,7 @@ cdef class MahalanobisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def dist_to_rdist(self, dist):
         return dist ** 2
 
-    cdef inline float64_t rdist_csr(
+    cdef inline {{INPUT_DTYPE_t}} rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1723,7 +1723,7 @@ cdef class MahalanobisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         return d
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1760,7 +1760,7 @@ cdef class HammingDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     .. math::
        D(x, y) = \frac{1}{N} \sum_i \delta_{x_i, y_i}
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1774,7 +1774,7 @@ cdef class HammingDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         return float(n_unequal) / size
 
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1835,7 +1835,7 @@ cdef class CanberraDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     .. math::
        D(x, y) = \sum_i \frac{|x_i - y_i|}{|x_i| + |y_i|}
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1849,7 +1849,7 @@ cdef class CanberraDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
                 d += fabs(x1[j] - x2[j]) / denom
         return d
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1910,7 +1910,7 @@ cdef class BrayCurtisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     .. math::
        D(x, y) = \frac{\sum_i |x_i - y_i|}{\sum_i(|x_i| + |y_i|)}
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1926,7 +1926,7 @@ cdef class BrayCurtisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         else:
             return 0.0
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1990,7 +1990,7 @@ cdef class JaccardDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = (N_TF + N_FT) / (N_TT + N_TF + N_FT)
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2010,7 +2010,7 @@ cdef class JaccardDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             return 0
         return (nnz - n_eq) * 1.0 / nnz
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2079,7 +2079,7 @@ cdef class MatchingDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = (N_TF + N_FT) / N
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2093,7 +2093,7 @@ cdef class MatchingDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_neq += (tf1 != tf2)
         return n_neq * 1. / size
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2154,7 +2154,7 @@ cdef class DiceDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         D(x, y) = (N_TF + N_FT) / (2 * N_TT + N_TF + N_FT)
 
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2169,7 +2169,7 @@ cdef class DiceDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_neq += (tf1 != tf2)
         return n_neq / (2.0 * n_tt + n_neq)
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2235,7 +2235,7 @@ cdef class KulsinskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         D(x, y) = 1 - N_TT / (N + N_TF + N_FT)
 
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2250,7 +2250,7 @@ cdef class KulsinskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_tt += (tf1 and tf2)
         return (n_neq - n_tt + size) * 1.0 / (n_neq + size)
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2314,7 +2314,7 @@ cdef class RogersTanimotoDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = 2 (N_TF + N_FT) / (N + N_TF + N_FT)
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2328,7 +2328,7 @@ cdef class RogersTanimotoDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_neq += (tf1 != tf2)
         return (2.0 * n_neq) / (size + n_neq)
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2391,7 +2391,7 @@ cdef class RussellRaoDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = (N - N_TT) / N
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2405,7 +2405,7 @@ cdef class RussellRaoDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_tt += (tf1 and tf2)
         return (size - n_tt) * 1. / size
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2461,7 +2461,7 @@ cdef class SokalMichenerDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = 2 (N_TF + N_FT) / (N + N_TF + N_FT)
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2475,7 +2475,7 @@ cdef class SokalMichenerDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_neq += (tf1 != tf2)
         return (2.0 * n_neq) / (size + n_neq)
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2538,7 +2538,7 @@ cdef class SokalSneathDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = (N_TF + N_FT) / (N_TT / 2 + N_FT + N_TF)
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2553,7 +2553,7 @@ cdef class SokalSneathDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_tt += (tf1 and tf2)
         return n_neq / (0.5 * n_tt + n_neq)
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2627,7 +2627,7 @@ cdef class HaversineDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             raise ValueError("Haversine distance only valid "
                              "in 2 dimensions")
 
-    cdef inline float64_t rdist(self,
+    cdef inline {{INPUT_DTYPE_t}} rdist(self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
@@ -2636,17 +2636,17 @@ cdef class HaversineDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         cdef float64_t sin_1 = sin(0.5 * ((x1[1]) - (x2[1])))
         return (sin_0 * sin_0 + cos(x1[0]) * cos(x2[0]) * sin_1 * sin_1)
 
-    cdef inline float64_t dist(self,
+    cdef inline {{INPUT_DTYPE_t}} dist(self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
     ) except -1 nogil:
         return 2 * asin(sqrt(self.rdist(x1, x2, size)))
 
-    cdef inline float64_t _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
         return 2 * asin(sqrt(rdist))
 
-    cdef inline float64_t _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
         cdef float64_t tmp = sin(0.5 *  dist)
         return tmp * tmp
 
@@ -2657,7 +2657,7 @@ cdef class HaversineDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         tmp = np.sin(0.5 * dist)
         return tmp * tmp
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2681,7 +2681,7 @@ cdef class HaversineDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             size,
         )))
 
-    cdef inline float64_t rdist_csr(
+    cdef inline {{INPUT_DTYPE_t}} rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2773,7 +2773,7 @@ cdef class PyFuncDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     # allowed in cython >= 0.26 since it is a redundant GIL acquisition. The
     # only way to be back compatible is to inherit `dist` from the base class
     # without GIL and called an inline `_dist` which acquire GIL.
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2781,7 +2781,7 @@ cdef class PyFuncDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     ) except -1 nogil:
         return self._dist(x1, x2, size)
 
-    cdef inline float64_t _dist(
+    cdef inline {{INPUT_DTYPE_t}} _dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,

--- a/sklearn/metrics/_dist_metrics.pyx.tp
+++ b/sklearn/metrics/_dist_metrics.pyx.tp
@@ -457,7 +457,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         """
         return
 
-    cdef {{INPUT_DTYPE_t}} dist(
+    cdef float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -469,7 +469,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         """
         return -999
 
-    cdef {{INPUT_DTYPE_t}} rdist(
+    cdef float64_t rdist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -515,7 +515,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
                 D[i1, i2] = self.dist(&X[i1, 0], &Y[i2, 0], X.shape[1])
         return 0
 
-    cdef {{INPUT_DTYPE_t}} dist_csr(
+    cdef float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -545,7 +545,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
 
         2. An alternative signature would be:
 
-            cdef {{INPUT_DTYPE_t}} dist_csr(
+            cdef float64_t dist_csr(
                 self,
                 const {{INPUT_DTYPE_t}}* x1_data,
                 const int32_t* x1_indices,
@@ -581,7 +581,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         """
         return -999
 
-    cdef {{INPUT_DTYPE_t}} rdist_csr(
+    cdef float64_t rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -698,11 +698,11 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
                 )
         return 0
 
-    cdef {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
+    cdef float64_t _rdist_to_dist(self, float64_t rdist) except -1 nogil:
         """Convert the rank-preserving surrogate distance to the distance"""
         return rdist
 
-    cdef {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
+    cdef float64_t _dist_to_rdist(self, float64_t dist) except -1 nogil:
         """Convert the distance to the rank-preserving surrogate distance"""
         return dist
 
@@ -992,24 +992,24 @@ cdef class EuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def __init__(self):
         self.p = 2
 
-    cdef inline {{INPUT_DTYPE_t}} dist(self,
+    cdef inline float64_t dist(self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
     ) except -1 nogil:
         return euclidean_dist{{name_suffix}}(x1, x2, size)
 
-    cdef inline {{INPUT_DTYPE_t}} rdist(self,
+    cdef inline float64_t rdist(self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
     ) except -1 nogil:
         return euclidean_rdist{{name_suffix}}(x1, x2, size)
 
-    cdef inline {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
+    cdef inline float64_t _rdist_to_dist(self, float64_t rdist) except -1 nogil:
         return sqrt(rdist)
 
-    cdef inline {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
+    cdef inline float64_t _dist_to_rdist(self, float64_t dist) except -1 nogil:
         return dist * dist
 
     def rdist_to_dist(self, rdist):
@@ -1018,7 +1018,7 @@ cdef class EuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def dist_to_rdist(self, dist):
         return dist ** 2
 
-    cdef inline {{INPUT_DTYPE_t}} rdist_csr(
+    cdef inline float64_t rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1070,7 +1070,7 @@ cdef class EuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         return d
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1113,7 +1113,7 @@ cdef class SEuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         if X.shape[1] != self.size:
             raise ValueError('SEuclidean dist: size of V does not match')
 
-    cdef inline {{INPUT_DTYPE_t}} rdist(
+    cdef inline float64_t rdist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1126,7 +1126,7 @@ cdef class SEuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             d += (tmp * tmp / self.vec[j])
         return d
 
-    cdef inline {{INPUT_DTYPE_t}} dist(
+    cdef inline float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1134,10 +1134,10 @@ cdef class SEuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     ) except -1 nogil:
         return sqrt(self.rdist(x1, x2, size))
 
-    cdef inline {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
+    cdef inline float64_t _rdist_to_dist(self, float64_t rdist) except -1 nogil:
         return sqrt(rdist)
 
-    cdef inline {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
+    cdef inline float64_t _dist_to_rdist(self, float64_t dist) except -1 nogil:
         return dist * dist
 
     def rdist_to_dist(self, rdist):
@@ -1146,7 +1146,7 @@ cdef class SEuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def dist_to_rdist(self, dist):
         return dist ** 2
 
-    cdef inline {{INPUT_DTYPE_t}} rdist_csr(
+    cdef inline float64_t rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1199,7 +1199,7 @@ cdef class SEuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
                 i1 = i1 + 1
         return d
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1236,7 +1236,7 @@ cdef class ManhattanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def __init__(self):
         self.p = 1
 
-    cdef inline {{INPUT_DTYPE_t}} dist(
+    cdef inline float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1248,7 +1248,7 @@ cdef class ManhattanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             d += fabs(x1[j] - x2[j])
         return d
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1266,7 +1266,7 @@ cdef class ManhattanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             intp_t i1 = x1_start
             intp_t i2 = x2_start
 
-            {{INPUT_DTYPE_t}} d = 0.0
+            float64_t d = 0.0
 
         while i1 < x1_end and i2 < x2_end:
             ix1 = x1_indices[i1]
@@ -1319,7 +1319,7 @@ cdef class ChebyshevDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def __init__(self):
         self.p = INF{{name_suffix}}
 
-    cdef inline {{INPUT_DTYPE_t}} dist(
+    cdef inline float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1332,7 +1332,7 @@ cdef class ChebyshevDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         return d
 
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1440,7 +1440,7 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
                              f"the number of features ({X.shape[1]}). "
                              f"Currently len(w)={self.size}.")
 
-    cdef inline {{INPUT_DTYPE_t}} rdist(
+    cdef inline float64_t rdist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1457,7 +1457,7 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
                 d += (pow(fabs(x1[j] - x2[j]), self.p))
         return d
 
-    cdef inline {{INPUT_DTYPE_t}} dist(
+    cdef inline float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1465,10 +1465,10 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     ) except -1 nogil:
         return pow(self.rdist(x1, x2, size), 1. / self.p)
 
-    cdef inline {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
+    cdef inline float64_t _rdist_to_dist(self, float64_t rdist) except -1 nogil:
         return pow(rdist, 1. / self.p)
 
-    cdef inline {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
+    cdef inline float64_t _dist_to_rdist(self, float64_t dist) except -1 nogil:
         return pow(dist, self.p)
 
     def rdist_to_dist(self, rdist):
@@ -1477,7 +1477,7 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def dist_to_rdist(self, dist):
         return dist ** self.p
 
-    cdef inline {{INPUT_DTYPE_t}} rdist_csr(
+    cdef inline float64_t rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1557,7 +1557,7 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
             return d
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1629,7 +1629,7 @@ cdef class MahalanobisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         if X.shape[1] != self.size:
             raise ValueError('Mahalanobis dist: size of V does not match')
 
-    cdef inline {{INPUT_DTYPE_t}} rdist(
+    cdef inline float64_t rdist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1649,7 +1649,7 @@ cdef class MahalanobisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             d += tmp * self.buffer[i]
         return d
 
-    cdef inline {{INPUT_DTYPE_t}} dist(
+    cdef inline float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1657,10 +1657,10 @@ cdef class MahalanobisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     ) except -1 nogil:
         return sqrt(self.rdist(x1, x2, size))
 
-    cdef inline {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
+    cdef inline float64_t _rdist_to_dist(self, float64_t rdist) except -1 nogil:
         return sqrt(rdist)
 
-    cdef inline {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
+    cdef inline float64_t _dist_to_rdist(self, float64_t dist) except -1 nogil:
         return dist * dist
 
     def rdist_to_dist(self, rdist):
@@ -1669,7 +1669,7 @@ cdef class MahalanobisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def dist_to_rdist(self, dist):
         return dist ** 2
 
-    cdef inline {{INPUT_DTYPE_t}} rdist_csr(
+    cdef inline float64_t rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1723,7 +1723,7 @@ cdef class MahalanobisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         return d
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1760,7 +1760,7 @@ cdef class HammingDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     .. math::
        D(x, y) = \frac{1}{N} \sum_i \delta_{x_i, y_i}
     """
-    cdef inline {{INPUT_DTYPE_t}} dist(
+    cdef inline float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1774,7 +1774,7 @@ cdef class HammingDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         return float(n_unequal) / size
 
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1835,7 +1835,7 @@ cdef class CanberraDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     .. math::
        D(x, y) = \sum_i \frac{|x_i - y_i|}{|x_i| + |y_i|}
     """
-    cdef inline {{INPUT_DTYPE_t}} dist(
+    cdef inline float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1849,7 +1849,7 @@ cdef class CanberraDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
                 d += fabs(x1[j] - x2[j]) / denom
         return d
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1910,7 +1910,7 @@ cdef class BrayCurtisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     .. math::
        D(x, y) = \frac{\sum_i |x_i - y_i|}{\sum_i(|x_i| + |y_i|)}
     """
-    cdef inline {{INPUT_DTYPE_t}} dist(
+    cdef inline float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1926,7 +1926,7 @@ cdef class BrayCurtisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         else:
             return 0.0
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1990,7 +1990,7 @@ cdef class JaccardDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = (N_TF + N_FT) / (N_TT + N_TF + N_FT)
     """
-    cdef inline {{INPUT_DTYPE_t}} dist(
+    cdef inline float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2010,7 +2010,7 @@ cdef class JaccardDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             return 0
         return (nnz - n_eq) * 1.0 / nnz
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2079,7 +2079,7 @@ cdef class MatchingDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = (N_TF + N_FT) / N
     """
-    cdef inline {{INPUT_DTYPE_t}} dist(
+    cdef inline float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2093,7 +2093,7 @@ cdef class MatchingDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_neq += (tf1 != tf2)
         return n_neq * 1. / size
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2154,7 +2154,7 @@ cdef class DiceDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         D(x, y) = (N_TF + N_FT) / (2 * N_TT + N_TF + N_FT)
 
     """
-    cdef inline {{INPUT_DTYPE_t}} dist(
+    cdef inline float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2169,7 +2169,7 @@ cdef class DiceDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_neq += (tf1 != tf2)
         return n_neq / (2.0 * n_tt + n_neq)
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2235,7 +2235,7 @@ cdef class KulsinskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         D(x, y) = 1 - N_TT / (N + N_TF + N_FT)
 
     """
-    cdef inline {{INPUT_DTYPE_t}} dist(
+    cdef inline float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2250,7 +2250,7 @@ cdef class KulsinskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_tt += (tf1 and tf2)
         return (n_neq - n_tt + size) * 1.0 / (n_neq + size)
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2314,7 +2314,7 @@ cdef class RogersTanimotoDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = 2 (N_TF + N_FT) / (N + N_TF + N_FT)
     """
-    cdef inline {{INPUT_DTYPE_t}} dist(
+    cdef inline float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2328,7 +2328,7 @@ cdef class RogersTanimotoDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_neq += (tf1 != tf2)
         return (2.0 * n_neq) / (size + n_neq)
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2391,7 +2391,7 @@ cdef class RussellRaoDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = (N - N_TT) / N
     """
-    cdef inline {{INPUT_DTYPE_t}} dist(
+    cdef inline float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2405,7 +2405,7 @@ cdef class RussellRaoDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_tt += (tf1 and tf2)
         return (size - n_tt) * 1. / size
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2461,7 +2461,7 @@ cdef class SokalMichenerDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = 2 (N_TF + N_FT) / (N + N_TF + N_FT)
     """
-    cdef inline {{INPUT_DTYPE_t}} dist(
+    cdef inline float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2475,7 +2475,7 @@ cdef class SokalMichenerDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_neq += (tf1 != tf2)
         return (2.0 * n_neq) / (size + n_neq)
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2538,7 +2538,7 @@ cdef class SokalSneathDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = (N_TF + N_FT) / (N_TT / 2 + N_FT + N_TF)
     """
-    cdef inline {{INPUT_DTYPE_t}} dist(
+    cdef inline float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2553,7 +2553,7 @@ cdef class SokalSneathDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_tt += (tf1 and tf2)
         return n_neq / (0.5 * n_tt + n_neq)
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2627,7 +2627,7 @@ cdef class HaversineDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             raise ValueError("Haversine distance only valid "
                              "in 2 dimensions")
 
-    cdef inline {{INPUT_DTYPE_t}} rdist(self,
+    cdef inline float64_t rdist(self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
@@ -2636,17 +2636,17 @@ cdef class HaversineDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         cdef float64_t sin_1 = sin(0.5 * ((x1[1]) - (x2[1])))
         return (sin_0 * sin_0 + cos(x1[0]) * cos(x2[0]) * sin_1 * sin_1)
 
-    cdef inline {{INPUT_DTYPE_t}} dist(self,
+    cdef inline float64_t dist(self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
     ) except -1 nogil:
         return 2 * asin(sqrt(self.rdist(x1, x2, size)))
 
-    cdef inline {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
+    cdef inline float64_t _rdist_to_dist(self, float64_t rdist) except -1 nogil:
         return 2 * asin(sqrt(rdist))
 
-    cdef inline {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
+    cdef inline float64_t _dist_to_rdist(self, float64_t dist) except -1 nogil:
         cdef float64_t tmp = sin(0.5 *  dist)
         return tmp * tmp
 
@@ -2657,7 +2657,7 @@ cdef class HaversineDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         tmp = np.sin(0.5 * dist)
         return tmp * tmp
 
-    cdef inline {{INPUT_DTYPE_t}} dist_csr(
+    cdef inline float64_t dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2681,7 +2681,7 @@ cdef class HaversineDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             size,
         )))
 
-    cdef inline {{INPUT_DTYPE_t}} rdist_csr(
+    cdef inline float64_t rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2773,7 +2773,7 @@ cdef class PyFuncDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     # allowed in cython >= 0.26 since it is a redundant GIL acquisition. The
     # only way to be back compatible is to inherit `dist` from the base class
     # without GIL and called an inline `_dist` which acquire GIL.
-    cdef inline {{INPUT_DTYPE_t}} dist(
+    cdef inline float64_t dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2781,7 +2781,7 @@ cdef class PyFuncDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     ) except -1 nogil:
         return self._dist(x1, x2, size)
 
-    cdef inline {{INPUT_DTYPE_t}} _dist(
+    cdef inline float64_t _dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,

--- a/sklearn/metrics/_dist_metrics.pyx.tp
+++ b/sklearn/metrics/_dist_metrics.pyx.tp
@@ -457,7 +457,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         """
         return
 
-    cdef float64_t dist(
+    cdef {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -469,7 +469,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         """
         return -999
 
-    cdef float64_t rdist(
+    cdef {{INPUT_DTYPE_t}} rdist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -515,7 +515,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
                 D[i1, i2] = self.dist(&X[i1, 0], &Y[i2, 0], X.shape[1])
         return 0
 
-    cdef float64_t dist_csr(
+    cdef {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -545,7 +545,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
 
         2. An alternative signature would be:
 
-            cdef float64_t dist_csr(
+            cdef {{INPUT_DTYPE_t}} dist_csr(
                 self,
                 const {{INPUT_DTYPE_t}}* x1_data,
                 const int32_t* x1_indices,
@@ -581,7 +581,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
         """
         return -999
 
-    cdef float64_t rdist_csr(
+    cdef {{INPUT_DTYPE_t}} rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -698,11 +698,11 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
                 )
         return 0
 
-    cdef float64_t _rdist_to_dist(self, float64_t rdist) except -1 nogil:
+    cdef {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
         """Convert the rank-preserving surrogate distance to the distance"""
         return rdist
 
-    cdef float64_t _dist_to_rdist(self, float64_t dist) except -1 nogil:
+    cdef {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
         """Convert the distance to the rank-preserving surrogate distance"""
         return dist
 
@@ -992,24 +992,24 @@ cdef class EuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def __init__(self):
         self.p = 2
 
-    cdef inline float64_t dist(self,
+    cdef inline {{INPUT_DTYPE_t}} dist(self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
     ) except -1 nogil:
         return euclidean_dist{{name_suffix}}(x1, x2, size)
 
-    cdef inline float64_t rdist(self,
+    cdef inline {{INPUT_DTYPE_t}} rdist(self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
     ) except -1 nogil:
         return euclidean_rdist{{name_suffix}}(x1, x2, size)
 
-    cdef inline float64_t _rdist_to_dist(self, float64_t rdist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
         return sqrt(rdist)
 
-    cdef inline float64_t _dist_to_rdist(self, float64_t dist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
         return dist * dist
 
     def rdist_to_dist(self, rdist):
@@ -1018,7 +1018,7 @@ cdef class EuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def dist_to_rdist(self, dist):
         return dist ** 2
 
-    cdef inline float64_t rdist_csr(
+    cdef inline {{INPUT_DTYPE_t}} rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1070,7 +1070,7 @@ cdef class EuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         return d
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1113,7 +1113,7 @@ cdef class SEuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         if X.shape[1] != self.size:
             raise ValueError('SEuclidean dist: size of V does not match')
 
-    cdef inline float64_t rdist(
+    cdef inline {{INPUT_DTYPE_t}} rdist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1126,7 +1126,7 @@ cdef class SEuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             d += (tmp * tmp / self.vec[j])
         return d
 
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1134,10 +1134,10 @@ cdef class SEuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     ) except -1 nogil:
         return sqrt(self.rdist(x1, x2, size))
 
-    cdef inline float64_t _rdist_to_dist(self, float64_t rdist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
         return sqrt(rdist)
 
-    cdef inline float64_t _dist_to_rdist(self, float64_t dist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
         return dist * dist
 
     def rdist_to_dist(self, rdist):
@@ -1146,7 +1146,7 @@ cdef class SEuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def dist_to_rdist(self, dist):
         return dist ** 2
 
-    cdef inline float64_t rdist_csr(
+    cdef inline {{INPUT_DTYPE_t}} rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1199,7 +1199,7 @@ cdef class SEuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
                 i1 = i1 + 1
         return d
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1236,7 +1236,7 @@ cdef class ManhattanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def __init__(self):
         self.p = 1
 
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1248,7 +1248,7 @@ cdef class ManhattanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             d += fabs(x1[j] - x2[j])
         return d
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1266,7 +1266,7 @@ cdef class ManhattanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             intp_t i1 = x1_start
             intp_t i2 = x2_start
 
-            float64_t d = 0.0
+            {{INPUT_DTYPE_t}} d = 0.0
 
         while i1 < x1_end and i2 < x2_end:
             ix1 = x1_indices[i1]
@@ -1319,7 +1319,7 @@ cdef class ChebyshevDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def __init__(self):
         self.p = INF{{name_suffix}}
 
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1332,7 +1332,7 @@ cdef class ChebyshevDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         return d
 
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1440,7 +1440,7 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
                              f"the number of features ({X.shape[1]}). "
                              f"Currently len(w)={self.size}.")
 
-    cdef inline float64_t rdist(
+    cdef inline {{INPUT_DTYPE_t}} rdist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1457,7 +1457,7 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
                 d += (pow(fabs(x1[j] - x2[j]), self.p))
         return d
 
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1465,10 +1465,10 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     ) except -1 nogil:
         return pow(self.rdist(x1, x2, size), 1. / self.p)
 
-    cdef inline float64_t _rdist_to_dist(self, float64_t rdist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
         return pow(rdist, 1. / self.p)
 
-    cdef inline float64_t _dist_to_rdist(self, float64_t dist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
         return pow(dist, self.p)
 
     def rdist_to_dist(self, rdist):
@@ -1477,7 +1477,7 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def dist_to_rdist(self, dist):
         return dist ** self.p
 
-    cdef inline float64_t rdist_csr(
+    cdef inline {{INPUT_DTYPE_t}} rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1557,7 +1557,7 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
             return d
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1629,7 +1629,7 @@ cdef class MahalanobisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         if X.shape[1] != self.size:
             raise ValueError('Mahalanobis dist: size of V does not match')
 
-    cdef inline float64_t rdist(
+    cdef inline {{INPUT_DTYPE_t}} rdist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1649,7 +1649,7 @@ cdef class MahalanobisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             d += tmp * self.buffer[i]
         return d
 
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1657,10 +1657,10 @@ cdef class MahalanobisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     ) except -1 nogil:
         return sqrt(self.rdist(x1, x2, size))
 
-    cdef inline float64_t _rdist_to_dist(self, float64_t rdist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
         return sqrt(rdist)
 
-    cdef inline float64_t _dist_to_rdist(self, float64_t dist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
         return dist * dist
 
     def rdist_to_dist(self, rdist):
@@ -1669,7 +1669,7 @@ cdef class MahalanobisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     def dist_to_rdist(self, dist):
         return dist ** 2
 
-    cdef inline float64_t rdist_csr(
+    cdef inline {{INPUT_DTYPE_t}} rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1723,7 +1723,7 @@ cdef class MahalanobisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         return d
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1760,7 +1760,7 @@ cdef class HammingDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     .. math::
        D(x, y) = \frac{1}{N} \sum_i \delta_{x_i, y_i}
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1774,7 +1774,7 @@ cdef class HammingDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         return float(n_unequal) / size
 
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1835,7 +1835,7 @@ cdef class CanberraDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     .. math::
        D(x, y) = \sum_i \frac{|x_i - y_i|}{|x_i| + |y_i|}
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1849,7 +1849,7 @@ cdef class CanberraDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
                 d += fabs(x1[j] - x2[j]) / denom
         return d
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1910,7 +1910,7 @@ cdef class BrayCurtisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     .. math::
        D(x, y) = \frac{\sum_i |x_i - y_i|}{\sum_i(|x_i| + |y_i|)}
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -1926,7 +1926,7 @@ cdef class BrayCurtisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         else:
             return 0.0
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -1990,7 +1990,7 @@ cdef class JaccardDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = (N_TF + N_FT) / (N_TT + N_TF + N_FT)
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2010,7 +2010,7 @@ cdef class JaccardDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             return 0
         return (nnz - n_eq) * 1.0 / nnz
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2079,7 +2079,7 @@ cdef class MatchingDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = (N_TF + N_FT) / N
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2093,7 +2093,7 @@ cdef class MatchingDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_neq += (tf1 != tf2)
         return n_neq * 1. / size
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2154,7 +2154,7 @@ cdef class DiceDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         D(x, y) = (N_TF + N_FT) / (2 * N_TT + N_TF + N_FT)
 
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2169,7 +2169,7 @@ cdef class DiceDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_neq += (tf1 != tf2)
         return n_neq / (2.0 * n_tt + n_neq)
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2235,7 +2235,7 @@ cdef class KulsinskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         D(x, y) = 1 - N_TT / (N + N_TF + N_FT)
 
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2250,7 +2250,7 @@ cdef class KulsinskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_tt += (tf1 and tf2)
         return (n_neq - n_tt + size) * 1.0 / (n_neq + size)
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2314,7 +2314,7 @@ cdef class RogersTanimotoDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = 2 (N_TF + N_FT) / (N + N_TF + N_FT)
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2328,7 +2328,7 @@ cdef class RogersTanimotoDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_neq += (tf1 != tf2)
         return (2.0 * n_neq) / (size + n_neq)
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2391,7 +2391,7 @@ cdef class RussellRaoDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = (N - N_TT) / N
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2405,7 +2405,7 @@ cdef class RussellRaoDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_tt += (tf1 and tf2)
         return (size - n_tt) * 1. / size
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2461,7 +2461,7 @@ cdef class SokalMichenerDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = 2 (N_TF + N_FT) / (N + N_TF + N_FT)
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2475,7 +2475,7 @@ cdef class SokalMichenerDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_neq += (tf1 != tf2)
         return (2.0 * n_neq) / (size + n_neq)
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2538,7 +2538,7 @@ cdef class SokalSneathDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
 
         D(x, y) = (N_TF + N_FT) / (N_TT / 2 + N_FT + N_TF)
     """
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2553,7 +2553,7 @@ cdef class SokalSneathDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             n_tt += (tf1 and tf2)
         return n_neq / (0.5 * n_tt + n_neq)
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2627,7 +2627,7 @@ cdef class HaversineDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             raise ValueError("Haversine distance only valid "
                              "in 2 dimensions")
 
-    cdef inline float64_t rdist(self,
+    cdef inline {{INPUT_DTYPE_t}} rdist(self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
@@ -2636,17 +2636,17 @@ cdef class HaversineDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         cdef float64_t sin_1 = sin(0.5 * ((x1[1]) - (x2[1])))
         return (sin_0 * sin_0 + cos(x1[0]) * cos(x2[0]) * sin_1 * sin_1)
 
-    cdef inline float64_t dist(self,
+    cdef inline {{INPUT_DTYPE_t}} dist(self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
         intp_t size,
     ) except -1 nogil:
         return 2 * asin(sqrt(self.rdist(x1, x2, size)))
 
-    cdef inline float64_t _rdist_to_dist(self, float64_t rdist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _rdist_to_dist(self, {{INPUT_DTYPE_t}} rdist) except -1 nogil:
         return 2 * asin(sqrt(rdist))
 
-    cdef inline float64_t _dist_to_rdist(self, float64_t dist) except -1 nogil:
+    cdef inline {{INPUT_DTYPE_t}} _dist_to_rdist(self, {{INPUT_DTYPE_t}} dist) except -1 nogil:
         cdef float64_t tmp = sin(0.5 *  dist)
         return tmp * tmp
 
@@ -2657,7 +2657,7 @@ cdef class HaversineDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         tmp = np.sin(0.5 * dist)
         return tmp * tmp
 
-    cdef inline float64_t dist_csr(
+    cdef inline {{INPUT_DTYPE_t}} dist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2681,7 +2681,7 @@ cdef class HaversineDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             size,
         )))
 
-    cdef inline float64_t rdist_csr(
+    cdef inline {{INPUT_DTYPE_t}} rdist_csr(
         self,
         const {{INPUT_DTYPE_t}}* x1_data,
         const int32_t* x1_indices,
@@ -2773,7 +2773,7 @@ cdef class PyFuncDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     # allowed in cython >= 0.26 since it is a redundant GIL acquisition. The
     # only way to be back compatible is to inherit `dist` from the base class
     # without GIL and called an inline `_dist` which acquire GIL.
-    cdef inline float64_t dist(
+    cdef inline {{INPUT_DTYPE_t}} dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,
@@ -2781,7 +2781,7 @@ cdef class PyFuncDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
     ) except -1 nogil:
         return self._dist(x1, x2, size)
 
-    cdef inline float64_t _dist(
+    cdef inline {{INPUT_DTYPE_t}} _dist(
         self,
         const {{INPUT_DTYPE_t}}* x1,
         const {{INPUT_DTYPE_t}}* x2,

--- a/sklearn/metrics/_dist_metrics.pyx.tp
+++ b/sklearn/metrics/_dist_metrics.pyx.tp
@@ -372,8 +372,8 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
     """
     def __cinit__(self):
         self.p = 2
-        self.vec = np.zeros(1, dtype={{INPUT_DTYPE}}, order='C')
-        self.mat = np.zeros((1, 1), dtype={{INPUT_DTYPE}}, order='C')
+        self.vec = np.zeros(1, dtype=np.float64, order='C')
+        self.mat = np.zeros((1, 1), dtype=np.float64, order='C')
         self.size = 1
 
     def __reduce__(self):
@@ -1105,7 +1105,7 @@ cdef class SEuclideanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
        D(x, y) = \sqrt{ \sum_i \frac{ (x_i - y_i) ^ 2}{V_i} }
     """
     def __init__(self, V):
-        self.vec = np.asarray(V, dtype={{INPUT_DTYPE}})
+        self.vec = np.asarray(V, dtype=np.float64)
         self.size = self.vec.shape[0]
         self.p = 2
 
@@ -1266,7 +1266,7 @@ cdef class ManhattanDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
             intp_t i1 = x1_start
             intp_t i2 = x2_start
 
-            float64_t d = 0.0
+            {{INPUT_DTYPE_t}} d = 0.0
 
         while i1 < x1_end and i2 < x2_end:
             ix1 = x1_indices[i1]
@@ -1424,14 +1424,14 @@ cdef class MinkowskiDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         self.p = p
         if w is not None:
             w_array = check_array(
-                w, ensure_2d=False, dtype={{INPUT_DTYPE}}, input_name="w"
+                w, ensure_2d=False, dtype=np.float64, input_name="w"
             )
             if (w_array < 0).any():
                 raise ValueError("w cannot contain negative weights")
             self.vec = w_array
             self.size = self.vec.shape[0]
         else:
-            self.vec = np.asarray([], dtype={{INPUT_DTYPE}})
+            self.vec = np.asarray([], dtype=np.float64)
             self.size = 0
 
     def _validate_data(self, X):
@@ -1613,7 +1613,7 @@ cdef class MahalanobisDistance{{name_suffix}}(DistanceMetric{{name_suffix}}):
         if VI.ndim != 2 or VI.shape[0] != VI.shape[1]:
             raise ValueError("V/VI must be square")
 
-        self.mat = np.asarray(VI, dtype={{INPUT_DTYPE}}, order='C')
+        self.mat = np.asarray(VI, dtype=np.float64, order='C')
 
         self.size = self.mat.shape[0]
 

--- a/sklearn/metrics/tests/test_dist_metrics.py
+++ b/sklearn/metrics/tests/test_dist_metrics.py
@@ -200,11 +200,8 @@ def test_distance_metrics_dtype_consistency(metric_param_grid):
         D64 = dm64.pairwise(X64)
         D32 = dm32.pairwise(X32)
 
-        # Both results are np.float64 dtype because the accumulation across
-        # features is done in float64. However the input data and the element
-        # wise arithmetic operations are done in float32 so we can expect a
-        # small discrepancy.
-        assert D64.dtype == D32.dtype == np.float64
+        assert D64.dtype == np.float64
+        assert D32.dtype == np.float32
 
         # assert_allclose introspects the dtype of the input arrays to decide
         # which rtol value to use by default but in this case we know that D32


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
Preserves dtype when computing distances, under the assumption that the precision of the input data is an implication of preferred precision of output data. Note that accumulation still largely occurs using `float64_t` with some exceptions.

#### Any other comments?
Current benchmarks ([generated here](https://gist.github.com/Micky774/394e20b00451426859b31b9cf209a6d4)) suggest that there is no regression in the dense case (`dist`), and a 10-25% speedup in the sparse case (`dist_csr`).

<details> 
<summary> Benchmark Plots </summary>

![428cfb6d-a17e-42cb-b96a-4c9a908fae16](https://github.com/scikit-learn/scikit-learn/assets/34613774/85cbf27b-2d51-454a-b8d4-ce24ff68e425)

![e588e219-e597-4650-af0a-d7eaacfb6c0c](https://github.com/scikit-learn/scikit-learn/assets/34613774/b085ab73-fbbb-475a-a8d3-4d463514db9c)

</details>

Memory profiling indicates a reduction of memory usage in [this script](https://gist.github.com/Micky774/0ee61235b751df83da6d1b93512b6ff3) from `763MiB` to `382MiB`.

cc: @jjerphan @OmarManzoor @thomasjpfan 