### PR TITLE
MAINT fix tests by passing 1d vector to unique

### DIFF
--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -136,7 +136,7 @@ def test_make_classification_informative_features():
 
             # Cluster by sign, viewed as strings to allow uniquing
             signs = np.sign(X)
-            signs = signs.view(dtype="|S{0}".format(signs.strides[0]))
+            signs = signs.view(dtype="|S{0}".format(signs.strides[0])).ravel()
             unique_signs, cluster_index = np.unique(signs, return_inverse=True)
 
             assert (


### PR DESCRIPTION
closes #28126

The returned of `np.unique` containing the index has now the same shape than the input data (that is consistent). The previous test was expecting that if you pass a column or row matrix, the output will be equivalent to a vector.

I think that the change of behaviour of NumPy is legitimate and it only break the code in a test. So we don't have to report any regression here.