### PR TITLE
FIX Adds float32 predict_proba support to CalibratedClassifierCV

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -12,6 +12,12 @@ Version 1.4.1
 Changelog
 ---------
 
+:mod:`sklearn.calibration`
+..........................
+
+- |Fix| `calibration.CalibratedClassifierCV` supports :term:`predict_proba` with
+  float32 output from the inner estimator. :pr:`xxxxx` by `Thomas Fan`_.
+
 :mod:`sklearn.cluster`
 ......................
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -16,7 +16,7 @@ Changelog
 ..........................
 
 - |Fix| `calibration.CalibratedClassifierCV` supports :term:`predict_proba` with
-  float32 output from the inner estimator. :pr:`xxxxx` by `Thomas Fan`_.
+  float32 output from the inner estimator. :pr:`28247` by `Thomas Fan`_.
 
 :mod:`sklearn.cluster`
 ......................

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -814,7 +814,7 @@ def _sigmoid_calibration(
     else:
         prior0 = float(np.sum(mask_negative_samples))
         prior1 = y.shape[0] - prior0
-    T = np.zeros_like(y, dtype=np.float64)
+    T = np.zeros_like(y, dtype=predictions.dtype)
     T[y > 0] = (prior1 + 1.0) / (prior1 + 2.0)
     T[y <= 0] = 1.0 / (prior0 + 2.0)
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -827,7 +827,7 @@ def _sigmoid_calibration(
             sample_weight=sample_weight,
         )
         loss = l.sum()
-        # TODO: Remove casting to np.float64 when minimum support SciPy is 1.11.2
+        # TODO: Remove casting to np.float64 when minimum supported SciPy is 1.11.2
         # With SciPy >= 1.11.2, the LBFGS implementation will cast to float64
         # https://github.com/scipy/scipy/pull/18825. 
         # Here we cast to float64 to support SciPy < 1.11.2

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -829,8 +829,8 @@ def _sigmoid_calibration(
         loss = l.sum()
         # TODO: Remove casting to np.float64 when minimum support SciPy is 1.11.2
         # With SciPy >= 1.11.2, the LBFGS implementation will cast to float64
-        # https://github.com/scipy/scipy/pull/18825 Here we cast to float64 to support
-        # SciPy < 1.11.2
+        # https://github.com/scipy/scipy/pull/18825. 
+        # Here we cast to float64 to support SciPy < 1.11.2
         grad = np.asarray([-g @ F, -g.sum()], dtype=np.float64)
         return loss, grad
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -827,7 +827,11 @@ def _sigmoid_calibration(
             sample_weight=sample_weight,
         )
         loss = l.sum()
-        grad = np.array([-g @ F, -g.sum()])
+        # TODO: Remove when minimum support SciPy is 1.11.2
+        # With SciPy >= 1.11.2, the LBFGS implementation will cast to float64
+        # https://github.com/scipy/scipy/pull/18825 Here we cast to float64 to support
+        # SciPy < 1.11.2
+        grad = np.asarray([-g @ F, -g.sum()], dtype=np.float64)
         return loss, grad
 
     AB0 = np.array([0.0, log((prior0 + 1.0) / (prior1 + 1.0))])

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -829,7 +829,7 @@ def _sigmoid_calibration(
         loss = l.sum()
         # TODO: Remove casting to np.float64 when minimum supported SciPy is 1.11.2
         # With SciPy >= 1.11.2, the LBFGS implementation will cast to float64
-        # https://github.com/scipy/scipy/pull/18825. 
+        # https://github.com/scipy/scipy/pull/18825.
         # Here we cast to float64 to support SciPy < 1.11.2
         grad = np.asarray([-g @ F, -g.sum()], dtype=np.float64)
         return loss, grad

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -827,7 +827,7 @@ def _sigmoid_calibration(
             sample_weight=sample_weight,
         )
         loss = l.sum()
-        # TODO: Remove when minimum support SciPy is 1.11.2
+        # TODO: Remove casting to np.float64 when minimum support SciPy is 1.11.2
         # With SciPy >= 1.11.2, the LBFGS implementation will cast to float64
         # https://github.com/scipy/scipy/pull/18825 Here we cast to float64 to support
         # SciPy < 1.11.2

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -1072,3 +1072,19 @@ def test_sigmoid_calibration_max_abs_prediction_threshold(global_random_seed):
     assert_allclose(a2, a3, atol=atol)
     assert_allclose(b1, b2, atol=atol)
     assert_allclose(b2, b3, atol=atol)
+
+
+def test_float32_predict_proba(data):
+    """Check that CalibratedClassifierCV works with float32 predict proba.
+
+    Non-regression test for gh-28245.
+    """
+
+    class DummyClassifer32(DummyClassifier):
+        def predict_proba(self, X):
+            return super().predict_proba(X).astype(np.float32)
+
+    model = DummyClassifer32()
+    calibrator = CalibratedClassifierCV(model)
+    # Does not raise an error
+    calibrator.fit(*data)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/28245


#### What does this implement/fix? Explain your changes.
This PR makes sure that `y_true` has the same type as the `predictions`, so they are compatible with `HalfBinomialLoss.loss_gradient`.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
