### PR TITLE
TST Add test `alpha=0.0` raises when `cv=None` for `_BaseRidgeCV`

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -110,6 +110,14 @@ Changelog
   by passing a function in place of a strategy name.
   :pr:`28053` by :user:`Mark Elliot <mark-thm>`.
 
+:mod:`sklearn.linear_model`
+...........................
+
+- |API| :class:`linear_model.RidgeCV` and :class:`linear_model.RidgeClassifierCV`
+  will now allow `alpha=0` when `cv != None`, which is consistent with
+  :class:`linear_model.Ridge` and :class:`linear_model.RidgeClassifier`.
+  :pr:`28425` by :user:`Lucy Liu <lucyleeow>`.
+
 :mod:`sklearn.metrics`
 ......................
 

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1383,6 +1383,28 @@ def test_ridgecv_alphas_conversion(Estimator):
     assert_array_equal(ridge_est.alphas, np.asarray(alphas))
 
 
+@pytest.mark.parametrize("cv", [None, 3])
+@pytest.mark.parametrize("Estimator", [RidgeCV, RidgeClassifierCV])
+def test_ridgecv_alphas_zero(cv, Estimator):
+    """Check alpha=0.0 raises error only when `cv=None`."""
+    rng = np.random.RandomState(0)
+    alphas = (0.0, 1.0, 10.0)
+
+    n_samples, n_features = 5, 5
+    if Estimator is RidgeCV:
+        y = rng.randn(n_samples)
+    else:
+        y = rng.randint(0, 2, n_samples)
+    X = rng.randn(n_samples, n_features)
+
+    ridge_est = Estimator(alphas=alphas, cv=cv)
+    if cv is None:
+        with pytest.raises(ValueError, match=r"alphas\[0\] == 0.0, must be > 0.0."):
+            ridge_est.fit(X, y)
+    else:
+        ridge_est.fit(X, y)
+
+
 def test_ridgecv_sample_weight():
     rng = np.random.RandomState(0)
     alphas = (0.1, 1.0, 10.0)


### PR DESCRIPTION
#### Reference Issues/PRs
Follow on from #28425, I realise I should have added a test.

Also added a whats new entry, but since the PR number is not the same as this PR, I hope the CI job passes...

cc @lorentzenchr 
