### PR TITLE
DOC Add a docstring example for covariance functions

### DIFF
--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -324,6 +324,32 @@ def graphical_lasso(
 
     One possible difference with the `glasso` R package is that the
     diagonal coefficients are not penalized.
+
+    Example:
+    --------
+    >>> import numpy as np
+    >>> from sklearn.covariance._graph_lasso import graphical_lasso
+    >>> emp_cov = np.array([[1, 0.5], [0.5, 1]])
+    >>> alpha = 0.1
+    >>> covariance, precision, costs, n_iter = graphical_lasso(emp_cov, alpha, return_costs=True, return_n_iter=True)
+    >>> print("Covariance matrix:")
+    >>> print(covariance)
+    Covariance matrix:
+    [[1.  0.4]
+     [0.4 1. ]]
+    >>> print("Precision matrix:")
+    >>> print(precision)
+    Precision matrix:
+    [[ 1.19047619 -0.47619048]
+     [-0.47619048  1.19047619]]
+    >>> print("Costs:")
+    >>> print(costs)
+    Costs:
+    [(9.178099258094727, 0.04409171075837724), (9.177154878492603, -1.249000902703301e-16)]
+    >>> print("Number of iterations:")
+    >>> print(n_iter)
+    Number of iterations:
+    2
     """
 
     if cov_init is not None:

--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -134,6 +134,20 @@ def shrunk_covariance(emp_cov, shrinkage=0.1):
         (1 - shrinkage) * cov + shrinkage * mu * np.identity(n_features)
 
     where `mu = trace(cov) / n_features`.
+
+    Example:
+    --------
+    >>> import numpy as np
+    >>> from _shrunk_covariance import shrunk_covariance
+    >>> emp_cov = np.array([[1, 0.5, 0.3], [0.5, 1, 0.2], [0.3, 0.2, 1]])
+    >>> shrinkage = 0.1
+    >>> shrunk_cov = shrunk_covariance(emp_cov, shrinkage)
+    >>> print("Shrunk covariance matrix:")
+    >>> print(shrunk_cov)
+    Shrunk covariance matrix:
+    [[1.   0.45 0.27]
+     [0.45 1.   0.18]
+     [0.27 0.18 1.  ]]
     """
     emp_cov = check_array(emp_cov, allow_nd=True)
     n_features = emp_cov.shape[-1]
@@ -316,6 +330,17 @@ def ledoit_wolf_shrinkage(X, assume_centered=False, block_size=1000):
     (1 - shrinkage) * cov + shrinkage * mu * np.identity(n_features)
 
     where mu = trace(cov) / n_features
+
+    Example:
+    --------
+    >>> import numpy as np
+    >>> from _shrunk_covariance import ledoit_wolf_shrinkage
+    >>> X = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    >>> shrinkage = ledoit_wolf_shrinkage(X)
+    >>> print("Shrinkage:")
+    >>> print(shrinkage)
+    Shrinkage:
+    0.25
     """
     X = check_array(X)
     # for only one feature, the result is the same whatever the shrinkage
@@ -419,6 +444,23 @@ def ledoit_wolf(X, *, assume_centered=False, block_size=1000):
     (1 - shrinkage) * cov + shrinkage * mu * np.identity(n_features)
 
     where mu = trace(cov) / n_features
+
+    Example:
+    --------
+    >>> import numpy as np
+    >>> from sklearn.covariance._shrunk_covariance import ledoit_wolf
+    >>> X = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    >>> shrunk_cov, shrinkage = ledoit_wolf(X)
+    >>> print("Shrunk covariance matrix:")
+    >>> print(shrunk_cov)
+    Shrunk covariance matrix:
+    [[6.  4.5 4.5]
+     [4.5 6.  4.5]
+     [4.5 4.5 6. ]]
+    >>> print("Shrinkage:")
+    >>> print(shrinkage)
+    Shrinkage:
+    0.25
     """
     estimator = LedoitWolf(
         assume_centered=assume_centered,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes parts of #27982

#### What does this implement/fix? Explain your changes.

Added a docstring example for each of the following covariance functions:

 sklearn.covariance.graphical_lasso
 sklearn.covariance.ledoit_wolf
 sklearn.covariance.ledoit_wolf_shrinkage
 sklearn.covariance.shrunk_covariance




<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
