### PR TITLE
MAINT include meson.build files into MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
 include *.rst
+include *.build
+recursive-include sklearn *.build
 recursive-include doc *
 recursive-include examples *
 recursive-include sklearn *.c *.cpp *.h *.pyx *.pxd *.pxi *.tp


### PR DESCRIPTION
closes #28238 

We should be including the `meson.build` files in the source files.
This should solve the issue in the CI.