### PR TITLE
CI Enable retry for curl on ARM builds

### DIFF
--- a/build_tools/cirrus/arm_wheel.yml
+++ b/build_tools/cirrus/arm_wheel.yml
@@ -22,7 +22,7 @@ macos_arm64_wheel_task:
         CIBW_BUILD: cp311-macosx_arm64
 
   conda_script:
-    - curl -L -o ~/mambaforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh
+    - curl -L --retry 10 -o ~/mambaforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh
     - bash ~/mambaforge.sh -b -p ~/mambaforge
 
   cibuildwheel_script:

--- a/build_tools/cirrus/build_test_arm.sh
+++ b/build_tools/cirrus/build_test_arm.sh
@@ -25,7 +25,7 @@ setup_ccache() {
 MAMBAFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-aarch64.sh"
 
 # Install Mambaforge
-curl -L $MAMBAFORGE_URL -o mambaforge.sh
+curl -L --retry 10 $MAMBAFORGE_URL -o mambaforge.sh
 MAMBAFORGE_PATH=$HOME/mambaforge
 bash ./mambaforge.sh -b -p $MAMBAFORGE_PATH
 export PATH=$MAMBAFORGE_PATH/bin:$PATH


### PR DESCRIPTION
Recently the [ARM CI failed](https://cirrus-ci.com/task/6515772000829440) failed for ARM. This PR adds a `--retry` to the curl command which adds a exponential backoff algorithm for retrying the request.