### PR TITLE
BENCH Bump cython to 3.0.3 for asv benchmarks

### DIFF
--- a/asv_benchmarks/asv.conf.json
+++ b/asv_benchmarks/asv.conf.json
@@ -78,7 +78,7 @@
     "matrix": {
         "numpy": ["1.25.2"],
         "scipy": ["1.11.2"],
-        "cython": ["3.0.2"],
+        "cython": ["3.0.3"],
         "joblib": ["1.3.2"],
         "threadpoolctl": ["3.2.0"],
         "pandas": ["2.1.0"]


### PR DESCRIPTION
As explained in https://github.com/scikit-learn/scikit-learn/issues/27086#issuecomment-1747111276, the performance regressions coming from cython 3 should be resolved in 3.0.3 which was just released yesterday. It should be confirmed by the asv benchmarks after we merge this PR :crossed_fingers: 