### PR TITLE
ENH Add warning when only one label found in `confusion_matrix`

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -376,6 +376,9 @@ Changelog
   `predict_proba`). Such scorer are specific to classification.
   :pr:`26840` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- |Enhancement| :func:`metrics.confusion_matrix` now warns when only one label was
+  found in `y_true` and `y_pred`. :pr:`27650` by :user:`Lucy Liu <lucyleeow>`.
+
 :mod:`sklearn.model_selection`
 ..............................
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -385,8 +385,9 @@ def confusion_matrix(
     if cm.shape == (1, 1):
         warnings.warn(
             (
-                "Only one label was found in 'y_true' and 'y_pred', use the 'labels' "
-                "parameter to pass all known labels."
+                "A single label was found in 'y_true' and 'y_pred'. For the confusion "
+                "matrix to have the correct shape, use the 'labels' parameter to pass "
+                "all known labels."
             ),
             UserWarning,
         )

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -382,6 +382,13 @@ def confusion_matrix(
             cm = cm / cm.sum()
         cm = np.nan_to_num(cm)
 
+    if cm.shape == (1,1):
+        warnings.warn(
+            "Only one label was found in 'y_true' and 'y_pred', use the 'labels' "
+            "parameter to pass all known labels.",
+            UserWarning,
+        )
+
     return cm
 
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -382,10 +382,12 @@ def confusion_matrix(
             cm = cm / cm.sum()
         cm = np.nan_to_num(cm)
 
-    if cm.shape == (1,1):
+    if cm.shape == (1, 1):
         warnings.warn(
-            "Only one label was found in 'y_true' and 'y_pred', use the 'labels' "
-            "parameter to pass all known labels.",
+            (
+                "Only one label was found in 'y_true' and 'y_pred', use the 'labels' "
+                "parameter to pass all known labels."
+            ),
             UserWarning,
         )
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -641,6 +641,7 @@ def test_confusion_matrix_single_label():
     with pytest.warns(UserWarning, match="A single label was found in"):
         confusion_matrix(y_pred, y_test)
 
+
 @pytest.mark.parametrize(
     "params, warn_msg",
     [

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -633,6 +633,14 @@ def test_confusion_matrix_normalize_single_class():
         confusion_matrix(y_pred, y_test, normalize="true")
 
 
+def test_confusion_matrix_single_label():
+    """Test `confusion_matrix` warns when only one label found."""
+    y_test = [0, 0, 0, 0]
+    y_pred = [0, 0, 0, 0]
+
+    with pytest.warns(UserWarning, match="A single label was found in"):
+        confusion_matrix(y_pred, y_test)
+
 @pytest.mark.parametrize(
     "params, warn_msg",
     [


### PR DESCRIPTION
#### Reference Issues/PRs
fixes #19756

#### What does this implement/fix? Explain your changes.
Add warning when only one label found in `confusion_matrix` and advise user to pass all labels via `labels` parameter.

