### PR TITLE
DOC use sphinx-gallery css variable to adapt light/dark theme

### DIFF
--- a/doc/themes/scikit-learn-modern/layout.html
+++ b/doc/themes/scikit-learn-modern/layout.html
@@ -11,7 +11,7 @@
 <!DOCTYPE html>
 <!-- data-theme below is forced to be "light" but should be changed if we use pydata-theme-sphinx in the future -->
 <!--[if IE 8]><html class="no-js lt-ie9" lang="{{ lang_attr }}" data-theme="light"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js" lang="{{ lang_attr }}" data-them="light"> <!--<![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="{{ lang_attr }}" data-theme="light"> <!--<![endif]-->
 <head>
   <meta charset="utf-8">
   {{ metatags }}

--- a/doc/themes/scikit-learn-modern/layout.html
+++ b/doc/themes/scikit-learn-modern/layout.html
@@ -9,8 +9,9 @@
 {%- set lang_attr = 'en' %}
 
 <!DOCTYPE html>
-<!--[if IE 8]><html class="no-js lt-ie9" lang="{{ lang_attr }}" > <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js" lang="{{ lang_attr }}" > <!--<![endif]-->
+<!-- data-theme below is forced to be "light" but should be changed if we use pydata-theme-sphinx in the future -->
+<!--[if IE 8]><html class="no-js lt-ie9" lang="{{ lang_attr }}" data-theme="light"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="{{ lang_attr }}" data-them="light"> <!--<![endif]-->
 <head>
   <meta charset="utf-8">
   {{ metatags }}

--- a/sklearn/utils/_estimator_html_repr.css
+++ b/sklearn/utils/_estimator_html_repr.css
@@ -14,16 +14,16 @@
   --sklearn-color-fitted-level-3: cornflowerblue;
 
   /* Specific color for light theme */
-  --sklearn-color-text-on-default-background: var(--theme-code-foreground, var(--jp-content-font-color1, black));
-  --sklearn-color-background: var(--theme-background, var(--jp-layout-color0, white));
-  --sklearn-color-border-box: var(--theme-code-foreground, var(--jp-content-font-color1, black));
+  --sklearn-color-text-on-default-background: var(--sg-text-color, var(--theme-code-foreground, var(--jp-content-font-color1, black)));
+  --sklearn-color-background: var(--sg-background-color, var(--theme-background, var(--jp-layout-color0, white)));
+  --sklearn-color-border-box: var(--sg-text-color, var(--theme-code-foreground, var(--jp-content-font-color1, black)));
   --sklearn-color-icon: #696969;
 
   @media (prefers-color-scheme: dark) {
     /* Redefinition of color scheme for dark theme */
-    --sklearn-color-text-on-default-background: var(--theme-code-foreground, var(--jp-content-font-color1, white));
-    --sklearn-color-background: var(--theme-background, var(--jp-layout-color0, #111));
-    --sklearn-color-border-box: var(--theme-code-foreground, var(--jp-content-font-color1, white));
+    --sklearn-color-text-on-default-background: var(--sg-text-color, var(--theme-code-foreground, var(--jp-content-font-color1, white)));
+    --sklearn-color-background: var(--sg-background-color, var(--theme-background, var(--jp-layout-color0, #111)));
+    --sklearn-color-border-box: var(--sg-text-color, var(--theme-code-foreground, var(--jp-content-font-color1, white)));
     --sklearn-color-icon: #878787;
   }
 }


### PR DESCRIPTION
The website rendering uses the CSS variable defined by sphinx-gallery. Therefore, we use the default OS preference while sphinx-gallery already provide some CSS variable.

Here, we intend to use these variables for a better integration (and it should make it compatible with pydata-theme for the future).