### PR TITLE
DOC drop linux distro version for better maintenability of the sklearn install docs

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -216,8 +216,7 @@ Debian/Ubuntu
 The Debian/Ubuntu package is split in three different packages called
 ``python3-sklearn`` (python modules), ``python3-sklearn-lib`` (low-level
 implementations and bindings), ``python3-sklearn-doc`` (documentation).
-Only the Python 3 version is available in the Debian Buster (the more recent
-Debian distribution).
+Only the Python 3 version is available.
 Packages can be installed using ``apt-get``:
 
 .. prompt:: bash $
@@ -229,7 +228,7 @@ Fedora
 ------
 
 The Fedora package is called ``python3-scikit-learn`` for the python 3 version,
-the only one available in Fedora30.
+the only one available in Fedora.
 It can be installed using ``dnf``:
 
 .. prompt:: bash $

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -216,7 +216,8 @@ Debian/Ubuntu
 The Debian/Ubuntu package is split in three different packages called
 ``python3-sklearn`` (python modules), ``python3-sklearn-lib`` (low-level
 implementations and bindings), ``python3-sklearn-doc`` (documentation).
-Only the Python 3 version is available.
+Note that scikit-learn requires Python 3, hence the need to use the `python3-`
+suffixed package names.
 Packages can be installed using ``apt-get``:
 
 .. prompt:: bash $


### PR DESCRIPTION
The docs install section (at https://scikit-learn.org/stable/install.html ) is not up-to-date, because it mentions debian buster and fedora 30 (both from 2019) as "current". I suggest to just drop linux distro version for better maintainability of this page.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
found none.

#### What does this implement/fix? Explain your changes.
fix outdated docs on https://scikit-learn.org/stable/install.html

#### Any other comments?
none.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
