### PR TITLE
MAINT Fix nightly wheels upload

### DIFF
--- a/build_tools/github/upload_anaconda.sh
+++ b/build_tools/github/upload_anaconda.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 # Note: build_wheels.sh has the same branch (only for NumPy 2.0 transition)
-if [ "$GITHUB_EVENT_NAME" == "schedule" || "$CIRRUS_CRON" == "nightly" ]; then
+if [[ "$GITHUB_EVENT_NAME" == "schedule" || "$CIRRUS_CRON" == "nightly" ]]; then
     ANACONDA_ORG="scientific-python-nightly-wheels"
     ANACONDA_TOKEN="$SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN"
 else


### PR DESCRIPTION
Looks like nightly wheels have not been uploaded to [scientific-python-nightly-wheels](https://anaconda.org/scientific-python-nightly-wheels/scikit-learn/files) following https://github.com/scikit-learn/scikit-learn/pull/27735. The latest files are from 3 days ago.

The reason is a missing `[` and `]` in the bash `if` condition which somehow does not turn into an error but into uploading the wheels to scikit-learn-wheels-staging rather than scientific-python-nightly-wheels. 

From the upload [log](https://github.com/scikit-learn/scikit-learn/actions/runs/6965346835/job/18954637513):

```
Run bash build_tools/github/upload_anaconda.sh
+ '[' schedule == schedule
build_tools/github/upload_anaconda.sh: line 7: [: missing `]'
+ '' == nightly ']'
build_tools/github/upload_anaconda.sh: line 7: : command not found
+ ANACONDA_ORG=scikit-learn-wheels-staging
```

