### PR TITLE
TST Extend tests for `scipy.sparse.*array` in `sklearn/svm/tests/test_bounds.py`

### DIFF
--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -14,21 +14,18 @@ Y1 = [0, 1, 1, 1]
 Y2 = [2, 1, 0, 0]
 
 
-@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+@pytest.mark.parametrize("X_container", CSR_CONTAINERS + [np.array])
 @pytest.mark.parametrize("loss", ["squared_hinge", "log"])
-@pytest.mark.parametrize("X_label", ["sparse", "dense"])
 @pytest.mark.parametrize("Y_label", ["two-classes", "multi-class"])
 @pytest.mark.parametrize("intercept_label", ["no-intercept", "fit-intercept"])
-def test_l1_min_c(csr_container, loss, X_label, Y_label, intercept_label):
-    sparse_X = csr_container(dense_X)
-    Xs = {"sparse": sparse_X, "dense": dense_X}
+def test_l1_min_c(X_container, loss, Y_label, intercept_label):
     Ys = {"two-classes": Y1, "multi-class": Y2}
     intercepts = {
         "no-intercept": {"fit_intercept": False},
         "fit-intercept": {"fit_intercept": True, "intercept_scaling": 10},
     }
 
-    X = Xs[X_label]
+    X = X_container(dense_X)
     Y = Ys[Y_label]
     intercept_params = intercepts[intercept_label]
     check_l1_min_c(X, Y, loss, **intercept_params)

--- a/sklearn/svm/tests/test_bounds.py
+++ b/sklearn/svm/tests/test_bounds.py
@@ -1,25 +1,26 @@
 import numpy as np
 import pytest
-from scipy import sparse as sp
 from scipy import stats
 
 from sklearn.linear_model import LogisticRegression
 from sklearn.svm import LinearSVC
 from sklearn.svm._bounds import l1_min_c
 from sklearn.svm._newrand import bounded_rand_int_wrap, set_seed_wrap
+from sklearn.utils.fixes import CSR_CONTAINERS
 
 dense_X = [[-1, 0], [0, 1], [1, 1], [1, 1]]
-sparse_X = sp.csr_matrix(dense_X)
 
 Y1 = [0, 1, 1, 1]
 Y2 = [2, 1, 0, 0]
 
 
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 @pytest.mark.parametrize("loss", ["squared_hinge", "log"])
 @pytest.mark.parametrize("X_label", ["sparse", "dense"])
 @pytest.mark.parametrize("Y_label", ["two-classes", "multi-class"])
 @pytest.mark.parametrize("intercept_label", ["no-intercept", "fit-intercept"])
-def test_l1_min_c(loss, X_label, Y_label, intercept_label):
+def test_l1_min_c(csr_container, loss, X_label, Y_label, intercept_label):
+    sparse_X = csr_container(dense_X)
     Xs = {"sparse": sparse_X, "dense": dense_X}
     Ys = {"two-classes": Y1, "multi-class": Y2}
     intercepts = {


### PR DESCRIPTION
Towards: #27090.