### PR TITLE
DOC Update Mixin classes documentation and examples

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1250,7 +1250,31 @@ class DensityMixin:
 
 
 class OutlierMixin:
-    """Mixin class for all outlier detection estimators in scikit-learn."""
+    """Mixin class for all outlier detection estimators in scikit-learn.
+    
+    This mixin defines the following functionality:
+
+    - `_estimator_type` class attribute defaulting to `outlier_detector`;
+    - `fit_predict` method that default to `fit` and `predict`.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.base import BaseEstimator, OutlierMixin
+    >>> class MyEstimator(OutlierMixin, BaseEstimator):
+    ...     def __init__(self, *, param=1):
+    ...         self.param = param
+    ...     def fit(self, X, y=None):
+    ...         self.is_fitted_ = True
+    ...         return self
+    ...     def predict(self, X):
+    ...         return np.full(shape=X.shape[0], fill_value=self.param)
+    >>> estimator = MyEstimator(param=1)
+    >>> X = np.array([[1, 2], [2, 3], [3, 4]])
+    >>> y = np.array([1, 0, 1])
+    >>> print(estimator.fit(X, y).predict(X))
+    [1, 1, 1]
+    """
 
     _estimator_type = "outlier_detector"
 

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -853,7 +853,32 @@ class RegressorMixin:
 
 
 class ClusterMixin:
-    """Mixin class for all cluster estimators in scikit-learn."""
+    """Mixin class for all cluster estimators in scikit-learn.
+    - `_estimator_type` class attribute defaulting to `"clusterer"`;
+    - `fit_predict` method that default to
+    :func:`~sklearn.cluster.estimate_clusters`.
+    - `_more_tags` method that adds the `preserves_dtype` tag to the estimator.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.base import BaseEstimator, ClusterMixin
+
+    >>> class MyClusterer(ClusterMixin, BaseEstimator):
+    ...    def __init__(self, *, n_clusters=2):
+    ...        self.n_clusters = n_clusters
+    ...    def fit_predict(self, X, y=None, **kwargs):
+    ...        labels = np.random.randint(low=0, high=self.n_clusters,
+    ...                                   size=X.shape[0])
+    ...        return labels
+
+    >>> clusterer = MyClusterer(n_clusters=3)
+    >>> X = np.array([[1, 2], [2, 3], [3, 4]])
+    >>> y = np.array([0, 1, 0])
+    >>> labels = clusterer.fit_predict(X, y)
+    >>> print(labels)
+    [1 1 1]
+    """
 
     _estimator_type = "clusterer"
 

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1292,7 +1292,7 @@ class MetaEstimatorMixin:
     This mixin defines the following functionality:
 
     - `_required_parameters` class attribute that lists the required parameters
-        of the estimator;
+        of the estimator.
            
     Examples
     --------

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1224,7 +1224,7 @@ class ClassNamePrefixFeaturesOutMixin:
 
 class DensityMixin:
     """Mixin class for all density estimators in scikit-learn.
-    
+
     This mixin defines the following functionality:
 
     - `_estimator_type` class attribute defaulting to `"density_estimator"`;
@@ -1273,7 +1273,7 @@ class DensityMixin:
 
 class OutlierMixin:
     """Mixin class for all outlier detection estimators in scikit-learn.
-    
+
     This mixin defines the following functionality:
 
     - `_estimator_type` class attribute defaulting to `outlier_detector`;
@@ -1355,12 +1355,12 @@ class OutlierMixin:
 
 class MetaEstimatorMixin:
     """Mixin class for all meta estimators in scikit-learn.
-    
+
     This mixin defines the following functionality:
 
     - `_required_parameters` class attribute that lists the required parameters
         of the estimator.
-           
+     
     Examples
     --------
     >>> import numpy as np

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1094,6 +1094,27 @@ class OneToOneFeatureMixin:
 
     This mixin assumes there's a 1-to-1 correspondence between input features
     and output features, such as :class:`~sklearn.preprocessing.StandardScaler`.
+
+    This mixin defines the following functionality:
+
+    - `get_feature_names_out` method that returns the same feature names as
+        input features.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.base import BaseEstimator, OneToOneFeatureMixin
+    >>> class MyEstimator(OneToOneFeatureMixin, BaseEstimator):
+    ...     def __init__(self, *, param=1):
+    ...         self.param = param
+    ...     def fit(self, X, y=None):
+    ...         return self
+    ...     def transform(self, X):
+    ...         return np.full(shape=X.shape, fill_value=self.param)
+    >>> estimator = MyEstimator(param=1)
+    >>> X = np.array([[1, 2], [2, 3], [3, 4]])
+    >>> print(estimator.fit(X).transform(X))
+    array([[1, 1], [1, 1], [1, 1]])
     """
 
     def get_feature_names_out(self, input_features=None):

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -856,7 +856,7 @@ class ClusterMixin:
     """Mixin class for all cluster estimators in scikit-learn.
     - `_estimator_type` class attribute defaulting to `"clusterer"`;
     - `fit_predict` method that default to
-    :func:`~sklearn.cluster.estimate_clusters`.
+    :func:`~sklearn.cluster.estimate_clusters`;
     - `_more_tags` method that adds the `preserves_dtype` tag to the estimator.
 
     Examples

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1180,7 +1180,33 @@ class ClassNamePrefixFeaturesOutMixin:
 
 
 class DensityMixin:
-    """Mixin class for all density estimators in scikit-learn."""
+    """Mixin class for all density estimators in scikit-learn.
+    
+    This mixin defines the following functionality:
+
+    - `_estimator_type` class attribute defaulting to `"density_estimator"`;
+    - `score` method that default to :func:`~sklearn.metrics.log_loss`.
+
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.base import BaseEstimator, DensityMixin
+    >>> # Mixin classes should always be on the left-hand side for a correct MRO
+    >>> class MyEstimator(DensityMixin, BaseEstimator):
+    ...     def __init__(self, *, param=1):
+    ...         self.param = param
+    ...     def fit(self, X, y=None):
+    ...         self.is_fitted_ = True
+    ...         return self
+    ...     def predict(self, X):
+    ...         return np.full(shape=X.shape[0], fill_value=self.param)
+    >>> estimator = MyEstimator(param=1)
+    >>> X = np.array([[1, 2], [2, 3], [3, 4]])
+    >>> y = np.array([1, 0, 1])
+    >>> print(estimator.fit(X, y).predict(X))
+    [1, 1, 1]
+    """
 
     _estimator_type = "DensityEstimator"
 

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1195,6 +1195,9 @@ class ClassNamePrefixFeaturesOutMixin:
     >>> estimator = MyEstimator(param=1)
     >>> X = np.array([[1, 2], [2, 3], [3, 4]])
     >>> estimator.fit(X).transform(X)
+    array([[1, 1, 1],
+              [1, 1, 1],
+              [1, 1, 1]])   
     >>> print(estimator.get_feature_names_out())
     ['myestimator0', 'myestimator1', 'myestimator2']
     """
@@ -1248,7 +1251,7 @@ class DensityMixin:
     >>> X = np.array([[1, 2], [2, 3], [3, 4]])
     >>> y = np.array([1, 0, 1])
     >>> print(estimator.fit(X, y).predict(X))
-    [1, 1, 1]
+    [1 1 1]
     """
 
     _estimator_type = "DensityEstimator"
@@ -1360,7 +1363,7 @@ class MetaEstimatorMixin:
 
     - `_required_parameters` class attribute that lists the required parameters
         of the estimator.
-     
+
     Examples
     --------
     >>> import numpy as np
@@ -1377,7 +1380,7 @@ class MetaEstimatorMixin:
     >>> X = np.array([[1, 2], [2, 3], [3, 4]])
     >>> y = np.array([1, 0, 1])
     >>> print(estimator.fit(X, y).predict(X))
-    [1, 1, 1]
+    [1 1 1]
     """
 
     _required_parameters = ["estimator"]

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1026,6 +1026,28 @@ class TransformerMixin(_SetOutputMixin):
     :class:`OneToOneFeatureMixin` and
     :class:`ClassNamePrefixFeaturesOutMixin` are helpful mixins for
     defining :term:`get_feature_names_out`.
+
+    This mixin defines the following functionality:
+
+    - `fit_transform` method that default to the identity transform.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.base import BaseEstimator, TransformerMixin
+    >>> class MyTransformer(TransformerMixin, BaseEstimator):
+    ...     def __init__(self, *, param=1):
+    ...         self.param = param
+    ...     def fit(self, X, y=None):
+    ...         return self
+    ...     def transform(self, X):
+    ...         return np.full(shape=X.shape, fill_value=self.param)
+    >>> transformer = MyTransformer(param=1)
+    >>> X = np.array([[1, 2], [2, 3], [3, 4]])
+    >>> print(transformer.fit(X).transform(X))
+    [[1 1]
+     [1 1]
+     [1 1]]
     """
 
     def fit_transform(self, X, y=None, **fit_params):

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1287,7 +1287,31 @@ class OutlierMixin:
 
 
 class MetaEstimatorMixin:
-    """Mixin class for all meta estimators in scikit-learn."""
+    """Mixin class for all meta estimators in scikit-learn.
+    
+    This mixin defines the following functionality:
+
+    - `_required_parameters` class attribute that lists the required parameters
+        of the estimator;
+           
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.base import BaseEstimator, MetaEstimatorMixin
+    >>> class MyEstimator(MetaEstimatorMixin, BaseEstimator):
+    ...     def __init__(self, *, param=1):
+    ...         self.param = param
+    ...     def fit(self, X, y=None):
+    ...         self.is_fitted_ = True
+    ...         return self
+    ...     def predict(self, X):
+    ...         return np.full(shape=X.shape[0], fill_value=self.param)
+    >>> estimator = MyEstimator(param=1)
+    >>> X = np.array([[1, 2], [2, 3], [3, 4]])
+    >>> y = np.array([1, 0, 1])
+    >>> print(estimator.fit(X, y).predict(X))
+    [1, 1, 1]
+    """
 
     _required_parameters = ["estimator"]
 

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1106,6 +1106,29 @@ class ClassNamePrefixFeaturesOutMixin:
     This mixin assumes that a `_n_features_out` attribute is defined when the
     transformer is fitted. `_n_features_out` is the number of output features
     that the transformer will return in `transform` of `fit_transform`.
+
+    This mixin defines the following functionality:
+
+    - `get_feature_names_out` method that returns the generated feature names out.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.base import BaseEstimator, ClassNamePrefixFeaturesOutMixin
+    >>> class MyEstimator(ClassNamePrefixFeaturesOutMixin, BaseEstimator):
+    ...     def __init__(self, *, param=1):
+    ...         self.param = param
+    ...     def fit(self, X, y=None):
+    ...         self._n_features_out = 3
+    ...         return self
+    ...     def transform(self, X):
+    ...         return np.full(shape=(X.shape[0], self._n_features_out),
+    ...                        fill_value=self.param)
+    >>> estimator = MyEstimator(param=1)
+    >>> X = np.array([[1, 2], [2, 3], [3, 4]])
+    >>> estimator.fit(X).transform(X)
+    >>> print(estimator.get_feature_names_out())
+    ['myestimator0', 'myestimator1', 'myestimator2']
     """
 
     def get_feature_names_out(self, input_features=None):


### PR DESCRIPTION
Fixes parts of #27982

This pull request updates the documentation and examples for the following Mixin classes:

- ClusterMixin

- TransformerMixin

- OneToOneFeatureMixin

- ClassNamePrefixFeaturesOutMixin

- DensityMixin

- OutlierMixin

- MetaEstimatorMixin

The changes include adding missing documentation and providing more detailed examples for each Mixin class.