### PR TITLE
FIX Make decision tree pickles deterministic

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -2,6 +2,23 @@
 
 .. currentmodule:: sklearn
 
+.. _changes_1_3_2:
+
+Version 1.3.2
+=============
+
+**October 2023**
+
+Changelog
+---------
+
+:mod:`sklearn.tree`
+...................
+
+- |Fix| Do not leak data via non-initialized memory in decision tree pickle files and make
+  the generation of those files deterministic. :pr:`27580` by :user:`Loïc Estève <lesteve>`.
+
+
 .. _changes_1_3_1:
 
 Version 1.3.1

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -424,9 +424,6 @@ Changelog
   :pr:`13649` by :user:`Samuel Ronsin <samronsin>`, initiated by
   :user:`Patrick O'Reilly <pat-oreilly>`.
 
-- |Fix| Do not leak data via non-initialized memory in decision tree pickle files and make
-  the generation of those files deterministic. :pr:`27580` by :user:`Loïc Estève <lesteve>`.
-
 :mod:`sklearn.utils`
 ....................
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -424,6 +424,9 @@ Changelog
   :pr:`13649` by :user:`Samuel Ronsin <samronsin>`, initiated by
   :user:`Patrick O'Reilly <pat-oreilly>`.
 
+- |Fix| Make decision tree pickles deterministic. :pr:`27580` by :user:`Loïc
+  Estève <lesteve>`.
+
 :mod:`sklearn.utils`
 ....................
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -424,8 +424,8 @@ Changelog
   :pr:`13649` by :user:`Samuel Ronsin <samronsin>`, initiated by
   :user:`Patrick O'Reilly <pat-oreilly>`.
 
-- |Fix| Make decision tree pickles deterministic. :pr:`27580` by :user:`Loïc
-  Estève <lesteve>`.
+- |Fix| Do not leak data via non-initialized memory in decision tree pickle files and make
+  the generation of those files deterministic. :pr:`27580` by :user:`Loïc Estève <lesteve>`.
 
 :mod:`sklearn.utils`
 ....................

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -908,11 +908,13 @@ cdef class Tree:
         safe_realloc(&self.nodes, capacity)
         safe_realloc(&self.value, capacity * self.value_stride)
 
-        # value memory is initialised to 0 to enable classifier argmax
         if capacity > self.capacity:
+            # value memory is initialised to 0 to enable classifier argmax
             memset(<void*>(self.value + self.capacity * self.value_stride), 0,
                    (capacity - self.capacity) * self.value_stride *
                    sizeof(float64_t))
+            # node memory is initialised to 0 to ensure deterministic pickle (padding in Node struct)
+            memset(<void*>(self.nodes + self.capacity), 0, (capacity - self.capacity) * sizeof(Node))
 
         # if capacity smaller than node_count, adjust the counter
         if capacity < self.node_count:

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -914,7 +914,7 @@ cdef class Tree:
                    (capacity - self.capacity) * self.value_stride *
                    sizeof(float64_t))
             # node memory is initialised to 0 to ensure deterministic pickle (padding in Node struct)
-            # memset(<void*>(self.nodes + self.capacity), 0, (capacity - self.capacity) * sizeof(Node))
+            memset(<void*>(self.nodes + self.capacity), 0, (capacity - self.capacity) * sizeof(Node))
 
         # if capacity smaller than node_count, adjust the counter
         if capacity < self.node_count:

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -914,7 +914,7 @@ cdef class Tree:
                    (capacity - self.capacity) * self.value_stride *
                    sizeof(float64_t))
             # node memory is initialised to 0 to ensure deterministic pickle (padding in Node struct)
-            memset(<void*>(self.nodes + self.capacity), 0, (capacity - self.capacity) * sizeof(Node))
+            # memset(<void*>(self.nodes + self.capacity), 0, (capacity - self.capacity) * sizeof(Node))
 
         # if capacity smaller than node_count, adjust the counter
         if capacity < self.node_count:

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2604,6 +2604,9 @@ def test_sample_weight_non_uniform(make_data, Tree):
 
 
 def test_deterministic_pickle():
+    # Non-regression test for:
+    # https://github.com/scikit-learn/scikit-learn/issues/27268
+    # Uninitialised memory would lead to the two pickle strings being different.
     tree1 = DecisionTreeClassifier(random_state=0).fit(iris.data, iris.target)
     tree2 = DecisionTreeClassifier(random_state=0).fit(iris.data, iris.target)
 

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2604,11 +2604,8 @@ def test_sample_weight_non_uniform(make_data, Tree):
 
 
 def test_deterministic_pickle():
-    tree1 = DecisionTreeClassifier(random_state=0)
-    tree1.fit(X, y)
-
-    tree2 = DecisionTreeClassifier(random_state=0)
-    tree2.fit(X, y)
+    tree1 = DecisionTreeClassifier(random_state=0).fit(iris.data, iris.target)
+    tree2 = DecisionTreeClassifier(random_state=0).fit(iris.data, iris.target)
 
     pickle1 = pickle.dumps(tree1)
     pickle2 = pickle.dumps(tree2)

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2601,3 +2601,16 @@ def test_sample_weight_non_uniform(make_data, Tree):
     tree_samples_removed.fit(X[1::2, :], y[1::2])
 
     assert_allclose(tree_samples_removed.predict(X), tree_with_sw.predict(X))
+
+
+def test_deterministic_pickle():
+    tree1 = DecisionTreeClassifier(random_state=0).fit(iris.data, iris.target)
+    tree1.fit(X, y)
+
+    tree2 = DecisionTreeClassifier(random_state=0).fit(X, y)
+    tree2.fit(X, y)
+
+    pickle1 = pickle.dumps(tree1)
+    pickle2 = pickle.dumps(tree2)
+
+    assert pickle1 == pickle2

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2604,10 +2604,10 @@ def test_sample_weight_non_uniform(make_data, Tree):
 
 
 def test_deterministic_pickle():
-    tree1 = DecisionTreeClassifier(random_state=0).fit(iris.data, iris.target)
+    tree1 = DecisionTreeClassifier(random_state=0)
     tree1.fit(X, y)
 
-    tree2 = DecisionTreeClassifier(random_state=0).fit(X, y)
+    tree2 = DecisionTreeClassifier(random_state=0)
     tree2.fit(X, y)
 
     pickle1 = pickle.dumps(tree1)


### PR DESCRIPTION
Following #27554 I had a look at why the decision tree pickle were non-deterministic. As I guessed this is due to unitialised memory in the C allocated arrays. This started happening with missing value support in trees (scikit-learn 1.3).

I used a `memset` to make sure the memory is initialised when allocating the node array. 

Unitialised memory comes from two places:
- padding in `NODE_DTYPE` (the last field is 1 byte but the dtype is padded to 64 bytes as you can see from `itemsize`)
```
In [3]: from sklearn.tree._tree import NODE_DTYPE
 ...: NODE_DTYPE
Out[3]: dtype({
    'names': ['left_child', 'right_child', 'feature', 'threshold', 'impurity', 'n_node_samples', 'weighted_n_node_samples', 'missing_go_to_left'],
    'formats': ['<i8', '<i8', '<i8', '<f8', '<f8', '<i8', '<f8', 'u1'],
    'offsets': [0, 8, 16, 24, 32, 40, 48, 56],
    'itemsize': 64})
```
- unitialised values in `missing_go_to_left` for leaf nodes (see `55` and `54` values below but of course numbers can be arbitrary)
```py
from sklearn.tree import DecisionTreeClassifier
from sklearn import datasets

X, y = datasets.load_iris(return_X_y=True)

tree1 = DecisionTreeClassifier(random_state=0).fit(X, y)
tree1.fit(X, y)

tree1.tree_.__getstate__()['nodes']
```
``` 
array([( 1,  2,  3,  0.80000001, 0.66666667, 150, 150.,  0),
       (-1, -1, -2, -2.        , 0.        ,  50,  50.,  0),
       ( 3, 12,  3,  1.75      , 0.5       , 100, 100.,  1),
       ( 4,  7,  2,  4.95000005, 0.16803841,  54,  54.,  1),
       ( 5,  6,  3,  1.65000004, 0.04079861,  48,  48.,  1),
       (-1, -1, -2, -2.        , 0.        ,  47,  47., 55),
       (-1, -1, -2, -2.        , 0.        ,   1,   1., 54),
       ( 8,  9,  3,  1.55000001, 0.44444444,   6,   6.,  0),
       (-1, -1, -2, -2.        , 0.        ,   3,   3.,  0),
       (10, 11,  2,  5.45000005, 0.44444444,   3,   3.,  1),
       (-1, -1, -2, -2.        , 0.        ,   2,   2.,  0),
       (-1, -1, -2, -2.        , 0.        ,   1,   1.,  0),
       (13, 16,  2,  4.85000014, 0.04253308,  46,  46.,  0),
       (14, 15,  1,  3.10000002, 0.44444444,   3,   3.,  1),
       (-1, -1, -2, -2.        , 0.        ,   2,   2.,  1),
       (-1, -1, -2, -2.        , 0.        ,   1,   1.,  1),
       (-1, -1, -2, -2.        , 0.        ,  43,  43.,  2)],
      dtype={'names': ['left_child', 'right_child', 'feature', 'threshold', 'impurity', 'n_node_samples', 'weighted_n_node_samples', 'missing_go_to_left'], 'formats': ['<i8', '<i8', '<i8', '<f8', '<f8', '<i8', '<f8', 'u1'], 'offsets': [0, 8, 16, 24, 32, 40, 48, 56], 'itemsize': 64})
```
