### PR TITLE
MNT SLEP6: metadata_routing.rst can now be tested

### DIFF
--- a/doc/conftest.py
+++ b/doc/conftest.py
@@ -145,13 +145,6 @@ def pytest_runtest_setup(item):
         setup_preprocessing()
     elif fname.endswith("statistical_inference/unsupervised_learning.rst"):
         setup_unsupervised_learning()
-    elif fname.endswith("metadata_routing.rst"):
-        # TODO: remove this once implemented
-        # Skip metarouting because is it is not fully implemented yet
-        raise SkipTest(
-            "Skipping doctest for metadata_routing.rst because it "
-            "is not fully implemented yet"
-        )
 
     rst_files_requiring_matplotlib = [
         "modules/partial_dependence.rst",

--- a/doc/metadata_routing.rst
+++ b/doc/metadata_routing.rst
@@ -76,7 +76,7 @@ metadata called ``sample_weight``::
   ...     lr,
   ...     X,
   ...     y,
-  ...     props={"sample_weight": my_weights, "groups": my_groups},
+  ...     params={"sample_weight": my_weights, "groups": my_groups},
   ...     cv=GroupKFold(),
   ...     scoring=weighted_acc,
   ... )
@@ -84,7 +84,7 @@ metadata called ``sample_weight``::
 Note that in this example, ``my_weights`` is passed to both the scorer and
 :class:`~linear_model.LogisticRegressionCV`.
 
-Error handling: if ``props={"sample_weigh": my_weights, ...}`` were passed
+Error handling: if ``params={"sample_weigh": my_weights, ...}`` were passed
 (note the typo), :func:`~model_selection.cross_validate` would raise an error,
 since ``sample_weigh`` was not requested by any of its underlying objects.
 
@@ -110,7 +110,7 @@ that :func:`~model_selection.cross_validate` does not pass the weights along::
   ...     X,
   ...     y,
   ...     cv=GroupKFold(),
-  ...     props={"sample_weight": my_weights, "groups": my_groups},
+  ...     params={"sample_weight": my_weights, "groups": my_groups},
   ...     scoring=weighted_acc,
   ... )
 
@@ -142,7 +142,7 @@ instance is set and ``sample_weight`` is not routed to it::
   ...     X,
   ...     y,
   ...     cv=GroupKFold(),
-  ...     props={"sample_weight": my_weights, "groups": my_groups},
+  ...     params={"sample_weight": my_weights, "groups": my_groups},
   ...     scoring=weighted_acc,
   ... )
 
@@ -166,7 +166,7 @@ consumers. In this example, we pass ``scoring_weight`` to the scorer, and
   ...     X,
   ...     y,
   ...     cv=GroupKFold(),
-  ...     props={
+  ...     params={
   ...         "scoring_weight": my_weights,
   ...         "fitting_weight": my_other_weights,
   ...         "groups": my_groups,

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -547,11 +547,12 @@ class _PassthroughScorer:
             routing information.
         """
         # This scorer doesn't do any validation or routing, it only exposes the
-        # score requests to the parent object. This object behaves as a
-        # consumer rather than a router.
-        res = MetadataRequest(owner=self._estimator.__class__.__name__)
-        res.score = get_routing_for_object(self._estimator).score
-        return res
+        # requests of the given estimator. This object behaves as a consumer
+        # rather than a router. Ideally it only exposes the score requests to
+        # the parent object; however, that requires computing the routing for
+        # meta-estimators, which would be more time consuming than simply
+        # returning the child object's requests.
+        return get_routing_for_object(self._estimator)
 
 
 def _check_multimetric_scoring(estimator, scoring):

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -55,7 +55,10 @@ from sklearn.multiclass import OneVsRestClassifier
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.pipeline import make_pipeline
 from sklearn.svm import LinearSVC
-from sklearn.tests.metadata_routing_common import assert_request_is_empty
+from sklearn.tests.metadata_routing_common import (
+    assert_request_equal,
+    assert_request_is_empty,
+)
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.utils._testing import (
     assert_almost_equal,
@@ -1291,11 +1294,11 @@ def test_PassthroughScorer_metadata_request():
         .set_score_request(sample_weight="alias")
         .set_fit_request(sample_weight=True)
     )
-    # test that _PassthroughScorer leaves everything other than `score` empty
-    assert_request_is_empty(scorer.get_metadata_routing(), exclude="score")
-    # test that _PassthroughScorer doesn't behave like a router and leaves
-    # the request as is.
-    assert scorer.get_metadata_routing().score.requests["sample_weight"] == "alias"
+    # Test that _PassthroughScorer doesn't change estimator's routing.
+    assert_request_equal(
+        scorer.get_metadata_routing(),
+        {"fit": {"sample_weight": True}, "score": {"sample_weight": "alias"}},
+    )
 
 
 @pytest.mark.usefixtures("enable_slep006")


### PR DESCRIPTION
Everything mentioned in the doc now supports metadata routing, hence it doesn't need to be skipped anymore.

cc @glemaitre @ArturoAmorQ 