### PR TITLE
FIX fix scipy bug with `sp.hstack` in `ClassifierChain` and `RegressorChain` 

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -672,7 +672,7 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
             # if `X` is a scipy sparse dok_array, we convert it to a sparse
             # coo_array format before hstacking, it's faster; see
             # https://github.com/scipy/scipy/issues/20060#issuecomment-1937007039:
-            if not sp.isspmatrix(X) and X.format == "dok":
+            if sp.issparse(X) and not sp.isspmatrix(X) and X.format == "dok":
                 X = sp.coo_array(X)
             X_aug = hstack((X, previous_predictions))
 

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -672,7 +672,7 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
             # if `X` is a scipy sparse dok_array, we convert it to a sparse
             # coo_array format before hstacking, it's faster; see
             # https://github.com/scipy/scipy/issues/20060#issuecomment-1937007039:
-            if isinstance(X, sp.dok_array):
+            if sp.issparse(X) and not sp.isspmatrix(X) and X.format == "dok":
                 X = sp.coo_array(X)
             X_aug = hstack((X, previous_predictions))
 
@@ -1100,7 +1100,7 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
         return router
 
     def _more_tags(self):
-        return {"_skip_test": True, "multioutput_only": True}
+        return {"_skip_test": True, "multioutput_only": True, "multilabel": True}
 
 
 class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -672,7 +672,7 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
             # if `X` is a scipy sparse dok_array, we convert it to a sparse
             # coo_array format before hstacking, it's faster; see
             # https://github.com/scipy/scipy/issues/20060#issuecomment-1937007039:
-            if sp.issparse(X) and not sp.isspmatrix(X) and X.format == "dok":
+            if isinstance(X, sp.dok_array):
                 X = sp.coo_array(X)
             X_aug = hstack((X, previous_predictions))
 

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -1100,7 +1100,7 @@ class ClassifierChain(MetaEstimatorMixin, ClassifierMixin, _BaseChain):
         return router
 
     def _more_tags(self):
-        return {"_skip_test": True, "multioutput_only": True, "multilabel": True}
+        return {"_skip_test": True, "multioutput_only": True}
 
 
 class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -669,6 +669,11 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
         hstack = sp.hstack if sp.issparse(X) else np.hstack
         for chain_idx, estimator in enumerate(self.estimators_):
             previous_predictions = Y_feature_chain[:, :chain_idx]
+            # if `X` is a scipy sparse dok_array, we convert it to a sparse
+            # coo_array format before hstacking, it's faster; see
+            # https://github.com/scipy/scipy/issues/20060#issuecomment-1937007039:
+            if not sp.isspmatrix(X) and X.format == "dok":
+                X = sp.coo_array(X)
             X_aug = hstack((X, previous_predictions))
 
             feature_predictions, _ = _get_response_values(


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes scipy bug that affected our repo after mergin both #27700 and #27576

#### What does this implement/fix? Explain your changes.
X is converted to a sparse coo array before hstacking in case it was a sparse dok array before.

Also see discussion on scipy: https://github.com/scipy/scipy/issues/20060#issuecomment-1937007039:
