### PR TITLE
MAINT Simplifies `node_split` API by moving `n_constant_features` into the SplitRecord

### DIFF
--- a/sklearn/tree/_splitter.pxd
+++ b/sklearn/tree/_splitter.pxd
@@ -28,7 +28,8 @@ cdef struct SplitRecord:
     float64_t lower_bound     # Lower bound on value of both children for monotonicity
     float64_t upper_bound     # Upper bound on value of both children for monotonicity
     unsigned char missing_go_to_left  # Controls if missing values go to the left node.
-    intp_t n_missing       # Number of missing values for the feature being split on
+    intp_t n_missing            # Number of missing values for the feature being split on
+    intp_t n_constant_features  # Number of constant features in the split from parent
 
 cdef class Splitter:
     # The splitter searches in the input space for a feature and a threshold
@@ -102,7 +103,6 @@ cdef class Splitter:
         self,
         float64_t impurity,   # Impurity of the node
         SplitRecord* split,
-        intp_t* n_constant_features,
         float64_t lower_bound,
         float64_t upper_bound,
     ) except -1 nogil

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -49,6 +49,7 @@ cdef inline void _init_split(SplitRecord* self, intp_t start_pos) noexcept nogil
     self.improvement = -INFINITY
     self.missing_go_to_left = False
     self.n_missing = 0
+    self.n_constant_features = 0
 
 cdef class Splitter:
     """Abstract splitter class.
@@ -233,7 +234,6 @@ cdef class Splitter:
         self,
         float64_t impurity,
         SplitRecord* split,
-        intp_t* n_constant_features,
         float64_t lower_bound,
         float64_t upper_bound,
     ) except -1 nogil:
@@ -303,7 +303,6 @@ cdef inline int node_split_best(
     Criterion criterion,
     float64_t impurity,
     SplitRecord* split,
-    intp_t* n_constant_features,
     bint with_monotonic_cst,
     const cnp.int8_t[:] monotonic_cst,
     float64_t lower_bound,
@@ -349,7 +348,7 @@ cdef inline int node_split_best(
     cdef intp_t n_found_constants = 0
     # Number of features known to be constant and drawn without replacement
     cdef intp_t n_drawn_constants = 0
-    cdef intp_t n_known_constants = n_constant_features[0]
+    cdef intp_t n_known_constants = split.n_constant_features
     # n_total_constants = n_known_constants + n_found_constants
     cdef intp_t n_total_constants = n_known_constants
 
@@ -559,8 +558,8 @@ cdef inline int node_split_best(
            sizeof(intp_t) * n_found_constants)
 
     # Return values
+    best_split.n_constant_features = n_total_constants
     split[0] = best_split
-    n_constant_features[0] = n_total_constants
     return 0
 
 
@@ -683,7 +682,6 @@ cdef inline int node_split_random(
     Criterion criterion,
     float64_t impurity,
     SplitRecord* split,
-    intp_t* n_constant_features,
     bint with_monotonic_cst,
     const cnp.int8_t[:] monotonic_cst,
     float64_t lower_bound,
@@ -717,7 +715,7 @@ cdef inline int node_split_random(
     cdef intp_t n_found_constants = 0
     # Number of features known to be constant and drawn without replacement
     cdef intp_t n_drawn_constants = 0
-    cdef intp_t n_known_constants = n_constant_features[0]
+    cdef intp_t n_known_constants = split.n_constant_features
     # n_total_constants = n_known_constants + n_found_constants
     cdef intp_t n_total_constants = n_known_constants
     cdef intp_t n_visited_features = 0
@@ -861,8 +859,8 @@ cdef inline int node_split_random(
            sizeof(intp_t) * n_found_constants)
 
     # Return values
+    best_split.n_constant_features = n_total_constants
     split[0] = best_split
-    n_constant_features[0] = n_total_constants
     return 0
 
 
@@ -1520,7 +1518,6 @@ cdef class BestSplitter(Splitter):
             self,
             float64_t impurity,
             SplitRecord* split,
-            intp_t* n_constant_features,
             float64_t lower_bound,
             float64_t upper_bound
     ) except -1 nogil:
@@ -1530,7 +1527,6 @@ cdef class BestSplitter(Splitter):
             self.criterion,
             impurity,
             split,
-            n_constant_features,
             self.with_monotonic_cst,
             self.monotonic_cst,
             lower_bound,
@@ -1556,7 +1552,6 @@ cdef class BestSparseSplitter(Splitter):
             self,
             float64_t impurity,
             SplitRecord* split,
-            intp_t* n_constant_features,
             float64_t lower_bound,
             float64_t upper_bound
     ) except -1 nogil:
@@ -1566,7 +1561,6 @@ cdef class BestSparseSplitter(Splitter):
             self.criterion,
             impurity,
             split,
-            n_constant_features,
             self.with_monotonic_cst,
             self.monotonic_cst,
             lower_bound,
@@ -1592,7 +1586,6 @@ cdef class RandomSplitter(Splitter):
             self,
             float64_t impurity,
             SplitRecord* split,
-            intp_t* n_constant_features,
             float64_t lower_bound,
             float64_t upper_bound
     ) except -1 nogil:
@@ -1602,7 +1595,6 @@ cdef class RandomSplitter(Splitter):
             self.criterion,
             impurity,
             split,
-            n_constant_features,
             self.with_monotonic_cst,
             self.monotonic_cst,
             lower_bound,
@@ -1627,7 +1619,6 @@ cdef class RandomSparseSplitter(Splitter):
             self,
             float64_t impurity,
             SplitRecord* split,
-            intp_t* n_constant_features,
             float64_t lower_bound,
             float64_t upper_bound
     ) except -1 nogil:
@@ -1637,7 +1628,6 @@ cdef class RandomSparseSplitter(Splitter):
             self.criterion,
             impurity,
             split,
-            n_constant_features,
             self.with_monotonic_cst,
             self.monotonic_cst,
             lower_bound,

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -215,7 +215,6 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
         cdef float64_t left_child_max
         cdef float64_t right_child_min
         cdef float64_t right_child_max
-        cdef intp_t n_constant_features
         cdef bint is_leaf
         cdef bint first = 1
         cdef intp_t max_depth_seen = -1
@@ -248,7 +247,7 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
                 parent = stack_record.parent
                 is_left = stack_record.is_left
                 impurity = stack_record.impurity
-                n_constant_features = stack_record.n_constant_features
+                split.n_constant_features = stack_record.n_constant_features
                 lower_bound = stack_record.lower_bound
                 upper_bound = stack_record.upper_bound
 
@@ -271,7 +270,6 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
                     splitter.node_split(
                         impurity,
                         &split,
-                        &n_constant_features,
                         lower_bound,
                         upper_bound
                     )
@@ -338,7 +336,7 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
                         "parent": node_id,
                         "is_left": 0,
                         "impurity": split.impurity_right,
-                        "n_constant_features": n_constant_features,
+                        "n_constant_features": split.n_constant_features,
                         "lower_bound": right_child_min,
                         "upper_bound": right_child_max,
                     })
@@ -351,7 +349,7 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
                         "parent": node_id,
                         "is_left": 1,
                         "impurity": split.impurity_left,
-                        "n_constant_features": n_constant_features,
+                        "n_constant_features": split.n_constant_features,
                         "lower_bound": left_child_min,
                         "upper_bound": left_child_max,
                     })
@@ -606,7 +604,7 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
         cdef SplitRecord split
         cdef intp_t node_id
         cdef intp_t n_node_samples
-        cdef intp_t n_constant_features = 0
+        split.n_constant_features = 0
         cdef float64_t min_impurity_decrease = self.min_impurity_decrease
         cdef float64_t weighted_n_node_samples
         cdef bint is_leaf
@@ -628,7 +626,6 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
             splitter.node_split(
                 impurity,
                 &split,
-                &n_constant_features,
                 lower_bound,
                 upper_bound
             )


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes: https://github.com/scikit-learn/scikit-learn/issues/28602#issuecomment-1989500905


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
