### PR TITLE
MAINT Update Pyodide to 0.24.1 for JupyterLite button

### DIFF
--- a/doc/jupyter-lite.json
+++ b/doc/jupyter-lite.json
@@ -3,7 +3,7 @@
   "jupyter-config-data": {
     "litePluginSettings": {
       "@jupyterlite/pyodide-kernel-extension:kernel": {
-        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.js"
+        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"
       }
     }
   }


### PR DESCRIPTION
Pyodide 0.24.1 was released September 26. Amongst other things, it has scikit-learn 1.3.1.

We may want to backport this one on top of https://github.com/scikit-learn/scikit-learn/pull/27405 for 1.3.1.

I tested this locally and the JupyterLite button works fine.