### PR TITLE
fix typo in HDBSCAN example

### DIFF
--- a/examples/cluster/plot_hdbscan.py
+++ b/examples/cluster/plot_hdbscan.py
@@ -107,7 +107,13 @@ fig, axes = plt.subplots(3, 1, figsize=(10, 12))
 hdb = HDBSCAN()
 for idx, scale in enumerate([1, 0.5, 3]):
     hdb.fit(X * scale)
-    plot(X * scale, hdb.labels_, hdb.probabilities_, ax=axes[idx], parameters={"scale": scale})
+    plot(
+        X * scale,
+        hdb.labels_,
+        hdb.probabilities_,
+        ax=axes[idx],
+        parameters={"scale": scale},
+    )
 # %%
 # Multi-Scale Clustering
 # ----------------------

--- a/examples/cluster/plot_hdbscan.py
+++ b/examples/cluster/plot_hdbscan.py
@@ -84,7 +84,7 @@ plot(X, labels=labels_true, ground_truth=True)
 # rescaled versions of the dataset.
 fig, axes = plt.subplots(3, 1, figsize=(10, 12))
 dbs = DBSCAN(eps=0.3)
-for idx, scale in enumerate((1, 0.5, 3)):
+for idx, scale in enumerate([1, 0.5, 3]):
     dbs.fit(X * scale)
     plot(X * scale, dbs.labels_, parameters={"scale": scale, "eps": 0.3}, ax=axes[idx])
 
@@ -105,9 +105,9 @@ plot(3 * X, dbs.labels_, parameters={"scale": 3, "eps": 0.9}, ax=axis)
 # One immediate advantage is that HDBSCAN is scale-invariant.
 fig, axes = plt.subplots(3, 1, figsize=(10, 12))
 hdb = HDBSCAN()
-for idx, scale in enumerate((1, 0.5, 3)):
-    hdb.fit(X)
-    plot(X, hdb.labels_, hdb.probabilities_, ax=axes[idx], parameters={"scale": scale})
+for idx, scale in enumerate([1, 0.5, 3]):
+    hdb.fit(X * scale)
+    plot(X * scale, hdb.labels_, hdb.probabilities_, ax=axes[idx], parameters={"scale": scale})
 # %%
 # Multi-Scale Clustering
 # ----------------------


### PR DESCRIPTION
The ` * scale` code was missed, even though it was intended to be there to illustrate the point

# What does this fix? Explain your changes.

On this page:
https://scikit-learn.org/stable/auto_examples/cluster/plot_hdbscan.html

The section "Scale Invariance" has:

> One immediate advantage is that HDBSCAN is scale-invariant.

The purpose of the code example that follows is to show that HDBSCAN is scale-invariant: that it will assign meaningful clusters to the scaled data, unlike the DBSCAN (which is right above it).

The original authors simply forgot to scale the data in the loop. 

---

I've tested my code changes - the HDBSCAN correctly assigns the clusters to the scaled data.
