### PR TITLE
DOC use n_iter instead of max_iter for TSNE and MDS examples

### DIFF
--- a/examples/manifold/plot_compare_methods.py
+++ b/examples/manifold/plot_compare_methods.py
@@ -164,7 +164,7 @@ plot_2d(S_isomap, S_color, "Isomap Embedding")
 
 md_scaling = manifold.MDS(
     n_components=n_components,
-    max_iter=50,
+    n_iter=50,
     n_init=4,
     random_state=0,
     normalized_stress=False,

--- a/examples/manifold/plot_compare_methods.py
+++ b/examples/manifold/plot_compare_methods.py
@@ -164,7 +164,7 @@ plot_2d(S_isomap, S_color, "Isomap Embedding")
 
 md_scaling = manifold.MDS(
     n_components=n_components,
-    n_iter=50,
+    max_iter=50,
     n_init=4,
     random_state=0,
     normalized_stress=False,
@@ -202,7 +202,7 @@ t_sne = manifold.TSNE(
     n_components=n_components,
     perplexity=30,
     init="random",
-    n_iter=250,
+    max_iter=250,
     random_state=0,
 )
 S_t_sne = t_sne.fit_transform(S_points)

--- a/examples/manifold/plot_lle_digits.py
+++ b/examples/manifold/plot_lle_digits.py
@@ -135,7 +135,7 @@ embeddings = {
     "LTSA LLE embedding": LocallyLinearEmbedding(
         n_neighbors=n_neighbors, n_components=2, method="ltsa"
     ),
-    "MDS embedding": MDS(n_components=2, n_init=1, max_iter=120, n_jobs=2),
+    "MDS embedding": MDS(n_components=2, n_init=1, n_iter=120, n_jobs=2),
     "Random Trees embedding": make_pipeline(
         RandomTreesEmbedding(n_estimators=200, max_depth=5, random_state=0),
         TruncatedSVD(n_components=2),

--- a/examples/manifold/plot_lle_digits.py
+++ b/examples/manifold/plot_lle_digits.py
@@ -135,7 +135,7 @@ embeddings = {
     "LTSA LLE embedding": LocallyLinearEmbedding(
         n_neighbors=n_neighbors, n_components=2, method="ltsa"
     ),
-    "MDS embedding": MDS(n_components=2, n_init=1, n_iter=120, n_jobs=2),
+    "MDS embedding": MDS(n_components=2, n_init=1, max_iter=120, n_jobs=2),
     "Random Trees embedding": make_pipeline(
         RandomTreesEmbedding(n_estimators=200, max_depth=5, random_state=0),
         TruncatedSVD(n_components=2),
@@ -145,7 +145,7 @@ embeddings = {
     ),
     "t-SNE embedding": TSNE(
         n_components=2,
-        n_iter=500,
+        max_iter=500,
         n_iter_without_progress=150,
         n_jobs=2,
         random_state=0,

--- a/examples/manifold/plot_t_sne_perplexity.py
+++ b/examples/manifold/plot_t_sne_perplexity.py
@@ -63,7 +63,7 @@ for i, perplexity in enumerate(perplexities):
         init="random",
         random_state=0,
         perplexity=perplexity,
-        n_iter=300,
+        max_iter=300,
     )
     Y = tsne.fit_transform(X)
     t1 = time()
@@ -93,7 +93,7 @@ for i, perplexity in enumerate(perplexities):
         random_state=0,
         perplexity=perplexity,
         learning_rate="auto",
-        n_iter=300,
+        max_iter=300,
     )
     Y = tsne.fit_transform(X)
     t1 = time()
@@ -130,7 +130,7 @@ for i, perplexity in enumerate(perplexities):
         init="random",
         random_state=0,
         perplexity=perplexity,
-        n_iter=400,
+        max_iter=400,
     )
     Y = tsne.fit_transform(X)
     t1 = time()


### PR DESCRIPTION
This is a follow-up to #28471 where we forgot to change the examples that now raises a warning.

This should fix the `doc` build in `main`.