### PR TITLE
DOC: add note about restarting conda environment after creation

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -431,6 +431,12 @@ in the user folder using conda:
     conda activate sklearn-dev
     pip install -v --no-use-pep517 --no-build-isolation -e .
 
+.. note::
+
+   If you installed these packages after creating and activating a new conda
+   environment, you will need to first deactivate and then reactivate the
+   environment for these changes to take effect.
+
 .. _compiler_freebsd:
 
 FreeBSD

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -292,7 +292,7 @@ scikit-learn from source:
 .. prompt:: bash $
 
     conda create -n sklearn-dev -c conda-forge python numpy scipy cython \
-        joblib threadpoolctl pytest compilers
+        joblib threadpoolctl pytest compilers llvm-openmp
 
 It is not always necessary but it is safer to open a new prompt before
 activating the newly created conda environment.

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -443,6 +443,8 @@ activating the newly created conda environment.
     conda activate sklearn-dev
     pip install -v --no-use-pep517 --no-build-isolation -e .
 
+.. _compiler_freebsd:
+
 FreeBSD
 -------
 

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -69,6 +69,12 @@ feature, code or documentation improvement).
    .. prompt:: bash $
 
      conda create -n sklearn-env -c conda-forge python=3.9 numpy scipy cython
+
+   It is not always necessary but it is safer to open a new prompt before
+   activating the newly created conda environment.
+
+   .. prompt:: bash $
+
      conda activate sklearn-env
 
 #. **Alternative to conda:** If you run Linux or similar, you can instead use
@@ -286,7 +292,13 @@ scikit-learn from source:
 .. prompt:: bash $
 
     conda create -n sklearn-dev -c conda-forge python numpy scipy cython \
-        joblib threadpoolctl pytest compilers llvm-openmp
+        joblib threadpoolctl pytest compilers
+
+It is not always necessary but it is safer to open a new prompt before
+activating the newly created conda environment.
+
+.. prompt:: bash $
+
     conda activate sklearn-dev
     make clean
     pip install -v --no-use-pep517 --no-build-isolation -e .
@@ -306,12 +318,6 @@ forge using the following command:
     conda list
 
 which should include ``compilers`` and ``llvm-openmp``.
-
-.. note::
-
-   If you installed these packages after creating and activating a new conda
-   environment, you will need to first deactivate and then reactivate the
-   environment for these changes to take effect.
 
 The compilers meta-package will automatically set custom environment
 variables:
@@ -428,16 +434,14 @@ in the user folder using conda:
 
     conda create -n sklearn-dev -c conda-forge python numpy scipy cython \
         joblib threadpoolctl pytest compilers
+
+It is not always necessary but it is safer to open a new prompt before
+activating the newly created conda environment.
+
+.. prompt:: bash $
+
     conda activate sklearn-dev
     pip install -v --no-use-pep517 --no-build-isolation -e .
-
-.. note::
-
-   If you installed these packages after creating and activating a new conda
-   environment, you will need to first deactivate and then reactivate the
-   environment for these changes to take effect.
-
-.. _compiler_freebsd:
 
 FreeBSD
 -------


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #27356

#### What does this implement/fix? Explain your changes.

Adds an explanatory notes section that the conda environment after creation needs to be deactivated and reactivated before environment variables become active. It is the same notes section as for the macOS conda build. The change in the rendered docs look like this:

![image](https://github.com/scikit-learn/scikit-learn/assets/40656107/b0f87755-5c92-489f-b852-f4ae796aaed9)

This is my first scikit learn PR. Apologies if the CI skipping strategy is not the correct one.