### PR TITLE
MAINT update SECURITY.md for 1.4.1.post1 release

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,10 @@
 
 ## Supported Versions
 
-| Version   | Supported          |
-| --------- | ------------------ |
-| 1.4.0     | :white_check_mark: |
-| < 1.4.0   | :x:                |
+| Version       | Supported          |
+| ------------- | ------------------ |
+| 1.4.1.post1   | :white_check_mark: |
+| < 1.4.1.post1 | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Related to #28423

Part of the scikit-learn 1.4.1.post1 release.

We need to update the the `SECURITY.md` file.