### PR TITLE
DOC fix some hooks that fail to capture the titles in pydata-sphinx-theme setup

### DIFF
--- a/doc/metadata_routing.rst
+++ b/doc/metadata_routing.rst
@@ -1,9 +1,8 @@
-
-.. _metadata_routing:
-
 .. currentmodule:: sklearn
 
 .. TODO: update doc/conftest.py once document is updated and examples run.
+
+.. _metadata_routing:
 
 Metadata Routing
 ================

--- a/doc/roadmap.rst
+++ b/doc/roadmap.rst
@@ -1,12 +1,12 @@
-﻿.. _roadmap:
-
-.. |ss| raw:: html
+﻿.. |ss| raw:: html
 
    <strike>
 
 .. |se| raw:: html
 
    </strike>
+
+.. _roadmap:
 
 Roadmap
 =======


### PR DESCRIPTION
This PR theoretically does not affect anything on the current website, but helps resolve some problem when switching to `pydata-sphinx-theme`, at least on my local machine.

Not exhaustive (just things I happened to come across).