### PR TITLE
DOC Add a docstring example for feature selection functions #27989

### DIFF
--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -278,6 +278,21 @@ def affinity_propagation(
     ----------
     Brendan J. Frey and Delbert Dueck, "Clustering by Passing Messages
     Between Data Points", Science Feb. 2007
+
+    Examples
+    --------
+
+    >>> from sklearn.cluster import affinity_propagation
+    >>> import numpy as np
+    >>> S = np.array([[-0.  , -1.41, -4.47, -5.83],
+    ...               [-1.41, -0.  , -4.24, -5.66],
+    ...               [-4.47, -4.24, -0.  , -1.41],
+    ...               [-5.83, -5.66, -1.41, -0.  ]])
+    >>> cluster_centers_indices, labels = affinity_propagation(S, random_state=0)
+    >>> cluster_centers_indices
+    array([1, 2])
+    >>> labels
+    array([0, 0, 1, 1])
     """
     estimator = AffinityPropagation(
         damping=damping,

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -270,6 +270,25 @@ def ward_tree(X, *, connectivity=None, n_clusters=None, return_distance=False):
         cluster in the forest, :math:`T=|v|+|s|+|t|`, and
         :math:`|*|` is the cardinality of its argument. This is also
         known as the incremental algorithm.
+
+    Examples
+    --------
+
+    >>> from sklearn.cluster import ward_tree
+    >>> X = np.array([[1, 2], [1, 4], [1, 0],
+    ...               [4, 2], [4, 4], [4, 0]])
+    >>> children, n_connected_components, n_leaves, parents = ward_tree(X)
+    >>> children
+    array([[0, 1],
+       [3, 5],
+       [2, 6],
+       [4, 7],
+       [8, 9]])
+    >>> n_connected_components
+    1
+    >>> n_leaves
+    6
+    >>> parents  # None
     """
     X = np.asarray(X)
     if X.ndim == 1:

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -275,6 +275,7 @@ def ward_tree(X, *, connectivity=None, n_clusters=None, return_distance=False):
     --------
 
     >>> from sklearn.cluster import ward_tree
+    >>> import numpy as np
     >>> X = np.array([[1, 2], [1, 4], [1, 0],
     ...               [4, 2], [4, 4], [4, 0]])
     >>> children, n_connected_components, n_leaves, parents = ward_tree(X)

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -433,7 +433,7 @@ def k_means(
     >>> import numpy as np
     >>> X = np.array([[1, 2], [1, 4], [1, 0],
     ...               [10, 2], [10, 4], [10, 0]])
-    >>> centroid, label, inertia = k_means(X, n_clusters=2, random_state=0, n_init="auto")
+    >>> centroid, label, inertia = k_means(X, n_clusters=2, n_init="auto", random_state=0)
     >>> centroid
     array([[10.,  2.],
            [ 1.,  2.]])

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -433,7 +433,7 @@ def k_means(
     >>> import numpy as np
     >>> X = np.array([[1, 2], [1, 4], [1, 0],
     ...               [10, 2], [10, 4], [10, 0]])
-    >>> centroid, label, inertia = k_means(X, n_clusters=2, n_init="auto", 
+    >>> centroid, label, inertia = k_means(X, n_clusters=2, n_init="auto",
     ...    random_state=0)
     >>> centroid
     array([[10.,  2.],

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -433,7 +433,8 @@ def k_means(
     >>> import numpy as np
     >>> X = np.array([[1, 2], [1, 4], [1, 0],
     ...               [10, 2], [10, 4], [10, 0]])
-    >>> centroid, label, inertia = k_means(X, n_clusters=2, n_init="auto", random_state=0)
+    >>> centroid, label, inertia = k_means(X, n_clusters=2, n_init="auto", 
+    ...    random_state=0)
     >>> centroid
     array([[10.,  2.],
            [ 1.,  2.]])

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -425,6 +425,22 @@ def k_means(
     best_n_iter : int
         Number of iterations corresponding to the best results.
         Returned only if `return_n_iter` is set to True.
+
+    Examples
+    --------
+
+    >>> from sklearn.cluster import k_means
+    >>> import numpy as np
+    >>> X = np.array([[1, 2], [1, 4], [1, 0],
+    ...               [10, 2], [10, 4], [10, 0]])
+    >>> centroid, label, inertia = k_means(X, n_clusters=2, random_state=0, n_init="auto")
+    >>> centroid
+    array([[10.,  2.],
+           [ 1.,  2.]])
+    >>> label
+    array([1, 1, 1, 0, 0, 0], dtype=int32)
+    >>> inertia
+    16.0
     """
     est = KMeans(
         n_clusters=n_clusters,

--- a/sklearn/cluster/_mean_shift.py
+++ b/sklearn/cluster/_mean_shift.py
@@ -222,6 +222,20 @@ def mean_shift(
     -----
     For an example, see :ref:`examples/cluster/plot_mean_shift.py
     <sphx_glr_auto_examples_cluster_plot_mean_shift.py>`.
+
+    Examples
+    --------
+
+    >>> from sklearn.cluster import mean_shift, estimate_bandwidth
+    >>> X = np.array([[1, 1], [2, 1], [1, 0],
+    ...               [4, 7], [3, 5], [3, 6]])
+    >>> bandwidth = estimate_bandwidth(X, quantile=0.5, random_state=0)
+    >>> cluster_centers, labels = mean_shift(X, bandwidth=bandwidth)
+    >>> cluster_centers
+    array([[3.33333333, 6.        ],
+    ...    [1.33333333, 0.66666667]])
+    >>> labels
+    array([1, 1, 1, 0, 0, 0])
     """
     model = MeanShift(
         bandwidth=bandwidth,

--- a/sklearn/cluster/_mean_shift.py
+++ b/sklearn/cluster/_mean_shift.py
@@ -234,7 +234,7 @@ def mean_shift(
     >>> cluster_centers, labels = mean_shift(X, bandwidth=bandwidth)
     >>> cluster_centers
     array([[3.33333333, 6.        ],
-    ...    [1.33333333, 0.66666667]])
+           [1.33333333, 0.66666667]])
     >>> labels
     array([1, 1, 1, 0, 0, 0])
     """

--- a/sklearn/cluster/_mean_shift.py
+++ b/sklearn/cluster/_mean_shift.py
@@ -227,6 +227,7 @@ def mean_shift(
     --------
 
     >>> from sklearn.cluster import mean_shift, estimate_bandwidth
+    >>> import numpy as np
     >>> X = np.array([[1, 1], [2, 1], [1, 0],
     ...               [4, 7], [3, 5], [3, 6]])
     >>> bandwidth = estimate_bandwidth(X, quantile=0.5, random_state=0)

--- a/sklearn/cluster/_mean_shift.py
+++ b/sklearn/cluster/_mean_shift.py
@@ -76,6 +76,17 @@ def estimate_bandwidth(X, *, quantile=0.3, n_samples=None, random_state=0, n_job
     -------
     bandwidth : float
         The bandwidth parameter.
+
+    Examples
+    --------
+
+    >>> from sklearn.cluster import estimate_bandwidth
+    >>> import numpy as np
+    >>> X = np.array([[1, 1], [2, 1], [1, 0],
+    ...               [4, 7], [3, 5], [3, 6]])
+    >>> bandwidth = estimate_bandwidth(X, quantile=0.5, random_state=0)
+    >>> bandwidth
+    1.6191294403531442
     """
     X = check_array(X)
 

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -571,14 +571,14 @@ def compute_optics_graph(
     >>> X = np.array([[1, 2], [2, 5], [3, 6],
     ...              [8, 7], [8, 8], [7, 3]])
     >>> ordering_, core_distances_, reachability_, predecessor_ = compute_optics_graph(
-    ...   X, 
+    ...   X,
     ...   min_samples=2,
-    ...   max_eps=np.inf, 
-    ...   metric="minkowski", 
-    ...   p=2, 
-    ...   metric_params=None, 
-    ...   algorithm="auto", 
-    ...   leaf_size=30, 
+    ...   max_eps=np.inf,
+    ...   metric="minkowski",
+    ...   p=2,
+    ...   metric_params=None,
+    ...   algorithm="auto",
+    ...   leaf_size=30,
     ...   n_jobs=None)
     >>> ordering_
     array([0, 1, 2, 5, 3, 4])
@@ -755,7 +755,8 @@ def cluster_optics_dbscan(*, reachability, core_distances, ordering, eps):
     >>> from sklearn.cluster import cluster_optics_dbscan
     >>> import numpy as np
     >>> reachability = np.array([np.inf, 3.16227766, 1.41421356, 4.12310563, 1., 5.])
-    >>> core_distances = np.array([3.16227766, 1.41421356, 1.41421356, 1., 1., 4.12310563])
+    >>> core_distances = np.array([3.16227766, 1.41421356, 1.41421356,
+    ...                            1.,         1.,         4.12310563])
     >>> ordering = np.array([0, 1, 2, 5, 3, 4])
     >>> eps = 4.5
     >>> labels_ = cluster_optics_dbscan(

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -562,6 +562,34 @@ def compute_optics_graph(
     .. [1] Ankerst, Mihael, Markus M. Breunig, Hans-Peter Kriegel,
        and Jörg Sander. "OPTICS: ordering points to identify the clustering
        structure." ACM SIGMOD Record 28, no. 2 (1999): 49-60.
+
+    Examples
+    --------
+
+    >>> from sklearn.cluster import OPTICS, compute_optics_graph
+    >>> import numpy as np
+    >>> X = np.array([[1, 2], [2, 5], [3, 6],
+    ...              [8, 7], [8, 8], [7, 3]])
+    >>> ordering_, core_distances_, reachability_, predecessor_ = compute_optics_graph(
+    ...   X, 
+    ...   min_samples=2,
+    ...   max_eps=np.inf, 
+    ...   metric="minkowski", 
+    ...   p=2, 
+    ...   metric_params=None, 
+    ...   algorithm="auto", 
+    ...   leaf_size=30, 
+    ...   n_jobs=None)
+    >>> ordering_
+    array([0, 1, 2, 5, 3, 4])
+    >>> core_distances_
+    array([3.16227766, 1.41421356, 1.41421356, 1.        , 1.        ,
+    ...   4.12310563])
+    >>> reachability_
+    array([       inf, 3.16227766, 1.41421356, 4.12310563, 1.        ,
+    ...   5.        ])
+    >>> predecessor_
+    array([-1,  0,  1,  5,  3,  2])
     """
     n_samples = X.shape[0]
     _validate_size(min_samples, n_samples, "min_samples")

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -863,9 +863,9 @@ def cluster_optics_xi(
     >>> ordering = np.array([0, 1, 2, 5, 3, 4])
     >>> min_samples = 2
     >>> labels, clusters = cluster_optics_xi(
-    ...    reachability=reachability, 
-    ...    predecessor=predecessor, 
-    ...    ordering=ordering, 
+    ...    reachability=reachability,
+    ...    predecessor=predecessor,
+    ...    ordering=ordering,
     ...    min_samples=min_samples)
     >>> labels
     array([0, 0, 0, 1, 1, 1])

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -720,6 +720,23 @@ def cluster_optics_dbscan(*, reachability, core_distances, ordering, eps):
     -------
     labels_ : array of shape (n_samples,)
         The estimated labels.
+
+    Examples
+    --------
+
+    >>> from sklearn.cluster import cluster_optics_dbscan
+    >>> import numpy as np
+    >>> reachability = np.array([np.inf, 3.16227766, 1.41421356, 4.12310563, 1., 5.])
+    >>> core_distances = np.array([3.16227766, 1.41421356, 1.41421356, 1., 1., 4.12310563])
+    >>> ordering = np.array([0, 1, 2, 5, 3, 4])
+    >>> eps = 4.5
+    >>> labels_ = cluster_optics_dbscan(
+    ...   reachability=reachability,
+    ...   core_distances=core_distances,
+    ...   ordering=ordering,
+    ...   eps=eps)
+    >>> labels_
+    array([0, 0, 0, 1, 1, 1])
     """
     n_samples = len(core_distances)
     labels = np.zeros(n_samples, dtype=int)

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -811,7 +811,7 @@ def cluster_optics_xi(
     --------
 
     >>> from sklearn.cluster import cluster_optics_xi
-    >>> from numpy import np
+    >>> import numpy as np
     >>> reachability = np.array([np.inf, 3.16227766, 1.41421356, 4.12310563, 1., 5.])
     >>> predecessor = np.array([-1, 0, 1, 5, 3, 2])
     >>> ordering = np.array([0, 1, 2, 5, 3, 4])

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -806,6 +806,27 @@ def cluster_optics_xi(
         clusters come after such nested smaller clusters. Since ``labels`` does
         not reflect the hierarchy, usually ``len(clusters) >
         np.unique(labels)``.
+
+    Examples
+    --------
+
+    >>> from sklearn.cluster import cluster_optics_xi
+    >>> from numpy import np
+    >>> reachability = np.array([np.inf, 3.16227766, 1.41421356, 4.12310563, 1., 5.])
+    >>> predecessor = np.array([-1, 0, 1, 5, 3, 2])
+    >>> ordering = np.array([0, 1, 2, 5, 3, 4])
+    >>> min_samples = 2
+    >>> labels, clusters = cluster_optics_xi(
+    ...    reachability=reachability, 
+    ...    predecessor=predecessor, 
+    ...    ordering=ordering, 
+    ...    min_samples=min_samples)
+    >>> labels
+    array([0, 0, 0, 1, 1, 1])
+    >>> clusters
+    array([[0, 2],
+    ...    [3, 5],
+    ...    [0, 5]])
     """
     n_samples = len(reachability)
     _validate_size(min_samples, n_samples, "min_samples")

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -584,10 +584,10 @@ def compute_optics_graph(
     array([0, 1, 2, 5, 3, 4])
     >>> core_distances_
     array([3.16227766, 1.41421356, 1.41421356, 1.        , 1.        ,
-    ...   4.12310563])
+           4.12310563])
     >>> reachability_
     array([       inf, 3.16227766, 1.41421356, 4.12310563, 1.        ,
-    ...   5.        ])
+           5.        ])
     >>> predecessor_
     array([-1,  0,  1,  5,  3,  2])
     """
@@ -871,8 +871,8 @@ def cluster_optics_xi(
     array([0, 0, 0, 1, 1, 1])
     >>> clusters
     array([[0, 2],
-    ...    [3, 5],
-    ...    [0, 5]])
+           [3, 5],
+           [0, 5]])
     """
     n_samples = len(reachability)
     _validate_size(min_samples, n_samples, "min_samples")

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -346,6 +346,21 @@ def spectral_clustering(
            streaming graph challenge (Preliminary version at arXiv.)
            David Zhuzhunashvili, Andrew Knyazev
            <10.1109/HPEC.2017.8091045>`
+
+    Examples
+    --------
+
+    >>> from sklearn.cluster import spectral_clustering
+    >>> affinity_matrix = np.array([[1.   , 0.368, 0.   , 0.   ],
+    ...                             [0.368, 1.   , 0.   , 0.   ],
+    ...                             [0.   , 0.   , 1.   , 0.135],
+    ...                             [0.   , 0.   , 0.135, 1.   ]])
+    >>> labels = spectral_clustering(
+    ...   affinity=affinity_matrix,
+    ...   n_clusters=2,
+    ...   random_state=0)
+    >>> labels
+    array([0, 0, 1, 1], dtype=int32)
     """
 
     clusterer = SpectralClustering(

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -351,6 +351,7 @@ def spectral_clustering(
     --------
 
     >>> from sklearn.cluster import spectral_clustering
+    >>> import numpy as np
     >>> affinity_matrix = np.array([[1.   , 0.368, 0.   , 0.   ],
     ...                             [0.368, 1.   , 0.   , 0.   ],
     ...                             [0.   , 0.   , 1.   , 0.135],

--- a/sklearn/feature_selection/_mutual_info.py
+++ b/sklearn/feature_selection/_mutual_info.py
@@ -487,6 +487,20 @@ def mutual_info_classif(
            Data Sets". PLoS ONE 9(2), 2014.
     .. [4] L. F. Kozachenko, N. N. Leonenko, "Sample Estimate of the Entropy
            of a Random Vector:, Probl. Peredachi Inf., 23:2 (1987), 9-16
+
+    Examples
+    --------
+
+    >>> from sklearn.feature_selection import mutual_info_classif
+    >>> import numpy as np
+    >>> X = np.array([[1, 1],
+    ...               [0, 1],
+    ...               [5, 4],
+    ...               [6, 6]])
+    >>> y = np.array([1, 1, 0, 0])
+    >>> mi = mutual_info_classif(X, y)
+    >>> mi
+    array([0.83333333, 0.20833333])
     """
     check_classification_targets(y)
     return _estimate_mi(X, y, discrete_features, True, n_neighbors, copy, random_state)

--- a/sklearn/feature_selection/_mutual_info.py
+++ b/sklearn/feature_selection/_mutual_info.py
@@ -396,6 +396,20 @@ def mutual_info_regression(
            Data Sets". PLoS ONE 9(2), 2014.
     .. [4] L. F. Kozachenko, N. N. Leonenko, "Sample Estimate of the Entropy
            of a Random Vector", Probl. Peredachi Inf., 23:2 (1987), 9-16
+
+    Examples
+    --------
+
+    >>> from sklearn.feature_selection import mutual_info_regression
+    >>> import numpy as np
+    >>> X = np.array([[1.5, 1],
+    ...               [2.1, 1],
+    ...               [3.4, 1],
+    ...               [3.9, 1]])
+    >>> y = np.array([4, 5, 6, 7])
+    >>> mi = mutual_info_regression(X, y)
+    >>> mi
+    array([0.00000000e+00, 1.11022302e-16])
     """
     return _estimate_mi(X, y, discrete_features, False, n_neighbors, copy, random_state)
 

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -345,6 +345,20 @@ def r_regression(X, y, *, center=True, force_finite=True):
     mutual_info_regression: Mutual information for a continuous target.
     f_classif: ANOVA F-value between label/feature for classification tasks.
     chi2: Chi-squared stats of non-negative features for classification tasks.
+
+    Examples
+    --------
+
+    >>> from sklearn.feature_selection import r_regression
+    >>> import numpy as np
+    >>> X = np.array([[1.5, 1],
+    ...               [2.1, 1],
+    ...               [3.4, 1],
+    ...               [3.9, 1]])
+    >>> y = np.array([4, 5, 6, 7])
+    >>> correlation_coef = r_regression(X, y)
+    >>> correlation_coef
+    array([0.98445326, 0.        ])
     """
     X, y = check_X_y(X, y, accept_sparse=["csr", "csc", "coo"], dtype=np.float64)
     n_samples = X.shape[0]

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -149,6 +149,22 @@ def f_classif(X, y):
     --------
     chi2 : Chi-squared stats of non-negative features for classification tasks.
     f_regression : F-value between label/feature for regression tasks.
+
+    Examples
+    --------
+
+    >>> from sklearn.feature_selection import f_classif
+    >>> import numpy as np
+    >>> X = np.array([[1, 1],
+    ...               [0, 1],
+    ...               [5, 4],
+    ...               [6, 6]])
+    >>> y = np.array([1, 1, 0, 0])
+    >>> f_statistic, p_values = f_classif(X, y)
+    >>> f_statistic
+    array([50., 16.])
+    >>> p_values
+    array([0.01941932, 0.05719096])
     """
     X, y = check_X_y(X, y, accept_sparse=["csr", "csc", "coo"])
     args = [X[safe_mask(X, y == k)] for k in np.unique(y)]
@@ -212,6 +228,15 @@ def chi2(X, y):
     p_values : ndarray of shape (n_features,)
         P-values for each feature.
 
+    See Also
+    --------
+    f_classif : ANOVA F-value between label/feature for classification tasks.
+    f_regression : F-value between label/feature for regression tasks.
+
+    Notes
+    -----
+    Complexity of this algorithm is O(n_classes * n_features).
+
     Examples
     --------
     >>> from sklearn.feature_selection import chi2
@@ -226,15 +251,6 @@ def chi2(X, y):
     array([8.33333333, 5.33333333])
     >>> p_values
     array([0.00389242, 0.02092134])
-
-    See Also
-    --------
-    f_classif : ANOVA F-value between label/feature for classification tasks.
-    f_regression : F-value between label/feature for regression tasks.
-
-    Notes
-    -----
-    Complexity of this algorithm is O(n_classes * n_features).
     """
 
     # XXX: we might want to do some of the following in logspace instead for

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -212,6 +212,21 @@ def chi2(X, y):
     p_values : ndarray of shape (n_features,)
         P-values for each feature.
 
+    Examples
+    --------
+    >>> from sklearn.feature_selection import chi2
+    >>> import numpy as np
+    >>> X = np.array([[1, 1],
+    ...               [0, 1],
+    ...               [5, 4],
+    ...               [6, 6]])
+    >>> y = np.array([1, 1, 0, 0])
+    >>> chi2_stats, p_values = chi2(X, y)
+    >>> chi2_stats
+    array([8.33333333, 5.33333333])
+    >>> p_values
+    array([0.00389242, 0.02092134])
+
     See Also
     --------
     f_classif : ANOVA F-value between label/feature for classification tasks.

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -152,7 +152,6 @@ def f_classif(X, y):
 
     Examples
     --------
-
     >>> from sklearn.feature_selection import f_classif
     >>> import numpy as np
     >>> X = np.array([[1, 1],
@@ -348,7 +347,6 @@ def r_regression(X, y, *, center=True, force_finite=True):
 
     Examples
     --------
-
     >>> from sklearn.feature_selection import r_regression
     >>> import numpy as np
     >>> X = np.array([[1.5, 1],
@@ -484,7 +482,6 @@ def f_regression(X, y, *, center=True, force_finite=True):
 
     Examples
     --------
-
     >>> from sklearn.feature_selection import f_regression
     >>> import numpy as np
     >>> X = np.array([[1.5, 1.2],

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -467,6 +467,22 @@ def f_regression(X, y, *, center=True, force_finite=True):
     SelectFwe: Select features based on family-wise error rate.
     SelectPercentile: Select features based on percentile of the highest
         scores.
+
+    Examples
+    --------
+
+    >>> from sklearn.feature_selection import f_regression
+    >>> import numpy as np
+    >>> X = np.array([[1.5, 1.2],
+    ...               [2.1, 2.3],
+    ...               [3.4, 3.6],
+    ...               [3.9, 4.1]])
+    >>> y = np.array([4, 5, 6, 7])
+    >>> f_statistic, p_values = f_regression(X, y)
+    >>> f_statistic
+    array([62.82608696, 71.42857143])
+    >>> p_values
+    array([0.01554674, 0.0137127 ])
     """
     correlation_coefficient = r_regression(
         X, y, center=center, force_finite=force_finite


### PR DESCRIPTION
Fixes parts of #27982 

Added a docstring example for each of the following feature selection functions:

- [x] sklearn.feature_selection.chi2
- [x] sklearn.feature_selection.f_classif
- [x] sklearn.feature_selection.f_regression
- [x] sklearn.feature_selection.mutual_info_classif
- [x] sklearn.feature_selection.mutual_info_regression
- [x] sklearn.feature_selectoin.r_regression

Note: I was not able to produce an example for `sklearn.feature_selection.SelectorMixin`. Maybe someone could take a look at this.