### PR TITLE
MNT mypy-joblib.* follow_imports = skip

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,9 @@ allow_redefinition = True
 exclude=
     sklearn/externals
 
+[mypy-joblib.*]
+follow_imports = skip
+
 [check-manifest]
 # ignore files missing in VCS
 ignore =


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
I experience a lot of trouble with the pre-commit-hook and mypy such that I end up committing manually via `git commit --no-verify`.

I don't know why the set option `ignore_missing_imports` in `setup.cfg` does not suppress errors of the form
```
error: Module "joblib" has no attribute "effective_n_jobs"  [attr-defined]
```
In the end, setting `follow_imports=skip` for joblib resolves all my issues.

#### Any other comments?