### PR TITLE
MNT Update `const` usage in `{Ball, KD}Tree` classes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -306,9 +306,9 @@ extension_config = {
         },
     ],
     "neighbors": [
-        {"sources": ["_binary_tree.pxi.tp"], "include_np": True, "language": "c++"},
-        {"sources": ["_ball_tree.pyx.tp"], "include_np": True, "language": "c++"},
-        {"sources": ["_kd_tree.pyx.tp"], "include_np": True, "language": "c++"},
+        {"sources": ["_binary_tree.pxi.tp"], "include_np": True},
+        {"sources": ["_ball_tree.pyx.tp"], "include_np": True},
+        {"sources": ["_kd_tree.pyx.tp"], "include_np": True},
         {"sources": ["_partition_nodes.pyx"], "language": "c++", "include_np": True},
         {"sources": ["_quad_tree.pyx"], "include_np": True},
     ],

--- a/setup.py
+++ b/setup.py
@@ -306,9 +306,9 @@ extension_config = {
         },
     ],
     "neighbors": [
-        {"sources": ["_binary_tree.pxi.tp"], "include_np": True},
-        {"sources": ["_ball_tree.pyx.tp"], "include_np": True},
-        {"sources": ["_kd_tree.pyx.tp"], "include_np": True},
+        {"sources": ["_binary_tree.pxi.tp"], "include_np": True, "language": "c++"},
+        {"sources": ["_ball_tree.pyx.tp"], "include_np": True, "language": "c++"},
+        {"sources": ["_kd_tree.pyx.tp"], "include_np": True, "language": "c++"},
         {"sources": ["_partition_nodes.pyx"], "language": "c++", "include_np": True},
         {"sources": ["_quad_tree.pyx"], "include_np": True},
     ],

--- a/sklearn/neighbors/_ball_tree.pyx.tp
+++ b/sklearn/neighbors/_ball_tree.pyx.tp
@@ -96,14 +96,14 @@ cdef int init_node{{name_suffix}}(
 
     cdef intp_t i, j
     cdef float64_t radius
-    cdef {{INPUT_DTYPE_t}} *this_pt
+    cdef const {{INPUT_DTYPE_t}} *this_pt
 
     cdef intp_t* idx_array = &tree.idx_array[0]
-    cdef {{INPUT_DTYPE_t}}* data = &tree.data[0, 0]
+    cdef const {{INPUT_DTYPE_t}}* data = &tree.data[0, 0]
     cdef {{INPUT_DTYPE_t}}* centroid = &tree.node_bounds[0, i_node, 0]
 
     cdef bint with_sample_weight = tree.sample_weight is not None
-    cdef {{INPUT_DTYPE_t}}* sample_weight
+    cdef const {{INPUT_DTYPE_t}}* sample_weight
     cdef float64_t sum_weight_node
     if with_sample_weight:
         sample_weight = &tree.sample_weight[0]
@@ -148,7 +148,7 @@ cdef int init_node{{name_suffix}}(
 cdef inline float64_t min_dist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
 ) except -1 nogil:
     """Compute the minimum distance between a point and a node"""
     cdef float64_t dist_pt = tree.dist(pt, &tree.node_bounds[0, i_node, 0],
@@ -159,7 +159,7 @@ cdef inline float64_t min_dist{{name_suffix}}(
 cdef inline float64_t max_dist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
 ) except -1:
     """Compute the maximum distance between a point and a node"""
     cdef float64_t dist_pt = tree.dist(pt, &tree.node_bounds[0, i_node, 0],
@@ -170,7 +170,7 @@ cdef inline float64_t max_dist{{name_suffix}}(
 cdef inline int min_max_dist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
     float64_t* min_dist,
     float64_t* max_dist,
 ) except -1 nogil:
@@ -186,7 +186,7 @@ cdef inline int min_max_dist{{name_suffix}}(
 cdef inline float64_t min_rdist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
 ) except -1 nogil:
     """Compute the minimum reduced-distance between a point and a node"""
     if tree.euclidean:
@@ -202,7 +202,7 @@ cdef inline float64_t min_rdist{{name_suffix}}(
 cdef inline float64_t max_rdist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
 ) except -1:
     """Compute the maximum reduced-distance between a point and a node"""
     if tree.euclidean:

--- a/sklearn/neighbors/_binary_tree.pxi.tp
+++ b/sklearn/neighbors/_binary_tree.pxi.tp
@@ -1143,7 +1143,7 @@ cdef class BinaryTree{{name_suffix}}:
 
         # flatten X, and save original shape information
         np_Xarr = X.reshape((-1, self.data.shape[1]))
-        cdef {{INPUT_DTYPE_t}}[:, ::1] Xarr = np_Xarr
+        cdef const {{INPUT_DTYPE_t}}[:, ::1] Xarr = np_Xarr
         cdef float64_t reduced_dist_LB
         cdef intp_t i
         cdef const {{INPUT_DTYPE_t}}* pt

--- a/sklearn/neighbors/_binary_tree.pxi.tp
+++ b/sklearn/neighbors/_binary_tree.pxi.tp
@@ -808,6 +808,7 @@ cdef class BinaryTree{{name_suffix}}:
 
     # TODO: idx_array and node_bounds must not be const, but this change needs
     # to happen in a way which preserves pickling
+    # See also: https://github.com/cython/cython/issues/5639
     cdef public const intp_t[::1] idx_array
     cdef public const NodeData_t[::1] node_data
     cdef public const {{INPUT_DTYPE_t}}[:, :, ::1] node_bounds

--- a/sklearn/neighbors/_binary_tree.pxi.tp
+++ b/sklearn/neighbors/_binary_tree.pxi.tp
@@ -806,7 +806,7 @@ cdef class BinaryTree{{name_suffix}}:
     cdef readonly const {{INPUT_DTYPE_t}}[::1] sample_weight
     cdef public float64_t sum_weight
 
-    cdef public intp_t[::1] idx_array
+    cdef public const intp_t[::1] idx_array
     cdef public const NodeData_t[::1] node_data
     cdef public {{INPUT_DTYPE_t}}[:, :, ::1] node_bounds
 

--- a/sklearn/neighbors/_binary_tree.pxi.tp
+++ b/sklearn/neighbors/_binary_tree.pxi.tp
@@ -806,9 +806,11 @@ cdef class BinaryTree{{name_suffix}}:
     cdef readonly const {{INPUT_DTYPE_t}}[::1] sample_weight
     cdef public float64_t sum_weight
 
+    # TODO: idx_array and node_bounds must not be const, but this change needs
+    # to happen in a way which preserves pickling
     cdef public const intp_t[::1] idx_array
     cdef public const NodeData_t[::1] node_data
-    cdef public {{INPUT_DTYPE_t}}[:, :, ::1] node_bounds
+    cdef public const {{INPUT_DTYPE_t}}[:, :, ::1] node_bounds
 
     cdef intp_t leaf_size
     cdef intp_t n_levels

--- a/sklearn/neighbors/_binary_tree.pxi.tp
+++ b/sklearn/neighbors/_binary_tree.pxi.tp
@@ -602,7 +602,7 @@ cdef class NeighborsHeap{{name_suffix}}:
 #  this computes the equivalent of
 #  j_max = np.argmax(np.max(data, 0) - np.min(data, 0))
 cdef intp_t find_node_split_dim(const floating* data,
-                                 intp_t* node_indices,
+                                 const intp_t* node_indices,
                                  intp_t n_features,
                                  intp_t n_points) except -1:
     """Find the dimension with the largest spread.
@@ -806,9 +806,9 @@ cdef class BinaryTree{{name_suffix}}:
     cdef readonly const {{INPUT_DTYPE_t}}[::1] sample_weight
     cdef public float64_t sum_weight
 
-    cdef public const intp_t[::1] idx_array
+    cdef public intp_t[::1] idx_array
     cdef public const NodeData_t[::1] node_data
-    cdef public const {{INPUT_DTYPE_t}}[:, :, ::1] node_bounds
+    cdef public {{INPUT_DTYPE_t}}[:, :, ::1] node_bounds
 
     cdef intp_t leaf_size
     cdef intp_t n_levels
@@ -1010,7 +1010,7 @@ cdef class BinaryTree{{name_suffix}}:
             self.node_bounds.base,
         )
 
-    cdef inline float64_t dist(self, {{INPUT_DTYPE_t}}* x1, {{INPUT_DTYPE_t}}* x2,
+    cdef inline float64_t dist(self, const {{INPUT_DTYPE_t}}* x1, const {{INPUT_DTYPE_t}}* x2,
                              intp_t size) except -1 nogil:
         """Compute the distance between arrays x1 and x2"""
         self.n_calls += 1
@@ -1019,7 +1019,7 @@ cdef class BinaryTree{{name_suffix}}:
         else:
             return self.dist_metric.dist(x1, x2, size)
 
-    cdef inline float64_t rdist(self, {{INPUT_DTYPE_t}}* x1, {{INPUT_DTYPE_t}}* x2,
+    cdef inline float64_t rdist(self, const {{INPUT_DTYPE_t}}* x1, const {{INPUT_DTYPE_t}}* x2,
                               intp_t size) except -1 nogil:
         """Compute the reduced distance between arrays x1 and x2.
 
@@ -1051,7 +1051,7 @@ cdef class BinaryTree{{name_suffix}}:
         cdef intp_t n_points = idx_end - idx_start
         cdef intp_t n_mid = n_points / 2
         cdef intp_t* idx_array = &self.idx_array[idx_start]
-        cdef {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
 
         # initialize node data
         init_node{{name_suffix}}(self, node_data, i_node, idx_start, idx_end)
@@ -1143,10 +1143,10 @@ cdef class BinaryTree{{name_suffix}}:
 
         # flatten X, and save original shape information
         np_Xarr = X.reshape((-1, self.data.shape[1]))
-        cdef const {{INPUT_DTYPE_t}}[:, ::1] Xarr = np_Xarr
+        cdef {{INPUT_DTYPE_t}}[:, ::1] Xarr = np_Xarr
         cdef float64_t reduced_dist_LB
         cdef intp_t i
-        cdef {{INPUT_DTYPE_t}}* pt
+        cdef const {{INPUT_DTYPE_t}}* pt
 
         # initialize heap for neighbors
         cdef NeighborsHeap{{name_suffix}} heap = NeighborsHeap{{name_suffix}}(Xarr.shape[0], k)
@@ -1263,7 +1263,7 @@ cdef class BinaryTree{{name_suffix}}:
         cdef intp_t n_features = self.data.shape[1]
         cdef {{INPUT_DTYPE_t}}[::1] dist_arr_i
         cdef intp_t[::1] idx_arr_i, counts
-        cdef {{INPUT_DTYPE_t}}* pt
+        cdef const {{INPUT_DTYPE_t}}* pt
         cdef intp_t** indices = NULL
         cdef {{INPUT_DTYPE_t}}** distances = NULL
 
@@ -1484,7 +1484,7 @@ cdef class BinaryTree{{name_suffix}}:
         log_density_arr = np.zeros(Xarr.shape[0], dtype={{INPUT_DTYPE}})
         cdef {{INPUT_DTYPE_t}}[::1] log_density = log_density_arr
 
-        cdef {{INPUT_DTYPE_t}}* pt = &Xarr[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* pt = &Xarr[0, 0]
 
         cdef NodeHeap nodeheap
         if breadth_first:
@@ -1589,7 +1589,7 @@ cdef class BinaryTree{{name_suffix}}:
         count = np.zeros(r.shape[0], dtype=np.intp)
         cdef intp_t[::1] carr = count
 
-        cdef {{INPUT_DTYPE_t}}* pt = &Xarr[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* pt = &Xarr[0, 0]
 
         if dualtree:
             other = self.__class__(Xarr, metric=self.dist_metric,
@@ -1607,7 +1607,7 @@ cdef class BinaryTree{{name_suffix}}:
     cdef int _query_single_depthfirst(
         self,
         intp_t i_node,
-        {{INPUT_DTYPE_t}}* pt,
+        const {{INPUT_DTYPE_t}}* pt,
         intp_t i_pt,
         NeighborsHeap{{name_suffix}} heap,
         float64_t reduced_dist_LB,
@@ -1618,7 +1618,7 @@ cdef class BinaryTree{{name_suffix}}:
         cdef float64_t dist_pt, reduced_dist_LB_1, reduced_dist_LB_2
         cdef intp_t i, i1, i2
 
-        cdef {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
 
         # ------------------------------------------------------------
         # Case 1: query point is outside node radius:
@@ -1661,7 +1661,7 @@ cdef class BinaryTree{{name_suffix}}:
 
     cdef int _query_single_breadthfirst(
         self,
-        {{INPUT_DTYPE_t}}* pt,
+        const {{INPUT_DTYPE_t}}* pt,
         intp_t i_pt,
         NeighborsHeap{{name_suffix}} heap,
         NodeHeap nodeheap,
@@ -1669,8 +1669,8 @@ cdef class BinaryTree{{name_suffix}}:
         """Non-recursive single-tree k-neighbors query, breadth-first search"""
         cdef intp_t i, i_node
         cdef float64_t dist_pt, reduced_dist_LB
-        cdef NodeData_t* node_data = &self.node_data[0]
-        cdef {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
+        cdef const NodeData_t* node_data = &self.node_data[0]
+        cdef const {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
 
         # Set up the node heap and push the head node onto it
         cdef NodeHeapData_t nodeheap_item
@@ -1727,8 +1727,8 @@ cdef class BinaryTree{{name_suffix}}:
         cdef NodeData_t node_info1 = self.node_data[i_node1]
         cdef NodeData_t node_info2 = other.node_data[i_node2]
 
-        cdef {{INPUT_DTYPE_t}}* data1 = &self.data[0, 0]
-        cdef {{INPUT_DTYPE_t}}* data2 = &other.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data1 = &self.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data2 = &other.data[0, 0]
         cdef intp_t n_features = self.data.shape[1]
 
         cdef float64_t bound_max, dist_pt, reduced_dist_LB1, reduced_dist_LB2
@@ -1826,11 +1826,11 @@ cdef class BinaryTree{{name_suffix}}:
         cdef intp_t i, i1, i2, i_node1, i_node2, i_pt
         cdef float64_t dist_pt, reduced_dist_LB
         cdef float64_t[::1] bounds = np.full(other.node_data.shape[0], np.inf)
-        cdef NodeData_t* node_data1 = &self.node_data[0]
-        cdef NodeData_t* node_data2 = &other.node_data[0]
+        cdef const NodeData_t* node_data1 = &self.node_data[0]
+        cdef const NodeData_t* node_data2 = &other.node_data[0]
         cdef NodeData_t node_info1, node_info2
-        cdef {{INPUT_DTYPE_t}}* data1 = &self.data[0, 0]
-        cdef {{INPUT_DTYPE_t}}* data2 = &other.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data1 = &self.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data2 = &other.data[0, 0]
         cdef intp_t n_features = self.data.shape[1]
 
         # Set up the node heap and push the head nodes onto it
@@ -1906,7 +1906,7 @@ cdef class BinaryTree{{name_suffix}}:
     cdef intp_t _query_radius_single(
         self,
         intp_t i_node,
-        {{INPUT_DTYPE_t}}* pt,
+        const {{INPUT_DTYPE_t}}* pt,
         float64_t r,
         intp_t* indices,
         {{INPUT_DTYPE_t}}* distances,
@@ -1915,7 +1915,7 @@ cdef class BinaryTree{{name_suffix}}:
         int return_distance,
     ) noexcept nogil:
         """recursive single-tree radius query, depth-first"""
-        cdef {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
         cdef intp_t* idx_array = &self.idx_array[0]
         cdef intp_t n_features = self.data.shape[1]
         cdef NodeData_t node_info = self.node_data[i_node]
@@ -1983,7 +1983,7 @@ cdef class BinaryTree{{name_suffix}}:
         return count
 
     cdef float64_t _kde_single_breadthfirst(
-        self, {{INPUT_DTYPE_t}}* pt,
+        self, const {{INPUT_DTYPE_t}}* pt,
         KernelType kernel,
         float64_t h,
         float64_t log_knorm,
@@ -2006,13 +2006,13 @@ cdef class BinaryTree{{name_suffix}}:
         cdef float64_t global_log_min_bound, global_log_bound_spread
         cdef float64_t global_log_max_bound
 
-        cdef {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
         cdef bint with_sample_weight = self.sample_weight is not None
-        cdef {{INPUT_DTYPE_t}}* sample_weight
+        cdef const {{INPUT_DTYPE_t}}* sample_weight
         if with_sample_weight:
             sample_weight = &self.sample_weight[0]
         cdef intp_t* idx_array = &self.idx_array[0]
-        cdef NodeData_t* node_data = &self.node_data[0]
+        cdef const NodeData_t* node_data = &self.node_data[0]
         cdef float64_t N
         cdef float64_t log_weight
         if with_sample_weight:
@@ -2153,7 +2153,7 @@ cdef class BinaryTree{{name_suffix}}:
     cdef int _kde_single_depthfirst(
         self,
         intp_t i_node,
-        {{INPUT_DTYPE_t}}* pt,
+        const {{INPUT_DTYPE_t}}* pt,
         KernelType kernel,
         float64_t h,
         float64_t log_knorm,
@@ -2173,10 +2173,10 @@ cdef class BinaryTree{{name_suffix}}:
         cdef intp_t i, i1, i2, iw, start, end
         cdef float64_t N1, N2
 
-        cdef {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
-        cdef NodeData_t* node_data = &self.node_data[0]
+        cdef const {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
+        cdef const NodeData_t* node_data = &self.node_data[0]
         cdef bint with_sample_weight = self.sample_weight is not None
-        cdef {{INPUT_DTYPE_t}}* sample_weight
+        cdef const {{INPUT_DTYPE_t}}* sample_weight
         cdef float64_t log_weight
         if with_sample_weight:
             sample_weight = &self.sample_weight[0]
@@ -2295,14 +2295,14 @@ cdef class BinaryTree{{name_suffix}}:
     cdef int _two_point_single(
         self,
         intp_t i_node,
-        {{INPUT_DTYPE_t}}* pt,
+        const {{INPUT_DTYPE_t}}* pt,
         float64_t* r,
         intp_t* count,
         intp_t i_min,
         intp_t i_max,
     ) except -1:
         """recursive single-tree two-point correlation function query"""
-        cdef {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
         cdef intp_t* idx_array = &self.idx_array[0]
         cdef intp_t n_features = self.data.shape[1]
         cdef NodeData_t node_info = self.node_data[i_node]
@@ -2358,8 +2358,8 @@ cdef class BinaryTree{{name_suffix}}:
         intp_t i_max,
     ) except -1:
         """recursive dual-tree two-point correlation function query"""
-        cdef {{INPUT_DTYPE_t}}* data1 = &self.data[0, 0]
-        cdef {{INPUT_DTYPE_t}}* data2 = &other.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data1 = &self.data[0, 0]
+        cdef const {{INPUT_DTYPE_t}}* data2 = &other.data[0, 0]
         cdef intp_t* idx_array1 = &self.idx_array[0]
         cdef intp_t* idx_array2 = &other.idx_array[0]
         cdef NodeData_t node_info1 = self.node_data[i_node1]
@@ -2469,9 +2469,9 @@ def nodeheap_sort(float64_t[::1] vals):
 
 
 cdef inline float64_t _total_node_weight(
-    NodeData_t* node_data,
+    const NodeData_t* node_data,
     const floating* sample_weight,
-    intp_t* idx_array,
+    const intp_t* idx_array,
     intp_t i_node,
 ):
     cdef intp_t i

--- a/sklearn/neighbors/_kd_tree.pyx.tp
+++ b/sklearn/neighbors/_kd_tree.pyx.tp
@@ -84,10 +84,10 @@ cdef int init_node{{name_suffix}}(
 
     cdef {{INPUT_DTYPE_t}}* lower_bounds = &tree.node_bounds[0, i_node, 0]
     cdef {{INPUT_DTYPE_t}}* upper_bounds = &tree.node_bounds[1, i_node, 0]
-    cdef {{INPUT_DTYPE_t}}* data = &tree.data[0, 0]
-    cdef intp_t* idx_array = &tree.idx_array[0]
+    cdef const {{INPUT_DTYPE_t}}* data = &tree.data[0, 0]
+    cdef const intp_t* idx_array = &tree.idx_array[0]
 
-    cdef {{INPUT_DTYPE_t}}* data_row
+    cdef const {{INPUT_DTYPE_t}}* data_row
 
     # determine Node bounds
     for j in range(n_features):
@@ -123,7 +123,7 @@ cdef int init_node{{name_suffix}}(
 cdef float64_t min_rdist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
 ) except -1 nogil:
     """Compute the minimum reduced-distance between a point and a node"""
     cdef intp_t n_features = tree.data.shape[1]
@@ -150,7 +150,7 @@ cdef float64_t min_rdist{{name_suffix}}(
 cdef float64_t min_dist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
 ) except -1:
     """Compute the minimum distance between a point and a node"""
     if tree.dist_metric.p == INF:
@@ -165,7 +165,7 @@ cdef float64_t min_dist{{name_suffix}}(
 cdef float64_t max_rdist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
 ) except -1:
     """Compute the maximum reduced-distance between a point and a node"""
     cdef intp_t n_features = tree.data.shape[1]
@@ -189,7 +189,7 @@ cdef float64_t max_rdist{{name_suffix}}(
 cdef float64_t max_dist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
 ) except -1:
     """Compute the maximum distance between a point and a node"""
     if tree.dist_metric.p == INF:
@@ -204,7 +204,7 @@ cdef float64_t max_dist{{name_suffix}}(
 cdef inline int min_max_dist{{name_suffix}}(
     BinaryTree{{name_suffix}} tree,
     intp_t i_node,
-    {{INPUT_DTYPE_t}}* pt,
+    const {{INPUT_DTYPE_t}}* pt,
     float64_t* min_dist,
     float64_t* max_dist,
 ) except -1 nogil:

--- a/sklearn/neighbors/_partition_nodes.pxd
+++ b/sklearn/neighbors/_partition_nodes.pxd
@@ -2,7 +2,7 @@ from cython cimport floating
 from ..utils._typedefs cimport float64_t, intp_t
 
 cdef int partition_node_indices(
-        floating *data,
+        const floating *data,
         intp_t *node_indices,
         intp_t split_dim,
         intp_t split_index,

--- a/sklearn/neighbors/_partition_nodes.pyx
+++ b/sklearn/neighbors/_partition_nodes.pyx
@@ -56,7 +56,7 @@ cdef extern from *:
     }
     """
     void partition_node_indices_inner[D, I](
-                D *data,
+                const D *data,
                 I *node_indices,
                 I split_dim,
                 I split_index,
@@ -65,7 +65,7 @@ cdef extern from *:
 
 
 cdef int partition_node_indices(
-        floating *data,
+        const floating *data,
         intp_t *node_indices,
         intp_t split_dim,
         intp_t split_index,


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
This PR updates the usage of `const` throughout the `{Ball, KD}Tree` classes to more accurately reflect usage, and to mitigate permissive changes.

#### Any other comments?
I set the language to `c++` to more easily see where permissive casts were being performed. Switching the language on these files to `c++` is **not necessary**, and will be reverted once the PR is closer to being complete.

Currently, tests are failing due to the change in `readonly` behavior since now `idx_array` is _no longer `const`_. However, I believe it needs to be non-`const` since `partition_nodes` uses `std::nth_element` on the index, and `std::nth_element` explicitly reorders the memory afaik.

I'm not sure if there's something else going on, since if my understanding is correct then we really shouldn't have been able to get away with this in the first place, right?

cc: @jjerphan