### PR TITLE
TST Extend tests for `scipy.sparse.*array` in `sklearn/decomposition/tests/test_incremental_pca.py`

### DIFF
--- a/sklearn/decomposition/tests/test_incremental_pca.py
+++ b/sklearn/decomposition/tests/test_incremental_pca.py
@@ -4,7 +4,6 @@ import warnings
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
-from scipy import sparse
 
 from sklearn import datasets
 from sklearn.decomposition import PCA, IncrementalPCA
@@ -13,6 +12,7 @@ from sklearn.utils._testing import (
     assert_almost_equal,
     assert_array_almost_equal,
 )
+from sklearn.utils.fixes import CSC_CONTAINERS, CSR_CONTAINERS, LIL_CONTAINERS
 
 iris = datasets.load_iris()
 
@@ -45,14 +45,14 @@ def test_incremental_pca():
 
 
 @pytest.mark.parametrize(
-    "matrix_class", [sparse.csc_matrix, sparse.csr_matrix, sparse.lil_matrix]
+    "sparse_container", CSC_CONTAINERS + CSR_CONTAINERS + LIL_CONTAINERS
 )
-def test_incremental_pca_sparse(matrix_class):
+def test_incremental_pca_sparse(sparse_container):
     # Incremental PCA on sparse arrays.
     X = iris.data
     pca = PCA(n_components=2)
     pca.fit_transform(X)
-    X_sparse = matrix_class(X)
+    X_sparse = sparse_container(X)
     batch_size = X_sparse.shape[0] // 3
     ipca = IncrementalPCA(n_components=2, batch_size=batch_size)
 


### PR DESCRIPTION
Towards #27090.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
