### PR TITLE
MNT Corrected HDBSCAN test that was rendered moot underspecified `ValueError`

### DIFF
--- a/sklearn/cluster/tests/test_hdbscan.py
+++ b/sklearn/cluster/tests/test_hdbscan.py
@@ -274,14 +274,15 @@ def test_hdbscan_callable_metric():
     assert n_clusters == n_clusters_true
 
 
-@pytest.mark.parametrize("tree", ["kd", "ball"])
+@pytest.mark.parametrize("tree", ["kd_tree", "ball_tree"])
 def test_hdbscan_precomputed_non_brute(tree):
     """
     Tests that HDBSCAN correctly raises an error when passing precomputed data
     while requesting a tree-based algorithm.
     """
-    hdb = HDBSCAN(metric="precomputed", algorithm=f"prims_{tree}tree")
-    with pytest.raises(ValueError):
+    hdb = HDBSCAN(metric="precomputed", algorithm=tree)
+    msg = "precomputed is not a valid metric for"
+    with pytest.raises(ValueError, match=msg):
         hdb.fit(X)
 
 


### PR DESCRIPTION
#### Reference Issues/PRs


#### What does this implement/fix? Explain your changes.
The `algorithm` argument used to accept `"prims_{kd, ball}tree` however it has been updated while the test remained unaltered. That, alongside an unspecified `ValueError` match meant this went unnoticed. This PR fixes this test to use the modern API and adds a string match for greater rigor.

#### Any other comments?
