### PR TITLE
DOC correct order of @deprecated and @property in documentation and linter

### DIFF
--- a/build_tools/linting.sh
+++ b/build_tools/linting.sh
@@ -56,7 +56,7 @@ else
 fi
 
 # For docstrings and warnings of deprecated attributes to be rendered
-# properly, the property decorator must come before the deprecated decorator
+# properly, the `deprecated` decorator must come before the `property` decorator
 # (else they are treated as functions)
 
 echo -e "### Checking for bad deprecation order ###\n"
@@ -64,7 +64,7 @@ bad_deprecation_property_order=`git grep -A 10 "@property"  -- "*.py" | awk '/@p
 
 if [ ! -z "$bad_deprecation_property_order" ]
 then
-    echo "property decorator should come before deprecated decorator"
+    echo "deprecated decorator should come before property decorator"
     echo "found the following occurrences:"
     echo $bad_deprecation_property_order
     echo -e "\nProblems detected by deprecation order check\n"

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1234,7 +1234,7 @@ to ``zero_one`` and call ``zero_one_loss`` from that function::
 
 If an attribute is to be deprecated,
 use the decorator ``deprecated`` on a property. Please note that the
-``property`` decorator should be placed before the ``deprecated``
+``deprecated`` decorator should be placed before the ``property``
 decorator for the docstrings to be rendered properly.
 E.g., renaming an attribute ``labels_`` to ``classes_`` can be done as::
 

--- a/sklearn/utils/deprecation.py
+++ b/sklearn/utils/deprecation.py
@@ -44,8 +44,8 @@ class deprecated:
         if isinstance(obj, type):
             return self._decorate_class(obj)
         elif isinstance(obj, property):
-            # Note that this is only triggered properly if the `property`
-            # decorator comes before the `deprecated` decorator, like so:
+            # Note that this is only triggered properly if the `deprecated`
+            # decorator is placed before the `property` decorator, like so:
             #
             # @deprecated(msg)
             # @property


### PR DESCRIPTION
When deprecating a property, the `@deprecated` needs to be placed before the `@property` and encompass it.

We check this correctly, but we did not communicate it correctly in the documentation and in the linter.