### PR TITLE
MNT improve first-party detection for ruff isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ select = ["E", "F", "W", "I"]
 line-length = 88
 target-version = "py38"
 
+# For detection of first-party import (isort)
+src = ["sklearn"]
+
 ignore=[
     # space before : (needed for how black formats slicing)
     "E203",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,3 +116,6 @@ exclude= '''
   | sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx
 )
 '''
+
+[tool.ruff.isort]
+known-first-party = ["sklearn"]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
Ruff's isort detects `joblib` as first party library on my system (and therefore pre-commit drives me crazy). This fixes the issue and I haven't found any reason why I'm affected and others not.

#### Any other comments?
