### PR TITLE
MAINT Update Pyodide to 0.24.1 for JupyterLite button  (#27474)

### DIFF
--- a/doc/jupyter-lite.json
+++ b/doc/jupyter-lite.json
@@ -3,7 +3,7 @@
   "jupyter-config-data": {
     "litePluginSettings": {
       "@jupyterlite/pyodide-kernel-extension:kernel": {
-        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.js"
+        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"
       }
     }
   }


### PR DESCRIPTION
Backported from #27474 to have scikit-learn 1.3.1 (via Pyodide 0.24.1) on the stable website JupyterLite button.

As suggested in https://github.com/scikit-learn/scikit-learn/pull/27474#issuecomment-1737409230.