### PR TITLE
Remove "filtering" from the description of Transformer API

### DIFF
--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -54,8 +54,8 @@ multiple interfaces):
 
 :Transformer:
 
-    For filtering or modifying the data, in a supervised or unsupervised
-    way, implements::
+    For modifying the data (but not filtering or adding rows), in a supervised
+    or unsupervised way, implements::
 
       new_data = transformer.transform(data)
 


### PR DESCRIPTION
"Filtering" usually means removing rows (eg in SQL), but I believe Transformers should not do that. 

"transformers that change the number of samples are not currently supported": https://github.com/scikit-learn/scikit-learn/issues/3855 

This causes confusion, eg here: https://stackoverflow.com/questions/68307502/sklearn-pipelines-and-filtering-out-records

Some relevant links:
* https://github.com/scikit-learn/scikit-learn/pull/9075
* https://github.com/scikit-learn/scikit-learn/issues/8174
