### PR TITLE
FIX _get_doc_link when a _-prefixed package contains a nonprefixed module

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -52,8 +52,8 @@ Changes impacting all modules
   documentation and is color-coded to denote whether the estimator is fitted or
   not (unfitted estimators are orange, fitted estimators are blue).
   :pr:`26616` by :user:`Riccardo Cappuzzo <rcap107>`,
-  :user:`Ines Ibnukhsein <Ines1999>`, :user:`Gael Varoquaux <GaelVaroquaux>`, and
-  :user:`Lilian Boulard <LilianBoulard>`.
+  :user:`Ines Ibnukhsein <Ines1999>`, :user:`Gael Varoquaux <GaelVaroquaux>`,
+  `Joel Nothman`_ and :user:`Lilian Boulard <LilianBoulard>`.
 
 - |Fix| Fixed a bug in most estimators and functions where setting a parameter to
   a large integer would cause a `TypeError`.

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -473,6 +473,9 @@ class _HTMLDocumentationLinkMixin:
         if self._doc_link_url_param_generator is None:
             estimator_name = self.__class__.__name__
             estimator_module = ".".join(
+                # Construct the estimator's module name, up to the first private submodule.
+                # This works because in scikit-learn all public estimators are exposed at
+                # that level, even if they actually live in a private sub-module.
                 itertools.takewhile(
                     lambda part: not part.startswith("_"),
                     self.__class__.__module__.split("."),

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -472,10 +472,10 @@ class _HTMLDocumentationLinkMixin:
 
         if self._doc_link_url_param_generator is None:
             estimator_name = self.__class__.__name__
+            # Construct the estimator's module name, up to the first private submodule.
+            # This works because in scikit-learn all public estimators are exposed at
+            # that level, even if they actually live in a private sub-module.
             estimator_module = ".".join(
-                # Construct the estimator's module name, up to the first private submodule.
-                # This works because in scikit-learn all public estimators are exposed at
-                # that level, even if they actually live in a private sub-module.
                 itertools.takewhile(
                     lambda part: not part.startswith("_"),
                     self.__class__.__module__.split("."),

--- a/sklearn/utils/_estimator_html_repr.py
+++ b/sklearn/utils/_estimator_html_repr.py
@@ -1,4 +1,5 @@
 import html
+import itertools
 from contextlib import closing
 from inspect import isclass
 from io import StringIO
@@ -472,11 +473,10 @@ class _HTMLDocumentationLinkMixin:
         if self._doc_link_url_param_generator is None:
             estimator_name = self.__class__.__name__
             estimator_module = ".".join(
-                [
-                    _
-                    for _ in self.__class__.__module__.split(".")
-                    if not _.startswith("_")
-                ]
+                itertools.takewhile(
+                    lambda part: not part.startswith("_"),
+                    self.__class__.__module__.split("."),
+                )
             )
             return self._doc_link_template.format(
                 estimator_module=estimator_module, estimator_name=estimator_name

--- a/sklearn/utils/tests/test_estimator_html_repr.py
+++ b/sklearn/utils/tests/test_estimator_html_repr.py
@@ -433,7 +433,33 @@ def test_html_documentation_link_mixin_sklearn(mock_version):
         )
 
 
-def test_html_documentation_link_mixin_get_doc_link():
+@pytest.mark.parametrize(
+    "module_path,expected_module",
+    [
+        ("prefix.mymodule", "prefix.mymodule"),
+        ("prefix._mymodule", "prefix"),
+        ("prefix.mypackage._mymodule", "prefix.mypackage"),
+        ("prefix.mypackage._mymodule.submodule", "prefix.mypackage"),
+        ("prefix.mypackage.mymodule.submodule", "prefix.mypackage.mymodule.submodule"),
+    ],
+)
+def test_html_documentation_link_mixin_get_doc_link(module_path, expected_module):
+    """Check the behaviour of the `_get_doc_link` with various parameter."""
+
+    class FooBar(_HTMLDocumentationLinkMixin):
+        pass
+
+    FooBar.__module__ = module_path
+    est = FooBar()
+    # if we set `_doc_link`, then we expect to infer a module and name for the estimator
+    est._doc_link_module = "prefix"
+    est._doc_link_template = (
+        "https://website.com/{estimator_module}.{estimator_name}.html"
+    )
+    assert est._get_doc_link() == f"https://website.com/{expected_module}.FooBar.html"
+
+
+def test_html_documentation_link_mixin_get_doc_link_out_of_library():
     """Check the behaviour of the `_get_doc_link` with various parameter."""
     mixin = _HTMLDocumentationLinkMixin()
 
@@ -442,16 +468,9 @@ def test_html_documentation_link_mixin_get_doc_link():
     mixin._doc_link_module = "xxx"
     assert mixin._get_doc_link() == ""
 
-    # if we set `_doc_link`, then we expect to infer a module and name for the estimator
-    mixin._doc_link_module = "sklearn"
-    mixin._doc_link_template = (
-        "https://website.com/{estimator_module}.{estimator_name}.html"
-    )
-    assert (
-        mixin._get_doc_link()
-        == "https://website.com/sklearn.utils._HTMLDocumentationLinkMixin.html"
-    )
 
+def test_html_documentation_link_mixin_doc_link_url_param_generator():
+    mixin = _HTMLDocumentationLinkMixin()
     # we can bypass the generation by providing our own callable
     mixin._doc_link_template = (
         "https://website.com/{my_own_variable}.{another_variable}.html"


### PR DESCRIPTION
In `main` / 1.4RC, the link for HistGradientBoostingClassifier is https://scikit-learn.org/dev/modules/generated/sklearn.ensemble.gradient_boosting.HistGradientBoostingClassifier.html when it should be https://scikit-learn.org/dev/modules/generated/sklearn.ensemble.HistGradientBoostingClassifier.html

This is because `HistGradientBoostingClassifier.__module__ == "sklearn.ensemble._hist_gradient_boosting.gradient_boosting"` had the `._hist_gradient_boosting` filtered out, rather than being interpretated as the end of the public import path.