### PR TITLE
MAINT cleanup utils.__init__: move nan utils into dedicated submodule

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -33,7 +33,8 @@ from ...metrics import check_scoring
 from ...metrics._scorer import _SCORERS
 from ...model_selection import train_test_split
 from ...preprocessing import FunctionTransformer, LabelEncoder, OrdinalEncoder
-from ...utils import check_random_state, compute_sample_weight, is_scalar_nan, resample
+from ...utils import check_random_state, compute_sample_weight, resample
+from ...utils._missing import is_scalar_nan
 from ...utils._openmp_helpers import _openmp_effective_n_threads
 from ...utils._param_validation import Hidden, Interval, RealNotInt, StrOptions
 from ...utils.multiclass import check_classification_targets

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -13,8 +13,8 @@ import numpy.ma as ma
 from scipy import sparse as sp
 
 from ..base import BaseEstimator, TransformerMixin, _fit_context
-from ..utils import _is_pandas_na, is_scalar_nan
 from ..utils._mask import _get_mask
+from ..utils._missing import is_pandas_na, is_scalar_nan
 from ..utils._param_validation import MissingValues, StrOptions
 from ..utils.fixes import _mode
 from ..utils.sparsefuncs import _get_median
@@ -22,7 +22,7 @@ from ..utils.validation import FLOAT_DTYPES, _check_feature_names_in, check_is_f
 
 
 def _check_inputs_dtype(X, missing_values):
-    if _is_pandas_na(missing_values):
+    if is_pandas_na(missing_values):
         # Allow using `pd.NA` as missing values to impute numerical arrays.
         return
     if X.dtype.kind in ("f", "i", "u") and not isinstance(missing_values, numbers.Real):
@@ -323,7 +323,7 @@ class SimpleImputer(_BaseImputer):
             # Use object dtype if fitted on object dtypes
             dtype = self._fit_dtype
 
-        if _is_pandas_na(self.missing_values) or is_scalar_nan(self.missing_values):
+        if is_pandas_na(self.missing_values) or is_scalar_nan(self.missing_values):
             force_all_finite = "allow-nan"
         else:
             force_all_finite = True
@@ -701,7 +701,7 @@ class SimpleImputer(_BaseImputer):
 
     def _more_tags(self):
         return {
-            "allow_nan": _is_pandas_na(self.missing_values) or is_scalar_nan(
+            "allow_nan": is_pandas_na(self.missing_values) or is_scalar_nan(
                 self.missing_values
             )
         }

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -14,9 +14,9 @@ from ..utils import (
     _safe_indexing,
     check_array,
     check_random_state,
-    is_scalar_nan,
 )
 from ..utils._mask import _get_mask
+from ..utils._missing import is_scalar_nan
 from ..utils._param_validation import HasMethods, Interval, StrOptions
 from ..utils.metadata_routing import (
     MetadataRouter,

--- a/sklearn/impute/_knn.py
+++ b/sklearn/impute/_knn.py
@@ -10,8 +10,8 @@ from ..base import _fit_context
 from ..metrics import pairwise_distances_chunked
 from ..metrics.pairwise import _NAN_METRICS
 from ..neighbors._base import _get_weights
-from ..utils import is_scalar_nan
 from ..utils._mask import _get_mask
+from ..utils._missing import is_scalar_nan
 from ..utils._param_validation import Hidden, Interval, StrOptions
 from ..utils.validation import FLOAT_DTYPES, _check_feature_names_in, check_is_fitted
 from ._base import _BaseImputer

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -25,9 +25,9 @@ from ..utils import (
     gen_batches,
     gen_even_slices,
     get_chunk_n_rows,
-    is_scalar_nan,
 )
 from ..utils._mask import _get_mask
+from ..utils._missing import is_scalar_nan
 from ..utils._param_validation import (
     Hidden,
     Interval,

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -10,9 +10,10 @@ import numpy as np
 from scipy import sparse
 
 from ..base import BaseEstimator, OneToOneFeatureMixin, TransformerMixin, _fit_context
-from ..utils import _safe_indexing, check_array, is_scalar_nan
+from ..utils import _safe_indexing, check_array
 from ..utils._encode import _check_unknown, _encode, _get_counts, _unique
 from ..utils._mask import _get_mask
+from ..utils._missing import is_scalar_nan
 from ..utils._param_validation import Interval, RealNotInt, StrOptions
 from ..utils._set_output import _get_output_config
 from ..utils.validation import _check_feature_names_in, check_is_fitted

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -6,7 +6,7 @@ from scipy import sparse
 
 from sklearn.exceptions import NotFittedError
 from sklearn.preprocessing import OneHotEncoder, OrdinalEncoder
-from sklearn.utils import is_scalar_nan
+from sklearn.utils._missing import is_scalar_nan
 from sklearn.utils._testing import (
     _convert_container,
     assert_allclose,

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -2,14 +2,13 @@
 The :mod:`sklearn.utils` module includes various utilities.
 """
 
-import math
 import numbers
 import platform
 import struct
 import timeit
 import warnings
 from collections.abc import Sequence
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from itertools import compress, islice
 
 import numpy as np
@@ -1088,65 +1087,3 @@ def get_chunk_n_rows(row_bytes, *, max_n_rows=None, working_memory=None):
         )
         chunk_n_rows = 1
     return chunk_n_rows
-
-
-def _is_pandas_na(x):
-    """Test if x is pandas.NA.
-
-    We intentionally do not use this function to return `True` for `pd.NA` in
-    `is_scalar_nan`, because estimators that support `pd.NA` are the exception
-    rather than the rule at the moment. When `pd.NA` is more universally
-    supported, we may reconsider this decision.
-
-    Parameters
-    ----------
-    x : any type
-
-    Returns
-    -------
-    boolean
-    """
-    with suppress(ImportError):
-        from pandas import NA
-
-        return x is NA
-
-    return False
-
-
-def is_scalar_nan(x):
-    """Test if x is NaN.
-
-    This function is meant to overcome the issue that np.isnan does not allow
-    non-numerical types as input, and that np.nan is not float('nan').
-
-    Parameters
-    ----------
-    x : any type
-        Any scalar value.
-
-    Returns
-    -------
-    bool
-        Returns true if x is NaN, and false otherwise.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from sklearn.utils import is_scalar_nan
-    >>> is_scalar_nan(np.nan)
-    True
-    >>> is_scalar_nan(float("nan"))
-    True
-    >>> is_scalar_nan(None)
-    False
-    >>> is_scalar_nan("")
-    False
-    >>> is_scalar_nan([np.nan])
-    False
-    """
-    return (
-        not isinstance(x, numbers.Integral)
-        and isinstance(x, numbers.Real)
-        and math.isnan(x)
-    )

--- a/sklearn/utils/_encode.py
+++ b/sklearn/utils/_encode.py
@@ -4,7 +4,7 @@ from typing import NamedTuple
 
 import numpy as np
 
-from . import is_scalar_nan
+from ._missing import is_scalar_nan
 
 
 def _unique(values, *, return_inverse=False, return_counts=False):

--- a/sklearn/utils/_mask.py
+++ b/sklearn/utils/_mask.py
@@ -3,7 +3,7 @@ from contextlib import suppress
 import numpy as np
 from scipy import sparse as sp
 
-from . import is_scalar_nan
+from ._missing import is_scalar_nan
 from .fixes import _object_dtype_isnan
 
 

--- a/sklearn/utils/_missing.py
+++ b/sklearn/utils/_missing.py
@@ -1,0 +1,65 @@
+import math
+import numbers
+from contextlib import suppress
+
+
+def is_scalar_nan(x):
+    """Test if x is NaN.
+
+    This function is meant to overcome the issue that np.isnan does not allow
+    non-numerical types as input, and that np.nan is not float('nan').
+
+    Parameters
+    ----------
+    x : any type
+        Any scalar value.
+
+    Returns
+    -------
+    bool
+        Returns true if x is NaN, and false otherwise.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.utils._missing import is_scalar_nan
+    >>> is_scalar_nan(np.nan)
+    True
+    >>> is_scalar_nan(float("nan"))
+    True
+    >>> is_scalar_nan(None)
+    False
+    >>> is_scalar_nan("")
+    False
+    >>> is_scalar_nan([np.nan])
+    False
+    """
+    return (
+        not isinstance(x, numbers.Integral)
+        and isinstance(x, numbers.Real)
+        and math.isnan(x)
+    )
+
+
+def is_pandas_na(x):
+    """Test if x is pandas.NA.
+
+    We intentionally do not use this function to return `True` for `pd.NA` in
+    `is_scalar_nan`, because estimators that support `pd.NA` are the exception
+    rather than the rule at the moment. When `pd.NA` is more universally
+    supported, we may reconsider this decision.
+
+    Parameters
+    ----------
+    x : any type
+
+    Returns
+    -------
+    boolean
+    """
+    with suppress(ImportError):
+        from pandas import NA
+
+        return x is NA
+
+    return False

--- a/sklearn/utils/_pprint.py
+++ b/sklearn/utils/_pprint.py
@@ -69,7 +69,7 @@ from collections import OrderedDict
 
 from .._config import get_config
 from ..base import BaseEstimator
-from . import is_scalar_nan
+from ._missing import is_scalar_nan
 
 
 class KeyValTuple(tuple):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -64,7 +64,8 @@ from ..utils._param_validation import (
 )
 from ..utils.fixes import parse_version, sp_version
 from ..utils.validation import check_is_fitted
-from . import IS_PYPY, is_scalar_nan, shuffle
+from . import IS_PYPY, shuffle
+from ._missing import is_scalar_nan
 from ._param_validation import Interval
 from ._tags import (
     _DEFAULT_TAGS,

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -24,11 +24,11 @@ from sklearn.utils import (
     deprecated,
     gen_even_slices,
     get_chunk_n_rows,
-    is_scalar_nan,
     resample,
     safe_mask,
     shuffle,
 )
+from sklearn.utils._missing import is_scalar_nan
 from sklearn.utils._mocking import MockDataFrame
 from sklearn.utils._testing import (
     _convert_container,


### PR DESCRIPTION
Extracted from https://github.com/scikit-learn/scikit-learn/pull/26686 to ease the reviews. The end goal is to clean the utils.init.py module as explained in the linked PR.

I didn't find a relevant already existing module to move `is_scalar_nan` and `_is_pandas_na` into so I created a dedicated `utils._missing` submodule. Maybe it could go into `vaildation` since it's kind of related to input/data validation but I not sure if it's the right place, let me know what you think.

Since both function are not listed in `classes.rst`, they're assumed private so I made them only importable from utils._missing.

I also took the opportunity to rename `_is_pandas_na` into `is_pandas_na` since there's no need to multiply the leading underscores: it already comes from a private module.