### PR TITLE
MAINT Remove -Wdiscarded-qualifiers compilation warning for sklearn.utils.arrayfuncs

### DIFF
--- a/sklearn/utils/arrayfuncs.pyx
+++ b/sklearn/utils/arrayfuncs.pyx
@@ -30,7 +30,7 @@ def min_pos(const floating[:] X):
 # n = rows
 #
 # TODO: put transpose as an option
-def cholesky_delete(const floating[:, :] L, int go_out):
+def cholesky_delete(floating[:, :] L, int go_out):
     cdef:
         int n = L.shape[0]
         int m = L.strides[0]


### PR DESCRIPTION
#### Reference Issues/PRs
Related to #24875.

#### What does this implement/fix? Explain your changes.
While compiling sklearn, we get the following warnings for module `sklearn.utils.arrayfuncs.pyx`:

```python
building 'sklearn.utils.arrayfuncs' extension
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -

I/usr/local/python/3.10.4/include/python3.10 -c sklearn/utils/arrayfuncs.c -o build/temp.linux-x86_64-cpython-310/sklearn/utils/arrayfuncs.o -g0 -O2 -fopenmp
sklearn/utils/arrayfuncs.c: In function ‘__pyx_pf_7sklearn_5utils_10arrayfuncs_10cholesky_delete’:
sklearn/utils/arrayfuncs.c:3942:14: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 3942 |   __pyx_v_L1 = ((&(*((float const  *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_L.data + __pyx_t_1 * __pyx_v_L.strides[0]) ) + __pyx_t_2 * 

__pyx_v_L.strides[1]) )))) + (__pyx_v_go_out * __pyx_v_m));
      |              ^
sklearn/utils/arrayfuncs.c:3984:14: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 3984 |   __pyx_v_L1 = ((&(*((float const  *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_L.data + __pyx_t_2 * __pyx_v_L.strides[0]) ) + __pyx_t_1 * 

__pyx_v_L.strides[1]) )))) + (__pyx_v_go_out * __pyx_v_m));
      |              ^
sklearn/utils/arrayfuncs.c: In function ‘__pyx_pf_7sklearn_5utils_10arrayfuncs_12cholesky_delete’:
sklearn/utils/arrayfuncs.c:4213:14: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 4213 |   __pyx_v_L1 = ((&(*((double const  *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_L.data + __pyx_t_1 * __pyx_v_L.strides[0]) ) + __pyx_t_2 * 

__pyx_v_L.strides[1]) )))) + (__pyx_v_go_out * __pyx_v_m));
      |              ^
sklearn/utils/arrayfuncs.c:4255:14: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 4255 |   __pyx_v_L1 = ((&(*((double const  *) ( /* dim=1 */ (( /* dim=0 */ (__pyx_v_L.data + __pyx_t_2 * __pyx_v_L.strides[0]) ) + __pyx_t_1 * 

__pyx_v_L.strides[1]) )))) + (__pyx_v_go_out * __pyx_v_m));
      |              ^
gcc -pthread -shared build/temp.linux-x86_64-cpython-310/sklearn/utils/arrayfuncs.o -Lbuild/temp.linux-x86_64-cpython-310 -lm -llibsvm-skl -lliblinear-skl -o 

build/lib.linux-x86_64-cpython-310/sklearn/utils/arrayfuncs.cpython-310-x86_64-linux-gnu.so -fopenmp
```

Reason: In module `sklearn.utils.arrayfuncs.pyx` we have the function
```python
def cholesky_delete(const floating[:, :] L, int go_out):
```
with argument `L` which is given as `const`.
This `L` is assigned to an array of floats `floating *L1` in line 47:
```python
L1 = &L[0, 0] + (go_out * m)
```
The generated C code misses a type cast `(floating *)` which leads to the warning.
In order to solve this one can either change `L1` to `const` as well.
Since `L1` gets further assignments this won't work.
Thus, instead the signature of `cholesky_delete()` is changed to:
```python
def cholesky_delete(floating[:, :] L, int go_out):
```

After this fix we get:

```python
building 'sklearn.utils.arrayfuncs' extension
gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -

I/usr/local/python/3.10.4/include/python3.10 -c sklearn/utils/arrayfuncs.c -o build/temp.linux-x86_64-cpython-310/sklearn/utils/arrayfuncs.o -g0 -O2 -fopenmp
gcc -pthread -shared build/temp.linux-x86_64-cpython-310/sklearn/utils/arrayfuncs.o -Lbuild/temp.linux-x86_64-cpython-310 -lm -llibsvm-skl -lliblinear-skl -o 

build/lib.linux-x86_64-cpython-310/sklearn/utils/arrayfuncs.cpython-310-x86_64-linux-gnu.so -fopenmp
```

#### Any other comments?
