### PR TITLE
FIX Fixes set_output with list input

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -9,6 +9,12 @@ Version 1.3.1
 
 **In development**
 
+Changes impacting all modules
+-----------------------------
+
+- |Fix| The `set_output` API correctly works with list input. :pr:`xxxxx` by
+  `Thomas Fan`_.
+
 Changelog
 ---------
 

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -12,7 +12,7 @@ Version 1.3.1
 Changes impacting all modules
 -----------------------------
 
-- |Fix| The `set_output` API correctly works with list input. :pr:`xxxxx` by
+- |Fix| The `set_output` API correctly works with list input. :pr:`27044` by
   `Thomas Fan`_.
 
 Changelog

--- a/sklearn/utils/_set_output.py
+++ b/sklearn/utils/_set_output.py
@@ -5,6 +5,7 @@ from scipy.sparse import issparse
 from .._config import get_config
 from . import check_pandas_support
 from ._available_if import available_if
+from .validation import _is_pandas_df
 
 
 def _wrap_in_pandas_container(
@@ -125,9 +126,10 @@ def _wrap_data_with_container(method, data_to_wrap, original_input, estimator):
         return data_to_wrap
 
     # dense_config == "pandas"
+    index = original_input.index if _is_pandas_df(original_input) else None
     return _wrap_in_pandas_container(
         data_to_wrap=data_to_wrap,
-        index=getattr(original_input, "index", None),
+        index=index,
         columns=estimator.get_feature_names_out,
     )
 

--- a/sklearn/utils/tests/test_set_output.py
+++ b/sklearn/utils/tests/test_set_output.py
@@ -315,3 +315,32 @@ def test_set_output_named_tuple_out():
     assert isinstance(X_trans, Output)
     assert_array_equal(X_trans.X, X)
     assert_array_equal(X_trans.Y, 2 * X)
+
+
+class EstimatorWithListInput(_SetOutputMixin):
+    def fit(self, X, y=None):
+        assert isinstance(X, list)
+        self.n_features_in_ = len(X[0])
+        return self
+
+    def transform(self, X, y=None):
+        return X
+
+    def get_feature_names_out(self, input_features=None):
+        return np.asarray([f"X{i}" for i in range(self.n_features_in_)], dtype=object)
+
+
+def test_set_output_list_input():
+    """Check set_output for list input.
+
+    Non-regression test for #27037.
+    """
+    pd = pytest.importorskip("pandas")
+
+    X = [[0, 1, 2, 3], [4, 5, 6, 7]]
+    est = EstimatorWithListInput()
+    est.set_output(transform="pandas")
+
+    X_out = est.fit(X).transform(X)
+    assert isinstance(X_out, pd.DataFrame)
+    assert_array_equal(X_out.columns, ["X0", "X1", "X2", "X3"])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes #27037


#### What does this implement/fix? Explain your changes.
This PR correctly checks that the input is a dataframe before getting `index`. The original issue happened because `list.index` exists but is not a valid index.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
