### PR TITLE
DOC fix meaning of indices in tree examples

### DIFF
--- a/examples/tree/plot_unveil_tree_structure.py
+++ b/examples/tree/plot_unveil_tree_structure.py
@@ -68,7 +68,7 @@ clf.fit(X_train, y_train)
 #   - ``weighted_n_node_samples[i]``: the weighted number of training samples
 #     reaching node ``i``
 #   - ``value[i, j, k]``: the summary of the training samples that reached node i for
-#     output j and class k (note that regression is represented having a single class).
+#     output j and class k (for regression tree, class is set to 1).
 #
 # Using the arrays, we can traverse the tree structure to compute various
 # properties. Below, we will compute the depth of each node and whether or not

--- a/examples/tree/plot_unveil_tree_structure.py
+++ b/examples/tree/plot_unveil_tree_structure.py
@@ -68,7 +68,7 @@ clf.fit(X_train, y_train)
 #   - ``weighted_n_node_samples[i]``: the weighted number of training samples
 #     reaching node ``i``
 #   - ``value[i, j, k]``: the summary of the training samples that reached node i for
-#     class j and output k.
+#     output j and class k (note that regression is represented having a single class).
 #
 # Using the arrays, we can traverse the tree structure to compute various
 # properties. Below, we will compute the depth of each node and whether or not


### PR DESCRIPTION
@fcharras mentioned that we have an issue with the meaning of the indices in this example.
I checked for both the classifier and regressor and indeed we have inverted class and output dimension.