### PR TITLE
FIX `EmptyRequest.get` defaults to `Bunch` of `METHODS`

### DIFF
--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1490,3 +1490,19 @@ def test_make_scorer_deprecation(deprecated_params, new_params, warn_msg):
     assert deprecated_roc_auc_scorer(classifier, X, y) == pytest.approx(
         roc_auc_scorer(classifier, X, y)
     )
+
+
+def test_metadata_routing_multimetric_behaves_equally_with_and_without_routing():
+    """Test multimetric scorer works with and without metadata routing enabled.
+
+    Non-regression test for https://github.com/scikit-learn/scikit-learn/issues/28256
+    """
+    X, y = make_classification(n_samples=50, n_features=10, random_state=0)
+    estimator = EstimatorWithFitAndPredict().fit(X, y)
+
+    multimetric_scorer = _MultimetricScorer(scorers={"acc": get_scorer("accuracy")})
+    with config_context(enable_metadata_routing=True):
+        multimetric_scorer(estimator, X, y)
+
+    with config_context(enable_metadata_routing=False):
+        multimetric_scorer(estimator, X, y)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1492,7 +1492,8 @@ def test_make_scorer_deprecation(deprecated_params, new_params, warn_msg):
     )
 
 
-def test_metadata_routing_multimetric_without_metadata_works_with_and_without_routing():
+@pytest.mark.parametrize("enable_metadata_routing", [True, False])
+def test_metadata_routing_multimetric_metadata_routing(enable_metadata_routing):
     """Test multimetric scorer works with and without metadata routing enabled when
     there is no actual metadata to pass.
 
@@ -1502,8 +1503,5 @@ def test_metadata_routing_multimetric_without_metadata_works_with_and_without_ro
     estimator = EstimatorWithFitAndPredict().fit(X, y)
 
     multimetric_scorer = _MultimetricScorer(scorers={"acc": get_scorer("accuracy")})
-    with config_context(enable_metadata_routing=True):
-        multimetric_scorer(estimator, X, y)
-
-    with config_context(enable_metadata_routing=False):
+    with config_context(enable_metadata_routing=enable_metadata_routing):
         multimetric_scorer(estimator, X, y)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1492,8 +1492,9 @@ def test_make_scorer_deprecation(deprecated_params, new_params, warn_msg):
     )
 
 
-def test_metadata_routing_multimetric_behaves_equally_with_and_without_routing():
-    """Test multimetric scorer works with and without metadata routing enabled.
+def test_metadata_routing_multimetric_without_metadata_works_with_and_without_routing():
+    """Test multimetric scorer works with and without metadata routing enabled when
+    there is no actual metadata to pass.
 
     Non-regression test for https://github.com/scikit-learn/scikit-learn/issues/28256
     """

--- a/sklearn/tests/test_metadata_routing.py
+++ b/sklearn/tests/test_metadata_routing.py
@@ -30,7 +30,6 @@ from sklearn.tests.metadata_routing_common import (
     assert_request_is_empty,
     check_recorded_metadata,
 )
-from sklearn.utils._bunch import Bunch
 from sklearn.utils import metadata_routing
 from sklearn.utils._metadata_requests import (
     COMPOSITE_METHODS,

--- a/sklearn/tests/test_metadata_routing.py
+++ b/sklearn/tests/test_metadata_routing.py
@@ -245,20 +245,20 @@ def test_process_routing_empty_params_get_with_default():
 
     # Behaviour should be an empty dictionary returned for each method when retrieved.
     for method in METHODS:
+        # This behaviour should be equivalent with using `get` with no default
         params_for_method = routed_params[method]
 
         # An empty dictionary for each method
         assert isinstance(params_for_method, dict)
         assert set(params_for_method.keys()) == set(METHODS)
 
-        # This behaviour should be equivalent with using `get` with no default
-        assert routed_params.get(method) == params_for_method
+        default_params_for_method = routed_params.get(method)
+        assert default_params_for_method == params_for_method
 
         # However, with a default, should return that instead.
         assert routed_params.get(method, default="default") == "default"
-
-        # This would fail due to use of `if not default` instead of `if default is None`
-        # assert routed_params.get(method, default=[]) == []
+        assert routed_params.get(method, default=[]) == []
+        assert routed_params.get(method, default=None) is None
 
 
 def test_simple_metadata_routing():

--- a/sklearn/tests/test_metadata_routing.py
+++ b/sklearn/tests/test_metadata_routing.py
@@ -15,7 +15,9 @@ from sklearn.base import (
     BaseEstimator,
     clone,
 )
+from sklearn.dummy import DummyClassifier
 from sklearn.linear_model import LinearRegression
+from sklearn.metrics._scorer import _MultimetricScorer, get_scorer
 from sklearn.tests.metadata_routing_common import (
     ConsumingClassifier,
     ConsumingRegressor,
@@ -990,3 +992,18 @@ def test_no_metadata_always_works():
         NotImplementedError, match="Estimator has not implemented metadata routing yet."
     ):
         MetaRegressor(estimator=Estimator()).fit(X, y, metadata=my_groups)
+
+
+def test_metadata_routing_multimetric_behaves_equally_with_and_without_routing():
+    """Test multimetric scorer works with and without metadata routing enabled.
+
+    Non-regression test for https://github.com/scikit-learn/scikit-learn/issues/28256
+    """
+
+    multimetric_scorer = _MultimetricScorer(scorers={"acc": get_scorer("accuracy")})
+    estimator = DummyClassifier().fit(X, y)
+    with config_context(enable_metadata_routing=True):
+        multimetric_scorer(estimator, X, y)
+
+    with config_context(enable_metadata_routing=False):
+        multimetric_scorer(estimator, X, y)

--- a/sklearn/tests/test_metadata_routing.py
+++ b/sklearn/tests/test_metadata_routing.py
@@ -249,7 +249,7 @@ def test_process_routing_empty_params_get_with_default():
 
         # An empty dictionary for each method
         assert isinstance(params_for_method, dict)
-        assert len(params_for_method) == 0
+        assert set(params_for_method.keys()) == set(METHODS)
 
         # This behaviour should be equivalent with using `get` with no default
         assert routed_params.get(method) == params_for_method

--- a/sklearn/tests/test_metadata_routing.py
+++ b/sklearn/tests/test_metadata_routing.py
@@ -245,20 +245,19 @@ def test_process_routing_empty_params_get_with_default():
 
     # Behaviour should be an empty dictionary returned for each method when retrieved.
     for method in METHODS:
-        # This behaviour should be equivalent with using `get` with no default
         params_for_method = routed_params[method]
 
         # An empty dictionary for each method
         assert isinstance(params_for_method, dict)
         assert set(params_for_method.keys()) == set(METHODS)
 
+        # No default to `get` should be equivalent to the default
         default_params_for_method = routed_params.get(method)
         assert default_params_for_method == params_for_method
 
-        # However, with a default, should return that instead.
-        assert routed_params.get(method, default="default") == "default"
-        assert routed_params.get(method, default=[]) == []
-        assert routed_params.get(method, default=None) is None
+        # Default to `get` is ignored and equivalent to the default
+        default_params_for_method = routed_params.get(method, default="default")
+        assert default_params_for_method == params_for_method
 
 
 def test_simple_metadata_routing():

--- a/sklearn/tests/test_metadata_routing.py
+++ b/sklearn/tests/test_metadata_routing.py
@@ -239,25 +239,20 @@ def test_process_routing_invalid_object():
         process_routing(InvalidObject(), "fit", groups=my_groups)
 
 
-def test_process_routing_empty_params_get_with_default():
+@pytest.mark.parametrize("method", METHODS)
+@pytest.mark.parametrize("default", [None, "default", []])
+def test_process_routing_empty_params_get_with_default(method, default):
     empty_params = {}
     routed_params = process_routing(ConsumingClassifier(), "fit", **empty_params)
 
     # Behaviour should be an empty dictionary returned for each method when retrieved.
-    for method in METHODS:
-        params_for_method = routed_params[method]
+    params_for_method = routed_params[method]
+    assert isinstance(params_for_method, dict)
+    assert set(params_for_method.keys()) == set(METHODS)
 
-        # An empty dictionary for each method
-        assert isinstance(params_for_method, dict)
-        assert set(params_for_method.keys()) == set(METHODS)
-
-        # No default to `get` should be equivalent to the default
-        default_params_for_method = routed_params.get(method)
-        assert default_params_for_method == params_for_method
-
-        # Default to `get` is ignored and equivalent to the default
-        default_params_for_method = routed_params.get(method, default="default")
-        assert default_params_for_method == params_for_method
+    # No default to `get` should be equivalent to the default
+    default_params_for_method = routed_params.get(method, default=default)
+    assert default_params_for_method == params_for_method
 
 
 def test_simple_metadata_routing():

--- a/sklearn/tests/test_metadata_routing.py
+++ b/sklearn/tests/test_metadata_routing.py
@@ -15,9 +15,7 @@ from sklearn.base import (
     BaseEstimator,
     clone,
 )
-from sklearn.dummy import DummyClassifier
 from sklearn.linear_model import LinearRegression
-from sklearn.metrics._scorer import _MultimetricScorer, get_scorer
 from sklearn.tests.metadata_routing_common import (
     ConsumingClassifier,
     ConsumingRegressor,
@@ -992,18 +990,3 @@ def test_no_metadata_always_works():
         NotImplementedError, match="Estimator has not implemented metadata routing yet."
     ):
         MetaRegressor(estimator=Estimator()).fit(X, y, metadata=my_groups)
-
-
-def test_metadata_routing_multimetric_behaves_equally_with_and_without_routing():
-    """Test multimetric scorer works with and without metadata routing enabled.
-
-    Non-regression test for https://github.com/scikit-learn/scikit-learn/issues/28256
-    """
-
-    multimetric_scorer = _MultimetricScorer(scorers={"acc": get_scorer("accuracy")})
-    estimator = DummyClassifier().fit(X, y)
-    with config_context(enable_metadata_routing=True):
-        multimetric_scorer(estimator, X, y)
-
-    with config_context(enable_metadata_routing=False):
-        multimetric_scorer(estimator, X, y)

--- a/sklearn/tests/test_metadata_routing.py
+++ b/sklearn/tests/test_metadata_routing.py
@@ -30,6 +30,7 @@ from sklearn.tests.metadata_routing_common import (
     assert_request_is_empty,
     check_recorded_metadata,
 )
+from sklearn.utils._bunch import Bunch
 from sklearn.utils import metadata_routing
 from sklearn.utils._metadata_requests import (
     COMPOSITE_METHODS,
@@ -237,6 +238,28 @@ def test_process_routing_invalid_object():
 
     with pytest.raises(AttributeError, match="either implement the routing method"):
         process_routing(InvalidObject(), "fit", groups=my_groups)
+
+
+def test_process_routing_empty_params_get_with_default():
+    empty_params = {}
+    routed_params = process_routing(ConsumingClassifier(), "fit", **empty_params)
+
+    # Behaviour should be an empty dictionary returned for each method when retrieved.
+    for method in METHODS:
+        params_for_method = routed_params[method]
+
+        # An empty dictionary for each method
+        assert isinstance(params_for_method, dict)
+        assert len(params_for_method) == 0
+
+        # This behaviour should be equivalent with using `get` with no default
+        assert routed_params.get(method) == params_for_method
+
+        # However, with a default, should return that instead.
+        assert routed_params.get(method, default="default") == "default"
+
+        # This would fail due to use of `if not default` instead of `if default is None`
+        # assert routed_params.get(method, default=[]) == []
 
 
 def test_simple_metadata_routing():

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -115,6 +115,9 @@ COMPOSITE_METHODS = {
 
 METHODS = SIMPLE_METHODS + list(COMPOSITE_METHODS.keys())
 
+# Used as a sentinel value to indicate nothing was passed.
+_MISSING = object()
+
 
 def _routing_enabled():
     """Return whether metadata routing is enabled.

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -1532,8 +1532,8 @@ def process_routing(_obj, _method, /, **kwargs):
         # try doing any routing, we can simply return a structure which returns
         # an empty dict on routed_params.ANYTHING.ANY_METHOD.
         class EmptyRequest:
-            def get(self, name, default=None):
-                if not default:
+            def get(self, name, default=_MISSING):
+                if default is _MISSING:
                     return Bunch(**{method: dict() for method in METHODS})
 
                 return default

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -115,9 +115,6 @@ COMPOSITE_METHODS = {
 
 METHODS = SIMPLE_METHODS + list(COMPOSITE_METHODS.keys())
 
-# Used as a sentinel value to indicate nothing was passed.
-_MISSING = object()
-
 
 def _routing_enabled():
     """Return whether metadata routing is enabled.
@@ -1085,8 +1082,12 @@ class MetadataRouter:
 
     def __iter__(self):
         if self._self_request:
-            yield "$self_request", RouterMappingPair(
-                mapping=MethodMapping.from_str("one-to-one"), router=self._self_request
+            yield (
+                "$self_request",
+                RouterMappingPair(
+                    mapping=MethodMapping.from_str("one-to-one"),
+                    router=self._self_request,
+                ),
             )
         for name, route_mapping in self._route_mappings.items():
             yield (name, route_mapping)
@@ -1532,11 +1533,8 @@ def process_routing(_obj, _method, /, **kwargs):
         # try doing any routing, we can simply return a structure which returns
         # an empty dict on routed_params.ANYTHING.ANY_METHOD.
         class EmptyRequest:
-            def get(self, name, default=_MISSING):
-                if default is _MISSING:
-                    return Bunch(**{method: dict() for method in METHODS})
-
-                return default
+            def get(self, name, default=None):
+                return Bunch(**{method: dict() for method in METHODS})
 
             def __getitem__(self, name):
                 return Bunch(**{method: dict() for method in METHODS})

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -1530,7 +1530,10 @@ def process_routing(_obj, _method, /, **kwargs):
         # an empty dict on routed_params.ANYTHING.ANY_METHOD.
         class EmptyRequest:
             def get(self, name, default=None):
-                return default if default else {}
+                if not default:
+                    return Bunch(**{method: dict() for method in METHODS})
+
+                return default
 
             def __getitem__(self, name):
                 return Bunch(**{method: dict() for method in METHODS})


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #28370

#### What does this implement/fix? Explain your changes.
This makes the `process_routing` behave _equally_ if `sklearn.config(enable_metadata_routing=True)` or `False`. Please see the reference issue for more information. 

#### Any other comments?
I could not run all tests locally, I am hoping to rely on the automated test runners. The changes attempted were trying to be minimal.

One other comment would be to change `get()` to check explicitly on `default is None` rather than implicit falsyness as things like `get(name, default=[])` would not work as it stands. 