### PR TITLE
MAINT Bump nogil CI dependencies (Cython 3.0.9 in particular)

### DIFF
--- a/build_tools/azure/python_nogil_lock.txt
+++ b/build_tools/azure/python_nogil_lock.txt
@@ -11,13 +11,13 @@ contourpy==1.1.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-cython==3.0.8
+cython==3.0.9
     # via -r /scikit-learn/build_tools/azure/python_nogil_requirements.txt
 exceptiongroup==1.2.0
     # via pytest
 execnet==2.0.2
     # via pytest-xdist
-fonttools==4.49.0
+fonttools==4.50.0
     # via matplotlib
 iniconfig==2.0.0
     # via pytest
@@ -33,7 +33,7 @@ numpy==1.24.0
     #   contourpy
     #   matplotlib
     #   scipy
-packaging==23.2
+packaging==24.0
     # via
     #   matplotlib
     #   pytest
@@ -41,15 +41,15 @@ pillow==9.5.0
     # via matplotlib
 pluggy==1.4.0
     # via pytest
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via matplotlib
-pytest==8.0.1
+pytest==8.1.1
     # via
     #   -r /scikit-learn/build_tools/azure/python_nogil_requirements.txt
     #   pytest-xdist
 pytest-xdist==3.5.0
     # via -r /scikit-learn/build_tools/azure/python_nogil_requirements.txt
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via matplotlib
 scipy==1.9.3
     # via -r /scikit-learn/build_tools/azure/python_nogil_requirements.txt


### PR DESCRIPTION
Context: #28640 would like to bump the minimum dependency for Cython to 3.0.9 to fix a Cython bug that prevents improving HGBDT.

The `nogil` build requires building dedicated wheels for each new Cython version. This was done as part of:

- https://github.com/colesbury/nogil-wheels/pull/7

This PRs updates the lock file for `nogil` CI to test if the tests pass with this new wheel.