### PR TITLE
ENH Add Array API compatibility to `zero_one_loss` and `accuracy_score`

### DIFF
--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -99,6 +99,12 @@ Estimators
 - :class:`preprocessing.MaxAbsScaler`
 - :class:`preprocessing.MinMaxScaler`
 
+Metrics
+-------
+
+- :func:`sklearn.metrics.accuracy_score`
+- :func:`sklearn.metrics.zero_one_loss`
+
 Tools
 -----
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -220,7 +220,7 @@ Changelog
   :pr:`26931` by `Thomas Fan`_.
 
 - |MajorFeature| :class:`preprocessing.MinMaxScaler` and :class:`preprocessing.MaxAbsScaler` now
-  supports the `Array API <https://data-apis.org/array-api/latest/>`_. Array API
+  support the `Array API <https://data-apis.org/array-api/latest/>`_. Array API
   support is considered experimental and might evolve without being subject to
   our usual rolling deprecation cycle policy. See
   :ref:`array_api` for more details. :pr:`26243` by `Tim Head`_ and :pr:`27110` by :user:`Edoardo Abati <EdAbati>`.
@@ -263,6 +263,9 @@ Changelog
   classes. the x- and y-axis limits are set to [0, 1] and the aspect ratio between
   both axis is set to be 1 to get a square plot.
   :pr:`26366` by :user:`Mojdeh Rastgoo <mrastgoo>`.
+
+- |Enhancement| :func:`sklearn.metrics.accuracy_score` and :func:`sklearn.metrics.zero_one_loss` now support
+  Array API compatible inputs. :pr:`27137` by :user:`Edoardo Abati <EdAbati>`.
 
 :mod:`sklearn.utils`
 ....................

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -12,7 +12,7 @@ from sklearn.datasets import load_iris
 from sklearn.decomposition import PCA
 from sklearn.decomposition._pca import _assess_dimension, _infer_dimension
 from sklearn.utils._array_api import (
-    _array_api_atol,
+    _atol_for_type,
     _convert_to_numpy,
     yield_namespace_device_dtype_combinations,
 )
@@ -718,7 +718,7 @@ def check_array_api_get_precision(name, estimator, array_namepsace, device, dtyp
         assert_allclose(
             _convert_to_numpy(precision_xp, xp=xp),
             precision_np,
-            atol=_array_api_atol(dtype),
+            atol=_atol_for_type(dtype),
         )
         covariance_xp = estimator_xp.get_covariance()
         assert covariance_xp.shape == (4, 4)
@@ -727,7 +727,7 @@ def check_array_api_get_precision(name, estimator, array_namepsace, device, dtyp
         assert_allclose(
             _convert_to_numpy(covariance_xp, xp=xp),
             covariance_np,
-            atol=_array_api_atol(dtype),
+            atol=_atol_for_type(dtype),
         )
 
 

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -16,9 +16,8 @@ from sklearn.utils._array_api import (
     _convert_to_numpy,
     yield_namespace_device_dtype_combinations,
 )
-from sklearn.utils._testing import assert_allclose
+from sklearn.utils._testing import _array_api_for_tests, assert_allclose
 from sklearn.utils.estimator_checks import (
-    _array_api_for_tests,
     _get_check_estimator_ids,
     check_array_api_input_and_values,
 )

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -12,6 +12,7 @@ from sklearn.datasets import load_iris
 from sklearn.decomposition import PCA
 from sklearn.decomposition._pca import _assess_dimension, _infer_dimension
 from sklearn.utils._array_api import (
+    _array_api_atol,
     _convert_to_numpy,
     yield_namespace_device_dtype_combinations,
 )
@@ -715,7 +716,7 @@ def check_array_api_get_precision(name, estimator, array_namepsace, device, dtyp
         assert_allclose(
             _convert_to_numpy(precision_xp, xp=xp),
             precision_np,
-            atol=np.finfo(dtype).eps * 100,
+            atol=_array_api_atol(dtype),
         )
         covariance_xp = estimator_xp.get_covariance()
         assert covariance_xp.shape == (4, 4)
@@ -724,7 +725,7 @@ def check_array_api_get_precision(name, estimator, array_namepsace, device, dtyp
         assert_allclose(
             _convert_to_numpy(covariance_xp, xp=xp),
             covariance_np,
-            atol=np.finfo(dtype).eps * 100,
+            atol=_array_api_atol(dtype),
         )
 
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1046,6 +1046,7 @@ def zero_one_loss(y_true, y_pred, *, normalize=True, sample_weight=None):
     >>> zero_one_loss(np.array([[0, 1], [1, 1]]), np.ones((2, 2)))
     0.5
     """
+    xp, _ = get_namespace(y_true, y_pred)
     score = accuracy_score(
         y_true, y_pred, normalize=normalize, sample_weight=sample_weight
     )
@@ -1054,7 +1055,7 @@ def zero_one_loss(y_true, y_pred, *, normalize=True, sample_weight=None):
         return 1 - score
     else:
         if sample_weight is not None:
-            n_samples = np.sum(sample_weight)
+            n_samples = xp.sum(sample_weight)
         else:
             n_samples = _num_samples(y_true)
         return n_samples - score

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -55,7 +55,7 @@ from sklearn.metrics._base import _average_binary_score
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.utils import shuffle
 from sklearn.utils._array_api import (
-    _array_api_atol,
+    _atol_for_type,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._testing import (
@@ -1746,7 +1746,7 @@ def check_array_api_metric(
         assert_allclose(
             metric_xp,
             metric_np,
-            atol=_array_api_atol(dtype),
+            atol=_atol_for_type(dtype),
         )
 
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -59,13 +59,13 @@ from sklearn.utils._array_api import (
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._testing import (
+    _array_api_for_tests,
     assert_allclose,
     assert_almost_equal,
     assert_array_equal,
     assert_array_less,
     ignore_warnings,
 )
-from sklearn.utils.estimator_checks import _array_api_for_tests
 from sklearn.utils.multiclass import type_of_target
 from sklearn.utils.validation import _num_samples, check_random_state
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1730,14 +1730,12 @@ def test_metrics_pos_label_error_str(metric, y_pred_threshold, dtype_y_str):
         metric(y1, y2)
 
 
-def check_array_api_metric(metric, array_namespace, _device, dtype):
-    xp, _device, dtype = _array_api_for_tests(array_namespace, _device, dtype)
-    # y_true_np = np.array([0, 2, 1, 3])
-    # y_pred_np = np.array([0, 1, 2, 3])
+def check_array_api_metric(metric, array_namespace, device, dtype):
+    xp, device, dtype = _array_api_for_tests(array_namespace, device, dtype)
     y_true_np = np.array([0, 0, 1, 1])
     y_pred_np = np.array([0, 1, 0, 1])
-    y_true_xp = xp.asarray(y_true_np, device=_device)
-    y_pred_xp = xp.asarray(y_pred_np, device=_device)
+    y_true_xp = xp.asarray(y_true_np, device=device)
+    y_pred_xp = xp.asarray(y_pred_np, device=device)
 
     metric_np = metric(y_true_np, y_pred_np)
 
@@ -1756,11 +1754,7 @@ def check_array_api_metric(metric, array_namespace, _device, dtype):
 )
 @pytest.mark.parametrize(
     "metric",
-    [
-        accuracy_score,
-        zero_one_loss,
-        partial(zero_one_loss, sample_weight=[1, 2, 3, 4]),
-    ],
+    [accuracy_score, zero_one_loss],
 )
 def test_array_api_compliance(metric, array_namespace, device, dtype):
     check_array_api_metric(metric, array_namespace, device, dtype)

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1797,9 +1797,6 @@ def yield_metric_checker_combinations(metric_checkers=metric_checkers):
 @pytest.mark.parametrize(
     "array_namespace, device, dtype", yield_namespace_device_dtype_combinations()
 )
-@pytest.mark.parametrize(
-    "metric, check_func",
-    yield_metric_checker_combinations(),
-)
+@pytest.mark.parametrize("metric, check_func", yield_metric_checker_combinations())
 def test_array_api_compliance(metric, array_namespace, device, dtype, check_func):
     check_func(metric, array_namespace, device, dtype)

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -468,7 +468,7 @@ def _weighted_sum(sample_score, sample_weight, normalize=False, xp=None):
         sample_score = xp.astype(xp.asarray(sample_score, device="cpu"), xp.float64)
 
     if sample_weight is not None:
-        sample_weight = xp.asarray(sample_weight)
+        sample_weight = xp.asarray(sample_weight, dtype=sample_score.dtype)
         if not xp.isdtype(sample_weight.dtype, "real floating"):
             sample_weight = xp.astype(sample_weight, xp.float64)
 

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -592,6 +592,6 @@ def _estimator_with_converted_arrays(estimator, converter):
     return new_estimator
 
 
-def _array_api_atol(dtype):
+def _atol_for_type(dtype):
     """Return the absolute tolerance for a given dtype."""
     return numpy.finfo(dtype).eps * 100

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -590,3 +590,8 @@ def _estimator_with_converted_arrays(estimator, converter):
             attribute = converter(attribute)
         setattr(new_estimator, key, attribute)
     return new_estimator
+
+
+def _array_api_atol(dtype):
+    """Return the absolute tolerance for a given dtype."""
+    return numpy.finfo(dtype).eps * 100

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -185,8 +185,12 @@ def test_asarray_with_order_ignored():
 def test_weighted_sum(
     array_namespace, device, dtype, sample_weight, normalize, expected
 ):
-    xp, device, _ = _array_api_for_tests(array_namespace, device, dtype)
-    sample_score = xp.asarray([1, 2, 3, 4])
+    xp, device, dtype = _array_api_for_tests(array_namespace, device, dtype)
+    sample_score = numpy.asarray([1, 2, 3, 4], dtype=dtype)
+    sample_score = xp.asarray(sample_score, device=device)
+    if sample_weight is not None:
+        sample_weight = numpy.asarray(sample_weight, dtype=dtype)
+        sample_weight = xp.asarray(sample_weight, device=device)
 
     with config_context(array_api_dispatch=True):
         result = _weighted_sum(sample_score, sample_weight, normalize)

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -176,8 +176,10 @@ def test_asarray_with_order_ignored():
     [
         (None, False, 10.0),
         (None, True, 2.5),
-        ([0.1, 0.2, 0.3, 0.4], False, 3.0),
-        ([0.1, 0.2, 0.3, 0.4], True, 3.0),
+        ([0.4, 0.4, 0.5, 0.7], False, 5.5),
+        ([0.4, 0.4, 0.5, 0.7], True, 2.75),
+        ([1, 2, 3, 4], False, 30.0),
+        ([1, 2, 3, 4], True, 3.0),
     ],
 )
 def test_weighted_sum(

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -20,8 +20,10 @@ from sklearn.utils._array_api import (
     supported_float_dtypes,
     yield_namespace_device_dtype_combinations,
 )
-from sklearn.utils._testing import skip_if_array_api_compat_not_configured
-from sklearn.utils.estimator_checks import _array_api_for_tests
+from sklearn.utils._testing import (
+    _array_api_for_tests,
+    skip_if_array_api_compat_not_configured,
+)
 
 pytestmark = pytest.mark.filterwarnings(
     "ignore:The numpy.array_api submodule:UserWarning"

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 from sklearn._config import config_context
 from sklearn.base import BaseEstimator
 from sklearn.utils._array_api import (
+    _array_api_atol,
     _ArrayAPIWrapper,
     _asarray_with_order,
     _convert_to_numpy,
@@ -189,7 +190,7 @@ def test_weighted_sum(
         result = _weighted_sum(sample_score, sample_weight, normalize)
 
     assert isinstance(result, float)
-    assert_allclose(result, expected)
+    assert_allclose(result, expected, atol=_array_api_atol(dtype))
 
 
 @skip_if_array_api_compat_not_configured

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -14,10 +14,13 @@ from sklearn.utils._array_api import (
     _nanmax,
     _nanmin,
     _NumPyAPIWrapper,
+    _weighted_sum,
     get_namespace,
     supported_float_dtypes,
+    yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._testing import skip_if_array_api_compat_not_configured
+from sklearn.utils.estimator_checks import _array_api_for_tests
 
 pytestmark = pytest.mark.filterwarnings(
     "ignore:The numpy.array_api submodule:UserWarning"
@@ -162,6 +165,31 @@ def test_asarray_with_order_ignored():
     X_new_np = numpy.asarray(X_new)
     assert X_new_np.flags["C_CONTIGUOUS"]
     assert not X_new_np.flags["F_CONTIGUOUS"]
+
+
+@pytest.mark.parametrize(
+    "array_namespace, device, dtype", yield_namespace_device_dtype_combinations()
+)
+@pytest.mark.parametrize(
+    "sample_weight, normalize, expected",
+    [
+        (None, False, 10.0),
+        (None, True, 2.5),
+        ([0.1, 0.2, 0.3, 0.4], False, 3.0),
+        ([0.1, 0.2, 0.3, 0.4], True, 3.0),
+    ],
+)
+def test_weighted_sum(
+    array_namespace, device, dtype, sample_weight, normalize, expected
+):
+    xp, device, _ = _array_api_for_tests(array_namespace, device, dtype)
+    sample_score = xp.asarray([1, 2, 3, 4])
+
+    with config_context(array_api_dispatch=True):
+        result = _weighted_sum(sample_score, sample_weight, normalize)
+
+    assert isinstance(result, float)
+    assert_allclose(result, expected)
 
 
 @skip_if_array_api_compat_not_configured

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -7,9 +7,9 @@ from numpy.testing import assert_allclose, assert_array_equal
 from sklearn._config import config_context
 from sklearn.base import BaseEstimator
 from sklearn.utils._array_api import (
-    _array_api_atol,
     _ArrayAPIWrapper,
     _asarray_with_order,
+    _atol_for_type,
     _convert_to_numpy,
     _estimator_with_converted_arrays,
     _nanmax,
@@ -192,7 +192,7 @@ def test_weighted_sum(
         result = _weighted_sum(sample_score, sample_weight, normalize)
 
     assert isinstance(result, float)
-    assert_allclose(result, expected, atol=_array_api_atol(dtype))
+    assert_allclose(result, expected, atol=_atol_for_type(dtype))
 
 
 @skip_if_array_api_compat_not_configured


### PR DESCRIPTION
#### Reference Issues/PRs

Towards https://github.com/scikit-learn/scikit-learn/issues/26024

#### What does this implement/fix? Explain your changes.

It makes the `zero_one_loss` and `accuracy_score`(since it was a dependency) implementations compatible and tested with the Array API.

#### Any other comments?

- I have added a test for `_weighted_sum`. When having `sample_weights` as floats I got the following from PyTorch:
  ```
  >           return float(sample_score @ sample_weight)
  E           RuntimeError: dot : expected both vectors to have same dtype, but found Double and Float
  ```
- It feels like I am missing some cases in the tests. For example, should I test with a `y_true` and `y_pred` that is not from binary classification? 🤔
