### PR TITLE
TST Extend tests for `scipy.sparse.*array` in `test_nmf.py`

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -110,7 +110,7 @@ Changelog
   :pr:`26315` by :user:`Mateusz Sokół <mtsokol>` and
   :user:`Olivier Grisel <ogrisel>`.
 
-- |Fix| :func:`decomposition.non_negative_factorization`, :class:`decomposition.NMF`,
+- |Enhancement| :func:`decomposition.non_negative_factorization`, :class:`decomposition.NMF`,
   and :class:`decomposition.MiniBatchNMF` now support :class:`scipy.sparse.sparray`
   subclasses.
   :pr:`27100` by :user:`Isaac Virshup <ivirshup>`

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -110,6 +110,11 @@ Changelog
   :pr:`26315` by :user:`Mateusz Sokół <mtsokol>` and
   :user:`Olivier Grisel <ogrisel>`.
 
+- |Fix| :func:`decomposition.non_negative_factorization`, :class:`decomposition.NMF`,
+  and :class:`decomposition.MiniBatchNMF` now support :class:`scipy.sparse.sparray`
+  subclasses.
+  :pr:`27100` by :user:`Isaac Virshup <ivirshup>`
+
 :mod:`sklearn.ensemble`
 .......................
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -113,7 +113,7 @@ Changelog
 - |Enhancement| :func:`decomposition.non_negative_factorization`, :class:`decomposition.NMF`,
   and :class:`decomposition.MiniBatchNMF` now support :class:`scipy.sparse.sparray`
   subclasses.
-  :pr:`27100` by :user:`Isaac Virshup <ivirshup>`
+  :pr:`27100` by :user:`Isaac Virshup <ivirshup>`.
 
 :mod:`sklearn.ensemble`
 .......................

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -126,7 +126,7 @@ def _beta_divergence(X, W, H, beta, square_root=False):
         if sp.issparse(X):
             norm_X = np.dot(X.data, X.data)
             norm_WH = trace_dot(np.linalg.multi_dot([W.T, W, H]), H)
-            cross_prod = trace_dot((X * H.T), W)
+            cross_prod = trace_dot((X @ H.T), W)
             res = (norm_X + norm_WH - 2.0 * cross_prod) / 2.0
         else:
             res = squared_norm(X - np.dot(W, H)) / 2.0

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -1327,7 +1327,7 @@ class _BaseNMF(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator,
 
         Returns
         -------
-        X : {ndarray, sparse matrix} of shape (n_samples, n_features)
+        X : ndarray of shape (n_samples, n_features)
             Returns a data matrix of the original shape.
         """
         if Xt is None and W is None:


### PR DESCRIPTION

#### Reference Issues/PRs

Towards #27090

#### What does this implement/fix? Explain your changes.

This modifies the NMF transformer to accept scipy.sparse.sparray classes.

#### Any other comments?

Still needs tests to check that the NMF returns the correct type. I am not 100% sure it's going to be obvious what the desired return type is.
