### PR TITLE
FIX Allow values less than 1 for the gamma param of spectral clustering

### DIFF
--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -682,7 +682,7 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
             self.gamma,
             "gamma",
             target_type=numbers.Real,
-            min_val=1.0,
+            min_val=0.0,
             include_boundaries="left",
         )
 

--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -131,8 +131,7 @@ def test_spectral_unknown_assign_labels():
             TypeError,
             "n_init must be an instance of int, not float",
         ),
-        (X, {"gamma": -1}, ValueError, "gamma == -1, must be >= 1"),
-        (X, {"gamma": 0}, ValueError, "gamma == 0, must be >= 1"),
+        (X, {"gamma": -1}, ValueError, "gamma == -1, must be >= 0"),
         (X, {"n_neighbors": -1}, ValueError, "n_neighbors == -1, must be >= 1"),
         (X, {"n_neighbors": 0}, ValueError, "n_neighbors == 0, must be >= 1"),
         (


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
In scikit-learn 1.1.0, the gamma value for spectral clustering was forced >=1.0 
This is incorrect as low values (< 1) are very useful (and almost standard in fact)

This reallows >=0 values instead of >=1 real values

#### Any other comments?
This is fixed by https://github.com/scikit-learn/scikit-learn/commit/46623efa0dd4ca16ea1be2990be45f187340a88c for versions >= 1.2.0 so there is no need to apply this on other branches