### PR TITLE
TST Extend tests for `scipy.sparse.*array` in `test_encoders.py`

### DIFF
--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -12,6 +12,7 @@ from sklearn.utils._testing import (
     assert_allclose,
     assert_array_equal,
 )
+from sklearn.utils.fixes import CSR_CONTAINERS
 
 
 def test_one_hot_encoder_sparse_dense():
@@ -1761,13 +1762,14 @@ def test_ordinal_encoder_handle_missing_and_unknown(X, expected_X_trans, X_test)
     assert_allclose(oe.transform(X_test), [[-1.0]])
 
 
-def test_ordinal_encoder_sparse():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_ordinal_encoder_sparse(csr_container):
     """Check that we raise proper error with sparse input in OrdinalEncoder.
     Non-regression test for:
     https://github.com/scikit-learn/scikit-learn/issues/19878
     """
     X = np.array([[3, 2, 1], [0, 1, 1]])
-    X_sparse = sparse.csr_matrix(X)
+    X_sparse = csr_container(X)
 
     encoder = OrdinalEncoder()
 
@@ -1778,7 +1780,7 @@ def test_ordinal_encoder_sparse():
         encoder.fit_transform(X_sparse)
 
     X_trans = encoder.fit_transform(X)
-    X_trans_sparse = sparse.csr_matrix(X_trans)
+    X_trans_sparse = csr_container(X_trans)
     with pytest.raises(TypeError, match=err_msg):
         encoder.inverse_transform(X_trans_sparse)
 


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #27090.


#### What does this implement/fix? Explain your changes.
This PR substitutes scipy sparse matrices with the scipy containers introduced in #27095 in the `sklearn/preprocessing/tests/test_encoders.py` test file.