### PR TITLE
Use modern `setuptools`' PEP 517 build backend explicitly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires = [
     "numpy>=1.25",
     "scipy>=1.6.0",
 ]
+build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
Without an explicit entry, the `__legacy__` fallback is used, that behaves slightly differently. In the long run, it's best to always have it set.