### PR TITLE
DOC fix deprecation warning in plot_separating_hyperplane_unbalanced

### DIFF
--- a/examples/svm/plot_separating_hyperplane_unbalanced.py
+++ b/examples/svm/plot_separating_hyperplane_unbalanced.py
@@ -25,6 +25,7 @@ unbalanced classes.
 
 """
 
+import matplotlib.lines as mlines
 import matplotlib.pyplot as plt
 
 from sklearn import svm
@@ -81,7 +82,10 @@ wdisp = DecisionBoundaryDisplay.from_estimator(
 )
 
 plt.legend(
-    [disp.surface_.collections[0], wdisp.surface_.collections[0]],
+    [
+        mlines.Line2D([], [], color="k", label="non weighted"),
+        mlines.Line2D([], [], color="r", label="weighted"),
+    ],
     ["non weighted", "weighted"],
     loc="upper right",
 )


### PR DESCRIPTION
Remove a matplotlib deprecation warning raised in `plot_seperating_hyperplane_unbalanced`:

```
WARNING: /Users/glemaitre/Documents/packages/scikit-learn/examples/svm/plot_separating_hyperplane_unbalanced.py failed to execute correctly: Traceback (most recent call last):
  File "/Users/glemaitre/Documents/packages/scikit-learn/examples/svm/plot_separating_hyperplane_unbalanced.py", line 84, in <module>
    [disp.surface_.collections[0], wdisp.surface_.collections[0]],
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/deprecation.py", line 158, in __get__
    emit_warning()
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/deprecation.py", line 193, in emit_warning
    warn_deprecated(
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/deprecation.py", line 96, in warn_deprecated
    warn_external(warning, category=MatplotlibDeprecationWarning)
  File "/Users/glemaitre/mambaforge/envs/sklearn_dev/lib/python3.10/site-packages/matplotlib/_api/__init__.py", line 381, in warn_external
    warnings.warn(message, category, stacklevel)
matplotlib._api.deprecation.MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed two minor releases later.
```