### PR TITLE
FIX _safe_divide should handle zero-division with numpy scalar

### DIFF
--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -71,6 +71,7 @@ def _safe_divide(numerator, denominator):
         if np.isinf(result):
             # Raise a runtime warning if overflow.
             warnings.warn("overflow encountered in divide", RuntimeWarning)
+        return result
     except ZeroDivisionError:
         warnings.warn("divide by zero encountered in divide", RuntimeWarning)
         return 0.0

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -64,7 +64,7 @@ _LOSSES.update(
 
 def _safe_divide(numerator, denominator):
     """Prevents overflow and division by zero."""
-    with np.errstate(divide="raise"):
+    with np.errstate(divide="raise", invalid="raise"):
         try:
             return numerator / denominator
         except FloatingPointError:

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -64,11 +64,9 @@ _LOSSES.update(
 
 def _safe_divide(numerator, denominator):
     """Prevents overflow and division by zero."""
-    with np.errstate(divide="raise", invalid="raise"):
-        try:
-            return numerator / denominator
-        except FloatingPointError:
-            return 0.0
+    if abs(denominator) < 1e-150:
+        return 0.0
+    return numerator / denominator
 
 
 def _init_raw_predictions(X, estimator, loss, use_predict_proba):
@@ -235,7 +233,9 @@ def _update_terminal_regions(
 
         # update each leaf (= perform line search)
         for leaf in np.nonzero(tree.children_left == TREE_LEAF)[0]:
-            indices = np.nonzero(terminal_regions == leaf)[0]  # of terminal regions
+            indices = np.nonzero(masked_terminal_regions == leaf)[
+                0
+            ]  # of terminal regions
             y_ = y.take(indices, axis=0)
             sw = None if sample_weight is None else sample_weight[indices]
             update = compute_update(y_, indices, neg_gradient, raw_prediction, k)

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -72,6 +72,7 @@ def _safe_divide(numerator, denominator):
             # Raise a runtime warning if overflow.
             warnings.warn("overflow encountered in divide", RuntimeWarning)
     except ZeroDivisionError:
+        warnings.warn("divide by zero encountered in divide", RuntimeWarning)
         return 0.0
 
 

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -64,6 +64,9 @@ _LOSSES.update(
 
 def _safe_divide(numerator, denominator):
     """Prevents overflow and division by zero."""
+    # We could implement the following using `np.errstate` but, at the time of
+    # writing (scikit-learn 1.4), `np.errstate` is not handled properly by Pyodide.
+    # We therefore risk to issue `nan` values, making GBDT training fail.
     if abs(denominator) < 1e-150:
         return 0.0
     return numerator / denominator

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -69,7 +69,6 @@ def _safe_divide(numerator, denominator):
         # on `np.errstate` that is not supported by Pyodide.
         result = float(numerator) / float(denominator)
         if np.isinf(result):
-            # Raise a runtime warning if overflow.
             warnings.warn("overflow encountered in divide", RuntimeWarning)
         return result
     except ZeroDivisionError:

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -69,10 +69,10 @@ def _safe_divide(numerator, denominator):
         # on `np.errstate` that is not supported by Pyodide.
         result = float(numerator) / float(denominator)
         if np.isinf(result):
-            warnings.warn("overflow encountered in divide", RuntimeWarning)
+            warnings.warn("overflow encountered in _safe_divide", RuntimeWarning)
         return result
     except ZeroDivisionError:
-        warnings.warn("divide by zero encountered in divide", RuntimeWarning)
+        warnings.warn("divide by zero encountered in _safe_divide", RuntimeWarning)
         return 0.0
 
 

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -64,6 +64,16 @@ _LOSSES.update(
 
 def _safe_divide(numerator, denominator):
     """Prevents overflow and division by zero."""
+    try:
+        # Cast to a Python float to triggers a ZeroDivisionError without relying
+        # on `np.errstate` that is not supported by Pyodide.
+        result = float(numerator) / float(denominator)
+        if np.isinf(result):
+            # Raise a runtime warning if overflow.
+            warnings.warn("overflow encountered in divide", RuntimeWarning)
+    except ZeroDivisionError:
+        return 0.0
+
     # We could implement the following using `np.errstate` but, at the time of
     # writing (scikit-learn 1.4), `np.errstate` is not handled properly by Pyodide.
     # We therefore risk to issue `nan` values, making GBDT training fail.

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -74,13 +74,6 @@ def _safe_divide(numerator, denominator):
     except ZeroDivisionError:
         return 0.0
 
-    # We could implement the following using `np.errstate` but, at the time of
-    # writing (scikit-learn 1.4), `np.errstate` is not handled properly by Pyodide.
-    # We therefore risk to issue `nan` values, making GBDT training fail.
-    if abs(denominator) < 1e-150:
-        return 0.0
-    return numerator / denominator
-
 
 def _init_raw_predictions(X, estimator, loss, use_predict_proba):
     """Return the initial raw predictions.

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -20,6 +20,7 @@ The module structure is the following:
 #          Arnaud Joly, Jacob Schreiber
 # License: BSD 3 clause
 
+import math
 import warnings
 from abc import ABCMeta, abstractmethod
 from numbers import Integral, Real
@@ -68,7 +69,7 @@ def _safe_divide(numerator, denominator):
         # Cast to Python float to trigger a ZeroDivisionError without relying
         # on `np.errstate` that is not supported by Pyodide.
         result = float(numerator) / float(denominator)
-        if np.isinf(result):
+        if math.isinf(result):
             warnings.warn("overflow encountered in _safe_divide", RuntimeWarning)
         return result
     except ZeroDivisionError:

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -65,7 +65,7 @@ _LOSSES.update(
 def _safe_divide(numerator, denominator):
     """Prevents overflow and division by zero."""
     try:
-        # Cast to a Python float to triggers a ZeroDivisionError without relying
+        # Cast to Python float to trigger a ZeroDivisionError without relying
         # on `np.errstate` that is not supported by Pyodide.
         result = float(numerator) / float(denominator)
         if np.isinf(result):

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1445,12 +1445,12 @@ def test_huber_vs_mean_and_median():
 
 def test_safe_divide():
     """Test that _safe_divide handles division by zero."""
-    assert _safe_divide(np.array([1e300]), 0) == 0
+    assert _safe_divide(np.float64(1e300), 0) == 0
     assert _safe_divide(np.float64(0.0), np.float64(0.0)) == 0
 
     with pytest.warns(RuntimeWarning, match="overflow"):
         # np.finfo(float).max = 1.7976931348623157e+308
-        _safe_divide(np.array([1e300]), 1e-10)
+        print(_safe_divide(np.float64(1e300), 1e-10))
 
 
 def test_squared_error_exact_backward_compat():

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1445,8 +1445,10 @@ def test_huber_vs_mean_and_median():
 
 def test_safe_divide():
     """Test that _safe_divide handles division by zero."""
-    assert _safe_divide(np.float64(1e300), 0) == 0
-    assert _safe_divide(np.float64(0.0), np.float64(0.0)) == 0
+    with pytest.warns(RuntimeWarning, match="divide"):
+        assert _safe_divide(np.float64(1e300), 0) == 0
+    with pytest.warns(RuntimeWarning, match="divide"):
+        assert _safe_divide(np.float64(0.0), np.float64(0.0)) == 0
 
     with pytest.warns(RuntimeWarning, match="overflow"):
         # np.finfo(float).max = 1.7976931348623157e+308

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1446,6 +1446,7 @@ def test_huber_vs_mean_and_median():
 def test_safe_divide():
     """Test that _safe_divide handles division by zero."""
     assert _safe_divide(np.array([1e300]), 0) == 0
+    assert _safe_divide(np.float64(0.0), np.float64(0.0)) == 0
 
     with pytest.warns(RuntimeWarning, match="overflow"):
         # np.finfo(float).max = 1.7976931348623157e+308

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1449,7 +1449,6 @@ def test_safe_divide():
         assert _safe_divide(np.float64(1e300), 0) == 0
     with pytest.warns(RuntimeWarning, match="divide"):
         assert _safe_divide(np.float64(0.0), np.float64(0.0)) == 0
-
     with pytest.warns(RuntimeWarning, match="overflow"):
         # np.finfo(float).max = 1.7976931348623157e+308
         print(_safe_divide(np.float64(1e300), 1e-10))

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1451,7 +1451,7 @@ def test_safe_divide():
         assert _safe_divide(np.float64(0.0), np.float64(0.0)) == 0
     with pytest.warns(RuntimeWarning, match="overflow"):
         # np.finfo(float).max = 1.7976931348623157e+308
-        print(_safe_divide(np.float64(1e300), 1e-10))
+        _safe_divide(np.float64(1e300), 1e-10)
 
 
 def test_squared_error_exact_backward_compat():


### PR DESCRIPTION
Fixing the `main` branch.

This PR should handle the case of zero-division with two numpy scalar.

ping @lorentzenchr @thomasjpfan @OmarManzoor @lesteve 

Edit: The CI failure popped up after merging #26278 in the example examples/ensemble/plot_gradient_boosting_regularization.py