### PR TITLE
DOC Added relation between ROC-AUC and the Gini Coefficient in docstring

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -537,14 +537,15 @@ def roc_auc_score(
         (ROC) curve given an estimator and some data.
     RocCurveDisplay.from_predictions : Plot Receiver Operating Characteristic
         (ROC) curve given the true and predicted values.
-    
+        
     Notes
     -----
-    The summary measure of the diagnostic ability of a binary classifier that is called the Gini Coefficient can be expressed using the area the Receiver Operating Characteristic curve as follows:
+    The summary measure of the diagnostic ability of a binary classifier that is called the Gini Coefficient. 
+    It can be expressed using the area the Receiver Operating Characteristic curve as follows:
 
     .. math:: G = 2*AUC - 1
 
-    Where :math:`G` is the Gini Coefficient and :math:`AUC` is the Area Under the Curve score.
+    Where :math:`G` is the Gini Coefficient and :math:`AUC` is the ROC-AUC score.
 
     References
     ----------

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -537,6 +537,14 @@ def roc_auc_score(
         (ROC) curve given an estimator and some data.
     RocCurveDisplay.from_predictions : Plot Receiver Operating Characteristic
         (ROC) curve given the true and predicted values.
+    
+    Notes
+    -----
+    The summary measure of the diagnostic ability of a binary classifier that is called the Gini Coefficient can be expressed using the area the Receiver Operating Characteristic curve as follows:
+
+    .. math:: G = 2*AUC - 1
+
+    Where :math:`G` is the Gini Coefficient and :math:`AUC` is the Area Under the Curve score.
 
     References
     ----------
@@ -558,6 +566,8 @@ def roc_auc_score(
             Under the ROC Curve for Multiple Class Classification Problems.
             Machine Learning, 45(2), 171-186.
             <http://link.springer.com/article/10.1023/A:1010920819831>`_
+    .. [6] `Wikipedia entry for the Gini coefficient 
+            <https://en.wikipedia.org/wiki/Gini_coefficient>`_
 
     Examples
     --------


### PR DESCRIPTION
#### Reference Issues/PRs

See #28144. 



#### What does this implement/fix? Explain your changes.
Improvement of docstring related to `roc_auc_score`. Added some notes about relation with the Gini coefficient