### PR TITLE
CI Fix lock-file update workflow

### DIFF
--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -17,16 +17,16 @@ jobs:
       matrix:
         include:
           - name: main
-            update_script_args: "--select-build-tag main-ci"
+            update_script_args: "--select-tag main-ci"
             additional_commit_message: "[doc build]"
           - name: scipy-dev
-            update_script_args: "--select-build-tag scipy-dev"
+            update_script_args: "--select-tag scipy-dev"
             additional_commit_message: "[scipy-dev]"
           - name: cirrus-arm
-            update_script_args: "--select-build-tag arm"
+            update_script_args: "--select-tag arm"
             additional_commit_message: "[cirrus arm]"
           - name: pypy
-            update_script_args: "--select-build-tag pypy"
+            update_script_args: "--select-tag pypy"
             additional_commit_message: "[pypy]"
 
     steps:


### PR DESCRIPTION
Follow-up of https://github.com/scikit-learn/scikit-learn/pull/28068

The update-lock-file failed, see [build log](https://github.com/scikit-learn/scikit-learn/actions/runs/7524548489/job/20479533590).

I used `--select-build-tag` instead of `--select-tag` (flip-flopped between the two namings) the right option in the workflow `.yml` ...
