### PR TITLE
DOC Fixes ColumnTransformer docstring 

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -230,6 +230,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
     ...     "documents": ["First item", "second one here", "Is this the last?"],
     ...     "width": [3, 4, 5],
     ... })  # doctest: +SKIP
+    >>> X["documents"] = X["documents"].str.split()
     >>> # "documents" is a string which configures ColumnTransformer to
     >>> # pass the documents column as a 1d array to the FeatureHasher
     >>> ct = ColumnTransformer(

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -231,7 +231,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
     ...     "width": [3, 4, 5],
     ... })  # doctest: +SKIP
     >>> # "documents" is a string which configures ColumnTransformer to
-    >>> # pass the documents column as a 1d array to the FeatureHasher
+    >>> # pass the documents column as a 1d array to the CountVectorizer
     >>> ct = ColumnTransformer(
     ...     [("text_preprocess", CountVectorizer(), "documents"),
     ...      ("num_preprocess", MinMaxScaler(), ["width"])])

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -223,18 +223,17 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
     :class:`ColumnTransformer` can be configured with a transformer that requires
     a 1d array by setting the column to a string:
 
-    >>> from sklearn.feature_extraction import FeatureHasher
+    >>> from sklearn.feature_extraction.text import CountVectorizer
     >>> from sklearn.preprocessing import MinMaxScaler
     >>> import pandas as pd   # doctest: +SKIP
     >>> X = pd.DataFrame({
     ...     "documents": ["First item", "second one here", "Is this the last?"],
     ...     "width": [3, 4, 5],
     ... })  # doctest: +SKIP
-    >>> X["documents"] = X["documents"].str.split()
     >>> # "documents" is a string which configures ColumnTransformer to
     >>> # pass the documents column as a 1d array to the FeatureHasher
     >>> ct = ColumnTransformer(
-    ...     [("text_preprocess", FeatureHasher(input_type="string"), "documents"),
+    ...     [("text_preprocess", CountVectorizer(), "documents"),
     ...      ("num_preprocess", MinMaxScaler(), ["width"])])
     >>> X_trans = ct.fit_transform(X)  # doctest: +SKIP
 


### PR DESCRIPTION
The second example of [Column Transformer documentation](https://scikit-learn.org/stable/modules/generated/sklearn.compose.ColumnTransformer.html) throws the following error:

```
ValueError: Samples can not be a single string. The input must be an iterable over iterables of strings.
```

#### Reference Issues/PRs

I couldn't find an issue or PR for it.

#### What does this implement/fix? Explain your changes.

A list of lists was required for it to run. It split the string (documents) into a list of strings (words).

#### Any other comments?
