### PR TITLE
DOC fix deprecation warning in plot_lof_novelty_detection

### DIFF
--- a/examples/neighbors/plot_lof_novelty_detection.py
+++ b/examples/neighbors/plot_lof_novelty_detection.py
@@ -26,6 +26,7 @@ n_neighbors=20 appears to work well in general.
 """
 
 import matplotlib
+import matplotlib.lines as mlines
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -71,7 +72,7 @@ plt.axis("tight")
 plt.xlim((-5, 5))
 plt.ylim((-5, 5))
 plt.legend(
-    [a.collections[0], b1, b2, c],
+    [mlines.Line2D([], [], color="darkred"), b1, b2, c],
     [
         "learned frontier",
         "training observations",


### PR DESCRIPTION
Remove deprecation warning raise by matplotlib in `plot_lof_novelty_detection`

```
WARNING: /Users/glemaitre/Documents/packages/scikit-learn/examples/neighbors/plot_lof_novelty_detection.py failed to execute correctly: Traceback (most recent call last):
  File "/Users/glemaitre/Documents/packages/scikit-learn/examples/neighbors/plot_lof_novelty_detection.py", line 74, in <module>
    [a.collections[0], b1, b2, c],
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/deprecation.py", line 158, in __get__
    emit_warning()
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/deprecation.py", line 193, in emit_warning
    warn_deprecated(
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/deprecation.py", line 96, in warn_deprecated
    warn_external(warning, category=MatplotlibDeprecationWarning)
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/__init__.py", line 381, in warn_external
    warnings.warn(message, category, stacklevel)
matplotlib._api.deprecation.MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed two minor releases later.
```