### PR TITLE
MAINT remove unneeded `robots.txt`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -235,9 +235,6 @@ html_static_path = ["images"]
 # template names.
 html_additional_pages = {"index": "index.html"}
 
-# Additional files to copy
-html_extra_path = ["robots.txt"]
-
 # If false, no module index is generated.
 html_domain_indices = False
 

--- a/doc/robots.txt
+++ b/doc/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /_pst_preview/


### PR DESCRIPTION
The file was added by https://github.com/scikit-learn/scikit-learn/pull/28376 but is not taking effect because it will be uploaded to this location: https://github.com/scikit-learn/scikit-learn.github.io/blob/main/dev/robots.txt

The workaround is https://github.com/scikit-learn/scikit-learn.github.io/pull/21 so we no longer need to `robots.txt` now.

@lesteve