### PR TITLE
TST remove sparse-np.float16 support in tests

### DIFF
--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -209,6 +209,8 @@ def test_standard_scaler_dtype(add_sample_weight, sparse_container):
         sample_weight = None
     with_mean = True
     if sparse_container is not None:
+        # scipy sparse containers do not support float16, see
+        # https://github.com/scipy/scipy/issues/7408 for more details.
         supported_dtype = [np.float64, np.float32]
     else:
         supported_dtype = [np.float64, np.float32, np.float16]

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -208,7 +208,11 @@ def test_standard_scaler_dtype(add_sample_weight, sparse_container):
     else:
         sample_weight = None
     with_mean = True
-    for dtype in [np.float16, np.float32, np.float64]:
+    if sparse_container is not None:
+        supported_dtype = [np.float64, np.float32]
+    else:
+        supported_dtype = [np.float64, np.float32, np.float16]
+    for dtype in supported_dtype:
         X = rng.randn(n_samples, n_features).astype(dtype)
         if sparse_container is not None:
             X = sparse_container(X)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1632,7 +1632,6 @@ def test_check_pandas_sparse_invalid(ntype1, ntype2):
     "ntype1, ntype2, expected_subtype",
     [
         ("double", "longdouble", np.floating),
-        ("float16", "half", np.floating),
         ("single", "float32", np.floating),
         ("double", "float64", np.floating),
         ("int8", "byte", np.integer),


### PR DESCRIPTION
closes https://github.com/scikit-learn/scikit-learn/issues/28589

Remove the combination of sparse matrix/arrays and `np.float16` since this is not supported in SciPy officially. We don't need to add safeguard within the `check_array` because a user will never be able to create such matrices and we will be converted to `np.float64` as a default dtype.