### PR TITLE
MAINT Remove deprecated support for int in boolean constraint

### DIFF
--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -587,20 +587,9 @@ class _Booleans(_Constraint):
         self._constraints = [
             _InstancesOf(bool),
             _InstancesOf(np.bool_),
-            _InstancesOf(Integral),
         ]
 
     def is_satisfied_by(self, val):
-        # TODO(1.4) remove support for Integral.
-        if isinstance(val, Integral) and not isinstance(val, bool):
-            warnings.warn(
-                (
-                    "Passing an int for a boolean parameter is deprecated in version"
-                    " 1.2 and won't be supported anymore in version 1.4."
-                ),
-                FutureWarning,
-            )
-
         return any(c.is_satisfied_by(val) for c in self._constraints)
 
     def __str__(self):

--- a/sklearn/utils/_param_validation.py
+++ b/sklearn/utils/_param_validation.py
@@ -2,7 +2,6 @@ import functools
 import math
 import operator
 import re
-import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from inspect import signature

--- a/sklearn/utils/tests/test_param_validation.py
+++ b/sklearn/utils/tests/test_param_validation.py
@@ -627,12 +627,6 @@ def test_boolean_constraint_deprecated_int():
     f(True)
     f(np.bool_(False))
 
-    # an int is also valid but deprecated
-    with pytest.warns(
-        FutureWarning, match="Passing an int for a boolean parameter is deprecated"
-    ):
-        f(1)
-
 
 def test_no_validation():
     """Check that validation can be skipped for a parameter."""


### PR DESCRIPTION
This PR removes the deprecated support for ints in the boolean constraint.