### PR TITLE
CI Fixes update tracker on ARM CI

### DIFF
--- a/build_tools/cirrus/arm_tests.yml
+++ b/build_tools/cirrus/arm_tests.yml
@@ -17,6 +17,10 @@ linux_aarch64_test_task:
     folder: /root/.conda/pkgs
     fingerprint_script: cat build_tools/cirrus/py39_conda_forge_linux-aarch64_conda.lock
 
+  install_python_script: |
+    # Install python so that update_tracking_issue has access to a Python
+    apt install -y python3 python-is-python3
+
   test_script: |
     bash build_tools/cirrus/build_test_arm.sh
     # On success, this script is run updating the issue.


### PR DESCRIPTION
The Cirrus ARM build [failed](https://cirrus-ci.com/task/6696112208216064?logs=test#L5257) because Python is not available for `update_tracking_issue.sh`. This PR installs Python from the system so that `update_tracking_issue.sh` has access to it.

I think it's better to install Python with `apt` and not use mambaforge's python, because the mambaforge installation may fail. If the mambaforge installation fails, then the update script will not run.