### PR TITLE
DOC Update hgbt docstrings on categorical_features default value

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1498,7 +1498,7 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         ``max_bins`` bins. In addition to the ``max_bins`` bins, one more bin
         is always reserved for missing values. Must be no larger than 255.
     categorical_features : array-like of {bool, int, str} of shape (n_features) \
-            or shape (n_categorical_features,), default=None
+            or shape (n_categorical_features,), default="warn"
         Indicates the categorical features.
 
         - None : no feature will be considered categorical.
@@ -1511,6 +1511,8 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
           considered to be categorical features. The input must be an object
           exposing a ``__dataframe__`` method such as pandas or polars
           DataFrames to use this feature.
+        - `"warn"`: issue a warning when the input dataframe has undeclared
+          categorical columns.
 
         For each categorical feature, there must be at most `max_bins` unique
         categories. Negative values for categorical features encoded as numeric
@@ -1874,7 +1876,7 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
         ``max_bins`` bins. In addition to the ``max_bins`` bins, one more bin
         is always reserved for missing values. Must be no larger than 255.
     categorical_features : array-like of {bool, int, str} of shape (n_features) \
-            or shape (n_categorical_features,), default=None
+            or shape (n_categorical_features,), default="warn"
         Indicates the categorical features.
 
         - None : no feature will be considered categorical.
@@ -1887,6 +1889,8 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
           considered to be categorical features. The input must be an object
           exposing a ``__dataframe__`` method such as pandas or polars
           DataFrames to use this feature.
+        - `"warn"`: issue a warning when the input dataframe has undeclared
+          categorical columns.
 
         For each categorical feature, there must be at most `max_bins` unique
         categories. Negative values for categorical features encoded as numeric


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

In #26411 we added the option the support of `categorical_features="from_dtype"`.
As mentioned in https://github.com/scikit-learn/scikit-learn/pull/26411#discussion_r1209972560, the docstrings need to be updated accordingly. It's still written default=None.

#### What does this implement/fix? Explain your changes.

This PR fixes the issue.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
