### PR TITLE
DOC  improve documentation of copy=False in preprocessing functions

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -637,9 +637,10 @@ def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
 
         When using :func:`~sklearn.preprocessing.minmax_scale` with parameter X
         of dtype not float and parameter `copy=False` a copy of X will be
-        forced regardless. This is the result of applying :func:`~sklearn.utils.validation.check_array`
-        on X. Specifically if X is not of dtype float because `check_array` is called
-        with dtype=FLOAT_DTYPES a dtype conversion of X is applied, triggering a copy.
+        forced regardless. This is the result of applying
+        :func:`~sklearn.utils.validation.check_array` on X. Specifically if X
+        is not of dtype float because `check_array` is called with
+        dtype=FLOAT_DTYPES a dtype conversion of X is applied, triggering a copy.
 
 
     See Also
@@ -659,9 +660,17 @@ def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
         X, copy=False, ensure_2d=False, dtype=FLOAT_DTYPES, force_all_finite="allow-nan"
     )
 
-    if not X.dtype == check_array(X, copy=False, ensure_2d=False, force_all_finite="allow-nan").dtype and not copy:
-        warning_msg = "Calling :func:`~sklearn.preprocessing.minmax_scale` with `copy=False` and " \
-                      "`X not dtype float` leads to a forced copy. Defaulted to `copy=True`."
+    if (
+        not X.dtype
+        == check_array(
+            X, copy=False, ensure_2d=False, force_all_finite="allow-nan"
+        ).dtype
+        and not copy
+    ):
+        warning_msg = (
+            "Calling :func:`~sklearn.preprocessing.minmax_scale` with `copy=False` and "
+            "`X not dtype float` leads to a forced copy. Defaulted to `copy=True`."
+        )
         warnings.warn(warning_msg)
 
     original_ndim = X.ndim

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -613,8 +613,10 @@ def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
         otherwise (if 1) scale each sample.
 
     copy : bool, default=True
-        Set to False to perform inplace scaling and avoid a copy (if the input
-        is already a numpy array).
+        If False, try to avoid a copy and do inplace scaling instead.
+        This is not guaranteed to always work inplace; e.g. if the data is
+        not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
+        float, a copy may still be returned.
 
     Returns
     -------
@@ -633,16 +635,6 @@ def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
         :ref:`Pipeline <pipeline>` in order to prevent most risks of data
         leaking: `pipe = make_pipeline(MinMaxScaler(), LogisticRegression())`.
 
-    .. warning:: Forced copy when dtype of parameter X not float
-
-        When using :func:`~sklearn.preprocessing.minmax_scale` with parameter X
-        of dtype not float and parameter `copy=False` a copy of X will be
-        forced regardless. This is the result of applying
-        :func:`~sklearn.utils.validation.check_array` on X. Specifically if X
-        is not of dtype float because `check_array` is called with
-        dtype=FLOAT_DTYPES a dtype conversion of X is applied, triggering a copy.
-
-
     See Also
     --------
     MinMaxScaler : Performs scaling to a given range using the Transformer
@@ -659,19 +651,6 @@ def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
     X = check_array(
         X, copy=False, ensure_2d=False, dtype=FLOAT_DTYPES, force_all_finite="allow-nan"
     )
-
-    if (
-        not X.dtype
-        == check_array(
-            X, copy=False, ensure_2d=False, force_all_finite="allow-nan"
-        ).dtype
-        and not copy
-    ):
-        warning_msg = (
-            "Calling :func:`~sklearn.preprocessing.minmax_scale` with `copy=False` and "
-            "`X not dtype float` leads to a forced copy. Defaulted to `copy=True`."
-        )
-        warnings.warn(warning_msg)
 
     original_ndim = X.ndim
 

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -156,8 +156,8 @@ def scale(X, *, axis=0, with_mean=True, with_std=True, copy=True):
 
     copy : bool, default=True
         If False, try to avoid a copy and scale in place.
-        This is not guaranteed to always work in place; e.g. if the data is 
-        a numpy array with an int dtype, a copy will be returned even with 
+        This is not guaranteed to always work in place; e.g. if the data is
+        a numpy array with an int dtype, a copy will be returned even with
         copy=False.
 
     Returns

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -157,7 +157,7 @@ def scale(X, *, axis=0, with_mean=True, with_std=True, copy=True):
     copy : bool, default=True
         If False, try to avoid a copy and scale in place.
         This is not guaranteed to always work in place; e.g. if the data is
-        not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
+        not a NumPy array, or is a scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.
 
     Returns
@@ -616,7 +616,7 @@ def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
     copy : bool, default=True
         If False, try to avoid a copy and scale in place.
         This is not guaranteed to always work in place; e.g. if the data is
-        not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
+        not a NumPy array, or is a scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.
 
     Returns
@@ -1341,7 +1341,7 @@ def maxabs_scale(X, *, axis=0, copy=True):
     copy : bool, default=True
         If False, try to avoid a copy and scale in place.
         This is not guaranteed to always work in place; e.g. if the data is
-        not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
+        not a NumPy array, or is a scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.
 
     Returns
@@ -1720,7 +1720,7 @@ def robust_scale(
     copy : bool, default=True
         If False, try to avoid a copy and scale in place.
         This is not guaranteed to always work in place; e.g. if the data is
-        not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
+        not a NumPy array, or is a scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.
 
     unit_variance : bool, default=False
@@ -1832,9 +1832,9 @@ def normalize(X, norm="l2", *, axis=1, copy=True, return_norm=False):
         normalize each sample, otherwise (if 0) normalize each feature.
 
     copy : bool, default=True
-        If False, try to avoid a copy and normalilze in place.
+        If False, try to avoid a copy and normalize in place.
         This is not guaranteed to always work in place; e.g. if the data is
-        not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
+        not a NumPy array, or is a scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.
 
     return_norm : bool, default=False
@@ -2068,8 +2068,7 @@ def binarize(X, *, threshold=0.0, copy=True):
     copy : bool, default=True
         If False, try to avoid a copy and binarize in place.
         This is not guaranteed to always work in place; e.g. if the data is
-        not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
-        float, a copy may still be returned.
+        not a NumPy array a copy may still be returned.
 
     Returns
     -------
@@ -2955,7 +2954,7 @@ def quantile_transform(
     copy : bool, default=True
         If False, try to avoid a copy and transform in place.
         This is not guaranteed to always work in place; e.g. if the data is
-        not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
+        not a NumPy array, or is a scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.
 
         .. versionchanged:: 0.23
@@ -3492,7 +3491,7 @@ def power_transform(X, method="yeo-johnson", *, standardize=True, copy=True):
     copy : bool, default=True
         If False, try to avoid a copy and transform in place.
         This is not guaranteed to always work in place; e.g. if the data is
-        not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
+        not a NumPy array, or is a scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.
 
     Returns

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -633,6 +633,15 @@ def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
         :ref:`Pipeline <pipeline>` in order to prevent most risks of data
         leaking: `pipe = make_pipeline(MinMaxScaler(), LogisticRegression())`.
 
+    .. warning:: Forced copy when dtype of parameter X not float
+
+        When using :func:`~sklearn.preprocessing.minmax_scale` with parameter X
+        of dtype not float and parameter `copy=False` a copy of X will be
+        forced regardless. This is the result of applying :func:`~sklearn.utils.validation.check_array`
+        on X. Specifically if X is not of dtype float because `check_array` is called
+        with dtype=FLOAT_DTYPES a dtype conversion of X is applied, triggering a copy.
+
+
     See Also
     --------
     MinMaxScaler : Performs scaling to a given range using the Transformer
@@ -649,6 +658,12 @@ def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
     X = check_array(
         X, copy=False, ensure_2d=False, dtype=FLOAT_DTYPES, force_all_finite="allow-nan"
     )
+
+    if not X.dtype == check_array(X, copy=False, ensure_2d=False, force_all_finite="allow-nan").dtype and not copy:
+        warning_msg = "Calling :func:`~sklearn.preprocessing.minmax_scale` with `copy=False` and " \
+                      "`X not dtype float` leads to a forced copy. Defaulted to `copy=True`."
+        warnings.warn(warning_msg)
+
     original_ndim = X.ndim
 
     if original_ndim == 1:

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -155,9 +155,10 @@ def scale(X, *, axis=0, with_mean=True, with_std=True, copy=True):
         unit standard deviation).
 
     copy : bool, default=True
-        Set to False to perform inplace row normalization and avoid a
-        copy (if the input is already a numpy array or a scipy.sparse
-        CSC matrix and if axis is 1).
+        If False, try to avoid a copy and scale in place.
+        This is not guaranteed to always work inplace; e.g. if the data is
+        not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
+        float, a copy may still be returned.
 
     Returns
     -------
@@ -1338,8 +1339,10 @@ def maxabs_scale(X, *, axis=0, copy=True):
         otherwise (if 1) scale each sample.
 
     copy : bool, default=True
-        Set to False to perform inplace scaling and avoid a copy (if the input
-        is already a numpy array).
+        If False, try to avoid a copy and scale in place.
+        This is not guaranteed to always work inplace; e.g. if the data is
+        not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
+        float, a copy may still be returned.
 
     Returns
     -------
@@ -1715,9 +1718,10 @@ def robust_scale(
         .. versionadded:: 0.18
 
     copy : bool, default=True
-        Set to `False` to perform inplace row normalization and avoid a
-        copy (if the input is already a numpy array or a scipy.sparse
-        CSR matrix and if axis is 1).
+        If False, try to avoid a copy and scale in place.
+        This is not guaranteed to always work inplace; e.g. if the data is
+        not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
+        float, a copy may still be returned.
 
     unit_variance : bool, default=False
         If `True`, scale data so that normally distributed features have a
@@ -1828,9 +1832,10 @@ def normalize(X, norm="l2", *, axis=1, copy=True, return_norm=False):
         normalize each sample, otherwise (if 0) normalize each feature.
 
     copy : bool, default=True
-        Set to False to perform inplace row normalization and avoid a
-        copy (if the input is already a numpy array or a scipy.sparse
-        CSR matrix and if axis is 1).
+        If False, try to avoid a copy and scale in place.
+        This is not guaranteed to always work inplace; e.g. if the data is
+        not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
+        float, a copy may still be returned.
 
     return_norm : bool, default=False
         Whether to return the computed norms.
@@ -2061,9 +2066,9 @@ def binarize(X, *, threshold=0.0, copy=True):
         Threshold may not be less than 0 for operations on sparse matrices.
 
     copy : bool, default=True
-        Set to False to perform inplace binarization and avoid a copy
-        (if the input is already a numpy array or a scipy.sparse CSR / CSC
-        matrix and if axis is 1).
+        If False, try to avoid a copy and scale in place.
+        This is not guaranteed to always work inplace; e.g. if the data is
+        not a NumPy array, a copy may still be returned.
 
     Returns
     -------
@@ -2947,9 +2952,10 @@ def quantile_transform(
         See :term:`Glossary <random_state>`.
 
     copy : bool, default=True
-        Set to False to perform inplace transformation and avoid a copy (if the
-        input is already a numpy array). If True, a copy of `X` is transformed,
-        leaving the original `X` unchanged.
+        If False, try to avoid a copy and scale in place.
+        This is not guaranteed to always work inplace; e.g. if the data is
+        not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
+        float, a copy may still be returned.
 
         .. versionchanged:: 0.23
             The default value of `copy` changed from False to True in 0.23.
@@ -3483,7 +3489,10 @@ def power_transform(X, method="yeo-johnson", *, standardize=True, copy=True):
         transformed output.
 
     copy : bool, default=True
-        Set to False to perform inplace computation during transformation.
+        If False, try to avoid a copy and scale in place.
+        This is not guaranteed to always work inplace; e.g. if the data is
+        not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
+        float, a copy may still be returned.
 
     Returns
     -------

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -156,7 +156,7 @@ def scale(X, *, axis=0, with_mean=True, with_std=True, copy=True):
 
     copy : bool, default=True
         If False, try to avoid a copy and scale in place.
-        This is not guaranteed to always work inplace; e.g. if the data is
+        This is not guaranteed to always work in place; e.g. if the data is
         not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.
 
@@ -1340,7 +1340,7 @@ def maxabs_scale(X, *, axis=0, copy=True):
 
     copy : bool, default=True
         If False, try to avoid a copy and scale in place.
-        This is not guaranteed to always work inplace; e.g. if the data is
+        This is not guaranteed to always work in place; e.g. if the data is
         not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.
 
@@ -1719,7 +1719,7 @@ def robust_scale(
 
     copy : bool, default=True
         If False, try to avoid a copy and scale in place.
-        This is not guaranteed to always work inplace; e.g. if the data is
+        This is not guaranteed to always work in place; e.g. if the data is
         not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.
 
@@ -1833,7 +1833,7 @@ def normalize(X, norm="l2", *, axis=1, copy=True, return_norm=False):
 
     copy : bool, default=True
         If False, try to avoid a copy and scale in place.
-        This is not guaranteed to always work inplace; e.g. if the data is
+        This is not guaranteed to always work in place; e.g. if the data is
         not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.
 
@@ -2067,8 +2067,9 @@ def binarize(X, *, threshold=0.0, copy=True):
 
     copy : bool, default=True
         If False, try to avoid a copy and scale in place.
-        This is not guaranteed to always work inplace; e.g. if the data is
-        not a NumPy array, a copy may still be returned.
+        This is not guaranteed to always work in place; e.g. if the data is
+        not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
+        float, a copy may still be returned.
 
     Returns
     -------
@@ -2953,7 +2954,7 @@ def quantile_transform(
 
     copy : bool, default=True
         If False, try to avoid a copy and scale in place.
-        This is not guaranteed to always work inplace; e.g. if the data is
+        This is not guaranteed to always work in place; e.g. if the data is
         not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.
 
@@ -3490,7 +3491,7 @@ def power_transform(X, method="yeo-johnson", *, standardize=True, copy=True):
 
     copy : bool, default=True
         If False, try to avoid a copy and scale in place.
-        This is not guaranteed to always work inplace; e.g. if the data is
+        This is not guaranteed to always work in place; e.g. if the data is
         not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.
 

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -615,7 +615,7 @@ def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
 
     copy : bool, default=True
         If False, try to avoid a copy and scale in place.
-        This is not guaranteed to always work inplace; e.g. if the data is
+        This is not guaranteed to always work in place; e.g. if the data is
         not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.
 
@@ -1832,7 +1832,7 @@ def normalize(X, norm="l2", *, axis=1, copy=True, return_norm=False):
         normalize each sample, otherwise (if 0) normalize each feature.
 
     copy : bool, default=True
-        If False, try to avoid a copy and scale in place.
+        If False, try to avoid a copy and normalilze in place.
         This is not guaranteed to always work in place; e.g. if the data is
         not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.
@@ -2066,7 +2066,7 @@ def binarize(X, *, threshold=0.0, copy=True):
         Threshold may not be less than 0 for operations on sparse matrices.
 
     copy : bool, default=True
-        If False, try to avoid a copy and scale in place.
+        If False, try to avoid a copy and binarize in place.
         This is not guaranteed to always work in place; e.g. if the data is
         not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.
@@ -2953,7 +2953,7 @@ def quantile_transform(
         See :term:`Glossary <random_state>`.
 
     copy : bool, default=True
-        If False, try to avoid a copy and scale in place.
+        If False, try to avoid a copy and transform in place.
         This is not guaranteed to always work in place; e.g. if the data is
         not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.
@@ -3490,7 +3490,7 @@ def power_transform(X, method="yeo-johnson", *, standardize=True, copy=True):
         transformed output.
 
     copy : bool, default=True
-        If False, try to avoid a copy and scale in place.
+        If False, try to avoid a copy and transform in place.
         This is not guaranteed to always work in place; e.g. if the data is
         not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -651,7 +651,6 @@ def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
     X = check_array(
         X, copy=False, ensure_2d=False, dtype=FLOAT_DTYPES, force_all_finite="allow-nan"
     )
-
     original_ndim = X.ndim
 
     if original_ndim == 1:

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -156,9 +156,9 @@ def scale(X, *, axis=0, with_mean=True, with_std=True, copy=True):
 
     copy : bool, default=True
         If False, try to avoid a copy and scale in place.
-        This is not guaranteed to always work in place; e.g. if the data is
-        not a NumPy array, or is a scipy.sparse CSR matrix, or is not of dtype
-        float, a copy may still be returned.
+        This is not guaranteed to always work in place; e.g. if the data is 
+        a numpy array with an int dtype, a copy will be returned even with 
+        copy=False.
 
     Returns
     -------
@@ -616,8 +616,8 @@ def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
     copy : bool, default=True
         If False, try to avoid a copy and scale in place.
         This is not guaranteed to always work in place; e.g. if the data is
-        not a NumPy array, or is a scipy.sparse CSR matrix, or is not of dtype
-        float, a copy may still be returned.
+        a numpy array with an int dtype, a copy will be returned even with
+        copy=False.
 
     Returns
     -------
@@ -1341,8 +1341,8 @@ def maxabs_scale(X, *, axis=0, copy=True):
     copy : bool, default=True
         If False, try to avoid a copy and scale in place.
         This is not guaranteed to always work in place; e.g. if the data is
-        not a NumPy array, or is a scipy.sparse CSR matrix, or is not of dtype
-        float, a copy may still be returned.
+        a numpy array with an int dtype, a copy will be returned even with
+        copy=False.
 
     Returns
     -------
@@ -1720,8 +1720,8 @@ def robust_scale(
     copy : bool, default=True
         If False, try to avoid a copy and scale in place.
         This is not guaranteed to always work in place; e.g. if the data is
-        not a NumPy array, or is a scipy.sparse CSR matrix, or is not of dtype
-        float, a copy may still be returned.
+        a numpy array with an int dtype, a copy will be returned even with
+        copy=False.
 
     unit_variance : bool, default=False
         If `True`, scale data so that normally distributed features have a
@@ -1834,8 +1834,8 @@ def normalize(X, norm="l2", *, axis=1, copy=True, return_norm=False):
     copy : bool, default=True
         If False, try to avoid a copy and normalize in place.
         This is not guaranteed to always work in place; e.g. if the data is
-        not a NumPy array, or is a scipy.sparse CSR matrix, or is not of dtype
-        float, a copy may still be returned.
+        a numpy array with an int dtype, a copy will be returned even with
+        copy=False.
 
     return_norm : bool, default=False
         Whether to return the computed norms.
@@ -2068,7 +2068,8 @@ def binarize(X, *, threshold=0.0, copy=True):
     copy : bool, default=True
         If False, try to avoid a copy and binarize in place.
         This is not guaranteed to always work in place; e.g. if the data is
-        not a NumPy array a copy may still be returned.
+        a numpy array with an object dtype, a copy will be returned even with
+        copy=False.
 
     Returns
     -------
@@ -2954,8 +2955,8 @@ def quantile_transform(
     copy : bool, default=True
         If False, try to avoid a copy and transform in place.
         This is not guaranteed to always work in place; e.g. if the data is
-        not a NumPy array, or is a scipy.sparse CSR matrix, or is not of dtype
-        float, a copy may still be returned.
+        a numpy array with an int dtype, a copy will be returned even with
+        copy=False.
 
         .. versionchanged:: 0.23
             The default value of `copy` changed from False to True in 0.23.
@@ -3491,8 +3492,8 @@ def power_transform(X, method="yeo-johnson", *, standardize=True, copy=True):
     copy : bool, default=True
         If False, try to avoid a copy and transform in place.
         This is not guaranteed to always work in place; e.g. if the data is
-        not a NumPy array, or is a scipy.sparse CSR matrix, or is not of dtype
-        float, a copy may still be returned.
+        a numpy array with an int dtype, a copy will be returned even with
+        copy=False.
 
     Returns
     -------

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -613,7 +613,7 @@ def minmax_scale(X, feature_range=(0, 1), *, axis=0, copy=True):
         otherwise (if 1) scale each sample.
 
     copy : bool, default=True
-        If False, try to avoid a copy and do inplace scaling instead.
+        If False, try to avoid a copy and scale in place.
         This is not guaranteed to always work inplace; e.g. if the data is
         not a NumPy array, is scipy.sparse CSR matrix, or is not of dtype
         float, a copy may still be returned.


### PR DESCRIPTION
#### Reference Issues/PRs

Example: Fixes #27307 (the issue was taken but had stalled)


#### What does this implement/fix? Explain your changes.

minmax_scale has an unexpected behavior when it is called with `X of dtype other than float` and `copy=False`. Specifically, even though `copy=False`, X is always first passed through the `~sklearn.utils.validation.check_array` function. If the dtype of X is not float check_array casts it to float triggering a copy. Any subsequent changes on X happen on the copy and not in-place.

I propose to first change the docstring of minmax_scale to reflect this unexpected behaviour. I also propose a check based on two calls of check_array that outputs a warning when this behaviour is detected.

#### Any other comments?

Other functions in the _data.py file probably have the same behavior and need to be modified accordingly. I'd be happy to change these as well.

