### PR TITLE
MNT Remove setuptools dependency in our test suite

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -217,6 +217,9 @@ def test_import_all_consistency():
     for modname in submods + ["sklearn"]:
         if ".tests." in modname:
             continue
+        # Avoid test suite depending on setuptools
+        if modname == "sklearn._build_utils.pre_build_helpers":
+            continue
         if IS_PYPY and (
             "_svmlight_format_io" in modname
             or "feature_extraction._hashing_fast" in modname

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -154,29 +154,6 @@ def test_docstring_parameters():
         raise AssertionError("Docstring Error:\n" + msg)
 
 
-@ignore_warnings(category=FutureWarning)
-def test_tabs():
-    # Test that there are no tabs in our source files
-    for importer, modname, ispkg in walk_packages(sklearn.__path__, prefix="sklearn."):
-        if IS_PYPY and (
-            "_svmlight_format_io" in modname
-            or "feature_extraction._hashing_fast" in modname
-        ):
-            continue
-
-        # because we don't import
-        mod = importlib.import_module(modname)
-
-        try:
-            source = inspect.getsource(mod)
-        except IOError:  # user probably should have run "make clean"
-            continue
-        assert "\t" not in source, (
-            '"%s" has tabs, please remove them ',
-            "or add it to the ignore list" % modname,
-        )
-
-
 def _construct_searchcv_instance(SearchCV):
     return SearchCV(LogisticRegression(), {"C": [0.1, 1]})
 


### PR DESCRIPTION
This was noticed when working on Python 3.12 wheels in https://github.com/scikit-learn/scikit-learn/pull/27027. In Python 3.12 setuptools is not a core dependency `venv` (see [this](https://docs.python.org/3.12/library/venv.html#creating-virtual-environments)).

As noted in https://github.com/scikit-learn/scikit-learn/pull/27027#issuecomment-1715046845, our test suite should not depend on setuptools.

This PR:
- remove `test_tabs` which is not useful since we are using black
- avoids importing `sklearn._build_utils.pre_build_helpers` (which is the only module depending on setuptools) to check its `__all__` in test_import_all_consistency`