### PR TITLE
Fix typo - "principle" should be "principal".

### DIFF
--- a/examples/preprocessing/plot_scaling_importance.py
+++ b/examples/preprocessing/plot_scaling_importance.py
@@ -15,7 +15,7 @@ completely different model fit compared to the fit with unscaled data (such as
 KNeighbors models). The latter is demoed on the first part of the present
 example.
 
-On the second part of the example we show how Principle Component Analysis (PCA)
+On the second part of the example we show how Principal Component Analysis (PCA)
 is impacted by normalization of features. To illustrate this, we compare the
 principal components found using :class:`~sklearn.decomposition.PCA` on unscaled
 data with those obatined when using a


### PR DESCRIPTION
Fixes minor typo - "Principal Component Analysis" is the correct spelling.