### PR TITLE
Adds __getitem__ to ColumnTransformer

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -315,6 +315,9 @@ Changelog
   The minimum supported version for polars is `0.19.12`.
   :pr:`26683` by `Thomas Fan`_.
 
+- |Feature| A fitted :class:`compose.ColumnTransformer` now implements `__getitem__`
+  which returns the fitted transformers by name. :pr:`xxxxx` by `Thomas Fan`_.
+
 - |Fix| :func:`cluster.spectral_clustering` and :class:`cluster.SpectralClustering`
   now raise an explicit error message indicating that sparse matrices and arrays
   with `np.int64` indices are not supported.

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -315,9 +315,6 @@ Changelog
   The minimum supported version for polars is `0.19.12`.
   :pr:`26683` by `Thomas Fan`_.
 
-- |Feature| A fitted :class:`compose.ColumnTransformer` now implements `__getitem__`
-  which returns the fitted transformers by name. :pr:`27990` by `Thomas Fan`_.
-
 - |Fix| :func:`cluster.spectral_clustering` and :class:`cluster.SpectralClustering`
   now raise an explicit error message indicating that sparse matrices and arrays
   with `np.int64` indices are not supported.

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -316,7 +316,7 @@ Changelog
   :pr:`26683` by `Thomas Fan`_.
 
 - |Feature| A fitted :class:`compose.ColumnTransformer` now implements `__getitem__`
-  which returns the fitted transformers by name. :pr:`xxxxx` by `Thomas Fan`_.
+  which returns the fitted transformers by name. :pr:`27990` by `Thomas Fan`_.
 
 - |Fix| :func:`cluster.spectral_clustering` and :class:`cluster.SpectralClustering`
   now raise an explicit error message indicating that sparse matrices and arrays

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -32,3 +32,9 @@ Thanks to everyone who has contributed to the maintenance and improvement of
 the project since version 1.4, including:
 
 TODO: update at the time of the release.
+
+:mod:`sklearn.compose`
+......................
+
+- |Feature| A fitted :class:`compose.ColumnTransformer` now implements `__getitem__`
+  which returns the fitted transformers by name. :pr:`27990` by `Thomas Fan`_.

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -1082,6 +1082,12 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             "parallel", transformers, names=names, name_details=name_details
         )
 
+    def __getitem__(self, key):
+        try:
+            return self.named_transformers_[key]
+        except AttributeError:
+            raise TypeError("ColumnTransformer is subscriptable after it is fitted")
+
     def _get_empty_routing(self):
         """Return empty routing.
 

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -1085,8 +1085,12 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
     def __getitem__(self, key):
         try:
             return self.named_transformers_[key]
-        except AttributeError:
-            raise TypeError("ColumnTransformer is subscriptable after it is fitted")
+        except AttributeError as e:
+            raise TypeError(
+                "ColumnTransformer is subscriptable after it is fitted"
+            ) from e
+        except KeyError as e:
+            raise KeyError(f"'{key}' is not a valid transformer name") from e
 
     def _get_empty_routing(self):
         """Return empty routing.

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -2301,6 +2301,20 @@ def test_dataframe_different_dataframe_libraries():
     assert_array_equal(out_pd_in, X_test_np)
 
 
+def test_column_transformer__getitem__():
+    """Check __getitem__ for ColumnTransformer."""
+    X = np.array([[0, 1, 2], [3, 4, 5]])
+    ct = ColumnTransformer([("t1", Trans(), [0, 1]), ("t2", Trans(), [1, 2])])
+
+    msg = "ColumnTransformer is subscriptable after it is fitted"
+    with pytest.raises(TypeError, match=msg):
+        ct["t1"]
+
+    ct.fit(X)
+    assert ct["t1"] is ct.named_transformers_["t1"]
+    assert ct["t2"] is ct.named_transformers_["t2"]
+
+
 # Metadata Routing Tests
 # ======================
 

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -2314,6 +2314,10 @@ def test_column_transformer__getitem__():
     assert ct["t1"] is ct.named_transformers_["t1"]
     assert ct["t2"] is ct.named_transformers_["t2"]
 
+    msg = "'does_not_exist' is not a valid transformer name"
+    with pytest.raises(KeyError, match=msg):
+        ct["does_not_exist"]
+
 
 # Metadata Routing Tests
 # ======================


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes https://github.com/scikit-learn/scikit-learn/issues/15346


#### What does this implement/fix? Explain your changes.
This PR adds a `__getitem__` to `ColumnTransformer`, which is the same as `columntransformer.named_transformer_[...]`. For now, the `__getitem__` is restricted to fitted column transformers.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
