### PR TITLE
CI Use the libmamba to install conda-lock on Azure Pipelines

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -49,7 +49,10 @@ pre_python_environment_install() {
 
 python_environment_install_and_activate() {
     if [[ "$DISTRIB" == "conda"* ]]; then
-        conda update -n base conda -y
+        # Install/update conda with the libmamba solver because the legacy
+        # solver can be slow at installing a specific version of conda-lock.
+        conda install -n base conda conda-libmamba-solver -y
+        conda config --set solver libmamba
         conda install -c conda-forge "$(get_dep conda-lock min)" -y
         conda-lock install --name $VIRTUALENV $LOCK_FILE
         source activate $VIRTUALENV

--- a/build_tools/azure/install_win.sh
+++ b/build_tools/azure/install_win.sh
@@ -7,6 +7,10 @@ set -x
 source build_tools/shared.sh
 
 if [[ "$DISTRIB" == "conda" ]]; then
+    # Install/update conda with the libmamba solver because the legacy solver
+    # can be slow at installing a specific version of conda-lock.
+    conda install -n base conda conda-libmamba-solver -y
+    conda config --set solver libmamba
     conda install -c conda-forge "$(get_dep conda-lock min)" -y
     conda-lock install --name $VIRTUALENV $LOCK_FILE
     source activate $VIRTUALENV


### PR DESCRIPTION
I noticed that installing conda-lock itself can take 2 to 3 minutes on our Azure CI:

```
2023-09-15T08:43:14.3473460Z + conda install -c conda-forge conda-lock==2.1.1 -y
2023-09-15T08:43:40.6414426Z Collecting package metadata (current_repodata.json): ...working... done
2023-09-15T08:43:40.6418712Z Solving environment: ...working... unsuccessful initial attempt using frozen solve. Retrying with flexible solve.
2023-09-15T08:45:49.7980620Z Collecting package metadata (repodata.json): ...working... done
2023-09-15T08:46:09.9460654Z Solving environment: ...working... done
```

Let's see if trying to force the use of the latest libmamba-solver can improve this.