### PR TITLE
FIX contrast colors confusion matrix with nan values

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -43,6 +43,14 @@ Changelog
   ``transform`` when ``add_indicator`` is set to ``True`` and missing values are observed
   during ``fit``. :pr:`26600` by :user:`Shreesha Kumar Bhat <Shreesha3112>`.
 
+:mod:`sklearn.metrics`
+......................
+
+- |Fix| Fix bug in :class:`sklearn.metrics.ConfusionMatrixDisplay` where text colors do
+  do not always contrast with background if the confusion matrix input contains `nan`
+  values.
+  :pr:`27306` by :user:`Ravi Selker <raviselker>`
+
 :mod:`sklearn.neighbors`
 ........................
 

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -49,7 +49,7 @@ Changelog
 - |Fix| Fix bug in :class:`sklearn.metrics.ConfusionMatrixDisplay` where text colors do
   do not always contrast with background if the confusion matrix input contains `nan`
   values.
-  :pr:`27306` by :user:`Ravi Selker <raviselker>`
+  :pr:`27320` by :user:`Ravi Selker <raviselker>`
 
 :mod:`sklearn.neighbors`
 ........................

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -153,7 +153,7 @@ class ConfusionMatrixDisplay:
             self.text_ = np.empty_like(cm, dtype=object)
 
             # print text with appropriate color depending on background
-            thresh = (cm.max() + cm.min()) / 2.0
+            thresh = (np.nanmax(cm) + np.nanmin(cm)) / 2.0
 
             for i, j in product(range(n_classes), range(n_classes)):
                 color = cmap_max if cm[i, j] < thresh else cmap_min

--- a/sklearn/metrics/_plot/tests/test_confusion_matrix_display.py
+++ b/sklearn/metrics/_plot/tests/test_confusion_matrix_display.py
@@ -267,6 +267,23 @@ def test_confusion_matrix_contrast(pyplot):
     assert_allclose(disp.text_[1, 1].get_color(), min_color)
 
 
+def test_confusion_matrix_with_nan_values_contrast(pyplot):
+    """Text values are displayed in contrasting colors for matrices with nans.
+
+    This is a regression test for #27306
+    """
+    cm = np.array([[1, 2], [3, np.nan]])
+    disp = ConfusionMatrixDisplay(cm)
+
+    disp.plot(cmap=pyplot.cm.Blues)
+    min_color = pyplot.cm.Blues(0)
+    max_color = pyplot.cm.Blues(255)
+    assert_allclose(disp.text_[0, 0].get_color(), max_color)
+    assert_allclose(disp.text_[0, 1].get_color(), min_color)
+    assert_allclose(disp.text_[1, 0].get_color(), min_color)
+    assert_allclose(disp.text_[1, 1].get_color(), min_color)
+
+
 @pytest.mark.parametrize(
     "clf",
     [


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #27306 

#### What does this implement/fix? Explain your changes.
Previously, when a confusion matrix (numpy array) had nan values, the threshold for the contrasting text color would have a nan value as well. This resulted in that the "max_color" was always chosen as the text color. To fix this, we (@caskok and me) implemented the suggestion mentioned in #27306, namely to remove nan values for calculating the contrasting color threshold.