### PR TITLE
DOC add link to plot_self_training_varying_threshold.py example

### DIFF
--- a/sklearn/semi_supervised/_self_training.py
+++ b/sklearn/semi_supervised/_self_training.py
@@ -145,7 +145,7 @@ class SelfTrainingClassifier(
     SelfTrainingClassifier(...)
 
     For a more detailed example of usage, see:
-    :ref:`sphx_glr_auto_examples_semi_supervised_
+    :ref:`sphx_glr_auto_examples_semi_supervised_\
     plot_self_training_varying_threshold.py`
     """
 

--- a/sklearn/semi_supervised/_self_training.py
+++ b/sklearn/semi_supervised/_self_training.py
@@ -143,6 +143,9 @@ class SelfTrainingClassifier(
     >>> self_training_model = SelfTrainingClassifier(svc)
     >>> self_training_model.fit(iris.data, iris.target)
     SelfTrainingClassifier(...)
+
+    For a more detailed example of usage, see:
+    :ref:`sphx_glr_auto_examples_semi_supervised_plot_self_training_varying_threshold.py`
     """
 
     _estimator_type = "classifier"

--- a/sklearn/semi_supervised/_self_training.py
+++ b/sklearn/semi_supervised/_self_training.py
@@ -145,9 +145,8 @@ class SelfTrainingClassifier(
     SelfTrainingClassifier(...)
 
     For a more detailed example of usage, see:
-    :ref:`sphx_glr_auto_examples_semi_supervised_\
-    plot_self_training_varying_threshold.py`
-    """
+    :ref:`sphx_glr_auto_examples_semi_supervised_plot_self_training_varying_threshold.py`
+    """ # noqa
 
     _estimator_type = "classifier"
 

--- a/sklearn/semi_supervised/_self_training.py
+++ b/sklearn/semi_supervised/_self_training.py
@@ -145,7 +145,8 @@ class SelfTrainingClassifier(
     SelfTrainingClassifier(...)
 
     For a more detailed example of usage, see:
-    :ref:`sphx_glr_auto_examples_semi_supervised_plot_self_training_varying_threshold.py`
+    :ref:`sphx_glr_auto_examples_semi_supervised_
+    plot_self_training_varying_threshold.py`
     """
 
     _estimator_type = "classifier"

--- a/sklearn/semi_supervised/_self_training.py
+++ b/sklearn/semi_supervised/_self_training.py
@@ -146,7 +146,7 @@ class SelfTrainingClassifier(
 
     For a more detailed example of usage, see:
     :ref:`sphx_glr_auto_examples_semi_supervised_plot_self_training_varying_threshold.py`
-    """ # noqa
+    """  # noqa
 
     _estimator_type = "classifier"
 


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #26927

#### What does this implement/fix? Explain your changes.
Includes a link to the `plot_self_training_varying_threshold.py` example.

#### Any other comments?
Added a [noqa](https://stackoverflow.com/questions/45346575/what-does-noqa-mean-in-python-comments) comment so that the linter could pass. Adding `\` to split the link in the docstring did not render the link properly. I think something similar would be encountered for long file names that exceed the number of characters per line such as:<br>
examples/semi_supervised:
- plot_label_propagation_digits_active_learning.py
- plot_semi_supervised_versus_svm_iris.py