### PR TITLE
FIX Array API related error in `sklearn.utils.mutilclass.is_multilabel` function

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -523,6 +523,10 @@ Changelog
   accept the same sparse input formats for SciPy sparse matrices and arrays.
   :pr:`27372` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- |Enhancement| :func:`~utils.multiclass.is_multilabel` now supports the Array API
+  compatible inputs.
+  :pr:`27601` by :user:`Yaroslav Korobko <Tialo>`.
+
 - |Fix| :func:`sklearn.utils.check_array` should accept both matrix and array from
   the sparse SciPy module. The previous implementation would fail if `copy=True` by
   calling specific NumPy `np.may_share_memory` that does not work with SciPy sparse

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -120,7 +120,9 @@ def unique_labels(*ys):
 
 def _is_integral_float(y):
     xp, is_array_api_compliant = get_namespace(y)
-    return xp.isdtype(y.dtype, "real floating") and bool(xp.all(xp.astype(y, int) == y))
+    return xp.isdtype(y.dtype, "real floating") and bool(
+        xp.all(xp.astype((xp.astype(y, xp.int64)), y.dtype) == y)
+    )
 
 
 def is_multilabel(y):
@@ -190,7 +192,7 @@ def is_multilabel(y):
     else:
         labels = xp.unique_values(y)
 
-        return len(labels) < 3 and (
+        return labels.shape[0] < 3 and (
             xp.isdtype(y.dtype, ("bool", "signed integer", "unsigned integer"))
             or _is_integral_float(labels)
         )

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -190,7 +190,8 @@ def is_multilabel(y):
         labels = xp.unique_values(y)
 
         return len(labels) < 3 and (
-            y.dtype.kind in "biu" or _is_integral_float(labels)  # bool, int, uint
+            xp.isdtype(y.dtype, ("bool", "signed integer", "unsigned integer"))
+            or _is_integral_float(labels)
         )
 
 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -119,7 +119,8 @@ def unique_labels(*ys):
 
 
 def _is_integral_float(y):
-    return y.dtype.kind == "f" and np.all(y.astype(int) == y)
+    xp, is_array_api_compliant = get_namespace(y)
+    return xp.isdtype(y.dtype, "real floating") and bool(xp.all(xp.astype(y, int) == y))
 
 
 def is_multilabel(y):

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from scipy.sparse import issparse
 
-from sklearn import datasets
+from sklearn import config_context, datasets
 from sklearn.model_selection import ShuffleSplit
 from sklearn.svm import SVC
 from sklearn.utils._array_api import yield_namespace_device_dtype_combinations
@@ -333,9 +333,10 @@ def test_is_multilabel_array_api_compliance(array_namespace, device, dtype):
                 example = np.asarray(example)
             example = xp.asarray(example, device=device)
 
-            assert dense_exp == is_multilabel(
-                example
-            ), f"is_multilabel({example!r}) should be {dense_exp}"
+            with config_context(array_api_dispatch=True):
+                assert dense_exp == is_multilabel(
+                    example
+                ), f"is_multilabel({example!r}) should be {dense_exp}"
 
 
 def test_check_classification_targets():

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -174,6 +174,127 @@ EXAMPLES = {
     ],
 }
 
+ARRAY_API_EXAMPLES = {
+    "multilabel-indicator": [
+        # valid when the data is formatted as sparse or dense, identified
+        # by CSR format when the testing takes place
+        *_generate_sparse(
+            np.random.RandomState(42).randint(2, size=(10, 10)),
+            sparse_containers=CSR_CONTAINERS,
+            dtypes=(int,),
+        ),
+        [[0, 1], [1, 0]],
+        [[0, 1]],
+        *_generate_sparse(
+            multilabel_explicit_zero, sparse_containers=CSC_CONTAINERS, dtypes=(int,)
+        ),
+        *_generate_sparse([[0, 1], [1, 0]]),
+        *_generate_sparse([[0, 0], [0, 0]]),
+        *_generate_sparse([[0, 1]]),
+        # Only valid when data is dense
+        [[-1, 1], [1, -1]],
+        np.array([[-1, 1], [1, -1]]),
+        np.array([[-3, 3], [3, -3]]),
+        _NotAnArray(np.array([[-3, 3], [3, -3]])),
+    ],
+    "multiclass": [
+        [1, 0, 2, 2, 1, 4, 2, 4, 4, 4],
+        np.array([1, 0, 2]),
+        np.array([1, 0, 2], dtype=np.int8),
+        np.array([1, 0, 2], dtype=np.uint8),
+        np.array([1, 0, 2], dtype=float),
+        np.array([1, 0, 2], dtype=np.float32),
+        np.array([[1], [0], [2]]),
+        _NotAnArray(np.array([1, 0, 2])),
+        [0, 1, 2],
+        ["a", "b", "c"],
+        np.array(["a", "b", "c"]),
+        np.array(["a", "b", "c"], dtype=object),
+        np.array(["a", "b", "c"], dtype=object),
+    ],
+    "multiclass-multioutput": [
+        [[1, 0, 2, 2], [1, 4, 2, 4]],
+        [["a", "b"], ["c", "d"]],
+        np.array([[1, 0, 2, 2], [1, 4, 2, 4]]),
+        np.array([[1, 0, 2, 2], [1, 4, 2, 4]], dtype=np.int8),
+        np.array([[1, 0, 2, 2], [1, 4, 2, 4]], dtype=np.uint8),
+        np.array([[1, 0, 2, 2], [1, 4, 2, 4]], dtype=float),
+        np.array([[1, 0, 2, 2], [1, 4, 2, 4]], dtype=np.float32),
+        *_generate_sparse(
+            [[1, 0, 2, 2], [1, 4, 2, 4]],
+            sparse_containers=CSC_CONTAINERS + CSR_CONTAINERS,
+            dtypes=(int, np.int8, np.uint8, float, np.float32),
+        ),
+        np.array([["a", "b"], ["c", "d"]]),
+        np.array([["a", "b"], ["c", "d"]]),
+        np.array([["a", "b"], ["c", "d"]], dtype=object),
+        np.array([[1, 0, 2]]),
+        _NotAnArray(np.array([[1, 0, 2]])),
+    ],
+    "binary": [
+        [0, 1],
+        [1, 1],
+        [],
+        [0],
+        np.array([0, 1, 1, 1, 0, 0, 0, 1, 1, 1]),
+        np.array([0, 1, 1, 1, 0, 0, 0, 1, 1, 1], dtype=bool),
+        np.array([0, 1, 1, 1, 0, 0, 0, 1, 1, 1], dtype=np.int8),
+        np.array([0, 1, 1, 1, 0, 0, 0, 1, 1, 1], dtype=np.uint8),
+        np.array([0, 1, 1, 1, 0, 0, 0, 1, 1, 1], dtype=float),
+        np.array([0, 1, 1, 1, 0, 0, 0, 1, 1, 1], dtype=np.float32),
+        np.array([[0], [1]]),
+        _NotAnArray(np.array([[0], [1]])),
+        [1, -1],
+        [3, 5],
+        ["a"],
+        ["a", "b"],
+        ["abc", "def"],
+        np.array(["abc", "def"]),
+        ["a", "b"],
+        np.array(["abc", "def"], dtype=object),
+    ],
+    "continuous": [
+        [1e-5],
+        [0, 0.5],
+        np.array([[0], [0.5]]),
+        np.array([[0], [0.5]], dtype=np.float32),
+    ],
+    "continuous-multioutput": [
+        np.array([[0, 0.5], [0.5, 0]]),
+        np.array([[0, 0.5], [0.5, 0]], dtype=np.float32),
+        np.array([[0, 0.5]]),
+        *_generate_sparse(
+            [[0, 0.5], [0.5, 0]],
+            sparse_containers=CSC_CONTAINERS + CSR_CONTAINERS,
+            dtypes=(float, np.float32),
+        ),
+        *_generate_sparse(
+            [[0, 0.5]],
+            sparse_containers=CSC_CONTAINERS + CSR_CONTAINERS,
+            dtypes=(float, np.float32),
+        ),
+    ],
+    "unknown": [
+        [[]],
+        np.array([[]], dtype=object),
+        [()],
+        # sequence of sequences that weren't supported even before deprecation
+        np.array([np.array([]), np.array([1, 2, 3])], dtype=object),
+        [np.array([]), np.array([1, 2, 3])],
+        [{1, 2, 3}, {1, 2}],
+        [frozenset([1, 2, 3]), frozenset([1, 2])],
+        # and also confusable as sequences of sequences
+        [{0: "a", 1: "b"}, {0: "a"}],
+        # ndim 0
+        np.array(0),
+        # empty second dimension
+        np.array([[], []]),
+        # 3d
+        np.array([[[0, 1], [2, 3]], [[4, 5], [6, 7]]]),
+    ],
+}
+
+
 NON_ARRAY_LIKE_EXAMPLES = [
     {1, 2, 3},
     {0: "a", 1: "b"},

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -319,14 +319,11 @@ def test_is_multilabel_array_api_compliance(array_namespace, device, dtype):
     for group, group_examples in EXAMPLES.items():
         dense_exp = group == "multilabel-indicator"
         for example in group_examples:
-            if not (
-                hasattr(example, "__array__")
-                and np.asarray(example).dtype.kind in "biuf"
-            ):
-                continue
             # Densify sparse examples before testing
             if issparse(example):
                 example = example.toarray()
+            if np.asarray(example).dtype.kind not in "biuf":
+                continue
             if np.asarray(example).dtype.kind == "f":
                 example = np.asarray(example, dtype=dtype)
             else:

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -385,14 +385,9 @@ def test_is_multilabel():
 def test_is_multilabel_array_api_compliance(array_namespace, device, dtype):
     xp, device, dtype = _array_api_for_tests(array_namespace, device, dtype)
 
-    for group, group_examples in EXAMPLES.items():
+    for group, group_examples in ARRAY_API_EXAMPLES.items():
         dense_exp = group == "multilabel-indicator"
         for example in group_examples:
-            # Densify sparse examples before testing
-            if issparse(example):
-                example = example.toarray()
-            if np.asarray(example).dtype.kind not in "biuf":
-                continue
             if np.asarray(example).dtype.kind == "f":
                 example = np.asarray(example, dtype=dtype)
             else:

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -176,22 +176,11 @@ EXAMPLES = {
 
 ARRAY_API_EXAMPLES = {
     "multilabel-indicator": [
-        # valid when the data is formatted as sparse or dense, identified
-        # by CSR format when the testing takes place
-        *_generate_sparse(
-            np.random.RandomState(42).randint(2, size=(10, 10)),
-            sparse_containers=CSR_CONTAINERS,
-            dtypes=(int,),
-        ),
+        np.random.RandomState(42).randint(2, size=(10, 10)),
         [[0, 1], [1, 0]],
         [[0, 1]],
-        *_generate_sparse(
-            multilabel_explicit_zero, sparse_containers=CSC_CONTAINERS, dtypes=(int,)
-        ),
-        *_generate_sparse([[0, 1], [1, 0]]),
-        *_generate_sparse([[0, 0], [0, 0]]),
-        *_generate_sparse([[0, 1]]),
-        # Only valid when data is dense
+        multilabel_explicit_zero,
+        [[0, 0], [0, 0]],
         [[-1, 1], [1, -1]],
         np.array([[-1, 1], [1, -1]]),
         np.array([[-3, 3], [3, -3]]),
@@ -207,27 +196,14 @@ ARRAY_API_EXAMPLES = {
         np.array([[1], [0], [2]]),
         _NotAnArray(np.array([1, 0, 2])),
         [0, 1, 2],
-        ["a", "b", "c"],
-        np.array(["a", "b", "c"]),
-        np.array(["a", "b", "c"], dtype=object),
-        np.array(["a", "b", "c"], dtype=object),
     ],
     "multiclass-multioutput": [
         [[1, 0, 2, 2], [1, 4, 2, 4]],
-        [["a", "b"], ["c", "d"]],
         np.array([[1, 0, 2, 2], [1, 4, 2, 4]]),
         np.array([[1, 0, 2, 2], [1, 4, 2, 4]], dtype=np.int8),
         np.array([[1, 0, 2, 2], [1, 4, 2, 4]], dtype=np.uint8),
         np.array([[1, 0, 2, 2], [1, 4, 2, 4]], dtype=float),
         np.array([[1, 0, 2, 2], [1, 4, 2, 4]], dtype=np.float32),
-        *_generate_sparse(
-            [[1, 0, 2, 2], [1, 4, 2, 4]],
-            sparse_containers=CSC_CONTAINERS + CSR_CONTAINERS,
-            dtypes=(int, np.int8, np.uint8, float, np.float32),
-        ),
-        np.array([["a", "b"], ["c", "d"]]),
-        np.array([["a", "b"], ["c", "d"]]),
-        np.array([["a", "b"], ["c", "d"]], dtype=object),
         np.array([[1, 0, 2]]),
         _NotAnArray(np.array([[1, 0, 2]])),
     ],
@@ -246,12 +222,6 @@ ARRAY_API_EXAMPLES = {
         _NotAnArray(np.array([[0], [1]])),
         [1, -1],
         [3, 5],
-        ["a"],
-        ["a", "b"],
-        ["abc", "def"],
-        np.array(["abc", "def"]),
-        ["a", "b"],
-        np.array(["abc", "def"], dtype=object),
     ],
     "continuous": [
         [1e-5],
@@ -263,33 +233,11 @@ ARRAY_API_EXAMPLES = {
         np.array([[0, 0.5], [0.5, 0]]),
         np.array([[0, 0.5], [0.5, 0]], dtype=np.float32),
         np.array([[0, 0.5]]),
-        *_generate_sparse(
-            [[0, 0.5], [0.5, 0]],
-            sparse_containers=CSC_CONTAINERS + CSR_CONTAINERS,
-            dtypes=(float, np.float32),
-        ),
-        *_generate_sparse(
-            [[0, 0.5]],
-            sparse_containers=CSC_CONTAINERS + CSR_CONTAINERS,
-            dtypes=(float, np.float32),
-        ),
     ],
     "unknown": [
         [[]],
-        np.array([[]], dtype=object),
         [()],
-        # sequence of sequences that weren't supported even before deprecation
-        np.array([np.array([]), np.array([1, 2, 3])], dtype=object),
-        [np.array([]), np.array([1, 2, 3])],
-        [{1, 2, 3}, {1, 2}],
-        [frozenset([1, 2, 3]), frozenset([1, 2])],
-        # and also confusable as sequences of sequences
-        [{0: "a", 1: "b"}, {0: "a"}],
-        # ndim 0
         np.array(0),
-        # empty second dimension
-        np.array([[], []]),
-        # 3d
         np.array([[[0, 1], [2, 3]], [[4, 5], [6, 7]]]),
     ],
 }

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -315,16 +315,15 @@ def test_is_multilabel(array_namespace, device, dtype):
             if issparse(example):
                 example = example.toarray()
             if use_array_api:
-                if (
+                if not (
                     hasattr(example, "__array__")
                     and np.asarray(example).dtype.kind in "biuf"
                 ):
-                    if np.asarray(example).dtype.kind == "f":
-                        example = np.asarray(example, dtype=dtype)
-                    else:
-                        example = np.asarray(example)
-                else:
                     continue
+                if np.asarray(example).dtype.kind == "f":
+                    example = np.asarray(example, dtype=dtype)
+                else:
+                    example = np.asarray(example)
                 example = xp.asarray(example, device=device)
 
             assert dense_exp == is_multilabel(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Relates to https://github.com/scikit-learn/scikit-learn/issues/26024
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
`is_multilabel` function used attribute `kind`, which is not defined in Array API standard

#### Any other comments?
Possibly, the same issue isn't fixed somewhere else, I can find them and create separate PRs or put them here.

#### Code to reproduce error
```python
import torch

from sklearn import set_config
from sklearn.utils.multiclass import is_multilabel

set_config(array_api_dispatch=True)

b = torch.tensor([[1, 0]])
print(is_multilabel(b))
```

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
