### PR TITLE
TST Extend tests for `scipy.sparse.*array` in `sklearn/utils/tests/test_set_output.py`

### DIFF
--- a/sklearn/utils/tests/test_set_output.py
+++ b/sklearn/utils/tests/test_set_output.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
-from scipy.sparse import csr_matrix
 
 from sklearn._config import config_context, get_config
 from sklearn.utils._set_output import (
@@ -12,6 +11,7 @@ from sklearn.utils._set_output import (
     _SetOutputMixin,
     _wrap_in_pandas_container,
 )
+from sklearn.utils.fixes import CSR_CONTAINERS
 
 
 def test__wrap_in_pandas_container_dense():
@@ -41,10 +41,11 @@ def test__wrap_in_pandas_container_dense_update_columns_and_index():
     assert_array_equal(new_df.index, X_df.index)
 
 
-def test__wrap_in_pandas_container_error_validation():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test__wrap_in_pandas_container_error_validation(csr_container):
     """Check errors in _wrap_in_pandas_container."""
     X = np.asarray([[1, 0, 3], [0, 0, 1]])
-    X_csr = csr_matrix(X)
+    X_csr = csr_container(X)
     match = "Pandas output does not support sparse data"
     with pytest.raises(ValueError, match=match):
         _wrap_in_pandas_container(X_csr, columns=["a", "b", "c"])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Towards https://github.com/scikit-learn/scikit-learn/issues/27090.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
