### PR TITLE
DOC fix TSNE.fit docstring: it returns self

### DIFF
--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -1143,8 +1143,8 @@ class TSNE(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
 
         Returns
         -------
-        X_new : array of shape (n_samples, n_components)
-            Embedding of the training data in low-dimensional space.
+        self : object
+            Fitted estimator.
         """
         self.fit_transform(X)
         return self


### PR DESCRIPTION
As visible 2 lines below and in compliance with the sklearn API, `TSNE.fit` returns the fitted object, not `X_new`. 