### PR TITLE
CI Run only common tests for PyPy

### DIFF
--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -60,6 +60,15 @@ if [[ -n "$SELECTED_TESTS" ]]; then
     export SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all"
 fi
 
+TEST_CMD="$TEST_CMD --pyargs sklearn"
+if [[ "$DISTRIB" == "conda-pypy3" ]]; then
+    # Run only common tests for PyPy. Running the full test suite uses too
+    # much memory and causes the test to time out sometimes. See
+    # https://github.com/scikit-learn/scikit-learn/issues/27662 for more
+    # details.
+    $TEST_CMD="$TEST_CMD.tests.test_common"
+fi
+
 set -x
-eval "$TEST_CMD --pyargs sklearn"
+eval "$TEST_CMD"
 set +x

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -66,7 +66,7 @@ if [[ "$DISTRIB" == "conda-pypy3" ]]; then
     # much memory and causes the test to time out sometimes. See
     # https://github.com/scikit-learn/scikit-learn/issues/27662 for more
     # details.
-    $TEST_CMD="$TEST_CMD.tests.test_common"
+    TEST_CMD="$TEST_CMD.tests.test_common"
 fi
 
 set -x


### PR DESCRIPTION
Fixes #28391 (workaround)

As discussed in the last developer meeting and in https://github.com/scikit-learn/scikit-learn/pull/28567#issuecomment-1978427572.

CI tends to fail because of memory usage exceeding limits of CI workers. See https://github.com/scikit-learn/scikit-learn/issues/27662 for more details.