### PR TITLE
Update getting_started.rst

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -97,7 +97,7 @@ the test data::
   >>> from sklearn.pipeline import make_pipeline
   >>> from sklearn.datasets import load_iris
   >>> from sklearn.model_selection import train_test_split
-  >>> from sklearn.metrics import accuracy_score
+  >>> from sklearn.metrics import r2_score
   ...
   >>> # create a pipeline object
   >>> pipe = make_pipeline(
@@ -114,8 +114,8 @@ the test data::
   Pipeline(steps=[('standardscaler', StandardScaler()),
                   ('logisticregression', LogisticRegression())])
   >>> # we can now use it like any other estimator
-  >>> accuracy_score(pipe.predict(X_test), y_test)
-  0.97...
+  >>> r2_score(pipe.predict(X_test), y_test)
+  0.89...
 
 Model evaluation
 ----------------


### PR DESCRIPTION
The existing documentation uses accuracy_score which can't be used on continuous data. I switched to r2_score. I am not an expert, so unclear if use of regression metric is good enough or if there should be some modification to the predicted output to keep using integer scoring.

```
# pipe.predict(X_test) returns continuous results but accuracy_score can't handle that directly
ValueError                                Traceback (most recent call last)
Cell In[36], line 1
----> 1 accuracy_score(pipe.predict(X_test), y_test)
...
ValueError: Classification metrics can't handle a mix of continuous and multiclass targets
```

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
