### PR TITLE
MAINT remove deprecated parameters in MiniBatchDictionaryLearning

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -289,6 +289,10 @@ Changelog
   Based on :user:`Alexander Tarashansky <atarashansky>`'s implementation in `scanpy <https://github.com/scverse/scanpy>`.
   :pr:`18689` by :user:`Isaac Virshup <ivirshup>` and :user:`Andrey Portnoy <andportnoy>`.
 
+- |Fix| :func:`decomposition.dict_learning_online` does not ignore anymore the parameter
+  `max_iter`.
+  :pr:`27834` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.ensemble`
 .......................
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -293,6 +293,11 @@ Changelog
   `max_iter`.
   :pr:`27834` by :user:`Guillaume Lemaitre <glemaitre>`.
 
+- |API| The option `max_iter=None` in :class:`decomposition.MiniBatchDictionaryLearning`
+  and :func:`decomposition.dict_learning_online` is deprecated and will be removed in
+  version 1.6. Use the default value instead.
+  :pr:`27834` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.ensemble`
 .......................
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -293,8 +293,10 @@ Changelog
   `max_iter`.
   :pr:`27834` by :user:`Guillaume Lemaitre <glemaitre>`.
 
-- |API| The option `max_iter=None` in :class:`decomposition.MiniBatchDictionaryLearning`
-  and :func:`decomposition.dict_learning_online` is deprecated and will be removed in
+- |API| The option `max_iter=None` in
+  :class:`decomposition.MiniBatchDictionaryLearning`,
+  :class:`decomposition.MiniBatchSparsePCA`, and
+  :func:`decomposition.dict_learning_online` is deprecated and will be removed in
   version 1.6. Use the default value instead.
   :pr:`27834` by :user:`Guillaume Lemaitre <glemaitre>`.
 

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -6,8 +6,6 @@
 import itertools
 import sys
 import time
-import warnings
-from math import ceil
 from numbers import Integral, Real
 
 import numpy as np
@@ -648,26 +646,12 @@ def _dict_learning(
         return code, dictionary, errors
 
 
-def _check_warn_deprecated(param, name, default, additional_message=None):
-    if param != "deprecated":
-        msg = (
-            f"'{name}' is deprecated in version 1.1 and will be removed in version 1.4."
-        )
-        if additional_message:
-            msg += f" {additional_message}"
-        warnings.warn(msg, FutureWarning)
-        return param
-    else:
-        return default
-
-
 def dict_learning_online(
     X,
     n_components=2,
     *,
     alpha=1,
-    n_iter="deprecated",
-    max_iter=None,
+    max_iter=1_000,
     return_code=True,
     dict_init=None,
     callback=None,
@@ -676,11 +660,7 @@ def dict_learning_online(
     shuffle=True,
     n_jobs=None,
     method="lars",
-    iter_offset="deprecated",
     random_state=None,
-    return_inner_stats="deprecated",
-    inner_stats="deprecated",
-    return_n_iter="deprecated",
     positive_dict=False,
     positive_code=False,
     method_max_iter=1000,
@@ -716,17 +696,10 @@ def dict_learning_online(
     alpha : float, default=1
         Sparsity controlling parameter.
 
-    n_iter : int, default=100
-        Number of mini-batch iterations to perform.
 
-        .. deprecated:: 1.1
-           `n_iter` is deprecated in 1.1 and will be removed in 1.4. Use
-           `max_iter` instead.
-
-    max_iter : int, default=None
+    max_iter : int, default=1_000
         Maximum number of iterations over the complete dataset before
         stopping independently of any early stopping criterion heuristics.
-        If ``max_iter`` is not None, ``n_iter`` is ignored.
 
         .. versionadded:: 1.1
 
@@ -767,44 +740,12 @@ def dict_learning_online(
           Lasso solution (`linear_model.Lasso`). Lars will be faster if
           the estimated components are sparse.
 
-    iter_offset : int, default=0
-        Number of previous iterations completed on the dictionary used for
-        initialization.
-
-        .. deprecated:: 1.1
-           `iter_offset` serves internal purpose only and will be removed in 1.4.
-
     random_state : int, RandomState instance or None, default=None
         Used for initializing the dictionary when ``dict_init`` is not
         specified, randomly shuffling the data when ``shuffle`` is set to
         ``True``, and updating the dictionary. Pass an int for reproducible
         results across multiple function calls.
         See :term:`Glossary <random_state>`.
-
-    return_inner_stats : bool, default=False
-        Return the inner statistics A (dictionary covariance) and B
-        (data approximation). Useful to restart the algorithm in an
-        online setting. If `return_inner_stats` is `True`, `return_code` is
-        ignored.
-
-        .. deprecated:: 1.1
-           `return_inner_stats` serves internal purpose only and will be removed in 1.4.
-
-    inner_stats : tuple of (A, B) ndarrays, default=None
-        Inner sufficient statistics that are kept by the algorithm.
-        Passing them at initialization is useful in online settings, to
-        avoid losing the history of the evolution.
-        `A` `(n_components, n_components)` is the dictionary covariance matrix.
-        `B` `(n_features, n_components)` is the data approximation matrix.
-
-        .. deprecated:: 1.1
-           `inner_stats` serves internal purpose only and will be removed in 1.4.
-
-    return_n_iter : bool, default=False
-        Whether or not to return the number of iterations.
-
-        .. deprecated:: 1.1
-           `return_n_iter` will be removed in 1.4 and n_iter will never be returned.
 
     positive_dict : bool, default=False
         Whether to enforce positivity when finding the dictionary.
@@ -861,218 +802,34 @@ def dict_learning_online(
     SparsePCA : Sparse Principal Components Analysis.
     MiniBatchSparsePCA : Mini-batch Sparse Principal Components Analysis.
     """
-    deps = (return_n_iter, return_inner_stats, iter_offset, inner_stats)
-    if max_iter is not None and not all(arg == "deprecated" for arg in deps):
-        raise ValueError(
-            "The following arguments are incompatible with 'max_iter': "
-            "return_n_iter, return_inner_stats, iter_offset, inner_stats"
-        )
+    transform_algorithm = "lasso_" + method
 
-    iter_offset = _check_warn_deprecated(iter_offset, "iter_offset", default=0)
-    return_inner_stats = _check_warn_deprecated(
-        return_inner_stats,
-        "return_inner_stats",
-        default=False,
-        additional_message="From 1.4 inner_stats will never be returned.",
-    )
-    inner_stats = _check_warn_deprecated(inner_stats, "inner_stats", default=None)
-    return_n_iter = _check_warn_deprecated(
-        return_n_iter,
-        "return_n_iter",
-        default=False,
-        additional_message=(
-            "From 1.4 'n_iter' will never be returned. Refer to the 'n_iter_' and "
-            "'n_steps_' attributes of the MiniBatchDictionaryLearning object instead."
-        ),
-    )
+    est = MiniBatchDictionaryLearning(
+        n_components=n_components,
+        alpha=alpha,
+        max_iter=max_iter,
+        n_jobs=n_jobs,
+        fit_algorithm=method,
+        batch_size=batch_size,
+        shuffle=shuffle,
+        dict_init=dict_init,
+        random_state=random_state,
+        transform_algorithm=transform_algorithm,
+        transform_alpha=alpha,
+        positive_code=positive_code,
+        positive_dict=positive_dict,
+        transform_max_iter=method_max_iter,
+        verbose=verbose,
+        callback=callback,
+        tol=tol,
+        max_no_improvement=max_no_improvement,
+    ).fit(X)
 
-    if max_iter is not None:
-        transform_algorithm = "lasso_" + method
-
-        est = MiniBatchDictionaryLearning(
-            n_components=n_components,
-            alpha=alpha,
-            n_iter=n_iter,
-            n_jobs=n_jobs,
-            fit_algorithm=method,
-            batch_size=batch_size,
-            shuffle=shuffle,
-            dict_init=dict_init,
-            random_state=random_state,
-            transform_algorithm=transform_algorithm,
-            transform_alpha=alpha,
-            positive_code=positive_code,
-            positive_dict=positive_dict,
-            transform_max_iter=method_max_iter,
-            verbose=verbose,
-            callback=callback,
-            tol=tol,
-            max_no_improvement=max_no_improvement,
-        ).fit(X)
-
-        if not return_code:
-            return est.components_
-        else:
-            code = est.transform(X)
-            return code, est.components_
-
-    # TODO(1.4) remove the whole old behavior
-    # Fallback to old behavior
-
-    n_iter = _check_warn_deprecated(
-        n_iter, "n_iter", default=100, additional_message="Use 'max_iter' instead."
-    )
-
-    if n_components is None:
-        n_components = X.shape[1]
-
-    if method not in ("lars", "cd"):
-        raise ValueError("Coding method not supported as a fit algorithm.")
-
-    _check_positive_coding(method, positive_code)
-
-    method = "lasso_" + method
-
-    t0 = time.time()
-    n_samples, n_features = X.shape
-    # Avoid integer division problems
-    alpha = float(alpha)
-    random_state = check_random_state(random_state)
-
-    # Init V with SVD of X
-    if dict_init is not None:
-        dictionary = dict_init
+    if not return_code:
+        return est.components_
     else:
-        _, S, dictionary = randomized_svd(X, n_components, random_state=random_state)
-        dictionary = S[:, np.newaxis] * dictionary
-    r = len(dictionary)
-    if n_components <= r:
-        dictionary = dictionary[:n_components, :]
-    else:
-        dictionary = np.r_[
-            dictionary,
-            np.zeros((n_components - r, dictionary.shape[1]), dtype=dictionary.dtype),
-        ]
-
-    if verbose == 1:
-        print("[dict_learning]", end=" ")
-
-    if shuffle:
-        X_train = X.copy()
-        random_state.shuffle(X_train)
-    else:
-        X_train = X
-
-    X_train = check_array(
-        X_train, order="C", dtype=[np.float64, np.float32], copy=False
-    )
-
-    # Fortran-order dict better suited for the sparse coding which is the
-    # bottleneck of this algorithm.
-    dictionary = check_array(dictionary, order="F", dtype=X_train.dtype, copy=False)
-    dictionary = np.require(dictionary, requirements="W")
-
-    batches = gen_batches(n_samples, batch_size)
-    batches = itertools.cycle(batches)
-
-    # The covariance of the dictionary
-    if inner_stats is None:
-        A = np.zeros((n_components, n_components), dtype=X_train.dtype)
-        # The data approximation
-        B = np.zeros((n_features, n_components), dtype=X_train.dtype)
-    else:
-        A = inner_stats[0].copy()
-        B = inner_stats[1].copy()
-
-    # If n_iter is zero, we need to return zero.
-    ii = iter_offset - 1
-
-    for ii, batch in zip(range(iter_offset, iter_offset + n_iter), batches):
-        this_X = X_train[batch]
-        dt = time.time() - t0
-        if verbose == 1:
-            sys.stdout.write(".")
-            sys.stdout.flush()
-        elif verbose:
-            if verbose > 10 or ii % ceil(100.0 / verbose) == 0:
-                print(
-                    "Iteration % 3i (elapsed time: % 3is, % 4.1fmn)" % (ii, dt, dt / 60)
-                )
-
-        this_code = sparse_encode(
-            this_X,
-            dictionary,
-            algorithm=method,
-            alpha=alpha,
-            n_jobs=n_jobs,
-            check_input=False,
-            positive=positive_code,
-            max_iter=method_max_iter,
-            verbose=verbose,
-        )
-
-        # Update the auxiliary variables
-        if ii < batch_size - 1:
-            theta = float((ii + 1) * batch_size)
-        else:
-            theta = float(batch_size**2 + ii + 1 - batch_size)
-        beta = (theta + 1 - batch_size) / (theta + 1)
-
-        A *= beta
-        A += np.dot(this_code.T, this_code)
-        B *= beta
-        B += np.dot(this_X.T, this_code)
-
-        # Update dictionary in place
-        _update_dict(
-            dictionary,
-            this_X,
-            this_code,
-            A,
-            B,
-            verbose=verbose,
-            random_state=random_state,
-            positive=positive_dict,
-        )
-
-        # Maybe we need a stopping criteria based on the amount of
-        # modification in the dictionary
-        if callback is not None:
-            callback(locals())
-
-    if return_inner_stats:
-        if return_n_iter:
-            return dictionary, (A, B), ii - iter_offset + 1
-        else:
-            return dictionary, (A, B)
-    if return_code:
-        if verbose > 1:
-            print("Learning code...", end=" ")
-        elif verbose == 1:
-            print("|", end=" ")
-        code = sparse_encode(
-            X,
-            dictionary,
-            algorithm=method,
-            alpha=alpha,
-            n_jobs=n_jobs,
-            check_input=False,
-            positive=positive_code,
-            max_iter=method_max_iter,
-            verbose=verbose,
-        )
-        if verbose > 1:
-            dt = time.time() - t0
-            print("done (total time: % 3is, % 4.1fmn)" % (dt, dt / 60))
-        if return_n_iter:
-            return code, dictionary, ii - iter_offset + 1
-        else:
-            return code, dictionary
-
-    if return_n_iter:
-        return dictionary, ii - iter_offset + 1
-    else:
-        return dictionary
+        code = est.transform(X)
+        return code, est.components_
 
 
 @validate_params(
@@ -1891,17 +1648,9 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
     alpha : float, default=1
         Sparsity controlling parameter.
 
-    n_iter : int, default=1000
-        Total number of iterations over data batches to perform.
-
-        .. deprecated:: 1.1
-           ``n_iter`` is deprecated in 1.1 and will be removed in 1.4. Use
-           ``max_iter`` instead.
-
-    max_iter : int, default=None
+    max_iter : int, default=1_000
         Maximum number of iterations over the complete dataset before
         stopping independently of any early stopping criterion heuristics.
-        If ``max_iter`` is not None, ``n_iter`` is ignored.
 
         .. versionadded:: 1.1
 
@@ -2086,11 +1835,9 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
     _parameter_constraints: dict = {
         "n_components": [Interval(Integral, 1, None, closed="left"), None],
         "alpha": [Interval(Real, 0, None, closed="left")],
-        "n_iter": [
-            Interval(Integral, 0, None, closed="left"),
-            Hidden(StrOptions({"deprecated"})),
-        ],
-        "max_iter": [Interval(Integral, 0, None, closed="left"), None],
+        # `max_iter=None` is equivalent to 1_000 and was used during n_iter deprecation
+        # Hide it to not silently support it.
+        "max_iter": [Interval(Integral, 0, None, closed="left"), Hidden(None)],
         "fit_algorithm": [StrOptions({"cd", "lars"})],
         "n_jobs": [None, Integral],
         "batch_size": [Interval(Integral, 1, None, closed="left")],
@@ -2117,8 +1864,7 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
         n_components=None,
         *,
         alpha=1,
-        n_iter="deprecated",
-        max_iter=None,
+        max_iter=1_000,
         fit_algorithm="lars",
         n_jobs=None,
         batch_size=256,
@@ -2148,7 +1894,6 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
         )
         self.n_components = n_components
         self.alpha = alpha
-        self.n_iter = n_iter
         self.max_iter = max_iter
         self.fit_algorithm = fit_algorithm
         self.dict_init = dict_init
@@ -2346,19 +2091,6 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
         )
 
         self._check_params(X)
-
-        if self.n_iter != "deprecated":
-            warnings.warn(
-                (
-                    "'n_iter' is deprecated in version 1.1 and will be removed "
-                    "in version 1.4. Use 'max_iter' and let 'n_iter' to its default "
-                    "value instead. 'n_iter' is also ignored if 'max_iter' is "
-                    "specified."
-                ),
-                FutureWarning,
-            )
-            n_iter = self.n_iter
-
         self._random_state = check_random_state(self.random_state)
 
         dictionary = self._initialize_dict(X, self._random_state)
@@ -2381,60 +2113,40 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
         )
         self._B = np.zeros((n_features, self._n_components), dtype=X_train.dtype)
 
-        if self.max_iter is not None:
-            # Attributes to monitor the convergence
-            self._ewa_cost = None
-            self._ewa_cost_min = None
-            self._no_improvement = 0
+        max_iter = 1_000 if self.max_iter is None else self.max_iter
+        # Attributes to monitor the convergence
+        self._ewa_cost = None
+        self._ewa_cost_min = None
+        self._no_improvement = 0
 
-            batches = gen_batches(n_samples, self._batch_size)
-            batches = itertools.cycle(batches)
-            n_steps_per_iter = int(np.ceil(n_samples / self._batch_size))
-            n_steps = self.max_iter * n_steps_per_iter
+        batches = gen_batches(n_samples, self._batch_size)
+        batches = itertools.cycle(batches)
+        n_steps_per_iter = int(np.ceil(n_samples / self._batch_size))
+        n_steps = max_iter * n_steps_per_iter
 
-            i = -1  # to allow max_iter = 0
+        i = -1  # to allow max_iter = 0
 
-            for i, batch in zip(range(n_steps), batches):
-                X_batch = X_train[batch]
+        for i, batch in zip(range(n_steps), batches):
+            X_batch = X_train[batch]
 
-                batch_cost = self._minibatch_step(
-                    X_batch, dictionary, self._random_state, i
-                )
+            batch_cost = self._minibatch_step(
+                X_batch, dictionary, self._random_state, i
+            )
 
-                if self._check_convergence(
-                    X_batch, batch_cost, dictionary, old_dict, n_samples, i, n_steps
-                ):
-                    break
+            if self._check_convergence(
+                X_batch, batch_cost, dictionary, old_dict, n_samples, i, n_steps
+            ):
+                break
 
-                # XXX callback param added for backward compat in #18975 but a common
-                # unified callback API should be preferred
-                if self.callback is not None:
-                    self.callback(locals())
+            # XXX callback param added for backward compat in #18975 but a common
+            # unified callback API should be preferred
+            if self.callback is not None:
+                self.callback(locals())
 
-                old_dict[:] = dictionary
+            old_dict[:] = dictionary
 
-            self.n_steps_ = i + 1
-            self.n_iter_ = np.ceil(self.n_steps_ / n_steps_per_iter)
-        else:
-            # TODO remove this branch in 1.4
-            n_iter = 1000 if self.n_iter == "deprecated" else self.n_iter
-
-            batches = gen_batches(n_samples, self._batch_size)
-            batches = itertools.cycle(batches)
-
-            for i, batch in zip(range(n_iter), batches):
-                self._minibatch_step(X_train[batch], dictionary, self._random_state, i)
-
-                trigger_verbose = self.verbose and i % ceil(100.0 / self.verbose) == 0
-                if self.verbose > 10 or trigger_verbose:
-                    print(f"{i} batches processed.")
-
-                if self.callback is not None:
-                    self.callback(locals())
-
-            self.n_steps_ = n_iter
-            self.n_iter_ = np.ceil(n_iter / int(np.ceil(n_samples / self._batch_size)))
-
+        self.n_steps_ = i + 1
+        self.n_iter_ = np.ceil(self.n_steps_ / n_steps_per_iter)
         self.components_ = dictionary
 
         return self

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -809,10 +809,10 @@ def dict_learning_online(
     if max_iter is None:
         warn(
             (
-                "max_iter=None is deprecated in 1.4 and will be removed in 1.6. "
-                "Use the default value (i.e. 100) instead."
+                "`max_iter=None` is deprecated in version 1.4 and will be removed in "
+                "version 1.6. Use the default value (i.e. `100`) instead."
             ),
-            DeprecationWarning,
+            FutureWarning,
         )
         max_iter = 100
 
@@ -2131,8 +2131,11 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
         # TODO(1.6): remove in 1.6
         if self.max_iter is None:
             warn(
-                "max_iter=None is deprecated in version 1.4 and will be removed in "
-                "version 1.6. Use max_iter=1_000 instead."
+                (
+                    "`max_iter=None` is deprecated in version 1.4 and will be removed"
+                    " in version 1.6. Use the default value (i.e. `1_000`) instead."
+                ),
+                FutureWarning,
             )
             max_iter = 1_000
         else:

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -651,7 +651,7 @@ def dict_learning_online(
     n_components=2,
     *,
     alpha=1,
-    max_iter=1_000,
+    max_iter=100,
     return_code=True,
     dict_init=None,
     callback=None,
@@ -697,7 +697,7 @@ def dict_learning_online(
         Sparsity controlling parameter.
 
 
-    max_iter : int, default=1_000
+    max_iter : int, default=100
         Maximum number of iterations over the complete dataset before
         stopping independently of any early stopping criterion heuristics.
 

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -487,7 +487,7 @@ class MiniBatchSparsePCA(_BaseSparsePCA):
         *,
         alpha=1,
         ridge_alpha=0.01,
-        max_iter=None,
+        max_iter=1_000,
         callback=None,
         batch_size=3,
         verbose=False,

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -358,19 +358,15 @@ class MiniBatchSparsePCA(_BaseSparsePCA):
         Amount of ridge shrinkage to apply in order to improve
         conditioning when calling the transform method.
 
-    n_iter : int, default=100
-        Number of iterations to perform for each mini batch.
-
-        .. deprecated:: 1.2
-           `n_iter` is deprecated in 1.2 and will be removed in 1.4. Use
-           `max_iter` instead.
-
-    max_iter : int, default=None
+    max_iter : int, default=1_000
         Maximum number of iterations over the complete dataset before
         stopping independently of any early stopping criterion heuristics.
-        If `max_iter` is not `None`, `n_iter` is ignored.
 
         .. versionadded:: 1.2
+
+        .. deprecated:: 1.4
+           `max_iter=None` is deprecated in 1.4 and will be removed in 1.6.
+           Use the default value (i.e. `100`) instead.
 
     callback : callable, default=None
         Callable that gets invoked every five iterations.
@@ -406,7 +402,7 @@ class MiniBatchSparsePCA(_BaseSparsePCA):
 
     tol : float, default=1e-3
         Control early stopping based on the norm of the differences in the
-        dictionary between 2 steps. Used only if `max_iter` is not None.
+        dictionary between 2 steps.
 
         To disable early stopping based on changes in the dictionary, set
         `tol` to 0.0.
@@ -415,8 +411,7 @@ class MiniBatchSparsePCA(_BaseSparsePCA):
 
     max_no_improvement : int or None, default=10
         Control early stopping based on the consecutive number of mini batches
-        that does not yield an improvement on the smoothed cost function. Used only if
-        `max_iter` is not None.
+        that does not yield an improvement on the smoothed cost function.
 
         To disable convergence detection based on cost function, set
         `max_no_improvement` to `None`.
@@ -479,7 +474,7 @@ class MiniBatchSparsePCA(_BaseSparsePCA):
 
     _parameter_constraints: dict = {
         **_BaseSparsePCA._parameter_constraints,
-        "max_iter": [Interval(Integral, 0, None, closed="left"), None],
+        "max_iter": [Interval(Integral, 0, None, closed="left"), Hidden(None)],
         "n_iter": [
             Interval(Integral, 0, None, closed="left"),
             Hidden(StrOptions({"deprecated"})),
@@ -496,7 +491,6 @@ class MiniBatchSparsePCA(_BaseSparsePCA):
         *,
         alpha=1,
         ridge_alpha=0.01,
-        n_iter="deprecated",
         max_iter=None,
         callback=None,
         batch_size=3,
@@ -519,7 +513,6 @@ class MiniBatchSparsePCA(_BaseSparsePCA):
             verbose=verbose,
             random_state=random_state,
         )
-        self.n_iter = n_iter
         self.callback = callback
         self.batch_size = batch_size
         self.shuffle = shuffle
@@ -532,7 +525,6 @@ class MiniBatchSparsePCA(_BaseSparsePCA):
         est = MiniBatchDictionaryLearning(
             n_components=n_components,
             alpha=self.alpha,
-            n_iter=self.n_iter,
             max_iter=self.max_iter,
             dict_init=None,
             batch_size=self.batch_size,

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -475,10 +475,6 @@ class MiniBatchSparsePCA(_BaseSparsePCA):
     _parameter_constraints: dict = {
         **_BaseSparsePCA._parameter_constraints,
         "max_iter": [Interval(Integral, 0, None, closed="left"), Hidden(None)],
-        "n_iter": [
-            Interval(Integral, 0, None, closed="left"),
-            Hidden(StrOptions({"deprecated"})),
-        ],
         "callback": [None, callable],
         "batch_size": [Interval(Integral, 1, None, closed="left")],
         "shuffle": ["boolean"],

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -972,3 +972,12 @@ def test_cd_work_on_joblib_memmapped_data(monkeypatch):
 
     # This must run and complete without error.
     dict_learner.fit(X_train)
+
+
+# TODO(1.6): remove in 1.6
+def test_xxx():
+    warn_msg = "`max_iter=None` is deprecated in version 1.4 and will be removed"
+    with pytest.warns(FutureWarning, match=warn_msg):
+        MiniBatchDictionaryLearning(max_iter=None, random_state=0).fit(X)
+    with pytest.warns(FutureWarning, match=warn_msg):
+        dict_learning_online(X, max_iter=None, random_state=0)

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -900,7 +900,8 @@ def test_dict_learning_online_numerical_consistency(method):
         batch_size=10,
         random_state=0,
         method=method,
-        tol=1e-1,
+        tol=0.0,
+        max_no_improvement=None,
     )
     U_32, V_32 = dict_learning_online(
         X.astype(np.float32),
@@ -910,7 +911,8 @@ def test_dict_learning_online_numerical_consistency(method):
         batch_size=10,
         random_state=0,
         method=method,
-        tol=1e-1,
+        tol=0.0,
+        max_no_improvement=None,
     )
 
     # Optimal solution (U*, V*) is not unique.

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -900,6 +900,7 @@ def test_dict_learning_online_numerical_consistency(method):
         batch_size=10,
         random_state=0,
         method=method,
+        tol=1e-1,
     )
     U_32, V_32 = dict_learning_online(
         X.astype(np.float32),
@@ -909,6 +910,7 @@ def test_dict_learning_online_numerical_consistency(method):
         batch_size=10,
         random_state=0,
         method=method,
+        tol=1e-1,
     )
 
     # Optimal solution (U*, V*) is not unique.

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -655,44 +655,6 @@ def test_sparse_coder_n_features_in():
     assert sc.n_features_in_ == d.shape[1]
 
 
-def test_minibatch_dict_learning_n_iter_deprecated():
-    # check the deprecation warning of n_iter
-    # TODO(1.4) remove
-    depr_msg = (
-        "'n_iter' is deprecated in version 1.1 and will be removed in version 1.4"
-    )
-    est = MiniBatchDictionaryLearning(
-        n_components=2, batch_size=4, n_iter=5, random_state=0
-    )
-
-    with pytest.warns(FutureWarning, match=depr_msg):
-        est.fit(X)
-
-
-@pytest.mark.parametrize(
-    "arg, val",
-    [
-        ("iter_offset", 0),
-        ("inner_stats", None),
-        ("return_inner_stats", False),
-        ("return_n_iter", False),
-        ("n_iter", 5),
-    ],
-)
-def test_dict_learning_online_deprecated_args(arg, val):
-    # check the deprecation warning for the deprecated args of
-    # dict_learning_online
-    # TODO(1.4) remove
-    depr_msg = (
-        f"'{arg}' is deprecated in version 1.1 and will be removed in version 1.4."
-    )
-
-    with pytest.warns(FutureWarning, match=depr_msg):
-        dict_learning_online(
-            X, n_components=2, batch_size=4, random_state=0, **{arg: val}
-        )
-
-
 def test_update_dict():
     # Check the dict update in batch mode vs online mode
     # Non-regression test for #4866
@@ -714,15 +676,6 @@ def test_update_dict():
     _update_dict(newd_online, X, code, A, B)
 
     assert_allclose(newd_batch, newd_online)
-
-
-# TODO(1.4) remove
-def test_dict_learning_online_n_iter_deprecated():
-    # Check that an error is raised when a deprecated argument is set when max_iter
-    # is also set.
-    msg = "The following arguments are incompatible with 'max_iter'"
-    with pytest.raises(ValueError, match=msg):
-        dict_learning_online(X, max_iter=10, return_inner_stats=True)
 
 
 @pytest.mark.parametrize(
@@ -1013,14 +966,3 @@ def test_cd_work_on_joblib_memmapped_data(monkeypatch):
 
     # This must run and complete without error.
     dict_learner.fit(X_train)
-
-
-# TODO(1.4) remove
-def test_minibatch_dictionary_learning_warns_and_ignore_n_iter():
-    """Check that we always raise a warning when `n_iter` is set even if it is
-    ignored if `max_iter` is set.
-    """
-    warn_msg = "'n_iter' is deprecated in version 1.1"
-    with pytest.warns(FutureWarning, match=warn_msg):
-        model = MiniBatchDictionaryLearning(batch_size=256, n_iter=2, max_iter=2).fit(X)
-    assert model.n_iter_ == 2

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -895,6 +895,7 @@ def test_dict_learning_online_numerical_consistency(method):
     U_64, V_64 = dict_learning_online(
         X.astype(np.float64),
         n_components=n_components,
+        max_iter=1_000,
         alpha=alpha,
         batch_size=10,
         random_state=0,
@@ -903,6 +904,7 @@ def test_dict_learning_online_numerical_consistency(method):
     U_32, V_32 = dict_learning_online(
         X.astype(np.float32),
         n_components=n_components,
+        max_iter=1_000,
         alpha=alpha,
         batch_size=10,
         random_state=0,

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -268,26 +268,16 @@ def test_spca_feature_names_out(SPCA):
     assert_array_equal([f"{estimator_name}{i}" for i in range(4)], names)
 
 
-# TODO (1.4): remove this test
-def test_spca_n_iter_deprecation():
-    """Check that we raise a warning for the deprecation of `n_iter` and it is ignored
-    when `max_iter` is specified.
-    """
+# TODO (1.6): remove in 1.6
+def test_spca_max_iter_None_deprecation():
+    """Check that we raise a warning for the deprecation of `max_iter=None`."""
     rng = np.random.RandomState(0)
     n_samples, n_features = 12, 10
     X = rng.randn(n_samples, n_features)
 
-    warn_msg = "'n_iter' is deprecated in version 1.1 and will be removed"
+    warn_msg = "`max_iter=None` is deprecated in version 1.4 and will be removed"
     with pytest.warns(FutureWarning, match=warn_msg):
-        MiniBatchSparsePCA(n_iter=2).fit(X)
-
-    n_iter, max_iter = 1, 100
-    with pytest.warns(FutureWarning, match=warn_msg):
-        model = MiniBatchSparsePCA(
-            n_iter=n_iter, max_iter=max_iter, random_state=0
-        ).fit(X)
-    assert model.n_iter_ > 1
-    assert model.n_iter_ <= max_iter
+        MiniBatchSparsePCA(max_iter=None).fit(X)
 
 
 def test_pca_n_features_deprecation():


### PR DESCRIPTION
Remove all parameters that have been deprecated in the `MiniBatchDictionaryLearning` and announced during a deprecation cycle.