### PR TITLE
FIX raise only ConvergenceWarning if linear-search fail in HuberRegressor

### DIFF
--- a/sklearn/linear_model/_huber.py
+++ b/sklearn/linear_model/_huber.py
@@ -334,11 +334,6 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
 
         parameters = opt_res.x
 
-        if opt_res.status == 2:
-            raise ValueError(
-                "HuberRegressor convergence failed: l-BFGS-b solver terminated with %s"
-                % opt_res.message
-            )
         self.n_iter_ = _check_optimize_result("lbfgs", opt_res, self.max_iter)
         self.scale_ = parameters[-1]
         if self.fit_intercept:

--- a/sklearn/linear_model/tests/test_huber.py
+++ b/sklearn/linear_model/tests/test_huber.py
@@ -226,6 +226,6 @@ def test_huber_convergence_failure():
     """
     X = np.array([10, 11, 28]).reshape(-1, 1)
     y = np.log(np.array([5000.0, 5000.0, 5000.0]))
-    sample_weights = np.array([2.0, 2.0, 2000.0])
+    sample_weight = np.array([2.0, 2.0, 2000.0])
     with pytest.warns(ConvergenceWarning):
         HuberRegressor().fit(X, y, sample_weight=sample_weight)

--- a/sklearn/linear_model/tests/test_huber.py
+++ b/sklearn/linear_model/tests/test_huber.py
@@ -6,6 +6,7 @@ import pytest
 from scipy import optimize
 
 from sklearn.datasets import make_regression
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import HuberRegressor, LinearRegression, Ridge, SGDRegressor
 from sklearn.linear_model._huber import _huber_loss_and_gradient
 from sklearn.utils._testing import (
@@ -14,8 +15,6 @@ from sklearn.utils._testing import (
     assert_array_equal,
 )
 from sklearn.utils.fixes import CSR_CONTAINERS
-
-from ...exceptions import ConvergenceWarning
 
 
 def make_regression_with_outliers(n_samples=50, n_features=20):

--- a/sklearn/linear_model/tests/test_huber.py
+++ b/sklearn/linear_model/tests/test_huber.py
@@ -218,10 +218,14 @@ def test_huber_bool():
 
 
 def test_huber_convergence_failure():
-    # test that the huber regressor raises a warning if the L-BFGS-B optimizer
-    # does not converge in a pathological case
+    """Check that we raise a `ConvergenceWarning` on pathological case without
+    raising an error.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/27777
+    """
     X = np.array([10, 11, 28]).reshape(-1, 1)
     y = np.log(np.array([5000.0, 5000.0, 5000.0]))
-    sample_weights = np.array([2.0, 2.0, 2.0])
+    sample_weights = np.array([2.0, 2.0, 2000.0])
     with pytest.warns(ConvergenceWarning):
-        HuberRegressor().fit(X, y, sample_weights)
+        HuberRegressor().fit(X, y, sample_weight=sample_weight)

--- a/sklearn/linear_model/tests/test_huber.py
+++ b/sklearn/linear_model/tests/test_huber.py
@@ -15,6 +15,8 @@ from sklearn.utils._testing import (
 )
 from sklearn.utils.fixes import CSR_CONTAINERS
 
+from ...exceptions import ConvergenceWarning
+
 
 def make_regression_with_outliers(n_samples=50, n_features=20):
     rng = np.random.RandomState(0)
@@ -214,3 +216,13 @@ def test_huber_bool():
     X, y = make_regression(n_samples=200, n_features=2, noise=4.0, random_state=0)
     X_bool = X > 0
     HuberRegressor().fit(X_bool, y)
+
+
+def test_huber_convergence_failure():
+    # test that the huber regressor raises a warning if the L-BFGS-B optimizer
+    # does not converge in a pathological case
+    X = np.array([10, 11, 28]).reshape(-1, 1)
+    y = np.log(np.array([5000.0, 5000.0, 5000.0]))
+    sample_weights = np.array([2.0, 2.0, 2.0])
+    with pytest.warns(ConvergenceWarning):
+        HuberRegressor().fit(X, y, sample_weights)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes https://github.com/scikit-learn/scikit-learn/issues/27777

#### What does this implement/fix? Explain your changes.

Raise a `ConvergenceWarning` instead of `ValueError` if `l-BFGS-B` does not converge.