### PR TITLE
TST Extend tests for `scipy.sparse.*array` in `sklearn/metrics/tests/test_pairwise.py`

### DIFF
--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -3,7 +3,7 @@ from types import GeneratorType
 
 import numpy as np
 from numpy import linalg
-from scipy.sparse import csr_matrix, dok_matrix, issparse
+from scipy.sparse import dok_matrix, issparse
 from scipy.spatial.distance import (
     cdist,
     cityblock,
@@ -62,11 +62,12 @@ from sklearn.utils._testing import (
     assert_array_equal,
     ignore_warnings,
 )
-from sklearn.utils.fixes import parse_version, sp_version
+from sklearn.utils.fixes import CSR_CONTAINERS, parse_version, sp_version
 from sklearn.utils.parallel import Parallel, delayed
 
 
-def test_pairwise_distances(global_dtype):
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_pairwise_distances(global_dtype, csr_container):
     # Test the pairwise_distance helper function.
     rng = np.random.RandomState(0)
 
@@ -146,8 +147,8 @@ def test_pairwise_distances(global_dtype):
 
     # Test with sparse X and Y,
     # currently only supported for Euclidean, L1 and cosine.
-    X_sparse = csr_matrix(X)
-    Y_sparse = csr_matrix(Y)
+    X_sparse = csr_container(X)
+    Y_sparse = csr_container(Y)
 
     S = pairwise_distances(X_sparse, Y_sparse, metric="euclidean")
     S2 = euclidean_distances(X_sparse, Y_sparse)
@@ -364,11 +365,12 @@ def test_pairwise_callable_nonstrict_metric():
 
 
 # Test with all metrics that should be in PAIRWISE_KERNEL_FUNCTIONS.
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 @pytest.mark.parametrize(
     "metric",
     ["rbf", "laplacian", "sigmoid", "polynomial", "linear", "chi2", "additive_chi2"],
 )
-def test_pairwise_kernels(metric):
+def test_pairwise_kernels(metric, csr_container):
     # Test the pairwise_kernels helper function.
 
     rng = np.random.RandomState(0)
@@ -390,8 +392,8 @@ def test_pairwise_kernels(metric):
     assert_allclose(K1, K2)
 
     # Test with sparse X and Y
-    X_sparse = csr_matrix(X)
-    Y_sparse = csr_matrix(Y)
+    X_sparse = csr_container(X)
+    Y_sparse = csr_container(Y)
     if metric in ["chi2", "additive_chi2"]:
         # these don't support sparse matrices yet
         return
@@ -431,8 +433,9 @@ def test_pairwise_kernels_filter_param():
         pairwise_kernels(X, Y, metric="rbf", **params)
 
 
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 @pytest.mark.parametrize("metric, func", PAIRED_DISTANCES.items())
-def test_paired_distances(metric, func):
+def test_paired_distances(metric, func, csr_container):
     # Test the pairwise_distance helper function.
     rng = np.random.RandomState(0)
     # Euclidean distance should be equivalent to calling the function.
@@ -443,7 +446,7 @@ def test_paired_distances(metric, func):
     S = paired_distances(X, Y, metric=metric)
     S2 = func(X, Y)
     assert_allclose(S, S2)
-    S3 = func(csr_matrix(X), csr_matrix(Y))
+    S3 = func(csr_container(X), csr_container(Y))
     assert_allclose(S, S3)
     if metric in PAIRWISE_DISTANCE_FUNCTIONS:
         # Check the pairwise_distances implementation
@@ -473,13 +476,14 @@ def test_paired_distances_callable(global_dtype):
         paired_distances(X, Y)
 
 
-def test_pairwise_distances_argmin_min(global_dtype):
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_pairwise_distances_argmin_min(global_dtype, csr_container):
     # Check pairwise minimum distances computation for any metric
     X = np.asarray([[0], [1]], dtype=global_dtype)
     Y = np.asarray([[-2], [3]], dtype=global_dtype)
 
     Xsp = dok_matrix(X)
-    Ysp = csr_matrix(Y, dtype=global_dtype)
+    Ysp = csr_container(Y, dtype=global_dtype)
 
     expected_idx = [0, 1]
     expected_vals = [2, 2]
@@ -628,15 +632,20 @@ def test_pairwise_distances_chunked_reduce_none(global_dtype):
     assert all(chunk is None for chunk in S_chunks)
 
 
+_chunked_reduce_valid_params_list = [
+    lambda D, start: list(D),
+    lambda D, start: np.array(D),
+    lambda D, start: (list(D), list(D)),
+    lambda D, start: (dok_matrix(D), np.array(D), list(D)),
+]
+_chunked_reduce_valid_params_list.extend(
+    [lambda D, start: csr_container(D) for csr_container in CSR_CONTAINERS]
+)
+
+
 @pytest.mark.parametrize(
     "good_reduce",
-    [
-        lambda D, start: list(D),
-        lambda D, start: np.array(D),
-        lambda D, start: csr_matrix(D),
-        lambda D, start: (list(D), list(D)),
-        lambda D, start: (dok_matrix(D), np.array(D), list(D)),
-    ],
+    _chunked_reduce_valid_params_list,
 )
 def test_pairwise_distances_chunked_reduce_valid(good_reduce):
     X = np.arange(10).reshape(-1, 1)
@@ -758,12 +767,8 @@ def test_pairwise_distances_chunked(global_dtype):
         next(gen)
 
 
-@pytest.mark.parametrize(
-    "x_array_constr", [np.array, csr_matrix], ids=["dense", "sparse"]
-)
-@pytest.mark.parametrize(
-    "y_array_constr", [np.array, csr_matrix], ids=["dense", "sparse"]
-)
+@pytest.mark.parametrize("x_array_constr", [np.array, *CSR_CONTAINERS])
+@pytest.mark.parametrize("y_array_constr", [np.array, *CSR_CONTAINERS])
 def test_euclidean_distances_known_result(x_array_constr, y_array_constr):
     # Check the pairwise Euclidean distances computation on known result
     X = x_array_constr([[0]])
@@ -772,9 +777,7 @@ def test_euclidean_distances_known_result(x_array_constr, y_array_constr):
     assert_allclose(D, [[1.0, 2.0]])
 
 
-@pytest.mark.parametrize(
-    "y_array_constr", [np.array, csr_matrix], ids=["dense", "sparse"]
-)
+@pytest.mark.parametrize("y_array_constr", [np.array, *CSR_CONTAINERS])
 def test_euclidean_distances_with_norms(global_dtype, y_array_constr):
     # check that we still get the right answers with {X,Y}_norm_squared
     # and that we get a wrong answer with wrong {X,Y}_norm_squared
@@ -841,12 +844,8 @@ def test_euclidean_distances_norm_shapes():
         euclidean_distances(X, Y, Y_norm_squared=Y_norm_squared[:5])
 
 
-@pytest.mark.parametrize(
-    "x_array_constr", [np.array, csr_matrix], ids=["dense", "sparse"]
-)
-@pytest.mark.parametrize(
-    "y_array_constr", [np.array, csr_matrix], ids=["dense", "sparse"]
-)
+@pytest.mark.parametrize("x_array_constr", [np.array, *CSR_CONTAINERS])
+@pytest.mark.parametrize("y_array_constr", [np.array, *CSR_CONTAINERS])
 def test_euclidean_distances(global_dtype, x_array_constr, y_array_constr):
     # check that euclidean distances gives same result as scipy cdist
     # when X and Y != X are provided
@@ -868,9 +867,7 @@ def test_euclidean_distances(global_dtype, x_array_constr, y_array_constr):
     assert distances.dtype == global_dtype
 
 
-@pytest.mark.parametrize(
-    "x_array_constr", [np.array, csr_matrix], ids=["dense", "sparse"]
-)
+@pytest.mark.parametrize("x_array_constr", [np.array, *CSR_CONTAINERS])
 def test_euclidean_distances_sym(global_dtype, x_array_constr):
     # check that euclidean distances gives same result as scipy pdist
     # when only X is provided
@@ -890,12 +887,8 @@ def test_euclidean_distances_sym(global_dtype, x_array_constr):
 
 
 @pytest.mark.parametrize("batch_size", [None, 5, 7, 101])
-@pytest.mark.parametrize(
-    "x_array_constr", [np.array, csr_matrix], ids=["dense", "sparse"]
-)
-@pytest.mark.parametrize(
-    "y_array_constr", [np.array, csr_matrix], ids=["dense", "sparse"]
-)
+@pytest.mark.parametrize("x_array_constr", [np.array, *CSR_CONTAINERS])
+@pytest.mark.parametrize("y_array_constr", [np.array, *CSR_CONTAINERS])
 def test_euclidean_distances_upcast(batch_size, x_array_constr, y_array_constr):
     # check batches handling when Y != X (#13910)
     rng = np.random.RandomState(0)
@@ -917,9 +910,7 @@ def test_euclidean_distances_upcast(batch_size, x_array_constr, y_array_constr):
 
 
 @pytest.mark.parametrize("batch_size", [None, 5, 7, 101])
-@pytest.mark.parametrize(
-    "x_array_constr", [np.array, csr_matrix], ids=["dense", "sparse"]
-)
+@pytest.mark.parametrize("x_array_constr", [np.array, *CSR_CONTAINERS])
 def test_euclidean_distances_upcast_sym(batch_size, x_array_constr):
     # check batches handling when X is Y (#13910)
     rng = np.random.RandomState(0)
@@ -1256,6 +1247,7 @@ def test_kernel_symmetry(kernel):
     assert_allclose(K, K.T, 15)
 
 
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 @pytest.mark.parametrize(
     "kernel",
     (
@@ -1267,10 +1259,10 @@ def test_kernel_symmetry(kernel):
         cosine_similarity,
     ),
 )
-def test_kernel_sparse(kernel):
+def test_kernel_sparse(kernel, csr_container):
     rng = np.random.RandomState(0)
     X = rng.random_sample((5, 4))
-    X_sparse = csr_matrix(X)
+    X_sparse = csr_container(X)
     K = kernel(X, X)
     K2 = kernel(X_sparse, X_sparse)
     assert_allclose(K, K2)
@@ -1304,15 +1296,16 @@ def test_laplacian_kernel():
     assert np.all(K - np.diag(np.diag(K)) < 1)
 
 
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 @pytest.mark.parametrize(
     "metric, pairwise_func", [("linear", linear_kernel), ("cosine", cosine_similarity)]
 )
-def test_pairwise_similarity_sparse_output(metric, pairwise_func):
+def test_pairwise_similarity_sparse_output(metric, pairwise_func, csr_container):
     rng = np.random.RandomState(0)
     X = rng.random_sample((5, 4))
     Y = rng.random_sample((3, 4))
-    Xcsr = csr_matrix(X)
-    Ycsr = csr_matrix(Y)
+    Xcsr = csr_container(X)
+    Ycsr = csr_container(Y)
 
     # should be sparse
     K1 = pairwise_func(Xcsr, Ycsr, dense_output=False)
@@ -1328,14 +1321,15 @@ def test_pairwise_similarity_sparse_output(metric, pairwise_func):
     assert_allclose(K1.toarray(), K3)
 
 
-def test_cosine_similarity():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_cosine_similarity(csr_container):
     # Test the cosine_similarity.
 
     rng = np.random.RandomState(0)
     X = rng.random_sample((5, 4))
     Y = rng.random_sample((3, 4))
-    Xcsr = csr_matrix(X)
-    Ycsr = csr_matrix(Y)
+    Xcsr = csr_container(X)
+    Ycsr = csr_container(Y)
 
     for X_, Y_ in ((X, None), (X, Y), (Xcsr, None), (Xcsr, Ycsr)):
         # Test that the cosine is kernel is equal to a linear kernel when data
@@ -1399,13 +1393,14 @@ def test_check_invalid_dimensions():
         check_pairwise_arrays(XA, XB)
 
 
-def test_check_sparse_arrays():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_check_sparse_arrays(csr_container):
     # Ensures that checks return valid sparse matrices.
     rng = np.random.RandomState(0)
     XA = rng.random_sample((5, 4))
-    XA_sparse = csr_matrix(XA)
+    XA_sparse = csr_container(XA)
     XB = rng.random_sample((5, 4))
-    XB_sparse = csr_matrix(XB)
+    XB_sparse = csr_container(XB)
     XA_checked, XB_checked = check_pairwise_arrays(XA_sparse, XB_sparse)
     # compare their difference because testing csr matrices for
     # equality with '==' does not work as expected.
@@ -1550,10 +1545,11 @@ def test_numeric_pairwise_distances_datatypes(metric, global_dtype, y_is_x):
     assert_allclose(dist, expected_dist)
 
 
-def test_sparse_manhattan_readonly_dataset():
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_sparse_manhattan_readonly_dataset(csr_container):
     # Non-regression test for: https://github.com/scikit-learn/scikit-learn/issues/7981
-    matrices1 = [csr_matrix(np.ones((5, 5)))]
-    matrices2 = [csr_matrix(np.ones((5, 5)))]
+    matrices1 = [csr_container(np.ones((5, 5)))]
+    matrices2 = [csr_container(np.ones((5, 5)))]
     # Joblib memory maps datasets which makes them read-only.
     # The following call was reporting as failing in #7981, but this must pass.
     Parallel(n_jobs=2, max_nbytes=0)(


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Towards #27090.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
I have expanded the tests for pairwise distance which tests over sparse arrays along with sparse matrices.



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
