### PR TITLE
MAINT Follow cython performance hints

### DIFF
--- a/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
@@ -82,7 +82,7 @@ cdef void _middle_term_sparse_dense_{{name_suffix}}(
     intp_t Y_end,
     bint c_ordered_middle_term,
     float64_t * dist_middle_terms,
-) nogil:
+) noexcept nogil:
     # This routine assumes that dist_middle_terms is a pointer to the first element
     # of a buffer filled with zeros of length at least equal to n_X × n_Y, conceptually
     # representing a 2-d C-ordered of F-ordered array.

--- a/sklearn/preprocessing/_csr_polynomial_expansion.pyx
+++ b/sklearn/preprocessing/_csr_polynomial_expansion.pyx
@@ -166,7 +166,7 @@ cpdef void _csr_polynomial_expansion(
     INDEX_B_t[:] result_indptr,     # OUT
     FLAG_t interaction_only,
     FLAG_t degree
-) nogil:
+):
     """
     Perform a second or third degree polynomial or interaction expansion on a
     compressed sparse row (CSR) matrix. The method used only takes products of

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -261,7 +261,7 @@ cdef inline void shift_missing_values_to_left_if_required(
     SplitRecord* best,
     SIZE_t[::1] samples,
     SIZE_t end,
-) nogil:
+) noexcept nogil:
     cdef SIZE_t i, p, current_end
     # The partitioner partitions the data such that the missing values are in
     # samples[-n_missing:] for the criterion to consume. If the missing values

--- a/sklearn/tree/_utils.pxd
+++ b/sklearn/tree/_utils.pxd
@@ -45,7 +45,7 @@ ctypedef fused realloc_ptr:
     (Cell*)
     (Node**)
 
-cdef realloc_ptr safe_realloc(realloc_ptr* p, size_t nelems) except * nogil
+cdef int safe_realloc(realloc_ptr* p, size_t nelems) except -1 nogil
 
 
 cdef cnp.ndarray sizet_ptr_to_ndarray(SIZE_t* data, SIZE_t size)

--- a/sklearn/tree/_utils.pyx
+++ b/sklearn/tree/_utils.pyx
@@ -22,22 +22,20 @@ from ..utils._random cimport our_rand_r
 # Helper functions
 # =============================================================================
 
-cdef realloc_ptr safe_realloc(realloc_ptr* p, size_t nelems) except * nogil:
+cdef int safe_realloc(realloc_ptr* p, size_t nelems) except -1 nogil:
     # sizeof(realloc_ptr[0]) would be more like idiomatic C, but causes Cython
     # 0.20.1 to crash.
     cdef size_t nbytes = nelems * sizeof(p[0][0])
     if nbytes / sizeof(p[0][0]) != nelems:
         # Overflow in the multiplication
-        with gil:
-            raise MemoryError("could not allocate (%d * %d) bytes"
-                              % (nelems, sizeof(p[0][0])))
+        raise MemoryError("could not allocate (%d * %d) bytes"
+                            % (nelems, sizeof(p[0][0])))
     cdef realloc_ptr tmp = <realloc_ptr>realloc(p[0], nbytes)
     if tmp == NULL:
-        with gil:
-            raise MemoryError("could not allocate %d bytes" % nbytes)
+        raise MemoryError("could not allocate %d bytes" % nbytes)
 
     p[0] = tmp
-    return tmp  # for convenience
+    return 0
 
 
 def _realloc_test():
@@ -111,7 +109,7 @@ cdef class WeightedPQueue:
         or 0 otherwise.
         """
         self.array_ptr = 0
-        # Since safe_realloc can raise MemoryError, use `except *`
+        # Since safe_realloc can raise MemoryError, use `except -1`
         safe_realloc(&self.array_, self.capacity)
         return 0
 

--- a/sklearn/tree/_utils.pyx
+++ b/sklearn/tree/_utils.pyx
@@ -28,11 +28,11 @@ cdef int safe_realloc(realloc_ptr* p, size_t nelems) except -1 nogil:
     cdef size_t nbytes = nelems * sizeof(p[0][0])
     if nbytes / sizeof(p[0][0]) != nelems:
         # Overflow in the multiplication
-        raise MemoryError("could not allocate (%d * %d) bytes"
-                            % (nelems, sizeof(p[0][0])))
+        raise MemoryError(f"could not allocate ({nelems} * {sizeof(p[0][0])}) bytes")
+
     cdef realloc_ptr tmp = <realloc_ptr>realloc(p[0], nbytes)
     if tmp == NULL:
-        raise MemoryError("could not allocate %d bytes" % nbytes)
+        raise MemoryError(f"could not allocate {nbytes} bytes")
 
     p[0] = tmp
     return 0


### PR DESCRIPTION
I noticed that recent cython warns during cythonization when a `nogil` function will still acquire the gil. Here's an example of such a warning:
```
performance hint: sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx:61:5: Exception check on '_middle_term_sparse_dense_64' will always require the GIL to be acquired. Possible solutions:
	1. Declare the function as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
	2. Use an 'int' return type on the function to allow an error code to be returned.
```

~~There are still some warnings related to `safe_realloc`. I did not deal with it for now becaue I'm not sure what to do. This function can raise an exception but it's put in a `with gil` statement. So `noexcept` is not appropriate but `except -1` or `except any other value` doesn't seem appropriate either.~~
EDIT: I made it return an int