### PR TITLE
DOC make up for errors in #26410

### DIFF
--- a/sklearn/utils/arrayfuncs.pyx
+++ b/sklearn/utils/arrayfuncs.pyx
@@ -33,7 +33,7 @@ def min_pos(const floating[:] X):
 
 
 def _all_with_any_reduction_axis_1(real_numeric[:, :] array, real_numeric value):
-    """Check that all values are equal to `value` along a specific axis.
+    """Check whether any row contains all values equal to `value`.
 
     It is equivalent to `np.any(np.all(X == value, axis=1))`, but it avoids to
     materialize the temporary boolean matrices in memory.

--- a/sklearn/utils/tests/test_arrayfuncs.py
+++ b/sklearn/utils/tests/test_arrayfuncs.py
@@ -29,7 +29,7 @@ def test_min_pos_no_positive(dtype):
 @pytest.mark.parametrize("dtype", [np.int16, np.int32, np.float32, np.float64])
 @pytest.mark.parametrize("value", [0, 1.5, -1])
 def test_all_with_any_reduction_axis_1(dtype, value):
-    # Check that return value is False when there is no row/column equal to `value`
+    # Check that return value is False when there is no row equal to `value`
     X = np.arange(12, dtype=dtype).reshape(3, 4)
     assert not _all_with_any_reduction_axis_1(X, value=value)
 


### PR DESCRIPTION
Sorry for having to spend an additional PR on #26410. When changing from `_all_with_any_reduction` to `_all_with_any_reduction_axis_1` there were some places that I forgot to fix, thus this PR.

@thomasjpfan.