### PR TITLE
CI Add cron schedule for lock-file workflow

### DIFF
--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -3,6 +3,8 @@ name: Update lock files
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * 1'
 
 jobs:
   update_lock_files:


### PR DESCRIPTION
I ran manually the lock-file bot actions twice and it seems to have worked fine, see [action runs](https://github.com/scikit-learn/scikit-learn/actions/workflows/update-lock-files.yml) and [created PRs](https://github.com/scikit-learn/scikit-learn/pulls?q=is%3Apr+sort%3Aupdated-desc+author%3Ascikit-learn-bot). The first run with failure was due to scikit-learn-bot permissions, see https://github.com/scikit-learn/scikit-learn/pull/27622#issuecomment-1785733450 for more details.

I used a weekly cron job that runs every Monday at 5am (see [this](https://crontab.guru/#0_5_*_*_1) for double-checking the cron syntax). If we want to run it less often, we could run it every 1st and 15th of the month (there is no easy way to do every two weeks with cron)

I left the workflow_dispatch that can still be handy to trigger manually the workflow in some cases where we don't want to wait for the next scheduled job.


