### PR TITLE
DOC add param `gamma` ignored for certain `affinity` values in `SpectralClustering` docstring 

### DIFF
--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -438,7 +438,8 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
 
     gamma : float, default=1.0
         Kernel coefficient for rbf, poly, sigmoid, laplacian and chi2 kernels.
-        Ignored for ``affinity='nearest_neighbors'``.
+        Ignored for ``affinity='nearest_neighbors'``, ``affinity='precomputed'``
+        or ``affinity='precomputed_nearest_neighbors'``.
 
     affinity : str or callable, default='rbf'
         How to construct the affinity matrix.


### PR DESCRIPTION
#### Reference Issues/PRs
closes #28470

#### What does this implement/fix? Explain your changes.
Updating when param `gamma` is ignored to the docstring.