### PR TITLE
DOC fix align table in API doc page (#28600)

### DIFF
--- a/doc/themes/scikit-learn-modern/static/css/theme.css
+++ b/doc/themes/scikit-learn-modern/static/css/theme.css
@@ -1001,6 +1001,7 @@ table.docutils {
   margin-bottom: 1rem;
   line-height: 1rem;
   max-width: 100%;
+  display: block;
   overflow-x: auto;
 }
 
@@ -1317,6 +1318,10 @@ div.sk-sponsor-div-box, div.sk-testimonial-div-box {
   div.sk-sponsor-div-box, div.sk-testimonial-div-box {
     width: 50%;
   }
+}
+
+div.sk-sponsor-div-box table.sk-sponsor-table {
+  display: table;
 }
 
 table.sk-sponsor-table tr, table.sk-sponsor-table tr:nth-child(odd) {


### PR DESCRIPTION
backport #28598 to fix the look of the API doc tables