### PR TITLE
DOC remove deprecation warnings plot_mahalanobis_distances example

### DIFF
--- a/examples/covariance/plot_mahalanobis_distances.py
+++ b/examples/covariance/plot_mahalanobis_distances.py
@@ -122,6 +122,7 @@ print(
 # MCD based Mahalanobis distances fit the inlier black points much better,
 # whereas the MLE based distances are more influenced by the outlier
 # red points.
+import matplotlib.lines as mlines
 
 fig, ax = plt.subplots(figsize=(10, 5))
 # Plot data set
@@ -154,8 +155,8 @@ robust_contour = ax.contour(
 # Add legend
 ax.legend(
     [
-        emp_cov_contour.collections[1],
-        robust_contour.collections[1],
+        mlines.Line2D([], [], color="tab:blue", linestyle="dashed"),
+        mlines.Line2D([], [], color="tab:orange", linestyle="dotted"),
         inlier_plot,
         outlier_plot,
     ],


### PR DESCRIPTION
Avoid the following deprecation warnings in the following example:

```
WARNING: /Users/glemaitre/Documents/packages/scikit-learn/examples/covariance/plot_mahalanobis_distances.py failed to execute correctly: Traceback (most recent call last):
  File "/Users/glemaitre/Documents/packages/scikit-learn/examples/covariance/plot_mahalanobis_distances.py", line 157, in <module>
    emp_cov_contour.collections[1],
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/deprecation.py", line 158, in __get__
    emit_warning()
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/deprecation.py", line 193, in emit_warning
    warn_deprecated(
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/deprecation.py", line 96, in warn_deprecated
    warn_external(warning, category=MatplotlibDeprecationWarning)
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/__init__.py", line 381, in warn_external
    warnings.warn(message, category, stacklevel)
matplotlib._api.deprecation.MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed two minor releases later.
```

I create a manual legend that does not required to much matplotlib boilerplate.