### PR TITLE
DOC Fix typo in FAQ

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -470,15 +470,6 @@ documentation <https://docs.python.org/3/library/multiprocessing.html#contexts-a
 
 .. _faq_mkl_threading:
 
-Why do estimators sometimes produce unexpected/spurious results?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-This can often be due to floating-point issues related to the ``dtype`` of your
-input array. If you experience unexpected results for ``'float32'`` data, try
-converting the data to ``'float64'`` instead for greater precision.
-
-You can find more on the `dtype section of the Glossary <https://scikit-learn.org/stable/glossary.html#term-dtype>`_.
-
 Why does my job use more cores than specified with ``n_jobs``?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -417,7 +417,7 @@ Note that the example above uses the third-party edit distance package
 `leven <https://pypi.org/project/leven/>`_. Similar tricks can be used,
 with some care, for tree kernels, graph kernels, etc.
 
-Why do I sometime get a crash/freeze with ``n_jobs > 1`` under OSX or Linux?
+Why do I sometimes get a crash/freeze with ``n_jobs > 1`` under OSX or Linux?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Several scikit-learn tools such as :class:`~model_selection.GridSearchCV` and
@@ -469,6 +469,15 @@ You can find more default on the new start methods in the `multiprocessing
 documentation <https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`_.
 
 .. _faq_mkl_threading:
+
+Why do estimators sometimes produce unexpected/spurious results?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This can often be due to floating-point issues related to the ``dtype`` of your
+input array. If you experience unexpected results for ``'float32'`` data, try
+converting the data to ``'float64'`` instead for greater precision.
+
+You can find more on the `dtype section of the Glossary <https://scikit-learn.org/stable/glossary.html#term-dtype>`_.
 
 Why does my job use more cores than specified with ``n_jobs``?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -418,7 +418,7 @@ Note that the example above uses the third-party edit distance package
 with some care, for tree kernels, graph kernels, etc.
 
 Why do I sometimes get a crash/freeze with ``n_jobs > 1`` under OSX or Linux?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Several scikit-learn tools such as :class:`~model_selection.GridSearchCV` and
 :class:`~model_selection.cross_val_score` rely internally on Python's


### PR DESCRIPTION
Additional frequently asked question to increase visibility of the effect of floating-point precision on estimator performance (in this case, PCA).

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
https://github.com/scikit-learn/scikit-learn/pull/28581

#### What does this implement/fix? Explain your changes.
The changes merely notify users that if they are experiencing unexpected performance, it might be due to the ``dtype`` of the input array. I found that ``'float32'`` data was susceptible to spurious results, but that ``'float64'`` data produced expected results every time.

#### Any other comments?
If I'd had this information it would have saved me hours of troubleshooting.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
