### PR TITLE
DOC fix return type of `make_sparse_spd_matrix`

### DIFF
--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1627,8 +1627,9 @@ def make_sparse_spd_matrix(
 
     Returns
     -------
-    prec : sparse matrix of shape (dim, dim)
-        The generated matrix.
+    prec : ndarray or sparse matrix of shape (dim, dim)
+        The generated matrix. If ``sparse_format=None``, this would be an ndarray.
+        Otherwise, this will be a sparse matrix of the specified format.
 
     See Also
     --------


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #27359.

#### What does this implement/fix? Explain your changes.

Doc cleanup of #27438 (forgot to change return type). Other doc modifications seem to have been done in #27438 already. Please let me know if there are any others @glemaitre.

_This does not seem to need a changelog._