### PR TITLE
Update _pca.py docs to reflect floating point issue

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -468,8 +468,6 @@ program. Insert the following instructions in your main script::
 You can find more default on the new start methods in the `multiprocessing
 documentation <https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`_.
 
-.. _faq_mkl_threading:
-
 Why do estimators sometimes produce unexpected/spurious results?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -478,6 +476,8 @@ input array. If you experience unexpected results for ``'float32'`` data, try
 converting the data to ``'float64'`` instead for greater precision.
 
 You can find more in the `dtype section of the Glossary <https://scikit-learn.org/stable/glossary.html#term-dtype>`_.
+
+.. _faq_mkl_threading:
 
 Why does my job use more cores than specified with ``n_jobs``?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -470,6 +470,15 @@ documentation <https://docs.python.org/3/library/multiprocessing.html#contexts-a
 
 .. _faq_mkl_threading:
 
+Why do estimators sometimes produce unexpected/spurious results?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This can often be due to floating-point issues related to the ``dtype`` of your
+input array. If you experience unexpected results for ``'float32'`` data, try
+converting the data to ``'float64'`` instead for greater precision.
+
+You can find more in the `dtype section of the Glossary <https://scikit-learn.org/stable/glossary.html#term-dtype>`_.
+
 Why does my job use more cores than specified with ``n_jobs``?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -134,6 +134,9 @@ class PCA(_BasePCA):
     used (i.e. through :func:`scipy.sparse.linalg.svds`). Alternatively, one
     may consider :class:`TruncatedSVD` where the data are not centered.
 
+    Spurious results may occur when fitting the `PCA()` model using data that
+    has dtype `'float32'`. In this instance convert input data to dtype `'float64'`.
+
     For a usage example, see
     :ref:`sphx_glr_auto_examples_decomposition_plot_pca_iris.py`
 
@@ -413,7 +416,9 @@ class PCA(_BasePCA):
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
             Training data, where `n_samples` is the number of samples
-            and `n_features` is the number of features.
+            and `n_features` is the number of features. If experiencing
+            unexpected performance with `X.dtype = 'float32'`, try
+            converting the dtype of `X` to `'float64'`.
 
         y : Ignored
             Ignored.
@@ -434,7 +439,9 @@ class PCA(_BasePCA):
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
             Training data, where `n_samples` is the number of samples
-            and `n_features` is the number of features.
+            and `n_features` is the number of features. If experiencing
+            unexpected performance with `X.dtype = 'float32'`, try
+            converting the dtype of `X` to `'float64'`.
 
         y : Ignored
             Ignored.


### PR DESCRIPTION
Updated docstrings to reflect spurious results encountered when applying the PCA model to large datasets of dtype `'float32'`. See the threads below:

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
 https://github.com/scikit-learn/scikit-learn/discussions/27946
 https://github.com/scipy/scipy/issues/20059

#### What does this implement/fix? Explain your changes.
The changes merely notify users that if they are experiencing unexpected performance, it might be due to the dtype of the input array. I found that `'float32'` data was susceptible to spurious results, but that `'float64'` data produced expected results every time.

#### Any other comments?
If I'd had this information it would have saved me hours of troubleshooting.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
