### PR TITLE
DOC add docstring examples for decomposition.fastica, cluster.dbscan and covariance.oas

### DIFF
--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -160,9 +160,7 @@ def dbscan(
     Examples
     --------
     >>> from sklearn.cluster import dbscan
-    >>> import numpy as np
-    >>> X = np.array([[1, 2], [2, 2], [2, 3],
-    ...               [8, 7], [8, 8], [25, 80]])
+    >>> X = [[1, 2], [2, 2], [2, 3], [8, 7], [8, 8], [25, 80]]
     >>> core_samples, labels = dbscan(X, eps=3, min_samples=2)
     >>> core_samples
     array([0, 1, 2, 3, 4])

--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -156,6 +156,18 @@ def dbscan(
     :doi:`"DBSCAN revisited, revisited: why and how you should (still) use DBSCAN."
     <10.1145/3068335>`
     ACM Transactions on Database Systems (TODS), 42(3), 19.
+
+    Examples
+    --------
+    >>> from sklearn.cluster import dbscan
+    >>> import numpy as np
+    >>> X = np.array([[1, 2], [2, 2], [2, 3],
+    ...               [8, 7], [8, 8], [25, 80]])
+    >>> core_samples, labels = dbscan(X, eps=3, min_samples=2)
+    >>> core_samples
+    array([0, 1, 2, 3, 4])
+    >>> labels
+    array([ 0,  0,  0,  1,  1, -1])
     """
 
     est = DBSCAN(

--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -667,12 +667,9 @@ def oas(X, *, assume_centered=False):
     --------
     >>> import numpy as np
     >>> from sklearn.covariance import oas
-    >>> real_cov = np.array([[.8, .3],
-    ...                      [.3, .4]])
     >>> rng = np.random.RandomState(0)
-    >>> X = rng.multivariate_normal(mean=[0, 0],
-    ...                             cov=real_cov,
-    ...                             size=500)
+    >>> real_cov = [[.8, .3], [.3, .4]]
+    >>> X = rng.multivariate_normal(mean=[0, 0], cov=real_cov, size=500)
     >>> shrunk_cov, shrinkage = oas(X)
     >>> shrunk_cov
     array([[0.7533..., 0.2763...],

--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -662,6 +662,23 @@ def oas(X, *, assume_centered=False):
            Chen, Y., Wiesel, A., Eldar, Y. C., & Hero, A. O.
            IEEE Transactions on Signal Processing, 58(10), 5016-5029, 2010.
            <0907.4698>`
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.covariance import oas
+    >>> real_cov = np.array([[.8, .3],
+    ...                      [.3, .4]])
+    >>> rng = np.random.RandomState(0)
+    >>> X = rng.multivariate_normal(mean=[0, 0],
+    ...                             cov=real_cov,
+    ...                             size=500)
+    >>> shrunk_cov, shrinkage = oas(X)
+    >>> shrunk_cov
+    array([[0.7533..., 0.2763...],
+           [0.2763..., 0.3964...]])
+    >>> shrinkage
+    0.0195...
     """
     estimator = OAS(
         assume_centered=assume_centered,

--- a/sklearn/decomposition/_fastica.py
+++ b/sklearn/decomposition/_fastica.py
@@ -320,6 +320,19 @@ def fastica(
     .. [1] A. Hyvarinen and E. Oja, "Fast Independent Component Analysis",
            Algorithms and Applications, Neural Networks, 13(4-5), 2000,
            pp. 411-430.
+
+    Examples
+    --------
+    >>> from sklearn.datasets import load_digits
+    >>> from sklearn.decomposition import fastica
+    >>> X, _ = load_digits(return_X_y=True)
+    >>> K, W, S = fastica(X, n_components=7, random_state=0, whiten='unit-variance')
+    >>> K.shape
+    (7, 64)
+    >>> W.shape
+    (7, 7)
+    >>> S.shape
+    (1797, 7)
     """
     est = FastICA(
         n_components=n_components,


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related #27982

#### What does this implement/fix? Explain your changes.
I reuse the examples from corresponding classes for the functions below. These three functions are public but not covered by the script in #27982. Weird they do not have the regular pattern like other classes or functions in the url (e.g. `fastica-function.html` vs `sklearn.decomposition.FastICA.html`).

- [sklearn.cluster.dbscan](https://scikit-learn.org/dev/modules/generated/dbscan-function.html)
- [sklearn.covariance.oas](https://scikit-learn.org/dev/modules/generated/oas-function.html)
- [sklearn.decomposition.fastica](https://scikit-learn.org/dev/modules/generated/fastica-function.html)

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
