### PR TITLE
DOC fix underline for Examples section in clear_data_home

### DIFF
--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -87,7 +87,7 @@ def clear_data_home(data_home=None):
         is `~/scikit_learn_data`.
 
     Examples
-    ----------
+    --------
     >>> from sklearn.datasets import clear_data_home
     >>> clear_data_home()  # doctest: +SKIP
     """


### PR DESCRIPTION
As mentioned by @Charlie-XIAO, numpydoc is currently raising a warning.