### PR TITLE
TST Extend tests for `scipy.sparse.*array` in `sklearn/utils/tests/test_sparsefuncs.py`

### DIFF
--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -438,26 +438,26 @@ def test_incr_mean_variance_axis_dim_mismatch(sparse_constructor):
             sp.random(5, 2, density=0.8, format="csr", random_state=0),
             sp.random(13, 2, density=0.8, format="csr", random_state=0),
         ),
-        *[
-            (
-                sp.random(5, 2, density=0.8, format="csr", random_state=0),
-                sp.hstack(
-                    [
-                        csr_container(np.full((13, 1), fill_value=np.nan)),
-                        sp.random(13, 1, density=0.8, random_state=42),
-                    ],
-                    format="csr",
-                ),
-            )
-            for csr_container in CSR_CONTAINERS
-        ],
+        (
+            sp.random(5, 2, density=0.8, format="csr", random_state=0),
+            sp.hstack(
+                [
+                    np.full((13, 1), fill_value=np.nan),
+                    sp.random(13, 1, density=0.8, random_state=42),
+                ],
+                format="csr",
+            ),
+        ),
     ],
 )
-def test_incr_mean_variance_axis_equivalence_mean_variance(X1, X2):
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_incr_mean_variance_axis_equivalence_mean_variance(X1, X2, csr_container):
     # non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/16448
     # check that computing the incremental mean and variance is equivalent to
     # computing the mean and variance on the stacked dataset.
+    X1 = csr_container(X1)
+    X2 = csr_container(X2)
     axis = 0
     last_mean, last_var = np.zeros(X1.shape[1]), np.zeros(X1.shape[1])
     last_n = np.zeros(X1.shape[1], dtype=np.int64)

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -7,6 +7,7 @@ from scipy import linalg
 
 from sklearn.datasets import make_classification
 from sklearn.utils._testing import assert_allclose
+from sklearn.utils.fixes import CSC_CONTAINERS, CSR_CONTAINERS, LIL_CONTAINERS
 from sklearn.utils.sparsefuncs import (
     count_nonzero,
     csc_median_axis_0,
@@ -26,21 +27,24 @@ from sklearn.utils.sparsefuncs_fast import (
 )
 
 
-def test_mean_variance_axis0():
+@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+@pytest.mark.parametrize("lil_container", LIL_CONTAINERS)
+def test_mean_variance_axis0(csc_container, csr_container, lil_container):
     X, _ = make_classification(5, 4, random_state=0)
     # Sparsify the array a little bit
     X[0, 0] = 0
     X[2, 1] = 0
     X[4, 3] = 0
-    X_lil = sp.lil_matrix(X)
+    X_lil = lil_container(X)
     X_lil[1, 0] = 0
     X[1, 0] = 0
 
     with pytest.raises(TypeError):
         mean_variance_axis(X_lil, axis=0)
 
-    X_csr = sp.csr_matrix(X_lil)
-    X_csc = sp.csc_matrix(X_lil)
+    X_csr = csr_container(X_lil)
+    X_csc = csc_container(X_lil)
 
     expected_dtypes = [
         (np.float32, np.float32),
@@ -61,7 +65,7 @@ def test_mean_variance_axis0():
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-@pytest.mark.parametrize("sparse_constructor", [sp.csr_matrix, sp.csc_matrix])
+@pytest.mark.parametrize("sparse_constructor", CSC_CONTAINERS + CSR_CONTAINERS)
 def test_mean_variance_axis0_precision(dtype, sparse_constructor):
     # Check that there's no big loss of precision when the real variance is
     # exactly 0. (#19766)
@@ -80,21 +84,24 @@ def test_mean_variance_axis0_precision(dtype, sparse_constructor):
     assert var < np.finfo(dtype).eps
 
 
-def test_mean_variance_axis1():
+@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+@pytest.mark.parametrize("lil_container", LIL_CONTAINERS)
+def test_mean_variance_axis1(csc_container, csr_container, lil_container):
     X, _ = make_classification(5, 4, random_state=0)
     # Sparsify the array a little bit
     X[0, 0] = 0
     X[2, 1] = 0
     X[4, 3] = 0
-    X_lil = sp.lil_matrix(X)
+    X_lil = lil_container(X)
     X_lil[1, 0] = 0
     X[1, 0] = 0
 
     with pytest.raises(TypeError):
         mean_variance_axis(X_lil, axis=1)
 
-    X_csr = sp.csr_matrix(X_lil)
-    X_csc = sp.csc_matrix(X_lil)
+    X_csr = csr_container(X_lil)
+    X_csc = csc_container(X_lil)
 
     expected_dtypes = [
         (np.float32, np.float32),
@@ -144,7 +151,7 @@ def test_mean_variance_axis1():
         ),
     ],
 )
-@pytest.mark.parametrize("sparse_constructor", [sp.csc_matrix, sp.csr_matrix])
+@pytest.mark.parametrize("sparse_constructor", CSC_CONTAINERS + CSR_CONTAINERS)
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_incr_mean_variance_axis_weighted_axis1(
     Xw, X, weights, sparse_constructor, dtype
@@ -241,7 +248,7 @@ def test_incr_mean_variance_axis_weighted_axis1(
         ),
     ],
 )
-@pytest.mark.parametrize("sparse_constructor", [sp.csc_matrix, sp.csr_matrix])
+@pytest.mark.parametrize("sparse_constructor", CSC_CONTAINERS + CSR_CONTAINERS)
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_incr_mean_variance_axis_weighted_axis0(
     Xw, X, weights, sparse_constructor, dtype
@@ -311,7 +318,10 @@ def test_incr_mean_variance_axis_weighted_axis0(
     assert n_incr_w1.dtype == dtype
 
 
-def test_incr_mean_variance_axis():
+@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+@pytest.mark.parametrize("lil_container", LIL_CONTAINERS)
+def test_incr_mean_variance_axis(csc_container, csr_container, lil_container):
     for axis in [0, 1]:
         rng = np.random.RandomState(0)
         n_features = 50
@@ -330,8 +340,8 @@ def test_incr_mean_variance_axis():
         X = np.array(data_chunks[0])
         X = np.atleast_2d(X)
         X = X.T if axis == 1 else X
-        X_lil = sp.lil_matrix(X)
-        X_csr = sp.csr_matrix(X_lil)
+        X_lil = lil_container(X)
+        X_csr = csr_container(X_lil)
 
         with pytest.raises(TypeError):
             incr_mean_variance_axis(
@@ -352,7 +362,7 @@ def test_incr_mean_variance_axis():
         # X.shape[axis] picks # samples
         assert_array_equal(X.shape[axis], n_incr)
 
-        X_csc = sp.csc_matrix(X_lil)
+        X_csc = csc_container(X_lil)
         X_means, X_vars = mean_variance_axis(X_csc, axis)
         assert_array_almost_equal(X_means, X_means_incr)
         assert_array_almost_equal(X_vars, X_vars_incr)
@@ -361,9 +371,9 @@ def test_incr_mean_variance_axis():
         # Test _incremental_mean_and_var with whole data
         X = np.vstack(data_chunks)
         X = X.T if axis == 1 else X
-        X_lil = sp.lil_matrix(X)
-        X_csr = sp.csr_matrix(X_lil)
-        X_csc = sp.csc_matrix(X_lil)
+        X_lil = lil_container(X)
+        X_csr = csr_container(X_lil)
+        X_csc = csc_container(X_lil)
 
         expected_dtypes = [
             (np.float32, np.float32),
@@ -392,7 +402,7 @@ def test_incr_mean_variance_axis():
                 assert_array_equal(X.shape[axis], n_incr)
 
 
-@pytest.mark.parametrize("sparse_constructor", [sp.csc_matrix, sp.csr_matrix])
+@pytest.mark.parametrize("sparse_constructor", CSC_CONTAINERS + CSR_CONTAINERS)
 def test_incr_mean_variance_axis_dim_mismatch(sparse_constructor):
     """Check that we raise proper error when axis=1 and the dimension mismatch.
     Non-regression test for:
@@ -428,16 +438,19 @@ def test_incr_mean_variance_axis_dim_mismatch(sparse_constructor):
             sp.random(5, 2, density=0.8, format="csr", random_state=0),
             sp.random(13, 2, density=0.8, format="csr", random_state=0),
         ),
-        (
-            sp.random(5, 2, density=0.8, format="csr", random_state=0),
-            sp.hstack(
-                [
-                    sp.csr_matrix(np.full((13, 1), fill_value=np.nan)),
-                    sp.random(13, 1, density=0.8, random_state=42),
-                ],
-                format="csr",
-            ),
-        ),
+        *[
+            (
+                sp.random(5, 2, density=0.8, format="csr", random_state=0),
+                sp.hstack(
+                    [
+                        csr_container(np.full((13, 1), fill_value=np.nan)),
+                        sp.random(13, 1, density=0.8, random_state=42),
+                    ],
+                    format="csr",
+                ),
+            )
+            for csr_container in CSR_CONTAINERS
+        ],
     ],
 )
 def test_incr_mean_variance_axis_equivalence_mean_variance(X1, X2):
@@ -492,7 +505,7 @@ def test_incr_mean_variance_n_float():
 
 
 @pytest.mark.parametrize("axis", [0, 1])
-@pytest.mark.parametrize("sparse_constructor", [sp.csc_matrix, sp.csr_matrix])
+@pytest.mark.parametrize("sparse_constructor", CSC_CONTAINERS + CSR_CONTAINERS)
 def test_incr_mean_variance_axis_ignore_nan(axis, sparse_constructor):
     old_means = np.array([535.0, 535.0, 535.0, 535.0])
     old_variances = np.array([4225.0, 4225.0, 4225.0, 4225.0])
@@ -540,13 +553,14 @@ def test_incr_mean_variance_axis_ignore_nan(axis, sparse_constructor):
     assert_allclose(X_nan_sample_count, X_sample_count)
 
 
-def test_mean_variance_illegal_axis():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_mean_variance_illegal_axis(csr_container):
     X, _ = make_classification(5, 4, random_state=0)
     # Sparsify the array a little bit
     X[0, 0] = 0
     X[2, 1] = 0
     X[4, 3] = 0
-    X_csr = sp.csr_matrix(X)
+    X_csr = csr_container(X)
     with pytest.raises(ValueError):
         mean_variance_axis(X_csr, axis=-3)
     with pytest.raises(ValueError):
@@ -570,9 +584,10 @@ def test_mean_variance_illegal_axis():
         )
 
 
-def test_densify_rows():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_densify_rows(csr_container):
     for dtype in (np.float32, np.float64):
-        X = sp.csr_matrix(
+        X = csr_container(
             [[0, 3, 0], [2, 4, 0], [0, 0, 0], [9, 8, 7], [4, 0, 5]], dtype=dtype
         )
         X_rows = np.array([0, 2, 3], dtype=np.intp)
@@ -650,12 +665,14 @@ def test_inplace_row_scale():
         inplace_column_scale(X.tolil(), scale)
 
 
-def test_inplace_swap_row():
+@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_inplace_swap_row(csc_container, csr_container):
     X = np.array(
         [[0, 3, 0], [2, 4, 0], [0, 0, 0], [9, 8, 7], [4, 0, 5]], dtype=np.float64
     )
-    X_csr = sp.csr_matrix(X)
-    X_csc = sp.csc_matrix(X)
+    X_csr = csr_container(X)
+    X_csc = csc_container(X)
 
     swap = linalg.get_blas_funcs(("swap",), (X,))
     swap = swap[0]
@@ -678,8 +695,8 @@ def test_inplace_swap_row():
     X = np.array(
         [[0, 3, 0], [2, 4, 0], [0, 0, 0], [9, 8, 7], [4, 0, 5]], dtype=np.float32
     )
-    X_csr = sp.csr_matrix(X)
-    X_csc = sp.csc_matrix(X)
+    X_csr = csr_container(X)
+    X_csc = csc_container(X)
     swap = linalg.get_blas_funcs(("swap",), (X,))
     swap = swap[0]
     X[0], X[-1] = swap(X[0], X[-1])
@@ -698,12 +715,14 @@ def test_inplace_swap_row():
         inplace_swap_row(X_csr.tolil())
 
 
-def test_inplace_swap_column():
+@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_inplace_swap_column(csc_container, csr_container):
     X = np.array(
         [[0, 3, 0], [2, 4, 0], [0, 0, 0], [9, 8, 7], [4, 0, 5]], dtype=np.float64
     )
-    X_csr = sp.csr_matrix(X)
-    X_csc = sp.csc_matrix(X)
+    X_csr = csr_container(X)
+    X_csc = csc_container(X)
 
     swap = linalg.get_blas_funcs(("swap",), (X,))
     swap = swap[0]
@@ -726,8 +745,8 @@ def test_inplace_swap_column():
     X = np.array(
         [[0, 3, 0], [2, 4, 0], [0, 0, 0], [9, 8, 7], [4, 0, 5]], dtype=np.float32
     )
-    X_csr = sp.csr_matrix(X)
-    X_csc = sp.csc_matrix(X)
+    X_csr = csr_container(X)
+    X_csc = csc_container(X)
     swap = linalg.get_blas_funcs(("swap",), (X,))
     swap = swap[0]
     X[:, 0], X[:, -1] = swap(X[:, 0], X[:, -1])
@@ -748,7 +767,7 @@ def test_inplace_swap_column():
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("axis", [0, 1, None])
-@pytest.mark.parametrize("sparse_format", [sp.csr_matrix, sp.csc_matrix])
+@pytest.mark.parametrize("sparse_format", CSC_CONTAINERS + CSR_CONTAINERS)
 @pytest.mark.parametrize(
     "missing_values, min_func, max_func, ignore_nan",
     [(0, np.min, np.max, False), (np.nan, np.nanmin, np.nanmax, True)],
@@ -784,12 +803,14 @@ def test_min_max(
     assert_array_equal(maxs_sparse, max_func(X, axis=axis))
 
 
-def test_min_max_axis_errors():
+@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_min_max_axis_errors(csc_container, csr_container):
     X = np.array(
         [[0, 3, 0], [2, -1, 0], [0, 0, 0], [9, 8, 7], [4, 0, 5]], dtype=np.float64
     )
-    X_csr = sp.csr_matrix(X)
-    X_csc = sp.csc_matrix(X)
+    X_csr = csr_container(X)
+    X_csc = csc_container(X)
     with pytest.raises(TypeError):
         min_max_axis(X_csr.tolil(), axis=0)
     with pytest.raises(ValueError):
@@ -798,12 +819,14 @@ def test_min_max_axis_errors():
         min_max_axis(X_csc, axis=-3)
 
 
-def test_count_nonzero():
+@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_count_nonzero(csc_container, csr_container):
     X = np.array(
         [[0, 3, 0], [2, -1, 0], [0, 0, 0], [9, 8, 7], [4, 0, 5]], dtype=np.float64
     )
-    X_csr = sp.csr_matrix(X)
-    X_csc = sp.csc_matrix(X)
+    X_csr = csr_container(X)
+    X_csc = csc_container(X)
     X_nonzero = X != 0
     sample_weight = [0.5, 0.2, 0.3, 0.1, 0.1]
     X_nonzero_weighted = X_nonzero * np.array(sample_weight)[:, None]
@@ -842,14 +865,16 @@ def test_count_nonzero():
         assert "according to the rule 'safe'" in e.args[0] and np.intp().nbytes < 8, e
 
 
-def test_csc_row_median():
+@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_csc_row_median(csc_container, csr_container):
     # Test csc_row_median actually calculates the median.
 
     # Test that it gives the same output when X is dense.
     rng = np.random.RandomState(0)
     X = rng.rand(100, 50)
     dense_median = np.median(X, axis=0)
-    csc = sp.csc_matrix(X)
+    csc = csc_container(X)
     sparse_median = csc_median_axis_0(csc)
     assert_array_equal(sparse_median, dense_median)
 
@@ -858,48 +883,52 @@ def test_csc_row_median():
     X[X < 0.7] = 0.0
     ind = rng.randint(0, 50, 10)
     X[ind] = -X[ind]
-    csc = sp.csc_matrix(X)
+    csc = csc_container(X)
     dense_median = np.median(X, axis=0)
     sparse_median = csc_median_axis_0(csc)
     assert_array_equal(sparse_median, dense_median)
 
     # Test for toy data.
     X = [[0, -2], [-1, -1], [1, 0], [2, 1]]
-    csc = sp.csc_matrix(X)
+    csc = csc_container(X)
     assert_array_equal(csc_median_axis_0(csc), np.array([0.5, -0.5]))
     X = [[0, -2], [-1, -5], [1, -3]]
-    csc = sp.csc_matrix(X)
+    csc = csc_container(X)
     assert_array_equal(csc_median_axis_0(csc), np.array([0.0, -3]))
 
     # Test that it raises an Error for non-csc matrices.
     with pytest.raises(TypeError):
-        csc_median_axis_0(sp.csr_matrix(X))
+        csc_median_axis_0(csr_container(X))
 
 
-def test_inplace_normalize():
-    ones = np.ones((10, 1))
+@pytest.mark.parametrize(
+    "inplace_csr_row_normalize",
+    (inplace_csr_row_normalize_l1, inplace_csr_row_normalize_l2),
+)
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_inplace_normalize(csr_container, inplace_csr_row_normalize):
+    if csr_container is sp.csr_matrix:
+        ones = np.ones((10, 1))
+    else:
+        ones = np.ones(10)
     rs = RandomState(10)
 
-    for inplace_csr_row_normalize in (
-        inplace_csr_row_normalize_l1,
-        inplace_csr_row_normalize_l2,
-    ):
-        for dtype in (np.float64, np.float32):
-            X = rs.randn(10, 5).astype(dtype)
-            X_csr = sp.csr_matrix(X)
-            for index_dtype in [np.int32, np.int64]:
-                # csr_matrix will use int32 indices by default,
-                # up-casting those to int64 when necessary
-                if index_dtype is np.int64:
-                    X_csr.indptr = X_csr.indptr.astype(index_dtype)
-                    X_csr.indices = X_csr.indices.astype(index_dtype)
-                assert X_csr.indices.dtype == index_dtype
-                assert X_csr.indptr.dtype == index_dtype
-                inplace_csr_row_normalize(X_csr)
-                assert X_csr.dtype == dtype
-                if inplace_csr_row_normalize is inplace_csr_row_normalize_l2:
-                    X_csr.data **= 2
-                assert_array_almost_equal(np.abs(X_csr).sum(axis=1), ones)
+    for dtype in (np.float64, np.float32):
+        X = rs.randn(10, 5).astype(dtype)
+        X_csr = csr_container(X)
+        for index_dtype in [np.int32, np.int64]:
+            # csr_matrix will use int32 indices by default,
+            # up-casting those to int64 when necessary
+            if index_dtype is np.int64:
+                X_csr.indptr = X_csr.indptr.astype(index_dtype)
+                X_csr.indices = X_csr.indices.astype(index_dtype)
+            assert X_csr.indices.dtype == index_dtype
+            assert X_csr.indptr.dtype == index_dtype
+            inplace_csr_row_normalize(X_csr)
+            assert X_csr.dtype == dtype
+            if inplace_csr_row_normalize is inplace_csr_row_normalize_l2:
+                X_csr.data **= 2
+            assert_array_almost_equal(np.abs(X_csr).sum(axis=1), ones)
 
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Towards #27090.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?
In tests like `test_mean_variance_axis0` I checked if `*array` will work with `*matrix`. If you think that we should check matrices only with matrices, same for arrays, I can reformat parameterisations using `zip`

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
