### PR TITLE
TST Extend tests for `scipy.sparse.*array` in `sklearn/utils/tests/test_mocking.py`

### DIFF
--- a/sklearn/utils/tests/test_mocking.py
+++ b/sklearn/utils/tests/test_mocking.py
@@ -10,6 +10,7 @@ from sklearn.utils._mocking import (
     _MockEstimatorOnOffPrediction,
 )
 from sklearn.utils._testing import _convert_container
+from sklearn.utils.fixes import CSR_CONTAINERS
 
 
 @pytest.fixture
@@ -121,9 +122,10 @@ def test_checking_classifier(iris, input_type):
     assert_allclose(y_decision, 0)
 
 
-def test_checking_classifier_with_params(iris):
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_checking_classifier_with_params(iris, csr_container):
     X, y = iris
-    X_sparse = sparse.csr_matrix(X)
+    X_sparse = csr_container(X)
 
     clf = CheckingClassifier(check_X=sparse.issparse)
     with pytest.raises(AssertionError):


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #27090.

#### What does this implement/fix? Explain your changes.
This PR substitutes scipy sparse matrices with the scipy containers introduced in #27095 in the `sklearn/utils/tests/test_mocking.py` test file.