### PR TITLE
MAINT reflect that we move the macos-arm64 to github actions

### DIFF
--- a/build_tools/github/check_wheels.py
+++ b/build_tools/github/check_wheels.py
@@ -20,7 +20,6 @@ cirrus_path = Path.cwd() / "build_tools" / "cirrus" / "arm_wheel.yml"
 with cirrus_path.open("r") as f:
     cirrus_config = yaml.safe_load(f)
 
-n_wheels += len(cirrus_config["macos_arm64_wheel_task"]["matrix"])
 n_wheels += len(cirrus_config["linux_arm64_wheel_task"]["matrix"])
 
 dist_files = list(Path("dist").glob("**/*"))


### PR DESCRIPTION
We recently moved MacOS ARM64 from Cirrus CI to GitHub Actions but we did not update the action that check expect these wheels are available in Cirrus CI.