### PR TITLE
EFF remove superfluous check_array call from LocalOutlierFactor._predict

### DIFF
--- a/sklearn/neighbors/_lof.py
+++ b/sklearn/neighbors/_lof.py
@@ -373,9 +373,9 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
         check_is_fitted(self)
 
         if X is not None:
-            X = check_array(X, accept_sparse="csr")
-            is_inlier = np.ones(X.shape[0], dtype=int)
-            is_inlier[self.decision_function(X) < 0] = -1
+            anomalies = self.decision_function(X)
+            is_inlier = np.ones(anomalies.shape[0], dtype=int)
+            is_inlier[anomalies < 0] = -1
         else:
             is_inlier = np.ones(self.n_samples_fit_, dtype=int)
             is_inlier[self.negative_outlier_factor_ < self.offset_] = -1

--- a/sklearn/neighbors/_lof.py
+++ b/sklearn/neighbors/_lof.py
@@ -373,9 +373,9 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
         check_is_fitted(self)
 
         if X is not None:
-            anomalies = self.decision_function(X)
-            is_inlier = np.ones(anomalies.shape[0], dtype=int)
-            is_inlier[anomalies < 0] = -1
+            shifted_opposite = self.decision_function(X)
+            is_inlier = np.ones(shifted_opposite.shape[0], dtype=int)
+            is_inlier[shifted_opposite < 0] = -1
         else:
             is_inlier = np.ones(self.n_samples_fit_, dtype=int)
             is_inlier[self.negative_outlier_factor_ < self.offset_] = -1

--- a/sklearn/neighbors/_lof.py
+++ b/sklearn/neighbors/_lof.py
@@ -373,9 +373,9 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
         check_is_fitted(self)
 
         if X is not None:
-            shifted_opposite = self.decision_function(X)
-            is_inlier = np.ones(shifted_opposite.shape[0], dtype=int)
-            is_inlier[shifted_opposite < 0] = -1
+            shifted_opposite_lof_score = self.decision_function(X)
+            is_inlier = np.ones(shifted_opposite_lof_score.shape[0], dtype=int)
+            is_inlier[shifted_opposite_lof_score < 0] = -1
         else:
             is_inlier = np.ones(self.n_samples_fit_, dtype=int)
             is_inlier[self.negative_outlier_factor_ < self.offset_] = -1

--- a/sklearn/neighbors/_lof.py
+++ b/sklearn/neighbors/_lof.py
@@ -373,9 +373,9 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
         check_is_fitted(self)
 
         if X is not None:
-            shifted_opposite_lof_score = self.decision_function(X)
-            is_inlier = np.ones(shifted_opposite_lof_score.shape[0], dtype=int)
-            is_inlier[shifted_opposite_lof_score < 0] = -1
+            shifted_opposite_lof_scores = self.decision_function(X)
+            is_inlier = np.ones(shifted_opposite_lof_scores.shape[0], dtype=int)
+            is_inlier[shifted_opposite_lof_scores < 0] = -1
         else:
             is_inlier = np.ones(self.n_samples_fit_, dtype=int)
             is_inlier[self.negative_outlier_factor_ < self.offset_] = -1


### PR DESCRIPTION
LocalOutlierFactor._predict utilizes the decision_function method, which itself calls score_subsample and eventually kneighbors. Both [score_subsample](https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/neighbors/_lof.py#L467) and [kneighbors](https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/neighbors/_base.py#L809) also do these checks. Given the overhead of finite checks, etc. performance can be gained by refactoring this function slightly.  Similar work should be done in removing a dtype check from score_subsample, but it is not clear if dtype is preserved for outputs from kneighbors.
