### PR TITLE
CI Fix scipy-dev build

### DIFF
--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -827,7 +827,7 @@ class MultiLabelBinarizer(TransformerMixin, BaseEstimator, auto_wrap_output_keys
         class_mapping[:] = tmp
         self.classes_, inverse = np.unique(class_mapping, return_inverse=True)
         # ensure yt.indices keeps its current dtype
-        yt.indices = np.array(inverse[yt.indices], dtype=yt.indices.dtype, copy=False)
+        yt.indices = np.asarray(inverse[yt.indices], dtype=yt.indices.dtype)
 
         if not self.sparse_output:
             yt = yt.toarray()

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -275,14 +275,17 @@ except ImportError:
     from scipy.integrate import trapz as trapezoid  # type: ignore  # noqa
 
 
-# TODO: Remove when Pandas > 2.2 is the minimum supported version
+# TODO: Adapt when Pandas > 2.2 is the minimum supported version
 def pd_fillna(pd, frame):
     pd_version = parse_version(pd.__version__).base_version
     if parse_version(pd_version) < parse_version("2.2"):
         frame = frame.fillna(value=np.nan)
     else:
+        infer_objects_kwargs = (
+            {} if parse_version(pd_version) >= parse_version("3") else {"copy": False}
+        )
         with pd.option_context("future.no_silent_downcasting", True):
-            frame = frame.fillna(value=np.nan).infer_objects(copy=False)
+            frame = frame.fillna(value=np.nan).infer_objects(**infer_objects_kwargs)
     return frame
 
 


### PR DESCRIPTION
Close https://github.com/scikit-learn/scikit-learn/issues/28531

The fix is a `np.array(..., copy=False)` -> `np.asarray`, most of the work was done in https://github.com/scikit-learn/scikit-learn/pull/28323 but this one was missed somehow.

I am expecting some more failures because of what seems like a regression in scipy sparse matrix that can not be created from float16 array. I have opened https://github.com/scipy/scipy/issues/20200.

```py
import numpy as np
from scipy.sparse import csc_matrix

csc_matrix(np.array([[1], [2]]), dtype=np.float16)
```

In scipy development version:
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[1], line 4
      1 import numpy as np
      2 from scipy.sparse import csc_matrix
----> 4 csc_matrix(np.array([[1], [2]]), dtype=np.float16)

File ~/micromamba/envs/scikit-learn-scipy-dev/lib/python3.12/site-packages/scipy/sparse/_compressed.py:88, in _cs_matrix.__init__(self, arg1, shape, dtype, copy)
     86         raise ValueError(msg) from e
     87     coo = self._coo_container(arg1, dtype=dtype)
---> 88     arrays = coo._coo_to_compressed(self._swap)
     89     self.indptr, self.indices, self.data, self._shape = arrays
     91 # Read matrix dimensions given, if any

File ~/micromamba/envs/scikit-learn-scipy-dev/lib/python3.12/site-packages/scipy/sparse/_coo.py:366, in _coo_base._coo_to_compressed(self, swap)
    363 indices = np.empty_like(minor, dtype=idx_dtype)
    364 data = np.empty_like(self.data, dtype=self.dtype)
--> 366 coo_tocsr(M, N, nnz, major, minor, self.data, indptr, indices, data)
    367 return indptr, indices, data, self.shape

ValueError: Output dtype not compatible with inputs.
```
