### PR TITLE
Support polars parser in fetch_openml

### DIFF
--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -457,16 +457,18 @@ def _load_arff_response(
     data_home : str
         The location where to cache the data.
 
-    parser : {"liac-arff", "pandas"}
+    parser : {"liac-arff", "pandas", "polars"}
         The parser used to parse the ARFF file.
 
-    output_type : {"numpy", "pandas", "sparse"}
+    output_type : {"numpy", "pandas", "polars", "sparse"}
         The type of the arrays that will be returned. The possibilities are:
 
         - `"numpy"`: both `X` and `y` will be NumPy arrays;
         - `"sparse"`: `X` will be sparse matrix and `y` will be a NumPy array;
         - `"pandas"`: `X` will be a pandas DataFrame and `y` will be either a
           pandas Series or DataFrame.
+        - `"polars"`: `X` will be a polars DataFrame and `y` will be either a
+          polars Series or DataFrame.
 
     openml_columns_info : dict
         The information provided by OpenML regarding the columns of the ARFF
@@ -598,7 +600,7 @@ def _download_data_to_bunch(
         The location where to cache the data.
 
     as_frame : bool
-        Whether or not to return the data into a pandas DataFrame.
+        Whether or not to return the data into a DataFrame.
 
     openml_columns_info : list of dict
         The information regarding the columns provided by OpenML for the
@@ -761,7 +763,7 @@ def _valid_data_column_names(features_list, target_columns):
         "n_retries": [Interval(Integral, 1, None, closed="left")],
         "delay": [Interval(Real, 0.0, None, closed="neither")],
         "parser": [
-            StrOptions({"auto", "pandas", "liac-arff"}),
+            StrOptions({"auto", "pandas", "liac-arff", "polars"}),
         ],
         "read_csv_kwargs": [dict, None],
     },


### PR DESCRIPTION

#### What does this implement/fix? Explain your changes.
it allows for polars to be selected as a `parser` in `fetch_openml`
```
from sklearn.datasets import fetch_openml
bike_sharing = fetch_openml(
    "Bike_Sharing_Demand", version=2, as_frame=True, parser="polars"
)
bike_sharing.frame
shape: (17_379, 13)
┌────────┬──────┬───────┬──────┬───┬───────────┬──────────┬───────────┬───────┐
│ season ┆ year ┆ month ┆ hour ┆ … ┆ feel_temp ┆ humidity ┆ windspeed ┆ count │
│ ---    ┆ ---  ┆ ---   ┆ ---  ┆   ┆ ---       ┆ ---      ┆ ---       ┆ ---   │
│ enum   ┆ f64  ┆ f64   ┆ f64  ┆   ┆ f64       ┆ f64      ┆ f64       ┆ f64   │
╞════════╪══════╪═══════╪══════╪═══╪═══════════╪══════════╪═══════════╪═══════╡
│ spring ┆ 0.0  ┆ 1.0   ┆ 0.0  ┆ … ┆ 14.395    ┆ 0.81     ┆ 0.0       ┆ 16.0  │
│ spring ┆ 0.0  ┆ 1.0   ┆ 1.0  ┆ … ┆ 13.635    ┆ 0.8      ┆ 0.0       ┆ 40.0  │
│ spring ┆ 0.0  ┆ 1.0   ┆ 2.0  ┆ … ┆ 13.635    ┆ 0.8      ┆ 0.0       ┆ 32.0  │
│ spring ┆ 0.0  ┆ 1.0   ┆ 3.0  ┆ … ┆ 14.395    ┆ 0.75     ┆ 0.0       ┆ 13.0  │
│ spring ┆ 0.0  ┆ 1.0   ┆ 4.0  ┆ … ┆ 14.395    ┆ 0.75     ┆ 0.0       ┆ 1.0   │
│ …      ┆ …    ┆ …     ┆ …    ┆ … ┆ …         ┆ …        ┆ …         ┆ …     │
│ spring ┆ 1.0  ┆ 12.0  ┆ 19.0 ┆ … ┆ 12.88     ┆ 0.6      ┆ 11.0014   ┆ 119.0 │
│ spring ┆ 1.0  ┆ 12.0  ┆ 20.0 ┆ … ┆ 12.88     ┆ 0.6      ┆ 11.0014   ┆ 89.0  │
│ spring ┆ 1.0  ┆ 12.0  ┆ 21.0 ┆ … ┆ 12.88     ┆ 0.6      ┆ 11.0014   ┆ 90.0  │
│ spring ┆ 1.0  ┆ 12.0  ┆ 22.0 ┆ … ┆ 13.635    ┆ 0.56     ┆ 8.9981    ┆ 61.0  │
│ spring ┆ 1.0  ┆ 12.0  ┆ 23.0 ┆ … ┆ 13.635    ┆ 0.65     ┆ 8.9981    ┆ 49.0  │
└────────┴──────┴───────┴──────┴───┴───────────┴──────────┴───────────┴───────┘
```

