### PR TITLE
DOC fix default dtype in OneHotEncoder

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -525,7 +525,7 @@ class OneHotEncoder(_BaseEncoder):
         .. versionadded:: 1.2
            `sparse` was renamed to `sparse_output`
 
-    dtype : number type, default=float
+    dtype : number type, default=np.float64
         Desired dtype of output.
 
     handle_unknown : {'error', 'ignore', 'infrequent_if_exist'}, \


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #27050

#### What does this implement/fix? Explain your changes.
Set ``np.float64`` to match the actual default value.

https://github.com/scikit-learn/scikit-learn/blob/3419e8cf8d8c7a3982dc0f8b8e739ab309151217/sklearn/preprocessing/_encoders.py#L741
