### PR TITLE
MAINT remove prerelease flag for Python 3.12

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -70,8 +70,6 @@ jobs:
           - os: windows-latest
             python: 312
             platform_id: win_amd64
-            # TODO: remove when Python 3.12 is released
-            prerelease: "True"
 
           # Linux 64 bit manylinux2014
           - os: ubuntu-latest
@@ -97,8 +95,6 @@ jobs:
             python: 312
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
-            # TODO: remove when Python 3.12 is released
-            prerelease: "True"
 
           # MacOS x86_64
           - os: macos-latest
@@ -116,8 +112,6 @@ jobs:
           - os: macos-latest
             python: 312
             platform_id: macosx_x86_64
-            # TODO: remove when Python 3.12 is released
-            prerelease: "True"
 
           # MacOS arm64
           # The wheel for the latest Python version is built and tested on

--- a/build_tools/cirrus/arm_wheel.yml
+++ b/build_tools/cirrus/arm_wheel.yml
@@ -25,8 +25,6 @@ macos_arm64_wheel_task:
     # is actually tested on Cirrus CI.
     - env:
         CIBW_BUILD: cp312-macosx_arm64
-        # TODO: remove when Python 3.12 is released
-        CIBW_PRERELEASE_PYTHONS: True
 
   conda_script:
     - curl -L --retry 10 -o ~/mambaforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh
@@ -78,8 +76,6 @@ linux_arm64_wheel_task:
         CIBW_TEST_SKIP: "*_aarch64"
     - env:
         CIBW_BUILD: cp312-manylinux_aarch64
-        # TODO: remove when Python 3.12 is released
-        CIBW_PRERELEASE_PYTHONS: True
 
   cibuildwheel_script:
     - apt install -y python3 python-is-python3


### PR DESCRIPTION
Remove the `prerelease` flag since Python 3.12 is already released.