### PR TITLE
Enhance docstring for LinearRegression.fit

### DIFF
--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -567,8 +567,8 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
             - `array-like`: should contain the individual weight of each sample.
             - `None`: all samples have a weight equal to 1.
             - `int` or `float`: all samples have a weight equal to the value \
-provided. Since there is no difference in the relative weight between samples, it is \
-equal to the case where `sample_weight=None`.
+provided. Since there is no difference in the relative weight between samples, \
+results in the same fitted model as when `sample_weight=None`.
 
             .. versionadded:: 0.17
                parameter *sample_weight* support to LinearRegression.

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -560,15 +560,13 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
         y : array-like of shape (n_samples,) or (n_samples, n_targets)
             Target values. Will be cast to X's dtype if necessary.
 
-        sample_weight : array-like of shape (n_samples,), int, float or None (default)
+        sample_weight : float or array-like of shape (n_samples,), default=None
 
             The options are:
 
+            - `float`: all samples have a weight equal to the value provided.
             - `array-like`: should contain the individual weight of each sample.
             - `None`: all samples have a weight equal to 1.
-            - `int` or `float`: all samples have a weight equal to the value \
-provided. Since there is no difference in the relative weight between samples, \
-results in the same fitted model as when `sample_weight=None`.
 
             .. versionadded:: 0.17
                parameter *sample_weight* support to LinearRegression.

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -560,8 +560,15 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
         y : array-like of shape (n_samples,) or (n_samples, n_targets)
             Target values. Will be cast to X's dtype if necessary.
 
-        sample_weight : array-like of shape (n_samples,), default=None
-            Individual weights for each sample.
+        sample_weight : array-like of shape (n_samples,), int, float or None (default)
+
+            The options are:
+
+            - `array-like`: should contain the individual weight of each sample.
+            - `None`: all samples have a weight equal to 1.
+            - `int` or `float`: all samples have a weight equal to the value \
+provided. Since there is no difference in the relative weight between samples, it is \
+equal to the case where `sample_weight=None`.
 
             .. versionadded:: 0.17
                parameter *sample_weight* support to LinearRegression.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #28732

#### What does this implement/fix? Explain your changes.
Changes the docstring to include all types that can be used for the `sample_weight` parameter, as well as explaining the user what happens in each type.