### PR TITLE
Installation guidelines now display default pip install commands and only expands in the notes

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -112,12 +112,12 @@ feature, code or documentation improvement).
 
     You will have to run the ``pip install -v -e .`` command every time the source code
     of a Cython file is updated (ending in `.pyx` or `.pxd`). This can happen when you
-    edit them or when you use certain git commands such as `git pull`. In order to only
-    compile the files you have modified rather than the whole project each time, you
-    can add the ``--no-build-isolation`` flag. Then also include the ``--no-use-pep517``
-    flag because the ``-no-build-isolation`` option might not work otherwise (this is
-    due to a bug which will be fixed in the future). Thus the full recommended command
-    in this case will be:
+    edit them or when you use certain git commands such as `git pull`. In order to save
+    time, you can compile the files you have modified only rather than the whole project
+    using` the ``--no-build-isolation`` flag. Then also include the
+    ``--no-use-pep517`` flag because the ``-no-build-isolation`` option might not work
+    otherwise (this is due to a bug which will be fixed in the future). Thus the full
+    recommended command in this case will be:
 
     .. prompt:: bash $
 

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -96,7 +96,7 @@ feature, code or documentation improvement).
 
    .. prompt:: bash $
 
-     pip install -v --no-use-pep517 --no-build-isolation -e .
+     pip install -v -e .
 
 #. Check that the installed scikit-learn has a version number ending with
    `.dev0`:
@@ -110,14 +110,19 @@ feature, code or documentation improvement).
 
 .. note::
 
-    You will have to run the ``pip install -v --no-use-pep517 --no-build-isolation -e .``
-    command every time the source code of a Cython file is updated
-    (ending in `.pyx` or `.pxd`). This can happen when you edit them or when you
-    use certain git commands such as `git pull`. Use the ``--no-build-isolation`` flag
-    to avoid compiling the whole project each time, only the files you have
-    modified. Include the ``--no-use-pep517`` flag because the ``--no-build-isolation``
-    option might not work otherwise (this is due to a bug which will be fixed in the
-    future).
+    You will have to run the ``pip install -v -e .`` command every time the source code
+    of a Cython file is updated (ending in `.pyx` or `.pxd`). This can happen when you
+    edit them or when you use certain git commands such as `git pull`. In order to only
+    compile the files you have modified rather than the whole project each time, you
+    can add the ``--no-build-isolation`` flag. Then also include the ``--no-use-pep517``
+    flag because the ``-no-build-isolation`` option might not work otherwise (this is
+    due to a bug which will be fixed in the future). Thus the full recommended command
+    in this case will be:
+
+    .. prompt:: bash $
+
+      pip install -v -e . --no-build-isolation --no-use-pep517
+
 
 Dependencies
 ------------
@@ -188,9 +193,9 @@ Editable mode
 
 If you run the development version, it is cumbersome to reinstall the package
 each time you update the sources. Therefore it is recommended that you install
-in with the ``pip install -v --no-use-pep517 --no-build-isolation -e .`` command,
-which allows you to edit the code in-place. This builds the extension in place and
-creates a link to the development directory (see `the pip docs
+in with the ``pip install -v -e .`` command, which allows you to edit the code in-place.
+This builds the extension in place and creates a link to the development directory (see
+`the pip docs
 <https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs>`_).
 
 As the doc above explains, this is fundamentally similar to using the command
@@ -253,7 +258,7 @@ Finally, build scikit-learn from this command prompt:
 
 .. prompt:: bash $
 
-    pip install -v --no-use-pep517 --no-build-isolation -e .
+    pip install -v -e .
 
 .. _compiler_macos:
 
@@ -301,7 +306,7 @@ activating the newly created conda environment.
 
     conda activate sklearn-dev
     make clean
-    pip install -v --no-use-pep517 --no-build-isolation -e .
+    pip install -v -e .
 
 .. note::
 
@@ -375,7 +380,7 @@ Finally, build scikit-learn in verbose mode (to check for the presence of the
 .. prompt:: bash $
 
     make clean
-    pip install -v --no-use-pep517 --no-build-isolation -e .
+    pip install -v -e .
 
 .. _compiler_linux:
 
@@ -401,7 +406,7 @@ then proceed as usual:
 .. prompt:: bash $
 
     pip3 install cython
-    pip3 install --verbose --editable .
+    pip3 install -v -e .
 
 Cython and the pre-compiled wheels for the runtime dependencies (numpy, scipy
 and joblib) should automatically be installed in
@@ -441,7 +446,7 @@ activating the newly created conda environment.
 .. prompt:: bash $
 
     conda activate sklearn-dev
-    pip install -v --no-use-pep517 --no-build-isolation -e .
+    pip install -v -e .
 
 .. _compiler_freebsd:
 
@@ -470,7 +475,7 @@ Finally, build the package using the standard command:
 
 .. prompt:: bash $
 
-    pip install -v --no-use-pep517 --no-build-isolation -e .
+    pip install -v -e .
 
 For the upcoming FreeBSD 12.1 and 11.3 versions, OpenMP will be included in
 the base system and these steps will not be necessary.
@@ -491,7 +496,7 @@ The following command will build scikit-learn using your default C/C++ compiler.
 
 .. prompt:: bash $
 
-    pip install --verbose --editable .
+    pip install -v -e .
 
 If you want to build scikit-learn with another compiler handled by ``setuptools``,
 use the following command:
@@ -531,7 +536,7 @@ and environment variable as follows before calling the ``pip install`` or
 ``python setup.py build_ext`` commands::
 
     export SKLEARN_BUILD_PARALLEL=3
-    pip install -v --no-use-pep517 --no-build-isolation -e .
+    pip install -v -e .
 
 On a machine with 2 CPU cores, it can be beneficial to use a parallelism level
 of 3 to overlap IO bound tasks (reading and writing files on disk) with CPU

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -338,10 +338,17 @@ The next steps now describe the process of modifying code and submitting a PR:
 
     .. prompt:: bash $
 
-        pip install -v --no-use-pep517 --no-build-isolation -e .
+        pip install -v -e .
 
-    Use the ``--no-build-isolation`` flag to avoid compiling the whole project
-    each time, only the files you have modified.
+    In order to save time, you can compile the files you have modified only rather than
+    the whole project, using the ``--no-build-isolation`` flag.Then also include the
+    ``--no-use-pep517`` flag because the ``-no-build-isolation`` option might not work
+    otherwise (this is due to a bug which will be fixed in the future). The full
+    recommended command in this case will be:
+
+    .. prompt:: bash $
+
+      pip install -v -e . --no-build-isolation --no-use-pep517
 
 It is often helpful to keep your local feature branch synchronized with the
 latest changes of the main scikit-learn repository:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Change the developers documentation to primarily showcase usage of pip with default flags rather than always with ``--no-build-isolation`` and ``--no-use-pep517``. Only suggests those flags in side notes. Why:

- It seems unstable. Preliminary investigation done with @lesteve suggests that this flag causes pytest bugs on windows (see https://github.com/scikit-learn/scikit-learn/issues/27806 ).
- ``--no-use-pep517`` is itself described as a temporary workaround for a bug ~ a bit worrying
- those flags have opaque names, the PR https://github.com/scikit-learn/scikit-learn/pull/26334 that adds them to the doc doesn't give explanations either

So I'm proposing to re-write it a way that hints that usage of those flags are for more experienced developers that need to optimize their workflow, and suggests that the default usage should be preferred for simpler cases or bug reports (maybe this could be explicitly stated too ?)