### PR TITLE
MAINT Deprecate `None` option in `pos_label` for precison/recall/f1 and jaccard metrics

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -770,6 +770,10 @@ def jaccard_score(
         For multiclass or multilabel targets, set `labels=[pos_label]` and
         `average != 'binary'` to report metrics for one label only.
 
+        .. versionchanged:: 1.4
+            Deprecated `None` as an option, since v0.18 `pos_label` is ignored
+            when `average` is not 'binary'.
+
     average : {'micro', 'macro', 'samples', 'weighted', \
             'binary'} or None, default='binary'
         If ``None``, the scores for each class are returned. Otherwise, this
@@ -1155,6 +1159,10 @@ def f1_score(
         For multiclass or multilabel targets, set `labels=[pos_label]` and
         `average != 'binary'` to report metrics for one label only.
 
+        .. versionchanged:: 1.4
+            Deprecated `None` as an option, since v0.18 `pos_label` is ignored
+            when `average` is not 'binary'.
+
     average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None, \
             default='binary'
         This parameter is required for multiclass/multilabel targets.
@@ -1348,6 +1356,10 @@ def fbeta_score(
         otherwise this parameter is ignored.
         For multiclass or multilabel targets, set `labels=[pos_label]` and
         `average != 'binary'` to report metrics for one label only.
+
+        .. versionchanged:: 1.4
+            Deprecated `None` as an option, since v0.18 `pos_label` is ignored
+            when `average` is not 'binary'.
 
     average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None, \
             default='binary'
@@ -1546,7 +1558,13 @@ def _check_set_wise_labels(y_true, y_pred, average, labels, pos_label):
                 "Target is %s but average='binary'. Please "
                 "choose another average setting, one of %r." % (y_type, average_options)
             )
-    elif pos_label not in (None, 1):
+    elif pos_label is None:
+        warnings.warn(
+            "The None option for 'pos_label' was deprecated in version 1.4 "
+            "and will be removed in 1.6. To keep past behavior, leave 'pos_label' "
+            " as default value.", FutureWarning
+        )
+    elif pos_label != 1:
         warnings.warn(
             "Note that pos_label (set to %r) is ignored when "
             "average != 'binary' (got %r). You may use "
@@ -1554,6 +1572,7 @@ def _check_set_wise_labels(y_true, y_pred, average, labels, pos_label):
             % (pos_label, average),
             UserWarning,
         )
+
     return labels
 
 
@@ -1645,6 +1664,10 @@ def precision_recall_fscore_support(
         otherwise this parameter is ignored.
         For multiclass or multilabel targets, set `labels=[pos_label]` and
         `average != 'binary'` to report metrics for one label only.
+
+        .. versionchanged:: 1.4
+            Deprecated `None` as an option, since v0.18 `pos_label` is ignored
+            when `average` is not 'binary'.
 
     average : {'binary', 'micro', 'macro', 'samples', 'weighted'}, \
             default=None
@@ -2076,6 +2099,10 @@ def precision_score(
         For multiclass or multilabel targets, set `labels=[pos_label]` and
         `average != 'binary'` to report metrics for one label only.
 
+        .. versionchanged:: 1.4
+            Deprecated `None` as an option, since v0.18 `pos_label` is ignored
+            when `average` is not 'binary'.
+
     average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None, \
             default='binary'
         This parameter is required for multiclass/multilabel targets.
@@ -2253,6 +2280,10 @@ def recall_score(
         otherwise this parameter is ignored.
         For multiclass or multilabel targets, set `labels=[pos_label]` and
         `average != 'binary'` to report metrics for one label only.
+
+        .. versionchanged:: 1.4
+            Deprecated `None` as an option, since v0.18 `pos_label` is ignored
+            when `average` is not 'binary'.
 
     average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None, \
             default='binary'

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1560,9 +1560,12 @@ def _check_set_wise_labels(y_true, y_pred, average, labels, pos_label):
             )
     elif pos_label is None:
         warnings.warn(
-            "The None option for 'pos_label' was deprecated in version 1.4 "
-            "and will be removed in 1.6. To keep past behavior, leave 'pos_label' "
-            " as default value.", FutureWarning
+            (
+                "The None option for 'pos_label' was deprecated in version 1.4 "
+                "and will be removed in 1.6. To keep past behavior, leave 'pos_label' "
+                " as default value."
+            ),
+            FutureWarning,
         )
     elif pos_label != 1:
         warnings.warn(


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #10010 - removal of `pos_label=None` as it is ill-defined and inconsistently implemented.


#### What does this implement/fix? Explain your changes.

Deprecate `None` option for `pos_label` in functions:
* `precision_recall_fscore_support` / `f1_score` / `fbeta_score` / `precision_score` / `recall_score`
* `jaccard_score`

Prior to v0.18 you needed to set `pos_label=None` if targets were binary but you wanted to use `average != 'binary'` ([ref](https://github.com/scikit-learn/scikit-learn/blame/e2648b18e568b112c9bcecee4e3ff76972ee19fb/sklearn/metrics/classification.py#L908-L910)). Now `pos_label` is just ignored if `average != 'binary'`, so you no longer need to worry about setting `pos_label` to any specific value. 

 `pos_label` is only used if `average='binary'` and in this case setting `pos_label=None` will raise an error.

The documentation of the `None` option has been (mostly) removed long ago in [this](https://github.com/scikit-learn/scikit-learn/commit/4fcf20a5d26ceff26ce5835aff42ab199e5cd880) commit. Removing support for `None` has been suggested previously: https://github.com/scikit-learn/scikit-learn/pull/13151/files#r262034515 but thought not suitable in that PR.

#### Any other comments?
Not sure what is the procedure for deprecating a parameter option (not yet in the [deprecation docs](https://scikit-learn.org/dev/developers/contributing.html#deprecation)). This was just a guess, am happy to make any changes.

related: #27714