### PR TITLE
DOC fix a sphinx warning and a rendering issue

### DIFF
--- a/doc/roadmap.rst
+++ b/doc/roadmap.rst
@@ -1,4 +1,4 @@
-﻿.. |ss| raw:: html
+.. |ss| raw:: html
 
    <strike>
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1579,6 +1579,7 @@ def check_is_fitted(estimator, attributes=None, *, msg=None, all_or_any=all):
 
     NotFittedError
         If the attributes are not found.
+
     Examples
     --------
     >>> from sklearn.linear_model import LogisticRegression


### PR DESCRIPTION
`sklearn.utils.validation`: A missing line between the newly added example section and the previous section.

`doc/roadmap.rst`: I spent quite some time to find out why this file failed to render correctly with `pydata-sphinx-theme`. When I checked the HTML I found something like `<p>&#xFEFF;.. _roadmap:</p>`, which is the *zero-width no-break space*. Not sure why but seems that the file was saved as *UTF8 with BOM*, and resaving as *UTF8* solves the problem.