### PR TITLE
FIX make dataset fetchers accept `os.Pathlike` for `data_home`

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -168,6 +168,13 @@ Changelog
   `kdtree` and `balltree` values will be removed in 1.6.
   :pr:`26744` by :user:`Shreesha Kumar Bhat <Shreesha3112>`.
 
+:mod:`sklearn.datasets`
+.......................
+
+- |Fix| All dataset fetchers now accept `data_home` as any object that implements
+  the :class:`os.PathLike` interface, for instance, :class:`pathlib.Path`.
+  :pr:`27468` by :user:`Yao Xiao <Charlie-XIAO>`.
+
 :mod:`sklearn.decomposition`
 ............................
 

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -20,11 +20,8 @@ from sklearn.datasets import (
     fetch_california_housing,
     fetch_covtype,
     fetch_kddcup99,
-    fetch_lfw_pairs,
-    fetch_lfw_people,
     fetch_olivetti_faces,
     fetch_rcv1,
-    fetch_species_distributions,
 )
 from sklearn.tests import random_seed
 from sklearn.utils import _IS_32BIT
@@ -71,11 +68,8 @@ dataset_fetchers = {
     "fetch_california_housing_fxt": fetch_california_housing,
     "fetch_covtype_fxt": fetch_covtype,
     "fetch_kddcup99_fxt": fetch_kddcup99,
-    "fetch_lfw_pairs": fetch_lfw_pairs,
-    "fetch_lfw_people": fetch_lfw_people,
     "fetch_olivetti_faces_fxt": fetch_olivetti_faces,
     "fetch_rcv1_fxt": fetch_rcv1,
-    "fetch_species_distributions": fetch_species_distributions,
 }
 
 if scipy_datasets_require_network:
@@ -116,11 +110,8 @@ fetch_20newsgroups_vectorized_fxt = _fetch_fixture(fetch_20newsgroups_vectorized
 fetch_california_housing_fxt = _fetch_fixture(fetch_california_housing)
 fetch_covtype_fxt = _fetch_fixture(fetch_covtype)
 fetch_kddcup99_fxt = _fetch_fixture(fetch_kddcup99)
-fetch_lfw_pairs_fxt = _fetch_fixture(fetch_lfw_pairs)
-fetch_lfw_poeple_fxt = _fetch_fixture(fetch_lfw_people)
 fetch_olivetti_faces_fxt = _fetch_fixture(fetch_olivetti_faces)
 fetch_rcv1_fxt = _fetch_fixture(fetch_rcv1)
-fetch_species_distributions_fxt = _fetch_fixture(fetch_species_distributions)
 raccoon_face_fxt = pytest.fixture(raccoon_face_or_skip)
 
 

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -20,8 +20,11 @@ from sklearn.datasets import (
     fetch_california_housing,
     fetch_covtype,
     fetch_kddcup99,
+    fetch_lfw_pairs,
+    fetch_lfw_people,
     fetch_olivetti_faces,
     fetch_rcv1,
+    fetch_species_distributions,
 )
 from sklearn.tests import random_seed
 from sklearn.utils import _IS_32BIT
@@ -68,8 +71,11 @@ dataset_fetchers = {
     "fetch_california_housing_fxt": fetch_california_housing,
     "fetch_covtype_fxt": fetch_covtype,
     "fetch_kddcup99_fxt": fetch_kddcup99,
+    "fetch_lfw_pairs": fetch_lfw_pairs,
+    "fetch_lfw_people": fetch_lfw_people,
     "fetch_olivetti_faces_fxt": fetch_olivetti_faces,
     "fetch_rcv1_fxt": fetch_rcv1,
+    "fetch_species_distributions": fetch_species_distributions,
 }
 
 if scipy_datasets_require_network:
@@ -110,8 +116,11 @@ fetch_20newsgroups_vectorized_fxt = _fetch_fixture(fetch_20newsgroups_vectorized
 fetch_california_housing_fxt = _fetch_fixture(fetch_california_housing)
 fetch_covtype_fxt = _fetch_fixture(fetch_covtype)
 fetch_kddcup99_fxt = _fetch_fixture(fetch_kddcup99)
+fetch_lfw_pairs_fxt = _fetch_fixture(fetch_lfw_pairs)
+fetch_lfw_poeple_fxt = _fetch_fixture(fetch_lfw_people)
 fetch_olivetti_faces_fxt = _fetch_fixture(fetch_olivetti_faces)
 fetch_rcv1_fxt = _fetch_fixture(fetch_rcv1)
+fetch_species_distributions_fxt = _fetch_fixture(fetch_species_distributions)
 raccoon_face_fxt = pytest.fixture(raccoon_face_or_skip)
 
 

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -57,7 +57,7 @@ def get_data_home(data_home=None) -> str:
     ----------
     data_home : str or path-like, default=None
         The path to scikit-learn data directory. If `None`, the default path
-        is `~/sklearn_learn_data`.
+        is `~/scikit_learn_data`.
 
     Returns
     -------
@@ -84,7 +84,7 @@ def clear_data_home(data_home=None):
     ----------
     data_home : str or path-like, default=None
         The path to scikit-learn data directory. If `None`, the default path
-        is `~/sklearn_learn_data`.
+        is `~/scikit_learn_data`.
     """
     data_home = get_data_home(data_home)
     shutil.rmtree(data_home)

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -57,7 +57,7 @@ def get_data_home(data_home=None) -> str:
     ----------
     data_home : str or path-like, default=None
         The path to scikit-learn data directory. If `None`, the default path
-        is `~/scikit_learn_data`.
+        is `~/sklearn_learn_data`.
 
     Returns
     -------
@@ -84,7 +84,7 @@ def clear_data_home(data_home=None):
     ----------
     data_home : str or path-like, default=None
         The path to scikit-learn data directory. If `None`, the default path
-        is `~/scikit_learn_data`.
+        is `~/sklearn_learn_data`.
     """
     data_home = get_data_home(data_home)
     shutil.rmtree(data_home)

--- a/sklearn/datasets/_california_housing.py
+++ b/sklearn/datasets/_california_housing.py
@@ -23,7 +23,7 @@ Statistics and Probability Letters, 33 (1997) 291-297.
 
 import logging
 import tarfile
-from os import makedirs, remove
+from os import PathLike, makedirs, remove
 from os.path import exists
 
 import joblib
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 
 @validate_params(
     {
-        "data_home": [str, None],
+        "data_home": [str, PathLike, None],
         "download_if_missing": ["boolean"],
         "return_X_y": ["boolean"],
         "as_frame": ["boolean"],
@@ -76,7 +76,7 @@ def fetch_california_housing(
 
     Parameters
     ----------
-    data_home : str, default=None
+    data_home : str or path-like, default=None
         Specify another download and cache folder for the datasets. By default
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 

--- a/sklearn/datasets/_california_housing.py
+++ b/sklearn/datasets/_california_housing.py
@@ -23,7 +23,7 @@ Statistics and Probability Letters, 33 (1997) 291-297.
 
 import logging
 import tarfile
-from os import PathLike, makedirs, remove
+from os import makedirs, remove
 from os.path import exists
 
 import joblib
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 
 @validate_params(
     {
-        "data_home": [str, PathLike, None],
+        "data_home": [str, None],
         "download_if_missing": ["boolean"],
         "return_X_y": ["boolean"],
         "as_frame": ["boolean"],
@@ -76,7 +76,7 @@ def fetch_california_housing(
 
     Parameters
     ----------
-    data_home : str or path-like, default=None
+    data_home : str, default=None
         Specify another download and cache folder for the datasets. By default
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 

--- a/sklearn/datasets/_covtype.py
+++ b/sklearn/datasets/_covtype.py
@@ -65,7 +65,7 @@ TARGET_NAMES = ["Cover_Type"]
 
 @validate_params(
     {
-        "data_home": [str, None],
+        "data_home": [str, os.PathLike, None],
         "download_if_missing": ["boolean"],
         "random_state": ["random_state"],
         "shuffle": ["boolean"],
@@ -98,7 +98,7 @@ def fetch_covtype(
 
     Parameters
     ----------
-    data_home : str, default=None
+    data_home : str or path-like, default=None
         Specify another download and cache folder for the datasets. By default
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 

--- a/sklearn/datasets/_covtype.py
+++ b/sklearn/datasets/_covtype.py
@@ -65,7 +65,7 @@ TARGET_NAMES = ["Cover_Type"]
 
 @validate_params(
     {
-        "data_home": [str, os.PathLike, None],
+        "data_home": [str, None],
         "download_if_missing": ["boolean"],
         "random_state": ["random_state"],
         "shuffle": ["boolean"],
@@ -98,7 +98,7 @@ def fetch_covtype(
 
     Parameters
     ----------
-    data_home : str or path-like, default=None
+    data_home : str, default=None
         Specify another download and cache folder for the datasets. By default
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 

--- a/sklearn/datasets/_kddcup99.py
+++ b/sklearn/datasets/_kddcup99.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 @validate_params(
     {
         "subset": [StrOptions({"SA", "SF", "http", "smtp"}), None],
-        "data_home": [str, None],
+        "data_home": [str, os.PathLike, None],
         "shuffle": ["boolean"],
         "random_state": ["random_state"],
         "percent10": ["boolean"],
@@ -92,7 +92,7 @@ def fetch_kddcup99(
         To return the corresponding classical subsets of kddcup 99.
         If None, return the entire kddcup 99 dataset.
 
-    data_home : str, default=None
+    data_home : str or path-like, default=None
         Specify another download and cache folder for the datasets. By default
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 

--- a/sklearn/datasets/_kddcup99.py
+++ b/sklearn/datasets/_kddcup99.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 @validate_params(
     {
         "subset": [StrOptions({"SA", "SF", "http", "smtp"}), None],
-        "data_home": [str, os.PathLike, None],
+        "data_home": [str, None],
         "shuffle": ["boolean"],
         "random_state": ["random_state"],
         "percent10": ["boolean"],
@@ -92,7 +92,7 @@ def fetch_kddcup99(
         To return the corresponding classical subsets of kddcup 99.
         If None, return the entire kddcup 99 dataset.
 
-    data_home : str or path-like, default=None
+    data_home : str, default=None
         Specify another download and cache folder for the datasets. By default
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 

--- a/sklearn/datasets/_lfw.py
+++ b/sklearn/datasets/_lfw.py
@@ -10,7 +10,7 @@ over the internet, all details are available on the official website:
 
 import logging
 from numbers import Integral, Real
-from os import listdir, makedirs, remove
+from os import PathLike, listdir, makedirs, remove
 from os.path import exists, isdir, join
 
 import numpy as np
@@ -234,7 +234,7 @@ def _fetch_lfw_people(
 
 @validate_params(
     {
-        "data_home": [str, None],
+        "data_home": [str, PathLike, None],
         "funneled": ["boolean"],
         "resize": [Interval(Real, 0, None, closed="neither"), None],
         "min_faces_per_person": [Interval(Integral, 0, None, closed="left"), None],
@@ -272,7 +272,7 @@ def fetch_lfw_people(
 
     Parameters
     ----------
-    data_home : str, default=None
+    data_home : str or path-like, default=None
         Specify another download and cache folder for the datasets. By default
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 
@@ -431,7 +431,7 @@ def _fetch_lfw_pairs(
 @validate_params(
     {
         "subset": [StrOptions({"train", "test", "10_folds"})],
-        "data_home": [str, None],
+        "data_home": [str, PathLike, None],
         "funneled": ["boolean"],
         "resize": [Interval(Real, 0, None, closed="neither"), None],
         "color": ["boolean"],
@@ -480,7 +480,7 @@ def fetch_lfw_pairs(
         official evaluation set that is meant to be used with a 10-folds
         cross validation.
 
-    data_home : str, default=None
+    data_home : str or path-like, default=None
         Specify another download and cache folder for the datasets. By
         default all scikit-learn data is stored in '~/scikit_learn_data'
         subfolders.

--- a/sklearn/datasets/_lfw.py
+++ b/sklearn/datasets/_lfw.py
@@ -10,7 +10,7 @@ over the internet, all details are available on the official website:
 
 import logging
 from numbers import Integral, Real
-from os import PathLike, listdir, makedirs, remove
+from os import listdir, makedirs, remove
 from os.path import exists, isdir, join
 
 import numpy as np
@@ -234,7 +234,7 @@ def _fetch_lfw_people(
 
 @validate_params(
     {
-        "data_home": [str, PathLike, None],
+        "data_home": [str, None],
         "funneled": ["boolean"],
         "resize": [Interval(Real, 0, None, closed="neither"), None],
         "min_faces_per_person": [Interval(Integral, 0, None, closed="left"), None],
@@ -272,7 +272,7 @@ def fetch_lfw_people(
 
     Parameters
     ----------
-    data_home : str or path-like, default=None
+    data_home : str, default=None
         Specify another download and cache folder for the datasets. By default
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 
@@ -431,7 +431,7 @@ def _fetch_lfw_pairs(
 @validate_params(
     {
         "subset": [StrOptions({"train", "test", "10_folds"})],
-        "data_home": [str, PathLike, None],
+        "data_home": [str, None],
         "funneled": ["boolean"],
         "resize": [Interval(Real, 0, None, closed="neither"), None],
         "color": ["boolean"],
@@ -480,7 +480,7 @@ def fetch_lfw_pairs(
         official evaluation set that is meant to be used with a 10-folds
         cross validation.
 
-    data_home : str or path-like, default=None
+    data_home : str, default=None
         Specify another download and cache folder for the datasets. By
         default all scikit-learn data is stored in '~/scikit_learn_data'
         subfolders.

--- a/sklearn/datasets/_olivetti_faces.py
+++ b/sklearn/datasets/_olivetti_faces.py
@@ -13,7 +13,7 @@ web page of Sam Roweis:
 # Copyright (c) 2011 David Warde-Farley <wardefar at iro dot umontreal dot ca>
 # License: BSD 3 clause
 
-from os import makedirs, remove
+from os import PathLike, makedirs, remove
 from os.path import exists
 
 import joblib
@@ -36,7 +36,7 @@ FACES = RemoteFileMetadata(
 
 @validate_params(
     {
-        "data_home": [str, None],
+        "data_home": [str, PathLike, None],
         "shuffle": ["boolean"],
         "random_state": ["random_state"],
         "download_if_missing": ["boolean"],
@@ -67,7 +67,7 @@ def fetch_olivetti_faces(
 
     Parameters
     ----------
-    data_home : str, default=None
+    data_home : str or path-like, default=None
         Specify another download and cache folder for the datasets. By default
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 

--- a/sklearn/datasets/_olivetti_faces.py
+++ b/sklearn/datasets/_olivetti_faces.py
@@ -13,7 +13,7 @@ web page of Sam Roweis:
 # Copyright (c) 2011 David Warde-Farley <wardefar at iro dot umontreal dot ca>
 # License: BSD 3 clause
 
-from os import PathLike, makedirs, remove
+from os import makedirs, remove
 from os.path import exists
 
 import joblib
@@ -36,7 +36,7 @@ FACES = RemoteFileMetadata(
 
 @validate_params(
     {
-        "data_home": [str, PathLike, None],
+        "data_home": [str, None],
         "shuffle": ["boolean"],
         "random_state": ["random_state"],
         "download_if_missing": ["boolean"],
@@ -67,7 +67,7 @@ def fetch_olivetti_faces(
 
     Parameters
     ----------
-    data_home : str or path-like, default=None
+    data_home : str, default=None
         Specify another download and cache folder for the datasets. By default
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -749,7 +749,7 @@ def _valid_data_column_names(features_list, target_columns):
         "name": [str, None],
         "version": [Interval(Integral, 1, None, closed="left"), StrOptions({"active"})],
         "data_id": [Interval(Integral, 1, None, closed="left"), None],
-        "data_home": [str, None],
+        "data_home": [str, os.PathLike, None],
         "target_column": [str, list, None],
         "cache": [bool],
         "return_X_y": [bool],
@@ -769,7 +769,7 @@ def fetch_openml(
     *,
     version: Union[str, int] = "active",
     data_id: Optional[int] = None,
-    data_home: Optional[str] = None,
+    data_home: Optional[Union[str, os.PathLike]] = None,
     target_column: Optional[Union[str, List]] = "default-target",
     cache: bool = True,
     return_X_y: bool = False,
@@ -815,7 +815,7 @@ def fetch_openml(
         dataset. If data_id is not given, name (and potential version) are
         used to obtain a dataset.
 
-    data_home : str, default=None
+    data_home : str or path-like, default=None
         Specify another download and cache folder for the data sets. By default
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -749,7 +749,7 @@ def _valid_data_column_names(features_list, target_columns):
         "name": [str, None],
         "version": [Interval(Integral, 1, None, closed="left"), StrOptions({"active"})],
         "data_id": [Interval(Integral, 1, None, closed="left"), None],
-        "data_home": [str, os.PathLike, None],
+        "data_home": [str, None],
         "target_column": [str, list, None],
         "cache": [bool],
         "return_X_y": [bool],
@@ -769,7 +769,7 @@ def fetch_openml(
     *,
     version: Union[str, int] = "active",
     data_id: Optional[int] = None,
-    data_home: Optional[Union[str, os.PathLike]] = None,
+    data_home: Optional[str] = None,
     target_column: Optional[Union[str, List]] = "default-target",
     cache: bool = True,
     return_X_y: bool = False,
@@ -815,7 +815,7 @@ def fetch_openml(
         dataset. If data_id is not given, name (and potential version) are
         used to obtain a dataset.
 
-    data_home : str or path-like, default=None
+    data_home : str, default=None
         Specify another download and cache folder for the data sets. By default
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 

--- a/sklearn/datasets/_rcv1.py
+++ b/sklearn/datasets/_rcv1.py
@@ -10,7 +10,7 @@ The dataset page is available at
 
 import logging
 from gzip import GzipFile
-from os import makedirs, remove
+from os import PathLike, makedirs, remove
 from os.path import exists, join
 
 import joblib
@@ -74,7 +74,7 @@ logger = logging.getLogger(__name__)
 
 @validate_params(
     {
-        "data_home": [str, None],
+        "data_home": [str, PathLike, None],
         "subset": [StrOptions({"train", "test", "all"})],
         "download_if_missing": ["boolean"],
         "random_state": ["random_state"],
@@ -111,7 +111,7 @@ def fetch_rcv1(
 
     Parameters
     ----------
-    data_home : str, default=None
+    data_home : str or path-like, default=None
         Specify another download and cache folder for the datasets. By default
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 

--- a/sklearn/datasets/_rcv1.py
+++ b/sklearn/datasets/_rcv1.py
@@ -10,7 +10,7 @@ The dataset page is available at
 
 import logging
 from gzip import GzipFile
-from os import PathLike, makedirs, remove
+from os import makedirs, remove
 from os.path import exists, join
 
 import joblib
@@ -74,7 +74,7 @@ logger = logging.getLogger(__name__)
 
 @validate_params(
     {
-        "data_home": [str, PathLike, None],
+        "data_home": [str, None],
         "subset": [StrOptions({"train", "test", "all"})],
         "download_if_missing": ["boolean"],
         "random_state": ["random_state"],
@@ -111,7 +111,7 @@ def fetch_rcv1(
 
     Parameters
     ----------
-    data_home : str or path-like, default=None
+    data_home : str, default=None
         Specify another download and cache folder for the datasets. By default
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 

--- a/sklearn/datasets/_species_distributions.py
+++ b/sklearn/datasets/_species_distributions.py
@@ -39,7 +39,7 @@ For an example of using this dataset, see
 
 import logging
 from io import BytesIO
-from os import makedirs, remove
+from os import PathLike, makedirs, remove
 from os.path import exists
 
 import joblib
@@ -136,7 +136,7 @@ def construct_grids(batch):
 
 
 @validate_params(
-    {"data_home": [str, None], "download_if_missing": ["boolean"]},
+    {"data_home": [str, PathLike, None], "download_if_missing": ["boolean"]},
     prefer_skip_nested_validation=True,
 )
 def fetch_species_distributions(*, data_home=None, download_if_missing=True):
@@ -146,7 +146,7 @@ def fetch_species_distributions(*, data_home=None, download_if_missing=True):
 
     Parameters
     ----------
-    data_home : str, default=None
+    data_home : str or path-like, default=None
         Specify another download and cache folder for the datasets. By default
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 

--- a/sklearn/datasets/_species_distributions.py
+++ b/sklearn/datasets/_species_distributions.py
@@ -39,7 +39,7 @@ For an example of using this dataset, see
 
 import logging
 from io import BytesIO
-from os import PathLike, makedirs, remove
+from os import makedirs, remove
 from os.path import exists
 
 import joblib
@@ -136,7 +136,7 @@ def construct_grids(batch):
 
 
 @validate_params(
-    {"data_home": [str, PathLike, None], "download_if_missing": ["boolean"]},
+    {"data_home": [str, None], "download_if_missing": ["boolean"]},
     prefer_skip_nested_validation=True,
 )
 def fetch_species_distributions(*, data_home=None, download_if_missing=True):
@@ -146,7 +146,7 @@ def fetch_species_distributions(*, data_home=None, download_if_missing=True):
 
     Parameters
     ----------
-    data_home : str or path-like, default=None
+    data_home : str, default=None
         Specify another download and cache folder for the datasets. By default
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 

--- a/sklearn/datasets/_twenty_newsgroups.py
+++ b/sklearn/datasets/_twenty_newsgroups.py
@@ -153,7 +153,7 @@ def strip_newsgroup_footer(text):
 
 @validate_params(
     {
-        "data_home": [str, None],
+        "data_home": [str, os.PathLike, None],
         "subset": [StrOptions({"train", "test", "all"})],
         "categories": ["array-like", None],
         "shuffle": ["boolean"],
@@ -191,7 +191,7 @@ def fetch_20newsgroups(
 
     Parameters
     ----------
-    data_home : str, default=None
+    data_home : str or path-like, default=None
         Specify a download and cache folder for the datasets. If None,
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 
@@ -351,7 +351,7 @@ def fetch_20newsgroups(
     {
         "subset": [StrOptions({"train", "test", "all"})],
         "remove": [tuple],
-        "data_home": [str, None],
+        "data_home": [str, os.PathLike, None],
         "download_if_missing": ["boolean"],
         "return_X_y": ["boolean"],
         "normalize": ["boolean"],
@@ -411,7 +411,7 @@ def fetch_20newsgroups_vectorized(
         ends of posts that look like signatures, and 'quotes' removes lines
         that appear to be quoting another post.
 
-    data_home : str, default=None
+    data_home : str or path-like, default=None
         Specify an download and cache folder for the datasets. If None,
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 

--- a/sklearn/datasets/_twenty_newsgroups.py
+++ b/sklearn/datasets/_twenty_newsgroups.py
@@ -153,7 +153,7 @@ def strip_newsgroup_footer(text):
 
 @validate_params(
     {
-        "data_home": [str, os.PathLike, None],
+        "data_home": [str, None],
         "subset": [StrOptions({"train", "test", "all"})],
         "categories": ["array-like", None],
         "shuffle": ["boolean"],
@@ -191,7 +191,7 @@ def fetch_20newsgroups(
 
     Parameters
     ----------
-    data_home : str or path-like, default=None
+    data_home : str, default=None
         Specify a download and cache folder for the datasets. If None,
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 
@@ -351,7 +351,7 @@ def fetch_20newsgroups(
     {
         "subset": [StrOptions({"train", "test", "all"})],
         "remove": [tuple],
-        "data_home": [str, os.PathLike, None],
+        "data_home": [str, None],
         "download_if_missing": ["boolean"],
         "return_X_y": ["boolean"],
         "normalize": ["boolean"],
@@ -411,7 +411,7 @@ def fetch_20newsgroups_vectorized(
         ends of posts that look like signatures, and 'quotes' removes lines
         that appear to be quoting another post.
 
-    data_home : str or path-like, default=None
+    data_home : str, default=None
         Specify an download and cache folder for the datasets. If None,
         all scikit-learn data is stored in '~/scikit_learn_data' subfolders.
 

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 import warnings
 from functools import partial
+from pathlib import Path
 from pickle import dumps, loads
 
 import numpy as np
@@ -29,6 +30,16 @@ from sklearn.datasets.tests.test_common import check_as_frame
 from sklearn.preprocessing import scale
 from sklearn.utils import Bunch
 from sklearn.utils.fixes import _is_resource
+
+
+class _DummyPath:
+    """Minimal class that implements the os.PathLike interface."""
+
+    def __init__(self, path):
+        self.path = path
+
+    def __fspath__(self):
+        return self.path
 
 
 def _remove_dir(path):
@@ -67,13 +78,18 @@ def test_category_dir_2(load_files_root):
     _remove_dir(test_category_dir2)
 
 
-def test_data_home(data_home):
+@pytest.mark.parametrize("path_container", [None, Path, _DummyPath])
+def test_data_home(path_container, data_home):
     # get_data_home will point to a pre-existing folder
+    if path_container is not None:
+        data_home = path_container(data_home)
     data_home = get_data_home(data_home=data_home)
     assert data_home == data_home
     assert os.path.exists(data_home)
 
     # clear_data_home will delete both the content and the folder it-self
+    if path_container is not None:
+        data_home = path_container(data_home)
     clear_data_home(data_home=data_home)
     assert not os.path.exists(data_home)
 

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -3,7 +3,6 @@ import shutil
 import tempfile
 import warnings
 from functools import partial
-from pathlib import Path
 from pickle import dumps, loads
 
 import numpy as np
@@ -30,16 +29,6 @@ from sklearn.datasets.tests.test_common import check_as_frame
 from sklearn.preprocessing import scale
 from sklearn.utils import Bunch
 from sklearn.utils.fixes import _is_resource
-
-
-class _DummyPath:
-    """A minimal class that implements os.PathLike interface."""
-
-    def __init__(self, path):
-        self.path = path
-
-    def __fspath__(self):
-        return self.path
 
 
 def _remove_dir(path):
@@ -78,55 +67,19 @@ def test_category_dir_2(load_files_root):
     _remove_dir(test_category_dir2)
 
 
-@pytest.mark.parametrize("path_container", [None, Path, _DummyPath])
-def test_data_home(data_home, path_container):
+def test_data_home(data_home):
     # get_data_home will point to a pre-existing folder
-    if path_container is not None:
-        data_home = path_container(data_home)
     data_home = get_data_home(data_home=data_home)
-
     assert data_home == data_home
     assert os.path.exists(data_home)
 
     # clear_data_home will delete both the content and the folder it-self
-    if path_container is not None:
-        data_home = path_container(data_home)
     clear_data_home(data_home=data_home)
     assert not os.path.exists(data_home)
 
     # if the folder is missing it will be created again
     data_home = get_data_home(data_home=data_home)
     assert os.path.exists(data_home)
-
-
-@pytest.mark.parametrize("path_container", [None, Path, _DummyPath])
-def test_fetcher_data_home(
-    path_container,
-    data_home,
-    fetch_20newsgroups_fxt,
-    fetch_20newsgroups_vectorized_fxt,
-    fetch_california_housing_fxt,
-    fetch_covtype_fxt,
-    fetch_kddcup99_fxt,
-    fetch_lfw_pairs_fxt,
-    fetch_lfw_poeple_fxt,
-    fetch_olivetti_faces_fxt,
-    fetch_rcv1_fxt,
-    fetch_species_distributions_fxt,
-):
-    if path_container is not None:
-        data_home = path_container(data_home)
-
-    fetch_20newsgroups_fxt(data_home=data_home)
-    fetch_20newsgroups_vectorized_fxt(data_home=data_home)
-    fetch_california_housing_fxt(data_home=data_home)
-    fetch_covtype_fxt(data_home=data_home)
-    fetch_kddcup99_fxt(data_home=data_home)
-    fetch_lfw_pairs_fxt(data_home=data_home)
-    fetch_lfw_poeple_fxt(data_home=data_home)
-    fetch_olivetti_faces_fxt(data_home=data_home)
-    fetch_rcv1_fxt(data_home=data_home)
-    fetch_species_distributions_fxt(data_home=data_home)
 
 
 def test_default_empty_load_files(load_files_root):

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 import warnings
 from functools import partial
+from pathlib import Path
 from pickle import dumps, loads
 
 import numpy as np
@@ -29,6 +30,16 @@ from sklearn.datasets.tests.test_common import check_as_frame
 from sklearn.preprocessing import scale
 from sklearn.utils import Bunch
 from sklearn.utils.fixes import _is_resource
+
+
+class _DummyPath:
+    """A minimal class that implements os.PathLike interface."""
+
+    def __init__(self, path):
+        self.path = path
+
+    def __fspath__(self):
+        return self.path
 
 
 def _remove_dir(path):
@@ -67,19 +78,55 @@ def test_category_dir_2(load_files_root):
     _remove_dir(test_category_dir2)
 
 
-def test_data_home(data_home):
+@pytest.mark.parametrize("path_container", [None, Path, _DummyPath])
+def test_data_home(data_home, path_container):
     # get_data_home will point to a pre-existing folder
+    if path_container is not None:
+        data_home = path_container(data_home)
     data_home = get_data_home(data_home=data_home)
+
     assert data_home == data_home
     assert os.path.exists(data_home)
 
     # clear_data_home will delete both the content and the folder it-self
+    if path_container is not None:
+        data_home = path_container(data_home)
     clear_data_home(data_home=data_home)
     assert not os.path.exists(data_home)
 
     # if the folder is missing it will be created again
     data_home = get_data_home(data_home=data_home)
     assert os.path.exists(data_home)
+
+
+@pytest.mark.parametrize("path_container", [None, Path, _DummyPath])
+def test_fetcher_data_home(
+    path_container,
+    data_home,
+    fetch_20newsgroups_fxt,
+    fetch_20newsgroups_vectorized_fxt,
+    fetch_california_housing_fxt,
+    fetch_covtype_fxt,
+    fetch_kddcup99_fxt,
+    fetch_lfw_pairs_fxt,
+    fetch_lfw_poeple_fxt,
+    fetch_olivetti_faces_fxt,
+    fetch_rcv1_fxt,
+    fetch_species_distributions_fxt,
+):
+    if path_container is not None:
+        data_home = path_container(data_home)
+
+    fetch_20newsgroups_fxt(data_home=data_home)
+    fetch_20newsgroups_vectorized_fxt(data_home=data_home)
+    fetch_california_housing_fxt(data_home=data_home)
+    fetch_covtype_fxt(data_home=data_home)
+    fetch_kddcup99_fxt(data_home=data_home)
+    fetch_lfw_pairs_fxt(data_home=data_home)
+    fetch_lfw_poeple_fxt(data_home=data_home)
+    fetch_olivetti_faces_fxt(data_home=data_home)
+    fetch_rcv1_fxt(data_home=data_home)
+    fetch_species_distributions_fxt(data_home=data_home)
 
 
 def test_default_empty_load_files(load_files_root):


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #27447.

#### What does this implement/fix? Explain your changes.

This PR changes the parameter constraints of the dataset fetchers from `[str, None]` to `[str, os.PathLike, None]`.

#### Any other comments?

The functions do have the ability to handle `os.PathLike`, but previously `validate_params` is disabling it. The unit test also only makes sure that it is able to handle these `data_home`, but does  check explicitly for each data fetcher. Not sure if this is sufficient.