### PR TITLE
DOC fix align table in API doc page

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -1320,6 +1320,10 @@ div.sk-sponsor-div-box, div.sk-testimonial-div-box {
   }
 }
 
+div.sk-sponsor-div-box table.sk-sponsor-table {
+  display: table;
+}
+
 table.sk-sponsor-table tr, table.sk-sponsor-table tr:nth-child(odd) {
   border-style: none;
   background-color: white;

--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -1001,6 +1001,7 @@ table.docutils {
   margin-bottom: 1rem;
   line-height: 1rem;
   max-width: 100%;
+  display: block;
   overflow-x: auto;
 }
 


### PR DESCRIPTION
In https://github.com/scikit-learn/scikit-learn/pull/28417, I made a change and remove `display: block;` but apparently it has a detrimental effect on the API pages.

I'm reverting this change. However, we need to come with a fix to center the table in the about page.