### PR TITLE
Issue #19614: Warn on irrelevant parameters for linear kernel in SVC

### DIFF
--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -1,4 +1,5 @@
 import warnings
+from warnings import warn
 from numbers import Integral, Real
 
 import numpy as np
@@ -307,6 +308,7 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
         self : object
             An instance of the estimator.
         """
+
         X, y = self._validate_data(
             X,
             y,
@@ -315,8 +317,23 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
             order="C",
             accept_large_sparse=False,
         )
+
         check_classification_targets(y)
+
         self.classes_ = np.unique(y)
+        if self.kernel == 'linear':
+            if self.gamma not in ('scale', 'auto'):
+                warn(
+                    "The 'gamma' parameter has been set but is not relevant for the 'linear' kernel. It will be ignored.",
+                    UserWarning)
+            if self.coef0 != 0:
+                warn(
+                    "The 'coef0' parameter has been set but is not relevant for the 'linear' kernel. It will be ignored.",
+                    UserWarning)
+            if self.degree != 3:
+                warn(
+                    "The 'degree' parameter has been set but is not relevant for the 'linear' kernel. It will be ignored.",
+                    UserWarning)
 
         _dual = _validate_dual_parameter(
             self.dual, self.loss, self.penalty, self.multi_class, X


### PR DESCRIPTION
### Fixes #XXXX

This pull request addresses the issue raised in #19614, where `SVC` does not warn users when irrelevant parameters (`gamma`, `coef0`, `degree`) are set for the `linear` kernel. Such parameters have no effect and can mislead users, especially those new to SVM or scikit-learn.

#### Changes Made:

- Modified `svm/_classes.py` to issue warnings when `gamma`, `coef0`, or `degree` is set to non-default values while using a `linear` kernel.


#### Rationale:

The changes improve user feedback and contribute to a more intuitive user experience by notifying users of potentially unintended parameter configurations. This approach follows scikit-learn's principles of transparency and user-friendliness in machine learning model configuration.
