### PR TITLE
ENH Add Array API compatibility to MaxAbsScaler

### DIFF
--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -96,8 +96,8 @@ Estimators
 - :class:`decomposition.PCA` (with `svd_solver="full"`,
   `svd_solver="randomized"` and `power_iteration_normalizer="QR"`)
 - :class:`discriminant_analysis.LinearDiscriminantAnalysis` (with `solver="svd"`)
-- :class:`preprocessing.MinMaxScaler`
 - :class:`preprocessing.MaxAbsScaler`
+- :class:`preprocessing.MinMaxScaler`
 
 Tools
 -----

--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -97,6 +97,7 @@ Estimators
   `svd_solver="randomized"` and `power_iteration_normalizer="QR"`)
 - :class:`discriminant_analysis.LinearDiscriminantAnalysis` (with `solver="svd"`)
 - :class:`preprocessing.MinMaxScaler`
+- :class:`preprocessing.MaxAbsScaler`
 
 Tools
 -----

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -108,7 +108,7 @@ Changelog
   `full` and `randomized` solvers (with QR power iterations). See
   :ref:`array_api` for more details.
   :pr:`26315` and :pr:`27098` by :user:`Mateusz Sokół <mtsokol>`,
-  :user:`Olivier Grisel <ogrisel>` and :user:` Edoardo Abati <EdAbati>`.
+  :user:`Olivier Grisel <ogrisel>` and :user:`Edoardo Abati <EdAbati>`.
 
 - |Enhancement| :func:`decomposition.non_negative_factorization`, :class:`decomposition.NMF`,
   and :class:`decomposition.MiniBatchNMF` now support :class:`scipy.sparse.sparray`

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -200,11 +200,11 @@ Changelog
   when `sparse_output=True` and the output is configured to be pandas.
   :pr:`26931` by `Thomas Fan`_.
 
-- |MajorFeature| :class:`preprocessing.MinMaxScaler` now
+- |MajorFeature| :class:`preprocessing.MinMaxScaler` and :class:`preprocessing.MaxAbsScaler` now
   supports the `Array API <https://data-apis.org/array-api/latest/>`_. Array API
   support is considered experimental and might evolve without being subject to
   our usual rolling deprecation cycle policy. See
-  :ref:`array_api` for more details. :pr:`26243` by `Tim Head`_.
+  :ref:`array_api` for more details. :pr:`26243` by `Tim Head`_ and :pr:`27110` by :user:`Edoardo Abati <EdAbati>`.
 
 :mod:`sklearn.tree`
 ...................

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1256,12 +1256,15 @@ class MaxAbsScaler(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
             Transformed array.
         """
         check_is_fitted(self)
+
+        xp, _ = get_namespace(X)
+
         X = self._validate_data(
             X,
             accept_sparse=("csr", "csc"),
             copy=self.copy,
             reset=False,
-            dtype=FLOAT_DTYPES,
+            dtype=_array_api.supported_float_dtypes(xp),
             force_all_finite="allow-nan",
         )
 
@@ -1285,11 +1288,14 @@ class MaxAbsScaler(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
             Transformed array.
         """
         check_is_fitted(self)
+
+        xp, _ = get_namespace(X)
+
         X = check_array(
             X,
             accept_sparse=("csr", "csc"),
             copy=self.copy,
-            dtype=FLOAT_DTYPES,
+            dtype=_array_api.supported_float_dtypes(xp),
             force_all_finite="allow-nan",
         )
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -701,7 +701,7 @@ def test_standard_check_array_of_inverse_transform():
 )
 @pytest.mark.parametrize(
     "estimator",
-    [MinMaxScaler(), MaxAbsScaler()],
+    [MaxAbsScaler(), MinMaxScaler()],
     ids=_get_check_estimator_ids,
 )
 def test_scaler_array_api_compliance(estimator, check, array_namespace, device, dtype):

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -41,6 +41,9 @@ from sklearn.preprocessing import (
 from sklearn.preprocessing._data import BOUNDS_THRESHOLD, _handle_zeros_in_scale
 from sklearn.svm import SVR
 from sklearn.utils import gen_batches, shuffle
+from sklearn.utils._array_api import (
+    yield_namespace_device_dtype_combinations,
+)
 from sklearn.utils._testing import (
     _convert_container,
     assert_allclose,
@@ -50,6 +53,10 @@ from sklearn.utils._testing import (
     assert_array_equal,
     assert_array_less,
     skip_if_32bit,
+)
+from sklearn.utils.estimator_checks import (
+    _get_check_estimator_ids,
+    check_array_api_input_and_values,
 )
 from sklearn.utils.sparsefuncs import mean_variance_axis
 
@@ -1638,6 +1645,26 @@ def test_robust_scaler_unit_variance():
     assert robust_scaler.center_ == pytest.approx(0, abs=1e-3)
     assert robust_scaler.scale_ == pytest.approx(1, abs=1e-2)
     assert X_trans.std() == pytest.approx(1, abs=1e-2)
+
+
+@pytest.mark.parametrize(
+    "array_namespace, device, dtype", yield_namespace_device_dtype_combinations()
+)
+@pytest.mark.parametrize(
+    "check",
+    [check_array_api_input_and_values],
+    ids=_get_check_estimator_ids,
+)
+@pytest.mark.parametrize(
+    "estimator",
+    [MinMaxScaler()],
+    ids=_get_check_estimator_ids,
+)
+def test_maxabscaler_array_api_compliance(
+    estimator, check, array_namespace, device, dtype
+):
+    name = estimator.__class__.__name__
+    check(name, estimator, array_namespace, device=device, dtype=dtype)
 
 
 def test_maxabs_scaler_zero_variance_features():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1677,7 +1677,7 @@ def test_robust_scaler_unit_variance():
 )
 @pytest.mark.parametrize(
     "estimator",
-    [MinMaxScaler()],
+    [MaxAbsScaler()],
     ids=_get_check_estimator_ids,
 )
 def test_maxabscaler_array_api_compliance(

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -701,12 +701,10 @@ def test_standard_check_array_of_inverse_transform():
 )
 @pytest.mark.parametrize(
     "estimator",
-    [MinMaxScaler()],
+    [MinMaxScaler(), MaxAbsScaler()],
     ids=_get_check_estimator_ids,
 )
-def test_minmaxscaler_array_api_compliance(
-    estimator, check, array_namespace, device, dtype
-):
+def test_scaler_array_api_compliance(estimator, check, array_namespace, device, dtype):
     name = estimator.__class__.__name__
     check(name, estimator, array_namespace, device=device, dtype=dtype)
 
@@ -1665,26 +1663,6 @@ def test_robust_scaler_unit_variance():
     assert robust_scaler.center_ == pytest.approx(0, abs=1e-3)
     assert robust_scaler.scale_ == pytest.approx(1, abs=1e-2)
     assert X_trans.std() == pytest.approx(1, abs=1e-2)
-
-
-@pytest.mark.parametrize(
-    "array_namespace, device, dtype", yield_namespace_device_dtype_combinations()
-)
-@pytest.mark.parametrize(
-    "check",
-    [check_array_api_input_and_values],
-    ids=_get_check_estimator_ids,
-)
-@pytest.mark.parametrize(
-    "estimator",
-    [MaxAbsScaler()],
-    ids=_get_check_estimator_ids,
-)
-def test_maxabscaler_array_api_compliance(
-    estimator, check, array_namespace, device, dtype
-):
-    name = estimator.__class__.__name__
-    check(name, estimator, array_namespace, device=device, dtype=dtype)
 
 
 def test_maxabs_scaler_zero_variance_features():

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -495,7 +495,7 @@ def _nanmin(X, axis=None):
 
     else:
         mask = xp.isnan(X)
-        X = xp.min(xp.where(mask, xp.asarray(+xp.inf), X), axis=axis)
+        X = xp.min(xp.where(mask, xp.asarray(+xp.inf, device=device(X)), X), axis=axis)
         # Replace Infs from all NaN slices with NaN again
         mask = xp.all(mask, axis=axis)
         if xp.any(mask):
@@ -512,7 +512,7 @@ def _nanmax(X, axis=None):
 
     else:
         mask = xp.isnan(X)
-        X = xp.max(xp.where(mask, xp.asarray(-xp.inf), X), axis=axis)
+        X = xp.max(xp.where(mask, xp.asarray(-xp.inf, device=device(X)), X), axis=axis)
         # Replace Infs from all NaN slices with NaN again
         mask = xp.all(mask, axis=axis)
         if xp.any(mask):


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #26024

#### What does this implement/fix? Explain your changes.

It makes the `MaxAbsScaler` implementation compatible with the Array API. 

#### Any other comments?

I had to make a small adjustment to `_nanmax` and `_nanmin`, because `mps` complained that those `+/-inf` arrays were not on the same (`mps`) device.
