### PR TITLE
FIX unstable test_pca_mle_array_api_compliance with PyTorch / CPU / float32 on macOS

### DIFF
--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -901,7 +901,6 @@ def test_pca_mle_array_api_compliance(
     estimator, check, array_namespace, device, dtype_name
 ):
     name = estimator.__class__.__name__
-    atol = _atol_for_type(dtype_name)
     check(name, estimator, array_namespace, device=device, dtype_name=dtype_name)
 
     # Simpler variant of the generic check_array_api_input checker tailored for
@@ -910,6 +909,7 @@ def test_pca_mle_array_api_compliance(
 
     X, y = make_classification(random_state=42)
     X = X.astype(dtype_name, copy=False)
+    atol = _atol_for_type(X.dtype)
 
     est = clone(estimator)
 

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_array_equal
 
 from sklearn import config_context, datasets
 from sklearn.base import clone
-from sklearn.datasets import load_iris
+from sklearn.datasets import load_iris, make_classification
 from sklearn.decomposition import PCA
 from sklearn.decomposition._pca import _assess_dimension, _infer_dimension
 from sklearn.utils._array_api import (
@@ -16,10 +16,10 @@ from sklearn.utils._array_api import (
     _convert_to_numpy,
     yield_namespace_device_dtype_combinations,
 )
+from sklearn.utils._array_api import device as array_device
 from sklearn.utils._testing import _array_api_for_tests, assert_allclose
 from sklearn.utils.estimator_checks import (
     _get_check_estimator_ids,
-    check_array_api_input,
     check_array_api_input_and_values,
 )
 from sklearn.utils.fixes import CSC_CONTAINERS, CSR_CONTAINERS
@@ -882,14 +882,17 @@ def test_pca_array_api_compliance(
 )
 @pytest.mark.parametrize(
     "check",
-    [check_array_api_input, check_array_api_get_precision],
+    [check_array_api_get_precision],
     ids=_get_check_estimator_ids,
 )
 @pytest.mark.parametrize(
     "estimator",
     [
         # PCA with mle cannot use check_array_api_input_and_values because of
-        # rounding errors in the noisy (low variance) components.
+        # rounding errors in the noisy (low variance) components. Even checking
+        # the shape of the `components_` is problematic because the number of
+        # components depends on trimming threshold of the mle algorithm which
+        # can depend on device-specific rounding errors.
         PCA(n_components="mle", svd_solver="full"),
     ],
     ids=_get_check_estimator_ids,
@@ -898,7 +901,58 @@ def test_pca_mle_array_api_compliance(
     estimator, check, array_namespace, device, dtype_name
 ):
     name = estimator.__class__.__name__
+    atol = _atol_for_type(dtype_name)
     check(name, estimator, array_namespace, device=device, dtype_name=dtype_name)
+
+    # Simpler variant of the generic check_array_api_input checker tailored for
+    # the specific case of PCA with mle-trimmed components.
+    xp = _array_api_for_tests(array_namespace, device)
+
+    X, y = make_classification(random_state=42)
+    X = X.astype(dtype_name, copy=False)
+
+    est = clone(estimator)
+
+    X_xp = xp.asarray(X, device=device)
+    y_xp = xp.asarray(y, device=device)
+
+    est.fit(X, y)
+
+    components_np = est.components_
+    explained_variance_np = est.explained_variance_
+
+    est_xp = clone(est)
+    with config_context(array_api_dispatch=True):
+        est_xp.fit(X_xp, y_xp)
+        components_xp = est_xp.components_
+        assert array_device(components_xp) == array_device(X_xp)
+        components_xp_np = _convert_to_numpy(components_xp, xp=xp)
+
+        explained_variance_xp = est_xp.explained_variance_
+        assert array_device(explained_variance_xp) == array_device(X_xp)
+        explained_variance_xp_np = _convert_to_numpy(explained_variance_xp, xp=xp)
+
+    assert components_xp_np.dtype == components_np.dtype
+    assert components_xp_np.shape[1] == components_np.shape[1]
+    assert explained_variance_xp_np.dtype == explained_variance_np.dtype
+
+    # Check that the explained variance values match for the
+    # common components:
+    min_components = min(components_xp_np.shape[0], components_np.shape[0])
+    assert_allclose(
+        explained_variance_xp_np[:min_components],
+        explained_variance_np[:min_components],
+        atol=atol,
+    )
+
+    # If the number of components differ, check that the explained variance of
+    # the trimmed components is very small.
+    if components_xp_np.shape[0] != components_np.shape[0]:
+        reference_variance = explained_variance_np[-1]
+        extra_variance_np = explained_variance_np[min_components:]
+        extra_variance_xp_np = explained_variance_xp_np[min_components:]
+        assert all(np.abs(extra_variance_np - reference_variance) < atol)
+        assert all(np.abs(extra_variance_xp_np - reference_variance) < atol)
 
 
 def test_array_api_error_and_warnings_on_unsupported_params():


### PR DESCRIPTION
On my macOS laptop with `PYTORCH_ENABLE_MPS_FALLBACK=1` I get `test_pca_mle_array_api_compliance` to fail because the first dimension of of `PCA(n_components="mle").components_` depends on platform-specific rounding errors.

This PR replaces the generic `check_array_api_input` by an estimator-specific alternative that takes those mathematical details into account.

I checked locally and this version of the test pass.