### PR TITLE
CI Remove pytest maxfail argument

### DIFF
--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -61,5 +61,5 @@ if [[ -n "$SELECTED_TESTS" ]]; then
 fi
 
 set -x
-eval "$TEST_CMD --maxfail=10 --pyargs sklearn"
+eval "$TEST_CMD --pyargs sklearn"
 set +x


### PR DESCRIPTION
`--maxfail` was added in https://github.com/scikit-learn/scikit-learn/pull/27910#issuecomment-1846907875. The main argument for it was:

> We might want to add --max-fail=10 by default in all our CIs as most of the time, when we get a very large number of failures at once, they are caused by a few common causes and trying to exhaustively analyze a gigantic error log is counter productive. We tend to fix problems incrementally when it happens.

Personally in most cases I find it convenient to get all the failures from the CI, so I can then work on them locally without having to run the full test suite. 

In scipy-dev, for example, it can happen quite quickly that you go over 10 failures and I want the tracking issue to list all of them to get a faithful status of the kind of failures and a faithful history of the failures.

I am not too bothered by the gigantic error log, since typically I go to the very end of the log to look at the summary get a quick feeling of the the different kind of errors and then can investigate failures one by one:
```
=========================== short test summary info ============================
FAILED datasets/tests/test_arff_parser.py::test_pandas_arff_parser_strip_single_quotes[_liac_arff_parser] - DeprecationWarning: The copy keyword is deprecated and will be removed in a...
FAILED datasets/tests/test_arff_parser.py::test_pandas_arff_parser_strip_double_quotes[_liac_arff_parser] - DeprecationWarning: The copy keyword is deprecated and will be removed in a...
FAILED datasets/tests/test_openml.py::test_fetch_openml_as_frame_true[True-liac-arff-61-dataset_params0-150-4-1] - DeprecationWarning: The copy keyword is deprecated and will be removed in a...
FAILED datasets/tests/test_openml.py::test_fetch_openml_as_frame_true[True-liac-arff-61-dataset_params1-150-4-1] - DeprecationWarning: The copy keyword is deprecated and will be removed in a...
FAILED datasets/tests/test_openml.py::test_fetch_openml_as_frame_true[True-liac-arff-2-dataset_params2-11-38-1] - DeprecationWarning: The copy keyword is deprecated and will be removed in a...
FAILED datasets/tests/test_openml.py::test_fetch_openml_as_frame_true[True-liac-arff-2-dataset_params3-11-38-1] - DeprecationWarning: The copy keyword is deprecated and will be removed in a...
FAILED datasets/tests/test_openml.py::test_fetch_openml_as_frame_true[True-liac-arff-561-dataset_params4-209-7-1] - DeprecationWarning: The copy keyword is deprecated and will be removed in a...
.
.
.
.
```

One recent example where I was annoyed by the `--maxfail` is https://github.com/scikit-learn/scikit-learn/pull/28583, I wanted to get an idea of the remaining scipy-dev issues and I got only a partial status. This has happened to me a few times (maybe 2-3 times?) since December where `--maxfail` was added.




