### PR TITLE
FIX `_partial_fit_binary`  passing classes only when classes are consumed

### DIFF
--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -93,7 +93,10 @@ def _fit_binary(estimator, X, y, classes=None):
 
 def _partial_fit_binary(estimator, X, y):
     """Partially fit a single binary estimator."""
-    estimator.partial_fit(X, y, np.array((0, 1)))
+    try:
+        estimator.partial_fit(X, y, classes=[0, 1])
+    except TypeError:
+        estimator.partial_fit(X, y)
     return estimator
 
 


### PR DESCRIPTION
This PR fixes the issue that `sklearn/multiclass._partial_fit_binary` would pass `classes` to any estimator, even if they wouldn't consume it.

Thanks @adrinjalali for your help here.