### PR TITLE
CI Adds environment for publishing to pypi

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: publish_pypi
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write


### PR DESCRIPTION
For publishing to PyPI, the [Trusted Publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) docs recommends placing the workflow in an environment. I already created the `publish_pypi` environment in this repo.

After this is merged and backported to `1.4.X`, I'll update the PyPI config to only allow uploads from this environment.

CC @lesteve 


For completeness here is what the Trusted Publisher PyPI doc says:
> Configuring an environment is optional, but strongly recommended: with a GitHub environment, you can apply additional restrictions to your trusted workflow, such as requiring manual approval on each run by a trusted subset of repository maintainers.