### PR TITLE
TST Speed up some of the slowest tests

### DIFF
--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -2062,16 +2062,16 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
     >>> from sklearn.datasets import make_sparse_coded_signal
     >>> from sklearn.decomposition import MiniBatchDictionaryLearning
     >>> X, dictionary, code = make_sparse_coded_signal(
-    ...     n_samples=100, n_components=15, n_features=20, n_nonzero_coefs=10,
+    ...     n_samples=30, n_components=15, n_features=20, n_nonzero_coefs=10,
     ...     random_state=42)
     >>> dict_learner = MiniBatchDictionaryLearning(
     ...     n_components=15, batch_size=3, transform_algorithm='lasso_lars',
-    ...     transform_alpha=0.1, random_state=42)
+    ...     transform_alpha=0.1, max_iter=20, random_state=42)
     >>> X_transformed = dict_learner.fit_transform(X)
 
     We can check the level of sparsity of `X_transformed`:
 
-    >>> np.mean(X_transformed == 0) < 0.5
+    >>> np.mean(X_transformed == 0) > 0.5
     True
 
     We can compare the average squared euclidean norm of the reconstruction
@@ -2080,7 +2080,7 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
 
     >>> X_hat = X_transformed @ dict_learner.components_
     >>> np.mean(np.sum((X_hat - X) ** 2, axis=1) / np.sum(X ** 2, axis=1))
-    0.057...
+    0.052...
     """
 
     _parameter_constraints: dict = {

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1692,7 +1692,7 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
     >>> from sklearn.datasets import make_sparse_coded_signal
     >>> from sklearn.decomposition import DictionaryLearning
     >>> X, dictionary, code = make_sparse_coded_signal(
-    ...     n_samples=100, n_components=15, n_features=20, n_nonzero_coefs=10,
+    ...     n_samples=30, n_components=15, n_features=20, n_nonzero_coefs=10,
     ...     random_state=42,
     ... )
     >>> dict_learner = DictionaryLearning(
@@ -1704,7 +1704,7 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
     We can check the level of sparsity of `X_transformed`:
 
     >>> np.mean(X_transformed == 0)
-    0.41...
+    0.52...
 
     We can compare the average squared euclidean norm of the reconstruction
     error of the sparse coded signal relative to the squared euclidean norm of
@@ -1712,7 +1712,7 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
 
     >>> X_hat = X_transformed @ dict_learner.components_
     >>> np.mean(np.sum((X_hat - X) ** 2, axis=1) / np.sum(X ** 2, axis=1))
-    0.07...
+    0.05...
     """
 
     _parameter_constraints: dict = {

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -43,7 +43,7 @@ def test_sparse_encode_shapes_omp():
     for n_components, n_samples in itertools.product([1, 5], [1, 9]):
         X_ = rng.randn(n_samples, n_features)
         dictionary = rng.randn(n_components, n_features)
-        for algorithm, n_jobs in itertools.product(algorithms, [1, 3]):
+        for algorithm, n_jobs in itertools.product(algorithms, [1, 2]):
             code = sparse_encode(X_, dictionary, algorithm=algorithm, n_jobs=n_jobs)
             assert code.shape == (n_samples, n_components)
 

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -120,12 +120,12 @@ def test_initialization():
 def test_mini_batch_correct_shapes():
     rng = np.random.RandomState(0)
     X = rng.randn(12, 10)
-    pca = MiniBatchSparsePCA(n_components=8, random_state=rng)
+    pca = MiniBatchSparsePCA(n_components=8, max_iter=1, random_state=rng)
     U = pca.fit_transform(X)
     assert pca.components_.shape == (8, 10)
     assert U.shape == (12, 8)
     # test overcomplete decomposition
-    pca = MiniBatchSparsePCA(n_components=13, random_state=rng)
+    pca = MiniBatchSparsePCA(n_components=13, max_iter=1, random_state=rng)
     U = pca.fit_transform(X)
     assert pca.components_.shape == (13, 10)
     assert U.shape == (12, 13)

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -99,10 +99,11 @@ def test_classification_toy(loss, global_random_seed):
 def test_classification_synthetic(loss, global_random_seed):
     # Test GradientBoostingClassifier on synthetic dataset used by
     # Hastie et al. in ESLII - Figure 10.9
-    X, y = datasets.make_hastie_10_2(n_samples=12000, random_state=global_random_seed)
+    X, y = datasets.make_hastie_10_2(n_samples=2000, random_state=global_random_seed)
 
-    X_train, X_test = X[:2000], X[2000:]
-    y_train, y_test = y[:2000], y[2000:]
+    split_idx = 500
+    X_train, X_test = X[:split_idx], X[split_idx:]
+    y_train, y_test = y[:split_idx], y[split_idx:]
 
     # Increasing the number of trees should decrease the test error
     common_params = {
@@ -111,13 +112,13 @@ def test_classification_synthetic(loss, global_random_seed):
         "loss": loss,
         "random_state": global_random_seed,
     }
-    gbrt_100_stumps = GradientBoostingClassifier(n_estimators=100, **common_params)
-    gbrt_100_stumps.fit(X_train, y_train)
+    gbrt_10_stumps = GradientBoostingClassifier(n_estimators=10, **common_params)
+    gbrt_10_stumps.fit(X_train, y_train)
 
-    gbrt_200_stumps = GradientBoostingClassifier(n_estimators=200, **common_params)
-    gbrt_200_stumps.fit(X_train, y_train)
+    gbrt_50_stumps = GradientBoostingClassifier(n_estimators=50, **common_params)
+    gbrt_50_stumps.fit(X_train, y_train)
 
-    assert gbrt_100_stumps.score(X_test, y_test) < gbrt_200_stumps.score(X_test, y_test)
+    assert gbrt_10_stumps.score(X_test, y_test) < gbrt_50_stumps.score(X_test, y_test)
 
     # Decision stumps are better suited for this dataset with a large number of
     # estimators.

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -99,6 +99,10 @@ def test_classification_toy(loss, global_random_seed):
 def test_classification_synthetic(loss, global_random_seed):
     # Test GradientBoostingClassifier on synthetic dataset used by
     # Hastie et al. in ESLII - Figure 10.9
+    # Note that Figure 10.9 reuses the dataset generated for figure 10.2
+    # and should have 2_000 train data points and 10_000 test data points.
+    # Here we intentionally use a smaller variant to make the test run faster,
+    # but the conclusions are still the same, despite the smaller datasets.
     X, y = datasets.make_hastie_10_2(n_samples=2000, random_state=global_random_seed)
 
     split_idx = 500

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -74,7 +74,6 @@ COMMON_VALID_METRICS = sorted(
 )  # type: ignore
 
 P = (1, 2, 3, 4, np.inf)
-JOBLIB_BACKENDS = list(joblib.parallel.BACKENDS.keys())
 
 # Filter deprecation warnings.
 neighbors.kneighbors_graph = ignore_warnings(neighbors.kneighbors_graph)
@@ -2044,10 +2043,10 @@ def test_same_radius_neighbors_parallel(algorithm):
     assert_allclose(graph, graph_parallel)
 
 
-@pytest.mark.parametrize("backend", JOBLIB_BACKENDS)
+@pytest.mark.parametrize("backend", ["threading", "loky"])
 @pytest.mark.parametrize("algorithm", ALGORITHMS)
 def test_knn_forcing_backend(backend, algorithm):
-    # Non-regression test which ensure the knn methods are properly working
+    # Non-regression test which ensures the knn methods are properly working
     # even when forcing the global joblib backend.
     with joblib.parallel_backend(backend):
         X, y = datasets.make_classification(
@@ -2056,12 +2055,12 @@ def test_knn_forcing_backend(backend, algorithm):
         X_train, X_test, y_train, y_test = train_test_split(X, y)
 
         clf = neighbors.KNeighborsClassifier(
-            n_neighbors=3, algorithm=algorithm, n_jobs=3
+            n_neighbors=3, algorithm=algorithm, n_jobs=2
         )
         clf.fit(X_train, y_train)
         clf.predict(X_test)
         clf.kneighbors(X_test)
-        clf.kneighbors_graph(X_test, mode="distance").toarray()
+        clf.kneighbors_graph(X_test, mode="distance")
 
 
 def test_dtype_convert():

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -804,10 +804,10 @@ def test_min_weight_fraction_leaf_with_min_samples_leaf_on_sparse_input(
     )
 
 
-def test_min_impurity_decrease():
+def test_min_impurity_decrease(global_random_seed):
     # test if min_impurity_decrease ensure that a split is made only if
     # if the impurity decrease is at least that value
-    X, y = datasets.make_classification(n_samples=10000, random_state=42)
+    X, y = datasets.make_classification(n_samples=100, random_state=global_random_seed)
 
     # test both DepthFirstTreeBuilder and BestFirstTreeBuilder
     # by setting max_leaf_nodes


### PR DESCRIPTION
Mostly by reducing the dataset sizes.

- slowest tests for `pylatest_conda_forge_mkl` on `main`:

```
============================= slowest 20 durations =============================
31.32s call     decomposition/_dict_learning.py::sklearn.decomposition._dict_learning.DictionaryLearning
26.73s call     ensemble/tests/test_gradient_boosting.py::test_classification_synthetic[5-log_loss]
25.88s call     neighbors/tests/test_neighbors.py::test_knn_forcing_backend[kd_tree-multiprocessing]
25.35s call     neighbors/tests/test_neighbors.py::test_knn_forcing_backend[auto-multiprocessing]
23.85s call     ensemble/tests/test_gradient_boosting.py::test_classification_synthetic[5-exponential]
22.09s call     neighbors/tests/test_neighbors.py::test_knn_forcing_backend[ball_tree-multiprocessing]
18.64s call     tree/tests/test_tree.py::test_min_impurity_decrease
17.27s call     decomposition/tests/test_sparse_pca.py::test_mini_batch_correct_shapes
14.74s call     experimental/tests/test_enable_successive_halving.py::test_imports_strategies
14.27s call     utils/tests/test_estimator_checks.py::test_check_estimator_clones
13.12s call     experimental/tests/test_enable_iterative_imputer.py::test_imports_strategies
12.71s call     decomposition/tests/test_dict_learning.py::test_cd_work_on_joblib_memmapped_data
11.94s call     utils/tests/test_parallel.py::test_dispatch_config_parallel[2]
11.44s call     feature_selection/tests/test_sequential.py::test_n_features_to_select_stopping_criterion[forward]
11.35s call     ensemble/tests/test_gradient_boosting.py::test_gradient_boosting_validation_fraction
11.28s call     decomposition/tests/test_sparse_pca.py::test_transform_inverse_transform_round_trip[MiniBatchSparsePCA]
10.55s call     decomposition/tests/test_dict_learning.py::test_sparse_encode_shapes_omp
10.18s call     feature_selection/tests/test_rfe.py::test_rfe_cv_groups
9.86s call     feature_extraction/image.py::sklearn.feature_extraction.image.PatchExtractor
9.83s call     preprocessing/tests/test_target_encoder.py::test_fit_transform_not_associated_with_y_if_ordinal_categorical_is_not[5]
```

- same report on this PR:

```
============================= slowest 20 durations =============================
13.73s call     utils/tests/test_parallel.py::test_dispatch_config_parallel[2]
11.97s call     experimental/tests/test_enable_successive_halving.py::test_imports_strategies
11.21s call     decomposition/tests/test_dict_learning.py::test_cd_work_on_joblib_memmapped_data
11.06s call     model_selection/tests/test_split.py::test_nested_cv
10.62s call     decomposition/tests/test_sparse_pca.py::test_transform_inverse_transform_round_trip[MiniBatchSparsePCA]
10.44s call     decomposition/tests/test_dict_learning.py::test_dict_learning_lassocd_readonly_data
10.43s call     feature_extraction/image.py::sklearn.feature_extraction.image.PatchExtractor
10.37s call     feature_selection/tests/test_sequential.py::test_n_features_to_select_stopping_criterion[forward]
10.32s call     experimental/tests/test_enable_iterative_imputer.py::test_imports_strategies
9.76s call     decomposition/tests/test_dict_learning.py::test_sparse_encode_shapes_omp
9.11s call     metrics/tests/test_pairwise.py::test_sparse_manhattan_readonly_dataset
9.04s call     linear_model/tests/test_sgd.py::test_multi_core_gridsearch_and_early_stopping
8.89s call     ensemble/tests/test_gradient_boosting.py::test_gradient_boosting_validation_fraction
8.79s call     utils/tests/test_estimator_checks.py::test_check_estimator_clones
8.73s call     inspection/tests/test_partial_dependence.py::test_partial_dependence_non_null_weight_idx[1-estimator2]
8.69s call     preprocessing/tests/test_target_encoder.py::test_fit_transform_not_associated_with_y_if_ordinal_categorical_is_not[5]
8.67s call     inspection/tests/test_partial_dependence.py::test_partial_dependence_non_null_weight_idx[0-estimator2]
8.55s call     model_selection/tests/test_search.py::test_random_search_bad_cv
8.34s call     manifold/tests/test_t_sne.py::test_tsne_with_mahalanobis_distance
8.10s call     inspection/tests/test_partial_dependence.py::test_partial_dependence_equivalence_equal_sample_weight[LogisticRegression-data1]
```