### PR TITLE
Fix Balanced Accuracy Calculation Discrepancy

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2316,7 +2316,9 @@ def recall_score(
     },
     prefer_skip_nested_validation=True,
 )
-def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=False, zero_division="warn"):
+def balanced_accuracy_score(
+    y_true, y_pred, *, sample_weight=None, adjusted=False, zero_division="warn"
+):
     """Compute the balanced accuracy.
 
     The balanced accuracy in binary and multiclass classification problems to
@@ -2344,7 +2346,7 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
         When true, the result is adjusted for chance, so that random
         performance would score 0, while keeping perfect performance at a score
         of 1.
-   
+
     zero_division : {"warn", 0.0, 1.0, np.nan}, default="warn"
         Sets the value to return when there is a zero division.
 
@@ -2396,14 +2398,15 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
         per_class = np.diag(C) / C.sum(axis=1)
     if np.any(np.isnan(per_class)):
         if zero_division == "warn":
-           msg = (
-                  "Balanced Accuracy is ill-defined and being set to 0.0 in labels with no true samples."
-                  "Use `zero_division` parameter to control this behavior."
-           )
-           warnings.warn(msg, UndefinedMetricWarning)
-           per_class=np.nan_to_num(per_class, nan=0.0)
+            msg = (
+                "Balanced Accuracy is ill-defined and being set to 0.0 in labels with"
+                " no true samples.Use `zero_division` parameter to control this"
+                " behavior."
+            )
+            warnings.warn(msg, UndefinedMetricWarning)
+            per_class = np.nan_to_num(per_class, nan=0.0)
         else:
-           per_class = np.nan_to_num(per_class, nan=zero_division)
+            per_class = np.nan_to_num(per_class, nan=zero_division)
     score = np.mean(per_class)
     if adjusted:
         n_classes = len(per_class)
@@ -2854,11 +2857,9 @@ def log_loss(
     else:
         # TODO: Remove user defined eps in 1.5
         warnings.warn(
-            (
-                "Setting the eps parameter is deprecated and will "
-                "be removed in 1.5. Instead eps will always have"
-                "a default value of `np.finfo(y_pred.dtype).eps`."
-            ),
+            "Setting the eps parameter is deprecated and will "
+            "be removed in 1.5. Instead eps will always have"
+            "a default value of `np.finfo(y_pred.dtype).eps`.",
             FutureWarning,
         )
 
@@ -2925,10 +2926,8 @@ def log_loss(
     y_pred_sum = y_pred.sum(axis=1)
     if not np.isclose(y_pred_sum, 1, rtol=1e-15, atol=5 * eps).all():
         warnings.warn(
-            (
-                "The y_pred values do not sum to one. Starting from 1.5 this"
-                "will result in an error."
-            ),
+            "The y_pred values do not sum to one. Starting from 1.5 this"
+            "will result in an error.",
             UserWarning,
         )
     y_pred = y_pred / y_pred_sum[:, np.newaxis]
@@ -3198,4 +3197,3 @@ def brier_score_loss(y_true, y_prob, *, sample_weight=None, pos_label=None):
             raise
     y_true = np.array(y_true == pos_label, int)
     return np.average((y_true - y_prob) ** 2, weights=sample_weight)
-

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2309,10 +2309,14 @@ def recall_score(
         "y_pred": ["array-like"],
         "sample_weight": ["array-like", None],
         "adjusted": ["boolean"],
+        "zero_division": [
+            Options(Real, {0.0, 1.0, np.nan}),
+            StrOptions({"warn"}),
+        ],
     },
     prefer_skip_nested_validation=True,
 )
-def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=False):
+def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=False, zero_division="warn"):
     """Compute the balanced accuracy.
 
     The balanced accuracy in binary and multiclass classification problems to
@@ -2340,7 +2344,13 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
         When true, the result is adjusted for chance, so that random
         performance would score 0, while keeping perfect performance at a score
         of 1.
+   
+    zero_division : {"warn", 0.0, 1.0, np.nan}, default="warn"
+        Sets the value to return when there is a zero division.
 
+        Notes:
+        - If set to "warn", this acts like 0, but a warning is also raised.
+        - If set to `np.nan`, such values will be excluded from the average.
     Returns
     -------
     balanced_accuracy : float
@@ -2385,8 +2395,15 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
     with np.errstate(divide="ignore", invalid="ignore"):
         per_class = np.diag(C) / C.sum(axis=1)
     if np.any(np.isnan(per_class)):
-        warnings.warn("y_pred contains classes not in y_true")
-        per_class = per_class[~np.isnan(per_class)]
+        if zero_division == "warn":
+           msg = (
+                  "Balanced Accuracy is ill-defined and being set to 0.0 in labels with no true samples."
+                  "Use `zero_division` parameter to control this behavior."
+           )
+           warnings.warn(msg, UndefinedMetricWarning)
+           per_class=np.nan_to_num(per_class, nan=0.0)
+        else:
+           per_class = np.nan_to_num(per_class, nan=zero_division)
     score = np.mean(per_class)
     if adjusted:
         n_classes = len(per_class)
@@ -3181,3 +3198,4 @@ def brier_score_loss(y_true, y_prob, *, sample_weight=None, pos_label=None):
             raise
     y_true = np.array(y_true == pos_label, int)
     return np.average((y_true - y_prob) ** 2, weights=sample_weight)
+

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2400,7 +2400,7 @@ def balanced_accuracy_score(
         if zero_division == "warn":
             msg = (
                 "Balanced Accuracy is ill-defined and being set to 0.0 in labels with"
-                " no true samples.Use `zero_division` parameter to control this"
+                " no true samples. Use `zero_division` parameter to control this"
                 " behavior."
             )
             warnings.warn(msg, UndefinedMetricWarning)

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1805,11 +1805,9 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
     if y_true.min() < 0:
         # TODO(1.4): Replace warning w/ ValueError
         warnings.warn(
-            (
-                "ndcg_score should not be used on negative y_true values. ndcg_score"
-                " will raise a ValueError on negative y_true values starting from"
-                " version 1.4."
-            ),
+            "ndcg_score should not be used on negative y_true values. ndcg_score"
+            " will raise a ValueError on negative y_true values starting from"
+            " version 1.4.",
             FutureWarning,
         )
     if y_true.ndim > 1 and y_true.shape[1] <= 1:
@@ -1968,10 +1966,8 @@ def top_k_accuracy_score(
 
     if k >= n_classes:
         warnings.warn(
-            (
-                f"'k' ({k}) greater than or equal to 'n_classes' ({n_classes}) "
-                "will result in a perfect score and is therefore meaningless."
-            ),
+            f"'k' ({k}) greater than or equal to 'n_classes' ({n_classes}) "
+            "will result in a perfect score and is therefore meaningless.",
             UndefinedMetricWarning,
         )
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1056,10 +1056,8 @@ def manhattan_distances(X, Y=None, *, sum_over_features="deprecated"):
     # TODO(1.4): remove sum_over_features
     if sum_over_features != "deprecated":
         warnings.warn(
-            (
-                "`sum_over_features` is deprecated in version 1.2 and will be"
-                " removed in version 1.4."
-            ),
+            "`sum_over_features` is deprecated in version 1.2 and will be"
+            " removed in version 1.4.",
             FutureWarning,
         )
     else:

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -2749,7 +2749,7 @@ def test_balanced_accuracy_score_unseen():
         "Balanced Accuracy is ill-defined and being set to 0.0 in labels with no true"
         " samples. Use `zero_division` parameter to control this behavior."
     )
-    with pytest.warns(UserWarning, match=msg):
+    with pytest.warns(UndefinedMetricWarning, match=msg):
         balanced_accuracy_score([0, 0, 0], [0, 0, 1])
 
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -2745,7 +2745,10 @@ def test_brier_score_loss():
 
 
 def test_balanced_accuracy_score_unseen():
-    msg = "Balanced Accuracy is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior."
+    msg = (
+        "Balanced Accuracy is ill-defined and being set to 0.0 in labels with no true"
+        " samples. Use `zero_division` parameter to control this behavior."
+    )
     with pytest.warns(UserWarning, match=msg):
         balanced_accuracy_score([0, 0, 0], [0, 0, 1])
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -2745,7 +2745,7 @@ def test_brier_score_loss():
 
 
 def test_balanced_accuracy_score_unseen():
-    msg = "y_pred contains classes not in y_true"
+    msg = "Balanced Accuracy is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior."
     with pytest.warns(UserWarning, match=msg):
         balanced_accuracy_score([0, 0, 0], [0, 0, 1])
 

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -737,10 +737,8 @@ def test_scoring_is_not_metric():
 
 
 @pytest.mark.parametrize(
-    (
-        "scorers,expected_predict_count,"
-        "expected_predict_proba_count,expected_decision_func_count"
-    ),
+    "scorers,expected_predict_count,"
+    "expected_predict_proba_count,expected_decision_func_count",
     [
         (
             {


### PR DESCRIPTION

#### Reference Issues/PRs

Fixes #26892

#### What does this implement/fix? Explain your changes.

Corrected the balanced accuracy calculation to ensure that it equals the recall_score when the average is "macro."
Added a new parameter, zero_division, in balanced accuracy to handle this problem .
Updated relevant documentation and test cases to reflect the corrected behavior and the new zero_division parameter.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
