### PR TITLE
ENH add predict_log_proba to ClassifierChain

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -417,6 +417,12 @@ Changelog
   object in the parameter grid if it's an estimator. :pr:`26786` by `Adrin
   Jalali`_.
 
+:mod:`sklearn.multioutput`
+..........................
+
+- |Enhancement| Add method `predict_log_proba` to :class:`multioutput.ClassifierChain`.
+  :pr:`xxxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.neighbors`
 ........................
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -421,7 +421,7 @@ Changelog
 ..........................
 
 - |Enhancement| Add method `predict_log_proba` to :class:`multioutput.ClassifierChain`.
-  :pr:`xxxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`27720` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.neighbors`
 ........................

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -956,6 +956,21 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
 
         return Y_prob
 
+    def predict_log_proba(self, X):
+        """Predict logarithm of probability estimates.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            The input data.
+
+        Returns
+        -------
+        Y_log_prob : array-like of shape (n_samples, n_classes)
+            The predicted logarithm of the probabilities.
+        """
+        return np.log(self.predict_proba(X))
+
     @_available_if_base_estimator_has("decision_function")
     def decision_function(self, X):
         """Evaluate the decision_function of the models in the chain.

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -548,7 +548,8 @@ def test_classifier_chain_vs_independent_models():
     )
 
 
-def test_base_chain_fit_and_predict():
+@pytest.mark.parametrize("response_method", ["predict_proba", "predict_log_proba"])
+def test_base_chain_fit_and_predict(response_method):
     # Fit base chain and verify predict performance
     X, Y = generate_multilabel_dataset_with_correlations()
     chains = [RegressorChain(Ridge()), ClassifierChain(LogisticRegression())]
@@ -560,7 +561,9 @@ def test_base_chain_fit_and_predict():
             range(X.shape[1], X.shape[1] + Y.shape[1])
         )
 
-    Y_prob = chains[1].predict_proba(X)
+    Y_prob = getattr(chains[1], response_method)(X)
+    if response_method == "predict_log_proba":
+        Y_prob = np.exp(Y_prob)
     Y_binary = Y_prob >= 0.5
     assert_array_equal(Y_binary, Y_pred)
 


### PR DESCRIPTION
Encounter in https://github.com/scikit-learn/scikit-learn/pull/27700 and https://github.com/scikit-learn/scikit-learn/pull/27719

This PR implements `predict_log_proba` in `ClassifierChain` whenever the `predict_proba` method is available.