### PR TITLE
MNT Avoid np.lib.arraysetops which is private in numpy 2

### DIFF
--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -830,7 +830,7 @@ def test_stratified_shuffle_split_iter():
             assert len(train) + len(test) == y.size
             assert len(train) == train_size
             assert len(test) == test_size
-            assert_array_equal(np.lib.arraysetops.intersect1d(train, test), [])
+            assert_array_equal(np.intersect1d(train, test), [])
 
 
 def test_stratified_shuffle_split_even():


### PR DESCRIPTION
Seen in https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=58641&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=ef785ae2-496b-5b02-9f0e-07a6c3ab3081&l=682

```
AttributeError: `np.lib.arraysetops` is now private. If you are using a public function, it should be available in the main numpy namespace, otherwise check the NumPy 2.0 migration guide.
```
