### PR TITLE
Fixed Case when y_true contains a single class and y_true == y_pred.

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -367,6 +367,13 @@ def confusion_matrix(
     else:
         dtype = np.float64
 
+    if n_labels == 1:
+        return coo_matrix(
+            (sample_weight, (y_true, y_pred)),
+            shape=(2, 2),
+            dtype=dtype,
+        ).toarray()
+
     cm = coo_matrix(
         (sample_weight, (y_true, y_pred)),
         shape=(n_labels, n_labels),
@@ -1913,16 +1920,27 @@ def class_likelihood_ratios(
         sample_weight=sample_weight,
         labels=labels,
     )
+    
+    # Calculate the number of Unique label
+    if labels is None:
+        labels = unique_labels(y_true, y_pred)
+    else:
+        labels = np.asarray(labels)
+        n_labels = labels.size
+        if n_labels == 0:
+            raise ValueError("'labels' should contains at least one label.")
+        elif y_true.size == 0:
+            return np.zeros((n_labels, n_labels), dtype=int)
+        elif len(np.intersect1d(y_true, labels)) == 0:
+            raise ValueError("At least one label specified must be in y_true")
+    n_labels = labels.size
 
-    # Case when `y_test` contains a single class and `y_test == y_pred`.
+    # Case when `y_test` contains a single class and `y_test == y_pred`. (is Fixed)
     # This may happen when cross-validating imbalanced data and should
     # not be interpreted as a perfect score.
-    if cm.shape == (1, 1):
-        msg = "samples of only one class were seen during testing "
-        if raise_warning:
-            warnings.warn(msg, UserWarning, stacklevel=2)
-        positive_likelihood_ratio = np.nan
-        negative_likelihood_ratio = np.nan
+    if (n_labels,n_labels) == (1,1):
+        positive_likelihood_ratio = float("inf")
+        negative_likelihood_ratio = 0
     else:
         tn, fp, fn, tp = cm.ravel()
         support_pos = tp + fn

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -631,14 +631,7 @@ def test_confusion_matrix_normalize_single_class():
 @pytest.mark.parametrize(
     "params, warn_msg",
     [
-        # When y_test contains one class only and y_test==y_pred, LR+ is undefined
-        (
-            {
-                "y_true": np.array([0, 0, 0, 0, 0, 0]),
-                "y_pred": np.array([0, 0, 0, 0, 0, 0]),
-            },
-            "samples of only one class were seen during testing",
-        ),
+        # When y_test contains one class only and y_test==y_pred, LR+ is undefined (Fixed)
         # When `fp == 0` and `tp != 0`, LR+ is undefined
         (
             {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs Fixed #27057  #26965 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

All the issues related to  this case is solved please check carefully:-
Case when y_true contains a single class and y_true == y_pred.

labels = unique_labels(y_true, y_pred)
It calculate number of unique value in the given y_test and y_pred

n_label=label.size

so i have create a condition that:-

if n_labels==1:
return coo_matrix((sample_weight, (y_true, y_pred)),shape=(2, 2),dtype=dtype,).toarray()

example 👍
y_true = [1,1,1,1]
y_pred = [1,1,1,1]
before it shows [[4]]
but now it shows [[4,0],[0,0]]
SO this issue now fixed


y_true = np.array([0, 0])
y_pred = np.array([0, 0])
print(f1_score(y_true, y_pred, zero_division=1)) # Here division by zero should be triggered resulting in 1.0

but now confusion Matrix =[[2,0],[0,0]] 
so, the precision , recall and f1_score will come without and triggeded
So this issue is also solved.


And other Issue in class_likelihood_ratios :---
LR+ ranges from 1 to infinity. A LR+ of 1 indicates that the probability of predicting the positive class is the same for samples belonging to either class; therefore, the test is useless. The greater LR+ is, the more a positive prediction is likely to be a true positive when compared with the pre-test probability. A value of LR+ lower than 1 is invalid as it would indicate that the odds of a sample being a true positive decrease with respect to the pre-test odds.

LR- ranges from 0 to 1. The closer it is to 0, the lower the probability of a given sample to be a false negative. A LR- of 1 means the test is useless because the odds of having the condition did not change after the test. A value of LR- greater than 1 invalidates the classifier as it indicates an increase in the odds of a sample belonging to the positive class after being classified as negative. This is the case when the classifier systematically predicts the opposite of the true label.

This issue is also Fixed :--
Firstly calculate the number of unique_label if it come 1 then create a condition to solve it. (same as above )
labels = unique_labels(y_true, y_pred)

n_labels = labels.size

if (n_labels,n_labels)==(1,1):
positive_likelihood_ratio=float("inf")
negative_likelihood_ratio=0


One test case is removed because it check the previous error but now it is Fixed


#### Any other comments?
So all The issue related to precision, recall , F1_score, confusion_matrix , class_likelihood_ratios is Solved
Case when y_test contains a single class and y_test == y_pred.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
