### PR TITLE
MAINT Update Pyodide version to 0.25.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,10 +127,10 @@ jobs:
     vmImage: ubuntu-22.04
   variables:
     # Need to match Python version and Emscripten version for the correct
-    # Pyodide version. For example, for Pyodide version 0.24.1, see
-    # https://github.com/pyodide/pyodide/blob/0.24.1/Makefile.envs
-    PYODIDE_VERSION: '0.24.1'
-    EMSCRIPTEN_VERSION: '3.1.45'
+    # Pyodide version. For example, for Pyodide version 0.25.0, see
+    # https://github.com/pyodide/pyodide/blob/0.25.0/Makefile.envs
+    PYODIDE_VERSION: '0.25.0'
+    EMSCRIPTEN_VERSION: '3.1.46'
     PYTHON_VERSION: '3.11.3'
 
   dependsOn: [git_commit, linting]

--- a/doc/jupyter-lite.json
+++ b/doc/jupyter-lite.json
@@ -3,7 +3,7 @@
   "jupyter-config-data": {
     "litePluginSettings": {
       "@jupyterlite/pyodide-kernel-extension:kernel": {
-        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"
+        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide.js"
       }
     }
   }


### PR DESCRIPTION
This updates Pyodide to 0.25.0 released mid-January 2024.

This affects two things:
- Pyodide version used in the CI Pyodide build
- Pyodide version used in Jupyterlite button in the examples gallery. The scikit-learn version will still be 1.3.1, see [Pyodide 0.25.0 package list](https://pyodide.org/en/0.25.0/usage/packages-in-pyodide.html)