### PR TITLE
FIX adding assert statement while comparing

### DIFF
--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -141,7 +141,7 @@ def test_additive_chi2_sampler_sample_steps(method, sample_steps):
         sample_interval=sample_interval,
     )
     getattr(transformer, method)(X)
-    transformer.sample_interval == sample_interval
+    assert transformer.sample_interval == sample_interval
 
 
 # TODO(1.5): remove


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #27600


#### What does this implement/fix? Explain your changes.
Added missing assert statement in test method `test_additive_chi2_sampler_sample_steps` which was comparing expected and gotten results using `==`