### PR TITLE
DOC Update Pairwise Distances Reductions' documentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ exclude=[
 # folder.
 "examples/*"=["E402"]
 "doc/conf.py"=["E402"]
-
+"sklearn/metrics/_pairwise_distances_reduction/__init__.py"=["E501"]
 
 [tool.cython-lint]
 # Ignore the same error codes as ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ exclude=[
 # folder.
 "examples/*"=["E402"]
 "doc/conf.py"=["E402"]
-"sklearn/metrics/_pairwise_distances_reduction/__init__.py"=["E501"]
+
 
 [tool.cython-lint]
 # Ignore the same error codes as ruff

--- a/sklearn/metrics/_pairwise_distances_reduction/__init__.py
+++ b/sklearn/metrics/_pairwise_distances_reduction/__init__.py
@@ -68,8 +68,8 @@
 #                              x    |                     |    x
 #             +-----------⊳ ArgKmin{32,64}         RadiusNeighbors{32,64} ⊲-------+
 #             |                |    ∆                     ∆    |                   |
-#   ArgKminClassmode{32,64}    |    |                     |    |   RadiusNeighborsClassMode{32,64}
-#   =================================== Specializations ==========================================
+#   ArgKminClassmode{32,64}    |    |                     |    |   RadiusNeighborsClassMode{32,64}  # noqa: E501
+#   =================================== Specializations ==========================================  # noqa: E501
 #                              |    |                     |    |
 #                              |    |                     |    |
 #                              x    |                     |    x

--- a/sklearn/metrics/_pairwise_distances_reduction/__init__.py
+++ b/sklearn/metrics/_pairwise_distances_reduction/__init__.py
@@ -1,3 +1,4 @@
+#
 # Pairwise Distances Reductions
 # =============================
 #
@@ -51,25 +52,25 @@
 #                                              ∆
 #                                              |
 #                                              |
-#                              +---------------+---------------+
-#                              |                               |
-#                         (dispatcher)                    (dispatcher)
-#                           ArgKmin                      RadiusNeighbors
-#                              |                               |
-#                              |                               |
-#                              |     (float{32,64} implem.)    |
-#                              | BaseDistancesReduction{32,64} |
-#                              |               ∆               |
-#                              |               |               |
-#                              |               |               |
-#                              |    +----------+----------+    |
-#                              |    |                     |    |
-#                              |    |                     |    |
-#                              x    |                     |    x
-#             +-----------⊳ ArgKmin{32,64}         RadiusNeighbors{32,64} ⊲-------+
-#             |                |    ∆                     ∆    |                   |
-#   ArgKminClassmode{32,64}    |    |                     |    |   RadiusNeighborsClassMode{32,64}  # noqa: E501
-#   =================================== Specializations ==========================================  # noqa: E501
+#           +------------------+---------------+---------------+------------------------+
+#           |                  |                               |                        |
+#           |             (dispatcher)                    (dispatcher)                  |
+#           |               ArgKmin                      RadiusNeighbors                |
+#           |                  |                               |                        |
+#           |                  |                               |                        |
+#           |                  |     (float{32,64} implem.)    |                        |
+#           |                  | BaseDistancesReduction{32,64} |                        |
+#           |                  |               ∆               |                        |
+#     (dispatcher)             |               |               |                 (dispatcher)
+#   ArgKminClassMode           |               |               |            RadiusNeighborsClassMode
+#           |                  |    +----------+----------+    |                        |
+#           |                  |    |                     |    |                        |
+#           |                  |    |                     |    |                        |
+#           |                  x    |                     |    x                        |
+#           |     +-------⊳ ArgKmin{32,64}         RadiusNeighbors{32,64} ⊲-------+     |
+#           x     |            |    ∆                     ∆    |                  |     x
+#   ArgKminClassMode{32,64}    |    |                     |    |   RadiusNeighborsClassMode{32,64}
+# ===================================== Specializations ==========================================
 #                              |    |                     |    |
 #                              |    |                     |    |
 #                              x    |                     |    x
@@ -107,3 +108,5 @@ __all__ = [
     "RadiusNeighborsClassMode",
     "sqeuclidean_row_norms",
 ]
+
+# ruff: noqa: E501

--- a/sklearn/metrics/_pairwise_distances_reduction/__init__.py
+++ b/sklearn/metrics/_pairwise_distances_reduction/__init__.py
@@ -1,7 +1,16 @@
 # Pairwise Distances Reductions
 # =============================
 #
-#    Author: Julien Jerphanion <git@jjerphan.xyz>
+#    Co-authors:
+#       Julien Jerphanion <git@jjerphan.xyz>
+#       Meekail Zain <meekail.zain@gmail>
+#       Omar Salman <omar.salman@arbisoft.com>
+#       Vincent Maladière <maladiere.vincent@gmail.com>
+#       Olivier Grisel <olivier.grisel@ensta.org>
+#       Thomas J. Fan <thomasjpfan@gmail>
+#       Christian Lorentzen <lorentzen.ch@gmail.com>
+#       Jérémie du Boisberranger <jeremie.du-boisberranger@inria.fr>
+#
 #
 # Overview
 # --------
@@ -45,46 +54,49 @@
 #      A ---x B: A dispatches to B
 #
 #
-#                               (base dispatcher)
-#                         BaseDistancesReductionDispatcher
-#                                       ∆
-#                                       |
-#                                       |
-#               +-----------------------+----------------------+
-#               |                                              |
-#          (dispatcher)                                   (dispatcher)
-#            ArgKmin                                     RadiusNeighbors
-#               |                                              |
-#               |                                              |
-#               |              (float{32,64} implem.)          |
-#               |           BaseDistancesReduction{32,64}      |
-#               |                       ∆                      |
-#               |                       |                      |
-#               |                       |                      |
-#               |     +-----------------+-----------------+    |
-#               |     |                                   |    |
-#               |     |                                   |    |
-#               x     |                                   |    x
-#            ArgKmin{32,64}                        RadiusNeighbors{32,64}
-#               |     ∆                                   ∆    |
-#               |     |                                   |    |
-#        ======================= Specializations =============================
-#               |     |                                   |    |
-#               |     |                                   |    |
-#               x     |                                   |    x
-#        EuclideanArgKmin{32,64}               EuclideanRadiusNeighbors{32,64}
+#                                      (base dispatcher)
+#                               BaseDistancesReductionDispatcher
+#                                              ∆
+#                                              |
+#                                              |
+#                              +---------------+---------------+
+#                              |                               |
+#                         (dispatcher)                    (dispatcher)
+#                           ArgKmin                      RadiusNeighbors
+#                              |                               |
+#                              |                               |
+#                              |     (float{32,64} implem.)    |
+#                              | BaseDistancesReduction{32,64} |
+#                              |               ∆               |
+#                              |               |               |
+#                              |               |               |
+#                              |    +----------+----------+    |
+#                              |    |                     |    |
+#                              |    |                     |    |
+#                              x    |                     |    x
+#             +-----------⊳ ArgKmin{32,64}         RadiusNeighbors{32,64} ⊲-------+
+#             |                |    ∆                     ∆    |                   |
+#   ArgKminClassmode{32,64}    |    |                     |    |   RadiusNeighborsClassMode{32,64}
+#   =================================== Specializations ==========================================
+#                              |    |                     |    |
+#                              |    |                     |    |
+#                              x    |                     |    x
+#                      EuclideanArgKmin{32,64}    EuclideanRadiusNeighbors{32,64}
+#
 #
 #    For instance :class:`ArgKmin` dispatches to:
 #      - :class:`ArgKmin64` if X and Y are two `float64` array-likes
 #      - :class:`ArgKmin32` if X and Y are two `float32` array-likes
 #
 #    In addition, if the metric parameter is set to "euclidean" or "sqeuclidean",
-#    then `ArgKmin{32,64}` further dispatches to `EuclideanArgKmin{32,64}`. For
-#    example, :class:`ArgKmin64` would dispatch to :class:`EuclideanArgKmin64`, a
-#    specialized subclass that optimally handles the Euclidean distance case
-#    using Generalized Matrix Multiplication over `float64` data (see the
-#    docstring of :class:`GEMMTermComputer64` for details).
-
+#    then some direct subclass of `BaseDistancesReduction{32,64}` further dispatches
+#    to one of their subclass for euclidean-specialized implementation. For instance,
+#    :class:`ArgKmin64` dispatches to :class:`EuclideanArgKmin64`.
+#
+#    Those Euclidean-specialized implementations relies on optimal implementations of
+#    a decomposition of the squared euclidean distance matrix into a sum of three terms
+#    (see :class:`MiddleTermComputer{32,64}`).
+#
 
 from ._dispatcher import (
     ArgKmin,

--- a/sklearn/metrics/_pairwise_distances_reduction/__init__.py
+++ b/sklearn/metrics/_pairwise_distances_reduction/__init__.py
@@ -52,25 +52,25 @@
 #                                              ∆
 #                                              |
 #                                              |
-#           +------------------+---------------+---------------+------------------------+
-#           |                  |                               |                        |
-#           |             (dispatcher)                    (dispatcher)                  |
-#           |               ArgKmin                      RadiusNeighbors                |
-#           |                  |                               |                        |
-#           |                  |                               |                        |
-#           |                  |     (float{32,64} implem.)    |                        |
-#           |                  | BaseDistancesReduction{32,64} |                        |
-#           |                  |               ∆               |                        |
-#     (dispatcher)             |               |               |                 (dispatcher)
-#   ArgKminClassMode           |               |               |            RadiusNeighborsClassMode
-#           |                  |    +----------+----------+    |                        |
-#           |                  |    |                     |    |                        |
-#           |                  |    |                     |    |                        |
-#           |                  x    |                     |    x                        |
-#           |     +-------⊳ ArgKmin{32,64}         RadiusNeighbors{32,64} ⊲-------+     |
-#           x     |            |    ∆                     ∆    |                  |     x
+#           +------------------+---------------+---------------+------------------+
+#           |                  |                               |                  |
+#           |             (dispatcher)                    (dispatcher)            |
+#           |               ArgKmin                      RadiusNeighbors          |
+#           |                  |                               |                  |
+#           |                  |                               |                  |
+#           |                  |     (float{32,64} implem.)    |                  |
+#           |                  | BaseDistancesReduction{32,64} |                  |
+#           |                  |               ∆               |                  |
+#      (dispatcher)            |               |               |             (dispatcher)
+#    ArgKminClassMode          |               |               |        RadiusNeighborsClassMode
+#           |                  |    +----------+----------+    |                  |
+#           |                  |    |                     |    |                  |
+#           |                  |    |                     |    |                  |
+#           |                  x    |                     |    x                  |
+#           |     +-------⊳ ArgKmin{32,64}         RadiusNeighbors{32,64} ⊲---+   |
+#           x     |            |    ∆                     ∆    |              |   x
 #   ArgKminClassMode{32,64}    |    |                     |    |   RadiusNeighborsClassMode{32,64}
-# ===================================== Specializations ==========================================
+# ===================================== Specializations ============================================
 #                              |    |                     |    |
 #                              |    |                     |    |
 #                              x    |                     |    x

--- a/sklearn/metrics/_pairwise_distances_reduction/__init__.py
+++ b/sklearn/metrics/_pairwise_distances_reduction/__init__.py
@@ -1,16 +1,8 @@
 # Pairwise Distances Reductions
 # =============================
 #
-#    Co-authors:
-#       Julien Jerphanion <git@jjerphan.xyz>
-#       Meekail Zain <meekail.zain@gmail>
-#       Omar Salman <omar.salman@arbisoft.com>
-#       Vincent Maladière <maladiere.vincent@gmail.com>
-#       Olivier Grisel <olivier.grisel@ensta.org>
-#       Thomas J. Fan <thomasjpfan@gmail>
-#       Christian Lorentzen <lorentzen.ch@gmail.com>
-#       Jérémie du Boisberranger <jeremie.du-boisberranger@inria.fr>
-#
+#   Authors: The scikit-learn developers.
+#   License: BSD 3 clause
 #
 # Overview
 # --------


### PR DESCRIPTION
#### Reference Issues/PRs

Part of #25888.

#### What does this implement/fix? Explain your changes.

Since I do not have as much bandwidth for scikit-learn as before, I am wondering how we can continue to actively maintain a shared understanding and ownership of the Private Distances Reductions' submodule.

There are already a few external resources out, but they are not entirely up to date, and to me it is more appropriate to actually have pieces of knowledge sit next to the actual implementations.

Currently this PR updates to the documentation of the private Pairwise Distances Reductions' sub-module to reflect the latest changes.

What do you think? Do you have any suggestions to help in this regards?

#### Any other comments?
