### PR TITLE
Fix docstring for RFECV method cv_results_

### DIFF
--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -566,7 +566,11 @@ class RFECV(RFE):
         The fitted estimator used to select features.
 
     cv_results_ : dict of ndarrays
-        A dict with keys:
+        All arrays (values of the dictionary) are sorted in ascending order
+        by the number of features used (i.e., the first element of the array
+        represents the models that used the least number of features, while the
+        last element represents the models that used all available features).
+        This dictionary contains the following keys:
 
         split(k)_test_score : ndarray of shape (n_subsets_of_features,)
             The cross-validation scores across (k)th fold.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #28580


#### What does this implement/fix? Explain your changes.
Improves the documentation of the `cv_results_` attribute to make it more explicit to the reader in which way the returned arrays are ordered.

Current docs:
![old](https://github.com/scikit-learn/scikit-learn/assets/66789107/bc5c6b63-4add-4cee-9cf6-df93b45b1a00)

Proposed docs:
![new](https://github.com/scikit-learn/scikit-learn/assets/66789107/73c83026-8c35-43aa-a59f-00648a13c993)

#### Any other comments?
N/A

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
