### PR TITLE
MAINT Replace setup_module by pytest fixtures

### DIFF
--- a/sklearn/datasets/tests/test_lfw.py
+++ b/sklearn/datasets/tests/test_lfw.py
@@ -21,10 +21,6 @@ from sklearn.datasets import fetch_lfw_pairs, fetch_lfw_people
 from sklearn.datasets.tests.test_common import check_return_X_y
 from sklearn.utils._testing import assert_array_equal
 
-SCIKIT_LEARN_DATA = None
-SCIKIT_LEARN_EMPTY_DATA = None
-LFW_HOME = None
-
 FAKE_NAMES = [
     "Abdelatif_Smith",
     "Abhati_Kepler",
@@ -36,19 +32,26 @@ FAKE_NAMES = [
 ]
 
 
-def setup_module():
+@pytest.fixture(scope="module")
+def mock_empty_data_home():
+    data_dir = tempfile.mkdtemp(prefix="scikit_learn_empty_test_")
+
+    yield data_dir
+
+    if os.path.isdir(data_dir):
+        shutil.rmtree(data_dir)
+
+
+@pytest.fixture(scope="module")
+def mock_data_home():
     """Test fixture run once and common to all tests of this module"""
     Image = pytest.importorskip("PIL.Image")
 
-    global SCIKIT_LEARN_DATA, SCIKIT_LEARN_EMPTY_DATA, LFW_HOME
+    data_dir = tempfile.mkdtemp(prefix="scikit_learn_lfw_test_")
+    lfw_home = os.path.join(data_dir, "lfw_home")
 
-    SCIKIT_LEARN_DATA = tempfile.mkdtemp(prefix="scikit_learn_lfw_test_")
-    LFW_HOME = os.path.join(SCIKIT_LEARN_DATA, "lfw_home")
-
-    SCIKIT_LEARN_EMPTY_DATA = tempfile.mkdtemp(prefix="scikit_learn_empty_test_")
-
-    if not os.path.exists(LFW_HOME):
-        os.makedirs(LFW_HOME)
+    if not os.path.exists(lfw_home):
+        os.makedirs(lfw_home)
 
     random_state = random.Random(42)
     np_rng = np.random.RandomState(42)
@@ -56,7 +59,7 @@ def setup_module():
     # generate some random jpeg files for each person
     counts = {}
     for name in FAKE_NAMES:
-        folder_name = os.path.join(LFW_HOME, "lfw_funneled", name)
+        folder_name = os.path.join(lfw_home, "lfw_funneled", name)
         if not os.path.exists(folder_name):
             os.makedirs(folder_name)
 
@@ -69,11 +72,11 @@ def setup_module():
             img.save(file_path)
 
     # add some random file pollution to test robustness
-    with open(os.path.join(LFW_HOME, "lfw_funneled", ".test.swp"), "wb") as f:
+    with open(os.path.join(lfw_home, "lfw_funneled", ".test.swp"), "wb") as f:
         f.write(b"Text file to be ignored by the dataset loader.")
 
     # generate some pairing metadata files using the same format as LFW
-    with open(os.path.join(LFW_HOME, "pairsDevTrain.txt"), "wb") as f:
+    with open(os.path.join(lfw_home, "pairsDevTrain.txt"), "wb") as f:
         f.write(b"10\n")
         more_than_two = [name for name, count in counts.items() if count >= 2]
         for i in range(5):
@@ -92,29 +95,26 @@ def setup_module():
                 ).encode()
             )
 
-    with open(os.path.join(LFW_HOME, "pairsDevTest.txt"), "wb") as f:
+    with open(os.path.join(lfw_home, "pairsDevTest.txt"), "wb") as f:
         f.write(b"Fake place holder that won't be tested")
 
-    with open(os.path.join(LFW_HOME, "pairs.txt"), "wb") as f:
+    with open(os.path.join(lfw_home, "pairs.txt"), "wb") as f:
         f.write(b"Fake place holder that won't be tested")
 
+    yield data_dir
 
-def teardown_module():
-    """Test fixture (clean up) run once after all tests of this module"""
-    if os.path.isdir(SCIKIT_LEARN_DATA):
-        shutil.rmtree(SCIKIT_LEARN_DATA)
-    if os.path.isdir(SCIKIT_LEARN_EMPTY_DATA):
-        shutil.rmtree(SCIKIT_LEARN_EMPTY_DATA)
+    if os.path.isdir(data_dir):
+        shutil.rmtree(data_dir)
 
 
-def test_load_empty_lfw_people():
+def test_load_empty_lfw_people(mock_empty_data_home):
     with pytest.raises(OSError):
-        fetch_lfw_people(data_home=SCIKIT_LEARN_EMPTY_DATA, download_if_missing=False)
+        fetch_lfw_people(data_home=mock_empty_data_home, download_if_missing=False)
 
 
-def test_load_fake_lfw_people():
+def test_load_fake_lfw_people(mock_data_home):
     lfw_people = fetch_lfw_people(
-        data_home=SCIKIT_LEARN_DATA, min_faces_per_person=3, download_if_missing=False
+        data_home=mock_data_home, min_faces_per_person=3, download_if_missing=False
     )
 
     # The data is croped around the center as a rectangular bounding box
@@ -132,7 +132,7 @@ def test_load_fake_lfw_people():
     # It is possible to ask for the original data without any croping or color
     # conversion and not limit on the number of picture per person
     lfw_people = fetch_lfw_people(
-        data_home=SCIKIT_LEARN_DATA,
+        data_home=mock_data_home,
         resize=None,
         slice_=None,
         color=True,
@@ -161,7 +161,7 @@ def test_load_fake_lfw_people():
     # test return_X_y option
     fetch_func = partial(
         fetch_lfw_people,
-        data_home=SCIKIT_LEARN_DATA,
+        data_home=mock_data_home,
         resize=None,
         slice_=None,
         color=True,
@@ -170,23 +170,23 @@ def test_load_fake_lfw_people():
     check_return_X_y(lfw_people, fetch_func)
 
 
-def test_load_fake_lfw_people_too_restrictive():
+def test_load_fake_lfw_people_too_restrictive(mock_data_home):
     with pytest.raises(ValueError):
         fetch_lfw_people(
-            data_home=SCIKIT_LEARN_DATA,
+            data_home=mock_data_home,
             min_faces_per_person=100,
             download_if_missing=False,
         )
 
 
-def test_load_empty_lfw_pairs():
+def test_load_empty_lfw_pairs(mock_empty_data_home):
     with pytest.raises(OSError):
-        fetch_lfw_pairs(data_home=SCIKIT_LEARN_EMPTY_DATA, download_if_missing=False)
+        fetch_lfw_pairs(data_home=mock_empty_data_home, download_if_missing=False)
 
 
-def test_load_fake_lfw_pairs():
+def test_load_fake_lfw_pairs(mock_data_home):
     lfw_pairs_train = fetch_lfw_pairs(
-        data_home=SCIKIT_LEARN_DATA, download_if_missing=False
+        data_home=mock_data_home, download_if_missing=False
     )
 
     # The data is croped around the center as a rectangular bounding box
@@ -203,7 +203,7 @@ def test_load_fake_lfw_pairs():
     # It is possible to ask for the original data without any croping or color
     # conversion
     lfw_pairs_train = fetch_lfw_pairs(
-        data_home=SCIKIT_LEARN_DATA,
+        data_home=mock_data_home,
         resize=None,
         slice_=None,
         color=True,
@@ -218,7 +218,7 @@ def test_load_fake_lfw_pairs():
     assert lfw_pairs_train.DESCR.startswith(".. _labeled_faces_in_the_wild_dataset:")
 
 
-def test_fetch_lfw_people_internal_cropping():
+def test_fetch_lfw_people_internal_cropping(mock_data_home):
     """Check that we properly crop the images.
 
     Non-regression test for:
@@ -229,7 +229,7 @@ def test_fetch_lfw_people_internal_cropping():
     # pre-allocated based on `slice_` parameter.
     slice_ = (slice(70, 195), slice(78, 172))
     lfw = fetch_lfw_people(
-        data_home=SCIKIT_LEARN_DATA,
+        data_home=mock_data_home,
         min_faces_per_person=3,
         download_if_missing=False,
         resize=None,

--- a/sklearn/datasets/tests/test_lfw.py
+++ b/sklearn/datasets/tests/test_lfw.py
@@ -11,7 +11,6 @@ joblib, successive runs will be fast (less than 200ms).
 import os
 import random
 import shutil
-import tempfile
 from functools import partial
 
 import numpy as np
@@ -33,8 +32,8 @@ FAKE_NAMES = [
 
 
 @pytest.fixture(scope="module")
-def mock_empty_data_home():
-    data_dir = tempfile.mkdtemp(prefix="scikit_learn_empty_test_")
+def mock_empty_data_home(tmp_path_factory):
+    data_dir = tmp_path_factory.mktemp("scikit_learn_empty_test")
 
     yield data_dir
 
@@ -43,11 +42,11 @@ def mock_empty_data_home():
 
 
 @pytest.fixture(scope="module")
-def mock_data_home():
+def mock_data_home(tmp_path_factory):
     """Test fixture run once and common to all tests of this module"""
     Image = pytest.importorskip("PIL.Image")
 
-    data_dir = tempfile.mkdtemp(prefix="scikit_learn_lfw_test_")
+    data_dir = tmp_path_factory.mktemp("scikit_learn_lfw_test")
     lfw_home = os.path.join(data_dir, "lfw_home")
 
     if not os.path.exists(lfw_home):
@@ -102,9 +101,6 @@ def mock_data_home():
         f.write(b"Fake place holder that won't be tested")
 
     yield data_dir
-
-    if os.path.isdir(data_dir):
-        shutil.rmtree(data_dir)
 
 
 def test_load_empty_lfw_people(mock_empty_data_home):

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1,9 +1,6 @@
-import atexit
-import functools
 import numbers
 import os
 import pickle
-import tempfile
 from copy import deepcopy
 from functools import partial
 from unittest.mock import Mock
@@ -62,7 +59,6 @@ from sklearn.tests.metadata_routing_common import (
 )
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.utils._testing import (
-    _delete_folder,
     assert_almost_equal,
     assert_array_equal,
     ignore_warnings,
@@ -169,8 +165,8 @@ def _make_estimators(X_train, y_train, y_ml_train):
 
 
 @pytest.fixture(scope="module")
-def memmap_data_and_estimators():
-    temp_folder = tempfile.mkdtemp(prefix="sklearn_test_score_objects_")
+def memmap_data_and_estimators(tmp_path_factory):
+    temp_folder = tmp_path_factory.mktemp("sklearn_test_score_objects")
     X, y = make_classification(n_samples=30, n_features=5, random_state=0)
     _, y_ml = make_multilabel_classification(n_samples=X.shape[0], random_state=0)
     filename = os.path.join(temp_folder, "test_data.pkl")
@@ -178,7 +174,6 @@ def memmap_data_and_estimators():
     X_mm, y_mm, y_ml_mm = joblib.load(filename, mmap_mode="r")
     estimators = _make_estimators(X_mm, y_mm, y_ml_mm)
 
-    atexit.register(functools.partial(_delete_folder, temp_folder, warn=True))
     yield X_mm, y_mm, y_ml_mm, estimators
 
 

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1,5 +1,4 @@
 import numbers
-import os
 import pickle
 from copy import deepcopy
 from functools import partial
@@ -169,7 +168,7 @@ def memmap_data_and_estimators(tmp_path_factory):
     temp_folder = tmp_path_factory.mktemp("sklearn_test_score_objects")
     X, y = make_classification(n_samples=30, n_features=5, random_state=0)
     _, y_ml = make_multilabel_classification(n_samples=X.shape[0], random_state=0)
-    filename = os.path.join(temp_folder, "test_data.pkl")
+    filename = temp_folder / "test_data.pkl"
     joblib.dump((X, y, y_ml), filename)
     X_mm, y_mm, y_ml_mm = joblib.load(filename, mmap_mode="r")
     estimators = _make_estimators(X_mm, y_mm, y_ml_mm)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1,7 +1,8 @@
+import atexit
+import functools
 import numbers
 import os
 import pickle
-import shutil
 import tempfile
 from copy import deepcopy
 from functools import partial
@@ -61,6 +62,7 @@ from sklearn.tests.metadata_routing_common import (
 )
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.utils._testing import (
+    _delete_folder,
     assert_almost_equal,
     assert_array_equal,
     ignore_warnings,
@@ -175,10 +177,9 @@ def memmap_data_and_estimators():
     joblib.dump((X, y, y_ml), filename)
     X_mm, y_mm, y_ml_mm = joblib.load(filename, mmap_mode="r")
     estimators = _make_estimators(X_mm, y_mm, y_ml_mm)
+
+    atexit.register(functools.partial(_delete_folder, temp_folder, warn=True))
     yield X_mm, y_mm, y_ml_mm, estimators
-    # GC closes the mmap file descriptors
-    X_mm, y_mm, y_ml_mm, estimators = None, None, None, None
-    shutil.rmtree(temp_folder)
 
 
 class EstimatorWithFit(BaseEstimator):

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -166,28 +166,19 @@ def _make_estimators(X_train, y_train, y_ml_train):
     )
 
 
-X_mm, y_mm, y_ml_mm = None, None, None
-ESTIMATORS = None
-TEMP_FOLDER = None
-
-
-def setup_module():
-    # Create some memory mapped data
-    global X_mm, y_mm, y_ml_mm, TEMP_FOLDER, ESTIMATORS
-    TEMP_FOLDER = tempfile.mkdtemp(prefix="sklearn_test_score_objects_")
+@pytest.fixture(scope="module")
+def memmap_data_and_estimators():
+    temp_folder = tempfile.mkdtemp(prefix="sklearn_test_score_objects_")
     X, y = make_classification(n_samples=30, n_features=5, random_state=0)
     _, y_ml = make_multilabel_classification(n_samples=X.shape[0], random_state=0)
-    filename = os.path.join(TEMP_FOLDER, "test_data.pkl")
+    filename = os.path.join(temp_folder, "test_data.pkl")
     joblib.dump((X, y, y_ml), filename)
     X_mm, y_mm, y_ml_mm = joblib.load(filename, mmap_mode="r")
-    ESTIMATORS = _make_estimators(X_mm, y_mm, y_ml_mm)
-
-
-def teardown_module():
-    global X_mm, y_mm, y_ml_mm, TEMP_FOLDER, ESTIMATORS
+    estimators = _make_estimators(X_mm, y_mm, y_ml_mm)
+    yield X_mm, y_mm, y_ml_mm, estimators
     # GC closes the mmap file descriptors
-    X_mm, y_mm, y_ml_mm, ESTIMATORS = None, None, None, None
-    shutil.rmtree(TEMP_FOLDER)
+    X_mm, y_mm, y_ml_mm, estimators = None, None, None, None
+    shutil.rmtree(temp_folder)
 
 
 class EstimatorWithFit(BaseEstimator):
@@ -688,10 +679,11 @@ def test_regression_scorer_sample_weight():
 
 
 @pytest.mark.parametrize("name", get_scorer_names())
-def test_scorer_memmap_input(name):
+def test_scorer_memmap_input(name, memmap_data_and_estimators):
     # Non-regression test for #6147: some score functions would
     # return singleton memmap when computed on memmap data instead of scalar
     # float values.
+    X_mm, y_mm, y_ml_mm, estimators = memmap_data_and_estimators
 
     if name in REQUIRE_POSITIVE_Y_SCORERS:
         y_mm_1 = _require_positive_y(y_mm)
@@ -701,7 +693,7 @@ def test_scorer_memmap_input(name):
 
     # UndefinedMetricWarning for P / R scores
     with ignore_warnings():
-        scorer, estimator = get_scorer(name), ESTIMATORS[name]
+        scorer, estimator = get_scorer(name), estimators[name]
         if name in MULTILABEL_ONLY_SCORERS:
             score = scorer(estimator, X_mm, y_ml_mm_1)
         else:


### PR DESCRIPTION
Context https://github.com/scikit-learn/scikit-learn/pull/28461.

Using pytest fixtures avoids the Pytest 8.0.1 bug https://github.com/pytest-dev/pytest/issues/12011 and is slightly more readable by not having to use module globals.

This is also recommended by Pytest in https://docs.pytest.org/en/stable/xunit_setup.html
