### PR TITLE
FIX improve warning message in `_ensure_sparse_format`

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -534,6 +534,10 @@ Changelog
   misdetects the CPU architecture.
   :pr:`27614` by :user:`Olivier Grisel <ogrisel>`.
 
+- |Fix| Error message in :func:`~utils._ensure_sparse_format` when a sparse matrix was
+  passed but `accept_sparse` is `False` now suggests to use `.toarray()` and not
+  `X.toarray()`. :pr:`27757` by :user:`Lucy Liu <lucyleeow>`.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -534,7 +534,7 @@ Changelog
   misdetects the CPU architecture.
   :pr:`27614` by :user:`Olivier Grisel <ogrisel>`.
 
-- |Fix| Error message in :func:`~utils._ensure_sparse_format` when a sparse matrix was
+- |Fix| Error message in :func:`~utils.check_array` when a sparse matrix was
   passed but `accept_sparse` is `False` now suggests to use `.toarray()` and not
   `X.toarray()`. :pr:`27757` by :user:`Lucy Liu <lucyleeow>`.
 

--- a/sklearn/cluster/tests/test_affinity_propagation.py
+++ b/sklearn/cluster/tests/test_affinity_propagation.py
@@ -106,7 +106,7 @@ def test_affinity_propagation_affinity_shape():
 
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 def test_affinity_propagation_precomputed_with_sparse_input(csr_container):
-    err_msg = "A sparse matrix was passed, but dense data is required"
+    err_msg = "Sparse data was passed for X, but dense data is required"
     with pytest.raises(TypeError, match=err_msg):
         AffinityPropagation(affinity="precomputed").fit(csr_container((3, 3)))
 

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -100,7 +100,7 @@ def test_linear_regression_sample_weights(
 
 
 def test_raises_value_error_if_positive_and_sparse():
-    error_msg = "A sparse matrix was passed, but dense data is required."
+    error_msg = "Sparse data was passed for X, but dense data is required."
     # X must not be sparse if positive == True
     X = sparse.eye(10)
     y = np.ones(10)

--- a/sklearn/metrics/tests/test_dist_metrics.py
+++ b/sklearn/metrics/tests/test_dist_metrics.py
@@ -368,7 +368,7 @@ def test_readonly_kwargs():
             (
                 csr_container([1, 1.5, 1]),
                 TypeError,
-                "Sparse matrix was passed for w, but dense data is required",
+                "Sparse data was passed for w, but dense data is required",
             )
             for csr_container in CSR_CONTAINERS
         ],

--- a/sklearn/metrics/tests/test_dist_metrics.py
+++ b/sklearn/metrics/tests/test_dist_metrics.py
@@ -368,7 +368,7 @@ def test_readonly_kwargs():
             (
                 csr_container([1, 1.5, 1]),
                 TypeError,
-                "A sparse matrix was passed, but dense data is required",
+                "Sparse matrix was passed for w, but dense data is required",
             )
             for csr_container in CSR_CONTAINERS
         ],

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -1790,7 +1790,7 @@ def test_ordinal_encoder_sparse(csr_container):
 
     encoder = OrdinalEncoder()
 
-    err_msg = "A sparse matrix was passed, but dense data is required"
+    err_msg = "Sparse data was passed, but dense data is required"
     with pytest.raises(TypeError, match=err_msg):
         encoder.fit(X_sparse)
     with pytest.raises(TypeError, match=err_msg):

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -741,11 +741,11 @@ def test_ecoc_delegate_sparse_base_estimator(csc_container):
     )
     ecoc = OutputCodeClassifier(base_estimator, random_state=0)
 
-    with pytest.raises(TypeError, match="A sparse matrix was passed"):
+    with pytest.raises(TypeError, match="Sparse data was passed"):
         ecoc.fit(X_sp, y)
 
     ecoc.fit(X, y)
-    with pytest.raises(TypeError, match="A sparse matrix was passed"):
+    with pytest.raises(TypeError, match="Sparse data was passed"):
         ecoc.predict(X_sp)
 
     # smoke test to check when sparse input should be supported

--- a/sklearn/utils/tests/test_mocking.py
+++ b/sklearn/utils/tests/test_mocking.py
@@ -136,7 +136,7 @@ def test_checking_classifier_with_params(iris, csr_container):
         check_X=check_array, check_X_params={"accept_sparse": False}
     )
     clf.fit(X, y)
-    with pytest.raises(TypeError, match="A sparse matrix was passed"):
+    with pytest.raises(TypeError, match="Sparse data was passed"):
         clf.fit(X_sparse, y)
 
 

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -168,7 +168,7 @@ def test_resample_stratify_sparse_error(csr_container):
     X = rng.normal(size=(n_samples, 2))
     y = rng.randint(0, 2, size=n_samples)
     stratify = csr_container(y)
-    with pytest.raises(TypeError, match="A sparse matrix was passed"):
+    with pytest.raises(TypeError, match="Sparse data was passed"):
         X, y = resample(X, y, n_samples=50, random_state=rng, stratify=stratify)
 
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -599,7 +599,7 @@ def test_check_array_accept_sparse_type_exception():
     invalid_type = SVR()
 
     msg = (
-        "A sparse matrix was passed, but dense data is required. "
+        "Sparse data was passed, but dense data is required. "
         r"Use '.toarray\(\)' to convert to a dense numpy array."
     )
     with pytest.raises(TypeError, match=msg):

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -600,7 +600,7 @@ def test_check_array_accept_sparse_type_exception():
 
     msg = (
         "A sparse matrix was passed, but dense data is required. "
-        r"Use X.toarray\(\) to convert to a dense numpy array."
+        r"Use '.toarray\(\)' to convert to a dense numpy array."
     )
     with pytest.raises(TypeError, match=msg):
         check_array(X_csr, accept_sparse=False)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -534,9 +534,10 @@ def _ensure_sparse_format(
     _check_large_sparse(sparse_container, accept_large_sparse)
 
     if accept_sparse is False:
+        padded_input = " for " + input_name if input_name else ""
         raise TypeError(
-            "Sparse data was passed, but dense data is required. Use '.toarray()' "
-            "to convert to a dense numpy array."
+            f"Sparse data was passed{padded_input}, but dense data is required. "
+            "Use '.toarray()' to convert to a dense numpy array."
         )
     elif isinstance(accept_sparse, (list, tuple)):
         if len(accept_sparse) == 0:

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -535,7 +535,7 @@ def _ensure_sparse_format(
 
     if accept_sparse is False:
         raise TypeError(
-            "A sparse matrix was passed, but dense data is required. Use '.toarray()' "
+            "Sparse data was passed, but dense data is required. Use '.toarray()' "
             "to convert to a dense numpy array."
         )
     elif isinstance(accept_sparse, (list, tuple)):

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -535,7 +535,7 @@ def _ensure_sparse_format(
 
     if accept_sparse is False:
         raise TypeError(
-            "A sparse matrix was passed, but dense data is required. Use X.toarray() "
+            "A sparse matrix was passed, but dense data is required. Use '.toarray()' "
             "to convert to a dense numpy array."
         )
     elif isinstance(accept_sparse, (list, tuple)):


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
`_ensure_sparse_format` is used to check `X` and `y` and other parameters but the warning says: 

> Use X.toarray() convert to a dense numpy array."

This updates the warning to "Use '.'toarray()'" because it is possible that it was not `X` that needs to be converted (and even so, the user has not necessarily named the data `X`).


