### PR TITLE
[DOC] Improve documentation of DBSCAN memory use

### DIFF
--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -189,8 +189,10 @@ class DBSCAN(ClusterMixin, BaseEstimator):
     Finds core samples of high density and expands clusters from them.
     Good for data which contains clusters of similar density.
 
-    The worst case memory complexity of DBSCAN is :math:`O({n}^2)`, which can
-    occur when the `eps` param is large and `min_samples` is low.
+    This implementation has a worst case memory complexity of :math:`O({n}^2)`,
+    which can occur when the `eps` param is large and `min_samples` is low,
+    while the original DBSCAN only uses linear memory.
+    For further details, see the Notes below.
 
     Read more in the :ref:`User Guide <dbscan>`.
 


### PR DESCRIPTION
Original DBSCAN only queries one point at a time.
It is a scikit-learn limitation that the bulk query may use quadratic memory.

A better documentation of the memory is already found below, in the Notes:

https://github.com/scikit-learn/scikit-learn/blob/070fe3b493b23e56b1a6bb1f22218a14e20589d3/sklearn/cluster/_dbscan.py#L129-L133

Funnily, the *incorrect* "DBSCAN needs quadratic memory" claim was introduced later, in #26783