### PR TITLE
Stop listing `wheel` as a build dep unconditionally

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 # Minimum requirements for the build system to execute.
 requires = [
     "setuptools",
-    "wheel",
     "Cython>=0.29.33",
     "numpy>=1.25",
     "scipy>=1.6.0",


### PR DESCRIPTION
This is a historical mistake that some guides suggested doing so. `setuptools` injects it automatically for building wheels, but it's not needed for building sdists.
