### PR TITLE
TST Skip test using subprocess in Pyodide

### DIFF
--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -823,6 +823,7 @@ def test_float32_aware_assert_allclose():
     assert_allclose(np.array([1e-5], dtype=np.float32), 0.0, atol=2e-5)
 
 
+@pytest.mark.xfail(_IS_WASM, reason="cannot start subprocess")
 def test_assert_run_python_script_without_output():
     code = "x = 1"
     assert_run_python_script_without_output(code)


### PR DESCRIPTION
Noticed this in https://github.com/lesteve/scikit-learn-tests-pyodide see [build log](https://github.com/lesteve/scikit-learn-tests-pyodide/actions/runs/7510179952/job/20448263953)

This failed in the CI too, see [build log](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=62367&view=logs&jobId=6fac3219-cc32-5595-eb73-7f086a643b12&j=6fac3219-cc32-5595-eb73-7f086a643b12&t=dfb0637f-eb02-5202-9884-61d82a155bad) but we don't have an automated issue created for Pyodide. I think Pyodide fails rarely enough so that is OK for now.