### PR TITLE
DOC use list for the ridge_regression docstring

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -552,14 +552,15 @@ def ridge_regression(
 
     Examples
     --------
+    >>> import numpy as np
     >>> from sklearn.datasets import make_regression
     >>> from sklearn.linear_model import ridge_regression
-    >>> X, y = make_regression(
-    ...     n_features=4, n_informative=2, shuffle=False, random_state=0
-    ... )
+    >>> rng = np.random.RandomState(0)
+    >>> X = rng.randn(100, 4)
+    >>> y = 2.0 * X[:, 0] - 1.0 * X[:, 1] + 0.1 * rng.standard_normal(100)
     >>> coef, intercept = ridge_regression(X, y, alpha=1.0, return_intercept=True)
-    >>> coef
-    array([20.2..., 33.7...,  0.1...,  0.0...])
+    >>> list(coef)
+    [1.97..., -1.00..., -0.0..., -0.0...]
     >>> intercept
     -0.0...
     """


### PR DESCRIPTION
It seems that the example for the `ridge_regression` was not stable in terms of string representation as the failure seen in: https://github.com/scikit-learn/scikit-learn/pull/28167

Using the list representation might be more stable for the digits representation since it will not switch to scientific notation.