### PR TITLE
DOC added examples to docstrings to make_sparse_*, make_swiss_roll, and make_s_curve

### DIFF
--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1505,7 +1505,11 @@ def make_sparse_coded_signal(
     Examples
     -------
     >>> from sklearn.datasets import make_sparse_coded_signal
-    >>> y, X, w = make_sparse_coded_signal(n_samples=1, n_components=2, n_features=2, n_nonzero_coefs=1, random_state=0)
+    >>> y, X, w = make_sparse_coded_signal(n_samples=1, 
+    ...                                    n_components=2, 
+    ...                                    n_features=2, 
+    ...                                    n_nonzero_coefs=1, 
+    ...                                    random_state=0)
     >>> y
     array([-1.24372273, -0.6900468 ])
     >>> X
@@ -1871,12 +1875,12 @@ def make_swiss_roll(n_samples=100, *, noise=0.0, random_state=None, hole=False):
     --------
     >>> from sklearn.datasets import make_swiss_roll
     >>> X,t = make_swiss_roll(n_samples=3, noise=0.1, random_state=34, hole=False)
-    >>> print(X)
-    [[ 1.64827294 13.16259723 -4.6964848 ]
-     [10.53141748  0.32063774 -5.75710103]
-     [ 4.24775516 19.75733211 -3.51094713]]
-    >>> print(t)
-    [ 5.07582426 12.06466261  5.58610129]
+    >>> X
+    array([[ 1.64827294, 13.16259723, -4.6964848 ],
+        [10.53141748,  0.32063774, -5.75710103],
+        [ 4.24775516, 19.75733211, -3.51094713]])
+    >>> t
+    array([ 5.07582426, 12.06466261,  5.58610129])
     """
     generator = check_random_state(random_state)
 

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1505,18 +1505,19 @@ def make_sparse_coded_signal(
     Examples
     --------
     >>> from sklearn.datasets import make_sparse_coded_signal
-    >>> data, dictionary, code = make_sparse_coded_signal(n_samples=1,
-    ...                                    n_components=2,
-    ...                                    n_features=2,
-    ...                                    n_nonzero_coefs=1,
-    ...                                    random_state=0)
-    >>> data
-    array([-1.24372273, -0.6900468 ])
-    >>> dictionary
-    array([[0.87442883, 0.48515381],
-       [0.17578966, 0.98442775]])
-    >>> code
-    array([-1.42232584,  0.        ])
+    >>> data, dictionary, code = make_sparse_coded_signal(
+    ...     n_samples=50,
+    ...     n_components=100,
+    ...     n_features=10,
+    ...     n_nonzero_coefs=4,
+    ...     random_state=0
+    ... )
+    >>> data.shape
+    (50, 10)
+    >>> dictionary.shape
+    (100, 10)
+    >>> code.shape
+    (50, 100)
     """
     generator = check_random_state(random_state)
 
@@ -1603,12 +1604,11 @@ def make_sparse_uncorrelated(n_samples=100, n_features=10, *, random_state=None)
     Examples
     --------
     >>> from sklearn.datasets import make_sparse_uncorrelated
-    >>> X, y = make_sparse_uncorrelated(n_samples=2, n_features=4, random_state=34)
-    >>> X
-    array([[ 0.2438351 , -0.74731818, -1.56117699, -0.46425312],
-       [-0.35206234, -1.28149188,  0.28929924,  0.9800285 ]])
-    >>> y
-    array([ 3.04585663, -4.5128692 ])
+    >>> X, y = make_sparse_uncorrelated(random_state=0)
+    >>> X.shape
+    (100, 10)
+    >>> y.shape
+    (100,)
     """
     generator = check_random_state(random_state)
 
@@ -1873,13 +1873,11 @@ def make_swiss_roll(n_samples=100, *, noise=0.0, random_state=None, hole=False):
     Examples
     --------
     >>> from sklearn.datasets import make_swiss_roll
-    >>> X,t = make_swiss_roll(n_samples=3, noise=0.1, random_state=34, hole=False)
-    >>> X
-    array([[ 1.64827294, 13.16259723, -4.6964848 ],
-        [10.53141748,  0.32063774, -5.75710103],
-        [ 4.24775516, 19.75733211, -3.51094713]])
-    >>> t
-    array([ 5.07582426, 12.06466261,  5.58610129])
+    >>> X, t = make_swiss_roll(noise=0.05, random_state=0)
+    >>> X.shape
+    (100, 3)
+    >>> t.shape
+    (100,)
     """
     generator = check_random_state(random_state)
 
@@ -1944,12 +1942,11 @@ def make_s_curve(n_samples=100, *, noise=0.0, random_state=None):
     Examples
     --------
     >>> from sklearn.datasets import make_s_curve
-    >>> X,t = make_s_curve(n_samples=2, noise=0.1, random_state=34)
-    >>> X
-    array([[ 0.77856344,  0.15020128,  1.38441714],
-           [ 0.43449844,  1.13763619, -1.77875957]])
-    >>> t
-    array([-4.3489537 ,  2.63988465])
+    >>> X, t = make_s_curve(noise=0.05, random_state=0)
+    >>> X.shape
+    (100, 3)
+    >>> t.shape
+    (100,)
     """
     generator = check_random_state(random_state)
 

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1505,19 +1505,18 @@ def make_sparse_coded_signal(
     Examples
     -------
     >>> from sklearn.datasets import make_sparse_coded_signal
-    >>> y, X, w = make_sparse_coded_signal(n_samples=1,
+    >>> data, dictionary, code = make_sparse_coded_signal(n_samples=1,
     ...                                    n_components=2,
     ...                                    n_features=2,
     ...                                    n_nonzero_coefs=1,
     ...                                    random_state=0)
-    >>> y
+    >>> data
     array([-1.24372273, -0.6900468 ])
-    >>> X
+    >>> dictionary
     array([[0.87442883, 0.48515381],
        [0.17578966, 0.98442775]])
-    >>> w
+    >>> code
     array([-1.42232584,  0.        ])
-
     """
     generator = check_random_state(random_state)
 

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1868,7 +1868,7 @@ def make_swiss_roll(n_samples=100, *, noise=0.0, random_state=None, hole=False):
            https://homepages.ecs.vuw.ac.nz/~marslast/Code/Ch6/lle.py
 
     Examples
-    -------- 
+    --------
     >>> from sklearn.datasets import make_swiss_roll
     >>> X,t = make_swiss_roll(n_samples=3, noise=0.1, random_state=34, hole=False)
     >>> print(X)

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1503,7 +1503,7 @@ def make_sparse_coded_signal(
         if `data_transposed` is False, otherwise it's `(n_components, n_samples)`.
 
     Examples
-    -------
+    --------
     >>> from sklearn.datasets import make_sparse_coded_signal
     >>> data, dictionary, code = make_sparse_coded_signal(n_samples=1,
     ...                                    n_components=2,
@@ -1915,8 +1915,8 @@ def make_swiss_roll(n_samples=100, *, noise=0.0, random_state=None, hole=False):
     prefer_skip_nested_validation=True,
 )
 def make_s_curve(n_samples=100, *, noise=0.0, random_state=None):
-    """Generate an S curve dataset.
-
+    r"""Generate an S curve dataset.
+    
     Read more in the :ref:`User Guide <sample_generators>`.
 
     Parameters
@@ -1938,11 +1938,11 @@ def make_s_curve(n_samples=100, *, noise=0.0, random_state=None):
         The points.
 
     t : ndarray of shape (n_samples,)
-        The univariate position of the sample according to the main dimension
-        of the points in the manifold.
+        The univariate position of the sample according 
+        to the main dimension of the points in the manifold.
 
     Examples
-    -------
+    --------
     >>> from sklearn.datasets import make_s_curve
     >>> X,t = make_s_curve(n_samples=2, noise=0.1, random_state=34)
     >>> X

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1501,6 +1501,19 @@ def make_sparse_coded_signal(
         The sparse code such that each column of this matrix has exactly
         n_nonzero_coefs non-zero items (X). The shape is `(n_samples, n_components)`
         if `data_transposed` is False, otherwise it's `(n_components, n_samples)`.
+
+    Examples
+    -------
+    >>> from sklearn.datasets import make_sparse_coded_signal
+    >>> y, X, w = make_sparse_coded_signal(n_samples=1, n_components=2, n_features=2, n_nonzero_coefs=1, random_state=0)
+    >>> y
+    array([-1.24372273, -0.6900468 ])
+    >>> X
+    array([[0.87442883, 0.48515381],
+       [0.17578966, 0.98442775]])
+    >>> w
+    array([-1.42232584,  0.        ])
+
     """
     generator = check_random_state(random_state)
 
@@ -1583,6 +1596,16 @@ def make_sparse_uncorrelated(n_samples=100, n_features=10, *, random_state=None)
     .. [1] G. Celeux, M. El Anbari, J.-M. Marin, C. P. Robert,
            "Regularization in regression: comparing Bayesian and frequentist
            methods in a poorly informative situation", 2009.
+
+    Examples
+    --------
+    >>> from sklearn.datasets import make_sparse_uncorrelated
+    >>> X, y = make_sparse_uncorrelated(n_samples=2, n_features=4, random_state=34)
+    >>> X
+    array([[ 0.2438351 , -0.74731818, -1.56117699, -0.46425312],
+       [-0.35206234, -1.28149188,  0.28929924,  0.9800285 ]])
+    >>> y
+    array([ 3.04585663, -4.5128692 ])
     """
     generator = check_random_state(random_state)
 
@@ -1843,6 +1866,17 @@ def make_swiss_roll(n_samples=100, *, noise=0.0, random_state=None, hole=False):
     .. [1] S. Marsland, "Machine Learning: An Algorithmic Perspective", 2nd edition,
            Chapter 6, 2014.
            https://homepages.ecs.vuw.ac.nz/~marslast/Code/Ch6/lle.py
+
+    Examples
+    -------- 
+    >>> from sklearn.datasets import make_swiss_roll
+    >>> X,t = make_swiss_roll(n_samples=3, noise=0.1, random_state=34, hole=False)
+    >>> print(X)
+    [[ 1.64827294 13.16259723 -4.6964848 ]
+     [10.53141748  0.32063774 -5.75710103]
+     [ 4.24775516 19.75733211 -3.51094713]]
+    >>> print(t)
+    [ 5.07582426 12.06466261  5.58610129]
     """
     generator = check_random_state(random_state)
 
@@ -1903,6 +1937,16 @@ def make_s_curve(n_samples=100, *, noise=0.0, random_state=None):
     t : ndarray of shape (n_samples,)
         The univariate position of the sample according to the main dimension
         of the points in the manifold.
+
+    Examples
+    -------
+    >>> from sklearn.datasets import make_s_curve
+    >>> X,t = make_s_curve(n_samples=2, noise=0.1, random_state=34)
+    >>> X
+    array([[ 0.77856344,  0.15020128,  1.38441714],
+           [ 0.43449844,  1.13763619, -1.77875957]])
+    >>> t
+    array([-4.3489537 ,  2.63988465])
     """
     generator = check_random_state(random_state)
 

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1915,8 +1915,8 @@ def make_swiss_roll(n_samples=100, *, noise=0.0, random_state=None, hole=False):
     prefer_skip_nested_validation=True,
 )
 def make_s_curve(n_samples=100, *, noise=0.0, random_state=None):
-    r"""Generate an S curve dataset.
-    
+    """Generate an S curve dataset.
+
     Read more in the :ref:`User Guide <sample_generators>`.
 
     Parameters
@@ -1938,7 +1938,7 @@ def make_s_curve(n_samples=100, *, noise=0.0, random_state=None):
         The points.
 
     t : ndarray of shape (n_samples,)
-        The univariate position of the sample according 
+        The univariate position of the sample according
         to the main dimension of the points in the manifold.
 
     Examples

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1505,10 +1505,10 @@ def make_sparse_coded_signal(
     Examples
     -------
     >>> from sklearn.datasets import make_sparse_coded_signal
-    >>> y, X, w = make_sparse_coded_signal(n_samples=1, 
-    ...                                    n_components=2, 
-    ...                                    n_features=2, 
-    ...                                    n_nonzero_coefs=1, 
+    >>> y, X, w = make_sparse_coded_signal(n_samples=1,
+    ...                                    n_components=2,
+    ...                                    n_features=2,
+    ...                                    n_nonzero_coefs=1,
     ...                                    random_state=0)
     >>> y
     array([-1.24372273, -0.6900468 ])


### PR DESCRIPTION

#### Reference Issues/PRs
#27982 


#### What does this implement/fix? Explain your changes.
Added docstring examples to the following functions:
- `make_sparse_coded_signal`
- `make_sparse_uncorrelated`
- `make_swiss_roll`
- `make_s_curve`