### PR TITLE
REL scikit-learn 1.4.1.post1

### DIFF
--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -169,7 +169,7 @@
         <li><strong>On-going development:</strong>
         <a href="whats_new/v1.5.html#version-1-5-0">scikit-learn 1.5 (Changelog)</a>
         </li>
-        <li><strong>February 2024.</strong> scikit-learn 1.4.1.post1 is available for download (<a href="whats_new/v1.4.html#version-1-4-1">Changelog</a>).
+        <li><strong>February 2024.</strong> scikit-learn 1.4.1.post1 is available for download (<a href="whats_new/v1.4.html#version-1-4-1-post1">Changelog</a>).
         </li>
         <li><strong>January 2024.</strong> scikit-learn 1.4.0 is available for download (<a href="whats_new/v1.4.html#version-1-4-0">Changelog</a>).
         </li>

--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -169,7 +169,7 @@
         <li><strong>On-going development:</strong>
         <a href="whats_new/v1.5.html#version-1-5-0">scikit-learn 1.5 (Changelog)</a>
         </li>
-        <li><strong>February 2024.</strong> scikit-learn 1.4.1 is available for download (<a href="whats_new/v1.4.html#version-1-4-1">Changelog</a>).
+        <li><strong>February 2024.</strong> scikit-learn 1.4.1.post1 is available for download (<a href="whats_new/v1.4.html#version-1-4-1">Changelog</a>).
         </li>
         <li><strong>January 2024.</strong> scikit-learn 1.4.0 is available for download (<a href="whats_new/v1.4.html#version-1-4-0">Changelog</a>).
         </li>

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -22,8 +22,8 @@ Version 1.4.1.post1
 
 .. note::
     The 1.4.1.post1 release includes a packaging fix requiring `numpy<2` to account for
-    incompatibilities with NumPy 2.0 ABI. This release version number is used instead of
-    1.4.1 that is not made available on PyPI and conda-forge.
+    incompatibilities with NumPy 2.0 ABI. Note that the 1.4.1 release is not available
+    on PyPI and conda-forge.
 
 Metadata Routing
 ----------------

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -20,6 +20,10 @@ Version 1.4.1
 
 **February 2024**
 
+.. note::
+    This release version number on PyPI and conda-forge is 1.4.1.post1 that follows
+    1.4.1 to fix a packaging issue to add an upper bound on the version of NumPy.
+
 Metadata Routing
 ----------------
 

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -21,8 +21,9 @@ Version 1.4.1.post1
 **February 2024**
 
 .. note::
-    This release version number on PyPI and conda-forge is 1.4.1.post1 that follows
-    1.4.1 to fix a packaging issue to add an upper bound on the version of NumPy.
+    The 1.4.1.post1 release includes a packaging fix requiring `numpy<2` to account for
+    incompatibilities with NumPy 2.0 ABI. This release version number is used instead of
+    1.4.1 that is not made available on PyPI and conda-forge.
 
 Metadata Routing
 ----------------

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -15,8 +15,8 @@ For a short description of the main highlights of the release, please refer to
 
 .. _changes_1_4_1:
 
-Version 1.4.1
-=============
+Version 1.4.1.post1
+===================
 
 **February 2024**
 

--- a/setup.py
+++ b/setup.py
@@ -614,6 +614,12 @@ def setup_package():
         },
     )
 
+    # Overwrite the dependencies to not allow for NumPy >= 2.0
+    metadata["install_requires"] = [
+        f"{dep},<2.0" if dep.startswith("numpy") else dep
+        for dep in metadata["install_requires"]
+    ]
+
     commands = [arg for arg in sys.argv[1:] if not arg.startswith("-")]
     if not all(
         command in ("egg_info", "dist_info", "clean", "check") for command in commands

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = "1.4.1"
+__version__ = "1.4.1.post1"
 
 
 # On OSX, we can get a runtime error due to multiple OpenMP libraries loaded


### PR DESCRIPTION
New release accounting for the upper bound of NumPy.


### TODO list:

* [x] update news and what's new date in release branch
* [x] update news and what's new date and sklearn dev0 version in main branch
* [x] check that the wheels for the release can be built successfully
* [x] merge the PR with `[cd build]` commit message to upload wheels to the staging repo
* [x] upload the wheels and source tarball to https://test.pypi.org
* [x] create tag on the main github repo
* [x] confirm bot detected at
  https://github.com/conda-forge/scikit-learn-feedstock and wait for merge
* [x] upload the wheels and source tarball to PyPI
* [x] https://github.com/scikit-learn/scikit-learn/releases publish (except for RC)
* [x] announce on mailing list and on Twitter, and LinkedIn
* [x] update symlink for stable in
  https://github.com/scikit-learn/scikit-learn.github.io (only major/minor)
* [x] update SECURITY.md in main branch (except for RC)