### PR TITLE
DOC Added relation between ROC-AUC and Gini in docstring of roc_auc_score

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -548,8 +548,6 @@ def roc_auc_score(
 
     Where :math:`G` is the Gini Coefficient and :math:`AUC` is the ROC-AUC score.
 
-    
-
     References
     ----------
     .. [1] `Wikipedia entry for the Receiver operating characteristic

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -537,14 +537,15 @@ def roc_auc_score(
         (ROC) curve given an estimator and some data.
     RocCurveDisplay.from_predictions : Plot Receiver Operating Characteristic
         (ROC) curve given the true and predicted values.
-    
+        
     Notes
     -----
-    The summary measure of the diagnostic ability of a binary classifier that is called the Gini Coefficient can be expressed using the area the Receiver Operating Characteristic curve as follows:
+    The summary measure of the diagnostic ability of a binary classifier that is called the Gini Coefficient. 
+    It can be expressed using the area the Receiver Operating Characteristic curve as follows:
 
     .. math:: G = 2*AUC - 1
 
-    Where :math:`G` is the Gini Coefficient and :math:`AUC` is the Area Under the Curve score.
+    Where :math:`G` is the Gini Coefficient and :math:`AUC` is the ROC-AUC score.
 
     References
     ----------

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -540,12 +540,15 @@ def roc_auc_score(
 
     Notes
     -----
-    The Gini Coefficient is a summary measure of the diagnostic ability of binary classifiers.
-    It can be expressed using the area under (ROC) curve as follows:
+    The Gini Coefficient is a summary measure of the diagnostic ability
+    of binary classifiers. It can be expressed using the area under
+    (ROC) as follows:
 
     .. math:: G = 2*AUC - 1
 
     Where :math:`G` is the Gini Coefficient and :math:`AUC` is the ROC-AUC score.
+
+    
 
     References
     ----------

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -537,11 +537,11 @@ def roc_auc_score(
         (ROC) curve given an estimator and some data.
     RocCurveDisplay.from_predictions : Plot Receiver Operating Characteristic
         (ROC) curve given the true and predicted values.
-        
+
     Notes
     -----
-    The summary measure of the diagnostic ability of a binary classifier that is called the Gini Coefficient. 
-    It can be expressed using the area the Receiver Operating Characteristic curve as follows:
+    The Gini Coefficient is a summary measure of the diagnostic ability of binary classifiers.
+    It can be expressed using the area under (ROC) curve as follows:
 
     .. math:: G = 2*AUC - 1
 
@@ -567,7 +567,7 @@ def roc_auc_score(
             Under the ROC Curve for Multiple Class Classification Problems.
             Machine Learning, 45(2), 171-186.
             <http://link.springer.com/article/10.1023/A:1010920819831>`_
-    .. [6] `Wikipedia entry for the Gini coefficient 
+    .. [6] `Wikipedia entry for the Gini coefficient
             <https://en.wikipedia.org/wiki/Gini_coefficient>`_
 
     Examples

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -540,13 +540,18 @@ def roc_auc_score(
 
     Notes
     -----
-    The Gini Coefficient is a summary measure of the diagnostic ability
-    of binary classifiers. It can be expressed using the area under
-    (ROC) as follows:
+    The Gini Coefficient is a summary measure of the ranking ability of binary
+    classifiers. It is expressed using the area under of the ROC as follows:
 
-    .. math:: G = 2*AUC - 1
+    G = 2 * AUC - 1
 
-    Where :math:`G` is the Gini Coefficient and :math:`AUC` is the ROC-AUC score.
+    Where G is the Gini coefficient and AUC is the ROC-AUC score. This normalisation
+    will ensure that random guessing will yield a score of 0 in expectation, and it is
+    upper bounded by 1.
+
+    Note that there is another version of the Gini coefficient for regressors of a
+    continuous positive target variable. In this case, AUC is taken over the Lorenz
+    curve instead of the ROC [6]_.
 
     References
     ----------

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -537,6 +537,14 @@ def roc_auc_score(
         (ROC) curve given an estimator and some data.
     RocCurveDisplay.from_predictions : Plot Receiver Operating Characteristic
         (ROC) curve given the true and predicted values.
+    
+    Notes
+    -----
+    The summary measure of the diagnostic ability of a binary classifier that is called the Gini Coefficient can be expressed using the area the Receiver Operating Characteristic curve as follows:
+
+    .. math:: G = 2*AUC - 1
+
+    Where :math:`G` is the Gini Coefficient and :math:`AUC` is the Area Under the Curve score.
 
     References
     ----------
@@ -558,6 +566,8 @@ def roc_auc_score(
             Under the ROC Curve for Multiple Class Classification Problems.
             Machine Learning, 45(2), 171-186.
             <http://link.springer.com/article/10.1023/A:1010920819831>`_
+    .. [6] `Wikipedia entry for the Gini coefficient 
+            <https://en.wikipedia.org/wiki/Gini_coefficient>`_
 
     Examples
     --------


### PR DESCRIPTION
#### Reference Issues/PRs
closes  #28144.

#### What does this implement/fix? Explain your changes.
Fixed the docstring of `roc_auc_score` by adding some additional linkage to the Gini coefficient, as described in issue