### PR TITLE
MAINT Param validation for dbscan

### DIFF
--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -17,13 +17,18 @@ from scipy import sparse
 from ..base import BaseEstimator, ClusterMixin, _fit_context
 from ..metrics.pairwise import _VALID_METRICS
 from ..neighbors import NearestNeighbors
-from ..utils._param_validation import Interval, StrOptions
+from ..utils._param_validation import Interval, StrOptions, validate_params
 from ..utils.validation import _check_sample_weight
 from ._dbscan_inner import dbscan_inner
 
 
-# This function is not validated using validate_params because
-# it's just a factory for DBSCAN.
+@validate_params(
+    {
+        "X": ["array-like", "sparse matrix"],
+        "sample_weight": ["array-like", None],
+    },
+    prefer_skip_nested_validation=False,
+)
 def dbscan(
     X,
     eps=0.5,

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -344,6 +344,7 @@ def test_function_param_validation(func_module):
 
 PARAM_VALIDATION_CLASS_WRAPPER_LIST = [
     ("sklearn.cluster.affinity_propagation", "sklearn.cluster.AffinityPropagation"),
+    ("sklearn.cluster.dbscan", "sklearn.cluster.DBSCAN"),
     ("sklearn.cluster.k_means", "sklearn.cluster.KMeans"),
     ("sklearn.cluster.mean_shift", "sklearn.cluster.MeanShift"),
     ("sklearn.cluster.spectral_clustering", "sklearn.cluster.SpectralClustering"),


### PR DESCRIPTION
Alternative to https://github.com/scikit-learn/scikit-learn/pull/26920
We do validate class wrappers, it's just that it's only a partial validation since the other parameters will be validated by the class anyway. This is how it was done for all the functions that are class wrappers, listed in `PARAM_VALIDATION_CLASS_WRAPPER_LIST`.

cc/ @glemaitre
