### PR TITLE
FIX Use torch.backends.mps.is_built() instead of torch.has_mps

### DIFF
--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1047,18 +1047,11 @@ def _array_api_for_tests(array_namespace, device, dtype):
                 "Skipping MPS device test because PYTORCH_ENABLE_MPS_FALLBACK is not "
                 "set."
             )
-        if not xp.has_mps:
-            if not xp.backends.mps.is_built():
-                raise SkipTest(
-                    "MPS is not available because the current PyTorch install was not "
-                    "built with MPS enabled."
-                )
-            else:
-                raise SkipTest(
-                    "MPS is not available because the current MacOS version is not"
-                    " 12.3+ and/or you do not have an MPS-enabled device on this"
-                    " machine."
-                )
+        if not xp.backends.mps.is_built():
+            raise SkipTest(
+                "MPS is not available because the current PyTorch install was not "
+                "built with MPS enabled."
+            )
     elif array_namespace in {"cupy", "cupy.array_api"}:  # pragma: nocover
         import cupy
 


### PR DESCRIPTION
Follow-up on #27606 but the MPS device on macOS.


`torch.has_mps` raises a `UserWarning` with PyTorch 2.1.0:

```python
In [1]: import torch

In [2]: torch.has_mps
<ipython-input-2-9f62291be6af>:1: UserWarning: 'has_mps' is deprecated, please use 'torch.backends.mps.is_built()'
  torch.has_mps
```