### PR TITLE
MNT remove doubled code in validation.py

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -841,9 +841,6 @@ def check_array(
         # Since we converted here, we do not need to convert again later
         dtype = None
 
-    if dtype is not None and _is_numpy_namespace(xp):
-        dtype = np.dtype(dtype)
-
     if force_all_finite not in (True, False, "allow-nan"):
         raise ValueError(
             'force_all_finite should be a bool or "allow-nan". Got {!r} instead'.format(


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Removes 2 lines of redundant code that has been brought into `check_array` twice. Lines 851-853 already hold the same assignment for `dtype`.