### PR TITLE
MAINT remove spurious semi-columns for `switch` statement in cpp file

### DIFF
--- a/sklearn/utils/src/MurmurHash3.cpp
+++ b/sklearn/utils/src/MurmurHash3.cpp
@@ -144,7 +144,7 @@ void MurmurHash3_x86_32 ( const void * key, int len,
   case 2: k1 ^= tail[1] << 8;
   case 1: k1 ^= tail[0];
           k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
-  };
+  }
 
   //----------
   // finalization
@@ -237,7 +237,7 @@ void MurmurHash3_x86_128 ( const void * key, const int len,
   case  2: k1 ^= tail[ 1] << 8;
   case  1: k1 ^= tail[ 0] << 0;
            k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
-  };
+  }
 
   //----------
   // finalization
@@ -322,7 +322,7 @@ void MurmurHash3_x64_128 ( const void * key, const int len,
   case  2: k1 ^= uint64_t(tail[ 1]) << 8;
   case  1: k1 ^= uint64_t(tail[ 0]) << 0;
            k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
-  };
+  }
 
   //----------
   // finalization


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
N/A

#### What does this implement/fix? Explain your changes.
Eliminates extraneous semicolons. These should not be here. This facilitates using `-Wextra-semi-stmt` during compilation.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
