### PR TITLE
MAINT use .toarray instead of .A that is deprecated

### DIFF
--- a/sklearn/cluster/_hdbscan/tests/test_reachibility.py
+++ b/sklearn/cluster/_hdbscan/tests/test_reachibility.py
@@ -45,7 +45,7 @@ def test_mutual_reachability_graph_equivalence_dense_sparse():
     mr_graph_dense = mutual_reachability_graph(X_dense, min_samples=3)
     mr_graph_sparse = mutual_reachability_graph(X_sparse, min_samples=3)
 
-    assert_allclose(mr_graph_dense, mr_graph_sparse.A)
+    assert_allclose(mr_graph_dense, mr_graph_sparse.toarray())
 
 
 @pytest.mark.parametrize("array_type", ["array", "sparse_csr"])

--- a/sklearn/feature_extraction/tests/test_dict_vectorizer.py
+++ b/sklearn/feature_extraction/tests/test_dict_vectorizer.py
@@ -30,7 +30,9 @@ def test_dictvectorizer(sparse, dtype, sort, iterable):
 
     if sparse:
         # CSR matrices can't be compared for equality
-        assert_array_equal(X.A, v.transform(iter(D) if iterable else D).A)
+        assert_array_equal(
+            X.toarray(), v.transform(iter(D) if iterable else D).toarray()
+        )
     else:
         assert_array_equal(X, v.transform(iter(D) if iterable else D))
 

--- a/sklearn/feature_extraction/tests/test_feature_hasher.py
+++ b/sklearn/feature_extraction/tests/test_feature_hasher.py
@@ -125,7 +125,7 @@ def test_hash_empty_input():
     feature_hasher = FeatureHasher(n_features=n_features, input_type="string")
     X = feature_hasher.transform(raw_X)
 
-    assert_array_equal(X.A, np.zeros((len(raw_X), n_features)))
+    assert_array_equal(X.toarray(), np.zeros((len(raw_X), n_features)))
 
 
 def test_hasher_zeros():

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1684,7 +1684,7 @@ def test_simple_imputer_constant_keep_empty_features(array_type, keep_empty_feat
         X_imputed = getattr(imputer, method)(X)
         assert X_imputed.shape == X.shape
         constant_feature = (
-            X_imputed[:, 0].A if array_type == "sparse" else X_imputed[:, 0]
+            X_imputed[:, 0].toarray() if array_type == "sparse" else X_imputed[:, 0]
         )
         assert_array_equal(constant_feature, fill_value)
 
@@ -1705,7 +1705,7 @@ def test_simple_imputer_keep_empty_features(strategy, array_type, keep_empty_fea
         if keep_empty_features:
             assert X_imputed.shape == X.shape
             constant_feature = (
-                X_imputed[:, 0].A if array_type == "sparse" else X_imputed[:, 0]
+                X_imputed[:, 0].toarray() if array_type == "sparse" else X_imputed[:, 0]
             )
             assert_array_equal(constant_feature, 0)
         else:

--- a/sklearn/manifold/tests/test_t_sne.py
+++ b/sklearn/manifold/tests/test_t_sne.py
@@ -452,7 +452,7 @@ def test_sparse_precomputed_distance(sparse_container):
     D_sparse = kneighbors_graph(X, n_neighbors=100, mode="distance", include_self=True)
     D = pairwise_distances(X)
     assert sp.issparse(D_sparse)
-    assert_almost_equal(D_sparse.A, D)
+    assert_almost_equal(D_sparse.toarray(), D)
 
     tsne = TSNE(
         metric="precomputed", random_state=0, init="random", learning_rate="auto"

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1847,7 +1847,7 @@ def test_non_euclidean_kneighbors():
             X, radius, metric=metric, mode="connectivity", include_self=True
         ).toarray()
         nbrs1 = neighbors.NearestNeighbors(metric=metric, radius=radius).fit(X)
-        assert_array_equal(nbrs_graph, nbrs1.radius_neighbors_graph(X).A)
+        assert_array_equal(nbrs_graph, nbrs1.radius_neighbors_graph(X).toarray())
 
     # Raise error when wrong parameters are supplied,
     X_nbrs = neighbors.NearestNeighbors(n_neighbors=3, metric="manhattan")
@@ -1884,13 +1884,15 @@ def test_k_and_radius_neighbors_train_is_not_query():
         check_object_arrays(ind, [[1], [0, 1]])
 
         # Test the graph variants.
-        assert_array_equal(nn.kneighbors_graph(test_data).A, [[0.0, 1.0], [0.0, 1.0]])
         assert_array_equal(
-            nn.kneighbors_graph([[2], [1]], mode="distance").A,
+            nn.kneighbors_graph(test_data).toarray(), [[0.0, 1.0], [0.0, 1.0]]
+        )
+        assert_array_equal(
+            nn.kneighbors_graph([[2], [1]], mode="distance").toarray(),
             np.array([[0.0, 1.0], [0.0, 0.0]]),
         )
         rng = nn.radius_neighbors_graph([[2], [1]], radius=1.5)
-        assert_array_equal(rng.A, [[0, 1], [1, 1]])
+        assert_array_equal(rng.toarray(), [[0, 1], [1, 1]])
 
 
 @pytest.mark.parametrize("algorithm", ALGORITHMS)
@@ -1912,7 +1914,7 @@ def test_k_and_radius_neighbors_X_None(algorithm):
     rng = nn.radius_neighbors_graph(None, radius=1.5)
     kng = nn.kneighbors_graph(None)
     for graph in [rng, kng]:
-        assert_array_equal(graph.A, [[0, 1], [1, 0]])
+        assert_array_equal(graph.toarray(), [[0, 1], [1, 0]])
         assert_array_equal(graph.data, [1, 1])
         assert_array_equal(graph.indices, [1, 0])
 
@@ -1920,7 +1922,7 @@ def test_k_and_radius_neighbors_X_None(algorithm):
     nn = neighbors.NearestNeighbors(n_neighbors=2, algorithm=algorithm)
     nn.fit(X)
     assert_array_equal(
-        nn.kneighbors_graph().A,
+        nn.kneighbors_graph().toarray(),
         np.array([[0.0, 1.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 0]]),
     )
 
@@ -1978,13 +1980,15 @@ def test_k_and_radius_neighbors_duplicates(algorithm):
 def test_include_self_neighbors_graph():
     # Test include_self parameter in neighbors_graph
     X = [[2, 3], [4, 5]]
-    kng = neighbors.kneighbors_graph(X, 1, include_self=True).A
-    kng_not_self = neighbors.kneighbors_graph(X, 1, include_self=False).A
+    kng = neighbors.kneighbors_graph(X, 1, include_self=True).toarray()
+    kng_not_self = neighbors.kneighbors_graph(X, 1, include_self=False).toarray()
     assert_array_equal(kng, [[1.0, 0.0], [0.0, 1.0]])
     assert_array_equal(kng_not_self, [[0.0, 1.0], [1.0, 0.0]])
 
-    rng = neighbors.radius_neighbors_graph(X, 5.0, include_self=True).A
-    rng_not_self = neighbors.radius_neighbors_graph(X, 5.0, include_self=False).A
+    rng = neighbors.radius_neighbors_graph(X, 5.0, include_self=True).toarray()
+    rng_not_self = neighbors.radius_neighbors_graph(
+        X, 5.0, include_self=False
+    ).toarray()
     assert_array_equal(rng, [[1.0, 1.0], [1.0, 1.0]])
     assert_array_equal(rng_not_self, [[0.0, 1.0], [1.0, 0.0]])
 
@@ -2073,7 +2077,7 @@ def test_dtype_convert():
 def test_sparse_metric_callable():
     def sparse_metric(x, y):  # Metric accepting sparse matrix input (only)
         assert issparse(x) and issparse(y)
-        return x.dot(y.T).A.item()
+        return x.dot(y.T).toarray().item()
 
     X = csr_matrix(
         [[1, 1, 1, 1, 1], [1, 0, 1, 0, 1], [0, 0, 1, 0, 0]]  # Population matrix

--- a/sklearn/preprocessing/tests/test_common.py
+++ b/sklearn/preprocessing/tests/test_common.py
@@ -131,13 +131,13 @@ def test_missing_value_handling(
                 warnings.simplefilter("error", RuntimeWarning)
                 Xt_sp = est_sparse.fit(X_train_sp).transform(X_test_sp)
 
-            assert_allclose(Xt_sp.A, Xt_dense)
+            assert_allclose(Xt_sp.toarray(), Xt_dense)
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", PendingDeprecationWarning)
                 warnings.simplefilter("error", RuntimeWarning)
                 Xt_inv_sp = est_sparse.inverse_transform(Xt_sp)
 
-            assert_allclose(Xt_inv_sp.A, Xt_inv_dense)
+            assert_allclose(Xt_inv_sp.toarray(), Xt_inv_dense)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -725,7 +725,7 @@ def test_polynomial_features_csc_X(deg, include_bias, interaction_only, dtype):
 
     assert sparse.issparse(Xt_csc) and Xt_csc.format == "csc"
     assert Xt_csc.dtype == Xt_dense.dtype
-    assert_array_almost_equal(Xt_csc.A, Xt_dense)
+    assert_array_almost_equal(Xt_csc.toarray(), Xt_dense)
 
 
 @pytest.mark.parametrize(
@@ -752,7 +752,7 @@ def test_polynomial_features_csr_X(deg, include_bias, interaction_only, dtype):
 
     assert sparse.issparse(Xt_csr) and Xt_csr.format == "csr"
     assert Xt_csr.dtype == Xt_dense.dtype
-    assert_array_almost_equal(Xt_csr.A, Xt_dense)
+    assert_array_almost_equal(Xt_csr.toarray(), Xt_dense)
 
 
 @pytest.mark.parametrize("n_features", [1, 4, 5])
@@ -811,7 +811,7 @@ def test_polynomial_features_csr_X_floats(deg, include_bias, interaction_only, d
 
     assert sparse.issparse(Xt_csr) and Xt_csr.format == "csr"
     assert Xt_csr.dtype == Xt_dense.dtype
-    assert_array_almost_equal(Xt_csr.A, Xt_dense)
+    assert_array_almost_equal(Xt_csr.toarray(), Xt_dense)
 
 
 @pytest.mark.parametrize(
@@ -842,7 +842,7 @@ def test_polynomial_features_csr_X_zero_row(zero_row_index, deg, interaction_onl
 
     assert sparse.issparse(Xt_csr) and Xt_csr.format == "csr"
     assert Xt_csr.dtype == Xt_dense.dtype
-    assert_array_almost_equal(Xt_csr.A, Xt_dense)
+    assert_array_almost_equal(Xt_csr.toarray(), Xt_dense)
 
 
 # This degree should always be one more than the highest degree supported by
@@ -863,7 +863,7 @@ def test_polynomial_features_csr_X_degree_4(include_bias, interaction_only):
 
     assert sparse.issparse(Xt_csr) and Xt_csr.format == "csr"
     assert Xt_csr.dtype == Xt_dense.dtype
-    assert_array_almost_equal(Xt_csr.A, Xt_dense)
+    assert_array_almost_equal(Xt_csr.toarray(), Xt_dense)
 
 
 @pytest.mark.parametrize(
@@ -891,7 +891,7 @@ def test_polynomial_features_csr_X_dim_edges(deg, dim, interaction_only):
 
     assert sparse.issparse(Xt_csr) and Xt_csr.format == "csr"
     assert Xt_csr.dtype == Xt_dense.dtype
-    assert_array_almost_equal(Xt_csr.A, Xt_dense)
+    assert_array_almost_equal(Xt_csr.toarray(), Xt_dense)
 
 
 @pytest.mark.parametrize("interaction_only", [True, False])

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -115,8 +115,8 @@ def test_additive_chi2_sampler(csr_container):
     X_sp_trans = transform.fit_transform(csr_container(X))
     Y_sp_trans = transform.transform(csr_container(Y))
 
-    assert_array_equal(X_trans, X_sp_trans.A)
-    assert_array_equal(Y_trans, Y_sp_trans.A)
+    assert_array_equal(X_trans, X_sp_trans.toarray())
+    assert_array_equal(Y_trans, Y_sp_trans.toarray())
 
     # test error is raised on negative input
     Y_neg = Y.copy()

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1489,7 +1489,7 @@ def _apply_on_subsets(func, X):
 
     if sparse.issparse(result_full):
         result_full = result_full.A
-        result_by_batch = [x.A for x in result_by_batch]
+        result_by_batch = [x.toarray() for x in result_by_batch]
 
     return np.ravel(result_full), np.ravel(result_by_batch)
 

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -468,9 +468,9 @@ def test_incr_mean_variance_axis_equivalence_mean_variance(X1, X2, csr_container
         X2, axis=axis, last_mean=updated_mean, last_var=updated_var, last_n=updated_n
     )
     X = sp.vstack([X1, X2])
-    assert_allclose(updated_mean, np.nanmean(X.A, axis=axis))
-    assert_allclose(updated_var, np.nanvar(X.A, axis=axis))
-    assert_allclose(updated_n, np.count_nonzero(~np.isnan(X.A), axis=0))
+    assert_allclose(updated_mean, np.nanmean(X.toarray(), axis=axis))
+    assert_allclose(updated_var, np.nanvar(X.toarray(), axis=axis))
+    assert_allclose(updated_n, np.count_nonzero(~np.isnan(X.toarray()), axis=0))
 
 
 def test_incr_mean_variance_no_new_n():


### PR DESCRIPTION
closes #27365 

Avoid deprecation warning by using `.toarray` instead of `.A`