### PR TITLE
DOC add examples in docstring for decomposition

### DIFF
--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -338,6 +338,23 @@ def sparse_encode(
     sklearn.linear_model.Lasso : Train Linear Model with L1 prior as regularizer.
     SparseCoder : Find a sparse representation of data from a fixed precomputed
         dictionary.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.decomposition import sparse_encode
+    >>> X = np.array([[-1, -1, -1], [0, 0, 3]])
+    >>> dictionary = np.array(
+    ...     [[0, 1, 0],
+    ...      [-1, -1, 2],
+    ...      [1, 1, 1],
+    ...      [0, 1, 1],
+    ...      [0, 2, 1]],
+    ...    dtype=np.float64
+    ... )
+    >>> sparse_encode(X, dictionary, alpha=1e-10)
+    array([[ 0.,  0., -1.,  0.,  0.],
+           [ 0.,  1.,  1.,  0.,  0.]])
     """
     if check_input:
         if algorithm == "lasso_cd":
@@ -804,6 +821,33 @@ def dict_learning_online(
         learning algorithm.
     SparsePCA : Sparse Principal Components Analysis.
     MiniBatchSparsePCA : Mini-batch Sparse Principal Components Analysis.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.datasets import make_sparse_coded_signal
+    >>> from sklearn.decomposition import dict_learning_online
+    >>> X, _, _ = make_sparse_coded_signal(
+    ...     n_samples=30, n_components=15, n_features=20, n_nonzero_coefs=10,
+    ...     random_state=42,
+    ... )
+    >>> U, V = dict_learning_online(
+    ...     X, 15, alpha=0.2, max_iter=20, batch_size=3,
+    ...     random_state=42,
+    ... )
+
+    We can check the level of sparsity of `U`:
+
+    >>> np.mean(U == 0)
+    0.53...
+
+    We can compare the average squared euclidean norm of the reconstruction
+    error of the sparse coded signal relative to the squared euclidean norm of
+    the original signal:
+
+    >>> X_hat = U @ V
+    >>> np.mean(np.sum((X_hat - X) ** 2, axis=1) / np.sum(X ** 2, axis=1))
+    0.05...
     """
     # TODO(1.6): remove in 1.6
     if max_iter is None:
@@ -982,6 +1026,30 @@ def dict_learning(
         of the dictionary learning algorithm.
     SparsePCA : Sparse Principal Components Analysis.
     MiniBatchSparsePCA : Mini-batch Sparse Principal Components Analysis.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.datasets import make_sparse_coded_signal
+    >>> from sklearn.decomposition import dict_learning
+    >>> X, _, _ = make_sparse_coded_signal(
+    ...     n_samples=30, n_components=15, n_features=20, n_nonzero_coefs=10,
+    ...     random_state=42,
+    ... )
+    >>> U, V, errors = dict_learning(X, 15, alpha=0.1, random_state=42)
+
+    We can check the level of sparsity of `U`:
+
+    >>> np.mean(U == 0)
+    0.62...
+
+    We can compare the average squared euclidean norm of the reconstruction
+    error of the sparse coded signal relative to the squared euclidean norm of
+    the original signal:
+
+    >>> X_hat = U @ V
+    >>> np.mean(np.sum((X_hat - X) ** 2, axis=1) / np.sum(X ** 2, axis=1))
+    0.01...
     """
     estimator = DictionaryLearning(
         n_components=n_components,

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -832,8 +832,7 @@ def dict_learning_online(
     ...     random_state=42,
     ... )
     >>> U, V = dict_learning_online(
-    ...     X, 15, alpha=0.2, max_iter=20, batch_size=3,
-    ...     random_state=42,
+    ...     X, n_components=15, alpha=0.2, max_iter=20, batch_size=3, random_state=42
     ... )
 
     We can check the level of sparsity of `U`:
@@ -1036,12 +1035,12 @@ def dict_learning(
     ...     n_samples=30, n_components=15, n_features=20, n_nonzero_coefs=10,
     ...     random_state=42,
     ... )
-    >>> U, V, errors = dict_learning(X, 15, alpha=0.1, random_state=42)
+    >>> U, V, errors = dict_learning(X, n_components=15, alpha=0.1, random_state=42)
 
     We can check the level of sparsity of `U`:
 
     >>> np.mean(U == 0)
-    0.62...
+    0.6...
 
     We can compare the average squared euclidean norm of the reconstruction
     error of the sparse coded signal relative to the squared euclidean norm of


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes parts of #27982

#### What does this implement/fix? Explain your changes.

Adds examples to docstring of the following functions:
* sklearn.decomposition.dict_learning
* sklearn.decomposition.dict_learning_online
* sklearn.decomposition.sparse_encode

#### Any other comments?

I try to reuse the corresponding examples in `DictionaryLearning`, `MiniBatchDictionaryLearning`, `SparseCoder`. 

Note that the results of functions are different from classes, since other than `alpha`, there is a different `transform_alpha` parameter that affects the behavior of `transform` in class.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
