### PR TITLE
CI Update codecov uploader to 0.7.1

### DIFF
--- a/build_tools/azure/upload_codecov.sh
+++ b/build_tools/azure/upload_codecov.sh
@@ -42,16 +42,16 @@ if [[ $OSTYPE == *"linux"* ]]; then
     SHA256SUM="b9282b8b43eef83f722646d8992c4dd36563046afe0806722184e7e9923a6d7b  codecov"
     echo "$SHA256SUM" | shasum -a256 -c
     chmod +x codecov
-    ./codecov -t ${CODECOV_TOKEN} -R $BUILD_REPOSITORY_LOCALPATH -f coverage.xml -Z
+    ./codecov -t ${CODECOV_TOKEN} -R $BUILD_REPOSITORY_LOCALPATH -f coverage.xml -Z --verbose
 elif [[ $OSTYPE == *"darwin"* ]]; then
     curl -Os "$CODECOV_BASE_URL/macos/codecov"
     SHA256SUM="e4ce34c144d3195eccb7f8b9ca8de092d2a4be114d927ca942500f3a6326225c  codecov"
     echo "$SHA256SUM" | shasum -a256 -c
     chmod +x codecov
-    ./codecov -t ${CODECOV_TOKEN} -R $BUILD_REPOSITORY_LOCALPATH -f coverage.xml -Z
+    ./codecov -t ${CODECOV_TOKEN} -R $BUILD_REPOSITORY_LOCALPATH -f coverage.xml -Z --verbose
 else
     curl -Os "$CODECOV_BASE_URL/windows/codecov.exe"
     SHA256SUM="f5de88026f061ff08b88a5895f9c11855523924ceb8174e027403dd20fa5e4d6  codecov.exe"
     echo "$SHA256SUM" | sha256sum -c
-    ./codecov.exe -t ${CODECOV_TOKEN} -R $BUILD_REPOSITORY_LOCALPATH -f coverage.xml -Z
+    ./codecov.exe -t ${CODECOV_TOKEN} -R $BUILD_REPOSITORY_LOCALPATH -f coverage.xml -Z --verbose
 fi

--- a/build_tools/azure/upload_codecov.sh
+++ b/build_tools/azure/upload_codecov.sh
@@ -10,7 +10,7 @@ fi
 # When we update the codecov uploader version, we need to update the checksums.
 # The checksum for each codecov binary is available at
 # https://uploader.codecov.io e.g. for linux
-# https://uploader.codecov.io/v0.4.1/linux/codecov.SHA256SUM.
+# https://uploader.codecov.io/v0.7.1/linux/codecov.SHA256SUM.
 
 # Instead of hardcoding a specific version and signature in this script, it
 # would be possible to use the "latest" symlink URL but then we need to
@@ -20,7 +20,7 @@ fi
 # However this approach would yield a larger number of downloads from
 # codecov.io and keybase.io, therefore increasing the risk of running into
 # network failures.
-CODECOV_UPLOADER_VERSION=0.4.1
+CODECOV_UPLOADER_VERSION=0.7.1
 CODECOV_BASE_URL="https://uploader.codecov.io/v$CODECOV_UPLOADER_VERSION"
 
 
@@ -39,19 +39,19 @@ fi
 
 if [[ $OSTYPE == *"linux"* ]]; then
     curl -Os "$CODECOV_BASE_URL/linux/codecov"
-    SHA256SUM="32cb14b5f3aaacd67f4c1ff55d82f037d3cd10c8e7b69c051f27391d2e66e15c  codecov"
+    SHA256SUM="b9282b8b43eef83f722646d8992c4dd36563046afe0806722184e7e9923a6d7b  codecov"
     echo "$SHA256SUM" | shasum -a256 -c
     chmod +x codecov
     ./codecov -t ${CODECOV_TOKEN} -R $BUILD_REPOSITORY_LOCALPATH -f coverage.xml -Z
 elif [[ $OSTYPE == *"darwin"* ]]; then
     curl -Os "$CODECOV_BASE_URL/macos/codecov"
-    SHA256SUM="4ab0f06f06e9c4d25464f155b0aff36bfc1e8dbcdb19bfffd586beed1269f3af  codecov"
+    SHA256SUM="e4ce34c144d3195eccb7f8b9ca8de092d2a4be114d927ca942500f3a6326225c  codecov"
     echo "$SHA256SUM" | shasum -a256 -c
     chmod +x codecov
     ./codecov -t ${CODECOV_TOKEN} -R $BUILD_REPOSITORY_LOCALPATH -f coverage.xml -Z
 else
     curl -Os "$CODECOV_BASE_URL/windows/codecov.exe"
-    SHA256SUM="e0cda212aeaebe695509ce8fa2d608760ff70bc932003f544f1ad368ac5450a8 codecov.exe"
+    SHA256SUM="f5de88026f061ff08b88a5895f9c11855523924ceb8174e027403dd20fa5e4d6  codecov.exe"
     echo "$SHA256SUM" | sha256sum -c
     ./codecov.exe -t ${CODECOV_TOKEN} -R $BUILD_REPOSITORY_LOCALPATH -f coverage.xml -Z
 fi


### PR DESCRIPTION
This may get rid of some codecov upload issues that we see from time to time. 

For example retry is done in more cases here https://github.com/codecov/uploader/pull/1203, which is released in 0.6.3 and we use 0.4.1.

The kind of errors that were seen in https://github.com/scikit-learn/scikit-learn/pull/28348:

```
Codecov report uploader 0.4.1
[2024-02-05T08:23:29.118Z] ['info'] => Project root located at: /home/vsts/work/1/s
[2024-02-05T08:23:29.122Z] ['info'] ->  Token found by arguments
[2024-02-05T08:23:29.136Z] ['info'] Searching for coverage files...
[2024-02-05T08:23:29.305Z] ['info'] => Found 1 possible coverage files:
  coverage.xml
[2024-02-05T08:23:29.306Z] ['info'] Processing /home/vsts/work/1/s/coverage.xml...
[2024-02-05T08:23:29.386Z] ['info'] Detected Azure Pipelines as the CI provider.
[2024-02-05T08:23:29.396Z] ['info']     Fixing merge commit SHA a1e9563299b3d02eaccd4d1231c826beeb1b064d -> 92f7a58fb1fc8d5c889d61c550f9b783a0c71c9a
[2024-02-05T08:23:29.399Z] ['info'] Pinging Codecov: https://codecov.io/upload/v4?package=uploader-0.4.1&token=*******&branch=refs%2Fpull%2F28348%2Fmerge&build=20240205.7&build_url=https%3A%2F%2Fdev.azure.com%2Fscikit-learn%2Fscikit-learn%2F_build%2Fresults%3FbuildId%3D63528&commit=92f7a58fb1fc8d5c889d61c550f9b783a0c71c9a&job=63528&pr=28348&project=scikit-learn&server_uri=https%3A%2F%2Fdev.azure.com%2Fscikit-learn%2F&service=azure_pipelines&slug=scikit-learn%2Fscikit-learn&name=&tag=&flags=&parent=
[2024-02-05T08:23:59.581Z] ['error'] There was an error running the uploader: Error uploading to https://codecov.io/: Error: There was an error fetching the storage URL during POST: 502 - 
<html><head>
<meta http-equiv="content-type" content="text/html;charset=utf-8">
<title>502 Server Error</title>
</head>
<body text=#000000 bgcolor=#ffffff>
<h1>Error: Server Error</h1>
<h2>The server encountered a temporary error and could not complete your request.<p>Please try again in 30 seconds.</h2>
<h2></h2>
</body></html>
```

```
Codecov report uploader 0.4.1
[2024-02-05T08:30:09.558Z] ['info'] => Project root located at: /home/vsts/work/1/s
[2024-02-05T08:30:09.561Z] ['info'] ->  Token found by arguments
[2024-02-05T08:30:09.574Z] ['info'] Searching for coverage files...
[2024-02-05T08:30:09.686Z] ['info'] => Found 1 possible coverage files:
  coverage.xml
[2024-02-05T08:30:09.687Z] ['info'] Processing /home/vsts/work/1/s/coverage.xml...
[2024-02-05T08:30:09.761Z] ['info'] Detected Azure Pipelines as the CI provider.
[2024-02-05T08:30:09.770Z] ['info']     Fixing merge commit SHA a1e9563299b3d02eaccd4d1231c826beeb1b064d -> 92f7a58fb1fc8d5c889d61c550f9b783a0c71c9a
[2024-02-05T08:30:09.772Z] ['info'] Pinging Codecov: https://codecov.io/upload/v4?package=uploader-0.4.1&token=*******&branch=refs%2Fpull%2F28348%2Fmerge&build=20240205.7&build_url=https%3A%2F%2Fdev.azure.com%2Fscikit-learn%2Fscikit-learn%2F_build%2Fresults%3FbuildId%3D63528&commit=92f7a58fb1fc8d5c889d61c550f9b783a0c71c9a&job=63528&pr=28348&project=scikit-learn&server_uri=https%3A%2F%2Fdev.azure.com%2Fscikit-learn%2F&service=azure_pipelines&slug=scikit-learn%2Fscikit-learn&name=&tag=&flags=&parent=
[2024-02-05T08:30:12.934Z] ['error'] There was an error running the uploader: Error uploading to https://codecov.io/: Error: There was an error fetching the storage URL during POST: 503 - upstream connect error or disconnect/reset before headers. reset reason: connection failure
```

