### PR TITLE
MAINT do not copy anymore conftest.py

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -129,8 +129,6 @@ jobs:
 
       - name: Build and test wheels
         env:
-          CONFTEST_PATH: ${{ github.workspace }}/conftest.py
-          CONFTEST_NAME: conftest.py
           CIBW_PRERELEASE_PYTHONS: ${{ matrix.prerelease }}
           CIBW_ENVIRONMENT: SKLEARN_SKIP_NETWORK_TESTS=1
                             SKLEARN_BUILD_PARALLEL=3

--- a/build_tools/cirrus/arm_wheel.yml
+++ b/build_tools/cirrus/arm_wheel.yml
@@ -2,8 +2,6 @@ macos_arm64_wheel_task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
   env:
-    CONFTEST_PATH: ${CIRRUS_WORKING_DIR}/conftest.py
-    CONFTEST_NAME: conftest.py
     CIBW_ENVIRONMENT: SKLEARN_SKIP_NETWORK_TESTS=1
                       SKLEARN_BUILD_PARALLEL=5
     CIBW_TEST_COMMAND: bash {project}/build_tools/wheels/test_wheels.sh
@@ -49,8 +47,6 @@ linux_arm64_wheel_task:
     cpu: 4
     memory: 4G
   env:
-    CONFTEST_PATH: ${CIRRUS_WORKING_DIR}/conftest.py
-    CONFTEST_NAME: conftest.py
     CIBW_ENVIRONMENT: SKLEARN_SKIP_NETWORK_TESTS=1
                       SKLEARN_BUILD_PARALLEL=5
     CIBW_TEST_COMMAND: bash {project}/build_tools/wheels/test_wheels.sh

--- a/build_tools/github/Windows
+++ b/build_tools/github/Windows
@@ -3,12 +3,10 @@ ARG PYTHON_VERSION
 FROM winamd64/python:$PYTHON_VERSION-windowsservercore
 
 ARG WHEEL_NAME
-ARG CONFTEST_NAME
 ARG CIBW_TEST_REQUIRES
 
 # Copy and install the Windows wheel
 COPY $WHEEL_NAME $WHEEL_NAME
-COPY $CONFTEST_NAME $CONFTEST_NAME
 RUN pip install $env:WHEEL_NAME
 
 # Install the testing dependencies

--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -20,7 +20,6 @@ fi
 # Build a minimal Windows Docker image for testing the wheels
 docker build --build-arg PYTHON_VERSION=$PYTHON_VERSION \
              --build-arg WHEEL_NAME=$WHEEL_NAME \
-             --build-arg CONFTEST_NAME=$CONFTEST_NAME \
              --build-arg CIBW_TEST_REQUIRES="$CIBW_TEST_REQUIRES" \
              -f build_tools/github/Windows \
              -t scikit-learn/minimal-windows .

--- a/build_tools/github/test_source.sh
+++ b/build_tools/github/test_source.sh
@@ -13,7 +13,6 @@ python -m pip install pytest pandas
 
 # Run the tests on the installed source distribution
 mkdir tmp_for_test
-cp scikit-learn/scikit-learn/conftest.py tmp_for_test
 cd tmp_for_test
 
 pytest --pyargs sklearn

--- a/build_tools/wheels/test_wheels.sh
+++ b/build_tools/wheels/test_wheels.sh
@@ -3,14 +3,6 @@
 set -e
 set -x
 
-UNAME=$(uname)
-
-if [[ "$UNAME" != "Linux" ]]; then
-    # The Linux test environment is run in a Docker container and
-    # it is not possible to copy the test configuration file (yet)
-    cp $CONFTEST_PATH $CONFTEST_NAME
-fi
-
 python -c "import joblib; print(f'Number of cores (physical): \
 {joblib.cpu_count()} ({joblib.cpu_count(only_physical_cores=True)})')"
 


### PR DESCRIPTION
closes #27956

I think that we don't need anymore the `conftest.py` since it is embedded inside `sklearn` and will be always available after install.