### PR TITLE
move non-local comment to its correct place

### DIFF
--- a/sklearn/metrics/_plot/tests/test_precision_recall_display.py
+++ b/sklearn/metrics/_plot/tests/test_precision_recall_display.py
@@ -283,7 +283,6 @@ def test_plot_precision_recall_pos_label(pyplot, constructor_name, response_meth
             y_pred_cancer,
             pos_label="cancer",
         )
-    # we should obtain the statistics of the "cancer" class
     avg_prec_limit = 0.65
     assert display.average_precision < avg_prec_limit
     assert -np.trapz(display.precision, display.recall) < avg_prec_limit

--- a/sklearn/metrics/_plot/tests/test_precision_recall_display.py
+++ b/sklearn/metrics/_plot/tests/test_precision_recall_display.py
@@ -269,6 +269,7 @@ def test_plot_precision_recall_pos_label(pyplot, constructor_name, response_meth
     y_pred_cancer = -1 * y_pred if y_pred.ndim == 1 else y_pred[:, 0]
     y_pred_not_cancer = y_pred if y_pred.ndim == 1 else y_pred[:, 1]
 
+    # we should obtain the statistics of the "cancer" class
     if constructor_name == "from_estimator":
         display = PrecisionRecallDisplay.from_estimator(
             classifier,


### PR DESCRIPTION
This PR moves a non-local comment (i.e. comment that provides systemwide information or mentions code that is not near) to its correct place.