### PR TITLE
MAINT: Adapt sklearn for NumPy default integer change

### DIFF
--- a/sklearn/cluster/_hdbscan/hdbscan.py
+++ b/sklearn/cluster/_hdbscan/hdbscan.py
@@ -124,7 +124,7 @@ def _brute_mst(mutual_reachability, min_samples):
     # Compute the minimum spanning tree for the sparse graph
     sparse_min_spanning_tree = csgraph.minimum_spanning_tree(mutual_reachability)
     rows, cols = sparse_min_spanning_tree.nonzero()
-    mst = np.core.records.fromarrays(
+    mst = np.rec.fromarrays(
         [rows, cols, sparse_min_spanning_tree.data],
         dtype=MST_edge_dtype,
     )

--- a/sklearn/utils/_random.pxd
+++ b/sklearn/utils/_random.pxd
@@ -16,10 +16,6 @@ cdef enum:
     # 32-bit signed integers (i.e. 2^31 - 1).
     RAND_R_MAX = 2147483647
 
-cpdef sample_without_replacement(cnp.int_t n_population,
-                                 cnp.int_t n_samples,
-                                 method=*,
-                                 random_state=*)
 
 # rand_r replacement using a 32bit XorShift generator
 # See http://www.jstatsoft.org/v08/i14/paper for details

--- a/sklearn/utils/_random.pyx
+++ b/sklearn/utils/_random.pyx
@@ -19,6 +19,10 @@ from . import check_random_state
 cdef UINT32_t DEFAULT_SEED = 1
 
 
+# Compatibility type to always accept the default int type used by NumPy, both
+# before and after NumPy 2. On Windows, `long` does not always match `cnp.inp_t`.
+# See the comments in the `sample_without_replacement` Python function for more
+# details.
 ctypedef fused default_int:
     cnp.intp_t
     long

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -3470,7 +3470,7 @@ def check_parameters_default_constructible(name, Estimator):
                 type,
             }
             # Any numpy numeric such as np.int32.
-            allowed_types.update(np.core.numerictypes.allTypes.values())
+            allowed_types.update(np.sctypeDict.values())
 
             allowed_value = (
                 type(init_param.default) in allowed_types


### PR DESCRIPTION
This adepts the `_random.pyx` file to return whatever is the NumPy default integer, which, on NumPy 2.0 would fix.
Since the cython symbol wasn't used, I just removed it as it bites with the overloading.

See https://github.com/numpy/numpy/pull/24224 for the commit which would make this necessary.

At the time this is a bit hard to test since the SciPy nightlies are incompatible with that NumPy branch.  But I thought I would put it out there for discussion.

The alternative and simpler solution might be to just force 64bit results on any 64bit system and not worry about the NumPy version.

---

The interesting part here will be windows testing, but that is a bit held up on scipy nightlies upload.  Although, if anyone does windows development and would try this that would be cool!
I.e. this is a draft, but I am hope I can hack in windows testing later.