### PR TITLE
CI Use environment variable for building with pip using build isolation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -256,6 +256,7 @@ jobs:
         # threaded because by default the tests configuration (sklearn/conftest.py)
         # makes sure that they are single threaded in each xdist subprocess.
         PYTEST_XDIST_VERSION: 'none'
+        PIP_BUILD_ISOLATION: 'true'
 
 - template: build_tools/azure/posix-docker.yml
   parameters:

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -128,8 +128,7 @@ scikit_learn_install() {
 
     if [[ "$BUILD_WITH_MESON" == "true" ]]; then
         make dev-meson
-    # TODO use a specific variable for this rather than using a particular build ...
-    elif [[ "$DISTRIB" == "conda-pip-latest" ]]; then
+    elif [[ "$PIP_BUILD_ISOLATION" == "true" ]]; then
         # Check that pip can automatically build scikit-learn with the build
         # dependencies specified in pyproject.toml using an isolated build
         # environment:


### PR DESCRIPTION
Rely on explict environment variable rather than `DISTRIB` name.