### PR TITLE
Add inverse-transform to _set_output

### DIFF
--- a/sklearn/utils/_set_output.py
+++ b/sklearn/utils/_set_output.py
@@ -329,6 +329,7 @@ class _SetOutputMixin:
         method_to_key = {
             "transform": "transform",
             "fit_transform": "transform",
+            "inverse_transform": "transform",
         }
         cls._sklearn_auto_wrap_output_keys = set()
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #27843
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
The problem is mentioned in the issue linked above. Here is how the current solution works.
```python
from sklearn.preprocessing import StandardScaler
from sklearn.datasets import load_breast_cancer

X, _ = load_breast_cancer(return_X_y=True, as_frame=True)

scaler = StandardScaler().set_output(transform="pandas").fit(X)
Xt = scaler.transform(X)

print(scaler.inverse_transform(Xt))
```
The above code will print a DataFrame.

<!--
#### Any other comments?
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
