### PR TITLE
MAINT: Prefer `np.fill_diagonal` over `diag_indices`

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1084,7 +1084,7 @@ def cosine_distances(X, Y=None):
     if X is Y or Y is None:
         # Ensure that distances between vectors and themselves are set to 0.0.
         # This may not be the case due to floating point rounding errors.
-        S[np.diag_indices_from(S)] = 0.0
+        np.fill_diagonal(S, 0.0)
     return S
 
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

`np.fill_diagonal` internally uses a faster implementation that never constructs the indices and uses simple slicing (ref [numpy docs](https://numpy.org/doc/stable/reference/generated/numpy.fill_diagonal.html))
