### PR TITLE
TST Extend tests for `scipy.sparse.*array` in `sklearn/decomposition/tests/test_kernel_pca.py`

### DIFF
--- a/sklearn/decomposition/tests/test_kernel_pca.py
+++ b/sklearn/decomposition/tests/test_kernel_pca.py
@@ -2,7 +2,6 @@ import warnings
 
 import numpy as np
 import pytest
-import scipy.sparse as sp
 
 from sklearn.datasets import make_blobs, make_circles
 from sklearn.decomposition import PCA, KernelPCA
@@ -17,6 +16,7 @@ from sklearn.utils._testing import (
     assert_array_almost_equal,
     assert_array_equal,
 )
+from sklearn.utils.fixes import CSR_CONTAINERS
 from sklearn.utils.validation import _check_psd_eigenvalues
 
 
@@ -116,15 +116,16 @@ def test_kernel_pca_deterministic_output():
         assert_allclose(transformed_X, np.tile(transformed_X[0, :], 20).reshape(20, 2))
 
 
-def test_kernel_pca_sparse():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_kernel_pca_sparse(csr_container):
     """Test that kPCA works on a sparse data input.
 
     Same test as ``test_kernel_pca except inverse_transform`` since it's not
     implemented for sparse matrices.
     """
     rng = np.random.RandomState(0)
-    X_fit = sp.csr_matrix(rng.random_sample((5, 4)))
-    X_pred = sp.csr_matrix(rng.random_sample((2, 4)))
+    X_fit = csr_container(rng.random_sample((5, 4)))
+    X_pred = csr_container(rng.random_sample((2, 4)))
 
     for eigen_solver in ("auto", "arpack", "randomized"):
         for kernel in ("linear", "rbf", "poly"):


### PR DESCRIPTION

Towards #27090

