### PR TITLE
MAINT avoid commit containing doc/sg_execution_times.rst

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ sklearn/**/*.html
 
 dist/
 MANIFEST
+doc/sg_execution_times.rst
 doc/_build/
 doc/auto_examples/
 doc/modules/generated/


### PR DESCRIPTION
It seems that `sphinx-gallery` create a file `sg_execution_times.rst` that could be added when doing pull-request. I think that we can safely add it to the `.gitignore` to avoid such issue.