### PR TITLE
REVERT DOC Fix typo - a better typo

### DIFF
--- a/doc/metadata_routing.rst
+++ b/doc/metadata_routing.rst
@@ -110,9 +110,9 @@ to both the scorer and :class:`~linear_model.LogisticRegressionCV`.
 If we would pass `sample_weight` in the params of
 :func:`~model_selection.cross_validate`, but not set any object to request it,
 `UnsetMetadataPassedError` would be raised, hinting to us that we need to explicitly set
-where to route it. The same applies if ``params={"sample_weight": my_weights, ...}`` were
-passed (note the typo), since ``sample_weight`` was not requested by any of its
-underlying objects.
+where to route it. The same applies if ``params={"sample_weights": my_weights, ...}``
+were passed (note the typo, i.e. ``weights`` instead of ``weight``), since
+``sample_weights`` was not requested by any of its underlying objects.
 
 Weighted scoring and unweighted fitting
 ---------------------------------------


### PR DESCRIPTION
This in effect reverts https://github.com/scikit-learn/scikit-learn/pull/28424, which removed an intentional typo.

This PR changes the typo and adds more of a note to make sure future contributors don't "fix" the typo.

cc @thomasjpfan 