### PR TITLE
MAINT Add numpy.import_array where missing

### DIFF
--- a/sklearn/cluster/_hdbscan/_linkage.pyx
+++ b/sklearn/cluster/_hdbscan/_linkage.pyx
@@ -41,6 +41,8 @@ from ...cluster._hdbscan._tree cimport HIERARCHY_t
 from ...cluster._hdbscan._tree import HIERARCHY_dtype
 from ...utils._typedefs cimport intp_t, float64_t, int64_t, uint8_t
 
+cnp.import_array()
+
 cdef extern from "numpy/arrayobject.h":
     intp_t * PyArray_SHAPE(cnp.PyArrayObject *)
 

--- a/sklearn/cluster/_hdbscan/_tree.pyx
+++ b/sklearn/cluster/_hdbscan/_tree.pyx
@@ -36,6 +36,8 @@ import cython
 
 import numpy as np
 
+cnp.import_array()
+
 cdef extern from "numpy/arrayobject.h":
     intp_t * PyArray_SHAPE(cnp.PyArrayObject *)
 

--- a/sklearn/manifold/_utils.pyx
+++ b/sklearn/manifold/_utils.pyx
@@ -2,6 +2,8 @@ from libc cimport math
 import numpy as np
 cimport numpy as cnp
 
+cnp.import_array()
+
 
 cdef extern from "numpy/npy_math.h":
     float NPY_INFINITY

--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -7,6 +7,8 @@ from scipy.special import gammaln
 import numpy as np
 cimport numpy as cnp
 
+cnp.import_array()
+
 
 def expected_mutual_information(contingency, cnp.int64_t n_samples):
     """Calculate the expected mutual information for two labelings."""

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -29,6 +29,8 @@ from ._utils cimport rand_int
 from ._utils cimport rand_uniform
 from ._utils cimport RAND_R_MAX
 
+cnp.import_array()
+
 cdef double INFINITY = np.inf
 
 # Mitigate precision differences between 32 bit and 64 bit


### PR DESCRIPTION
Looking at the warnings generated by cython (when setting `show_all_warnings=True`), I saw that we're missing `numpy.import_array` in some files. It turns out that cython adds them automatically when we forget to but it's better to add them explicitly.