### PR TITLE
FIX Add common test to check for unfitted behaviour in classifiers and fix RadiusNeighborsClassifier and ClassifierChain correspondingly

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -936,6 +936,7 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
         Y_prob : array-like of shape (n_samples, n_classes)
             The predicted probabilities.
         """
+        check_is_fitted(self, "estimators_")
         X = self._validate_data(X, accept_sparse=True, reset=False)
         Y_prob_chain = np.zeros((X.shape[0], len(self.estimators_)))
         Y_pred_chain = np.zeros((X.shape[0], len(self.estimators_)))
@@ -968,6 +969,7 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
             Returns the decision function of the sample for each model
             in the chain.
         """
+        check_is_fitted(self, "estimators_")
         X = self._validate_data(X, accept_sparse=True, reset=False)
         Y_decision_chain = np.zeros((X.shape[0], len(self.estimators_)))
         Y_pred_chain = np.zeros((X.shape[0], len(self.estimators_)))

--- a/sklearn/neighbors/_classification.py
+++ b/sklearn/neighbors/_classification.py
@@ -708,6 +708,7 @@ class RadiusNeighborsClassifier(RadiusNeighborsMixin, ClassifierMixin, Neighbors
             by lexicographic order.
         """
 
+        check_is_fitted(self, "_fit_method")
         n_queries = _num_samples(X)
 
         neigh_dist, neigh_ind = self.radius_neighbors(X)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -2303,21 +2303,3 @@ def test_nearest_neighbours_works_with_p_less_than_1():
 
     y = neigh.kneighbors(X[0].reshape(1, -1), return_distance=False)
     assert_allclose(y[0], [0, 1, 2])
-
-
-def test_radius_neighbors_is_fitted_before_calling_predict_proba():
-    """Check that :class:`RadiusNeighborsClassifier` is fitted before
-    calling the :meth:`predict` and :meth:`predict_proba`.
-    """
-    rng = np.random.RandomState(42)
-    X = rng.rand(10, 2)
-    y = rng.rand(10, 1).round()
-
-    clf = neighbors.RadiusNeighborsClassifier()
-
-    msg = "is not fitted yet."
-    with pytest.raises(NotFittedError, match=msg):
-        clf.predict_proba(X)
-
-    clf.fit(X, y)
-    clf.predict_proba(X)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -2303,3 +2303,21 @@ def test_nearest_neighbours_works_with_p_less_than_1():
 
     y = neigh.kneighbors(X[0].reshape(1, -1), return_distance=False)
     assert_allclose(y[0], [0, 1, 2])
+
+
+def test_radius_neighbors_is_fitted_before_calling_predict_proba():
+    """Check that :class:`RadiusNeighborsClassifier` is fitted before
+    calling the :meth:`predict` and :meth:`predict_proba`.
+    """
+    rng = np.random.RandomState(42)
+    X = rng.rand(10, 2)
+    y = rng.rand(10, 1).round()
+
+    clf = neighbors.RadiusNeighborsClassifier()
+
+    msg = "is not fitted yet."
+    with pytest.raises(NotFittedError, match=msg):
+        clf.predict_proba(X)
+
+    clf.fit(X, y)
+    clf.predict_proba(X)

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -74,6 +74,7 @@ from sklearn.utils.estimator_checks import (
     check_class_weight_balanced_linear_classifier,
     check_dataframe_column_names_consistency,
     check_estimator,
+    check_estimators_unfitted,
     check_get_feature_names_out_error,
     check_global_output_transform_pandas,
     check_n_features_in_after_fitting,
@@ -602,3 +603,14 @@ def test_global_output_transform_pandas(estimator):
     _set_checking_parameters(estimator)
     with ignore_warnings(category=(FutureWarning)):
         check_global_output_transform_pandas(estimator.__class__.__name__, estimator)
+
+
+@pytest.mark.parametrize(
+    "classifier",
+    _tested_estimators(type_filter="classifier"),
+    ids=_get_check_estimator_ids,
+)
+def test_classifiers_unfitted(classifier):
+    classifier_name = classifier.__class__.__name__
+    _set_checking_parameters(classifier)
+    check_estimators_unfitted(classifier_name, classifier)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Relates to #26828

#### What does this implement/fix? Explain your changes.
- Adds a common test to check for unfitted issues in classifiers.
- Adds the check_is_fitted check at the beginning of predict_proba in RadiusNeighborsClassifier.
- Adds the check_is_fitted check in predict_proba and decision_function in ClassifierChain.

#### Any other comments?
CC: @jjerphan 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
