### PR TITLE
DOC Use effective value for `max_iter` in `BayesianRidge` and `ARDRegression`

### DIFF
--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -79,10 +79,9 @@ class BayesianRidge(RegressorMixin, LinearModel):
 
     Parameters
     ----------
-    max_iter : int, default=None
+    max_iter : int, default=300
         Maximum number of iterations over the complete dataset before
-        stopping independently of any early stopping criterion. If `None`, it
-        corresponds to `max_iter=300`.
+        stopping independently of any early stopping criterion.
 
         .. versionchanged:: 1.3
 
@@ -499,8 +498,8 @@ class ARDRegression(RegressorMixin, LinearModel):
 
     Parameters
     ----------
-    max_iter : int, default=None
-        Maximum number of iterations. If `None`, it corresponds to `max_iter=300`.
+    max_iter : int, default=300
+        Maximum number of iterations.
 
         .. versionchanged:: 1.3
 


### PR DESCRIPTION
#### Reference Issues/PRs
Noticed in: https://github.com/scikit-learn/scikit-learn/pull/28471#discussion_r1495406106

#### What does this implement/fix? Explain your changes.
Use effective value for `max_iter`, instead of `None` then explaining that `None` effectively means 300. This is done elsewhere https://github.com/scikit-learn/scikit-learn/pull/28471#discussion_r1495406106

#### Any other comments?
cc @betatim 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
