### PR TITLE
DOC update the formula regarding the computation of the F1-score

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -908,7 +908,8 @@ contribution to the mean weighted by some parameter :math:`\beta`:
 
 To avoid division by zero when precision and recall are zero, Scikit-Learn calculates F-measure with this
 otherwise-equivalent formula:
-
+To avoid division by zero when precision and recall are zero, we can define the
+F-measure with this otherwise-equivalent formula:
 .. math::
 
    F_\beta = \frac{(1 + \beta^2) \text{tp}}{(1 + \beta^2) \text{tp} + \text{fp} + \beta^2 \text{fn}}.

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -905,7 +905,7 @@ some parameter :math:`\beta`:
 
    F_\beta = (1 + \beta^2) \frac{\text{precision} \times \text{recall}}{\beta^2 \text{precision} + \text{recall}}
 
-To avoid zero division when precision and recall are zero, Scikit-Learn calculates F-measure with this
+To avoid division by zero when precision and recall are zero, Scikit-Learn calculates F-measure with this
 otherwise-equivalent formula:
 
 .. math::

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -894,7 +894,7 @@ In this context, we can define the notions of precision and recall:
 
 .. math::
 
-   \text{recall} = \frac{tp}{\text{tp} + \text{fn}},
+   \text{recall} = \frac{\text{tp}}{\text{tp} + \text{fn}},
 
 (Sometimes recall is also called ''sensitivity'')
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -900,7 +900,8 @@ In this context, we can define the notions of precision and recall:
 
 F-measure is the weighted harmonic mean of precision and recall, with precision's contribution to the mean weighted by
 some parameter :math:`\beta`:
-
+F-measure is the weighted harmonic mean of precision and recall, with precision's
+contribution to the mean weighted by some parameter :math:`\beta`:
 .. math::
 
    F_\beta = (1 + \beta^2) \frac{\text{precision} \times \text{recall}}{\beta^2 \text{precision} + \text{recall}}

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -917,7 +917,10 @@ F-measure with this otherwise-equivalent formula:
 Note that this formula is still undefined when there are no true positives, false positives, nor false negatives. By
 default, F-1 for a set of exclusively true negatives is calculated as 0, however this behavior can be changed using the
 `zero_division` parameter.
-
+Note that this formula is still undefined when there are no true positives, false
+positives, nor false negatives. By default, F-1 for a set of exclusively true negatives
+is calculated as 0, however this behavior can be changed using the `zero_division`
+parameter.
 Here are some small examples in binary classification::
 
   >>> from sklearn import metrics

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -886,7 +886,7 @@ following table:
 |                   | Missing result      | Correct absence of result|
 +-------------------+---------------------+--------------------------+
 
-In this context, we can define the notions of precision, recall and F-measure:
+In this context, we can define the notions of precision and recall:
 
 .. math::
 
@@ -896,11 +896,25 @@ In this context, we can define the notions of precision, recall and F-measure:
 
    \text{recall} = \frac{tp}{\text{tp} + \text{fn}},
 
+(Sometimes recall is also called ''sensitivity'')
+
+F-measure is the weighted harmonic mean of precision and recall, with precision's contribution to the mean weighted by
+some parameter :math:`\beta`:
+
+.. math::
+
+   F_\beta = (1 + \beta^2) \frac{\text{precision} \times \text{recall}}{\beta^2 \text{precision} + \text{recall}}
+
+To avoid zero division when precision and recall are zero, Scikit-Learn calculates F-measure with this
+otherwise-equivalent formula:
+
 .. math::
 
    F_\beta = \frac{(1 + \beta^2) \text{tp}}{(1 + \beta^2) \text{tp} + \text{fp} + \beta^2 \text{fn}}.
 
-Sometimes recall is also called ''sensitivity''.
+Note that this formula is still undefined when there are no true positives, false positives, nor false negatives. By
+default, F-1 for a set of exclusively true negatives is calculated as 0, however this behavior can be changed using the
+`zero_division` parameter.
 
 Here are some small examples in binary classification::
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -890,15 +890,15 @@ In this context, we can define the notions of precision, recall and F-measure:
 
 .. math::
 
-   \text{precision} = \frac{tp}{tp + fp},
+   \text{precision} = \frac{\text{tp}}{\text{tp} + \text{fp}},
 
 .. math::
 
-   \text{recall} = \frac{tp}{tp + fn},
+   \text{recall} = \frac{tp}{\text{tp} + \text{fn}},
 
 .. math::
 
-   F_\beta = (1 + \beta^2) \frac{\text{precision} \times \text{recall}}{\beta^2 \text{precision} + \text{recall}}.
+   F_\beta = \frac{(1 + \beta^2) \text{tp}}{(1 + \beta^2) \text{tp} + \text{fp} + \beta^2 \text{fn}}.
 
 Sometimes recall is also called ''sensitivity''.
 

--- a/examples/model_selection/plot_precision_recall.py
+++ b/examples/model_selection/plot_precision_recall.py
@@ -37,16 +37,11 @@ over the number of true positives plus the number of false negatives
 
 :math:`R = \\frac{T_p}{T_p + F_n}`
 
-These quantities are also related to the :math:`F_1` score, which is usually
-defined as the harmonic mean of precision and recall.
+These quantities are also related to the :math:`F_1` score, which is the
+harmonic mean of precision and recall. Scikit-Learn calculates :math:`F_1`
+using the following formula:
 
-:math:`F1 = 2\\frac{P \\times R}{P+R}`
-
-However, for practical purposes, Scikit-Learn uses a definition of :math:`F_1`
-that is equivalent except that it is defined as 0 when precision and recall
-are both 0.
-
-:math:`F1 = \\frac{2T_p}{2T_p + F_p + F_n}`
+:math:`F_1 = \\frac{2T_p}{2T_p + F_p + F_n}`
 
 Note that the precision may not decrease with recall. The
 definition of precision (:math:`\\frac{T_p}{T_p + F_p}`) shows that lowering

--- a/examples/model_selection/plot_precision_recall.py
+++ b/examples/model_selection/plot_precision_recall.py
@@ -38,7 +38,7 @@ over the number of true positives plus the number of false negatives
 :math:`R = \\frac{T_p}{T_p + F_n}`
 
 These quantities are also related to the :math:`F_1` score, which is the
-harmonic mean of precision and recall. Scikit-Learn calculates :math:`F_1`
+harmonic mean of precision and recall. Thus, we can compute the :math:`F_1`
 using the following formula:
 
 :math:`F_1 = \\frac{2T_p}{2T_p + F_p + F_n}`

--- a/examples/model_selection/plot_precision_recall.py
+++ b/examples/model_selection/plot_precision_recall.py
@@ -43,7 +43,7 @@ defined as the harmonic mean of precision and recall.
 :math:`F1 = 2\\frac{P \\times R}{P+R}`
 
 However, for practical purposes, Scikit-Learn uses a definition of :math:`F_1`
-that is equivalent except that it is defined (as 0) when precision and recall
+that is equivalent except that it is defined as 0 when precision and recall
 are both 0.
 
 :math:`F1 = \\frac{2T_p}{2T_p + F_p + F_n}`

--- a/examples/model_selection/plot_precision_recall.py
+++ b/examples/model_selection/plot_precision_recall.py
@@ -37,10 +37,16 @@ over the number of true positives plus the number of false negatives
 
 :math:`R = \\frac{T_p}{T_p + F_n}`
 
-These quantities are also related to the (:math:`F_1`) score, which is defined
-as the harmonic mean of precision and recall.
+These quantities are also related to the (:math:`F_1`) score, which is usually
+defined as the harmonic mean of precision and recall.
 
 :math:`F1 = 2\\frac{P \\times R}{P+R}`
+
+However, for practical purposes, Scikit-Learn uses a definition of (:math:`F_1`)
+that is equivalent except that it is defined (as 0) when precision and recall
+are both 0.
+
+:math:`F1 = \\frac{2T_p}{2T_p + F_p + F_n}
 
 Note that the precision may not decrease with recall. The
 definition of precision (:math:`\\frac{T_p}{T_p + F_p}`) shows that lowering

--- a/examples/model_selection/plot_precision_recall.py
+++ b/examples/model_selection/plot_precision_recall.py
@@ -37,16 +37,16 @@ over the number of true positives plus the number of false negatives
 
 :math:`R = \\frac{T_p}{T_p + F_n}`
 
-These quantities are also related to the (:math:`F_1`) score, which is usually
+These quantities are also related to the :math:`F_1` score, which is usually
 defined as the harmonic mean of precision and recall.
 
 :math:`F1 = 2\\frac{P \\times R}{P+R}`
 
-However, for practical purposes, Scikit-Learn uses a definition of (:math:`F_1`)
+However, for practical purposes, Scikit-Learn uses a definition of :math:`F_1`
 that is equivalent except that it is defined (as 0) when precision and recall
 are both 0.
 
-:math:`F1 = \\frac{2T_p}{2T_p + F_p + F_n}
+:math:`F1 = \\frac{2T_p}{2T_p + F_p + F_n}`
 
 Note that the precision may not decrease with recall. The
 definition of precision (:math:`\\frac{T_p}{T_p + F_p}`) shows that lowering

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1119,15 +1119,9 @@ def f1_score(
         F1 = 2 * TP / (2 * TP + FN + FP)
 
     Where "TP" is the number of true positives, "FN" is the number of false
-    negatives, and "FP" is the number of false positives.
-
-    This is equivalent to::
-
-        F1 = 2 * precision * recall / (precision + recall)
-
-    except in the case where precision and recall are both 0. It is recommended
-    to refer to the previous definition of F1, especially for understanding the
-    behavior of the ``zero_division`` parameter.
+    negatives, and "FP" is the number of false positives. F1 is by default
+    calculated as 0.0 when there are no true positives, false negatives, nor
+    false positives.
 
     Support beyond term:`binary` targets is achieved by treating :term:`multiclass`
     and :term:`multilabel` data as a collection of binary problems, one for each

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1222,12 +1222,12 @@ def f1_score(
 
     Notes
     -----
-    When ``true positive + false positive == 0``, precision is undefined.
-    When ``true positive + false negative == 0``, recall is undefined.
-    In such cases, by default the metric will be set to 0, as will f-score,
-    and ``UndefinedMetricWarning`` will be raised. This behavior can be
-    modified with ``zero_division``. Note that if `zero_division` is np.nan,
-    scores being `np.nan` will be ignored for averaging.
+    When ``true positive + false positive + false negative == 0`` (i.e. a class
+    is completely absent from both ``y_true`` or ``y_pred``), f-score is
+    undefined. In such cases, by default the metric will be set to 0.0, and
+    ``UndefinedMetricWarning`` will be raised. This behavior can be modified by
+    setting ``zero_division`` to ``0.0`` (to skip the warning), ``1.0``, or
+    ``np.nan``.
 
     References
     ----------

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1415,7 +1415,7 @@ def fbeta_score(
     Notes
     -----
     When ``true positive + false positive + false negative == 0``, f-score
-    returns 0 and raises ``UndefinedMetricWarning``. This behavior can be
+    returns 0.0 and raises ``UndefinedMetricWarning``. This behavior can be
     modified by setting ``zero_division``.
 
     References

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1259,12 +1259,12 @@ def f1_score(
 
     Notes
     -----
-    When there are no ``true positive + false positive + false negative == 0``
-    (i.e. a class is completely absent from both ``y_true`` or ``y_pred``),
-    f-score is undefined. In such cases, by default the metric will be set to
-    0.0, and ``UndefinedMetricWarning`` will be raised. This behavior can be
-    modified by setting ``zero_division`` to ``0.0`` (to skip the warning),
-    ``1.0``, or ``np.nan``.
+    When ``true positive + false positive + false negative == 0`` (i.e. a class
+    is completely absent from both ``y_true`` or ``y_pred``), f-score is
+    undefined. In such cases, by default the metric will be set to 0.0, and
+    ``UndefinedMetricWarning`` will be raised. This behavior can be modified by
+    setting ``zero_division`` to ``0.0`` (to skip the warning), ``1.0``, or
+    ``np.nan``.
     """
     return fbeta_score(
         y_true,

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1121,6 +1121,14 @@ def f1_score(
     Where "TP" is the number of true positives, "FN" is the number of false
     negatives, and "FP" is the number of false positives.
 
+    This is equivalent to::
+
+        F1 = 2 * precision * recall / (precision + recall)
+
+    except in the case where precision and recall are both 0. It is recommended
+    to refer to the previous definition of F1, especially for understanding the
+    behavior of the ``zero_division`` parameter.
+
     Support beyond term:`binary` targets is achieved by treating :term:`multiclass`
     and :term:`multilabel` data as a collection of binary problems, one for each
     label. For the :term:`binary` case, setting `average='binary'` will return

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1224,10 +1224,9 @@ def f1_score(
     -----
     When ``true positive + false positive + false negative == 0`` (i.e. a class
     is completely absent from both ``y_true`` or ``y_pred``), f-score is
-    undefined. In such cases, by default the metric will be set to 0.0, and
+    undefined. In such cases, by default f-score will be set to 0.0, and
     ``UndefinedMetricWarning`` will be raised. This behavior can be modified by
-    setting ``zero_division`` to ``0.0`` (to skip the warning), ``1.0``, or
-    ``np.nan``.
+    setting the ``zero_division`` parameter.
 
     References
     ----------

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1256,6 +1256,15 @@ def f1_score(
     >>> y_pred = [[0, 0, 0], [1, 1, 1], [1, 1, 0]]
     >>> f1_score(y_true, y_pred, average=None)
     array([0.66666667, 1.        , 0.66666667])
+
+    Notes
+    -----
+    When there are no ``true positive + false positive + false negative == 0``
+    (i.e. a class is completely absent from both ``y_true`` or ``y_pred``),
+    f-score is undefined. In such cases, by default the metric will be set to
+    0.0, and ``UndefinedMetricWarning`` will be raised. This behavior can be
+    modified by setting ``zero_division`` to ``0.0`` (to skip the warning),
+    ``1.0``, or ``np.nan``.
     """
     return fbeta_score(
         y_true,
@@ -1407,10 +1416,9 @@ def fbeta_score(
 
     Notes
     -----
-    When ``true positive + false positive == 0`` or
-    ``true positive + false negative == 0``, f-score returns 0 and raises
-    ``UndefinedMetricWarning``. This behavior can be
-    modified with ``zero_division``.
+    When ``true positive + false positive + false negative == 0``, f-score
+    returns 0 and raises ``UndefinedMetricWarning``. This behavior can be
+    modified by setting ``zero_division``.
 
     References
     ----------
@@ -1702,10 +1710,11 @@ def precision_recall_fscore_support(
     Notes
     -----
     When ``true positive + false positive == 0``, precision is undefined.
-    When ``true positive + false negative == 0``, recall is undefined.
-    In such cases, by default the metric will be set to 0, as will f-score,
-    and ``UndefinedMetricWarning`` will be raised. This behavior can be
-    modified with ``zero_division``.
+    When ``true positive + false negative == 0``, recall is undefined. When
+    ``true positive + false negative + false positive == 0``, f-score is
+    undefined. In such cases, by default the metric will be set to 0, and
+    ``UndefinedMetricWarning`` will be raised. This behavior can be modified
+    with ``zero_division``.
 
     References
     ----------

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1264,15 +1264,6 @@ def f1_score(
     >>> y_pred = [[0, 0, 0], [1, 1, 1], [1, 1, 0]]
     >>> f1_score(y_true, y_pred, average=None)
     array([0.66666667, 1.        , 0.66666667])
-
-    Notes
-    -----
-    When ``true positive + false positive + false negative == 0`` (i.e. a class
-    is completely absent from both ``y_true`` or ``y_pred``), f-score is
-    undefined. In such cases, by default the metric will be set to 0.0, and
-    ``UndefinedMetricWarning`` will be raised. This behavior can be modified by
-    setting ``zero_division`` to ``0.0`` (to skip the warning), ``1.0``, or
-    ``np.nan``.
     """
     return fbeta_score(
         y_true,

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1116,7 +1116,10 @@ def f1_score(
     The relative contribution of precision and recall to the F1 score are
     equal. The formula for the F1 score is::
 
-        F1 = 2 * (precision * recall) / (precision + recall)
+        F1 = 2 * TP / (2 * TP + FN + FP)
+
+    Where "TP" is the number of true positives, "FN" is the number of false
+    negatives, and "FP" is the number of false positives.
 
     Support beyond term:`binary` targets is achieved by treating :term:`multiclass`
     and :term:`multilabel` data as a collection of binary problems, one for each


### PR DESCRIPTION
#### Reference Issues/PRs

Depends on #27577
Fixes #27189

#### What does this implement/fix? Explain your changes.

This updates the documentation to show the correct definition of F-1:

$$ \frac{2 * \textrm{TP} }{ 2 * \textrm{TP} + \textrm{FN} + \textrm{FP}} $$

instead of:

$$ \frac{ 2 * \textrm{precision} * \textrm{recall}}{\textrm{precision} + \textrm{recall}} $$

The updated formula is better because:

1. The updated formula is defined (correctly, as $0.0$) when precision and recall are both $0$. The previous formulation (in the documentation) implied that the value of F-1 was undefined or ambiguous when all of a classifier's predictions are incorrect.
2. The purpose of the `zero_division` parameter in `f1_score` and `classification_report` is now much clearer. Rather than defining behavior when precision and recall are zero (i.e. when there are false positives & false negatives, but no true positives), but rather it defines the behavior when there are _only_ true negatives (i.e. the positive class is completely absent from the true examples and the classifier successfully only predicts "negative").

The purpose of the `zero_division` parameter in the current version of `f1_score` (and by extension `classification_report`) is _really_ confusing (using the current formula for F-1); so much so, that when I tried to make a [Reddit post](https://www.reddit.com/r/MachineLearning/comments/18du5vc/d_major_bug_in_scikitlearns_implementation_of_f1/) alerting Redditors to the bug described in #26965, a majority of Redditors insisted that it was not a bug at all, and that the argument `zero_division=1.0` meant that F-1 should be `1.0` when precision and recall are both `0.0` (which, would of course be a pointless and absurd feature!)