### PR TITLE
MAINT remove sparse parameter in OneHotEncoder

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -13,7 +13,7 @@ from ..base import BaseEstimator, OneToOneFeatureMixin, TransformerMixin, _fit_c
 from ..utils import _safe_indexing, check_array, is_scalar_nan
 from ..utils._encode import _check_unknown, _encode, _get_counts, _unique
 from ..utils._mask import _get_mask
-from ..utils._param_validation import Hidden, Interval, RealNotInt, StrOptions
+from ..utils._param_validation import Interval, RealNotInt, StrOptions
 from ..utils._set_output import _get_output_config
 from ..utils.validation import _check_feature_names_in, check_is_fitted
 
@@ -528,13 +528,6 @@ class OneHotEncoder(_BaseEncoder):
         .. versionchanged:: 1.1
             Support for dropping infrequent categories.
 
-    sparse : bool, default=True
-        Will return sparse matrix if set True else will return an array.
-
-        .. deprecated:: 1.2
-           `sparse` is deprecated in 1.2 and will be removed in 1.4. Use
-           `sparse_output` instead.
-
     sparse_output : bool, default=True
         When ``True``, it returns a :class:`scipy.sparse.csr_matrix`,
         i.e. a sparse matrix in "Compressed Sparse Row" (CSR) format.
@@ -743,7 +736,6 @@ class OneHotEncoder(_BaseEncoder):
             Interval(RealNotInt, 0, 1, closed="neither"),
             None,
         ],
-        "sparse": [Hidden(StrOptions({"deprecated"})), "boolean"],  # deprecated
         "sparse_output": ["boolean"],
         "feature_name_combiner": [StrOptions({"concat"}), callable],
     }
@@ -753,7 +745,6 @@ class OneHotEncoder(_BaseEncoder):
         *,
         categories="auto",
         drop=None,
-        sparse="deprecated",
         sparse_output=True,
         dtype=np.float64,
         handle_unknown="error",
@@ -762,8 +753,6 @@ class OneHotEncoder(_BaseEncoder):
         feature_name_combiner="concat",
     ):
         self.categories = categories
-        # TODO(1.4): Remove self.sparse
-        self.sparse = sparse
         self.sparse_output = sparse_output
         self.dtype = dtype
         self.handle_unknown = handle_unknown
@@ -986,17 +975,6 @@ class OneHotEncoder(_BaseEncoder):
         self
             Fitted encoder.
         """
-        if self.sparse != "deprecated":
-            warnings.warn(
-                (
-                    "`sparse` was renamed to `sparse_output` in version 1.2 and "
-                    "will be removed in 1.4. `sparse_output` is ignored unless you "
-                    "leave `sparse` to its default value."
-                ),
-                FutureWarning,
-            )
-            self.sparse_output = self.sparse
-
         self._fit(
             X,
             handle_unknown=self.handle_unknown,

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -1350,15 +1350,6 @@ def test_ohe_infrequent_user_cats_unknown_training_errors(kwargs):
     assert_allclose(X_trans, [[1], [1]])
 
 
-# TODO(1.4): Remove when `sparse` parameter is replaced by `sparse_output`
-def test_one_hot_encoder_sparse_deprecated():
-    X = [["Male", 1], ["Female", 3], ["Female", 2]]
-
-    msg = "`sparse` was renamed to `sparse_output`"
-    with pytest.warns(FutureWarning, match=msg):
-        OneHotEncoder(sparse=False).fit(X)
-
-
 # deliberately omit 'OS' as an invalid combo
 @pytest.mark.parametrize(
     "input_dtype, category_dtype", ["OO", "OU", "UO", "UU", "SO", "SU", "SS"]


### PR DESCRIPTION
Remove the parameter `sparse` in `OneHotEncoder` in favor of `sparse_output` as announced by the deprecation.