### PR TITLE
FIX CUDA detection when using PyTorch

### DIFF
--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1087,7 +1087,11 @@ def _array_api_for_tests(array_namespace, device, dtype):
     # This is because `cupy` is not the same as the compatibility wrapped
     # namespace of a CuPy array.
     xp = array_api_compat.get_namespace(array_mod.asarray(1))
-    if array_namespace == "torch" and device == "cuda" and not xp.has_cuda:
+    if (
+        array_namespace == "torch"
+        and device == "cuda"
+        and not xp.backends.cuda.is_built()
+    ):
         raise SkipTest("PyTorch test requires cuda, which is not available")
     elif array_namespace == "torch" and device == "mps":
         if os.getenv("PYTORCH_ENABLE_MPS_FALLBACK") != "1":

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -256,7 +256,7 @@ def test_convert_to_numpy_gpu(library):  # pragma: nocover
     xp = pytest.importorskip(library)
 
     if library == "torch":
-        if not xp.has_cuda:
+        if not xp.backends.cuda.is_built():
             pytest.skip("test requires cuda")
         X_gpu = xp.asarray([1.0, 2.0, 3.0], device="cuda")
     else:


### PR DESCRIPTION
In pytorch 2.1 the `torch.has_cuda` attribute became deprecated, switching to the new recommended way for detecting CUDA support.
