### PR TITLE
TST Extend tests for `scipy.sparse.*array` in `sklearn/covariance/tests/test_graphical_lasso.py` 

### DIFF
--- a/sklearn/covariance/tests/tempCodeRunnerFile.python
+++ b/sklearn/covariance/tests/tempCodeRunnerFile.python
@@ -1,0 +1,3 @@
+import sklearn
+
+print("scikit-learn version:", sklearn.__version__)

--- a/sklearn/covariance/tests/tempCodeRunnerFile.python
+++ b/sklearn/covariance/tests/tempCodeRunnerFile.python
@@ -1,3 +1,0 @@
-import sklearn
-
-print("scikit-learn version:", sklearn.__version__)

--- a/sklearn/covariance/tests/test_graphical_lasso.py
+++ b/sklearn/covariance/tests/test_graphical_lasso.py
@@ -278,3 +278,20 @@ def test_graphical_lasso_cov_init_deprecation():
     emp_cov = empirical_covariance(X)
     with pytest.warns(FutureWarning, match="cov_init parameter is deprecated"):
         graphical_lasso(emp_cov, alpha=0.1, cov_init=emp_cov)
+
+
+# Parameterised test which compares the results of the graphical lasso with the actual true structure of our data
+@pytest.mark.parametrize("alpha", [1]) 
+def test_graphical_lasso_structure(alpha):
+    data = np.array([[1.0, 0.2, 0.3], [0.2, 1.0, 0.5], [0.3, 0.5, 1.0]])
+    true_structure = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+
+    estimated_structure = graphical_lasso(data, alpha=alpha)[0]
+    print(estimated_structure)
+    print(true_structure)
+
+    # Comparing the estimated structure to our true structure
+    assert np.all(estimated_structure == true_structure), "Graphical Lasso did not match the true structure."
+
+
+    


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Towards #27090

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This PR add a parameterized test for graphical_lasso. It checks the estimated_output of the graphical_lasso function with the true structure of the sparse matrix to the version of SciPy so that we can extend tests as part of https://github.com/scikit-learn/scikit-learn/issues/27090.

#### Any other comments?
Please let me know if there are any issues in the PR.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
