### PR TITLE
DOC [PST] use jinja2 template for rst generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ doc/css/*
 !doc/css/.gitkeep
 doc/modules/generated/
 doc/datasets/generated/
+doc/index.rst
 doc/min_dependency_table.rst
 doc/min_dependency_substitutions.rst
 *.pdf

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -885,13 +885,21 @@ else:
         "https://github.com/": {"Authorization": f"token {github_token}"},
     }
 
-# Convert the template rst files into actual rst files prior to any sphinx event
+# -- Convert .rst.template files to .rst ---------------------------------------
 
 from sklearn._min_dependencies import dependent_packages
 
-# (template name, file name, kwargs for rendering)
+# If development build, link to local page in the top navbar; otherwise link to the
+# development version; see https://github.com/scikit-learn/scikit-learn/pull/22550
+if parsed_version.is_devrelease:
+    development_link = "developers/index"
+else:
+    development_link = "https://scikit-learn.org/dev/developers/index.html"
+
+# Define the templates and target files for conversion
+# Each entry is in the format (template name, file name, kwargs for rendering)
 rst_templates = [
-    ("index", "index", {"is_devrelease": parsed_version.is_devrelease}),
+    ("index", "index", {"development_link": development_link}),
     (
         "min_dependency_table",
         "min_dependency_table",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -889,18 +889,28 @@ else:
 
 from sklearn._min_dependencies import dependent_packages
 
-# (file name without suffix, kwargs for rendering)
+# (template name, file name, kwargs for rendering)
 rst_templates = [
-    ("index", {"is_devrelease": parsed_version.is_devrelease}),
-    ("min_dependency_table", {"dependent_packages": dependent_packages}),
-    ("min_dependency_substitutions", {"dependent_packages": dependent_packages}),
+    ("index", "index", {"is_devrelease": parsed_version.is_devrelease}),
+    (
+        "min_dependency_table",
+        "min_dependency_table",
+        {"dependent_packages": dependent_packages},
+    ),
+    (
+        "min_dependency_substitutions",
+        "min_dependency_substitutions",
+        {"dependent_packages": dependent_packages},
+    ),
 ]
 
-for target_name, kwargs in rst_templates:
+for rst_template_name, rst_target_name, kwargs in rst_templates:
     # Read the corresponding template file into jinja2
-    with (Path(".") / f"{target_name}.rst.template").open("r", encoding="utf-8") as f:
+    with (Path(".") / f"{rst_template_name}.rst.template").open(
+        "r", encoding="utf-8"
+    ) as f:
         t = jinja2.Template(f.read())
 
     # Render the template and write to the target
-    with (Path(".") / f"{target_name}.rst").open("w", encoding="utf-8") as f:
+    with (Path(".") / f"{rst_target_name}.rst").open("w", encoding="utf-8") as f:
         f.write(t.render(**kwargs))

--- a/doc/index.rst.template
+++ b/doc/index.rst.template
@@ -3,14 +3,6 @@
 .. Define the overall structure, that affects the prev-next buttons and the order
    of the sections in the top navbar.
 
-{#- If development build, link to local page; otherwise link to the development -#}
-{#- version; see https://github.com/scikit-learn/scikit-learn/pull/22550 -#}
-{% if is_devrelease -%}
-  {%- set development_link = "developers/index" -%}
-{%- else -%}
-  {%- set development_link = "https://scikit-learn.org/dev/developers/index.html" -%}
-{%- endif %}
-
 .. toctree::
    :hidden:
    :maxdepth: 2

--- a/doc/index.rst.template
+++ b/doc/index.rst.template
@@ -1,0 +1,34 @@
+.. title:: Index
+
+.. Define the overall structure, that affects the prev-next buttons and the order
+   of the sections in the top navbar.
+
+{#- If development build, link to local page; otherwise link to the development -#}
+{#- version; see https://github.com/scikit-learn/scikit-learn/pull/22550 -#}
+{% if is_devrelease -%}
+  {%- set development_link = "developers/index" -%}
+{%- else -%}
+  {%- set development_link = "https://scikit-learn.org/dev/developers/index.html" -%}
+{%- endif %}
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+
+   Install <install>
+   user_guide
+   API <modules/classes>
+   auto_examples/index
+   Community <https://blog.scikit-learn.org/>
+   getting_started
+   Tutorials <tutorial/index>
+   whats_new
+   Glossary <glossary>
+   Development <{{ development_link }}>
+   FAQ <faq>
+   support
+   related_projects
+   roadmap
+   Governance <governance>
+   about
+   Other Versions and Download <https://scikit-learn.org/dev/versions.html>

--- a/doc/min_dependency_substitutions.rst.template
+++ b/doc/min_dependency_substitutions.rst.template
@@ -1,0 +1,3 @@
+{% for package, (version, _) in dependent_packages.items() -%}
+.. |{{ package|capitalize }}MinVersion| replace:: {{ version }}
+{% endfor %}

--- a/doc/min_dependency_table.rst.template
+++ b/doc/min_dependency_table.rst.template
@@ -1,0 +1,13 @@
+.. list-table::
+  :header-rows: 1
+
+  * - Dependency
+    - Minimum Version
+    - Purpose
+
+  {% for package, (version, tags) in dependent_packages.items() -%}
+  * - {{ package }}
+    - {{ version }}
+    - {{ tags }}
+
+  {% endfor %}


### PR DESCRIPTION
**Please note that this PR targets the `new_web_theme` branch!**

Towards #28084. This uses `jinja2` to convert template rst into actual rst. My reasons are:

- It simplifies `conf.py`. Instead of creating a different function to generate each file, the templating approach allows to generate all files with a uniform function.
- It is easier to know the structure from a template rst instead of by looking at the generating function.
- One would have syntax highlighting (to some extent) for those files.
- I found [`pandas` using this approach](https://github.com/pandas-dev/pandas/blob/fc37c83c2deb59253ae2d10ca631b6a1242cfdcb/doc/source/conf.py#L119-L127) and thought it is nice.

By the way I forgot to add `doc/index.rst` to `.gitignore` in #28331 and added it here.

- [Index page](https://output.circle-artifacts.com/output/job/b0724501-bcf8-4970-8f05-b146ecaf001a/artifacts/0/doc/index.html)
- [Minimum versions table](https://output.circle-artifacts.com/output/job/b0724501-bcf8-4970-8f05-b146ecaf001a/artifacts/0/doc/install.html#installing-the-latest-release) (scroll down a bit)