### PR TITLE
Remove a redundant self-assignment in multilayer perceptron

### DIFF
--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -701,7 +701,6 @@ class BaseMultilayerPerceptron(BaseEstimator, metaclass=ABCMeta):
             # restore best weights
             self.coefs_ = self._best_coefs
             self.intercepts_ = self._best_intercepts
-            self.validation_scores_ = self.validation_scores_
 
     def _update_no_improvement_count(self, early_stopping, X_val, y_val):
         if early_stopping:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This statement seems redundant to me unless I am missing something.