### PR TITLE
DOC Add examples to docstring to functions of class_weight module

### DIFF
--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -54,10 +54,9 @@ def compute_class_weight(class_weight, *, classes, y):
     --------
     >>> import numpy as np
     >>> from sklearn.utils.class_weight import compute_class_weight
-    >>> y = np.array([0, 1, 0, 1, 1, 1, 1, 1, 0, 1])
-    >>> classes = np.unique(y)
-    >>> compute_class_weight("balanced", classes=classes, y=y)
-    array([1.66666667, 0.71428571])
+    >>> y = [1, 1, 1, 1, 0, 0]
+    >>> compute_class_weight(class_weight="balanced", classes=np.unique(y), y=y)
+    array([1.5 , 0.75])
     """
     # Import error caused by circular imports.
     from ..preprocessing import LabelEncoder
@@ -145,12 +144,10 @@ def compute_sample_weight(class_weight, y, *, indices=None):
 
     Examples
     --------
-    >>> import numpy as np
     >>> from sklearn.utils.class_weight import compute_sample_weight
-    >>> y = np.array([0, 1, 0, 1, 1, 1, 1, 1, 0, 1])
-    >>> compute_sample_weight("balanced", y)
-    array([1.66666667, 0.71428571, 1.66666667, 0.71428571, 0.71428571,
-           0.71428571, 0.71428571, 0.71428571, 1.66666667, 0.71428571])
+    >>> y = [1, 1, 1, 1, 0, 0]
+    >>> compute_sample_weight(class_weight="balanced", y=y)
+    array([0.75, 0.75, 0.75, 0.75, 1.5 , 1.5 ])
     """
 
     # Ensure y is 2D. Sparse matrices are already 2D.

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -145,8 +145,9 @@ def compute_sample_weight(class_weight, y, *, indices=None):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from sklearn.utils.class_weight import compute_sample_weight
-    >>> y = [0, 1, 0, 1, 1, 1, 1, 1, 0, 1]
+    >>> y = np.array([0, 1, 0, 1, 1, 1, 1, 1, 0, 1])
     >>> compute_sample_weight("balanced", y)
     array([1.66666667, 0.71428571, 1.66666667, 0.71428571, 0.71428571,
            0.71428571, 0.71428571, 0.71428571, 1.66666667, 0.71428571])

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -49,6 +49,15 @@ def compute_class_weight(class_weight, *, classes, y):
     ----------
     The "balanced" heuristic is inspired by
     Logistic Regression in Rare Events Data, King, Zen, 2001.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.utils.class_weight import compute_class_weight
+    >>> y = np.array([0, 1, 0, 1, 1, 1, 1, 1, 0, 1])
+    >>> classes = np.unique(y)
+    >>> compute_class_weight("balanced", classes=classes, y=y)
+    array([1.66666667, 0.71428571])
     """
     # Import error caused by circular imports.
     from ..preprocessing import LabelEncoder

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -52,8 +52,9 @@ def compute_class_weight(class_weight, *, classes, y):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from sklearn.utils.class_weight import compute_class_weight
-    >>> y = [0, 1, 0, 1, 1, 1, 1, 1, 0, 1]
+    >>> y = np.array([0, 1, 0, 1, 1, 1, 1, 1, 0, 1])
     >>> classes = np.unique(y)
     >>> compute_class_weight("balanced", classes=classes, y=y)
     array([1.66666667, 0.71428571])

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -52,9 +52,8 @@ def compute_class_weight(class_weight, *, classes, y):
 
     Examples
     --------
-    >>> import numpy as np
     >>> from sklearn.utils.class_weight import compute_class_weight
-    >>> y = np.array([0, 1, 0, 1, 1, 1, 1, 1, 0, 1])
+    >>> y = [0, 1, 0, 1, 1, 1, 1, 1, 0, 1]
     >>> classes = np.unique(y)
     >>> compute_class_weight("balanced", classes=classes, y=y)
     array([1.66666667, 0.71428571])
@@ -142,6 +141,14 @@ def compute_sample_weight(class_weight, y, *, indices=None):
     -------
     sample_weight_vect : ndarray of shape (n_samples,)
         Array with sample weights as applied to the original `y`.
+
+    Examples
+    --------
+    >>> from sklearn.utils.class_weight import compute_sample_weight
+    >>> y = [0, 1, 0, 1, 1, 1, 1, 1, 0, 1]
+    >>> compute_sample_weight("balanced", y)
+    array([1.66666667, 0.71428571, 1.66666667, 0.71428571, 0.71428571,
+           0.71428571, 0.71428571, 0.71428571, 1.66666667, 0.71428571])
     """
 
     # Ensure y is 2D. Sparse matrices are already 2D.


### PR DESCRIPTION
**Reference Issues/PRs**

Fixes parts of https://github.com/scikit-learn/scikit-learn/issues/27982

Added an example to docstring for each of the following functions from the `class_weight` module:
 - sklearn.utils.class_weight.compute_class_weight
 - sklearn.utils.class_weight.compute_sample_weight