### PR TITLE
FIX improve error message in check_array when getting a Series and expecting a 2-D container

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -530,6 +530,10 @@ Changelog
   misdetects the CPU architecture.
   :pr:`27614` by :user:`Olivier Grisel <ogrisel>`.
 
+- |Fix| Fix the function :func:`~utils.check_array` to output the right error message when
+  the input is Series instead of a DataFrame. 
+  :pr:`xxxxx` by :user:`Stan Furrer <stanFurrer>`.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -303,6 +303,14 @@ def test_check_array_force_all_finite_object_unsafe_casting(
         check_array(X, dtype=int, force_all_finite=force_all_finite)
 
 
+def test_check_array_series():
+    # ensure_2d=True with Serie
+    pd = pytest.importorskip("pandas")
+    serie = pd.Series([1, 2, 3])
+    with pytest.raises(ValueError, match="Expected 2D array, got Serie instead"):
+        check_array(serie, ensure_2d=True)
+
+
 @ignore_warnings
 def test_check_array():
     # accept_sparse == False

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -788,6 +788,7 @@ def check_array(
     # DataFrame), and store them. If not, store None.
     dtypes_orig = None
     pandas_requires_conversion = False
+    is_series = False
     if hasattr(array, "dtypes") and hasattr(array.dtypes, "__array__"):
         # throw warning if columns are sparse. If all columns are sparse, then
         # array.sparse exists and sparsity will be preserved (later).
@@ -817,6 +818,7 @@ def check_array(
         array, "dtype"
     ):
         # array is a pandas series
+        is_series = _is_series(array)
         pandas_requires_conversion = _pandas_dtype_needs_early_conversion(array.dtype)
         if isinstance(array.dtype, np.dtype):
             dtype_orig = array.dtype
@@ -936,7 +938,6 @@ def check_array(
         # result is that np.array(..) produces an array of complex dtype
         # and we need to catch and raise exception for such cases.
         _ensure_no_complex_data(array)
-
         if ensure_2d:
             # If input is scalar raise error
             if array.ndim == 0:
@@ -948,12 +949,17 @@ def check_array(
                 )
             # If input is 1D raise error
             if array.ndim == 1:
-                raise ValueError(
-                    "Expected 2D array, got 1D array instead:\narray={}.\n"
+                # If input is a Serie (eg. Pandas series or Polar series)
+                if is_series: 
+                    msg = ("Expected 1D array, got series instead:\n{}\n"
+                       "Pass a dataframe instead of a series with df[[column_name]] "
+                       "instead of df[column_name].").format(array)
+                else: 
+                    msg = ("Expected 2D array, got 1D array instead:\narray={}.\n"
                     "Reshape your data either using array.reshape(-1, 1) if "
                     "your data has a single feature or array.reshape(1, -1) "
-                    "if it contains a single sample.".format(array)
-                )
+                    "if it contains a single sample.").format(array)
+                raise ValueError(msg)
 
         if dtype_numeric and hasattr(array.dtype, "kind") and array.dtype.kind in "USV":
             raise ValueError(
@@ -2009,6 +2015,18 @@ def _is_pandas_df(X):
         except KeyError:
             return False
         return isinstance(X, pd.DataFrame)
+    return False
+
+
+def _is_series(X):
+    """"Return true if X is a serie (eg.Pandas serie or Polars series)."""
+    if hasattr(X, "columns") and hasattr(X, "iloc"):
+        # Likely a pandas DataFrame, we explicitly check the type to confirm.
+        try:
+            pd = sys.modules["pandas"]
+        except KeyError:
+            return False
+        return isinstance(X, pd.Series)
     return False
 
 


### PR DESCRIPTION
Fixes #27498 

Description
Fix the function `check_array ` to output the right error message when the input is **Series** instead of a **DataFrame**. 

