### PR TITLE
ENH add calibrated parameter to precision_recall_curve and average_precision_score in `sklearn/metrics/_ranking.py`

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -700,6 +700,13 @@ Changelog
 - |API| The `eps` parameter of the :func:`metrics.log_loss` has been deprecated and
   will be removed in 1.5. :pr:`25299` by :user:`Omar Salman <OmarManzoor>`.
 
+- |Enhancement| :meth:`metrics.precision_recall_curve` and
+  :meth:`metrics.average_precision_score` now accept one new
+  parameter called `calibrated`. It is useful when there are a lots of negative
+  labels and few positive labels. The precision will be weighted by the ratio
+  between the number of negative labels and the number of positive labels.
+  :pr:`27574` by :user:`Luigi Seminara <Gigi-G>`.
+
 :mod:`sklearn.gaussian_process`
 ...............................
 

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -126,7 +126,13 @@ def auc(x, y):
     prefer_skip_nested_validation=True,
 )
 def average_precision_score(
-    y_true, y_score, *, average="macro", pos_label=1, sample_weight=None, calibrated=False
+    y_true,
+    y_score,
+    *,
+    average="macro",
+    pos_label=1,
+    sample_weight=None,
+    calibrated=False,
 ):
     """Compute average precision (AP) from prediction scores.
 
@@ -180,9 +186,10 @@ def average_precision_score(
 
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights.
-    
+
     calibrated : bool, default=False
-        Calculate the calibrated precision, which outputs the calibrated average precision.
+        Calculate the calibrated precision, which outputs the calibrated
+        average precision.
 
     Returns
     -------
@@ -206,7 +213,7 @@ def average_precision_score(
     .. [1] `Wikipedia entry for the Average precision
            <https://en.wikipedia.org/w/index.php?title=Information_retrieval&
            oldid=793358396#Average_precision>`_
-    
+
     .. [2] `Online Action Detection
            <https://arxiv.org/pdf/1604.06506.pdf>`_
 
@@ -235,7 +242,11 @@ def average_precision_score(
         y_true, y_score, pos_label=1, sample_weight=None, calibrated=False
     ):
         precision, recall, _ = precision_recall_curve(
-            y_true, y_score, pos_label=pos_label, sample_weight=sample_weight, calibrated=calibrated
+            y_true,
+            y_score,
+            pos_label=pos_label,
+            sample_weight=sample_weight,
+            calibrated=calibrated,
         )
         # Return the step function integral
         # The following works because the last entry of precision is
@@ -270,7 +281,9 @@ def average_precision_score(
         y_true = label_binarize(y_true, classes=present_labels)
 
     average_precision = partial(
-        _binary_uninterpolated_average_precision, pos_label=pos_label, calibrated=calibrated
+        _binary_uninterpolated_average_precision,
+        pos_label=pos_label,
+        calibrated=calibrated,
     )
     return _average_binary_score(
         average_precision, y_true, y_score, average, sample_weight=sample_weight
@@ -868,7 +881,13 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
     prefer_skip_nested_validation=True,
 )
 def precision_recall_curve(
-    y_true, probas_pred, *, pos_label=None, sample_weight=None, drop_intermediate=False, calibrated=False
+    y_true,
+    probas_pred,
+    *,
+    pos_label=None,
+    sample_weight=None,
+    drop_intermediate=False,
+    calibrated=False,
 ):
     """Compute precision-recall pairs for different probability thresholds.
 
@@ -915,11 +934,11 @@ def precision_recall_curve(
         Whether to drop some suboptimal thresholds which would not appear
         on a plotted precision-recall curve. This is useful in order to create
         lighter precision-recall curves.
-    
+
     calibrated : bool, default=False
-        This is useful when there are a lots of negative labels and few positive labels. 
-        The precision will be weighted by the ratio between the number of negative labels 
-        and the number of positive labels.
+        This is useful when there are a lots of negative labels and few positive
+        labels. The precision will be weighted by the ratio between the number
+        of negative labels and the number of positive labels.
 
         .. versionadded:: 1.3
 
@@ -984,10 +1003,10 @@ def precision_recall_curve(
     # Initialize the result array with zeros to make sure that precision[ps == 0]
     # does not contain uninitialized values.
     precision = np.zeros_like(tps)
-    
+
     # If 'calibrated' is True and there are both positive and negative labels,
     # calculate the weight 'w' as the ratio between the number of negative labels
-    # and the number of positive labels. The negatives becomes equal to the total 
+    # and the number of positive labels. The negatives becomes equal to the total
     # weight of the positives.
     if calibrated and (len(y_true) - sum(y_true)) > 0 and sum(y_true) > 0:
         w = (len(y_true) - sum(y_true)) / sum(y_true)

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1014,6 +1014,20 @@ def test_precision_recall_curve_toydata(drop):
         assert_almost_equal(average_precision_score(y_true, y_score), 1.0)
         assert_array_almost_equal(p, [1.0, 1.0, 1.0])
         assert_array_almost_equal(r, [1, 0.5, 0.0])
+        
+        y_true = [1, 1]
+        y_score = [0.25, 0.75]
+        p, r, _ = precision_recall_curve(y_true, y_score, drop_intermediate=drop, calibrated=True)
+        assert_almost_equal(average_precision_score(y_true, y_score, calibrated=True), 1.0)
+        assert_array_almost_equal(p, [1.0, 1.0, 1.0])
+        assert_array_almost_equal(r, [1, 0.5, 0.0])
+        
+        y_true = [1, 0, 0]
+        y_score = [0.5, 0.5, 0.0]
+        p, r, _ = precision_recall_curve(y_true, y_score, drop_intermediate=drop, calibrated=True)
+        assert_almost_equal(average_precision_score(y_true, y_score, calibrated=True), 0.6666666666666666)
+        assert_array_almost_equal(p, [0.5, 0.6666666666666666 , 1.0])
+        assert_array_almost_equal(r, [1.0, 1.0, 0.0])
 
         # Multi-label classification task
         y_true = np.array([[0, 1], [0, 1]])
@@ -1104,6 +1118,22 @@ def test_precision_recall_curve_toydata(drop):
         assert_almost_equal(
             average_precision_score(y_true, y_score, average="micro"), 0.5
         )
+        
+        y_true = np.array([[1, 0], [0, 1], [0, 0]])
+        y_score = np.array([[0.5, 0.5], [0.5, 0.5], [0.5, 0.5]])
+        assert_almost_equal(
+            average_precision_score(y_true, y_score, average="macro", calibrated=True), 0.5
+        )
+        assert_almost_equal(
+            average_precision_score(y_true, y_score, average="weighted", calibrated=True), 0.5
+        )
+        assert_almost_equal(
+            average_precision_score(y_true, y_score, average="micro", calibrated=True), 0.5
+        )
+        with pytest.warns(UserWarning, match="No positive class found in y_true"):
+            assert_almost_equal(
+                average_precision_score(y_true, y_score, average="samples", calibrated=True), 0.3333333333333333
+            )
 
     with np.errstate(all="ignore"):
         # if one class is never present weighted should not be NaN

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1014,19 +1014,28 @@ def test_precision_recall_curve_toydata(drop):
         assert_almost_equal(average_precision_score(y_true, y_score), 1.0)
         assert_array_almost_equal(p, [1.0, 1.0, 1.0])
         assert_array_almost_equal(r, [1, 0.5, 0.0])
-        
+
         y_true = [1, 1]
         y_score = [0.25, 0.75]
-        p, r, _ = precision_recall_curve(y_true, y_score, drop_intermediate=drop, calibrated=True)
-        assert_almost_equal(average_precision_score(y_true, y_score, calibrated=True), 1.0)
+        p, r, _ = precision_recall_curve(
+            y_true, y_score, drop_intermediate=drop, calibrated=True
+        )
+        assert_almost_equal(
+            average_precision_score(y_true, y_score, calibrated=True), 1.0
+        )
         assert_array_almost_equal(p, [1.0, 1.0, 1.0])
         assert_array_almost_equal(r, [1, 0.5, 0.0])
-        
+
         y_true = [1, 0, 0]
         y_score = [0.5, 0.5, 0.0]
-        p, r, _ = precision_recall_curve(y_true, y_score, drop_intermediate=drop, calibrated=True)
-        assert_almost_equal(average_precision_score(y_true, y_score, calibrated=True), 0.6666666666666666)
-        assert_array_almost_equal(p, [0.5, 0.6666666666666666 , 1.0])
+        p, r, _ = precision_recall_curve(
+            y_true, y_score, drop_intermediate=drop, calibrated=True
+        )
+        assert_almost_equal(
+            average_precision_score(y_true, y_score, calibrated=True),
+            0.6666666666666666,
+        )
+        assert_array_almost_equal(p, [0.5, 0.6666666666666666, 1.0])
         assert_array_almost_equal(r, [1.0, 1.0, 0.0])
 
         # Multi-label classification task
@@ -1118,21 +1127,29 @@ def test_precision_recall_curve_toydata(drop):
         assert_almost_equal(
             average_precision_score(y_true, y_score, average="micro"), 0.5
         )
-        
+
         y_true = np.array([[1, 0], [0, 1], [0, 0]])
         y_score = np.array([[0.5, 0.5], [0.5, 0.5], [0.5, 0.5]])
         assert_almost_equal(
-            average_precision_score(y_true, y_score, average="macro", calibrated=True), 0.5
+            average_precision_score(y_true, y_score, average="macro", calibrated=True),
+            0.5,
         )
         assert_almost_equal(
-            average_precision_score(y_true, y_score, average="weighted", calibrated=True), 0.5
+            average_precision_score(
+                y_true, y_score, average="weighted", calibrated=True
+            ),
+            0.5,
         )
         assert_almost_equal(
-            average_precision_score(y_true, y_score, average="micro", calibrated=True), 0.5
+            average_precision_score(y_true, y_score, average="micro", calibrated=True),
+            0.5,
         )
         with pytest.warns(UserWarning, match="No positive class found in y_true"):
             assert_almost_equal(
-                average_precision_score(y_true, y_score, average="samples", calibrated=True), 0.3333333333333333
+                average_precision_score(
+                    y_true, y_score, average="samples", calibrated=True
+                ),
+                0.3333333333333333,
             )
 
     with np.errstate(all="ignore"):


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
*calibrated Average Precision* is introduced to make performance evaluation more robust and less sensitive to variations in the ratio of positive and negative labels, allowing for fair comparisons.

All details about this metric are explained in the work of [*De Geest, R., Gavves, E., Ghodrati, A., Li, Z., Snoek, C., & Tuytelaars, T. (2016). Online action detection. In Computer Vision–ECCV 2016: 14th European Conference, Amsterdam, The Netherlands, October 11-14, 2016, Proceedings, Part V 14 (pp. 269-284). Springer International Publishing.*](https://arxiv.org/pdf/1604.06506.pdf)

To enable an easy, fair comparison, they introduced the *calibrated precision*:

$cPrec = \frac{TP}{TP + \frac{FP}{w}} = \frac{w * TP}{w * TP + FP}$

$w$ is equal to the ratio between negative labels and positive labels.
