### PR TITLE
FIX accept `array-like` in `feature_names` for `plot_tree`

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -70,6 +70,9 @@ Changelog
 - |Fix| :func:`tree.plot_tree` now accepts `class_names=True` as documented.
   :pr:`26903` by :user:`Thomas Roehr <2maz>`
 
+- |Fix| :func:`tree.plot_tree` now accepts `feature_names` as array-like
+  rather than as a list. :pr:`27292` by :user:`Rahil Parikh <rprkh>`
+
 .. _changes_1_3:
 
 Version 1.3.0

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -71,7 +71,7 @@ Changelog
   :pr:`26903` by :user:`Thomas Roehr <2maz>`
 
 - |Fix| :func:`tree.plot_tree` now accepts `feature_names` as array-like
-  rather than as a list. :pr:`27292` by :user:`Rahil Parikh <rprkh>`
+  rather than as a list. :pr:`27292` by :user:`Rahil Parikh <rprkh>`.
 
 .. _changes_1_3:
 

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -70,8 +70,8 @@ Changelog
 - |Fix| :func:`tree.plot_tree` now accepts `class_names=True` as documented.
   :pr:`26903` by :user:`Thomas Roehr <2maz>`
 
-- |Fix| :func:`tree.plot_tree` now accepts `feature_names` as array-like
-  rather than as a list. :pr:`27292` by :user:`Rahil Parikh <rprkh>`.
+- |Fix| The `feature_names` parameter of :func:`tree.plot_tree` now accepts any kind of
+  array-like instead of just a list. :pr:`27292` by :user:`Rahil Parikh <rprkh>`.
 
 .. _changes_1_3:
 

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -78,7 +78,7 @@ SENTINEL = Sentinel()
     {
         "decision_tree": [DecisionTreeClassifier, DecisionTreeRegressor],
         "max_depth": [Interval(Integral, 0, None, closed="left"), None],
-        "feature_names": [list, "array-like", None],
+        "feature_names": ["array-like", None],
         "class_names": ["array-like", "boolean", None],
         "label": [StrOptions({"all", "root", "none"})],
         "filled": ["boolean"],
@@ -130,7 +130,7 @@ def plot_tree(
         The maximum depth of the representation. If None, the tree is fully
         generated.
 
-    feature_names : list of str, default=None
+    feature_names : array-like of str, default=None
         Names of each of the features.
         If None, generic names will be used ("x[0]", "x[1]", ...).
 

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -78,7 +78,7 @@ SENTINEL = Sentinel()
     {
         "decision_tree": [DecisionTreeClassifier, DecisionTreeRegressor],
         "max_depth": [Interval(Integral, 0, None, closed="left"), None],
-        "feature_names": [list, None],
+        "feature_names": [list, "array-like", None],
         "class_names": ["array-like", "boolean", None],
         "label": [StrOptions({"all", "root", "none"})],
         "filled": ["boolean"],


### PR DESCRIPTION
#### Reference Issues/PRs
Partially fixes #27271

#### What does this implement/fix? Explain your changes.
The `feature_names` parameter now accepts an array.

#### Any other comments?

```
from sklearn.datasets import load_breast_cancer
from sklearn.model_selection import train_test_split
from sklearn.tree import DecisionTreeClassifier
from sklearn.tree import plot_tree
import matplotlib.pyplot as plt


cancer = load_breast_cancer()
X_train, X_test, y_train, y_test = train_test_split(cancer.data, cancer.target)
tree = DecisionTreeClassifier(max_depth=1).fit(X_train, y_train)

plot_tree(tree, class_names=cancer.target_names,
          feature_names=cancer.feature_names)
plt.show()
```

The code above will execute without any errors