### PR TITLE
MAINT Explicit cython options for better discovery

### DIFF
--- a/doc/developers/cython.rst
+++ b/doc/developers/cython.rst
@@ -63,7 +63,7 @@ Tips to ease development
          # You might want to add this alias to your shell script config.
          alias cythonX="cython -X language_level=3 -X boundscheck=False -X wraparound=False -X initializedcheck=False -X nonecheck=False -X cdivision=True"
 
-         # This generates `source.c` as as if you had recompiled scikit-learn entirely.
+         # This generates `source.c` as if you had recompiled scikit-learn entirely.
          cythonX --annotate source.pyx
 
 * Using the ``--annotate`` option with this flag allows generating a HTML report of code annotation.

--- a/sklearn/_build_utils/__init__.py
+++ b/sklearn/_build_utils/__init__.py
@@ -75,12 +75,14 @@ def cythonize_extensions(extension):
         "initializedcheck": False,
         "nonecheck": False,
         "cdivision": True,
+        "profile": False,
     }
 
     return cythonize(
         extension,
         nthreads=n_jobs,
         compiler_directives=compiler_directives,
+        annotate=False,
     )
 
 

--- a/sklearn/_loss/_loss.pxd
+++ b/sklearn/_loss/_loss.pxd
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 # Fused types for input like y_true, raw_prediction, sample_weights.
 ctypedef fused floating_in:
     double


### PR DESCRIPTION
I propose to add the cython `profile` directive and `annotate` parameter, set to their default value (False). Even if it's their default value I think it writing them explicitly can help to easily recover where they should be set, and quickly switch them to investigate performance issues.