### PR TITLE
MNT Remove test suite setuptools dependency for good

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -218,7 +218,7 @@ def test_import_all_consistency():
         if ".tests." in modname:
             continue
         # Avoid test suite depending on setuptools
-        if modname == "sklearn._build_utils.pre_build_helpers":
+        if "sklearn._build_utils" in modname:
             continue
         if IS_PYPY and (
             "_svmlight_format_io" in modname


### PR DESCRIPTION
Follow-up of #27355 which was not enough to remove the setuptools dependency, since 
`sklearn._build_utils.openmp_helpers` will import `sklearn._build_utils.pre_build_helpers` which will import setuptools.

Seen in https://github.com/scikit-learn/scikit-learn/pull/27027 e.g. this [build](https://github.com/scikit-learn/scikit-learn/actions/runs/6236141824/job/16926761896?pr=27027#step:4:4799)