### PR TITLE
fix typo "In is recommended" -> "It is recommended"

### DIFF
--- a/examples/model_selection/plot_cv_predict.py
+++ b/examples/model_selection/plot_cv_predict.py
@@ -74,6 +74,6 @@ plt.show()
 # :func:`~sklearn.model_selection.cross_val_predict`
 # when the different CV folds vary by size and distributions.
 #
-# In is recommended to compute per-fold performance metrics using:
+# It is recommended to compute per-fold performance metrics using:
 # :func:`~sklearn.model_selection.cross_val_score` or
 # :func:`~sklearn.model_selection.cross_validate` instead.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

This fixes a small typo in the documentation. (https://scikit-learn.org/stable/auto_examples/model_selection/plot_cv_predict.html)

The original sentence was "In is recommended to compute per-fold performance ...". This pull request proposes changing that to "It is recommended to compute per-fold performance".

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
