### PR TITLE
FIX fixes memory leak seen in PyPy in C losses

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -36,7 +36,7 @@ random sampling procedures.
       specified `tol`, for small values you will get more precise results.
 
 - |Fix| fixes a memory leak seen in PyPy for estimators using the Cython loss functions.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`27670` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 Changes impacting all modules
 -----------------------------

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -35,6 +35,9 @@ random sampling procedures.
       solvers (when fit on the same data again). The amount of change depends on the
       specified `tol`, for small values you will get more precise results.
 
+- |Fix| fixes a memory leak seen in PyPy for estimators using the Cython loss functions.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 Changes impacting all modules
 -----------------------------
 

--- a/sklearn/_loss/_loss.pyx.tp
+++ b/sklearn/_loss/_loss.pyx.tp
@@ -899,7 +899,7 @@ cdef class CyLossFunction:
     ):
         """Compute gradient of loss w.r.t raw_prediction for each input.
 
-        The gradient is written to `gradient_out` and not array is returned.
+        The gradient is written to `gradient_out` and no array is returned.
 
         Parameters
         ----------

--- a/sklearn/_loss/_loss.pyx.tp
+++ b/sklearn/_loss/_loss.pyx.tp
@@ -872,7 +872,7 @@ cdef class CyLossFunction:
     ):
         """Compute the point-wise loss value for each input.
 
-        The point-wise loss is affected to `loss_out` without returning the array.
+        The point-wise loss is written to `loss_out` and no array is returned.
 
         Parameters
         ----------

--- a/sklearn/_loss/_loss.pyx.tp
+++ b/sklearn/_loss/_loss.pyx.tp
@@ -958,7 +958,6 @@ cdef class CyLossFunction:
         """
         self.loss(y_true, raw_prediction, sample_weight, loss_out, n_threads)
         self.gradient(y_true, raw_prediction, sample_weight, gradient_out, n_threads)
-        return np.asarray(loss_out), np.asarray(gradient_out)
 
     def gradient_hessian(
         self,
@@ -1045,8 +1044,6 @@ cdef class {{name}}(CyLossFunction):
             ):
                 loss_out[i] = sample_weight[i] * {{closs}}(y_true[i], raw_prediction[i]{{with_param}})
 
-        return np.asarray(loss_out)
-
     {{if closs_grad is not None}}
     def loss_gradient(
         self,
@@ -1077,7 +1074,6 @@ cdef class {{name}}(CyLossFunction):
                 loss_out[i] = sample_weight[i] * dbl2.val1
                 gradient_out[i] = sample_weight[i] * dbl2.val2
 
-        return np.asarray(loss_out), np.asarray(gradient_out)
     {{endif}}
 
     def gradient(
@@ -1102,8 +1098,6 @@ cdef class {{name}}(CyLossFunction):
                 n_samples, schedule='static', nogil=True, num_threads=n_threads
             ):
                 gradient_out[i] = sample_weight[i] * {{cgrad}}(y_true[i], raw_prediction[i]{{with_param}})
-
-        return np.asarray(gradient_out)
 
     def gradient_hessian(
         self,
@@ -1133,8 +1127,6 @@ cdef class {{name}}(CyLossFunction):
                 dbl2 = {{cgrad_hess}}(y_true[i], raw_prediction[i]{{with_param}})
                 gradient_out[i] = sample_weight[i] * dbl2.val1
                 hessian_out[i] = sample_weight[i] * dbl2.val2
-
-        return np.asarray(gradient_out), np.asarray(hessian_out)
 
 {{endfor}}
 
@@ -1216,8 +1208,6 @@ cdef class CyHalfMultinomialLoss(CyLossFunction):
 
                 free(p)
 
-        return np.asarray(loss_out)
-
     def loss_gradient(
         self,
         const floating_in[::1] y_true,           # IN
@@ -1278,8 +1268,6 @@ cdef class CyHalfMultinomialLoss(CyLossFunction):
 
                 free(p)
 
-        return np.asarray(loss_out), np.asarray(gradient_out)
-
     def gradient(
         self,
         const floating_in[::1] y_true,           # IN
@@ -1326,8 +1314,6 @@ cdef class CyHalfMultinomialLoss(CyLossFunction):
                         gradient_out[i, k] = (p[k] - (y_true[i] == k)) * sample_weight[i]
 
                 free(p)
-
-        return np.asarray(gradient_out)
 
     def gradient_hessian(
         self,
@@ -1381,9 +1367,6 @@ cdef class CyHalfMultinomialLoss(CyLossFunction):
 
                 free(p)
 
-        return np.asarray(gradient_out), np.asarray(hessian_out)
-
-
     # This method simplifies the implementation of hessp in linear models,
     # i.e. the matrix-vector product of the full hessian, not only of the
     # diagonal (in the classes) approximation as implemented above.
@@ -1434,5 +1417,3 @@ cdef class CyHalfMultinomialLoss(CyLossFunction):
                         gradient_out[i, k] = (proba_out[i, k] - (y_true[i] == k)) * sample_weight[i]
 
                 free(p)
-
-        return np.asarray(gradient_out), np.asarray(proba_out)

--- a/sklearn/_loss/_loss.pyx.tp
+++ b/sklearn/_loss/_loss.pyx.tp
@@ -870,7 +870,9 @@ cdef class CyLossFunction:
         floating_out[::1] loss_out,             # OUT
         int n_threads=1
     ):
-        """Compute the pointwise loss value for each input.
+        """Compute the point-wise loss value for each input.
+
+        The point-wise loss is affected to `loss_out` without returning the array.
 
         Parameters
         ----------
@@ -884,11 +886,6 @@ cdef class CyLossFunction:
             A location into which the result is stored.
         n_threads : int
             Number of threads used by OpenMP (if any).
-
-        Returns
-        -------
-        loss : array of shape (n_samples,)
-            Element-wise loss function.
         """
         pass
 
@@ -902,6 +899,8 @@ cdef class CyLossFunction:
     ):
         """Compute gradient of loss w.r.t raw_prediction for each input.
 
+        The gradient is affected to `gradient_out` without returning the array.
+
         Parameters
         ----------
         y_true : array of shape (n_samples,)
@@ -914,11 +913,6 @@ cdef class CyLossFunction:
             A location into which the result is stored.
         n_threads : int
             Number of threads used by OpenMP (if any).
-
-        Returns
-        -------
-        gradient : array of shape (n_samples,)
-            Element-wise gradients.
         """
         pass
 
@@ -932,6 +926,9 @@ cdef class CyLossFunction:
         int n_threads=1
     ):
         """Compute loss and gradient of loss w.r.t raw_prediction.
+
+        The loss and gradient are affected to `loss_out` and `gradient_out` without
+        returning those arrays.
 
         Parameters
         ----------
@@ -947,14 +944,6 @@ cdef class CyLossFunction:
             A location into which the gradient is stored.
         n_threads : int
             Number of threads used by OpenMP (if any).
-
-        Returns
-        -------
-        loss : array of shape (n_samples,)
-            Element-wise loss function.
-
-        gradient : array of shape (n_samples,)
-            Element-wise gradients.
         """
         self.loss(y_true, raw_prediction, sample_weight, loss_out, n_threads)
         self.gradient(y_true, raw_prediction, sample_weight, gradient_out, n_threads)
@@ -970,6 +959,9 @@ cdef class CyLossFunction:
     ):
         """Compute gradient and hessian of loss w.r.t raw_prediction.
 
+        The gradient and hessian are affected to `gradient_out` and `hessian_out`
+        without returning these arrays.
+
         Parameters
         ----------
         y_true : array of shape (n_samples,)
@@ -984,14 +976,6 @@ cdef class CyLossFunction:
             A location into which the hessian is stored.
         n_threads : int
             Number of threads used by OpenMP (if any).
-
-        Returns
-        -------
-        gradient : array of shape (n_samples,)
-            Element-wise gradients.
-
-        hessian : array of shape (n_samples,)
-            Element-wise hessians.
         """
         pass
 

--- a/sklearn/_loss/_loss.pyx.tp
+++ b/sklearn/_loss/_loss.pyx.tp
@@ -899,7 +899,7 @@ cdef class CyLossFunction:
     ):
         """Compute gradient of loss w.r.t raw_prediction for each input.
 
-        The gradient is affected to `gradient_out` without returning the array.
+        The gradient is written to `gradient_out` and not array is returned.
 
         Parameters
         ----------
@@ -927,8 +927,8 @@ cdef class CyLossFunction:
     ):
         """Compute loss and gradient of loss w.r.t raw_prediction.
 
-        The loss and gradient are affected to `loss_out` and `gradient_out` without
-        returning those arrays.
+        The loss and gradient are written to `loss_out` and `gradient_out` and no arrays
+        are returned.
 
         Parameters
         ----------
@@ -959,8 +959,8 @@ cdef class CyLossFunction:
     ):
         """Compute gradient and hessian of loss w.r.t raw_prediction.
 
-        The gradient and hessian are affected to `gradient_out` and `hessian_out`
-        without returning these arrays.
+        The gradient and hessian are written to `gradient_out` and `hessian_out` and no
+        arrays are returned.
 
         Parameters
         ----------

--- a/sklearn/_loss/loss.py
+++ b/sklearn/_loss/loss.py
@@ -189,13 +189,14 @@ class BaseLoss:
         if raw_prediction.ndim == 2 and raw_prediction.shape[1] == 1:
             raw_prediction = raw_prediction.squeeze(1)
 
-        return self.closs.loss(
+        self.closs.loss(
             y_true=y_true,
             raw_prediction=raw_prediction,
             sample_weight=sample_weight,
             loss_out=loss_out,
             n_threads=n_threads,
         )
+        return loss_out
 
     def loss_gradient(
         self,
@@ -250,7 +251,7 @@ class BaseLoss:
         if gradient_out.ndim == 2 and gradient_out.shape[1] == 1:
             gradient_out = gradient_out.squeeze(1)
 
-        return self.closs.loss_gradient(
+        self.closs.loss_gradient(
             y_true=y_true,
             raw_prediction=raw_prediction,
             sample_weight=sample_weight,
@@ -258,6 +259,7 @@ class BaseLoss:
             gradient_out=gradient_out,
             n_threads=n_threads,
         )
+        return loss_out, gradient_out
 
     def gradient(
         self,
@@ -299,13 +301,14 @@ class BaseLoss:
         if gradient_out.ndim == 2 and gradient_out.shape[1] == 1:
             gradient_out = gradient_out.squeeze(1)
 
-        return self.closs.gradient(
+        self.closs.gradient(
             y_true=y_true,
             raw_prediction=raw_prediction,
             sample_weight=sample_weight,
             gradient_out=gradient_out,
             n_threads=n_threads,
         )
+        return gradient_out
 
     def gradient_hessian(
         self,
@@ -363,7 +366,7 @@ class BaseLoss:
         if hessian_out.ndim == 2 and hessian_out.shape[1] == 1:
             hessian_out = hessian_out.squeeze(1)
 
-        return self.closs.gradient_hessian(
+        self.closs.gradient_hessian(
             y_true=y_true,
             raw_prediction=raw_prediction,
             sample_weight=sample_weight,
@@ -371,6 +374,7 @@ class BaseLoss:
             hessian_out=hessian_out,
             n_threads=n_threads,
         )
+        return gradient_out, hessian_out
 
     def __call__(self, y_true, raw_prediction, sample_weight=None, n_threads=1):
         """Compute the weighted average loss.
@@ -1075,7 +1079,7 @@ class HalfMultinomialLoss(BaseLoss):
         elif proba_out is None:
             proba_out = np.empty_like(gradient_out)
 
-        return self.closs.gradient_proba(
+        self.closs.gradient_proba(
             y_true=y_true,
             raw_prediction=raw_prediction,
             sample_weight=sample_weight,
@@ -1083,6 +1087,7 @@ class HalfMultinomialLoss(BaseLoss):
             proba_out=proba_out,
             n_threads=n_threads,
         )
+        return gradient_out, proba_out
 
 
 class ExponentialLoss(BaseLoss):

--- a/sklearn/_loss/tests/test_loss.py
+++ b/sklearn/_loss/tests/test_loss.py
@@ -383,34 +383,32 @@ def test_loss_same_as_C_functions(loss, sample_weight):
     out_g2 = np.empty_like(raw_prediction)
     out_h1 = np.empty_like(raw_prediction)
     out_h2 = np.empty_like(raw_prediction)
-    assert_allclose(
-        loss.loss(
-            y_true=y_true,
-            raw_prediction=raw_prediction,
-            sample_weight=sample_weight,
-            loss_out=out_l1,
-        ),
-        loss.closs.loss(
-            y_true=y_true,
-            raw_prediction=raw_prediction,
-            sample_weight=sample_weight,
-            loss_out=out_l2,
-        ),
+    loss.loss(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+        loss_out=out_l1,
     )
-    assert_allclose(
-        loss.gradient(
-            y_true=y_true,
-            raw_prediction=raw_prediction,
-            sample_weight=sample_weight,
-            gradient_out=out_g1,
-        ),
-        loss.closs.gradient(
-            y_true=y_true,
-            raw_prediction=raw_prediction,
-            sample_weight=sample_weight,
-            gradient_out=out_g2,
-        ),
+    loss.closs.loss(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+        loss_out=out_l2,
+    ),
+    assert_allclose(out_l1, out_l2)
+    loss.gradient(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+        gradient_out=out_g1,
     )
+    loss.closs.gradient(
+        y_true=y_true,
+        raw_prediction=raw_prediction,
+        sample_weight=sample_weight,
+        gradient_out=out_g2,
+    )
+    assert_allclose(out_g1, out_g2)
     loss.closs.loss_gradient(
         y_true=y_true,
         raw_prediction=raw_prediction,


### PR DESCRIPTION
partially addresses #27662

Avoid to use `np.asarray` that creates a reference to the memory view and seems to not be garbage collected in PyPy.