### PR TITLE
BENCH bump cython to latest version

### DIFF
--- a/asv_benchmarks/asv.conf.json
+++ b/asv_benchmarks/asv.conf.json
@@ -78,7 +78,7 @@
     "matrix": {
         "numpy": ["1.25.2"],
         "scipy": ["1.11.2"],
-        "cython": ["0.29.36"],
+        "cython": ["3.0.2"],
         "joblib": ["1.3.2"],
         "threadpoolctl": ["3.2.0"],
         "pandas": ["2.1.0"]


### PR DESCRIPTION
Follow-up of https://github.com/scikit-learn/scikit-learn/pull/27264

in https://github.com/scikit-learn/scikit-learn/pull/27264 we pinned cython 2 to be able to better identify the regressions coming from cython 3: they will come from the merge commit of this PR.