### PR TITLE
add dbcv score (unsupervised clustering score) and one test comparing kmeans and dbscan dbcv score

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -607,9 +607,6 @@ Changelog
   :func:`metrics.root_mean_squared_log_error` instead.
   :pr:`26734` by :user:`Alejandro Martin Gil <101AlexMartin>`.
 
-- |Feature| :func:`metrics.cluster.dbcv_score`
-  :pr:`28036` by :user:`Nils Cercariolo <Nylio-prog>`.
-
 :mod:`sklearn.model_selection`
 ..............................
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -607,6 +607,9 @@ Changelog
   :func:`metrics.root_mean_squared_log_error` instead.
   :pr:`26734` by :user:`Alejandro Martin Gil <101AlexMartin>`.
 
+- |Feature| :func:`metrics.cluster.dbcv_score`
+  :pr:`28036` by :user:`Nils Cercariolo <Nylio-prog>`.
+
 :mod:`sklearn.model_selection`
 ..............................
 

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -38,3 +38,9 @@ TODO: update at the time of the release.
 
 - |Feature| A fitted :class:`compose.ColumnTransformer` now implements `__getitem__`
   which returns the fitted transformers by name. :pr:`27990` by `Thomas Fan`_.
+
+:mod:`sklearn.metrics`
+......................
+
+- |Feature| :func:`metrics.cluster.dbcv_score`
+  :pr:`28036` by :user:`Nils Cercariolo <Nylio-prog>`.

--- a/sklearn/metrics/cluster/__init__.py
+++ b/sklearn/metrics/cluster/__init__.py
@@ -25,6 +25,7 @@ from ._supervised import (
 from ._unsupervised import (
     calinski_harabasz_score,
     davies_bouldin_score,
+    dbcv_score,
     silhouette_samples,
     silhouette_score,
 )
@@ -49,4 +50,5 @@ __all__ = [
     "calinski_harabasz_score",
     "davies_bouldin_score",
     "consensus_score",
+    "dbcv_score",
 ]

--- a/sklearn/metrics/cluster/_dbcv_helper.py
+++ b/sklearn/metrics/cluster/_dbcv_helper.py
@@ -1,0 +1,215 @@
+import numpy as np
+import scipy.sparse.csgraph
+import scipy.spatial.distance
+import scipy.stats
+
+
+def compute_pair_to_pair_dists(X, metric):
+    """
+    Computes the pairwise distance matrix between samples in the input array
+      `X` using the specified distance metric.
+
+    Parameters:
+    - X (numpy.ndarray): Sample embeddings with shape (N, D).
+    - metric (str): Distance metric to compute dissimilarity between observations.
+
+    Returns:
+    - dists (numpy.ndarray): Pairwise distance matrix with shape (N, N).
+    """
+    dists = scipy.spatial.distance.cdist(X, X, metric=metric)
+    np.maximum(dists, 1e-12, out=dists)
+    np.fill_diagonal(dists, val=np.inf)
+    return dists
+
+
+def get_subarray(arr, inds_a=None, inds_b=None):
+    """
+    Retrieves a subarray from the input array based on specified indices.
+
+    Parameters:
+    - arr (numpy.ndarray): Input array.
+    - inds_a (numpy.ndarray, optional): Indices for the first dimension.
+    Defaults to None.
+    - inds_b (numpy.ndarray, optional): Indices for the second dimension.
+    If None, defaults to `inds_a`.
+
+    Returns:
+    - subarray (numpy.ndarray): Subarray based on specified indices.
+    """
+    if inds_a is None:
+        return arr
+    if inds_b is None:
+        inds_b = inds_a
+    inds_a_mesh, inds_b_mesh = np.meshgrid(inds_a, inds_b)
+    return arr[inds_a_mesh, inds_b_mesh]
+
+
+def get_internal_objects(mutual_reach_dists):
+    """
+    Identifies internal nodes and corresponding edge weights in a Minimum
+    Spanning Tree (MST) represented by `mutual_reach_dists`.
+
+    Parameters:
+    - mutual_reach_dists (numpy.ndarray): Matrix representing mutual
+    reachability distances.
+
+    Returns:
+    - internal_node_inds (numpy.ndarray): Indices of internal nodes.
+    - internal_edge_weights (numpy.ndarray): Edge weights corresponding
+    to internal nodes.
+    """
+    mst = scipy.sparse.csgraph.minimum_spanning_tree(mutual_reach_dists)
+    mst = mst.toarray()
+
+    is_mst_edges = mst > 0.0
+
+    internal_node_inds = (is_mst_edges + is_mst_edges.T).sum(axis=0) > 1
+    internal_node_inds = np.flatnonzero(internal_node_inds)
+
+    internal_edge_weights = get_subarray(mst, inds_a=internal_node_inds)
+
+    return internal_node_inds, internal_edge_weights
+
+
+def compute_cluster_core_distance(dists, d):
+    """
+    Computes the core distances for each sample in a given distance matrix.
+
+    Parameters:
+    - dists (numpy.ndarray): Pairwise distance matrix.
+    - d (int): Exponent value for the core distance computation.
+
+    Returns:
+    - core_dists (numpy.ndarray): Core distances for each sample.
+    """
+    n, m = dists.shape
+
+    if n == m and n > 800:
+        from ...neighbors import NearestNeighbors
+
+        nn = NearestNeighbors(n_neighbors=801, metric="precomputed")
+        dists, _ = nn.fit(np.nan_to_num(dists, posinf=0.0)).kneighbors(
+            return_distance=True
+        )
+        n = dists.shape[1]
+
+    core_dists = np.power(dists, -d).sum(axis=-1, keepdims=True) / (n - 1 + 1e-12)
+
+    np.clip(core_dists, a_min=1e-12, a_max=1e12, out=core_dists)
+
+    np.power(core_dists, -1.0 / d, out=core_dists)
+
+    return core_dists
+
+
+def compute_mutual_reach_dists(
+    dists, d, is_symmetric, cls_inds_a=None, cls_inds_b=None
+):
+    """
+    Computes mutual reachability distances based on the given distance matrix
+      and clustering indices.
+
+    Parameters:
+    - dists (numpy.ndarray): Pairwise distance matrix.
+    - d (float): Exponent value for core distance computation.
+    - is_symmetric (bool): Indicates whether the computation is for symmetric
+    mutual reachability distances.
+    - cls_inds_a (numpy.ndarray, optional): Indices for the first cluster.
+    Defaults to None.
+    - cls_inds_b (numpy.ndarray, optional): Indices for the second cluster.
+    Defaults to None.
+
+    Returns:
+    - mutual_reach_dists (numpy.ndarray): Matrix of mutual reachability distances.
+    """
+    cls_dists = get_subarray(dists, inds_a=cls_inds_a, inds_b=cls_inds_b)
+
+    if is_symmetric:
+        core_dists_a = core_dists_b = compute_cluster_core_distance(
+            d=d, dists=cls_dists
+        )
+
+    else:
+        core_dists_a = compute_cluster_core_distance(d=d, dists=cls_dists)
+        core_dists_b = compute_cluster_core_distance(d=d, dists=cls_dists.T).T
+
+    mutual_reach_dists = cls_dists.copy()
+    np.maximum(mutual_reach_dists, core_dists_a, out=mutual_reach_dists)
+    np.maximum(mutual_reach_dists, core_dists_b, out=mutual_reach_dists)
+
+    return mutual_reach_dists
+
+
+def fn_density_sparseness(cls_inds, dists, d):
+    """
+    Computes the density sparseness of a cluster based on its indices and the
+      pairwise distance matrix.
+
+    Parameters:
+    - cls_inds (numpy.ndarray): Indices of samples in the cluster.
+    - dists (numpy.ndarray): Pairwise distance matrix.
+    - d (int): Exponent value for core distance computation.
+
+    Returns:
+    - dsc (float): Density sparseness of the cluster.
+    - internal_node_inds (numpy.ndarray): Indices of internal nodes in the cluster.
+    """
+    if cls_inds.size <= 3:
+        return 0.0, np.empty(0, dtype=int)
+
+    mutual_reach_dists = compute_mutual_reach_dists(dists=dists, d=d, is_symmetric=True)
+    internal_node_inds, internal_edge_weights = get_internal_objects(mutual_reach_dists)
+
+    dsc = float(internal_edge_weights.max())
+    internal_node_inds = cls_inds[internal_node_inds]
+
+    return dsc, internal_node_inds
+
+
+def fn_density_separation(cls_i, cls_j, dists, d):
+    """
+    Computes the density separation between two clusters based on their
+    indices and the pairwise distance matrix.
+
+    Parameters:
+    - cls_i (int): Cluster ID of the first cluster.
+    - cls_j (int): Cluster ID of the second cluster.
+    - dists (numpy.ndarray): Pairwise distance matrix.
+    - d (int): Exponent value for core distance computation.
+
+    Returns:
+    - cls_i (int): Cluster ID of the first cluster.
+    - cls_j (int): Cluster ID of the second cluster.
+    - dspc_ij (float): Density separation between the two clusters.
+    """
+    mutual_reach_dists = compute_mutual_reach_dists(
+        dists=dists, d=d, is_symmetric=False
+    )
+    dspc_ij = float(mutual_reach_dists.min()) if mutual_reach_dists.size else np.inf
+    return cls_i, cls_j, dspc_ij
+
+
+def _check_duplicated_samples(X, threshold=1e-9):
+    """
+    Checks for duplicated samples in the input array `X` based
+    on a specified threshold.
+
+    Parameters:
+    - X (numpy.ndarray): Input array containing samples.
+    - threshold (float, optional): Threshold for considering samples as duplicated.
+      Defaults to 1e-9.
+
+    Raises:
+    - ValueError: If duplicated samples are found in `X`.
+    """
+    if X.shape[0] <= 1:
+        return
+
+    from ...neighbors import NearestNeighbors
+
+    nn = NearestNeighbors(n_neighbors=1)
+    nn.fit(X)
+    dists, _ = nn.kneighbors(return_distance=True)
+
+    if np.any(dists < threshold):
+        raise ValueError("Duplicated samples have been found in X.")

--- a/sklearn/metrics/cluster/_unsupervised.py
+++ b/sklearn/metrics/cluster/_unsupervised.py
@@ -470,13 +470,9 @@ def dbcv_score(
     check_duplicates : (bool, optional)
         If True, check for duplicated samples.
         Defaults to True.
-    n_processes : (int or "auto", optional)
+    n_processes : (int, optional)
         Maximum number of parallel processes
         for processing clusters and cluster pairs.
-        If "auto", the number of parallel processes will
-        be set to 1 for datasets
-        with 200 or fewer instances, and 4 for datasets with more than
-        200 instances.
         Defaults to 1.
 
     Returns
@@ -529,9 +525,6 @@ def dbcv_score(
     internal_objects_per_cls = {}
 
     cls_inds = [np.flatnonzero(y == cls_id) for cls_id in cluster_ids]
-
-    if n_processes == "auto":
-        n_processes = 4 if y.size > 200 else 1
 
     with multiprocessing.Pool(processes=min(n_processes, cluster_ids.size)) as ppool:
         fn_density_sparseness_ = functools.partial(fn_density_sparseness, d=d)

--- a/sklearn/metrics/cluster/_unsupervised.py
+++ b/sklearn/metrics/cluster/_unsupervised.py
@@ -434,7 +434,11 @@ def davies_bouldin_score(X, labels):
 @validate_params(
     {
         "X": ["array-like"],
-        "labels": ["array-like"],
+        "y": ["array-like"],
+        "metric": [StrOptions(set(_VALID_METRICS))],
+        "noise_id": [int],
+        "check_duplicates": [bool],
+        "n_processes": [int],
     },
     prefer_skip_nested_validation=True,
 )
@@ -447,27 +451,45 @@ def dbcv_score(
     DBCV is an intrinsic (unsupervised/unlabeled) relative metric that evaluates
       the quality of clusters in a dataset.
 
-    Parameters:
-    - X (numpy.ndarray): Sample embeddings of shape (N, D).
-    - y (numpy.ndarray): Cluster IDs assigned to each sample in X, shape (N,).
-    - metric (str, optional): Metric function to compute dissimilarity between
-    observations. Defaults to "sqeuclidean".
-    - noise_id (int, optional): Noise "cluster" ID. Defaults to -1.
-    - check_duplicates (bool, optional): If True, check for duplicated samples.
-    Defaults to True.
-    - n_processes (int or "auto", optional): Maximum number of parallel processes
-      for processing clusters and cluster pairs.
-      If "auto", the number of parallel processes will be set to 1 for datasets
-        with 200 or fewer instances, and 4 for datasets with more than 200 instances.
-      Defaults to -1, which means using the maximum available CPUs.
+    Parameters
+    ----------
+    X : array-like of shape (n_samples, n_features)
+        A list of ``n_features``-dimensional data points. Each row corresponds
+        to a single data point.
 
-    Returns:
-    - float: DBCV metric estimation.
+    X : array-like of shape (n_sampled, n_features)
+        A list of ``n_features``-dimensional data points. Each row corresponds
+        to a single data point.
+    y : array-like of shape
+        Cluster IDs assigned to each sample in X, shape (N,).
+    metric : (str, optional)
+        Metric function to compute dissimilarity between
+        observations. Defaults to "sqeuclidean".
+    noise_id : (int, optional)
+        Noise "cluster" ID. Defaults to -1.
+    check_duplicates : (bool, optional)
+        If True, check for duplicated samples.
+        Defaults to True.
+    n_processes : (int or "auto", optional)
+        Maximum number of parallel processes
+        for processing clusters and cluster pairs.
+        If "auto", the number of parallel processes will
+        be set to 1 for datasets
+        with 200 or fewer instances, and 4 for datasets with more than
+        200 instances.
+        Defaults to 1.
 
-    Source:
-    - "Density-Based Clustering Validation". Davoud Moulavi, Pablo A. Jaskowiak,
-    Ricardo J. G. B. Campello, Arthur Zimek, Jörg Sander.
-      https://www.dbs.ifi.lmu.de/~zimek/publications/SDM2014/DBCV.pdf
+    Returns
+    -------
+    score: float
+        The resulting DBCV metric estimation.
+
+    References
+    ----------
+        "Density-Based Clustering Validation". Davoud Moulavi,
+        Pablo A. Jaskowiak, Ricardo J. G. B. Campello, Arthur Zimek,
+        Jörg Sander.
+        https://www.dbs.ifi.lmu.de/~zimek/publications/SDM2014/DBCV.pdf
     """
 
     X = np.asfarray(X)

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -520,8 +520,8 @@ def test_fn_density_separation(sample_data):
 
 def test_check_duplicated_samples_unique_value():
     X = np.array([1])
-    with pytest.raises(ValueError, match="Duplicated samples have been found in X."):
-        _check_duplicated_samples(X)
+    result = _check_duplicated_samples(X)
+    assert result is None
 
 
 def test_check_duplicated_samples():

--- a/sklearn/metrics/cluster/tests/test_unsupervised.py
+++ b/sklearn/metrics/cluster/tests/test_unsupervised.py
@@ -10,6 +10,7 @@ from sklearn.metrics import pairwise_distances
 from sklearn.metrics.cluster import (
     calinski_harabasz_score,
     davies_bouldin_score,
+    dbcv_score,
     silhouette_samples,
     silhouette_score,
 )
@@ -411,3 +412,26 @@ def test_silhouette_score_integer_precomputed():
         silhouette_score(
             [[1, 1, 2], [1, 0, 1], [2, 1, 0]], [0, 0, 1], metric="precomputed"
         )
+
+
+def test_dbcv_kmeans_dbscan():
+    X, _ = datasets.make_moons(n_samples=100, noise=0.05, random_state=1782)
+
+    from sklearn.cluster import KMeans
+
+    kmeans = KMeans(n_clusters=2, algorithm="lloyd", n_init=10)
+    kmeans_labels = kmeans.fit_predict(X)
+
+    from sklearn.cluster import DBSCAN
+
+    dbscanner = DBSCAN(algorithm="ball_tree")
+    dbscan_labels = dbscanner.fit_predict(X)
+
+    actual_kmeans_score = dbcv_score(X, kmeans_labels)
+    actual_dbscan_score = dbcv_score(X, dbscan_labels)
+
+    expected_dbscan_score = 0.9999999999997616
+
+    # Kmeans_score is randomly between -0.2 and -0.5 so we can't give a unique value
+    assert -0.5 <= actual_kmeans_score <= 0.2
+    assert actual_dbscan_score == pytest.approx(expected_dbscan_score, rel=1e-6)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Towards #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #27259


#### What does this implement/fix? Explain your changes.

This adds the dbcv score which is a density based score for unsupervised clustering. I've also included one test that compares kmeans and dbscan's dbcv scores with the moon dataset. This follows [this paper](https://www.dbs.ifi.lmu.de/~zimek/publications/SDM2014/DBCV.pdf).

#### Any other comments?

I wasn't sure where to add all the helper functions for dbcv score as it is a bit more complex than other metrics so I added another file but feel free to propose other options as it is my first PR. The implementation follows closely [this repo](https://github.com/FelSiq/DBCV).

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
