### PR TITLE
TST Tweak one more test to facilitate Meson usage

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -262,9 +262,10 @@ def test_all_tests_are_importable():
         "sklearn.datasets.descr",
         "sklearn.datasets.images",
     }
+    sklearn_path = [os.path.dirname(sklearn.__file__)]
     lookup = {
         name: ispkg
-        for _, name, ispkg in pkgutil.walk_packages(sklearn.__path__, prefix="sklearn.")
+        for _, name, ispkg in pkgutil.walk_packages(sklearn_path, prefix="sklearn.")
     }
     missing_tests = [
         name


### PR DESCRIPTION
Follow up of #28094. As mentioned in https://github.com/scikit-learn/scikit-learn/pull/28040#issuecomment-1889585441, I missed a `sklearn.__path__` replacement ~~causing less tests to be collected.~~