### PR TITLE
DOC fix the changelog and group entries together

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -36,11 +36,6 @@ The following models now support metadata routing in one or more or their
 methods. Refer to the :ref:`Metadata Routing User Guide <metadata_routing>` for
 more details.
 
-- |API|:func:`~utils.metadata_routing.process_routing` now has a different
-  signature. The first two (the object and the method) are positional only,
-  and all metadata are passed as keyword arguments. :pr:`26909` by `Adrin
-  Jalali`_.
-
 - |Enhancement| :class:`~compose.ColumnTransformer` now supports metadata routing
   according to :ref:`metadata routing user guide <metadata_routing>`. :pr:`27005`
   by `Adrin Jalali`_.
@@ -51,11 +46,6 @@ more details.
   scorer. :meth:`linear_model.LogisticRegressionCV.score` now accepts
   ``**score_params`` which are passed to the underlying scorer.
   :pr:`26525` by :user:`Omar Salman <OmarManzoor>`.
-
-- |Enhancement| :class:`~utils.metadata_routing.MetadataRequest` and
-  :class:`~utils.metadata_routing.MetadataRouter` now have a ``consumes`` method
-  which can be used to check whether a given set of parameters would be consumed.
-  :pr:`26831` by `Adrin Jalali`_.
 
 - |Feature| :class:`pipeline.Pipeline` now supports metadata routing according
   to :ref:`metadata routing user guide <metadata_routing>`. :pr:`26789` by
@@ -125,6 +115,11 @@ Changelog
 
 :mod:`sklearn.base`
 ...................
+
+- |API|:func:`~utils.metadata_routing.process_routing` now has a different
+  signature. The first two (the object and the method) are positional only,
+  and all metadata are passed as keyword arguments. :pr:`26909` by `Adrin
+  Jalali`_.
 
 - |Enhancement| :meth:`base.ClusterMixin.fit_predict` and
   :meth:`base.OutlierMixin.fit_predict` now accept ``**kwargs`` which are
@@ -301,6 +296,11 @@ Changelog
   improved adaptability to dark mode environments.
   :pr:`26862` by :user:`Andrew Goh Yisheng <9y5>`, `Thomas Fan`_, `Adrin
   Jalali`_.
+
+- |Enhancement| :class:`~utils.metadata_routing.MetadataRequest` and
+  :class:`~utils.metadata_routing.MetadataRouter` now have a ``consumes`` method
+  which can be used to check whether a given set of parameters would be consumed.
+  :pr:`26831` by `Adrin Jalali`_.
 
 - |Fix| :func:`sklearn.utils.check_array` should accept both matrix and array from
   the sparse SciPy module. The previous implementation would fail if `copy=True` by

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -36,17 +36,6 @@ The following models now support metadata routing in one or more or their
 methods. Refer to the :ref:`Metadata Routing User Guide <metadata_routing>` for
 more details.
 
-- |Enhancement| :class:`~compose.ColumnTransformer` now supports metadata routing
-  according to :ref:`metadata routing user guide <metadata_routing>`. :pr:`27005`
-  by `Adrin Jalali`_.
-
-- |Enhancement| :class:`linear_model.LogisticRegressionCV` now supports
-  metadata routing. :meth:`linear_model.LogisticRegressionCV.fit` now
-  accepts ``**params`` which are passed to the underlying splitter and
-  scorer. :meth:`linear_model.LogisticRegressionCV.score` now accepts
-  ``**score_params`` which are passed to the underlying scorer.
-  :pr:`26525` by :user:`Omar Salman <OmarManzoor>`.
-
 - |Feature| :class:`pipeline.Pipeline` now supports metadata routing according
   to :ref:`metadata routing user guide <metadata_routing>`. :pr:`26789` by
   `Adrin Jalali`_.
@@ -68,6 +57,17 @@ more details.
   in their ``fit`` and ``score``, and route metadata to the underlying
   estimator's ``fit``, the CV splitter, and the scorer. :pr:`27058` by `Adrin
   Jalali`_.
+
+- |Enhancement| :class:`~compose.ColumnTransformer` now supports metadata routing
+  according to :ref:`metadata routing user guide <metadata_routing>`. :pr:`27005`
+  by `Adrin Jalali`_.
+
+- |Enhancement| :class:`linear_model.LogisticRegressionCV` now supports
+  metadata routing. :meth:`linear_model.LogisticRegressionCV.fit` now
+  accepts ``**params`` which are passed to the underlying splitter and
+  scorer. :meth:`linear_model.LogisticRegressionCV.score` now accepts
+  ``**score_params`` which are passed to the underlying scorer.
+  :pr:`26525` by :user:`Omar Salman <OmarManzoor>`.
 
 Support for SciPy sparse arrays
 -------------------------------
@@ -116,11 +116,6 @@ Changelog
 :mod:`sklearn.base`
 ...................
 
-- |API|:func:`~utils.metadata_routing.process_routing` now has a different
-  signature. The first two (the object and the method) are positional only,
-  and all metadata are passed as keyword arguments. :pr:`26909` by `Adrin
-  Jalali`_.
-
 - |Enhancement| :meth:`base.ClusterMixin.fit_predict` and
   :meth:`base.OutlierMixin.fit_predict` now accept ``**kwargs`` which are
   passed to the ``fit`` method of the estimator. :pr:`26506` by `Adrin
@@ -134,6 +129,11 @@ Changelog
 
 - |Enhancement| :func:`base.clone` now supports `dict` as input and creates a
   copy. :pr:`26786` by `Adrin Jalali`_.
+
+- |API|:func:`~utils.metadata_routing.process_routing` now has a different
+  signature. The first two (the object and the method) are positional only,
+  and all metadata are passed as keyword arguments. :pr:`26909` by `Adrin
+  Jalali`_.
 
 :mod:`sklearn.calibration`
 ..........................
@@ -170,9 +170,19 @@ Changelog
 :mod:`sklearn.ensemble`
 .......................
 
-- |API| In :class:`AdaBoostClassifier`, the `algorithm` argument `SAMME.R` was
-  deprecated and will be removed in 1.6. :pr:`26830` by :user:`Stefanie Senger
-  <StefanieSenger>`.
+- |MajorFeature| :class:`ensemble.RandomForestClassifier` and
+  :class:`ensemble.RandomForestRegressor` support missing values when
+  the criterion is `gini`, `entropy`, or `log_loss`,
+  for classification or `squared_error`, `friedman_mse`, or `poisson`
+  for regression. :pr:`26391` by `Thomas Fan`_.
+
+- |Feature| :class:`ensemble.RandomForestClassifier`,
+  :class:`ensemble.RandomForestRegressor`, :class:`ensemble.ExtraTreesClassifier`
+  and :class:`ensemble.ExtraTreesRegressor` now support monotonic constraints,
+  useful when features are supposed to have a positive/negative effect on the target.
+  Missing values in the train data and multi-output targets are not supported.
+  :pr:`13649` by :user:`Samuel Ronsin <samronsin>`,
+  initiated by :user:`Patrick O'Reilly <pat-oreilly>`.
 
 - |Efficiency| :class:`ensemble.GradientBoostingClassifier` is faster,
   for binary and in particular for multiclass problems thanks to the private loss
@@ -184,19 +194,9 @@ Changelog
   :class:`ensemble.GradientBoostingRegressor` when trained on sparse data.
   :pr:`26957` by `Thomas Fan`_.
 
-- |Feature| :class:`ensemble.RandomForestClassifier`,
-  :class:`ensemble.RandomForestRegressor`, :class:`ensemble.ExtraTreesClassifier`
-  and :class:`ensemble.ExtraTreesRegressor` now support monotonic constraints,
-  useful when features are supposed to have a positive/negative effect on the target.
-  Missing values in the train data and multi-output targets are not supported.
-  :pr:`13649` by :user:`Samuel Ronsin <samronsin>`,
-  initiated by :user:`Patrick O'Reilly <pat-oreilly>`.
-
-- |MajorFeature| :class:`ensemble.RandomForestClassifier` and
-  :class:`ensemble.RandomForestRegressor` support missing values when
-  the criterion is `gini`, `entropy`, or `log_loss`,
-  for classification or `squared_error`, `friedman_mse`, or `poisson`
-  for regression. :pr:`26391` by `Thomas Fan`_.
+- |API| In :class:`AdaBoostClassifier`, the `algorithm` argument `SAMME.R` was
+  deprecated and will be removed in 1.6. :pr:`26830` by :user:`Stefanie Senger
+  <StefanieSenger>`.
 
 :mod:`sklearn.linear_model`
 ...........................
@@ -208,12 +208,6 @@ Changelog
 
 :mod:`sklearn.metrics`
 ......................
-
-- |API| The `squared` parameter of :func:`metrics.mean_squared_error` and
-  :func:`metrics.mean_squared_log_error` is deprecated and will be removed in 1.6.
-  Use the new functions :func:`metrics.root_mean_squared_error` and
-  :func:`root_mean_squared_log_error` instead.
-  :pr:`26734` by :user:`Alejandro Martin Gil <101AlexMartin>`.
 
 - |Efficiency| Computing pairwise distances via :class:`metrics.DistanceMetric`
   for CSR × CSR,  Dense × CSR, and CSR × Dense datasets is now 1.5x faster.
@@ -237,8 +231,17 @@ Changelog
   :func:`sklearn.metrics.zero_one_loss` now support Array API compatible inputs.
   :pr:`27137` by :user:`Edoardo Abati <EdAbati>`.
 
+- |API| The `squared` parameter of :func:`metrics.mean_squared_error` and
+  :func:`metrics.mean_squared_log_error` is deprecated and will be removed in 1.6.
+  Use the new functions :func:`metrics.root_mean_squared_error` and
+  :func:`root_mean_squared_log_error` instead.
+  :pr:`26734` by :user:`Alejandro Martin Gil <101AlexMartin>`.
+
 :mod:`sklearn.model_selection`
 ..............................
+
+- |Enhancement| :func:`sklearn.model_selection.train_test_split` now supports
+  Array API compatible inputs. :pr:`26855` by `Tim Head`_.
 
 - |Fix| :class:`model_selection.GridSearchCV`,
   :class:`model_selection.RandomizedSearchCV`, and
@@ -246,11 +249,13 @@ Changelog
   object in the parameter grid if it's an estimator. :pr:`26786` by `Adrin
   Jalali`_.
 
-- |Enhancement| :func:`sklearn.model_selection.train_test_split` now supports
-  Array API compatible inputs. :pr:`26855` by `Tim Head`_.
-
 :mod:`sklearn.neighbors`
 ........................
+
+- |Efficiency| :meth:`sklearn.neighbors.KNeighborsRegressor.predict` and
+  :meth:`sklearn.neighbors.KNeighborsRegressor.predict_proba` now efficiently support
+  pairs of dense and sparse datasets.
+  :pr:`27018` by :user:`Julien Jerphanion <jjerphan>`.
 
 - |API| :class:`neighbors.KNeighborsRegressor` now accepts
   :class:`metric.DistanceMetric` objects directly via the `metric` keyword
@@ -258,13 +263,16 @@ Changelog
   :class:`metric.DistanceMetric` objects.
   :pr:`26267` by :user:`Meekail Zain <micky774>`
 
-- |Efficiency| :meth:`sklearn.neighbors.KNeighborsRegressor.predict` and
-  :meth:`sklearn.neighbors.KNeighborsRegressor.predict_proba` now efficiently support
-  pairs of dense and sparse datasets.
-  :pr:`27018` by :user:`Julien Jerphanion <jjerphan>`.
-
 :mod:`sklearn.preprocessing`
 ............................
+
+- |MajorFeature| :class:`preprocessing.MinMaxScaler` and
+  :class:`preprocessing.MaxAbsScaler` now
+  support the `Array API <https://data-apis.org/array-api/latest/>`_. Array API
+  support is considered experimental and might evolve without being subject to
+  our usual rolling deprecation cycle policy. See
+  :ref:`array_api` for more details.
+  :pr:`26243` by `Tim Head`_ and :pr:`27110` by :user:`Edoardo Abati <EdAbati>`.
 
 - |Efficiency| :class:`preprocessing.OrdinalEncoder` avoids calculating
   missing indices twice to improve efficiency.
@@ -276,14 +284,6 @@ Changelog
 
 - |Enhancement| :class:`preprocessing.TargetEncoder` now supports `target_type`
   'multiclass'. :pr:`26674` by :user:`Lucy Liu <lucyleeow>`.
-
-- |MajorFeature| :class:`preprocessing.MinMaxScaler` and
-  :class:`preprocessing.MaxAbsScaler` now
-  support the `Array API <https://data-apis.org/array-api/latest/>`_. Array API
-  support is considered experimental and might evolve without being subject to
-  our usual rolling deprecation cycle policy. See
-  :ref:`array_api` for more details.
-  :pr:`26243` by `Tim Head`_ and :pr:`27110` by :user:`Edoardo Abati <EdAbati>`.
 
 :mod:`sklearn.tree`
 ...................

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -36,6 +36,11 @@ The following models now support metadata routing in one or more or their
 methods. Refer to the :ref:`Metadata Routing User Guide <metadata_routing>` for
 more details.
 
+- |API|:func:`~utils.metadata_routing.process_routing` now has a different
+  signature. The first two (the object and the method) are positional only,
+  and all metadata are passed as keyword arguments. :pr:`26909` by `Adrin
+  Jalali`_.
+
 - |Enhancement| :class:`~compose.ColumnTransformer` now supports metadata routing
   according to :ref:`metadata routing user guide <metadata_routing>`. :pr:`27005`
   by `Adrin Jalali`_.
@@ -46,6 +51,11 @@ more details.
   scorer. :meth:`linear_model.LogisticRegressionCV.score` now accepts
   ``**score_params`` which are passed to the underlying scorer.
   :pr:`26525` by :user:`Omar Salman <OmarManzoor>`.
+
+- |Enhancement| :class:`~utils.metadata_routing.MetadataRequest` and
+  :class:`~utils.metadata_routing.MetadataRouter` now have a ``consumes`` method
+  which can be used to check whether a given set of parameters would be consumed.
+  :pr:`26831` by `Adrin Jalali`_.
 
 - |Feature| :class:`pipeline.Pipeline` now supports metadata routing according
   to :ref:`metadata routing user guide <metadata_routing>`. :pr:`26789` by
@@ -68,6 +78,35 @@ more details.
   in their ``fit`` and ``score``, and route metadata to the underlying
   estimator's ``fit``, the CV splitter, and the scorer. :pr:`27058` by `Adrin
   Jalali`_.
+
+Support for SciPy sparse arrays
+-------------------------------
+
+Several estimators are now supporting SciPy sparse arrays. The following functions
+and classes are impacted:
+
+**Functions:**
+
+- :func:`decomposition.non_negative_factorization` in :pr:`27100` by
+  :user:`Isaac Virshup <ivirshup>`;
+- :func:`metrics.f_regression` in :pr:`27239` by :user:`Yaroslav Korobko <Tialo>`;
+- :func:`metrics.r_regression` in :pr:`27239` by :user:`Yaroslav Korobko <Tialo>`;
+- :func:`sklearn.utils.multiclass.type_of_target` in :pr:`27274` by
+  :user:`Yao Xiao <Charlie-XIAO>`.
+
+**Classes:**
+
+- :class:`decomposition.NMF` in :pr:`27100` by :user:`Isaac Virshup <ivirshup>`;
+- :class:`decomposition.MiniBatchNMF` in :pr:`27100` by
+  :user:`Isaac Virshup <ivirshup>`;
+- :class:`feature_extraction.text.TfidfTransformer` in :pr:`27219` by
+  :user:`Yao Xiao <Charlie-XIAO>`;
+- :class:`impute.SimpleImputer` in :pr:`27277` by :user:`Yao Xiao <Charlie-XIAO>`;
+- :class:`impute.IterativeImputer` in :pr:`27277` by :user:`Yao Xiao <Charlie-XIAO>`;
+- :class:`impute.KNNImputer` in :pr:`27277` by :user:`Yao Xiao <Charlie-XIAO>`;
+- :class:`kernel_approximation.PolynomialCountSketch` in  :pr:`27301` by
+  :user:`Lohit SundaramahaLingam <lohitslohit>`;
+- :class:`neural_network.BernoulliRBM` in :pr:`27252` by `Yao Xiao <Charlie-XIAO>`.
 
 Changelog
 ---------
@@ -101,11 +140,6 @@ Changelog
 - |Enhancement| :func:`base.clone` now supports `dict` as input and creates a
   copy. :pr:`26786` by `Adrin Jalali`_.
 
-- |API|:func:`~utils.metadata_routing.process_routing` now has a different
-  signature. The first two (the object and the method) are positional only,
-  and all metadata are passed as keyword arguments. :pr:`26909` by `Adrin
-  Jalali`_.
-
 :mod:`sklearn.calibration`
 ..........................
 
@@ -114,7 +148,7 @@ Changelog
   private loss module. :pr:`27185` by :user:`Omar Salman <OmarManzoor>`.
 
 :mod:`sklearn.cluster`
-............................
+......................
 
 - |API| : `kdtree` and `balltree` values are now deprecated and are renamed as
   `kd_tree` and `ball_tree` respectively for the `algorithm` parameter of
@@ -138,27 +172,8 @@ Changelog
   :pr:`26315` and :pr:`27098` by :user:`Mateusz Sokół <mtsokol>`,
   :user:`Olivier Grisel <ogrisel>` and :user:`Edoardo Abati <EdAbati>`.
 
-- |Enhancement| :func:`decomposition.non_negative_factorization`, :class:`decomposition.NMF`,
-  and :class:`decomposition.MiniBatchNMF` now support :class:`scipy.sparse.sparray`
-  subclasses.
-  :pr:`27100` by :user:`Isaac Virshup <ivirshup>`.
-
 :mod:`sklearn.ensemble`
 .......................
-
-- |MajorFeature| :class:`ensemble.RandomForestClassifier` and
-  :class:`ensemble.RandomForestRegressor` support missing values when
-  the criterion is `gini`, `entropy`, or `log_loss`,
-  for classification or `squared_error`, `friedman_mse`, or `poisson`
-  for regression. :pr:`26391` by `Thomas Fan`_.
-
-- |Feature| :class:`ensemble.RandomForestClassifier`,
-  :class:`ensemble.RandomForestRegressor`, :class:`ensemble.ExtraTreesClassifier`
-  and :class:`ensemble.ExtraTreesRegressor` now support monotonic constraints,
-  useful when features are supposed to have a positive/negative effect on the target.
-  Missing values in the train data and multi-output targets are not supported.
-  :pr:`13649` by :user:`Samuel Ronsin <samronsin>`,
-  initiated by :user:`Patrick O'Reilly <pat-oreilly>`.
 
 - |API| In :class:`AdaBoostClassifier`, the `algorithm` argument `SAMME.R` was
   deprecated and will be removed in 1.6. :pr:`26830` by :user:`Stefanie Senger
@@ -174,40 +189,19 @@ Changelog
   :class:`ensemble.GradientBoostingRegressor` when trained on sparse data.
   :pr:`26957` by `Thomas Fan`_.
 
-:mod:`sklearn.feature_extraction`
-.................................
+- |Feature| :class:`ensemble.RandomForestClassifier`,
+  :class:`ensemble.RandomForestRegressor`, :class:`ensemble.ExtraTreesClassifier`
+  and :class:`ensemble.ExtraTreesRegressor` now support monotonic constraints,
+  useful when features are supposed to have a positive/negative effect on the target.
+  Missing values in the train data and multi-output targets are not supported.
+  :pr:`13649` by :user:`Samuel Ronsin <samronsin>`,
+  initiated by :user:`Patrick O'Reilly <pat-oreilly>`.
 
-- |Enhancement| :class:`feature_extraction.text.TfidfTransformer` now supports
-  SciPy sparse arrays.
-  :pr:`27219` by :user:`Yao Xiao <Charlie-XIAO>`.
-
-:mod:`sklearn.impute`
-.....................
-
-- |Enhancement| In :class:`impute.SimpleImputer`, :class:`impute.IterativeImputer`, and
-  :class:`impute.KNNImputer` with ``add_indicator=True``, using sparse arrays now
-  behaves in consistent with using sparse matrices in the `transform` and
-  `fit_transform` methods. :pr:`27277` by :user:`Yao Xiao <Charlie-XIAO>`.
-
-:mod:`sklearn.kernel_approximation`
-...................................
-
-- |Enhancement| :func:`kernel_approximation.PolynomialCountSketch` now supports
-  :class:`scipy.sparse.sparray` subclasses.
-  :pr:`27301` by :user:`Lohit SundaramahaLingam <lohitslohit>`.
-
-:mod:`sklearn.metrics`
-......................
-
-- |Enhancement| :func:`metrics.f_regression` and :func:`metrics.r_regression` now
-  support SciPy sparse arrays.
-  :pr:`27239` by :user:`Yaroslav Korobko <Tialo>`.
-
-:mod:`sklearn.preprocessing`
-............................
-
-- |Enhancement| :class:`preprocessing.TargetEncoder` now supports `target_type`
-  'multiclass'. :pr:`26674` by :user:`Lucy Liu <lucyleeow>`.
+- |MajorFeature| :class:`ensemble.RandomForestClassifier` and
+  :class:`ensemble.RandomForestRegressor` support missing values when
+  the criterion is `gini`, `entropy`, or `log_loss`,
+  for classification or `squared_error`, `friedman_mse`, or `poisson`
+  for regression. :pr:`26391` by `Thomas Fan`_.
 
 :mod:`sklearn.metrics`
 ......................
@@ -217,80 +211,6 @@ Changelog
   Use the new functions :func:`metrics.root_mean_squared_error` and
   :func:`root_mean_squared_log_error` instead.
   :pr:`26734` by :user:`Alejandro Martin Gil <101AlexMartin>`.
-
-- |Enhancement| Added `neg_root_mean_squared_log_error_scorer` as scorer
-  :pr:`26734` by :user:`Alejandro Martin Gil <101AlexMartin>`.
-
-:mod:`sklearn.preprocessing`
-............................
-
-- |Enhancement| Improves warnings in :class:`preprocessing.FunctionTransfomer` when
-  `func` returns a pandas dataframe and the output is configured to be pandas.
-  :pr:`26944` by `Thomas Fan`_.
-
-:mod:`sklearn.model_selection`
-..............................
-
-- |Fix| :class:`model_selection.GridSearchCV`,
-  :class:`model_selection.RandomizedSearchCV`, and
-  :class:`model_selection.HalvingGridSearchCV` now don't change the given
-  object in the parameter grid if it's an estimator. :pr:`26786` by `Adrin
-  Jalali`_.
-
-- |Enhancement| :func:`sklearn.model_selection.train_test_split` now supports
-  Array API compatible inputs. :pr:`26855` by `Tim Head`_.
-
-:mod:`sklearn.neighbors`
-........................
-
-- |Efficiency| :meth:`sklearn.neighbors.KNeighborsRegressor.predict` and
-  :meth:`sklearn.neighbors.KNeighborsRegressor.predict_proba` now efficiently support
-  pairs of dense and sparse datasets.
-  :pr:`27018` by :user:`Julien Jerphanion <jjerphan>`.
-
-:mod:`sklearn.preprocessing`
-............................
-
-- |Efficiency| :class:`preprocessing.OrdinalEncoder` avoids calculating
-  missing indices twice to improve efficiency.
-  :pr:`27017` by :user:`Xuefeng Xu <xuefeng-xu>`.
-
-- |MajorFeature| :class:`preprocessing.MinMaxScaler` and :class:`preprocessing.MaxAbsScaler` now
-  support the `Array API <https://data-apis.org/array-api/latest/>`_. Array API
-  support is considered experimental and might evolve without being subject to
-  our usual rolling deprecation cycle policy. See
-  :ref:`array_api` for more details. :pr:`26243` by `Tim Head`_ and :pr:`27110` by :user:`Edoardo Abati <EdAbati>`.
-
-:mod:`sklearn.tree`
-...................
-
-- |Feature| :class:`tree.DecisionTreeClassifier`, :class:`tree.DecisionTreeRegressor`,
-  :class:`tree.ExtraTreeClassifier` and :class:`tree.ExtraTreeRegressor` now support
-  monotonic constraints, useful when features are supposed to have a positive/negative
-  effect on the target. Missing values in the train data and multi-output targets are
-  not supported.
-  :pr:`13649` by :user:`Samuel Ronsin <samronsin>`, initiated by
-  :user:`Patrick O'Reilly <pat-oreilly>`.
-
-
-:mod:`sklearn.neighbors`
-........................
-
-- |API| :class:`neighbors.KNeighborsRegressor` now accepts
-  :class:`metric.DistanceMetric` objects directly via the `metric` keyword
-  argument allowing for the use of accelerated third-party
-  :class:`metric.DistanceMetric` objects.
-  :pr:`26267` by :user:`Meekail Zain <micky774>`
-
-:mod:`sklearn.neural_network`
-.............................
-
-- |Enhancement| :meth:`neural_network.BernoulliRBM.score_samples` now supports Scipy
-  sparse arrays.
-  :pr:`27252` by `Yao Xiao <Charlie-XIAO>`
-
-:mod:`sklearn.metrics`
-......................
 
 - |Efficiency| Computing pairwise distances via :class:`metrics.DistanceMetric`
   for CSR × CSR,  Dense × CSR, and CSR × Dense datasets is now 1.5x faster.
@@ -307,8 +227,71 @@ Changelog
   both axis is set to be 1 to get a square plot.
   :pr:`26366` by :user:`Mojdeh Rastgoo <mrastgoo>`.
 
-- |Enhancement| :func:`sklearn.metrics.accuracy_score` and :func:`sklearn.metrics.zero_one_loss` now support
-  Array API compatible inputs. :pr:`27137` by :user:`Edoardo Abati <EdAbati>`.
+- |Enhancement| Added `neg_root_mean_squared_log_error_scorer` as scorer
+  :pr:`26734` by :user:`Alejandro Martin Gil <101AlexMartin>`.
+
+- |Enhancement| :func:`sklearn.metrics.accuracy_score` and
+  :func:`sklearn.metrics.zero_one_loss` now support Array API compatible inputs.
+  :pr:`27137` by :user:`Edoardo Abati <EdAbati>`.
+
+:mod:`sklearn.model_selection`
+..............................
+
+- |Fix| :class:`model_selection.GridSearchCV`,
+  :class:`model_selection.RandomizedSearchCV`, and
+  :class:`model_selection.HalvingGridSearchCV` now don't change the given
+  object in the parameter grid if it's an estimator. :pr:`26786` by `Adrin
+  Jalali`_.
+
+- |Enhancement| :func:`sklearn.model_selection.train_test_split` now supports
+  Array API compatible inputs. :pr:`26855` by `Tim Head`_.
+
+:mod:`sklearn.neighbors`
+........................
+
+- |API| :class:`neighbors.KNeighborsRegressor` now accepts
+  :class:`metric.DistanceMetric` objects directly via the `metric` keyword
+  argument allowing for the use of accelerated third-party
+  :class:`metric.DistanceMetric` objects.
+  :pr:`26267` by :user:`Meekail Zain <micky774>`
+
+- |Efficiency| :meth:`sklearn.neighbors.KNeighborsRegressor.predict` and
+  :meth:`sklearn.neighbors.KNeighborsRegressor.predict_proba` now efficiently support
+  pairs of dense and sparse datasets.
+  :pr:`27018` by :user:`Julien Jerphanion <jjerphan>`.
+
+:mod:`sklearn.preprocessing`
+............................
+
+- |Efficiency| :class:`preprocessing.OrdinalEncoder` avoids calculating
+  missing indices twice to improve efficiency.
+  :pr:`27017` by :user:`Xuefeng Xu <xuefeng-xu>`.
+
+- |Enhancement| Improves warnings in :class:`preprocessing.FunctionTransfomer` when
+  `func` returns a pandas dataframe and the output is configured to be pandas.
+  :pr:`26944` by `Thomas Fan`_.
+
+- |Enhancement| :class:`preprocessing.TargetEncoder` now supports `target_type`
+  'multiclass'. :pr:`26674` by :user:`Lucy Liu <lucyleeow>`.
+
+- |MajorFeature| :class:`preprocessing.MinMaxScaler` and
+  :class:`preprocessing.MaxAbsScaler` now
+  support the `Array API <https://data-apis.org/array-api/latest/>`_. Array API
+  support is considered experimental and might evolve without being subject to
+  our usual rolling deprecation cycle policy. See
+  :ref:`array_api` for more details.
+  :pr:`26243` by `Tim Head`_ and :pr:`27110` by :user:`Edoardo Abati <EdAbati>`.
+
+:mod:`sklearn.tree`
+...................
+
+- |Feature| :class:`tree.DecisionTreeClassifier`, :class:`tree.DecisionTreeRegressor`,
+  :class:`tree.ExtraTreeClassifier` and :class:`tree.ExtraTreeRegressor` now support
+  monotonic constraints, useful when features are supposed to have a positive/negative
+  effect on the target. Missing values in the train data and multi-output targets are
+  not supported.
+  :pr:`13649` by :user:`Samuel Ronsin <samronsin>`, initiated by
+  :user:`Patrick O'Reilly <pat-oreilly>`.
 
 :mod:`sklearn.utils`
 ....................
@@ -319,20 +302,11 @@ Changelog
   :pr:`26862` by :user:`Andrew Goh Yisheng <9y5>`, `Thomas Fan`_, `Adrin
   Jalali`_.
 
-- |Enhancement| :class:`~utils.metadata_routing.MetadataRequest` and
-  :class:`~utils.metadata_routing.MetadataRouter` now have a ``consumes`` method
-  which can be used to check whether a given set of parameters would be consumed.
-  :pr:`26831` by `Adrin Jalali`_.
-
 - |Fix| :func:`sklearn.utils.check_array` should accept both matrix and array from
   the sparse SciPy module. The previous implementation would fail if `copy=True` by
   calling specific NumPy `np.may_share_memory` that does not work with SciPy sparse
   array and does not return the correct result for SciPy sparse matrix.
   :pr:`27336` by :user:`Guillaume Lemaitre <glemaitre>`.
-
-- |Enhancement| :func`sklearn.utils.multiclass.type_of_target` now supports Scipy
-  sparse arrays.
-  :pr:`27274` by `Yao Xiao <Charlie-XIAO>`
 
 Code and Documentation Contributors
 -----------------------------------


### PR DESCRIPTION
Fixing some issues seen in the changelog of 1.4.
Also grouped together PRs linked to support for sparse matrices.

I also think it could be meaningful to do the same for the Array-API if we think that we will have a rather wide support for the next release. I did not do it here. I would let @ogrisel @betatim to let me know what they think.
