### PR TITLE
TST Speed-up test by running setup.py check rather than setup.py config

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -160,20 +160,9 @@ def test_check_estimator_generate_only():
     assert isgenerator(all_instance_gen_checks)
 
 
-@pytest.mark.skipif(
-    sklearn._BUILT_WITH_MESON,
-    reason=(
-        "This test does not make too much sense when building with Meson. "
-        "It cythonizes pyx files, and takes more than one minute on CIs."
-    ),
-)
-def test_configure():
-    # Smoke test `python setup.py config` command run at the root of the
+def test_setup_py_check():
+    # Smoke test `python setup.py check` command run at the root of the
     # scikit-learn source tree.
-    # This test requires Cython which is not necessarily there when running
-    # the tests of an installed version of scikit-learn or when scikit-learn
-    # is installed in editable mode by pip build isolation enabled.
-    pytest.importorskip("Cython")
     cwd = os.getcwd()
     setup_path = Path(sklearn.__file__).parent.parent
     setup_filename = os.path.join(setup_path, "setup.py")
@@ -182,7 +171,7 @@ def test_configure():
     try:
         os.chdir(setup_path)
         old_argv = sys.argv
-        sys.argv = ["setup.py", "config"]
+        sys.argv = ["setup.py", "check"]
 
         with warnings.catch_warnings():
             # The configuration spits out warnings when not finding

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -160,6 +160,13 @@ def test_check_estimator_generate_only():
     assert isgenerator(all_instance_gen_checks)
 
 
+@pytest.mark.skipif(
+    sklearn._BUILT_WITH_MESON,
+    reason=(
+        "This test does not make too much sense when building with Meson. "
+        "It cythonizes pyx files, and takes more than one minute on CIs."
+    ),
+)
 def test_configure():
     # Smoke test `python setup.py config` command run at the root of the
     # scikit-learn source tree.


### PR DESCRIPTION
Seen in https://github.com/scikit-learn/scikit-learn/pull/28704#issuecomment-2022494538 where it takes 6 minutes for PyPy.

I don't think checking that `python setup.py config` works makes too much sense when building with Meson. Full-disclosure: I am not too sure what `python setup.py config` is actually supposed to check ...

Quickly checking, it is generally the slowest test in the [CI log](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=65328&view=logs&jobId=8102f444-d347-5a1c-8351-04c0279c7dd4&j=689a1c8f-ff4e-5689-1a1a-6fa551ae9eba&t=0b7e60d2-0e3c-59af-8129-1150b3e7bf0c) and generally takes more than 1 minute in most CI builds.