### PR TITLE
FIX LogisticRegression's handling of the `tol` parameter with `solver="lbfgs"`

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -32,6 +32,14 @@ Changelog
   ``transform`` when ``add_indicator`` is set to ``True`` and missing values are observed
   during ``fit``. :pr:`26600` by :user:`Shreesha Kumar Bhat <Shreesha3112>`.
 
+:mode:`sklearn.linear_model`
+............................
+
+- |Fix| :class:`linear_model.LogisticRegression` with `solver="lbfgs"`
+  converges to a higher precision solution when setting `tol` to values orders
+  of magnitude smaller than the default value of `1e-4`. :pr:`27191` by
+  `Olivier Grisel`_.
+
 :mod:`sklearn.neighbors`
 ........................
 

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -782,6 +782,31 @@ def test_logistic_regression_solvers_multinomial(C, global_random_seed):
         )
 
 
+@pytest.mark.parametrize("solver", SOLVERS)
+def test_logistic_regression_progressive_tolerance(solver, global_random_seed):
+    # Check that progressively decreasing the tolerance leads larger number of
+    # iterations.
+    X, y = make_classification(
+        n_samples=100,
+        n_features=10,
+        n_informative=5,
+        n_classes=2,
+        random_state=global_random_seed,
+    )
+    n_iters = [
+        LogisticRegression(
+            solver=solver,
+            tol=tol,
+            max_iter=int(1e4),
+            random_state=global_random_seed,
+        )
+        .fit(X, y)
+        .n_iter_[0]
+        for tol in [1e-1, 1e-4, 1e-8]
+    ]
+    assert (np.diff(n_iters) > 0).all(), n_iters
+
+
 @pytest.mark.parametrize("weight", [{0: 0.1, 1: 0.2}, {0: 0.1, 1: 0.2, 2: 0.5}])
 @pytest.mark.parametrize("class_weight", ["weight", "balanced"])
 def test_logistic_regressioncv_class_weights(weight, class_weight):

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -763,9 +763,6 @@ def test_logistic_regression_solvers_multinomial(C, global_random_seed):
         "sag": int(1e5),
         "saga": int(1e5),
     }
-    multinomial_solvers = list(SOLVERS)
-    multinomial_solvers.remove("liblinear")
-    multinomial_solvers.remove("newton-cholesky")
     regressors = {
         solver: LogisticRegression(
             solver=solver,
@@ -773,7 +770,8 @@ def test_logistic_regression_solvers_multinomial(C, global_random_seed):
             max_iter=solver_specific_max_iter.get(solver, max_iter),
             **params,
         ).fit(X, y)
-        for solver in multinomial_solvers
+        for solver in SOLVERS
+        if solver not in ("liblinear", "newton-cholesky")
     }
 
     for solver_1, solver_2 in itertools.combinations(regressors, r=2):


### PR DESCRIPTION
I believe this fixes #18074.

This is a draft fix to set `ftol` while preserving the default behavior.

This PR is still a draft, here are some TODOs:

- [x] Inspect a full CI run to make sure that this fix does not break existing tests, or at least not for a good reason.
- [x] Check whether the linear scale between `gtol` and `ftol` is a good strategy: in particular does it cause problem for very low values of `tol`? It does not seem to be the case from the experiment in the first comment of this PR.
- [ ] In particular: review the difference with the stopping condition implemented for lbfgs in `_GeneralizedLinearRegressor`: https://github.com/scikit-learn/scikit-learn/pull/27191#issuecomment-1698639957
- [x] Plot objective function value for different values of tol with lbfgs against alternative solvers: https://github.com/scikit-learn/scikit-learn/pull/27191#issuecomment-1697004848
- [x] Add a non-regression test for #18074.
- [x] Add an entry to the changelog.

Note: this PR does not investigate the potential problem of scaling of the penalization term (#24752) but is probably a prerequisite to be able to conduct proper benchmarking with varying `tol` values.