### PR TITLE
DOC fix some entries location of the changelog

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -497,10 +497,6 @@ Changelog
   which allows to retrieve the training sample indices used for each tree estimator.
   :pr:`26736` by :user:`Adam Li <adam2392>`.
 
-- |Efficiency| Improves runtime of `predict` of
-  :class:`ensemble.HistGradientBoostingClassifier` by avoiding to call `predict_proba`.
-  :pr:`27844` by :user:`Christian Lorentzen <lorentzenchr>`.
-
 - |Fix| Fixes :class:`ensemble.IsolationForest` when the input is a sparse matrix and
   `contamination` is set to a float value.
   :pr:`27645` by :user:`Guillaume Lemaitre <glemaitre>`.

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -33,11 +33,18 @@ Changelog
   which returns the fitted transformers by name. :pr:`27990` by `Thomas Fan`_.
 
 :mod:`sklearn.dummy`
-.......................
+....................
 
 - |Enhancement| :class:`dummy.DummyClassifier` and :class:`dummy.DummyRegressor` now
   have the `n_features_in_` and `feature_names_in_` attributes after `fit`.
   :pr:`27937` by :user:`Marco vd Boom <tvdboom>`.
+
+:mod:`sklearn.ensemble`
+.......................
+
+- |Efficiency| Improves runtime of `predict` of
+  :class:`ensemble.HistGradientBoostingClassifier` by avoiding to call `predict_proba`.
+  :pr:`27844` by :user:`Christian Lorentzen <lorentzenchr>`.
 
 :mod:`sklearn.feature_extraction`
 .................................
@@ -51,13 +58,6 @@ Changelog
   the data type of the input matrix if it is `np.float64` or `np.float32`.
   :pr:`28136` by :user:`Guillaume Lemaitre <glemaitre>`.
 
-:mod:`sklearn.impute`
-.....................
-
-- |Enhancement| :class:`impute.SimpleImputer` now supports custom strategies
-  by passing a function in place of a strategy name.
-  :pr:`28053` by :user:`Mark Elliot <mark-thm>`.
-
 :mod:`sklearn.feature_selection`
 ................................
 
@@ -66,11 +66,19 @@ Changelog
   :pr:`28085` by :user:`Neto Menoci <netomenoci>` and
   :user:`Florin Andrei <FlorinAndrei>`.
 
+:mod:`sklearn.impute`
+.....................
+
+- |Enhancement| :class:`impute.SimpleImputer` now supports custom strategies
+  by passing a function in place of a strategy name.
+  :pr:`28053` by :user:`Mark Elliot <mark-thm>`.
+
 :mod:`sklearn.metrics`
 ......................
 
 - |Efficiency| Improve efficiency of functions :func:`~metrics.brier_score_loss`,
-  :func:`~metrics.calibration_curve`, :func:`~metrics.det_curve`, :func:`~metrics.precision_recall_curve`,
+  :func:`~metrics.calibration_curve`, :func:`~metrics.det_curve`,
+  :func:`~metrics.precision_recall_curve`,
   :func:`~metrics.roc_curve` when `pos_label` argument is specified.
   Also improve efficiency of methods `from_estimator`
   and `from_predictions` in :class:`~metrics.RocCurveDisplay`,


### PR DESCRIPTION
Fixing the changelog entries. Notably, we add #27844 in 1.4 instead of 1.5