### PR TITLE
CI Fix misleading bot comment when lint job is canceled

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,6 +63,7 @@ jobs:
   comment:
     needs: lint
     if: always()
+    # if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
 
     # We need these permissions to be able to post / update comments

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,8 +62,7 @@ jobs:
 
   comment:
     needs: lint
-    if: always()
-    # if: ${{ !cancelled() }}
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
 
     # We need these permissions to be able to post / update comments


### PR DESCRIPTION
This can happen when you push quickly (less than 1-2 minutes appart) two commits in a PR branch. We don't want to post a comment with a link to a misleading error because the workflow has been canceled (see original bot comment below by clicking on the edited button)

I used the recommendation from the [github doc](https://docs.github.com/en/actions/learn-github-actions/expressions#always).

cc @glemaitre from https://github.com/scikit-learn/scikit-learn/pull/27773#issuecomment-1809956230

I tested this on my fork and I think this work, see [this workflow](https://github.com/lesteve/scikit-learn/actions/runs/6873183695/job/18692846962?pr=30) where the lint job gets canceled and the comment job is canceled too. 

Note this can not be tested in this PR, the workflow use `pull_request_target` so the workflow is run using the file from `main` and not from the PR branch.