### PR TITLE
CI Build musllinux wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -89,6 +89,24 @@ jobs:
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
 
+          # Linux 64 bit musllinux_1_1
+          - os: ubuntu-latest
+            python: 39
+            platform_id: musllinux_x86_64
+            musllinux_image: musllinux_1_1
+          - os: ubuntu-latest
+            python: 310
+            platform_id: musllinux_x86_64
+            musllinux_image: musllinux_1_1
+          - os: ubuntu-latest
+            python: 311
+            platform_id: musllinux_x86_64
+            musllinux_image: musllinux_1_1
+          - os: ubuntu-latest
+            python: 312
+            platform_id: musllinux_x86_64
+            musllinux_image: musllinux_1_1
+
           # MacOS x86_64
           - os: macos-latest
             python: 39
@@ -163,6 +181,8 @@ jobs:
           CIBW_ARCHS: all
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.manylinux_image }}
+          CIBW_MUSLLINUX_X86_64_IMAGE: ${{ matrix.musllinux_image }}
+          CIBW_MUSLLINUX_I686_IMAGE: ${{ matrix.musllinux_image }}
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: bash build_tools/github/repair_windows_wheels.sh {wheel} {dest_dir}
           CIBW_BEFORE_TEST_WINDOWS: bash build_tools/github/build_minimal_windows_image.sh ${{ matrix.python }}
           CIBW_TEST_REQUIRES: pytest pandas threadpoolctl


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #27004
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
I've added a wheel-output for musllinux, for faster installation on (among others) Alpine-Linux.

#### Any other comments?
Since Alpine-Linux is used increasingly, pre-building wheels for Alpine-Linux is a must-have IMO.

I'm unfamiliar with the codebase, so I might've missed something. I tried my best to test it locally by running `CIBW_PROJECT_REQUIRES_PYTHON=">=3.12" CIBW_BUILD=cp312-musllinux_x86_64 cibuildwheel --platform=linux --output-dir wheelhouse --archs x86_64` on my M2 ARM MacBook.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
