### PR TITLE
ENH Improved error messages for `UnsetMetadataPassedError`

### DIFF
--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -19,7 +19,7 @@ __all__ = [
 
 class UnsetMetadataPassedError(ValueError):
     """Exception class to raise if a metadata is passed which is not explicitly \
-        requested.
+        requested (metadata=True) or not requested (metadata=False).
 
     .. versionadded:: 1.3
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -399,9 +399,14 @@ def cross_validate(
             # to make it more suitable for this case.
             raise UnsetMetadataPassedError(
                 message=(
-                    f"{sorted(e.unrequested_params.keys())} are passed to cross"
-                    " validation but are not explicitly requested or unrequested. See"
-                    " the Metadata Routing User guide"
+                    f"{sorted(e.unrequested_params.keys())} are passed to"
+                    " `cross_validate` but are not explicitly set as requested or not"
+                    " requested for cross_validate's estimator:"
+                    f" {estimator.__class__.__name__}. Call"
+                    " `.set_fit_request(metadata=True)` on the estimator for each"
+                    f" metadata in {sorted(e.unrequested_params.keys())} that you want"
+                    " to use and `metadata=False` for not using it. See the Metadata"
+                    " Routing User guide"
                     " <https://scikit-learn.org/stable/metadata_routing.html> for more"
                     " information."
                 ),
@@ -1240,9 +1245,14 @@ def cross_val_predict(
             # to make it more suitable for this case.
             raise UnsetMetadataPassedError(
                 message=(
-                    f"{sorted(e.unrequested_params.keys())} are passed to cross"
-                    " validation but are not explicitly requested or unrequested. See"
-                    " the Metadata Routing User guide"
+                    f"{sorted(e.unrequested_params.keys())} are passed to"
+                    " `cross_val_predict` but are not explicitly set as requested or"
+                    " not requested for cross_validate's estimator:"
+                    f" {estimator.__class__.__name__}. Call"
+                    " `.set_fit_request(metadata=True)` on the estimator for each"
+                    f" metadata in {sorted(e.unrequested_params.keys())} that you want"
+                    " to use and `metadata=False` for not using it. See the Metadata"
+                    " Routing User guide"
                     " <https://scikit-learn.org/stable/metadata_routing.html> for more"
                     " information."
                 ),

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -397,14 +397,14 @@ def cross_validate(
             # `process_routing` code, we pass `fit` as the caller. However,
             # the user is not calling `fit` directly, so we change the message
             # to make it more suitable for this case.
+            unrequested_params = sorted(e.unrequested_params)
             raise UnsetMetadataPassedError(
                 message=(
-                    f"{sorted(e.unrequested_params.keys())} are passed to cross"
-                    " validation but are not explicitly set as requested or not"
-                    " requested for cross_validate's estimator:"
-                    f" {estimator.__class__.__name__}. Call"
+                    f"{unrequested_params} are passed to cross validation but are not"
+                    " explicitly set as requested or not requested for cross_validate's"
+                    f" estimator: {estimator.__class__.__name__}. Call"
                     " `.set_fit_request({{metadata}}=True)` on the estimator for"
-                    f" each metadata in {sorted(e.unrequested_params.keys())} that you"
+                    f" each metadata in {unrequested_params} that you"
                     " want to use and `metadata=False` for not using it. See the"
                     " Metadata Routing User guide"
                     " <https://scikit-learn.org/stable/metadata_routing.html> for more"
@@ -1243,18 +1243,17 @@ def cross_val_predict(
             # `process_routing` code, we pass `fit` as the caller. However,
             # the user is not calling `fit` directly, so we change the message
             # to make it more suitable for this case.
+            unrequested_params = sorted(e.unrequested_params)
             raise UnsetMetadataPassedError(
                 message=(
-                    f"{sorted(e.unrequested_params.keys())} are passed to"
-                    " `cross_val_predict` but are not explicitly set as requested or"
-                    " not requested for cross_validate's estimator:"
-                    f" {estimator.__class__.__name__}. Call"
+                    f"{unrequested_params} are passed to `cross_val_predict` but are"
+                    " not explicitly set as requested or not requested for"
+                    f" cross_validate's estimator: {estimator.__class__.__name__} Call"
                     " `.set_fit_request({{metadata}}=True)` on the estimator for"
-                    f" each metadata in {sorted(e.unrequested_params.keys())} that you"
-                    " want to use and `metadata=False` for not using it. See the"
-                    " Metadata Routing User guide"
-                    " <https://scikit-learn.org/stable/metadata_routing.html> for more"
-                    " information."
+                    f" each metadata in {unrequested_params} that you want to use and"
+                    " `metadata=False` for not using it. See the Metadata Routing User"
+                    " guide <https://scikit-learn.org/stable/metadata_routing.html>"
+                    " for more information."
                 ),
                 unrequested_params=e.unrequested_params,
                 routed_params=e.routed_params,

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -399,14 +399,14 @@ def cross_validate(
             # to make it more suitable for this case.
             raise UnsetMetadataPassedError(
                 message=(
-                    f"{sorted(e.unrequested_params.keys())} are passed to"
-                    " cross validation but are not explicitly set as requested or not"
+                    f"{sorted(e.unrequested_params.keys())} are passed to cross"
+                    " validation but are not explicitly set as requested or not"
                     " requested for cross_validate's estimator:"
                     f" {estimator.__class__.__name__}. Call"
-                    " `.set_fit_request(metadata=True)` on the estimator for each"
-                    f" metadata in {sorted(e.unrequested_params.keys())} that you want"
-                    " to use and `metadata=False` for not using it. See the Metadata"
-                    " Routing User guide"
+                    " `.set_fit_request({{metadata}}=True)` on the estimator for"
+                    f" each metadata in {sorted(e.unrequested_params.keys())} that you"
+                    " want to use and `metadata=False` for not using it. See the"
+                    " Metadata Routing User guide"
                     " <https://scikit-learn.org/stable/metadata_routing.html> for more"
                     " information."
                 ),
@@ -1249,10 +1249,10 @@ def cross_val_predict(
                     " `cross_val_predict` but are not explicitly set as requested or"
                     " not requested for cross_validate's estimator:"
                     f" {estimator.__class__.__name__}. Call"
-                    " `.set_fit_request(metadata=True)` on the estimator for each"
-                    f" metadata in {sorted(e.unrequested_params.keys())} that you want"
-                    " to use and `metadata=False` for not using it. See the Metadata"
-                    " Routing User guide"
+                    " `.set_fit_request({{metadata}}=True)` on the estimator for"
+                    f" each metadata in {sorted(e.unrequested_params.keys())} that you"
+                    " want to use and `metadata=False` for not using it. See the"
+                    " Metadata Routing User guide"
                     " <https://scikit-learn.org/stable/metadata_routing.html> for more"
                     " information."
                 ),

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -400,7 +400,7 @@ def cross_validate(
             raise UnsetMetadataPassedError(
                 message=(
                     f"{sorted(e.unrequested_params.keys())} are passed to"
-                    " `cross_validate` but are not explicitly set as requested or not"
+                    " cross validation but are not explicitly set as requested or not"
                     " requested for cross_validate's estimator:"
                     f" {estimator.__class__.__name__}. Call"
                     " `.set_fit_request(metadata=True)` on the estimator for each"

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -2517,7 +2517,7 @@ def test_groups_with_routing_validation(cv_method):
 def test_passed_unrequested_metadata(cv_method):
     """Check that we raise an error when passing metadata that is not
     requested."""
-    err_msg = re.escape("['metadata'] are passed to cross validation")
+    err_msg = re.escape("but are not explicitly set as requested or not requested")
     with pytest.raises(ValueError, match=err_msg):
         cv_method(
             estimator=ConsumingClassifier(),


### PR DESCRIPTION
This PR suggests to improve the error messages from `UnsetMetadataPassedError` for the cross validation functions.

It's now mentioning the estimator, on which the `set_fit_request()` method needs to be called and how.