### PR TITLE
DOC correct Xy shape in `lars_path` and `lars_path_gram`

### DIFF
--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -98,8 +98,7 @@ def lars_path(
     y : None or ndarray of shape (n_samples,)
         Input targets.
 
-    Xy : array-like of shape (n_features,) or (n_features, n_targets), \
-            default=None
+    Xy : array-like of shape (n_features,), default=None
         `Xy = X.T @ y` that can be precomputed. It is useful
         only when the Gram matrix is precomputed.
 
@@ -262,7 +261,7 @@ def lars_path_gram(
 
     Parameters
     ----------
-    Xy : ndarray of shape (n_features,) or (n_features, n_targets)
+    Xy : ndarray of shape (n_features,)
         `Xy = X.T @ y`.
 
     Gram : ndarray of shape (n_features, n_features)
@@ -409,8 +408,7 @@ def _lars_path_solver(
     y : None or ndarray of shape (n_samples,)
         Input targets.
 
-    Xy : array-like of shape (n_features,) or (n_features, n_targets), \
-            default=None
+    Xy : array-like of shape (n_features,), default=None
         `Xy = np.dot(X.T, y)` that can be precomputed. It is useful
         only when the Gram matrix is precomputed.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Ran into the same issue as #27887 when using `lars_path`.

#### What does this implement/fix? Explain your changes.
After going through the source code of `_lars_path_solver`, I think these functions only work for single-target `y`, therefore suggest the changes in docstrings.

#### Any other comments?
Code to reproduce errors.
```python
from sklearn.datasets import make_regression
from sklearn.linear_model import lars_path, lars_path_gram
X, y = make_regression(n_features=10, n_targets=2, random_state=0)
Xy = np.dot(X.T, y)
Gram = np.dot(X.T, X)
lars_path(X, y, Xy=Xy, Gram=Gram)  # ValueError
lars_path_gram(Xy, Gram=Gram, n_samples=X.shape[0])  # ValueError

```

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
