### PR TITLE
MAINT remove affinity after deprecation cycle

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -235,11 +235,17 @@ Changelog
 :mod:`sklearn.cluster`
 ......................
 
-- |API| : `kdtree` and `balltree` values are now deprecated and are renamed as
+- |API| `kdtree` and `balltree` values are now deprecated and are renamed as
   `kd_tree` and `ball_tree` respectively for the `algorithm` parameter of
   :class:`cluster.HDBSCAN` ensuring consistency in naming convention.
   `kdtree` and `balltree` values will be removed in 1.6.
   :pr:`26744` by :user:`Shreesha Kumar Bhat <Shreesha3112>`.
+
+- |API| The option `metric=None` in
+  :class:`cluster.AggomerativeClustering` and :class:`cluster.FeatureAgglomeration`
+  is deprecated in version 1.4 and will be removed in version 1.6. Use the default
+  value instead.
+  :pr:`27828` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.compose`
 ......................

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -782,6 +782,10 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
 
         .. versionadded:: 1.2
 
+        .. deprecated:: 1.4
+           `metric=None` is deprecated in 1.4 and will be removed in 1.6.
+           Let `metric` be the default value (i.e. `"euclidean"`) instead.
+
     memory : str or object with the joblib.Memory interface, default=None
         Used to cache the output of the computation of the tree.
         By default, no caching is done. If a string is given, it is the
@@ -904,8 +908,6 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
         "metric": [
             StrOptions(set(_VALID_METRICS) | {"precomputed"}),
             callable,
-            # equivalent to "euclidean" used during the deprecation of `affinity`
-            # parameter
             Hidden(None),
         ],
         "memory": [str, HasMethods("cache"), None],
@@ -974,7 +976,19 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
             Returns the fitted instance.
         """
         memory = check_memory(self.memory)
-        self._metric = "euclidean" if self.metric is None else self.metric
+
+        # TODO(1.6): remove in 1.6
+        if self.metric is None:
+            warnings.warn(
+                (
+                    "`metric=None` is deprecated in 1.4 and will be removed in 1.6. "
+                    "Let `metric` be the default value (i.e. `'euclidean'`) instead."
+                ),
+                FutureWarning,
+            )
+            self._metric = "euclidean"
+        else:
+            self._metric = self.metric
 
         if not ((self.n_clusters is None) ^ (self.distance_threshold is None)):
             raise ValueError(
@@ -1109,6 +1123,10 @@ class FeatureAgglomeration(
 
         .. versionadded:: 1.2
 
+        .. deprecated:: 1.4
+           `metric=None` is deprecated in 1.4 and will be removed in 1.6.
+           Let `metric` be the default value (i.e. `"euclidean"`) instead.
+
     memory : str or object with the joblib.Memory interface, default=None
         Used to cache the output of the computation of the tree.
         By default, no caching is done. If a string is given, it is the
@@ -1235,7 +1253,6 @@ class FeatureAgglomeration(
         "metric": [
             StrOptions(set(_VALID_METRICS) | {"precomputed"}),
             callable,
-            # equivalent to "euclidean" used during the deprecation of `affinity`
             Hidden(None),
         ],
         "memory": [str, HasMethods("cache"), None],

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -901,11 +901,6 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
 
     _parameter_constraints: dict = {
         "n_clusters": [Interval(Integral, 1, None, closed="left"), None],
-        "affinity": [
-            Hidden(StrOptions({"deprecated"})),
-            StrOptions(set(_VALID_METRICS) | {"precomputed"}),
-            callable,
-        ],
         "metric": [
             StrOptions(set(_VALID_METRICS) | {"precomputed"}),
             callable,

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -981,8 +981,9 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
         if self.metric is None:
             warnings.warn(
                 (
-                    "`metric=None` is deprecated in 1.4 and will be removed in 1.6. "
-                    "Let `metric` be the default value (i.e. `'euclidean'`) instead."
+                    "`metric=None` is deprecated in version 1.4 and will be removed in "
+                    "version 1.6. Let `metric` be the default value "
+                    "(i.e. `'euclidean'`) instead."
                 ),
                 FutureWarning,
             )

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -776,7 +776,7 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
 
     metric : str or callable, default="euclidean"
         Metric used to compute the linkage. Can be "euclidean", "l1", "l2",
-        "manhattan", "cosine", or "precomputed".If linkage is "ward", only
+        "manhattan", "cosine", or "precomputed". If linkage is "ward", only
         "euclidean" is accepted. If "precomputed", a distance matrix is needed
         as input for the fit method.
 

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -774,25 +774,11 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
         The number of clusters to find. It must be ``None`` if
         ``distance_threshold`` is not ``None``.
 
-    affinity : str or callable, default='euclidean'
-        The metric to use when calculating distance between instances in a
-        feature array. If metric is a string or callable, it must be one of
-        the options allowed by :func:`sklearn.metrics.pairwise_distances` for
-        its metric parameter.
-        If linkage is "ward", only "euclidean" is accepted.
-        If "precomputed", a distance matrix (instead of a similarity matrix)
-        is needed as input for the fit method.
-
-        .. deprecated:: 1.2
-            `affinity` was deprecated in version 1.2 and will be renamed to
-            `metric` in 1.4.
-
-    metric : str or callable, default=None
+    metric : str or callable, default="euclidean"
         Metric used to compute the linkage. Can be "euclidean", "l1", "l2",
-        "manhattan", "cosine", or "precomputed". If set to `None` then
-        "euclidean" is used. If linkage is "ward", only "euclidean" is
-        accepted. If "precomputed", a distance matrix is needed as input for
-        the fit method.
+        "manhattan", "cosine", or "precomputed".If linkage is "ward", only
+        "euclidean" is accepted. If "precomputed", a distance matrix is needed
+        as input for the fit method.
 
         .. versionadded:: 1.2
 
@@ -923,7 +909,9 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
         "metric": [
             StrOptions(set(_VALID_METRICS) | {"precomputed"}),
             callable,
-            None,
+            # equivalent to "euclidean" used during the deprecation of `affinity`
+            # parameter
+            Hidden(None),
         ],
         "memory": [str, HasMethods("cache"), None],
         "connectivity": ["array-like", callable, None],
@@ -937,8 +925,7 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
         self,
         n_clusters=2,
         *,
-        affinity="deprecated",  # TODO(1.4): Remove
-        metric=None,  # TODO(1.4): Set to "euclidean"
+        metric="euclidean",
         memory=None,
         connectivity=None,
         compute_full_tree="auto",
@@ -952,7 +939,6 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
         self.connectivity = connectivity
         self.compute_full_tree = compute_full_tree
         self.linkage = linkage
-        self.affinity = affinity
         self.metric = metric
         self.compute_distances = compute_distances
 
@@ -993,26 +979,7 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
             Returns the fitted instance.
         """
         memory = check_memory(self.memory)
-
-        self._metric = self.metric
-        # TODO(1.4): Remove
-        if self.affinity != "deprecated":
-            if self.metric is not None:
-                raise ValueError(
-                    "Both `affinity` and `metric` attributes were set. Attribute"
-                    " `affinity` was deprecated in version 1.2 and will be removed in"
-                    " 1.4. To avoid this error, only set the `metric` attribute."
-                )
-            warnings.warn(
-                (
-                    "Attribute `affinity` was deprecated in version 1.2 and will be"
-                    " removed in 1.4. Use `metric` instead"
-                ),
-                FutureWarning,
-            )
-            self._metric = self.affinity
-        elif self.metric is None:
-            self._metric = "euclidean"
+        self._metric = "euclidean" if self.metric is None else self.metric
 
         if not ((self.n_clusters is None) ^ (self.distance_threshold is None)):
             raise ValueError(
@@ -1139,25 +1106,11 @@ class FeatureAgglomeration(
         The number of clusters to find. It must be ``None`` if
         ``distance_threshold`` is not ``None``.
 
-    affinity : str or callable, default='euclidean'
-        The metric to use when calculating distance between instances in a
-        feature array. If metric is a string or callable, it must be one of
-        the options allowed by :func:`sklearn.metrics.pairwise_distances` for
-        its metric parameter.
-        If linkage is "ward", only "euclidean" is accepted.
-        If "precomputed", a distance matrix (instead of a similarity matrix)
-        is needed as input for the fit method.
-
-        .. deprecated:: 1.2
-            `affinity` was deprecated in version 1.2 and will be renamed to
-            `metric` in 1.4.
-
-    metric : str or callable, default=None
+    metric : str or callable, default="euclidean"
         Metric used to compute the linkage. Can be "euclidean", "l1", "l2",
-        "manhattan", "cosine", or "precomputed". If set to `None` then
-        "euclidean" is used. If linkage is "ward", only "euclidean" is
-        accepted. If "precomputed", a distance matrix is needed as input for
-        the fit method.
+        "manhattan", "cosine", or "precomputed". If linkage is "ward", only
+        "euclidean" is accepted. If "precomputed", a distance matrix is needed
+        as input for the fit method.
 
         .. versionadded:: 1.2
 
@@ -1284,15 +1237,11 @@ class FeatureAgglomeration(
 
     _parameter_constraints: dict = {
         "n_clusters": [Interval(Integral, 1, None, closed="left"), None],
-        "affinity": [
-            Hidden(StrOptions({"deprecated"})),
-            StrOptions(set(_VALID_METRICS) | {"precomputed"}),
-            callable,
-        ],
         "metric": [
             StrOptions(set(_VALID_METRICS) | {"precomputed"}),
             callable,
-            None,
+            # equivalent to "euclidean" used during the deprecation of `affinity`
+            Hidden(None),
         ],
         "memory": [str, HasMethods("cache"), None],
         "connectivity": ["array-like", callable, None],
@@ -1307,8 +1256,7 @@ class FeatureAgglomeration(
         self,
         n_clusters=2,
         *,
-        affinity="deprecated",  # TODO(1.4): Remove
-        metric=None,  # TODO(1.4): Set to "euclidean"
+        metric="euclidean",
         memory=None,
         connectivity=None,
         compute_full_tree="auto",
@@ -1323,7 +1271,6 @@ class FeatureAgglomeration(
             connectivity=connectivity,
             compute_full_tree=compute_full_tree,
             linkage=linkage,
-            affinity=affinity,
             metric=metric,
             distance_threshold=distance_threshold,
             compute_distances=compute_distances,

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -849,7 +849,7 @@ def test_invalid_shape_precomputed_dist_matrix():
         AgglomerativeClustering(metric="precomputed", linkage="complete").fit(X)
 
 
-def test_precomputed_connectivity_affinit_with_2_connected_components():
+def test_precomputed_connectivity_metric_with_2_connected_components():
     """Check that connecting components works when connectivity and
     affinity are both precomputed and the number of connected components is
     greater than 1. Non-regression test for #16151.

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -849,7 +849,7 @@ def test_invalid_shape_precomputed_dist_matrix():
         AgglomerativeClustering(metric="precomputed", linkage="complete").fit(X)
 
 
-def test_precomputed_connectivity_affinity_with_2_connected_components():
+def test_precomputed_connectivity_affinit_with_2_connected_components():
     """Check that connecting components works when connectivity and
     affinity are both precomputed and the number of connected components is
     greater than 1. Non-regression test for #16151.
@@ -872,7 +872,7 @@ def test_precomputed_connectivity_affinity_with_2_connected_components():
 
     X_dist = pairwise_distances(X)
     clusterer_precomputed = AgglomerativeClustering(
-        affinity="precomputed", connectivity=connectivity_matrix, linkage="complete"
+        metric="precomputed", connectivity=connectivity_matrix, linkage="complete"
     )
     msg = "Completing it to avoid stopping the tree early"
     with pytest.warns(UserWarning, match=msg):
@@ -886,26 +886,3 @@ def test_precomputed_connectivity_affinity_with_2_connected_components():
 
     assert_array_equal(clusterer.labels_, clusterer_precomputed.labels_)
     assert_array_equal(clusterer.children_, clusterer_precomputed.children_)
-
-
-# TODO(1.4): Remove
-def test_deprecate_affinity():
-    rng = np.random.RandomState(42)
-    X = rng.randn(50, 10)
-
-    af = AgglomerativeClustering(affinity="euclidean")
-    msg = (
-        "Attribute `affinity` was deprecated in version 1.2 and will be removed in 1.4."
-        " Use `metric` instead"
-    )
-    with pytest.warns(FutureWarning, match=msg):
-        af.fit(X)
-    with pytest.warns(FutureWarning, match=msg):
-        af.fit_predict(X)
-
-    af = AgglomerativeClustering(metric="euclidean", affinity="euclidean")
-    msg = "Both `affinity` and `metric` attributes were set. Attribute"
-    with pytest.raises(ValueError, match=msg):
-        af.fit(X)
-    with pytest.raises(ValueError, match=msg):
-        af.fit_predict(X)

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -886,3 +886,14 @@ def test_precomputed_connectivity_metric_with_2_connected_components():
 
     assert_array_equal(clusterer.labels_, clusterer_precomputed.labels_)
     assert_array_equal(clusterer.children_, clusterer_precomputed.children_)
+
+
+# TODO(1.6): remove in 1.6
+@pytest.mark.parametrize(
+    "Agglomeration", [AgglomerativeClustering, FeatureAgglomeration]
+)
+def test_deprecation_warning_metric_None(Agglomeration):
+    X = np.array([[1, 2], [1, 4], [1, 0], [4, 2], [4, 4], [4, 0]])
+    warn_msg = "`metric=None` is deprecated in 1.4 and will be removed in 1.6"
+    with pytest.warns(FutureWarning, match=warn_msg):
+        Agglomeration(metric=None).fit(X)

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -894,6 +894,6 @@ def test_precomputed_connectivity_metric_with_2_connected_components():
 )
 def test_deprecation_warning_metric_None(Agglomeration):
     X = np.array([[1, 2], [1, 4], [1, 0], [4, 2], [4, 4], [4, 0]])
-    warn_msg = "`metric=None` is deprecated in 1.4 and will be removed in 1.6"
+    warn_msg = "`metric=None` is deprecated in version 1.4 and will be removed"
     with pytest.warns(FutureWarning, match=warn_msg):
         Agglomeration(metric=None).fit(X)


### PR DESCRIPTION
Remove the `affinity` parameter after its deprecation cycle.