### PR TITLE
TST Extend tests for `scipy.sparse.*array` in `sklearn/preprocessing/tests/test_label.py`

### DIFF
--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -1,13 +1,6 @@
 import numpy as np
 import pytest
-from scipy.sparse import (
-    coo_matrix,
-    csc_matrix,
-    csr_matrix,
-    dok_matrix,
-    issparse,
-    lil_matrix,
-)
+from scipy.sparse import issparse
 
 from sklearn import datasets
 from sklearn.preprocessing._label import (
@@ -20,6 +13,13 @@ from sklearn.preprocessing._label import (
 )
 from sklearn.utils import _to_object_array
 from sklearn.utils._testing import assert_array_equal, ignore_warnings
+from sklearn.utils.fixes import (
+    COO_CONTAINERS,
+    CSC_CONTAINERS,
+    CSR_CONTAINERS,
+    DOK_CONTAINERS,
+    LIL_CONTAINERS,
+)
 from sklearn.utils.multiclass import type_of_target
 
 iris = datasets.load_iris()
@@ -171,13 +171,14 @@ def test_label_binarizer_errors():
 
     # Fail on y_type
     err_msg = "foo format is not supported"
-    with pytest.raises(ValueError, match=err_msg):
-        _inverse_binarize_thresholding(
-            y=csr_matrix([[1, 2], [2, 1]]),
-            output_type="foo",
-            classes=[1, 2],
-            threshold=0,
-        )
+    for csr_container in CSR_CONTAINERS:
+        with pytest.raises(ValueError, match=err_msg):
+            _inverse_binarize_thresholding(
+                y=csr_container([[1, 2], [2, 1]]),
+                output_type="foo",
+                classes=[1, 2],
+                threshold=0,
+            )
 
     # Sequence of seq type should raise ValueError
     y_seq_of_seqs = [[], [1, 2], [3], [0, 1, 3], [2]]
@@ -187,13 +188,14 @@ def test_label_binarizer_errors():
 
     # Fail on the number of classes
     err_msg = "The number of class is not equal to the number of dimension of y."
-    with pytest.raises(ValueError, match=err_msg):
-        _inverse_binarize_thresholding(
-            y=csr_matrix([[1, 2], [2, 1]]),
-            output_type="foo",
-            classes=[1, 2, 3],
-            threshold=0,
-        )
+    for csr_container in CSR_CONTAINERS:
+        with pytest.raises(ValueError, match=err_msg):
+            _inverse_binarize_thresholding(
+                y=csr_container([[1, 2], [2, 1]]),
+                output_type="foo",
+                classes=[1, 2, 3],
+                threshold=0,
+            )
 
     # Fail on the dimension of 'binary'
     err_msg = "output_type='binary', but y.shape"
@@ -350,8 +352,11 @@ def test_sparse_output_multilabel_binarizer():
             assert_array_equal([1, 2, 3], mlb.classes_)
             assert mlb.inverse_transform(got) == inverse
 
-    with pytest.raises(ValueError):
-        mlb.inverse_transform(csr_matrix(np.array([[0, 1, 1], [2, 0, 0], [1, 1, 0]])))
+    for csr_container in CSR_CONTAINERS:
+        with pytest.raises(ValueError):
+            mlb.inverse_transform(
+                csr_container(np.array([[0, 1, 1], [2, 0, 0], [1, 1, 0]]))
+            )
 
 
 def test_multilabel_binarizer():
@@ -620,25 +625,24 @@ def test_label_binarize_multiclass():
         )
 
 
-def test_label_binarize_multilabel():
+@pytest.mark.parametrize(
+    "arr_type",
+    [np.array]
+    + COO_CONTAINERS
+    + CSC_CONTAINERS
+    + CSR_CONTAINERS
+    + DOK_CONTAINERS
+    + LIL_CONTAINERS,
+)
+def test_label_binarize_multilabel(arr_type):
     y_ind = np.array([[0, 1, 0], [1, 1, 1], [0, 0, 0]])
     classes = [0, 1, 2]
     pos_label = 2
     neg_label = 0
     expected = pos_label * y_ind
-    y_sparse = [
-        sparse_matrix(y_ind)
-        for sparse_matrix in [
-            coo_matrix,
-            csc_matrix,
-            csr_matrix,
-            dok_matrix,
-            lil_matrix,
-        ]
-    ]
+    y = arr_type(y_ind)
 
-    for y in [y_ind] + y_sparse:
-        check_binarized_results(y, classes, pos_label, neg_label, expected)
+    check_binarized_results(y, classes, pos_label, neg_label, expected)
 
     with pytest.raises(ValueError):
         label_binarize(
@@ -655,9 +659,10 @@ def test_invalid_input_label_binarize():
         label_binarize([[1, 3]], classes=[1, 2, 3])
 
 
-def test_inverse_binarize_multiclass():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_inverse_binarize_multiclass(csr_container):
     got = _inverse_binarize_multiclass(
-        csr_matrix([[0, 1, 0], [-1, 0, -1], [0, 0, 0]]), np.arange(3)
+        csr_container([[0, 1, 0], [-1, 0, -1], [0, 0, 0]]), np.arange(3)
     )
     assert_array_equal(got, np.array([1, 1, 0]))
 

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -169,17 +169,6 @@ def test_label_binarizer_errors():
     with pytest.raises(ValueError, match=err_msg):
         lb.fit(input_labels)
 
-    # Fail on y_type
-    err_msg = "foo format is not supported"
-    for csr_container in CSR_CONTAINERS:
-        with pytest.raises(ValueError, match=err_msg):
-            _inverse_binarize_thresholding(
-                y=csr_container([[1, 2], [2, 1]]),
-                output_type="foo",
-                classes=[1, 2],
-                threshold=0,
-            )
-
     # Sequence of seq type should raise ValueError
     y_seq_of_seqs = [[], [1, 2], [3], [0, 1, 3], [2]]
     err_msg = "You appear to be using a legacy multi-label data representation"
@@ -206,6 +195,16 @@ def test_label_binarizer_errors():
 
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 def test_label_binarizer_sparse_errors(csr_container):
+    # Fail on y_type
+    err_msg = "foo format is not supported"
+    with pytest.raises(ValueError, match=err_msg):
+        _inverse_binarize_thresholding(
+            y=csr_container([[1, 2], [2, 1]]),
+            output_type="foo",
+            classes=[1, 2],
+            threshold=0,
+        )
+
     # Fail on the number of classes
     err_msg = "The number of class is not equal to the number of dimension of y."
     with pytest.raises(ValueError, match=err_msg):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Towards #27090.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?
I used for loops instead of parameterisation in some tests to save time and do not repeat other checks in test that do not depend on sparse type.
Also i fixed test `test_label_binarize_multilabel`. It used only last `y` from for loop in `pytest.raises(ValueError)`

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
