### PR TITLE
Ignore .python-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,8 @@ benchmarks/HIGGS.csv.gz
 .pydevproject
 .idea
 .vscode
-.python-version  # used by pyenv
+# used by pyenv
+.python-version
 
 *.c
 *.cpp


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Related to https://github.com/scikit-learn/scikit-learn/issues/28645.


#### What does this implement/fix? Explain your changes.
In the `.gitignore` file, the `#` character only demarks a comment if at the start of a line ([ref](https://stackoverflow.com/a/8865858/7388758)). So when we have:
```
.python-version # used by pyenv
```
It means this line was not actually ignoring the `.python-version` file.

This PR corrects this, and moves the comment into the line above.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
