### PR TITLE
feat(Voting): Allow a `prefit` option to `VotingClassifier/Regressor`

### DIFF
--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -297,8 +297,6 @@ class VotingClassifier(_RoutingNotSupportedMixin, ClassifierMixin, _BaseVoting):
         the estimators can be used for voting correctly and set the attributes
         of this VotingClassifier accordingly.
 
-        .. versionadded:: 1.5
-
     See Also
     --------
     VotingRegressor : Prediction voting regressor.
@@ -615,8 +613,6 @@ class VotingRegressor(_RoutingNotSupportedMixin, RegressorMixin, _BaseVoting):
         fitted. In this case `fit()` will simply perform validation that
         the estimators can be used for voting correctly and set the attributes
         of this VotingRegressor accordingly.
-
-        .. versionadded:: 1.5
 
     Attributes
     ----------


### PR DESCRIPTION
#### Reference Issues/PRs
* Closes #12297

#### What does this implement/fix? Explain your changes.
This feature enables the user to pass in prefit estimators to both `VotingClassifier` and `VotingRegressor` by specifying `prefit=True`.

The `VotingX` is still required to have `fit()` called on it to do validation of the prefit estimators but it does not perform model fitting during this period.

Along with this, I've provided some basic first testing to ensure that the prefit estimators work equally if fit outside vs inside the Voter and validation checks during the call to `VotingX.fit()` to ensure that that prefit estimators are aligned in terms of the data that can flow through them.

#### Any other comments?
This is mainly a draft PR to backup [my comment](https://github.com/scikit-learn/scikit-learn/issues/12297#issuecomment-1947969744) left on issue #12297 with an initial implementation. There are likely a lot of missing features and issues that could arise.

Below is a list of issues that need to be resolved for this feature to integrate properly or issues that need to be discussed.

**Issues**
* When calling `VotingX(estimators, prefit=True).fit(X, y)`, should the `Voter` validate that the estimators are aligned with eachother, or with the passed in `X, y`, in terms of attributes like `n_features_in_` and `n_feature_names_`?
* What should be the defined `clone` behavior of this estimator, in relation [to this comment](https://github.com/scikit-learn/scikit-learn/issues/12297#issuecomment-427400873) by @amueller, linking to #8370
* What tags should be attached to the prefit version of a `Voter` with respect to the suite of estimator tests that exist for scikit-learn integrations.

As a meta-level question, should there exist a separate `PrefitVotingX` to alleviate some of this issues and simplify internals, at the expense of introducing a new estimator class?

---

### TODOs if accepted
* Add a `..versionadded:: ` to the docstrings
* Add a changelog entry