### PR TITLE
BLD: Build scikit-learn nightlies using NumPy nightlies

### DIFF
--- a/build_tools/cirrus/arm_wheel.yml
+++ b/build_tools/cirrus/arm_wheel.yml
@@ -117,10 +117,6 @@ wheels_upload_task:
   upload_script: |
     conda install curl unzip -y
 
-    if [[ "$CIRRUS_CRON" == "nightly" ]]; then
-      export GITHUB_EVENT_NAME="schedule"
-    fi
-
     # Download and show wheels
     curl https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/wheels.zip --output wheels.zip
     unzip wheels.zip

--- a/build_tools/github/upload_anaconda.sh
+++ b/build_tools/github/upload_anaconda.sh
@@ -3,7 +3,8 @@
 set -e
 set -x
 
-if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
+# Note: build_wheels.sh has the same branch (only for NumPy 2.0 transition)
+if [ "$GITHUB_EVENT_NAME" == "schedule" || "$CIRRUS_CRON" == "nightly" ]; then
     ANACONDA_ORG="scientific-python-nightly-wheels"
     ANACONDA_TOKEN="$SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN"
 else

--- a/build_tools/wheels/build_wheels.sh
+++ b/build_tools/wheels/build_wheels.sh
@@ -45,6 +45,16 @@ if [[ $(uname) == "Darwin" ]]; then
     fi
 fi
 
+
+if [[ "$GITHUB_EVENT_NAME" == "schedule" || "$CIRRUS_CRON" == "nightly" ]]; then
+    # Nightly build:  See also `../github/upload_anaconda.sh` (same branching).
+    # To help with NumPy 2.0 transition, ensure that we use the NumPy 2.0
+    # nightlies.  This lives on the edge and opts-in to all pre-releases.
+    # That could be an issue, in which case no-build-isolation and a targeted
+    # NumPy install may be necessary, instead.
+    export CIBW_BUILD_FRONTEND='pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"'
+fi
+
 # The version of the built dependencies are specified
 # in the pyproject.toml file, while the tests are run
 # against the most recent version of the dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,16 +5,11 @@ requires = [
     "wheel",
     "Cython>=0.29.33",
 
-    # use oldest-supported-numpy which provides the oldest numpy version with
-    # wheels on PyPI
-    #
-    # see: https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
-    "oldest-supported-numpy; python_version!='3.10' or platform_system!='Windows' or platform_python_implementation=='PyPy'",
-    # For CPython 3.10 under Windows, SciPy requires NumPy 1.22.3 while the
-    # oldest supported NumPy is defined as 1.21.6. We therefore need to force
-    # it for this specific configuration. For details, see
-    # https://github.com/scipy/scipy/blob/c58b608c83d30800aceee6a4dab5c3464cb1de7d/pyproject.toml#L38-L41
-    "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
+    # Starting with NumPy 1.25, NumPy is (by default) as far back compatible
+    # as oldest-support-numpy was (customizable with a NPY_TARGET_VERSION
+    # define).  For older Python versions continue using oldest-support-numpy.
+    "numpy>=1.25; python_version>='3.9'",
+    "oldest-supported-numpy; python_version<'3.9'",
 
     "scipy>=1.5.0",
 ]

--- a/sklearn/tests/test_min_dependencies_readme.py
+++ b/sklearn/tests/test_min_dependencies_readme.py
@@ -74,12 +74,15 @@ def test_min_dependencies_pyproject_toml():
     pyproject_build_min_versions = {}
     for requirement in build_requirements:
         if ">=" in requirement:
+            # Don't check NumPy: this requirement is only build time.
+            if "numpy>=1.25" in requirement:
+                continue
             package, version = requirement.split(">=")
             package = package.lower()
             pyproject_build_min_versions[package] = version
 
     # Only scipy and cython are listed in pyproject.toml
-    # NumPy is more complex using oldest-supported-numpy.
+    # NumPy is more complex using oldest-supported-numpy or >=1.25.
     assert set(["scipy", "cython"]) == set(pyproject_build_min_versions)
 
     for package, version in pyproject_build_min_versions.items():


### PR DESCRIPTION
There are two commits here:
1. Adapt the requirements to use `>=1.25`, except on Python <3.9 because NumPy 1.25 isn't compatible with that.  (For new releases prior to NumPy 2.0, it would be good to add `<2.0` probably.)
2. Build the wheels with all pre-releases.  This lives on the edge, and it is perfectly reasonable if you don't like it (matplotlib opted for that, but I am not sure it is generally liked).  Living on the edge, also requires the change in 1. (unlike build isolation), but is the smaller change.
   (one could also make use `<=2.0.0.dev0` as a requirement.  That is odd, but explicitly allows the nightlies, while rejecting a 2.0 release if it came up in an actual released version.)

I moved the `"$CIRRUS_CRON" == "nightly"` logic to avoid additional duplication.  I tested it locally (in parts), and it build with 2.0 nightlies (failing, since my other PR is needed).

**This requires gh-27041 to be merged, or the build will fail!**