### PR TITLE
Put correct name for OAS

### DIFF
--- a/doc/modules/lda_qda.rst
+++ b/doc/modules/lda_qda.rst
@@ -190,7 +190,7 @@ matrix.
 The shrunk Ledoit and Wolf estimator of covariance may not always be the
 best choice. For example if the distribution of the data
 is normally distributed, the
-Oracle Shrinkage Approximating estimator :class:`sklearn.covariance.OAS`
+Oracle Approximating Shrinkage estimator :class:`sklearn.covariance.OAS`
 yields a smaller Mean Squared Error than the one given by Ledoit and Wolf's
 formula used with shrinkage="auto". In LDA, the data are assumed to be gaussian
 conditionally to the class. If these assumptions hold, using LDA with

--- a/examples/classification/plot_lda.py
+++ b/examples/classification/plot_lda.py
@@ -3,8 +3,8 @@
 Normal, Ledoit-Wolf and OAS Linear Discriminant Analysis for classification
 ===========================================================================
 
-This example illustrates how the Ledoit-Wolf and Oracle Shrinkage
-Approximating (OAS) estimators of covariance can improve classification.
+This example illustrates how the Ledoit-Wolf and Oracle Approximating
+Shrinkage (OAS) estimators of covariance can improve classification.
 
 """
 


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
(none)
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
There is a typo in the documentation; the description of OAS as "Oracle Shrinkage Approximating" should be "Oracle Approximating Shrinkage"

#### Any other comments?

A reference to the original paper:

 "Convergence of this iterative method is established and a closed form expression for the limit is determined, which is referred to as the oracle approximating shrinkage (OAS) estimator." (see https://arxiv.org/abs/0907.4698)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
