### PR TITLE
DOC fix overflow-x using auto instead of scroll

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -778,7 +778,7 @@ span.descclassname {
 dl.field-list {
   display: flex;
   flex-wrap: wrap;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 dl.field-list > dt {
@@ -1002,7 +1002,7 @@ table.docutils {
   line-height: 1rem;
   max-width: 100%;
   display: block;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 table.docutils p {


### PR DESCRIPTION
Currently we have this ugly horizontal bar at the end of each table:

![image](https://github.com/scikit-learn/scikit-learn/assets/7454015/47b9cfc6-f072-4e59-9977-035f71929c99)

It is due to the option `overflow-x: scroll` that always have an horizontal scrolling even if the content fit in the container.

Switching to `auto` let the container creating the horizontal scrolling if needed and therefore does not show this ugly bar when everything already fit in the table:

![image](https://github.com/scikit-learn/scikit-learn/assets/7454015/7959da79-44af-4e1d-b961-7e44c8d741bb)

With my test on mobile, it seems that the scrolling happen as it was intended in #17638