### PR TITLE
MAINT Remove `-Wsign-compare` compilation warning for `_radius_neighbors.pyx.tp`

### DIFF
--- a/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx.tp
@@ -300,7 +300,8 @@ cdef class RadiusNeighbors{{name_suffix}}(BaseDistancesReduction{{name_suffix}})
     cdef void compute_exact_distances(self) noexcept nogil:
         """Convert rank-preserving distances to pairwise distances in parallel."""
         cdef:
-            intp_t i, j
+            intp_t i
+            vector[intp_t].size_type j
 
         for i in prange(self.n_samples_X, nogil=True, schedule='static',
                         num_threads=self.effective_n_threads):


### PR DESCRIPTION
#### Reference Issues/PRs

Related to #24875.

#### What does this implement/fix? Explain your changes.
While compiling sklearn, we get the following warnings for module `sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors`:

```
building 'sklearn.metrics._pairwise_distances_reduction._radius_neighbors' extension
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -I/home/codespace/.local/lib/python3.10/site-packages/numpy/core/include -I/usr/local/python/3.10.4/include/python3.10 -c sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.cpp -o build/temp.linux-x86_64-cpython-310/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.o -std=c++11 -g0 -O2 -fopenmp
sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.cpp: In function ‘void 
__pyx_f_7sklearn_7metrics_29_pairwise_distances_reduction_17_radius_neighbors_17RadiusNeighbors64_compute_exact_distances(__pyx_obj_7sklearn_7metrics_29_pairwise_distances_reduction_17_radius_neighbors_RadiusNeighbors64*)’:
sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.cpp:6342:59: warning: comparison of integer expressions of different signedness: ‘__pyx_t_7sklearn_5utils_9_typedefs_intp_t’ {aka ‘long int’} and ‘std::vector<long int>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
 6342 |                             for (__pyx_t_6 = 0; __pyx_t_6 < __pyx_t_5; __pyx_t_6+=1) {
      |                                                 ~~~~~~~~~~^~~~~~~~~~~
sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.cpp: In function ‘void 
__pyx_f_7sklearn_7metrics_29_pairwise_distances_reduction_17_radius_neighbors_17RadiusNeighbors32_compute_exact_distances(__pyx_obj_7sklearn_7metrics_29_pairwise_distances_reduction_17_radius_neighbors_RadiusNeighbors32*)’:
sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.cpp:10455:59: warning: comparison of integer expressions of different signedness: ‘__pyx_t_7sklearn_5utils_9_typedefs_intp_t’ {aka ‘long int’} and ‘std::vector<long int>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
10455 |                             for (__pyx_t_6 = 0; __pyx_t_6 < __pyx_t_5; __pyx_t_6+=1) {
      |                                                 ~~~~~~~~~~^~~~~~~~~~~
g++ -pthread -shared build/temp.linux-x86_64-cpython-310/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.o -Lbuild/temp.linux-x86_64-cpython-310 -lm -llibsvm-skl -lliblinear-skl -o build/lib.linux-x86_64-cpython-310/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.cpython-310-x86_64-linux-gnu.so -fopenmp
```

The C code generated by Cython generates a type mismatch.
Reason:
In file `sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx.tp` for a loop at line 308 the type `intp_t` was used as index type for variable `j` as usual for sklearn.
The loop 
```python
for j in range(deref(self.neigh_indices)[i].size()):
```
loops with `j` over `self.neigh_indices[i]`. Vector `self.neigh_indices` is a Cython vector over Cython vectors defined as
```python
self.neigh_indices = make_shared[vector[vector[intp_t]]](self.n_samples_X)
```
From this follows that `self.neigh_indices[i]` is defined as `vector[intp_t]`.
The `size()` method of `vector[intp_t]` returns an unsigned integer which is compared with `intp_t` which is a signed integer.

Since we loop over a Cython container, which can not be changed, I changed the variable `j` to the index type of this Cython container: `vector[intp_t].size_type`.

After this fix we get:
```
building 'sklearn.metrics._pairwise_distances_reduction._radius_neighbors' extension
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -I/home/codespace/.local/lib/python3.10/site-packages/numpy/core/include -I/usr/local/python/3.10.4/include/python3.10 -c sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.cpp -o build/temp.linux-x86_64-cpython-310/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.o -std=c++11 -g0 -O2 -fopenmp
g++ -pthread -shared build/temp.linux-x86_64-cpython-310/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.o -Lbuild/temp.linux-x86_64-cpython-310 -lm -llibsvm-skl -lliblinear-skl -o build/lib.linux-x86_64-cpython-310/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.cpython-310-x86_64-linux-gnu.so -fopenmp
```

#### Any other comments?
