### PR TITLE
FIX Allow alpha 0 when not using LOO in `RidgeCV`

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -194,10 +194,9 @@ Setting the regularization parameter: leave-one-out Cross-Validation
 --------------------------------------------------------------------
 
 :class:`RidgeCV` and :class:`RidgeClassifierCV` implement ridge
-regression/classification with built-in
-cross-validation of the alpha parameter. They work in the same way
-as GridSearchCV except that it defaults to efficient Leave-One-Out
-:term:`cross-validation`.
+regression/classification with built-in cross-validation of the alpha parameter.
+They work in the same way as :class:`~sklearn.model_selection.GridSearchCV` except
+that it defaults to efficient Leave-One-Out :term:`cross-validation`.
 When using the default :term:`cross-validation`, alpha cannot be 0 due to the
 formulation used to calculate Leave-One-Out error. See [RL2007]_ for details.
 
@@ -215,8 +214,7 @@ Usage example::
 Specifying the value of the :term:`cv` attribute will trigger the use of
 cross-validation with :class:`~sklearn.model_selection.GridSearchCV`, for
 example `cv=10` for 10-fold cross-validation, rather than Leave-One-Out
-Cross-Validation. When using Leave-One-Out Cross-Validation alphas cannot be 0.
-
+Cross-Validation.
 
 .. topic:: References:
 

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -196,8 +196,12 @@ Setting the regularization parameter: leave-one-out Cross-Validation
 :class:`RidgeCV` and :class:`RidgeClassifierCV` implement ridge
 regression/classification with built-in
 cross-validation of the alpha parameter. They work in the same way
-as GridSearchCV except that it defaults to efficient Leave-One-Out Cross-Validation,
-see [RL2007]_::
+as GridSearchCV except that it defaults to efficient Leave-One-Out
+:term:`cross-validation`.
+When using the default :term:`cross-validation`, alpha cannot be 0 due to the
+formulation used to calculate Leave-One-Out error. See [RL2007]_ for details.
+
+Usage example::
 
     >>> import numpy as np
     >>> from sklearn import linear_model

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -193,9 +193,11 @@ This method has the same order of complexity as
 Setting the regularization parameter: leave-one-out Cross-Validation
 --------------------------------------------------------------------
 
-:class:`RidgeCV` implements ridge regression with built-in
-cross-validation of the alpha parameter. The object works in the same way
-as GridSearchCV except that it defaults to Leave-One-Out Cross-Validation::
+:class:`RidgeCV` and :class:`RidgeClassifierCV` implement ridge
+regression/classification with built-in
+cross-validation of the alpha parameter. They work in the same way
+as GridSearchCV except that it defaults to efficient Leave-One-Out Cross-Validation,
+see [RL2007]_::
 
     >>> import numpy as np
     >>> from sklearn import linear_model
@@ -209,18 +211,16 @@ as GridSearchCV except that it defaults to Leave-One-Out Cross-Validation::
 Specifying the value of the :term:`cv` attribute will trigger the use of
 cross-validation with :class:`~sklearn.model_selection.GridSearchCV`, for
 example `cv=10` for 10-fold cross-validation, rather than Leave-One-Out
-Cross-Validation.
+Cross-Validation. When using Leave-One-Out Cross-Validation alphas cannot be 0.
 
-|details-start|
-**References**
-|details-split|
 
-* "Notes on Regularized Least Squares", Rifkin & Lippert (`technical report
-  <http://cbcl.mit.edu/publications/ps/MIT-CSAIL-TR-2007-025.pdf>`_,
-  `course slides
-  <https://www.mit.edu/~9.520/spring07/Classes/rlsslides.pdf>`_).
+.. topic:: References:
 
-|details-end|
+
+  .. [RL2007] "Notes on Regularized Least Squares", Rifkin & Lippert (`technical report
+    <http://cbcl.mit.edu/publications/ps/MIT-CSAIL-TR-2007-025.pdf>`_,
+    `course slides
+    <https://www.mit.edu/~9.520/spring07/Classes/rlsslides.pdf>`_).
 
 .. _lasso:
 

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2281,7 +2281,7 @@ class RidgeCV(
         Alpha corresponds to ``1 / (2C)`` in other linear models such as
         :class:`~sklearn.linear_model.LogisticRegression` or
         :class:`~sklearn.svm.LinearSVC`.
-        If using Leave-One-Out cross-validation, alphas must be > 0.
+        If using Leave-One-Out cross-validation, alphas must be strictly positive.
 
     fit_intercept : bool, default=True
         Whether to calculate the intercept for this model. If set

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2188,12 +2188,21 @@ class _BaseRidgeCV(LinearModel):
         """
         cv = self.cv
 
-        check_scalar_alpha = partial(
-            check_scalar,
-            target_type=numbers.Real,
-            min_val=0.0,
-            include_boundaries="neither",
-        )
+        # `_RidgeGCV` does not work for alpha = 0
+        if cv is None:
+            check_scalar_alpha = partial(
+                check_scalar,
+                target_type=numbers.Real,
+                min_val=0.0,
+                include_boundaries="neither",
+            )
+        else:
+            check_scalar_alpha = partial(
+                check_scalar,
+                target_type=numbers.Real,
+                min_val=0.0,
+                include_boundaries="left",
+            )
 
         if isinstance(self.alphas, (np.ndarray, list, tuple)):
             n_alphas = 1 if np.ndim(self.alphas) == 0 else len(self.alphas)
@@ -2272,7 +2281,7 @@ class RidgeCV(
         Alpha corresponds to ``1 / (2C)`` in other linear models such as
         :class:`~sklearn.linear_model.LogisticRegression` or
         :class:`~sklearn.svm.LinearSVC`.
-        If using Leave-One-Out cross-validation, alphas must be positive.
+        If using Leave-One-Out cross-validation, alphas must be > 0.
 
     fit_intercept : bool, default=True
         Whether to calculate the intercept for this model. If set
@@ -2439,6 +2448,7 @@ class RidgeClassifierCV(_RoutingNotSupportedMixin, _RidgeClassifierMixin, _BaseR
         Alpha corresponds to ``1 / (2C)`` in other linear models such as
         :class:`~sklearn.linear_model.LogisticRegression` or
         :class:`~sklearn.svm.LinearSVC`.
+        If using Leave-One-Out cross-validation, alphas must be > 0.
 
     fit_intercept : bool, default=True
         Whether to calculate the intercept for this model. If set

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2448,7 +2448,7 @@ class RidgeClassifierCV(_RoutingNotSupportedMixin, _RidgeClassifierMixin, _BaseR
         Alpha corresponds to ``1 / (2C)`` in other linear models such as
         :class:`~sklearn.linear_model.LogisticRegression` or
         :class:`~sklearn.svm.LinearSVC`.
-        If using Leave-One-Out cross-validation, alphas must be > 0.
+        If using Leave-One-Out cross-validation, alphas must be strictly positive.
 
     fit_intercept : bool, default=True
         Whether to calculate the intercept for this model. If set


### PR DESCRIPTION
#### Reference Issues/PRs
closes #23074


#### What does this implement/fix? Explain your changes.
Allow alpha 0 when not using default cv LOO, consistent with what happens when you use `Ridge` and `GridSearchCV`
Adds note in user guide about this.

#### Any other comments?
Happy to change.


