### PR TITLE
DOC linked isotonic regression example to isotonic regression doc

### DIFF
--- a/doc/modules/isotonic.rst
+++ b/doc/modules/isotonic.rst
@@ -31,3 +31,6 @@ thus form a function that is piecewise linear:
 .. figure:: ../auto_examples/miscellaneous/images/sphx_glr_plot_isotonic_regression_001.png
    :target: ../auto_examples/miscellaneous/plot_isotonic_regression.html
    :align: center
+
+For implementation of Isotonic regression using scikit-learn:
+:ref:`sphx_glr_auto_examples_miscellaneous_plot_isotonic_regression.py`

--- a/doc/modules/isotonic.rst
+++ b/doc/modules/isotonic.rst
@@ -32,5 +32,6 @@ thus form a function that is piecewise linear:
    :target: ../auto_examples/miscellaneous/plot_isotonic_regression.html
    :align: center
 
-For implementation of Isotonic regression using scikit-learn:
-:ref:`sphx_glr_auto_examples_miscellaneous_plot_isotonic_regression.py`
+.. topic:: Examples:
+
+  * :ref:`sphx_glr_auto_examples_miscellaneous_plot_isotonic_regression.py`


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Issue #26927 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes.
This PR add link in `doc/Module/Isotonic` for example of isotonic regression - `miscellaneous/plot_isotonic_regression.py`

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
