### PR TITLE
MAINT make sure canonical link is https://scikit-learn.org

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@ review, either the pull request needs some benchmarking, tinkering,
 convincing, etc. or more likely the reviewers are simply busy. In either
 case, we ask for your understanding during the review process.
 For more information, see our FAQ on this topic:
-http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.
+https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.
 
 Thanks for contributing!
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Documentation can be found under the
 But there are many other ways to help. In particular answering queries on the
 [issue tracker](https://github.com/scikit-learn/scikit-learn/issues),
 investigating bugs, and [reviewing other developers' pull
-requests](http://scikit-learn.org/dev/developers/contributing.html#code-review-guidelines)
+requests](https://scikit-learn.org/dev/developers/contributing.html#code-review-guidelines)
 are very valuable contributions that decrease the burden on the project
 maintainers.
 
@@ -30,8 +30,8 @@ link to it from your website, or simply star it in GitHub to say "I use it".
 Quick links
 -----------
 
-* [Submitting a bug report or feature request](http://scikit-learn.org/dev/developers/contributing.html#submitting-a-bug-report-or-a-feature-request)
-* [Contributing code](http://scikit-learn.org/dev/developers/contributing.html#contributing-code)
+* [Submitting a bug report or feature request](https://scikit-learn.org/dev/developers/contributing.html#submitting-a-bug-report-or-a-feature-request)
+* [Contributing code](https://scikit-learn.org/dev/developers/contributing.html#contributing-code)
 * [Coding guidelines](https://scikit-learn.org/dev/developers/develop.html#coding-guidelines)
 * [Tips to read current code](https://scikit-learn.org/dev/developers/contributing.html#reading-the-existing-code-base)
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,6 +1,6 @@
 # Documentation for scikit-learn
 
 This directory contains the full manual and website as displayed at
-http://scikit-learn.org. See
-http://scikit-learn.org/dev/developers/contributing.html#documentation for
-detailed information about the documentation. 
+https://scikit-learn.org. See
+https://scikit-learn.org/dev/developers/contributing.html#documentation for
+detailed information about the documentation.

--- a/doc/themes/scikit-learn-modern/layout.html
+++ b/doc/themes/scikit-learn-modern/layout.html
@@ -20,7 +20,7 @@
   {% block htmltitle %}
   <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
   {% endblock %}
-  <link rel="canonical" href="http://scikit-learn.org/stable/{{pagename}}.html" />
+  <link rel="canonical" href="https://scikit-learn.org/stable/{{pagename}}.html" />
 
   {% if favicon_url %}
   <link rel="shortcut icon" href="{{ favicon_url|e }}"/>
@@ -69,7 +69,7 @@
         <div class="alert alert-danger p-1 mb-2" role="alert">
           <p class="text-center mb-0">
           <strong>scikit-learn {{ release }}</strong><br/>
-          <a href="http://scikit-learn.org/dev/versions.html">Other versions</a>
+          <a href="https://scikit-learn.org/dev/versions.html">Other versions</a>
           </p>
         </div>
         {%- endif %}

--- a/doc/whats_new/older_versions.rst
+++ b/doc/whats_new/older_versions.rst
@@ -1124,7 +1124,7 @@ Changelog
 ---------
 
 - New `stochastic gradient
-  <http://scikit-learn.org/stable/modules/sgd.html>`_ descent
+  <https://scikit-learn.org/stable/modules/sgd.html>`_ descent
   module by Peter Prettenhofer. The module comes with complete
   documentation and examples.
 
@@ -1256,9 +1256,9 @@ Documentation
 - Improved documentation for many modules, now separating
   narrative documentation from the class reference. As an example,
   see `documentation for the SVM module
-  <http://scikit-learn.org/stable/modules/svm.html>`_ and the
+  <https://scikit-learn.org/stable/modules/svm.html>`_ and the
   complete `class reference
-  <http://scikit-learn.org/stable/modules/classes.html>`_.
+  <https://scikit-learn.org/stable/modules/classes.html>`_.
 
 Fixes
 -----
@@ -1280,7 +1280,7 @@ Examples
   :ref:`sphx_glr_auto_examples_text_plot_document_classification_20newsgroups.py`
 
 - Many more examples. `See here
-  <http://scikit-learn.org/stable/auto_examples/index.html>`_
+  <https://scikit-learn.org/stable/auto_examples/index.html>`_
   the full list of examples.
 
 

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -14,7 +14,7 @@ get information about the working environment.
 # that are accessible to everybody and reusable in various contexts:
 # machine-learning as a versatile tool for science and engineering.
 #
-# See http://scikit-learn.org for complete documentation.
+# See https://scikit-learn.org for complete documentation.
 
 import logging
 import os


### PR DESCRIPTION
While working on #28478, it seems that Algolia find that the canonical link is `http://scikit-learn.org` that does not match the landing page.

So I corrected the canonical link in `layout.html`. In addition, I make the other links in the documentation to match `https`.