### PR TITLE
DOC Use `labels` instead of `pos_label=None` in `precision_recall_fscore_support` docstring

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1125,7 +1125,7 @@ def f1_score(
         .. versionchanged:: 0.17
            Parameter `labels` improved for multiclass problem.
 
-    pos_label : int, float, bool, str or None, default=1
+    pos_label : int, float, bool or str, default=1
         The class to report if ``average='binary'`` and the data is binary.
         If the data are multiclass or multilabel, this will be ignored;
         setting ``labels=[pos_label]`` and ``average != 'binary'`` will report


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Current `precision_recall_fscore_support` says:

https://github.com/scikit-learn/scikit-learn/blob/fb6b9f59469a4ffcffee2999f531f4bb4c2128fd/sklearn/metrics/_classification.py#L1580-L1582

`pos_label=None` will technically work when `average` is not 'binary' (see: https://github.com/scikit-learn/scikit-learn/pull/13151/files#r262034515), but I think we've dropped documented support for `pos_labels-None` as it's ill-defined. Have changed docstring to use `labels` equal to both binary labels instead.

Happy to amend. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
