### PR TITLE
clarifies brief description of Transformer API

### DIFF
--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -54,8 +54,8 @@ multiple interfaces):
 
 :Transformer:
 
-    For modifying the data (but not filtering or adding rows), in a supervised
-    or unsupervised way, implements::
+    For modifying the data in a supervised or unsupervised way (e.g. by adding, changing, 
+    or removing columns, but not by adding or removing rows). Implements::
 
       new_data = transformer.transform(data)
 


### PR DESCRIPTION
As requested in #27900 

I've removed the term "filtering" - to some people it might include removing columns, but to me (influenced by SQL) I think filtering only refers to rows. The new message is unambiguous without this term.