### PR TITLE
DOC Add a docstring example for covariance functions.

### DIFF
--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -324,6 +324,32 @@ def graphical_lasso(
 
     One possible difference with the `glasso` R package is that the
     diagonal coefficients are not penalized.
+
+    Example:
+    --------
+    >>> import numpy as np
+    >>> from sklearn.covariance._graph_lasso import graphical_lasso
+    >>> emp_cov = np.array([[1, 0.5], [0.5, 1]])
+    >>> alpha = 0.1
+    >>> covariance, precision, costs, n_iter = graphical_lasso(emp_cov, alpha, return_costs=True, return_n_iter=True)
+    >>> print("Covariance matrix:")
+    >>> print(covariance)
+    Covariance matrix:
+    [[1.  0.4]
+     [0.4 1. ]]
+    >>> print("Precision matrix:")
+    >>> print(precision)
+    Precision matrix:
+    [[ 1.19047619 -0.47619048]
+     [-0.47619048  1.19047619]]
+    >>> print("Costs:")
+    >>> print(costs)
+    Costs:
+    [(9.178099258094727, 0.04409171075837724), (9.177154878492603, -1.249000902703301e-16)]
+    >>> print("Number of iterations:")
+    >>> print(n_iter)
+    Number of iterations:
+    2
     """
 
     if cov_init is not None:

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -331,7 +331,8 @@ def graphical_lasso(
     >>> from sklearn.covariance._graph_lasso import graphical_lasso
     >>> emp_cov = np.array([[1, 0.5], [0.5, 1]])
     >>> alpha = 0.1
-    >>> covariance, precision, costs, n_iter = graphical_lasso(emp_cov, alpha, return_costs=True, return_n_iter=True)
+    >>> result = graphical_lasso(emp_cov, alpha, return_costs=True, return_n_iter=True)
+    >>> covariance, precision, costs, n_iter = result
     >>> print("Covariance matrix:")
     >>> print(covariance)
     Covariance matrix:
@@ -345,7 +346,8 @@ def graphical_lasso(
     >>> print("Costs:")
     >>> print(costs)
     Costs:
-    [(9.178099258094727, 0.04409171075837724), (9.177154878492603, -1.249000902703301e-16)]
+    [(9.178099258094727, 0.04409171075837724),
+     (9.177154878492603, -1.249000902703301e-16)]
     >>> print("Number of iterations:")
     >>> print(n_iter)
     Number of iterations:

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -333,24 +333,16 @@ def graphical_lasso(
     >>> alpha = 0.1
     >>> result = graphical_lasso(emp_cov, alpha, return_costs=True, return_n_iter=True)
     >>> covariance, precision, costs, n_iter = result
-    >>> print("Covariance matrix:")
     >>> print(covariance)
-    Covariance matrix:
     [[1.  0.4]
      [0.4 1. ]]
-    >>> print("Precision matrix:")
     >>> print(precision)
-    Precision matrix:
     [[ 1.19047619 -0.47619048]
      [-0.47619048  1.19047619]]
-    >>> print("Costs:")
     >>> print(costs)
-    Costs:
     [(9.178099258094727, 0.04409171075837724),
      (9.177154878492603, -1.249000902703301e-16)]
-    >>> print("Number of iterations:")
     >>> print(n_iter)
-    Number of iterations:
     2
     """
 

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -325,7 +325,7 @@ def graphical_lasso(
     One possible difference with the `glasso` R package is that the
     diagonal coefficients are not penalized.
 
-    Example:
+    Examples
     --------
     >>> import numpy as np
     >>> from sklearn.covariance._graph_lasso import graphical_lasso

--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -134,6 +134,20 @@ def shrunk_covariance(emp_cov, shrinkage=0.1):
         (1 - shrinkage) * cov + shrinkage * mu * np.identity(n_features)
 
     where `mu = trace(cov) / n_features`.
+
+    Example:
+    --------
+    >>> import numpy as np
+    >>> from _shrunk_covariance import shrunk_covariance
+    >>> emp_cov = np.array([[1, 0.5, 0.3], [0.5, 1, 0.2], [0.3, 0.2, 1]])
+    >>> shrinkage = 0.1
+    >>> shrunk_cov = shrunk_covariance(emp_cov, shrinkage)
+    >>> print("Shrunk covariance matrix:")
+    >>> print(shrunk_cov)
+    Shrunk covariance matrix:
+    [[1.   0.45 0.27]
+     [0.45 1.   0.18]
+     [0.27 0.18 1.  ]]
     """
     emp_cov = check_array(emp_cov, allow_nd=True)
     n_features = emp_cov.shape[-1]
@@ -316,6 +330,17 @@ def ledoit_wolf_shrinkage(X, assume_centered=False, block_size=1000):
     (1 - shrinkage) * cov + shrinkage * mu * np.identity(n_features)
 
     where mu = trace(cov) / n_features
+
+    Example:
+    --------
+    >>> import numpy as np
+    >>> from _shrunk_covariance import ledoit_wolf_shrinkage
+    >>> X = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    >>> shrinkage = ledoit_wolf_shrinkage(X)
+    >>> print("Shrinkage:")
+    >>> print(shrinkage)
+    Shrinkage:
+    0.25
     """
     X = check_array(X)
     # for only one feature, the result is the same whatever the shrinkage
@@ -419,6 +444,23 @@ def ledoit_wolf(X, *, assume_centered=False, block_size=1000):
     (1 - shrinkage) * cov + shrinkage * mu * np.identity(n_features)
 
     where mu = trace(cov) / n_features
+
+    Example:
+    --------
+    >>> import numpy as np
+    >>> from sklearn.covariance._shrunk_covariance import ledoit_wolf
+    >>> X = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    >>> shrunk_cov, shrinkage = ledoit_wolf(X)
+    >>> print("Shrunk covariance matrix:")
+    >>> print(shrunk_cov)
+    Shrunk covariance matrix:
+    [[6.  4.5 4.5]
+     [4.5 6.  4.5]
+     [4.5 4.5 6. ]]
+    >>> print("Shrinkage:")
+    >>> print(shrinkage)
+    Shrinkage:
+    0.25
     """
     estimator = LedoitWolf(
         assume_centered=assume_centered,

--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -138,13 +138,11 @@ def shrunk_covariance(emp_cov, shrinkage=0.1):
     Example:
     --------
     >>> import numpy as np
-    >>> from _shrunk_covariance import shrunk_covariance
+    >>> from sklearn.covariance._shrunk_covariance import shrunk_covariance
     >>> emp_cov = np.array([[1, 0.5, 0.3], [0.5, 1, 0.2], [0.3, 0.2, 1]])
     >>> shrinkage = 0.1
     >>> shrunk_cov = shrunk_covariance(emp_cov, shrinkage)
-    >>> print("Shrunk covariance matrix:")
     >>> print(shrunk_cov)
-    Shrunk covariance matrix:
     [[1.   0.45 0.27]
      [0.45 1.   0.18]
      [0.27 0.18 1.  ]]
@@ -337,9 +335,7 @@ def ledoit_wolf_shrinkage(X, assume_centered=False, block_size=1000):
     >>> from _shrunk_covariance import ledoit_wolf_shrinkage
     >>> X = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     >>> shrinkage = ledoit_wolf_shrinkage(X)
-    >>> print("Shrinkage:")
     >>> print(shrinkage)
-    Shrinkage:
     0.25
     """
     X = check_array(X)
@@ -451,15 +447,11 @@ def ledoit_wolf(X, *, assume_centered=False, block_size=1000):
     >>> from sklearn.covariance._shrunk_covariance import ledoit_wolf
     >>> X = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     >>> shrunk_cov, shrinkage = ledoit_wolf(X)
-    >>> print("Shrunk covariance matrix:")
     >>> print(shrunk_cov)
-    Shrunk covariance matrix:
     [[6.  4.5 4.5]
      [4.5 6.  4.5]
      [4.5 4.5 6. ]]
-    >>> print("Shrinkage:")
     >>> print(shrinkage)
-    Shrinkage:
     0.25
     """
     estimator = LedoitWolf(

--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -135,7 +135,7 @@ def shrunk_covariance(emp_cov, shrinkage=0.1):
 
     where `mu = trace(cov) / n_features`.
 
-    Example:
+    Examples
     --------
     >>> import numpy as np
     >>> from sklearn.covariance._shrunk_covariance import shrunk_covariance
@@ -329,10 +329,10 @@ def ledoit_wolf_shrinkage(X, assume_centered=False, block_size=1000):
 
     where mu = trace(cov) / n_features
 
-    Example:
+    Examples
     --------
     >>> import numpy as np
-    >>> from _shrunk_covariance import ledoit_wolf_shrinkage
+    >>> from sklearn.covariance._shrunk_covariance import ledoit_wolf_shrinkage
     >>> X = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     >>> shrinkage = ledoit_wolf_shrinkage(X)
     >>> print(shrinkage)
@@ -441,7 +441,7 @@ def ledoit_wolf(X, *, assume_centered=False, block_size=1000):
 
     where mu = trace(cov) / n_features
 
-    Example:
+    Examples
     --------
     >>> import numpy as np
     >>> from sklearn.covariance._shrunk_covariance import ledoit_wolf


### PR DESCRIPTION
Fixes parts of #27982

Added a docstring example for each of the following covariance functions:

sklearn.covariance.graphical_lasso
sklearn.covariance.ledoit_wolf
sklearn.covariance.ledoit_wolf_shrinkage
sklearn.covariance.shrunk_covariance