### PR TITLE
FIX divide by zero in line search of GradientBoostingClassifier

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -436,7 +436,7 @@ Changelog
 - |Efficiency| :class:`ensemble.GradientBoostingClassifier` is faster,
   for binary and in particular for multiclass problems thanks to the private loss
   function module.
-  :pr:`26278` by :user:`Christian Lorentzen <lorentzenchr>`.
+  :pr:`26278` and :pr:`28095` by :user:`Christian Lorentzen <lorentzenchr>`.
 
 - |Efficiency| Improves runtime and memory usage for
   :class:`ensemble.GradientBoostingClassifier` and

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1452,9 +1452,9 @@ def test_huber_vs_mean_and_median():
 
 def test_safe_divide():
     """Test that _safe_divide handles division by zero."""
-    with pytest.warns(RuntimeWarning, match="divide"):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         assert _safe_divide(np.float64(1e300), 0) == 0
-    with pytest.warns(RuntimeWarning, match="divide"):
         assert _safe_divide(np.float64(0.0), np.float64(0.0)) == 0
     with pytest.warns(RuntimeWarning, match="overflow"):
         # np.finfo(float).max = 1.7976931348623157e+308


### PR DESCRIPTION
#### Reference Issues/PRs
This is a fix introduces in #26278 and #27312.

#### What does this implement/fix? Explain your changes.
This PR fixes a situation where the probability in a line search step of `GradientBoostingClassifier` reaches exactly `0` or `1` leading  to a division by zero.

The first commit adds the test. CI will prove that it failed. After that, a fix will be added.

#### Any other comments?
@ogrisel https://github.com/scikit-learn/scikit-learn/pull/28048#pullrequestreview-1811388451
> Would it make sense to include such a case as a public API level non-regression tests?

Yes! I'm convinced now.
@glemaitre @lesteve This might be worth to be included in 1.4.0 or, later, in 1.4.1.


#### Some history
The check `denominator == 0` was introduces in https://github.com/scikit-learn/scikit-learn/commit/d63f39c669177747b665711ced742ef40efe602b.
The check `abs(denominator) < 1e-150` was introduces in https://github.com/scikit-learn/scikit-learn/pull/7970.
#26278 added `_safe_divide` which handled `denominator == 0` correctly, but not on Pyodide.
#27312 fixed the Pyodide thing, but introduced a `RuntimeWarnings`.
This PR puts back the `abs(denominator) < 1e-150` without warnings.