### PR TITLE
FIX handle outlier detector in _get_response_values

### DIFF
--- a/sklearn/utils/_response.py
+++ b/sklearn/utils/_response.py
@@ -116,13 +116,14 @@ def _get_response_values(
     pos_label=None,
     return_response_method_used=False,
 ):
-    """Compute the response values of a classifier or a regressor.
+    """Compute the response values of a classifier, an outlier detector, or a regressor.
 
     The response values are predictions such that it follows the following shape:
 
     - for binary classification, it is a 1d array of shape `(n_samples,)`;
     - for multiclass classification, it is a 2d array of shape `(n_samples, n_classes)`;
     - for multilabel classification, it is a 2d array of shape `(n_samples, n_outputs)`;
+    - for outlier detection, it is a 1d array of shape `(n_samples,)`;
     - for regression, it is a 1d array of shape `(n_samples,)`.
 
     If `estimator` is a binary classifier, also return the label for the
@@ -135,8 +136,9 @@ def _get_response_values(
     Parameters
     ----------
     estimator : estimator instance
-        Fitted classifier or regressor or a fitted :class:`~sklearn.pipeline.Pipeline`
-        in which the last estimator is a classifier or a regressor.
+        Fitted classifier, outlier detector, or regressor or a
+        fitted :class:`~sklearn.pipeline.Pipeline` in which the last estimator is a
+        classifier, an outlier detector, or a regressor.
 
     X : {array-like, sparse matrix} of shape (n_samples, n_features)
         Input values.
@@ -188,7 +190,7 @@ def _get_response_values(
         If the response method can be applied to a classifier only and
         `estimator` is a regressor.
     """
-    from sklearn.base import is_classifier  # noqa
+    from sklearn.base import is_classifier, is_outlier_detector  # noqa
 
     if is_classifier(estimator):
         prediction_method = _check_response_method(estimator, response_method)
@@ -220,6 +222,9 @@ def _get_response_values(
                 classes=classes,
                 pos_label=pos_label,
             )
+    elif is_outlier_detector(estimator):
+        prediction_method = _check_response_method(estimator, response_method)
+        y_pred, pos_label = prediction_method(X), None
     else:  # estimator is a regressor
         if response_method != "predict":
             raise ValueError(

--- a/sklearn/utils/tests/test_response.py
+++ b/sklearn/utils/tests/test_response.py
@@ -7,6 +7,7 @@ from sklearn.datasets import (
     make_multilabel_classification,
     make_regression,
 )
+from sklearn.ensemble import IsolationForest
 from sklearn.linear_model import (
     LinearRegression,
     LogisticRegression,
@@ -50,6 +51,33 @@ def test_get_response_values_regressor(return_response_method_used):
     assert results[1] is None
     if return_response_method_used:
         assert results[2] == "predict"
+
+
+@pytest.mark.parametrize(
+    "response_method",
+    ["predict", "decision_function", ["decision_function", "predict"]],
+)
+@pytest.mark.parametrize("return_response_method_used", [True, False])
+def test_get_response_values_outlier_detection(
+    response_method, return_response_method_used
+):
+    """Check the behaviour of `_get_response_values` with outlier detector."""
+    X, y = make_classification(n_samples=50, random_state=0)
+    outlier_detector = IsolationForest(random_state=0).fit(X, y)
+    results = _get_response_values(
+        outlier_detector,
+        X,
+        response_method=response_method,
+        return_response_method_used=return_response_method_used,
+    )
+    chosen_response_method = (
+        response_method[0] if isinstance(response_method, list) else response_method
+    )
+    prediction_method = getattr(outlier_detector, chosen_response_method)
+    assert_array_equal(results[0], prediction_method(X))
+    assert results[1] is None
+    if return_response_method_used:
+        assert results[2] == chosen_response_method
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When merging #27291, I broke `main` because we use `DecisionBoundaryDisplay` with outlier detector but only in the documentation.

This PR addresses this regression and add 2 new tests where we use outlier detector in the tests of `DecisionBoundaryDisplay` and `_get_response_values`. I don't need any entry in the changelog since this is a regression just in `main`.

Here is the traceback on `main`:

<details>

```pytb
Extension error:
Here is a summary of the problems encountered when running the examples

Unexpected failing examples:
/home/circleci/project/examples/ensemble/plot_isolation_forest.py failed leaving traceback:
Traceback (most recent call last):
  File "/home/circleci/project/examples/ensemble/plot_isolation_forest.py", line 112, in <module>
    disp = DecisionBoundaryDisplay.from_estimator(
  File "/home/circleci/project/sklearn/inspection/_plot/decision_boundary.py", line 359, in from_estimator
    response, _, response_method_used = _get_response_values(
  File "/home/circleci/project/sklearn/utils/_response.py", line 225, in _get_response_values
    raise ValueError(
ValueError: IsolationForest should either be a classifier to be used with response_method=decision_function or the response_method should be 'predict'. Got a regressor with response_method=decision_function instead.


/home/circleci/project/examples/svm/plot_oneclass.py failed leaving traceback:
Traceback (most recent call last):
  File "/home/circleci/project/examples/svm/plot_oneclass.py", line 50, in <module>
    DecisionBoundaryDisplay.from_estimator(
  File "/home/circleci/project/sklearn/inspection/_plot/decision_boundary.py", line 359, in from_estimator
    response, _, response_method_used = _get_response_values(
  File "/home/circleci/project/sklearn/utils/_response.py", line 225, in _get_response_values
    raise ValueError(
ValueError: OneClassSVM should either be a classifier to be used with response_method=decision_function or the response_method should be 'predict'. Got a regressor with response_method=decision_function instead.


/home/circleci/project/examples/linear_model/plot_sgdocsvm_vs_ocsvm.py failed leaving traceback:
Traceback (most recent call last):
  File "/home/circleci/project/examples/linear_model/plot_sgdocsvm_vs_ocsvm.py", line 85, in <module>
    DecisionBoundaryDisplay.from_estimator(
  File "/home/circleci/project/sklearn/inspection/_plot/decision_boundary.py", line 359, in from_estimator
    response, _, response_method_used = _get_response_values(
  File "/home/circleci/project/sklearn/utils/_response.py", line 225, in _get_response_values
    raise ValueError(
ValueError: OneClassSVM should either be a classifier to be used with response_method=decision_function or the response_method should be 'predict'. Got a regressor with response_method=decision_function instead.


/home/circleci/project/examples/applications/plot_outlier_detection_wine.py failed leaving traceback:
Traceback (most recent call last):
  File "/home/circleci/project/examples/applications/plot_outlier_detection_wine.py", line 66, in <module>
    DecisionBoundaryDisplay.from_estimator(
  File "/home/circleci/project/sklearn/inspection/_plot/decision_boundary.py", line 359, in from_estimator
    response, _, response_method_used = _get_response_values(
  File "/home/circleci/project/sklearn/utils/_response.py", line 225, in _get_response_values
    raise ValueError(
ValueError: EllipticEnvelope should either be a classifier to be used with response_method=decision_function or the response_method should be 'predict'. Got a regressor with response_method=decision_function instead.
```

</details>