### PR TITLE
Update _lda.py perp_tol documentation

### DIFF
--- a/sklearn/decomposition/_lda.py
+++ b/sklearn/decomposition/_lda.py
@@ -240,8 +240,7 @@ class LatentDirichletAllocation(
         Total number of documents. Only used in the :meth:`partial_fit` method.
 
     perp_tol : float, default=1e-1
-        Perplexity tolerance. Only used when
-        ``evaluate_every`` is greater than 0.
+        Perplexity tolerance. Only used when ``evaluate_every`` is greater than 0.
 
     mean_change_tol : float, default=1e-3
         Stopping tolerance for updating document topic distribution in E-step.

--- a/sklearn/decomposition/_lda.py
+++ b/sklearn/decomposition/_lda.py
@@ -240,7 +240,7 @@ class LatentDirichletAllocation(
         Total number of documents. Only used in the :meth:`partial_fit` method.
 
     perp_tol : float, default=1e-1
-        Perplexity tolerance in batch learning. Only used when
+        Perplexity tolerance. Only used when
         ``evaluate_every`` is greater than 0.
 
     mean_change_tol : float, default=1e-3


### PR DESCRIPTION
fix documentation of the parameter "perp_tol" : it is also used in online learning.

https://github.com/scikit-learn/scikit-learn/blob/9b7d176b5a85d7dd681ffa69e55a82a3338096c5/sklearn/decomposition/_lda.py#L663-L692