### PR TITLE
EXA Fix typo in dataset name

### DIFF
--- a/examples/ensemble/plot_gradient_boosting_categorical.py
+++ b/examples/ensemble/plot_gradient_boosting_categorical.py
@@ -18,7 +18,7 @@ particular, we will evaluate:
   category support <categorical_support_gbdt>` of the
   :class:`~ensemble.HistGradientBoostingRegressor` estimator.
 
-We will work with the Ames Lowa Housing dataset which consists of numerical
+We will work with the Ames Iowa Housing dataset which consists of numerical
 and categorical features, where the houses' sales prices is the target.
 
 """


### PR DESCRIPTION
Lowa -> Iowa

Ames is indeed in Iowa, see https://jse.amstat.org/v19n3/decock/DataDocumentation.txt if you want to double-check