### PR TITLE
TST ensure to raise deterministic warning in learning curve test

### DIFF
--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -2420,7 +2420,9 @@ def test_learning_curve_partial_fit_regressors():
 def test_learning_curve_some_failing_fits_warning():
     """Checks for fit failures in `learning_curve` and raises the required warning"""
 
-    X, y = make_classification(n_classes=3, n_informative=6, shuffle=False)
+    X, y = make_classification(
+        n_classes=3, n_informative=6, shuffle=False, random_state=0
+    )
     svc = SVC()
     warning_message = "10 fits failed out of a total of 50"
 

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -2417,25 +2417,35 @@ def test_learning_curve_partial_fit_regressors():
     learning_curve(MLPRegressor(), X, y, exploit_incremental_learning=True, cv=2)
 
 
-def test_learning_curve_some_failing_fits_warning():
+def test_learning_curve_some_failing_fits_warning(global_random_seed):
     """Checks for fit failures in `learning_curve` and raises the required warning"""
 
     X, y = make_classification(
-        n_classes=3, n_informative=6, shuffle=False, random_state=0
+        n_samples=30,
+        n_classes=3,
+        n_informative=6,
+        shuffle=False,
+        random_state=global_random_seed,
     )
+    # sorting the target to trigger SVC error on the 2 first splits because a single
+    # class is present
+    sorted_idx = np.argsort(y)
+    X, y = X[sorted_idx], y[sorted_idx]
+
     svc = SVC()
-    warning_message = "10 fits failed out of a total of 50"
+    warning_message = "10 fits failed out of a total of 25"
 
     with pytest.warns(FitFailedWarning, match=warning_message):
         _, train_score, test_score, *_ = learning_curve(
-            svc, X, y, cv=10, error_score=np.nan
+            svc, X, y, cv=5, error_score=np.nan
         )
 
-    # the first split should lead to raise the warning
-    assert np.isnan(train_score[0]).all()
-    assert np.isnan(test_score[0]).all()
+    # the first 2 splits should lead to warnings and thus np.nan scores
+    for idx in range(2):
+        assert np.isnan(train_score[idx]).all()
+        assert np.isnan(test_score[idx]).all()
 
-    for idx in range(1, train_score.shape[0]):
+    for idx in range(2, train_score.shape[0]):
         assert not np.isnan(train_score[idx]).any()
         assert not np.isnan(test_score[idx]).any()
 


### PR DESCRIPTION
I saw the CI failing in windows in this PR:
https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=60981&view=logs&jobId=0238e32a-2fbb-5be1-f782-cfff4ef2924e&j=0238e32a-2fbb-5be1-f782-cfff4ef2924e&t=7a1155ea-f171-542f-2ca6-f7f6ff076f10

I really believed that the tests would be deterministic.
In the meanwhile, we can fix the seed.