### PR TITLE
DOC Remove old docstring notes from `sklearn/feature_extraction/image.py`

### DIFF
--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -174,15 +174,6 @@ def img_to_graph(img, *, mask=None, return_as=sparse.coo_matrix, dtype=None):
     -------
     graph : ndarray or a sparse matrix class
         The computed adjacency matrix.
-
-    Notes
-    -----
-    For scikit-learn versions 0.14.1 and prior, return_as=np.ndarray was
-    handled by returning a dense np.matrix instance.  Going forward, np.ndarray
-    returns an np.ndarray, as expected.
-
-    For compatibility, user code relying on this method should wrap its
-    calls in ``np.asarray`` to avoid type issues.
     """
     img = np.atleast_3d(img)
     n_x, n_y, n_z = img.shape
@@ -228,15 +219,6 @@ def grid_to_graph(
     -------
     graph : np.ndarray or a sparse matrix class
         The computed adjacency matrix.
-
-    Notes
-    -----
-    For scikit-learn versions 0.14.1 and prior, return_as=np.ndarray was
-    handled by returning a dense np.matrix instance.  Going forward, np.ndarray
-    returns an np.ndarray, as expected.
-
-    For compatibility, user code relying on this method should wrap its
-    calls in ``np.asarray`` to avoid type issues.
 
     Examples
     --------


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes issue #28454

#### What does this implement/fix? Explain your changes.
This PR removes too old notes which are contained in two docstrings at

https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/feature_extraction/image.py#L178-L185

and

https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/feature_extraction/image.py#L232-L239

as discussed in issue ##28454.

#### Any other comments?
