### PR TITLE
DOC fix deprecation warning in plot_sgdocsvm_vs_ocsvm

### DIFF
--- a/examples/linear_model/plot_sgdocsvm_vs_ocsvm.py
+++ b/examples/linear_model/plot_sgdocsvm_vs_ocsvm.py
@@ -20,6 +20,7 @@ show that we obtain similar results on a toy dataset.
 """  # noqa: E501
 
 import matplotlib
+import matplotlib.lines as mlines
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -96,7 +97,7 @@ plt.axis("tight")
 plt.xlim((-4.5, 4.5))
 plt.ylim((-4.5, 4.5))
 plt.legend(
-    [a.collections[0], b1, b2, c],
+    [mlines.Line2D([], [], color="darkred", label="learned frontier"), b1, b2, c],
     [
         "learned frontier",
         "training observations",
@@ -132,7 +133,7 @@ plt.axis("tight")
 plt.xlim((-4.5, 4.5))
 plt.ylim((-4.5, 4.5))
 plt.legend(
-    [a.collections[0], b1, b2, c],
+    [mlines.Line2D([], [], color="darkred", label="learned frontier"), b1, b2, c],
     [
         "learned frontier",
         "training observations",

--- a/examples/linear_model/plot_sgdocsvm_vs_ocsvm.py
+++ b/examples/linear_model/plot_sgdocsvm_vs_ocsvm.py
@@ -19,6 +19,7 @@ show that we obtain similar results on a toy dataset.
 
 """  # noqa: E501
 
+# %%
 import matplotlib
 import matplotlib.lines as mlines
 import matplotlib.pyplot as plt
@@ -45,8 +46,6 @@ X_test = np.r_[X + 2, X - 2]
 # Generate some abnormal novel observations
 X_outliers = rng.uniform(low=-4, high=4, size=(20, 2))
 
-xx, yy = np.meshgrid(np.linspace(-4.5, 4.5, 50), np.linspace(-4.5, 4.5, 50))
-
 # OCSVM hyperparameters
 nu = 0.05
 gamma = 2.0
@@ -60,10 +59,6 @@ y_pred_outliers = clf.predict(X_outliers)
 n_error_train = y_pred_train[y_pred_train == -1].size
 n_error_test = y_pred_test[y_pred_test == -1].size
 n_error_outliers = y_pred_outliers[y_pred_outliers == 1].size
-
-Z = clf.decision_function(np.c_[xx.ravel(), yy.ravel()])
-Z = Z.reshape(xx.shape)
-
 
 # Fit the One-Class SVM using a kernel approximation and SGD
 transform = Nystroem(gamma=gamma, random_state=random_state)
@@ -79,24 +74,58 @@ n_error_train_sgd = y_pred_train_sgd[y_pred_train_sgd == -1].size
 n_error_test_sgd = y_pred_test_sgd[y_pred_test_sgd == -1].size
 n_error_outliers_sgd = y_pred_outliers_sgd[y_pred_outliers_sgd == 1].size
 
-Z_sgd = pipe_sgd.decision_function(np.c_[xx.ravel(), yy.ravel()])
-Z_sgd = Z_sgd.reshape(xx.shape)
 
-# plot the level sets of the decision function
-plt.figure(figsize=(9, 6))
-plt.title("One Class SVM")
-plt.contourf(xx, yy, Z, levels=np.linspace(Z.min(), 0, 7), cmap=plt.cm.PuBu)
-a = plt.contour(xx, yy, Z, levels=[0], linewidths=2, colors="darkred")
-plt.contourf(xx, yy, Z, levels=[0, Z.max()], colors="palevioletred")
+# %%
+from sklearn.inspection import DecisionBoundaryDisplay
+
+_, ax = plt.subplots(figsize=(9, 6))
+
+xx, yy = np.meshgrid(np.linspace(-4.5, 4.5, 50), np.linspace(-4.5, 4.5, 50))
+X = np.concatenate([xx.ravel().reshape(-1, 1), yy.ravel().reshape(-1, 1)], axis=1)
+DecisionBoundaryDisplay.from_estimator(
+    clf,
+    X,
+    response_method="decision_function",
+    plot_method="contourf",
+    ax=ax,
+    cmap="PuBu",
+)
+DecisionBoundaryDisplay.from_estimator(
+    clf,
+    X,
+    response_method="decision_function",
+    plot_method="contour",
+    ax=ax,
+    linewidths=2,
+    colors="darkred",
+    levels=[0],
+)
+DecisionBoundaryDisplay.from_estimator(
+    clf,
+    X,
+    response_method="decision_function",
+    plot_method="contourf",
+    ax=ax,
+    colors="palevioletred",
+    levels=[0, clf.decision_function(X).max()],
+)
 
 s = 20
 b1 = plt.scatter(X_train[:, 0], X_train[:, 1], c="white", s=s, edgecolors="k")
 b2 = plt.scatter(X_test[:, 0], X_test[:, 1], c="blueviolet", s=s, edgecolors="k")
 c = plt.scatter(X_outliers[:, 0], X_outliers[:, 1], c="gold", s=s, edgecolors="k")
-plt.axis("tight")
-plt.xlim((-4.5, 4.5))
-plt.ylim((-4.5, 4.5))
-plt.legend(
+
+ax.set(
+    title="One-Class SVM",
+    xlim=(-4.5, 4.5),
+    ylim=(-4.5, 4.5),
+    xlabel=(
+        f"error train: {n_error_train}/{X_train.shape[0]}; "
+        f"errors novel regular: {n_error_test}/{X_test.shape[0]}; "
+        f"errors novel abnormal: {n_error_outliers}/{X_outliers.shape[0]}"
+    ),
+)
+_ = ax.legend(
     [mlines.Line2D([], [], color="darkred", label="learned frontier"), b1, b2, c],
     [
         "learned frontier",
@@ -106,33 +135,56 @@ plt.legend(
     ],
     loc="upper left",
 )
-plt.xlabel(
-    "error train: %d/%d; errors novel regular: %d/%d; errors novel abnormal: %d/%d"
-    % (
-        n_error_train,
-        X_train.shape[0],
-        n_error_test,
-        X_test.shape[0],
-        n_error_outliers,
-        X_outliers.shape[0],
-    )
-)
-plt.show()
 
-plt.figure(figsize=(9, 6))
-plt.title("Online One-Class SVM")
-plt.contourf(xx, yy, Z_sgd, levels=np.linspace(Z_sgd.min(), 0, 7), cmap=plt.cm.PuBu)
-a = plt.contour(xx, yy, Z_sgd, levels=[0], linewidths=2, colors="darkred")
-plt.contourf(xx, yy, Z_sgd, levels=[0, Z_sgd.max()], colors="palevioletred")
+# %%
+_, ax = plt.subplots(figsize=(9, 6))
+
+xx, yy = np.meshgrid(np.linspace(-4.5, 4.5, 50), np.linspace(-4.5, 4.5, 50))
+X = np.concatenate([xx.ravel().reshape(-1, 1), yy.ravel().reshape(-1, 1)], axis=1)
+DecisionBoundaryDisplay.from_estimator(
+    pipe_sgd,
+    X,
+    response_method="decision_function",
+    plot_method="contourf",
+    ax=ax,
+    cmap="PuBu",
+)
+DecisionBoundaryDisplay.from_estimator(
+    pipe_sgd,
+    X,
+    response_method="decision_function",
+    plot_method="contour",
+    ax=ax,
+    linewidths=2,
+    colors="darkred",
+    levels=[0],
+)
+DecisionBoundaryDisplay.from_estimator(
+    pipe_sgd,
+    X,
+    response_method="decision_function",
+    plot_method="contourf",
+    ax=ax,
+    colors="palevioletred",
+    levels=[0, pipe_sgd.decision_function(X).max()],
+)
 
 s = 20
 b1 = plt.scatter(X_train[:, 0], X_train[:, 1], c="white", s=s, edgecolors="k")
 b2 = plt.scatter(X_test[:, 0], X_test[:, 1], c="blueviolet", s=s, edgecolors="k")
 c = plt.scatter(X_outliers[:, 0], X_outliers[:, 1], c="gold", s=s, edgecolors="k")
-plt.axis("tight")
-plt.xlim((-4.5, 4.5))
-plt.ylim((-4.5, 4.5))
-plt.legend(
+
+ax.set(
+    title="Online One-Class SVM",
+    xlim=(-4.5, 4.5),
+    ylim=(-4.5, 4.5),
+    xlabel=(
+        f"error train: {n_error_train_sgd}/{X_train.shape[0]}; "
+        f"errors novel regular: {n_error_test_sgd}/{X_test.shape[0]}; "
+        f"errors novel abnormal: {n_error_outliers_sgd}/{X_outliers.shape[0]}"
+    ),
+)
+ax.legend(
     [mlines.Line2D([], [], color="darkred", label="learned frontier"), b1, b2, c],
     [
         "learned frontier",
@@ -141,16 +193,5 @@ plt.legend(
         "new abnormal observations",
     ],
     loc="upper left",
-)
-plt.xlabel(
-    "error train: %d/%d; errors novel regular: %d/%d; errors novel abnormal: %d/%d"
-    % (
-        n_error_train_sgd,
-        X_train.shape[0],
-        n_error_test_sgd,
-        X_test.shape[0],
-        n_error_outliers_sgd,
-        X_outliers.shape[0],
-    )
 )
 plt.show()


### PR DESCRIPTION
Remove matplotlib deprecation in the example `plot_sgdocsvm_vs_ocsvm`:

```
WARNING: /Users/glemaitre/Documents/packages/scikit-learn/examples/linear_model/plot_sgdocsvm_vs_ocsvm.py failed to execute correctly: Traceback (most recent call last):
  File "/Users/glemaitre/Documents/packages/scikit-learn/examples/linear_model/plot_sgdocsvm_vs_ocsvm.py", line 99, in <module>
    [a.collections[0], b1, b2, c],
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/deprecation.py", line 158, in __get__
    emit_warning()
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/deprecation.py", line 193, in emit_warning
    warn_deprecated(
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/deprecation.py", line 96, in warn_deprecated
    warn_external(warning, category=MatplotlibDeprecationWarning)
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/__init__.py", line 381, in warn_external
    warnings.warn(message, category, stacklevel)
matplotlib._api.deprecation.MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed two minor releases later.
```