### PR TITLE
TST make sure to not have ties in sparse callable NN test

### DIFF
--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -2117,7 +2117,7 @@ def test_sparse_metric_callable(csr_container):
         [[1, 1, 1, 1, 1], [1, 0, 1, 0, 1], [0, 0, 1, 0, 0]]  # Population matrix
     )
 
-    Y = csr_container([[1, 1, 0, 1, 1], [1, 0, 0, 0, 1]])  # Query matrix
+    Y = csr_container([[1, 1, 0, 1, 1], [1, 0, 0, 1, 1]])  # Query matrix
 
     nn = neighbors.NearestNeighbors(
         algorithm="brute", n_neighbors=2, metric=sparse_metric


### PR DESCRIPTION
Fixing the issue seen in `scipy-dev`. This is due to ties in the distance and a change of behaviour due to: https://github.com/numpy/numpy/pull/24201

I change the test to not have any tie because this is not the purpose of the test itself.

Close #27423 

<details>

```pytb
/usr/share/miniconda/envs/testvenv/lib/python3.11/site-packages/pandas/core/internals/blocks.py:534: FutureWarning
___________________ test_sparse_metric_callable[csr_matrix] ____________________
[gw1] linux -- Python 3.11.4 /usr/share/miniconda/envs/testvenv/bin/python

csr_container = <class 'scipy.sparse._csr.csr_matrix'>

    @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
    def test_sparse_metric_callable(csr_container):
        def sparse_metric(x, y):  # Metric accepting sparse matrix input (only)
            assert issparse(x) and issparse(y)
            return x.dot(y.T).toarray().item()
       [2, 1]]))
func       = <function assert_array_compare at 0x7f8ae6b65d00>
kwds       = {'err_msg': '', 'header': 'Arrays are not equal', 'strict': False, 'verbose': True}
self       = <contextlib._GeneratorContextManager object at 0x7f8ae6ba1810>
```

</details>