### PR TITLE
MAINT fix line too long in docstring in covariance estimators

### DIFF
--- a/sklearn/covariance/_robust_covariance.py
+++ b/sklearn/covariance/_robust_covariance.py
@@ -373,8 +373,8 @@ def fast_mcd(
         The proportion of points to be included in the support of the raw
         MCD estimate. Default is `None`, which implies that the minimum
         value of `support_fraction` will be used within the algorithm:
-        `(n_samples + n_features + 1) / 2 * n_samples`. This parameter must be in the
-        range (0, 1).
+        `(n_samples + n_features + 1) / 2 * n_samples`. This parameter must be
+        in the range (0, 1).
 
     cov_computation_method : callable, \
             default=:func:`sklearn.covariance.empirical_covariance`
@@ -607,8 +607,8 @@ class MinCovDet(EmpiricalCovariance):
         The proportion of points to be included in the support of the raw
         MCD estimate. Default is None, which implies that the minimum
         value of support_fraction will be used within the algorithm:
-        `(n_samples + n_features + 1) / 2 * n_samples`. The parameter must be in the range
-        (0, 1].
+        `(n_samples + n_features + 1) / 2 * n_samples`. The parameter must be
+        in the range (0, 1].
 
     random_state : int, RandomState instance or None, default=None
         Determines the pseudo random number generator for shuffling the data.


### PR DESCRIPTION
Fix a line too long in covariance estimators