### PR TITLE
Fix prevent infinite loop in KMeans

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -2,6 +2,23 @@
 
 .. currentmodule:: sklearn
 
+.. _changes_1_4_1:
+
+Version 1.4.1
+=============
+
+**In development**
+
+Changelog
+---------
+
+:mod:`sklearn.cluster`
+.......................
+
+- |Fix| Avoid inifinte loop in :class:`cluster.KMeans` when the number of clusters is
+  larger than the number of non-duplicate samples.
+  :pr:`28165` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
 .. _changes_1_4:
 
 Version 1.4.0

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -13,6 +13,7 @@ Changelog
 ---------
 
 :mod:`sklearn.cluster`
+......................
 
 - |Fix| :class:`cluster.AffinityPropagation` now avoids assigning multiple different
   clusters for equal points.

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -20,7 +20,7 @@ Changelog
   :pr:`28121` by :user:`Pietro Peterlongo <pietroppeter>` and
   :user:`Yao Xiao <Charlie-XIAO>`.
 
-- |Fix| Avoid inifinte loop in :class:`cluster.KMeans` when the number of clusters is
+- |Fix| Avoid infinite loop in :class:`cluster.KMeans` when the number of clusters is
   larger than the number of non-duplicate samples.
   :pr:`28165` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 

--- a/sklearn/cluster/_k_means_common.pyx
+++ b/sklearn/cluster/_k_means_common.pyx
@@ -284,12 +284,18 @@ cdef void _average_centers(
         int n_features = centers.shape[1]
         int j, k
         floating alpha
+        int argmax_weight = np.argmax(weight_in_clusters)
 
     for j in range(n_clusters):
         if weight_in_clusters[j] > 0:
             alpha = 1.0 / weight_in_clusters[j]
             for k in range(n_features):
                 centers[j, k] *= alpha
+        else:
+            # For convenience, we avoid setting empty clusters at the origin but place
+            #them at the location of the biggest cluster.
+            for k in range(n_features):
+                centers[j, k] = centers[argmax_weight, k]
 
 
 cdef void _center_shift(

--- a/sklearn/cluster/_k_means_common.pyx
+++ b/sklearn/cluster/_k_means_common.pyx
@@ -293,7 +293,7 @@ cdef void _average_centers(
                 centers[j, k] *= alpha
         else:
             # For convenience, we avoid setting empty clusters at the origin but place
-            #them at the location of the biggest cluster.
+            # them at the location of the biggest cluster.
             for k in range(n_features):
                 centers[j, k] = centers[argmax_weight, k]
 

--- a/sklearn/cluster/_k_means_common.pyx
+++ b/sklearn/cluster/_k_means_common.pyx
@@ -192,6 +192,11 @@ cpdef void _relocate_empty_clusters_dense(
         int new_cluster_id, old_cluster_id, far_idx, idx, k
         floating weight
 
+    if np.max(distances) == 0:
+        # Happens when there are more clusters than non-duplicate samples. Relocating
+        # is pointless in this case.
+        return
+
     for idx in range(n_empty):
 
         new_cluster_id = empty_clusters[idx]
@@ -240,6 +245,11 @@ cpdef void _relocate_empty_clusters_sparse(
             X_data[X_indptr[i]: X_indptr[i + 1]],
             X_indices[X_indptr[i]: X_indptr[i + 1]],
             centers_old[j], centers_squared_norms[j], True)
+
+    if np.max(distances) == 0:
+        # Happens when there are more clusters than non-duplicate samples. Relocating
+        # is pointless in this case.
+        return
 
     cdef:
         int[::1] far_from_centers = np.argpartition(distances, -n_empty)[:-n_empty-1:-1].astype(np.int32)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -1359,7 +1359,8 @@ def test_sample_weight_zero(init, global_random_seed):
 def test_relocating_with_duplicates(algorithm, array_constr):
     """Check that kmeans stops when there are more centers than non-duplicate samples
 
-    non-regression test for issue #28055
+    Non-regression test for issue:
+    https://github.com/scikit-learn/scikit-learn/issues/28055
     """
     X = np.array([[0, 0], [1, 1], [1, 1], [1, 0], [0, 1]])
     km = KMeans(n_clusters=5, init=X, algorithm=algorithm)

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -1363,7 +1363,7 @@ def test_relocating_with_duplicates(algorithm, array_constr):
     """
     X = np.array([[0, 0], [1, 1], [1, 1], [1, 0], [0, 1]])
     km = KMeans(n_clusters=5, init=X, algorithm=algorithm)
-    
+
     msg = r"Number of distinct clusters \(4\) found smaller than n_clusters \(5\)"
     with pytest.warns(ConvergenceWarning, match=msg):
         km.fit(array_constr(X))

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -1368,4 +1368,4 @@ def test_relocating_with_duplicates(algorithm, array_constr):
     with pytest.warns(ConvergenceWarning, match=msg):
         km.fit(array_constr(X))
 
-    assert km.n_iter_ == 2
+    assert km.n_iter_ == 1

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -1352,3 +1352,20 @@ def test_sample_weight_zero(init, global_random_seed):
     # (i.e. be at a distance=0 from it)
     d = euclidean_distances(X[::2], clusters_weighted)
     assert not np.any(np.isclose(d, 0))
+
+
+@pytest.mark.parametrize("array_constr", data_containers, ids=data_containers_ids)
+@pytest.mark.parametrize("algorithm", ["lloyd", "elkan"])
+def test_relocating_with_duplicates(algorithm, array_constr):
+    """Check that kmeans stops when there are more centers than non-duplicate samples
+
+    non-regression test for issue #28055
+    """
+    X = np.array([[0, 0], [1, 1], [1, 1], [1, 0], [0, 1]])
+    km = KMeans(n_clusters=5, init=X, algorithm=algorithm)
+    
+    msg = r"Number of distinct clusters \(4\) found smaller than n_clusters \(5\)"
+    with pytest.warns(ConvergenceWarning, match=msg):
+        km.fit(array_constr(X))
+
+    assert km.n_iter_ == 2


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/28055

When there are more centers than non-duplicate samples, the relocation of empty cluster will trigger at every iteration preventing the algorithm to stop.