### PR TITLE
ENH use log1p and expm1 in Yeo-Johnson transformation and its inverse

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -3304,6 +3304,9 @@ class PowerTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
         """Return inverse-transformed input x following Yeo-Johnson inverse
         transform with parameter lambda.
         """
+        if lmbda == 1:
+            return x
+
         x_inv = np.zeros_like(x)
         pos = x >= 0
 
@@ -3325,6 +3328,8 @@ class PowerTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
         """Return transformed input x following Yeo-Johnson transform with
         parameter lambda.
         """
+        if lmbda == 1:
+            return x
 
         out = np.zeros_like(x)
         pos = x >= 0  # binary mask

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -3309,15 +3309,15 @@ class PowerTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
 
         # when x >= 0
         if abs(lmbda) < np.spacing(1.0):
-            x_inv[pos] = np.exp(x[pos]) - 1
+            x_inv[pos] = np.expm1(x[pos])
         else:  # lmbda != 0
-            x_inv[pos] = np.power(x[pos] * lmbda + 1, 1 / lmbda) - 1
+            x_inv[pos] = np.expm1(np.log1p(x[pos] * lmbda) / lmbda)
 
         # when x < 0
         if abs(lmbda - 2) > np.spacing(1.0):
-            x_inv[~pos] = 1 - np.power(-(2 - lmbda) * x[~pos] + 1, 1 / (2 - lmbda))
+            x_inv[~pos] = -np.expm1(np.log1p((lmbda - 2) * x[~pos]) / (2 - lmbda))
         else:  # lmbda == 2
-            x_inv[~pos] = 1 - np.exp(-x[~pos])
+            x_inv[~pos] = -np.expm1(-x[~pos])
 
         return x_inv
 
@@ -3333,11 +3333,11 @@ class PowerTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
         if abs(lmbda) < np.spacing(1.0):
             out[pos] = np.log1p(x[pos])
         else:  # lmbda != 0
-            out[pos] = (np.power(x[pos] + 1, lmbda) - 1) / lmbda
+            out[pos] = np.expm1(lmbda * np.log1p(x[pos])) / lmbda
 
         # when x < 0
         if abs(lmbda - 2) > np.spacing(1.0):
-            out[~pos] = -(np.power(-x[~pos] + 1, 2 - lmbda) - 1) / (2 - lmbda)
+            out[~pos] = -np.expm1((2 - lmbda) * np.log1p(-x[~pos])) / (2 - lmbda)
         else:  # lmbda == 2
             out[~pos] = -np.log1p(-x[~pos])
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

This PR was inspired by scipy's YJ transformation and also implement its inverse.
https://github.com/scipy/scipy/blob/fcf7b652bc27e47d215557bda61c84d19adc3aae/scipy/stats/_morestats.py#L1495-L1516

Specifically, if $\lambda=1$, we could skip the computation and return x directly.

#### Any other comments?
The formula of YJ transformation
![image](https://github.com/scikit-learn/scikit-learn/assets/41134380/0d2abc91-d8f6-4bd3-9fd7-e9d12c8209a7)



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
