### PR TITLE
ENH minor improvement of binomial hessian

### DIFF
--- a/sklearn/_loss/_loss.pyx.tp
+++ b/sklearn/_loss/_loss.pyx.tp
@@ -765,9 +765,8 @@ cdef inline double_pair cgrad_hess_half_binomial(
         gh.val1 = ((1 - y_true) - y_true * gh.val2) / (1 + gh.val2)  # gradient
         gh.val2 = gh.val2 / (1 + gh.val2)**2                         # hessian
     else:
-        gh.val2 = exp(raw_prediction)
+        gh.val2 = exp(raw_prediction)  # = 1. order Taylor in exp(raw_prediction)
         gh.val1 = gh.val2 - y_true
-        gh.val2 *= (1 - gh.val2)
     return gh
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
#28048

#### What does this implement/fix? Explain your changes.
First, the formula for the hessian is wrong, but the difference is beyond machine precision.

For `raw_prediction <= -37`, `exp(raw_prediction) <= 8.533047625744066e-17` is tiny.
Correct formula: `hessian = exp(raw_prediction) / (1 + exp(raw_prediction))**2`
2nd order hessian: `hessian = exp(raw_prediction) * (1 - 2 * exp(raw_prediction))`
1st order hessian: `hessian = exp(raw_prediction)`

The 2nd order hessian is wrongly implemented without the factor 2.

#### Any other comments?
