### PR TITLE
MAINT cleanup utils.__init__: move check_matplotlib/pandas_support into dedicated submodule

### DIFF
--- a/sklearn/datasets/_arff_parser.py
+++ b/sklearn/datasets/_arff_parser.py
@@ -10,11 +10,8 @@ import scipy as sp
 
 from ..externals import _arff
 from ..externals._arff import ArffSparseDataType
-from ..utils import (
-    _chunk_generator,
-    check_pandas_support,
-    get_chunk_n_rows,
-)
+from ..utils import _chunk_generator, get_chunk_n_rows
+from ..utils._optional_dependencies import check_pandas_support
 from ..utils.fixes import pd_fillna
 
 

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -22,7 +22,8 @@ from urllib.request import urlretrieve
 import numpy as np
 
 from ..preprocessing import scale
-from ..utils import Bunch, check_pandas_support, check_random_state
+from ..utils import Bunch, check_random_state
+from ..utils._optional_dependencies import check_pandas_support
 from ..utils._param_validation import Interval, StrOptions, validate_params
 
 DATA_MODULE = "sklearn.datasets.data"

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -15,10 +15,8 @@ from warnings import warn
 
 import numpy as np
 
-from ..utils import (
-    Bunch,
-    check_pandas_support,  # noqa  # noqa
-)
+from ..utils import Bunch
+from ..utils._optional_dependencies import check_pandas_support  # noqa
 from ..utils._param_validation import (
     Integral,
     Interval,

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -21,7 +21,8 @@ from sklearn.datasets._openml import (
     _open_openml_url,
     _retry_with_clean_cache,
 )
-from sklearn.utils import Bunch, check_pandas_support
+from sklearn.utils import Bunch
+from sklearn.utils._optional_dependencies import check_pandas_support
 from sklearn.utils._testing import (
     SkipTest,
     assert_allclose,

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -26,8 +26,8 @@ from ..utils import (
     _safe_assign,
     _safe_indexing,
     check_array,
-    check_matplotlib_support,  # noqa
 )
+from ..utils._optional_dependencies import check_matplotlib_support  # noqa
 from ..utils._param_validation import (
     HasMethods,
     Integral,

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -2,7 +2,8 @@ import numpy as np
 
 from ...base import is_regressor
 from ...preprocessing import LabelEncoder
-from ...utils import _safe_indexing, check_matplotlib_support
+from ...utils import _safe_indexing
+from ...utils._optional_dependencies import check_matplotlib_support
 from ...utils._response import _get_response_values
 from ...utils.validation import (
     _is_arraylike_not_scalar,

--- a/sklearn/inspection/_plot/partial_dependence.py
+++ b/sklearn/inspection/_plot/partial_dependence.py
@@ -11,10 +11,10 @@ from ...utils import (
     Bunch,
     _safe_indexing,
     check_array,
-    check_matplotlib_support,  # noqa
     check_random_state,
 )
 from ...utils._encode import _unique
+from ...utils._optional_dependencies import check_matplotlib_support  # noqa
 from ...utils.parallel import Parallel, delayed
 from .. import partial_dependence
 from .._pd_utils import _check_feature_names, _get_feature_index

--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -3,7 +3,7 @@ from itertools import product
 import numpy as np
 
 from ...base import is_classifier
-from ...utils import check_matplotlib_support
+from ...utils._optional_dependencies import check_matplotlib_support
 from ...utils.multiclass import unique_labels
 from .. import confusion_matrix
 

--- a/sklearn/metrics/_plot/regression.py
+++ b/sklearn/metrics/_plot/regression.py
@@ -2,7 +2,8 @@ import numbers
 
 import numpy as np
 
-from ...utils import _safe_indexing, check_matplotlib_support, check_random_state
+from ...utils import _safe_indexing, check_random_state
+from ...utils._optional_dependencies import check_matplotlib_support
 
 
 class PredictionErrorDisplay:

--- a/sklearn/model_selection/_plot.py
+++ b/sklearn/model_selection/_plot.py
@@ -2,7 +2,7 @@ import warnings
 
 import numpy as np
 
-from ..utils import check_matplotlib_support
+from ..utils._optional_dependencies import check_matplotlib_support
 from ..utils._plotting import _interval_max_min_ratio, _validate_score_name
 from ._validation import learning_curve, validation_curve
 

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -71,7 +71,6 @@ __all__ = [
     "register_parallel_backend",
     "resample",
     "shuffle",
-    "check_matplotlib_support",
     "all_estimators",
     "DataConversionWarning",
     "estimator_html_repr",
@@ -1253,47 +1252,3 @@ def _approximate_mode(class_counts, n_draws, rng):
             if need_to_add == 0:
                 break
     return floored.astype(int)
-
-
-def check_matplotlib_support(caller_name):
-    """Raise ImportError with detailed error message if mpl is not installed.
-
-    Plot utilities like any of the Display's plotting functions should lazily import
-    matplotlib and call this helper before any computation.
-
-    Parameters
-    ----------
-    caller_name : str
-        The name of the caller that requires matplotlib.
-    """
-    try:
-        import matplotlib  # noqa
-    except ImportError as e:
-        raise ImportError(
-            "{} requires matplotlib. You can install matplotlib with "
-            "`pip install matplotlib`".format(caller_name)
-        ) from e
-
-
-def check_pandas_support(caller_name):
-    """Raise ImportError with detailed error message if pandas is not installed.
-
-    Plot utilities like :func:`fetch_openml` should lazily import
-    pandas and call this helper before any computation.
-
-    Parameters
-    ----------
-    caller_name : str
-        The name of the caller that requires pandas.
-
-    Returns
-    -------
-    pandas
-        The pandas package.
-    """
-    try:
-        import pandas  # noqa
-
-        return pandas
-    except ImportError as e:
-        raise ImportError("{} requires pandas.".format(caller_name)) from e

--- a/sklearn/utils/_optional_dependencies.py
+++ b/sklearn/utils/_optional_dependencies.py
@@ -1,0 +1,42 @@
+def check_matplotlib_support(caller_name):
+    """Raise ImportError with detailed error message if mpl is not installed.
+
+    Plot utilities like any of the Display's plotting functions should lazily import
+    matplotlib and call this helper before any computation.
+
+    Parameters
+    ----------
+    caller_name : str
+        The name of the caller that requires matplotlib.
+    """
+    try:
+        import matplotlib  # noqa
+    except ImportError as e:
+        raise ImportError(
+            "{} requires matplotlib. You can install matplotlib with "
+            "`pip install matplotlib`".format(caller_name)
+        ) from e
+
+
+def check_pandas_support(caller_name):
+    """Raise ImportError with detailed error message if pandas is not installed.
+
+    Plot utilities like :func:`fetch_openml` should lazily import
+    pandas and call this helper before any computation.
+
+    Parameters
+    ----------
+    caller_name : str
+        The name of the caller that requires pandas.
+
+    Returns
+    -------
+    pandas
+        The pandas package.
+    """
+    try:
+        import pandas  # noqa
+
+        return pandas
+    except ImportError as e:
+        raise ImportError("{} requires pandas.".format(caller_name)) from e

--- a/sklearn/utils/_plotting.py
+++ b/sklearn/utils/_plotting.py
@@ -1,6 +1,7 @@
 import numpy as np
 
-from . import check_consistent_length, check_matplotlib_support
+from . import check_consistent_length
+from ._optional_dependencies import check_matplotlib_support
 from ._response import _get_response_values_binary
 from .multiclass import type_of_target
 from .validation import _check_pos_label_consistency


### PR DESCRIPTION
Extracted from https://github.com/scikit-learn/scikit-learn/pull/26686 to ease the reviews. The end goal is to clean the utils.__init__.py module as explained in the linked PR.

I didn't find an already existing submodule relevant for `check_matplotlib_support` and `check_pandas_support` so I created a dedicated submodule named `_optional_dependencies`.

These functions are not listed in `classes.rst` so assumed private, this is why I made them only importable from `utils._optional_dependencies`.