### PR TITLE
DOC Use sklearn link in standard replies

### DIFF
--- a/doc/developers/tips.rst
+++ b/doc/developers/tips.rst
@@ -129,7 +129,7 @@ Issue: You're welcome to update the docs
 Issue: Self-contained example for bug
     ::
 
-        Please provide [self-contained example code](https://stackoverflow.com/help/mcve), including imports and data (if possible), so that other contributors can just run it and reproduce your issue. Ideally your example code should be minimal.
+        Please provide [self-contained example code](https://scikit-learn.org/stable/developers/minimal_reproducer.html), including imports and data (if possible), so that other contributors can just run it and reproduce your issue. Ideally your example code should be minimal.
 
 Issue: Software versions
     ::

--- a/doc/developers/tips.rst
+++ b/doc/developers/tips.rst
@@ -129,7 +129,7 @@ Issue: You're welcome to update the docs
 Issue: Self-contained example for bug
     ::
 
-        Please provide [self-contained example code](https://scikit-learn.org/stable/developers/minimal_reproducer.html), including imports and data (if possible), so that other contributors can just run it and reproduce your issue. Ideally your example code should be minimal.
+        Please provide [self-contained example code](https://scikit-learn.org/dev/developers/minimal_reproducer.html), including imports and data (if possible), so that other contributors can just run it and reproduce your issue. Ideally your example code should be minimal.
 
 Issue: Software versions
     ::


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Use link to our 'Crafting a minimal reproducer for scikit-learn' page (instead of stackoverflow) in standard replies.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
