### PR TITLE
ENH use check_finite=False when calling scipy.linalg functions in randomized_range_finder

### DIFF
--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -304,12 +304,12 @@ def randomized_range_finder(
     else:
         # Use scipy.linalg instead of numpy.linalg when not explicitly
         # using the Array API.
-        qr_normalizer = partial(linalg.qr, mode="economic")
+        qr_normalizer = partial(linalg.qr, mode="economic", check_finite=False)
 
     if power_iteration_normalizer == "QR":
         normalizer = qr_normalizer
     elif power_iteration_normalizer == "LU":
-        normalizer = partial(linalg.lu, permute_l=True)
+        normalizer = partial(linalg.lu, permute_l=True, check_finite=False)
     else:
         normalizer = lambda x: (x, None)
 


### PR DESCRIPTION
While profiling PCA solvers while working on #27491 I noticed redundant calls to `numpy.asarray_check_finite` which typically add a 5% overhead to this solver.

So here is a quick PR to remove skip them (since input data is already validated).

I think the performance impact is too small to deserve an entry in the changelog though but I can still add one if reviewers would like me to do so.
