### PR TITLE
FIX RandomForestRegressor OOB fails with integer-values multiple targets

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -339,7 +339,7 @@ Changelog
   which allows to retrieve the training sample indices used for each tree estimator.
   :pr:`26736` by :user:`Adam Li <adam2392>`.
 
-- |Fix| ValueError in :class:`ensemble.RandomForestRegressor` and
+- |Fix| Raises a `ValueError` in :class:`ensemble.RandomForestRegressor` and
   :class:`ensemble.ExtraTreesRegressor` when requesting OOB score with multioutput model
   for the targets being all rounded to integer. It was recognized as a multiclass problem.
   :pr:`27817` by :user:`Daniele Ongari <danieleongari>`

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -339,10 +339,10 @@ Changelog
   which allows to retrieve the training sample indices used for each tree estimator.
   :pr:`26736` by :user:`Adam Li <adam2392>`.
 
-- |Fix| ValueError in :class:`ensemble._forest.BaseForest` when requesting OOB score
-  with multioutput model and regression training data for the targets being all
-  rounded to integer, as :func:`~utils.multiclass.type_of_target` recognizes the dataset as
-  a multiclass problem. :pr:`27817` by :user:`Daniele Ongari <danieleongari>`
+- |Fix| ValueError in :class:`ensemble.RandomForestRegressor` and
+  :class:`ensemble.ExtraTreesRegressor` when requesting OOB score with multioutput model
+  for the targets being all rounded to integer. It was recognized as a multiclass problem.
+  :pr:`27817` by :user:`Daniele Ongari <danieleongari>`
 
 :mod:`sklearn.feature_selection`
 ................................

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -331,12 +331,18 @@ Changelog
 - |API| In :class:`ensemble.AdaBoostClassifier`, the `algorithm` argument `SAMME.R` was
   deprecated and will be removed in 1.6. :pr:`26830` by :user:`Stefanie Senger
   <StefanieSenger>`.
+
 - |Enhancement| A fitted property, ``estimators_samples_``, was added to all Forest methods,
   including
   :class:`ensemble.RandomForestClassifier`, :class:`ensemble.RandomForestRegressor`,
   :class:`ensemble.ExtraTreesClassifier` and :class:`ensemble.ExtraTreesRegressor`,
   which allows to retrieve the training sample indices used for each tree estimator.
   :pr:`26736` by :user:`Adam Li <adam2392>`.
+
+- |Fix| ValueError in :class:`ensemble._forest.BaseForest` when requesting OOB score
+  with multioutput model and regression training data for the targets being all
+  rounded to integer, as :func:`~utils.multiclass.type_of_target` recognizes the dataset as
+  a multiclass problem. :pr:`27817` by :user:`Daniele Ongari <danieleongari>`
 
 :mod:`sklearn.feature_selection`
 ................................

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -516,7 +516,10 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
             n_more_estimators > 0 or not hasattr(self, "oob_score_")
         ):
             y_type = type_of_target(y)
-            if y_type in ("multiclass-multioutput", "unknown"):
+            if y_type == "unknown" or (
+                y_type == "multiclass-multioutput"
+                and isinstance(self, (RandomForestClassifier, ExtraTreesClassifier))
+            ):
                 # FIXME: we could consider to support multiclass-multioutput if
                 # we introduce or reuse a constructor parameter (e.g.
                 # oob_score) allowing our user to pass a callable defining the

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -519,7 +519,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
             if y_type == "unknown" or (
                 self._estimator_type == "classifier"
                 and y_type == "multiclass-multioutput"
-            )):
+            ):
                 # FIXME: we could consider to support multiclass-multioutput if
                 # we introduce or reuse a constructor parameter (e.g.
                 # oob_score) allowing our user to pass a callable defining the

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -517,9 +517,9 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         ):
             y_type = type_of_target(y)
             if y_type == "unknown" or (
-                y_type == "multiclass-multioutput"
-                and isinstance(self, (RandomForestClassifier, ExtraTreesClassifier))
-            ):
+                self._estimator_type == "classifier"
+                and y_type == "multiclass-multioutput"
+            )):
                 # FIXME: we could consider to support multiclass-multioutput if
                 # we introduce or reuse a constructor parameter (e.g.
                 # oob_score) allowing our user to pass a callable defining the

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -597,28 +597,35 @@ def test_forest_oob_warning(ForestEstimator):
         estimator.fit(iris.data, iris.target)
 
 
-@pytest.mark.parametrize("ForestEstimator", FOREST_CLASSIFIERS.values())
-@pytest.mark.parametrize(
-    "X, y, params, err_msg",
-    [
-        (
-            iris.data,
-            iris.target,
-            {"oob_score": True, "bootstrap": False},
-            "Out of bag estimation only available if bootstrap=True",
-        ),
-        (
-            iris.data,
-            rng.randint(low=0, high=5, size=(iris.data.shape[0], 2)),
-            {"oob_score": True, "bootstrap": True},
-            "The type of target cannot be used to compute OOB estimates",
-        ),
-    ],
-)
-def test_forest_oob_error(ForestEstimator, X, y, params, err_msg):
+@pytest.mark.parametrize("ForestEstimator", FOREST_CLASSIFIERS_REGRESSORS.values())
+def test_forest_boostrap_false_oob_error(ForestEstimator):
+    X = iris.data
+    y = iris.target
+    params = {"oob_score": True, "bootstrap": False}
+    err_msg = "Out of bag estimation only available if bootstrap=True"
     estimator = ForestEstimator(**params)
     with pytest.raises(ValueError, match=err_msg):
         estimator.fit(X, y)
+
+
+@pytest.mark.parametrize("ForestClassifier", FOREST_CLASSIFIERS.values())
+def test_forest_moutput_int_oob_error(ForestClassifier):
+    X = iris.data
+    y = rng.randint(low=0, high=5, size=(iris.data.shape[0], 2))
+    params = {"oob_score": True, "bootstrap": True}
+    err_msg = "The type of target cannot be used to compute OOB estimates"
+    estimator = ForestClassifier(**params)
+    with pytest.raises(ValueError, match=err_msg):
+        estimator.fit(X, y)
+
+
+@pytest.mark.parametrize("ForestRegressor", FOREST_REGRESSORS.values())
+def test_forest_moutput_int_oob(ForestRegressor):
+    X = iris.data
+    y = rng.randint(low=0, high=5, size=(iris.data.shape[0], 2))
+    params = {"oob_score": True, "bootstrap": True}
+    estimator = ForestRegressor(**params)
+    estimator.fit(X, y)
 
 
 @pytest.mark.parametrize("oob_score", [True, False])

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -597,7 +597,7 @@ def test_forest_oob_warning(ForestEstimator):
         estimator.fit(iris.data, iris.target)
 
 
-@pytest.mark.parametrize("ForestEstimator", FOREST_CLASSIFIERS_REGRESSORS.values())
+@pytest.mark.parametrize("ForestEstimator", FOREST_CLASSIFIERS.values())
 @pytest.mark.parametrize(
     "X, y, params, err_msg",
     [

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -617,6 +617,7 @@ def test_classifier_error_oob_score_multiclass_multioutput(ForestClassifier):
     """Check that we raise an error with when requesting OOB score with
     multiclass-multioutput classification target.
     """
+    rng = np.random.RandomState(42)
     X = iris.data
     y = rng.randint(low=0, high=5, size=(iris.data.shape[0], 2))
     y_type = type_of_target(y)

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -636,7 +636,9 @@ def test_forest_multioutput_integral_regression_target(ForestRegressor):
     rng = np.random.RandomState(42)
     X = iris.data
     y = rng.randint(low=0, high=10, size=(iris.data.shape[0], 2))
-    estimator = ForestRegressor(n_estimators=20, oob_score=True, bootstrap=True)
+    estimator = ForestRegressor(
+        n_estimators=20, oob_score=True, bootstrap=True, random_state=0
+    )
     estimator.fit(X, y)
 
     n_samples_bootstrap = _get_n_samples_bootstrap(len(X), estimator.max_samples)

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -633,6 +633,7 @@ def test_forest_multioutput_integral_regression_target(ForestRegressor):
     """Check that multioutput regression with integral values is not interpreted
     as a multiclass-multioutput target and OOB score can be computed.
     """
+    rng = np.random.RandomState(42)
     X = iris.data
     y = rng.randint(low=0, high=10, size=(iris.data.shape[0], 2))
     estimator = ForestRegressor(n_estimators=20, oob_score=True, bootstrap=True)

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -638,20 +638,20 @@ def test_forest_multioutput_integral_regression_target(ForestRegressor):
     estimator.fit(X, y)
 
     n_samples_bootstrap = _get_n_samples_bootstrap(len(X), estimator.max_samples)
-    nsamples_test = 3
-    oob_pred = np.zeros([nsamples_test, 2])
-    for isample, sample in enumerate(X[:nsamples_test]):
-        nsamples_oob = 0
+    n_samples_test = 3
+    oob_pred = np.zeros([n_samples_test, 2])
+    for sample_idx, sample in enumerate(X[:n_samples_test]):
+        n_samples_oob = 0
         oob_pred_sample = np.zeros(2)
         for tree in estimator.estimators_:
-            sample_idx = _generate_sample_indices(
+            oob_sample_indices = _generate_sample_indices(
                 tree.random_state, len(X), n_samples_bootstrap
             )
-            if isample not in sample_idx:
-                nsamples_oob += 1
-                oob_pred_sample += tree.predict(np.atleast_2d(sample))[0]
-        oob_pred[isample] = oob_pred_sample / nsamples_oob
-    assert (oob_pred == estimator.oob_prediction_[:nsamples_test]).all()
+            if sample_idx not in oob_sample_indices:
+                n_samples_oob += 1
+                oob_pred_sample += tree.predict(sample.reshape(1, -1)).squeeze()
+        oob_pred[sample_idx] = oob_pred_sample / n_samples_oob
+    assert_allclose(oob_pred, estimator.oob_prediction_[:n_samples_test])
 
 
 @pytest.mark.parametrize("oob_score", [True, False])


### PR DESCRIPTION
Fixes #27814

Allow to compute the OOB score with `RandomForestRegressor` and an integral multi-target regression.