### PR TITLE
DOC `TransformedTargetRegressor` docstring mentions that `inverse_func` needs to be set together with `func`

### DIFF
--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -69,9 +69,9 @@ class TransformedTargetRegressor(
 
     func : function, default=None
         Function to apply to `y` before passing to :meth:`fit`. Cannot be set
-        at the same time as `transformer`. The function needs to return a
-        2-dimensional array. If `func is None`, the function used will be the
-        identity function.
+        at the same time as `transformer`. If `func is None`, the function used will be
+        the identity function. If `func` is set, `inverse_func` also needs to be
+        provided. The function needs to return a 2-dimensional array.
 
     inverse_func : function, default=None
         Function to apply to the prediction of the regressor. Cannot be set at


### PR DESCRIPTION
#### Reference Issues/PRs
closes #28473

#### What does this implement/fix? Explain your changes.
This PR adds the constraint used in the code to the docstring of `TransformedTargetRegressor`: `inverse_func` needs to be set together with `func`.