### PR TITLE
FIX handle properly null weights in SVC

### DIFF
--- a/sklearn/svm/_libsvm_sparse.pyx
+++ b/sklearn/svm/_libsvm_sparse.pyx
@@ -169,6 +169,7 @@ def libsvm_sparse_train (int n_features,
     blas_functions.dot = _dot[double]
     # call svm_train, this does the real work
     cdef int fit_status = 0
+
     with nogil:
         model = svm_csr_train(problem, param, &fit_status, &blas_functions)
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -565,7 +565,7 @@ def test_svm_equivalence_sample_weight_C():
     "Estimator, err_msg",
     [
         (svm.SVC, "Invalid input - all samples have zero or negative weights."),
-        (svm.NuSVC, "(negative dimensions are not allowed|nu is infeasible)"),
+        (svm.NuSVC, "Invalid input - all samples have zero|specified nu is infeasible"),
         (svm.SVR, "Invalid input - all samples have zero or negative weights."),
         (svm.NuSVR, "Invalid input - all samples have zero or negative weights."),
         (svm.OneClassSVM, "Invalid input - all samples have zero or negative weights."),

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -1448,3 +1448,13 @@ def test_dual_auto_edge_cases():
         "auto", "squared_hinge", "l1", "ovr", np.asarray(X).T
     )
     assert dual is False  # only supports False
+
+
+# TODO: the same test should be done for sparse matrix as input
+def test_svc_null_weight():
+    """Check that the indices of support vectors are correct with null weights."""
+    X = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+    y = [0, 1, 2]
+    sample_weight = [0.0, 1.0, 1.0]
+    clf = svm.SVC().fit(X, y, sample_weight=sample_weight)
+    assert_array_equal(clf.support_, [1, 2])


### PR DESCRIPTION
closes https://github.com/scikit-learn/scikit-learn/issues/5150
closes https://github.com/scikit-learn/scikit-learn/issues/25380

This changes intends to:

- [x] fix the indexing of the support vector `support_` since negative and zeros samples are removed
- [x] fix the value reported by `n_support_`
- [ ] fix the dual coefficient when the removing sample via sample weights are cancelling an entire class
- bonus trying to make the code more readable by removing single letter variable