### PR TITLE
MAINT remove deprecated class_weight_ attribute

### DIFF
--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -331,8 +331,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
             y,
             svm_type=solver_type,
             sample_weight=sample_weight,
-            # TODO(1.4): Replace "_class_weight" with "class_weight_"
-            class_weight=getattr(self, "_class_weight", np.empty(0)),
+            class_weight=getattr(self, "class_weight_", np.empty(0)),
             kernel=kernel,
             C=self.C,
             nu=self.nu,
@@ -381,8 +380,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
             self.coef0,
             self.tol,
             self.C,
-            # TODO(1.4): Replace "_class_weight" with "class_weight_"
-            getattr(self, "_class_weight", np.empty(0)),
+            getattr(self, "class_weight_", np.empty(0)),
             sample_weight,
             self.nu,
             self.cache_size,
@@ -492,8 +490,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
             self.coef0,
             self.tol,
             C,
-            # TODO(1.4): Replace "_class_weight" with "class_weight_"
-            getattr(self, "_class_weight", np.empty(0)),
+            getattr(self, "class_weight_", np.empty(0)),
             self.nu,
             self.epsilon,
             self.shrinking,
@@ -593,8 +590,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
             self.coef0,
             self.tol,
             self.C,
-            # TODO(1.4): Replace "_class_weight" with "class_weight_"
-            getattr(self, "_class_weight", np.empty(0)),
+            getattr(self, "class_weight_", np.empty(0)),
             self.nu,
             self.epsilon,
             self.shrinking,
@@ -950,8 +946,7 @@ class BaseSVC(ClassifierMixin, BaseLibSVM, metaclass=ABCMeta):
             self.coef0,
             self.tol,
             self.C,
-            # TODO(1.4): Replace "_class_weight" with "class_weight_"
-            getattr(self, "_class_weight", np.empty(0)),
+            getattr(self, "class_weight_", np.empty(0)),
             self.nu,
             self.epsilon,
             self.shrinking,
@@ -996,14 +991,6 @@ class BaseSVC(ClassifierMixin, BaseLibSVM, metaclass=ABCMeta):
         ndarray of shape  (n_classes * (n_classes - 1) / 2)
         """
         return self._probB
-
-    # TODO(1.4): Remove
-    @property
-    def _class_weight(self):
-        """Weights per class"""
-        # Class weights are defined for classifiers during
-        # fit.
-        return self.class_weight_
 
 
 def _get_liblinear_solver_type(multi_class, penalty, loss, dual):

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from ..base import BaseEstimator, OutlierMixin, RegressorMixin, _fit_context
 from ..linear_model._base import LinearClassifierMixin, LinearModel, SparseCoefMixin
-from ..utils import deprecated
 from ..utils._param_validation import Hidden, Interval, StrOptions
 from ..utils.multiclass import check_classification_targets
 from ..utils.validation import _num_samples
@@ -1249,13 +1248,6 @@ class SVR(RegressorMixin, BaseLibSVM):
 
     Attributes
     ----------
-    class_weight_ : ndarray of shape (n_classes,)
-        Multipliers of parameter C for each class.
-        Computed based on the ``class_weight`` parameter.
-
-        .. deprecated:: 1.2
-            `class_weight_` was deprecated in version 1.2 and will be removed in 1.4.
-
     coef_ : ndarray of shape (1, n_features)
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of a linear kernel.
@@ -1372,15 +1364,6 @@ class SVR(RegressorMixin, BaseLibSVM):
             random_state=None,
         )
 
-    # TODO(1.4): Remove
-    @deprecated(  # type: ignore
-        "Attribute `class_weight_` was deprecated in version 1.2 and will be removed in"
-        " 1.4."
-    )
-    @property
-    def class_weight_(self):
-        return np.empty(0)
-
     def _more_tags(self):
         return {
             "_xfail_checks": {
@@ -1457,13 +1440,6 @@ class NuSVR(RegressorMixin, BaseLibSVM):
 
     Attributes
     ----------
-    class_weight_ : ndarray of shape (n_classes,)
-        Multipliers of parameter C for each class.
-        Computed based on the ``class_weight`` parameter.
-
-        .. deprecated:: 1.2
-            `class_weight_` was deprecated in version 1.2 and will be removed in 1.4.
-
     coef_ : ndarray of shape (1, n_features)
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of a linear kernel.
@@ -1580,15 +1556,6 @@ class NuSVR(RegressorMixin, BaseLibSVM):
             random_state=None,
         )
 
-    # TODO(1.4): Remove
-    @deprecated(  # type: ignore
-        "Attribute `class_weight_` was deprecated in version 1.2 and will be removed in"
-        " 1.4."
-    )
-    @property
-    def class_weight_(self):
-        return np.empty(0)
-
     def _more_tags(self):
         return {
             "_xfail_checks": {
@@ -1661,13 +1628,6 @@ class OneClassSVM(OutlierMixin, BaseLibSVM):
 
     Attributes
     ----------
-    class_weight_ : ndarray of shape (n_classes,)
-        Multipliers of parameter C for each class.
-        Computed based on the ``class_weight`` parameter.
-
-        .. deprecated:: 1.2
-            `class_weight_` was deprecated in version 1.2 and will be removed in 1.4.
-
     coef_ : ndarray of shape (1, n_features)
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of a linear kernel.
@@ -1776,15 +1736,6 @@ class OneClassSVM(OutlierMixin, BaseLibSVM):
             max_iter,
             random_state=None,
         )
-
-    # TODO(1.4): Remove
-    @deprecated(  # type: ignore
-        "Attribute `class_weight_` was deprecated in version 1.2 and will be removed in"
-        " 1.4."
-    )
-    @property
-    def class_weight_(self):
-        return np.empty(0)
 
     def fit(self, X, y=None, sample_weight=None):
         """Detect the soft boundary of the set of samples X.

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -4,7 +4,6 @@ Testing for Support Vector Machine module (sklearn.svm)
 TODO: remove hard coded numerical results when possible
 """
 import re
-import warnings
 
 import numpy as np
 import pytest
@@ -1396,21 +1395,6 @@ def test_n_iter_libsvm(estimator, expected_n_iter_type, dataset):
     if estimator in [svm.SVC, svm.NuSVC]:
         n_classes = len(np.unique(y))
         assert n_iter.shape == (n_classes * (n_classes - 1) // 2,)
-
-
-# TODO(1.4): Remove
-@pytest.mark.parametrize("Klass", [SVR, NuSVR, OneClassSVM])
-def test_svm_class_weights_deprecation(Klass):
-    clf = Klass()
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", FutureWarning)
-        clf.fit(X, Y)
-    msg = (
-        "Attribute `class_weight_` was deprecated in version 1.2 and will be removed"
-        " in 1.4"
-    )
-    with pytest.warns(FutureWarning, match=re.escape(msg)):
-        getattr(clf, "class_weight_")
 
 
 # TODO(1.5): Remove


### PR DESCRIPTION
Remove the `class_weight_` attribute in some SVM classes as announced during the deprecation cycle.