### PR TITLE
TST Extend tests for `scipy.sparse.*array` in `sklearn/datasets/tests/test_svmlight_format.py`

### DIFF
--- a/sklearn/datasets/tests/test_svmlight_format.py
+++ b/sklearn/datasets/tests/test_svmlight_format.py
@@ -17,7 +17,7 @@ from sklearn.utils._testing import (
     assert_array_equal,
     fails_if_pypy,
 )
-from sklearn.utils.fixes import _open_binary, _path
+from sklearn.utils.fixes import CSR_CONTAINERS, _open_binary, _path
 
 TEST_DATA_MODULE = "sklearn.datasets.tests.data"
 datafile = "svmlight_classification.txt"
@@ -254,10 +254,11 @@ def test_invalid_filename():
         load_svmlight_file("trou pic nic douille")
 
 
-def test_dump():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_dump(csr_container):
     X_sparse, y_dense = _load_svmlight_local_test_file(datafile)
     X_dense = X_sparse.toarray()
-    y_sparse = sp.csr_matrix(y_dense)
+    y_sparse = csr_container(y_dense)
 
     # slicing a csr_matrix can unsort its .indices, so test that we sort
     # those correctly
@@ -323,10 +324,11 @@ def test_dump():
                         )
 
 
-def test_dump_multilabel():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_dump_multilabel(csr_container):
     X = [[1, 0, 3, 0, 5], [0, 0, 0, 0, 0], [0, 5, 0, 1, 0]]
     y_dense = [[0, 1, 0], [1, 0, 1], [1, 1, 0]]
-    y_sparse = sp.csr_matrix(y_dense)
+    y_sparse = csr_container(y_dense)
     for y in [y_dense, y_sparse]:
         f = BytesIO()
         dump_svmlight_file(X, y, f, multilabel=True)
@@ -465,9 +467,10 @@ def test_load_with_long_qid():
     assert_array_equal(X.toarray(), true_X)
 
 
-def test_load_zeros():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_load_zeros(csr_container):
     f = BytesIO()
-    true_X = sp.csr_matrix(np.zeros(shape=(3, 4)))
+    true_X = csr_container(np.zeros(shape=(3, 4)))
     true_y = np.array([0, 1, 0])
     dump_svmlight_file(true_X, true_y, f)
 
@@ -481,12 +484,13 @@ def test_load_zeros():
 @pytest.mark.parametrize("sparsity", [0, 0.1, 0.5, 0.99, 1])
 @pytest.mark.parametrize("n_samples", [13, 101])
 @pytest.mark.parametrize("n_features", [2, 7, 41])
-def test_load_with_offsets(sparsity, n_samples, n_features):
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_load_with_offsets(sparsity, n_samples, n_features, csr_container):
     rng = np.random.RandomState(0)
     X = rng.uniform(low=0.0, high=1.0, size=(n_samples, n_features))
     if sparsity:
         X[X < sparsity] = 0.0
-    X = sp.csr_matrix(X)
+    X = csr_container(X)
     y = rng.randint(low=0, high=2, size=n_samples)
 
     f = BytesIO()
@@ -517,7 +521,8 @@ def test_load_with_offsets(sparsity, n_samples, n_features):
     assert_array_almost_equal(X.toarray(), X_concat.toarray())
 
 
-def test_load_offset_exhaustive_splits():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_load_offset_exhaustive_splits(csr_container):
     rng = np.random.RandomState(0)
     X = np.array(
         [
@@ -530,7 +535,7 @@ def test_load_offset_exhaustive_splits():
             [1, 0, 0, 0, 0, 0],
         ]
     )
-    X = sp.csr_matrix(X)
+    X = csr_container(X)
     n_samples, n_features = X.shape
     y = rng.randint(low=0, high=2, size=n_samples)
     query_id = np.arange(n_samples) // 2
@@ -564,7 +569,8 @@ def test_load_with_offsets_error():
         _load_svmlight_local_test_file(datafile, offset=3, length=3)
 
 
-def test_multilabel_y_explicit_zeros(tmp_path):
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_multilabel_y_explicit_zeros(tmp_path, csr_container):
     """
     Ensure that if y contains explicit zeros (i.e. elements of y.data equal to
     0) then those explicit zeros are not encoded.
@@ -576,7 +582,7 @@ def test_multilabel_y_explicit_zeros(tmp_path):
     indices = np.array([0, 2, 2, 0, 1, 2])
     # The first and last element are explicit zeros.
     data = np.array([0, 1, 1, 1, 1, 0])
-    y = sp.csr_matrix((data, indices, indptr), shape=(3, 3))
+    y = csr_container((data, indices, indptr), shape=(3, 3))
     # y as a dense array would look like
     # [[0, 0, 1],
     #  [0, 0, 1],


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Towards #27090.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
