### PR TITLE
DOC fix deprecation warning in plot_oneclass

### DIFF
--- a/examples/svm/plot_oneclass.py
+++ b/examples/svm/plot_oneclass.py
@@ -45,7 +45,7 @@ from sklearn.inspection import DecisionBoundaryDisplay
 _, ax = plt.subplots()
 
 # generate grid for the boundary display
-xx, yy = np.meshgrid(np.linspace(-5, 5, 500), np.linspace(-5, 5, 500))
+xx, yy = np.meshgrid(np.linspace(-5, 5, 10), np.linspace(-5, 5, 10))
 X = np.concatenate([xx.reshape(-1, 1), yy.reshape(-1, 1)], axis=1)
 DecisionBoundaryDisplay.from_estimator(
     clf,

--- a/examples/svm/plot_oneclass.py
+++ b/examples/svm/plot_oneclass.py
@@ -11,14 +11,11 @@ classifying new data as similar or different to the training set.
 
 """
 
-import matplotlib.font_manager
-import matplotlib.lines as mlines
-import matplotlib.pyplot as plt
+# %%
 import numpy as np
 
 from sklearn import svm
 
-xx, yy = np.meshgrid(np.linspace(-5, 5, 500), np.linspace(-5, 5, 500))
 # Generate train data
 X = 0.3 * np.random.randn(100, 2)
 X_train = np.r_[X + 2, X - 2]
@@ -38,22 +35,50 @@ n_error_train = y_pred_train[y_pred_train == -1].size
 n_error_test = y_pred_test[y_pred_test == -1].size
 n_error_outliers = y_pred_outliers[y_pred_outliers == 1].size
 
-# plot the line, the points, and the nearest vectors to the plane
-Z = clf.decision_function(np.c_[xx.ravel(), yy.ravel()])
-Z = Z.reshape(xx.shape)
+# %%
+import matplotlib.font_manager
+import matplotlib.lines as mlines
+import matplotlib.pyplot as plt
 
-plt.title("Novelty Detection")
-plt.contourf(xx, yy, Z, levels=np.linspace(Z.min(), 0, 7), cmap=plt.cm.PuBu)
-a = plt.contour(xx, yy, Z, levels=[0], linewidths=2, colors="darkred")
-plt.contourf(xx, yy, Z, levels=[0, Z.max()], colors="palevioletred")
+from sklearn.inspection import DecisionBoundaryDisplay
+
+_, ax = plt.subplots()
+
+# generate grid for the boundary display
+xx, yy = np.meshgrid(np.linspace(-5, 5, 500), np.linspace(-5, 5, 500))
+X = np.concatenate([xx.reshape(-1, 1), yy.reshape(-1, 1)], axis=1)
+DecisionBoundaryDisplay.from_estimator(
+    clf,
+    X,
+    response_method="decision_function",
+    plot_method="contourf",
+    ax=ax,
+    cmap="PuBu",
+)
+DecisionBoundaryDisplay.from_estimator(
+    clf,
+    X,
+    response_method="decision_function",
+    plot_method="contourf",
+    ax=ax,
+    levels=[0, 10000],
+    colors="palevioletred",
+)
+DecisionBoundaryDisplay.from_estimator(
+    clf,
+    X,
+    response_method="decision_function",
+    plot_method="contour",
+    ax=ax,
+    levels=[0],
+    colors="darkred",
+    linewidths=2,
+)
 
 s = 40
-b1 = plt.scatter(X_train[:, 0], X_train[:, 1], c="white", s=s, edgecolors="k")
-b2 = plt.scatter(X_test[:, 0], X_test[:, 1], c="blueviolet", s=s, edgecolors="k")
-c = plt.scatter(X_outliers[:, 0], X_outliers[:, 1], c="gold", s=s, edgecolors="k")
-plt.axis("tight")
-plt.xlim((-5, 5))
-plt.ylim((-5, 5))
+b1 = ax.scatter(X_train[:, 0], X_train[:, 1], c="white", s=s, edgecolors="k")
+b2 = ax.scatter(X_test[:, 0], X_test[:, 1], c="blueviolet", s=s, edgecolors="k")
+c = ax.scatter(X_outliers[:, 0], X_outliers[:, 1], c="gold", s=s, edgecolors="k")
 plt.legend(
     [mlines.Line2D([], [], color="darkred"), b1, b2, c],
     [
@@ -65,8 +90,13 @@ plt.legend(
     loc="upper left",
     prop=matplotlib.font_manager.FontProperties(size=11),
 )
-plt.xlabel(
-    "error train: %d/200 ; errors novel regular: %d/40 ; errors novel abnormal: %d/40"
-    % (n_error_train, n_error_test, n_error_outliers)
+ax.set(
+    xlabel=(
+        f"error train: {n_error_train}/200 ; errors novel regular: {n_error_test}/40 ;"
+        f" errors novel abnormal: {n_error_outliers}/40"
+    ),
+    title="Novelty Detection",
+    xlim=(-5, 5),
+    ylim=(-5, 5),
 )
 plt.show()

--- a/examples/svm/plot_oneclass.py
+++ b/examples/svm/plot_oneclass.py
@@ -12,6 +12,7 @@ classifying new data as similar or different to the training set.
 """
 
 import matplotlib.font_manager
+import matplotlib.lines as mlines
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -54,7 +55,7 @@ plt.axis("tight")
 plt.xlim((-5, 5))
 plt.ylim((-5, 5))
 plt.legend(
-    [a.collections[0], b1, b2, c],
+    [mlines.Line2D([], [], color="darkred"), b1, b2, c],
     [
         "learned frontier",
         "training observations",


### PR DESCRIPTION
Remove deprecation warning raised by matplotlib in `plot_oneclass.py`:

```
WARNING: /Users/glemaitre/Documents/packages/scikit-learn/examples/svm/plot_oneclass.py failed to execute correctly: Traceback (most recent call last):
  File "/Users/glemaitre/Documents/packages/scikit-learn/examples/svm/plot_oneclass.py", line 57, in <module>
    [a.collections[0], b1, b2, c],
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/deprecation.py", line 158, in __get__
    emit_warning()
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/deprecation.py", line 193, in emit_warning
    warn_deprecated(
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/deprecation.py", line 96, in warn_deprecated
    warn_external(warning, category=MatplotlibDeprecationWarning)
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/__init__.py", line 381, in warn_external
    warnings.warn(message, category, stacklevel)
matplotlib._api.deprecation.MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed two minor releases later.
```