### PR TITLE
CI Moves macos arm64 wheel building to GitHub Actions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -129,11 +129,20 @@ jobs:
       - name: Install conda for macos arm64
         if: ${{ matrix.platform_id == 'macosx_arm64' }}
         run: |
+          set -ex
           # macos arm64 runners do not have conda installed. Thus we much install conda manually
+          EXPECTED_SHA ="dd832d8a65a861b5592b2cf1d55f26031f7c1491b30321754443931e7b1e6832"
           MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/download/23.11.0-0/Mambaforge-23.11.0-0-MacOSX-arm64.sh"
+          curl -L --retry 10 $MINIFORGE_URL -o miniforge.sh
+
+          # Check SHA
+          file_hash=$(shasum -a 256 miniforge.sh | awk '{print $1}')
+          if [ "$EXPECTED_SHA" != "$file_sha" ]; then
+              echo "SHA values did not match!"
+              exit 1
+          fi
 
           # Install miniforge
-          curl -L --retry 10 $MINIFORGE_URL -o miniforge.sh
           MINIFORGE_PATH=$HOME/miniforge
           bash ./miniforge.sh -b -p $MINIFORGE_PATH
           echo "$MINIFORGE_PATH/bin" >> $GITHUB_PATH

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -129,6 +129,7 @@ jobs:
       - name: Install conda for macos arm64
         if: ${{ matrix.platform_id == 'macosx_arm64' }}
         run: |
+          # macos arm64 runners do not have conda installed. Thus we much install conda manually
           MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/download/23.11.0-0/Mambaforge-23.11.0-0-MacOSX-arm64.sh"
 
           # Install miniforge
@@ -148,7 +149,7 @@ jobs:
         env:
           CIBW_PRERELEASE_PYTHONS: ${{ matrix.prerelease }}
           CIBW_ENVIRONMENT: SKLEARN_SKIP_NETWORK_TESTS=1
-                            SKLEARN_BUILD_PARALLEL=3
+            SKLEARN_BUILD_PARALLEL=3
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
           CIBW_ARCHS: all
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
@@ -190,7 +191,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'  # update once build dependencies are available
+          python-version: "3.9" # update once build dependencies are available
 
       - name: Build source distribution
         run: bash build_tools/github/build_source.sh

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -136,7 +136,7 @@ jobs:
           curl -L --retry 10 $MINIFORGE_URL -o miniforge.sh
 
           # Check SHA
-          file_hash=$(shasum -a 256 miniforge.sh | awk '{print $1}')
+          file_sha=$(shasum -a 256 miniforge.sh | awk '{print $1}')
           if [ "$EXPECTED_SHA" != "$file_sha" ]; then
               echo "SHA values did not match!"
               exit 1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -104,18 +104,17 @@ jobs:
             platform_id: macosx_x86_64
 
           # MacOS arm64
-          # The wheel for the latest Python version is built and tested on
-          # Cirrus CI but due to limited build time for free accounts on Cirrus
-          # CI, we build the macOS arm64 wheels for the other Python versions on
-          # Github Actions via cross-compilation (without running the tests).
           - os: macos-latest
             python: 39
             platform_id: macosx_arm64
           - os: macos-latest
             python: 310
             platform_id: macosx_arm64
-          - os: macos-latest
+          - os: macos-14
             python: 311
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 312
             platform_id: macosx_arm64
 
     steps:
@@ -125,7 +124,25 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'  # update once build dependencies are available
+          python-version: "3.11" # update once build dependencies are available
+
+      - name: Install conda for macos arm64
+        if: ${{ matrix.platform_id == 'macosx_arm64' }}
+        run: |
+          MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/download/23.11.0-0/Mambaforge-23.11.0-0-MacOSX-arm64.sh"
+
+          # Install miniforge
+          curl -L --retry 10 $MINIFORGE_URL -o miniforge.sh
+          MINIFORGE_PATH=$HOME/miniforge
+          bash ./miniforge.sh -b -p $MINIFORGE_PATH
+          echo "$MINIFORGE_PATH/bin" >> $GITHUB_PATH
+          echo "CONDA_HOME=$MINIFORGE_PATH" >> $GITHUB_ENV
+
+      - name: Set conda environment for non-macos arm64 environments
+        if: ${{ matrix.platform_id != 'macosx_arm64' }}
+        run: |
+          # Non-macos arm64 envrionments already have conda installed
+          echo "CONDA_HOME=/usr/local/miniconda" >> $GITHUB_ENV
 
       - name: Build and test wheels
         env:
@@ -136,14 +153,12 @@ jobs:
           CIBW_ARCHS: all
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.manylinux_image }}
-          CIBW_TEST_SKIP: "*-macosx_arm64"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: bash build_tools/github/repair_windows_wheels.sh {wheel} {dest_dir}
           CIBW_BEFORE_TEST_WINDOWS: bash build_tools/github/build_minimal_windows_image.sh ${{ matrix.python }}
           CIBW_TEST_REQUIRES: pytest pandas threadpoolctl
           CIBW_TEST_COMMAND: bash {project}/build_tools/wheels/test_wheels.sh
           CIBW_TEST_COMMAND_WINDOWS: bash {project}/build_tools/github/test_windows_wheels.sh ${{ matrix.python }}
           CIBW_BUILD_VERBOSITY: 1
-          CONDA_HOME: /usr/local/miniconda
 
         run: bash build_tools/wheels/build_wheels.sh
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -104,10 +104,10 @@ jobs:
             platform_id: macosx_x86_64
 
           # MacOS arm64
-          - os: macos-latest
+          - os: macos-14
             python: 39
             platform_id: macosx_arm64
-          - os: macos-latest
+          - os: macos-14
             python: 310
             platform_id: macosx_arm64
           - os: macos-14

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           set -ex
           # macos arm64 runners do not have conda installed. Thus we much install conda manually
-          EXPECTED_SHA ="dd832d8a65a861b5592b2cf1d55f26031f7c1491b30321754443931e7b1e6832"
+          EXPECTED_SHA="dd832d8a65a861b5592b2cf1d55f26031f7c1491b30321754443931e7b1e6832"
           MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/download/23.11.0-0/Mambaforge-23.11.0-0-MacOSX-arm64.sh"
           curl -L --retry 10 $MINIFORGE_URL -o miniforge.sh
 
@@ -158,7 +158,7 @@ jobs:
         env:
           CIBW_PRERELEASE_PYTHONS: ${{ matrix.prerelease }}
           CIBW_ENVIRONMENT: SKLEARN_SKIP_NETWORK_TESTS=1
-                            SKLEARN_BUILD_PARALLEL=3
+            SKLEARN_BUILD_PARALLEL=3
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
           CIBW_ARCHS: all
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
@@ -200,7 +200,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'  # update once build dependencies are available
+          python-version: "3.9" # update once build dependencies are available
 
       - name: Build source distribution
         run: bash build_tools/github/build_source.sh

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -149,7 +149,7 @@ jobs:
         env:
           CIBW_PRERELEASE_PYTHONS: ${{ matrix.prerelease }}
           CIBW_ENVIRONMENT: SKLEARN_SKIP_NETWORK_TESTS=1
-            SKLEARN_BUILD_PARALLEL=3
+                            SKLEARN_BUILD_PARALLEL=3
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
           CIBW_ARCHS: all
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
@@ -191,7 +191,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9" # update once build dependencies are available
+          python-version: '3.9'  # update once build dependencies are available
 
       - name: Build source distribution
         run: bash build_tools/github/build_source.sh

--- a/build_tools/cirrus/arm_wheel.yml
+++ b/build_tools/cirrus/arm_wheel.yml
@@ -1,43 +1,3 @@
-macos_arm64_wheel_task:
-  macos_instance:
-    image: ghcr.io/cirruslabs/macos-monterey-xcode
-  env:
-    CIBW_ENVIRONMENT: SKLEARN_SKIP_NETWORK_TESTS=1
-                      SKLEARN_BUILD_PARALLEL=5
-    CIBW_TEST_COMMAND: bash {project}/build_tools/wheels/test_wheels.sh
-    CIBW_TEST_REQUIRES: pytest pandas threadpoolctl pytest-xdist
-    CIBW_BUILD_VERBOSITY: 1
-    PATH: $HOME/mambaforge/bin/:$PATH
-    CONDA_HOME: $HOME/mambaforge
-    # Upload tokens have been encrypted via the CirrusCI interface:
-    # https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables
-    # See `maint_tools/update_tracking_issue.py` for details on the permissions the token requires.
-    BOT_GITHUB_TOKEN: ENCRYPTED[9b50205e2693f9e4ce9a3f0fcb897a259289062fda2f5a3b8aaa6c56d839e0854a15872f894a70fca337dd4787274e0f]
-  matrix:
-    # Only the latest Python version is built and tested on Cirrus CI, the other
-    # macOS arm64 builds are on GitHub Actions. The reason is that macOS time is
-    # 5x more expensive than Linux times on Cirrus CI and the credits are limited
-    # (for free accounts).
-    # Note that the macOS arm64 builds are cross compiled on GitHub Actions (without
-    # running the tests) and while the macOS arm64 build for the latest Python version
-    # is actually tested on Cirrus CI.
-    - env:
-        CIBW_BUILD: cp312-macosx_arm64
-
-  conda_script:
-    - curl -L --retry 10 -o ~/mambaforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh
-    - bash ~/mambaforge.sh -b -p ~/mambaforge
-
-  cibuildwheel_script:
-    - bash build_tools/wheels/build_wheels.sh
-
-  on_failure:
-    update_tracker_script:
-      - bash build_tools/cirrus/update_tracking_issue.sh false
-
-  wheels_artifacts:
-    path: "wheelhouse/*"
-
 linux_arm64_wheel_task:
   compute_engine_instance:
     image_project: cirrus-images
@@ -84,7 +44,6 @@ linux_arm64_wheel_task:
 # Update tracker when all jobs are successful
 update_tracker_success:
   depends_on:
-    - macos_arm64_wheel
     - linux_arm64_wheel
   container:
     image: python:3.11
@@ -95,7 +54,6 @@ update_tracker_success:
 
 wheels_upload_task:
   depends_on:
-    - macos_arm64_wheel
     - linux_arm64_wheel
   container:
     image: continuumio/miniconda3:22.11.1


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes https://github.com/scikit-learn/scikit-learn/issues/28325


#### What does this implement/fix? Explain your changes.
This PR migrates the macos arm64 wheel builder from CirrusCI to GitHub Actions.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
