### PR TITLE
DOC fix the confusing ordering of `whats_new/v1.5.rst`

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -25,26 +25,18 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123455 is the *pull request* number, not the issue number.
 
-:mod:`sklearn.impute`
-.....................
-- |Enhancement| :class:`impute.SimpleImputer` now supports custom strategies
-  by passing a function in place of a strategy name.
-  :pr:`28053` by :user:`Mark Elliot <mark-thm>`.
-
-Code and Documentation Contributors
------------------------------------
-
-Thanks to everyone who has contributed to the maintenance and improvement of
-the project since version 1.4, including:
-
-TODO: update at the time of the release.
-
 :mod:`sklearn.compose`
 ......................
 
 - |Feature| A fitted :class:`compose.ColumnTransformer` now implements `__getitem__`
   which returns the fitted transformers by name. :pr:`27990` by `Thomas Fan`_.
 
+:mod:`sklearn.impute`
+.....................
+
+- |Enhancement| :class:`impute.SimpleImputer` now supports custom strategies
+  by passing a function in place of a strategy name.
+  :pr:`28053` by :user:`Mark Elliot <mark-thm>`.
 
 :mod:`sklearn.metrics`
 ......................
@@ -56,4 +48,13 @@ TODO: update at the time of the release.
   and `from_predictions` in :class:`~metrics.RocCurveDisplay`,
   :class:`~metrics.PrecisionRecallDisplay`, :class:`~metrics.DetCurveDisplay`,
   :class:`~calibration.CalibrationDisplay`.
-  :pr:`28051` by :user:`Pierre de Fréminville <pidefrem>`
+  :pr:`28051` by :user:`Pierre de Fréminville <pidefrem>`.
+
+
+Code and Documentation Contributors
+-----------------------------------
+
+Thanks to everyone who has contributed to the maintenance and improvement of
+the project since version 1.4, including:
+
+TODO: update at the time of the release.


### PR DESCRIPTION
Just reordered `whats_new/v1.5.rst`. Originally some of the changelogs are misplaced after the "contributors" section, which makes me confused where to put my changelog, thus this PR.