### PR TITLE
MAINT: Adjust the codebase to the new `np.array`'s `copy` keyword meaning

### DIFF
--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -523,7 +523,7 @@ class AffinityPropagation(ClusterMixin, BaseEstimator):
             preference = np.median(self.affinity_matrix_)
         else:
             preference = self.preference
-        preference = np.array(preference, copy=False)
+        preference = np.asarray(preference)
 
         random_state = check_random_state(self.random_state)
 

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -792,7 +792,7 @@ class ForestClassifier(ClassifierMixin, BaseForest, metaclass=ABCMeta):
             The OOB associated predictions.
         """
         y_pred = tree.predict_proba(X, check_input=False)
-        y_pred = np.array(y_pred, copy=False)
+        y_pred = np.asarray(y_pred)
         if y_pred.ndim == 2:
             # binary and multiclass
             y_pred = y_pred[..., np.newaxis]

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -669,7 +669,7 @@ def partial_dependence(
     if categorical_features is None:
         is_categorical = [False] * len(features_indices)
     else:
-        categorical_features = np.array(categorical_features, copy=False)
+        categorical_features = np.asarray(categorical_features)
         if categorical_features.dtype.kind == "b":
             # categorical features provided as a list of boolean
             if categorical_features.size != n_features:

--- a/sklearn/inspection/_plot/partial_dependence.py
+++ b/sklearn/inspection/_plot/partial_dependence.py
@@ -602,7 +602,7 @@ class PartialDependenceDisplay:
         else:
             # we need to create a boolean indicator of which features are
             # categorical from the categorical_features list.
-            categorical_features = np.array(categorical_features, copy=False)
+            categorical_features = np.asarray(categorical_features)
             if categorical_features.dtype.kind == "b":
                 # categorical features provided as a list of boolean
                 if categorical_features.size != n_features:

--- a/sklearn/model_selection/_plot.py
+++ b/sklearn/model_selection/_plot.py
@@ -891,7 +891,7 @@ class ValidationCurveDisplay(_BaseCurveDisplay):
 
         viz = cls(
             param_name=param_name,
-            param_range=np.array(param_range, copy=False),
+            param_range=np.asarray(param_range),
             train_scores=train_scores,
             test_scores=test_scores,
             score_name=score_name,

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -1275,7 +1275,7 @@ def _nanaverage(a, weights=None):
     if weights is None:
         return np.nanmean(a)
 
-    weights = np.array(weights, copy=False)
+    weights = np.asarray(weights)
     a, weights = a[~mask], weights[~mask]
     try:
         return np.average(a, weights=weights)


### PR DESCRIPTION
Hi!

This PR addresses changes planned for NumPy in https://github.com/numpy/numpy/pull/25168 (new `copy` keyword for `np.asarray` and `np.array`).

`np.array(..., copy=False)` will now throw and exception if a copy is needed. To retain the same behavior `np.asarray(...)` can be used, so a copy is made only when needed.

I applied changes in a backward-compatible way, so that no NumPy version check & branching is needed.