### PR TITLE
FIX force node values outside of [0, 1] range for monotonically constraints classification trees

### DIFF
--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -1065,23 +1065,12 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
         proba = self.tree_.predict(X)
 
         if self.n_outputs_ == 1:
-            proba = proba[:, : self.n_classes_]
-            normalizer = proba.sum(axis=1)[:, np.newaxis]
-            normalizer[normalizer == 0.0] = 1.0
-            proba /= normalizer
-
-            return proba
-
+            return proba[:, : self.n_classes_]
         else:
             all_proba = []
-
             for k in range(self.n_outputs_):
                 proba_k = proba[:, k, : self.n_classes_[k]]
-                normalizer = proba_k.sum(axis=1)[:, np.newaxis]
-                normalizer[normalizer == 0.0] = 1.0
-                proba_k /= normalizer
                 all_proba.append(proba_k)
-
             return all_proba
 
     def predict_log_proba(self, X):

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -575,7 +575,7 @@ cdef class ClassificationCriterion(Criterion):
                 dest[c] = self.sum_total[k, c] / self.weighted_n_node_samples
             dest += self.max_n_classes
 
-    cdef void clip_node_value(
+    cdef inline void clip_node_value(
         self, float64_t * dest, float64_t lower_bound, float64_t upper_bound
     ) noexcept nogil:
         """Clip the values in dest such that predicted probabilities stay between

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -575,9 +575,6 @@ cdef class ClassificationCriterion(Criterion):
             memcpy(dest, &self.sum_total[k, 0], self.n_classes[k] * sizeof(float64_t))
             dest += self.max_n_classes
 
-    cdef void clip_node_value(self, float64_t * dest, float64_t lower_bound, float64_t upper_bound) noexcept nogil:
-        """Clip the values in dest such that predicted probabilities stay between lower_bound and upper_bound when
-        monotonic constraints are enforced.
     cdef void clip_node_value(
         self, float64_t * dest, float64_t lower_bound, float64_t upper_bound
     ) noexcept nogil:

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -167,12 +167,6 @@ cdef class Criterion:
         """
         pass
 
-    # cdef float64_t sum_left_(self) noexcept nogil:
-    #     pass
-    # cdef float64_t sum_right_(self) noexcept nogil:
-    #     pass
-    # cdef float64_t sum_missing_(self) noexcept nogil:
-    #     pass
     cdef float64_t proxy_impurity_improvement(self) noexcept nogil:
         """Compute a proxy of the impurity reduction.
 

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -578,14 +578,19 @@ cdef class ClassificationCriterion(Criterion):
     cdef void clip_node_value(self, float64_t * dest, float64_t lower_bound, float64_t upper_bound) noexcept nogil:
         """Clip the values in dest such that predicted probabilities stay between lower_bound and upper_bound when
         monotonic constraints are enforced.
-
+    cdef void clip_node_value(
+        self, float64_t * dest, float64_t lower_bound, float64_t upper_bound
+    ) noexcept nogil:
+        """Clip the values in dest such that predicted probabilities stay between
+        `lower_bound` and `upper_bound` when monotonic constraints are enforced.
         Note that monotonicity constraints are only supported for:
         - single-output trees and
         - binary classifications.
         """
-        cdef float64_t total_weighted_count = dest[0] + dest[1]
-        cdef float64_t scaled_lower_bound = (<float32_t>lower_bound) * total_weighted_count
-        cdef float64_t scaled_upper_bound = (<float32_t>upper_bound) * total_weighted_count
+        cdef:
+            float64_t total_weighted_count = dest[0] + dest[1]
+            float64_t scaled_lower_bound = (<float32_t>lower_bound) * total_weighted_count
+            float64_t scaled_upper_bound = (<float32_t>upper_bound) * total_weighted_count
         if dest[0] < scaled_lower_bound:
             dest[0] = scaled_lower_bound
         elif dest[0] > scaled_upper_bound:

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -581,18 +581,14 @@ cdef class ClassificationCriterion(Criterion):
         - single-output trees and
         - binary classifications.
         """
-        if dest[0] < lower_bound:
-            dest[0] = lower_bound
-        elif dest[0] > upper_bound:
-            dest[0] = upper_bound
+        cdef float64_t total_weighted_count = dest[0] + dest[1]
+        if dest[0] < (lower_bound * total_weighted_count):
+            dest[0] = lower_bound * total_weighted_count
+        elif dest[0] > (upper_bound * total_weighted_count):
+            dest[0] = upper_bound * total_weighted_count
 
-        if dest[0] < 0.:
-            dest[0] = 0
-        elif dest[0] > 1.:
-            dest[0] = 1.
-
-        # Class proportions for binary classification must sum to 1.
-        dest[1] = 1 - dest[0]
+        # Values for binary classification must sum to total_weighted_count.
+        dest[1] = total_weighted_count - dest[0]
 
     cdef inline float64_t middle_value(self) noexcept nogil:
         """Compute the middle value of a split for monotonicity constraints as the simple average

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -586,6 +586,11 @@ cdef class ClassificationCriterion(Criterion):
         elif dest[0] > upper_bound:
             dest[0] = upper_bound
 
+        if dest[0] < 0.:
+            dest[0] = 0
+        elif dest[0] > 1.:
+            dest[0] = 1.
+
         # Class proportions for binary classification must sum to 1.
         dest[1] = 1 - dest[0]
 

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -271,14 +271,15 @@ class _BaseTreeExporter:
                 # Find max and min values in leaf nodes for regression
                 self.colors["bounds"] = (np.min(tree.value), np.max(tree.value))
         if tree.n_outputs == 1:
-            node_val = tree.value[node_id][0, :] / tree.weighted_n_node_samples[node_id]
-            if tree.n_classes[0] == 1:
-                # Regression or degraded classification with single class
-                node_val = tree.value[node_id][0, :]
-                if isinstance(node_val, Iterable) and self.colors["bounds"] is not None:
-                    # Only unpack the float only for the regression tree case.
-                    # Classification tree requires an Iterable in `get_color`.
-                    node_val = node_val.item()
+            node_val = tree.value[node_id][0, :]
+            if (
+                tree.n_classes[0] == 1
+                and isinstance(node_val, Iterable)
+                and self.colors["bounds"] is not None
+            ):
+                # Unpack the float only for the regression tree case.
+                # Classification tree requires an Iterable in `get_color`.
+                node_val = node_val.item()
         else:
             # If multi-output color node by impurity
             node_val = -tree.impurity[node_id]
@@ -347,9 +348,9 @@ class _BaseTreeExporter:
             node_string += str(tree.n_node_samples[node_id]) + characters[4]
 
         # Write node class distribution / regression value
-        if self.proportion and tree.n_classes[0] != 1:
+        if not self.proportion and tree.n_classes[0] != 1:
             # For classification this will show the proportion of samples
-            value = value / tree.weighted_n_node_samples[node_id]
+            value = value * tree.weighted_n_node_samples[node_id]
         if labels:
             node_string += "value = "
         if tree.n_classes[0] == 1:

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -1077,7 +1077,10 @@ def export_text(
         val = ""
         if isinstance(decision_tree, DecisionTreeClassifier):
             if show_weights:
-                val = ["{1:.{0}f}, ".format(decimals, v * weighted_n_node_samples) for v in value]
+                val = [
+                    "{1:.{0}f}, ".format(decimals, v * weighted_n_node_samples)
+                    for v in value
+                ]
                 val = "[" + "".join(val)[:-2] + "]"
                 weighted_n_node_samples
             val += " class: " + str(class_name)

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -42,11 +42,11 @@ def test_graphviz_toy():
         'node [shape=box, fontname="helvetica"] ;\n'
         'edge [fontname="helvetica"] ;\n'
         '0 [label="x[0] <= 0.0\\ngini = 0.5\\nsamples = 6\\n'
-        'value = [3, 3]"] ;\n'
-        '1 [label="gini = 0.0\\nsamples = 3\\nvalue = [3, 0]"] ;\n'
+        'value = [0.5, 0.5]"] ;\n'
+        '1 [label="gini = 0.0\\nsamples = 3\\nvalue = [1, 0]"] ;\n'
         "0 -> 1 [labeldistance=2.5, labelangle=45, "
         'headlabel="True"] ;\n'
-        '2 [label="gini = 0.0\\nsamples = 3\\nvalue = [0, 3]"] ;\n'
+        '2 [label="gini = 0.0\\nsamples = 3\\nvalue = [0, 1]"] ;\n'
         "0 -> 2 [labeldistance=2.5, labelangle=-45, "
         'headlabel="False"] ;\n'
         "}"
@@ -71,13 +71,13 @@ def test_graphviz_toy():
         'fontname="sans"] ;\n'
         'edge [fontname="sans"] ;\n'
         "0 [label=<x<SUB>0</SUB> &le; 0.0<br/>samples = 100.0%<br/>"
-        'value = [0.5, 0.5]>, fillcolor="#ffffff"] ;\n'
-        "1 [label=<samples = 50.0%<br/>value = [1.0, 0.0]>, "
-        'fillcolor="#e58139"] ;\n'
+        'value = [0.083, 0.083]>, fillcolor="#ffffff"] ;\n'
+        "1 [label=<samples = 50.0%<br/>value = [0.333, 0.0]>, "
+        'fillcolor="#f6d5bd"] ;\n'
         "0 -> 1 [labeldistance=2.5, labelangle=45, "
         'headlabel="True"] ;\n'
-        "2 [label=<samples = 50.0%<br/>value = [0.0, 1.0]>, "
-        'fillcolor="#399de5"] ;\n'
+        "2 [label=<samples = 50.0%<br/>value = [0.0, 0.333]>, "
+        'fillcolor="#bddef6"] ;\n'
         "0 -> 2 [labeldistance=2.5, labelangle=-45, "
         'headlabel="False"] ;\n'
         "}"
@@ -92,7 +92,7 @@ def test_graphviz_toy():
         'node [shape=box, fontname="helvetica"] ;\n'
         'edge [fontname="helvetica"] ;\n'
         '0 [label="x[0] <= 0.0\\ngini = 0.5\\nsamples = 6\\n'
-        'value = [3, 3]\\nclass = y[0]"] ;\n'
+        'value = [0.5, 0.5]\\nclass = y[0]"] ;\n'
         '1 [label="(...)"] ;\n'
         "0 -> 1 ;\n"
         '2 [label="(...)"] ;\n'
@@ -112,7 +112,7 @@ def test_graphviz_toy():
         'fontname="helvetica"] ;\n'
         'edge [fontname="helvetica"] ;\n'
         '0 [label="node #0\\nx[0] <= 0.0\\ngini = 0.5\\n'
-        'samples = 6\\nvalue = [3, 3]", fillcolor="#ffffff"] ;\n'
+        'samples = 6\\nvalue = [0.5, 0.5]", fillcolor="#ffffff"] ;\n'
         '1 [label="(...)", fillcolor="#C0C0C0"] ;\n'
         "0 -> 1 ;\n"
         '2 [label="(...)", fillcolor="#C0C0C0"] ;\n'
@@ -135,22 +135,22 @@ def test_graphviz_toy():
         'fontname="helvetica"] ;\n'
         'edge [fontname="helvetica"] ;\n'
         '0 [label="x[0] <= 0.0\\nsamples = 6\\n'
-        "value = [[3.0, 1.5, 0.0]\\n"
-        '[3.0, 1.0, 0.5]]", fillcolor="#ffffff"] ;\n'
-        '1 [label="samples = 3\\nvalue = [[3, 0, 0]\\n'
-        '[3, 0, 0]]", fillcolor="#e58139"] ;\n'
+        "value = [[0.667, 0.333, 0.0]\\n"
+        '[0.667, 0.222, 0.111]]", fillcolor="#ffffff"] ;\n'
+        '1 [label="samples = 3\\nvalue = [[1, 0, 0]\\n'
+        '[1, 0, 0]]", fillcolor="#e58139"] ;\n'
         "0 -> 1 [labeldistance=2.5, labelangle=45, "
         'headlabel="True"] ;\n'
         '2 [label="x[0] <= 1.5\\nsamples = 3\\n'
-        "value = [[0.0, 1.5, 0.0]\\n"
-        '[0.0, 1.0, 0.5]]", fillcolor="#f1bd97"] ;\n'
+        "value = [[0.0, 1.0, 0.0]\\n"
+        '[0.0, 0.667, 0.333]]", fillcolor="#f1bd97"] ;\n'
         "0 -> 2 [labeldistance=2.5, labelangle=-45, "
         'headlabel="False"] ;\n'
         '3 [label="samples = 2\\nvalue = [[0, 1, 0]\\n'
         '[0, 1, 0]]", fillcolor="#e58139"] ;\n'
         "2 -> 3 ;\n"
-        '4 [label="samples = 1\\nvalue = [[0.0, 0.5, 0.0]\\n'
-        '[0.0, 0.0, 0.5]]", fillcolor="#e58139"] ;\n'
+        '4 [label="samples = 1\\nvalue = [[0, 1, 0]\\n'
+        '[0, 0, 1]]", fillcolor="#e58139"] ;\n'
         "2 -> 4 ;\n"
         "}"
     )
@@ -231,11 +231,11 @@ def test_graphviz_feature_class_names_array_support(constructor):
         'node [shape=box, fontname="helvetica"] ;\n'
         'edge [fontname="helvetica"] ;\n'
         '0 [label="feature0 <= 0.0\\ngini = 0.5\\nsamples = 6\\n'
-        'value = [3, 3]"] ;\n'
-        '1 [label="gini = 0.0\\nsamples = 3\\nvalue = [3, 0]"] ;\n'
+        'value = [0.5, 0.5]"] ;\n'
+        '1 [label="gini = 0.0\\nsamples = 3\\nvalue = [1, 0]"] ;\n'
         "0 -> 1 [labeldistance=2.5, labelangle=45, "
         'headlabel="True"] ;\n'
-        '2 [label="gini = 0.0\\nsamples = 3\\nvalue = [0, 3]"] ;\n'
+        '2 [label="gini = 0.0\\nsamples = 3\\nvalue = [0, 1]"] ;\n'
         "0 -> 2 [labeldistance=2.5, labelangle=-45, "
         'headlabel="False"] ;\n'
         "}"
@@ -252,12 +252,12 @@ def test_graphviz_feature_class_names_array_support(constructor):
         'node [shape=box, fontname="helvetica"] ;\n'
         'edge [fontname="helvetica"] ;\n'
         '0 [label="x[0] <= 0.0\\ngini = 0.5\\nsamples = 6\\n'
-        'value = [3, 3]\\nclass = yes"] ;\n'
-        '1 [label="gini = 0.0\\nsamples = 3\\nvalue = [3, 0]\\n'
+        'value = [0.5, 0.5]\\nclass = yes"] ;\n'
+        '1 [label="gini = 0.0\\nsamples = 3\\nvalue = [1, 0]\\n'
         'class = yes"] ;\n'
         "0 -> 1 [labeldistance=2.5, labelangle=45, "
         'headlabel="True"] ;\n'
-        '2 [label="gini = 0.0\\nsamples = 3\\nvalue = [0, 3]\\n'
+        '2 [label="gini = 0.0\\nsamples = 3\\nvalue = [0, 1]\\n'
         'class = no"] ;\n'
         "0 -> 2 [labeldistance=2.5, labelangle=-45, "
         'headlabel="False"] ;\n'
@@ -390,9 +390,9 @@ def test_export_text():
 
     expected_report = dedent("""
     |--- feature_1 <= 0.00
-    |   |--- weights: [3.00, 0.00] class: -1
+    |   |--- weights: [1.00, 0.00] class: -1
     |--- feature_1 >  0.00
-    |   |--- weights: [0.00, 3.00] class: 1
+    |   |--- weights: [0.00, 1.00] class: 1
     """).lstrip()
     assert export_text(clf, show_weights=True) == expected_report
 
@@ -486,10 +486,10 @@ def test_plot_tree_entropy(pyplot):
     assert len(nodes) == 3
     assert (
         nodes[0].get_text()
-        == "first feat <= 0.0\nentropy = 1.0\nsamples = 6\nvalue = [3, 3]"
+        == "first feat <= 0.0\nentropy = 1.0\nsamples = 6\nvalue = [0.5, 0.5]"
     )
-    assert nodes[1].get_text() == "entropy = 0.0\nsamples = 3\nvalue = [3, 0]"
-    assert nodes[2].get_text() == "entropy = 0.0\nsamples = 3\nvalue = [0, 3]"
+    assert nodes[1].get_text() == "entropy = 0.0\nsamples = 3\nvalue = [1, 0]"
+    assert nodes[2].get_text() == "entropy = 0.0\nsamples = 3\nvalue = [0, 1]"
 
 
 def test_plot_tree_gini(pyplot):
@@ -506,10 +506,10 @@ def test_plot_tree_gini(pyplot):
     assert len(nodes) == 3
     assert (
         nodes[0].get_text()
-        == "first feat <= 0.0\ngini = 0.5\nsamples = 6\nvalue = [3, 3]"
+        == "first feat <= 0.0\ngini = 0.5\nsamples = 6\nvalue = [0.5, 0.5]"
     )
-    assert nodes[1].get_text() == "gini = 0.0\nsamples = 3\nvalue = [3, 0]"
-    assert nodes[2].get_text() == "gini = 0.0\nsamples = 3\nvalue = [0, 3]"
+    assert nodes[1].get_text() == "gini = 0.0\nsamples = 3\nvalue = [1, 0]"
+    assert nodes[2].get_text() == "gini = 0.0\nsamples = 3\nvalue = [0, 1]"
 
 
 def test_not_fitted_tree(pyplot):

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -390,9 +390,9 @@ def test_export_text():
 
     expected_report = dedent("""
     |--- feature_1 <= 0.00
-    |   |--- weights: [1.00, 0.00] class: -1
+    |   |--- weights: [3.00, 0.00] class: -1
     |--- feature_1 >  0.00
-    |   |--- weights: [0.00, 1.00] class: 1
+    |   |--- weights: [0.00, 3.00] class: 1
     """).lstrip()
     assert export_text(clf, show_weights=True) == expected_report
 

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -42,11 +42,11 @@ def test_graphviz_toy():
         'node [shape=box, fontname="helvetica"] ;\n'
         'edge [fontname="helvetica"] ;\n'
         '0 [label="x[0] <= 0.0\\ngini = 0.5\\nsamples = 6\\n'
-        'value = [0.5, 0.5]"] ;\n'
-        '1 [label="gini = 0.0\\nsamples = 3\\nvalue = [1, 0]"] ;\n'
+        'value = [3, 3]"] ;\n'
+        '1 [label="gini = 0.0\\nsamples = 3\\nvalue = [3, 0]"] ;\n'
         "0 -> 1 [labeldistance=2.5, labelangle=45, "
         'headlabel="True"] ;\n'
-        '2 [label="gini = 0.0\\nsamples = 3\\nvalue = [0, 1]"] ;\n'
+        '2 [label="gini = 0.0\\nsamples = 3\\nvalue = [0, 3]"] ;\n'
         "0 -> 2 [labeldistance=2.5, labelangle=-45, "
         'headlabel="False"] ;\n'
         "}"
@@ -71,13 +71,13 @@ def test_graphviz_toy():
         'fontname="sans"] ;\n'
         'edge [fontname="sans"] ;\n'
         "0 [label=<x<SUB>0</SUB> &le; 0.0<br/>samples = 100.0%<br/>"
-        'value = [0.083, 0.083]>, fillcolor="#ffffff"] ;\n'
-        "1 [label=<samples = 50.0%<br/>value = [0.333, 0.0]>, "
-        'fillcolor="#f6d5bd"] ;\n'
+        'value = [0.5, 0.5]>, fillcolor="#ffffff"] ;\n'
+        "1 [label=<samples = 50.0%<br/>value = [1.0, 0.0]>, "
+        'fillcolor="#e58139"] ;\n'
         "0 -> 1 [labeldistance=2.5, labelangle=45, "
         'headlabel="True"] ;\n'
-        "2 [label=<samples = 50.0%<br/>value = [0.0, 0.333]>, "
-        'fillcolor="#bddef6"] ;\n'
+        "2 [label=<samples = 50.0%<br/>value = [0.0, 1.0]>, "
+        'fillcolor="#399de5"] ;\n'
         "0 -> 2 [labeldistance=2.5, labelangle=-45, "
         'headlabel="False"] ;\n'
         "}"
@@ -92,7 +92,7 @@ def test_graphviz_toy():
         'node [shape=box, fontname="helvetica"] ;\n'
         'edge [fontname="helvetica"] ;\n'
         '0 [label="x[0] <= 0.0\\ngini = 0.5\\nsamples = 6\\n'
-        'value = [0.5, 0.5]\\nclass = y[0]"] ;\n'
+        'value = [3, 3]\\nclass = y[0]"] ;\n'
         '1 [label="(...)"] ;\n'
         "0 -> 1 ;\n"
         '2 [label="(...)"] ;\n'
@@ -112,7 +112,7 @@ def test_graphviz_toy():
         'fontname="helvetica"] ;\n'
         'edge [fontname="helvetica"] ;\n'
         '0 [label="node #0\\nx[0] <= 0.0\\ngini = 0.5\\n'
-        'samples = 6\\nvalue = [0.5, 0.5]", fillcolor="#ffffff"] ;\n'
+        'samples = 6\\nvalue = [3, 3]", fillcolor="#ffffff"] ;\n'
         '1 [label="(...)", fillcolor="#C0C0C0"] ;\n'
         "0 -> 1 ;\n"
         '2 [label="(...)", fillcolor="#C0C0C0"] ;\n'
@@ -135,22 +135,22 @@ def test_graphviz_toy():
         'fontname="helvetica"] ;\n'
         'edge [fontname="helvetica"] ;\n'
         '0 [label="x[0] <= 0.0\\nsamples = 6\\n'
-        "value = [[0.667, 0.333, 0.0]\\n"
-        '[0.667, 0.222, 0.111]]", fillcolor="#ffffff"] ;\n'
-        '1 [label="samples = 3\\nvalue = [[1, 0, 0]\\n'
-        '[1, 0, 0]]", fillcolor="#e58139"] ;\n'
+        "value = [[3.0, 1.5, 0.0]\\n"
+        '[3.0, 1.0, 0.5]]", fillcolor="#ffffff"] ;\n'
+        '1 [label="samples = 3\\nvalue = [[3, 0, 0]\\n'
+        '[3, 0, 0]]", fillcolor="#e58139"] ;\n'
         "0 -> 1 [labeldistance=2.5, labelangle=45, "
         'headlabel="True"] ;\n'
         '2 [label="x[0] <= 1.5\\nsamples = 3\\n'
-        "value = [[0.0, 1.0, 0.0]\\n"
-        '[0.0, 0.667, 0.333]]", fillcolor="#f1bd97"] ;\n'
+        "value = [[0.0, 1.5, 0.0]\\n"
+        '[0.0, 1.0, 0.5]]", fillcolor="#f1bd97"] ;\n'
         "0 -> 2 [labeldistance=2.5, labelangle=-45, "
         'headlabel="False"] ;\n'
         '3 [label="samples = 2\\nvalue = [[0, 1, 0]\\n'
         '[0, 1, 0]]", fillcolor="#e58139"] ;\n'
         "2 -> 3 ;\n"
-        '4 [label="samples = 1\\nvalue = [[0, 1, 0]\\n'
-        '[0, 0, 1]]", fillcolor="#e58139"] ;\n'
+        '4 [label="samples = 1\\nvalue = [[0.0, 0.5, 0.0]\\n'
+        '[0.0, 0.0, 0.5]]", fillcolor="#e58139"] ;\n'
         "2 -> 4 ;\n"
         "}"
     )
@@ -231,11 +231,11 @@ def test_graphviz_feature_class_names_array_support(constructor):
         'node [shape=box, fontname="helvetica"] ;\n'
         'edge [fontname="helvetica"] ;\n'
         '0 [label="feature0 <= 0.0\\ngini = 0.5\\nsamples = 6\\n'
-        'value = [0.5, 0.5]"] ;\n'
-        '1 [label="gini = 0.0\\nsamples = 3\\nvalue = [1, 0]"] ;\n'
+        'value = [3, 3]"] ;\n'
+        '1 [label="gini = 0.0\\nsamples = 3\\nvalue = [3, 0]"] ;\n'
         "0 -> 1 [labeldistance=2.5, labelangle=45, "
         'headlabel="True"] ;\n'
-        '2 [label="gini = 0.0\\nsamples = 3\\nvalue = [0, 1]"] ;\n'
+        '2 [label="gini = 0.0\\nsamples = 3\\nvalue = [0, 3]"] ;\n'
         "0 -> 2 [labeldistance=2.5, labelangle=-45, "
         'headlabel="False"] ;\n'
         "}"
@@ -252,12 +252,12 @@ def test_graphviz_feature_class_names_array_support(constructor):
         'node [shape=box, fontname="helvetica"] ;\n'
         'edge [fontname="helvetica"] ;\n'
         '0 [label="x[0] <= 0.0\\ngini = 0.5\\nsamples = 6\\n'
-        'value = [0.5, 0.5]\\nclass = yes"] ;\n'
-        '1 [label="gini = 0.0\\nsamples = 3\\nvalue = [1, 0]\\n'
+        'value = [3, 3]\\nclass = yes"] ;\n'
+        '1 [label="gini = 0.0\\nsamples = 3\\nvalue = [3, 0]\\n'
         'class = yes"] ;\n'
         "0 -> 1 [labeldistance=2.5, labelangle=45, "
         'headlabel="True"] ;\n'
-        '2 [label="gini = 0.0\\nsamples = 3\\nvalue = [0, 1]\\n'
+        '2 [label="gini = 0.0\\nsamples = 3\\nvalue = [0, 3]\\n'
         'class = no"] ;\n'
         "0 -> 2 [labeldistance=2.5, labelangle=-45, "
         'headlabel="False"] ;\n'
@@ -486,10 +486,10 @@ def test_plot_tree_entropy(pyplot):
     assert len(nodes) == 3
     assert (
         nodes[0].get_text()
-        == "first feat <= 0.0\nentropy = 1.0\nsamples = 6\nvalue = [0.5, 0.5]"
+        == "first feat <= 0.0\nentropy = 1.0\nsamples = 6\nvalue = [3, 3]"
     )
-    assert nodes[1].get_text() == "entropy = 0.0\nsamples = 3\nvalue = [1, 0]"
-    assert nodes[2].get_text() == "entropy = 0.0\nsamples = 3\nvalue = [0, 1]"
+    assert nodes[1].get_text() == "entropy = 0.0\nsamples = 3\nvalue = [3, 0]"
+    assert nodes[2].get_text() == "entropy = 0.0\nsamples = 3\nvalue = [0, 3]"
 
 
 def test_plot_tree_gini(pyplot):
@@ -506,10 +506,10 @@ def test_plot_tree_gini(pyplot):
     assert len(nodes) == 3
     assert (
         nodes[0].get_text()
-        == "first feat <= 0.0\ngini = 0.5\nsamples = 6\nvalue = [0.5, 0.5]"
+        == "first feat <= 0.0\ngini = 0.5\nsamples = 6\nvalue = [3, 3]"
     )
-    assert nodes[1].get_text() == "gini = 0.0\nsamples = 3\nvalue = [1, 0]"
-    assert nodes[2].get_text() == "gini = 0.0\nsamples = 3\nvalue = [0, 1]"
+    assert nodes[1].get_text() == "gini = 0.0\nsamples = 3\nvalue = [3, 0]"
+    assert nodes[2].get_text() == "gini = 0.0\nsamples = 3\nvalue = [0, 3]"
 
 
 def test_not_fitted_tree(pyplot):

--- a/sklearn/tree/tests/test_monotonic_tree.py
+++ b/sklearn/tree/tests/test_monotonic_tree.py
@@ -79,6 +79,9 @@ def test_monotonic_constraints_classifications(
     est.fit(X_train, y_train)
     y = est.predict_proba(X_test)[:, 1]
 
+    assert np.all(est.predict_proba(X_test) >= 0.)
+    assert np.all(est.predict_proba(X_test) <= 1.)
+
     # Monotonic increase constraint, it applies to the positive class
     assert np.all(est.predict_proba(X_test_0incr)[:, 1] >= y)
     assert np.all(est.predict_proba(X_test_0decr)[:, 1] <= y)

--- a/sklearn/tree/tests/test_monotonic_tree.py
+++ b/sklearn/tree/tests/test_monotonic_tree.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-
 from numpy.testing import assert_array_almost_equal
 
 from sklearn.datasets import make_classification, make_regression

--- a/sklearn/tree/tests/test_monotonic_tree.py
+++ b/sklearn/tree/tests/test_monotonic_tree.py
@@ -14,8 +14,8 @@ from sklearn.tree import (
     ExtraTreeClassifier,
     ExtraTreeRegressor,
 )
-from sklearn.utils.fixes import CSC_CONTAINERS
 from sklearn.utils._testing import assert_allclose
+from sklearn.utils.fixes import CSC_CONTAINERS
 
 TREE_CLASSIFIER_CLASSES = [DecisionTreeClassifier, ExtraTreeClassifier]
 TREE_REGRESSOR_CLASSES = [DecisionTreeRegressor, ExtraTreeRegressor]
@@ -80,10 +80,10 @@ def test_monotonic_constraints_classifications(
     est.fit(X_train, y_train)
     proba_test = est.predict_proba(X_test)
 
-    assert np.logical_and(proba_test >= 0.0, proba_test <= 1.0).all(), (
-        "Probability should always be in [0, 1] range."
-    )
-    assert_allclose(proba_test.sum(axis=1), 1.)
+    assert np.logical_and(
+        proba_test >= 0.0, proba_test <= 1.0
+    ).all(), "Probability should always be in [0, 1] range."
+    assert_allclose(proba_test.sum(axis=1), 1.0)
 
     # Monotonic increase constraint, it applies to the positive class
     assert np.all(est.predict_proba(X_test_0incr)[:, 1] >= proba_test[:, 1])

--- a/sklearn/tree/tests/test_monotonic_tree.py
+++ b/sklearn/tree/tests/test_monotonic_tree.py
@@ -79,8 +79,8 @@ def test_monotonic_constraints_classifications(
     est.fit(X_train, y_train)
     y = est.predict_proba(X_test)[:, 1]
 
-    assert np.all(est.predict_proba(X_test) >= 0.)
-    assert np.all(est.predict_proba(X_test) <= 1.)
+    assert np.all(est.predict_proba(X_test) >= 0.0)
+    assert np.all(est.predict_proba(X_test) <= 1.0)
 
     # Monotonic increase constraint, it applies to the positive class
     assert np.all(est.predict_proba(X_test_0incr)[:, 1] >= y)

--- a/sklearn/tree/tests/test_monotonic_tree.py
+++ b/sklearn/tree/tests/test_monotonic_tree.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from numpy.testing import assert_array_almost_equal
+
 from sklearn.datasets import make_classification, make_regression
 from sklearn.ensemble import (
     ExtraTreesClassifier,
@@ -77,18 +79,19 @@ def test_monotonic_constraints_classifications(
     if sparse_splitter:
         X_train = csc_container(X_train)
     est.fit(X_train, y_train)
-    y = est.predict_proba(X_test)[:, 1]
+    proba_test = est.predict_proba(X_test)
 
-    assert np.all(est.predict_proba(X_test) >= 0.0)
-    assert np.all(est.predict_proba(X_test) <= 1.0)
+    assert np.all(proba_test >= 0.0)
+    assert np.all(proba_test <= 1.0)
+    assert_array_almost_equal(np.sum(proba_test, axis=1), np.ones(proba_test.shape[0]))
 
     # Monotonic increase constraint, it applies to the positive class
-    assert np.all(est.predict_proba(X_test_0incr)[:, 1] >= y)
-    assert np.all(est.predict_proba(X_test_0decr)[:, 1] <= y)
+    assert np.all(est.predict_proba(X_test_0incr)[:, 1] >= proba_test[:, 1])
+    assert np.all(est.predict_proba(X_test_0decr)[:, 1] <= proba_test[:, 1])
 
     # Monotonic decrease constraint, it applies to the positive class
-    assert np.all(est.predict_proba(X_test_1incr)[:, 1] <= y)
-    assert np.all(est.predict_proba(X_test_1decr)[:, 1] >= y)
+    assert np.all(est.predict_proba(X_test_1incr)[:, 1] <= proba_test[:, 1])
+    assert np.all(est.predict_proba(X_test_1decr)[:, 1] >= proba_test[:, 1])
 
 
 @pytest.mark.parametrize("TreeRegressor", TREE_BASED_REGRESSOR_CLASSES)

--- a/sklearn/tree/tests/test_monotonic_tree.py
+++ b/sklearn/tree/tests/test_monotonic_tree.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal
 
 from sklearn.datasets import make_classification, make_regression
 from sklearn.ensemble import (
@@ -16,6 +15,7 @@ from sklearn.tree import (
     ExtraTreeRegressor,
 )
 from sklearn.utils.fixes import CSC_CONTAINERS
+from sklearn.utils._testing import assert_allclose
 
 TREE_CLASSIFIER_CLASSES = [DecisionTreeClassifier, ExtraTreeClassifier]
 TREE_REGRESSOR_CLASSES = [DecisionTreeRegressor, ExtraTreeRegressor]
@@ -80,9 +80,10 @@ def test_monotonic_constraints_classifications(
     est.fit(X_train, y_train)
     proba_test = est.predict_proba(X_test)
 
-    assert np.all(proba_test >= 0.0)
-    assert np.all(proba_test <= 1.0)
-    assert_array_almost_equal(np.sum(proba_test, axis=1), np.ones(proba_test.shape[0]))
+    assert np.logical_and(proba_test >= 0.0, proba_test <= 1.0).all(), (
+        "Probability should always be in [0, 1] range."
+    )
+    assert_allclose(proba_test.sum(axis=1), 1.)
 
     # Monotonic increase constraint, it applies to the positive class
     assert np.all(est.predict_proba(X_test_0incr)[:, 1] >= proba_test[:, 1])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up on #13649 to fix a bug where classification probabilities predictions are outside of the [0, 1] range.

#### What does this implement/fix? Explain your changes.

Currently on `main` branch, probabilities predicted by all tree-based models supporting `montonic_cst` can be (and often are) outside of the expected [0, 1] range when enforcing a `montonic_cst`.
```python
from sklearn.datasets import make_classification

n_samples = 1000
X, y = make_classification(
    n_samples=n_samples,
    n_classes=2,
    n_features=5,
    n_informative=5,
    n_redundant=0,
    random_state=1234,
)

from sklearn.tree import DecisionTreeClassifier
clf = DecisionTreeClassifier(monotonic_cst=[-1,1,0,0,0])
clf.fit(X, y)
clf.predict_proba(X)
```
```
>>> array([[  0.        ,   1.        ],
       [ 10.        ,  -9.        ],
       [  0.        ,   1.        ],
       ...,
       [ 47.        , -46.        ],
       [  6.        ,  -5.        ],
       [  0.79027778,   0.20972222]])
```
😱 😱 😱 😱 
Same with random splitter:
``` python
clf = ExtraTreeClassifier(monotonic_cst=[-1,1,0,0,0], random_state=1234)
clf.fit(X, y)
clf.predict_proba(X)
```
```
>>> array([[   9.,   -8.],
       [ 191., -190.],
       [   9.,   -8.],
       ...,
       [ 191., -190.],
       [  55.,  -54.],
       [ 191., -190.]])
```

After the fix all the probabilities lie between 0 and 1 😅.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

I need to investigate further, but the bug seems another occurence (see #27630) of unexpected `middle_values` that are propagated down and end up producing unexpected node values through clipping.