### PR TITLE
CI Use environment variable to turn warnings into errors in tests and doc build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,9 @@ jobs:
       - OPENBLAS_NUM_THREADS: 2
       - CONDA_ENV_NAME: testenv
       - LOCK_FILE: build_tools/circle/doc_min_dependencies_linux-64_conda.lock
-      # Do not fail if the documentation build generates warnings
+      # Do not fail if the documentation build generates warnings with minimum
+      # dependencies as long as we can avoid raising warnings with more recent
+      # versions of the same dependencies.
       - SKLEARN_WARNINGS_AS_ERRORS: '0'
     steps:
       - checkout
@@ -60,7 +62,8 @@ jobs:
       - OPENBLAS_NUM_THREADS: 2
       - CONDA_ENV_NAME: testenv
       - LOCK_FILE: build_tools/circle/doc_linux-64_conda.lock
-      # Make sure that we fail if the documentation build generates warnings
+      # Make sure that we fail if the documentation build generates warnings with
+      # recent versions of the dependencies.
       - SKLEARN_WARNINGS_AS_ERRORS: '1'
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - CONDA_ENV_NAME: testenv
       - LOCK_FILE: build_tools/circle/doc_min_dependencies_linux-64_conda.lock
       # Do not fail if the documentation build generates warnings
-      - SKLEARN_DOC_BUILD_WARNINGS_AS_ERRORS: 'false'
+      - SKLEARN_WARNINGS_AS_ERRORS: '0'
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh
@@ -61,7 +61,7 @@ jobs:
       - CONDA_ENV_NAME: testenv
       - LOCK_FILE: build_tools/circle/doc_linux-64_conda.lock
       # Make sure that we fail if the documentation build generates warnings
-      - SKLEARN_DOC_BUILD_WARNINGS_AS_ERRORS: 'true'
+      - SKLEARN_WARNINGS_AS_ERRORS: '1'
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ jobs:
       pylatest_pip_scipy_dev:
         DISTRIB: 'conda-pip-scipy-dev'
         LOCK_FILE: './build_tools/azure/pylatest_pip_scipy_dev_linux-64_conda.lock'
-        CHECK_WARNINGS: 'true'
+        SKLEARN_WARNINGS_AS_ERRORS: '1'
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
         # Tests that require large downloads over the networks are skipped in CI.
         # Here we make sure, that they are still run on a regular basis.
@@ -195,7 +195,7 @@ jobs:
       pymin_conda_forge_openblas_ubuntu_2204:
         DISTRIB: 'conda'
         LOCK_FILE: './build_tools/azure/pymin_conda_forge_openblas_ubuntu_2204_linux-64_conda.lock'
-        CHECK_WARNINGS: 'true'
+        SKLEARN_WARNINGS_AS_ERRORS: '1'
         COVERAGE: 'false'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '0'  # non-default seed
 
@@ -249,7 +249,7 @@ jobs:
         DISTRIB: 'conda-pip-latest'
         LOCK_FILE: './build_tools/azure/pylatest_pip_openblas_pandas_linux-64_conda.lock'
         CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-        CHECK_WARNINGS: 'true'
+        SKLEARN_WARNINGS_AS_ERRORS: '1'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '3'  # non-default seed
         # disable pytest-xdist to have 1 job where OpenMP and BLAS are not single
         # threaded because by default the tests configuration (sklearn/conftest.py)
@@ -315,7 +315,7 @@ jobs:
       pymin_conda_forge_mkl:
         DISTRIB: 'conda'
         LOCK_FILE: ./build_tools/azure/pymin_conda_forge_mkl_win-64_conda.lock
-        CHECK_WARNINGS: 'true'
+        SKLEARN_WARNINGS_AS_ERRORS: '1'
         # The Azure Windows runner is typically much slower than other CI
         # runners due to the lack of compiler cache. Running the tests with
         # coverage enabled make them run extra slower. Since very few parts of

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -48,26 +48,6 @@ if [[ "$COVERAGE" == "true" ]]; then
     TEST_CMD="$TEST_CMD --cov-config='$COVERAGE_PROCESS_START' --cov sklearn --cov-report="
 fi
 
-if [[ -n "$CHECK_WARNINGS" ]]; then
-    TEST_CMD="$TEST_CMD -Werror::DeprecationWarning -Werror::FutureWarning -Werror::sklearn.utils.fixes.VisibleDeprecationWarning"
-
-    # Ignore pkg_resources deprecation warnings triggered by pyamg
-    TEST_CMD="$TEST_CMD -W 'ignore:pkg_resources is deprecated as an API:DeprecationWarning'"
-    TEST_CMD="$TEST_CMD -W 'ignore:Deprecated call to \`pkg_resources:DeprecationWarning'"
-
-    # pytest-cov issue https://github.com/pytest-dev/pytest-cov/issues/557 not
-    # fixed although it has been closed. https://github.com/pytest-dev/pytest-cov/pull/623
-    # would probably fix it.
-    TEST_CMD="$TEST_CMD -W 'ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning'"
-
-    # In some case, exceptions are raised (by bug) in tests, and captured by pytest,
-    # but not raised again. This is for instance the case when Cython directives are
-    # activated: IndexErrors (which aren't fatal) are raised on out-of-bound accesses.
-    # In those cases, pytest instead raises pytest.PytestUnraisableExceptionWarnings,
-    # which we must treat as errors on the CI.
-    TEST_CMD="$TEST_CMD -Werror::pytest.PytestUnraisableExceptionWarning"
-fi
-
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
     XDIST_WORKERS=$(python -c "import joblib; print(joblib.cpu_count(only_physical_cores=True))")
     TEST_CMD="$TEST_CMD -n$XDIST_WORKERS"

--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -317,11 +317,17 @@ Users looking for the best performance might want to tune this variable using
 powers of 2 so as to get the best parallelism behavior for their hardware,
 especially with respect to their caches' sizes.
 
-`SKLEARN_DOC_BUILD_WARNINGS_AS_ERRORS`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`SKLEARN_WARNINGS_AS_ERRORS`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This environment variable issue errors instead of warnings when building the
-documentation. It ensures that we don't introduce new warnings in the example
-gallery. By default, the warnings are treated as errors (e.g. `"true"`). This
-is different from `SPHINXOPTS="-W"` that catch syntax warnings from the rst
-generation.
+This environment variable is used to turn warnings into errors in two different places:
+- tests, for example by running `SKLEARN_WARNINGS_AS_ERRORS=1 pytest sklearn`.
+- documentation build, where it is turned on by default when you do `make
+  html`. You can do `SKLEARN_WARNINGS_AS_ERRORS=0 make html` if you want to
+  ignore warnings. Note that this checks that running examples don't produce
+  any warnings which is not the same as `SHPINXOPTS="-W:` that checks syntax
+  issues in the rst files.
+
+This environment variable use specific warning filters, since sometimes
+warnings come from third-party libraries. You can see them in the
+`turn_warnings_into_errors` function in `sklearn/utils/_testing.py`.

--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -321,11 +321,12 @@ especially with respect to their caches' sizes.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This environment variable is used to turn warnings into errors in two different places:
+
 - tests, for example by running `SKLEARN_WARNINGS_AS_ERRORS=1 pytest sklearn`.
 - documentation build, where it is turned on by default when you do `make
   html`. You can do `SKLEARN_WARNINGS_AS_ERRORS=0 make html` if you want to
   ignore warnings. Note that this checks that running examples don't produce
-  any warnings which is not the same as `SHPINXOPTS="-W:` that checks syntax
+  any warnings which is not the same as `SHPINXOPTS="-W"` that checks syntax
   issues in the rst files.
 
 This environment variable use specific warning filters, since sometimes

--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -337,3 +337,8 @@ This environment variable use specific warning filters to ignore some warnings,
 since sometimes warnings originate from third-party libraries and there is not
 much we can do about it. You can see the warning filters in the
 `_get_warnings_filters_info_list` function in `sklearn/utils/_testing.py`.
+
+Note that for documentation build, `SKLEARN_WARNING_AS_ERRORS=1` is checking
+that the documentation build, in particular running examples, does not produce
+any warnings. This is different from the `-W` `sphinx-build` argument that
+catches syntax warnings in the rst files.

--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -320,15 +320,20 @@ especially with respect to their caches' sizes.
 `SKLEARN_WARNINGS_AS_ERRORS`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This environment variable is used to turn warnings into errors in two different places:
+This environment variable is used to turn warnings into errors in tests and
+documentation build.
 
-- tests, for example by running `SKLEARN_WARNINGS_AS_ERRORS=1 pytest sklearn`.
-- documentation build, where it is turned on by default when you do `make
-  html`. You can do `SKLEARN_WARNINGS_AS_ERRORS=0 make html` if you want to
-  ignore warnings. Note that this checks that running examples don't produce
-  any warnings which is not the same as `SHPINXOPTS="-W"` that checks syntax
-  issues in the rst files.
+Some CI (Continuous Integration) builds set `SKLEARN_WARNINGS_AS_ERRORS=1`, for
+example to make sure that we catch deprecation warnings from our dependencies
+and that we adapt our code.
 
-This environment variable use specific warning filters, since sometimes
-warnings come from third-party libraries. You can see them in the
-`turn_warnings_into_errors` function in `sklearn/utils/_testing.py`.
+To locally run with the same "warnings as errors" setting as in these CI builds
+you can set `SKLEARN_WARNINGS_AS_ERRORS=1`.
+
+By default, warnings are not turned into errors. This is the case if
+`SKLEARN_WARNINGS_AS_ERRORS` is unset, or `SKLEARN_WARNINGS_AS_ERRORS=0`.
+
+This environment variable use specific warning filters to ignore some warnings,
+since sometimes warnings originate from third-party libraries and there is not
+much we can do about it. You can see the warning filters in the
+`_get_warnings_filters_info_list` function in `sklearn/utils/_testing.py`.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,6 +19,7 @@ from io import StringIO
 from pathlib import Path
 
 from sklearn.externals._packaging.version import parse
+from sklearn.utils._testing import turn_warning_into_errors
 
 # If extensions (or modules to document with autodoc) are in another
 # directory, add these directories to sys.path here. If the directory
@@ -702,8 +703,6 @@ linkcode_resolve = make_linkcode_resolve(
     ),
 )
 
-from sklearn.utils.fixes import VisibleDeprecationWarning
-
 warnings.filterwarnings(
     "ignore",
     category=UserWarning,
@@ -712,26 +711,8 @@ warnings.filterwarnings(
         " non-GUI backend, so cannot show the figure."
     ),
 )
-if os.environ.get("SKLEARN_WARNINGS_AS_ERRORS", "1") != "0":
-    # Raise warning as error in example to catch warnings when building the
-    # documentation Since we are using lock files to build the documentation, we should
-    # not have any warnings. Before updating the lock files, we need to fix them.
-    for warning_type in (FutureWarning, DeprecationWarning, VisibleDeprecationWarning):
-        warnings.filterwarnings("error", category=warning_type)
-    # TODO: remove when pyamg > 5.0.1
-    # Avoid a deprecation warning due pkg_resources deprecation in pyamg.
-    warnings.filterwarnings(
-        "ignore",
-        message="pkg_resources is deprecated as an API",
-        category=DeprecationWarning,
-    )
-    # XXX: Easiest way to ignore Pyarrow DeprecationWarning in the short-term.
-    # See https://github.com/pandas-dev/pandas/issues/54466 for more details.
-    warnings.filterwarnings(
-        "ignore",
-        message=r"\s*Pyarrow will become a required dependency of pandas.*",
-        category=DeprecationWarning,
-    )
+if os.environ.get("SKLEARN_WARNINGS_AS_ERRORS", "0") != "0":
+    turn_warning_into_errors()
 
 # maps functions with a class name that is indistinguishable when case is
 # ignore to another filename

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -712,7 +712,7 @@ warnings.filterwarnings(
         " non-GUI backend, so cannot show the figure."
     ),
 )
-if os.environ.get("SKLEARN_DOC_BUILD_WARNINGS_AS_ERRORS", "true").lower() == "true":
+if os.environ.get("SKLEARN_WARNINGS_AS_ERRORS", "1") != "0":
     # Raise warning as error in example to catch warnings when building the
     # documentation Since we are using lock files to build the documentation, we should
     # not have any warnings. Before updating the lock files, we need to fix them.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,7 +19,7 @@ from io import StringIO
 from pathlib import Path
 
 from sklearn.externals._packaging.version import parse
-from sklearn.utils._testing import turn_warning_into_errors
+from sklearn.utils._testing import turn_warnings_into_errors
 
 # If extensions (or modules to document with autodoc) are in another
 # directory, add these directories to sys.path here. If the directory
@@ -712,7 +712,7 @@ warnings.filterwarnings(
     ),
 )
 if os.environ.get("SKLEARN_WARNINGS_AS_ERRORS", "0") != "0":
-    turn_warning_into_errors()
+    turn_warnings_into_errors()
 
 # maps functions with a class name that is indistinguishable when case is
 # ignore to another filename

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,9 +21,6 @@ addopts =
     # source folder.
     -p sklearn.tests.random_seed
 
-filterwarnings =
-    ignore:the matrix subclass:PendingDeprecationWarning
-
 [mypy]
 ignore_missing_imports = True
 allow_redefinition = True

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -302,15 +302,6 @@ def print_changed_only_false():
     set_config(print_changed_only=True)  # reset to default
 
 
-def pytest_addoption(parser):
-    parser.addoption(
-        "--check-warnings",
-        action="store_true",
-        default=False,
-        help="Whether to turn warning into errors",
-    )
-
-
 def pytest_sessionstart(session):
     if environ.get("SKLEARN_WARNINGS_AS_ERRORS", "0") != "0":
         # XXX: if sys.warnoptions is empty (i.e. PYTHONWARNINGS environment

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -305,10 +305,10 @@ def print_changed_only_false():
 def pytest_sessionstart(session):
     if environ.get("SKLEARN_WARNINGS_AS_ERRORS", "0") != "0":
         # XXX: if sys.warnoptions is empty (i.e. PYTHONWARNINGS environment
-        # variable is not set) pytest adds its own filters for
-        # DeprecationWarning), see
+        # variable is not set), pytest adds its own filters for
+        # DeprecationWarning, see
         # https://github.com/pytest-dev/pytest/blob/404d31a942975c04d4a7d48e258260584930819f/src/_pytest/warnings.py#L45-L48
-        # This would overrides our warning filters modifications so we set it
-        # to a non-empty value
+        # This would overrides our warning filters modifications so we set
+        # sys.warnoptions to a non-empty value
         sys.warnoptions = "hack-to-avoid-pytest-overriding-warning-filters"
         turn_warnings_into_errors()

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -322,21 +322,6 @@ def pytest_collection(session):
             ),
             category=DeprecationWarning,
         )
-        # warnings has been fixed from dateutil main but not released yet, see
-        # https://github.com/dateutil/dateutil/issues/1314
-        warnings.filterwarnings(
-            "ignore",
-            message="datetime.datetime.utcfromtimestamp",
-            category=DeprecationWarning,
-        )
-        # Python 3.12 warnings from joblib fixed in master but not released yet,
-        # see https://github.com/joblib/joblib/pull/1518
-        warnings.filterwarnings(
-            "ignore", message="ast.Num is deprecated", category=DeprecationWarning
-        )
-        warnings.filterwarnings(
-            "ignore", message="Attribute n is deprecated", category=DeprecationWarning
-        )
         # XXX: Easiest way to ignore pandas Pyarrow DeprecationWarning in the
         # short-term. See https://github.com/pandas-dev/pandas/issues/54466 for
         # more details.

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -26,7 +26,7 @@ from sklearn.datasets import (
 )
 from sklearn.tests import random_seed
 from sklearn.utils import _IS_32BIT
-from sklearn.utils._testing import get_pytest_filterwarning_str
+from sklearn.utils._testing import get_pytest_filterwarning_lines
 from sklearn.utils.fixes import (
     np_base_version,
     parse_version,
@@ -284,7 +284,7 @@ def pytest_configure(config):
         # This seems like the only way to programmatically change the config
         # filterwarnings. This was suggested in
         # https://github.com/pytest-dev/pytest/issues/3311#issuecomment-373177592
-        for line in get_pytest_filterwarning_str():
+        for line in get_pytest_filterwarning_lines():
             config.addinivalue_line("filterwarnings", line)
 
 

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -284,7 +284,8 @@ def pytest_configure(config):
         # This seems like the only way to programmatically change the config
         # filterwarnings. This was suggested in
         # https://github.com/pytest-dev/pytest/issues/3311#issuecomment-373177592
-        config._inicache["filterwarnings"] += get_pytest_filterwarning_str()
+        for line in get_pytest_filterwarning_str():
+            config.addinivalue_line("filterwarnings", line)
 
 
 @pytest.fixture

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -281,12 +281,10 @@ def pytest_configure(config):
         config.pluginmanager.register(random_seed)
 
     if environ.get("SKLEARN_WARNINGS_AS_ERRORS", "0") != "0":
-        # This seems like the only way to programatically change the config
+        # This seems like the only way to programmatically change the config
         # filterwarnings. This was suggested in
         # https://github.com/pytest-dev/pytest/issues/3311#issuecomment-373177592
-        print(config.getini("filterwarnings"))
         config._inicache["filterwarnings"] += get_pytest_filterwarning_str()
-        print(config.getini("filterwarnings"))
 
 
 @pytest.fixture

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1118,7 +1118,7 @@ def _get_warnings_filters_info_list():
         WarningInfo("error", category=FutureWarning),
         WarningInfo("error", category=VisibleDeprecationWarning),
         # TODO: remove when pyamg > 5.0.1
-        # Avoid a deprecation warning due pkg_resources deprecation in pyamg.
+        # Avoid a deprecation warning due pkg_resources usage in pyamg.
         WarningInfo(
             "ignore",
             message="pkg_resources is deprecated as an API",

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1117,6 +1117,8 @@ def _get_warnings_filters_info_list():
         WarningInfo("error", category=DeprecationWarning),
         WarningInfo("error", category=FutureWarning),
         WarningInfo("error", category=VisibleDeprecationWarning),
+        # TODO: remove when pyamg > 5.0.1
+        # Avoid a deprecation warning due pkg_resources deprecation in pyamg.
         WarningInfo(
             "ignore",
             message="pkg_resources is deprecated as an API",

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1149,7 +1149,7 @@ def _get_warnings_filters_info_list():
     ]
 
 
-def get_pytest_filterwarning_str():
+def get_pytest_filterwarning_lines():
     warning_filters_info_list = _get_warnings_filters_info_list()
     return [
         warning_info.to_filterwarning_str()

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1141,7 +1141,11 @@ def _get_warnings_filters_info_list():
         # XXX: Easiest way to ignore pandas Pyarrow DeprecationWarning in the
         # short-term. See https://github.com/pandas-dev/pandas/issues/54466 for
         # more details.
-        WarningInfo("ignore", message=r"\s*Pyarrow", category=DeprecationWarning),
+        WarningInfo(
+            "ignore",
+            message=r"\s*Pyarrow will become a required dependency",
+            category=DeprecationWarning,
+        ),
     ]
 
 
@@ -1153,7 +1157,7 @@ def get_pytest_filterwarning_str():
     ]
 
 
-def turn_warning_into_errors():
+def turn_warnings_into_errors():
     warnings_filters_info_list = _get_warnings_filters_info_list()
     for warning_info in warnings_filters_info_list:
         warnings.filterwarnings(

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -14,6 +14,7 @@ from sklearn.utils._testing import (
     TempMemmap,
     _convert_container,
     _delete_folder,
+    _get_warnings_filters_info_list,
     assert_allclose,
     assert_allclose_dense_sparse,
     assert_no_warnings,
@@ -26,6 +27,7 @@ from sklearn.utils._testing import (
     ignore_warnings,
     raises,
     set_random_state,
+    turn_warnings_into_errors,
 )
 from sklearn.utils.deprecation import deprecated
 from sklearn.utils.fixes import (
@@ -882,3 +884,40 @@ def test_convert_container_sparse_to_sparse(constructor_name):
     """
     X_sparse = sparse.random(10, 10, density=0.1, format="csr")
     _convert_container(X_sparse, constructor_name)
+
+
+def check_warnings_as_errors(warning_info, warnings_as_errors):
+    if warning_info.action == "error" and warnings_as_errors:
+        with pytest.raises(warning_info.category, match=warning_info.message):
+            warnings.warn(
+                message=warning_info.message,
+                category=warning_info.category,
+            )
+    if warning_info.action == "ignore":
+        with warnings.catch_warnings(record=True) as record:
+            message = warning_info.message
+            # Special treatment when regex is used
+            if "Pyarrow" in message:
+                message = r"\nPyarrow will become a required dependency"
+
+            warnings.warn(
+                message=message,
+                category=warning_info.category,
+            )
+            assert len(record) == 0 if warnings_as_errors else 1
+            if record:
+                assert str(record[0].message) == message
+                assert record[0].category == warning_info.category
+
+
+@pytest.mark.parametrize("warning_info", _get_warnings_filters_info_list())
+def test_sklearn_warnings_as_errors(warning_info):
+    warnings_as_errors = os.environ.get("SKLEARN_WARNINGS_AS_ERRORS", "0") != "0"
+    check_warnings_as_errors(warning_info, warnings_as_errors=warnings_as_errors)
+
+
+@pytest.mark.parametrize("warning_info", _get_warnings_filters_info_list())
+def test_turn_warnings_into_errors(warning_info):
+    with warnings.catch_warnings():
+        turn_warnings_into_errors()
+        check_warnings_as_errors(warning_info, warnings_as_errors=True)

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -898,7 +898,7 @@ def check_warnings_as_errors(warning_info, warnings_as_errors):
             message = warning_info.message
             # Special treatment when regex is used
             if "Pyarrow" in message:
-                message = r"\nPyarrow will become a required dependency"
+                message = "\nPyarrow will become a required dependency"
 
             warnings.warn(
                 message=message,

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -656,11 +656,13 @@ def X_64bit(request):
     X = sp.rand(20, 10, format=request.param)
 
     if request.param == "coo":
-        if hasattr(X, "indices"):
+        if hasattr(X, "coords"):
             # for scipy >= 1.13 .indices is a new attribute and is a tuple. The
             # .col and .row attributes do not seem to be able to change the
             # dtype, for more details see https://github.com/scipy/scipy/pull/18530/
-            X.indices = tuple(v.astype("int64") for v in X.indices)
+            # Also indices was renamed to coords in
+            # https://github.com/scipy/scipy/pull/20003
+            X.coords = tuple(v.astype("int64") for v in X.coords)
         else:
             # scipy < 1.13
             X.row = X.row.astype("int64")

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -656,13 +656,11 @@ def X_64bit(request):
     X = sp.rand(20, 10, format=request.param)
 
     if request.param == "coo":
-        if hasattr(X, "coords"):
+        if hasattr(X, "indices"):
             # for scipy >= 1.13 .indices is a new attribute and is a tuple. The
             # .col and .row attributes do not seem to be able to change the
             # dtype, for more details see https://github.com/scipy/scipy/pull/18530/
-            # Also indices was renamed to coords in
-            # https://github.com/scipy/scipy/pull/20003
-            X.coords = tuple(v.astype("int64") for v in X.coords)
+            X.indices = tuple(v.astype("int64") for v in X.indices)
         else:
             # scipy < 1.13
             X.row = X.row.astype("int64")


### PR DESCRIPTION
Follow-up of https://github.com/scikit-learn/scikit-learn/pull/28348#issuecomment-1924511584 to make it easier to run locally with the same "warnings as errors" setup as in the CI:

```
SKLEARN_WARNINGS_AS_ERRORS=1 pytest sklearn
```

Warning filters have grown a bit and will grow a bit more once there is a Python 3.12 build in the CI (`dateutil`, `joblib` latest releases create warnings with Python 3.12). There is now a single place where warning filters is defined instead of having `setup.cfg`, `test_script.sh` (CI), and `sklearn/conftest.py`.

While I was at it I use the same function for "warnings as errors" in the doc build.

For now there is a hack with `sys.warnoptions`, see comments in `sklearn/conftest.py`, I looked for some time, but I haven't found anything better ...

cc @adrinjalali @ogrisel who put a :heart: on my original comment.