### PR TITLE
DOC fixes pandas deprecation warning in plot_partial_dependence

### DIFF
--- a/examples/inspection/plot_partial_dependence.py
+++ b/examples/inspection/plot_partial_dependence.py
@@ -112,7 +112,7 @@ xtick_start, xtick_period = 6, 12
 fig, axs = plt.subplots(nrows=2, figsize=(8, 6), sharey=True, sharex=True)
 average_bike_rentals = bikes.frame.groupby(
     ["year", "season", "weekday", "hour"], observed=True
-).mean(numeric_only=True,)["count"]
+).mean(numeric_only=True)["count"]
 for ax, (idx, df) in zip(axs, average_bike_rentals.groupby("year")):
     df.groupby("season").plot(ax=ax, legend=True)
 

--- a/examples/inspection/plot_partial_dependence.py
+++ b/examples/inspection/plot_partial_dependence.py
@@ -114,7 +114,7 @@ average_bike_rentals = bikes.frame.groupby(
     ["year", "season", "weekday", "hour"], observed=True
 ).mean(numeric_only=True)["count"]
 for ax, (idx, df) in zip(axs, average_bike_rentals.groupby("year")):
-    df.groupby("season").plot(ax=ax, legend=True)
+    df.groupby("season", observed=True).plot(ax=ax, legend=True)
 
     # decorate the plot
     ax.set_xticks(

--- a/examples/inspection/plot_partial_dependence.py
+++ b/examples/inspection/plot_partial_dependence.py
@@ -110,9 +110,9 @@ xticklabels = [f"{day}\n{hour}:00" for day, hour in product(days, hours)]
 xtick_start, xtick_period = 6, 12
 
 fig, axs = plt.subplots(nrows=2, figsize=(8, 6), sharey=True, sharex=True)
-average_bike_rentals = bikes.frame.groupby(["year", "season", "weekday", "hour"]).mean(
-    numeric_only=True
-)["count"]
+average_bike_rentals = bikes.frame.groupby(
+    ["year", "season", "weekday", "hour"], observed=True
+).mean(numeric_only=True,)["count"]
 for ax, (idx, df) in zip(axs, average_bike_rentals.groupby("year")):
     df.groupby("season").plot(ax=ax, legend=True)
 


### PR DESCRIPTION
Remove deprecation warning raised by Pandas 2.1.0:


```
WARNING: /Users/glemaitre/Documents/packages/scikit-learn/examples/inspection/plot_partial_dependence.py failed to execute correctly: Traceback (most recent call last):
  File "/Users/glemaitre/Documents/packages/scikit-learn/examples/inspection/plot_partial_dependence.py", line 113, in <module>
    average_bike_rentals = bikes.frame.groupby(["year", "season", "weekday", "hour"]).mean(
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/pandas/core/frame.py", line 8872, in groupby
    return DataFrameGroupBy(
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/pandas/core/groupby/groupby.py", line 1286, in __init__
    warnings.warn(
FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning.
```