### PR TITLE
update transform with self.gamma_

### DIFF
--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -491,6 +491,12 @@ class KernelPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator
             Returns the instance itself.
         """
         check_is_fitted(self)
+        
+        #for backward compatibility when fitted in previous version where self.gamma_ did not exists  
+        # check if self.gamma_ exists if not set it to self.gamma
+        if not hasattr(self, "gamma_"):
+            self.gamma_ = self.gamma
+        
         X = self._validate_data(X, accept_sparse="csr", reset=False)
 
         # Compute centered gram matrix between X and training data X_fit_


### PR DESCRIPTION
Hi All,

This change fixes an issue where kpca was fitted in earlier version of scikit-learn (<1.3) where self.gamma_ did not exits  and transform is called using newer version(1.3).

Thanks

MLivako

(sorry if did anything wrong this is my very first request... dont hate :) )