### PR TITLE
[WIP] Implement Ridge CCA in Cross Decomposition Module

### DIFF
--- a/benchmarks/bench_ridgecca_pls.py
+++ b/benchmarks/bench_ridgecca_pls.py
@@ -82,14 +82,23 @@ def compute_bench(n_samples, features_range, methods, n_repeats=5):
 
 def plot_results(results, features_range, title):
     plt.figure(figsize=(10, 6))
-    markers = ['o', 's', 'D', '^',
-               'x']  # You can add more markers if you have more methods
+    markers = [
+        "o",
+        "s",
+        "D",
+        "^",
+        "x",
+    ]  # You can add more markers if you have more methods
     for (method, times), marker in zip(results.items(), markers):
         mean_times = np.mean(times, axis=1)
         std_times = np.std(times, axis=1)
         plt.errorbar(
-            features_range, mean_times, yerr=std_times, label=method, capsize=5,
-            marker=marker
+            features_range,
+            mean_times,
+            yerr=std_times,
+            label=method,
+            capsize=5,
+            marker=marker,
         )
 
     plt.xlabel("Number of Features", fontsize=14)
@@ -97,7 +106,6 @@ def plot_results(results, features_range, title):
     plt.title(title, fontsize=16)
     plt.legend()
     plt.grid(True)
-    plt.show()
 
 
 if __name__ == "__main__":
@@ -109,8 +117,10 @@ if __name__ == "__main__":
     cca_methods = [("cca", cca), ("pca-cca", pca_cca)]
     cca_results = compute_bench(n_samples, cca_features_range, cca_methods)
     plot_results(cca_results, cca_features_range, "Benchmarking CCA Methods")
+    plt.show()
 
     # Compute benchmarks for PLS
     pls_methods = [("plssvd", plssvd), ("pca-pls", pca_pls)]
     pls_results = compute_bench(n_samples, pls_features_range, pls_methods)
     plot_results(pls_results, pls_features_range, "Benchmarking PLS Methods")
+    plt.show()

--- a/benchmarks/bench_ridgecca_pls.py
+++ b/benchmarks/bench_ridgecca_pls.py
@@ -3,13 +3,14 @@ Benchmark of Ridge and SVD solvers for the CCA problem at different dimensions
 """
 import gc
 import sys
-import numpy as np
 from collections import defaultdict
 from time import time
-import matplotlib.pyplot as plt
 
-from sklearn.datasets import make_regression
+import matplotlib.pyplot as plt
+import numpy as np
+
 from sklearn.cross_decomposition import PLSSVD, RidgeCCA
+from sklearn.datasets import make_regression
 
 plssvd = PLSSVD(n_components=1)
 ridgecca = RidgeCCA(n_components=1, alpha_x=1.0, alpha_y=1.0)

--- a/benchmarks/bench_ridgecca_pls.py
+++ b/benchmarks/bench_ridgecca_pls.py
@@ -1,0 +1,69 @@
+"""
+Benchmark of Ridge and SVD solvers for the CCA problem at different dimensions
+"""
+import gc
+import sys
+import numpy as np
+from collections import defaultdict
+from time import time
+import matplotlib.pyplot as plt
+
+from sklearn.datasets import make_regression
+from sklearn.cross_decomposition import PLSSVD, RidgeCCA
+
+plssvd = PLSSVD(n_components=1)
+ridgecca = RidgeCCA(n_components=1, alpha_x=1.0, alpha_y=1.0)
+
+def compute_bench(n_samples, features_range, n_repeats=5):
+    results = defaultdict(lambda: [])
+
+    for n_features in features_range:
+        print("====================")
+        print(f"Features: {n_features}")
+        print("====================")
+
+        for _ in range(n_repeats):
+            dataset_kwargs = {
+                "n_samples": n_samples,
+                "n_features": n_features,
+                "n_targets": n_features,
+                "n_informative": n_features // 10,
+                "bias": 0.0,
+            }
+            X, y = make_regression(**dataset_kwargs)
+
+            for name, estimator in [("plssvd", plssvd), ("ridgecca", ridgecca)]:
+                gc.collect()
+                print(f"benchmarking {name}:", end="")
+                sys.stdout.flush()
+                tstart = time()
+                estimator.fit(X, y)
+                delta = time() - tstart
+                print("%0.3fs" % delta)
+                results[name].append(delta)
+
+    # Convert lists to numpy arrays for easier manipulation
+    for key in results:
+        results[key] = np.array(results[key]).reshape(-1, n_repeats)
+
+    return results
+
+def plot_results(results, features_range):
+    plt.figure(figsize=(10, 6))
+    for method, times in results.items():
+        mean_times = np.mean(times, axis=1)
+        std_times = np.std(times, axis=1)
+        plt.errorbar(features_range, mean_times, yerr=std_times, label=method, capsize=5)
+
+    plt.xlabel('Number of Features')
+    plt.ylabel('Time (seconds)')
+    plt.title('Benchmarking Ridge and SVD Solvers for CCA')
+    plt.legend()
+    plt.grid(True)
+    plt.show()
+
+if __name__ == "__main__":
+    n_samples = 100
+    features_range = [100, 200, 1000]
+    results = compute_bench(n_samples, features_range)
+    plot_results(results, features_range)

--- a/benchmarks/bench_ridgecca_pls.py
+++ b/benchmarks/bench_ridgecca_pls.py
@@ -1,3 +1,33 @@
+"""
+Benchmarking CCA/PLS Methods with Constant Sample Size
+
+In this benchmark we show that PCA-CCA and PCA-PLS (i.e. solving the CCA and PLS
+problems in the PCA space) are faster than the standard CCA and PLS algorithms,
+respectively for high-dimensional data.
+The RidgeCCA estimator uses PCA behind the scenes and thus can be applied by setting
+the alpha_x and alpha_yparameters to 0.0 (CCA) or 1.0 (PLS).
+
+PCA-CCA consistently outperforms the standard CCA algorithm in terms of computation
+time across the entire range of feature sizes. Notably, the standard CCA method is
+constrained to datasets where the number of features is less than the number of
+samples (p < n), which limits the maximum feature size to 400 in our tests. This
+limitation is due to the requirement of CCA for the inversion of the covariance
+matrix, which must be full rank and thus invertible.
+
+As observed in the plot, the PLSSVD method initially performs faster than the 
+pca_pls method. However, as the number of features increases, we notice a 
+'crossover' point: the computation time for PLSSVD grows more rapidly than for 
+pca_pls. Beyond this crossover, pca_pls becomes the more efficient 
+algorithm in terms of computation time. This suggests that pca_pls may be better 
+suited for high-dimensional data scenarios typically encountered in modern datasets.
+
+It's important to note that for CCA problems, which are closely related to PLS, 
+the Ridge CCA method demonstrates faster computation times across all feature sizes 
+tested. However, unlike PLS, CCA is only uniquely defined when the number of features 
+(p) is less than the number of samples (n), which constrained our tests to a maximum 
+of 400 features for the CCA benchmark.
+"""
+
 import gc
 import sys
 from collections import defaultdict
@@ -6,14 +36,14 @@ from time import time
 import matplotlib.pyplot as plt
 import numpy as np
 
-from sklearn.cross_decomposition import PLSSVD, RidgeCCA, CCA
+from sklearn.cross_decomposition import CCA, PLSSVD, RidgeCCA
 from sklearn.datasets import make_regression
 
 # Initialize models
 cca = CCA(n_components=1)
-ridgecca_cca = RidgeCCA(n_components=1, alpha_x=0.0, alpha_y=0.0)
+pca_cca = RidgeCCA(n_components=1, alpha_x=0.0, alpha_y=0.0)
 plssvd = PLSSVD(n_components=1)
-ridgecca_pls = RidgeCCA(n_components=1, alpha_x=1.0, alpha_y=1.0)
+pca_pls = RidgeCCA(n_components=1, alpha_x=1.0, alpha_y=1.0)
 
 
 def compute_bench(n_samples, features_range, methods, n_repeats=5):
@@ -71,16 +101,16 @@ def plot_results(results, features_range, title):
 
 
 if __name__ == "__main__":
-    n_samples=500
+    n_samples = 500
     cca_features_range = [100, 200, 400]
     pls_features_range = [100, 200, 500, 1000, 2000]
 
     # Compute benchmarks for CCA
-    cca_methods = [("cca", cca), ("ridgecca_cca", ridgecca_cca)]
+    cca_methods = [("cca", cca), ("pca-cca", pca_cca)]
     cca_results = compute_bench(n_samples, cca_features_range, cca_methods)
     plot_results(cca_results, cca_features_range, "Benchmarking CCA Methods")
 
     # Compute benchmarks for PLS
-    pls_methods = [("plssvd", plssvd), ("ridgecca_pls", ridgecca_pls)]
+    pls_methods = [("plssvd", plssvd), ("pca-pls", pca_pls)]
     pls_results = compute_bench(n_samples, pls_features_range, pls_methods)
     plot_results(pls_results, pls_features_range, "Benchmarking PLS Methods")

--- a/benchmarks/bench_ridgecca_pls.py
+++ b/benchmarks/bench_ridgecca_pls.py
@@ -5,7 +5,7 @@ In this benchmark we show that PCA-CCA and PCA-PLS (i.e. solving the CCA and PLS
 problems in the PCA space) are faster than the standard CCA and PLS algorithms,
 respectively for high-dimensional data.
 The RidgeCCA estimator uses PCA behind the scenes and thus can be applied by setting
-the alpha_x and alpha_yparameters to 0.0 (CCA) or 1.0 (PLS).
+the alpha_x and alpha_y parameters to 0.0 (CCA) or 1.0 (PLS).
 
 PCA-CCA consistently outperforms the standard CCA algorithm in terms of computation
 time across the entire range of feature sizes. Notably, the standard CCA method is
@@ -14,17 +14,17 @@ samples (p < n), which limits the maximum feature size to 400 in our tests. This
 limitation is due to the requirement of CCA for the inversion of the covariance
 matrix, which must be full rank and thus invertible.
 
-As observed in the plot, the PLSSVD method initially performs faster than the 
-pca_pls method. However, as the number of features increases, we notice a 
-'crossover' point: the computation time for PLSSVD grows more rapidly than for 
-pca_pls. Beyond this crossover, pca_pls becomes the more efficient 
-algorithm in terms of computation time. This suggests that pca_pls may be better 
+As observed in the plot, the PLSSVD method initially performs faster than the
+pca_pls method. However, as the number of features increases, we notice a
+'crossover' point: the computation time for PLSSVD grows more rapidly than for
+pca_pls. Beyond this crossover, pca_pls becomes the more efficient
+algorithm in terms of computation time. This suggests that pca_pls may be better
 suited for high-dimensional data scenarios typically encountered in modern datasets.
 
-It's important to note that for CCA problems, which are closely related to PLS, 
-the Ridge CCA method demonstrates faster computation times across all feature sizes 
-tested. However, unlike PLS, CCA is only uniquely defined when the number of features 
-(p) is less than the number of samples (n), which constrained our tests to a maximum 
+It's important to note that for CCA problems, which are closely related to PLS,
+ the Ridge CCA method demonstrates faster computation times across all feature sizes
+tested. However, unlike PLS, CCA is only uniquely defined when the number of features
+(p) is less than the number of samples (n), which constrained our tests to a maximum
 of 400 features for the CCA benchmark.
 """
 

--- a/benchmarks/bench_ridgecca_pls.py
+++ b/benchmarks/bench_ridgecca_pls.py
@@ -14,6 +14,7 @@ from sklearn.cross_decomposition import PLSSVD, RidgeCCA
 plssvd = PLSSVD(n_components=1)
 ridgecca = RidgeCCA(n_components=1, alpha_x=1.0, alpha_y=1.0)
 
+
 def compute_bench(n_samples, features_range, n_repeats=5):
     results = defaultdict(lambda: [])
 
@@ -48,19 +49,23 @@ def compute_bench(n_samples, features_range, n_repeats=5):
 
     return results
 
+
 def plot_results(results, features_range):
     plt.figure(figsize=(10, 6))
     for method, times in results.items():
         mean_times = np.mean(times, axis=1)
         std_times = np.std(times, axis=1)
-        plt.errorbar(features_range, mean_times, yerr=std_times, label=method, capsize=5)
+        plt.errorbar(
+            features_range, mean_times, yerr=std_times, label=method, capsize=5
+        )
 
-    plt.xlabel('Number of Features')
-    plt.ylabel('Time (seconds)')
-    plt.title('Benchmarking Ridge and SVD Solvers for CCA')
+    plt.xlabel("Number of Features")
+    plt.ylabel("Time (seconds)")
+    plt.title("Benchmarking Ridge and SVD Solvers for CCA")
     plt.legend()
     plt.grid(True)
     plt.show()
+
 
 if __name__ == "__main__":
     n_samples = 100

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -234,6 +234,7 @@ details.
    cross_decomposition.PLSCanonical
    cross_decomposition.PLSRegression
    cross_decomposition.PLSSVD
+    cross_decoposition.RidgeCCA
 
 .. _datasets_ref:
 

--- a/doc/modules/classes.rst
+++ b/doc/modules/classes.rst
@@ -234,7 +234,7 @@ details.
    cross_decomposition.PLSCanonical
    cross_decomposition.PLSRegression
    cross_decomposition.PLSSVD
-    cross_decoposition.RidgeCCA
+   cross_decoposition.RidgeCCA
 
 .. _datasets_ref:
 

--- a/doc/modules/cross_decomposition.rst
+++ b/doc/modules/cross_decomposition.rst
@@ -42,7 +42,7 @@ multicollinearity among the features. By contrast, standard linear regression
 would fail in these cases unless it is regularized.
 
 Classes included in this module are :class:`PLSRegression`,
-:class:`PLSCanonical`, :class:`CCA` and :class:`PLSSVD`
+:class:`PLSCanonical`, :class:`CCA`, :class:`PLSSVD`, and :class:`RidgeCCA`.
 
 PLSCanonical
 ------------
@@ -180,6 +180,14 @@ Since :class:`CCA` involves the inversion of :math:`X_k^TX_k` and
 :math:`Y_k^TY_k`, this estimator can be unstable if the number of features or
 targets is greater than the number of samples.
 
+Ridge Canonical Correlation Analysis
+-----------------------------------−
+
+:class:`RCCA` is a regularized version of :class:`CCA`, where the
+regularization parameter `alpha` controls the amount of regularization.
+At `alpha_x=0` and `alpha_y=0`, :class:`RCCA` is equivalent to :class:`CCA`. At `alpha_x=1`
+and `alpha_y=1`, :class:`RCCA` is equivalent to :class:`PLSCanonical`.
+
 
 .. topic:: Reference:
 
@@ -187,8 +195,13 @@ targets is greater than the number of samples.
       the two-block case
       <https://stat.uw.edu/sites/default/files/files/reports/2000/tr371.pdf>`_
       JA Wegelin
+    .. [2] `Canonical ridge and econometrics of joint production.
+        Journal of econometrics 4.2 (1976): 147-166`_
+        H Vinod
+
 
 .. topic:: Examples:
 
     * :ref:`sphx_glr_auto_examples_cross_decomposition_plot_compare_cross_decomposition.py`
     * :ref:`sphx_glr_auto_examples_cross_decomposition_plot_pcr_vs_pls.py`
+    * :ref:`sphx_glr_auto_examples_cross_decomposition_plot_ridge_cca.py`

--- a/doc/modules/cross_decomposition.rst
+++ b/doc/modules/cross_decomposition.rst
@@ -183,10 +183,10 @@ targets is greater than the number of samples.
 Ridge Canonical Correlation Analysis
 -----------------------------------−
 
-:class:`RCCA` is a regularized version of :class:`CCA`, where the
+:class:`RidgeCCA` is a regularized version of :class:`CCA`, where the
 regularization parameter `alpha` controls the amount of regularization.
-At `alpha_x=0` and `alpha_y=0`, :class:`RCCA` is equivalent to :class:`CCA`. At `alpha_x=1`
-and `alpha_y=1`, :class:`RCCA` is equivalent to :class:`PLSCanonical`.
+At `alpha_x=0` and `alpha_y=0`, :class:`RidgeCCA` is equivalent to :class:`CCA`. At `alpha_x=1`
+and `alpha_y=1`, :class:`RidgeCCA` is equivalent to :class:`PLSCanonical`.
 
 
 .. topic:: Reference:

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -253,6 +253,14 @@ Changelog
   with `np.int64` indices are not supported.
   :pr:`27240` by :user:`Yao Xiao <Charlie-XIAO>`.
 
+:mod:`sklearn.cross_decomposition`
+...................................
+
+- |MajorFeature| Added :class:`cross_decomposition.RidgeCCA`, a new class implementing
+  Ridge CCA (RidgeCCA). This feature extends the CCA and PLS family by
+  introducing tunable l2 regularization.
+  See :pr:`27878` by :user:`James Chapman <jameschapman19>`.
+
 :mod:`sklearn.datasets`
 .......................
 

--- a/examples/cross_decomposition/plot_ridge_cca.py
+++ b/examples/cross_decomposition/plot_ridge_cca.py
@@ -1,0 +1,15 @@
+"""
+==========================================
+Ridge CCA
+==========================================
+This example illustrates
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from sklearn.cross_decomposition import RidgeCCA
+from sklearn.model_selection import GridSearchCV
+
+model = RidgeCCA(alpha_x=0.1, alpha_y=0.1)
+

--- a/examples/cross_decomposition/plot_ridge_cca.py
+++ b/examples/cross_decomposition/plot_ridge_cca.py
@@ -12,4 +12,3 @@ from sklearn.cross_decomposition import RidgeCCA
 from sklearn.model_selection import GridSearchCV
 
 model = RidgeCCA(alpha_x=0.1, alpha_y=0.1)
-

--- a/examples/cross_decomposition/plot_ridge_cca.py
+++ b/examples/cross_decomposition/plot_ridge_cca.py
@@ -10,35 +10,35 @@ import numpy as np
 import matplotlib.pyplot as plt
 from sklearn.cross_decomposition import RidgeCCA, PLSCanonical, CCA
 
-n = 1000
+n = 100
 p = q = 50
-snr = 0.0000001
+
 # generate random data with correlation
 rng = np.random.default_rng(0)
 z = rng.normal(size=(n, 1))
 Wx = rng.normal(size=(1, p))
 Wy = rng.normal(size=(1, q))
 
-#random covariance matrix with correlated variables
+# random covariance matrix with correlated variables
 Cx = rng.uniform(low=-1, high=1, size=(p, p))
 Cx = np.dot(Cx, Cx.T)
 Cy = rng.uniform(low=-1, high=1, size=(q, q))
 Cy = np.dot(Cy, Cy.T)
 
-X = np.dot(z, Wx)*snr + rng.multivariate_normal(mean=np.zeros(p), cov=Cx, size=n)
-Y = np.dot(z, Wy)*snr + rng.multivariate_normal(mean=np.zeros(p), cov=Cy, size=n)
+X = np.dot(z, Wx) + rng.multivariate_normal(mean=np.zeros(p), cov=Cx, size=n)
+Y = np.dot(z, Wy) + rng.multivariate_normal(mean=np.zeros(p), cov=Cy, size=n)
 
 X_train = X[: n // 2]
 Y_train = Y[: n // 2]
 X_test = X[n // 2:]
 Y_test = Y[n // 2:]
 
+
 # Function to calculate covariance and correlation
 def calculate_cov_corr(X, Y):
     cov = np.cov(X.T, Y.T)[0, 1]
     corr = np.corrcoef(X.T, Y.T)[0, 1]
     return np.mean(cov), np.mean(corr)
-
 
 # Fit and evaluate CCA and PLS models
 cca_model = CCA(n_components=1)
@@ -59,7 +59,7 @@ pls_train_cov, pls_train_corr = calculate_cov_corr(X_train_pls, Y_train_pls)
 pls_test_cov, pls_test_corr = calculate_cov_corr(X_test_pls, Y_test_pls)
 
 # Analyzing effect of alpha on train and test correlation and covariance
-alphas = [0,1e-3,1e-2,1e-1,1, 10, 100, 1000, 10000, 100000]
+alphas = [1e-3, 1e-2, 1e-1, 1, 10, 100, 1000]
 train_covs = []
 test_covs = []
 train_corrs = []
@@ -111,6 +111,6 @@ plt.yticks(fontsize=12)
 
 # Move the legend outside of the plot
 plt.legend(loc='upper left', bbox_to_anchor=(1, 1))
- # Adjust the rect to make room for the legend
+# Adjust the rect to make room for the legend
 plt.show()
 print()

--- a/examples/cross_decomposition/plot_ridge_cca.py
+++ b/examples/cross_decomposition/plot_ridge_cca.py
@@ -31,8 +31,8 @@ Y = np.dot(z, Wy) + rng.multivariate_normal(mean=np.zeros(p), cov=Cy, size=n)
 
 X_train = X[: n // 2]
 Y_train = Y[: n // 2]
-X_test = X[n // 2:]
-Y_test = Y[n // 2:]
+X_test = X[n // 2 :]
+Y_test = Y[n // 2 :]
 
 
 # Function to calculate covariance and correlation
@@ -129,4 +129,3 @@ plt.yticks(fontsize=12)
 plt.legend(loc="upper left", bbox_to_anchor=(1, 1))
 # Adjust the rect to make room for the legend
 plt.show()
-print()

--- a/examples/cross_decomposition/plot_ridge_cca.py
+++ b/examples/cross_decomposition/plot_ridge_cca.py
@@ -1,14 +1,116 @@
 """
 ==========================================
-Ridge CCA
+Effect of Alpha on Ridge CCA
 ==========================================
-This example illustrates
+This example illustrates tuning Ridge CCA using a range of alpha values and visualizes how train and test
+correlation and covariance vary with alpha.
 """
 
-import matplotlib.pyplot as plt
 import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.cross_decomposition import RidgeCCA, PLSCanonical, CCA
 
-from sklearn.cross_decomposition import RidgeCCA
-from sklearn.model_selection import GridSearchCV
+n = 1000
+p = q = 50
+snr = 0.0000001
+# generate random data with correlation
+rng = np.random.default_rng(0)
+z = rng.normal(size=(n, 1))
+Wx = rng.normal(size=(1, p))
+Wy = rng.normal(size=(1, q))
 
-model = RidgeCCA(alpha_x=0.1, alpha_y=0.1)
+#random covariance matrix with correlated variables
+Cx = rng.uniform(low=-1, high=1, size=(p, p))
+Cx = np.dot(Cx, Cx.T)
+Cy = rng.uniform(low=-1, high=1, size=(q, q))
+Cy = np.dot(Cy, Cy.T)
+
+X = np.dot(z, Wx)*snr + rng.multivariate_normal(mean=np.zeros(p), cov=Cx, size=n)
+Y = np.dot(z, Wy)*snr + rng.multivariate_normal(mean=np.zeros(p), cov=Cy, size=n)
+
+X_train = X[: n // 2]
+Y_train = Y[: n // 2]
+X_test = X[n // 2:]
+Y_test = Y[n // 2:]
+
+# Function to calculate covariance and correlation
+def calculate_cov_corr(X, Y):
+    cov = np.cov(X.T, Y.T)[0, 1]
+    corr = np.corrcoef(X.T, Y.T)[0, 1]
+    return np.mean(cov), np.mean(corr)
+
+
+# Fit and evaluate CCA and PLS models
+cca_model = CCA(n_components=1)
+pls_model = PLSCanonical(n_components=1)
+
+cca_model.fit(X_train, Y_train)
+pls_model.fit(X_train, Y_train)
+
+# Transform test data and calculate metrics for CCA and PLS
+X_train_cca, Y_train_cca = cca_model.transform(X_train, Y_train)
+X_test_cca, Y_test_cca = cca_model.transform(X_test, Y_test)
+X_train_pls, Y_train_pls = pls_model.transform(X_train, Y_train)
+X_test_pls, Y_test_pls = pls_model.transform(X_test, Y_test)
+
+cca_train_cov, cca_train_corr = calculate_cov_corr(X_train_cca, Y_train_cca)
+cca_test_cov, cca_test_corr = calculate_cov_corr(X_test_cca, Y_test_cca)
+pls_train_cov, pls_train_corr = calculate_cov_corr(X_train_pls, Y_train_pls)
+pls_test_cov, pls_test_corr = calculate_cov_corr(X_test_pls, Y_test_pls)
+
+# Analyzing effect of alpha on train and test correlation and covariance
+alphas = [0,1e-3,1e-2,1e-1,1, 10, 100, 1000, 10000, 100000]
+train_covs = []
+test_covs = []
+train_corrs = []
+test_corrs = []
+
+for alpha in alphas:
+    model = RidgeCCA(n_components=1, alpha_x=alpha, alpha_y=alpha)
+    model.fit(X_train, Y_train)
+
+    # Train data
+    X_train_trans, Y_train_trans = model.transform(X_train, Y_train)
+    train_cov, train_corr = calculate_cov_corr(X_train_trans, Y_train_trans)
+    train_covs.append(train_cov)
+    train_corrs.append(train_corr)
+
+    # Test data
+    X_test_trans, Y_test_trans = model.transform(X_test, Y_test)
+    test_cov, test_corr = calculate_cov_corr(X_test_trans, Y_test_trans)
+    test_covs.append(test_cov)
+    test_corrs.append(test_corr)
+
+plt.figure(figsize=(10, 6))
+
+# Define markers for better visibility
+markers = ['o', 's', 'D', '^', 'v', '*', 'x', '.']
+
+# Plot with markers and different line styles
+plt.plot(alphas, train_corrs, label='Ridge Train Correlation', color='blue', linestyle='-', marker=markers[0])
+plt.plot(alphas, test_corrs, label='Ridge Test Correlation', color='blue', linestyle='--', marker=markers[1])
+plt.axhline(cca_train_corr, color='red', linestyle='-', label='CCA Train Correlation')
+plt.axhline(cca_test_corr, color='red', linestyle='--', label='CCA Test Correlation')
+plt.axhline(pls_train_corr, color='green', linestyle='-', label='PLS Train Correlation')
+plt.axhline(pls_test_corr, color='green', linestyle='--', label='PLS Test Correlation')
+
+# Add gridlines
+plt.grid(which='both', linestyle='--', linewidth=0.5)
+
+# Increase font sizes
+plt.xlabel('Alpha', fontsize=14)
+plt.ylabel('Mean Correlation', fontsize=14)
+plt.title('Effect of Alpha on Correlation', fontsize=16)
+
+# Modify x-axis to log scale
+plt.xscale('log')
+
+# Increase tick sizes
+plt.xticks(fontsize=12)
+plt.yticks(fontsize=12)
+
+# Move the legend outside of the plot
+plt.legend(loc='upper left', bbox_to_anchor=(1, 1))
+ # Adjust the rect to make room for the legend
+plt.show()
+print()

--- a/examples/cross_decomposition/plot_ridge_cca.py
+++ b/examples/cross_decomposition/plot_ridge_cca.py
@@ -2,13 +2,14 @@
 ==========================================
 Effect of Alpha on Ridge CCA
 ==========================================
-This example illustrates tuning Ridge CCA using a range of alpha values and visualizes how train and test
-correlation and covariance vary with alpha.
+This example illustrates tuning Ridge CCA using a range of alpha values and
+visualizes how train and test correlation and covariance vary with alpha.
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
-from sklearn.cross_decomposition import RidgeCCA, PLSCanonical, CCA
+import numpy as np
+
+from sklearn.cross_decomposition import CCA, PLSCanonical, RidgeCCA
 
 n = 100
 p = q = 50
@@ -39,6 +40,7 @@ def calculate_cov_corr(X, Y):
     cov = np.cov(X.T, Y.T)[0, 1]
     corr = np.corrcoef(X.T, Y.T)[0, 1]
     return np.mean(cov), np.mean(corr)
+
 
 # Fit and evaluate CCA and PLS models
 cca_model = CCA(n_components=1)
@@ -84,33 +86,47 @@ for alpha in alphas:
 plt.figure(figsize=(10, 6))
 
 # Define markers for better visibility
-markers = ['o', 's', 'D', '^', 'v', '*', 'x', '.']
+markers = ["o", "s", "D", "^", "v", "*", "x", "."]
 
 # Plot with markers and different line styles
-plt.plot(alphas, train_corrs, label='Ridge Train Correlation', color='blue', linestyle='-', marker=markers[0])
-plt.plot(alphas, test_corrs, label='Ridge Test Correlation', color='blue', linestyle='--', marker=markers[1])
-plt.axhline(cca_train_corr, color='red', linestyle='-', label='CCA Train Correlation')
-plt.axhline(cca_test_corr, color='red', linestyle='--', label='CCA Test Correlation')
-plt.axhline(pls_train_corr, color='green', linestyle='-', label='PLS Train Correlation')
-plt.axhline(pls_test_corr, color='green', linestyle='--', label='PLS Test Correlation')
+plt.plot(
+    alphas,
+    train_corrs,
+    label="Ridge Train Correlation",
+    color="blue",
+    linestyle="-",
+    marker=markers[0],
+)
+plt.plot(
+    alphas,
+    test_corrs,
+    label="Ridge Test Correlation",
+    color="blue",
+    linestyle="--",
+    marker=markers[1],
+)
+plt.axhline(cca_train_corr, color="red", linestyle="-", label="CCA Train Correlation")
+plt.axhline(cca_test_corr, color="red", linestyle="--", label="CCA Test Correlation")
+plt.axhline(pls_train_corr, color="green", linestyle="-", label="PLS Train Correlation")
+plt.axhline(pls_test_corr, color="green", linestyle="--", label="PLS Test Correlation")
 
 # Add gridlines
-plt.grid(which='both', linestyle='--', linewidth=0.5)
+plt.grid(which="both", linestyle="--", linewidth=0.5)
 
 # Increase font sizes
-plt.xlabel('Alpha', fontsize=14)
-plt.ylabel('Mean Correlation', fontsize=14)
-plt.title('Effect of Alpha on Correlation', fontsize=16)
+plt.xlabel("Alpha", fontsize=14)
+plt.ylabel("Mean Correlation", fontsize=14)
+plt.title("Effect of Alpha on Correlation", fontsize=16)
 
 # Modify x-axis to log scale
-plt.xscale('log')
+plt.xscale("log")
 
 # Increase tick sizes
 plt.xticks(fontsize=12)
 plt.yticks(fontsize=12)
 
 # Move the legend outside of the plot
-plt.legend(loc='upper left', bbox_to_anchor=(1, 1))
+plt.legend(loc="upper left", bbox_to_anchor=(1, 1))
 # Adjust the rect to make room for the legend
 plt.show()
 print()

--- a/sklearn/cross_decomposition/__init__.py
+++ b/sklearn/cross_decomposition/__init__.py
@@ -1,3 +1,3 @@
-from ._pls import CCA, PLSSVD, PLSCanonical, PLSRegression
+from ._pls import CCA, PLSSVD, PLSCanonical, PLSRegression, RidgeCCA
 
-__all__ = ["PLSCanonical", "PLSRegression", "PLSSVD", "CCA"]
+__all__ = ["PLSCanonical", "PLSRegression", "PLSSVD", "CCA", "RidgeCCA"]

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -27,8 +27,7 @@ from ..utils.extmath import svd_flip
 from ..utils.fixes import parse_version, sp_version
 from ..utils.validation import FLOAT_DTYPES, check_is_fitted
 
-__all__ = ["PLSCanonical", "PLSRegression", "PLSSVD"]
-
+__all__ = ["PLSCanonical", "PLSRegression", "PLSSVD", "RidgeCCA"]
 
 if sp_version >= parse_version("1.7"):
     # Starting in scipy 1.7 pinv2 was deprecated in favor of pinv.
@@ -57,7 +56,7 @@ def _pinv2_old(a):
 
 
 def _get_first_singular_vectors_power_method(
-    X, Y, mode="A", max_iter=500, tol=1e-06, norm_y_weights=False
+        X, Y, mode="A", max_iter=500, tol=1e-06, norm_y_weights=False
 ):
     """Return the first left and right singular vectors of X'Y.
 
@@ -123,6 +122,38 @@ def _get_first_singular_vectors_svd(X, Y):
     C = np.dot(X.T, Y)
     U, _, Vt = svd(C, full_matrices=False)
     return U[:, 0], Vt[0, :]
+
+
+def _get_first_singular_vectors_ridge(X, Y, alpha_x=0.0, alpha_y=0.0, tol=1e-06):
+    """Return the first left and right singular vectors of X'Y in principal components space.
+
+    This function performs the inverse Cholesky decomposition of the covariance matrices
+    of the principal components and returns the singular vectors in the data space.
+    """
+
+    # Step 1: Compute the principal components of X and Y
+    Ux, Sx, Vxt = svd(X, full_matrices=False)
+    Uy, Sy, Vyt = svd(Y, full_matrices=False)
+
+    Rx = Ux@np.diag(Sx)
+    Ry = Uy@np.diag(Sy)
+
+    Bx = np.linalg.inv(np.linalg.cholesky(Rx.T@Rx + alpha_x*np.eye(Rx.shape[1])))
+    By = np.linalg.inv(np.linalg.cholesky(Ry.T@Ry + alpha_y*np.eye(Ry.shape[1])))
+
+    # Step 3: Compute the singular value decomposition of the transformed matrices
+    C = np.dot(Bx@Rx.T, Ry @ By)
+    U, _, Vt = svd(C, full_matrices=False)
+
+    # Step 4: Return the first left and right singular vectors in the data space
+    left_singular_vector = Vxt.T@Bx.T@U[:, 0]
+    right_singular_vector = Vyt.T@By.T@Vt[0, :]
+
+    # Step 5: Normalize the singular vectors
+    left_singular_vector /= np.sqrt(np.dot(left_singular_vector, left_singular_vector))
+    right_singular_vector /= np.sqrt(np.dot(right_singular_vector, right_singular_vector))
+
+    return left_singular_vector, right_singular_vector
 
 
 def _center_scale_xy(X, Y, scale=True):
@@ -191,16 +222,16 @@ class _PLS(
 
     @abstractmethod
     def __init__(
-        self,
-        n_components=2,
-        *,
-        scale=True,
-        deflation_mode="regression",
-        mode="A",
-        algorithm="nipals",
-        max_iter=500,
-        tol=1e-06,
-        copy=True,
+            self,
+            n_components=2,
+            *,
+            scale=True,
+            deflation_mode="regression",
+            mode="A",
+            algorithm="nipals",
+            max_iter=500,
+            tol=1e-06,
+            copy=True,
     ):
         self.n_components = n_components
         self.deflation_mode = deflation_mode
@@ -309,7 +340,9 @@ class _PLS(
 
             elif self.algorithm == "svd":
                 x_weights, y_weights = _get_first_singular_vectors_svd(Xk, Yk)
-
+            elif self.algorithm == "ridge":
+                x_weights, y_weights = _get_first_singular_vectors_ridge(Xk, Yk, alpha_x=self.alpha_x,
+                                                                         alpha_y=self.alpha_x, tol=self.tol)
             # inplace sign flip for consistency across solvers and archs
             _svd_flip_1d(x_weights, y_weights)
 
@@ -609,7 +642,7 @@ class PLSRegression(_PLS):
     #     - "pls" with function oscorespls.fit(X, Y)
 
     def __init__(
-        self, n_components=2, *, scale=True, max_iter=500, tol=1e-06, copy=True
+            self, n_components=2, *, scale=True, max_iter=500, tol=1e-06, copy=True
     ):
         super().__init__(
             n_components=n_components,
@@ -756,14 +789,14 @@ class PLSCanonical(_PLS):
     # y_weights to one.
 
     def __init__(
-        self,
-        n_components=2,
-        *,
-        scale=True,
-        algorithm="nipals",
-        max_iter=500,
-        tol=1e-06,
-        copy=True,
+            self,
+            n_components=2,
+            *,
+            scale=True,
+            algorithm="nipals",
+            max_iter=500,
+            tol=1e-06,
+            copy=True,
     ):
         super().__init__(
             n_components=n_components,
@@ -870,7 +903,7 @@ class CCA(_PLS):
         _parameter_constraints.pop(param)
 
     def __init__(
-        self, n_components=2, *, scale=True, max_iter=500, tol=1e-06, copy=True
+            self, n_components=2, *, scale=True, max_iter=500, tol=1e-06, copy=True
     ):
         super().__init__(
             n_components=n_components,
@@ -1069,3 +1102,93 @@ class PLSSVD(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
             `(X_transformed, Y_transformed)` otherwise.
         """
         return self.fit(X, y).transform(X, y)
+
+
+class RidgeCCA(_PLS):
+    """Partial Least Square SVD.
+
+    This transformer simply performs a SVD on the cross-covariance matrix
+    `X'Y`. It is able to project both the training data `X` and the targets
+    `Y`. The training data `X` is projected on the left singular vectors, while
+    the targets are projected on the right singular vectors.
+
+    Read more in the :ref:`User Guide <cross_decomposition>`.
+
+    .. versionadded:: 0.8
+
+    Parameters
+    ----------
+    n_components : int, default=2
+        The number of components to keep. Should be in `[1,
+        min(n_samples, n_features, n_targets)]`.
+
+    scale : bool, default=True
+        Whether to scale `X` and `Y`.
+
+    copy : bool, default=True
+        Whether to copy `X` and `Y` in fit before applying centering, and
+        potentially scaling. If `False`, these operations will be done inplace,
+        modifying both arrays.
+
+    Attributes
+    ----------
+    x_weights_ : ndarray of shape (n_features, n_components)
+        The left singular vectors of the SVD of the cross-covariance matrix.
+        Used to project `X` in :meth:`transform`.
+
+    y_weights_ : ndarray of (n_targets, n_components)
+        The right singular vectors of the SVD of the cross-covariance matrix.
+        Used to project `X` in :meth:`transform`.
+
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
+
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of features seen during :term:`fit`. Defined only when `X`
+        has feature names that are all strings.
+
+        .. versionadded:: 1.0
+
+    See Also
+    --------
+    PLSCanonical : Partial Least Squares transformer and regressor.
+    CCA : Canonical Correlation Analysis.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.cross_decomposition import PLSSVD
+    >>> X = np.array([[0., 0., 1.],
+    ...               [1., 0., 0.],
+    ...               [2., 2., 2.],
+    ...               [2., 5., 4.]])
+    >>> Y = np.array([[0.1, -0.2],
+    ...               [0.9, 1.1],
+    ...               [6.2, 5.9],
+    ...               [11.9, 12.3]])
+    >>> pls = RidgeCCA(n_components=2, alpha_x=0.5,alpha_y=0.5).fit(X, Y)
+    >>> X_c, Y_c = pls.transform(X, Y)
+    >>> X_c.shape, Y_c.shape
+    ((4, 2), (4, 2))
+    """
+
+    _parameter_constraints: dict = {
+        "n_components": [Interval(Integral, 1, None, closed="left")],
+        "scale": ["boolean"],
+        "copy": ["boolean"],
+    }
+
+    def __init__(
+            self, n_components=2, *, scale=True, max_iter=500, tol=1e-06, copy=True, alpha_x=0.0, alpha_y=0.0
+    ):
+        super().__init__(
+            n_components=n_components,
+            scale=scale,
+            deflation_mode="canonical",
+            algorithm="ridge",
+            max_iter=max_iter,
+            tol=tol,
+            copy=copy,
+        )
+        self.alpha_x = alpha_x
+        self.alpha_y = alpha_y

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -56,7 +56,7 @@ def _pinv2_old(a):
 
 
 def _get_first_singular_vectors_power_method(
-        X, Y, mode="A", max_iter=500, tol=1e-06, norm_y_weights=False
+    X, Y, mode="A", max_iter=500, tol=1e-06, norm_y_weights=False
 ):
     """Return the first left and right singular vectors of X'Y.
 
@@ -125,33 +125,37 @@ def _get_first_singular_vectors_svd(X, Y):
 
 
 def _get_first_singular_vectors_ridge(X, Y, alpha_x=0.0, alpha_y=0.0, tol=1e-06):
-    """Return the first left and right singular vectors of X'Y in principal components space.
+    """Return the first left and right singular vectors of X'Y in principal components
+    space.
 
-    This function performs the inverse Cholesky decomposition of the covariance matrices
-    of the principal components and returns the singular vectors in the data space.
+    This function performs the inverse Cholesky decomposition of the covariance
+    matrices of the principal components and returns the singular vectors in the data
+    space.
     """
 
     # Step 1: Compute the principal components of X and Y
     Ux, Sx, Vxt = svd(X, full_matrices=False)
     Uy, Sy, Vyt = svd(Y, full_matrices=False)
 
-    Rx = Ux@np.diag(Sx)
-    Ry = Uy@np.diag(Sy)
+    Rx = Ux @ np.diag(Sx)
+    Ry = Uy @ np.diag(Sy)
 
-    Bx = np.linalg.inv(np.linalg.cholesky(Rx.T@Rx + alpha_x*np.eye(Rx.shape[1])))
-    By = np.linalg.inv(np.linalg.cholesky(Ry.T@Ry + alpha_y*np.eye(Ry.shape[1])))
+    Bx = np.linalg.inv(np.linalg.cholesky(Rx.T @ Rx + alpha_x * np.eye(Rx.shape[1])))
+    By = np.linalg.inv(np.linalg.cholesky(Ry.T @ Ry + alpha_y * np.eye(Ry.shape[1])))
 
     # Step 3: Compute the singular value decomposition of the transformed matrices
-    C = np.dot(Bx@Rx.T, Ry @ By)
+    C = np.dot(Bx @ Rx.T, Ry @ By)
     U, _, Vt = svd(C, full_matrices=False)
 
     # Step 4: Return the first left and right singular vectors in the data space
-    left_singular_vector = Vxt.T@Bx.T@U[:, 0]
-    right_singular_vector = Vyt.T@By.T@Vt[0, :]
+    left_singular_vector = Vxt.T @ Bx.T @ U[:, 0]
+    right_singular_vector = Vyt.T @ By.T @ Vt[0, :]
 
     # Step 5: Normalize the singular vectors
     left_singular_vector /= np.sqrt(np.dot(left_singular_vector, left_singular_vector))
-    right_singular_vector /= np.sqrt(np.dot(right_singular_vector, right_singular_vector))
+    right_singular_vector /= np.sqrt(
+        np.dot(right_singular_vector, right_singular_vector)
+    )
 
     return left_singular_vector, right_singular_vector
 
@@ -222,16 +226,16 @@ class _PLS(
 
     @abstractmethod
     def __init__(
-            self,
-            n_components=2,
-            *,
-            scale=True,
-            deflation_mode="regression",
-            mode="A",
-            algorithm="nipals",
-            max_iter=500,
-            tol=1e-06,
-            copy=True,
+        self,
+        n_components=2,
+        *,
+        scale=True,
+        deflation_mode="regression",
+        mode="A",
+        algorithm="nipals",
+        max_iter=500,
+        tol=1e-06,
+        copy=True,
     ):
         self.n_components = n_components
         self.deflation_mode = deflation_mode
@@ -341,8 +345,9 @@ class _PLS(
             elif self.algorithm == "svd":
                 x_weights, y_weights = _get_first_singular_vectors_svd(Xk, Yk)
             elif self.algorithm == "ridge":
-                x_weights, y_weights = _get_first_singular_vectors_ridge(Xk, Yk, alpha_x=self.alpha_x,
-                                                                         alpha_y=self.alpha_x, tol=self.tol)
+                x_weights, y_weights = _get_first_singular_vectors_ridge(
+                    Xk, Yk, alpha_x=self.alpha_x, alpha_y=self.alpha_x, tol=self.tol
+                )
             # inplace sign flip for consistency across solvers and archs
             _svd_flip_1d(x_weights, y_weights)
 
@@ -642,7 +647,7 @@ class PLSRegression(_PLS):
     #     - "pls" with function oscorespls.fit(X, Y)
 
     def __init__(
-            self, n_components=2, *, scale=True, max_iter=500, tol=1e-06, copy=True
+        self, n_components=2, *, scale=True, max_iter=500, tol=1e-06, copy=True
     ):
         super().__init__(
             n_components=n_components,
@@ -789,14 +794,14 @@ class PLSCanonical(_PLS):
     # y_weights to one.
 
     def __init__(
-            self,
-            n_components=2,
-            *,
-            scale=True,
-            algorithm="nipals",
-            max_iter=500,
-            tol=1e-06,
-            copy=True,
+        self,
+        n_components=2,
+        *,
+        scale=True,
+        algorithm="nipals",
+        max_iter=500,
+        tol=1e-06,
+        copy=True,
     ):
         super().__init__(
             n_components=n_components,
@@ -903,7 +908,7 @@ class CCA(_PLS):
         _parameter_constraints.pop(param)
 
     def __init__(
-            self, n_components=2, *, scale=True, max_iter=500, tol=1e-06, copy=True
+        self, n_components=2, *, scale=True, max_iter=500, tol=1e-06, copy=True
     ):
         super().__init__(
             n_components=n_components,
@@ -1179,7 +1184,15 @@ class RidgeCCA(_PLS):
     }
 
     def __init__(
-            self, n_components=2, *, scale=True, max_iter=500, tol=1e-06, copy=True, alpha_x=0.0, alpha_y=0.0
+        self,
+        n_components=2,
+        *,
+        scale=True,
+        max_iter=500,
+        tol=1e-06,
+        copy=True,
+        alpha_x=0.0,
+        alpha_y=0.0,
     ):
         super().__init__(
             n_components=n_components,

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -56,7 +56,7 @@ def _pinv2_old(a):
 
 
 def _get_first_singular_vectors_power_method(
-        X, Y, mode="A", max_iter=500, tol=1e-06, norm_y_weights=False
+    X, Y, mode="A", max_iter=500, tol=1e-06, norm_y_weights=False
 ):
     """Return the first left and right singular vectors of X'Y.
 
@@ -142,11 +142,17 @@ def _get_first_singular_vectors_ridge(X, Y, alpha_x=0.0, alpha_y=0.0):
         Ry = Uy @ np.diag(Sy)
 
         # Ensure Rx and Ry are not near-singular
-        if np.isclose(np.linalg.cond(Rx), np.inf) or np.isclose(np.linalg.cond(Ry), np.inf):
+        if np.isclose(np.linalg.cond(Rx), np.inf) or np.isclose(
+            np.linalg.cond(Ry), np.inf
+        ):
             raise ValueError("Rx or Ry is near-singular.")
 
-        Bx = np.linalg.pinv(np.linalg.cholesky(Rx.T @ Rx + alpha_x * np.eye(Rx.shape[1])))
-        By = np.linalg.pinv(np.linalg.cholesky(Ry.T @ Ry + alpha_y * np.eye(Ry.shape[1])))
+        Bx = np.linalg.pinv(
+            np.linalg.cholesky(Rx.T @ Rx + alpha_x * np.eye(Rx.shape[1]))
+        )
+        By = np.linalg.pinv(
+            np.linalg.cholesky(Ry.T @ Ry + alpha_y * np.eye(Ry.shape[1]))
+        )
 
         # Step 3: Compute the singular value decomposition of the transformed matrices
         C = np.dot(Bx @ Rx.T, Ry @ By)
@@ -158,9 +164,7 @@ def _get_first_singular_vectors_ridge(X, Y, alpha_x=0.0, alpha_y=0.0):
 
         # Step 5: Normalize the singular vectors
         x_weights /= np.sqrt(np.dot(x_weights, x_weights))
-        y_weights /= np.sqrt(
-            np.dot(y_weights, y_weights)
-        )
+        y_weights /= np.sqrt(np.dot(y_weights, y_weights))
     else:
         Cx = np.cov(X.T)
         Cy = np.cov(Y.T)
@@ -177,9 +181,7 @@ def _get_first_singular_vectors_ridge(X, Y, alpha_x=0.0, alpha_y=0.0):
 
     # Step 5: Normalize the singular vectors
     x_weights /= np.sqrt(np.dot(x_weights, x_weights))
-    y_weights /= np.sqrt(
-        np.dot(y_weights, y_weights)
-    )
+    y_weights /= np.sqrt(np.dot(y_weights, y_weights))
 
     return x_weights, y_weights
 
@@ -250,16 +252,16 @@ class _PLS(
 
     @abstractmethod
     def __init__(
-            self,
-            n_components=2,
-            *,
-            scale=True,
-            deflation_mode="regression",
-            mode="A",
-            algorithm="nipals",
-            max_iter=500,
-            tol=1e-06,
-            copy=True,
+        self,
+        n_components=2,
+        *,
+        scale=True,
+        deflation_mode="regression",
+        mode="A",
+        algorithm="nipals",
+        max_iter=500,
+        tol=1e-06,
+        copy=True,
     ):
         self.n_components = n_components
         self.deflation_mode = deflation_mode
@@ -671,7 +673,7 @@ class PLSRegression(_PLS):
     #     - "pls" with function oscorespls.fit(X, Y)
 
     def __init__(
-            self, n_components=2, *, scale=True, max_iter=500, tol=1e-06, copy=True
+        self, n_components=2, *, scale=True, max_iter=500, tol=1e-06, copy=True
     ):
         super().__init__(
             n_components=n_components,
@@ -818,14 +820,14 @@ class PLSCanonical(_PLS):
     # y_weights to one.
 
     def __init__(
-            self,
-            n_components=2,
-            *,
-            scale=True,
-            algorithm="nipals",
-            max_iter=500,
-            tol=1e-06,
-            copy=True,
+        self,
+        n_components=2,
+        *,
+        scale=True,
+        algorithm="nipals",
+        max_iter=500,
+        tol=1e-06,
+        copy=True,
     ):
         super().__init__(
             n_components=n_components,
@@ -932,7 +934,7 @@ class CCA(_PLS):
         _parameter_constraints.pop(param)
 
     def __init__(
-            self, n_components=2, *, scale=True, max_iter=500, tol=1e-06, copy=True
+        self, n_components=2, *, scale=True, max_iter=500, tol=1e-06, copy=True
     ):
         super().__init__(
             n_components=n_components,
@@ -1208,15 +1210,15 @@ class RidgeCCA(_PLS):
     }
 
     def __init__(
-            self,
-            n_components=2,
-            *,
-            scale=True,
-            max_iter=500,
-            tol=1e-06,
-            copy=True,
-            alpha_x=0.0,
-            alpha_y=0.0,
+        self,
+        n_components=2,
+        *,
+        scale=True,
+        max_iter=500,
+        tol=1e-06,
+        copy=True,
+        alpha_x=0.0,
+        alpha_y=0.0,
     ):
         super().__init__(
             n_components=n_components,

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -6,10 +6,11 @@ from numpy.testing import assert_allclose, assert_array_almost_equal, assert_arr
 
 from sklearn.cross_decomposition import CCA, PLSSVD, PLSCanonical, PLSRegression
 from sklearn.cross_decomposition._pls import (
+    RidgeCCA,
     _center_scale_xy,
     _get_first_singular_vectors_power_method,
     _get_first_singular_vectors_svd,
-    _svd_flip_1d, RidgeCCA,
+    _svd_flip_1d,
 )
 from sklearn.datasets import load_linnerud, make_regression
 from sklearn.ensemble import VotingRegressor
@@ -360,17 +361,13 @@ def test_sanity_check_ridge_cca():
     Y = np.concatenate((Y, rng.normal(size=q_noise * n).reshape(n, q_noise)), axis=1)
 
     rcca = RidgeCCA(n_components=1, alpha_x=1.0, alpha_y=1.0)
-    zx_ridge,zy_ridge=rcca.fit_transform(X, Y)
+    zx_ridge, zy_ridge = rcca.fit_transform(X, Y)
 
     pls = PLSSVD(n_components=1)
-    zx_pls,zy_pls=pls.fit_transform(X, Y)
+    zx_pls, zy_pls = pls.fit_transform(X, Y)
 
     assert_array_almost_equal(np.abs(zx_ridge), np.abs(zx_pls))
     assert_array_almost_equal(np.abs(zy_ridge), np.abs(zy_pls))
-
-
-
-
 
 
 def test_convergence_fail():


### PR DESCRIPTION
#### What does this implement do? Explain your changes.

This pull request implements the Ridge CCA (RidgeCCA) algorithm in the sklearn.cross_decomposition module. Ridge CCA slides between an unregularized (CCA) solution and a maximally regularized (PLS) solution. This implementation includes:

- The Ridge CCA algorithm with options to set the number of components and ridge parameters for x and y (we use \alpha to match with Ridge Regression in scikit-learn).

- Appropriate unit tests to ensure functionality and compliance with sklearn standards.

- Documentation updates, including a description of Ridge CCA, its use cases, and a comparison with other CCA/PLS methods.

Any other comments?

I expect this to be really useful in lots of practical applications. Using PLS or CCA is analagous to only having access to LinearRegression or Ridge with \alpha=1,000,000,000 i.e. a pure covariance based regression rather than correlation. In fact CCA with a univariate y is equivalent in a sense to LinearRegression.

For this reason, the performance of a tuned Ridge CCA is obviously lower bounded by PLS and CCA but in practice will almost always outperform them both (analagous with ridge regression).

A subtle implementation detail choice is whether to use (CCA) 0<alpha_x,alpha_y<1 (PLS) , or (CCA) 0<alpha_x,alpha_y<unbounded (PLS in the limit as alpha-> infinity). Both have been used in the literature. The latter is closer to the sklearn ridge regression, while the former better highlights the sliding between CCA and PLS.

Thanks for reviewing this contribution!

[1] Mihalik, A., Chapman, J., Adams, R. A., Winter, N. R., Ferreira, F. S., Shawe-Taylor, J., ... & Alzheimer’s Disease Neuroimaging Initiative. (2022). Canonical correlation analysis and partial least squares for identifying brain-behaviour associations: a tutorial and a comparative study. Biological Psychiatry: Cognitive Neuroscience and Neuroimaging.