### PR TITLE
ENH allow up to 65536 bins in HGBT

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -179,6 +179,11 @@ Changelog
 :mod:`sklearn.ensemble`
 .......................
 
+- |Enhancement| :class:`ensemble.HistGradientBoostingClassifier` and
+  :class:`ensemble.HistGradientBoostingRegressor` now support up to 2**16 = 65536
+  bins for categorical levels (including one bin for missing values).
+  :pr:`28603` by :user:`Christian Lorentzen <lorentzenchr>`.
+
 - |Efficiency| Improves runtime of `predict` of
   :class:`ensemble.HistGradientBoostingClassifier` by avoiding to call `predict_proba`.
   :pr:`27844` by :user:`Christian Lorentzen <lorentzenchr>`.

--- a/sklearn/ensemble/_hist_gradient_boosting/_binning.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/_binning.pyx
@@ -3,13 +3,14 @@
 from cython.parallel import prange
 from libc.math cimport isnan
 
+from sklearn.utils._typedefs cimport uint16_t
 from .common cimport X_DTYPE_C, X_BINNED_DTYPE_C
 
 
-def _map_to_bins(const X_DTYPE_C [:, :] data,
+def _map_to_bins(const X_DTYPE_C[:, :] data,
+                 const uint16_t[::1] n_bins_non_missing,
                  list binning_thresholds,
                  const unsigned char[::1] is_categorical,
-                 const unsigned char missing_values_bin_idx,
                  int n_threads,
                  X_BINNED_DTYPE_C [::1, :] binned):
     """Bin continuous and categorical values to discrete integer-coded levels.
@@ -21,6 +22,10 @@ def _map_to_bins(const X_DTYPE_C [:, :] data,
     ----------
     data : ndarray, shape (n_samples, n_features)
         The data to bin.
+    n_bins_non_missing : ndarray of shape (n_features,) dtype=np.uint16
+        For each feature, gives the number of bins actually used for non-missing
+        values. The index of the bin where missing values are mapped is always
+        given by the last bin, i.e. bin index ``n_bins_non_missing_``.
     binning_thresholds : list of arrays
         For each feature, stores the increasing numeric values that are
         used to separate the bins.
@@ -36,20 +41,20 @@ def _map_to_bins(const X_DTYPE_C [:, :] data,
 
     for feature_idx in range(data.shape[1]):
         _map_col_to_bins(
-            data[:, feature_idx],
-            binning_thresholds[feature_idx],
-            is_categorical[feature_idx],
-            missing_values_bin_idx,
-            n_threads,
-            binned[:, feature_idx]
+            data=data[:, feature_idx],
+            binning_thresholds=binning_thresholds[feature_idx],
+            is_categorical=is_categorical[feature_idx],
+            missing_values_bin_idx=n_bins_non_missing[feature_idx],
+            n_threads=n_threads,
+            binned=binned[:, feature_idx]
         )
 
 
 cdef void _map_col_to_bins(
-    const X_DTYPE_C [:] data,
-    const X_DTYPE_C [:] binning_thresholds,
+    const X_DTYPE_C[:] data,
+    const X_DTYPE_C[:] binning_thresholds,
     const unsigned char is_categorical,
-    const unsigned char missing_values_bin_idx,
+    const uint16_t missing_values_bin_idx,
     int n_threads,
     X_BINNED_DTYPE_C [:] binned
 ):

--- a/sklearn/ensemble/_hist_gradient_boosting/_binning.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/_binning.pyx
@@ -3,8 +3,8 @@
 from cython.parallel import prange
 from libc.math cimport isnan
 
-from sklearn.utils._typedefs cimport uint16_t
-from .common cimport X_DTYPE_C, X_BINNED_DTYPE_C
+from sklearn.utils._typedefs cimport uint8_t, uint16_t
+from .common cimport X_DTYPE_C, X_BINNED_DTYPE_FUSED_C, BinnedData
 
 
 def _map_to_bins(const X_DTYPE_C[:, :] data,
@@ -12,7 +12,7 @@ def _map_to_bins(const X_DTYPE_C[:, :] data,
                  list binning_thresholds,
                  const unsigned char[::1] is_categorical,
                  int n_threads,
-                 X_BINNED_DTYPE_C [::1, :] binned):
+                 BinnedData binned):
     """Bin continuous and categorical values to discrete integer-coded levels.
 
     A given value x is mapped into bin value i iff
@@ -38,16 +38,30 @@ def _map_to_bins(const X_DTYPE_C[:, :] data,
     """
     cdef:
         int feature_idx
+        uint8_t[::1] binned_f8
+        uint16_t[::1] binned_f16
 
     for feature_idx in range(data.shape[1]):
-        _map_col_to_bins(
-            data=data[:, feature_idx],
-            binning_thresholds=binning_thresholds[feature_idx],
-            is_categorical=is_categorical[feature_idx],
-            missing_values_bin_idx=n_bins_non_missing[feature_idx],
-            n_threads=n_threads,
-            binned=binned[:, feature_idx]
-        )
+        if binned.feature_is_8bit_view[feature_idx]:
+            binned_f8 = binned[:, feature_idx]
+            _map_col_to_bins[uint8_t](
+                data=data[:, feature_idx],
+                binning_thresholds=binning_thresholds[feature_idx],
+                is_categorical=is_categorical[feature_idx],
+                missing_values_bin_idx=n_bins_non_missing[feature_idx],
+                n_threads=n_threads,
+                binned=binned_f8,
+            )
+        else:
+            binned_f16 = binned[:, feature_idx]
+            _map_col_to_bins[uint16_t](
+                data=data[:, feature_idx],
+                binning_thresholds=binning_thresholds[feature_idx],
+                is_categorical=is_categorical[feature_idx],
+                missing_values_bin_idx=n_bins_non_missing[feature_idx],
+                n_threads=n_threads,
+                binned=binned_f16,
+            )
 
 
 cdef void _map_col_to_bins(
@@ -56,7 +70,7 @@ cdef void _map_col_to_bins(
     const unsigned char is_categorical,
     const uint16_t missing_values_bin_idx,
     int n_threads,
-    X_BINNED_DTYPE_C [:] binned
+    X_BINNED_DTYPE_FUSED_C[::1] binned,
 ):
     """Binary search to find the bin index for each value in the data."""
     cdef:

--- a/sklearn/ensemble/_hist_gradient_boosting/_bitset.pxd
+++ b/sklearn/ensemble/_hist_gradient_boosting/_bitset.pxd
@@ -1,18 +1,10 @@
 from .common cimport X_BINNED_DTYPE_C
-from .common cimport BITSET_DTYPE_C
 from .common cimport BITSET_INNER_DTYPE_C
 from .common cimport X_DTYPE_C
+from .common cimport Bitsets
 
-cdef void init_bitset(BITSET_DTYPE_C bitset) noexcept nogil
+cdef void set_bitset(BITSET_INNER_DTYPE_C* bitset, X_BINNED_DTYPE_C val) noexcept nogil
 
-cdef void set_bitset(BITSET_DTYPE_C bitset, X_BINNED_DTYPE_C val) noexcept nogil
+cdef unsigned char in_bitset(const BITSET_INNER_DTYPE_C* bitset, X_BINNED_DTYPE_C val) noexcept nogil
 
-cdef unsigned char in_bitset(BITSET_DTYPE_C bitset, X_BINNED_DTYPE_C val) noexcept nogil
-
-cpdef unsigned char in_bitset_memoryview(const BITSET_INNER_DTYPE_C[:] bitset,
-                                         X_BINNED_DTYPE_C val) noexcept nogil
-
-cdef unsigned char in_bitset_2d_memoryview(
-    const BITSET_INNER_DTYPE_C [:, :] bitset,
-    X_BINNED_DTYPE_C val,
-    unsigned int row) noexcept nogil
+cdef create_feature_bitset_array(Bitsets b, int bitset_idx)

--- a/sklearn/ensemble/_hist_gradient_boosting/_bitset.pxd
+++ b/sklearn/ensemble/_hist_gradient_boosting/_bitset.pxd
@@ -1,10 +1,14 @@
-from .common cimport X_BINNED_DTYPE_C
+from .common cimport X_BINNED_DTYPE_FUSED_C
 from .common cimport BITSET_INNER_DTYPE_C
 from .common cimport X_DTYPE_C
 from .common cimport Bitsets
 
-cdef void set_bitset(BITSET_INNER_DTYPE_C* bitset, X_BINNED_DTYPE_C val) noexcept nogil
+cdef void set_bitset(
+    BITSET_INNER_DTYPE_C* bitset, X_BINNED_DTYPE_FUSED_C val
+) noexcept nogil
 
-cdef unsigned char in_bitset(const BITSET_INNER_DTYPE_C* bitset, X_BINNED_DTYPE_C val) noexcept nogil
+cdef unsigned char in_bitset(
+    const BITSET_INNER_DTYPE_C* bitset, X_BINNED_DTYPE_FUSED_C val
+) noexcept nogil
 
 cdef create_feature_bitset_array(Bitsets b, int bitset_idx)

--- a/sklearn/ensemble/_hist_gradient_boosting/_bitset.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/_bitset.pyx
@@ -1,7 +1,10 @@
+from .common cimport Bitsets
 from .common cimport BITSET_INNER_DTYPE_C
-from .common cimport BITSET_DTYPE_C
 from .common cimport X_DTYPE_C
 from .common cimport X_BINNED_DTYPE_C
+from ...utils._typedefs cimport uint8_t
+
+import numpy as np
 
 
 # A bitset is a data structure used to represent sets of integers in [0, n]. We
@@ -12,46 +15,57 @@ from .common cimport X_BINNED_DTYPE_C
 # https://en.wikipedia.org/wiki/Bitwise_operation
 
 
-cdef inline void init_bitset(BITSET_DTYPE_C bitset) noexcept nogil:  # OUT
-    cdef:
-        unsigned int i
-
-    for i in range(8):
-        bitset[i] = 0
-
-
-cdef inline void set_bitset(BITSET_DTYPE_C bitset,  # OUT
-                            X_BINNED_DTYPE_C val) noexcept nogil:
+cdef inline void set_bitset(
+    BITSET_INNER_DTYPE_C* bitset, X_BINNED_DTYPE_C val
+) noexcept nogil:
     bitset[val // 32] |= (1 << (val % 32))
 
 
-cdef inline unsigned char in_bitset(BITSET_DTYPE_C bitset,
-                                    X_BINNED_DTYPE_C val) noexcept nogil:
-
+cdef inline unsigned char in_bitset(
+    const BITSET_INNER_DTYPE_C* bitset, X_BINNED_DTYPE_C val
+) noexcept nogil:
     return (bitset[val // 32] >> (val % 32)) & 1
 
 
-cpdef inline unsigned char in_bitset_memoryview(const BITSET_INNER_DTYPE_C[:] bitset,
-                                                X_BINNED_DTYPE_C val) noexcept nogil:
-    return (bitset[val // 32] >> (val % 32)) & 1
-
-cdef inline unsigned char in_bitset_2d_memoryview(const BITSET_INNER_DTYPE_C [:, :] bitset,
-                                                  X_BINNED_DTYPE_C val,
-                                                  unsigned int row) noexcept nogil:
-
-    # Same as above but works on 2d memory views to avoid the creation of 1d
-    # memory views. See https://github.com/scikit-learn/scikit-learn/issues/17299
-    return (bitset[row, val // 32] >> (val % 32)) & 1
+def set_bitset_memoryview(
+    BITSET_INNER_DTYPE_C[:] bitset, X_BINNED_DTYPE_C val
+):
+    """For testing only."""
+    set_bitset(&bitset[0], val)
 
 
-cpdef inline void set_bitset_memoryview(BITSET_INNER_DTYPE_C[:] bitset,  # OUT
-                                        X_BINNED_DTYPE_C val):
-    bitset[val // 32] |= (1 << (val % 32))
+def in_bitset_memoryview(
+    const BITSET_INNER_DTYPE_C[:] bitset, X_BINNED_DTYPE_C val
+):
+    """For testing only."""
+    return in_bitset(&bitset[0], val)
 
 
-def set_raw_bitset_from_binned_bitset(BITSET_INNER_DTYPE_C[:] raw_bitset,  # OUT
-                                      BITSET_INNER_DTYPE_C[:] binned_bitset,
-                                      X_DTYPE_C[:] categories):
+cdef create_feature_bitset_array(Bitsets b, int bitset_idx):
+    return np.copy(
+        b.bitsets_view[
+            b.offsets_view[bitset_idx] : b.offsets_view[bitset_idx + 1]
+        ]
+    )
+
+
+def copyto_feature_bitset_array(
+    Bitsets dst, int bitset_idx, BITSET_INNER_DTYPE_C[::1] src
+):
+    np.copyto(
+        dst=dst.bitsets[
+            dst.offsets_view[bitset_idx] : dst.offsets_view[bitset_idx + 1]
+        ],
+        src=src,
+    )
+
+
+def set_raw_bitset_from_binned_bitset(
+    Bitsets raw_bitsets,  # OUT
+    BITSET_INNER_DTYPE_C[:] binned_bitset,
+    X_DTYPE_C[:] categories,
+    unsigned int bitset_idx,
+):
     """Set the raw_bitset from the values of the binned bitset
 
     categories is a mapping from binned category value to raw category value.
@@ -59,7 +73,43 @@ def set_raw_bitset_from_binned_bitset(BITSET_INNER_DTYPE_C[:] raw_bitset,  # OUT
     cdef:
         int binned_cat_value
         X_DTYPE_C raw_cat_value
+        BITSET_INNER_DTYPE_C* raw_bitset = raw_bitsets.at(bitset_idx)
 
     for binned_cat_value, raw_cat_value in enumerate(categories):
-        if in_bitset_memoryview(binned_bitset, binned_cat_value):
-            set_bitset_memoryview(raw_bitset, <X_BINNED_DTYPE_C>raw_cat_value)
+        if in_bitset(&binned_bitset[0], binned_cat_value):
+            set_bitset(raw_bitset, <X_BINNED_DTYPE_C>raw_cat_value)
+
+
+def set_known_cat_bitset_from_known_categories(
+    Bitsets known_cat_bitsets,  # OUT
+    object known_categories,
+    uint8_t[:] is_categorical,
+):
+    """Set the bitsets for known categories.
+
+    Parameters
+    ----------
+    known_cat_bitsets : Bitsets
+        The bitsets to set/fill.
+    known_categories : list of {ndarray, None} of shape (n_features,) \
+            dtype=X_DTYPE, default=none
+        For each categorical feature, the array indicates the set of unique
+        categorical values. These should be the possible values over all the
+        data, not just the training data. For continuous features, the
+        corresponding entry should be None.
+    is_categorical : ndarray of shape (n_features,), dtype=np.uint8
+        Indicator for categorical features.
+    """
+    cdef:
+        unsigned int f_idx
+        unsigned int n_features = is_categorical.shape[0]
+        X_DTYPE_C raw_cat_value
+        BITSET_INNER_DTYPE_C* raw_bitset
+
+    # TODO: Think twice if it's worth to parallelize, which would require to wrap
+    # know_categories in a single array and a 2nd offset array.
+    for f_idx in range(n_features):
+        if is_categorical[f_idx]:
+            raw_bitset = known_cat_bitsets.at(f_idx)
+            for raw_cat_value in known_categories[f_idx]:
+                set_bitset(raw_bitset, <X_BINNED_DTYPE_C>raw_cat_value)

--- a/sklearn/ensemble/_hist_gradient_boosting/_predictor.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/_predictor.pyx
@@ -4,7 +4,7 @@ from cython.parallel import prange
 from libc.math cimport isnan
 import numpy as np
 
-from ...utils._typedefs cimport intp_t
+from ...utils._typedefs cimport intp_t, uint16_t
 from .common cimport X_DTYPE_C
 from .common cimport Y_DTYPE_C
 from .common import Y_DTYPE
@@ -89,7 +89,7 @@ def _predict_from_binned_data(
         node_struct [:] nodes,
         const X_BINNED_DTYPE_C [:, :] binned_data,
         BITSET_INNER_DTYPE_C [:, :] binned_left_cat_bitsets,
-        const unsigned char missing_values_bin_idx,
+        const uint16_t [::1] n_bins_non_missing,
         int n_threads,
         Y_DTYPE_C [:] out):
 
@@ -100,8 +100,9 @@ def _predict_from_binned_data(
                     num_threads=n_threads):
         out[i] = _predict_one_from_binned_data(nodes,
                                                binned_data,
-                                               binned_left_cat_bitsets, i,
-                                               missing_values_bin_idx)
+                                               binned_left_cat_bitsets,
+                                               i,
+                                               n_bins_non_missing)
 
 
 cdef inline Y_DTYPE_C _predict_one_from_binned_data(
@@ -109,7 +110,7 @@ cdef inline Y_DTYPE_C _predict_one_from_binned_data(
         const X_BINNED_DTYPE_C [:, :] binned_data,
         const BITSET_INNER_DTYPE_C [:, :] binned_left_cat_bitsets,
         const int row,
-        const unsigned char missing_values_bin_idx) noexcept nogil:
+        const uint16_t [::1] n_bins_non_missing) noexcept nogil:
     # Need to pass the whole array and the row index, else prange won't work.
     # See issue Cython #2798
 
@@ -117,12 +118,14 @@ cdef inline Y_DTYPE_C _predict_one_from_binned_data(
         node_struct node = nodes[0]
         unsigned int node_idx = 0
         X_BINNED_DTYPE_C data_val
+        uint16_t missing_values_bin_idx
 
     while True:
         if node.is_leaf:
             return node.value
 
         data_val = binned_data[row, node.feature_idx]
+        missing_values_bin_idx = n_bins_non_missing[node.feature_idx]
 
         if data_val == missing_values_bin_idx:
             if node.missing_go_to_left:

--- a/sklearn/ensemble/_hist_gradient_boosting/_predictor.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/_predictor.pyx
@@ -5,21 +5,20 @@ from libc.math cimport isnan
 import numpy as np
 
 from ...utils._typedefs cimport intp_t, uint16_t
+from ._bitset cimport in_bitset
+from .common cimport Bitsets
 from .common cimport X_DTYPE_C
 from .common cimport Y_DTYPE_C
 from .common import Y_DTYPE
 from .common cimport X_BINNED_DTYPE_C
-from .common cimport BITSET_INNER_DTYPE_C
 from .common cimport node_struct
-from ._bitset cimport in_bitset_2d_memoryview
 
 
 def _predict_from_raw_data(  # raw data = non-binned data
         const node_struct [:] nodes,
         const X_DTYPE_C [:, :] numeric_data,
-        const BITSET_INNER_DTYPE_C [:, ::1] raw_left_cat_bitsets,
-        const BITSET_INNER_DTYPE_C [:, ::1] known_cat_bitsets,
-        const unsigned int [::1] f_idx_map,
+        Bitsets raw_left_cat_bitsets,
+        Bitsets known_cat_bitsets,
         int n_threads,
         Y_DTYPE_C [:] out):
 
@@ -31,15 +30,14 @@ def _predict_from_raw_data(  # raw data = non-binned data
         out[i] = _predict_one_from_raw_data(
             nodes, numeric_data, raw_left_cat_bitsets,
             known_cat_bitsets,
-            f_idx_map, i)
+            i)
 
 
 cdef inline Y_DTYPE_C _predict_one_from_raw_data(
         const node_struct [:] nodes,
         const X_DTYPE_C [:, :] numeric_data,
-        const BITSET_INNER_DTYPE_C [:, ::1] raw_left_cat_bitsets,
-        const BITSET_INNER_DTYPE_C [:, ::1] known_cat_bitsets,
-        const unsigned int [::1] f_idx_map,
+        Bitsets raw_left_cat_bitsets,
+        Bitsets known_cat_bitsets,
         const int row) noexcept nogil:
     # Need to pass the whole array and the row index, else prange won't work.
     # See issue Cython #2798
@@ -64,15 +62,15 @@ cdef inline Y_DTYPE_C _predict_one_from_raw_data(
             if data_val < 0:
                 # data_val is not in the accepted range, so it is treated as missing value
                 node_idx = node.left if node.missing_go_to_left else node.right
-            elif in_bitset_2d_memoryview(
-                    raw_left_cat_bitsets,
-                    <X_BINNED_DTYPE_C>data_val,
-                    node.bitset_idx):
+            elif in_bitset(
+                raw_left_cat_bitsets.at(node.bitset_idx),
+                <X_BINNED_DTYPE_C>data_val,
+            ):
                 node_idx = node.left
-            elif in_bitset_2d_memoryview(
-                    known_cat_bitsets,
-                    <X_BINNED_DTYPE_C>data_val,
-                    f_idx_map[node.feature_idx]):
+            elif in_bitset(
+                known_cat_bitsets.at(node.feature_idx),
+                <X_BINNED_DTYPE_C>data_val,
+            ):
                 node_idx = node.right
             else:
                 # Treat unknown categories as missing.
@@ -88,7 +86,7 @@ cdef inline Y_DTYPE_C _predict_one_from_raw_data(
 def _predict_from_binned_data(
         node_struct [:] nodes,
         const X_BINNED_DTYPE_C [:, :] binned_data,
-        BITSET_INNER_DTYPE_C [:, :] binned_left_cat_bitsets,
+        Bitsets binned_left_cat_bitsets,
         const uint16_t [::1] n_bins_non_missing,
         int n_threads,
         Y_DTYPE_C [:] out):
@@ -108,7 +106,7 @@ def _predict_from_binned_data(
 cdef inline Y_DTYPE_C _predict_one_from_binned_data(
         node_struct [:] nodes,
         const X_BINNED_DTYPE_C [:, :] binned_data,
-        const BITSET_INNER_DTYPE_C [:, :] binned_left_cat_bitsets,
+        Bitsets binned_left_cat_bitsets,
         const int row,
         const uint16_t [::1] n_bins_non_missing) noexcept nogil:
     # Need to pass the whole array and the row index, else prange won't work.
@@ -133,10 +131,10 @@ cdef inline Y_DTYPE_C _predict_one_from_binned_data(
             else:
                 node_idx = node.right
         elif node.is_categorical:
-            if in_bitset_2d_memoryview(
-                    binned_left_cat_bitsets,
-                    data_val,
-                    node.bitset_idx):
+            if in_bitset(
+                binned_left_cat_bitsets.at(node.bitset_idx),
+                data_val,
+            ):
                 node_idx = node.left
             else:
                 node_idx = node.right

--- a/sklearn/ensemble/_hist_gradient_boosting/_predictor.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/_predictor.pyx
@@ -1,17 +1,25 @@
 # Author: Nicolas Hug
 
-from cython.parallel import prange
 from libc.math cimport isnan
-import numpy as np
 
-from ...utils._typedefs cimport intp_t, uint16_t
+from ...utils._typedefs cimport intp_t, uint8_t, uint16_t
 from ._bitset cimport in_bitset
+from .common cimport BinnedData
 from .common cimport Bitsets
 from .common cimport X_DTYPE_C
 from .common cimport Y_DTYPE_C
-from .common import Y_DTYPE
 from .common cimport X_BINNED_DTYPE_C
 from .common cimport node_struct
+
+import numpy as np
+from cython.parallel import prange
+from .common import Y_DTYPE
+
+
+ctypedef fused X_BINNED_PREDICT:
+    uint8_t[:, :]
+    uint16_t[:, :]
+    BinnedData
 
 
 def _predict_from_raw_data(  # raw data = non-binned data
@@ -85,7 +93,7 @@ cdef inline Y_DTYPE_C _predict_one_from_raw_data(
 
 def _predict_from_binned_data(
         node_struct [:] nodes,
-        const X_BINNED_DTYPE_C [:, :] binned_data,
+        X_BINNED_PREDICT binned_data,
         Bitsets binned_left_cat_bitsets,
         const uint16_t [::1] n_bins_non_missing,
         int n_threads,
@@ -93,19 +101,34 @@ def _predict_from_binned_data(
 
     cdef:
         int i
+        int n_samples = binned_data.shape[0]
 
-    for i in prange(binned_data.shape[0], schedule='static', nogil=True,
-                    num_threads=n_threads):
-        out[i] = _predict_one_from_binned_data(nodes,
-                                               binned_data,
-                                               binned_left_cat_bitsets,
-                                               i,
-                                               n_bins_non_missing)
+    if X_BINNED_PREDICT == BinnedData:
+        for i in prange(
+            n_samples, schedule='static', nogil=True, num_threads=n_threads
+        ):
+            out[i] = _predict_one_from_binned_data[BinnedData](
+                nodes, binned_data, binned_left_cat_bitsets, i, n_bins_non_missing
+            )
+    elif X_BINNED_PREDICT == uint8_t[:, :]:
+        for i in prange(
+            n_samples, schedule='static', nogil=True, num_threads=n_threads
+        ):
+            out[i] = _predict_one_from_binned_data[uint8_t[:, :]](
+                nodes, binned_data, binned_left_cat_bitsets, i, n_bins_non_missing
+            )
+    else:
+        for i in prange(
+            n_samples, schedule='static', nogil=True, num_threads=n_threads
+        ):
+            out[i] = _predict_one_from_binned_data[uint16_t[:, :]](
+                nodes, binned_data, binned_left_cat_bitsets, i, n_bins_non_missing
+            )
 
 
 cdef inline Y_DTYPE_C _predict_one_from_binned_data(
         node_struct [:] nodes,
-        const X_BINNED_DTYPE_C [:, :] binned_data,
+        X_BINNED_PREDICT X_binned,
         Bitsets binned_left_cat_bitsets,
         const int row,
         const uint16_t [::1] n_bins_non_missing) noexcept nogil:
@@ -117,13 +140,21 @@ cdef inline Y_DTYPE_C _predict_one_from_binned_data(
         unsigned int node_idx = 0
         X_BINNED_DTYPE_C data_val
         uint16_t missing_values_bin_idx
+        int feature_idx
 
     while True:
         if node.is_leaf:
             return node.value
 
-        data_val = binned_data[row, node.feature_idx]
-        missing_values_bin_idx = n_bins_non_missing[node.feature_idx]
+        feature_idx = node.feature_idx
+        if X_BINNED_PREDICT == BinnedData:
+            if X_binned.feature_is_8bit_view[feature_idx]:
+                data_val = X_binned.get_item8(row, feature_idx)
+            else:
+                data_val = X_binned.get_item16(row, feature_idx)
+        else:
+            data_val = X_binned[row, feature_idx]
+        missing_values_bin_idx = n_bins_non_missing[feature_idx]
 
         if data_val == missing_values_bin_idx:
             if node.missing_go_to_left:

--- a/sklearn/ensemble/_hist_gradient_boosting/common.pxd
+++ b/sklearn/ensemble/_hist_gradient_boosting/common.pxd
@@ -48,7 +48,7 @@ cdef class Histograms:
         int n_features
         uint32_t [::1] bin_offsets_view
         hist_struct [::1] histograms_view
-    cdef readonly:
+    cdef public:
         object bin_offsets
         # Only the attribute histograms will be used in the splitter.
         object histograms

--- a/sklearn/ensemble/_hist_gradient_boosting/common.pxd
+++ b/sklearn/ensemble/_hist_gradient_boosting/common.pxd
@@ -6,7 +6,6 @@ ctypedef uint8_t X_BINNED_DTYPE_C
 ctypedef float64_t Y_DTYPE_C
 ctypedef float32_t G_H_DTYPE_C
 ctypedef uint32_t BITSET_INNER_DTYPE_C
-ctypedef BITSET_INNER_DTYPE_C[8] BITSET_DTYPE_C
 
 
 cdef packed struct hist_struct:
@@ -56,3 +55,17 @@ cdef class Histograms:
     cdef inline uint32_t n_bins(self, int feature_idx) noexcept nogil
 
     cdef inline hist_struct* at(self, int feature_idx, uint32_t bin_idx) noexcept nogil
+
+
+cdef class Bitsets:
+    cdef:
+        const uint32_t [::1] offsets_view
+        BITSET_INNER_DTYPE_C [::1] bitsets_view
+    cdef public:
+        object offsets
+        # Only the attribute histograms will be used in the splitter.
+        object bitsets
+
+    cdef inline uint32_t n_inner_bitsets(self, int feature_idx) noexcept nogil
+
+    cdef inline BITSET_INNER_DTYPE_C* at(self, int feature_idx) noexcept nogil

--- a/sklearn/ensemble/_hist_gradient_boosting/common.pxd
+++ b/sklearn/ensemble/_hist_gradient_boosting/common.pxd
@@ -41,3 +41,18 @@ cpdef enum MonotonicConstraint:
     NO_CST = 0
     POS = 1
     NEG = -1
+
+
+cdef class Histograms:
+    cdef:
+        int n_features
+        uint32_t [::1] bin_offsets_view
+        hist_struct [::1] histograms_view
+    cdef readonly:
+        object bin_offsets
+        # Only the attribute histograms will be used in the splitter.
+        object histograms
+
+    cdef inline uint32_t n_bins(self, int feature_idx) noexcept nogil
+
+    cdef inline hist_struct* at(self, int feature_idx, uint32_t bin_idx) noexcept nogil

--- a/sklearn/ensemble/_hist_gradient_boosting/common.pxd
+++ b/sklearn/ensemble/_hist_gradient_boosting/common.pxd
@@ -1,8 +1,13 @@
-from ...utils._typedefs cimport float32_t, float64_t, intp_t, uint8_t, uint32_t
+from ...utils._typedefs cimport (
+    float32_t, float64_t, int32_t, intp_t, uint8_t, uint16_t, uint32_t
+)
 
 
 ctypedef float64_t X_DTYPE_C
-ctypedef uint8_t X_BINNED_DTYPE_C
+ctypedef uint16_t X_BINNED_DTYPE_C
+ctypedef fused X_BINNED_DTYPE_FUSED_C:
+    uint8_t
+    uint16_t
 ctypedef float64_t Y_DTYPE_C
 ctypedef float32_t G_H_DTYPE_C
 ctypedef uint32_t BITSET_INNER_DTYPE_C
@@ -69,3 +74,25 @@ cdef class Bitsets:
     cdef inline uint32_t n_inner_bitsets(self, int feature_idx) noexcept nogil
 
     cdef inline BITSET_INNER_DTYPE_C* at(self, int feature_idx) noexcept nogil
+
+
+cdef class BinnedData:
+    # A data container for mixed uint8 and uint16 columns.
+    cdef:
+        uint8_t[::1, :] X8_view
+        uint16_t[::1, :] X16_view
+        uint8_t[::1] feature_is_8bit_view  # Python bool ~ unsigned char = uint8
+        int32_t[::1] feature_index_view
+    cdef public:
+        object X8
+        object X16
+        object feature_is_8bit
+        object feature_index
+
+    cdef inline uint8_t[::1] get_feature_view8(self, int feature_idx) noexcept nogil
+
+    cdef inline uint16_t[::1] get_feature_view16(self, int feature_idx) noexcept nogil
+
+    cdef inline uint8_t get_item8(self, int i, int feature_idx) noexcept nogil
+
+    cdef inline uint16_t get_item16(self, int i, int feature_idx) noexcept nogil

--- a/sklearn/ensemble/_hist_gradient_boosting/common.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/common.pyx
@@ -1,5 +1,8 @@
 import numpy as np
 
+cimport cython
+from ...utils._typedefs cimport uint32_t
+
 # Y_DYTPE is the dtype to which the targets y are converted to. This is also
 # dtype for leaf values, gains, and sums of gradients / hessians. The gradients
 # and hessians arrays are stored as floats to avoid using too much memory.
@@ -42,3 +45,52 @@ PREDICTOR_RECORD_DTYPE = np.dtype([
 ])
 
 ALMOST_INF = 1e300  # see LightGBM AvoidInf()
+
+
+@cython.final
+cdef class Histograms:
+    """An extension type (class) for histograms with variable bins.
+
+    This class only allocates the smallest possible 1d ndarray and provides access
+    to it like a 2d jagged array. It is comparable to a jagged/ragged array.
+
+    Attributes
+    ----------
+    Public, i.e. accessible from Python:
+
+        bin_offsets : ndarray of shape (n_features + 1), dtype=np.uint32
+            The bin offsets specify which partition of the histograms ndarray belongs
+            to which features: feature j goes from `histograms[bin_offsets[j]]` until
+            `histograms[bin_offsets[j + 1] - 1]`. `bin_offsets[n_features + 1]` gives
+            the total number of bins over all features.
+        histograms : ndarray of shape (bin_offsets[n_features + 1],), \
+                dtype=HISTOGRAM_DTYPE
+            The 1-dimensional array of all histograms for all features.
+
+    Private, i.e. only accessible from Cython:
+
+        bin_offsets_view : memoryview of `bin_offsets`, dtype=uint32_t
+        histograms_view : memoryview of `histograms`, dtype=hist_stucts
+        n_features : int
+    """
+
+    def __init__(self, n_features, bin_offsets):
+        self.n_features = n_features
+        if isinstance(bin_offsets, int):
+            self.bin_offsets = np.zeros(shape=self.n_features + 1, dtype=np.uint32)
+            self.bin_offsets[1:] = np.cumsum(np.full(shape=n_features, fill_value=bin_offsets))
+        else:
+            self.bin_offsets = bin_offsets
+        self.bin_offsets_view = self.bin_offsets
+
+        self.histograms = np.empty(
+            shape=self.bin_offsets[self.bin_offsets.shape[0] - 1],  # bin_offsets[-1]
+            dtype=HISTOGRAM_DTYPE,
+        )
+        self.histograms_view = self.histograms
+
+    cdef inline uint32_t n_bins(self, int feature_idx) noexcept nogil:
+        return self.bin_offsets_view[feature_idx + 1] - self.bin_offsets_view[feature_idx]
+
+    cdef inline hist_struct* at(self, int feature_idx, uint32_t bin_idx) noexcept nogil:
+        return &self.histograms_view[self.bin_offsets_view[feature_idx] + bin_idx]

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -679,8 +679,10 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
             X_binned_val = None
 
         # Uses binned data to check for missing values
+        # Note that the missing bin index is always the last bin, i.e. the value of
+        # n_bins_non_missing.
         has_missing_values = (
-            (X_binned_train == self._bin_mapper.missing_values_bin_idx_)
+            (X_binned_train == self._bin_mapper.n_bins_non_missing_)
             .any(axis=0)
             .astype(np.uint8)
         )
@@ -940,7 +942,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                     for k, pred in enumerate(self._predictors[-1]):
                         raw_predictions_val[:, k] += pred.predict_binned(
                             X_binned_val,
-                            self._bin_mapper.missing_values_bin_idx_,
+                            self._bin_mapper.n_bins_non_missing_,
                             n_threads,
                         )
 
@@ -1296,7 +1298,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                 if is_binned:
                     predict = partial(
                         predictor.predict_binned,
-                        missing_values_bin_idx=self._bin_mapper.missing_values_bin_idx_,
+                        n_bins_non_missing=self._bin_mapper.n_bins_non_missing_,
                         n_threads=n_threads,
                     )
                 else:

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -352,6 +352,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                     f"have a cardinality <= {self.max_bins} but actually "
                     f"has a cardinality of {categories.size}."
                 )
+            # TODO: Decide if dtype=uint16 would be a better fit.
             known_categories[feature_idx] = np.arange(len(categories), dtype=X_DTYPE)
         return known_categories
 
@@ -1288,10 +1289,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
     def _predict_iterations(self, X, predictors, raw_predictions, is_binned, n_threads):
         """Add the predictions of the predictors to raw_predictions."""
         if not is_binned:
-            (
-                known_cat_bitsets,
-                f_idx_map,
-            ) = self._bin_mapper.make_known_categories_bitsets()
+            known_cat_bitsets = self._bin_mapper.make_known_categories_bitsets()
 
         for predictors_of_ith_iteration in predictors:
             for k, predictor in enumerate(predictors_of_ith_iteration):
@@ -1305,7 +1303,6 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                     predict = partial(
                         predictor.predict,
                         known_cat_bitsets=known_cat_bitsets,
-                        f_idx_map=f_idx_map,
                         n_threads=n_threads,
                     )
                 raw_predictions[:, k] += predict(X)

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -18,6 +18,7 @@ from ...utils.arrayfuncs import sum_parallel
 from ._bitset import copyto_feature_bitset_array, set_raw_bitset_from_binned_bitset
 from .common import (
     PREDICTOR_RECORD_DTYPE,
+    BinnedData,
     Bitsets,
     MonotonicConstraint,
 )
@@ -366,13 +367,13 @@ class TreeGrower:
 
         Also validate parameters passed to splitter.
         """
-        if X_binned.dtype != np.uint8:
-            raise NotImplementedError("X_binned must be of type uint8.")
-        if not X_binned.flags.f_contiguous:
+        if not isinstance(X_binned, BinnedData):
             raise ValueError(
-                "X_binned should be passed as Fortran contiguous "
-                "array for maximum efficiency."
+                "X_binned must be of type BinnedData (mixed uint8/uin16), with "
+                "internal Fortran contiguous arrays for maximum efficiency."
             )
+            # As BinnedData is guaranteed to be F-contiguous, we do not need to check
+            # the array.flags.f_contiguous.
         if min_gain_to_split < 0:
             raise ValueError(
                 "min_gain_to_split={} must be positive.".format(min_gain_to_split)

--- a/sklearn/ensemble/_hist_gradient_boosting/histogram.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/histogram.pyx
@@ -11,6 +11,7 @@ from .common cimport G_H_DTYPE_C
 from .common cimport Histograms
 from .common cimport hist_struct
 
+import numpy as np
 from cython.parallel import prange
 
 # Notes:
@@ -58,9 +59,10 @@ cdef class HistogramBuilder:
     ----------
     X_binned : ndarray of int, shape (n_samples, n_features)
         The binned input samples. Must be Fortran-aligned.
-    n_bins : int
-        The total number of bins, including the bin for missing values. Used
-        to define the shape of the histograms.
+    n_bins : int or ndarray of shape (n_features,), dtype=np.uint32
+        The total number of bins for each feature, always including the bin for missing
+        values as the last bin. Used to define the shape of the histograms.
+        If an integer is passed, it is considered as `np.array([n_bins] * n_features)`.
     gradients : ndarray, shape (n_samples,)
         The gradients of each training sample. Those are the gradients of the
         loss w.r.t the predictions, evaluated at iteration i - 1.
@@ -69,11 +71,20 @@ cdef class HistogramBuilder:
         loss w.r.t the predictions, evaluated at iteration i - 1.
     hessians_are_constant : bool
         Whether hessians are constant.
+
+    Attributes
+    ----------
+    bin_offsets : ndarray of shape (n_features + 1), dtype=np.uint32
+        The bin offsets specify which partition of the histograms ndarray belongs
+        to which features: feature j goes from `histograms[bin_offsets[j]]` until
+        `histograms[bin_offsets[j + 1] - 1]`. `bin_offsets[n_features + 1]` gives
+        the total number of bins over all features.
     """
     cdef public:
         const X_BINNED_DTYPE_C [::1, :] X_binned
         unsigned int n_features
-        unsigned int n_bins
+        uint32_t [::1] n_bins
+        uint32_t [::1] bin_offsets
         G_H_DTYPE_C [::1] gradients
         G_H_DTYPE_C [::1] hessians
         G_H_DTYPE_C [::1] ordered_gradients
@@ -82,17 +93,24 @@ cdef class HistogramBuilder:
         int n_threads
 
     def __init__(
-        self, const X_BINNED_DTYPE_C [::1, :] X_binned,
-        unsigned int n_bins, G_H_DTYPE_C [::1] gradients,
+        self,
+        const X_BINNED_DTYPE_C [::1, :] X_binned,
+        object n_bins,
+        G_H_DTYPE_C [::1] gradients,
         G_H_DTYPE_C [::1] hessians,
         unsigned char hessians_are_constant,
-        int n_threads
+        int n_threads,
     ):
         self.X_binned = X_binned
         self.n_features = X_binned.shape[1]
-        # Note: all histograms will have <n_bins> bins, but some of the
-        # bins may be unused if a feature has a small number of unique values.
-        self.n_bins = n_bins
+        if isinstance(n_bins, int):
+            # Note: all histograms will have <n_bins> bins, but some of the
+            # bins may be unused if a feature has a small number of unique values.
+            self.n_bins = np.full(
+                shape=self.n_features, fill_value=n_bins, dtype=np.uint32,
+            )
+        else:
+            self.n_bins = n_bins
         self.gradients = gradients
         self.hessians = hessians
         # for root node, gradients and hessians are already ordered
@@ -100,6 +118,11 @@ cdef class HistogramBuilder:
         self.ordered_hessians = hessians.copy()
         self.hessians_are_constant = hessians_are_constant
         self.n_threads = n_threads
+        # bin_offsets[j] is the start of the bins of feature j,
+        # bin_offsets[n_features + 1] gives the total number of bins
+        bin_offsets = np.zeros(shape=self.n_features + 1, dtype=np.uint32)
+        bin_offsets[1:] = np.cumsum(self.n_bins)
+        self.bin_offsets = bin_offsets
 
     def compute_histograms_brute(
         HistogramBuilder self,
@@ -140,7 +163,7 @@ cdef class HistogramBuilder:
             # Here we just allocate the array, i.e. __init__ calls:
             # np.empty(shape=self.bin_offsets[-1], dtype=HISTOGRAM_DTYPE)
             Histograms histograms = Histograms(
-                n_features=self.n_features, bin_offsets=256
+                n_features=self.n_features, bin_offsets=self.bin_offsets
             )
             bint has_interaction_cst = allowed_features is not None
             int n_threads = self.n_threads

--- a/sklearn/ensemble/_hist_gradient_boosting/histogram.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/histogram.pyx
@@ -5,10 +5,11 @@
 cimport cython
 from libc.string cimport memset
 
-from ...utils._typedefs cimport uint32_t
-from .common cimport X_BINNED_DTYPE_C
+from ...utils._typedefs cimport uint8_t, uint16_t, uint32_t
+from .common cimport BinnedData
 from .common cimport G_H_DTYPE_C
 from .common cimport Histograms
+from .common cimport X_BINNED_DTYPE_FUSED_C
 from .common cimport hist_struct
 
 import numpy as np
@@ -57,8 +58,8 @@ cdef class HistogramBuilder:
 
     Parameters
     ----------
-    X_binned : ndarray of int, shape (n_samples, n_features)
-        The binned input samples. Must be Fortran-aligned.
+    X_binned : BinnedData of shape (n_samples, n_features)
+        The binned input samples. Underlying arrays are Fortran-aligned.
     n_bins : int or ndarray of shape (n_features,), dtype=np.uint32
         The total number of bins for each feature, always including the bin for missing
         values as the last bin. Used to define the shape of the histograms.
@@ -81,7 +82,7 @@ cdef class HistogramBuilder:
         the total number of bins over all features.
     """
     cdef public:
-        const X_BINNED_DTYPE_C [::1, :] X_binned
+        BinnedData X_binned
         unsigned int n_features
         uint32_t [::1] n_bins
         uint32_t [::1] bin_offsets
@@ -94,7 +95,7 @@ cdef class HistogramBuilder:
 
     def __init__(
         self,
-        const X_BINNED_DTYPE_C [::1, :] X_binned,
+        BinnedData X_binned,
         object n_bins,
         G_H_DTYPE_C [::1] gradients,
         G_H_DTYPE_C [::1] hessians,
@@ -197,14 +198,26 @@ cdef class HistogramBuilder:
                 else:
                     feature_idx = f_idx
 
-                self._compute_histogram_brute_single_feature(
-                    feature_idx, sample_indices, histograms
-                )
+                if self.X_binned.feature_is_8bit_view[feature_idx]:
+                    self._compute_histogram_brute_single_feature[uint8_t](
+                        X_binned=self.X_binned.get_feature_view8(feature_idx),
+                        feature_idx=feature_idx,
+                        sample_indices=sample_indices,
+                        histograms=histograms,
+                    )
+                else:
+                    self._compute_histogram_brute_single_feature[uint16_t](
+                        X_binned=self.X_binned.get_feature_view16(feature_idx),
+                        feature_idx=feature_idx,
+                        sample_indices=sample_indices,
+                        histograms=histograms,
+                    )
 
         return histograms
 
     cdef void _compute_histogram_brute_single_feature(
         HistogramBuilder self,
+        const X_BINNED_DTYPE_FUSED_C [::1] X_binned,
         const int feature_idx,
         const unsigned int [::1] sample_indices,  # IN
         Histograms histograms,                    # OUT
@@ -213,8 +226,6 @@ cdef class HistogramBuilder:
 
         cdef:
             unsigned int n_samples = sample_indices.shape[0]
-            const X_BINNED_DTYPE_C [::1] X_binned = \
-                self.X_binned[:, feature_idx]
             unsigned int root_node = X_binned.shape[0] == n_samples
             G_H_DTYPE_C [::1] ordered_gradients = \
                 self.ordered_gradients[:n_samples]
@@ -310,7 +321,7 @@ cdef class HistogramBuilder:
 cpdef void _build_histogram_naive(
     const int feature_idx,
     unsigned int [:] sample_indices,      # IN
-    X_BINNED_DTYPE_C [:] binned_feature,  # IN
+    X_BINNED_DTYPE_FUSED_C [:] binned_feature,  # IN
     G_H_DTYPE_C [:] ordered_gradients,    # IN
     G_H_DTYPE_C [:] ordered_hessians,     # IN
     Histograms out,                       # OUT
@@ -363,7 +374,7 @@ cpdef void _subtract_histograms(
 cpdef void _build_histogram(
     const int feature_idx,
     const unsigned int [::1] sample_indices,      # IN
-    const X_BINNED_DTYPE_C [::1] binned_feature,  # IN
+    const X_BINNED_DTYPE_FUSED_C [::1] binned_feature,  # IN
     const G_H_DTYPE_C [::1] ordered_gradients,    # IN
     const G_H_DTYPE_C [::1] ordered_hessians,     # IN
     Histograms out,                               # OUT
@@ -412,7 +423,7 @@ cpdef void _build_histogram(
 cpdef void _build_histogram_no_hessian(
     const int feature_idx,
     const unsigned int [::1] sample_indices,      # IN
-    const X_BINNED_DTYPE_C [::1] binned_feature,  # IN
+    const X_BINNED_DTYPE_FUSED_C [::1] binned_feature,  # IN
     const G_H_DTYPE_C [::1] ordered_gradients,    # IN
     Histograms out,                     # OUT
 ) noexcept nogil:
@@ -456,7 +467,7 @@ cpdef void _build_histogram_no_hessian(
 
 cpdef void _build_histogram_root(
     const int feature_idx,
-    const X_BINNED_DTYPE_C [::1] binned_feature,  # IN
+    const X_BINNED_DTYPE_FUSED_C [::1] binned_feature,  # IN
     const G_H_DTYPE_C [::1] all_gradients,        # IN
     const G_H_DTYPE_C [::1] all_hessians,         # IN
     Histograms out,                     # OUT
@@ -510,7 +521,7 @@ cpdef void _build_histogram_root(
 
 cpdef void _build_histogram_root_no_hessian(
     const int feature_idx,
-    const X_BINNED_DTYPE_C [::1] binned_feature,  # IN
+    const X_BINNED_DTYPE_FUSED_C [::1] binned_feature,  # IN
     const G_H_DTYPE_C [::1] all_gradients,        # IN
     Histograms out,                               # OUT
 ) noexcept nogil:

--- a/sklearn/ensemble/_hist_gradient_boosting/predictor.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/predictor.py
@@ -78,8 +78,8 @@ class TreePredictor:
 
         Parameters
         ----------
-        X : ndarray, shape (n_samples, n_features)
-            The input samples.
+        X : BinnedData of shape (n_samples, n_features)
+            The binned input samples.
         n_bins_non_missing : ndarray of shape (n_features,), dtype=np.uint16
             For each feature, gives the number of bins actually used for non-missing
             values. The index of the bin where missing values are mapped is always

--- a/sklearn/ensemble/_hist_gradient_boosting/predictor.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/predictor.py
@@ -20,10 +20,10 @@ class TreePredictor:
     ----------
     nodes : ndarray of PREDICTOR_RECORD_DTYPE
         The nodes of the tree.
-    binned_left_cat_bitsets : ndarray of shape (n_categorical_splits, 8), dtype=uint32
+    binned_left_cat_bitsets : Bitsets
         Array of bitsets for binned categories used in predict_binned when a
         split is categorical.
-    raw_left_cat_bitsets : ndarray of shape (n_categorical_splits, 8), dtype=uint32
+    raw_left_cat_bitsets : Bitsets
         Array of bitsets for raw categories used in predict when a split is
         categorical.
     """
@@ -41,7 +41,7 @@ class TreePredictor:
         """Return maximum depth among all leaves."""
         return int(self.nodes["depth"].max())
 
-    def predict(self, X, known_cat_bitsets, f_idx_map, n_threads):
+    def predict(self, X, known_cat_bitsets, n_threads):
         """Predict raw values for non-binned data.
 
         Parameters
@@ -49,12 +49,9 @@ class TreePredictor:
         X : ndarray, shape (n_samples, n_features)
             The input samples.
 
-        known_cat_bitsets : ndarray of shape (n_categorical_features, 8)
-            Array of bitsets of known categories, for each categorical feature.
-
-        f_idx_map : ndarray of shape (n_features,)
-            Map from original feature index to the corresponding index in the
-            known_cat_bitsets array.
+        known_cat_bitsets : Bitsets
+            Bitsets of known categories for each categorical feature.
+            Offsets map from feature index to position of the bitsets array.
 
         n_threads : int
             Number of OpenMP threads to use.
@@ -71,7 +68,6 @@ class TreePredictor:
             X,
             self.raw_left_cat_bitsets,
             known_cat_bitsets,
-            f_idx_map,
             n_threads,
             out,
         )

--- a/sklearn/ensemble/_hist_gradient_boosting/predictor.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/predictor.py
@@ -77,17 +77,17 @@ class TreePredictor:
         )
         return out
 
-    def predict_binned(self, X, missing_values_bin_idx, n_threads):
+    def predict_binned(self, X, n_bins_non_missing, n_threads):
         """Predict raw values for binned data.
 
         Parameters
         ----------
         X : ndarray, shape (n_samples, n_features)
             The input samples.
-        missing_values_bin_idx : uint8
-            Index of the bin that is used for missing values. This is the
-            index of the last bin and is always equal to max_bins (as passed
-            to the GBDT classes), or equivalently to n_bins - 1.
+        n_bins_non_missing : ndarray of shape (n_features,), dtype=np.uint16
+            For each feature, gives the number of bins actually used for non-missing
+            values. The index of the bin where missing values are mapped is always
+            given by the last bin, i.e. bin index ``n_bins_non_missing``.
         n_threads : int
             Number of OpenMP threads to use.
 
@@ -101,7 +101,7 @@ class TreePredictor:
             self.nodes,
             X,
             self.binned_left_cat_bitsets,
-            missing_values_bin_idx,
+            n_bins_non_missing,
             n_threads,
             out,
         )

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -8,14 +8,14 @@
 # Author: Nicolas Hug
 
 cimport cython
-from cython.parallel import prange
-import numpy as np
 from libc.math cimport INFINITY, ceil
 from libc.stdlib cimport malloc, free, qsort
 from libc.string cimport memcpy
 
-from ...utils._typedefs cimport uint8_t
+from ...utils._typedefs cimport uint8_t, uint16_t, uint32_t
+from .common cimport BinnedData
 from .common cimport X_BINNED_DTYPE_C
+from .common cimport X_BINNED_DTYPE_FUSED_C
 from .common cimport Y_DTYPE_C
 from .common cimport BITSET_INNER_DTYPE_C
 from .common cimport Bitsets
@@ -25,7 +25,9 @@ from .common cimport hist_struct
 from ._bitset cimport create_feature_bitset_array
 from ._bitset cimport set_bitset
 from ._bitset cimport in_bitset
-from ...utils._typedefs cimport uint16_t, uint32_t
+
+from cython.parallel import prange
+import numpy as np
 
 
 cdef struct split_info_struct:
@@ -123,8 +125,8 @@ cdef class Splitter:
 
     Parameters
     ----------
-    X_binned : ndarray of int, shape (n_samples, n_features)
-        The binned input samples. Must be Fortran-aligned.
+    X_binned : BinnedData of shape (n_samples, n_features)
+        The binned input samples. Underlying arrays are Fortran-aligned.
     n_bins_non_missing : ndarray of shape (n_features,), dtype=np.uint16
         For each feature, gives the number of bins actually used for
         non-missing values.
@@ -173,7 +175,7 @@ cdef class Splitter:
         the total number of base bitsets (X_BITSET_INNER_DTYPE) over all features.
     """
     cdef public:
-        const X_BINNED_DTYPE_C [::1, :] X_binned
+        BinnedData X_binned
         unsigned int n_features
         unsigned int n_categorical_features
         const uint16_t [::1] n_bins_non_missing
@@ -195,7 +197,7 @@ cdef class Splitter:
         int n_threads
 
     def __init__(self,
-                 const X_BINNED_DTYPE_C [::1, :] X_binned,
+                 BinnedData X_binned,
                  const uint16_t [::1] n_bins_non_missing,
                  const unsigned char [::1] has_missing_values,
                  const unsigned char [::1] is_categorical,
@@ -327,8 +329,6 @@ cdef class Splitter:
             X_BINNED_DTYPE_C bin_idx = split_info.bin_idx
             unsigned char missing_go_to_left = split_info.missing_go_to_left
             uint16_t missing_values_bin_idx = self.n_bins_non_missing[feature_idx]
-            const X_BINNED_DTYPE_C [::1] X_binned = \
-                self.X_binned[:, feature_idx]
             unsigned int [::1] left_indices_buffer = self.left_indices_buffer
             unsigned int [::1] right_indices_buffer = self.right_indices_buffer
             unsigned char is_categorical = split_info.is_categorical
@@ -340,15 +340,10 @@ cdef class Splitter:
             int [:] offset_in_buffers = np.zeros(n_threads, dtype=np.int32)
             int [:] left_counts = np.empty(n_threads, dtype=np.int32)
             int [:] right_counts = np.empty(n_threads, dtype=np.int32)
-            int left_count
-            int right_count
             int start
             int stop
-            int i
             int thread_idx
-            int sample_idx
             int right_child_position
-            unsigned char turn_left
             int [:] left_offset = np.zeros(n_threads, dtype=np.int32)
             int [:] right_offset = np.zeros(n_threads, dtype=np.int32)
 
@@ -367,28 +362,42 @@ cdef class Splitter:
             # map indices from sample_indices to left/right_indices_buffer
             for thread_idx in prange(n_threads, schedule='static',
                                      chunksize=1, num_threads=n_threads):
-                left_count = 0
-                right_count = 0
-
                 start = offset_in_buffers[thread_idx]
                 stop = start + sizes[thread_idx]
-                for i in range(start, stop):
-                    sample_idx = sample_indices[i]
-                    turn_left = sample_goes_left(
-                        missing_go_to_left,
-                        missing_values_bin_idx, bin_idx,
-                        X_binned[sample_idx], is_categorical,
-                        left_cat_bitset)
-
-                    if turn_left:
-                        left_indices_buffer[start + left_count] = sample_idx
-                        left_count = left_count + 1
-                    else:
-                        right_indices_buffer[start + right_count] = sample_idx
-                        right_count = right_count + 1
-
-                left_counts[thread_idx] = left_count
-                right_counts[thread_idx] = right_count
+                if self.X_binned.feature_is_8bit_view[feature_idx]:
+                    sample_to_left_or_right(
+                        X_binned=self.X_binned.get_feature_view8(feature_idx),
+                        sample_indices=sample_indices,
+                        start=start,
+                        stop=stop,
+                        thread_idx=thread_idx,
+                        missing_go_to_left=missing_go_to_left,
+                        missing_values_bin_idx=missing_values_bin_idx,
+                        bin_idx=bin_idx,
+                        is_categorical=is_categorical,
+                        left_cat_bitset=left_cat_bitset,
+                        left_indices_buffer=left_indices_buffer,  # OUT
+                        right_indices_buffer=right_indices_buffer,  # OUT
+                        left_counts=left_counts,  # OUT
+                        right_counts=right_counts,  # OUT
+                    )
+                else:
+                    sample_to_left_or_right(
+                        X_binned=self.X_binned.get_feature_view16(feature_idx),
+                        sample_indices=sample_indices,
+                        start=start,
+                        stop=stop,
+                        thread_idx=thread_idx,
+                        missing_go_to_left=missing_go_to_left,
+                        missing_values_bin_idx=missing_values_bin_idx,
+                        bin_idx=bin_idx,
+                        is_categorical=is_categorical,
+                        left_cat_bitset=left_cat_bitset,
+                        left_indices_buffer=left_indices_buffer,  # OUT
+                        right_indices_buffer=right_indices_buffer,  # OUT
+                        left_counts=left_counts,  # OUT
+                        right_counts=right_counts,  # OUT
+                    )
 
             # position of right child = just after the left child
             right_child_position = 0
@@ -1113,6 +1122,73 @@ cdef class Splitter:
 cdef int compare_cat_infos(const void * a, const void * b) noexcept nogil:
     return -1 if (<categorical_info *>a).value < (<categorical_info *>b).value else 1
 
+
+cdef void sample_to_left_or_right(
+    const X_BINNED_DTYPE_FUSED_C [::1] X_binned,
+    unsigned int [::1] sample_indices,
+    int start,
+    int stop,
+    int thread_idx,
+    unsigned char missing_go_to_left,
+    uint16_t missing_values_bin_idx,
+    X_BINNED_DTYPE_C bin_idx,
+    unsigned char is_categorical,
+    BITSET_INNER_DTYPE_C [:] left_cat_bitset,
+    unsigned int [::1] left_indices_buffer,  # OUT
+    unsigned int [::1] right_indices_buffer,  # OUT
+    int [:] left_counts,  # OUT
+    int [:] right_counts,  # OUT
+) noexcept nogil:
+    cdef:
+        int left_count = 0
+        int right_count = 0
+        int sample_idx
+        unsigned char turn_left
+
+    for i in range(start, stop):
+        sample_idx = sample_indices[i]
+        turn_left = sample_goes_left(
+            missing_go_to_left,
+            missing_values_bin_idx,
+            bin_idx,
+            X_binned[sample_idx],
+            is_categorical,
+            left_cat_bitset,
+        )
+        if turn_left:
+            left_indices_buffer[start + left_count] = sample_idx
+            left_count = left_count + 1
+        else:
+            right_indices_buffer[start + right_count] = sample_idx
+            right_count = right_count + 1
+
+    left_counts[thread_idx] = left_count
+    right_counts[thread_idx] = right_count
+
+
+cdef inline unsigned char sample_goes_left(
+        unsigned char missing_go_to_left,
+        uint16_t missing_values_bin_idx,
+        X_BINNED_DTYPE_C split_bin_idx,
+        X_BINNED_DTYPE_FUSED_C bin_value,
+        unsigned char is_categorical,
+        BITSET_INNER_DTYPE_C [:] left_cat_bitset) noexcept nogil:
+    """Helper to decide whether sample should go to left or right child."""
+
+    if is_categorical:
+        # note: if any, missing values are encoded in left_cat_bitset
+        return in_bitset(&left_cat_bitset[0], bin_value)
+    else:
+        return (
+            (
+                missing_go_to_left and
+                bin_value == missing_values_bin_idx
+            )
+            or (
+                bin_value <= split_bin_idx
+            ))
+
+
 cdef inline Y_DTYPE_C _split_gain(
         Y_DTYPE_C sum_gradient_left,
         Y_DTYPE_C sum_hessian_left,
@@ -1162,6 +1238,7 @@ cdef inline Y_DTYPE_C _split_gain(
 
     return gain
 
+
 cdef inline Y_DTYPE_C _loss_from_value(
         Y_DTYPE_C value,
         Y_DTYPE_C sum_gradient) noexcept nogil:
@@ -1172,28 +1249,6 @@ cdef inline Y_DTYPE_C _loss_from_value(
     <1603.02754>.`
     """
     return sum_gradient * value
-
-cdef inline unsigned char sample_goes_left(
-        unsigned char missing_go_to_left,
-        uint16_t missing_values_bin_idx,
-        X_BINNED_DTYPE_C split_bin_idx,
-        X_BINNED_DTYPE_C bin_value,
-        unsigned char is_categorical,
-        BITSET_INNER_DTYPE_C [:] left_cat_bitset) noexcept nogil:
-    """Helper to decide whether sample should go to left or right child."""
-
-    if is_categorical:
-        # note: if any, missing values are encoded in left_cat_bitset
-        return in_bitset(&left_cat_bitset[0], bin_value)
-    else:
-        return (
-            (
-                missing_go_to_left and
-                bin_value == missing_values_bin_idx
-            )
-            or (
-                bin_value <= split_bin_idx
-            ))
 
 
 cpdef inline Y_DTYPE_C compute_node_value(

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -17,10 +17,10 @@ from libc.string cimport memcpy
 from ...utils._typedefs cimport uint8_t
 from .common cimport X_BINNED_DTYPE_C
 from .common cimport Y_DTYPE_C
-from .common cimport hist_struct
 from .common cimport BITSET_INNER_DTYPE_C
 from .common cimport BITSET_DTYPE_C
 from .common cimport MonotonicConstraint
+from .common cimport Histograms
 from ._bitset cimport init_bitset
 from ._bitset cimport set_bitset
 from ._bitset cimport in_bitset
@@ -427,7 +427,7 @@ cdef class Splitter:
     def find_node_split(
             Splitter self,
             unsigned int n_samples,
-            hist_struct [:, ::1] histograms,  # IN
+            Histograms histograms,  # IN
             const Y_DTYPE_C sum_gradients,
             const Y_DTYPE_C sum_hessians,
             const Y_DTYPE_C value,
@@ -623,7 +623,7 @@ cdef class Splitter:
             Splitter self,
             unsigned int feature_idx,
             unsigned char has_missing_values,
-            const hist_struct [:, ::1] histograms,  # IN
+            Histograms histograms,  # IN
             unsigned int n_samples,
             Y_DTYPE_C sum_gradients,
             Y_DTYPE_C sum_hessians,
@@ -672,17 +672,17 @@ cdef class Splitter:
         loss_current_node = _loss_from_value(value, sum_gradients)
 
         for bin_idx in range(end):
-            n_samples_left += histograms[feature_idx, bin_idx].count
+            n_samples_left += histograms.at(feature_idx, bin_idx).count
             n_samples_right = n_samples_ - n_samples_left
 
             if self.hessians_are_constant:
-                sum_hessian_left += histograms[feature_idx, bin_idx].count
+                sum_hessian_left += histograms.at(feature_idx, bin_idx).count
             else:
                 sum_hessian_left += \
-                    histograms[feature_idx, bin_idx].sum_hessians
+                    histograms.at(feature_idx, bin_idx).sum_hessians
             sum_hessian_right = sum_hessians - sum_hessian_left
 
-            sum_gradient_left += histograms[feature_idx, bin_idx].sum_gradients
+            sum_gradient_left += histograms.at(feature_idx, bin_idx).sum_gradients
             sum_gradient_right = sum_gradients - sum_gradient_left
 
             if n_samples_left < self.min_samples_leaf:
@@ -737,7 +737,7 @@ cdef class Splitter:
     cdef void _find_best_bin_to_split_right_to_left(
             self,
             unsigned int feature_idx,
-            const hist_struct [:, ::1] histograms,  # IN
+            Histograms histograms,  # IN
             unsigned int n_samples,
             Y_DTYPE_C sum_gradients,
             Y_DTYPE_C sum_hessians,
@@ -785,18 +785,18 @@ cdef class Splitter:
         loss_current_node = _loss_from_value(value, sum_gradients)
 
         for bin_idx in range(start, -1, -1):
-            n_samples_right += histograms[feature_idx, bin_idx + 1].count
+            n_samples_right += histograms.at(feature_idx, bin_idx + 1).count
             n_samples_left = n_samples_ - n_samples_right
 
             if self.hessians_are_constant:
-                sum_hessian_right += histograms[feature_idx, bin_idx + 1].count
+                sum_hessian_right += histograms.at(feature_idx, bin_idx + 1).count
             else:
                 sum_hessian_right += \
-                    histograms[feature_idx, bin_idx + 1].sum_hessians
+                    histograms.at(feature_idx, bin_idx + 1).sum_hessians
             sum_hessian_left = sum_hessians - sum_hessian_right
 
             sum_gradient_right += \
-                histograms[feature_idx, bin_idx + 1].sum_gradients
+                histograms.at(feature_idx, bin_idx + 1).sum_gradients
             sum_gradient_left = sum_gradients - sum_gradient_right
 
             if n_samples_right < self.min_samples_leaf:
@@ -852,7 +852,7 @@ cdef class Splitter:
             self,
             unsigned int feature_idx,
             unsigned char has_missing_values,
-            const hist_struct [:, ::1] histograms,  # IN
+            Histograms histograms,  # IN
             unsigned int n_samples,
             Y_DTYPE_C sum_gradients,
             Y_DTYPE_C sum_hessians,
@@ -881,7 +881,7 @@ cdef class Splitter:
             int best_direction = 0
             unsigned int middle
             unsigned int i
-            const hist_struct[::1] feature_hist = histograms[feature_idx, :]
+            # const hist_struct[::1] feature_hist = histograms[feature_idx, :]
             Y_DTYPE_C sum_gradients_bin
             Y_DTYPE_C sum_hessians_bin
             Y_DTYPE_C loss_current_node
@@ -944,12 +944,15 @@ cdef class Splitter:
         # fill cat_infos while filtering out categories based on MIN_CAT_SUPPORT
         for bin_idx in range(n_bins_non_missing):
             if self.hessians_are_constant:
-                sum_hessians_bin = feature_hist[bin_idx].count
+                # sum_hessians_bin = feature_hist[bin_idx].count
+                sum_hessians_bin = histograms.at(feature_idx, bin_idx).count
             else:
-                sum_hessians_bin = feature_hist[bin_idx].sum_hessians
+                # sum_hessians_bin = feature_hist[bin_idx].sum_hessians
+                sum_hessians_bin = histograms.at(feature_idx, bin_idx).sum_hessians
             if sum_hessians_bin * support_factor >= MIN_CAT_SUPPORT:
                 cat_infos[n_used_bins].bin_idx = bin_idx
-                sum_gradients_bin = feature_hist[bin_idx].sum_gradients
+                # sum_gradients_bin = feature_hist[bin_idx].sum_gradients
+                sum_gradients_bin = histograms.at(feature_idx, bin_idx).sum_gradients
 
                 cat_infos[n_used_bins].value = (
                     sum_gradients_bin / (sum_hessians_bin + MIN_CAT_SUPPORT)
@@ -959,13 +962,18 @@ cdef class Splitter:
         # Also add missing values bin so that nans are considered as a category
         if has_missing_values:
             if self.hessians_are_constant:
-                sum_hessians_bin = feature_hist[missing_values_bin_idx].count
+                # sum_hessians_bin = feature_hist[missing_values_bin_idx].count
+                sum_hessians_bin = histograms.at(feature_idx, missing_values_bin_idx).count
             else:
-                sum_hessians_bin = feature_hist[missing_values_bin_idx].sum_hessians
+                # sum_hessians_bin = feature_hist[missing_values_bin_idx].sum_hessians
+                sum_hessians_bin = histograms.at(feature_idx, missing_values_bin_idx).sum_hessians
             if sum_hessians_bin * support_factor >= MIN_CAT_SUPPORT:
                 cat_infos[n_used_bins].bin_idx = missing_values_bin_idx
+                # sum_gradients_bin = (
+                #     feature_hist[missing_values_bin_idx].sum_gradients
+                # )
                 sum_gradients_bin = (
-                    feature_hist[missing_values_bin_idx].sum_gradients
+                    histograms.at(feature_idx, missing_values_bin_idx).sum_gradients
                 )
 
                 cat_infos[n_used_bins].value = (
@@ -998,16 +1006,20 @@ cdef class Splitter:
                 sorted_cat_idx = i if direction == 1 else n_used_bins - 1 - i
                 bin_idx = cat_infos[sorted_cat_idx].bin_idx
 
-                n_samples_left += feature_hist[bin_idx].count
+                # n_samples_left += feature_hist[bin_idx].count
+                n_samples_left += histograms.at(feature_idx, bin_idx).count
                 n_samples_right = n_samples - n_samples_left
 
                 if self.hessians_are_constant:
-                    sum_hessian_left += feature_hist[bin_idx].count
+                    # sum_hessian_left += feature_hist[bin_idx].count
+                    sum_hessian_left += histograms.at(feature_idx, bin_idx).count
                 else:
-                    sum_hessian_left += feature_hist[bin_idx].sum_hessians
+                    # sum_hessian_left += feature_hist[bin_idx].sum_hessians
+                    sum_hessian_left += histograms.at(feature_idx, bin_idx).sum_hessians
                 sum_hessian_right = sum_hessians - sum_hessian_left
 
-                sum_gradient_left += feature_hist[bin_idx].sum_gradients
+                # sum_gradient_left += feature_hist[bin_idx].sum_gradients
+                sum_gradient_left += histograms.at(feature_idx, bin_idx).sum_gradients
                 sum_gradient_right = sum_gradients - sum_gradient_left
 
                 if (

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -18,14 +18,14 @@ from ...utils._typedefs cimport uint8_t
 from .common cimport X_BINNED_DTYPE_C
 from .common cimport Y_DTYPE_C
 from .common cimport BITSET_INNER_DTYPE_C
-from .common cimport BITSET_DTYPE_C
+from .common cimport Bitsets
 from .common cimport MonotonicConstraint
 from .common cimport Histograms
 from .common cimport hist_struct
-from ._bitset cimport init_bitset
+from ._bitset cimport create_feature_bitset_array
 from ._bitset cimport set_bitset
 from ._bitset cimport in_bitset
-from ...utils._typedefs cimport uint16_t
+from ...utils._typedefs cimport uint16_t, uint32_t
 
 
 cdef struct split_info_struct:
@@ -44,7 +44,6 @@ cdef struct split_info_struct:
     Y_DTYPE_C value_left
     Y_DTYPE_C value_right
     unsigned char is_categorical
-    BITSET_DTYPE_C left_cat_bitset
 
 
 # used in categorical splits for sorting categories by increasing values of
@@ -161,14 +160,27 @@ cdef class Splitter:
     rng : Generator
     n_threads : int, default=1
         Number of OpenMP threads to use.
+
+    Attributes
+    ----------
+    n_features : unsigned int
+    n_categorical_features : unsigned int
+        Number of categorical features, i.e. `sum(is_categorical)`.
+    bitsets_offsets : ndarray of shape (n_features + 1), dtype=np.uint32
+        The offsets specify which partition of the bitsets ndarray belongs
+        to which features: feature j goes from `bitsets[offsets[j]]` until
+        `bitsets[offsets[j + 1] - 1]`. `offsets[n_features + 1]` gives
+        the total number of base bitsets (X_BITSET_INNER_DTYPE) over all features.
     """
     cdef public:
         const X_BINNED_DTYPE_C [::1, :] X_binned
         unsigned int n_features
+        unsigned int n_categorical_features
         const uint16_t [::1] n_bins_non_missing
         const unsigned char [::1] has_missing_values
         const unsigned char [::1] is_categorical
         const signed char [::1] monotonic_cst
+        uint32_t [::1] bitsets_offsets
         unsigned char hessians_are_constant
         Y_DTYPE_C l2_regularization
         Y_DTYPE_C min_hessian_to_split
@@ -202,6 +214,7 @@ cdef class Splitter:
         self.n_bins_non_missing = n_bins_non_missing
         self.has_missing_values = has_missing_values
         self.is_categorical = is_categorical
+        self.n_categorical_features = np.sum(is_categorical)
         self.monotonic_cst = monotonic_cst
         self.l2_regularization = l2_regularization
         self.min_hessian_to_split = min_hessian_to_split
@@ -225,6 +238,15 @@ cdef class Splitter:
         # buffers used in split_indices to support parallel splitting.
         self.left_indices_buffer = np.empty_like(self.partition)
         self.right_indices_buffer = np.empty_like(self.partition)
+
+        # bitsets_offsets[j] is the start of the bitset of feature j,
+        # bitsets_offsets[n_features + 1] gives the total number of base bitsets.
+        bitsets_offsets = np.zeros(shape=self.n_features + 1, dtype=np.uint32)
+        n_base_bitsets = np.ceil(np.divide(np.add(self.n_bins_non_missing, 1), 32))
+        bitsets_offsets[1:] = np.cumsum(
+            np.multiply(n_base_bitsets, self.is_categorical), dtype=np.uint32
+        )
+        self.bitsets_offsets = bitsets_offsets
 
     def split_indices(Splitter self, split_info, unsigned int [::1]
                       sample_indices):
@@ -310,10 +332,7 @@ cdef class Splitter:
             unsigned int [::1] left_indices_buffer = self.left_indices_buffer
             unsigned int [::1] right_indices_buffer = self.right_indices_buffer
             unsigned char is_categorical = split_info.is_categorical
-            # Cython is unhappy if we set left_cat_bitset to
-            # split_info.left_cat_bitset directly, so we need a tmp var
-            BITSET_INNER_DTYPE_C [:] cat_bitset_tmp = split_info.left_cat_bitset
-            BITSET_DTYPE_C left_cat_bitset
+            BITSET_INNER_DTYPE_C [:] left_cat_bitset
             int n_threads = self.n_threads
 
             int [:] sizes = np.full(n_threads, n_samples // n_threads,
@@ -335,7 +354,7 @@ cdef class Splitter:
 
         # only set left_cat_bitset when is_categorical is True
         if is_categorical:
-            left_cat_bitset = &cat_bitset_tmp[0]
+            left_cat_bitset = split_info.left_cat_bitset
 
         with nogil:
             for thread_idx in range(n_samples % n_threads):
@@ -505,6 +524,9 @@ cdef class Splitter:
             # https://github.com/numpy/numpy/issues/18273
             subsample_mask = subsample_mask_arr
 
+        # Allocate bitsets for categorical features before the nogil.
+        left_cat_bitsets = Bitsets(offsets=self.bitsets_offsets)
+
         with nogil:
 
             split_infos = <split_info_struct *> malloc(
@@ -541,7 +563,9 @@ cdef class Splitter:
                         feature_idx, has_missing_values[feature_idx],
                         histograms, n_samples, sum_gradients, sum_hessians,
                         value, monotonic_cst[feature_idx], lower_bound,
-                        upper_bound, &split_infos[split_info_idx])
+                        upper_bound, &split_infos[split_info_idx],
+                        left_cat_bitsets.at(feature_idx),
+                    )
                 else:
                     # We will scan bins from left to right (in all cases), and
                     # if there are any missing values, we will also scan bins
@@ -594,7 +618,10 @@ cdef class Splitter:
         )
         # Only set bitset if the split is categorical
         if split_info.is_categorical:
-            out.left_cat_bitset = np.asarray(split_info.left_cat_bitset, dtype=np.uint32)
+            # Here, we make a copy of the bitset.
+            out.left_cat_bitset = create_feature_bitset_array(
+                left_cat_bitsets, split_info.feature_idx
+            )
 
         free(split_infos)
         return out
@@ -856,18 +883,20 @@ cdef class Splitter:
                 lower_bound, upper_bound, self.l2_regularization)
 
     cdef void _find_best_bin_to_split_category(
-            self,
-            unsigned int feature_idx,
-            unsigned char has_missing_values,
-            Histograms histograms,  # IN
-            unsigned int n_samples,
-            Y_DTYPE_C sum_gradients,
-            Y_DTYPE_C sum_hessians,
-            Y_DTYPE_C value,
-            char monotonic_cst,
-            Y_DTYPE_C lower_bound,
-            Y_DTYPE_C upper_bound,
-            split_info_struct * split_info) noexcept nogil:  # OUT
+        self,
+        unsigned int feature_idx,
+        unsigned char has_missing_values,
+        Histograms histograms,  # IN
+        unsigned int n_samples,
+        Y_DTYPE_C sum_gradients,
+        Y_DTYPE_C sum_hessians,
+        Y_DTYPE_C value,
+        char monotonic_cst,
+        Y_DTYPE_C lower_bound,
+        Y_DTYPE_C upper_bound,
+        split_info_struct * split_info,  # OUT
+        BITSET_INNER_DTYPE_C* left_cat_bitset,  # OUT
+    ) noexcept nogil:
         """Find best split for categorical features.
 
         Categories are first sorted according to their variance, and then
@@ -1064,19 +1093,19 @@ cdef class Splitter:
                 lower_bound, upper_bound, self.l2_regularization)
 
             # create bitset with values from best_cat_infos_thresh
-            init_bitset(split_info.left_cat_bitset)
             if best_direction == 1:
                 for sorted_cat_idx in range(best_cat_infos_thresh + 1):
                     bin_idx = cat_infos[sorted_cat_idx].bin_idx
-                    set_bitset(split_info.left_cat_bitset, bin_idx)
+                    set_bitset(left_cat_bitset, bin_idx)
             else:
                 for sorted_cat_idx in range(n_used_bins - 1, best_cat_infos_thresh - 1, -1):
                     bin_idx = cat_infos[sorted_cat_idx].bin_idx
-                    set_bitset(split_info.left_cat_bitset, bin_idx)
+                    set_bitset(left_cat_bitset, bin_idx)
 
             if has_missing_values:
                 split_info.missing_go_to_left = in_bitset(
-                    split_info.left_cat_bitset, missing_values_bin_idx)
+                    left_cat_bitset, missing_values_bin_idx
+                )
 
         free(cat_infos)
 
@@ -1150,12 +1179,12 @@ cdef inline unsigned char sample_goes_left(
         X_BINNED_DTYPE_C split_bin_idx,
         X_BINNED_DTYPE_C bin_value,
         unsigned char is_categorical,
-        BITSET_DTYPE_C left_cat_bitset) noexcept nogil:
+        BITSET_INNER_DTYPE_C [:] left_cat_bitset) noexcept nogil:
     """Helper to decide whether sample should go to left or right child."""
 
     if is_categorical:
         # note: if any, missing values are encoded in left_cat_bitset
-        return in_bitset(left_cat_bitset, bin_value)
+        return in_bitset(&left_cat_bitset[0], bin_value)
     else:
         return (
             (

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -21,6 +21,7 @@ from .common cimport BITSET_INNER_DTYPE_C
 from .common cimport BITSET_DTYPE_C
 from .common cimport MonotonicConstraint
 from .common cimport Histograms
+from .common cimport hist_struct
 from ._bitset cimport init_bitset
 from ._bitset cimport set_bitset
 from ._bitset cimport in_bitset
@@ -666,23 +667,24 @@ cdef class Splitter:
             unsigned int best_n_samples_left
             Y_DTYPE_C best_gain = -1
 
+            hist_struct * hist = histograms.at(feature_idx, 0)
+
         sum_gradient_left, sum_hessian_left = 0., 0.
         n_samples_left = 0
 
         loss_current_node = _loss_from_value(value, sum_gradients)
 
         for bin_idx in range(end):
-            n_samples_left += histograms.at(feature_idx, bin_idx).count
+            n_samples_left += hist[bin_idx].count
             n_samples_right = n_samples_ - n_samples_left
 
             if self.hessians_are_constant:
-                sum_hessian_left += histograms.at(feature_idx, bin_idx).count
+                sum_hessian_left += hist[bin_idx].count
             else:
-                sum_hessian_left += \
-                    histograms.at(feature_idx, bin_idx).sum_hessians
+                sum_hessian_left += hist[bin_idx].sum_hessians
             sum_hessian_right = sum_hessians - sum_hessian_left
 
-            sum_gradient_left += histograms.at(feature_idx, bin_idx).sum_gradients
+            sum_gradient_left += hist[bin_idx].sum_gradients
             sum_gradient_right = sum_gradients - sum_gradient_left
 
             if n_samples_left < self.min_samples_leaf:
@@ -779,24 +781,24 @@ cdef class Splitter:
             unsigned int best_n_samples_left
             Y_DTYPE_C best_gain = split_info.gain  # computed during previous scan
 
+            hist_struct * hist = histograms.at(feature_idx, 0)
+
         sum_gradient_right, sum_hessian_right = 0., 0.
         n_samples_right = 0
 
         loss_current_node = _loss_from_value(value, sum_gradients)
 
         for bin_idx in range(start, -1, -1):
-            n_samples_right += histograms.at(feature_idx, bin_idx + 1).count
+            n_samples_right += hist[bin_idx + 1].count
             n_samples_left = n_samples_ - n_samples_right
 
             if self.hessians_are_constant:
-                sum_hessian_right += histograms.at(feature_idx, bin_idx + 1).count
+                sum_hessian_right += hist[bin_idx + 1].count
             else:
-                sum_hessian_right += \
-                    histograms.at(feature_idx, bin_idx + 1).sum_hessians
+                sum_hessian_right += hist[bin_idx + 1].sum_hessians
             sum_hessian_left = sum_hessians - sum_hessian_right
 
-            sum_gradient_right += \
-                histograms.at(feature_idx, bin_idx + 1).sum_gradients
+            sum_gradient_right += hist[bin_idx + 1].sum_gradients
             sum_gradient_left = sum_gradients - sum_gradient_right
 
             if n_samples_right < self.min_samples_leaf:
@@ -881,7 +883,7 @@ cdef class Splitter:
             int best_direction = 0
             unsigned int middle
             unsigned int i
-            # const hist_struct[::1] feature_hist = histograms[feature_idx, :]
+            hist_struct * hist = histograms.at(feature_idx, 0)
             Y_DTYPE_C sum_gradients_bin
             Y_DTYPE_C sum_hessians_bin
             Y_DTYPE_C loss_current_node
@@ -944,15 +946,12 @@ cdef class Splitter:
         # fill cat_infos while filtering out categories based on MIN_CAT_SUPPORT
         for bin_idx in range(n_bins_non_missing):
             if self.hessians_are_constant:
-                # sum_hessians_bin = feature_hist[bin_idx].count
-                sum_hessians_bin = histograms.at(feature_idx, bin_idx).count
+                sum_hessians_bin = hist[bin_idx].count
             else:
-                # sum_hessians_bin = feature_hist[bin_idx].sum_hessians
-                sum_hessians_bin = histograms.at(feature_idx, bin_idx).sum_hessians
+                sum_hessians_bin = hist[bin_idx].sum_hessians
             if sum_hessians_bin * support_factor >= MIN_CAT_SUPPORT:
                 cat_infos[n_used_bins].bin_idx = bin_idx
-                # sum_gradients_bin = feature_hist[bin_idx].sum_gradients
-                sum_gradients_bin = histograms.at(feature_idx, bin_idx).sum_gradients
+                sum_gradients_bin = hist[bin_idx].sum_gradients
 
                 cat_infos[n_used_bins].value = (
                     sum_gradients_bin / (sum_hessians_bin + MIN_CAT_SUPPORT)
@@ -962,19 +961,12 @@ cdef class Splitter:
         # Also add missing values bin so that nans are considered as a category
         if has_missing_values:
             if self.hessians_are_constant:
-                # sum_hessians_bin = feature_hist[missing_values_bin_idx].count
-                sum_hessians_bin = histograms.at(feature_idx, missing_values_bin_idx).count
+                sum_hessians_bin = hist[missing_values_bin_idx].count
             else:
-                # sum_hessians_bin = feature_hist[missing_values_bin_idx].sum_hessians
-                sum_hessians_bin = histograms.at(feature_idx, missing_values_bin_idx).sum_hessians
+                sum_hessians_bin = hist[missing_values_bin_idx].sum_hessians
             if sum_hessians_bin * support_factor >= MIN_CAT_SUPPORT:
                 cat_infos[n_used_bins].bin_idx = missing_values_bin_idx
-                # sum_gradients_bin = (
-                #     feature_hist[missing_values_bin_idx].sum_gradients
-                # )
-                sum_gradients_bin = (
-                    histograms.at(feature_idx, missing_values_bin_idx).sum_gradients
-                )
+                sum_gradients_bin = hist[missing_values_bin_idx].sum_gradients
 
                 cat_infos[n_used_bins].value = (
                     sum_gradients_bin / (sum_hessians_bin + MIN_CAT_SUPPORT)
@@ -1006,20 +998,16 @@ cdef class Splitter:
                 sorted_cat_idx = i if direction == 1 else n_used_bins - 1 - i
                 bin_idx = cat_infos[sorted_cat_idx].bin_idx
 
-                # n_samples_left += feature_hist[bin_idx].count
-                n_samples_left += histograms.at(feature_idx, bin_idx).count
+                n_samples_left += hist[bin_idx].count
                 n_samples_right = n_samples - n_samples_left
 
                 if self.hessians_are_constant:
-                    # sum_hessian_left += feature_hist[bin_idx].count
-                    sum_hessian_left += histograms.at(feature_idx, bin_idx).count
+                    sum_hessian_left += hist[bin_idx].count
                 else:
-                    # sum_hessian_left += feature_hist[bin_idx].sum_hessians
-                    sum_hessian_left += histograms.at(feature_idx, bin_idx).sum_hessians
+                    sum_hessian_left += hist[bin_idx].sum_hessians
                 sum_hessian_right = sum_hessians - sum_hessian_left
 
-                # sum_gradient_left += feature_hist[bin_idx].sum_gradients
-                sum_gradient_left += histograms.at(feature_idx, bin_idx).sum_gradients
+                sum_gradient_left += hist[bin_idx].sum_gradients
                 sum_gradient_right = sum_gradients - sum_gradient_left
 
                 if (

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -25,6 +25,7 @@ from .common cimport hist_struct
 from ._bitset cimport init_bitset
 from ._bitset cimport set_bitset
 from ._bitset cimport in_bitset
+from ...utils._typedefs cimport uint16_t
 
 
 cdef struct split_info_struct:
@@ -125,13 +126,9 @@ cdef class Splitter:
     ----------
     X_binned : ndarray of int, shape (n_samples, n_features)
         The binned input samples. Must be Fortran-aligned.
-    n_bins_non_missing : ndarray, shape (n_features,)
+    n_bins_non_missing : ndarray of shape (n_features,), dtype=np.uint16
         For each feature, gives the number of bins actually used for
         non-missing values.
-    missing_values_bin_idx : uint8
-        Index of the bin that is used for missing values. This is the index of
-        the last bin and is always equal to max_bins (as passed to the GBDT
-        classes), or equivalently to n_bins - 1.
     has_missing_values : ndarray, shape (n_features,)
         Whether missing values were observed in the training data, for each
         feature.
@@ -168,8 +165,7 @@ cdef class Splitter:
     cdef public:
         const X_BINNED_DTYPE_C [::1, :] X_binned
         unsigned int n_features
-        const unsigned int [::1] n_bins_non_missing
-        unsigned char missing_values_bin_idx
+        const uint16_t [::1] n_bins_non_missing
         const unsigned char [::1] has_missing_values
         const unsigned char [::1] is_categorical
         const signed char [::1] monotonic_cst
@@ -188,8 +184,7 @@ cdef class Splitter:
 
     def __init__(self,
                  const X_BINNED_DTYPE_C [::1, :] X_binned,
-                 const unsigned int [::1] n_bins_non_missing,
-                 const unsigned char missing_values_bin_idx,
+                 const uint16_t [::1] n_bins_non_missing,
                  const unsigned char [::1] has_missing_values,
                  const unsigned char [::1] is_categorical,
                  const signed char [::1] monotonic_cst,
@@ -205,7 +200,6 @@ cdef class Splitter:
         self.X_binned = X_binned
         self.n_features = X_binned.shape[1]
         self.n_bins_non_missing = n_bins_non_missing
-        self.missing_values_bin_idx = missing_values_bin_idx
         self.has_missing_values = has_missing_values
         self.is_categorical = is_categorical
         self.monotonic_cst = monotonic_cst
@@ -307,10 +301,10 @@ cdef class Splitter:
 
         cdef:
             int n_samples = sample_indices.shape[0]
+            int feature_idx = split_info.feature_idx
             X_BINNED_DTYPE_C bin_idx = split_info.bin_idx
             unsigned char missing_go_to_left = split_info.missing_go_to_left
-            unsigned char missing_values_bin_idx = self.missing_values_bin_idx
-            int feature_idx = split_info.feature_idx
+            uint16_t missing_values_bin_idx = self.n_bins_non_missing[feature_idx]
             const X_BINNED_DTYPE_C [::1] X_binned = \
                 self.X_binned[:, feature_idx]
             unsigned int [::1] left_indices_buffer = self.left_indices_buffer
@@ -647,12 +641,14 @@ cdef class Splitter:
             unsigned int n_samples_left
             unsigned int n_samples_right
             unsigned int n_samples_ = n_samples
+            unsigned int count
             # We set the 'end' variable such that the last non-missing-values
             # bin never goes to the left child (which would result in and
             # empty right child), unless there are missing values, since these
             # would go to the right child.
-            unsigned int end = \
+            uint16_t end = (
                 self.n_bins_non_missing[feature_idx] - 1 + has_missing_values
+            )
             Y_DTYPE_C sum_hessian_left
             Y_DTYPE_C sum_hessian_right
             Y_DTYPE_C sum_gradient_left
@@ -675,11 +671,15 @@ cdef class Splitter:
         loss_current_node = _loss_from_value(value, sum_gradients)
 
         for bin_idx in range(end):
-            n_samples_left += hist[bin_idx].count
+            count = hist[bin_idx].count
+            n_samples_left += count
             n_samples_right = n_samples_ - n_samples_left
 
-            if self.hessians_are_constant:
-                sum_hessian_left += hist[bin_idx].count
+            if count == 0:
+                # Empty bin.
+                continue
+            elif self.hessians_are_constant:
+                sum_hessian_left += count
             else:
                 sum_hessian_left += hist[bin_idx].sum_hessians
             sum_hessian_right = sum_hessians - sum_hessian_left
@@ -766,13 +766,14 @@ cdef class Splitter:
             unsigned int n_samples_left
             unsigned int n_samples_right
             unsigned int n_samples_ = n_samples
+            unsigned int count
             Y_DTYPE_C sum_hessian_left
             Y_DTYPE_C sum_hessian_right
             Y_DTYPE_C sum_gradient_left
             Y_DTYPE_C sum_gradient_right
             Y_DTYPE_C loss_current_node
             Y_DTYPE_C gain
-            unsigned int start = self.n_bins_non_missing[feature_idx] - 2
+            uint16_t start = self.n_bins_non_missing[feature_idx] - 2
             unsigned char found_better_split = False
 
             Y_DTYPE_C best_sum_hessian_left
@@ -789,11 +790,15 @@ cdef class Splitter:
         loss_current_node = _loss_from_value(value, sum_gradients)
 
         for bin_idx in range(start, -1, -1):
-            n_samples_right += hist[bin_idx + 1].count
+            count = hist[bin_idx + 1].count
+            n_samples_right += count
             n_samples_left = n_samples_ - n_samples_right
 
-            if self.hessians_are_constant:
-                sum_hessian_right += hist[bin_idx + 1].count
+            if count == 0:
+                # Empty bin.
+                continue
+            elif self.hessians_are_constant:
+                sum_hessian_right += count
             else:
                 sum_hessian_right += hist[bin_idx + 1].sum_hessians
             sum_hessian_left = sum_hessians - sum_hessian_right
@@ -873,8 +878,8 @@ cdef class Splitter:
 
         cdef:
             unsigned int bin_idx
-            unsigned int n_bins_non_missing = self.n_bins_non_missing[feature_idx]
-            unsigned int missing_values_bin_idx = self.missing_values_bin_idx
+            uint16_t n_bins_non_missing = self.n_bins_non_missing[feature_idx]
+            uint16_t missing_values_bin_idx = n_bins_non_missing
             categorical_info * cat_infos
             unsigned int sorted_cat_idx
             unsigned int n_used_bins = 0
@@ -1141,7 +1146,7 @@ cdef inline Y_DTYPE_C _loss_from_value(
 
 cdef inline unsigned char sample_goes_left(
         unsigned char missing_go_to_left,
-        unsigned char missing_values_bin_idx,
+        uint16_t missing_values_bin_idx,
         X_BINNED_DTYPE_C split_bin_idx,
         X_BINNED_DTYPE_C bin_value,
         unsigned char is_categorical,

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_compare_lightgbm.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_compare_lightgbm.py
@@ -74,7 +74,9 @@ def test_same_predictions_regression(
     if n_samples > 255:
         # bin data and convert it to float32 so that the estimator doesn't
         # treat it as pre-binned
-        X = _BinMapper(n_bins=max_bins + 1).fit_transform(X).astype(np.float32)
+        X = np.asarray(_BinMapper(n_bins=max_bins + 1).fit_transform(X)).astype(
+            np.float32
+        )
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=rng)
 
@@ -150,7 +152,9 @@ def test_same_predictions_classification(
     if n_samples > 255:
         # bin data and convert it to float32 so that the estimator doesn't
         # treat it as pre-binned
-        X = _BinMapper(n_bins=max_bins + 1).fit_transform(X).astype(np.float32)
+        X = np.asarray(_BinMapper(n_bins=max_bins + 1).fit_transform(X)).astype(
+            np.float32
+        )
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=rng)
 
@@ -225,7 +229,9 @@ def test_same_predictions_multiclass_classification(
     if n_samples > 255:
         # bin data and convert it to float32 so that the estimator doesn't
         # treat it as pre-binned
-        X = _BinMapper(n_bins=max_bins + 1).fit_transform(X).astype(np.float32)
+        X = np.asarray(_BinMapper(n_bins=max_bins + 1).fit_transform(X)).astype(
+            np.float32
+        )
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=rng)
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -818,7 +818,7 @@ def test_sum_hessians_are_sample_weight(Loss):
 
     for feature_idx in range(n_features):
         for bin_idx in range(bin_mapper.n_bins):
-            assert histograms[feature_idx, bin_idx]["sum_hessians"] == (
+            assert histograms.value_at(feature_idx, bin_idx)["sum_hessians"] == (
                 pytest.approx(sum_sw[feature_idx, bin_idx], rel=1e-5)
             )
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -1096,9 +1096,9 @@ def test_categorical_encoding_strategies():
         assert cross_val_score(clf_cat, X, y).mean() == 1
 
     # quick sanity check for the bitset: 0, 2, 4 = 2**0 + 2**2 + 2**4 = 21
-    expected_left_bitset = [21, 0, 0, 0, 0, 0, 0, 0]
-    left_bitset = clf_cat.fit(X, y)._predictors[0][0].raw_left_cat_bitsets[0]
-    assert_array_equal(left_bitset, expected_left_bitset)
+    expected_left_bitset = [21]
+    raw_left_bitsets = clf_cat.fit(X, y)._predictors[0][0].raw_left_cat_bitsets
+    assert_array_equal(raw_left_bitsets.bitsets, expected_left_bitset)
 
     # Treating categories as ordered, we need more depth / more splits to get
     # the same predictions

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_histogram.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_histogram.py
@@ -8,6 +8,7 @@ from sklearn.ensemble._hist_gradient_boosting.common import (
     Histograms,
 )
 from sklearn.ensemble._hist_gradient_boosting.histogram import (
+    HistogramBuilder,
     _build_histogram,
     _build_histogram_naive,
     _build_histogram_no_hessian,
@@ -15,6 +16,42 @@ from sklearn.ensemble._hist_gradient_boosting.histogram import (
     _build_histogram_root_no_hessian,
     _subtract_histograms,
 )
+
+
+@pytest.mark.parametrize("n_bins", (12, np.array([4, 8, 12], dtype=np.uint32)))
+def test_histogram_init_via_histogram_builder(n_bins):
+    """Test that histograms are initialized correctly."""
+    n_samples, n_features = 4, 3
+    # X_binned = [[ 0,  4,  8],
+    #             [ 1,  5,  9],
+    #             [ 2,  6, 10],
+    #             [ 3,  7, 11]]
+    X_binned = np.asfortranarray(
+        np.arange(n_samples * n_features).reshape((n_features, n_samples)).T,
+        dtype=X_BINNED_DTYPE,
+    )
+    gradients = np.array(np.arange(n_samples) ** 2, dtype=G_H_DTYPE)
+    hessians = np.ones_like(gradients)
+    sample_indices = np.arange(n_samples, dtype=np.uint32)
+    builder = HistogramBuilder(
+        X_binned=X_binned,
+        n_bins=n_bins,
+        gradients=gradients,
+        hessians=hessians,
+        hessians_are_constant=False,
+        n_threads=1,
+    )
+    histograms = builder.compute_histograms_brute(sample_indices)
+    assert histograms.histograms.ndim == 1
+    if isinstance(n_bins, int):
+        assert histograms.histograms.shape[0] == n_bins * n_features
+        assert_array_equal(histograms.bin_offsets, [0, n_bins, 2 * n_bins, 3 * n_bins])
+    else:
+        assert histograms.histograms.shape[0] == np.sum(n_bins)
+        assert_array_equal(
+            histograms.bin_offsets,
+            [0, n_bins[0], n_bins[0] + n_bins[1], n_bins[0] + n_bins[1] + n_bins[2]],
+        )
 
 
 @pytest.mark.parametrize("build_func", [_build_histogram_naive, _build_histogram])

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -10,6 +10,7 @@ from sklearn.ensemble import (
 from sklearn.ensemble._hist_gradient_boosting.common import (
     G_H_DTYPE,
     X_BINNED_DTYPE,
+    BinnedData,
     MonotonicConstraint,
 )
 from sklearn.ensemble._hist_gradient_boosting.grower import TreeGrower
@@ -171,7 +172,7 @@ def test_nodes_values(monotonic_cst, seed):
     n_samples = 1000
     n_features = 1
     X_binned = rng.randint(0, 255, size=(n_samples, n_features), dtype=np.uint8)
-    X_binned = np.asfortranarray(X_binned)
+    X_binned = BinnedData.from_array(np.asfortranarray(X_binned))
 
     gradients = rng.normal(size=n_samples).astype(G_H_DTYPE)
     hessians = np.ones(shape=1, dtype=G_H_DTYPE)
@@ -190,7 +191,7 @@ def test_nodes_values(monotonic_cst, seed):
 
     # We pass undefined binning_thresholds because we won't use predict anyway
     predictor = grower.make_predictor(
-        binning_thresholds=np.zeros((X_binned.shape[1], X_binned.max() + 1))
+        binning_thresholds=np.zeros((X_binned.shape[1], np.max(X_binned) + 1))
     )
 
     # The consistency of the bounds can only be checked on the tree grower
@@ -349,6 +350,7 @@ def test_bounded_value_min_gain_to_split():
     min_samples_leaf = 1
     n_bins = n_samples = 5
     X_binned = np.arange(n_samples).reshape(-1, 1).astype(X_BINNED_DTYPE)
+    X_binned = BinnedData.from_array(X_binned)
     sample_indices = np.arange(n_samples, dtype=np.uint32)
     all_hessians = np.ones(n_samples, dtype=G_H_DTYPE)
     all_gradients = np.array([1, 1, 100, 1, 1], dtype=G_H_DTYPE)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -359,20 +359,18 @@ def test_bounded_value_min_gain_to_split():
     builder = HistogramBuilder(
         X_binned, n_bins, all_gradients, all_hessians, hessians_are_constant, n_threads
     )
-    n_bins_non_missing = np.array([n_bins - 1] * X_binned.shape[1], dtype=np.uint32)
+    n_bins_non_missing = np.array([n_bins - 1] * X_binned.shape[1], dtype=np.uint16)
     has_missing_values = np.array([False] * X_binned.shape[1], dtype=np.uint8)
     monotonic_cst = np.array(
         [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
     )
     is_categorical = np.zeros_like(monotonic_cst, dtype=np.uint8)
-    missing_values_bin_idx = n_bins - 1
     children_lower_bound, children_upper_bound = -np.inf, np.inf
 
     min_gain_to_split = 2000
     splitter = Splitter(
         X_binned,
         n_bins_non_missing,
-        missing_values_bin_idx,
         has_missing_values,
         is_categorical,
         monotonic_cst,

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
@@ -154,8 +154,9 @@ def test_categorical_predictor(bins_go_left, expected_predictions):
     predictor = TreePredictor(nodes, binned_cat_bitsets, raw_categorical_bitsets)
 
     # Check binned data gives correct predictions
+    n_bins_non_missing = np.array([6], dtype=np.uint16)
     prediction_binned = predictor.predict_binned(
-        X_binned, missing_values_bin_idx=6, n_threads=n_threads
+        X_binned, n_bins_non_missing=n_bins_non_missing, n_threads=n_threads
     )
     assert_allclose(prediction_binned, expected_predictions)
 
@@ -173,7 +174,7 @@ def test_categorical_predictor(bins_go_left, expected_predictions):
     # Check missing goes left because missing_values_bin_idx=6
     X_binned_missing = np.array([[6]], dtype=X_BINNED_DTYPE).T
     predictions = predictor.predict_binned(
-        X_binned_missing, missing_values_bin_idx=6, n_threads=n_threads
+        X_binned_missing, n_bins_non_missing=n_bins_non_missing, n_threads=n_threads
     )
     assert_allclose(predictions, [1])
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
@@ -14,6 +14,7 @@ from sklearn.ensemble._hist_gradient_boosting.common import (
     PREDICTOR_RECORD_DTYPE,
     X_BINNED_DTYPE,
     X_DTYPE,
+    BinnedData,
     Bitsets,
 )
 from sklearn.ensemble._hist_gradient_boosting.grower import TreeGrower
@@ -119,6 +120,7 @@ def test_categorical_predictor(bins_go_left, expected_predictions):
     # Test predictor outputs are correct with categorical features
 
     X_binned = np.array([[0, 1, 2, 3, 4, 5]], dtype=X_BINNED_DTYPE).T
+    X_binned = BinnedData.from_array(X_binned)
     categories = np.array([2, 5, 6, 8, 10, 15], dtype=X_DTYPE)
 
     bins_go_left = np.array(bins_go_left, dtype=X_BINNED_DTYPE)
@@ -174,7 +176,7 @@ def test_categorical_predictor(bins_go_left, expected_predictions):
     assert_allclose(predictions, expected_predictions)
 
     # Check missing goes left because missing_values_bin_idx=6
-    X_binned_missing = np.array([[6]], dtype=X_BINNED_DTYPE).T
+    X_binned_missing = BinnedData.from_array(np.array([[6]], dtype=X_BINNED_DTYPE).T)
     predictions = predictor.predict_binned(
         X_binned_missing, n_bins_non_missing=n_bins_non_missing, n_threads=n_threads
     )

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
@@ -4,7 +4,6 @@ from numpy.testing import assert_array_equal
 
 from sklearn.ensemble._hist_gradient_boosting.common import (
     G_H_DTYPE,
-    HISTOGRAM_DTYPE,
     X_BINNED_DTYPE,
     MonotonicConstraint,
 )
@@ -215,9 +214,6 @@ def test_gradient_and_hessian_sanity(constant_hessian):
 
     # make sure sum of gradients in histograms are the same for all features,
     # and make sure they're equal to their expected value
-    hists_parent = np.asarray(hists_parent, dtype=HISTOGRAM_DTYPE)
-    hists_left = np.asarray(hists_left, dtype=HISTOGRAM_DTYPE)
-    hists_right = np.asarray(hists_right, dtype=HISTOGRAM_DTYPE)
     for hists, indices in (
         (hists_parent, sample_indices),
         (hists_left, sample_indices_left),
@@ -226,9 +222,11 @@ def test_gradient_and_hessian_sanity(constant_hessian):
         # note: gradients and hessians have shape (n_features,),
         # we're comparing them to *scalars*. This has the benefit of also
         # making sure that all the entries are equal across features.
-        gradients = hists["sum_gradients"].sum(axis=1)  # shape = (n_features,)
+        # gradients = hists["sum_gradients"].sum(axis=1)  # shape = (n_features,)
+        gradients = hists.feature_sum("sum_gradients")
         expected_gradient = all_gradients[indices].sum()  # scalar
-        hessians = hists["sum_hessians"].sum(axis=1)
+        # hessians = hists["sum_hessians"].sum(axis=1)
+        hessians = hists.feature_sum("sum_hessians")
         if constant_hessian:
             # 0 is not the actual hessian, but it's not computed in this case
             expected_hessian = 0.0

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
@@ -52,26 +52,24 @@ def test_histogram_split(n_bins):
                 n_threads,
             )
             n_bins_non_missing = np.array(
-                [n_bins - 1] * X_binned.shape[1], dtype=np.uint32
+                [n_bins - 1] * X_binned.shape[1], dtype=np.uint16
             )
             has_missing_values = np.array([False] * X_binned.shape[1], dtype=np.uint8)
             monotonic_cst = np.array(
                 [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
             )
             is_categorical = np.zeros_like(monotonic_cst, dtype=np.uint8)
-            missing_values_bin_idx = n_bins - 1
             splitter = Splitter(
-                X_binned,
-                n_bins_non_missing,
-                missing_values_bin_idx,
-                has_missing_values,
-                is_categorical,
-                monotonic_cst,
-                l2_regularization,
-                min_hessian_to_split,
-                min_samples_leaf,
-                min_gain_to_split,
-                hessians_are_constant,
+                X_binned=X_binned,
+                n_bins_non_missing=n_bins_non_missing,
+                has_missing_values=has_missing_values,
+                is_categorical=is_categorical,
+                monotonic_cst=monotonic_cst,
+                l2_regularization=l2_regularization,
+                min_hessian_to_split=min_hessian_to_split,
+                min_samples_leaf=min_samples_leaf,
+                min_gain_to_split=min_gain_to_split,
+                hessians_are_constant=hessians_are_constant,
             )
 
             histograms = builder.compute_histograms_brute(sample_indices)
@@ -131,17 +129,15 @@ def test_gradient_and_hessian_sanity(constant_hessian):
     builder = HistogramBuilder(
         X_binned, n_bins, all_gradients, all_hessians, constant_hessian, n_threads
     )
-    n_bins_non_missing = np.array([n_bins - 1] * X_binned.shape[1], dtype=np.uint32)
+    n_bins_non_missing = np.array([n_bins - 1] * X_binned.shape[1], dtype=np.uint16)
     has_missing_values = np.array([False] * X_binned.shape[1], dtype=np.uint8)
     monotonic_cst = np.array(
         [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
     )
     is_categorical = np.zeros_like(monotonic_cst, dtype=np.uint8)
-    missing_values_bin_idx = n_bins - 1
     splitter = Splitter(
         X_binned,
         n_bins_non_missing,
-        missing_values_bin_idx,
         has_missing_values,
         is_categorical,
         monotonic_cst,
@@ -273,17 +269,15 @@ def test_split_indices():
     builder = HistogramBuilder(
         X_binned, n_bins, all_gradients, all_hessians, hessians_are_constant, n_threads
     )
-    n_bins_non_missing = np.array([n_bins] * X_binned.shape[1], dtype=np.uint32)
+    n_bins_non_missing = np.array([n_bins] * X_binned.shape[1], dtype=np.uint16)
     has_missing_values = np.array([False] * X_binned.shape[1], dtype=np.uint8)
     monotonic_cst = np.array(
         [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
     )
     is_categorical = np.zeros_like(monotonic_cst, dtype=np.uint8)
-    missing_values_bin_idx = n_bins - 1
     splitter = Splitter(
         X_binned,
         n_bins_non_missing,
-        missing_values_bin_idx,
         has_missing_values,
         is_categorical,
         monotonic_cst,
@@ -349,17 +343,15 @@ def test_min_gain_to_split():
     builder = HistogramBuilder(
         X_binned, n_bins, all_gradients, all_hessians, hessians_are_constant, n_threads
     )
-    n_bins_non_missing = np.array([n_bins - 1] * X_binned.shape[1], dtype=np.uint32)
+    n_bins_non_missing = np.array([n_bins - 1] * X_binned.shape[1], dtype=np.uint16)
     has_missing_values = np.array([False] * X_binned.shape[1], dtype=np.uint8)
     monotonic_cst = np.array(
         [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
     )
     is_categorical = np.zeros_like(monotonic_cst, dtype=np.uint8)
-    missing_values_bin_idx = n_bins - 1
     splitter = Splitter(
         X_binned,
         n_bins_non_missing,
-        missing_values_bin_idx,
         has_missing_values,
         is_categorical,
         monotonic_cst,
@@ -392,7 +384,7 @@ def test_min_gain_to_split():
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],  # X_binned
             [1, 1, 1, 1, 5, 5, 5, 5, 5, 5],  # gradients
             False,  # no missing values
-            10,  # n_bins_non_missing
+            10,  # n_bins_non_missing = index of missing value bin
             False,  # don't split on nans
             3,  # expected_bin_idx
             "not_applicable",
@@ -404,7 +396,7 @@ def test_min_gain_to_split():
         (
             [8, 0, 1, 8, 2, 3, 4, 5, 6, 7],  # 8 <=> missing
             [1, 1, 1, 1, 5, 5, 5, 5, 5, 5],
-            True,  # missing values
+            True,  # missing values = index of missing value bin
             8,  # n_bins_non_missing
             False,  # don't split on nans
             1,  # cut on bin_idx=1
@@ -415,7 +407,7 @@ def test_min_gain_to_split():
             [9, 0, 1, 9, 2, 3, 4, 5, 6, 7],  # 9 <=> missing
             [1, 1, 1, 1, 5, 5, 5, 5, 5, 5],
             True,  # missing values
-            8,  # n_bins_non_missing
+            9,  # n_bins_non_missing = index of missing value bin
             False,  # don't split on nans
             1,  # cut on bin_idx=1
             True,
@@ -425,7 +417,7 @@ def test_min_gain_to_split():
             [0, 1, 2, 3, 8, 4, 8, 5, 6, 7],  # 8 <=> missing
             [1, 1, 1, 1, 5, 5, 5, 5, 5, 5],
             True,  # missing values
-            8,  # n_bins_non_missing
+            8,  # n_bins_non_missing = index of missing value bin
             False,  # don't split on nans
             3,  # cut on bin_idx=3 (like in first case)
             False,
@@ -435,7 +427,7 @@ def test_min_gain_to_split():
             [0, 1, 2, 3, 9, 4, 9, 5, 6, 7],  # 9 <=> missing
             [1, 1, 1, 1, 5, 5, 5, 5, 5, 5],
             True,  # missing values
-            8,  # n_bins_non_missing
+            8,  # n_bins_non_missing = index of missing value bin
             False,  # don't split on nans
             3,  # cut on bin_idx=3 (like in first case)
             False,
@@ -446,7 +438,7 @@ def test_min_gain_to_split():
             [0, 1, 2, 3, 4, 4, 4, 4, 4, 4],  # 4 <=> missing
             [1, 1, 1, 1, 5, 5, 5, 5, 5, 5],
             True,  # missing values
-            4,  # n_bins_non_missing
+            4,  # n_bins_non_missing = index of missing value bin
             True,  # split on nans
             3,  # cut on bin_idx=3
             False,
@@ -456,7 +448,7 @@ def test_min_gain_to_split():
             [0, 1, 2, 3, 9, 9, 9, 9, 9, 9],  # 9 <=> missing
             [1, 1, 1, 1, 1, 1, 5, 5, 5, 5],
             True,  # missing values
-            4,  # n_bins_non_missing
+            9,  # n_bins_non_missing = index of missing value bin
             True,  # split on nans
             3,  # cut on bin_idx=3
             False,
@@ -465,7 +457,7 @@ def test_min_gain_to_split():
             [6, 6, 6, 6, 0, 1, 2, 3, 4, 5],  # 6 <=> missing
             [1, 1, 1, 1, 5, 5, 5, 5, 5, 5],
             True,  # missing values
-            6,  # n_bins_non_missing
+            6,  # n_bins_non_missing = index of missing value bin
             True,  # split on nans
             5,  # cut on bin_idx=5
             False,
@@ -475,7 +467,7 @@ def test_min_gain_to_split():
             [9, 9, 9, 9, 0, 1, 2, 3, 4, 5],  # 9 <=> missing
             [1, 1, 1, 1, 5, 5, 5, 5, 5, 5],
             True,  # missing values
-            6,  # n_bins_non_missing
+            9,  # n_bins_non_missing = index of missing value bin
             True,  # split on nans
             5,  # cut on bin_idx=5
             False,
@@ -521,16 +513,14 @@ def test_splitting_missing_values(
         X_binned, n_bins, all_gradients, all_hessians, hessians_are_constant, n_threads
     )
 
-    n_bins_non_missing = np.array([n_bins_non_missing], dtype=np.uint32)
+    n_bins_non_missing = np.array([n_bins_non_missing], dtype=np.uint16)
     monotonic_cst = np.array(
         [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
     )
     is_categorical = np.zeros_like(monotonic_cst, dtype=np.uint8)
-    missing_values_bin_idx = n_bins - 1
     splitter = Splitter(
         X_binned,
         n_bins_non_missing,
-        missing_values_bin_idx,
         has_missing_values,
         is_categorical,
         monotonic_cst,
@@ -553,7 +543,8 @@ def test_splitting_missing_values(
     if has_missing_values:
         assert split_info.missing_go_to_left == expected_go_to_left
 
-    split_on_nan = split_info.bin_idx == n_bins_non_missing[0] - 1
+    n_empty_bins = n_bins - len(set(X_binned.flat))
+    split_on_nan = split_info.bin_idx == n_bins_non_missing[0] - 1 - n_empty_bins
     assert split_on_nan == expected_split_on_nan
 
     # Make sure the split is properly computed.
@@ -570,11 +561,12 @@ def test_splitting_missing_values(
     else:
         # When we split on nans, samples with missing values are always mapped
         # to the right child.
+        # Note that missing value bin of feature j = n_bins_non_missing[j]
         missing_samples_indices = np.flatnonzero(
-            np.array(X_binned) == missing_values_bin_idx
+            np.array(X_binned) == n_bins_non_missing
         )
         non_missing_samples_indices = np.flatnonzero(
-            np.array(X_binned) != missing_values_bin_idx
+            np.array(X_binned) != n_bins_non_missing
         )
 
         assert set(samples_right) == set(missing_samples_indices)
@@ -625,17 +617,15 @@ def test_splitting_categorical_cat_smooth(
         X_binned, n_bins, all_gradients, all_hessians, hessians_are_constant, n_threads
     )
 
-    n_bins_non_missing = np.array([n_bins_non_missing], dtype=np.uint32)
+    n_bins_non_missing = np.array([n_bins_non_missing], dtype=np.uint16)
     monotonic_cst = np.array(
         [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
     )
     is_categorical = np.ones_like(monotonic_cst, dtype=np.uint8)
-    missing_values_bin_idx = n_bins - 1
 
     splitter = Splitter(
         X_binned,
         n_bins_non_missing,
-        missing_values_bin_idx,
         has_missing_values,
         is_categorical,
         monotonic_cst,
@@ -676,7 +666,7 @@ def _assert_categories_equals_bitset(categories, bitset):
 @pytest.mark.parametrize(
     (
         "X_binned, all_gradients, expected_categories_left, n_bins_non_missing,"
-        "missing_values_bin_idx, has_missing_values, expected_missing_go_to_left"
+        "has_missing_values, expected_missing_go_to_left"
     ),
     [
         # 4 categories
@@ -684,8 +674,7 @@ def _assert_categories_equals_bitset(categories, bitset):
             [0, 1, 2, 3] * 11,  # X_binned
             [10, 1, 10, 10] * 11,  # all_gradients
             [1],  # expected_categories_left
-            4,  # n_bins_non_missing
-            4,  # missing_values_bin_idx
+            4,  # n_bins_non_missing = index of missing value bin
             False,  # has_missing_values
             None,
         ),  # expected_missing_go_to_left, unchecked
@@ -696,8 +685,7 @@ def _assert_categories_equals_bitset(categories, bitset):
             [0, 1, 2, 3] * 11,  # X_binned
             [10, 10, 10, 1] * 11,  # all_gradients
             [3],  # expected_categories_left
-            4,  # n_bins_non_missing
-            4,  # missing_values_bin_idx
+            4,  # n_bins_non_missing = index of missing value bin
             False,  # has_missing_values
             None,
         ),  # expected_missing_go_to_left, unchecked
@@ -707,8 +695,7 @@ def _assert_categories_equals_bitset(categories, bitset):
             [0, 1, 2, 3] * 11 + [4] * 5,  # X_binned
             [10, 10, 10, 1] * 11 + [10] * 5,  # all_gradients
             [3],  # expected_categories_left
-            4,  # n_bins_non_missing
-            4,  # missing_values_bin_idx
+            4,  # n_bins_non_missing = index of missing value bin
             False,  # has_missing_values
             None,
         ),  # expected_missing_go_to_left, unchecked
@@ -722,28 +709,25 @@ def _assert_categories_equals_bitset(categories, bitset):
             [0, 1, 2, 3] * 11 + [4] * 5,  # X_binned
             [10, 10, 10, 1] * 11 + [1] * 5,  # all_gradients
             [3],  # expected_categories_left
-            4,  # n_bins_non_missing
-            4,  # missing_values_bin_idx
+            4,  # n_bins_non_missing = index of missing value bin
             False,  # has_missing_values
             None,
         ),  # expected_missing_go_to_left, unchecked
         # 4 categories with missing values that go to the right
         (
-            [0, 1, 2] * 11 + [9] * 11,  # X_binned
+            [0, 1, 2] * 11 + [3] * 11,  # X_binned
             [10, 1, 10] * 11 + [10] * 11,  # all_gradients
             [1],  # expected_categories_left
             3,  # n_bins_non_missing
-            9,  # missing_values_bin_idx
             True,  # has_missing_values
             False,
         ),  # expected_missing_go_to_left
         # 4 categories with missing values that go to the left
         (
-            [0, 1, 2] * 11 + [9] * 11,  # X_binned
+            [0, 1, 2] * 11 + [3] * 11,  # X_binned
             [10, 1, 10] * 11 + [1] * 11,  # all_gradients
-            [1, 9],  # expected_categories_left
-            3,  # n_bins_non_missing
-            9,  # missing_values_bin_idx
+            [1, 3],  # expected_categories_left
+            3,  # n_bins_non_missing = index of missing value bin
             True,  # has_missing_values
             True,
         ),  # expected_missing_go_to_left
@@ -752,8 +736,7 @@ def _assert_categories_equals_bitset(categories, bitset):
             [0, 1, 2, 3, 4] * 11 + [255] * 12,  # X_binned
             [10, 10, 10, 10, 10] * 11 + [1] * 12,  # all_gradients
             [255],  # expected_categories_left
-            5,  # n_bins_non_missing
-            255,  # missing_values_bin_idx
+            255,  # n_bins_non_missing = index of missing value bin
             True,  # has_missing_values
             True,
         ),  # expected_missing_go_to_left
@@ -762,8 +745,7 @@ def _assert_categories_equals_bitset(categories, bitset):
             list(range(60)) * 12,  # X_binned
             [10, 1] * 360,  # all_gradients
             list(range(1, 60, 2)),  # expected_categories_left
-            59,  # n_bins_non_missing
-            59,  # missing_values_bin_idx
+            59,  # n_bins_non_missing = index of missing value bin
             True,  # has_missing_values
             True,
         ),  # expected_missing_go_to_left
@@ -772,8 +754,7 @@ def _assert_categories_equals_bitset(categories, bitset):
             list(range(256)) * 12,  # X_binned
             [10, 10, 10, 10, 10, 10, 10, 1] * 384,  # all_gradients
             list(range(7, 256, 8)),  # expected_categories_left
-            255,  # n_bins_non_missing
-            255,  # missing_values_bin_idx
+            255,  # n_bins_non_missing = index of missing value bin
             True,  # has_missing_values
             True,
         ),  # expected_missing_go_to_left
@@ -784,7 +765,6 @@ def test_splitting_categorical_sanity(
     all_gradients,
     expected_categories_left,
     n_bins_non_missing,
-    missing_values_bin_idx,
     has_missing_values,
     expected_missing_go_to_left,
 ):
@@ -813,7 +793,7 @@ def test_splitting_categorical_sanity(
         X_binned, n_bins, all_gradients, all_hessians, hessians_are_constant, n_threads
     )
 
-    n_bins_non_missing = np.array([n_bins_non_missing], dtype=np.uint32)
+    n_bins_non_missing = np.array([n_bins_non_missing], dtype=np.uint16)
     monotonic_cst = np.array(
         [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
     )
@@ -822,7 +802,6 @@ def test_splitting_categorical_sanity(
     splitter = Splitter(
         X_binned,
         n_bins_non_missing,
-        missing_values_bin_idx,
         has_missing_values,
         is_categorical,
         monotonic_cst,
@@ -903,17 +882,15 @@ def test_split_interaction_constraints():
             hessians_are_constant,
             n_threads,
         )
-        n_bins_non_missing = np.array([n_bins] * X_binned.shape[1], dtype=np.uint32)
+        n_bins_non_missing = np.array([n_bins] * X_binned.shape[1], dtype=np.uint16)
         has_missing_values = np.array([False] * X_binned.shape[1], dtype=np.uint8)
         monotonic_cst = np.array(
             [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
         )
         is_categorical = np.zeros_like(monotonic_cst, dtype=np.uint8)
-        missing_values_bin_idx = n_bins - 1
         splitter = Splitter(
             X_binned,
             n_bins_non_missing,
-            missing_values_bin_idx,
             has_missing_values,
             is_categorical,
             monotonic_cst,
@@ -1005,18 +982,16 @@ def test_split_feature_fraction_per_split(forbidden_features):
     value = compute_node_value(
         sum_gradients, sum_hessians, -np.inf, np.inf, l2_regularization
     )
-    n_bins_non_missing = np.array([n_bins] * X_binned.shape[1], dtype=np.uint32)
+    n_bins_non_missing = np.array([n_bins] * X_binned.shape[1], dtype=np.uint16)
     has_missing_values = np.array([False] * X_binned.shape[1], dtype=np.uint8)
     monotonic_cst = np.array(
         [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
     )
     is_categorical = np.zeros_like(monotonic_cst, dtype=np.uint8)
-    missing_values_bin_idx = n_bins - 1
 
     params = dict(
         X_binned=X_binned,
         n_bins_non_missing=n_bins_non_missing,
-        missing_values_bin_idx=missing_values_bin_idx,
         has_missing_values=has_missing_values,
         is_categorical=is_categorical,
         monotonic_cst=monotonic_cst,

--- a/sklearn/utils/_typedefs.pxd
+++ b/sklearn/utils/_typedefs.pxd
@@ -13,6 +13,7 @@
 # use these consistently throughout the codebase.
 # NOTE: Extend this list as needed when converting more cython extensions.
 ctypedef unsigned char uint8_t
+ctypedef unsigned short uint16_t
 ctypedef unsigned int uint32_t
 ctypedef unsigned long long uint64_t
 # Note: In NumPy 2, indexing always happens with npy_intp which is an alias for

--- a/sklearn/utils/_typedefs.pyx
+++ b/sklearn/utils/_typedefs.pyx
@@ -14,6 +14,7 @@ ctypedef fused testing_type_t:
     int64_t
     intp_t
     uint8_t
+    uint16_t
     uint32_t
     uint64_t
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #26277.

#### What does this implement/fix? Explain your changes.
This PR extents the maximum number of bins (including missing bin) from 256 (8bit) to 65536 (16bit) in `HistGradientBoostingRegressor` and `HistGradientBoostingClassifier`.

This PR uses the extended bins only on categorical variables if needed and still applies `max_bins` restricted to 255 to numerical features. This could easily be extended.

#### Any other comments?
This PR introduces 3 new data structures as Cython extension types:
- `cdef class Histograms`
  This has one underlying 1-dim numpy array to hold all bins of all features. An offset array tells where the bins of a feature starts and where it ends
  ```
  feature      |  0  |      1      |
  histograms = |- - - - - - - - - -|   each - is a single bin
  offsets   =  |0     3            10|
  ```
  Compared to main, this saves bins as there are no unused bins anymore.
  All commits up to and including [ENH adapt HGBT to new histograms everywhere](https://github.com/scikit-learn/scikit-learn/pull/28603/commits/91608fbd0b43ac7ae2c6118ccaff849d9604aab9).
- `cdef class Bitsets`
  This extends the fixed sized bitsets arrays and works similar to the Histogram class, a 1-dim numpy array to hold all bitsets of all features and an offset array to tell where each feature begins and ends.
  Just commit [ENH add Bitsets extension type](https://github.com/scikit-learn/scikit-learn/pull/28603/commits/0107e777b3dfd12f8bcc5c3337bd39a6877a7026).
- `cdef class BinnedData`
  This class is a container for mixed uint8 and uint16 typed arrays. It holds track which feature is uint8 and which is uint16. Underlying are two 2-dim arrays of uint8 and uint16.
  Just commit [ENH add BinnedData extension type for mixed uint8 uint16 data](https://github.com/scikit-learn/scikit-learn/pull/28603/commits/d769848abe73a4a6bb3d17dc4b913519d83e510d).

Benchmarks indicate no performance regression:
On this PR commit https://github.com/scikit-learn/scikit-learn/pull/28603/commits/d769848abe73a4a6bb3d17dc4b913519d83e510d
```
python benchmarks/bench_hist_gradient_boosting_higgsboson.py --n-trees 100
...
Fit 100 trees in 62.059 s, (3100 total leaves)
Time spent computing histograms: 36.785s
Time spent finding best splits:  0.260s
Time spent applying splits:      7.671s
Time spent predicting:           1.895s
fitted in 62.199s
predicted in 6.769s, ROC AUC: 0.8228, ACC: 0.7415
```
while on main f59c16de7
```
Fit 100 trees in 62.321 s, (3100 total leaves)
Time spent computing histograms: 36.230s
Time spent finding best splits:  0.192s
Time spent applying splits:      8.075s
Time spent predicting:           1.935s
fitted in 62.501s
predicted in 8.073s, ROC AUC: 0.8228, ACC: 0.7415
```
(I can do some more if requested.)

Disadvantages:
- In case we want to add row-wise histogram computation, this becomes more complicated as `BinnedData` is inherently F-contiguous and it is harder to define dynamic mixed types for a C-contiguous layout.
- Code complexity increases. I would say, only a little.
- Predictor nodes field `"bin_threshold"` is now uint16 instead of uint16, adding a tiny bit more memory to fitted estimator objects.

Further notes:
- This PR needs Cython >= 3.0.10 which fixes earlier CI failures (it needed fixes from Cython 3.0.9 as well as 3.0.10).
- So far, commits are relatively clean. Therefore, this PR could be split into several smaller ones.