### PR TITLE
TST Extend tests for `scipy.sparse.*array` in `sklearn/cluster/tests/test_dbscan.py` + `test_birch.py` + `test_column_transformer.py`

### DIFF
--- a/sklearn/cluster/tests/test_birch.py
+++ b/sklearn/cluster/tests/test_birch.py
@@ -92,6 +92,7 @@ def test_n_clusters(global_random_seed, global_dtype):
     with pytest.warns(ConvergenceWarning):
         brc4.fit(X)
 
+
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 def test_sparse_X(global_random_seed, global_dtype, csr_container):
     # Test that sparse and dense data give same results

--- a/sklearn/cluster/tests/test_birch.py
+++ b/sklearn/cluster/tests/test_birch.py
@@ -4,7 +4,6 @@ Tests for the birch clustering algorithm.
 
 import numpy as np
 import pytest
-from scipy import sparse
 
 from sklearn.cluster import AgglomerativeClustering, Birch
 from sklearn.cluster.tests.common import generate_clustered_data
@@ -12,6 +11,7 @@ from sklearn.datasets import make_blobs
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.metrics import pairwise_distances_argmin, v_measure_score
 from sklearn.utils._testing import assert_allclose, assert_array_equal
+from sklearn.utils.fixes import CSR_CONTAINERS
 
 
 def test_n_samples_leaves_roots(global_random_seed, global_dtype):
@@ -92,15 +92,15 @@ def test_n_clusters(global_random_seed, global_dtype):
     with pytest.warns(ConvergenceWarning):
         brc4.fit(X)
 
-
-def test_sparse_X(global_random_seed, global_dtype):
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_sparse_X(global_random_seed, global_dtype, csr_container):
     # Test that sparse and dense data give same results
     X, y = make_blobs(n_samples=100, centers=10, random_state=global_random_seed)
     X = X.astype(global_dtype, copy=False)
     brc = Birch(n_clusters=10)
     brc.fit(X)
 
-    csr = sparse.csr_matrix(X)
+    csr = csr_container(X)
     brc_sparse = Birch(n_clusters=10)
     brc_sparse.fit(csr)
 

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -65,7 +65,8 @@ def test_dbscan_feature():
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
     assert n_clusters_2 == n_clusters
 
-pytest.mark.parametrize("lil_container", LIL_CONTAINERS)
+
+@pytest.mark.parametrize("lil_container", LIL_CONTAINERS)
 def test_dbscan_sparse(lil_container):
     core_sparse, labels_sparse = dbscan(lil_container(X), eps=0.8, min_samples=10)
     core_dense, labels_dense = dbscan(X, eps=0.8, min_samples=10)
@@ -106,20 +107,20 @@ def test_dbscan_sparse_precomputed_different_eps():
     assert_array_equal(dbscan_lower[1], dbscan_higher[1])
 
 
-@pytest.mark.parametrize("use_sparse", [True, False])
 @pytest.mark.parametrize("metric", ["precomputed", "minkowski"])
-@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
-def test_dbscan_input_not_modified(use_sparse, metric, csr_container):
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS + [None])
+def test_dbscan_input_not_modified(metric, csr_container):
     # test that the input is not modified by dbscan
     X = np.random.RandomState(0).rand(10, 10)
-    X = csr_container(X) if use_sparse else X
+    X = csr_container(X) if csr_container is not None else X
     X_copy = X.copy()
     dbscan(X, metric=metric)
 
-    if use_sparse:
+    if csr_container is not None:
         assert_array_equal(X.toarray(), X_copy.toarray())
     else:
         assert_array_equal(X, X_copy)
+
 
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 def test_dbscan_no_core_samples(csr_container):
@@ -390,6 +391,7 @@ def test_dbscan_precomputed_metric_with_degenerate_input_arrays():
     X = np.zeros((10, 10))
     labels = DBSCAN(eps=0.5, metric="precomputed").fit(X).labels_
     assert len(set(labels)) == 1
+
 
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 def test_dbscan_precomputed_metric_with_initial_rows_zero(csr_container):

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -7,7 +7,6 @@ import warnings
 
 import numpy as np
 import pytest
-from scipy import sparse
 from scipy.spatial import distance
 
 from sklearn.cluster import DBSCAN, dbscan
@@ -15,6 +14,7 @@ from sklearn.cluster.tests.common import generate_clustered_data
 from sklearn.metrics.pairwise import pairwise_distances
 from sklearn.neighbors import NearestNeighbors
 from sklearn.utils._testing import assert_array_equal
+from sklearn.utils.fixes import CSR_CONTAINERS, LIL_CONTAINERS
 
 n_clusters = 3
 X = generate_clustered_data(n_clusters=n_clusters)
@@ -65,9 +65,9 @@ def test_dbscan_feature():
     n_clusters_2 = len(set(labels)) - int(-1 in labels)
     assert n_clusters_2 == n_clusters
 
-
-def test_dbscan_sparse():
-    core_sparse, labels_sparse = dbscan(sparse.lil_matrix(X), eps=0.8, min_samples=10)
+pytest.mark.parametrize("lil_container", LIL_CONTAINERS)
+def test_dbscan_sparse(lil_container):
+    core_sparse, labels_sparse = dbscan(lil_container(X), eps=0.8, min_samples=10)
     core_dense, labels_dense = dbscan(X, eps=0.8, min_samples=10)
     assert_array_equal(core_dense, core_sparse)
     assert_array_equal(labels_dense, labels_sparse)
@@ -108,10 +108,11 @@ def test_dbscan_sparse_precomputed_different_eps():
 
 @pytest.mark.parametrize("use_sparse", [True, False])
 @pytest.mark.parametrize("metric", ["precomputed", "minkowski"])
-def test_dbscan_input_not_modified(use_sparse, metric):
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_dbscan_input_not_modified(use_sparse, metric, csr_container):
     # test that the input is not modified by dbscan
     X = np.random.RandomState(0).rand(10, 10)
-    X = sparse.csr_matrix(X) if use_sparse else X
+    X = csr_container(X) if use_sparse else X
     X_copy = X.copy()
     dbscan(X, metric=metric)
 
@@ -120,13 +121,13 @@ def test_dbscan_input_not_modified(use_sparse, metric):
     else:
         assert_array_equal(X, X_copy)
 
-
-def test_dbscan_no_core_samples():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_dbscan_no_core_samples(csr_container):
     rng = np.random.RandomState(0)
     X = rng.rand(40, 10)
     X[X < 0.8] = 0
 
-    for X_ in [X, sparse.csr_matrix(X)]:
+    for X_ in [X, csr_container(X)]:
         db = DBSCAN(min_samples=6).fit(X_)
         assert_array_equal(db.components_, np.empty((0, X_.shape[1])))
         assert_array_equal(db.labels_, -1)
@@ -390,8 +391,8 @@ def test_dbscan_precomputed_metric_with_degenerate_input_arrays():
     labels = DBSCAN(eps=0.5, metric="precomputed").fit(X).labels_
     assert len(set(labels)) == 1
 
-
-def test_dbscan_precomputed_metric_with_initial_rows_zero():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_dbscan_precomputed_metric_with_initial_rows_zero(csr_container):
     # sample matrix with initial two row all zero
     ar = np.array(
         [
@@ -404,6 +405,6 @@ def test_dbscan_precomputed_metric_with_initial_rows_zero():
             [0.0, 0.0, 0.0, 0.0, 0.3, 0.1, 0.0],
         ]
     )
-    matrix = sparse.csr_matrix(ar)
+    matrix = csr_container(ar)
     labels = DBSCAN(eps=0.2, metric="precomputed", min_samples=2).fit(matrix).labels_
     assert_array_equal(labels, [-1, -1, 0, 0, 0, 1, 1])

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -435,10 +435,10 @@ def test_column_transformer_sparse_array(csr_container):
     X_sparse = csr_container(sparse.eye(3, 2))
 
     # no distinction between 1D and 2D
-    X_res_first = X_sparse[:, 0]
+    X_res_first = X_sparse[:, [0]]
     X_res_both = X_sparse
 
-    for col in [0, [0], slice(0, 1)]:
+    for col in [(0,), [0], slice(0, 1)]:
         for remainder, res in [("drop", X_res_first), ("passthrough", X_res_both)]:
             ct = ColumnTransformer(
                 [("trans", Trans(), col)], remainder=remainder, sparse_threshold=0.8

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -28,6 +28,7 @@ from sklearn.utils._testing import (
     assert_almost_equal,
     assert_array_equal,
 )
+from sklearn.utils.fixes import CSR_CONTAINERS
 
 
 class Trans(TransformerMixin, BaseEstimator):
@@ -53,12 +54,15 @@ class DoubleTrans(BaseEstimator):
 
 
 class SparseMatrixTrans(BaseEstimator):
+    def __init__(self, csr_container):
+        self.csr_container = csr_container
+
     def fit(self, X, y=None):
         return self
 
     def transform(self, X, y=None):
         n_samples = len(X)
-        return sparse.eye(n_samples, n_samples).tocsr()
+        return self.csr_container(sparse.eye(n_samples, n_samples))
 
 
 class TransNo2D(BaseEstimator):
@@ -426,8 +430,9 @@ def test_column_transformer_output_indices_df():
     assert_array_equal(X_trans[:, []], X_trans[:, ct.output_indices_["remainder"]])
 
 
-def test_column_transformer_sparse_array():
-    X_sparse = sparse.eye(3, 2).tocsr()
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_column_transformer_sparse_array(csr_container):
+    X_sparse = csr_container(sparse.eye(3, 2))
 
     # no distinction between 1D and 2D
     X_res_first = X_sparse[:, 0]
@@ -469,10 +474,11 @@ def test_column_transformer_list():
     assert_array_equal(ct.fit(X_list).transform(X_list), expected_result)
 
 
-def test_column_transformer_sparse_stacking():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_column_transformer_sparse_stacking(csr_container):
     X_array = np.array([[0, 1, 2], [2, 4, 6]]).T
     col_trans = ColumnTransformer(
-        [("trans1", Trans(), [0]), ("trans2", SparseMatrixTrans(), 1)],
+        [("trans1", Trans(), [0]), ("trans2", SparseMatrixTrans(csr_container), 1)],
         sparse_threshold=0.8,
     )
     col_trans.fit(X_array)
@@ -484,7 +490,7 @@ def test_column_transformer_sparse_stacking():
     assert col_trans.transformers_[-1][0] != "remainder"
 
     col_trans = ColumnTransformer(
-        [("trans1", Trans(), [0]), ("trans2", SparseMatrixTrans(), 1)],
+        [("trans1", Trans(), [0]), ("trans2", SparseMatrixTrans(csr_container), 1)],
         sparse_threshold=0.1,
     )
     col_trans.fit(X_array)
@@ -994,11 +1000,14 @@ def test_column_transformer_drops_all_remainder_transformer():
     assert_array_equal(ct.transformers_[-1][2], [1, 2])
 
 
-def test_column_transformer_sparse_remainder_transformer():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_column_transformer_sparse_remainder_transformer(csr_container):
     X_array = np.array([[0, 1, 2], [2, 4, 6], [8, 6, 4]]).T
 
     ct = ColumnTransformer(
-        [("trans1", Trans(), [0])], remainder=SparseMatrixTrans(), sparse_threshold=0.8
+        [("trans1", Trans(), [0])],
+        remainder=SparseMatrixTrans(csr_container),
+        sparse_threshold=0.8,
     )
 
     X_trans = ct.fit_transform(X_array)
@@ -1015,10 +1024,13 @@ def test_column_transformer_sparse_remainder_transformer():
     assert_array_equal(ct.transformers_[-1][2], [1, 2])
 
 
-def test_column_transformer_drop_all_sparse_remainder_transformer():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_column_transformer_drop_all_sparse_remainder_transformer(csr_container):
     X_array = np.array([[0, 1, 2], [2, 4, 6], [8, 6, 4]]).T
     ct = ColumnTransformer(
-        [("trans1", "drop", [0])], remainder=SparseMatrixTrans(), sparse_threshold=0.8
+        [("trans1", "drop", [0])],
+        remainder=SparseMatrixTrans(csr_container),
+        sparse_threshold=0.8,
     )
 
     X_trans = ct.fit_transform(X_array)
@@ -1226,7 +1238,7 @@ def test_column_transformer_negative_column_indexes():
     assert_array_equal(tf_1.fit_transform(X), tf_2.fit_transform(X))
 
 
-@pytest.mark.parametrize("array_type", [np.asarray, sparse.csr_matrix])
+@pytest.mark.parametrize("array_type", [np.asarray, *CSR_CONTAINERS])
 def test_column_transformer_mask_indexing(array_type):
     # Regression test for #14510
     # Boolean array-like does not behave as boolean array with sparse matrices.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards [27090](https://github.com/scikit-learn/scikit-learn/issues/27090).

#### What does this implement/fix? Explain your changes.
This PR introduces sparse containers' list conditionally to the version of SciPy so that we can extend tests as part of [27090](https://github.com/scikit-learn/scikit-learn/issues/27090).

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
