### PR TITLE
FIX warn when requested polars DataFrame but no column names are found

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -62,6 +62,14 @@ Changelog
 - |Enhancement| Pandas and Polars dataframe are validated directly without ducktyping
   checks. :pr:`28195` by `Thomas Fan`_.
 
+:mod:`sklearn.preprocessing`
+............................
+
+- |Fix| :class:`preprocessing.FunctionTransformer` now also warns when `set_output`
+  is called with `transform="polars"` and `func` does not return a Polars dataframe or
+  `feature_names_out` is not specified.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 :mod:`sklearn.utils`
 ....................
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -68,7 +68,7 @@ Changelog
 - |Fix| :class:`preprocessing.FunctionTransformer` now also warns when `set_output`
   is called with `transform="polars"` and `func` does not return a Polars dataframe or
   `feature_names_out` is not specified.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`28263` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 :mod:`sklearn.utils`
 ....................

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -266,8 +266,8 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
         output_config = _get_output_config("transform", self)["dense"]
         if self.feature_names_out is None:
             warn_msg = (
-                "When `set_output` is configured to be '{}', `func` should return "
-                "a DataFrame to follow the `set_output` API  or `feature_names_out` "
+                "When `set_output` is configured to be '{0}', `func` should return "
+                f"a {0} DataFrame to follow the `set_output` API  or `feature_names_out` "
                 "should be defined."
             )
             if output_config == "pandas" and not _is_pandas_df(out):

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -267,8 +267,8 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
         if self.feature_names_out is None:
             warn_msg = (
                 "When `set_output` is configured to be '{0}', `func` should return "
-                f"a {0} DataFrame to follow the `set_output` API  or `feature_names_out` "
-                "should be defined."
+                "a {0} DataFrame to follow the `set_output` API  or `feature_names_out`"
+                " should be defined."
             )
             if output_config == "pandas" and not _is_pandas_df(out):
                 warnings.warn(warn_msg.format("pandas"))

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -10,6 +10,7 @@ from ..utils.validation import (
     _allclose_dense_sparse,
     _check_feature_names_in,
     _is_pandas_df,
+    _is_polars_df,
     check_array,
 )
 
@@ -263,16 +264,17 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
                 )
 
         output_config = _get_output_config("transform", self)["dense"]
-        if (
-            output_config == "pandas"
-            and self.feature_names_out is None
-            and not _is_pandas_df(out)
-        ):
-            warnings.warn(
-                "When `set_output` is configured to be 'pandas', `func` should return "
+        if self.feature_names_out is None:
+            warn_msg = (
+                "When `set_output` is configured to be '{}', `func` should return "
                 "a DataFrame to follow the `set_output` API  or `feature_names_out` "
                 "should be defined."
             )
+            if output_config == "pandas" and not _is_pandas_df(out):
+                warnings.warn(warn_msg.format("pandas"))
+            elif output_config == "polars" and not _is_polars_df(out):
+                warnings.warn(warn_msg.format("polars"))
+
         return out
 
     def inverse_transform(self, X):

--- a/sklearn/preprocessing/tests/test_function_transformer.py
+++ b/sklearn/preprocessing/tests/test_function_transformer.py
@@ -473,7 +473,10 @@ def test_set_output_func():
 
     for transform in ("pandas", "polars"):
         ft_np.set_output(transform=transform)
-        msg = f"When `set_output` is configured to be '{transform}'"
+        msg = (
+            f"When `set_output` is configured to be '{transform}'.*{transform} "
+            "DataFrame.*"
+        )
         with pytest.warns(UserWarning, match=msg):
             ft_np.fit_transform(X)
 

--- a/sklearn/preprocessing/tests/test_function_transformer.py
+++ b/sklearn/preprocessing/tests/test_function_transformer.py
@@ -470,11 +470,12 @@ def test_set_output_func():
 
     # Warning is raised when func returns a ndarray
     ft_np = FunctionTransformer(lambda x: np.asarray(x))
-    ft_np.set_output(transform="pandas")
 
-    msg = "When `set_output` is configured to be 'pandas'"
-    with pytest.warns(UserWarning, match=msg):
-        ft_np.fit_transform(X)
+    for transform in ("pandas", "polars"):
+        ft_np.set_output(transform=transform)
+        msg = f"When `set_output` is configured to be '{transform}'"
+        with pytest.warns(UserWarning, match=msg):
+            ft_np.fit_transform(X)
 
     # default transform does not warn
     ft_np.set_output(transform="default")


### PR DESCRIPTION
While working on https://github.com/scikit-learn/scikit-learn/issues/28260, I found out that we are not warning about not returning a polars DataFrame or requesting column names as we do for pandas in the `FunctionTransformer`.

This is particularly disturbing because you get an array but without really knowing the reason.