### PR TITLE
MAINT Remove deprecated kwargs support in density

### DIFF
--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -133,34 +133,19 @@ def fast_logdet(A):
     return ld
 
 
-def density(w, **kwargs):
+def density(w):
     """Compute density of a sparse vector.
 
     Parameters
     ----------
     w : array-like
         The sparse vector.
-    **kwargs : keyword arguments
-        Ignored.
-
-        .. deprecated:: 1.2
-            ``**kwargs`` were deprecated in version 1.2 and will be removed in
-            1.4.
 
     Returns
     -------
     float
         The density of w, between 0 and 1.
     """
-    if kwargs:
-        warnings.warn(
-            (
-                "Additional keyword arguments are deprecated in version 1.2 and will be"
-                " removed in version 1.4."
-            ),
-            FutureWarning,
-        )
-
     if hasattr(w, "toarray"):
         d = float(w.nnz) / (w.shape[0] * w.shape[1])
     else:

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -60,20 +60,6 @@ def test_density(sparse_container):
     assert density(sparse_container(X)) == density(X)
 
 
-# TODO(1.4): Remove test
-def test_density_deprecated_kwargs():
-    """Check that future warning is raised when user enters keyword arguments."""
-    test_array = np.array([[1, 2, 3], [4, 5, 6]])
-    with pytest.warns(
-        FutureWarning,
-        match=(
-            "Additional keyword arguments are deprecated in version 1.2 and will be"
-            " removed in version 1.4."
-        ),
-    ):
-        density(test_array, a=1)
-
-
 def test_uniform_weights():
     # with uniform weights, results should be identical to stats.mode
     rng = np.random.RandomState(0)


### PR DESCRIPTION
This PR removes the deprecated kwargs support in `extmath.density`.