### PR TITLE
FIX _convert_container should be able to convert from sparse to sparse

### DIFF
--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -812,12 +812,12 @@ def _convert_container(
     elif constructor_name == "slice":
         return slice(container[0], container[1])
     elif "sparse" in constructor_name:
-        container = (
-            # sparse constructor only works with 2D array-like
-            np.atleast_2d(container)
-            if not sp.sparse.issparse(container)
-            else container
-        )
+        if not sp.sparse.issparse(container):
+            # For scipy >= 1.13, sparse array constructed from 1d array may be
+            # 1d or raise an exception. For more details, see
+            # https://github.com/scipy/scipy/pull/18530#issuecomment-1878005149
+            container = np.atleast_2d(container)
+
         if "array" in constructor_name and sp_version < parse_version("1.8"):
             raise ValueError(
                 f"{constructor_name} is only available with scipy>=1.8.0, got "

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -775,8 +775,6 @@ def _convert_container(
             return tuple(np.asarray(container, dtype=dtype).tolist())
     elif constructor_name == "array":
         return np.asarray(container, dtype=dtype)
-    elif constructor_name == "sparse":
-        return sp.sparse.csr_matrix(np.atleast_2d(container), dtype=dtype)
     elif constructor_name in ("pandas", "dataframe"):
         pd = pytest.importorskip("pandas", minversion=minversion)
         result = pd.DataFrame(container, columns=columns_name, dtype=dtype, copy=False)
@@ -825,7 +823,8 @@ def _convert_container(
                 f"{constructor_name} is only available with scipy>=1.8.0, got "
                 f"{sp_version}"
             )
-        if constructor_name == "sparse_csr":
+        if constructor_name in ("sparse", "sparse_csr"):
+            # sparse and sparse_csr are equivalent for legacy reasons
             return sp.sparse.csr_matrix(container, dtype=dtype)
         elif constructor_name == "sparse_csr_array":
             return sp.sparse.csr_array(container, dtype=dtype)

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -814,7 +814,8 @@ def _convert_container(
     elif "sparse" in constructor_name:
         if not sp.sparse.issparse(container):
             # For scipy >= 1.13, sparse array constructed from 1d array may be
-            # 1d or raise an exception. For more details, see
+            # 1d or raise an exception. To avoid this, we make sure that the
+            # input container is 2d. For more details, see
             # https://github.com/scipy/scipy/pull/18530#issuecomment-1878005149
             container = np.atleast_2d(container)
 

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -813,22 +813,26 @@ def _convert_container(
         return pd.Index(container, dtype=dtype)
     elif constructor_name == "slice":
         return slice(container[0], container[1])
-    elif constructor_name == "sparse_csr":
-        return sp.sparse.csr_matrix(np.atleast_2d(container), dtype=dtype)
-    elif constructor_name == "sparse_csr_array":
-        if sp_version >= parse_version("1.8"):
-            return sp.sparse.csr_array(np.atleast_2d(container), dtype=dtype)
-        raise ValueError(
-            f"sparse_csr_array is only available with scipy>=1.8.0, got {sp_version}"
+    elif "sparse" in constructor_name:
+        container = (
+            # sparse constructor only works with 2D array-like
+            np.atleast_2d(container)
+            if not sp.sparse.issparse(container)
+            else container
         )
-    elif constructor_name == "sparse_csc":
-        return sp.sparse.csc_matrix(np.atleast_2d(container), dtype=dtype)
-    elif constructor_name == "sparse_csc_array":
-        if sp_version >= parse_version("1.8"):
-            return sp.sparse.csc_array(np.atleast_2d(container), dtype=dtype)
-        raise ValueError(
-            f"sparse_csc_array is only available with scipy>=1.8.0, got {sp_version}"
-        )
+        if "array" in constructor_name and sp_version < parse_version("1.8"):
+            raise ValueError(
+                f"{constructor_name} is only available with scipy>=1.8.0, got "
+                f"{sp_version}"
+            )
+        if constructor_name == "sparse_csr":
+            return sp.sparse.csr_matrix(container, dtype=dtype)
+        elif constructor_name == "sparse_csr_array":
+            return sp.sparse.csr_array(container, dtype=dtype)
+        elif constructor_name == "sparse_csc":
+            return sp.sparse.csc_matrix(container, dtype=dtype)
+        elif constructor_name == "sparse_csc_array":
+            return sp.sparse.csc_array(container, dtype=dtype)
 
 
 def raises(expected_exc_type, match=None, may_pass=False, err_msg=None):

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -845,3 +845,32 @@ def test_assert_run_python_script_without_output():
         match="output was not supposed to match.+got.+something to stderr",
     ):
         assert_run_python_script_without_output(code, pattern="to.+stderr")
+
+
+@pytest.mark.parametrize(
+    "constructor_name",
+    [
+        "sparse_csr",
+        "sparse_csc",
+        pytest.param(
+            "sparse_csr_array",
+            marks=pytest.mark.skipif(
+                sp_version < parse_version("1.8"),
+                reason="sparse arrays are available as of scipy 1.8.0",
+            ),
+        ),
+        pytest.param(
+            "sparse_csc_array",
+            marks=pytest.mark.skipif(
+                sp_version < parse_version("1.8"),
+                reason="sparse arrays are available as of scipy 1.8.0",
+            ),
+        ),
+    ],
+)
+def test_convert_container_sparse_to_sparse(constructor_name):
+    """Non-regression test to check that we can still convert a sparse container
+    from a given format to another format.
+    """
+    X_sparse = sparse.random(10, 10, density=0.1, format="csr")
+    _convert_container(X_sparse, constructor_name)


### PR DESCRIPTION
While working on `imbalanced-learn` I catch a regression where `_convert_container` is not anymore able to convert from sparse container to another sparse container. The reason is that `np.atleast_2d` does not do what we think on sparse container.

It was introduced in #28047.

It might not be a big deal since this is testing tool kind of private.