### PR TITLE
TST: missing test for unsigned integers types in _typedefs.pxd

### DIFF
--- a/sklearn/utils/tests/test_typedefs.py
+++ b/sklearn/utils/tests/test_typedefs.py
@@ -8,11 +8,13 @@ from sklearn.utils._typedefs import testing_make_array_from_typed_val
     "type_t, value, expected_dtype",
     [
         ("uint8_t", 1, np.uint8),
+        ("uint32_t", 1, np.uint32),
+        ("uint64_t", 1, np.uint64),
         ("intp_t", 1, np.intp),
-        ("float64_t", 1.0, np.float64),
-        ("float32_t", 1.0, np.float32),
         ("int32_t", 1, np.int32),
         ("int64_t", 1, np.int64),
+        ("float64_t", 1.0, np.float64),
+        ("float32_t", 1.0, np.float32),
     ],
 )
 def test_types(type_t, value, expected_dtype):


### PR DESCRIPTION
To settle the discussion in https://github.com/scikit-learn/scikit-learn/issues/25572#issuecomment-1760217146 to prepare a review of #28656.