### PR TITLE
DEBUG hgbt variable bins #28603

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/_binning.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/_binning.pyx
@@ -3,13 +3,14 @@
 from cython.parallel import prange
 from libc.math cimport isnan
 
+from sklearn.utils._typedefs cimport uint16_t
 from .common cimport X_DTYPE_C, X_BINNED_DTYPE_C
 
 
-def _map_to_bins(const X_DTYPE_C [:, :] data,
+def _map_to_bins(const X_DTYPE_C[:, :] data,
+                 const uint16_t[::1] n_bins_non_missing,
                  list binning_thresholds,
                  const unsigned char[::1] is_categorical,
-                 const unsigned char missing_values_bin_idx,
                  int n_threads,
                  X_BINNED_DTYPE_C [::1, :] binned):
     """Bin continuous and categorical values to discrete integer-coded levels.
@@ -21,6 +22,10 @@ def _map_to_bins(const X_DTYPE_C [:, :] data,
     ----------
     data : ndarray, shape (n_samples, n_features)
         The data to bin.
+    n_bins_non_missing : ndarray of shape (n_features,) dtype=np.uint16
+        For each feature, gives the number of bins actually used for non-missing
+        values. The index of the bin where missing values are mapped is always
+        given by the last bin, i.e. bin index ``n_bins_non_missing_``.
     binning_thresholds : list of arrays
         For each feature, stores the increasing numeric values that are
         used to separate the bins.
@@ -36,20 +41,20 @@ def _map_to_bins(const X_DTYPE_C [:, :] data,
 
     for feature_idx in range(data.shape[1]):
         _map_col_to_bins(
-            data[:, feature_idx],
-            binning_thresholds[feature_idx],
-            is_categorical[feature_idx],
-            missing_values_bin_idx,
-            n_threads,
-            binned[:, feature_idx]
+            data=data[:, feature_idx],
+            binning_thresholds=binning_thresholds[feature_idx],
+            is_categorical=is_categorical[feature_idx],
+            missing_values_bin_idx=n_bins_non_missing[feature_idx],
+            n_threads=n_threads,
+            binned=binned[:, feature_idx]
         )
 
 
 cdef void _map_col_to_bins(
-    const X_DTYPE_C [:] data,
-    const X_DTYPE_C [:] binning_thresholds,
+    const X_DTYPE_C[:] data,
+    const X_DTYPE_C[:] binning_thresholds,
     const unsigned char is_categorical,
-    const unsigned char missing_values_bin_idx,
+    const uint16_t missing_values_bin_idx,
     int n_threads,
     X_BINNED_DTYPE_C [:] binned
 ):

--- a/sklearn/ensemble/_hist_gradient_boosting/common.pxd
+++ b/sklearn/ensemble/_hist_gradient_boosting/common.pxd
@@ -50,7 +50,7 @@ cdef class Histograms:
         int n_features
         uint32_t [::1] bin_offsets_view
         hist_struct [::1] histograms_view
-    cdef readonly:
+    cdef public:
         object bin_offsets
         # Only the attribute histograms will be used in the splitter.
         object histograms

--- a/sklearn/ensemble/_hist_gradient_boosting/common.pxd
+++ b/sklearn/ensemble/_hist_gradient_boosting/common.pxd
@@ -1,5 +1,5 @@
 cimport numpy as cnp
-from sklearn.utils._typedefs cimport intp_t
+from sklearn.utils._typedefs cimport intp_t, uint32_t
 
 cnp.import_array()
 
@@ -10,6 +10,7 @@ ctypedef cnp.npy_float64 Y_DTYPE_C
 ctypedef cnp.npy_float32 G_H_DTYPE_C
 ctypedef cnp.npy_uint32 BITSET_INNER_DTYPE_C
 ctypedef BITSET_INNER_DTYPE_C[8] BITSET_DTYPE_C
+
 
 cdef packed struct hist_struct:
     # Same as histogram dtype but we need a struct to declare views. It needs
@@ -42,3 +43,18 @@ cpdef enum MonotonicConstraint:
     NO_CST = 0
     POS = 1
     NEG = -1
+
+
+cdef class Histograms:
+    cdef:
+        int n_features
+        uint32_t [::1] bin_offsets_view
+        hist_struct [::1] histograms_view
+    cdef readonly:
+        object bin_offsets
+        # Only the attribute histograms will be used in the splitter.
+        object histograms
+
+    cdef inline uint32_t n_bins(self, int feature_idx) noexcept nogil
+
+    cdef inline hist_struct* at(self, int feature_idx, uint32_t bin_idx) noexcept nogil

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -679,8 +679,10 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
             X_binned_val = None
 
         # Uses binned data to check for missing values
+        # Note that the missing bin index is always the last bin, i.e. the value of
+        # n_bins_non_missing.
         has_missing_values = (
-            (X_binned_train == self._bin_mapper.missing_values_bin_idx_)
+            (X_binned_train == self._bin_mapper.n_bins_non_missing_)
             .any(axis=0)
             .astype(np.uint8)
         )
@@ -940,7 +942,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                     for k, pred in enumerate(self._predictors[-1]):
                         raw_predictions_val[:, k] += pred.predict_binned(
                             X_binned_val,
-                            self._bin_mapper.missing_values_bin_idx_,
+                            self._bin_mapper.n_bins_non_missing_,
                             n_threads,
                         )
 
@@ -1296,7 +1298,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                 if is_binned:
                     predict = partial(
                         predictor.predict_binned,
-                        missing_values_bin_idx=self._bin_mapper.missing_values_bin_idx_,
+                        n_bins_non_missing=self._bin_mapper.n_bins_non_missing_,
                         n_threads=n_threads,
                     )
                 else:

--- a/sklearn/ensemble/_hist_gradient_boosting/histogram.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/histogram.pyx
@@ -5,13 +5,13 @@
 cimport cython
 from cython.parallel import prange
 from libc.string cimport memset
+cimport numpy as cnp
+cnp.import_array()
 
-import numpy as np
-
-from .common import HISTOGRAM_DTYPE
-from .common cimport hist_struct
+from ...utils._typedefs cimport uint32_t
 from .common cimport X_BINNED_DTYPE_C
 from .common cimport G_H_DTYPE_C
+from .common cimport Histograms
 
 
 # Notes:
@@ -82,12 +82,13 @@ cdef class HistogramBuilder:
         unsigned char hessians_are_constant
         int n_threads
 
-    def __init__(self, const X_BINNED_DTYPE_C [::1, :] X_binned,
-                 unsigned int n_bins, G_H_DTYPE_C [::1] gradients,
-                 G_H_DTYPE_C [::1] hessians,
-                 unsigned char hessians_are_constant,
-                 int n_threads):
-
+    def __init__(
+        self, const X_BINNED_DTYPE_C [::1, :] X_binned,
+        unsigned int n_bins, G_H_DTYPE_C [::1] gradients,
+        G_H_DTYPE_C [::1] hessians,
+        unsigned char hessians_are_constant,
+        int n_threads
+    ):
         self.X_binned = X_binned
         self.n_features = X_binned.shape[1]
         # Note: all histograms will have <n_bins> bins, but some of the
@@ -136,10 +137,11 @@ cdef class HistogramBuilder:
             G_H_DTYPE_C [::1] gradients = self.gradients
             G_H_DTYPE_C [::1] ordered_hessians = self.ordered_hessians
             G_H_DTYPE_C [::1] hessians = self.hessians
-            # Histograms will be initialized to zero later within a prange
-            hist_struct [:, ::1] histograms = np.empty(
-                shape=(self.n_features, self.n_bins),
-                dtype=HISTOGRAM_DTYPE
+            # Histograms will be initialized to zero later within a prange.
+            # Here we just allocate the array, i.e. __init__ calls:
+            # np.empty(shape=self.bin_offsets[-1], dtype=HISTOGRAM_DTYPE)
+            Histograms histograms = Histograms(
+                n_features=self.n_features, bin_offsets=256
             )
             bint has_interaction_cst = allowed_features is not None
             int n_threads = self.n_threads
@@ -180,10 +182,11 @@ cdef class HistogramBuilder:
         return histograms
 
     cdef void _compute_histogram_brute_single_feature(
-            HistogramBuilder self,
-            const int feature_idx,
-            const unsigned int [::1] sample_indices,  # IN
-            hist_struct [:, ::1] histograms) noexcept nogil:  # OUT
+        HistogramBuilder self,
+        const int feature_idx,
+        const unsigned int [::1] sample_indices,  # IN
+        Histograms histograms,                    # OUT
+    ) noexcept nogil:
         """Compute the histogram for a given feature."""
 
         cdef:
@@ -197,9 +200,10 @@ cdef class HistogramBuilder:
                 self.ordered_hessians[:n_samples]
             unsigned char hessians_are_constant = \
                 self.hessians_are_constant
+            uint32_t n_bins = histograms.n_bins(feature_idx)
 
         # Set histograms to zero.
-        memset(&histograms[feature_idx, 0], 0, self.n_bins * sizeof(hist_struct))
+        memset(histograms.at(feature_idx, 0), 0, n_bins * sizeof(hist_struct))
 
         if root_node:
             if hessians_are_constant:
@@ -222,8 +226,8 @@ cdef class HistogramBuilder:
 
     def compute_histograms_subtraction(
         HistogramBuilder self,
-        hist_struct [:, ::1] parent_histograms,        # IN and OUT
-        hist_struct [:, ::1] sibling_histograms,       # IN
+        Histograms parent_histograms,        # IN and OUT
+        Histograms sibling_histograms,       # IN
         const unsigned int [:] allowed_features=None,  # IN
     ):
         """Compute the histograms of the node using the subtraction trick.
@@ -274,7 +278,6 @@ cdef class HistogramBuilder:
 
             _subtract_histograms(
                 feature_idx,
-                self.n_bins,
                 parent_histograms,
                 sibling_histograms,
             )
@@ -282,12 +285,13 @@ cdef class HistogramBuilder:
 
 
 cpdef void _build_histogram_naive(
-        const int feature_idx,
-        unsigned int [:] sample_indices,  # IN
-        X_BINNED_DTYPE_C [:] binned_feature,  # IN
-        G_H_DTYPE_C [:] ordered_gradients,  # IN
-        G_H_DTYPE_C [:] ordered_hessians,  # IN
-        hist_struct [:, :] out) noexcept nogil:  # OUT
+    const int feature_idx,
+    unsigned int [:] sample_indices,      # IN
+    X_BINNED_DTYPE_C [:] binned_feature,  # IN
+    G_H_DTYPE_C [:] ordered_gradients,    # IN
+    G_H_DTYPE_C [:] ordered_hessians,     # IN
+    Histograms out,                       # OUT
+) noexcept nogil:
     """Build histogram in a naive way, without optimizing for cache hit.
 
     Used in tests to compare with the optimized version."""
@@ -295,22 +299,21 @@ cpdef void _build_histogram_naive(
         unsigned int i
         unsigned int n_samples = sample_indices.shape[0]
         unsigned int sample_idx
-        unsigned int bin_idx
+        uint32_t bin_idx
 
     for i in range(n_samples):
         sample_idx = sample_indices[i]
         bin_idx = binned_feature[sample_idx]
-        out[feature_idx, bin_idx].sum_gradients += ordered_gradients[i]
-        out[feature_idx, bin_idx].sum_hessians += ordered_hessians[i]
-        out[feature_idx, bin_idx].count += 1
+        out.at(feature_idx, bin_idx).sum_gradients += ordered_gradients[i]
+        out.at(feature_idx, bin_idx).sum_hessians += ordered_hessians[i]
+        out.at(feature_idx, bin_idx).count += 1
 
 
 cpdef void _subtract_histograms(
-        const int feature_idx,
-        unsigned int n_bins,
-        hist_struct [:, ::1] hist_a,  # IN and OUT
-        hist_struct [:, ::1] hist_b,  # IN
-) noexcept nogil:  # OUT
+    const int feature_idx,
+    Histograms hist_a,  # IN and OUT
+    Histograms hist_b,  # IN
+) noexcept nogil:
     """compute hist_a = hist_a - hist_b"""
     # Note that subtraction of large sums of floating point numbers, as we have here,
     # can exhibit catastrophic cancallation. This is in particular true for gradients
@@ -324,31 +327,33 @@ cpdef void _subtract_histograms(
     #     sum_hessians = max(0, sum_hessians)
     # But as we use float64 for summing float32, that's veeeery unlikely.
     cdef:
-        unsigned int i = 0
+        uint32_t i = 0
+        uint32_t n_bins = hist_a.n_bins(feature_idx)
     for i in range(n_bins):
-        hist_a[feature_idx, i].sum_gradients -= hist_b[feature_idx, i].sum_gradients
-        hist_a[feature_idx, i].sum_hessians -= hist_b[feature_idx, i].sum_hessians
-        hist_a[feature_idx, i].count -= hist_b[feature_idx, i].count
+        hist_a.at(feature_idx, i).sum_gradients -= hist_b.at(feature_idx, i).sum_gradients
+        hist_a.at(feature_idx, i).sum_hessians  -= hist_b.at(feature_idx, i).sum_hessians
+        hist_a.at(feature_idx, i).count         -= hist_b.at(feature_idx, i).count
 
 
 cpdef void _build_histogram(
-        const int feature_idx,
-        const unsigned int [::1] sample_indices,  # IN
-        const X_BINNED_DTYPE_C [::1] binned_feature,  # IN
-        const G_H_DTYPE_C [::1] ordered_gradients,  # IN
-        const G_H_DTYPE_C [::1] ordered_hessians,  # IN
-        hist_struct [:, ::1] out) noexcept nogil:  # OUT
+    const int feature_idx,
+    const unsigned int [::1] sample_indices,      # IN
+    const X_BINNED_DTYPE_C [::1] binned_feature,  # IN
+    const G_H_DTYPE_C [::1] ordered_gradients,    # IN
+    const G_H_DTYPE_C [::1] ordered_hessians,     # IN
+    Histograms out,                               # OUT
+) noexcept nogil:
     """Return histogram for a given feature."""
     cdef:
         unsigned int i = 0
         unsigned int n_node_samples = sample_indices.shape[0]
         unsigned int unrolled_upper = (n_node_samples // 4) * 4
 
-        unsigned int bin_0
-        unsigned int bin_1
-        unsigned int bin_2
-        unsigned int bin_3
-        unsigned int bin_idx
+        uint32_t bin_0
+        uint32_t bin_1
+        uint32_t bin_2
+        uint32_t bin_3
+        uint32_t bin_idx
 
     for i in range(0, unrolled_upper, 4):
         bin_0 = binned_feature[sample_indices[i]]
@@ -356,49 +361,49 @@ cpdef void _build_histogram(
         bin_2 = binned_feature[sample_indices[i + 2]]
         bin_3 = binned_feature[sample_indices[i + 3]]
 
-        out[feature_idx, bin_0].sum_gradients += ordered_gradients[i]
-        out[feature_idx, bin_1].sum_gradients += ordered_gradients[i + 1]
-        out[feature_idx, bin_2].sum_gradients += ordered_gradients[i + 2]
-        out[feature_idx, bin_3].sum_gradients += ordered_gradients[i + 3]
+        out.at(feature_idx, bin_0).sum_gradients += ordered_gradients[i]
+        out.at(feature_idx, bin_1).sum_gradients += ordered_gradients[i + 1]
+        out.at(feature_idx, bin_2).sum_gradients += ordered_gradients[i + 2]
+        out.at(feature_idx, bin_3).sum_gradients += ordered_gradients[i + 3]
 
-        out[feature_idx, bin_0].sum_hessians += ordered_hessians[i]
-        out[feature_idx, bin_1].sum_hessians += ordered_hessians[i + 1]
-        out[feature_idx, bin_2].sum_hessians += ordered_hessians[i + 2]
-        out[feature_idx, bin_3].sum_hessians += ordered_hessians[i + 3]
+        out.at(feature_idx, bin_0).sum_hessians += ordered_hessians[i]
+        out.at(feature_idx, bin_1).sum_hessians += ordered_hessians[i + 1]
+        out.at(feature_idx, bin_2).sum_hessians += ordered_hessians[i + 2]
+        out.at(feature_idx, bin_3).sum_hessians += ordered_hessians[i + 3]
 
-        out[feature_idx, bin_0].count += 1
-        out[feature_idx, bin_1].count += 1
-        out[feature_idx, bin_2].count += 1
-        out[feature_idx, bin_3].count += 1
+        out.at(feature_idx, bin_0).count += 1
+        out.at(feature_idx, bin_1).count += 1
+        out.at(feature_idx, bin_2).count += 1
+        out.at(feature_idx, bin_3).count += 1
 
     for i in range(unrolled_upper, n_node_samples):
         bin_idx = binned_feature[sample_indices[i]]
-        out[feature_idx, bin_idx].sum_gradients += ordered_gradients[i]
-        out[feature_idx, bin_idx].sum_hessians += ordered_hessians[i]
-        out[feature_idx, bin_idx].count += 1
+        out.at(feature_idx, bin_idx).sum_gradients += ordered_gradients[i]
+        out.at(feature_idx, bin_idx).sum_hessians += ordered_hessians[i]
+        out.at(feature_idx, bin_idx).count += 1
 
 
 cpdef void _build_histogram_no_hessian(
-        const int feature_idx,
-        const unsigned int [::1] sample_indices,  # IN
-        const X_BINNED_DTYPE_C [::1] binned_feature,  # IN
-        const G_H_DTYPE_C [::1] ordered_gradients,  # IN
-        hist_struct [:, ::1] out) noexcept nogil:  # OUT
+    const int feature_idx,
+    const unsigned int [::1] sample_indices,      # IN
+    const X_BINNED_DTYPE_C [::1] binned_feature,  # IN
+    const G_H_DTYPE_C [::1] ordered_gradients,    # IN
+    Histograms out,                     # OUT
+) noexcept nogil:
     """Return histogram for a given feature, not updating hessians.
 
     Used when the hessians of the loss are constant (typically LS loss).
     """
-
     cdef:
         unsigned int i = 0
         unsigned int n_node_samples = sample_indices.shape[0]
         unsigned int unrolled_upper = (n_node_samples // 4) * 4
 
-        unsigned int bin_0
-        unsigned int bin_1
-        unsigned int bin_2
-        unsigned int bin_3
-        unsigned int bin_idx
+        uint32_t bin_0
+        uint32_t bin_1
+        uint32_t bin_2
+        uint32_t bin_3
+        uint32_t bin_idx
 
     for i in range(0, unrolled_upper, 4):
         bin_0 = binned_feature[sample_indices[i]]
@@ -406,28 +411,29 @@ cpdef void _build_histogram_no_hessian(
         bin_2 = binned_feature[sample_indices[i + 2]]
         bin_3 = binned_feature[sample_indices[i + 3]]
 
-        out[feature_idx, bin_0].sum_gradients += ordered_gradients[i]
-        out[feature_idx, bin_1].sum_gradients += ordered_gradients[i + 1]
-        out[feature_idx, bin_2].sum_gradients += ordered_gradients[i + 2]
-        out[feature_idx, bin_3].sum_gradients += ordered_gradients[i + 3]
+        out.at(feature_idx, bin_0).sum_gradients += ordered_gradients[i]
+        out.at(feature_idx, bin_1).sum_gradients += ordered_gradients[i + 1]
+        out.at(feature_idx, bin_2).sum_gradients += ordered_gradients[i + 2]
+        out.at(feature_idx, bin_3).sum_gradients += ordered_gradients[i + 3]
 
-        out[feature_idx, bin_0].count += 1
-        out[feature_idx, bin_1].count += 1
-        out[feature_idx, bin_2].count += 1
-        out[feature_idx, bin_3].count += 1
+        out.at(feature_idx, bin_0).count += 1
+        out.at(feature_idx, bin_1).count += 1
+        out.at(feature_idx, bin_2).count += 1
+        out.at(feature_idx, bin_3).count += 1
 
     for i in range(unrolled_upper, n_node_samples):
         bin_idx = binned_feature[sample_indices[i]]
-        out[feature_idx, bin_idx].sum_gradients += ordered_gradients[i]
-        out[feature_idx, bin_idx].count += 1
+        out.at(feature_idx, bin_idx).sum_gradients += ordered_gradients[i]
+        out.at(feature_idx, bin_idx).count += 1
 
 
 cpdef void _build_histogram_root(
-        const int feature_idx,
-        const X_BINNED_DTYPE_C [::1] binned_feature,  # IN
-        const G_H_DTYPE_C [::1] all_gradients,  # IN
-        const G_H_DTYPE_C [::1] all_hessians,  # IN
-        hist_struct [:, ::1] out) noexcept nogil:  # OUT
+    const int feature_idx,
+    const X_BINNED_DTYPE_C [::1] binned_feature,  # IN
+    const G_H_DTYPE_C [::1] all_gradients,        # IN
+    const G_H_DTYPE_C [::1] all_hessians,         # IN
+    Histograms out,                     # OUT
+) noexcept nogil:
     """Compute histogram of the root node.
 
     Unlike other nodes, the root node has to find the split among *all* the
@@ -440,46 +446,46 @@ cpdef void _build_histogram_root(
         unsigned int n_samples = binned_feature.shape[0]
         unsigned int unrolled_upper = (n_samples // 4) * 4
 
-        unsigned int bin_0
-        unsigned int bin_1
-        unsigned int bin_2
-        unsigned int bin_3
-        unsigned int bin_idx
+        uint32_t bin_0
+        uint32_t bin_1
+        uint32_t bin_2
+        uint32_t bin_3
+        uint32_t bin_idx
 
     for i in range(0, unrolled_upper, 4):
-
         bin_0 = binned_feature[i]
         bin_1 = binned_feature[i + 1]
         bin_2 = binned_feature[i + 2]
         bin_3 = binned_feature[i + 3]
 
-        out[feature_idx, bin_0].sum_gradients += all_gradients[i]
-        out[feature_idx, bin_1].sum_gradients += all_gradients[i + 1]
-        out[feature_idx, bin_2].sum_gradients += all_gradients[i + 2]
-        out[feature_idx, bin_3].sum_gradients += all_gradients[i + 3]
+        out.at(feature_idx, bin_0).sum_gradients += all_gradients[i]
+        out.at(feature_idx, bin_1).sum_gradients += all_gradients[i + 1]
+        out.at(feature_idx, bin_2).sum_gradients += all_gradients[i + 2]
+        out.at(feature_idx, bin_3).sum_gradients += all_gradients[i + 3]
 
-        out[feature_idx, bin_0].sum_hessians += all_hessians[i]
-        out[feature_idx, bin_1].sum_hessians += all_hessians[i + 1]
-        out[feature_idx, bin_2].sum_hessians += all_hessians[i + 2]
-        out[feature_idx, bin_3].sum_hessians += all_hessians[i + 3]
+        out.at(feature_idx, bin_0).sum_hessians += all_hessians[i]
+        out.at(feature_idx, bin_1).sum_hessians += all_hessians[i + 1]
+        out.at(feature_idx, bin_2).sum_hessians += all_hessians[i + 2]
+        out.at(feature_idx, bin_3).sum_hessians += all_hessians[i + 3]
 
-        out[feature_idx, bin_0].count += 1
-        out[feature_idx, bin_1].count += 1
-        out[feature_idx, bin_2].count += 1
-        out[feature_idx, bin_3].count += 1
+        out.at(feature_idx, bin_0).count += 1
+        out.at(feature_idx, bin_1).count += 1
+        out.at(feature_idx, bin_2).count += 1
+        out.at(feature_idx, bin_3).count += 1
 
     for i in range(unrolled_upper, n_samples):
         bin_idx = binned_feature[i]
-        out[feature_idx, bin_idx].sum_gradients += all_gradients[i]
-        out[feature_idx, bin_idx].sum_hessians += all_hessians[i]
-        out[feature_idx, bin_idx].count += 1
+        out.at(feature_idx, bin_idx).sum_gradients += all_gradients[i]
+        out.at(feature_idx, bin_idx).sum_hessians += all_hessians[i]
+        out.at(feature_idx, bin_idx).count += 1
 
 
 cpdef void _build_histogram_root_no_hessian(
-        const int feature_idx,
-        const X_BINNED_DTYPE_C [::1] binned_feature,  # IN
-        const G_H_DTYPE_C [::1] all_gradients,  # IN
-        hist_struct [:, ::1] out) noexcept nogil:  # OUT
+    const int feature_idx,
+    const X_BINNED_DTYPE_C [::1] binned_feature,  # IN
+    const G_H_DTYPE_C [::1] all_gradients,        # IN
+    Histograms out,                               # OUT
+) noexcept nogil:
     """Compute histogram of the root node, not updating hessians.
 
     Used when the hessians of the loss are constant (typically LS loss).
@@ -490,11 +496,11 @@ cpdef void _build_histogram_root_no_hessian(
         unsigned int n_samples = binned_feature.shape[0]
         unsigned int unrolled_upper = (n_samples // 4) * 4
 
-        unsigned int bin_0
-        unsigned int bin_1
-        unsigned int bin_2
-        unsigned int bin_3
-        unsigned int bin_idx
+        uint32_t bin_0
+        uint32_t bin_1
+        uint32_t bin_2
+        uint32_t bin_3
+        uint32_t bin_idx
 
     for i in range(0, unrolled_upper, 4):
         bin_0 = binned_feature[i]
@@ -502,17 +508,17 @@ cpdef void _build_histogram_root_no_hessian(
         bin_2 = binned_feature[i + 2]
         bin_3 = binned_feature[i + 3]
 
-        out[feature_idx, bin_0].sum_gradients += all_gradients[i]
-        out[feature_idx, bin_1].sum_gradients += all_gradients[i + 1]
-        out[feature_idx, bin_2].sum_gradients += all_gradients[i + 2]
-        out[feature_idx, bin_3].sum_gradients += all_gradients[i + 3]
+        out.at(feature_idx, bin_0).sum_gradients += all_gradients[i]
+        out.at(feature_idx, bin_1).sum_gradients += all_gradients[i + 1]
+        out.at(feature_idx, bin_2).sum_gradients += all_gradients[i + 2]
+        out.at(feature_idx, bin_3).sum_gradients += all_gradients[i + 3]
 
-        out[feature_idx, bin_0].count += 1
-        out[feature_idx, bin_1].count += 1
-        out[feature_idx, bin_2].count += 1
-        out[feature_idx, bin_3].count += 1
+        out.at(feature_idx, bin_0).count += 1
+        out.at(feature_idx, bin_1).count += 1
+        out.at(feature_idx, bin_2).count += 1
+        out.at(feature_idx, bin_3).count += 1
 
     for i in range(unrolled_upper, n_samples):
         bin_idx = binned_feature[i]
-        out[feature_idx, bin_idx].sum_gradients += all_gradients[i]
-        out[feature_idx, bin_idx].count += 1
+        out.at(feature_idx, bin_idx).sum_gradients += all_gradients[i]
+        out.at(feature_idx, bin_idx).count += 1

--- a/sklearn/ensemble/_hist_gradient_boosting/histogram.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/histogram.pyx
@@ -9,9 +9,10 @@ cimport numpy as cnp
 cnp.import_array()
 
 from ...utils._typedefs cimport uint32_t
+from .common cimport hist_struct
+from .common cimport Histograms
 from .common cimport X_BINNED_DTYPE_C
 from .common cimport G_H_DTYPE_C
-from .common cimport Histograms
 
 
 # Notes:
@@ -201,9 +202,10 @@ cdef class HistogramBuilder:
             unsigned char hessians_are_constant = \
                 self.hessians_are_constant
             uint32_t n_bins = histograms.n_bins(feature_idx)
+            hist_struct * hist = histograms.at(feature_idx, 0)
 
         # Set histograms to zero.
-        memset(histograms.at(feature_idx, 0), 0, n_bins * sizeof(hist_struct))
+        memset(hist, 0, n_bins * sizeof(hist_struct))
 
         if root_node:
             if hessians_are_constant:
@@ -329,10 +331,12 @@ cpdef void _subtract_histograms(
     cdef:
         uint32_t i = 0
         uint32_t n_bins = hist_a.n_bins(feature_idx)
+        hist_struct * ha = hist_a.at(feature_idx, 0)
+        hist_struct * hb = hist_b.at(feature_idx, 0)
     for i in range(n_bins):
-        hist_a.at(feature_idx, i).sum_gradients -= hist_b.at(feature_idx, i).sum_gradients
-        hist_a.at(feature_idx, i).sum_hessians  -= hist_b.at(feature_idx, i).sum_hessians
-        hist_a.at(feature_idx, i).count         -= hist_b.at(feature_idx, i).count
+        ha[i].sum_gradients -= hb[i].sum_gradients  # no-cython-lint
+        ha[i].sum_hessians  -= hb[i].sum_hessians   # no-cython-lint
+        ha[i].count         -= hb[i].count          # no-cython-lint
 
 
 cpdef void _build_histogram(
@@ -354,6 +358,7 @@ cpdef void _build_histogram(
         uint32_t bin_2
         uint32_t bin_3
         uint32_t bin_idx
+        hist_struct * hist = out.at(feature_idx, 0)
 
     for i in range(0, unrolled_upper, 4):
         bin_0 = binned_feature[sample_indices[i]]
@@ -361,26 +366,26 @@ cpdef void _build_histogram(
         bin_2 = binned_feature[sample_indices[i + 2]]
         bin_3 = binned_feature[sample_indices[i + 3]]
 
-        out.at(feature_idx, bin_0).sum_gradients += ordered_gradients[i]
-        out.at(feature_idx, bin_1).sum_gradients += ordered_gradients[i + 1]
-        out.at(feature_idx, bin_2).sum_gradients += ordered_gradients[i + 2]
-        out.at(feature_idx, bin_3).sum_gradients += ordered_gradients[i + 3]
+        hist[bin_0].sum_gradients += ordered_gradients[i]
+        hist[bin_1].sum_gradients += ordered_gradients[i + 1]
+        hist[bin_2].sum_gradients += ordered_gradients[i + 2]
+        hist[bin_3].sum_gradients += ordered_gradients[i + 3]
 
-        out.at(feature_idx, bin_0).sum_hessians += ordered_hessians[i]
-        out.at(feature_idx, bin_1).sum_hessians += ordered_hessians[i + 1]
-        out.at(feature_idx, bin_2).sum_hessians += ordered_hessians[i + 2]
-        out.at(feature_idx, bin_3).sum_hessians += ordered_hessians[i + 3]
+        hist[bin_0].sum_hessians += ordered_hessians[i]
+        hist[bin_1].sum_hessians += ordered_hessians[i + 1]
+        hist[bin_2].sum_hessians += ordered_hessians[i + 2]
+        hist[bin_3].sum_hessians += ordered_hessians[i + 3]
 
-        out.at(feature_idx, bin_0).count += 1
-        out.at(feature_idx, bin_1).count += 1
-        out.at(feature_idx, bin_2).count += 1
-        out.at(feature_idx, bin_3).count += 1
+        hist[bin_0].count += 1
+        hist[bin_1].count += 1
+        hist[bin_2].count += 1
+        hist[bin_3].count += 1
 
     for i in range(unrolled_upper, n_node_samples):
         bin_idx = binned_feature[sample_indices[i]]
-        out.at(feature_idx, bin_idx).sum_gradients += ordered_gradients[i]
-        out.at(feature_idx, bin_idx).sum_hessians += ordered_hessians[i]
-        out.at(feature_idx, bin_idx).count += 1
+        hist[bin_idx].sum_gradients += ordered_gradients[i]
+        hist[bin_idx].sum_hessians += ordered_hessians[i]
+        hist[bin_idx].count += 1
 
 
 cpdef void _build_histogram_no_hessian(
@@ -404,6 +409,7 @@ cpdef void _build_histogram_no_hessian(
         uint32_t bin_2
         uint32_t bin_3
         uint32_t bin_idx
+        hist_struct * hist = out.at(feature_idx, 0)
 
     for i in range(0, unrolled_upper, 4):
         bin_0 = binned_feature[sample_indices[i]]
@@ -411,20 +417,20 @@ cpdef void _build_histogram_no_hessian(
         bin_2 = binned_feature[sample_indices[i + 2]]
         bin_3 = binned_feature[sample_indices[i + 3]]
 
-        out.at(feature_idx, bin_0).sum_gradients += ordered_gradients[i]
-        out.at(feature_idx, bin_1).sum_gradients += ordered_gradients[i + 1]
-        out.at(feature_idx, bin_2).sum_gradients += ordered_gradients[i + 2]
-        out.at(feature_idx, bin_3).sum_gradients += ordered_gradients[i + 3]
+        hist[bin_0].sum_gradients += ordered_gradients[i]
+        hist[bin_1].sum_gradients += ordered_gradients[i + 1]
+        hist[bin_2].sum_gradients += ordered_gradients[i + 2]
+        hist[bin_3].sum_gradients += ordered_gradients[i + 3]
 
-        out.at(feature_idx, bin_0).count += 1
-        out.at(feature_idx, bin_1).count += 1
-        out.at(feature_idx, bin_2).count += 1
-        out.at(feature_idx, bin_3).count += 1
+        hist[bin_0].count += 1
+        hist[bin_1].count += 1
+        hist[bin_2].count += 1
+        hist[bin_3].count += 1
 
     for i in range(unrolled_upper, n_node_samples):
         bin_idx = binned_feature[sample_indices[i]]
-        out.at(feature_idx, bin_idx).sum_gradients += ordered_gradients[i]
-        out.at(feature_idx, bin_idx).count += 1
+        hist[bin_idx].sum_gradients += ordered_gradients[i]
+        hist[bin_idx].count += 1
 
 
 cpdef void _build_histogram_root(
@@ -451,6 +457,7 @@ cpdef void _build_histogram_root(
         uint32_t bin_2
         uint32_t bin_3
         uint32_t bin_idx
+        hist_struct * hist = out.at(feature_idx, 0)
 
     for i in range(0, unrolled_upper, 4):
         bin_0 = binned_feature[i]
@@ -458,26 +465,26 @@ cpdef void _build_histogram_root(
         bin_2 = binned_feature[i + 2]
         bin_3 = binned_feature[i + 3]
 
-        out.at(feature_idx, bin_0).sum_gradients += all_gradients[i]
-        out.at(feature_idx, bin_1).sum_gradients += all_gradients[i + 1]
-        out.at(feature_idx, bin_2).sum_gradients += all_gradients[i + 2]
-        out.at(feature_idx, bin_3).sum_gradients += all_gradients[i + 3]
+        hist[bin_0].sum_gradients += all_gradients[i]
+        hist[bin_1].sum_gradients += all_gradients[i + 1]
+        hist[bin_2].sum_gradients += all_gradients[i + 2]
+        hist[bin_3].sum_gradients += all_gradients[i + 3]
 
-        out.at(feature_idx, bin_0).sum_hessians += all_hessians[i]
-        out.at(feature_idx, bin_1).sum_hessians += all_hessians[i + 1]
-        out.at(feature_idx, bin_2).sum_hessians += all_hessians[i + 2]
-        out.at(feature_idx, bin_3).sum_hessians += all_hessians[i + 3]
+        hist[bin_0].sum_hessians += all_hessians[i]
+        hist[bin_1].sum_hessians += all_hessians[i + 1]
+        hist[bin_2].sum_hessians += all_hessians[i + 2]
+        hist[bin_3].sum_hessians += all_hessians[i + 3]
 
-        out.at(feature_idx, bin_0).count += 1
-        out.at(feature_idx, bin_1).count += 1
-        out.at(feature_idx, bin_2).count += 1
-        out.at(feature_idx, bin_3).count += 1
+        hist[bin_0].count += 1
+        hist[bin_1].count += 1
+        hist[bin_2].count += 1
+        hist[bin_3].count += 1
 
     for i in range(unrolled_upper, n_samples):
         bin_idx = binned_feature[i]
-        out.at(feature_idx, bin_idx).sum_gradients += all_gradients[i]
-        out.at(feature_idx, bin_idx).sum_hessians += all_hessians[i]
-        out.at(feature_idx, bin_idx).count += 1
+        hist[bin_idx].sum_gradients += all_gradients[i]
+        hist[bin_idx].sum_hessians += all_hessians[i]
+        hist[bin_idx].count += 1
 
 
 cpdef void _build_histogram_root_no_hessian(
@@ -501,6 +508,7 @@ cpdef void _build_histogram_root_no_hessian(
         uint32_t bin_2
         uint32_t bin_3
         uint32_t bin_idx
+        hist_struct * hist = out.at(feature_idx, 0)
 
     for i in range(0, unrolled_upper, 4):
         bin_0 = binned_feature[i]
@@ -508,17 +516,17 @@ cpdef void _build_histogram_root_no_hessian(
         bin_2 = binned_feature[i + 2]
         bin_3 = binned_feature[i + 3]
 
-        out.at(feature_idx, bin_0).sum_gradients += all_gradients[i]
-        out.at(feature_idx, bin_1).sum_gradients += all_gradients[i + 1]
-        out.at(feature_idx, bin_2).sum_gradients += all_gradients[i + 2]
-        out.at(feature_idx, bin_3).sum_gradients += all_gradients[i + 3]
+        hist[bin_0].sum_gradients += all_gradients[i]
+        hist[bin_1].sum_gradients += all_gradients[i + 1]
+        hist[bin_2].sum_gradients += all_gradients[i + 2]
+        hist[bin_3].sum_gradients += all_gradients[i + 3]
 
-        out.at(feature_idx, bin_0).count += 1
-        out.at(feature_idx, bin_1).count += 1
-        out.at(feature_idx, bin_2).count += 1
-        out.at(feature_idx, bin_3).count += 1
+        hist[bin_0].count += 1
+        hist[bin_1].count += 1
+        hist[bin_2].count += 1
+        hist[bin_3].count += 1
 
     for i in range(unrolled_upper, n_samples):
         bin_idx = binned_feature[i]
-        out.at(feature_idx, bin_idx).sum_gradients += all_gradients[i]
-        out.at(feature_idx, bin_idx).count += 1
+        hist[bin_idx].sum_gradients += all_gradients[i]
+        hist[bin_idx].count += 1

--- a/sklearn/ensemble/_hist_gradient_boosting/predictor.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/predictor.py
@@ -77,17 +77,17 @@ class TreePredictor:
         )
         return out
 
-    def predict_binned(self, X, missing_values_bin_idx, n_threads):
+    def predict_binned(self, X, n_bins_non_missing, n_threads):
         """Predict raw values for binned data.
 
         Parameters
         ----------
         X : ndarray, shape (n_samples, n_features)
             The input samples.
-        missing_values_bin_idx : uint8
-            Index of the bin that is used for missing values. This is the
-            index of the last bin and is always equal to max_bins (as passed
-            to the GBDT classes), or equivalently to n_bins - 1.
+        n_bins_non_missing : ndarray of shape (n_features,), dtype=np.uint16
+            For each feature, gives the number of bins actually used for non-missing
+            values. The index of the bin where missing values are mapped is always
+            given by the last bin, i.e. bin index ``n_bins_non_missing``.
         n_threads : int
             Number of OpenMP threads to use.
 
@@ -101,7 +101,7 @@ class TreePredictor:
             self.nodes,
             X,
             self.binned_left_cat_bitsets,
-            missing_values_bin_idx,
+            n_bins_non_missing,
             n_threads,
             out,
         )

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -21,6 +21,7 @@ from .common cimport BITSET_INNER_DTYPE_C
 from .common cimport BITSET_DTYPE_C
 from .common cimport MonotonicConstraint
 from .common cimport Histograms
+from .common cimport hist_struct
 from ._bitset cimport init_bitset
 from ._bitset cimport set_bitset
 from ._bitset cimport in_bitset
@@ -668,23 +669,24 @@ cdef class Splitter:
             unsigned int best_n_samples_left
             Y_DTYPE_C best_gain = -1
 
+            hist_struct * hist = histograms.at(feature_idx, 0)
+
         sum_gradient_left, sum_hessian_left = 0., 0.
         n_samples_left = 0
 
         loss_current_node = _loss_from_value(value, sum_gradients)
 
         for bin_idx in range(end):
-            n_samples_left += histograms.at(feature_idx, bin_idx).count
+            n_samples_left += hist[bin_idx].count
             n_samples_right = n_samples_ - n_samples_left
 
             if self.hessians_are_constant:
-                sum_hessian_left += histograms.at(feature_idx, bin_idx).count
+                sum_hessian_left += hist[bin_idx].count
             else:
-                sum_hessian_left += \
-                    histograms.at(feature_idx, bin_idx).sum_hessians
+                sum_hessian_left += hist[bin_idx].sum_hessians
             sum_hessian_right = sum_hessians - sum_hessian_left
 
-            sum_gradient_left += histograms.at(feature_idx, bin_idx).sum_gradients
+            sum_gradient_left += hist[bin_idx].sum_gradients
             sum_gradient_right = sum_gradients - sum_gradient_left
 
             if n_samples_left < self.min_samples_leaf:
@@ -781,24 +783,24 @@ cdef class Splitter:
             unsigned int best_n_samples_left
             Y_DTYPE_C best_gain = split_info.gain  # computed during previous scan
 
+            hist_struct * hist = histograms.at(feature_idx, 0)
+
         sum_gradient_right, sum_hessian_right = 0., 0.
         n_samples_right = 0
 
         loss_current_node = _loss_from_value(value, sum_gradients)
 
         for bin_idx in range(start, -1, -1):
-            n_samples_right += histograms.at(feature_idx, bin_idx + 1).count
+            n_samples_right += hist[bin_idx + 1].count
             n_samples_left = n_samples_ - n_samples_right
 
             if self.hessians_are_constant:
-                sum_hessian_right += histograms.at(feature_idx, bin_idx + 1).count
+                sum_hessian_right += hist[bin_idx + 1].count
             else:
-                sum_hessian_right += \
-                    histograms.at(feature_idx, bin_idx + 1).sum_hessians
+                sum_hessian_right += hist[bin_idx + 1].sum_hessians
             sum_hessian_left = sum_hessians - sum_hessian_right
 
-            sum_gradient_right += \
-                histograms.at(feature_idx, bin_idx + 1).sum_gradients
+            sum_gradient_right += hist[bin_idx + 1].sum_gradients
             sum_gradient_left = sum_gradients - sum_gradient_right
 
             if n_samples_right < self.min_samples_leaf:
@@ -883,7 +885,7 @@ cdef class Splitter:
             int best_direction = 0
             unsigned int middle
             unsigned int i
-            # const hist_struct[::1] feature_hist = histograms[feature_idx, :]
+            hist_struct * hist = histograms.at(feature_idx, 0)
             Y_DTYPE_C sum_gradients_bin
             Y_DTYPE_C sum_hessians_bin
             Y_DTYPE_C loss_current_node
@@ -946,15 +948,12 @@ cdef class Splitter:
         # fill cat_infos while filtering out categories based on MIN_CAT_SUPPORT
         for bin_idx in range(n_bins_non_missing):
             if self.hessians_are_constant:
-                # sum_hessians_bin = feature_hist[bin_idx].count
-                sum_hessians_bin = histograms.at(feature_idx, bin_idx).count
+                sum_hessians_bin = hist[bin_idx].count
             else:
-                # sum_hessians_bin = feature_hist[bin_idx].sum_hessians
-                sum_hessians_bin = histograms.at(feature_idx, bin_idx).sum_hessians
+                sum_hessians_bin = hist[bin_idx].sum_hessians
             if sum_hessians_bin * support_factor >= MIN_CAT_SUPPORT:
                 cat_infos[n_used_bins].bin_idx = bin_idx
-                # sum_gradients_bin = feature_hist[bin_idx].sum_gradients
-                sum_gradients_bin = histograms.at(feature_idx, bin_idx).sum_gradients
+                sum_gradients_bin = hist[bin_idx].sum_gradients
 
                 cat_infos[n_used_bins].value = (
                     sum_gradients_bin / (sum_hessians_bin + MIN_CAT_SUPPORT)
@@ -964,19 +963,12 @@ cdef class Splitter:
         # Also add missing values bin so that nans are considered as a category
         if has_missing_values:
             if self.hessians_are_constant:
-                # sum_hessians_bin = feature_hist[missing_values_bin_idx].count
-                sum_hessians_bin = histograms.at(feature_idx, missing_values_bin_idx).count
+                sum_hessians_bin = hist[missing_values_bin_idx].count
             else:
-                # sum_hessians_bin = feature_hist[missing_values_bin_idx].sum_hessians
-                sum_hessians_bin = histograms.at(feature_idx, missing_values_bin_idx).sum_hessians
+                sum_hessians_bin = hist[missing_values_bin_idx].sum_hessians
             if sum_hessians_bin * support_factor >= MIN_CAT_SUPPORT:
                 cat_infos[n_used_bins].bin_idx = missing_values_bin_idx
-                # sum_gradients_bin = (
-                #     feature_hist[missing_values_bin_idx].sum_gradients
-                # )
-                sum_gradients_bin = (
-                    histograms.at(feature_idx, missing_values_bin_idx).sum_gradients
-                )
+                sum_gradients_bin = hist[missing_values_bin_idx].sum_gradients
 
                 cat_infos[n_used_bins].value = (
                     sum_gradients_bin / (sum_hessians_bin + MIN_CAT_SUPPORT)
@@ -1008,20 +1000,16 @@ cdef class Splitter:
                 sorted_cat_idx = i if direction == 1 else n_used_bins - 1 - i
                 bin_idx = cat_infos[sorted_cat_idx].bin_idx
 
-                # n_samples_left += feature_hist[bin_idx].count
-                n_samples_left += histograms.at(feature_idx, bin_idx).count
+                n_samples_left += hist[bin_idx].count
                 n_samples_right = n_samples - n_samples_left
 
                 if self.hessians_are_constant:
-                    # sum_hessian_left += feature_hist[bin_idx].count
-                    sum_hessian_left += histograms.at(feature_idx, bin_idx).count
+                    sum_hessian_left += hist[bin_idx].count
                 else:
-                    # sum_hessian_left += feature_hist[bin_idx].sum_hessians
-                    sum_hessian_left += histograms.at(feature_idx, bin_idx).sum_hessians
+                    sum_hessian_left += hist[bin_idx].sum_hessians
                 sum_hessian_right = sum_hessians - sum_hessian_left
 
-                # sum_gradient_left += feature_hist[bin_idx].sum_gradients
-                sum_gradient_left += histograms.at(feature_idx, bin_idx).sum_gradients
+                sum_gradient_left += hist[bin_idx].sum_gradients
                 sum_gradient_right = sum_gradients - sum_gradient_left
 
                 if (

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -25,6 +25,7 @@ from .common cimport hist_struct
 from ._bitset cimport init_bitset
 from ._bitset cimport set_bitset
 from ._bitset cimport in_bitset
+from ...utils._typedefs cimport uint16_t
 
 cnp.import_array()
 
@@ -127,13 +128,9 @@ cdef class Splitter:
     ----------
     X_binned : ndarray of int, shape (n_samples, n_features)
         The binned input samples. Must be Fortran-aligned.
-    n_bins_non_missing : ndarray, shape (n_features,)
+    n_bins_non_missing : ndarray of shape (n_features,), dtype=np.uint16
         For each feature, gives the number of bins actually used for
         non-missing values.
-    missing_values_bin_idx : uint8
-        Index of the bin that is used for missing values. This is the index of
-        the last bin and is always equal to max_bins (as passed to the GBDT
-        classes), or equivalently to n_bins - 1.
     has_missing_values : ndarray, shape (n_features,)
         Whether missing values were observed in the training data, for each
         feature.
@@ -170,8 +167,7 @@ cdef class Splitter:
     cdef public:
         const X_BINNED_DTYPE_C [::1, :] X_binned
         unsigned int n_features
-        const unsigned int [::1] n_bins_non_missing
-        unsigned char missing_values_bin_idx
+        const uint16_t [::1] n_bins_non_missing
         const unsigned char [::1] has_missing_values
         const unsigned char [::1] is_categorical
         const signed char [::1] monotonic_cst
@@ -190,8 +186,7 @@ cdef class Splitter:
 
     def __init__(self,
                  const X_BINNED_DTYPE_C [::1, :] X_binned,
-                 const unsigned int [::1] n_bins_non_missing,
-                 const unsigned char missing_values_bin_idx,
+                 const uint16_t [::1] n_bins_non_missing,
                  const unsigned char [::1] has_missing_values,
                  const unsigned char [::1] is_categorical,
                  const signed char [::1] monotonic_cst,
@@ -207,7 +202,6 @@ cdef class Splitter:
         self.X_binned = X_binned
         self.n_features = X_binned.shape[1]
         self.n_bins_non_missing = n_bins_non_missing
-        self.missing_values_bin_idx = missing_values_bin_idx
         self.has_missing_values = has_missing_values
         self.is_categorical = is_categorical
         self.monotonic_cst = monotonic_cst
@@ -309,10 +303,10 @@ cdef class Splitter:
 
         cdef:
             int n_samples = sample_indices.shape[0]
+            int feature_idx = split_info.feature_idx
             X_BINNED_DTYPE_C bin_idx = split_info.bin_idx
             unsigned char missing_go_to_left = split_info.missing_go_to_left
-            unsigned char missing_values_bin_idx = self.missing_values_bin_idx
-            int feature_idx = split_info.feature_idx
+            uint16_t missing_values_bin_idx = self.n_bins_non_missing[feature_idx]
             const X_BINNED_DTYPE_C [::1] X_binned = \
                 self.X_binned[:, feature_idx]
             unsigned int [::1] left_indices_buffer = self.left_indices_buffer
@@ -653,8 +647,9 @@ cdef class Splitter:
             # bin never goes to the left child (which would result in and
             # empty right child), unless there are missing values, since these
             # would go to the right child.
-            unsigned int end = \
+            uint16_t end = (
                 self.n_bins_non_missing[feature_idx] - 1 + has_missing_values
+            )
             Y_DTYPE_C sum_hessian_left
             Y_DTYPE_C sum_hessian_right
             Y_DTYPE_C sum_gradient_left
@@ -774,7 +769,7 @@ cdef class Splitter:
             Y_DTYPE_C sum_gradient_right
             Y_DTYPE_C loss_current_node
             Y_DTYPE_C gain
-            unsigned int start = self.n_bins_non_missing[feature_idx] - 2
+            uint16_t start = self.n_bins_non_missing[feature_idx] - 2
             unsigned char found_better_split = False
 
             Y_DTYPE_C best_sum_hessian_left
@@ -875,8 +870,8 @@ cdef class Splitter:
 
         cdef:
             unsigned int bin_idx
-            unsigned int n_bins_non_missing = self.n_bins_non_missing[feature_idx]
-            unsigned int missing_values_bin_idx = self.missing_values_bin_idx
+            uint16_t n_bins_non_missing = self.n_bins_non_missing[feature_idx]
+            uint16_t missing_values_bin_idx = n_bins_non_missing
             categorical_info * cat_infos
             unsigned int sorted_cat_idx
             unsigned int n_used_bins = 0
@@ -1143,7 +1138,7 @@ cdef inline Y_DTYPE_C _loss_from_value(
 
 cdef inline unsigned char sample_goes_left(
         unsigned char missing_go_to_left,
-        unsigned char missing_values_bin_idx,
+        uint16_t missing_values_bin_idx,
         X_BINNED_DTYPE_C split_bin_idx,
         X_BINNED_DTYPE_C bin_value,
         unsigned char is_categorical,

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -643,6 +643,7 @@ cdef class Splitter:
             unsigned int n_samples_left
             unsigned int n_samples_right
             unsigned int n_samples_ = n_samples
+            unsigned int count
             # We set the 'end' variable such that the last non-missing-values
             # bin never goes to the left child (which would result in and
             # empty right child), unless there are missing values, since these
@@ -672,11 +673,16 @@ cdef class Splitter:
         loss_current_node = _loss_from_value(value, sum_gradients)
 
         for bin_idx in range(end):
-            n_samples_left += hist[bin_idx].count
+            count = hist[bin_idx].count
+            n_samples_left += count
             n_samples_right = n_samples_ - n_samples_left
 
-            if self.hessians_are_constant:
-                sum_hessian_left += hist[bin_idx].count
+            if count == 0:
+                # Can only happen for empty bins, i.e., if not the full X_binned
+                # was passed for growing trees.
+                continue
+            elif self.hessians_are_constant:
+                sum_hessian_left += count
             else:
                 sum_hessian_left += hist[bin_idx].sum_hessians
             sum_hessian_right = sum_hessians - sum_hessian_left
@@ -763,6 +769,7 @@ cdef class Splitter:
             unsigned int n_samples_left
             unsigned int n_samples_right
             unsigned int n_samples_ = n_samples
+            unsigned int count
             Y_DTYPE_C sum_hessian_left
             Y_DTYPE_C sum_hessian_right
             Y_DTYPE_C sum_gradient_left
@@ -786,11 +793,16 @@ cdef class Splitter:
         loss_current_node = _loss_from_value(value, sum_gradients)
 
         for bin_idx in range(start, -1, -1):
-            n_samples_right += hist[bin_idx + 1].count
+            count = hist[bin_idx + 1].count
+            n_samples_right += count
             n_samples_left = n_samples_ - n_samples_right
 
-            if self.hessians_are_constant:
-                sum_hessian_right += hist[bin_idx + 1].count
+            if count == 0:
+                # Can only happen for empty bins, i.e., if not the full X_binned
+                # was passed for growing trees.
+                continue
+            elif self.hessians_are_constant:
+                sum_hessian_right += count
             else:
                 sum_hessian_right += hist[bin_idx + 1].sum_hessians
             sum_hessian_left = sum_hessians - sum_hessian_right

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -431,7 +431,6 @@ cdef class Splitter:
             const Y_DTYPE_C lower_bound=-INFINITY,
             const Y_DTYPE_C upper_bound=INFINITY,
             const unsigned int [:] allowed_features=None,
-            unsigned char debug=False,
             ):
         """For each feature, find the best bin to split on at a given node.
 
@@ -560,9 +559,7 @@ cdef class Splitter:
                         feature_idx, has_missing_values[feature_idx],
                         histograms, n_samples, sum_gradients, sum_hessians,
                         value, monotonic_cst[feature_idx],
-                        lower_bound, upper_bound, &split_infos[split_info_idx],
-                        debug=debug,
-                    )
+                        lower_bound, upper_bound, &split_infos[split_info_idx])
 
                     if has_missing_values[feature_idx]:
                         # We need to explore both directions to check whether
@@ -572,9 +569,7 @@ cdef class Splitter:
                             feature_idx, histograms, n_samples,
                             sum_gradients, sum_hessians,
                             value, monotonic_cst[feature_idx],
-                            lower_bound, upper_bound, &split_infos[split_info_idx],
-                            debug=debug,
-                        )
+                            lower_bound, upper_bound, &split_infos[split_info_idx])
 
             # then compute best possible split among all features
             # split_info is set to the best of split_infos
@@ -633,9 +628,7 @@ cdef class Splitter:
             signed char monotonic_cst,
             Y_DTYPE_C lower_bound,
             Y_DTYPE_C upper_bound,
-            split_info_struct * split_info,
-            unsigned char debug=False,
-    ) noexcept nogil:  # OUT
+            split_info_struct * split_info) noexcept nogil:  # OUT
         """Find best bin to split on for a given feature.
 
         Splits that do not satisfy the splitting constraints
@@ -711,9 +704,6 @@ cdef class Splitter:
                                upper_bound,
                                self.l2_regularization)
 
-            if debug:
-                with gil:
-                    print(f"_find_best_bin_to_split_left_to_right \ngain > best_gain: {gain=} > {best_gain} {gain > best_gain} at {bin_idx=}", flush=True)
             if gain > best_gain and gain > self.min_gain_to_split:
                 found_better_split = True
                 best_gain = gain
@@ -754,9 +744,7 @@ cdef class Splitter:
             signed char monotonic_cst,
             Y_DTYPE_C lower_bound,
             Y_DTYPE_C upper_bound,
-            split_info_struct * split_info,
-            unsigned char debug=False,
-    ) noexcept nogil:  # OUT
+            split_info_struct * split_info) noexcept nogil:  # OUT
         """Find best bin to split on for a given feature.
 
         Splits that do not satisfy the splitting constraints
@@ -830,9 +818,6 @@ cdef class Splitter:
                                upper_bound,
                                self.l2_regularization)
 
-            if debug:
-                with gil:
-                    print(f"_find_best_bin_to_split_right_to_left \ngain > best_gain: {gain=} > {best_gain} {gain > best_gain} at {bin_idx=}", flush=True)
             if gain > best_gain and gain > self.min_gain_to_split:
                 found_better_split = True
                 best_gain = gain

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -431,6 +431,7 @@ cdef class Splitter:
             const Y_DTYPE_C lower_bound=-INFINITY,
             const Y_DTYPE_C upper_bound=INFINITY,
             const unsigned int [:] allowed_features=None,
+            unsigned char debug=False,
             ):
         """For each feature, find the best bin to split on at a given node.
 
@@ -559,7 +560,9 @@ cdef class Splitter:
                         feature_idx, has_missing_values[feature_idx],
                         histograms, n_samples, sum_gradients, sum_hessians,
                         value, monotonic_cst[feature_idx],
-                        lower_bound, upper_bound, &split_infos[split_info_idx])
+                        lower_bound, upper_bound, &split_infos[split_info_idx],
+                        debug=debug,
+                    )
 
                     if has_missing_values[feature_idx]:
                         # We need to explore both directions to check whether
@@ -569,7 +572,9 @@ cdef class Splitter:
                             feature_idx, histograms, n_samples,
                             sum_gradients, sum_hessians,
                             value, monotonic_cst[feature_idx],
-                            lower_bound, upper_bound, &split_infos[split_info_idx])
+                            lower_bound, upper_bound, &split_infos[split_info_idx],
+                            debug=debug,
+                        )
 
             # then compute best possible split among all features
             # split_info is set to the best of split_infos
@@ -628,7 +633,9 @@ cdef class Splitter:
             signed char monotonic_cst,
             Y_DTYPE_C lower_bound,
             Y_DTYPE_C upper_bound,
-            split_info_struct * split_info) noexcept nogil:  # OUT
+            split_info_struct * split_info,
+            unsigned char debug=False,
+    ) noexcept nogil:  # OUT
         """Find best bin to split on for a given feature.
 
         Splits that do not satisfy the splitting constraints
@@ -704,6 +711,9 @@ cdef class Splitter:
                                upper_bound,
                                self.l2_regularization)
 
+            if debug:
+                with gil:
+                    print(f"_find_best_bin_to_split_left_to_right \ngain > best_gain: {gain=} > {best_gain} {gain > best_gain} at {bin_idx=}", flush=True)
             if gain > best_gain and gain > self.min_gain_to_split:
                 found_better_split = True
                 best_gain = gain
@@ -744,7 +754,9 @@ cdef class Splitter:
             signed char monotonic_cst,
             Y_DTYPE_C lower_bound,
             Y_DTYPE_C upper_bound,
-            split_info_struct * split_info) noexcept nogil:  # OUT
+            split_info_struct * split_info,
+            unsigned char debug=False,
+    ) noexcept nogil:  # OUT
         """Find best bin to split on for a given feature.
 
         Splits that do not satisfy the splitting constraints
@@ -818,6 +830,9 @@ cdef class Splitter:
                                upper_bound,
                                self.l2_regularization)
 
+            if debug:
+                with gil:
+                    print(f"_find_best_bin_to_split_right_to_left \ngain > best_gain: {gain=} > {best_gain} {gain > best_gain} at {bin_idx=}", flush=True)
             if gain > best_gain and gain > self.min_gain_to_split:
                 found_better_split = True
                 best_gain = gain

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -818,7 +818,7 @@ def test_sum_hessians_are_sample_weight(Loss):
 
     for feature_idx in range(n_features):
         for bin_idx in range(bin_mapper.n_bins):
-            assert histograms[feature_idx, bin_idx]["sum_hessians"] == (
+            assert histograms.value_at(feature_idx, bin_idx)["sum_hessians"] == (
                 pytest.approx(sum_sw[feature_idx, bin_idx], rel=1e-5)
             )
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
@@ -359,20 +359,18 @@ def test_bounded_value_min_gain_to_split():
     builder = HistogramBuilder(
         X_binned, n_bins, all_gradients, all_hessians, hessians_are_constant, n_threads
     )
-    n_bins_non_missing = np.array([n_bins - 1] * X_binned.shape[1], dtype=np.uint32)
+    n_bins_non_missing = np.array([n_bins - 1] * X_binned.shape[1], dtype=np.uint16)
     has_missing_values = np.array([False] * X_binned.shape[1], dtype=np.uint8)
     monotonic_cst = np.array(
         [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
     )
     is_categorical = np.zeros_like(monotonic_cst, dtype=np.uint8)
-    missing_values_bin_idx = n_bins - 1
     children_lower_bound, children_upper_bound = -np.inf, np.inf
 
     min_gain_to_split = 2000
     splitter = Splitter(
         X_binned,
         n_bins_non_missing,
-        missing_values_bin_idx,
         has_missing_values,
         is_categorical,
         monotonic_cst,

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
@@ -154,8 +154,9 @@ def test_categorical_predictor(bins_go_left, expected_predictions):
     predictor = TreePredictor(nodes, binned_cat_bitsets, raw_categorical_bitsets)
 
     # Check binned data gives correct predictions
+    n_bins_non_missing = np.array([6], dtype=np.uint16)
     prediction_binned = predictor.predict_binned(
-        X_binned, missing_values_bin_idx=6, n_threads=n_threads
+        X_binned, n_bins_non_missing=n_bins_non_missing, n_threads=n_threads
     )
     assert_allclose(prediction_binned, expected_predictions)
 
@@ -173,7 +174,7 @@ def test_categorical_predictor(bins_go_left, expected_predictions):
     # Check missing goes left because missing_values_bin_idx=6
     X_binned_missing = np.array([[6]], dtype=X_BINNED_DTYPE).T
     predictions = predictor.predict_binned(
-        X_binned_missing, missing_values_bin_idx=6, n_threads=n_threads
+        X_binned_missing, n_bins_non_missing=n_bins_non_missing, n_threads=n_threads
     )
     assert_allclose(predictions, [1])
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
@@ -532,15 +532,12 @@ def test_splitting_missing_values(
     )
 
     histograms = builder.compute_histograms_brute(sample_indices)
-    print("DEBUG info")
-    print(f" histogram of feature 0 = {histograms.feature_histo(0)}")
     value = compute_node_value(
         sum_gradients, sum_hessians, -np.inf, np.inf, l2_regularization
     )
     split_info = splitter.find_node_split(
-        n_samples, histograms, sum_gradients, sum_hessians, value, debug=True
+        n_samples, histograms, sum_gradients, sum_hessians, value
     )
-    print(f"{value=} {sum_gradients=} {sum_hessians=}")
 
     assert split_info.bin_idx == expected_bin_idx
     if has_missing_values:

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
@@ -4,7 +4,6 @@ from numpy.testing import assert_array_equal
 
 from sklearn.ensemble._hist_gradient_boosting.common import (
     G_H_DTYPE,
-    HISTOGRAM_DTYPE,
     X_BINNED_DTYPE,
     MonotonicConstraint,
 )
@@ -215,9 +214,6 @@ def test_gradient_and_hessian_sanity(constant_hessian):
 
     # make sure sum of gradients in histograms are the same for all features,
     # and make sure they're equal to their expected value
-    hists_parent = np.asarray(hists_parent, dtype=HISTOGRAM_DTYPE)
-    hists_left = np.asarray(hists_left, dtype=HISTOGRAM_DTYPE)
-    hists_right = np.asarray(hists_right, dtype=HISTOGRAM_DTYPE)
     for hists, indices in (
         (hists_parent, sample_indices),
         (hists_left, sample_indices_left),
@@ -226,9 +222,11 @@ def test_gradient_and_hessian_sanity(constant_hessian):
         # note: gradients and hessians have shape (n_features,),
         # we're comparing them to *scalars*. This has the benefit of also
         # making sure that all the entries are equal across features.
-        gradients = hists["sum_gradients"].sum(axis=1)  # shape = (n_features,)
+        # gradients = hists["sum_gradients"].sum(axis=1)  # shape = (n_features,)
+        gradients = hists.feature_sum("sum_gradients")
         expected_gradient = all_gradients[indices].sum()  # scalar
-        hessians = hists["sum_hessians"].sum(axis=1)
+        # hessians = hists["sum_hessians"].sum(axis=1)
+        hessians = hists.feature_sum("sum_hessians")
         if constant_hessian:
             # 0 is not the actual hessian, but it's not computed in this case
             expected_hessian = 0.0

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
@@ -532,12 +532,15 @@ def test_splitting_missing_values(
     )
 
     histograms = builder.compute_histograms_brute(sample_indices)
+    print("DEBUG info")
+    print(f" histogram of feature 0 = {histograms.feature_histo(0)}")
     value = compute_node_value(
         sum_gradients, sum_hessians, -np.inf, np.inf, l2_regularization
     )
     split_info = splitter.find_node_split(
-        n_samples, histograms, sum_gradients, sum_hessians, value
+        n_samples, histograms, sum_gradients, sum_hessians, value, debug=True
     )
+    print(f"{value=} {sum_gradients=} {sum_hessians=}")
 
     assert split_info.bin_idx == expected_bin_idx
     if has_missing_values:

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
@@ -52,26 +52,24 @@ def test_histogram_split(n_bins):
                 n_threads,
             )
             n_bins_non_missing = np.array(
-                [n_bins - 1] * X_binned.shape[1], dtype=np.uint32
+                [n_bins - 1] * X_binned.shape[1], dtype=np.uint16
             )
             has_missing_values = np.array([False] * X_binned.shape[1], dtype=np.uint8)
             monotonic_cst = np.array(
                 [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
             )
             is_categorical = np.zeros_like(monotonic_cst, dtype=np.uint8)
-            missing_values_bin_idx = n_bins - 1
             splitter = Splitter(
-                X_binned,
-                n_bins_non_missing,
-                missing_values_bin_idx,
-                has_missing_values,
-                is_categorical,
-                monotonic_cst,
-                l2_regularization,
-                min_hessian_to_split,
-                min_samples_leaf,
-                min_gain_to_split,
-                hessians_are_constant,
+                X_binned=X_binned,
+                n_bins_non_missing=n_bins_non_missing,
+                has_missing_values=has_missing_values,
+                is_categorical=is_categorical,
+                monotonic_cst=monotonic_cst,
+                l2_regularization=l2_regularization,
+                min_hessian_to_split=min_hessian_to_split,
+                min_samples_leaf=min_samples_leaf,
+                min_gain_to_split=min_gain_to_split,
+                hessians_are_constant=hessians_are_constant,
             )
 
             histograms = builder.compute_histograms_brute(sample_indices)
@@ -131,17 +129,15 @@ def test_gradient_and_hessian_sanity(constant_hessian):
     builder = HistogramBuilder(
         X_binned, n_bins, all_gradients, all_hessians, constant_hessian, n_threads
     )
-    n_bins_non_missing = np.array([n_bins - 1] * X_binned.shape[1], dtype=np.uint32)
+    n_bins_non_missing = np.array([n_bins - 1] * X_binned.shape[1], dtype=np.uint16)
     has_missing_values = np.array([False] * X_binned.shape[1], dtype=np.uint8)
     monotonic_cst = np.array(
         [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
     )
     is_categorical = np.zeros_like(monotonic_cst, dtype=np.uint8)
-    missing_values_bin_idx = n_bins - 1
     splitter = Splitter(
         X_binned,
         n_bins_non_missing,
-        missing_values_bin_idx,
         has_missing_values,
         is_categorical,
         monotonic_cst,
@@ -273,17 +269,15 @@ def test_split_indices():
     builder = HistogramBuilder(
         X_binned, n_bins, all_gradients, all_hessians, hessians_are_constant, n_threads
     )
-    n_bins_non_missing = np.array([n_bins] * X_binned.shape[1], dtype=np.uint32)
+    n_bins_non_missing = np.array([n_bins] * X_binned.shape[1], dtype=np.uint16)
     has_missing_values = np.array([False] * X_binned.shape[1], dtype=np.uint8)
     monotonic_cst = np.array(
         [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
     )
     is_categorical = np.zeros_like(monotonic_cst, dtype=np.uint8)
-    missing_values_bin_idx = n_bins - 1
     splitter = Splitter(
         X_binned,
         n_bins_non_missing,
-        missing_values_bin_idx,
         has_missing_values,
         is_categorical,
         monotonic_cst,
@@ -349,17 +343,15 @@ def test_min_gain_to_split():
     builder = HistogramBuilder(
         X_binned, n_bins, all_gradients, all_hessians, hessians_are_constant, n_threads
     )
-    n_bins_non_missing = np.array([n_bins - 1] * X_binned.shape[1], dtype=np.uint32)
+    n_bins_non_missing = np.array([n_bins - 1] * X_binned.shape[1], dtype=np.uint16)
     has_missing_values = np.array([False] * X_binned.shape[1], dtype=np.uint8)
     monotonic_cst = np.array(
         [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
     )
     is_categorical = np.zeros_like(monotonic_cst, dtype=np.uint8)
-    missing_values_bin_idx = n_bins - 1
     splitter = Splitter(
         X_binned,
         n_bins_non_missing,
-        missing_values_bin_idx,
         has_missing_values,
         is_categorical,
         monotonic_cst,
@@ -392,7 +384,7 @@ def test_min_gain_to_split():
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],  # X_binned
             [1, 1, 1, 1, 5, 5, 5, 5, 5, 5],  # gradients
             False,  # no missing values
-            10,  # n_bins_non_missing
+            10,  # n_bins_non_missing = index of missing value bin
             False,  # don't split on nans
             3,  # expected_bin_idx
             "not_applicable",
@@ -404,7 +396,7 @@ def test_min_gain_to_split():
         (
             [8, 0, 1, 8, 2, 3, 4, 5, 6, 7],  # 8 <=> missing
             [1, 1, 1, 1, 5, 5, 5, 5, 5, 5],
-            True,  # missing values
+            True,  # missing values = index of missing value bin
             8,  # n_bins_non_missing
             False,  # don't split on nans
             1,  # cut on bin_idx=1
@@ -415,7 +407,7 @@ def test_min_gain_to_split():
             [9, 0, 1, 9, 2, 3, 4, 5, 6, 7],  # 9 <=> missing
             [1, 1, 1, 1, 5, 5, 5, 5, 5, 5],
             True,  # missing values
-            8,  # n_bins_non_missing
+            9,  # n_bins_non_missing = index of missing value bin
             False,  # don't split on nans
             1,  # cut on bin_idx=1
             True,
@@ -425,7 +417,7 @@ def test_min_gain_to_split():
             [0, 1, 2, 3, 8, 4, 8, 5, 6, 7],  # 8 <=> missing
             [1, 1, 1, 1, 5, 5, 5, 5, 5, 5],
             True,  # missing values
-            8,  # n_bins_non_missing
+            8,  # n_bins_non_missing = index of missing value bin
             False,  # don't split on nans
             3,  # cut on bin_idx=3 (like in first case)
             False,
@@ -435,7 +427,7 @@ def test_min_gain_to_split():
             [0, 1, 2, 3, 9, 4, 9, 5, 6, 7],  # 9 <=> missing
             [1, 1, 1, 1, 5, 5, 5, 5, 5, 5],
             True,  # missing values
-            8,  # n_bins_non_missing
+            8,  # n_bins_non_missing = index of missing value bin
             False,  # don't split on nans
             3,  # cut on bin_idx=3 (like in first case)
             False,
@@ -446,7 +438,7 @@ def test_min_gain_to_split():
             [0, 1, 2, 3, 4, 4, 4, 4, 4, 4],  # 4 <=> missing
             [1, 1, 1, 1, 5, 5, 5, 5, 5, 5],
             True,  # missing values
-            4,  # n_bins_non_missing
+            4,  # n_bins_non_missing = index of missing value bin
             True,  # split on nans
             3,  # cut on bin_idx=3
             False,
@@ -456,7 +448,7 @@ def test_min_gain_to_split():
             [0, 1, 2, 3, 9, 9, 9, 9, 9, 9],  # 9 <=> missing
             [1, 1, 1, 1, 1, 1, 5, 5, 5, 5],
             True,  # missing values
-            4,  # n_bins_non_missing
+            9,  # n_bins_non_missing = index of missing value bin
             True,  # split on nans
             3,  # cut on bin_idx=3
             False,
@@ -465,7 +457,7 @@ def test_min_gain_to_split():
             [6, 6, 6, 6, 0, 1, 2, 3, 4, 5],  # 6 <=> missing
             [1, 1, 1, 1, 5, 5, 5, 5, 5, 5],
             True,  # missing values
-            6,  # n_bins_non_missing
+            6,  # n_bins_non_missing = index of missing value bin
             True,  # split on nans
             5,  # cut on bin_idx=5
             False,
@@ -475,7 +467,7 @@ def test_min_gain_to_split():
             [9, 9, 9, 9, 0, 1, 2, 3, 4, 5],  # 9 <=> missing
             [1, 1, 1, 1, 5, 5, 5, 5, 5, 5],
             True,  # missing values
-            6,  # n_bins_non_missing
+            9,  # n_bins_non_missing = index of missing value bin
             True,  # split on nans
             5,  # cut on bin_idx=5
             False,
@@ -521,16 +513,14 @@ def test_splitting_missing_values(
         X_binned, n_bins, all_gradients, all_hessians, hessians_are_constant, n_threads
     )
 
-    n_bins_non_missing = np.array([n_bins_non_missing], dtype=np.uint32)
+    n_bins_non_missing = np.array([n_bins_non_missing], dtype=np.uint16)
     monotonic_cst = np.array(
         [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
     )
     is_categorical = np.zeros_like(monotonic_cst, dtype=np.uint8)
-    missing_values_bin_idx = n_bins - 1
     splitter = Splitter(
         X_binned,
         n_bins_non_missing,
-        missing_values_bin_idx,
         has_missing_values,
         is_categorical,
         monotonic_cst,
@@ -553,7 +543,8 @@ def test_splitting_missing_values(
     if has_missing_values:
         assert split_info.missing_go_to_left == expected_go_to_left
 
-    split_on_nan = split_info.bin_idx == n_bins_non_missing[0] - 1
+    n_empty_bins = n_bins - len(set(X_binned.flat))
+    split_on_nan = split_info.bin_idx == n_bins_non_missing[0] - 1 - n_empty_bins
     assert split_on_nan == expected_split_on_nan
 
     # Make sure the split is properly computed.
@@ -570,11 +561,12 @@ def test_splitting_missing_values(
     else:
         # When we split on nans, samples with missing values are always mapped
         # to the right child.
+        # Note that missing value bin of feature j = n_bins_non_missing[j]
         missing_samples_indices = np.flatnonzero(
-            np.array(X_binned) == missing_values_bin_idx
+            np.array(X_binned) == n_bins_non_missing
         )
         non_missing_samples_indices = np.flatnonzero(
-            np.array(X_binned) != missing_values_bin_idx
+            np.array(X_binned) != n_bins_non_missing
         )
 
         assert set(samples_right) == set(missing_samples_indices)
@@ -625,17 +617,15 @@ def test_splitting_categorical_cat_smooth(
         X_binned, n_bins, all_gradients, all_hessians, hessians_are_constant, n_threads
     )
 
-    n_bins_non_missing = np.array([n_bins_non_missing], dtype=np.uint32)
+    n_bins_non_missing = np.array([n_bins_non_missing], dtype=np.uint16)
     monotonic_cst = np.array(
         [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
     )
     is_categorical = np.ones_like(monotonic_cst, dtype=np.uint8)
-    missing_values_bin_idx = n_bins - 1
 
     splitter = Splitter(
         X_binned,
         n_bins_non_missing,
-        missing_values_bin_idx,
         has_missing_values,
         is_categorical,
         monotonic_cst,
@@ -676,7 +666,7 @@ def _assert_categories_equals_bitset(categories, bitset):
 @pytest.mark.parametrize(
     (
         "X_binned, all_gradients, expected_categories_left, n_bins_non_missing,"
-        "missing_values_bin_idx, has_missing_values, expected_missing_go_to_left"
+        "has_missing_values, expected_missing_go_to_left"
     ),
     [
         # 4 categories
@@ -684,8 +674,7 @@ def _assert_categories_equals_bitset(categories, bitset):
             [0, 1, 2, 3] * 11,  # X_binned
             [10, 1, 10, 10] * 11,  # all_gradients
             [1],  # expected_categories_left
-            4,  # n_bins_non_missing
-            4,  # missing_values_bin_idx
+            4,  # n_bins_non_missing = index of missing value bin
             False,  # has_missing_values
             None,
         ),  # expected_missing_go_to_left, unchecked
@@ -696,8 +685,7 @@ def _assert_categories_equals_bitset(categories, bitset):
             [0, 1, 2, 3] * 11,  # X_binned
             [10, 10, 10, 1] * 11,  # all_gradients
             [3],  # expected_categories_left
-            4,  # n_bins_non_missing
-            4,  # missing_values_bin_idx
+            4,  # n_bins_non_missing = index of missing value bin
             False,  # has_missing_values
             None,
         ),  # expected_missing_go_to_left, unchecked
@@ -707,8 +695,7 @@ def _assert_categories_equals_bitset(categories, bitset):
             [0, 1, 2, 3] * 11 + [4] * 5,  # X_binned
             [10, 10, 10, 1] * 11 + [10] * 5,  # all_gradients
             [3],  # expected_categories_left
-            4,  # n_bins_non_missing
-            4,  # missing_values_bin_idx
+            4,  # n_bins_non_missing = index of missing value bin
             False,  # has_missing_values
             None,
         ),  # expected_missing_go_to_left, unchecked
@@ -722,28 +709,25 @@ def _assert_categories_equals_bitset(categories, bitset):
             [0, 1, 2, 3] * 11 + [4] * 5,  # X_binned
             [10, 10, 10, 1] * 11 + [1] * 5,  # all_gradients
             [3],  # expected_categories_left
-            4,  # n_bins_non_missing
-            4,  # missing_values_bin_idx
+            4,  # n_bins_non_missing = index of missing value bin
             False,  # has_missing_values
             None,
         ),  # expected_missing_go_to_left, unchecked
         # 4 categories with missing values that go to the right
         (
-            [0, 1, 2] * 11 + [9] * 11,  # X_binned
+            [0, 1, 2] * 11 + [3] * 11,  # X_binned
             [10, 1, 10] * 11 + [10] * 11,  # all_gradients
             [1],  # expected_categories_left
             3,  # n_bins_non_missing
-            9,  # missing_values_bin_idx
             True,  # has_missing_values
             False,
         ),  # expected_missing_go_to_left
         # 4 categories with missing values that go to the left
         (
-            [0, 1, 2] * 11 + [9] * 11,  # X_binned
+            [0, 1, 2] * 11 + [3] * 11,  # X_binned
             [10, 1, 10] * 11 + [1] * 11,  # all_gradients
-            [1, 9],  # expected_categories_left
-            3,  # n_bins_non_missing
-            9,  # missing_values_bin_idx
+            [1, 3],  # expected_categories_left
+            3,  # n_bins_non_missing = index of missing value bin
             True,  # has_missing_values
             True,
         ),  # expected_missing_go_to_left
@@ -752,8 +736,7 @@ def _assert_categories_equals_bitset(categories, bitset):
             [0, 1, 2, 3, 4] * 11 + [255] * 12,  # X_binned
             [10, 10, 10, 10, 10] * 11 + [1] * 12,  # all_gradients
             [255],  # expected_categories_left
-            5,  # n_bins_non_missing
-            255,  # missing_values_bin_idx
+            255,  # n_bins_non_missing = index of missing value bin
             True,  # has_missing_values
             True,
         ),  # expected_missing_go_to_left
@@ -762,8 +745,7 @@ def _assert_categories_equals_bitset(categories, bitset):
             list(range(60)) * 12,  # X_binned
             [10, 1] * 360,  # all_gradients
             list(range(1, 60, 2)),  # expected_categories_left
-            59,  # n_bins_non_missing
-            59,  # missing_values_bin_idx
+            59,  # n_bins_non_missing = index of missing value bin
             True,  # has_missing_values
             True,
         ),  # expected_missing_go_to_left
@@ -772,8 +754,7 @@ def _assert_categories_equals_bitset(categories, bitset):
             list(range(256)) * 12,  # X_binned
             [10, 10, 10, 10, 10, 10, 10, 1] * 384,  # all_gradients
             list(range(7, 256, 8)),  # expected_categories_left
-            255,  # n_bins_non_missing
-            255,  # missing_values_bin_idx
+            255,  # n_bins_non_missing = index of missing value bin
             True,  # has_missing_values
             True,
         ),  # expected_missing_go_to_left
@@ -784,7 +765,6 @@ def test_splitting_categorical_sanity(
     all_gradients,
     expected_categories_left,
     n_bins_non_missing,
-    missing_values_bin_idx,
     has_missing_values,
     expected_missing_go_to_left,
 ):
@@ -813,7 +793,7 @@ def test_splitting_categorical_sanity(
         X_binned, n_bins, all_gradients, all_hessians, hessians_are_constant, n_threads
     )
 
-    n_bins_non_missing = np.array([n_bins_non_missing], dtype=np.uint32)
+    n_bins_non_missing = np.array([n_bins_non_missing], dtype=np.uint16)
     monotonic_cst = np.array(
         [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
     )
@@ -822,7 +802,6 @@ def test_splitting_categorical_sanity(
     splitter = Splitter(
         X_binned,
         n_bins_non_missing,
-        missing_values_bin_idx,
         has_missing_values,
         is_categorical,
         monotonic_cst,
@@ -903,17 +882,15 @@ def test_split_interaction_constraints():
             hessians_are_constant,
             n_threads,
         )
-        n_bins_non_missing = np.array([n_bins] * X_binned.shape[1], dtype=np.uint32)
+        n_bins_non_missing = np.array([n_bins] * X_binned.shape[1], dtype=np.uint16)
         has_missing_values = np.array([False] * X_binned.shape[1], dtype=np.uint8)
         monotonic_cst = np.array(
             [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
         )
         is_categorical = np.zeros_like(monotonic_cst, dtype=np.uint8)
-        missing_values_bin_idx = n_bins - 1
         splitter = Splitter(
             X_binned,
             n_bins_non_missing,
-            missing_values_bin_idx,
             has_missing_values,
             is_categorical,
             monotonic_cst,
@@ -1005,18 +982,16 @@ def test_split_feature_fraction_per_split(forbidden_features):
     value = compute_node_value(
         sum_gradients, sum_hessians, -np.inf, np.inf, l2_regularization
     )
-    n_bins_non_missing = np.array([n_bins] * X_binned.shape[1], dtype=np.uint32)
+    n_bins_non_missing = np.array([n_bins] * X_binned.shape[1], dtype=np.uint16)
     has_missing_values = np.array([False] * X_binned.shape[1], dtype=np.uint8)
     monotonic_cst = np.array(
         [MonotonicConstraint.NO_CST] * X_binned.shape[1], dtype=np.int8
     )
     is_categorical = np.zeros_like(monotonic_cst, dtype=np.uint8)
-    missing_values_bin_idx = n_bins - 1
 
     params = dict(
         X_binned=X_binned,
         n_bins_non_missing=n_bins_non_missing,
-        missing_values_bin_idx=missing_values_bin_idx,
         has_missing_values=has_missing_values,
         is_categorical=is_categorical,
         monotonic_cst=monotonic_cst,

--- a/sklearn/utils/_typedefs.pxd
+++ b/sklearn/utils/_typedefs.pxd
@@ -15,6 +15,7 @@
 # use these consistently throughout the codebase.
 # NOTE: Extend this list as needed when converting more cython extensions.
 ctypedef unsigned char uint8_t
+ctypedef unsigned short uint16_t
 ctypedef unsigned int uint32_t
 ctypedef unsigned long long uint64_t
 ctypedef Py_ssize_t intp_t

--- a/sklearn/utils/_typedefs.pyx
+++ b/sklearn/utils/_typedefs.pyx
@@ -8,6 +8,7 @@ import numpy as np
 
 ctypedef fused testing_type_t:
     uint8_t
+    uint16_t
     uint32_t
     uint64_t
     intp_t


### PR DESCRIPTION
#### Reference Issues/PRs
This PR debugs #28603 which is needed for errors on 32bit platforms (CI).

#### Bug description
This PR confirms that there is bug already with the commits until https://github.com/scikit-learn/scikit-learn/pull/28621/commits/9785084900326d339fa023552de34bd83eb6e825 for Linux_Docker debian_atlas_32bit, see CI run https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=64959&view=logs&j=aabdcdc3-bb64-5414-b357-ed024fe8659e&t=b7b3ba55-d585-563b-a032-f235636c22b0 or https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=65028&view=logs&j=aabdcdc3-bb64-5414-b357-ed024fe8659e:
```python
=================================== FAILURES ===================================
_ test_splitting_missing_values[X_binned8-all_gradients8-True-9-True-5-False] __
# LAST TEST CASE
>       assert split_info.bin_idx == expected_bin_idx
E       assert 8 == 5

/io/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py:542: AssertionError
```

<details>

```
=================================== FAILURES ===================================
_ test_splitting_missing_values[X_binned8-all_gradients8-True-9-True-5-False] __

X_binned = array([[9],
       [9],
       [9],
       [9],
       [0],
       [1],
       [2],
       [3],
       [4],
       [5]], dtype=uint8)
all_gradients = array([1., 1., 1., 1., 5., 5., 5., 5., 5., 5.], dtype=float32)
has_missing_values = array([1], dtype=uint8)
n_bins_non_missing = array([9], dtype=uint16),
expected_split_on_nan = True
expected_bin_idx = 5,
expected_go_to_left = False

    def test_splitting_missing_values(
        X_binned,
        all_gradients,
        has_missing_values,
        n_bins_non_missing,
        expected_split_on_nan,
        expected_bin_idx,
        expected_go_to_left,
    ):
...
>       assert split_info.bin_idx == expected_bin_idx
E       assert 8 == 5
E        +  where 8 = <sklearn.ensemble._hist_gradient_boosting.splitting.SplitInfo object at 0xe28c53b8>.bin_idx

/io/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py:542: AssertionError
```

</details>

**Very oddly, with the DEBUG commit** https://github.com/scikit-learn/scikit-learn/pull/28621/commits/490763a145eeaadf4afdfe7681d0dc4f51c218d1, that only adds print statements (also in Cython), **3 CI runs in a row are all green** (https://github.com/scikit-learn/scikit-learn/runs/22647313519, https://github.com/scikit-learn/scikit-learn/runs/22657509017, https://github.com/scikit-learn/scikit-learn/pull/28621/checks?check_run_id=22662390708)