### PR TITLE
DOC Adding Concrete ML in related projects

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -228,6 +228,10 @@ Note scikit-learn own modern gradient boosting estimators
 - `Flower <https://flower.dev/>`_ A friendly federated learning framework with a
   unified approach that can federate any workload, any ML framework, and any programming language.
 
+**Privacy Preserving Machine Learning**
+
+- `Concrete ML <https://github.com/zama-ai/concrete-ml/>`_ A privacy preserving ML framework built on top of `Concrete <https://github.com/zama-ai/concrete>`_, with bindings to traditional ML frameworks, thanks to fully homomorphic encryption. APIs of so-called Concrete ML built-in models are very close to scikit-learn APIs.
+
 **Broad scope**
 
 - `mlxtend <https://github.com/rasbt/mlxtend>`_ Includes a number of additional

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -230,7 +230,11 @@ Note scikit-learn own modern gradient boosting estimators
 
 **Privacy Preserving Machine Learning**
 
-- `Concrete ML <https://github.com/zama-ai/concrete-ml/>`_ A privacy preserving ML framework built on top of `Concrete <https://github.com/zama-ai/concrete>`_, with bindings to traditional ML frameworks, thanks to fully homomorphic encryption. APIs of so-called Concrete ML built-in models are very close to scikit-learn APIs.
+- `Concrete ML <https://github.com/zama-ai/concrete-ml/>`_ A privacy preserving
+  ML framework built on top of `Concrete
+  <https://github.com/zama-ai/concrete>`_, with bindings to traditional ML
+  frameworks, thanks to fully homomorphic encryption. APIs of so-called
+  Concrete ML built-in models are very close to scikit-learn APIs.
 
 **Broad scope**
 


### PR DESCRIPTION

#### Reference Issues/PRs

Refs #27375

#### What does this implement/fix? Explain your changes.

It adds Concrete ML, a related project in the related projects. That's a first step: I'd like also to add examples, if this is agreed with the maintainers.

#### Any other comments?

scikit-learn is amazing. I come from another world (the cryptography) and I am amazed by how easy / simple / natural sklearn is. This is impressing. 