### PR TITLE
DOC update release dates for 1.3.1

### DIFF
--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -169,6 +169,8 @@
         <li><strong>On-going development:</strong>
         <a href="https://scikit-learn.org/dev/whats_new.html"><strong>What's new</strong> (Changelog)</a>
         </li>
+	<li><strong>September 2023.</strong> scikit-learn 1.3.1 is available for download (<a href="whats_new/v1.3.html#version-1-3-1">Changelog</a>).
+        </li>
         <li><strong>June 2023.</strong> scikit-learn 1.3.0 is available for download (<a href="whats_new/v1.3.html#version-1-3-0">Changelog</a>).
         </li>
         <li><strong>March 2023.</strong> scikit-learn 1.2.2 is available for download (<a href="whats_new/v1.2.html#version-1-2-2">Changelog</a>).

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -7,7 +7,7 @@
 Version 1.3.1
 =============
 
-**In development**
+**September 2023**
 
 Changed models
 --------------


### PR DESCRIPTION
Part of the release 1.3.1.

Update the release dates in the changelog and in the "News" of the website.