### PR TITLE
CI Fix scipy-dev issues related to numpy 2.0 changes

### DIFF
--- a/sklearn/cluster/_hdbscan/_linkage.pyx
+++ b/sklearn/cluster/_hdbscan/_linkage.pyx
@@ -90,7 +90,7 @@ cpdef cnp.ndarray[MST_edge_t, ndim=1, mode='c'] mst_from_mutual_reachability(
     mst = np.empty(n_samples - 1, dtype=MST_edge_dtype)
     current_labels = np.arange(n_samples, dtype=np.int64)
     current_node = 0
-    min_reachability = np.full(n_samples, fill_value=np.infty, dtype=np.float64)
+    min_reachability = np.full(n_samples, fill_value=np.inf, dtype=np.float64)
     for i in range(0, n_samples - 1):
         label_filter = current_labels != current_node
         current_labels = current_labels[label_filter]
@@ -156,7 +156,7 @@ cpdef cnp.ndarray[MST_edge_t, ndim=1, mode='c'] mst_from_data_matrix(
     mst = np.empty(n_samples - 1, dtype=MST_edge_dtype)
 
     in_tree = np.zeros(n_samples, dtype=np.uint8)
-    min_reachability = np.full(n_samples, fill_value=np.infty, dtype=np.float64)
+    min_reachability = np.full(n_samples, fill_value=np.inf, dtype=np.float64)
     current_sources = np.ones(n_samples, dtype=np.int64)
 
     current_node = 0

--- a/sklearn/impute/tests/test_common.py
+++ b/sklearn/impute/tests/test_common.py
@@ -192,9 +192,9 @@ def test_imputation_adds_missing_indicator_if_add_indicator_is_true(
 
     Non-regression test for gh-26590.
     """
-    X_train = np.array([[0, np.NaN], [1, 2]])
+    X_train = np.array([[0, np.nan], [1, 2]])
 
-    # Test data where missing_value_test variable can be set to np.NaN or 1.
+    # Test data where missing_value_test variable can be set to np.nan or 1.
     X_test = np.array([[0, missing_value_test], [1, 2]])
 
     imputer.set_params(add_indicator=True)

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -414,7 +414,7 @@ def test_X_is_not_1D_pandas(method):
             np.object_,
         ),
         (np.array([["A", "cat"], ["B", "cat"]]), [["A", "B"], ["cat"]], np.str_),
-        (np.array([[1, 2], [np.nan, 2]]), [[1, np.nan], [2]], np.float_),
+        (np.array([[1, 2], [np.nan, 2]]), [[1, np.nan], [2]], np.float64),
         (
             np.array([["A", np.nan], [None, np.nan]], dtype=object),
             [["A", None], [np.nan]],

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -197,6 +197,6 @@ def _contents(data_module):
 # For +1.25 NumPy versions exceptions and warnings are being moved
 # to a dedicated submodule.
 if np_version >= parse_version("1.25.0"):
-    from numpy.exceptions import VisibleDeprecationWarning
+    from numpy.exceptions import ComplexWarning, VisibleDeprecationWarning
 else:
-    from numpy import VisibleDeprecationWarning  # type: ignore  # noqa
+    from numpy import ComplexWarning, VisibleDeprecationWarning  # type: ignore  # noqa

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1586,7 +1586,7 @@ def test_check_pandas_sparse_invalid(ntype1, ntype2):
 @pytest.mark.parametrize(
     "ntype1, ntype2, expected_subtype",
     [
-        ("longfloat", "longdouble", np.floating),
+        ("double", "longdouble", np.floating),
         ("float16", "half", np.floating),
         ("single", "float32", np.floating),
         ("double", "float64", np.floating),

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -21,12 +21,10 @@ import joblib
 import numpy as np
 import scipy.sparse as sp
 
-# mypy error: Module 'numpy.core.numeric' has no attribute 'ComplexWarning'
-from numpy.core.numeric import ComplexWarning  # type: ignore
-
 from .. import get_config as _get_config
 from ..exceptions import DataConversionWarning, NotFittedError, PositiveSpectrumWarning
 from ..utils._array_api import _asarray_with_order, _is_numpy_namespace, get_namespace
+from ..utils.fixes import ComplexWarning
 from ._isfinite import FiniteStatus, cy_isfinite
 from .fixes import _object_dtype_isnan
 


### PR DESCRIPTION
`numpy.core.numeric.ComplexWarning` was removed in numpy dev recently
https://github.com/numpy/numpy/pull/24376/files#diff-68601ddf5a8d7364167feb9c1546348682ed4adbd37ab7c24aa66a43fb874da5

This is causing the scipy-dev build to fail early see this [build](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=58382&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=ef785ae2-496b-5b02-9f0e-07a6c3ab3081) for example with the following stack-trace:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/vsts/work/1/s/sklearn/__init__.py", line 83, in <module>
    from .base import clone
  File "/home/vsts/work/1/s/sklearn/base.py", line 19, in <module>
    from .utils import _IS_32BIT
  File "/home/vsts/work/1/s/sklearn/utils/__init__.py", line 22, in <module>
    from ._param_validation import Integral, Interval, validate_params
  File "/home/vsts/work/1/s/sklearn/utils/_param_validation.py", line 15, in <module>
    from .validation import _is_arraylike_not_scalar
  File "/home/vsts/work/1/s/sklearn/utils/validation.py", line 25, in <module>
    from numpy.core.numeric import ComplexWarning  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ImportError: cannot import name 'ComplexWarning' from 'numpy.core.numeric' (/usr/share/miniconda/envs/testvenv/lib/python3.11/site-packages/numpy/core/numeric.py)
```

Edit: more fixes for numpy 2.0 changes while I was at it:
- `np.infty` -> `np.inf`
- `np.NaN` -> `np.nan`
- `np.float_` -> `np.float64`