### PR TITLE
[MRG] ENH Add 'minimum' and 'maximum' strategies to SimpleImputer

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -494,12 +494,6 @@ Changelog
   not check for nans during input validation.
   :pr:`21807` by `Thomas Fan`_.
 
-:mod:`sklearn.impute`
-.....................
-- |Enhancement| :class:`impute.SimpleImputer` now supports `minimum` and `maximum`
-  as imputation strategies.
-  :pr:`27986` by :user:`Mark Elliot <mark-thm>`.
-
 :mod:`sklearn.inspection`
 .........................
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -494,6 +494,12 @@ Changelog
   not check for nans during input validation.
   :pr:`21807` by `Thomas Fan`_.
 
+:mod:`sklearn.impute`
+.....................
+- |Enhancement| :class:`impute.SimpleImputer` now supports `minimum` and `maximum`
+  as imputation strategies.
+  :pr:`27986` by :user:`Mark Elliot <mark-thm>`.
+
 :mod:`sklearn.inspection`
 .........................
 

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -25,6 +25,12 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123455 is the *pull request* number, not the issue number.
 
+:mod:`sklearn.impute`
+.....................
+- |Enhancement| :class:`impute.SimpleImputer` now supports `minimum` and `maximum`
+  as imputation strategies.
+  :pr:`27986` by :user:`Mark Elliot <mark-thm>`.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -470,6 +470,9 @@ class SimpleImputer(_BaseImputer):
                     elif strategy == "minimum":
                         statistics[i] = np.min(column)
 
+                    else:
+                        raise RuntimeError(f"Unknown strategy {strategy}")
+
         super()._fit_indicator(missing_mask)
 
         return statistics
@@ -545,6 +548,9 @@ class SimpleImputer(_BaseImputer):
             minimum = np.ma.getdata(minimum_masked)
             minimum[np.ma.getmaskarray(minimum_masked)] = np.nan
             return minimum
+
+        else:
+            raise RuntimeError(f"Unknown strategy {strategy}")
 
     def transform(self, X):
         """Impute all missing values in `X`.

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1710,3 +1710,71 @@ def test_simple_imputer_keep_empty_features(strategy, array_type, keep_empty_fea
             assert_array_equal(constant_feature, 0)
         else:
             assert X_imputed.shape == (X.shape[0], X.shape[1] - 1)
+
+
+@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
+def test_imputation_maximum(csc_container):
+    X = np.array(
+        [
+            [1.1, 1.1, 1.1],
+            [3.9, 1.2, np.nan],
+            [np.nan, 1.3, np.nan],
+            [0.1, 1.4, 1.4],
+            [4.9, 1.5, 1.5],
+            [np.nan, 1.6, 1.6],
+        ]
+    )
+
+    X_true = np.array(
+        [
+            [1.1, 1.1, 1.1],
+            [3.9, 1.2, 1.6],
+            [4.9, 1.3, 1.6],
+            [0.1, 1.4, 1.4],
+            [4.9, 1.5, 1.5],
+            [4.9, 1.6, 1.6],
+        ]
+    )
+
+    imputer = SimpleImputer(missing_values=np.nan, strategy="maximum")
+    X_trans = imputer.fit_transform(X)
+    assert_array_equal(X_trans, X_true)
+
+    # Sparse matrix
+    imputer = SimpleImputer(missing_values=np.nan, strategy="maximum")
+    X_trans = imputer.fit_transform(csc_container(X))
+    assert_array_equal(X_trans.toarray(), X_true)
+
+
+@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
+def test_imputation_minimum(csc_container):
+    X = np.array(
+        [
+            [1.1, 1.1, 1.1],
+            [3.9, 1.2, np.nan],
+            [np.nan, 1.3, np.nan],
+            [0.1, 1.4, 1.4],
+            [4.9, 1.5, 1.5],
+            [np.nan, 1.6, 1.6],
+        ]
+    )
+
+    X_true = np.array(
+        [
+            [1.1, 1.1, 1.1],
+            [3.9, 1.2, 1.1],
+            [0.1, 1.3, 1.1],
+            [0.1, 1.4, 1.4],
+            [4.9, 1.5, 1.5],
+            [0.1, 1.6, 1.6],
+        ]
+    )
+
+    imputer = SimpleImputer(missing_values=np.nan, strategy="minimum")
+    X_trans = imputer.fit_transform(X)
+    assert_array_equal(X_trans, X_true)
+
+    # Sparse matrix
+    imputer = SimpleImputer(missing_values=np.nan, strategy="minimum")
+    X_trans = imputer.fit_transform(csc_container(X))
+    assert_array_equal(X_trans.toarray(), X_true)

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1778,3 +1778,15 @@ def test_imputation_minimum(csc_container):
     imputer = SimpleImputer(missing_values=np.nan, strategy="minimum")
     X_trans = imputer.fit_transform(csc_container(X))
     assert_array_equal(X_trans.toarray(), X_true)
+
+
+@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
+def test_imputation_errors_on_unknown_strategy(csc_container):
+    imputer = SimpleImputer(missing_values=np.nan, strategy="minimum")
+    X = np.array([[0, 0, 0]])
+
+    with pytest.raises(RuntimeError):
+        imputer._dense_fit(X, "unknown", np.nan, 0)
+
+    with pytest.raises(RuntimeError):
+        imputer._sparse_fit(csc_container(X), "unknown", np.nan, 0)


### PR DESCRIPTION
#### Reference Issues/PRs
none

#### What does this implement/fix? Explain your changes.
Adds 'minimum' and 'maximum' strategies to `SimpleImputer` to impute values based on minimum or maximum values, respectively.


#### Any other comments?

