### PR TITLE
MAINT replace obj and grad in sigmoid calibration with private loss module

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -87,7 +87,7 @@ Changelog
 
 - |Enhancement| The internal objective and gradient of the `sigmoid` method
   of :class:`calibration.CalibratedClassifierCV` have been replaced by the
-  private loss module. :pr:27185 by :user:`Omar Salman <OmarManzoor>`.
+  private loss module. :pr:`27185` by :user:`Omar Salman <OmarManzoor>`.
 
 :mod:`sklearn.cluster`
 ............................

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -85,6 +85,10 @@ Changelog
   produce large prediction scores. Before it was numerically unstable.
   :pr:`26913` by :user:`Omar Salman <OmarManzoor>`.
 
+- |Enhancement| The internal objective and gradient of the `sigmoid` method
+  of :class:`calibration.CalibratedClassifierCV` have been replaced by the
+  private loss module. :pr:27185 by :user:`Omar Salman <OmarManzoor>`.
+
 :mod:`sklearn.cluster`
 ............................
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -890,16 +890,14 @@ def _sigmoid_calibration(
     bin_loss = HalfBinomialLoss()
 
     def loss_grad(AB):
-        P = bin_loss.link.inverse(-(AB[0] * F + AB[1]))
-        raw_prediction = bin_loss.link.link(P)
-        _loss, _grad = bin_loss.loss_gradient(
+        l, g = bin_loss.loss_gradient(
             y_true=T,
-            raw_prediction=raw_prediction,
+            raw_prediction=-(AB[0] * F + AB[1]),
             sample_weight=sample_weight,
         )
-        _grad = -_grad
-        grad = np.array([_grad @ F, _grad.sum()])
-        return _loss.sum(), grad
+        loss = l.sum()
+        grad = np.array([-g @ F, -g.sum()])
+        return loss, grad
 
     AB0 = np.array([0.0, log((prior0 + 1.0) / (prior1 + 1.0))])
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -907,8 +907,6 @@ def _sigmoid_calibration(
         method="L-BFGS-B",
         jac=True,
         options={
-            "iprint": 1,
-            "maxls": 50,
             "gtol": 1e-6,
             "ftol": 64 * np.finfo(float).eps,
         },

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -56,6 +56,7 @@ _DOCSTRING_IGNORES = [
     "sklearn.pipeline.make_union",
     "sklearn.utils.extmath.safe_sparse_dot",
     "sklearn.utils._joblib",
+    "HalfBinomialLoss",
 ]
 
 # Methods where y param should be ignored if y=None by default


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up of #26913

#### What does this implement/fix? Explain your changes.
- Replaces the objective and gradient in sigmoid calibration with the methods of the private loss module.
- Uses HalfBinomialLoss as the base loss.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
