### PR TITLE
CI Adds environment to upload_anaconda (#28441)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -221,6 +221,7 @@ jobs:
   upload_anaconda:
     name: Upload to Anaconda
     runs-on: ubuntu-latest
+    environment: upload_anaconda
     needs: [build_wheels, build_sdist]
     # The artifacts cannot be uploaded on PRs
     if: github.event_name != 'pull_request'


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follow up to https://github.com/scikit-learn/scikit-learn/pull/28441#pullrequestreview-1886489673


#### What does this implement/fix? Explain your changes.
This PR cherry picks https://github.com/scikit-learn/scikit-learn/pull/28441 to add  `environment: upload_anaconda` to the 1.4.X branch. Afterwards, we can remove the non-environment repository secrets for uploading to anaconda.

CC @lesteve 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
