### PR TITLE
DOC fix docstring for `sklearn.datasets.get_data_home`

### DIFF
--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -55,13 +55,13 @@ def get_data_home(data_home=None) -> str:
 
     Parameters
     ----------
-    data_home : str, default=None
+    data_home : str or path-like, default=None
         The path to scikit-learn data directory. If `None`, the default path
         is `~/sklearn_learn_data`.
 
     Returns
     -------
-    data_home: str or path-like, default=None
+    data_home: str
         The path to scikit-learn data directory.
     """
     if data_home is None:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
`sklearn.datasets.get_data_home` takes str or path-like as parameter and returns str. Docstrings are updated to conform with the behavior.