### PR TITLE
Fix MAINT Directly cimport interfaces from std::algorithm

### DIFF
--- a/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
@@ -25,12 +25,8 @@ from ...utils._cython_blas cimport (
 )
 from ...utils._typedefs cimport float64_t, float32_t, int32_t, intp_t
 
-# TODO: change for `libcpp.algorithm.fill` once Cython 3 is used
-# Introduction in Cython:
-#
-# https://github.com/cython/cython/blob/05059e2a9b89bf6738a7750b905057e5b1e3fe2e/Cython/Includes/libcpp/algorithm.pxd#L50 #noqa
-cdef extern from "<algorithm>" namespace "std" nogil:
-    void fill[Iter, T](Iter first, Iter last, const T& value) except + #noqa
+#Updated for Cython 3
+from libcpp.algorithm cimport fill
 
 import numpy as np
 from scipy.sparse import issparse, csr_matrix

--- a/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx.tp
@@ -26,7 +26,11 @@ from ...utils._cython_blas cimport (
 from ...utils._typedefs cimport float64_t, float32_t, int32_t, intp_t
 
 #Updated for Cython 3
-from libcpp.algorithm cimport fill
+if parse_version(Cython.__version__) < parse_version('3.0.0'):
+   cdef extern from "<algorithm>" namespace "std" nogil: 
+     void fill[Iter, T](Iter first, Iter last, const T& value) except + #noqa 
+else:
+     from libcpp.algorithm cimport fill
 
 import numpy as np
 from scipy.sparse import issparse, csr_matrix

--- a/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx.tp
@@ -19,11 +19,8 @@ from ...utils.fixes import threadpool_limits
 
 cnp.import_array()
 
-# TODO: change for `libcpp.algorithm.move` once Cython 3 is used
-# Introduction in Cython:
-# https://github.com/cython/cython/blob/05059e2a9b89bf6738a7750b905057e5b1e3fe2e/Cython/Includes/libcpp/algorithm.pxd#L47 #noqa
-cdef extern from "<algorithm>" namespace "std" nogil:
-    OutputIt move[InputIt, OutputIt](InputIt first, InputIt last, OutputIt d_first) except + #noqa
+ # Updated for Cython 3
+from libcpp.algorithm cimport move
 
 ######################
 

--- a/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx.tp
@@ -20,7 +20,11 @@ from ...utils.fixes import threadpool_limits
 cnp.import_array()
 
  # Updated for Cython 3
-from libcpp.algorithm cimport move
+if parse_version(Cython.__version__) < parse_version('3.0.0'):
+     cdef extern from "<algorithm>" namespace "std" nogil: 
+     OutputIt move[InputIt, OutputIt](InputIt first, InputIt last, OutputIt d_first) except + #noqa 
+else:
+    from libcpp.algorithm cimport move
 
 ######################
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #27682


#### What does this implement/fix? Explain your changes.

This replaces the interface importing that was using Cython below version 3 syntax. It has now been updated to use the simpler method in Cython >= 3

#### Any other comments?
This does not take into consideration, that some may be using a previous version. See https://github.com/scikit-learn/scikit-learn/issues/27682#issuecomment-1787262476

