### PR TITLE
[MRG] Fix <Name of a class impacts the value of its __metadata_request__* variables>

### DIFF
--- a/sklearn/tests/metadata_routing_common.py
+++ b/sklearn/tests/metadata_routing_common.py
@@ -337,7 +337,7 @@ class ConsumingScorer(_Scorer):
         return super()._score(method_caller, clf, X, y, sample_weight=sample_weight)
 
 
-class ConsumingSplitter(BaseCrossValidator, GroupsConsumerMixin):
+class ConsumingSplitter(GroupsConsumerMixin, BaseCrossValidator):
     def __init__(self, registry=None):
         self.registry = registry
 

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -1437,7 +1437,6 @@ class _MetadataRequester:
                 if "__metadata_request__" in attr
             }
             defaults.update(base_defaults)
-        defaults = dict(sorted(defaults.items()))
 
         for attr, value in defaults.items():
             # we don't check for attr.startswith() since python prefixes attrs


### PR DESCRIPTION
<!--
Thanks for contributing to the pull request! Please ensure you have reviewed the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #28430

The bug was observed in 2 classes with the same implementation but different names. The first one was named `class_1`, and the other `Class_1`.
It was observed that in the `_metadata_requests` functions, sorting was performed between dictionary keys. Considering that the default `sorted()` function follows ASCII order, where uppercase letters precede lowercase letters and underscores precede alphanumeric characters.
It appears that the sorting order is affecting the final results of `._get_metadata_request()`.

#### What does this implement/fix? Explain your changes.
Removed the sorting of the dictionary `defaults` in `_metadata_requests.py`.
By sorting this dictionary, the `__metadata_request__*` attributes were not the same as the child class but the same as the last class in the sorted dictionary.
