### PR TITLE
MNT changed order pre-commits hooks following ruff recommendation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,16 +5,16 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-    -   id: black
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.0.272
     hooks:
     -   id: ruff
         args: ["--fix", "--show-source"]
+-   repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+    -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.3.0
     hooks:


### PR DESCRIPTION
#### What does this implement/fix?
Simple pull request that changes the order in which the pre-commit hooks are implemented. In particular, Ruff is moved to the second position since, according to their developers: _When running with --fix, Ruff's lint hook should be placed before Ruff's formatter hook, and before **Black**, isort, and other formatting tools, as Ruff's fix behavior can output code changes that require reformatting._ (https://github.com/astral-sh/ruff-pre-commit)

