### PR TITLE
Add custom imputation strategy to SimpleImputer

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -25,6 +25,12 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123455 is the *pull request* number, not the issue number.
 
+:mod:`sklearn.impute`
+.....................
+- |Enhancement| :class:`impute.SimpleImputer` now supports `custom` imputation strategies 
+  using `sparse_fn` and `dense_fn` for sparse and dense input matrices, respectively.
+  :pr:`28053` by :user:`Mark Elliot <mark-thm>`.
+
 Code and Documentation Contributors
 -----------------------------------
 

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -27,8 +27,8 @@ Changelog
 
 :mod:`sklearn.impute`
 .....................
-- |Enhancement| :class:`impute.SimpleImputer` now supports `custom` imputation strategies 
-  using `sparse_fn` and `dense_fn` for sparse and dense input matrices, respectively.
+- |Enhancement| :class:`impute.SimpleImputer` now supports custom strategies
+  by passing a function in place of a strategy name.
   :pr:`28053` by :user:`Mark Elliot <mark-thm>`.
 
 Code and Documentation Contributors

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -276,7 +276,7 @@ class SimpleImputer(_BaseImputer):
         **_BaseImputer._parameter_constraints,
         "strategy": [
             StrOptions({"mean", "median", "most_frequent", "constant"}),
-            type(np.min),
+            callable,
         ],
         "fill_value": "no_validation",  # any object is valid
         "copy": ["boolean"],

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -3,9 +3,11 @@
 # License: BSD 3 clause
 
 import numbers
+import types
 import warnings
 from collections import Counter
 from functools import partial
+from typing import Callable
 
 import numpy as np
 import numpy.ma as ma
@@ -143,6 +145,10 @@ class _BaseImputer(TransformerMixin, BaseEstimator):
         return {"allow_nan": is_scalar_nan(self.missing_values)}
 
 
+def _is_callable(maybe):
+    return isinstance(maybe, Callable)
+
+
 class SimpleImputer(_BaseImputer):
     """Univariate imputer for completing missing values with simple strategies.
 
@@ -175,10 +181,9 @@ class SimpleImputer(_BaseImputer):
           If there is more than one such value, only the smallest is returned.
         - If "constant", then replace missing values with fill_value. Can be
           used with strings or numeric data.
-        - If "custom", then replace missing values using sparse_fn and dense_fn
-          based on whether the input array is sparse or dense. Note that callers
-          may supply only one of these implementations if it's known that only
-          exclusively sparse or dense data will be passed.
+        - If an instance of Callable, then replace missing values using the
+          scalar statistic returned by running the callable over a dense 1d
+          array containing non-missing values of each column.
 
         .. versionadded:: 0.20
            strategy="constant" for fixed value imputation.
@@ -214,24 +219,6 @@ class SimpleImputer(_BaseImputer):
         in which case `fill_value` will be used instead.
 
         .. versionadded:: 1.2
-
-    dense_fn : Callable[[dense matrix, *, axis], numerical value], default=None
-        Optional function to use in producing a custom imputation value when
-        the input to fit is a dense matrix and `strategy="custom"`.
-
-        If callers know that only sparse matrices will be supplied to fit,
-        callers may omit this argument even when `strategy="custom"`.
-
-        .. versionadded:: 1.5
-
-    sparse_fn : Callable[[sparse matrix], numerical value], default=None
-        Optional function to use in producing a custom imputation value when
-        the input to fit is a sparse matrix and `strategy="custom"`.
-
-        If callers know that only dense matrices will be supplied to fit,
-        callers may omit this argument even when `strategy="custom"`.
-
-        .. versionadded:: 1.5
 
 
     Attributes
@@ -294,7 +281,8 @@ class SimpleImputer(_BaseImputer):
     _parameter_constraints: dict = {
         **_BaseImputer._parameter_constraints,
         "strategy": [
-            StrOptions({"mean", "median", "most_frequent", "constant", "custom"})
+            StrOptions({"mean", "median", "most_frequent", "constant"}),
+            type(np.min),
         ],
         "fill_value": "no_validation",  # any object is valid
         "copy": ["boolean"],
@@ -309,8 +297,6 @@ class SimpleImputer(_BaseImputer):
         copy=True,
         add_indicator=False,
         keep_empty_features=False,
-        dense_fn=None,
-        sparse_fn=None,
     ):
         super().__init__(
             missing_values=missing_values,
@@ -320,8 +306,6 @@ class SimpleImputer(_BaseImputer):
         self.strategy = strategy
         self.fill_value = fill_value
         self.copy = copy
-        self.dense_fn = dense_fn
-        self.sparse_fn = sparse_fn
 
     def _validate_input(self, X, in_fit):
         if self.strategy in ("most_frequent", "constant"):
@@ -485,8 +469,8 @@ class SimpleImputer(_BaseImputer):
                     elif strategy == "most_frequent":
                         statistics[i] = _most_frequent(column, 0, n_zeros)
 
-                    elif strategy == "custom":
-                        statistics[i] = self.sparse_fn(column)
+                    elif isinstance(strategy, Callable):
+                        statistics[i] = self.strategy(column)
 
                     else:
                         raise RuntimeError(f"Unknown strategy {strategy}")
@@ -554,11 +538,11 @@ class SimpleImputer(_BaseImputer):
             return np.full(X.shape[1], fill_value, dtype=X.dtype)
 
         # Custom
-        elif strategy == "custom":
-            custom_masked = self.dense_fn(masked_X, axis=0)
-            custom = np.ma.getdata(custom_masked)
-            custom[np.ma.getmaskarray(custom_masked)] = np.nan
-            return custom
+        elif isinstance(strategy, Callable):
+            statistics = np.empty(masked_X.shape[1])
+            for i in range(masked_X.shape[1]):
+                statistics[i] = self.strategy(masked_X[:, i].compressed())
+            return statistics
 
         else:
             raise RuntimeError(f"Unknown strategy {strategy}")

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -183,6 +183,9 @@ class SimpleImputer(_BaseImputer):
         .. versionadded:: 0.20
            strategy="constant" for fixed value imputation.
 
+        .. versionadded:: 1.5
+           strategy=callable for custom value imputation.
+
     fill_value : str or numerical value, default=None
         When strategy == "constant", `fill_value` is used to replace all
         occurrences of missing_values. For string or object data types,

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -469,9 +469,6 @@ class SimpleImputer(_BaseImputer):
                     elif isinstance(strategy, Callable):
                         statistics[i] = self.strategy(column)
 
-                    else:
-                        raise RuntimeError(f"Unknown strategy {strategy}")
-
         super()._fit_indicator(missing_mask)
 
         return statistics
@@ -540,9 +537,6 @@ class SimpleImputer(_BaseImputer):
             for i in range(masked_X.shape[1]):
                 statistics[i] = self.strategy(masked_X[:, i].compressed())
             return statistics
-
-        else:
-            raise RuntimeError(f"Unknown strategy {strategy}")
 
     def transform(self, X):
         """Impute all missing values in `X`.

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -144,10 +144,6 @@ class _BaseImputer(TransformerMixin, BaseEstimator):
         return {"allow_nan": is_scalar_nan(self.missing_values)}
 
 
-def _is_callable(maybe):
-    return isinstance(maybe, Callable)
-
-
 class SimpleImputer(_BaseImputer):
     """Univariate imputer for completing missing values with simple strategies.
 

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -3,7 +3,6 @@
 # License: BSD 3 clause
 
 import numbers
-import types
 import warnings
 from collections import Counter
 from functools import partial

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -164,7 +164,7 @@ class SimpleImputer(_BaseImputer):
         nullable integer dtypes with missing values, `missing_values`
         can be set to either `np.nan` or `pd.NA`.
 
-    strategy : str, default='mean'
+    strategy : str or Callable, default='mean'
         The imputation strategy.
 
         - If "mean", then replace missing values using the mean along
@@ -214,7 +214,6 @@ class SimpleImputer(_BaseImputer):
         in which case `fill_value` will be used instead.
 
         .. versionadded:: 1.2
-
 
     Attributes
     ----------

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1736,22 +1736,12 @@ def test_imputation_custom(csc_container):
         ]
     )
 
-    imputer = SimpleImputer(
-        missing_values=np.nan,
-        strategy="custom",
-        sparse_fn=np.min,
-        dense_fn=np.ma.min,
-    )
+    imputer = SimpleImputer(missing_values=np.nan, strategy=np.min)
     X_trans = imputer.fit_transform(X)
     assert_array_equal(X_trans, X_true)
 
     # Sparse matrix
-    imputer = SimpleImputer(
-        missing_values=np.nan,
-        strategy="custom",
-        sparse_fn=np.min,
-        dense_fn=np.ma.min,
-    )
+    imputer = SimpleImputer(missing_values=np.nan, strategy=np.min)
     X_trans = imputer.fit_transform(csc_container(X))
     assert_array_equal(X_trans.toarray(), X_true)
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1744,15 +1744,3 @@ def test_imputation_custom(csc_container):
     imputer = SimpleImputer(missing_values=np.nan, strategy=np.min)
     X_trans = imputer.fit_transform(csc_container(X))
     assert_array_equal(X_trans.toarray(), X_true)
-
-
-@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
-def test_imputation_errors_on_unknown_strategy(csc_container):
-    imputer = SimpleImputer(missing_values=np.nan, strategy="mean")
-    X = np.array([[0, 0, 0]])
-
-    with pytest.raises(RuntimeError):
-        imputer._dense_fit(X, "unknown", np.nan, 0)
-
-    with pytest.raises(RuntimeError):
-        imputer._sparse_fit(csc_container(X), "unknown", np.nan, 0)

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1710,3 +1710,59 @@ def test_simple_imputer_keep_empty_features(strategy, array_type, keep_empty_fea
             assert_array_equal(constant_feature, 0)
         else:
             assert X_imputed.shape == (X.shape[0], X.shape[1] - 1)
+
+
+@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
+def test_imputation_custom(csc_container):
+    X = np.array(
+        [
+            [1.1, 1.1, 1.1],
+            [3.9, 1.2, np.nan],
+            [np.nan, 1.3, np.nan],
+            [0.1, 1.4, 1.4],
+            [4.9, 1.5, 1.5],
+            [np.nan, 1.6, 1.6],
+        ]
+    )
+
+    X_true = np.array(
+        [
+            [1.1, 1.1, 1.1],
+            [3.9, 1.2, 1.1],
+            [0.1, 1.3, 1.1],
+            [0.1, 1.4, 1.4],
+            [4.9, 1.5, 1.5],
+            [0.1, 1.6, 1.6],
+        ]
+    )
+
+    imputer = SimpleImputer(
+        missing_values=np.nan,
+        strategy="custom",
+        sparse_fn=np.min,
+        dense_fn=np.ma.min,
+    )
+    X_trans = imputer.fit_transform(X)
+    assert_array_equal(X_trans, X_true)
+
+    # Sparse matrix
+    imputer = SimpleImputer(
+        missing_values=np.nan,
+        strategy="custom",
+        sparse_fn=np.min,
+        dense_fn=np.ma.min,
+    )
+    X_trans = imputer.fit_transform(csc_container(X))
+    assert_array_equal(X_trans.toarray(), X_true)
+
+
+@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
+def test_imputation_errors_on_unknown_strategy(csc_container):
+    imputer = SimpleImputer(missing_values=np.nan, strategy="mean")
+    X = np.array([[0, 0, 0]])
+
+    with pytest.raises(RuntimeError):
+        imputer._dense_fit(X, "unknown", np.nan, 0)
+
+    with pytest.raises(RuntimeError):
+        imputer._sparse_fit(csc_container(X), "unknown", np.nan, 0)


### PR DESCRIPTION
#### Reference Issues/PRs
#27986


#### What does this implement/fix? Explain your changes.
Adds a 'custom' strategy to `SimpleImputer` that enables supplying ones own statistics to produce an imputation value.

In my experience, it's useful to be able to compute, for instance, minimum and maximum values of the inputs in addition to, for instance, mean, and this enables unifying the imputation logic and producing a single location to manage all imputations.


#### Any other comments?
I proposed a similar change in #27986 and @adrinjalali and @jnothman requested to see a variation that accepts a callable instead of explicitly supporting new statistics.
