### PR TITLE
TST Fix locally_linear_embedding test with scipy-dev

### DIFF
--- a/sklearn/manifold/tests/test_locally_linear.py
+++ b/sklearn/manifold/tests/test_locally_linear.py
@@ -134,9 +134,9 @@ def test_pipeline():
 
 # Test the error raised when the weight matrix is singular
 def test_singular_matrix():
-    M = np.ones((10, 3))
+    M = np.ones((200, 3))
     f = ignore_warnings
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Error in determining null-space with ARPACK"):
         f(
             manifold.locally_linear_embedding(
                 M,


### PR DESCRIPTION
Fix #27578 

The test_singular_matrix one is probably due to scipy using upstream SuperLU code https://github.com/scipy/scipy/pull/19284. This seems to change the behaviour slightly. In particular the smallest eigenvalue is not exactly 0 but of the order of 1e-16 and the error is not raised.


