### PR TITLE
DOC Fix `pos_label` description in `precision_recall_fscore_support` docstring  

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1577,9 +1577,10 @@ def precision_recall_fscore_support(
 
     The support is the number of occurrences of each class in ``y_true``.
 
-    If ``labels=None`` and not binary classification, this function
-    returns the average precision, recall and F-measure if ``average``
-    is one of ``'micro'``, ``'macro'``, ``'weighted'`` or ``'samples'``.
+    When `average != 'binary'`, this function returns the average precision, recall and
+    F-measure. The labels to include in this average is determined by the `labels`
+    parameter, with `labels=None` including all labels in `y_true`` and ``y_pred``
+    in sorted order.
 
     Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1577,7 +1577,7 @@ def precision_recall_fscore_support(
 
     The support is the number of occurrences of each class in ``y_true``.
 
-    If ``pos_label is None`` and in binary classification, this function
+    If ``labels=None`` and not binary classification, this function
     returns the average precision, recall and F-measure if ``average``
     is one of ``'micro'``, ``'macro'``, ``'weighted'`` or ``'samples'``.
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

`precision_recall_fscore_support` docstring currently says:

https://github.com/scikit-learn/scikit-learn/blob/fb6b9f59469a4ffcffee2999f531f4bb4c2128fd/sklearn/metrics/_classification.py#L1580-L1582

We no longer support `pos_label=None` and it is ignored unless `average='binary'` and type of target is 'binary'. I think it makes more sense to talk about averaging, which happens when `average != 'binary'` but happy to change.

I am confused about the "and in binary classification," part (which was added in [this commit](https://github.com/scikit-learn/scikit-learn/commit/d33634d0ce7a88829c69418547398bd63ef64524#diff-fb45cb4c322cde2f9e11d24044e42251ec099e121beb2ef13c8432f298a13a77)) because I don't understand why you would be interested in averaging precision/recall/fscore/support in the binary case? Regardless, I don't think it is possible with the current implementation to return average scores in the binary case (because `pos_label` must be int, float, bool or str). Happy to change if I've mis-understood.





