### PR TITLE
TST Tweak tests to facilitate Meson usage

### DIFF
--- a/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py
+++ b/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py
@@ -15,4 +15,5 @@ def test_import_raises_warning():
     with pytest.warns(UserWarning, match="it is not needed to import"):
         from sklearn.experimental import enable_hist_gradient_boosting  # noqa
     """
-    assert_run_python_script_without_output(textwrap.dedent(code))
+    pattern = "it is not needed to import enable_hist_gradient_boosting anymore"
+    assert_run_python_script_without_output(textwrap.dedent(code), pattern=pattern)

--- a/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py
+++ b/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py
@@ -5,7 +5,7 @@ import textwrap
 import pytest
 
 from sklearn.utils import _IS_WASM
-from sklearn.utils._testing import assert_run_python_script
+from sklearn.utils._testing import assert_run_python_script_without_output
 
 
 @pytest.mark.xfail(_IS_WASM, reason="cannot start subprocess")
@@ -15,4 +15,4 @@ def test_import_raises_warning():
     with pytest.warns(UserWarning, match="it is not needed to import"):
         from sklearn.experimental import enable_hist_gradient_boosting  # noqa
     """
-    assert_run_python_script(textwrap.dedent(code))
+    assert_run_python_script_without_output(textwrap.dedent(code))

--- a/sklearn/experimental/tests/test_enable_iterative_imputer.py
+++ b/sklearn/experimental/tests/test_enable_iterative_imputer.py
@@ -5,7 +5,7 @@ import textwrap
 import pytest
 
 from sklearn.utils import _IS_WASM
-from sklearn.utils._testing import assert_run_python_script
+from sklearn.utils._testing import assert_run_python_script_without_output
 
 
 @pytest.mark.xfail(_IS_WASM, reason="cannot start subprocess")
@@ -16,28 +16,33 @@ def test_imports_strategies():
     # for every test case. Else, the tests would not be independent
     # (manually removing the imports from the cache (sys.modules) is not
     # recommended and can lead to many complications).
-
+    pattern = "IterativeImputer is experimental"
     good_import = """
     from sklearn.experimental import enable_iterative_imputer
     from sklearn.impute import IterativeImputer
     """
-    assert_run_python_script(textwrap.dedent(good_import))
+    assert_run_python_script_without_output(
+        textwrap.dedent(good_import), pattern=pattern
+    )
 
     good_import_with_ensemble_first = """
     import sklearn.ensemble
     from sklearn.experimental import enable_iterative_imputer
     from sklearn.impute import IterativeImputer
     """
-    assert_run_python_script(textwrap.dedent(good_import_with_ensemble_first))
+    assert_run_python_script_without_output(
+        textwrap.dedent(good_import_with_ensemble_first),
+        pattern=pattern,
+    )
 
-    bad_imports = """
+    bad_imports = f"""
     import pytest
 
-    with pytest.raises(ImportError, match='IterativeImputer is experimental'):
+    with pytest.raises(ImportError, match={pattern!r}):
         from sklearn.impute import IterativeImputer
 
     import sklearn.experimental
-    with pytest.raises(ImportError, match='IterativeImputer is experimental'):
+    with pytest.raises(ImportError, match={pattern!r}):
         from sklearn.impute import IterativeImputer
     """
-    assert_run_python_script(textwrap.dedent(bad_imports))
+    assert_run_python_script_without_output(textwrap.dedent(bad_imports))

--- a/sklearn/experimental/tests/test_enable_iterative_imputer.py
+++ b/sklearn/experimental/tests/test_enable_iterative_imputer.py
@@ -45,4 +45,7 @@ def test_imports_strategies():
     with pytest.raises(ImportError, match={pattern!r}):
         from sklearn.impute import IterativeImputer
     """
-    assert_run_python_script_without_output(textwrap.dedent(bad_imports))
+    assert_run_python_script_without_output(
+        textwrap.dedent(bad_imports),
+        pattern=pattern,
+    )

--- a/sklearn/experimental/tests/test_enable_successive_halving.py
+++ b/sklearn/experimental/tests/test_enable_successive_halving.py
@@ -47,4 +47,7 @@ def test_imports_strategies():
     with pytest.raises(ImportError, match={pattern!r}):
         from sklearn.model_selection import HalvingRandomSearchCV
     """
-    assert_run_python_script_without_output(textwrap.dedent(bad_imports))
+    assert_run_python_script_without_output(
+        textwrap.dedent(bad_imports),
+        pattern=pattern,
+    )

--- a/sklearn/experimental/tests/test_enable_successive_halving.py
+++ b/sklearn/experimental/tests/test_enable_successive_halving.py
@@ -5,7 +5,7 @@ import textwrap
 import pytest
 
 from sklearn.utils import _IS_WASM
-from sklearn.utils._testing import assert_run_python_script
+from sklearn.utils._testing import assert_run_python_script_without_output
 
 
 @pytest.mark.xfail(_IS_WASM, reason="cannot start subprocess")
@@ -16,13 +16,15 @@ def test_imports_strategies():
     # for every test case. Else, the tests would not be independent
     # (manually removing the imports from the cache (sys.modules) is not
     # recommended and can lead to many complications).
-
+    pattern = "Halving(Grid|Random)SearchCV is experimental"
     good_import = """
     from sklearn.experimental import enable_halving_search_cv
     from sklearn.model_selection import HalvingGridSearchCV
     from sklearn.model_selection import HalvingRandomSearchCV
     """
-    assert_run_python_script(textwrap.dedent(good_import))
+    assert_run_python_script_without_output(
+        textwrap.dedent(good_import), pattern=pattern
+    )
 
     good_import_with_model_selection_first = """
     import sklearn.model_selection
@@ -30,16 +32,19 @@ def test_imports_strategies():
     from sklearn.model_selection import HalvingGridSearchCV
     from sklearn.model_selection import HalvingRandomSearchCV
     """
-    assert_run_python_script(textwrap.dedent(good_import_with_model_selection_first))
+    assert_run_python_script_without_output(
+        textwrap.dedent(good_import_with_model_selection_first),
+        pattern=pattern,
+    )
 
-    bad_imports = """
+    bad_imports = f"""
     import pytest
 
-    with pytest.raises(ImportError, match='HalvingGridSearchCV is experimental'):
+    with pytest.raises(ImportError, match={pattern!r}):
         from sklearn.model_selection import HalvingGridSearchCV
 
     import sklearn.experimental
-    with pytest.raises(ImportError, match='HalvingRandomSearchCV is experimental'):
+    with pytest.raises(ImportError, match={pattern!r}):
         from sklearn.model_selection import HalvingRandomSearchCV
     """
-    assert_run_python_script(textwrap.dedent(bad_imports))
+    assert_run_python_script_without_output(textwrap.dedent(bad_imports))

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -14,6 +14,7 @@ import warnings
 from functools import partial
 from inspect import isgenerator, signature
 from itertools import chain, product
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -167,7 +168,7 @@ def test_configure():
     # is installed in editable mode by pip build isolation enabled.
     pytest.importorskip("Cython")
     cwd = os.getcwd()
-    setup_path = os.path.abspath(os.path.join(sklearn.__path__[0], ".."))
+    setup_path = Path(sklearn.__file__).parent.parent
     setup_filename = os.path.join(setup_path, "setup.py")
     if not os.path.exists(setup_filename):
         pytest.skip("setup.py not available")
@@ -211,10 +212,11 @@ def test_class_weight_balanced_linear_classifiers(name, Classifier):
 @pytest.mark.xfail(_IS_WASM, reason="importlib not supported for Pyodide packages")
 @ignore_warnings
 def test_import_all_consistency():
+    sklearn_path = [os.path.dirname(sklearn.__file__)]
     # Smoke test to check that any name in a __all__ list is actually defined
     # in the namespace of the module or package.
     pkgs = pkgutil.walk_packages(
-        path=sklearn.__path__, prefix="sklearn.", onerror=lambda _: None
+        path=sklearn_path, prefix="sklearn.", onerror=lambda _: None
     )
     submods = [modname for _, modname, _ in pkgs]
     for modname in submods + ["sklearn"]:
@@ -236,9 +238,10 @@ def test_import_all_consistency():
 
 
 def test_root_import_all_completeness():
+    sklearn_path = [os.path.dirname(sklearn.__file__)]
     EXCEPTIONS = ("utils", "tests", "base", "setup", "conftest")
     for _, modname, _ in pkgutil.walk_packages(
-        path=sklearn.__path__, onerror=lambda _: None
+        path=sklearn_path, onerror=lambda _: None
     ):
         if "." in modname or modname.startswith("_") or modname in EXCEPTIONS:
             continue

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -4,6 +4,7 @@
 
 import importlib
 import inspect
+import os
 import warnings
 from inspect import signature
 from pkgutil import walk_packages
@@ -40,7 +41,7 @@ from sklearn.utils.fixes import parse_version, sp_version
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", FutureWarning)
     # mypy error: Module has no attribute "__path__"
-    sklearn_path = sklearn.__path__  # type: ignore  # mypy issue #1422
+    sklearn_path = [os.path.dirname(sklearn.__file__)]
     PUBLIC_MODULES = set(
         [
             pckg[1]

--- a/sklearn/tests/test_min_dependencies_readme.py
+++ b/sklearn/tests/test_min_dependencies_readme.py
@@ -28,7 +28,7 @@ def test_min_dependencies_readme():
         + r"( [0-9]+\.[0-9]+(\.[0-9]+)?)"
     )
 
-    readme_path = Path(sklearn.__path__[0]).parents[0]
+    readme_path = Path(sklearn.__file__).parent.parent
     readme_file = readme_path / "README.rst"
 
     if not os.path.exists(readme_file):
@@ -58,7 +58,7 @@ def test_min_dependencies_pyproject_toml():
     # tomllib is available in Python 3.11
     tomllib = pytest.importorskip("tomllib")
 
-    root_directory = Path(sklearn.__path__[0]).parent
+    root_directory = Path(sklearn.__file__).parent.parent
     pyproject_toml_path = root_directory / "pyproject.toml"
 
     if not pyproject_toml_path.exists():

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -682,7 +682,7 @@ def assert_run_python_script_without_output(source_code, pattern=".+", timeout=6
     source_code : str
         The Python source code to execute.
     pattern : str
-        Pattern that the the stdout + stderr should not match. By default, unless
+        Pattern that the stdout + stderr should not match. By default, unless
         stdout + stderr are both empty, an error will be raised.
     timeout : int, default=60
         Time in seconds before timeout.

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -717,7 +717,7 @@ def assert_run_python_script_without_output(source_code, pattern=".+", timeout=6
             out = out.decode("utf-8")
             if re.search(pattern, out):
                 if pattern == ".+":
-                    expectation = "Expected empty output"
+                    expectation = "Expected no output"
                 else:
                     expectation = f"The output was not supposed to match {pattern!r}"
 

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -66,7 +66,7 @@ __all__ = [
     "assert_array_less",
     "assert_approx_equal",
     "assert_allclose",
-    "assert_run_python_script",
+    "assert_run_python_script_without_output",
     "assert_no_warnings",
     "SkipTest",
 ]
@@ -669,11 +669,11 @@ def check_docstring_parameters(func, doc=None, ignore=None):
     return incorrect
 
 
-def assert_run_python_script(source_code, timeout=60):
+def assert_run_python_script_without_output(source_code, pattern=".+", timeout=60):
     """Utility to check assertions in an independent Python subprocess.
 
-    The script provided in the source code should return 0 and not print
-    anything on stderr or stdout.
+    The script provided in the source code should return 0 and the stdtout +
+    stderr should not match the pattern `pattern`.
 
     This is a port from cloudpickle https://github.com/cloudpipe/cloudpickle
 
@@ -681,6 +681,9 @@ def assert_run_python_script(source_code, timeout=60):
     ----------
     source_code : str
         The Python source code to execute.
+    pattern : str
+        Pattern that the the stdout + stderr should not match. By default, unless
+        stdout + stderr are both empty, an error will be raised.
     timeout : int, default=60
         Time in seconds before timeout.
     """
@@ -710,8 +713,16 @@ def assert_run_python_script(source_code, timeout=60):
                 raise RuntimeError(
                     "script errored with output:\n%s" % e.output.decode("utf-8")
                 )
-            if out != b"":
-                raise AssertionError(out.decode("utf-8"))
+
+            out = out.decode("utf-8")
+            if re.search(pattern, out):
+                if pattern == ".+":
+                    expectation = "Expected empty output"
+                else:
+                    expectation = f"The output was not supposed to match {pattern!r}"
+
+                message = f"{expectation}, got the following output instead: {out!r}"
+                raise AssertionError(message)
         except TimeoutExpired as e:
             raise RuntimeError(
                 "script timeout, output so far:\n%s" % e.output.decode("utf-8")

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -20,6 +20,7 @@ from sklearn.utils._testing import (
     assert_raise_message,
     assert_raises,
     assert_raises_regex,
+    assert_run_python_script_without_output,
     check_docstring_parameters,
     create_memmap_backed_data,
     ignore_warnings,
@@ -820,3 +821,26 @@ def test_float32_aware_assert_allclose():
     with pytest.raises(AssertionError):
         assert_allclose(np.array([1e-5], dtype=np.float32), 0.0)
     assert_allclose(np.array([1e-5], dtype=np.float32), 0.0, atol=2e-5)
+
+
+def test_assert_run_python_script_without_output():
+    code = "x = 1"
+    assert_run_python_script_without_output(code)
+
+    code = "print('something to stdout')"
+    with pytest.raises(AssertionError, match="Expected empty output"):
+        assert_run_python_script_without_output(code)
+
+    code = "print('something to stdout')"
+    with pytest.raises(
+        AssertionError,
+        match="output was not supposed to match.+got.+something to stdout",
+    ):
+        assert_run_python_script_without_output(code, pattern="to.+stdout")
+
+    code = "\n".join(["import sys", "print('something to stderr', file=sys.stderr)"])
+    with pytest.raises(
+        AssertionError,
+        match="output was not supposed to match.+got.+something to stderr",
+    ):
+        assert_run_python_script_without_output(code, pattern="to.+stderr")

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -828,7 +828,7 @@ def test_assert_run_python_script_without_output():
     assert_run_python_script_without_output(code)
 
     code = "print('something to stdout')"
-    with pytest.raises(AssertionError, match="Expected empty output"):
+    with pytest.raises(AssertionError, match="Expected no output"):
         assert_run_python_script_without_output(code)
 
     code = "print('something to stdout')"


### PR DESCRIPTION
as asked in https://github.com/scikit-learn/scikit-learn/pull/28040#discussion_r1443784026 to facilitate Meson PR review #28040.

This PR should be merged before #28040 and then I can update the PR branch to have the testing fixes.

- use `__file__` rather than `__path__`, `__path__` seems to be broken in Meson editable installs see https://github.com/mesonbuild/meson-python/issues/557
- tweak `assert_run_python_script_without_output` to be able to use a regex matching the output that we don't want to see (warnings in our case for experimental stuff) + add tests. Previously any output would be an error. This is an issue for meson editable install which outputs things like "Nothing to be done" or Meson output "Compiling ..."
 
cc @thomasjpfan