### PR TITLE
DOC improve RandomForest docstring by explicitely stating the splitter strategy used

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -885,8 +885,7 @@ from a sample drawn with replacement (i.e., a bootstrap sample) from the
 training set.
 
 Furthermore, when splitting each node during the construction of a tree, the
-best split is found either from all input features or a random subset of size
-``max_features``. (See the :ref:`parameter tuning guidelines
+best split is found through an exhaustive search of the features values of either all input features or a random subset of size ``max_features``. (See the :ref:`parameter tuning guidelines
 <random_forest_parameters>` for more details).
 
 The purpose of these two sources of randomness is to decrease the variance of

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -885,8 +885,9 @@ from a sample drawn with replacement (i.e., a bootstrap sample) from the
 training set.
 
 Furthermore, when splitting each node during the construction of a tree, the
-best split is found through an exhaustive search of the features values of either all input features or a random subset of size ``max_features``. (See the :ref:`parameter tuning guidelines
-<random_forest_parameters>` for more details).
+best split is found through an exhaustive search of the features values of 
+either all input features or a random subset of size ``max_features``. 
+(See the :ref:`parameter tuning guidelines <random_forest_parameters>` for more details.)
 
 The purpose of these two sources of randomness is to decrease the variance of
 the forest estimator. Indeed, individual decision trees typically exhibit high

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1177,7 +1177,8 @@ class RandomForestClassifier(ForestClassifier):
     A random forest is a meta estimator that fits a number of decision tree
     classifiers on various sub-samples of the dataset and uses averaging to
     improve the predictive accuracy and control over-fitting.
-    Trees in a forest use the parameter `splitter="best"`.
+    Trees in a forest use the best split strategy, i.e. equivalent to passing `splitter="best"`
+    to the underlying :class:`~sklearn.tree.DecisionTreeRegressor`.
     The sub-sample size is controlled with the `max_samples` parameter if
     `bootstrap=True` (default), otherwise the whole dataset is used to build
     each tree.
@@ -1569,7 +1570,8 @@ class RandomForestRegressor(ForestRegressor):
     A random forest is a meta estimator that fits a number of decision
     tree regressors on various sub-samples of the dataset and uses averaging
     to improve the predictive accuracy and control over-fitting.
-    Trees in a forest use the parameter `splitter="best"`.
+    Trees in a forest use the best split strategy, i.e. equivalent to passing `splitter="best"`
+    to the underlying :class:`~sklearn.tree.DecisionTreeRegressor`.
     The sub-sample size is controlled with the `max_samples` parameter if
     `bootstrap=True` (default), otherwise the whole dataset is used to build
     each tree.

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1569,7 +1569,7 @@ class RandomForestRegressor(ForestRegressor):
     A random forest is a meta estimator that fits a number of decision
     tree regressors on various sub-samples of the dataset and uses averaging
     to improve the predictive accuracy and control over-fitting.
-    Trees in a forest use the parameter `splitter="best"`. 
+    Trees in a forest use the parameter `splitter="best"`.
     The sub-sample size is controlled with the `max_samples` parameter if
     `bootstrap=True` (default), otherwise the whole dataset is used to build
     each tree.

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1568,7 +1568,7 @@ class RandomForestRegressor(ForestRegressor):
     A random forest regressor.
 
     A random forest is a meta estimator that fits a number of decision tree
-    classifiers on various sub-samples of the dataset and uses averaging to
+    regressors on various sub-samples of the dataset and uses averaging to
     improve the predictive accuracy and control over-fitting.
     Trees in the forest use the best split strategy, i.e. equivalent to passing
     `splitter="best"` to the underlying :class:`~sklearn.tree.DecisionTreeRegressor`.

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1177,8 +1177,8 @@ class RandomForestClassifier(ForestClassifier):
     A random forest is a meta estimator that fits a number of decision tree
     classifiers on various sub-samples of the dataset and uses averaging to
     improve the predictive accuracy and control over-fitting.
-    Trees in the forest use the best split strategy, i.e. equivalent to passing `splitter="best"`
-    to the underlying :class:`~sklearn.tree.DecisionTreeRegressor`.
+    Trees in the forest use the best split strategy, i.e. equivalent to passing
+    `splitter="best"` to the underlying :class:`~sklearn.tree.DecisionTreeRegressor`.
     The sub-sample size is controlled with the `max_samples` parameter if
     `bootstrap=True` (default), otherwise the whole dataset is used to build
     each tree.

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1177,7 +1177,7 @@ class RandomForestClassifier(ForestClassifier):
     A random forest is a meta estimator that fits a number of decision tree
     classifiers on various sub-samples of the dataset and uses averaging to
     improve the predictive accuracy and control over-fitting.
-    Trees in a forest use the best split strategy, i.e. equivalent to passing `splitter="best"`
+    Trees in the forest use the best split strategy, i.e. equivalent to passing `splitter="best"`
     to the underlying :class:`~sklearn.tree.DecisionTreeRegressor`.
     The sub-sample size is controlled with the `max_samples` parameter if
     `bootstrap=True` (default), otherwise the whole dataset is used to build
@@ -1570,7 +1570,7 @@ class RandomForestRegressor(ForestRegressor):
     A random forest is a meta estimator that fits a number of decision
     tree regressors on various sub-samples of the dataset and uses averaging
     to improve the predictive accuracy and control over-fitting.
-    Trees in a forest use the best split strategy, i.e. equivalent to passing `splitter="best"`
+    Trees in the forest use the best split strategy, i.e. equivalent to passing `splitter="best"`
     to the underlying :class:`~sklearn.tree.DecisionTreeRegressor`.
     The sub-sample size is controlled with the `max_samples` parameter if
     `bootstrap=True` (default), otherwise the whole dataset is used to build

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1567,11 +1567,11 @@ class RandomForestRegressor(ForestRegressor):
     """
     A random forest regressor.
 
-    A random forest is a meta estimator that fits a number of decision
-    tree regressors on various sub-samples of the dataset and uses averaging
-    to improve the predictive accuracy and control over-fitting.
-    Trees in the forest use the best split strategy, i.e. equivalent to passing `splitter="best"`
-    to the underlying :class:`~sklearn.tree.DecisionTreeRegressor`.
+    A random forest is a meta estimator that fits a number of decision tree
+    classifiers on various sub-samples of the dataset and uses averaging to
+    improve the predictive accuracy and control over-fitting.
+    Trees in the forest use the best split strategy, i.e. equivalent to passing
+    `splitter="best"` to the underlying :class:`~sklearn.tree.DecisionTreeRegressor`.
     The sub-sample size is controlled with the `max_samples` parameter if
     `bootstrap=True` (default), otherwise the whole dataset is used to build
     each tree.

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1177,6 +1177,7 @@ class RandomForestClassifier(ForestClassifier):
     A random forest is a meta estimator that fits a number of decision tree
     classifiers on various sub-samples of the dataset and uses averaging to
     improve the predictive accuracy and control over-fitting.
+    Trees in a forest use the parameter `splitter="best"`.
     The sub-sample size is controlled with the `max_samples` parameter if
     `bootstrap=True` (default), otherwise the whole dataset is used to build
     each tree.
@@ -1568,6 +1569,7 @@ class RandomForestRegressor(ForestRegressor):
     A random forest is a meta estimator that fits a number of decision
     tree regressors on various sub-samples of the dataset and uses averaging
     to improve the predictive accuracy and control over-fitting.
+    Trees in a forest use the parameter `splitter="best"`. 
     The sub-sample size is controlled with the `max_samples` parameter if
     `bootstrap=True` (default), otherwise the whole dataset is used to build
     each tree.


### PR DESCRIPTION
Partially addresses issue #27159

Addressed the first two bullet points of glemaitre's comment

- added a sentence in the classes RandomForestRegressor and RandomForestClassifier to state that splitter='best' is the splitter setting
- checked RandomForestRegressor for mentions of classifier but did not find any
- reconfigured the first sentence in the user guide to make clear how the partition is being made

@betatim @glemaitre 