### PR TITLE
Added a way to choose how sample_y in GP regression samples the multivariate normal

### DIFF
--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -495,7 +495,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             else:
                 return y_mean
 
-    def sample_y(self, X, n_samples=1, random_state=0, cov_method = "svd"):
+    def sample_y(self, X, n_samples=1, random_state=0, sample_method = "svd"):
         """Draw samples from Gaussian process and evaluate at X.
 
         Parameters

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -495,7 +495,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             else:
                 return y_mean
 
-    def sample_y(self, X, n_samples=1, random_state=0):
+    def sample_y(self, X, n_samples=1, random_state=0, cov_method = "svd"):
         """Draw samples from Gaussian process and evaluate at X.
 
         Parameters
@@ -511,7 +511,8 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             Pass an int for reproducible results across multiple function
             calls.
             See :term:`Glossary <random_state>`.
-
+        sample_method : str, default = "svd"
+            Chooses how the multivariate normal RNG uses the covariance matrix.
         Returns
         -------
         y_samples : ndarray of shape (n_samples_X, n_samples), or \
@@ -523,11 +524,11 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
         y_mean, y_cov = self.predict(X, return_cov=True)
         if y_mean.ndim == 1:
-            y_samples = rng.multivariate_normal(y_mean, y_cov, n_samples).T
+            y_samples = rng.multivariate_normal(y_mean, y_cov, n_samples, method=sample_method).T
         else:
             y_samples = [
                 rng.multivariate_normal(
-                    y_mean[:, target], y_cov[..., target], n_samples
+                    y_mean[:, target], y_cov[..., target], n_samples, method=sample_method
                 ).T[:, np.newaxis]
                 for target in range(y_mean.shape[1])
             ]

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -170,13 +170,13 @@ def test_prior(kernel):
 
 
 @pytest.mark.parametrize("kernel", kernels)
-def test_sample_statistics(kernel):
+def test_sample_statistics_svd(kernel):
     # Test that statistics of samples drawn from GP are correct.
     gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
 
     y_mean, y_cov = gpr.predict(X2, return_cov=True)
 
-    samples = gpr.sample_y(X2, 300000)
+    samples = gpr.sample_y(X2, 300000, sample_method="svd")
 
     # More digits accuracy would require many more samples
     assert_almost_equal(y_mean, np.mean(samples, 1), 1)
@@ -186,7 +186,23 @@ def test_sample_statistics(kernel):
         1,
     )
 
+@pytest.mark.parametrize("kernel", kernels)
+def test_sample_statistics_cholesky(kernel):
+    # Test that statistics of samples drawn from GP are correct.
+    gpr = GaussianProcessRegressor(kernel=kernel).fit(X, y)
 
+    y_mean, y_cov = gpr.predict(X2, return_cov=True)
+
+    samples = gpr.sample_y(X2, 300000, sample_method="cholesky")
+
+    # More digits accuracy would require many more samples
+    assert_almost_equal(y_mean, np.mean(samples, 1), 1)
+    assert_almost_equal(
+        np.diag(y_cov) / np.diag(y_cov).max(),
+        np.var(samples, 1) / np.diag(y_cov).max(),
+        1,
+    )
+    
 def test_no_optimizer():
     # Test that kernel parameters are unmodified when optimizer is None.
     kernel = RBF(1.0)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### What does this implement/fix? Explain your changes.

In the GP regression `sample_y` method, `rng.multivariate_normal` is called with its default `method` argument, i.e. "svd". This is fine when `sample_y` is called on a small number of points, but I found that for a large set of evaluation points, this could get quite costly. 

Using the example in the docs,

```python 
X = np.linspace(start=0, stop=10, num=1_000).reshape(-1, 1)
y = np.squeeze(X * np.sin(X))

gpr = GaussianProcessRegressor(Matern(nu=2.5))

_ = gpr.fit(X,y)

x_sample = np.random.uniform(0,10,1000)
_ = gpr.sample_y(x_sample)
# takes 0.6 seconds, of which 0.4 is in multivariate_normal 

x_sample = np.random.uniform(0,10,5000)
_ = gpr.sample_y(x_sample)
# takes 38 seconds, of which 36 is in multivariate_normal 
```
Repeating the same exercise with `method = "cholesky"` in `rng.multivariate_normal` reduces the runtime to a much more reasonable 2.5 seconds. 


#### Any other comments?

I kept the default to "svd" so users shouldnt see any change unless they opt in. 
