### PR TITLE
MAINT: Cleanup expired ndarray methods

### DIFF
--- a/examples/applications/plot_stock_market.py
+++ b/examples/applications/plot_stock_market.py
@@ -263,12 +263,12 @@ for index, (name, label, (x, y)) in enumerate(zip(names, labels, embedding.T)):
     )
 
 plt.xlim(
-    embedding[0].min() - 0.15 * embedding[0].ptp(),
-    embedding[0].max() + 0.10 * embedding[0].ptp(),
+    embedding[0].min() - 0.15 * np.ptp(embedding[0]),
+    embedding[0].max() + 0.10 * np.ptp(embedding[0]),
 )
 plt.ylim(
-    embedding[1].min() - 0.03 * embedding[1].ptp(),
-    embedding[1].max() + 0.03 * embedding[1].ptp(),
+    embedding[1].min() - 0.03 * np.ptp(embedding[1]),
+    embedding[1].max() + 0.03 * np.ptp(embedding[1]),
 )
 
 plt.show()

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2083,7 +2083,7 @@ def test_different_endianness_pickle():
     score = clf.score(X, y)
 
     def reduce_ndarray(arr):
-        return arr.byteswap().newbyteorder().__reduce__()
+        return arr.byteswap().view(arr.dtype.newbyteorder()).__reduce__()
 
     def get_pickle_non_native_endianness():
         f = io.BytesIO()
@@ -2110,7 +2110,7 @@ def test_different_endianness_joblib_pickle():
     class NonNativeEndiannessNumpyPickler(NumpyPickler):
         def save(self, obj):
             if isinstance(obj, np.ndarray):
-                obj = obj.byteswap().newbyteorder()
+                obj = obj.byteswap().view(obj.dtype.newbyteorder())
             super().save(obj)
 
     def get_joblib_pickle_non_native_endianness():


### PR DESCRIPTION
Hi!
This PR reflects changes introduced in https://github.com/numpy/numpy/pull/24682.