### PR TITLE
Remove the float64 accumulator in r2_score sums

### DIFF
--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1193,10 +1193,10 @@ def r2_score(
     else:
         weight = 1.0
 
-    numerator = (weight * (y_true - y_pred) ** 2).sum(axis=0, dtype=np.float64)
+    numerator = (weight * (y_true - y_pred) ** 2).sum(axis=0)
     denominator = (
         weight * (y_true - np.average(y_true, axis=0, weights=sample_weight)) ** 2
-    ).sum(axis=0, dtype=np.float64)
+    ).sum(axis=0)
 
     return _assemble_r2_explained_variance(
         numerator=numerator,


### PR DESCRIPTION
#2158 was merged without non regression tests 10 years ago to use `float64` accumulators in the 2 sum operations (across samples) used to compute the numerator and denominator of the final expression computed by `r2_score`.

Since the summed terms are all positive, [I have the feeling](https://github.com/scikit-learn/scikit-learn/pull/27904#discussion_r1494858270) that those sums should be numerically stable by default (contrary to what was suggested in #2158). I tried to conduct an empirical study both on `main` and on this PR to see if I could trigger non-numerically stable sums in r2 scores computed on 100,000,000 predictions.

Here is the code to collect the results:

<details>

```python
# %%
from sklearn.metrics import r2_score
import numpy as np
import os
import subprocess
import pandas as pd
import sklearn


n_samples = int(1e8)
rng = np.random.default_rng(0)
cwd = os.getcwd()
os.chdir(os.path.dirname(sklearn.__file__))
branch_name = (
    subprocess.check_output("git rev-parse --abbrev-ref HEAD".split())
    .strip()
    .decode("utf-8")
)
# check that there are no uncommitted changes:
assert not subprocess.check_output("git diff".split()).strip()
os.chdir(cwd)

# Precompute RNG numbers to be assembled later at each iteration:
base_signal = rng.normal(loc=0, scale=1, size=n_samples)
base_noise = rng.normal(loc=0, scale=1, size=n_samples)
w = rng.uniform(0, 1, size=n_samples)

signal_buffer = np.empty_like(base_signal)
noise_buffer = np.empty_like(base_noise)

print(f"Branch: {branch_name}")
records = []
for loc in np.logspace(-3, 3, 3):
    for scale in np.logspace(-6, 6, 5):
        for noise_scale_factor in [1e-6, 0.1, 0.5, 0.999]:
            noise_scale = scale * noise_scale_factor

            # Generate the data at single precision
            signal_buffer[:] = base_signal
            signal_buffer *= scale
            signal_buffer += loc
            y_true = signal_buffer.astype(np.float32, copy=True)

            noise_buffer[:] = base_noise
            noise_buffer *= noise_scale
            noise_buffer += signal_buffer
            y_pred = noise_buffer.astype(np.float32, copy=True)
            sample_weight = w.astype(np.float32, copy=True)

            # Peform the computation at single precision (optionally with
            # double precision upcasts depending on the code in scikit-learn):
            r2_f32 = r2_score(y_true, y_pred, sample_weight=sample_weight)

            # Upcast the same data to perform all computation with double precision.
            r2_f64 = r2_score(
                y_true.astype(np.float64),
                y_pred.astype(np.float64),
                sample_weight=sample_weight.astype(np.float64),
            )
            abs_diff = np.abs(r2_f32 - r2_f64)
            print(
                f"loc={loc:.2e}, scale={scale:.2e}, noise_scale_factor={noise_scale_factor:.2e}, "
                f"score_float32_input={r2_f32:.6f}, score_float64_input={r2_f64:.6f}, "
                f"abs_diff={abs_diff:.6f}"
            )
            records.append(
                {
                    "loc": loc,
                    "scale": scale,
                    "noise_scale_factor": noise_scale_factor,
                    "r2_float32": r2_f32,
                    "r2_float64": r2_f64,
                }
            )

# %%
filename = f"float32_r2_score_{branch_name}.parquet"
pd.DataFrame(records).to_parquet(filename)
```

</details>

Note that this code tries many `y_true` scales and offsets and correlations with `y_pred`.

I ran it both on this branch and on `main` to evaluate the impact of the `np.float64` upcast in the sum operations.

Here is the code to combine the results:

<details>

```python
import pandas as pd
import numpy as np

df_main = pd.read_parquet("float32_r2_score_main.parquet")
df_branch = pd.read_parquet("float32_r2_score_float32-r2_score.parquet")

df = pd.merge(
    df_main,
    df_branch,
    on=("loc", "scale", "noise_scale_factor"),
    suffixes=("_main", "_branch"),
)
np.testing.assert_allclose(df["r2_float64_main"], df["r2_float64_branch"])

df["diff_float32_branches"] = np.abs(df["r2_float32_main"] - df["r2_float32_branch"])
df["diff_float32_float64_main"] = np.abs(df["r2_float32_main"] - df["r2_float64_main"])
```

</details>

- First we can observe that when computing from the difference in r2 score compute between the 2 branches on float32 data, the difference is never bigger than 5e-06 which seems ok to me:

```python
print(df.sort_values("diff_float32_branches", ascending=False).head(5).to_markdown())
```

|    |      loc |   scale |   noise_scale_factor |   r2_float32_main |   r2_float64_main |   r2_float32_branch |   r2_float64_branch |   diff_float32_branches |
|---:|---------:|--------:|---------------------:|------------------:|------------------:|--------------------:|--------------------:|------------------------:|
|  3 |    0.001 |   1e-06 |                0.999 |        0.00166918 |       0.00166847  |          0.00166547 |         0.00166847  |             3.71002e-06 |
| 23 |    1     |   1e-06 |                0.999 |        0.00447393 |       0.000944231 |          0.00447714 |         0.000944231 |             3.20946e-06 |
| 39 |    1     |   1e+06 |                0.999 |        0.00166847 |       0.00166847  |          0.00166625 |         0.00166847  |             2.22143e-06 |
| 19 |    0.001 |   1e+06 |                0.999 |        0.00166847 |       0.00166847  |          0.00166625 |         0.00166847  |             2.22143e-06 |
| 59 | 1000     |   1e+06 |                0.999 |        0.00166847 |       0.00166847  |          0.00166625 |         0.00166847  |             2.22143e-06 


- However, when comparing r2_score with `float32` data and their `float64` counter part, both on `main`, there are a few edge cases where it's not numerically stable:

```python
print(df.sort_values("diff_float32_float64_main", ascending=False).head(5).to_markdown())
```

|    |   loc |   scale |   noise_scale_factor |   r2_float32_main |   r2_float64_main |   r2_float32_branch |   r2_float64_branch |   diff_float32_float64_main |
|---:|------:|--------:|---------------------:|------------------:|------------------:|--------------------:|--------------------:|----------------------------:|
| 47 |  1000 |   0.001 |                0.999 |        0.770511   |       0.00136753  |          0.770511   |         0.00136753  |                 0.769143    |
| 46 |  1000 |   0.001 |                0.5   |        0.942406   |       0.749375    |          0.942406   |         0.749375    |                 0.19303     |
| 45 |  1000 |   0.001 |                0.1   |        0.99756    |       0.98938     |          0.99756    |         0.98938     |                 0.00817938  |
| 23 |     1 |   1e-06 |                0.999 |        0.00447393 |       0.000944231 |          0.00447714 |         0.000944231 |                 0.0035297   |
| 22 |     1 |   1e-06 |                0.5   |        0.749516   |       0.748628    |          0.749518   |         0.748628    |                 0.000888106 |

But note that this numerical stability problems are kind of expected since the `y_true` has a large offset (around 1000) and a very small scale of variation (0.001). So those are pathological data to represent in `float32`.

More importantly, this problem already exist on `main` and this PR where I disable the `np.float64` does not change anything in that respect.

So my conclusions is that:

- I could not find cases where the `np.float64` in the sum operations are significantly improving numerical stability.
- Pathological cases that are numerically unstable when computing `r2_score` on `np.float32` data be fixed by only using `np.float64` accumulators in the sum: all the computation should be done in `float64`.