### PR TITLE
ENH Add Feature Importances to _MultiOutputEstimator for Both Classifier and Regressor

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -350,7 +350,7 @@ class _MultiOutputEstimator(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta
             trees consisting of only the root node, in which case it will be an
             array of zeros.
         """
-        if not hasattr(self.estimators_[0], 'feature_importances_'):
+        if not hasattr(self.estimators_[0], "feature_importances_"):
             raise AttributeError(
                 "Unable to compute feature importances "
                 "since estimator does not have a "

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -330,6 +330,39 @@ class _MultiOutputEstimator(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta
         )
         return router
 
+    @property
+    def feature_importances_(self):
+        """The impurity-based feature importances.
+
+        The higher, the more important the feature.
+        The importance of a feature is computed as the (normalized)
+        total reduction of the criterion brought by that feature.  It is also
+        known as the Gini importance.
+
+        Warning: impurity-based feature importances can be misleading for
+        high cardinality features (many unique values). See
+        :func:`sklearn.inspection.permutation_importance` as an alternative.
+
+        Returns
+        -------
+        feature_importances_ : ndarray of shape (n_features,)
+            The values of this array sum to 1, unless all trees are single node
+            trees consisting of only the root node, in which case it will be an
+            array of zeros.
+        """
+        if not hasattr(self.estimators_[0], 'feature_importances_'):
+            raise AttributeError(
+                "Unable to compute feature importances "
+                "since estimator does not have a "
+                "feature_importances_ attribute"
+            )
+        
+        all_feature_importances = [
+            estimator.feature_importances_ for estimator in self.estimators_
+        ]
+        
+        return np.mean(all_feature_importances, axis=0)
+
 
 class MultiOutputRegressor(RegressorMixin, _MultiOutputEstimator):
     """Multi target regression.

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -356,11 +356,11 @@ class _MultiOutputEstimator(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta
                 "since estimator does not have a "
                 "feature_importances_ attribute"
             )
-        
+
         all_feature_importances = [
             estimator.feature_importances_ for estimator in self.estimators_
         ]
-        
+
         return np.mean(all_feature_importances, axis=0)
 
 


### PR DESCRIPTION
This implement `feature_importances_` attribute in `_MultiOutputEstimator` when the base estimator supports it.


#### Reference Issues/PRs


To my knowledge, there are no open issues that this directly addresses or closes.

#### What does this implement/fix? Explain your changes.
This PR adds a `feature_importances_` attribute to the `_MultiOutputEstimator` class to accommodate both classifiers and regressors from `sklearn.ensemble`.

#### Any other comments?

I believe it would be more convenient to be able to access `feature_importances_` directly from our `_MultiOutputEstimator` object, rather than through a loop each time, as illustrated below :

```python
feature_importances = [estimator.feature_importances_ for estimator in self.estimators_]
```

Example Usage:
```python

import numpy as np
from sklearn.multioutput import MultiOutputRegressor, MultiOutputClassifier
from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor

X, y = np.random.rand(100, 3), np.random.rand(100, 2)

# For regressor
rf_regressor = RandomForestRegressor(n_estimators=10)
multi_rf_regressor = MultiOutputRegressor(rf_regressor)
multi_rf_regressor.fit(X, y)
print("Average Feature Importances for Regressor:", multi_rf_regressor.feature_importances_)

# For classifier
y_classifier = np.random.randint(0, 2, size=(100, 2))
rf_classifier = RandomForestClassifier(n_estimators=10)
multi_rf_classifier = MultiOutputClassifier(rf_classifier)
multi_rf_classifier.fit(X, y_classifier)
print("Average Feature Importances for Classifier:", multi_rf_classifier.feature_importances_)
