### PR TITLE
MAINT remove parameter sum_over_features in manhattan_distances

### DIFF
--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -222,23 +222,6 @@ def test_pairwise_distances_for_sparse_data(
         pairwise_distances(X, Y_sparse, metric="minkowski")
 
 
-# TODO(1.4): Remove test when `sum_over_features` parameter is removed
-@pytest.mark.parametrize("sum_over_features", [True, False])
-def test_manhattan_distances_deprecated_sum_over_features(sum_over_features):
-    # Check that future warning is raised when user
-    # enters `sum_over_features` argument.
-    X = [[1, 2], [3, 4]]
-    Y = [[1, 2], [0, 3]]
-    with pytest.warns(
-        FutureWarning,
-        match=(
-            "`sum_over_features` is deprecated in version 1.2 and will be"
-            " removed in version 1.4."
-        ),
-    ):
-        manhattan_distances(X, Y, sum_over_features=sum_over_features)
-
-
 @pytest.mark.parametrize("metric", PAIRWISE_BOOLEAN_FUNCTIONS)
 def test_pairwise_boolean_distance(metric):
     # test that we convert to boolean arrays for boolean distances


### PR DESCRIPTION
Remove the parameter `sum_over_features` in `manhattan_distances` as announced during the deprecation cycle.