### PR TITLE
BENCH pin dependencies in asv benchmarks

### DIFF
--- a/asv_benchmarks/asv.conf.json
+++ b/asv_benchmarks/asv.conf.json
@@ -72,12 +72,12 @@
     // followed by the pip installed packages).
     //
     "matrix": {
-        "numpy": [],
-        "scipy": [],
-        "cython": [],
-        "joblib": [],
-        "threadpoolctl": [],
-        "pandas": []
+        "numpy": ["1.25.2"],
+        "scipy": ["1.11.2"],
+        "cython": ["0.29.36"],
+        "joblib": ["1.3.2"],
+        "threadpoolctl": ["3.2.0"],
+        "pandas": ["2.1.0"]
     },
 
     // Combinations of libraries/python versions can be excluded/included

--- a/asv_benchmarks/asv.conf.json
+++ b/asv_benchmarks/asv.conf.json
@@ -71,6 +71,10 @@
     // pip (with all the conda available packages installed first,
     // followed by the pip installed packages).
     //
+    // The versions of the dependencies should be bumped in a dedicated commit
+    // to easily identify regressions/imrovements due to code changes from
+    // those due to dependency changes.
+    //
     "matrix": {
         "numpy": ["1.25.2"],
         "scipy": ["1.11.2"],


### PR DESCRIPTION
From the discussions in https://github.com/scikit-learn/scikit-learn/issues/27086

Currently the asv benchmarks run against the latest available versions of the dependencies.
This PR allows to easily distinguish between perf regressions due to a change in the codebase from perf regressions due to an upgrade of some dependency. This way, bumping a dependency in the benchmarks will correspond to a specific commit in the history.

For now I pinned cython < 3 because of the perf regressions we're observing in https://github.com/scikit-learn/scikit-learn/issues/27086. Then I propose to make a new PR after that bumping to cython 3 to have a specific commit identifying the cython 3 regressions.