### PR TITLE
 Added verbose argument to permutation_importance API.

### DIFF
--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -232,6 +232,7 @@ def permutation_importance(
         Controls the verbosity level: If non-zero, progress messages are printed.
         The frequency of the messages increases with the verbosity level.
         
+        
     -------
     result : :class:`~sklearn.utils.Bunch` or dict of such instances
         Dictionary-like object, with the following attributes.

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -130,6 +130,7 @@ def _create_importances_bunch(baseline_score, permuted_score):
             Interval(Integral, 1, None, closed="left"),
             Interval(RealNotInt, 0, 1, closed="right"),
         ],
+        "verbose": ["verbose"],
     },
     prefer_skip_nested_validation=True,
 )
@@ -144,7 +145,7 @@ def permutation_importance(
     random_state=None,
     sample_weight=None,
     max_samples=1.0,
-    verbose=0
+    verbose=0,
 ):
     """Permutation importance for feature evaluation [BRE]_.
 
@@ -227,12 +228,12 @@ def permutation_importance(
         the computational speed vs statistical accuracy trade-off of this method.
 
         .. versionadded:: 1.0
-    
+
     verbose : int
         Controls the verbosity level: If non-zero, progress messages are printed.
         The frequency of the messages increases with the verbosity level.
-        
-        
+
+
     Returns
     -------
     result : :class:`~sklearn.utils.Bunch` or dict of such instances
@@ -263,7 +264,7 @@ def permutation_importance(
     >>> y = [1, 1, 1, 0, 0, 0]
     >>> clf = LogisticRegression().fit(X, y)
     >>> result = permutation_importance(clf, X, y, n_repeats=10,
-    ...                                 random_state=0)
+    ...                                 random_state=0,verbose=0)
     >>> result.importances_mean
     array([0.4666..., 0.       , 0.       ])
     >>> result.importances_std
@@ -295,7 +296,7 @@ def permutation_importance(
 
     baseline_score = _weights_scorer(scorer, estimator, X, y, sample_weight)
 
-    scores = Parallel(n_jobs=n_jobs,verbose=verbose)(
+    scores = Parallel(n_jobs=n_jobs, verbose=verbose)(
         delayed(_calculate_permutation_scores)(
             estimator,
             X,

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -144,7 +144,7 @@ def permutation_importance(
     random_state=None,
     sample_weight=None,
     max_samples=1.0,
-    verbose = 0
+    verbose=0
 ):
     """Permutation importance for feature evaluation [BRE]_.
 
@@ -233,6 +233,7 @@ def permutation_importance(
         The frequency of the messages increases with the verbosity level.
         
         
+    Returns
     -------
     result : :class:`~sklearn.utils.Bunch` or dict of such instances
         Dictionary-like object, with the following attributes.

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -233,7 +233,6 @@ def permutation_importance(
         Controls the verbosity level: If non-zero, progress messages are printed.
         The frequency of the messages increases with the verbosity level.
 
-
     Returns
     -------
     result : :class:`~sklearn.utils.Bunch` or dict of such instances

--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -144,6 +144,7 @@ def permutation_importance(
     random_state=None,
     sample_weight=None,
     max_samples=1.0,
+    verbose = 0
 ):
     """Permutation importance for feature evaluation [BRE]_.
 
@@ -226,8 +227,11 @@ def permutation_importance(
         the computational speed vs statistical accuracy trade-off of this method.
 
         .. versionadded:: 1.0
-
-    Returns
+    
+    verbose : int
+        Controls the verbosity level: If non-zero, progress messages are printed.
+        The frequency of the messages increases with the verbosity level.
+        
     -------
     result : :class:`~sklearn.utils.Bunch` or dict of such instances
         Dictionary-like object, with the following attributes.
@@ -289,7 +293,7 @@ def permutation_importance(
 
     baseline_score = _weights_scorer(scorer, estimator, X, y, sample_weight)
 
-    scores = Parallel(n_jobs=n_jobs)(
+    scores = Parallel(n_jobs=n_jobs,verbose=verbose)(
         delayed(_calculate_permutation_scores)(
             estimator,
             X,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
This change is for the request as mentioned in #28093.

#### What does this implement/fix? Explain your changes.
Added verbose argument to the permutation_importance API. The API now shows the progress messages for the parallel jobs when verbosity is given a non-zero value. 

![image](https://github.com/scikit-learn/scikit-learn/assets/110726731/587d7d1d-42fc-40bf-8313-e72092cfeedc)

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
