### PR TITLE
DOC add example to make_ spd_matrix

### DIFF
--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1607,12 +1607,10 @@ def make_spd_matrix(n_dim, *, random_state=None):
     Examples
     --------
     >>> from sklearn.datasets import make_spd_matrix
-    >>> X = make_spd_matrix(n_dim=2,random_state=42)
-    >>> X.shape
-    (2, 2)
+    >>> make_spd_matrix(n_dim=2, random_state=42)
     >>> X
-    array([[2.09417602, 0.34617642],
-           [0.34617642, 0.21783715]])
+    array([[2.09..., 0.34...],
+           [0.34..., 0.21...]])
     """
     generator = check_random_state(random_state)
 

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1608,7 +1608,6 @@ def make_spd_matrix(n_dim, *, random_state=None):
     --------
     >>> from sklearn.datasets import make_spd_matrix
     >>> make_spd_matrix(n_dim=2, random_state=42)
-    >>> X
     array([[2.09..., 0.34...],
            [0.34..., 0.21...]])
     """

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1612,7 +1612,7 @@ def make_spd_matrix(n_dim, *, random_state=None):
     (2, 2)
     >>> X
     array([[2.09417602, 0.34617642],
-          [0.34617642, 0.21783715]])
+           [0.34617642, 0.21783715]])
     """
     generator = check_random_state(random_state)
 

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1603,6 +1603,16 @@ def make_spd_matrix(n_dim, *, random_state=None):
     See Also
     --------
     make_sparse_spd_matrix: Generate a sparse symmetric definite positive matrix.
+
+    Examples
+    --------
+    >>> from sklearn.datasets import make_spd_matrix
+    >>> X = make_spd_matrix(n_dim=2,random_state=42)
+    >>> X.shape
+    (2, 2)
+    >>> X
+    array([[2.09417602, 0.34617642],
+          [0.34617642, 0.21783715]])
     """
     generator = check_random_state(random_state)
 


### PR DESCRIPTION
#### Reference Issues/PRs

Contributes to  #27982

#### What does this implement/fix? Explain your changes.

It adds an example to the docstring of sklearn.datasets.make_spd_matrix





