### PR TITLE
DOC [PST] fix styling/simplify structure of testimonial and about pages

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -13,8 +13,8 @@ this project as part of his thesis.
 In 2010 Fabian Pedregosa, Gael Varoquaux, Alexandre Gramfort and Vincent
 Michel of INRIA took leadership of the project and made the first public
 release, February the 1st 2010. Since then, several releases have appeared
-following a ~ 3-month cycle, and a thriving international community has
-been leading the development.
+following an approximately 3-month cycle, and a thriving international
+community has been leading the development.
 
 Governance
 ----------
@@ -23,31 +23,33 @@ The decision making process and governance structure of scikit-learn is laid
 out in the :ref:`governance document <governance>`.
 
 Authors
--------
+.......
 
 The following people are currently core contributors to scikit-learn's development
 and maintenance:
 
 .. include:: authors.rst
 
-Please do not email the authors directly to ask for assistance or report issues.
-Instead, please see `What's the best way to ask questions about scikit-learn
-<https://scikit-learn.org/stable/faq.html#what-s-the-best-way-to-get-help-on-scikit-learn-usage>`_
-in the FAQ.
+.. note::
+
+  Please do not email the authors directly to ask for assistance or report issues.
+  Instead, please see `What's the best way to ask questions about scikit-learn
+  <https://scikit-learn.org/stable/faq.html#what-s-the-best-way-to-get-help-on-scikit-learn-usage>`_
+  in the FAQ.
 
 .. seealso::
 
-   :ref:`How you can contribute to the project <contributing>`
+  How you can :ref:`contribute to the project <contributing>`.
 
 Documentation Team
-------------------
+..................
 
 The following people help with documenting the project:
 
 .. include:: documentation_team.rst
 
 Contributor Experience Team
----------------------------
+...........................
 
 The following people are active contributors who also help with
 :ref:`triaging issues <bug_triaging>`, PRs, and general
@@ -56,16 +58,15 @@ maintenance:
 .. include:: contributor_experience_team.rst
 
 Communication Team
-------------------
+..................
 
 The following people help with :ref:`communication around scikit-learn
 <communication_team>`.
 
 .. include:: communication_team.rst
 
-
 Emeritus Core Developers
-------------------------
+........................
 
 The following people have been active contributors in the past, but are no
 longer active in the project:
@@ -73,7 +74,7 @@ longer active in the project:
 .. include:: authors_emeritus.rst
 
 Emeritus Communication Team
----------------------------
+...........................
 
 The following people have been active in the communication team in the
 past, but no longer have communication responsibilities:
@@ -81,7 +82,7 @@ past, but no longer have communication responsibilities:
 .. include:: communication_team_emeritus.rst
 
 Emeritus Contributor Experience Team
-------------------------------------
+....................................
 
 The following people have been active in the contributor experience team in the
 past:
@@ -143,462 +144,291 @@ High quality PNG and SVG logos are available in the `doc/logos/
 source directory.
 
 .. image:: images/scikit-learn-logo-notext.png
-   :align: center
+  :align: center
 
 Funding
 -------
-Scikit-Learn is a community driven project, however institutional and private
+
+Scikit-learn is a community driven project, however institutional and private
 grants help to assure its sustainability.
 
 The project would like to thank the following funders.
 
 ...................................
 
+.. div:: sk-text-image-grid-small
 
-.. raw:: html
+  .. div:: text-box
 
-   <div class="sk-sponsor-div">
-   <div class="sk-sponsor-div-box">
+    `:probabl. <https://probabl.ai>`_ funds Adrin Jalali, Arturo Amor, François Goupil,
+    Guillaume Lemaitre, Jérémie du Boisberranger, Olivier Grisel, and Stefanie Senger.
 
-`:probabl. <https://probabl.ai>`_ funds Adrin Jalali, Arturo Amor,
-François Goupil, Guillaume Lemaitre, Jérémie du Boisberranger, Olivier Grisel, and
-Stefanie Senger.
+  .. div:: image-box
 
-.. raw:: html
-
-   </div>
-
-   <div class="sk-sponsor-div-box">
-
-.. image:: images/probabl.png
-   :width: 75pt
-   :align: center
-   :target: https://probabl.ai
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/probabl.png
+      :target: https://probabl.ai
 
 ..........
-
-.. raw:: html
-
-   <div class="sk-sponsor-div">
-   <div class="sk-sponsor-div-box">
-
-The `Members <https://scikit-learn.fondation-inria.fr/en/home/#sponsors>`_ of
-the `Scikit-Learn Consortium at Inria Foundation
-<https://scikit-learn.fondation-inria.fr/en/home/>`_ help at maintaining and
-improving the project through their financial support.
-
-.. raw:: html
-
-   </div>
 
 .. |chanel| image:: images/chanel.png
-   :width: 55pt
-   :target: https://www.chanel.com
+  :target: https://www.chanel.com
 
 .. |axa| image:: images/axa.png
-   :width: 40pt
-   :target: https://www.axa.fr/
+  :target: https://www.axa.fr/
 
 .. |bnp| image:: images/bnp.png
-   :width: 120pt
-   :target: https://www.bnpparibascardif.com/
+  :target: https://www.bnpparibascardif.com/
 
 .. |dataiku| image:: images/dataiku.png
-   :width: 55pt
-   :target: https://www.dataiku.com/
+  :target: https://www.dataiku.com/
 
 .. |hf| image:: images/huggingface_logo-noborder.png
-   :width: 55pt
-   :target: https://huggingface.co
+  :target: https://huggingface.co
 
 .. |nvidia| image:: images/nvidia.png
-   :width: 55pt
-   :target: https://www.nvidia.com
+  :target: https://www.nvidia.com
 
 .. |inria| image:: images/inria-logo.jpg
-   :width: 75pt
-   :target: https://www.inria.fr
-
+  :target: https://www.inria.fr
 
 .. raw:: html
 
-   <div class="sk-sponsor-div-box">
+  <style>
+    table.image-subtable tr {
+      border-color: transparent;
+    }
 
-.. table::
-   :class: sk-sponsor-table
+    table.image-subtable td {
+      width: 50%;
+      vertical-align: middle;
+      text-align: center;
+    }
 
-   +----------+-----------+
-   |       |chanel|       |
-   +----------+-----------+
-   |                      |
-   +----------+-----------+
-   |  |axa|   |    |bnp|  |
-   +----------+-----------+
-   |                      |
-   +----------+-----------+
-   | |nvidia| |    |hf|   |
-   +----------+-----------+
-   |                      |
-   +----------+-----------+
-   |       |dataiku|      |
-   +----------+-----------+
-   |                      |
-   +----------+-----------+
-   |        |inria|       |
-   +----------+-----------+
+    table.image-subtable td img {
+      max-height: 40px !important;
+      max-width: 90% !important;
+    }
+  </style>
 
-.. raw:: html
+.. div:: sk-text-image-grid-small
 
-   </div>
-   </div>
+  .. div:: text-box
+
+    The `Members <https://scikit-learn.fondation-inria.fr/en/home/#sponsors>`_ of
+    the `Scikit-learn Consortium at Inria Foundation
+    <https://scikit-learn.fondation-inria.fr/en/home/>`_ help at maintaining and
+    improving the project through their financial support.
+
+  .. div:: image-box
+
+    .. table::
+      :class: image-subtable
+
+      +----------+-----------+
+      |       |chanel|       |
+      +----------+-----------+
+      |  |axa|   |    |bnp|  |
+      +----------+-----------+
+      | |nvidia| |    |hf|   |
+      +----------+-----------+
+      |       |dataiku|      |
+      +----------+-----------+
+      |        |inria|       |
+      +----------+-----------+
 
 ..........
 
-.. raw:: html
+.. div:: sk-text-image-grid-small
 
-   <div class="sk-sponsor-div">
-   <div class="sk-sponsor-div-box">
+  .. div:: text-box
 
-`NVidia <https://nvidia.com>`_ funds Tim Head since 2022
-and is part of the scikit-learn consortium at Inria.
+    `NVidia <https://nvidia.com>`_ funds Tim Head since 2022
+    and is part of the scikit-learn consortium at Inria.
 
-.. raw:: html
+  .. div:: image-box
 
-   </div>
-
-   <div class="sk-sponsor-div-box">
-
-.. image:: images/nvidia.png
-   :width: 55pt
-   :align: center
-   :target: https://nvidia.com
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/nvidia.png
+      :target: https://nvidia.com
 
 ..........
 
-.. raw:: html
+.. div:: sk-text-image-grid-small
 
-   <div class="sk-sponsor-div">
-   <div class="sk-sponsor-div-box">
+  .. div:: text-box
 
-`Microsoft <https://microsoft.com/>`_ funds Andreas Müller since 2020.
+    `Microsoft <https://microsoft.com/>`_ funds Andreas Müller since 2020.
 
-.. raw:: html
+  .. div:: image-box
 
-   </div>
-
-   <div class="sk-sponsor-div-box">
-
-.. image:: images/microsoft.png
-   :width: 100pt
-   :align: center
-   :target: https://www.microsoft.com/
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/microsoft.png
+      :target: https://microsoft.com
 
 ...........
 
-.. raw:: html
+.. div:: sk-text-image-grid-small
 
-   <div class="sk-sponsor-div">
-   <div class="sk-sponsor-div-box">
+  .. div:: text-box
 
-`Quansight Labs <https://labs.quansight.org>`_ funds Lucy Liu since 2022.
+    `Quansight Labs <https://labs.quansight.org>`_ funds Lucy Liu since 2022.
 
-.. raw:: html
+  .. div:: image-box
 
-   </div>
+    .. image:: images/quansight-labs.png
+      :target: https://labs.quansight.org
 
-   <div class="sk-sponsor-div-box">
+...........
 
-.. image:: images/quansight-labs.png
-   :width: 100pt
-   :align: center
-   :target: https://labs.quansight.org
-
-.. raw:: html
-
-   </div>
-   </div>
 
 Past Sponsors
 .............
 
-.. raw:: html
+.. div:: sk-text-image-grid-small
 
-   <div class="sk-sponsor-div">
-   <div class="sk-sponsor-div-box">
+  .. div:: text-box
 
-`Quansight Labs <https://labs.quansight.org>`_ funded Meekail Zain in 2022 and 2023 and,
-funded Thomas J. Fan from 2021 to 2023.
+    `Quansight Labs <https://labs.quansight.org>`_ funded Meekail Zain in 2022 and 2023,
+    and funded Thomas J. Fan from 2021 to 2023.
 
-.. raw:: html
+  .. div:: image-box
 
-   </div>
-
-   <div class="sk-sponsor-div-box">
-
-.. image:: images/quansight-labs.png
-   :width: 100pt
-   :align: center
-   :target: https://labs.quansight.org
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/quansight-labs.png
+      :target: https://labs.quansight.org
 
 ...........
 
-.. raw:: html
+.. div:: sk-text-image-grid-small
 
-   <div class="sk-sponsor-div">
-   <div class="sk-sponsor-div-box">
+  .. div:: text-box
 
-`Columbia University <https://columbia.edu/>`_ funded Andreas Müller
-(2016-2020).
+    `Columbia University <https://columbia.edu/>`_ funded Andreas Müller
+    (2016-2020).
 
-.. raw:: html
+  .. div:: image-box
 
-   </div>
-
-   <div class="sk-sponsor-div-box">
-
-.. image:: images/columbia.png
-   :width: 50pt
-   :align: center
-   :target: https://www.columbia.edu/
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/columbia.png
+      :target: https://columbia.edu
 
 ........
 
-.. raw:: html
+.. div:: sk-text-image-grid-small
 
-   <div class="sk-sponsor-div">
-   <div class="sk-sponsor-div-box">
+  .. div:: text-box
 
-`The University of Sydney <https://sydney.edu.au/>`_ funded Joel Nothman
-(2017-2021).
+    `The University of Sydney <https://sydney.edu.au/>`_ funded Joel Nothman
+    (2017-2021).
 
-.. raw:: html
+  .. div:: image-box
 
-   </div>
-
-   <div class="sk-sponsor-div-box">
-
-.. image:: images/sydney-primary.jpeg
-   :width: 100pt
-   :align: center
-   :target: https://sydney.edu.au/
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/sydney-primary.jpeg
+      :target: https://sydney.edu.au/
 
 ...........
 
-.. raw:: html
+.. div:: sk-text-image-grid-small
 
-   <div class="sk-sponsor-div">
-   <div class="sk-sponsor-div-box">
+  .. div:: text-box
 
-Andreas Müller received a grant to improve scikit-learn from the
-`Alfred P. Sloan Foundation <https://sloan.org>`_ .
-This grant supported the position of Nicolas Hug and Thomas J. Fan.
+    Andreas Müller received a grant to improve scikit-learn from the
+    `Alfred P. Sloan Foundation <https://sloan.org>`_ .
+    This grant supported the position of Nicolas Hug and Thomas J. Fan.
 
-.. raw:: html
+  .. div:: image-box
 
-   </div>
-
-   <div class="sk-sponsor-div-box">
-
-.. image:: images/sloan_banner.png
-   :width: 100pt
-   :align: center
-   :target: https://sloan.org/
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/sloan_banner.png
+      :target: https://sloan.org/
 
 .............
 
-.. raw:: html
+.. div:: sk-text-image-grid-small
 
-   <div class="sk-sponsor-div">
-   <div class="sk-sponsor-div-box">
+  .. div:: text-box
 
-`INRIA <https://www.inria.fr>`_ actively supports this project. It has
-provided funding for Fabian Pedregosa (2010-2012), Jaques Grobler
-(2012-2013) and Olivier Grisel (2013-2017) to work on this project
-full-time. It also hosts coding sprints and other events.
+    `INRIA <https://www.inria.fr>`_ actively supports this project. It has
+    provided funding for Fabian Pedregosa (2010-2012), Jaques Grobler
+    (2012-2013) and Olivier Grisel (2013-2017) to work on this project
+    full-time. It also hosts coding sprints and other events.
 
-.. raw:: html
+  .. div:: image-box
 
-   </div>
-
-   <div class="sk-sponsor-div-box">
-
-.. image:: images/inria-logo.jpg
-   :width: 100pt
-   :align: center
-   :target: https://www.inria.fr
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/inria-logo.jpg
+      :target: https://www.inria.fr
 
 .....................
 
-.. raw:: html
+.. div:: sk-text-image-grid-small
 
-   <div class="sk-sponsor-div">
-   <div class="sk-sponsor-div-box">
+  .. div:: text-box
 
-`Paris-Saclay Center for Data Science
-<http://www.datascience-paris-saclay.fr/>`_
-funded one year for a developer to work on the project full-time
-(2014-2015), 50% of the time of Guillaume Lemaitre (2016-2017) and 50% of the
-time of Joris van den Bossche (2017-2018).
+    `Paris-Saclay Center for Data Science <http://www.datascience-paris-saclay.fr/>`_
+    funded one year for a developer to work on the project full-time (2014-2015), 50%
+    of the time of Guillaume Lemaitre (2016-2017) and 50% of the time of Joris van den
+    Bossche (2017-2018).
 
-.. raw:: html
+  .. div:: image-box
 
-   </div>
-   <div class="sk-sponsor-div-box">
-
-.. image:: images/cds-logo.png
-   :width: 100pt
-   :align: center
-   :target: http://www.datascience-paris-saclay.fr/
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/cds-logo.png
+      :target: http://www.datascience-paris-saclay.fr/
 
 ..........................
 
-.. raw:: html
+.. div:: sk-text-image-grid-small
 
-   <div class="sk-sponsor-div">
-   <div class="sk-sponsor-div-box">
+  .. div:: text-box
 
-`NYU Moore-Sloan Data Science Environment <https://cds.nyu.edu/mooresloan/>`_
-funded Andreas Mueller (2014-2016) to work on this project. The Moore-Sloan
-Data Science Environment also funds several students to work on the project
-part-time.
+    `NYU Moore-Sloan Data Science Environment <https://cds.nyu.edu/mooresloan/>`_
+    funded Andreas Mueller (2014-2016) to work on this project. The Moore-Sloan
+    Data Science Environment also funds several students to work on the project
+    part-time.
 
-.. raw:: html
+  .. div:: image-box
 
-   </div>
-   <div class="sk-sponsor-div-box">
-
-.. image:: images/nyu_short_color.png
-   :width: 100pt
-   :align: center
-   :target: https://cds.nyu.edu/mooresloan/
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/nyu_short_color.png
+      :target: https://cds.nyu.edu/mooresloan/
 
 ........................
 
-.. raw:: html
+.. div:: sk-text-image-grid-small
 
-   <div class="sk-sponsor-div">
-   <div class="sk-sponsor-div-box">
+  .. div:: text-box
 
-`Télécom Paristech <https://www.telecom-paristech.fr/>`_ funded Manoj Kumar
-(2014), Tom Dupré la Tour (2015), Raghav RV (2015-2017), Thierry Guillemot
-(2016-2017) and Albert Thomas (2017) to work on scikit-learn.
+    `Télécom Paristech <https://www.telecom-paristech.fr/>`_ funded Manoj Kumar
+    (2014), Tom Dupré la Tour (2015), Raghav RV (2015-2017), Thierry Guillemot
+    (2016-2017) and Albert Thomas (2017) to work on scikit-learn.
 
-.. raw:: html
+  .. div:: image-box
 
-   </div>
-   <div class="sk-sponsor-div-box">
-
-.. image:: images/telecom.png
-   :width: 50pt
-   :align: center
-   :target: https://www.telecom-paristech.fr/
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/telecom.png
+      :target: https://www.telecom-paristech.fr/
 
 .....................
 
-.. raw:: html
+.. div:: sk-text-image-grid-small
 
-   <div class="sk-sponsor-div">
-   <div class="sk-sponsor-div-box">
+  .. div:: text-box
 
-`The Labex DigiCosme <https://digicosme.lri.fr>`_ funded Nicolas Goix
-(2015-2016), Tom Dupré la Tour (2015-2016 and 2017-2018), Mathurin Massias
-(2018-2019) to work part time on scikit-learn during their PhDs. It also
-funded a scikit-learn coding sprint in 2015.
+    `The Labex DigiCosme <https://digicosme.lri.fr>`_ funded Nicolas Goix
+    (2015-2016), Tom Dupré la Tour (2015-2016 and 2017-2018), Mathurin Massias
+    (2018-2019) to work part time on scikit-learn during their PhDs. It also
+    funded a scikit-learn coding sprint in 2015.
 
-.. raw:: html
+  .. div:: image-box
 
-   </div>
-   <div class="sk-sponsor-div-box">
-
-.. image:: images/digicosme.png
-   :width: 100pt
-   :align: center
-   :target: https://digicosme.lri.fr
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/digicosme.png
+      :target: https://digicosme.lri.fr
 
 .....................
 
-.. raw:: html
+.. div:: sk-text-image-grid-small
 
-   <div class="sk-sponsor-div">
-   <div class="sk-sponsor-div-box">
+  .. div:: text-box
 
-`The Chan-Zuckerberg Initiative <https://chanzuckerberg.com/>`_ funded Nicolas
-Hug to work full-time on scikit-learn in 2020.
+    `The Chan-Zuckerberg Initiative <https://chanzuckerberg.com/>`_ funded Nicolas
+    Hug to work full-time on scikit-learn in 2020.
 
-.. raw:: html
+  .. div:: image-box
 
-   </div>
-   <div class="sk-sponsor-div-box">
-
-.. image:: images/czi_logo.svg
-   :width: 100pt
-   :align: center
-   :target: https://chanzuckerberg.com
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/czi_logo.svg
+      :target: https://chanzuckerberg.com
 
 ......................
 
@@ -609,9 +439,9 @@ program.
 
 - 2007 - David Cournapeau
 - 2011 - `Vlad Niculae`_
-- 2012 - `Vlad Niculae`_, Immanuel Bayer.
+- 2012 - `Vlad Niculae`_, Immanuel Bayer
 - 2013 - Kemal Eren, Nicolas Trésegnie
-- 2014 - Hamzeh Alsalhi, Issam Laradji, Maheshakya Wijewardena, Manoj Kumar.
+- 2014 - Hamzeh Alsalhi, Issam Laradji, Maheshakya Wijewardena, Manoj Kumar
 - 2015 - `Raghav RV <https://github.com/raghavrv>`_, Wei Xue
 - 2016 - `Nelson Liu <http://nelsonliu.me>`_, `YenChen Lin <https://yenchenlin.me/>`_
 
@@ -630,86 +460,112 @@ The following organizations funded the scikit-learn consortium at Inria in
 the past:
 
 .. |msn| image:: images/microsoft.png
-   :width: 100pt
-   :target: https://www.microsoft.com/
+  :target: https://www.microsoft.com/
 
 .. |bcg| image:: images/bcg.png
-   :width: 100pt
-   :target: https://www.bcg.com/beyond-consulting/bcg-gamma/default.aspx
+  :target: https://www.bcg.com/beyond-consulting/bcg-gamma/default.aspx
 
 .. |fujitsu| image:: images/fujitsu.png
-   :width: 100pt
-   :target: https://www.fujitsu.com/global/
+  :target: https://www.fujitsu.com/global/
 
 .. |aphp| image:: images/logo_APHP_text.png
-   :width: 150pt
-   :target: https://aphp.fr/
+  :target: https://aphp.fr/
 
+.. raw:: html
 
-|bcg| |msn| |fujitsu| |aphp|
+  <style>
+    div.image-subgrid img {
+      max-height: 50px;
+      max-width: 90%;
+    }
+  </style>
+
+.. grid:: 2 2 4 4
+  :class-row: image-subgrid
+  :gutter: 1
+
+  .. grid-item::
+    :class: sd-text-center
+    :child-align: center
+
+    |msn|
+
+  .. grid-item::
+    :class: sd-text-center
+    :child-align: center
+
+    |bcg|
+
+  .. grid-item::
+    :class: sd-text-center
+    :child-align: center
+
+    |fujitsu|
+
+  .. grid-item::
+    :class: sd-text-center
+    :child-align: center
+
+    |aphp|
 
 
 Sprints
 -------
 
-The International 2019 Paris sprint was kindly hosted by `AXA <https://www.axa.fr/>`_.
-Also some participants could attend thanks to the support of the `Alfred P.
-Sloan Foundation <https://sloan.org>`_, the `Python Software
-Foundation <https://www.python.org/psf/>`_ (PSF) and the `DATAIA Institute
-<https://dataia.eu/en>`_.
+- The International 2019 Paris sprint was kindly hosted by `AXA <https://www.axa.fr/>`_.
+  Also some participants could attend thanks to the support of the `Alfred P.
+  Sloan Foundation <https://sloan.org>`_, the `Python Software
+  Foundation <https://www.python.org/psf/>`_ (PSF) and the `DATAIA Institute
+  <https://dataia.eu/en>`_.
 
-.....................
+- The 2013 International Paris Sprint was made possible thanks to the support of
+  `Télécom Paristech <https://www.telecom-paristech.fr/>`_, `tinyclues
+  <https://www.tinyclues.com/>`_, the `French Python Association
+  <https://www.afpy.org/>`_ and the `Fonds de la Recherche Scientifique
+  <https://www.frs-fnrs.be>`_.
 
-The 2013 International Paris Sprint was made possible thanks to the support of
-`Télécom Paristech <https://www.telecom-paristech.fr/>`_, `tinyclues
-<https://www.tinyclues.com/>`_, the `French Python Association
-<https://www.afpy.org/>`_ and the `Fonds de la Recherche Scientifique
-<https://www.frs-fnrs.be>`_.
+- The 2011 International Granada sprint was made possible thanks to the support
+  of the `PSF <https://www.python.org/psf/>`_ and `tinyclues
+  <https://www.tinyclues.com/>`_.
 
-..............
-
-The 2011 International Granada sprint was made possible thanks to the support
-of the `PSF <https://www.python.org/psf/>`_ and `tinyclues
-<https://www.tinyclues.com/>`_.
 
 Donating to the project
-.......................
+-----------------------
 
 If you are interested in donating to the project or to one of our code-sprints,
 please donate via the `NumFOCUS Donations Page
 <https://numfocus.org/donate-to-scikit-learn>`_.
 
-.. raw :: html
+.. raw:: html
 
-   <div style="text-align: center;">
-   <a class="btn btn-warning btn-big sk-donate-btn mb-1" href="https://numfocus.org/donate-to-scikit-learn">Help us, <strong>donate!</strong></a>
-   </div>
-   </br>
+  <p class="text-center">
+    <a class="btn sk-btn-orange mb-1" href="https://numfocus.org/donate-to-scikit-learn">
+      Help us, <strong>donate!</strong>
+    </a>
+  </p>
 
-All donations will be handled by `NumFOCUS
-<https://numfocus.org/>`_, a non-profit-organization which is
-managed by a board of `Scipy community members
-<https://numfocus.org/board.html>`_. NumFOCUS's mission is to foster
-scientific computing software, in particular in Python. As a fiscal home
-of scikit-learn, it ensures that money is available when needed to keep
-the project funded and available while in compliance with tax regulations.
+All donations will be handled by `NumFOCUS <https://numfocus.org/>`_, a non-profit
+organization which is managed by a board of `Scipy community members
+<https://numfocus.org/board.html>`_. NumFOCUS's mission is to foster scientific
+computing software, in particular in Python. As a fiscal home of scikit-learn, it
+ensures that money is available when needed to keep the project funded and available
+while in compliance with tax regulations.
 
-The received donations for the scikit-learn project mostly will go towards
-covering travel-expenses for code sprints, as well as towards the organization
-budget of the project [#f1]_.
-
+The received donations for the scikit-learn project mostly will go towards covering
+travel-expenses for code sprints, as well as towards the organization budget of the
+project [#f1]_.
 
 .. rubric:: Notes
 
 .. [#f1] Regarding the organization budget, in particular, we might use some of
-         the donated funds to pay for other project expenses such as DNS,
-         hosting or continuous integration services.
+  the donated funds to pay for other project expenses such as DNS,
+  hosting or continuous integration services.
+
 
 Infrastructure support
 ----------------------
 
-- We would also like to thank `Microsoft Azure
-  <https://azure.microsoft.com/en-us/>`_, `Cirrus Cl <https://cirrus-ci.org>`_,
-  `CircleCl <https://circleci.com/>`_ for free CPU time on their Continuous
-  Integration servers, and `Anaconda Inc. <https://www.anaconda.com>`_ for the
-  storage they provide for our staging and nightly builds.
+We would also like to thank `Microsoft Azure <https://azure.microsoft.com/en-us/>`_,
+`Cirrus Cl <https://cirrus-ci.org>`_, `CircleCl <https://circleci.com/>`_ for free CPU
+time on their Continuous Integration servers, and `Anaconda Inc. <https://www.anaconda.com>`_
+for the storage they provide for our staging and nightly builds.

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -121,3 +121,57 @@ a.btn {
     }
   }
 }
+
+/* scikit-learn avatar grid, see build_tools/generate_authors_table.py */
+
+div.sk-authors-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+
+  > div {
+    width: 6rem;
+    margin: 0.5rem;
+    font-size: 0.9rem;
+  }
+}
+
+/* scikit-learn text-image grid, used in testimonials and sponsors pages */
+
+@mixin sk-text-image-grid($img-max-height) {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+
+  div.text-box,
+  div.image-box {
+    width: 50%;
+
+    @media screen and (max-width: 500px) {
+      width: 100%;
+    }
+  }
+
+  div.text-box .annotation {
+    font-size: 0.9rem;
+    font-style: italic;
+    color: var(--pst-color-text-muted);
+  }
+
+  div.image-box {
+    text-align: center;
+
+    img {
+      max-height: $img-max-height;
+      max-width: 50%;
+    }
+  }
+}
+
+div.sk-text-image-grid-small {
+  @include sk-text-image-grid(60px);
+}
+
+div.sk-text-image-grid-large {
+  @include sk-text-image-grid(100px);
+}

--- a/doc/testimonials/testimonials.rst
+++ b/doc/testimonials/testimonials.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. title:: Testimonials
 
 .. _testimonials:

--- a/doc/testimonials/testimonials.rst
+++ b/doc/testimonials/testimonials.rst
@@ -1,1151 +1,750 @@
+.. title:: Testimonials
+
 .. _testimonials:
 
-================================================================================
+==========================
 Who is using scikit-learn?
-================================================================================
-
-.. raw:: html
-
-  <div class="testimonial">
-
-
-.. to add a testimonials, just XXX
+==========================
 
 `J.P.Morgan <https://www.jpmorgan.com>`_
-------------------------------------------
+----------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-Scikit-learn is an indispensable part of the Python machine learning
-toolkit at JPMorgan. It is very widely used across all parts of the bank
-for classification, predictive analytics, and very many other machine
-learning tasks. Its straightforward API, its breadth of algorithms, and
-the quality of its documentation combine to make scikit-learn
-simultaneously very approachable and very powerful.
+    Scikit-learn is an indispensable part of the Python machine learning
+    toolkit at JPMorgan. It is very widely used across all parts of the bank
+    for classification, predictive analytics, and very many other machine
+    learning tasks. Its straightforward API, its breadth of algorithms, and
+    the quality of its documentation combine to make scikit-learn
+    simultaneously very approachable and very powerful.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Stephen Simmons, VP, Athena Research, JPMorgan
 
-Stephen Simmons, VP, Athena Research, JPMorgan
+  .. div:: image-box
 
-.. raw:: html
+    .. image:: images/jpmorgan.png
+      :target: https://www.jpmorgan.com
 
-   </span>
-    </div>
-    <div class="sk-testimonial-div-box">
-
-.. image:: images/jpmorgan.png
-    :width: 120pt
-    :align: center
-    :target: https://www.jpmorgan.com
-
-.. raw:: html
-
-   </div>
-   </div>
 
 `Spotify <https://www.spotify.com>`_
 ------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-Scikit-learn provides a toolbox with solid implementations of a bunch of
-state-of-the-art models and makes it easy to plug them into existing
-applications. We've been using it quite a lot for music recommendations at
-Spotify and I think it's the most well-designed ML package I've seen so
-far.
+    Scikit-learn provides a toolbox with solid implementations of a bunch of
+    state-of-the-art models and makes it easy to plug them into existing
+    applications. We've been using it quite a lot for music recommendations at
+    Spotify and I think it's the most well-designed ML package I've seen so far.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Erik Bernhardsson, Engineering Manager Music Discovery & Machine Learning, Spotify
 
-Erik Bernhardsson, Engineering Manager Music Discovery & Machine Learning, Spotify
+  .. div:: image-box
 
-.. raw:: html
+    .. image:: images/spotify.png
+      :target: https://www.spotify.com
 
-   </span>
-    </div>
-    <div class="sk-testimonial-div-box">
-
-.. image:: images/spotify.png
-    :width: 120pt
-    :align: center
-    :target: https://www.spotify.com
-
-.. raw:: html
-
-   </div>
-   </div>
 
 `Inria <https://www.inria.fr/>`_
 --------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-.. title Scikit-learn for efficient and easier machine learning research
-.. Author: Gaël Varoquaux
+    At INRIA, we use scikit-learn to support leading-edge basic research in many
+    teams: `Parietal <https://team.inria.fr/parietal/>`_ for neuroimaging, `Lear
+    <https://lear.inrialpes.fr/>`_ for computer vision, `Visages
+    <https://team.inria.fr/visages/>`_ for medical image analysis, `Privatics
+    <https://team.inria.fr/privatics>`_ for security. The project is a fantastic
+    tool to address difficult applications of machine learning in an academic
+    environment as it is performant and versatile, but all easy-to-use and well
+    documented, which makes it well suited to grad students.
 
+    .. rst-class:: annotation
 
-At INRIA, we use scikit-learn to support leading-edge basic research in many
-teams: `Parietal <https://team.inria.fr/parietal/>`_ for neuroimaging, `Lear
-<https://lear.inrialpes.fr/>`_ for computer vision, `Visages
-<https://team.inria.fr/visages/>`_ for medical image analysis, `Privatics
-<https://team.inria.fr/privatics>`_ for security. The project is a fantastic
-tool to address difficult applications of machine learning in an academic
-environment as it is performant and versatile, but all easy-to-use and well
-documented, which makes it well suited to grad students.
+      Gaël Varoquaux, research at Parietal
 
+  .. div:: image-box
 
-.. raw:: html
-
-   <span class="testimonial-author">
-
-Gaël Varoquaux, research at Parietal
-
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/inria.png
-    :width: 120pt
-    :align: center
-    :target: https://www.inria.fr/
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/inria.png
+      :target: https://www.inria.fr/
 
 
 `betaworks <https://betaworks.com>`_
 ------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-Betaworks is a NYC-based startup studio that builds new products, grows
-companies, and invests in others. Over the past 8 years we've launched a
-handful of social data analytics-driven services, such as Bitly, Chartbeat,
-digg and Scale Model. Consistently the betaworks data science team uses
-Scikit-learn for a variety of tasks. From exploratory analysis, to product
-development, it is an essential part of our toolkit. Recent uses are included
-in `digg's new video recommender system
-<https://medium.com/i-data/the-digg-video-recommender-2f9ade7c4ba3>`_,
-and Poncho's `dynamic heuristic subspace clustering
-<https://medium.com/@DiggData/scaling-poncho-using-data-ca24569d56fd>`_.
+    Betaworks is a NYC-based startup studio that builds new products, grows
+    companies, and invests in others. Over the past 8 years we've launched a
+    handful of social data analytics-driven services, such as Bitly, Chartbeat,
+    digg and Scale Model. Consistently the betaworks data science team uses
+    Scikit-learn for a variety of tasks. From exploratory analysis, to product
+    development, it is an essential part of our toolkit. Recent uses are included
+    in `digg's new video recommender system
+    <https://medium.com/i-data/the-digg-video-recommender-2f9ade7c4ba3>`_,
+    and Poncho's `dynamic heuristic subspace clustering
+    <https://medium.com/@DiggData/scaling-poncho-using-data-ca24569d56fd>`_.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Gilad Lotan, Chief Data Scientist
 
-Gilad Lotan, Chief Data Scientist
+  .. div:: image-box
 
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/betaworks.png
-    :width: 120pt
-    :align: center
-    :target: https://betaworks.com
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/betaworks.png
+      :target: https://betaworks.com
 
 
 `Hugging Face <https://huggingface.co>`_
 ----------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-At Hugging Face we're using NLP and probabilistic models to generate
-conversational Artificial intelligences that are fun to chat with. Despite using
-deep neural nets for `a few <https://medium.com/huggingface/understanding-emotions-from-keras-to-pytorch-3ccb61d5a983>`_
-of our `NLP tasks <https://huggingface.co/coref/>`_, scikit-learn is still the bread-and-butter of
-our daily machine learning routine. The ease of use and predictability of the
-interface, as well as the straightforward mathematical explanations that are
-here when you need them, is the killer feature. We use a variety of scikit-learn
-models in production and they are also operationally very pleasant to work with.
+    At Hugging Face we're using NLP and probabilistic models to generate
+    conversational Artificial intelligences that are fun to chat with. Despite using
+    deep neural nets for `a few <https://medium.com/huggingface/understanding-emotions-from-keras-to-pytorch-3ccb61d5a983>`_
+    of our `NLP tasks <https://huggingface.co/coref/>`_, scikit-learn is still the
+    bread-and-butter of our daily machine learning routine. The ease of use and
+    predictability of the interface, as well as the straightforward mathematical
+    explanations that are here when you need them, is the killer feature. We use a
+    variety of scikit-learn models in production and they are also operationally very
+    pleasant to work with.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Julien Chaumond, Chief Technology Officer
 
-Julien Chaumond, Chief Technology Officer
+  .. div:: image-box
 
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/huggingface.png
-    :width: 120pt
-    :align: center
-    :target: https://huggingface.co
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/huggingface.png
+      :target: https://huggingface.co
 
 
 `Evernote <https://evernote.com>`_
 ----------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-Building a classifier is typically an iterative process of exploring
-the data, selecting the features (the attributes of the data believed
-to be predictive in some way), training the models, and finally
-evaluating them. For many of these tasks, we relied on the excellent
-scikit-learn package for Python.
+    Building a classifier is typically an iterative process of exploring
+    the data, selecting the features (the attributes of the data believed
+    to be predictive in some way), training the models, and finally
+    evaluating them. For many of these tasks, we relied on the excellent
+    scikit-learn package for Python.
 
-`Read more <http://blog.evernote.com/tech/2013/01/22/stay-classified/>`_
+    `Read more <http://blog.evernote.com/tech/2013/01/22/stay-classified/>`_
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Mark Ayzenshtat, VP, Augmented Intelligence
 
-Mark Ayzenshtat, VP, Augmented Intelligence
+  .. div:: image-box
 
-.. raw:: html
+    .. image:: images/evernote.png
+      :target: https://evernote.com
 
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/evernote.png
-    :width: 120pt
-    :align: center
-    :target: https://evernote.com
-
-.. raw:: html
-
-   </div>
-   </div>
 
 `Télécom ParisTech <https://www.telecom-paristech.fr/>`_
 --------------------------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-At Telecom ParisTech, scikit-learn is used for hands-on sessions and home
-assignments in introductory and advanced machine learning courses. The classes
-are for undergrads and masters students. The great benefit of scikit-learn is
-its fast learning curve that allows students to quickly start working on
-interesting and motivating problems.
+    At Telecom ParisTech, scikit-learn is used for hands-on sessions and home
+    assignments in introductory and advanced machine learning courses. The classes
+    are for undergrads and masters students. The great benefit of scikit-learn is
+    its fast learning curve that allows students to quickly start working on
+    interesting and motivating problems.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Alexandre Gramfort, Assistant Professor
 
-Alexandre Gramfort, Assistant Professor
+  .. div:: image-box
 
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/telecomparistech.jpg
-    :width: 120pt
-    :align: center
-    :target: https://www.telecom-paristech.fr/
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/telecomparistech.jpg
+      :target: https://www.telecom-paristech.fr/
 
 
 `Booking.com <https://www.booking.com>`_
------------------------------------------
-.. raw:: html
-
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
-
-At Booking.com, we use machine learning algorithms for many different
-applications, such as recommending hotels and destinations to our customers,
-detecting fraudulent reservations, or scheduling our customer service agents.
-Scikit-learn is one of the tools we use when implementing standard algorithms
-for prediction tasks. Its API and documentations are excellent and make it easy
-to use. The scikit-learn developers do a great job of incorporating state of
-the art implementations and new algorithms into the package. Thus, scikit-learn
-provides convenient access to a wide spectrum of algorithms, and allows us to
-readily find the right tool for the right job.
-
-
-.. raw:: html
-
-   <span class="testimonial-author">
-
-Melanie Mueller, Data Scientist
-
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/booking.png
-    :width: 120pt
-    :align: center
-    :target: https://www.booking.com
-
-.. raw:: html
-
-   </div>
-   </div>
-
-`AWeber <https://www.aweber.com/>`_
-------------------------------------------
-
-.. raw:: html
-
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
-
-The scikit-learn toolkit is indispensable for the Data Analysis and Management
-team at AWeber.  It allows us to do AWesome stuff we would not otherwise have
-the time or resources to accomplish. The documentation is excellent, allowing
-new engineers to quickly evaluate and apply many different algorithms to our
-data. The text feature extraction utilities are useful when working with the
-large volume of email content we have at AWeber. The RandomizedPCA
-implementation, along with Pipelining and FeatureUnions, allows us to develop
-complex machine learning algorithms efficiently and reliably.
-
-Anyone interested in learning more about how AWeber deploys scikit-learn in a
-production environment should check out talks from PyData Boston by AWeber's
-Michael Becker available at https://github.com/mdbecker/pydata_2013
-
-.. raw:: html
-
-   <span class="testimonial-author">
-
-Michael Becker, Software Engineer, Data Analysis and Management Ninjas
-
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/aweber.png
-    :width: 120pt
-    :align: center
-    :target: https://www.aweber.com/
-
-.. raw:: html
-
-   </div>
-   </div>
-
-`Yhat <https://www.yhat.com>`_
-------------------------------------------
-
-.. raw:: html
-
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
-
-The combination of consistent APIs, thorough documentation, and top notch
-implementation make scikit-learn our favorite machine learning package in
-Python. scikit-learn makes doing advanced analysis in Python accessible to
-anyone. At Yhat, we make it easy to integrate these models into your production
-applications. Thus eliminating the unnecessary dev time encountered
-productionizing analytical work.
-
-
-.. raw:: html
-
-   <span class="testimonial-author">
-
-Greg Lamp, Co-founder Yhat
-
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/yhat.png
-    :width: 120pt
-    :align: center
-    :target: https://www.yhat.com
-
-.. raw:: html
-
-   </div>
-   </div>
-
-`Rangespan <http://www.rangespan.com>`_
 ----------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-The Python scikit-learn toolkit is a core tool in the data science
-group at Rangespan. Its large collection of well documented models and
-algorithms allow our team of data scientists to prototype fast and
-quickly iterate to find the right solution to our learning problems.
-We find that scikit-learn is not only the right tool for prototyping,
-but its careful and well tested implementation give us the confidence
-to run scikit-learn models in production.
+    At Booking.com, we use machine learning algorithms for many different
+    applications, such as recommending hotels and destinations to our customers,
+    detecting fraudulent reservations, or scheduling our customer service agents.
+    Scikit-learn is one of the tools we use when implementing standard algorithms
+    for prediction tasks. Its API and documentations are excellent and make it easy
+    to use. The scikit-learn developers do a great job of incorporating state of
+    the art implementations and new algorithms into the package. Thus, scikit-learn
+    provides convenient access to a wide spectrum of algorithms, and allows us to
+    readily find the right tool for the right job.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Melanie Mueller, Data Scientist
 
-Jurgen Van Gael, Data Science Director at Rangespan Ltd
+  .. div:: image-box
 
-.. raw:: html
+    .. image:: images/booking.png
+      :target: https://www.booking.com
 
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
 
-.. image:: images/rangespan.png
-    :width: 120pt
-    :align: center
-    :target: http://www.rangespan.com
+`AWeber <https://www.aweber.com/>`_
+-----------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   </div>
-   </div>
+  .. div:: text-box
+
+    The scikit-learn toolkit is indispensable for the Data Analysis and Management
+    team at AWeber.  It allows us to do AWesome stuff we would not otherwise have
+    the time or resources to accomplish. The documentation is excellent, allowing
+    new engineers to quickly evaluate and apply many different algorithms to our
+    data. The text feature extraction utilities are useful when working with the
+    large volume of email content we have at AWeber. The RandomizedPCA
+    implementation, along with Pipelining and FeatureUnions, allows us to develop
+    complex machine learning algorithms efficiently and reliably.
+
+    Anyone interested in learning more about how AWeber deploys scikit-learn in a
+    production environment should check out talks from PyData Boston by AWeber's
+    Michael Becker available at https://github.com/mdbecker/pydata_2013.
+
+    .. rst-class:: annotation
+
+      Michael Becker, Software Engineer, Data Analysis and Management Ninjas
+
+  .. div:: image-box
+
+    .. image:: images/aweber.png
+      :target: https://www.aweber.com
+
+
+`Yhat <https://www.yhat.com>`_
+------------------------------
+
+.. div:: sk-text-image-grid-large
+
+  .. div:: text-box
+
+    The combination of consistent APIs, thorough documentation, and top notch
+    implementation make scikit-learn our favorite machine learning package in
+    Python. scikit-learn makes doing advanced analysis in Python accessible to
+    anyone. At Yhat, we make it easy to integrate these models into your production
+    applications. Thus eliminating the unnecessary dev time encountered
+    productionizing analytical work.
+
+    .. rst-class:: annotation
+
+      Greg Lamp, Co-founder
+
+  .. div:: image-box
+
+    .. image:: images/yhat.png
+      :target: https://www.yhat.com
+
+
+`Rangespan <http://www.rangespan.com>`_
+---------------------------------------
+
+.. div:: sk-text-image-grid-large
+
+  .. div:: text-box
+
+    The Python scikit-learn toolkit is a core tool in the data science
+    group at Rangespan. Its large collection of well documented models and
+    algorithms allow our team of data scientists to prototype fast and
+    quickly iterate to find the right solution to our learning problems.
+    We find that scikit-learn is not only the right tool for prototyping,
+    but its careful and well tested implementation give us the confidence
+    to run scikit-learn models in production.
+
+    .. rst-class:: annotation
+
+      Jurgen Van Gael, Data Science Director
+
+  .. div:: image-box
+
+    .. image:: images/rangespan.png
+      :target: http://www.rangespan.com
+
 
 `Birchbox <https://www.birchbox.com>`_
-------------------------------------------
+--------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-At Birchbox, we face a range of machine learning problems typical to
-E-commerce: product recommendation, user clustering, inventory prediction,
-trends detection, etc. Scikit-learn lets us experiment with many models,
-especially in the exploration phase of a new project: the data can be passed
-around in a consistent way; models are easy to save and reuse; updates keep us
-informed of new developments from the pattern discovery research community.
-Scikit-learn is an important tool for our team, built the right way in the
-right language.
+    At Birchbox, we face a range of machine learning problems typical to
+    E-commerce: product recommendation, user clustering, inventory prediction,
+    trends detection, etc. Scikit-learn lets us experiment with many models,
+    especially in the exploration phase of a new project: the data can be passed
+    around in a consistent way; models are easy to save and reuse; updates keep us
+    informed of new developments from the pattern discovery research community.
+    Scikit-learn is an important tool for our team, built the right way in the
+    right language.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Thierry Bertin-Mahieux, Data Scientist
 
-Thierry Bertin-Mahieux, Birchbox, Data Scientist
+  .. div:: image-box
 
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/birchbox.jpg
-    :width: 120pt
-    :align: center
-    :target: https://www.birchbox.com
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/birchbox.jpg
+      :target: https://www.birchbox.com
 
 
 `Bestofmedia Group <http://www.bestofmedia.com>`_
---------------------------------------------------
+-------------------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-Scikit-learn is our #1 toolkit for all things machine learning
-at Bestofmedia. We use it for a variety of tasks (e.g. spam fighting,
-ad click prediction, various ranking models) thanks to the varied,
-state-of-the-art algorithm implementations packaged into it.
-In the lab it accelerates prototyping of complex pipelines. In
-production I can say it has proven to be robust and efficient enough
-to be deployed for business critical components.
+    Scikit-learn is our #1 toolkit for all things machine learning
+    at Bestofmedia. We use it for a variety of tasks (e.g. spam fighting,
+    ad click prediction, various ranking models) thanks to the varied,
+    state-of-the-art algorithm implementations packaged into it.
+    In the lab it accelerates prototyping of complex pipelines. In
+    production I can say it has proven to be robust and efficient enough
+    to be deployed for business critical components.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Eustache Diemert, Lead Scientist
 
-Eustache Diemert, Lead Scientist Bestofmedia Group
+  .. div:: image-box
 
-.. raw:: html
+    .. image:: images/bestofmedia-logo.png
+      :target: http://www.bestofmedia.com
 
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/bestofmedia-logo.png
-    :width: 120pt
-    :align: center
-    :target: http://www.bestofmedia.com
-
-.. raw:: html
-
-   </div>
-   </div>
 
 `Change.org <https://www.change.org>`_
 --------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-At change.org we automate the use of scikit-learn's RandomForestClassifier
-in our production systems to drive email targeting that reaches millions
-of users across the world each week. In the lab, scikit-learn's ease-of-use,
-performance, and overall variety of algorithms implemented has proved invaluable
-in giving us a single reliable source to turn to for our machine-learning needs.
+    At change.org we automate the use of scikit-learn's RandomForestClassifier
+    in our production systems to drive email targeting that reaches millions
+    of users across the world each week. In the lab, scikit-learn's ease-of-use,
+    performance, and overall variety of algorithms implemented has proved invaluable
+    in giving us a single reliable source to turn to for our machine-learning needs.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Vijay Ramesh, Software Engineer in Data/science at Change.org
 
-Vijay Ramesh, Software Engineer in Data/science at Change.org
+  .. div:: image-box
 
-.. raw:: html
+    .. image:: images/change-logo.png
+      :target: https://www.change.org
 
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/change-logo.png
-    :width: 120pt
-    :align: center
-    :target: https://www.change.org
-
-.. raw:: html
-
-   </div>
-   </div>
 
 `PHIMECA Engineering <https://www.phimeca.com/?lang=en>`_
-----------------------------------------------------------
+---------------------------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-At PHIMECA Engineering, we use scikit-learn estimators as surrogates for
-expensive-to-evaluate numerical models (mostly but not exclusively
-finite-element mechanical models) for speeding up the intensive post-processing
-operations involved in our simulation-based decision making framework.
-Scikit-learn's fit/predict API together with its efficient cross-validation
-tools considerably eases the task of selecting the best-fit estimator. We are
-also using scikit-learn for illustrating concepts in our training sessions.
-Trainees are always impressed by the ease-of-use of scikit-learn despite the
-apparent theoretical complexity of machine learning.
+    At PHIMECA Engineering, we use scikit-learn estimators as surrogates for
+    expensive-to-evaluate numerical models (mostly but not exclusively
+    finite-element mechanical models) for speeding up the intensive post-processing
+    operations involved in our simulation-based decision making framework.
+    Scikit-learn's fit/predict API together with its efficient cross-validation
+    tools considerably eases the task of selecting the best-fit estimator. We are
+    also using scikit-learn for illustrating concepts in our training sessions.
+    Trainees are always impressed by the ease-of-use of scikit-learn despite the
+    apparent theoretical complexity of machine learning.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Vincent Dubourg, PHIMECA Engineering, PhD Engineer
 
-Vincent Dubourg, PHIMECA Engineering, PhD Engineer
+  .. div:: image-box
 
-.. raw:: html
+    .. image:: images/phimeca.png
+      :target: https://www.phimeca.com/?lang=en
 
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/phimeca.png
-    :width: 120pt
-    :align: center
-    :target: https://www.phimeca.com/?lang=en
-
-.. raw:: html
-
-   </div>
-   </div>
 
 `HowAboutWe <http://www.howaboutwe.com/>`_
-----------------------------------------------------------
+------------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-At HowAboutWe, scikit-learn lets us implement a wide array of machine learning
-techniques in analysis and in production, despite having a small team.  We use
-scikit-learn's classification algorithms to predict user behavior, enabling us
-to (for example) estimate the value of leads from a given traffic source early
-in the lead's tenure on our site. Also, our users' profiles consist of
-primarily unstructured data (answers to open-ended questions), so we use
-scikit-learn's feature extraction and dimensionality reduction tools to
-translate these unstructured data into inputs for our matchmaking system.
+    At HowAboutWe, scikit-learn lets us implement a wide array of machine learning
+    techniques in analysis and in production, despite having a small team.  We use
+    scikit-learn's classification algorithms to predict user behavior, enabling us
+    to (for example) estimate the value of leads from a given traffic source early
+    in the lead's tenure on our site. Also, our users' profiles consist of
+    primarily unstructured data (answers to open-ended questions), so we use
+    scikit-learn's feature extraction and dimensionality reduction tools to
+    translate these unstructured data into inputs for our matchmaking system.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Daniel Weitzenfeld, Senior Data Scientist at HowAboutWe
 
-Daniel Weitzenfeld, Senior Data Scientist at HowAboutWe
+  .. div:: image-box
 
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/howaboutwe.png
-    :width: 120pt
-    :align: center
-    :target: http://www.howaboutwe.com/
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/howaboutwe.png
+      :target: http://www.howaboutwe.com/
 
 
 `PeerIndex <https://www.brandwatch.com/peerindex-and-brandwatch>`_
 ------------------------------------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-At PeerIndex we use scientific methodology to build the Influence Graph - a
-unique dataset that allows us to identify who's really influential and in which
-context. To do this, we have to tackle a range of machine learning and
-predictive modeling problems. Scikit-learn has emerged as our primary tool for
-developing prototypes and making quick progress. From predicting missing data
-and classifying tweets to clustering communities of social media users, scikit-
-learn proved useful in a variety of applications. Its very intuitive interface
-and excellent compatibility with other python tools makes it and indispensable
-tool in our daily research efforts.
+    At PeerIndex we use scientific methodology to build the Influence Graph - a
+    unique dataset that allows us to identify who's really influential and in which
+    context. To do this, we have to tackle a range of machine learning and
+    predictive modeling problems. Scikit-learn has emerged as our primary tool for
+    developing prototypes and making quick progress. From predicting missing data
+    and classifying tweets to clustering communities of social media users, scikit-
+    learn proved useful in a variety of applications. Its very intuitive interface
+    and excellent compatibility with other python tools makes it and indispensable
+    tool in our daily research efforts.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Ferenc Huszar, Senior Data Scientist at Peerindex
 
-Ferenc Huszar - Senior Data Scientist at Peerindex
+  .. div:: image-box
 
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/peerindex.png
-    :width: 120pt
-    :align: center
-    :target: https://www.brandwatch.com/peerindex-and-brandwatch
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/peerindex.png
+      :target: https://www.brandwatch.com/peerindex-and-brandwatch
 
 
 `DataRobot <https://www.datarobot.com>`_
 ----------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-DataRobot is building next generation predictive analytics software to make data scientists more productive, and scikit-learn is an integral part of our system. The variety of machine learning techniques in combination with the solid implementations that scikit-learn offers makes it a one-stop-shopping library for machine learning in Python. Moreover, its consistent API, well-tested code and permissive licensing allow us to use it in a production environment. Scikit-learn has literally saved us years of work we would have had to do ourselves to bring our product to market.
+    DataRobot is building next generation predictive analytics software to make data
+    scientists more productive, and scikit-learn is an integral part of our system. The
+    variety of machine learning techniques in combination with the solid implementations
+    that scikit-learn offers makes it a one-stop-shopping library for machine learning
+    in Python. Moreover, its consistent API, well-tested code and permissive licensing
+    allow us to use it in a production environment. Scikit-learn has literally saved us
+    years of work we would have had to do ourselves to bring our product to market.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Jeremy Achin, CEO & Co-founder DataRobot Inc.
 
-Jeremy Achin, CEO & Co-founder DataRobot Inc.
+  .. div:: image-box
 
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/datarobot.png
-    :width: 120pt
-    :align: center
-    :target: https://www.datarobot.com
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/datarobot.png
+      :target: https://www.datarobot.com
 
 
 `OkCupid <https://www.okcupid.com/>`_
---------------------------------------
+-------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-We're using scikit-learn at OkCupid to evaluate and improve our matchmaking
-system. The range of features it has, especially preprocessing utilities, means
-we can use it for a wide variety of projects, and it's performant enough to
-handle the volume of data that we need to sort through. The documentation is
-really thorough, as well, which makes the library quite easy to use.
+    We're using scikit-learn at OkCupid to evaluate and improve our matchmaking
+    system. The range of features it has, especially preprocessing utilities, means
+    we can use it for a wide variety of projects, and it's performant enough to
+    handle the volume of data that we need to sort through. The documentation is
+    really thorough, as well, which makes the library quite easy to use.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      David Koh - Senior Data Scientist at OkCupid
 
-David Koh - Senior Data Scientist at OkCupid
+  .. div:: image-box
 
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/okcupid.png
-    :width: 120pt
-    :align: center
-    :target: https://www.okcupid.com
-
-.. raw:: html
-
-    </div>
-    </div>
+    .. image:: images/okcupid.png
+      :target: https://www.okcupid.com
 
 
 `Lovely <https://livelovely.com/>`_
 -----------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-At Lovely, we strive to deliver the best apartment marketplace, with respect to
-our users and our listings. From understanding user behavior, improving data
-quality, and detecting fraud, scikit-learn is a regular tool for gathering
-insights, predictive modeling and improving our product. The easy-to-read
-documentation and intuitive architecture of the API makes machine learning both
-explorable and accessible to a wide range of python developers. I'm constantly
-recommending that more developers and scientists try scikit-learn.
+    At Lovely, we strive to deliver the best apartment marketplace, with respect to
+    our users and our listings. From understanding user behavior, improving data
+    quality, and detecting fraud, scikit-learn is a regular tool for gathering
+    insights, predictive modeling and improving our product. The easy-to-read
+    documentation and intuitive architecture of the API makes machine learning both
+    explorable and accessible to a wide range of python developers. I'm constantly
+    recommending that more developers and scientists try scikit-learn.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Simon Frid - Data Scientist, Lead at Lovely
 
-Simon Frid - Data Scientist, Lead at Lovely
+  .. div:: image-box
 
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/lovely.png
-    :width: 120pt
-    :align: center
-    :target: https://livelovely.com
-
-.. raw:: html
-
-   </div>
-   </div>
-
+    .. image:: images/lovely.png
+      :target: https://livelovely.com
 
 
 `Data Publica <http://www.data-publica.com/>`_
 ----------------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-Data Publica builds a new predictive sales tool for commercial and marketing teams called C-Radar.
-We extensively use scikit-learn to build segmentations of customers through clustering, and to predict future customers based on past partnerships success or failure.
-We also categorize companies using their website communication thanks to scikit-learn and its machine learning algorithm implementations.
-Eventually, machine learning makes it possible to detect weak signals that traditional tools cannot see.
-All these complex tasks are performed in an easy and straightforward way thanks to the great quality of the scikit-learn framework.
+    Data Publica builds a new predictive sales tool for commercial and marketing teams
+    called C-Radar. We extensively use scikit-learn to build segmentations of customers
+    through clustering, and to predict future customers based on past partnerships
+    success or failure. We also categorize companies using their website communication
+    thanks to scikit-learn and its machine learning algorithm implementations.
+    Eventually, machine learning makes it possible to detect weak signals that
+    traditional tools cannot see. All these complex tasks are performed in an easy and
+    straightforward way thanks to the great quality of the scikit-learn framework.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Guillaume Lebourgeois & Samuel Charron - Data Scientists at Data Publica
 
-Guillaume Lebourgeois & Samuel Charron - Data Scientists at Data Publica
+  .. div:: image-box
 
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/datapublica.png
-    :width: 120pt
-    :align: center
-    :target: http://www.data-publica.com/
-
-.. raw:: html
-
-   </div>
-   </div>
-
+    .. image:: images/datapublica.png
+      :target: http://www.data-publica.com/
 
 
 `Machinalis <https://www.machinalis.com/>`_
 -------------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-Scikit-learn is the cornerstone of all the machine learning projects carried at
-Machinalis. It has a consistent API, a wide selection of algorithms and lots
-of auxiliary tools to deal with the boilerplate.
-We have used it in production environments on a variety of projects
-including click-through rate prediction, `information extraction <https://github.com/machinalis/iepy>`_,
-and even counting sheep!
+    Scikit-learn is the cornerstone of all the machine learning projects carried at
+    Machinalis. It has a consistent API, a wide selection of algorithms and lots of
+    auxiliary tools to deal with the boilerplate. We have used it in production
+    environments on a variety of projects including click-through rate prediction,
+    `information extraction <https://github.com/machinalis/iepy>`_, and even counting
+    sheep!
 
-In fact, we use it so much that we've started to freeze our common use cases
-into Python packages, some of them open-sourced, like
-`FeatureForge <https://github.com/machinalis/featureforge>`_ .
-Scikit-learn in one word: Awesome.
+    In fact, we use it so much that we've started to freeze our common use cases
+    into Python packages, some of them open-sourced, like `FeatureForge
+    <https://github.com/machinalis/featureforge>`_. Scikit-learn in one word: Awesome.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Rafael Carrascosa, Lead developer
 
-Rafael Carrascosa, Lead developer
+  .. div:: image-box
 
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/machinalis.png
-    :width: 120pt
-    :align: center
-    :target: https://www.machinalis.com/
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/machinalis.png
+      :target: https://www.machinalis.com/
 
 
 `solido <https://www.solidodesign.com/>`_
 -----------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-Scikit-learn is helping to drive Moore's Law, via Solido. Solido creates
-computer-aided design tools used by the majority of top-20 semiconductor
-companies and fabs, to design the bleeding-edge chips inside smartphones,
-automobiles, and more. Scikit-learn helps to power Solido's algorithms for
-rare-event estimation, worst-case verification, optimization, and more. At
-Solido, we are particularly fond of scikit-learn's libraries for Gaussian
-Process models, large-scale regularized linear regression, and classification.
-Scikit-learn has increased our productivity, because for many ML problems we no
-longer need to “roll our own” code. `This PyData 2014 talk <https://www.youtube.com/watch?v=Jm-eBD9xR3w>`_ has details.
+    Scikit-learn is helping to drive Moore's Law, via Solido. Solido creates
+    computer-aided design tools used by the majority of top-20 semiconductor
+    companies and fabs, to design the bleeding-edge chips inside smartphones,
+    automobiles, and more. Scikit-learn helps to power Solido's algorithms for
+    rare-event estimation, worst-case verification, optimization, and more. At
+    Solido, we are particularly fond of scikit-learn's libraries for Gaussian
+    Process models, large-scale regularized linear regression, and classification.
+    Scikit-learn has increased our productivity, because for many ML problems we no
+    longer need to “roll our own” code. `This PyData 2014 talk
+    <https://www.youtube.com/watch?v=Jm-eBD9xR3w>`_ has details.
 
+    .. rst-class:: annotation
 
-.. raw:: html
+      Trent McConaghy, founder, Solido Design Automation Inc.
 
-  <span class="testimonial-author">
+  .. div:: image-box
 
-Trent McConaghy, founder, Solido Design Automation Inc.
-
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/solido_logo.png
-    :width: 120pt
-    :align: center
-    :target: https://www.solidodesign.com/
-
-.. raw:: html
-
-   </div>
-   </div>
-
+    .. image:: images/solido_logo.png
+      :target: https://www.solidodesign.com/
 
 
 `INFONEA <http://www.infonea.com/en/>`_
------------------------------------------
+---------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-We employ scikit-learn for rapid prototyping and custom-made Data Science
-solutions within our in-memory based Business Intelligence Software
-INFONEA®. As a well-documented and comprehensive collection of
-state-of-the-art algorithms and pipelining methods, scikit-learn enables
-us to provide flexible and scalable scientific analysis solutions. Thus,
-scikit-learn is immensely valuable in realizing a powerful integration of
-Data Science technology within self-service business analytics.
+    We employ scikit-learn for rapid prototyping and custom-made Data Science
+    solutions within our in-memory based Business Intelligence Software
+    INFONEA®. As a well-documented and comprehensive collection of
+    state-of-the-art algorithms and pipelining methods, scikit-learn enables
+    us to provide flexible and scalable scientific analysis solutions. Thus,
+    scikit-learn is immensely valuable in realizing a powerful integration of
+    Data Science technology within self-service business analytics.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-  <span class="testimonial-author">
+      Thorsten Kranz, Data Scientist, Coma Soft AG.
 
-Thorsten Kranz, Data Scientist, Coma Soft AG.
+  .. div:: image-box
 
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/infonea.jpg
-    :width: 120pt
-    :align: center
-    :target: http://www.infonea.com/en/
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/infonea.jpg
+      :target: http://www.infonea.com/en/
 
 
 `Dataiku <https://www.dataiku.com/>`_
------------------------------------------
+-------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-Our software, Data Science Studio (DSS), enables users to create data services
-that combine `ETL <https://en.wikipedia.org/wiki/Extract,_transform,_load>`_ with
-Machine Learning. Our Machine Learning module integrates
-many scikit-learn algorithms. The scikit-learn library is a perfect integration
-with DSS because it offers algorithms for virtually all business cases. Our goal
-is to offer a transparent and flexible tool that makes it easier to optimize
-time consuming aspects of building a data service, preparing data, and training
-machine learning algorithms on all types of data.
+    Our software, Data Science Studio (DSS), enables users to create data services
+    that combine `ETL <https://en.wikipedia.org/wiki/Extract,_transform,_load>`_ with
+    Machine Learning. Our Machine Learning module integrates
+    many scikit-learn algorithms. The scikit-learn library is a perfect integration
+    with DSS because it offers algorithms for virtually all business cases. Our goal
+    is to offer a transparent and flexible tool that makes it easier to optimize
+    time consuming aspects of building a data service, preparing data, and training
+    machine learning algorithms on all types of data.
 
+    .. rst-class:: annotation
 
-.. raw:: html
+      Florian Douetteau, CEO, Dataiku
 
-  <span class="testimonial-author">
+  .. div:: image-box
 
-Florian Douetteau, CEO, Dataiku
+    .. image:: images/dataiku_logo.png
+      :target: https://www.dataiku.com/
 
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/dataiku_logo.png
-    :width: 120pt
-    :align: center
-    :target: https://www.dataiku.com/
-
-.. raw:: html
-
-   </div>
-   </div>
 
 `Otto Group <https://ottogroup.com/>`_
------------------------------------------
-
-.. raw:: html
-
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
-
-Here at Otto Group, one of global Big Five B2C online retailers, we are using
-scikit-learn in all aspects of our daily work from data exploration to development
-of machine learning application to the productive deployment of those services.
-It helps us to tackle machine learning problems ranging from e-commerce to logistics.
-It consistent APIs enabled us to build the `Palladium REST-API framework
-<https://github.com/ottogroup/palladium/>`_ around it and continuously deliver
-scikit-learn based services.
-
-
-.. raw:: html
-
-  <span class="testimonial-author">
-
-Christian Rammig, Head of Data Science, Otto Group
-
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/ottogroup_logo.png
-    :width: 120pt
-    :align: center
-    :target: https://ottogroup.com
-
-.. raw:: html
-
-   </div>
-   </div>
-
-`Zopa <https://zopa.com/>`_
------------------------------------------
-
-.. raw:: html
-
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box"-->
-
-At Zopa, the first ever Peer-to-Peer lending platform, we extensively use scikit-learn
-to run the business and optimize our users' experience. It powers our
-Machine Learning models involved in credit risk, fraud risk, marketing, and pricing,
-and has been used for originating at least 1 billion GBP worth of Zopa loans.
-It is very well documented, powerful, and simple to use. We are grateful for the
-capabilities it has provided, and for allowing us to deliver on our mission of making
-money simple and fair.
-
-.. raw:: html
-
-  <span class="testimonial-author">
-
-Vlasios Vasileiou, Head of Data Science, Zopa
-
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box"-->
-
-.. image:: images/zopa.png
-    :width: 120pt
-    :align: center
-    :target: https://zopa.com
-
-.. raw:: html
-
-   </div>
-   </div>
-
-`MARS <https://www.mars.com/global>`_
 --------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-Scikit-Learn is integral to the Machine Learning Ecosystem at Mars. Whether
-we're designing better recipes for petfood or closely analysing our cocoa
-supply chain, Scikit-Learn is used as a tool for rapidly prototyping ideas
-and taking them to production. This allows us to better understand and meet
-the needs of our consumers worldwide. Scikit-Learn's feature-rich toolset is
-easy to use and equips our associates with the capabilities they need to
-solve the business challenges they face every day.
+    Here at Otto Group, one of global Big Five B2C online retailers, we are using
+    scikit-learn in all aspects of our daily work from data exploration to development
+    of machine learning application to the productive deployment of those services.
+    It helps us to tackle machine learning problems ranging from e-commerce to logistics.
+    It consistent APIs enabled us to build the `Palladium REST-API framework
+    <https://github.com/ottogroup/palladium/>`_ around it and continuously deliver
+    scikit-learn based services.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Christian Rammig, Head of Data Science, Otto Group
 
-Michael Fitzke Next Generation Technologies Sr Leader, Mars Inc.
+  .. div:: image-box
 
-.. raw:: html
+    .. image:: images/ottogroup_logo.png
+      :target: https://ottogroup.com
 
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
 
-.. image:: images/mars.png
-    :width: 120pt
-    :align: center
-    :target: https://www.mars.com/global
+`Zopa <https://zopa.com/>`_
+---------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   </div>
-   </div>
+  .. div:: text-box
+
+    At Zopa, the first ever Peer-to-Peer lending platform, we extensively use
+    scikit-learn to run the business and optimize our users' experience. It powers our
+    Machine Learning models involved in credit risk, fraud risk, marketing, and pricing,
+    and has been used for originating at least 1 billion GBP worth of Zopa loans. It is
+    very well documented, powerful, and simple to use. We are grateful for the
+    capabilities it has provided, and for allowing us to deliver on our mission of
+    making money simple and fair.
+
+    .. rst-class:: annotation
+
+      Vlasios Vasileiou, Head of Data Science, Zopa
+
+  .. div:: image-box
+
+    .. image:: images/zopa.png
+      :target: https://zopa.com
+
+
+`MARS <https://www.mars.com/global>`_
+-------------------------------------
+
+.. div:: sk-text-image-grid-large
+
+  .. div:: text-box
+
+    Scikit-Learn is integral to the Machine Learning Ecosystem at Mars. Whether
+    we're designing better recipes for petfood or closely analysing our cocoa
+    supply chain, Scikit-Learn is used as a tool for rapidly prototyping ideas
+    and taking them to production. This allows us to better understand and meet
+    the needs of our consumers worldwide. Scikit-Learn's feature-rich toolset is
+    easy to use and equips our associates with the capabilities they need to
+    solve the business challenges they face every day.
+
+    .. rst-class:: annotation
+
+      Michael Fitzke, Next Generation Technologies Sr Leader, Mars Inc.
+
+  .. div:: image-box
+
+    .. image:: images/mars.png
+      :target: https://www.mars.com/global
 
 
 `BNP Paribas Cardif <https://www.bnpparibascardif.com/>`_
 ---------------------------------------------------------
 
-.. raw:: html
+.. div:: sk-text-image-grid-large
 
-   <div class="sk-testimonial-div">
-   <div class="sk-testimonial-div-box">
+  .. div:: text-box
 
-BNP Paribas Cardif uses scikit-learn for several of its machine learning models
-in production. Our internal community of developers and data scientists has
-been using scikit-learn since 2015, for several reasons: the quality of the
-developments, documentation and contribution governance, and the sheer size of
-the contributing community. We even explicitly mention the use of
-scikit-learn's pipelines in our internal model risk governance as one of our
-good practices to decrease operational risks and overfitting risk. As a way to
-support open source software development and in particular scikit-learn
-project, we decided to participate to scikit-learn's consortium at La Fondation
-Inria since its creation in 2018.
+    BNP Paribas Cardif uses scikit-learn for several of its machine learning models
+    in production. Our internal community of developers and data scientists has
+    been using scikit-learn since 2015, for several reasons: the quality of the
+    developments, documentation and contribution governance, and the sheer size of
+    the contributing community. We even explicitly mention the use of
+    scikit-learn's pipelines in our internal model risk governance as one of our
+    good practices to decrease operational risks and overfitting risk. As a way to
+    support open source software development and in particular scikit-learn
+    project, we decided to participate to scikit-learn's consortium at La Fondation
+    Inria since its creation in 2018.
 
-.. raw:: html
+    .. rst-class:: annotation
 
-   <span class="testimonial-author">
+      Sébastien Conort, Chief Data Scientist, BNP Paribas Cardif
 
-Sébastien Conort, Chief Data Scientist, BNP Paribas Cardif
+  .. div:: image-box
 
-.. raw:: html
-
-   </span>
-   </div>
-   <div class="sk-testimonial-div-box">
-
-.. image:: images/bnp_paribas_cardif.png
-    :width: 120pt
-    :align: center
-    :target: https://www.bnpparibascardif.com/
-
-.. raw:: html
-
-   </div>
-   </div>
+    .. image:: images/bnp_paribas_cardif.png
+      :target: https://www.bnpparibascardif.com/


### PR DESCRIPTION
**Please note that this PR targets the `new_web_theme` branch!**

Towards #28084. This is mainly to fix the styling of testimonial and about pages. Previously #28270 so pinging @adrinjalali and @glemaitre who reviewed that PR. It is essentially the same as #28270 except that it uses `sphinx-design` components to simplify the code. Rendered docs: [about](https://output.circle-artifacts.com/output/job/2f646b10-7fd3-4c3a-b0f4-caa0e529f812/artifacts/0/doc/about.html), [testimonials](https://output.circle-artifacts.com/output/job/2f646b10-7fd3-4c3a-b0f4-caa0e529f812/artifacts/0/doc/testimonials/testimonials.html).

Some thoughts: should we remove the secondary sidebar on the testimonials page?