### PR TITLE
CI Fix scipy-dev build

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -821,9 +821,10 @@ def _sigmoid_calibration(
     bin_loss = HalfBinomialLoss()
 
     def loss_grad(AB):
+        raw_prediction = -(AB[0] * F + AB[1]).astype(dtype=predictions.dtype)
         l, g = bin_loss.loss_gradient(
             y_true=T,
-            raw_prediction=-(AB[0] * F + AB[1]),
+            raw_prediction=raw_prediction,
             sample_weight=sample_weight,
         )
         loss = l.sum()

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -821,6 +821,10 @@ def _sigmoid_calibration(
     bin_loss = HalfBinomialLoss()
 
     def loss_grad(AB):
+        # .astype below is needed to ensure y_true and raw_prediction have the
+        # same dtype. With result = np.float64(0) * np.array([1, 2], dtype=np.float32)
+        # - in Numpy 2, result.dtype is float64
+        # - in Numpy<2, result.dtype is float32
         raw_prediction = -(AB[0] * F + AB[1]).astype(dtype=predictions.dtype)
         l, g = bin_loss.loss_gradient(
             y_true=T,

--- a/sklearn/cluster/_hdbscan/hdbscan.py
+++ b/sklearn/cluster/_hdbscan/hdbscan.py
@@ -864,6 +864,9 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
 
         self._single_linkage_tree_ = mst_func(**kwargs)
 
+        from joblib import hash
+
+        print(hash(self._single_linkage_tree_))
         self.labels_, self.probabilities_ = tree_to_labels(
             self._single_linkage_tree_,
             self.min_cluster_size,
@@ -938,6 +941,7 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
         """
         # Number of non-noise clusters
         n_clusters = len(set(self.labels_) - {-1, -2})
+        print(f"{n_clusters=}")
         mask = np.empty((X.shape[0],), dtype=np.bool_)
         make_centroids = self.store_centers in ("centroid", "both")
         make_medoids = self.store_centers in ("medoid", "both")

--- a/sklearn/cluster/_hdbscan/hdbscan.py
+++ b/sklearn/cluster/_hdbscan/hdbscan.py
@@ -864,9 +864,6 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
 
         self._single_linkage_tree_ = mst_func(**kwargs)
 
-        from joblib import hash
-
-        print(hash(self._single_linkage_tree_))
         self.labels_, self.probabilities_ = tree_to_labels(
             self._single_linkage_tree_,
             self.min_cluster_size,
@@ -941,7 +938,6 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
         """
         # Number of non-noise clusters
         n_clusters = len(set(self.labels_) - {-1, -2})
-        print(f"{n_clusters=}")
         mask = np.empty((X.shape[0],), dtype=np.bool_)
         make_centroids = self.store_centers in ("centroid", "both")
         make_medoids = self.store_centers in ("medoid", "both")

--- a/sklearn/cluster/tests/test_hdbscan.py
+++ b/sklearn/cluster/tests/test_hdbscan.py
@@ -307,10 +307,6 @@ def test_hdbscan_centers(algorithm):
     H, _ = make_blobs(n_samples=2000, random_state=0, centers=centers, cluster_std=0.5)
     hdb = HDBSCAN(store_centers="both").fit(H)
 
-    print(set(hdb.labels_))
-    print(f"{centers=}")
-    print(f"{hdb.centroids_=}")
-
     for center, centroid, medoid in zip(centers, hdb.centroids_, hdb.medoids_):
         assert_allclose(center, centroid, rtol=1, atol=0.05)
         assert_allclose(center, medoid, rtol=1, atol=0.05)

--- a/sklearn/cluster/tests/test_hdbscan.py
+++ b/sklearn/cluster/tests/test_hdbscan.py
@@ -307,6 +307,10 @@ def test_hdbscan_centers(algorithm):
     H, _ = make_blobs(n_samples=1000, random_state=0, centers=centers, cluster_std=0.5)
     hdb = HDBSCAN(store_centers="both").fit(H)
 
+    print(set(hdb.labels_))
+    print(f"{centers=}")
+    print(f"{hdb.centroids_=}")
+
     for center, centroid, medoid in zip(centers, hdb.centroids_, hdb.medoids_):
         assert_allclose(center, centroid, rtol=1, atol=0.05)
         assert_allclose(center, medoid, rtol=1, atol=0.05)

--- a/sklearn/cluster/tests/test_hdbscan.py
+++ b/sklearn/cluster/tests/test_hdbscan.py
@@ -304,7 +304,7 @@ def test_hdbscan_centers(algorithm):
     accurate to the data.
     """
     centers = [(0.0, 0.0), (3.0, 3.0)]
-    H, _ = make_blobs(n_samples=1000, random_state=0, centers=centers, cluster_std=0.5)
+    H, _ = make_blobs(n_samples=2000, random_state=0, centers=centers, cluster_std=0.5)
     hdb = HDBSCAN(store_centers="both").fit(H)
 
     print(set(hdb.labels_))

--- a/sklearn/datasets/_species_distributions.py
+++ b/sklearn/datasets/_species_distributions.py
@@ -103,7 +103,7 @@ def _load_csv(F):
     """
     names = F.readline().decode("ascii").strip().split(",")
 
-    rec = np.loadtxt(F, skiprows=0, delimiter=",", dtype="a22,f4,f4")
+    rec = np.loadtxt(F, skiprows=0, delimiter=",", dtype="S22,f4,f4")
     rec.dtype.names = names
     return rec
 


### PR DESCRIPTION
This fixes a DeprecationWarning in Numpy 2.0 `a` -> `S`. There may be other errors since scipy-dev has not been run without errors for a while ...

Close https://github.com/scikit-learn/scikit-learn/issues/28194.