### PR TITLE
CI/FIX Enable numpy dev in [scipy-dev] build and fix Bayesian linear models for numpy 2 compat

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -72,6 +72,12 @@ python_environment_install_and_activate() {
         echo "Installing development dependency wheels"
         dev_anaconda_url=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
         pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy pandas scipy
+
+        # XXX: at the time of writing, installing scipy or pandas from the dev
+        # wheels forces the numpy dependency to be < 2.0.0. Let's force the
+        # installation of numpy dev wheels instead.
+        pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy
+
         echo "Installing Cython from latest sources"
         pip install https://github.com/cython/cython/archive/master.zip
         echo "Installing joblib from latest sources"

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -431,8 +431,8 @@ Changelog
 
 - |Fix| Ensure that the `sigma_` attribute of
   :class:`linear_model.ARDRegression` and :class:`linear_model.BayesianRidge`
-  always as dtype `float32` when fitted on `float32` data, even with the type
-  promition rules of numpy 2.
+  always has a `float32` dtype when fitted on `float32` data, even with the
+  type promotion rules of numpy 2.
   :pr:`27899` by :user:`Olivier Grisel <ogrisel>`.
 
 :mod:`sklearn.metrics`

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -429,6 +429,12 @@ Changelog
   proportional to the number of coefficients (`n_features * n_classes`).
   :pr:`27417` by :user:`Christian Lorentzen <lorentzenchr>`.
 
+- |Fix| Ensure that the `sigma_` attribute of
+  :class:`linear_model.ARDRegression` and :class:`linear_model.BayesianRidge`
+  always as dtype `float32` when fitted on `float32` data, even with the type
+  promition rules of numpy 2.
+  :pr:`27899` by :user:`Olivier Grisel <ogrisel>`.
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -293,9 +293,10 @@ class BayesianRidge(RegressorMixin, LinearModel):
         max_iter = _deprecate_n_iter(self.n_iter, self.max_iter)
 
         X, y = self._validate_data(X, y, dtype=[np.float64, np.float32], y_numeric=True)
+        dtype = X.dtype
 
         if sample_weight is not None:
-            sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
+            sample_weight = _check_sample_weight(sample_weight, X, dtype=dtype)
 
         X, y, X_offset_, y_offset_, X_scale_ = _preprocess_data(
             X,
@@ -323,6 +324,10 @@ class BayesianRidge(RegressorMixin, LinearModel):
             alpha_ = 1.0 / (np.var(y) + eps)
         if lambda_ is None:
             lambda_ = 1.0
+
+        # Avoid unintended type promotion to float64 with numpy 2
+        alpha_ = np.asarray(alpha_, dtype=dtype)
+        lambda_ = np.asarray(lambda_, dtype=dtype)
 
         verbose = self.verbose
         lambda_1 = self.lambda_1
@@ -689,9 +694,10 @@ class ARDRegression(RegressorMixin, LinearModel):
         X, y = self._validate_data(
             X, y, dtype=[np.float64, np.float32], y_numeric=True, ensure_min_samples=2
         )
+        dtype = X.dtype
 
         n_samples, n_features = X.shape
-        coef_ = np.zeros(n_features, dtype=X.dtype)
+        coef_ = np.zeros(n_features, dtype=dtype)
 
         X, y, X_offset_, y_offset_, X_scale_ = _preprocess_data(
             X, y, self.fit_intercept, copy=self.copy_X
@@ -712,9 +718,10 @@ class ARDRegression(RegressorMixin, LinearModel):
         # Initialization of the values of the parameters
         eps = np.finfo(np.float64).eps
         # Add `eps` in the denominator to omit division by zero if `np.var(y)`
-        # is zero
-        alpha_ = 1.0 / (np.var(y) + eps)
-        lambda_ = np.ones(n_features, dtype=X.dtype)
+        # is zero.
+        # Explicitly set dtype to avoid unintended type promotion with numpy 2.
+        alpha_ = np.asarray(1.0 / (np.var(y) + eps), dtype=dtype)
+        lambda_ = np.ones(n_features, dtype=dtype)
 
         self.scores_ = list()
         coef_old_ = None


### PR DESCRIPTION
While reviewing #27075, I realized that the current state of our `Linux_Nightly` `pylatest_pip_scipy_dev` does not actually test against numpy dev without us upper-bounding the version of numpy explicitly (yet):

https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=61365&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=eb5122d5-ab7e-5479-a8ce-245b4d64938b&l=442

The goal of this PR is to trigger a run to:

- check if scipy and pandas actually break at import time when running against numpy 2 dev,
- if not, check if scikit-learn itself can import successfully and then run its own tests,
- fix scikit-learn itself in case of small problems revealed by the test results.