### PR TITLE
DOC fix referencing in TargetEncoder docstring

### DIFF
--- a/sklearn/preprocessing/_target_encoder.py
+++ b/sklearn/preprocessing/_target_encoder.py
@@ -37,7 +37,7 @@ class TargetEncoder(OneToOneFeatureMixin, _BaseEncoder):
 
     For a demo on the importance of the `TargetEncoder` internal cross-fitting,
     see
-    ref:`sphx_glr_auto_examples_preprocessing_plot_target_encoder_cross_val.py`.
+    :ref:`sphx_glr_auto_examples_preprocessing_plot_target_encoder_cross_val.py`.
     For a comparison of different encoders, refer to
     :ref:`sphx_glr_auto_examples_preprocessing_plot_target_encoder.py`. Read
     more in the :ref:`User Guide <target_encoder>`.


### PR DESCRIPTION
Fixing a broken referencing in the `TargetEncoder` docstring.