### PR TITLE
ENH alleviate the clipping effect due to subsampling in QuantileTransformer

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -214,6 +214,12 @@ Changelog
 - |Enhancement| :class:`preprocessing.TargetEncoder` now supports `target_type`
   'multiclass'. :pr:`26674` by :user:`Lucy Liu <lucyleeow>`.
 
+- |Enhancement| Alleviate the clipping effect due to subsampling in
+  :class:`preprocessing.QuantileTransformer` and
+  :func:`preprocessing.quantile_transform` by always picking the min-max samples values
+  for each feature.
+  :pr:`27374` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.model_selection`
 ..............................
 

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2592,9 +2592,12 @@ class QuantileTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator)
         self.quantiles_ = []
         for col in X.T:
             if self.subsample < n_samples:
+                min_idx, max_idx = col.argmin(), col.argmax()
+                indices = np.delete(np.arange(n_samples), [min_idx, max_idx])
                 subsample_idx = random_state.choice(
-                    n_samples, size=self.subsample, replace=False
+                    indices, size=self.subsample - 2, replace=False
                 )
+                subsample_idx = np.hstack((min_idx, max_idx, subsample_idx))
                 col = col.take(subsample_idx, mode="clip")
             self.quantiles_.append(np.nanpercentile(col, references))
         self.quantiles_ = np.transpose(self.quantiles_)
@@ -2626,9 +2629,13 @@ class QuantileTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator)
                     column_data = np.zeros(shape=column_subsample, dtype=X.dtype)
                 else:
                     column_data = np.zeros(shape=self.subsample, dtype=X.dtype)
-                column_data[:column_subsample] = random_state.choice(
-                    column_nnz_data, size=column_subsample, replace=False
+                min_idx, max_idx = column_nnz_data.argmin(), column_nnz_data.argmax()
+                indices = np.delete(np.arange(len(column_nnz_data)), [min_idx, max_idx])
+                subsample_idx = random_state.choice(
+                    indices, size=column_subsample - 2, replace=False
                 )
+                subsample_idx = np.hstack((min_idx, max_idx, subsample_idx))
+                column_data[:column_subsample] = column_nnz_data[subsample_idx]
             else:
                 if self.ignore_implicit_zeros:
                     column_data = np.zeros(shape=len(column_nnz_data), dtype=X.dtype)

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2535,6 +2535,10 @@ class QuantileTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator)
     NaNs are treated as missing values: disregarded in fit, and maintained in
     transform.
 
+    To alleviate the clipping effect potentially introduced by the `subsampling`
+    parameter, the minimum and maximum values of each feature are always
+    preserved and map to the quantile 0 and 1 respectively.
+
     Examples
     --------
     >>> import numpy as np
@@ -2974,6 +2978,10 @@ def quantile_transform(
     -----
     NaNs are treated as missing values: disregarded in fit, and maintained in
     transform.
+
+    To alleviate the clipping effect potentially introduced by the `subsampling`
+    parameter, the minimum and maximum values of each feature are always
+    preserved and map to the quantile 0 and 1 respectively.
 
     .. warning:: Risk of data leak
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1340,6 +1340,11 @@ def test_quantile_transform_subsampling():
             subsample=n_samples // 10,
         )
         transformer.fit(X)
+        # to limit the clipping effect the min-max are always sampled, check this is the
+        # case
+        X_min, X_max = X.min(axis=0), X.max(axis=0)
+        assert_allclose(transformer.quantiles_[0], X_min)
+        assert_allclose(transformer.quantiles_[-1], X_max)
         diff = np.linspace(0, 1, n_quantiles) - np.ravel(transformer.quantiles_)
         inf_norm = np.max(np.abs(diff))
         assert inf_norm < 1e-2
@@ -1359,6 +1364,11 @@ def test_quantile_transform_subsampling():
             subsample=n_samples // 10,
         )
         transformer.fit(X)
+        # to limit the clipping effect the min-max are always sampled, check this is the
+        # case
+        X_min, X_max = X.min(axis=0).toarray(), X.max(axis=0).toarray()
+        assert_allclose(transformer.quantiles_[0], X_min[0])
+        assert_allclose(transformer.quantiles_[-1], X_max[0])
         diff = np.linspace(0, 1, n_quantiles) - np.ravel(transformer.quantiles_)
         inf_norm = np.max(np.abs(diff))
         assert inf_norm < 1e-1


### PR DESCRIPTION
closes #27373 

We can alleviate the clipping effect observe by using subsampling in `QuantileTransformer` by always selecting the min/max for each feature. It introduce a small bias but it might be better than the current behaviour.