### PR TITLE
FIX handle dataframe in ARDRegression when predict requests std. dev.

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -118,6 +118,13 @@ Changelog
   together with subsampling (i.e. `max_features` < 1.0).
   :pr:`28184` by :user:`Michael Mayer <mayer79>`.
 
+:mod:`sklearn.linear_model`
+...........................
+
+- |Fix| :class:`linear_model.ARDRegression` now handles pandas input types
+  for `predict_proba(X, return_std=True)`.
+  :pr:`28377` by :user:`Eddie Bergman <eddiebergman>`.
+
 :mod:`sklearn.preprocessing`
 ............................
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -122,7 +122,7 @@ Changelog
 ...........................
 
 - |Fix| :class:`linear_model.ARDRegression` now handles pandas input types
-  for `predict_proba(X, return_std=True)`.
+  for `predict(X, return_std=True)`.
   :pr:`28377` by :user:`Eddie Bergman <eddiebergman>`.
 
 :mod:`sklearn.preprocessing`

--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -14,6 +14,7 @@ from scipy import linalg
 from scipy.linalg import pinvh
 
 from ..base import RegressorMixin, _fit_context
+from ..utils import _safe_indexing
 from ..utils._param_validation import Hidden, Interval, StrOptions
 from ..utils.extmath import fast_logdet
 from ..utils.validation import _check_sample_weight
@@ -849,7 +850,8 @@ class ARDRegression(RegressorMixin, LinearModel):
         if return_std is False:
             return y_mean
         else:
-            X = X.iloc[:, self.lambda_ < self.threshold_lambda]
+            col_index = self.lambda_ < self.threshold_lambda
+            X = _safe_indexing(X, indices=col_index, axis=1)
             sigmas_squared_data = (np.dot(X, self.sigma_) * X).sum(axis=1)
             y_std = np.sqrt(sigmas_squared_data + (1.0 / self.alpha_))
             return y_mean, y_std

--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -849,7 +849,7 @@ class ARDRegression(RegressorMixin, LinearModel):
         if return_std is False:
             return y_mean
         else:
-            X = X[:, self.lambda_ < self.threshold_lambda]
+            X = X.iloc[:, self.lambda_ < self.threshold_lambda]
             sigmas_squared_data = (np.dot(X, self.sigma_) * X).sum(axis=1)
             y_std = np.sqrt(sigmas_squared_data + (1.0 / self.alpha_))
             return y_mean, y_std

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -6,6 +6,7 @@
 from math import log
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from sklearn import datasets
@@ -209,7 +210,8 @@ def test_ard_accuracy_on_easy_problem(global_random_seed, n_samples, n_features)
     assert abs_coef_error < 1e-10
 
 
-def test_return_std():
+@pytest.mark.parametrize("as_frame", [True, False])
+def test_return_std(as_frame: bool):
     # Test return_std option for both Bayesian regressors
     def f(X):
         return np.dot(X, w) + b
@@ -230,14 +232,23 @@ def test_return_std():
     for decimal, noise_mult in enumerate([1, 0.1, 0.01]):
         y = f_noise(X, noise_mult)
 
+        if as_frame:
+            _X = pd.DataFrame(X)
+            _y = pd.Series(y)
+            _X_test = pd.DataFrame(X_test)
+        else:
+            _X = X
+            _y = y
+            _X_test = X_test
+
         m1 = BayesianRidge()
-        m1.fit(X, y)
-        y_mean1, y_std1 = m1.predict(X_test, return_std=True)
+        m1.fit(_X, _y)
+        y_mean1, y_std1 = m1.predict(_X_test, return_std=True)
         assert_array_almost_equal(y_std1, noise_mult, decimal=decimal)
 
         m2 = ARDRegression()
-        m2.fit(X, y)
-        y_mean2, y_std2 = m2.predict(X_test, return_std=True)
+        m2.fit(_X, _y)
+        y_mean2, y_std2 = m2.predict(_X_test, return_std=True)
         assert_array_almost_equal(y_std2, noise_mult, decimal=decimal)
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
* Closes #28310


#### What does this implement/fix? Explain your changes.
Only change was just to use `_safe_indexing`. 

#### Any other comments?
* I added a test for this, not sure if it's the best test.
* Should this bug fix be documented in the Changelog?
* I checked `BayesianRidge` which seems to be tightly related to `ArdRegression` in testing. The problem doesn't exist there as it doesn't use indexing.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
