### PR TITLE
ENH `TransformedTargetRegressor.fit()` raises if only `inverse_func` is provided

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -64,6 +64,10 @@ Changelog
 - |Feature| A fitted :class:`compose.ColumnTransformer` now implements `__getitem__`
   which returns the fitted transformers by name. :pr:`27990` by `Thomas Fan`_.
 
+- |ENH| :class:`compose.TransformedTargetRegressor` now raises an error in `fit` if
+  only `inverse_func` is provided without `func` (that would default to identity) being
+  explicitly set as well. :pr:`28483` by :user:`Stefanie Senger <StefanieSenger>`.
+
 :mod:`sklearn.dummy`
 ....................
 

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -75,9 +75,10 @@ class TransformedTargetRegressor(
 
     inverse_func : function, default=None
         Function to apply to the prediction of the regressor. Cannot be set at
-        the same time as `transformer`. The function needs to return a
-        2-dimensional array. The inverse function is used to return
-        predictions to the same space of the original training labels.
+        the same time as `transformer`. The inverse function is used to return
+        predictions to the same space of the original training labels. If
+        `inverse_func` is set, `func` also needs to be provided. The function
+        needs to return a 2-dimensional array.
 
     check_inverse : bool, default=True
         Whether to check that `transform` followed by `inverse_transform`
@@ -173,9 +174,18 @@ class TransformedTargetRegressor(
         elif self.transformer is not None:
             self.transformer_ = clone(self.transformer)
         else:
-            if self.func is not None and self.inverse_func is None:
+            if (self.func is not None and self.inverse_func is None) or (
+                self.inverse_func is not None and self.func is None
+            ):
+                lacking_param, existing_param = (
+                    ("func", "inverse_func")
+                    if self.func is None
+                    else ("inverse_func", "func")
+                )
                 raise ValueError(
-                    "When 'func' is provided, 'inverse_func' must also be provided"
+                    f"When '{existing_param}' is provided, '{lacking_param}' must also"
+                    f" be provided. If {lacking_param} is supposed to be the default,"
+                    " you need to explicitly pass it the identity function."
                 )
             self.transformer_ = FunctionTransformer(
                 func=self.func,

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -77,8 +77,8 @@ class TransformedTargetRegressor(
         Function to apply to the prediction of the regressor. Cannot be set at
         the same time as `transformer`. The inverse function is used to return
         predictions to the same space of the original training labels. If
-        `inverse_func` is set, `func` also needs to be provided. The function
-        needs to return a 2-dimensional array.
+        `inverse_func` is set, `func` also needs to be provided. The inverse
+        function needs to return a 2-dimensional array.
 
     check_inverse : bool, default=True
         Whether to check that `transform` followed by `inverse_transform`
@@ -175,7 +175,7 @@ class TransformedTargetRegressor(
             self.transformer_ = clone(self.transformer)
         else:
             if (self.func is not None and self.inverse_func is None) or (
-                self.inverse_func is not None and self.func is None
+                self.func is None and self.inverse_func is not None
             ):
                 lacking_param, existing_param = (
                     ("func", "inverse_func")

--- a/sklearn/compose/tests/test_target.py
+++ b/sklearn/compose/tests/test_target.py
@@ -37,11 +37,19 @@ def test_transform_target_regressor_error():
         match=r"fit\(\) got an unexpected " "keyword argument 'sample_weight'",
     ):
         regr.fit(X, y, sample_weight=sample_weight)
-    # func is given but inverse_func is not
+
+    # one of (func, inverse_func) is given but the other one is not
     regr = TransformedTargetRegressor(func=np.exp)
     with pytest.raises(
         ValueError,
         match="When 'func' is provided, 'inverse_func' must also be provided",
+    ):
+        regr.fit(X, y)
+
+    regr = TransformedTargetRegressor(inverse_func=np.log)
+    with pytest.raises(
+        ValueError,
+        match="When 'inverse_func' is provided, 'func' must also be provided",
     ):
         regr.fit(X, y)
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
 This PR suggests to raise an error if users only provide `inverse_func` to `TransformedTargetRegressor()` without explicitely setting `func` as well.

It's losely connected to #28480, where I came across this issue.

Not sure if I should add a changelog entry here.