### PR TITLE
TST Extend tests for `scipy.sparse.*array` in `sklearn/tests/test_kernel_ridge.py`

### DIFF
--- a/sklearn/tests/test_kernel_ridge.py
+++ b/sklearn/tests/test_kernel_ridge.py
@@ -1,15 +1,14 @@
 import numpy as np
-import scipy.sparse as sp
+import pytest
 
 from sklearn.datasets import make_regression
 from sklearn.kernel_ridge import KernelRidge
 from sklearn.linear_model import Ridge
 from sklearn.metrics.pairwise import pairwise_kernels
 from sklearn.utils._testing import assert_array_almost_equal, ignore_warnings
+from sklearn.utils.fixes import CSC_CONTAINERS, CSR_CONTAINERS
 
 X, y = make_regression(n_features=10, random_state=0)
-Xcsr = sp.csr_matrix(X)
-Xcsc = sp.csc_matrix(X)
 Y = np.array([y, y]).T
 
 
@@ -19,7 +18,9 @@ def test_kernel_ridge():
     assert_array_almost_equal(pred, pred2)
 
 
-def test_kernel_ridge_csr():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_kernel_ridge_csr(csr_container):
+    Xcsr = csr_container(X)
     pred = (
         Ridge(alpha=1, fit_intercept=False, solver="cholesky")
         .fit(Xcsr, y)
@@ -29,7 +30,9 @@ def test_kernel_ridge_csr():
     assert_array_almost_equal(pred, pred2)
 
 
-def test_kernel_ridge_csc():
+@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
+def test_kernel_ridge_csc(csc_container):
+    Xcsc = csc_container(X)
     pred = (
         Ridge(alpha=1, fit_intercept=False, solver="cholesky")
         .fit(Xcsc, y)

--- a/sklearn/tests/test_kernel_ridge.py
+++ b/sklearn/tests/test_kernel_ridge.py
@@ -18,27 +18,15 @@ def test_kernel_ridge():
     assert_array_almost_equal(pred, pred2)
 
 
-@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
-def test_kernel_ridge_csr(csr_container):
-    Xcsr = csr_container(X)
+@pytest.mark.parametrize("sparse_container", [*CSR_CONTAINERS, *CSC_CONTAINERS])
+def test_kernel_ridge_sparse(sparse_container):
+    X_sparse = sparse_container(X)
     pred = (
         Ridge(alpha=1, fit_intercept=False, solver="cholesky")
-        .fit(Xcsr, y)
-        .predict(Xcsr)
+        .fit(X_sparse, y)
+        .predict(X_sparse)
     )
-    pred2 = KernelRidge(kernel="linear", alpha=1).fit(Xcsr, y).predict(Xcsr)
-    assert_array_almost_equal(pred, pred2)
-
-
-@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
-def test_kernel_ridge_csc(csc_container):
-    Xcsc = csc_container(X)
-    pred = (
-        Ridge(alpha=1, fit_intercept=False, solver="cholesky")
-        .fit(Xcsc, y)
-        .predict(Xcsc)
-    )
-    pred2 = KernelRidge(kernel="linear", alpha=1).fit(Xcsc, y).predict(Xcsc)
+    pred2 = KernelRidge(kernel="linear", alpha=1).fit(X_sparse, y).predict(X_sparse)
     assert_array_almost_equal(pred, pred2)
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #27090 

#### What does this implement/fix? Explain your changes.
Use `scipy.sparse.*array` in `sklearn/tests/test_kernel_ridge.py`