### PR TITLE
[WIP] Add predict_proba and predict_log_proba to the NearestCentroid classifier

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -31,6 +31,12 @@ Changelog
   by passing a function in place of a strategy name.
   :pr:`28053` by :user:`Mark Elliot <mark-thm>`.
 
+:mod:`sklearn.neighbors`
+........................
+- |Feature| :class:`neighbors.NearestCentroid` now has predict_proba and
+  predict_log_proba methods.
+  :pr:`28071` by :user:`Filip Karlo Došilović <fkdosilovic>`.
+
 Code and Documentation Contributors
 -----------------------------------
 


### PR DESCRIPTION
#### Reference Issues/PRs

None

#### What does this implement/fix? Explain your changes.

This PR:
- adds the `predict_proba` (implementation suggested in the references) and `predict_log_proba` methods to the classifier,
- refactors the `fit` method

#### Any other comments?

Currently, the class priors are computed from the targets provided to the fit method. Maybe adding the priors/weights parameter to `__init__` would be more useful?
