### PR TITLE
FIX apply check_array before stacking in ColumnTransformer

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -227,6 +227,15 @@ Changelog
 :mod:`sklearn.compose`
 ......................
 
+- When transformers in the |API| |FIX| :class:`~compose.ColumnTransformer`
+  output arrays using pandas extension dtypes (eg `pd.Float64Dtype`), those are
+  replaced with numpy dtypes and `pd.NA` is replaced by `np.nan`. Such arrays
+  used to result in outputs of dtype `object` containing `pd.NA`, which could
+  break subsequent estimators in a pipeline. No transformation is applied when
+  the transformer outputs DataFrames (ie when calling
+  `ColumnTransformer.set_output(transform="pandas")`). :pr:`27671` by
+  :user:`Jérôme Dockès <jeromedockes>`.
+
 - |API| |FIX| :class:`~compose.ColumnTransformer` now replaces `"passthrough"`
   with a corresponding :class:`~preprocessing.FunctionTransformer` in the
   fitted ``transformers_`` attribute. :pr:`27204` by `Adrin Jalali`_.

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -1045,7 +1045,14 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
                 output.columns = names_out
                 return output
 
-            return np.hstack(Xs)
+            return np.hstack(
+                [
+                    check_array(
+                        X, force_all_finite=False, accept_sparse=True, dtype=None
+                    )
+                    for X in Xs
+                ]
+            )
 
     def _sk_visual_block_(self):
         if isinstance(self.remainder, str) and self.remainder == "drop":

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -2263,9 +2263,9 @@ def test_transform_pd_na():
     pd_transformer = make_column_transformer(("passthrough", ["A"]))
     pd_transformer.set_output(transform="pandas")
     X_pd = pd_transformer.fit_transform(X)
-    assert X_pd.dtypes.iloc[0] == pd.Float64Dtype()
-
     assert_array_equal(X_np, check_array(X_pd))
+    if hasattr(pd, "Float64Dtype"):
+        assert X_pd.dtypes.iloc[0] == pd.Float64Dtype()
 
 
 # Metadata Routing Tests

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -2252,7 +2252,9 @@ def test_remainder_set_output():
 def test_transform_pd_na():
     """pd.Float64 with pd.NA input → np.float64 with np.nan output
 
-    Non-regression test for #27482"""
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/27482
+    """
     pd = pytest.importorskip("pandas")
     X = pd.DataFrame({"A": [0.5]}).convert_dtypes()
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

fixes #27482 

#### What does this implement/fix? Explain your changes.

The `ColumnTransformer` (without `set_output(transform="pandas")`), when it transforms pandas columns that contain `pd.NA`, outputs arrays of dtype `object` that contain `pd.NA`, which can cause subsequent estimators in a pipeline to fail because `check_array(dtype="numeric")` raises a TypeError on such arrays.

The proposal here is to apply `check_array(dtype=None)` on the transformers' outputs before performing the horizontal stacking. This will convert `pd.Float64` to `np.float64` and `pd.NA` to `np.nan`

#### Any other comments?

Another option is to forbid `pd.NA` in the individual transformers' output if the ColumnTransformer does not have its output transform set to "pandas". Before performing the `hstack` we can check for `pd.NA` and raise if any are found.

This still has the drawback that the output for `pd.Float64` columns (without missing values) will be `object` rather than `np.float64`

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
