### PR TITLE
API rename `Y` to `y` for estimators from the PLS module

### DIFF
--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -995,21 +995,28 @@ class PLSSVD(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         self : object
             Fitted estimator.
         """
-        check_consistent_length(X, Y)
+
+        if Y is not None:
+            warnings.warn(
+                "The use of Y as a parameter is currently being deprecated in favour"
+                " of y."
+            )
+            y = Y
+        check_consistent_length(X, y)
         X = self._validate_data(
             X, dtype=np.float64, copy=self.copy, ensure_min_samples=2
         )
         y = check_array(
-            Y, input_name="y", dtype=np.float64, copy=self.copy, ensure_2d=False
+            y, input_name="y", dtype=np.float64, copy=self.copy, ensure_2d=False
         )
         if y.ndim == 1:
-            Y = Y.reshape(-1, 1)
+            y = y.reshape(-1, 1)
 
         # we'll compute the SVD of the cross-covariance matrix = X.T.dot(Y)
         # This matrix rank is at most min(n_samples, n_features, n_targets) so
         # n_components cannot be bigger than that.
         n_components = self.n_components
-        rank_upper_bound = min(X.shape[0], X.shape[1], Y.shape[1])
+        rank_upper_bound = min(X.shape[0], X.shape[1], y.shape[1])
         if n_components > rank_upper_bound:
             raise ValueError(
                 f"`n_components` upper bound is {rank_upper_bound}. "


### PR DESCRIPTION
 I replaced Y for y in fit functions and introduced a deprecation warning in case the user still uses Y.

I have only replaced it on the fit functions. Please let me know if replacing it in the entire module would be better



#### Reference Issues/PRs

Fixes #26945



#### What does this implement/fix? 
The issue mentions that Y should be replaced for y in the sci-kit learn interface. I wasn't sure if it should be for the entire module so I just replaced it on the fit functions. 

#### Any other comments?
No extra comments, this is my first contribution I welcome feedback and criticism.  Thanks!