### PR TITLE
CI Fix lint workflow concurrency

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
   - pull_request_target
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
With the lock file bot, I discovered that a workflow in one PR can cancel the workflow in another. This is because pull_request_target runs on main and not on the PR so that the `github.ref` is main in all the PRs.

See [this build](https://github.com/scikit-learn/scikit-learn/actions/runs/6845886695)

and the error
```
Canceling since a higher priority waiting request for 'linter-refs/heads/main' exists
```
