### PR TITLE
DOC Linked examples for LDA and QDA in their docstrings (#26927)

### DIFF
--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -193,8 +193,8 @@ class LinearDiscriminantAnalysis(
     `transform` method.
 
     .. versionadded:: 0.17
-       *LinearDiscriminantAnalysis*. 
-    
+       *LinearDiscriminantAnalysis*.
+
     For a comparison between :class:`~sklearn.discriminant_analysis.LinearDiscriminantAnalysis`
     and :class:`~sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`, see
     :ref:`sphx_glr_auto_examples_classification_plot_lda_qda.py`.
@@ -225,7 +225,7 @@ class LinearDiscriminantAnalysis(
 
         This should be left to None if `covariance_estimator` is used.
         Note that shrinkage works only with 'lsqr' and 'eigen' solvers.
-        
+
         For an example usage, see
         :ref:`sphx_glr_auto_examples_classification_plot_lda.py`.
 
@@ -238,8 +238,8 @@ class LinearDiscriminantAnalysis(
         dimensionality reduction. If None, will be set to
         min(n_classes - 1, n_features). This parameter only affects the
         `transform` method.
-        
-        For an example usage for dimensionality reduction, see 
+
+        For an example usage for dimensionality reduction, see
         :ref:`sphx_glr_auto_examples_decomposition_plot_pca_vs_lda.py`.
 
     store_covariance : bool, default=False

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -195,7 +195,8 @@ class LinearDiscriminantAnalysis(
     .. versionadded:: 0.17
        *LinearDiscriminantAnalysis*.
 
-    For a comparison between :class:`~sklearn.discriminant_analysis.LinearDiscriminantAnalysis`
+    For a comparison between
+    :class:`~sklearn.discriminant_analysis.LinearDiscriminantAnalysis`
     and :class:`~sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`, see
     :ref:`sphx_glr_auto_examples_classification_plot_lda_qda.py`.
 
@@ -776,8 +777,9 @@ class QuadraticDiscriminantAnalysis(ClassifierMixin, BaseEstimator):
 
     .. versionadded:: 0.17
        *QuadraticDiscriminantAnalysis*
-       
-    For a comparison between :class:`~sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`
+
+    For a comparison between 
+    :class:`~sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`
     and :class:`~sklearn.discriminant_analysis.LinearDiscriminantAnalysis`, see
     :ref:`sphx_glr_auto_examples_classification_plot_lda_qda.py`.
 

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -193,7 +193,11 @@ class LinearDiscriminantAnalysis(
     `transform` method.
 
     .. versionadded:: 0.17
-       *LinearDiscriminantAnalysis*.
+       *LinearDiscriminantAnalysis*. 
+    
+    For a comparison between :class:`~sklearn.discriminant_analysis.LinearDiscriminantAnalysis`
+    and :class:`~sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`, see
+    :ref:`sphx_glr_auto_examples_classification_plot_lda_qda.py`.
 
     Read more in the :ref:`User Guide <lda_qda>`.
 
@@ -221,6 +225,9 @@ class LinearDiscriminantAnalysis(
 
         This should be left to None if `covariance_estimator` is used.
         Note that shrinkage works only with 'lsqr' and 'eigen' solvers.
+        
+        For an example usage, see
+        :ref:`sphx_glr_auto_examples_classification_plot_lda.py`.
 
     priors : array-like of shape (n_classes,), default=None
         The class prior probabilities. By default, the class proportions are
@@ -231,6 +238,9 @@ class LinearDiscriminantAnalysis(
         dimensionality reduction. If None, will be set to
         min(n_classes - 1, n_features). This parameter only affects the
         `transform` method.
+        
+        For an example usage for dimensionality reduction, see 
+        :ref:`sphx_glr_auto_examples_decomposition_plot_pca_vs_lda.py`.
 
     store_covariance : bool, default=False
         If True, explicitly compute the weighted within-class covariance
@@ -766,6 +776,10 @@ class QuadraticDiscriminantAnalysis(ClassifierMixin, BaseEstimator):
 
     .. versionadded:: 0.17
        *QuadraticDiscriminantAnalysis*
+       
+    For a comparison between :class:`~sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`
+    and :class:`~sklearn.discriminant_analysis.LinearDiscriminantAnalysis`, see
+    :ref:`sphx_glr_auto_examples_classification_plot_lda_qda.py`.
 
     Read more in the :ref:`User Guide <lda_qda>`.
 

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -193,7 +193,6 @@ class LinearDiscriminantAnalysis(
     `transform` method.
 
     .. versionadded:: 0.17
-       *LinearDiscriminantAnalysis*.
 
     For a comparison between
     :class:`~sklearn.discriminant_analysis.LinearDiscriminantAnalysis`
@@ -776,7 +775,6 @@ class QuadraticDiscriminantAnalysis(ClassifierMixin, BaseEstimator):
     The model fits a Gaussian density to each class.
 
     .. versionadded:: 0.17
-       *QuadraticDiscriminantAnalysis*
 
     For a comparison between
     :class:`~sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -227,7 +227,7 @@ class LinearDiscriminantAnalysis(
         This should be left to None if `covariance_estimator` is used.
         Note that shrinkage works only with 'lsqr' and 'eigen' solvers.
 
-        For an example usage, see
+        For a usage example, see
         :ref:`sphx_glr_auto_examples_classification_plot_lda.py`.
 
     priors : array-like of shape (n_classes,), default=None
@@ -240,7 +240,7 @@ class LinearDiscriminantAnalysis(
         min(n_classes - 1, n_features). This parameter only affects the
         `transform` method.
 
-        For an example usage for dimensionality reduction, see
+        For a usage example, see
         :ref:`sphx_glr_auto_examples_decomposition_plot_pca_vs_lda.py`.
 
     store_covariance : bool, default=False
@@ -778,7 +778,7 @@ class QuadraticDiscriminantAnalysis(ClassifierMixin, BaseEstimator):
     .. versionadded:: 0.17
        *QuadraticDiscriminantAnalysis*
 
-    For a comparison between 
+    For a comparison between
     :class:`~sklearn.discriminant_analysis.QuadraticDiscriminantAnalysis`
     and :class:`~sklearn.discriminant_analysis.LinearDiscriminantAnalysis`, see
     :ref:`sphx_glr_auto_examples_classification_plot_lda_qda.py`.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Adds links to examples/classification mentioned in #26927 

#### What does this implement/fix? Explain your changes.
Adds links to auto-generated examples for classes `LinearDiscriminantAnalysis` and `QuadraticDiscriminantAnalysis`

#### Any other comments?
Examples linked:

- `examples/classification`
    - `plot_lda.py`
    - `plot_lda_qda.py`
- `examples/decomposition`
    - `plot_pca_vs_lda.py`


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
