### PR TITLE
DOC Clarify monotonicity contraints of HGBT Regressor

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1307,8 +1307,6 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         If an array, the features are mapped to constraints by position. See
         :ref:`monotonic_cst_features_names` for a usage example.
 
-        The constraints are only valid for binary classifications and hold
-        over the probability of the positive class.
         Read more in the :ref:`User Guide <monotonic_cst_gbdt>`.
 
         .. versionadded:: 0.23


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #27737

#### What does this implement/fix? Explain your changes.
Removes a sentence from the docstring of HistGBM **Regressor** about the `monotonic_cst` argument: "The constraints are only valid for binary classifications and hold over the probability of the positive class."
  
This sentence also appears in the docstring of HistGBM **Classifier**, which makes sense. The sentence doesn't seem to apply to the **Regressor**, and in this context it could be interpreted as stating that monotonic constraints are not valid and should not be used for Regression.