### PR TITLE
DOC Enable sphinx search summary

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -309,7 +309,7 @@ for old_link in redirects:
     html_additional_pages[old_link] = "redirects.html"
 
 # Not showing the search summary makes the search page load faster.
-html_show_search_summary = False
+html_show_search_summary = True
 
 
 # The "summary-anchor" IDs will be overwritten via JavaScript to be unique.

--- a/doc/themes/scikit-learn-modern/layout.html
+++ b/doc/themes/scikit-learn-modern/layout.html
@@ -35,7 +35,7 @@
     {%- endif %}
   {%- endfor %}
   <link rel="stylesheet" href="{{ pathto('_static/' + styles[0], 1) }}" type="text/css" />
-<script id="documentation_options" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
+<script id="documentation_options" data-url_root="{{ url_root }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
 <script src="{{ pathto('_static/js/vendor/jquery-3.6.3.slim.min.js', 1) }}"></script>
 <script src="{{ pathto('_static/js/details-permalink.js', 1) }}"></script>
 {%- block extrahead %} {% endblock %}

--- a/doc/themes/scikit-learn-modern/layout.html
+++ b/doc/themes/scikit-learn-modern/layout.html
@@ -10,8 +10,8 @@
 
 <!DOCTYPE html>
 <!-- data-theme below is forced to be "light" but should be changed if we use pydata-theme-sphinx in the future -->
-<!--[if IE 8]><html class="no-js lt-ie9" lang="{{ lang_attr }}" data-theme="light"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js" lang="{{ lang_attr }}" data-theme="light" data-content_root="{{ url_root }}"> <!--<![endif]-->
+<!--[if IE 8]><html class="no-js lt-ie9" lang="{{ lang_attr }}" data-content_root="{{ url_root }}" data-theme="light"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="{{ lang_attr }}" data-content_root="{{ url_root }}" data-theme="light"> <!--<![endif]-->
 <head>
   <meta charset="utf-8">
   {{ metatags }}

--- a/doc/themes/scikit-learn-modern/layout.html
+++ b/doc/themes/scikit-learn-modern/layout.html
@@ -11,7 +11,7 @@
 <!DOCTYPE html>
 <!-- data-theme below is forced to be "light" but should be changed if we use pydata-theme-sphinx in the future -->
 <!--[if IE 8]><html class="no-js lt-ie9" lang="{{ lang_attr }}" data-theme="light"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js" lang="{{ lang_attr }}" data-theme="light"> <!--<![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="{{ lang_attr }}" data-theme="light" data-content_root="{{ url_root }}"> <!--<![endif]-->
 <head>
   <meta charset="utf-8">
   {{ metatags }}
@@ -35,7 +35,7 @@
     {%- endif %}
   {%- endfor %}
   <link rel="stylesheet" href="{{ pathto('_static/' + styles[0], 1) }}" type="text/css" />
-<script id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
+<script id="documentation_options" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
 <script src="{{ pathto('_static/js/vendor/jquery-3.6.3.slim.min.js', 1) }}"></script>
 <script src="{{ pathto('_static/js/details-permalink.js', 1) }}"></script>
 {%- block extrahead %} {% endblock %}


### PR DESCRIPTION
Showing the context of the hint is handy to decide which link is more likely to have the information we want when we use the doc search bar.
### This PR:
![image](https://github.com/scikit-learn/scikit-learn/assets/1680079/089593f4-a6c7-4158-8026-d012c80bf1d1)

### our current search:
![image](https://github.com/scikit-learn/scikit-learn/assets/1680079/d9842c32-c74c-40e5-88c5-2f8d58b217de)

I think it was disabled because for consistency with the custom search code we had previously and maybe out of a concern that it was slow, e.g. https://github.com/scikit-learn/scikit-learn/pull/24128#issuecomment-1206840623. It does not feel too slow for me in the CircleCI artifacts: https://output.circle-artifacts.com/output/job/b8445a52-e0db-4fb5-99c9-eb974695f950/artifacts/0/doc/search.html?q=ridge

While doing that I noticed that `html_search_show_summary=True` was not working. This is a change in sphinx 7.2 that was also noticed in sphinx-pydata-theme: https://github.com/pydata/pydata-sphinx-theme/issues/1498 with the fix in https://github.com/pydata/pydata-sphinx-theme/pull/1559

The sphinx 7.2 change is here:
https://github.com/sphinx-doc/sphinx/commit/8e730ae303ae686705ea12f44ef11da926a87cf5#diff-a5066e933cbf65adc46e0d1ab9a0b44e0a53ca64cc95dca7e6aa902aed6bd468R105

This is wonderful by the way, direct commit in `main`, no context to understand the reason for the change, no changelog entry, oh well "c'est la vie" as we say :wink: 

Side-comment: maybe we can remove the "Internet Explorer < 9" line, these days I think nobody uses this anymore. Internet Explorer 9 was released in March 2011.