### PR TITLE
FIX potentially redundant marker argument

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -1190,12 +1190,13 @@ class CalibrationDisplay(_BinaryClassifierCurveDisplayMixin):
         if name is not None:
             line_kwargs["label"] = name
         line_kwargs.update(**kwargs)
+        line_kwargs.setdefault("marker", "s")
 
         ref_line_label = "Perfectly calibrated"
         existing_ref_line = ref_line_label in self.ax_.get_legend_handles_labels()[1]
         if ref_line and not existing_ref_line:
             self.ax_.plot([0, 1], [0, 1], "k:", label=ref_line_label)
-        self.line_ = self.ax_.plot(self.prob_pred, self.prob_true, "s-", **line_kwargs)[
+        self.line_ = self.ax_.plot(self.prob_pred, self.prob_true, "-", **line_kwargs)[
             0
         ]
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -1186,11 +1186,10 @@ class CalibrationDisplay(_BinaryClassifierCurveDisplayMixin):
             f"(Positive class: {self.pos_label})" if self.pos_label is not None else ""
         )
 
-        line_kwargs = {}
+        line_kwargs = {"marker": "s"}
         if name is not None:
             line_kwargs["label"] = name
         line_kwargs.update(**kwargs)
-        line_kwargs.setdefault("marker", "s")
 
         ref_line_label = "Perfectly calibrated"
         existing_ref_line = ref_line_label in self.ax_.get_legend_handles_labels()[1]

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -1186,7 +1186,7 @@ class CalibrationDisplay(_BinaryClassifierCurveDisplayMixin):
             f"(Positive class: {self.pos_label})" if self.pos_label is not None else ""
         )
 
-        line_kwargs = {"marker": "s"}
+        line_kwargs = {"marker": "s", "linestyle": "-"}
         if name is not None:
             line_kwargs["label"] = name
         line_kwargs.update(**kwargs)

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -1195,9 +1195,7 @@ class CalibrationDisplay(_BinaryClassifierCurveDisplayMixin):
         existing_ref_line = ref_line_label in self.ax_.get_legend_handles_labels()[1]
         if ref_line and not existing_ref_line:
             self.ax_.plot([0, 1], [0, 1], "k:", label=ref_line_label)
-        self.line_ = self.ax_.plot(self.prob_pred, self.prob_true, "-", **line_kwargs)[
-            0
-        ]
+        self.line_ = self.ax_.plot(self.prob_pred, self.prob_true, **line_kwargs)[0]
 
         # We always have to show the legend for at least the reference line
         self.ax_.legend(loc="lower right")


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

The [Comparison of Calibration of Classifiers example](https://scikit-learn.org/dev/auto_examples/calibration/plot_compare_calibration.html) is raising a

```python-traceback
UserWarning:

marker is redundantly defined by the 'marker' keyword argument and the fmt string "s-" (-> marker='s'). The keyword argument will take precedence.
```

As users may want to customize the marker as done in this example, this PR uses the `setdefault` method to check if `'marker'` is already a key in `line_kwargs`. If it's not present, it adds the key with the value `'s'`. If it's already present, it does nothing, avoiding the redundancy.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
