### PR TITLE
MAINT remove parameter setting in test_docstring

### DIFF
--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -224,11 +224,7 @@ def test_fit_docstring_attributes(name, Estimator):
         # default raises an error, perplexity must be less than n_samples
         est.set_params(perplexity=2)
 
-    # TODO(1.4): TO BE REMOVED for 1.4 (avoid FutureWarning)
-    if Estimator.__name__ in ("KMeans", "MiniBatchKMeans"):
-        est.set_params(n_init="auto")
-
-    # TODO(1.4): TO BE REMOVED for 1.5 (avoid FutureWarning)
+    # TODO(1.5): TO BE REMOVED for 1.5 (avoid FutureWarning)
     if Estimator.__name__ in ("LinearSVC", "LinearSVR"):
         est.set_params(dual="auto")
 


### PR DESCRIPTION
Remove an occurrence in `docstring_parameters` where we fix the default of `n_init`.
This is not needed anymore.