### PR TITLE
CI Use gh for assign and unassign instead of curl

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -20,5 +20,5 @@ jobs:
     steps:
       - run: |
           echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -X "DELETE" https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/help%20wanted
+          gh issue edit ${{ github.event.issue.number }} --add-assignee ${{ github.event.comment.user.login }}
+          gh issue edit ${{ github.event.issue.number }} --remove-label "help wanted"

--- a/.github/workflows/unassign.yml
+++ b/.github/workflows/unassign.yml
@@ -18,4 +18,4 @@ jobs:
         if: github.event.issue.state == 'open'
         run: |
           echo "Marking issue ${{ github.event.issue.number }} as help wanted"
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"labels": ["help wanted"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels
+          gh issue edit ${{ github.event.issue.number }} --add-label "help wanted"


### PR DESCRIPTION
This PR replaces the long `curl` commands with the `gh` CLI for assigning and un-assigning people. 

I tested this workflow on my fork here: https://github.com/thomasjpfan/scikit-learn/issues/123