### PR TITLE
MAINT update default of n_init in KMeans family

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -1971,7 +1971,7 @@ cluster analysis:
   >>> kmeans_model = KMeans(n_clusters=3, random_state=1).fit(X)
   >>> labels = kmeans_model.labels_
   >>> metrics.calinski_harabasz_score(X, labels)
-  561.62...
+  561.59...
 
 Advantages
 ~~~~~~~~~~
@@ -2047,7 +2047,7 @@ cluster analysis as follows:
   >>> kmeans = KMeans(n_clusters=3, random_state=1).fit(X)
   >>> labels = kmeans.labels_
   >>> davies_bouldin_score(X, labels)
-  0.6619...
+  0.666...
 
 
 Advantages

--- a/doc/tutorial/statistical_inference/unsupervised_learning.rst
+++ b/doc/tutorial/statistical_inference/unsupervised_learning.rst
@@ -32,7 +32,7 @@ algorithms. The simplest clustering algorithm is :ref:`k_means`.
     >>> k_means.fit(X_iris)
     KMeans(n_clusters=3)
     >>> print(k_means.labels_[::10])
-    [1 1 1 1 1 0 0 0 0 0 2 2 2 2 2]
+    [1 1 1 1 1 2 0 0 0 0 2 2 2 2 2]
     >>> print(y_iris[::10])
     [0 0 0 0 0 1 1 1 1 1 2 2 2 2 2]
 

--- a/examples/cluster/plot_cluster_comparison.py
+++ b/examples/cluster/plot_cluster_comparison.py
@@ -159,7 +159,6 @@ for i_dataset, (dataset, algo_params) in enumerate(datasets):
     ms = cluster.MeanShift(bandwidth=bandwidth, bin_seeding=True)
     two_means = cluster.MiniBatchKMeans(
         n_clusters=params["n_clusters"],
-        n_init="auto",
         random_state=params["random_state"],
     )
     ward = cluster.AgglomerativeClustering(

--- a/examples/cluster/plot_cluster_iris.py
+++ b/examples/cluster/plot_cluster_iris.py
@@ -39,8 +39,8 @@ X = iris.data
 y = iris.target
 
 estimators = [
-    ("k_means_iris_8", KMeans(n_clusters=8, n_init="auto")),
-    ("k_means_iris_3", KMeans(n_clusters=3, n_init="auto")),
+    ("k_means_iris_8", KMeans(n_clusters=8)),
+    ("k_means_iris_3", KMeans(n_clusters=3)),
     ("k_means_iris_bad_init", KMeans(n_clusters=3, n_init=1, init="random")),
 ]
 

--- a/examples/cluster/plot_color_quantization.py
+++ b/examples/cluster/plot_color_quantization.py
@@ -53,9 +53,7 @@ image_array = np.reshape(china, (w * h, d))
 print("Fitting model on a small sub-sample of the data")
 t0 = time()
 image_array_sample = shuffle(image_array, random_state=0, n_samples=1_000)
-kmeans = KMeans(n_clusters=n_colors, n_init="auto", random_state=0).fit(
-    image_array_sample
-)
+kmeans = KMeans(n_clusters=n_colors, random_state=0).fit(image_array_sample)
 print(f"done in {time() - t0:0.3f}s.")
 
 # Get labels for all points

--- a/examples/cluster/plot_kmeans_silhouette_analysis.py
+++ b/examples/cluster/plot_kmeans_silhouette_analysis.py
@@ -69,7 +69,7 @@ for n_clusters in range_n_clusters:
 
     # Initialize the clusterer with n_clusters value and a random generator
     # seed of 10 for reproducibility.
-    clusterer = KMeans(n_clusters=n_clusters, n_init="auto", random_state=10)
+    clusterer = KMeans(n_clusters=n_clusters, random_state=10)
     cluster_labels = clusterer.fit_predict(X)
 
     # The silhouette_score gives the average value for all the samples.

--- a/examples/decomposition/plot_faces_decomposition.py
+++ b/examples/decomposition/plot_faces_decomposition.py
@@ -193,7 +193,6 @@ kmeans_estimator = cluster.MiniBatchKMeans(
     batch_size=20,
     max_iter=50,
     random_state=rng,
-    n_init="auto",
 )
 kmeans_estimator.fit(faces_centered)
 plot_gallery(

--- a/sklearn/cluster/_bisect_k_means.py
+++ b/sklearn/cluster/_bisect_k_means.py
@@ -8,7 +8,7 @@ import scipy.sparse as sp
 
 from ..base import _fit_context
 from ..utils._openmp_helpers import _openmp_effective_n_threads
-from ..utils._param_validation import StrOptions
+from ..utils._param_validation import Integral, Interval, StrOptions
 from ..utils.extmath import row_norms
 from ..utils.validation import _check_sample_weight, check_is_fitted, check_random_state
 from ._k_means_common import _inertia_dense, _inertia_sparse
@@ -207,6 +207,7 @@ class BisectingKMeans(_BaseKMeans):
     _parameter_constraints: dict = {
         **_BaseKMeans._parameter_constraints,
         "init": [StrOptions({"k-means++", "random"}), callable],
+        "n_init": [Interval(Integral, 1, None, closed="left")],
         "copy_x": ["boolean"],
         "algorithm": [StrOptions({"lloyd", "elkan"})],
         "bisecting_strategy": [StrOptions({"biggest_inertia", "largest_cluster"})],

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -29,7 +29,7 @@ from ..exceptions import ConvergenceWarning
 from ..metrics.pairwise import _euclidean_distances, euclidean_distances
 from ..utils import check_array, check_random_state
 from ..utils._openmp_helpers import _openmp_effective_n_threads
-from ..utils._param_validation import Hidden, Interval, StrOptions, validate_params
+from ..utils._param_validation import Interval, StrOptions, validate_params
 from ..utils.extmath import row_norms, stable_cumsum
 from ..utils.fixes import threadpool_info, threadpool_limits
 from ..utils.sparsefuncs import mean_variance_axis
@@ -305,7 +305,7 @@ def k_means(
     *,
     sample_weight=None,
     init="k-means++",
-    n_init="warn",
+    n_init="auto",
     max_iter=300,
     verbose=False,
     tol=1e-4,
@@ -348,7 +348,7 @@ def k_means(
         - If a callable is passed, it should take arguments `X`, `n_clusters` and a
           random state and return an initialization.
 
-    n_init : 'auto' or int, default=10
+    n_init : 'auto' or int, default="auto"
         Number of time the k-means algorithm will be run with different
         centroid seeds. The final results will be the best output of
         n_init consecutive runs in terms of inertia.
@@ -361,7 +361,7 @@ def k_means(
            Added 'auto' option for `n_init`.
 
         .. versionchanged:: 1.4
-           Default value for `n_init` will change from 10 to `'auto'` in version 1.4.
+           Default value for `n_init` changed to `'auto'`.
 
     max_iter : int, default=300
         Maximum number of iterations of the k-means algorithm to run.
@@ -832,7 +832,6 @@ class _BaseKMeans(
         "init": [StrOptions({"k-means++", "random"}), callable, "array-like"],
         "n_init": [
             StrOptions({"auto"}),
-            Hidden(StrOptions({"warn"})),
             Interval(Integral, 1, None, closed="left"),
         ],
         "max_iter": [Interval(Integral, 1, None, closed="left")],
@@ -871,20 +870,7 @@ class _BaseKMeans(
         self._tol = _tolerance(X, self.tol)
 
         # n-init
-        # TODO(1.4): Remove
-        self._n_init = self.n_init
-        if self._n_init == "warn":
-            warnings.warn(
-                (
-                    "The default value of `n_init` will change from "
-                    f"{default_n_init} to 'auto' in 1.4. Set the value of `n_init`"
-                    " explicitly to suppress the warning"
-                ),
-                FutureWarning,
-                stacklevel=2,
-            )
-            self._n_init = default_n_init
-        if self._n_init == "auto":
+        if self.n_init == "auto":
             if isinstance(self.init, str) and self.init == "k-means++":
                 self._n_init = 1
             elif isinstance(self.init, str) and self.init == "random":
@@ -893,6 +879,8 @@ class _BaseKMeans(
                 self._n_init = default_n_init
             else:  # array-like
                 self._n_init = 1
+        else:
+            self._n_init = self.n_init
 
         if _is_arraylike_not_scalar(self.init) and self._n_init != 1:
             warnings.warn(
@@ -1243,7 +1231,7 @@ class KMeans(_BaseKMeans):
         For an example of how to use the different `init` strategy, see the example
         entitled :ref:`sphx_glr_auto_examples_cluster_plot_kmeans_digits.py`.
 
-    n_init : 'auto' or int, default=10
+    n_init : 'auto' or int, default='auto'
         Number of times the k-means algorithm is run with different centroid
         seeds. The final results is the best output of `n_init` consecutive runs
         in terms of inertia. Several runs are recommended for sparse
@@ -1257,7 +1245,7 @@ class KMeans(_BaseKMeans):
            Added 'auto' option for `n_init`.
 
         .. versionchanged:: 1.4
-           Default value for `n_init` will change from 10 to `'auto'` in version 1.4.
+           Default value for `n_init` changed to `'auto'`.
 
     max_iter : int, default=300
         Maximum number of iterations of the k-means algorithm for a
@@ -1391,7 +1379,7 @@ class KMeans(_BaseKMeans):
         n_clusters=8,
         *,
         init="k-means++",
-        n_init="warn",
+        n_init="auto",
         max_iter=300,
         tol=1e-4,
         verbose=0,
@@ -1779,7 +1767,7 @@ class MiniBatchKMeans(_BaseKMeans):
         If `None`, the heuristic is `init_size = 3 * batch_size` if
         `3 * batch_size < n_clusters`, else `init_size = 3 * n_clusters`.
 
-    n_init : 'auto' or int, default=3
+    n_init : 'auto' or int, default="auto"
         Number of random initializations that are tried.
         In contrast to KMeans, the algorithm is only run once, using the best of
         the `n_init` initializations as measured by inertia. Several runs are
@@ -1794,7 +1782,7 @@ class MiniBatchKMeans(_BaseKMeans):
            Added 'auto' option for `n_init`.
 
         .. versionchanged:: 1.4
-           Default value for `n_init` will change from 3 to `'auto'` in version 1.4.
+           Default value for `n_init` changed to `'auto'` in version.
 
     reassignment_ratio : float, default=0.01
         Control the fraction of the maximum number of counts for a center to
@@ -1911,7 +1899,7 @@ class MiniBatchKMeans(_BaseKMeans):
         tol=0.0,
         max_no_improvement=10,
         init_size=None,
-        n_init="warn",
+        n_init="auto",
         reassignment_ratio=0.01,
     ):
         super().__init__(

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -1,7 +1,6 @@
 """Testing for K-means"""
 import re
 import sys
-import warnings
 from io import StringIO
 
 import numpy as np
@@ -1123,24 +1122,6 @@ def test_inertia(dtype, global_random_seed):
     assert_allclose(inertia_dense, inertia_sparse, rtol=rtol)
     assert_allclose(inertia_dense, expected, rtol=rtol)
     assert_allclose(inertia_sparse, expected, rtol=rtol)
-
-
-# TODO(1.4): Remove
-@pytest.mark.parametrize("Klass, default_n_init", [(KMeans, 10), (MiniBatchKMeans, 3)])
-def test_change_n_init_future_warning(Klass, default_n_init):
-    est = Klass(n_init=1)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", FutureWarning)
-        est.fit(X)
-
-    default_n_init = 10 if Klass.__name__ == "KMeans" else 3
-    msg = (
-        f"The default value of `n_init` will change from {default_n_init} to 'auto'"
-        " in 1.4"
-    )
-    est = Klass()
-    with pytest.warns(FutureWarning, match=msg):
-        est.fit(X)
 
 
 @pytest.mark.parametrize("Klass, default_n_init", [(KMeans, 10), (MiniBatchKMeans, 3)])


### PR DESCRIPTION
Changing the default of `n_init` to `"auto"` as announced during the deprecation cycle.

Also, do not allow `"auto"` in `BisectingKMeans` since this was not documented and we have a constant default to 1.