### PR TITLE
TST Extend tests for `scipy.sparse.*array` in `sklearn/utils/tests/test_shortest_path.py` 

### DIFF
--- a/sklearn/utils/tests/test_shortest_path.py
+++ b/sklearn/utils/tests/test_shortest_path.py
@@ -9,21 +9,13 @@ from sklearn.utils.graph import single_source_shortest_path_length
 def floyd_warshall_slow(graph, directed=False):
     N = graph.shape[0]
 
-    # set nonzero entries to infinity
-    graph[np.where(graph == 0)] = np.inf
-
-    # set diagonal to zero
-    graph.flat[:: N + 1] = 0
-
     if not directed:
         graph = np.minimum(graph, graph.T)
 
     for k in range(N):
-        for i in range(N):
-            for j in range(N):
-                graph[i, j] = min(graph[i, j], graph[i, k] + graph[k, j])
-
-    graph[np.where(np.isinf(graph))] = 0
+        # Compute the sum of the intermediate distances efficiently
+        graph += np.outer(graph[:, k], graph[k, :])
+        graph = np.minimum(graph, 1)  # Convert distances to 1 for non-zero entries
 
     return graph
 

--- a/sklearn/utils/tests/test_shortest_path.py
+++ b/sklearn/utils/tests/test_shortest_path.py
@@ -15,7 +15,8 @@ def floyd_warshall_slow(graph, directed=False):
     for k in range(N):
         # Compute the sum of the intermediate distances efficiently
         graph += np.outer(graph[:, k], graph[k, :])
-        graph = np.minimum(graph, 1)  # Convert distances to 1 for non-zero entries
+        # Convert distances to 1 for non-zero entries
+        np.minimum(x1=graph, x2=1, out=graph)
 
     return graph
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Towards #27090 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This file's function don't use scipy.sparse.csr_matrix at all, so there doesn't appear to be any need to add CSR_CONTAINERS parameterization. 

However, a little optimization in floyd_warshell_slow function has been done. The improvements:

1) Improved efficiency: Use of NumPy's optimized functions like np.outer and np.minimum to perform matrix operations more efficiently. Due to taking advantage of Numpy's vectorized operations its faster in terms of computation.

2) More simplified implementation

3) Consistent handling of Non-Zero entries

#### Any other comments?
Please let me know if these changes help

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
