### PR TITLE
FIX allow set_{method}_request methods to be unbound

### DIFF
--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -27,6 +27,10 @@ Metadata Routing
   attributes.
   :pr:`28435` by `Adrin Jalali`_.
 
+- |FIX| Fix an issue when `set_{method}_request` methods are used as unbound
+  methods, which can happen if one tries to decorate them.
+  :pr:`28651` by `Adrin Jalali`_.
+
 Changelog
 ---------
 


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/28632

Similar to what we did for `available_if`, we let these methods to be unbound.

@leycec could you confirm this works for you?