### PR TITLE
DOC add docstring example for sklearn.covariance.graphical_lasso and sklearn.datasets.make_sparse_spd_matrix

### DIFF
--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -327,18 +327,18 @@ def graphical_lasso(
 
     Examples
     --------
-    >>> from sklearn.covariance import graphical_lasso
-    >>> from sklearn.datasets import make_sparse_spd_matrix
     >>> import numpy as np
+    >>> from sklearn.datasets import make_sparse_spd_matrix
+    >>> from sklearn.covariance import empirical_covariance, graphical_lasso
     >>> true_cov = make_sparse_spd_matrix(n_dim=3,random_state=42)
-    >>> np.random.seed(42)
-    >>> X = np.random.multivariate_normal(mean=np.zeros(3), cov=true_cov, size=3)
-    >>> emp_cov=np.cov(X.T)
-    >>> emp_cov, _ = graphical_lasso(emp_cov, alpha=.05)
-    >>> print(emp_cov)
-    [[ 0.37138063  0.12630962 -0.30459686]
-    [ 0.12630962  0.30544403 -0.14382785]
-    [-0.30459686 -0.14382785  0.34684215]]
+    >>> rng = np.random.RandomState(42)
+    >>> X = rng.multivariate_normal(mean=np.zeros(3), cov=true_cov, size=3)
+    >>> emp_cov = empirical_covariance(X, assume_centered=True)
+    >>> emp_cov, _ = graphical_lasso(emp_cov, alpha=0.05)
+    >>> emp_cov
+    array([[ 1.68...,  0.21..., -0.20...],
+           [ 0.21...,  0.22..., -0.08...],
+           [-0.20..., -0.08...,  0.23...]])
     """
 
     if cov_init is not None:

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -324,6 +324,21 @@ def graphical_lasso(
 
     One possible difference with the `glasso` R package is that the
     diagonal coefficients are not penalized.
+
+    Examples
+    --------
+    >>> from sklearn.covariance import graphical_lasso
+    >>> from sklearn.datasets import make_sparse_spd_matrix
+    >>> import numpy as np
+    >>> true_cov = make_sparse_spd_matrix(n_dim=3,random_state=42)
+    >>> np.random.seed(42)
+    >>> X = np.random.multivariate_normal(mean=np.zeros(3), cov=true_cov, size=3)
+    >>> emp_cov=np.cov(X.T)
+    >>> emp_cov, _ = graphical_lasso(emp_cov, alpha=.05)
+    >>> print(emp_cov)
+    [[ 0.37138063  0.12630962 -0.30459686]
+    [ 0.12630962  0.30544403 -0.14382785]
+    [-0.30459686 -0.14382785  0.34684215]]
     """
 
     if cov_init is not None:

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1723,11 +1723,11 @@ def make_sparse_spd_matrix(
     Examples
     --------
     >>> from sklearn.datasets import make_sparse_spd_matrix
-    >>> make_sparse_spd_matrix(n_dim=4,random_state=42,norm_diag=False)
+    >>> make_sparse_spd_matrix(n_dim=4, norm_diag=False, random_state=42)
     array([[1., 0., 0., 0.],
-       [0., 1., 0., 0.],
-       [0., 0., 1., 0.],
-       [0., 0., 0., 1.]])
+           [0., 1., 0., 0.],
+           [0., 0., 1., 0.],
+           [0., 0., 0., 1.]])
     """
     random_state = check_random_state(random_state)
 

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1719,6 +1719,15 @@ def make_sparse_spd_matrix(
     The sparsity is actually imposed on the cholesky factor of the matrix.
     Thus alpha does not translate directly into the filling fraction of
     the matrix itself.
+
+    Examples
+    --------
+    >>> from sklearn.datasets import make_sparse_spd_matrix
+    >>> make_sparse_spd_matrix(n_dim=4,random_state=42,norm_diag=False)
+    array([[1., 0., 0., 0.],
+       [0., 1., 0., 0.],
+       [0., 0., 1., 0.],
+       [0., 0., 0., 1.]])
     """
     random_state = check_random_state(random_state)
 


### PR DESCRIPTION
#27982

I see that sklearn.covariance.graphical_lasso is checked off, but it still does not appear to be present. These examples were from my previous work, but I closed them once ledoit_wolf was already merged and forgot I had them


![Here is the screenshot](https://github.com/scikit-learn/scikit-learn/assets/55243596/fbd20aeb-0577-4cd8-83ff-ceaf11236f44)

