### PR TITLE
TST Use _sklearn_version rather than version in pickle tests

### DIFF
--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -425,7 +425,7 @@ def test_pickle_version_warning_is_not_raised_with_matching_version():
     iris = datasets.load_iris()
     tree = DecisionTreeClassifier().fit(iris.data, iris.target)
     tree_pickle = pickle.dumps(tree)
-    assert b"version" in tree_pickle
+    assert b"sklearn_version" in tree_pickle
     tree_restored = assert_no_warnings(pickle.loads, tree_pickle)
 
     # test that we can predict with the restored decision tree classifier
@@ -478,7 +478,7 @@ def test_pickle_version_warning_is_issued_when_no_version_info_in_pickle():
     tree = TreeNoVersion().fit(iris.data, iris.target)
 
     tree_pickle_noversion = pickle.dumps(tree)
-    assert b"version" not in tree_pickle_noversion
+    assert b"sklearn_version" not in tree_pickle_noversion
     message = pickle_error_message.format(
         estimator="TreeNoVersion",
         old_version="pre-0.18",

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -425,7 +425,7 @@ def test_pickle_version_warning_is_not_raised_with_matching_version():
     iris = datasets.load_iris()
     tree = DecisionTreeClassifier().fit(iris.data, iris.target)
     tree_pickle = pickle.dumps(tree)
-    assert b"sklearn_version" in tree_pickle
+    assert b"_sklearn_version" in tree_pickle
     tree_restored = assert_no_warnings(pickle.loads, tree_pickle)
 
     # test that we can predict with the restored decision tree classifier
@@ -478,7 +478,7 @@ def test_pickle_version_warning_is_issued_when_no_version_info_in_pickle():
     tree = TreeNoVersion().fit(iris.data, iris.target)
 
     tree_pickle_noversion = pickle.dumps(tree)
-    assert b"sklearn_version" not in tree_pickle_noversion
+    assert b"_sklearn_version" not in tree_pickle_noversion
     message = pickle_error_message.format(
         estimator="TreeNoVersion",
         old_version="pre-0.18",

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2078,7 +2078,7 @@ def check_estimators_pickle(name, estimator_orig, readonly_memmap=False):
         ):
             # strict check for sklearn estimators that are not implemented in test
             # modules.
-            assert b"version" in pickled_estimator
+            assert b"sklearn_version" in pickled_estimator
         unpickled_estimator = pickle.loads(pickled_estimator)
 
     result = dict()

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2078,7 +2078,7 @@ def check_estimators_pickle(name, estimator_orig, readonly_memmap=False):
         ):
             # strict check for sklearn estimators that are not implemented in test
             # modules.
-            assert b"sklearn_version" in pickled_estimator
+            assert b"_sklearn_version" in pickled_estimator
         unpickled_estimator = pickle.loads(pickled_estimator)
 
     result = dict()


### PR DESCRIPTION
Fix #27268.

This PR checks for `_sklearn_version` rather than `version` since this is what we put in the pickle.

I saw this test failing in Pyodide see [build log](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=59937&view=logs&j=6fac3219-cc32-5595-eb73-7f086a643b12&t=dfb0637f-eb02-5202-9884-61d82a155bad)

I can reproduce locally inside Pyodide with a failure that happens ~ 2 times out of 1000.

With this PR I can not reproduce the issue running 100,000 times inside Pyodide.

I looked a bit at it and there is some randomness in the pickle (even with normal Python, not Pyodide related). I guess this is due to uninitialized memory in C buffers inside the Cython tree code? The only explanation I can't think of, is that if you are unlucky this unitialized bytes combined to make `version` and the test fails.

If this explanation is at least partially correct, checking for a longer string makes it less likely that that this test fail.

Full disclosure: this is not the complete story since even inside Pyodide I can not reproduce without using pytest for some reason ... let's just say that I have spent enough time on this already :wink:.

