### PR TITLE
FIX raise a ValueError with axis=1 and list input in _safe_indexing

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -32,7 +32,7 @@ Changelog
 
 - |Fix| :func:`utils._safe_indexing` now raises a `ValueError` when `X` is a Python list
   and `axis=1`, as documented in the docstring.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`28222` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 .. _changes_1_4:
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -27,6 +27,13 @@ Changelog
 - |Enhancement| Pandas and Polars dataframe are validated directly without ducktyping
   checks. :pr:`28195` by `Thomas Fan`_.
 
+:mod:`sklearn.utils`
+....................
+
+- |Fix| :func:`utils._safe_indexing` now raises a `ValueError` when `X` is a Python list
+  and `axis=1`, as documented in the docstring.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 .. _changes_1_4:
 
 Version 1.4.0

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -360,6 +360,9 @@ def _safe_indexing(X, indices, *, axis=0):
     if axis == 0 and indices_dtype == "str":
         raise ValueError("String indexing is not supported with 'axis=0'")
 
+    if axis == 1 and isinstance(X, list):
+        raise ValueError("axis=1 is not supported for lists")
+
     if axis == 1 and hasattr(X, "ndim") and X.ndim != 2:
         raise ValueError(
             "'X' should be a 2D NumPy array, 2D sparse matrix or pandas "

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -475,6 +475,15 @@ def test_safe_indexing_pandas_no_settingwithcopy_warning():
     assert X.iloc[0, 0] == 1
 
 
+@pytest.mark.parametrize("indices", [0, [0, 1], slice(0, 2), np.array([0, 1])])
+def test_safe_indexing_list_axis_1_unsupported(indices):
+    """Check that we raise a ValueError when axis=1 with input as list."""
+    X = [[1, 2], [4, 5], [7, 8]]
+    err_msg = "axis=1 is not supported for lists"
+    with pytest.raises(ValueError, match=err_msg):
+        _safe_indexing(X, indices, axis=1)
+
+
 @pytest.mark.parametrize(
     "key, err_msg",
     [


### PR DESCRIPTION
Just found out that we don't raise an error. However, we documented that we don't support this case. It was silently returning a wrong results.