### PR TITLE
Raise ValueError instead of RuntimeWarning for LinearModelLoss

### DIFF
--- a/sklearn/ensemble/tests/test_stacking.py
+++ b/sklearn/ensemble/tests/test_stacking.py
@@ -26,7 +26,7 @@ from sklearn.ensemble import (
     StackingClassifier,
     StackingRegressor,
 )
-from sklearn.exceptions import ConvergenceWarning, NotFittedError
+from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import (
     LinearRegression,
     LogisticRegression,
@@ -42,7 +42,6 @@ from sklearn.utils._mocking import CheckingClassifier
 from sklearn.utils._testing import (
     assert_allclose,
     assert_allclose_dense_sparse,
-    ignore_warnings,
 )
 from sklearn.utils.fixes import COO_CONTAINERS, CSC_CONTAINERS, CSR_CONTAINERS
 

--- a/sklearn/ensemble/tests/test_stacking.py
+++ b/sklearn/ensemble/tests/test_stacking.py
@@ -53,6 +53,8 @@ X_multilabel, y_multilabel = make_multilabel_classification(
     n_classes=3, random_state=42
 )
 X_binary, y_binary = make_classification(n_classes=2, random_state=42)
+X_breast_cancer, y_breast_cancer = load_breast_cancer(return_X_y=True)
+X_breast_cancer = scale(X_breast_cancer)
 
 
 @pytest.mark.parametrize(
@@ -434,10 +436,8 @@ def test_stacking_classifier_stratify_default():
                 final_estimator=LogisticRegression(),
                 cv=KFold(shuffle=True, random_state=42),
             ),
-            *[
-                scale(data) if idx == 0 else data
-                for idx, data in list(enumerate(load_breast_cancer(return_X_y=True)))
-            ],
+            X_breast_cancer,
+            y_breast_cancer,
         ),
         (
             StackingRegressor(
@@ -500,10 +500,8 @@ def test_stacking_classifier_sample_weight_fit_param():
                 ],
                 final_estimator=LogisticRegression(),
             ),
-            *[
-                scale(data) if idx == 0 else data
-                for idx, data in list(enumerate(load_breast_cancer(return_X_y=True)))
-            ],
+            X_breast_cancer,
+            y_breast_cancer,
         ),
         (
             StackingRegressor(

--- a/sklearn/ensemble/tests/test_stacking.py
+++ b/sklearn/ensemble/tests/test_stacking.py
@@ -467,18 +467,15 @@ def test_stacking_with_sample_weight(stacker, X, y):
         X, y, total_sample_weight, random_state=42
     )
 
-    with ignore_warnings(category=ConvergenceWarning):
-        stacker.fit(X_train, y_train)
+    stacker.fit(X_train, y_train)
     y_pred_no_weight = stacker.predict(X_test)
 
-    with ignore_warnings(category=ConvergenceWarning):
-        stacker.fit(X_train, y_train, sample_weight=np.ones(y_train.shape))
+    stacker.fit(X_train, y_train, sample_weight=np.ones(y_train.shape))
     y_pred_unit_weight = stacker.predict(X_test)
 
     assert_allclose(y_pred_no_weight, y_pred_unit_weight)
 
-    with ignore_warnings(category=ConvergenceWarning):
-        stacker.fit(X_train, y_train, sample_weight=sample_weight_train)
+    stacker.fit(X_train, y_train, sample_weight=sample_weight_train)
     y_pred_biased = stacker.predict(X_test)
 
     assert np.abs(y_pred_no_weight - y_pred_biased).sum() > 0
@@ -493,7 +490,6 @@ def test_stacking_classifier_sample_weight_fit_param():
     stacker.fit(X_iris, y_iris, sample_weight=np.ones(X_iris.shape[0]))
 
 
-@pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
 @pytest.mark.parametrize(
     "stacker, X, y",
     [

--- a/sklearn/ensemble/tests/test_stacking.py
+++ b/sklearn/ensemble/tests/test_stacking.py
@@ -435,7 +435,10 @@ def test_stacking_classifier_stratify_default():
                 final_estimator=LogisticRegression(),
                 cv=KFold(shuffle=True, random_state=42),
             ),
-            *load_breast_cancer(return_X_y=True),
+            *[
+                scale(data) if idx == 0 else data
+                for idx, data in list(enumerate(load_breast_cancer(return_X_y=True)))
+            ],
         ),
         (
             StackingRegressor(
@@ -502,7 +505,10 @@ def test_stacking_classifier_sample_weight_fit_param():
                 ],
                 final_estimator=LogisticRegression(),
             ),
-            *load_breast_cancer(return_X_y=True),
+            *[
+                scale(data) if idx == 0 else data
+                for idx, data in list(enumerate(load_breast_cancer(return_X_y=True)))
+            ],
         ),
         (
             StackingRegressor(

--- a/sklearn/linear_model/_linear_loss.py
+++ b/sklearn/linear_model/_linear_loss.py
@@ -291,13 +291,29 @@ class LinearModelLoss:
 
         if not self.base_loss.is_multiclass:
             grad = np.empty_like(coef, dtype=weights.dtype)
-            grad[:n_features] = X.T @ grad_pointwise + l2_reg_strength * weights
+            with np.errstate(all="raise"):
+                try:
+                    grad[:n_features] = X.T @ grad_pointwise + l2_reg_strength * weights
+                except FloatingPointError:
+                    raise ValueError(
+                        "Overflow detected. Try scaling the target variable or"
+                        " features, or using a different solver"
+                    ) from None
             if self.fit_intercept:
                 grad[-1] = grad_pointwise.sum()
         else:
             grad = np.empty((n_classes, n_dof), dtype=weights.dtype, order="F")
             # grad_pointwise.shape = (n_samples, n_classes)
-            grad[:, :n_features] = grad_pointwise.T @ X + l2_reg_strength * weights
+            with np.errstate(all="raise"):
+                try:
+                    grad[:, :n_features] = (
+                        grad_pointwise.T @ X + l2_reg_strength * weights
+                    )
+                except FloatingPointError:
+                    raise ValueError(
+                        "Overflow detected. Try scaling the target variable or"
+                        " features, or using a different solver"
+                    ) from None
             if self.fit_intercept:
                 grad[:, -1] = grad_pointwise.sum(axis=0)
             if coef.ndim == 1:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #27016  


#### What does this implement/fix? Explain your changes.

Fixes an issue where ```PoissonRegressor``` (and other regressors) encounter a ```RuntimeWarning```, without any suggestion of the cause or ways to fix.

The fix captures the ```RuntimeWarning``` and raises a ```ValueError``` instead, in the case where the gradient vector contains invalid entries (e.g. inf, null), during a matmul. It also has a message suggesting scaling of features or target variable, or to use another solver.

#### Any other comments?

So far I have just tested that this exception/message occur on the same test data where I encountered the issue (see the issue #27016).

I have included the same change for the case where the loss is multiclass, but haven't directly tested this on a multiclass problem.

The change caused some pre-existing pytests to start failing, due to warning that would have been raised being replaced by a ValueError as part of the issue. I have included a change to scale the X dataset so that this error doesn't occur to get those tests passing.

Questions:

1. Is the update to the pytest valid? And if it is, should it be part of this PR or a separate one?
2. Could throwing a ValueError rather than just a warning break some pipelines/uses of linear loss that are currently 'working'? ('Working' in the sense that there is only a RuntimeWarning, not an error/exception) If so, is it possible (or better even) to instead just update the message on the RuntimeWarning?
3. There are still 3 checks that are failing - how could they be resolved?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
