### PR TITLE
MNT move warnigns to setup.cfg

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -271,7 +271,7 @@ jobs:
       )
     matrix:
       debian_atlas_32bit:
-        DOCKER_CONTAINER: 'i386/debian:12.4'
+        DOCKER_CONTAINER: 'i386/debian:11.2'
         DISTRIB: 'debian-32'
         COVERAGE: "true"
         LOCK_FILE: './build_tools/azure/debian_atlas_32bit_lock.txt'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -271,7 +271,7 @@ jobs:
       )
     matrix:
       debian_atlas_32bit:
-        DOCKER_CONTAINER: 'i386/debian:11.2'
+        DOCKER_CONTAINER: 'i386/debian:12.4'
         DISTRIB: 'debian-32'
         COVERAGE: "true"
         LOCK_FILE: './build_tools/azure/debian_atlas_32bit_lock.txt'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,6 @@ jobs:
       pylatest_pip_scipy_dev:
         DISTRIB: 'conda-pip-scipy-dev'
         LOCK_FILE: './build_tools/azure/pylatest_pip_scipy_dev_linux-64_conda.lock'
-        CHECK_WARNINGS: 'true'
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
         # Tests that require large downloads over the networks are skipped in CI.
         # Here we make sure, that they are still run on a regular basis.
@@ -99,6 +98,7 @@ jobs:
         DOCKER_CONTAINER: 'nogil/python'
         DISTRIB: 'pip-nogil'
         LOCK_FILE: './build_tools/azure/python_nogil_lock.txt'
+        IGNORE_WARNINGS: 'true'
         COVERAGE: 'false'
 
 - template: build_tools/azure/posix-docker.yml
@@ -120,6 +120,7 @@ jobs:
         DOCKER_CONTAINER: 'condaforge/miniforge3:4.10.3-5'
         DISTRIB: 'conda-pypy3'
         LOCK_FILE: './build_tools/azure/pypy3_linux-64_conda.lock'
+        IGNORE_WARNINGS: 'true'
 
 
 - job: Linux_Nightly_Pyodide
@@ -170,6 +171,7 @@ jobs:
       pylatest_conda_forge_mkl:
         DISTRIB: 'conda'
         LOCK_FILE: './build_tools/azure/pylatest_conda_forge_mkl_linux-64_conda.lock'
+        IGNORE_WARNINGS: 'true'
         COVERAGE: 'true'
         BUILD_WITH_MESON: 'true'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '42'  # default global random seed
@@ -195,7 +197,6 @@ jobs:
       pymin_conda_forge_openblas_ubuntu_2204:
         DISTRIB: 'conda'
         LOCK_FILE: './build_tools/azure/pymin_conda_forge_openblas_ubuntu_2204_linux-64_conda.lock'
-        CHECK_WARNINGS: 'true'
         COVERAGE: 'false'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '0'  # non-default seed
 
@@ -217,6 +218,7 @@ jobs:
       ubuntu_atlas:
         DISTRIB: 'ubuntu'
         LOCK_FILE: './build_tools/azure/ubuntu_atlas_lock.txt'
+        IGNORE_WARNINGS: 'true'
         COVERAGE: 'false'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '1'  # non-default seed
 
@@ -236,6 +238,7 @@ jobs:
       pymin_conda_defaults_openblas:
         DISTRIB: 'conda'
         LOCK_FILE: './build_tools/azure/pymin_conda_defaults_openblas_linux-64_conda.lock'
+        IGNORE_WARNINGS: 'true'
         # Enable debug Cython directives to capture IndexError exceptions in
         # combination with the -Werror::pytest.PytestUnraisableExceptionWarning
         # flag for pytest.
@@ -249,7 +252,6 @@ jobs:
         DISTRIB: 'conda-pip-latest'
         LOCK_FILE: './build_tools/azure/pylatest_pip_openblas_pandas_linux-64_conda.lock'
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-        CHECK_WARNINGS: 'true'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '3'  # non-default seed
         # disable pytest-xdist to have 1 job where OpenMP and BLAS are not single
         # threaded because by default the tests configuration (sklearn/conftest.py)
@@ -273,6 +275,7 @@ jobs:
         DISTRIB: 'debian-32'
         COVERAGE: "true"
         LOCK_FILE: './build_tools/azure/debian_atlas_32bit_lock.txt'
+        IGNORE_WARNINGS: 'true'
         # disable pytest xdist due to unknown bug with 32-bit container
         PYTEST_XDIST_VERSION: 'none'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '4'  # non-default seed
@@ -292,10 +295,12 @@ jobs:
       pylatest_conda_forge_mkl:
         DISTRIB: 'conda'
         LOCK_FILE: './build_tools/azure/pylatest_conda_forge_mkl_osx-64_conda.lock'
+        IGNORE_WARNINGS: 'true'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '5'  # non-default seed
       pylatest_conda_mkl_no_openmp:
         DISTRIB: 'conda'
         LOCK_FILE: './build_tools/azure/pylatest_conda_mkl_no_openmp_osx-64_conda.lock'
+        IGNORE_WARNINGS: 'true'
         SKLEARN_TEST_NO_OPENMP: 'true'
         SKLEARN_SKIP_OPENMP_TEST: 'true'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '6'  # non-default seed
@@ -315,7 +320,6 @@ jobs:
       pymin_conda_forge_mkl:
         DISTRIB: 'conda'
         LOCK_FILE: ./build_tools/azure/pymin_conda_forge_mkl_win-64_conda.lock
-        CHECK_WARNINGS: 'true'
         # The Azure Windows runner is typically much slower than other CI
         # runners due to the lack of compiler cache. Running the tests with
         # coverage enabled make them run extra slower. Since very few parts of

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -48,24 +48,10 @@ if [[ "$COVERAGE" == "true" ]]; then
     TEST_CMD="$TEST_CMD --cov-config='$COVERAGE_PROCESS_START' --cov sklearn --cov-report="
 fi
 
-if [[ -n "$CHECK_WARNINGS" ]]; then
-    TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Werror::sklearn.utils.fixes.VisibleDeprecationWarning"
-
-    # Ignore pkg_resources deprecation warnings triggered by pyamg
-    TEST_CMD="$TEST_CMD -W 'ignore:pkg_resources is deprecated as an API:DeprecationWarning'"
-    TEST_CMD="$TEST_CMD -W 'ignore:Deprecated call to \`pkg_resources:DeprecationWarning'"
-
-    # pytest-cov issue https://github.com/pytest-dev/pytest-cov/issues/557 not
-    # fixed although it has been closed. https://github.com/pytest-dev/pytest-cov/pull/623
-    # would probably fix it.
-    TEST_CMD="$TEST_CMD -W 'ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning'"
-
-    # In some case, exceptions are raised (by bug) in tests, and captured by pytest,
-    # but not raised again. This is for instance the case when Cython directives are
-    # activated: IndexErrors (which aren't fatal) are raised on out-of-bound accesses.
-    # In those cases, pytest instead raises pytest.PytestUnraisableExceptionWarnings,
-    # which we must treat as errors on the CI.
-    TEST_CMD="$TEST_CMD -Werror::pytest.PytestUnraisableExceptionWarning"
+if [[ -n "$IGNORE_WARNINGS" ]]; then
+    # override the warnings settings in setup.cfg
+    TEST_CMD="$TEST_CMD -Walways -Wignore::DeprecationWarning -Wignore::FutureWarning"
+    TEST_CMD="$TEST_CMD -Wignore::sklearn.utils.fixes.VisibleDeprecationWarning"
 fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -50,7 +50,7 @@ fi
 
 if [[ -n "$IGNORE_WARNINGS" ]]; then
     # override the warnings settings in setup.cfg
-    TEST_CMD="$TEST_CMD -Walways -Wignore::DeprecationWarning -Wignore::FutureWarning"
+    TEST_CMD="$TEST_CMD -Wdefault -Wignore::DeprecationWarning -Wignore::FutureWarning"
     TEST_CMD="$TEST_CMD -Wignore::sklearn.utils.fixes.VisibleDeprecationWarning"
 fi
 

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -54,7 +54,7 @@ multiple interfaces):
 
 :Transformer:
 
-    For modifying the data in a supervised or unsupervised way (e.g. by adding, changing, 
+    For modifying the data in a supervised or unsupervised way (e.g. by adding, changing,
     or removing columns, but not by adding or removing rows). Implements::
 
       new_data = transformer.transform(data)
@@ -244,7 +244,7 @@ interactions with `pytest`)::
 
   >>> from sklearn.utils.estimator_checks import check_estimator
   >>> from sklearn.svm import LinearSVC
-  >>> check_estimator(LinearSVC())  # passes
+  >>> check_estimator(LinearSVC(dual="auto"))  # passes
 
 The main motivation to make a class compatible to the scikit-learn estimator
 interface might be that you want to use it together with model evaluation and

--- a/doc/developers/tips.rst
+++ b/doc/developers/tips.rst
@@ -93,11 +93,6 @@ Other `pytest` options that may become useful include:
 - ``--tb=short`` or ``--tb=line`` to control the length of the logs,
 - ``--runxfail`` also run tests marked as a known failure (XFAIL) and report errors.
 
-Since our continuous integration tests will error if
-``FutureWarning`` isn't properly caught,
-it is also recommended to run ``pytest`` along with the
-``-Werror::FutureWarning`` flag.
-
 .. _saved_replies:
 
 Standard replies for reviewing

--- a/doc/modules/partial_dependence.rst
+++ b/doc/modules/partial_dependence.rst
@@ -108,7 +108,7 @@ the plots, you can use the
     >>> results = partial_dependence(clf, X, [0])
     >>> results["average"]
     array([[ 2.466...,  2.466..., ...
-    >>> results["values"]
+    >>> results["grid_values"]
     [array([-1.624..., -1.592..., ...
 
 The values at which the partial dependence should be evaluated are directly

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,28 @@ addopts =
     -p sklearn.tests.random_seed
 
 filterwarnings =
+    error::DeprecationWarning
+    error::FutureWarning
+    error::sklearn.utils.fixes.VisibleDeprecationWarning
     ignore:the matrix subclass:PendingDeprecationWarning
+    # The following warning is raised when PyArrow is not installed on pandas 2.2
+    ignore:(?s).*Pyarrow will become a required dependency of pandas.*:DeprecationWarning
+    # Ignore pkg_resources deprecation warnings triggered by pyamg
+    ignore:pkg_resources is deprecated as an API:DeprecationWarning
+    ignore:Deprecated call to \`pkg_resources:DeprecationWarning
+
+    # pytest-cov issue https://github.com/pytest-dev/pytest-cov/issues/557 not
+    # fixed although it has been closed. https://github.com/pytest-dev/pytest-cov/pull/623
+    # would probably fix it.
+    ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning
+
+    # In some case, exceptions are raised (by bug) in tests, and captured by pytest,
+    # but not raised again. This is for instance the case when Cython directives are
+    # activated: IndexErrors (which aren't fatal) are raised on out-of-bound accesses.
+    # In those cases, pytest instead raises pytest.PytestUnraisableExceptionWarnings,
+    # which we must treat as errors on the CI.
+    error::pytest.PytestUnraisableExceptionWarning
+
 
 [mypy]
 ignore_missing_imports = True


### PR DESCRIPTION
Getting parts of https://github.com/scikit-learn/scikit-learn/pull/28258 here.

The main thing is to move warnings from the CI to `setup.cfg` to have them reproduce locally.