### PR TITLE
FIX dump svmlight when data is read-only

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -2,6 +2,24 @@
 
 .. currentmodule:: sklearn
 
+.. _changes_1_4_1:
+
+Version 1.4.1
+=============
+
+**In Development**
+
+Changelog
+---------
+
+:mod:`sklearn.datasets`
+.......................
+
+- |Fix| :func:`datasets.dump_svmlight_file` now does not raise `ValueError` when `X`
+  is read-only, e.g., a `numpy.memmap` instance.
+  :pr:`28111` by :user:`Yao Xiao <Charlie-XIAO>`.
+
+
 .. _changes_1_4:
 
 Version 1.4.0

--- a/sklearn/datasets/_svmlight_format_fast.pyx
+++ b/sklearn/datasets/_svmlight_format_fast.pyx
@@ -131,7 +131,7 @@ ctypedef fused int_or_longlong:
 
 
 def get_dense_row_string(
-    int_or_float[:, :] X,
+    const int_or_float[:, :] X,
     Py_ssize_t[:] x_inds,
     double_or_longlong[:] x_vals,
     Py_ssize_t row,

--- a/sklearn/datasets/tests/test_svmlight_format.py
+++ b/sklearn/datasets/tests/test_svmlight_format.py
@@ -16,6 +16,7 @@ from sklearn.utils._testing import (
     assert_allclose,
     assert_array_almost_equal,
     assert_array_equal,
+    create_memmap_backed_data,
     fails_if_pypy,
 )
 from sklearn.utils.fixes import CSR_CONTAINERS
@@ -596,3 +597,20 @@ def test_multilabel_y_explicit_zeros(tmp_path, csr_container):
     _, y_load = load_svmlight_file(save_path, multilabel=True)
     y_true = [(2.0,), (2.0,), (0.0, 1.0)]
     assert y_load == y_true
+
+
+def test_dump_read_only(tmp_path):
+    """
+    Ensure that there is no ValueError when dumping a read-only `X`.
+
+    https://github.com/scikit-learn/scikit-learn/issues/28026
+    """
+    rng = np.random.RandomState(42)
+    X = rng.randn(5, 2)
+    y = rng.randn(5)
+
+    # Convert to memmap-backed which are read-only
+    X, y = create_memmap_backed_data([X, y])
+
+    save_path = str(tmp_path / "svm_read_only")
+    dump_svmlight_file(X, y, save_path)

--- a/sklearn/datasets/tests/test_svmlight_format.py
+++ b/sklearn/datasets/tests/test_svmlight_format.py
@@ -600,9 +600,9 @@ def test_multilabel_y_explicit_zeros(tmp_path, csr_container):
 
 
 def test_dump_read_only(tmp_path):
-    """
-    Ensure that there is no ValueError when dumping a read-only `X`.
+    """Ensure that there is no ValueError when dumping a read-only `X`.
 
+    Non-regression test for:
     https://github.com/scikit-learn/scikit-learn/issues/28026
     """
     rng = np.random.RandomState(42)


### PR DESCRIPTION
Fixes #28026.

The original signature would raise `ValueError: buffer source array is read-only` if `X` is for instance memmap-based.
