### PR TITLE
Fix low level crash in BisectingKMeans.predict on rescaled data

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -18,6 +18,13 @@ Changes impacting all modules
 Changelog
 ---------
 
+:mod:`sklearn.cluster`
+......................
+
+- |Fix| :class:`cluster.BisectingKMeans` could crash when predicting on data
+  with a different scale than the data used to fit the model.
+  :pr:`27167` by `Olivier Grisel`_.
+
 :mod:`sklearn.impute`
 .....................
 

--- a/sklearn/cluster/_bisect_k_means.py
+++ b/sklearn/cluster/_bisect_k_means.py
@@ -508,25 +508,18 @@ class BisectingKMeans(_BaseKMeans):
             self._n_threads,
             return_inertia=False,
         )
-        first_cluster_mask = cluster_labels == 0
+        mask = cluster_labels == 0
 
         # Compute the labels for each subset of the data points.
         labels = np.full(X.shape[0], -1, dtype=np.int32)
 
-        if first_cluster_mask.any():
-            labels[first_cluster_mask] = self._predict_recursive(
-                X[first_cluster_mask],
-                sample_weight[first_cluster_mask],
-                cluster_node.left,
-            )
+        labels[mask] = self._predict_recursive(
+            X[mask], sample_weight[mask], cluster_node.left
+        )
 
-        other_cluster_mask = ~first_cluster_mask
-        if other_cluster_mask.any():
-            labels[other_cluster_mask] = self._predict_recursive(
-                X[other_cluster_mask],
-                sample_weight[other_cluster_mask],
-                cluster_node.right,
-            )
+        labels[~mask] = self._predict_recursive(
+            X[~mask], sample_weight[~mask], cluster_node.right
+        )
 
         return labels
 

--- a/sklearn/cluster/_bisect_k_means.py
+++ b/sklearn/cluster/_bisect_k_means.py
@@ -508,18 +508,25 @@ class BisectingKMeans(_BaseKMeans):
             self._n_threads,
             return_inertia=False,
         )
-        mask = cluster_labels == 0
+        first_cluster_mask = cluster_labels == 0
 
         # Compute the labels for each subset of the data points.
         labels = np.full(X.shape[0], -1, dtype=np.int32)
 
-        labels[mask] = self._predict_recursive(
-            X[mask], sample_weight[mask], cluster_node.left
-        )
+        if first_cluster_mask.any():
+            labels[first_cluster_mask] = self._predict_recursive(
+                X[first_cluster_mask],
+                sample_weight[first_cluster_mask],
+                cluster_node.left,
+            )
 
-        labels[~mask] = self._predict_recursive(
-            X[~mask], sample_weight[~mask], cluster_node.right
-        )
+        other_cluster_mask = ~first_cluster_mask
+        if other_cluster_mask.any():
+            labels[other_cluster_mask] = self._predict_recursive(
+                X[other_cluster_mask],
+                sample_weight[other_cluster_mask],
+                cluster_node.right,
+            )
 
         return labels
 

--- a/sklearn/cluster/_k_means_elkan.pyx
+++ b/sklearn/cluster/_k_means_elkan.pyx
@@ -264,7 +264,7 @@ def elkan_iter_chunked_dense(
         int n_clusters = centers_new.shape[0]
 
     if n_samples == 0:
-        # An empty array was passed, do no thing and return early (before
+        # An empty array was passed, do nothing and return early (before
         # attempting to compute n_chunks). This can typically happen when
         # calling the prediction function of a bisecting k-means model with a
         # large fraction of outiers.
@@ -507,7 +507,7 @@ def elkan_iter_chunked_sparse(
         int n_clusters = centers_new.shape[0]
 
     if n_samples == 0:
-        # An empty array was passed, do no thing and return early (before
+        # An empty array was passed, do nothing and return early (before
         # attempting to compute n_chunks). This can typically happen when
         # calling the prediction function of a bisecting k-means model with a
         # large fraction of outiers.

--- a/sklearn/cluster/_k_means_elkan.pyx
+++ b/sklearn/cluster/_k_means_elkan.pyx
@@ -263,6 +263,14 @@ def elkan_iter_chunked_dense(
         int n_features = X.shape[1]
         int n_clusters = centers_new.shape[0]
 
+    if n_samples == 0:
+        # An empty array was passed, do no thing and return early (before
+        # attempting to compute n_chunks). This can typically happen when
+        # calling the prediction function of a bisecting k-means model with a
+        # large fraction of outiers.
+        return
+
+    cdef:
         # hard-coded number of samples per chunk. Splitting in chunks is
         # necessary to get parallelism. Chunk size chosen to be same as lloyd's
         int n_samples_chunk = CHUNK_SIZE if n_samples > CHUNK_SIZE else n_samples
@@ -498,6 +506,14 @@ def elkan_iter_chunked_sparse(
         int n_features = X.shape[1]
         int n_clusters = centers_new.shape[0]
 
+    if n_samples == 0:
+        # An empty array was passed, do no thing and return early (before
+        # attempting to compute n_chunks). This can typically happen when
+        # calling the prediction function of a bisecting k-means model with a
+        # large fraction of outiers.
+        return
+
+    cdef:
         floating[::1] X_data = X.data
         int[::1] X_indices = X.indices
         int[::1] X_indptr = X.indptr

--- a/sklearn/cluster/_k_means_lloyd.pyx
+++ b/sklearn/cluster/_k_means_lloyd.pyx
@@ -82,6 +82,13 @@ def lloyd_iter_chunked_dense(
         int n_features = X.shape[1]
         int n_clusters = centers_old.shape[0]
 
+    if n_samples == 0:
+        # An empty array was passed, avoid divide-by-zero error later. It's
+        # useless to call this function this way, but let's avoid low level
+        # errors in case there is a bug in the calling Python code.
+        return
+
+    cdef:
         # hard-coded number of samples per chunk. Appeared to be close to
         # optimal in all situations.
         int n_samples_chunk = CHUNK_SIZE if n_samples > CHUNK_SIZE else n_samples
@@ -267,12 +274,18 @@ def lloyd_iter_chunked_sparse(
           the algorithm. This is useful especially when calling predict on a
           fitted model.
     """
-    # print(X.indices.dtype)
     cdef:
         int n_samples = X.shape[0]
         int n_features = X.shape[1]
         int n_clusters = centers_old.shape[0]
 
+    if n_samples == 0:
+        # An empty array was passed, avoid divide-by-zero error later. It's
+        # useless to call this function this way, but let's avoid low level
+        # errors in case there is a bug in the calling Python code.
+        return
+
+    cdef:
         # Choose same as for dense. Does not have the same impact since with
         # sparse data the pairwise distances matrix is not precomputed.
         # However, splitting in chunks is necessary to get parallelism.

--- a/sklearn/cluster/_k_means_lloyd.pyx
+++ b/sklearn/cluster/_k_means_lloyd.pyx
@@ -83,9 +83,10 @@ def lloyd_iter_chunked_dense(
         int n_clusters = centers_old.shape[0]
 
     if n_samples == 0:
-        # An empty array was passed, avoid divide-by-zero error later. It's
-        # useless to call this function this way, but let's avoid low level
-        # errors in case there is a bug in the calling Python code.
+        # An empty array was passed, do no thing and return early (before
+        # attempting to compute n_chunks). This can typically happen when
+        # calling the prediction function of a bisecting k-means model with a
+        # large fraction of outiers.
         return
 
     cdef:
@@ -280,9 +281,10 @@ def lloyd_iter_chunked_sparse(
         int n_clusters = centers_old.shape[0]
 
     if n_samples == 0:
-        # An empty array was passed, avoid divide-by-zero error later. It's
-        # useless to call this function this way, but let's avoid low level
-        # errors in case there is a bug in the calling Python code.
+        # An empty array was passed, do no thing and return early (before
+        # attempting to compute n_chunks). This can typically happen when
+        # calling the prediction function of a bisecting k-means model with a
+        # large fraction of outiers.
         return
 
     cdef:

--- a/sklearn/cluster/_k_means_lloyd.pyx
+++ b/sklearn/cluster/_k_means_lloyd.pyx
@@ -83,7 +83,7 @@ def lloyd_iter_chunked_dense(
         int n_clusters = centers_old.shape[0]
 
     if n_samples == 0:
-        # An empty array was passed, do no thing and return early (before
+        # An empty array was passed, do nothing and return early (before
         # attempting to compute n_chunks). This can typically happen when
         # calling the prediction function of a bisecting k-means model with a
         # large fraction of outiers.
@@ -281,7 +281,7 @@ def lloyd_iter_chunked_sparse(
         int n_clusters = centers_old.shape[0]
 
     if n_samples == 0:
-        # An empty array was passed, do no thing and return early (before
+        # An empty array was passed, do nothing and return early (before
         # attempting to compute n_chunks). This can typically happen when
         # calling the prediction function of a bisecting k-means model with a
         # large fraction of outiers.

--- a/sklearn/cluster/tests/test_bisect_k_means.py
+++ b/sklearn/cluster/tests/test_bisect_k_means.py
@@ -135,7 +135,7 @@ def test_float32_float64_equivalence(csr_container):
     assert_array_equal(km32.labels_, km64.labels_)
 
 
-@pytest.mark.parametrize("algorithm", ("lloyd", "elkan")):
+@pytest.mark.parametrize("algorithm", ("lloyd", "elkan"))
 def test_no_crash_on_empty_bisections(algorithm):
     # Non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/27081

--- a/sklearn/cluster/tests/test_bisect_k_means.py
+++ b/sklearn/cluster/tests/test_bisect_k_means.py
@@ -133,3 +133,17 @@ def test_float32_float64_equivalence(csr_container):
 
     assert_allclose(km32.cluster_centers_, km64.cluster_centers_)
     assert_array_equal(km32.labels_, km64.labels_)
+
+
+def test_non_regression_segfault_on_empty_bisections():
+    # Non-regression test for:
+    # https://github.com/scikit-learn/scikit-learn/issues/27081
+    rng = np.random.RandomState(0)
+    X_train = rng.rand(3000, 10)
+    bkm = BisectingKMeans(n_clusters=10).fit(X_train)
+
+    # predict on scaled data to trigger pathologic case
+    # where the inner mask leads to empty bisections.
+    X_test = 50 * rng.rand(100, 10)
+    labels = bkm.predict(X_test)  # should not segfault
+    assert np.isin(np.unique(labels), np.arange(10)).all()

--- a/sklearn/cluster/tests/test_bisect_k_means.py
+++ b/sklearn/cluster/tests/test_bisect_k_means.py
@@ -135,12 +135,13 @@ def test_float32_float64_equivalence(csr_container):
     assert_array_equal(km32.labels_, km64.labels_)
 
 
-def test_non_regression_segfault_on_empty_bisections():
+@pytest.mark.parametrize("algorithm", ("lloyd", "elkan")):
+def test_no_crash_on_empty_bisections(algorithm):
     # Non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/27081
     rng = np.random.RandomState(0)
     X_train = rng.rand(3000, 10)
-    bkm = BisectingKMeans(n_clusters=10).fit(X_train)
+    bkm = BisectingKMeans(n_clusters=10, algorithm=algorithm).fit(X_train)
 
     # predict on scaled data to trigger pathologic case
     # where the inner mask leads to empty bisections.

--- a/sklearn/cluster/tests/test_bisect_k_means.py
+++ b/sklearn/cluster/tests/test_bisect_k_means.py
@@ -146,5 +146,5 @@ def test_no_crash_on_empty_bisections(algorithm):
     # predict on scaled data to trigger pathologic case
     # where the inner mask leads to empty bisections.
     X_test = 50 * rng.rand(100, 10)
-    labels = bkm.predict(X_test)  # should not segfault
+    labels = bkm.predict(X_test)  # should not crash with idiv by 0
     assert np.isin(np.unique(labels), np.arange(10)).all()


### PR DESCRIPTION
Fixes #27081.

I will first open this PR with the non-regression test that should hopefully make the macOS Intel CI workers segfault (for some reason, this bug seems to stay silent on other platforms)...

Then I will push a fix for the underlying root cause.