### PR TITLE
DOC more precise calibration wording

### DIFF
--- a/doc/modules/calibration.rst
+++ b/doc/modules/calibration.rst
@@ -76,7 +76,7 @@ by showing the number of samples in each predicted probability bin.
 
 :class:`LogisticRegression` is more likely to return well calibrated predictions by default as it has a
 canonical link function for its loss, i.e. the logit-link for the :ref:`log_loss`.
-This leads to the so-called **balance property**, see [8]_ and :ref:`Logistic_regression`.
+In the unpenalized case, this leads to the so-called **balance property**, see [8]_ and :ref:`Logistic_regression`.
 In the plot above, data is generated according to a linear mechanism, which is
 consistent with the :class:`LogisticRegression` model (the model is 'well specified'),
 which then returns accurate predictions from its `predict_proba` method.

--- a/doc/modules/calibration.rst
+++ b/doc/modules/calibration.rst
@@ -79,7 +79,7 @@ canonical link function for its loss, i.e. the logit-link for the :ref:`log_loss
 In the unpenalized case, this leads to the so-called **balance property**, see [8]_ and :ref:`Logistic_regression`.
 In the plot above, data is generated according to a linear mechanism, which is
 consistent with the :class:`LogisticRegression` model (the model is 'well specified'),
-and the value of the regularization parameter `C` (chosen arbitrarily here) happens to be
+and the value of the regularization parameter `C` happens to be
 appropriate (neither too strong nor too low). As a consequence, this model returns
 accurate predictions from its `predict_proba` method.
 In contrast to that, the other shown models return biased probabilities; with

--- a/doc/modules/calibration.rst
+++ b/doc/modules/calibration.rst
@@ -74,12 +74,14 @@ by showing the number of samples in each predicted probability bin.
 
 .. currentmodule:: sklearn.linear_model
 
-:class:`LogisticRegression` is more likely to return well calibrated predictions by default as it has a
+:class:`LogisticRegression` is more likely to return well calibrated predictions by itself as it has a
 canonical link function for its loss, i.e. the logit-link for the :ref:`log_loss`.
 In the unpenalized case, this leads to the so-called **balance property**, see [8]_ and :ref:`Logistic_regression`.
 In the plot above, data is generated according to a linear mechanism, which is
 consistent with the :class:`LogisticRegression` model (the model is 'well specified'),
-which then returns accurate predictions from its `predict_proba` method.
+and the value of the regularization parameter `C` (chosen arbitrarily here) happens to be
+appropriate (neither too strong nor too low). As a consequence, this model returns
+accurate predictions from its `predict_proba` method.
 In contrast to that, the other shown models return biased probabilities; with
 different biases per model.
 

--- a/doc/modules/calibration.rst
+++ b/doc/modules/calibration.rst
@@ -79,7 +79,7 @@ canonical link function for its loss, i.e. the logit-link for the :ref:`log_loss
 In the unpenalized case, this leads to the so-called **balance property**, see [8]_ and :ref:`Logistic_regression`.
 In the plot above, data is generated according to a linear mechanism, which is
 consistent with the :class:`LogisticRegression` model (the model is 'well specified'),
-and the value of the regularization parameter `C` happens to be
+and the value of the regularization parameter `C` is tuned to be
 appropriate (neither too strong nor too low). As a consequence, this model returns
 accurate predictions from its `predict_proba` method.
 In contrast to that, the other shown models return biased probabilities; with

--- a/doc/modules/calibration.rst
+++ b/doc/modules/calibration.rst
@@ -74,10 +74,12 @@ by showing the number of samples in each predicted probability bin.
 
 .. currentmodule:: sklearn.linear_model
 
-:class:`LogisticRegression` returns well calibrated predictions by default as it has a
+:class:`LogisticRegression` is more likely to return well calibrated predictions by default as it has a
 canonical link function for its loss, i.e. the logit-link for the :ref:`log_loss`.
-This leads to the so-called **balance property**, see [8]_ and
-:ref:`Logistic_regression`.
+This leads to the so-called **balance property**, see [8]_ and :ref:`Logistic_regression`.
+In the above example, the data is generated according to a linear mechanism, which is
+consistent with the :class:`LogisticRegression` model (the model is 'well specified'),
+which then returns accurate predictions from its `predict_proba` method.
 In contrast to that, the other shown models return biased probabilities; with
 different biases per model.
 

--- a/doc/modules/calibration.rst
+++ b/doc/modules/calibration.rst
@@ -77,7 +77,7 @@ by showing the number of samples in each predicted probability bin.
 :class:`LogisticRegression` is more likely to return well calibrated predictions by default as it has a
 canonical link function for its loss, i.e. the logit-link for the :ref:`log_loss`.
 This leads to the so-called **balance property**, see [8]_ and :ref:`Logistic_regression`.
-In the above example, the data is generated according to a linear mechanism, which is
+In the plot above, data is generated according to a linear mechanism, which is
 consistent with the :class:`LogisticRegression` model (the model is 'well specified'),
 which then returns accurate predictions from its `predict_proba` method.
 In contrast to that, the other shown models return biased probabilities; with


### PR DESCRIPTION
A logistic regression will return well-calibrated predictions only if it is well specified. Some people were interpreting our text out of context and over-generalizing the sentence saying the a log-reg returns well-calibrated predictions.

Here is a minor modification to make it more precise