### PR TITLE
Empirical covariance bug fix

### DIFF
--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -103,10 +103,8 @@ def empirical_covariance(X, *, assume_centered=False):
             "Only one sample available. You may want to reshape your data array"
         )
 
-    if assume_centered:
-        covariance = np.dot(X.T, X) / X.shape[0]
-    else:
-        covariance = np.cov(X.T, bias=1)
+    ddof = 0 if assume_centered else 1
+    covariance=(X.T @ X) / (X.shape[0] - ddof)
 
     if covariance.ndim == 0:
         covariance = np.array([[covariance]])

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -104,7 +104,7 @@ def empirical_covariance(X, *, assume_centered=False):
         )
 
     ddof = 0 if assume_centered else 1
-    covariance=(X.T @ X) / (X.shape[0] - ddof)
+    covariance = (X.T @ X) / (X.shape[0] - ddof)
 
     if covariance.ndim == 0:
         covariance = np.array([[covariance]])

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -102,6 +102,7 @@ def empirical_covariance(X, *, assume_centered=False):
         warnings.warn(
             "Only one sample available. You may want to reshape your data array"
         )
+        return np.zeros((X.shape[1], X.shape[1]), dtype=X.dtype)
 
     ddof = 0 if assume_centered else 1
     covariance = (X.T @ X) / (X.shape[0] - ddof)


### PR DESCRIPTION
#### Reference Issues/PRs
References #27485 

#### What does this implement/fix? Explain your changes.
This fixes a bug where the argument assume_centered=False does not have any effect and incorrectly normalizes the empirical covariance by N and not N-1. (N is the number of rows of the input dataset)

#### Any other comments?
@glemaitre  seems to have benchmarked that the raw matrix multiplication is faster than np.cov.

Many of the covariance tests fail because of this change, perhaps there are hard coded values in the tests?
