### PR TITLE
MAINT force encoding when opening file to not be platform specific

### DIFF
--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -21,8 +21,13 @@ class _IDCounter:
         return f"{self.prefix}-{self.count}"
 
 
+def _get_css_style():
+    return Path(__file__).with_suffix(".css").read_text(encoding="utf-8")
+
+
 _CONTAINER_ID_COUNTER = _IDCounter("sk-container-id")
 _ESTIMATOR_ID_COUNTER = _IDCounter("sk-estimator-id")
+_CSS_STYLE = _get_css_style()
 
 
 class _VisualBlock:
@@ -309,11 +314,6 @@ def _write_estimator_html(
         )
 
 
-with open(Path(__file__).with_suffix(".css"), mode="r", encoding="utf-8") as style_file:
-    # use the style defined in the css file
-    _STYLE = style_file.read()
-
-
 def estimator_html_repr(estimator):
     """Build a HTML representation of an estimator.
 
@@ -350,7 +350,7 @@ def estimator_html_repr(estimator):
     )
     with closing(StringIO()) as out:
         container_id = _CONTAINER_ID_COUNTER.get_id()
-        style_template = Template(_STYLE)
+        style_template = Template(_CSS_STYLE)
         style_with_id = style_template.substitute(id=container_id)
         estimator_str = str(estimator)
 

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -309,7 +309,7 @@ def _write_estimator_html(
         )
 
 
-with open(Path(__file__).with_suffix(".css"), "r") as style_file:
+with open(Path(__file__).with_suffix(".css"), mode="r", encoding="utf-8") as style_file:
     # use the style defined in the css file
     _STYLE = style_file.read()
 

--- a/sklearn/utils/tests/test_estimator_html_repr.py
+++ b/sklearn/utils/tests/test_estimator_html_repr.py
@@ -1,4 +1,5 @@
 import html
+import locale
 import re
 from contextlib import closing
 from io import StringIO
@@ -26,6 +27,7 @@ from sklearn.preprocessing import OneHotEncoder, StandardScaler
 from sklearn.svm import LinearSVC, LinearSVR
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.utils._estimator_html_repr import (
+    _get_css_style,
     _get_visual_block,
     _HTMLDocumentationLinkMixin,
     _write_label_html,
@@ -464,3 +466,26 @@ def test_html_documentation_link_mixin_get_doc_link():
     mixin._doc_link_url_param_generator = url_param_generator
 
     assert mixin._get_doc_link() == "https://website.com/value_1.value_2.html"
+
+
+@pytest.fixture
+def set_non_utf8_locale():
+    """Pytest fixture to set non utf-8 locale during the test.
+
+    The locale is set to the default one after the test has run.
+    """
+    orig_locale = locale.getlocale()
+    try:
+        locale.setlocale(locale.LC_ALL, "C")
+    except locale.Error:
+        pytest.skip("'C' locale is not available on this OS")
+    yield
+    locale.setlocale(locale.LC_ALL, orig_locale)
+
+
+def test_non_utf8_locale(set_non_utf8_locale):
+    """Checks that utf8 encoding is used when reading the CSS file.
+
+    Non-regression test for https://github.com/scikit-learn/scikit-learn/issues/27725
+    """
+    _get_css_style()

--- a/sklearn/utils/tests/test_estimator_html_repr.py
+++ b/sklearn/utils/tests/test_estimator_html_repr.py
@@ -472,7 +472,7 @@ def test_html_documentation_link_mixin_get_doc_link():
 def set_non_utf8_locale():
     """Pytest fixture to set non utf-8 locale during the test.
 
-    The locale is set to the default one after the test has run.
+    The locale is set to the original one after the test has run.
     """
     orig_locale = locale.getlocale()
     try:

--- a/sklearn/utils/tests/test_estimator_html_repr.py
+++ b/sklearn/utils/tests/test_estimator_html_repr.py
@@ -474,13 +474,21 @@ def set_non_utf8_locale():
 
     The locale is set to the original one after the test has run.
     """
-    orig_locale = locale.getlocale()
     try:
-        locale.setlocale(locale.LC_ALL, "C")
+        locale.setlocale(locale.LC_CTYPE, "C")
     except locale.Error:
         pytest.skip("'C' locale is not available on this OS")
+
     yield
-    locale.setlocale(locale.LC_ALL, orig_locale)
+
+    # Resets the locale to the original one. Python calles setlocale(LC_TYPE, "")
+    # at startup according to
+    # https://docs.python.org/3/library/locale.html#background-details-hints-tips-and-caveats.
+    # This assumes that no other locale changes have been made. For some reason,
+    # on some platforms, trying to restore locale with something like
+    # locale.setlocale(locale.LC_CTYPE, locale.getlocale()) raises a
+    # locale.Error: unsupported locale setting
+    locale.setlocale(locale.LC_CTYPE, "")
 
 
 def test_non_utf8_locale(set_non_utf8_locale):


### PR DESCRIPTION
closes #27725 

Trying to enforce the encoding while reading the CSS file such that it is not platform dependent.

@Charlie-XIAO Could you try to know if you still have the issue locally.