### PR TITLE
CI Do not run doctests for numpy 2

### DIFF
--- a/doc/conftest.py
+++ b/doc/conftest.py
@@ -187,6 +187,9 @@ def pytest_collection_modifyitems(config, items):
     """
     skip_doctests = False
     if np_base_version >= parse_version("2"):
+        # Skip doctests when using numpy 2 for now. See the following discussion
+        # to decide what to do in the longer term:
+        # https://github.com/scikit-learn/scikit-learn/issues/27339
         reason = "Due to NEP 51 numpy scalar repr has changed in numpy 2"
         skip_doctests = True
 

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -25,7 +25,7 @@ from sklearn.datasets import (
 )
 from sklearn.tests import random_seed
 from sklearn.utils import _IS_32BIT
-from sklearn.utils.fixes import parse_version, sp_version
+from sklearn.utils.fixes import np_base_version, parse_version, sp_version
 
 if parse_version(pytest.__version__) < parse_version(PYTEST_MIN_VERSION):
     raise ImportError(
@@ -185,6 +185,10 @@ def pytest_collection_modifyitems(config, items):
             "doctests are not run for Windows because numpy arrays "
             "repr is inconsistent across platforms."
         )
+        skip_doctests = True
+
+    if np_base_version >= parse_version("2"):
+        reason = "Due to NEP 51 numpy scalar repr has changed in numpy 2"
         skip_doctests = True
 
     # Normally doctest has the entire module's scope. Here we set globs to an empty dict

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -25,6 +25,7 @@ from ..externals._packaging.version import parse as parse_version
 from .deprecation import deprecated
 
 np_version = parse_version(np.__version__)
+np_base_version = parse_version(np_version.base_version)
 sp_version = parse_version(scipy.__version__)
 sp_base_version = parse_version(sp_version.base_version)
 


### PR DESCRIPTION
This should get rid of doctest issues in scipy-dev build see this [build](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=58914&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=a5a438e1-a911-5517-158f-26a140e5cbbf)