### PR TITLE
MNT Prune unused argument in `_array_api_for_tests` util

### DIFF
--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -818,7 +818,7 @@ def test_variance_correctness(copy):
 
 
 def check_array_api_get_precision(name, estimator, array_namespace, device, dtype):
-    xp, device = _array_api_for_tests(array_namespace, device)
+    xp = _array_api_for_tests(array_namespace, device)
     iris_np = iris.data.astype(dtype)
     iris_xp = xp.asarray(iris_np, device=device)
 

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -818,7 +818,7 @@ def test_variance_correctness(copy):
 
 
 def check_array_api_get_precision(name, estimator, array_namespace, device, dtype):
-    xp, device, dtype = _array_api_for_tests(array_namespace, device, dtype)
+    xp, device = _array_api_for_tests(array_namespace, device)
     iris_np = iris.data.astype(dtype)
     iris_xp = xp.asarray(iris_np, device=device)
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1735,7 +1735,7 @@ def test_metrics_pos_label_error_str(metric, y_pred_threshold, dtype_y_str):
 def check_array_api_metric(
     metric, array_namespace, device, dtype, y_true_np, y_pred_np, sample_weight=None
 ):
-    xp, device, dtype = _array_api_for_tests(array_namespace, device, dtype)
+    xp = _array_api_for_tests(array_namespace, device)
     y_true_xp = xp.asarray(y_true_np, device=device)
     y_pred_xp = xp.asarray(y_pred_np, device=device)
 

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1279,7 +1279,7 @@ def test_train_test_split_default_test_size(train_size, exp_train, exp_test):
     ),
 )
 def test_array_api_train_test_split(shuffle, stratify, array_namespace, device, dtype):
-    xp, device, dtype = _array_api_for_tests(array_namespace, device, dtype)
+    xp, device = _array_api_for_tests(array_namespace, device)
 
     X = np.arange(100).reshape((10, 10))
     y = np.arange(10)

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1279,7 +1279,7 @@ def test_train_test_split_default_test_size(train_size, exp_train, exp_test):
     ),
 )
 def test_array_api_train_test_split(shuffle, stratify, array_namespace, device, dtype):
-    xp, device = _array_api_for_tests(array_namespace, device)
+    xp = _array_api_for_tests(array_namespace, device)
 
     X = np.arange(100).reshape((10, 10))
     y = np.arange(10)

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1030,7 +1030,7 @@ class MinimalTransformer:
         return self.fit(X, y).transform(X, y)
 
 
-def _array_api_for_tests(array_namespace, device, dtype):
+def _array_api_for_tests(array_namespace, device):
     try:
         if array_namespace == "numpy.array_api":
             # FIXME: once it is not experimental anymore
@@ -1079,4 +1079,4 @@ def _array_api_for_tests(array_namespace, device, dtype):
 
         if cupy.cuda.runtime.getDeviceCount() == 0:
             raise SkipTest("CuPy test requires cuda, which is not available")
-    return xp, device, dtype
+    return xp, device

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1079,4 +1079,4 @@ def _array_api_for_tests(array_namespace, device):
 
         if cupy.cuda.runtime.getDeviceCount() == 0:
             raise SkipTest("CuPy test requires cuda, which is not available")
-    return xp, device
+    return xp

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -875,7 +875,7 @@ def check_array_api_input(
     When check_values is True, it also checks that calling the estimator on the
     array_api Array gives the same results as ndarrays.
     """
-    xp, device, dtype = _array_api_for_tests(array_namespace, device, dtype)
+    xp, device = _array_api_for_tests(array_namespace, device)
 
     X, y = make_classification(random_state=42)
     X = X.astype(dtype, copy=False)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -875,7 +875,7 @@ def check_array_api_input(
     When check_values is True, it also checks that calling the estimator on the
     array_api Array gives the same results as ndarrays.
     """
-    xp, device = _array_api_for_tests(array_namespace, device)
+    xp = _array_api_for_tests(array_namespace, device)
 
     X, y = make_classification(random_state=42)
     X = X.astype(dtype, copy=False)

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -187,7 +187,7 @@ def test_asarray_with_order_ignored():
 def test_weighted_sum(
     array_namespace, device, dtype, sample_weight, normalize, expected
 ):
-    xp, device, dtype = _array_api_for_tests(array_namespace, device, dtype)
+    xp, device = _array_api_for_tests(array_namespace, device)
     sample_score = numpy.asarray([1, 2, 3, 4], dtype=dtype)
     sample_score = xp.asarray(sample_score, device=device)
     if sample_weight is not None:

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -187,7 +187,7 @@ def test_asarray_with_order_ignored():
 def test_weighted_sum(
     array_namespace, device, dtype, sample_weight, normalize, expected
 ):
-    xp, device = _array_api_for_tests(array_namespace, device)
+    xp = _array_api_for_tests(array_namespace, device)
     sample_score = numpy.asarray([1, 2, 3, 4], dtype=dtype)
     sample_score = xp.asarray(sample_score, device=device)
     if sample_weight is not None:

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -383,7 +383,7 @@ def test_is_multilabel():
     yield_namespace_device_dtype_combinations(),
 )
 def test_is_multilabel_array_api_compliance(array_namespace, device, dtype):
-    xp, device = _array_api_for_tests(array_namespace, device)
+    xp = _array_api_for_tests(array_namespace, device)
 
     for group, group_examples in ARRAY_API_EXAMPLES.items():
         dense_exp = group == "multilabel-indicator"

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -383,7 +383,7 @@ def test_is_multilabel():
     yield_namespace_device_dtype_combinations(),
 )
 def test_is_multilabel_array_api_compliance(array_namespace, device, dtype):
-    xp, device, dtype = _array_api_for_tests(array_namespace, device, dtype)
+    xp, device = _array_api_for_tests(array_namespace, device)
 
     for group, group_examples in ARRAY_API_EXAMPLES.items():
         dense_exp = group == "multilabel-indicator"


### PR DESCRIPTION
I noticed that the `dtype` input is not used by this function and returned unchanged. The PR proposes to remove `dtype` both from input and output.