### PR TITLE
TST Extend tests for `scipy.sparse.*array` in `sklearn/cluster/tests/test_affinity_propagation`

### DIFF
--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -7,7 +7,6 @@ import warnings
 
 import numpy as np
 import pytest
-from scipy.sparse import csr_matrix
 
 from sklearn.cluster import AffinityPropagation, affinity_propagation
 from sklearn.cluster._affinity_propagation import _equal_similarities_and_preferences
@@ -257,13 +256,14 @@ def test_affinity_propagation_random_state():
     assert np.mean((centers0 - centers76) ** 2) > 1
 
 
-@pytest.mark.parametrize("centers", [csr_matrix(np.zeros((1, 10))), np.zeros((1, 10))])
-def test_affinity_propagation_convergence_warning_dense_sparse(centers, global_dtype):
+@pytest.mark.parametrize("container", CSR_CONTAINERS + [np.array])
+def test_affinity_propagation_convergence_warning_dense_sparse(container, global_dtype):
     """
     Check that having sparse or dense `centers` format should not
     influence the convergence.
     Non-regression test for gh-13334.
     """
+    centers = container(np.zeros((1, 10)))
     rng = np.random.RandomState(42)
     X = rng.rand(40, 10).astype(global_dtype, copy=False)
     y = (4 * rng.rand(40)).astype(int)

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -27,6 +27,8 @@ np_version = parse_version(np.__version__)
 sp_version = parse_version(scipy.__version__)
 sp_base_version = parse_version(sp_version.base_version)
 
+# TODO: We can consider removing the containers and importing
+# directly from SciPy when sparse matrices will be deprecated.
 CSR_CONTAINERS = [scipy.sparse.csr_matrix]
 CSC_CONTAINERS = [scipy.sparse.csc_matrix]
 COO_CONTAINERS = [scipy.sparse.coo_matrix]

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -38,7 +38,8 @@ BSR_CONTAINERS = [scipy.sparse.bsr_matrix]
 
 if parse_version(scipy.__version__) >= parse_version("1.8"):
     # Sparse Arrays have been added in SciPy 1.8
-    # TODO: Remove this when SciPy 1.8 is the minimum supported version
+    # TODO: When SciPy 1.8 is the minimum supported version,
+    # those list can be created directly without this condition.
     # See: https://github.com/scikit-learn/scikit-learn/issues/27090
     CSR_CONTAINERS.append(scipy.sparse.csr_array)
     CSC_CONTAINERS.append(scipy.sparse.csc_array)

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -27,6 +27,23 @@ np_version = parse_version(np.__version__)
 sp_version = parse_version(scipy.__version__)
 sp_base_version = parse_version(sp_version.base_version)
 
+CSR_CONTAINERS = [scipy.sparse.csr_matrix]
+CSC_CONTAINERS = [scipy.sparse.csc_matrix]
+COO_CONTAINERS = [scipy.sparse.coo_matrix]
+LIL_CONTAINERS = [scipy.sparse.lil_matrix]
+DOK_CONTAINERS = [scipy.sparse.dok_matrix]
+BSR_CONTAINERS = [scipy.sparse.bsr_matrix]
+
+if parse_version(scipy.__version__) >= parse_version("1.8"):
+    # Sparse Arrays have been added in SciPy 1.8
+    # TODO: Remove this when SciPy 1.8 is the minimum supported version
+    # See: https://github.com/scikit-learn/scikit-learn/issues/27090
+    CSR_CONTAINERS.append(scipy.sparse.csr_array)
+    CSC_CONTAINERS.append(scipy.sparse.csc_array)
+    COO_CONTAINERS.append(scipy.sparse.coo_array)
+    LIL_CONTAINERS.append(scipy.sparse.lil_array)
+    DOK_CONTAINERS.append(scipy.sparse.dok_array)
+    BSR_CONTAINERS.append(scipy.sparse.bsr_array)
 
 try:
     from scipy.optimize._linesearch import line_search_wolfe1, line_search_wolfe2


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #27090.

#### What does this implement/fix? Explain your changes.

This PR introduces sparse containers' list conditionnaly to the version of SciPy so that we can extend tests as part of #27090.

#### Any other comments?

