### PR TITLE
DOC fixed wrong equation reference in adaboost docstring

### DIFF
--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -892,7 +892,7 @@ class AdaBoostClassifier(
     def _compute_proba_from_decision(decision, n_classes):
         """Compute probabilities from the decision function.
 
-        This is based eq. (4) of [1] where:
+        This is based eq. (15) of [1] where:
             p(y=c|X) = exp((1 / K-1) f_c(X)) / sum_k(exp((1 / K-1) f_k(X)))
                      = softmax((1 / K-1) * f(X))
 


### PR DESCRIPTION
#### Reference Issues/PRs

Already gave this a try using the github hosted web editor. This PR is more clean.

#### What does this implement/fix? Explain your changes.

Quite small contribution fixing the reference to the equation in 
https://www.intlpress.com/site/pub/pages/journals/items/sii/content/vols/0002/0003/a008/
mentioned in the AdaBoost code base.
 
#### Any other comments?

The formula just below my edit reads a bit quirky compared to the paper (difference of `f_c(X)` versus `f_k(X)` and how it relates to the paper). This might be improved in the future.  