### PR TITLE
DOC fix jupyterlab and binder could not find `polars`

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -7,3 +7,4 @@ seaborn
 Pillow
 sphinx-gallery
 scikit-learn
+polars

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -495,6 +495,8 @@ def notebook_modification_function(notebook_content, notebook_filename):
         code_lines.append("%pip install plotly")
     if "skimage" in notebook_content_str:
         code_lines.append("%pip install scikit-image")
+    if "polars" in notebook_content_str:
+        code_lines.append("%pip install polars")
     if "fetch_" in notebook_content_str:
         code_lines.extend(
             [


### PR DESCRIPTION
The example `plot_release_highlights_1_4_0` imports `polars` but we do not add that to binder and jupyterlab.

- Jupyterlab: https://scikit-learn.org/dev/lite/lab/?path=auto_examples/release_highlights/plot_release_highlights_1_4_0.ipynb
- Binder: https://mybinder.org/v2/gh/scikit-learn/scikit-learn/main?urlpath=lab/tree/notebooks/auto_examples/release_highlights/plot_release_highlights_1_4_0.ipynb