### PR TITLE
DOC Separate predefined scorer names from the ones requiring make_scorer

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -102,6 +102,7 @@ Scoring                                Function                                 
 'neg_mean_poisson_deviance'            :func:`metrics.mean_poisson_deviance`
 'neg_mean_gamma_deviance'              :func:`metrics.mean_gamma_deviance`
 'neg_mean_absolute_percentage_error'   :func:`metrics.mean_absolute_percentage_error`
+'d2_absolute_error_score' 	           :func:`metrics.d2_absolute_error_score`
 ====================================   ==============================================     ==================================
 
 Usage examples:

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -103,6 +103,25 @@ Scoring                                Function                                 
 'neg_mean_absolute_percentage_error'   :func:`metrics.mean_absolute_percentage_error`
 ====================================   ==============================================     ==================================
 
+The following metrics functions are not implemented as named
+scorers. They cannot be passed to the ``scoring`` parameters; instead
+their callable needs to be passed to :func:`make_scorer` together with the
+value of the user-settable parameters. See :ref:`scoring` for more
+details on :func:`make_scorer` usage.
+
+==============================================     ==================================
+Function                                           User-settable parameter name
+==============================================     ==================================
+**Classification**
+:func:`metrics.fbeta_score`                        ``beta``
+
+**Regression**
+:func:`metrics.mean_tweedie_deviance`              ``power``
+:func:`metrics.mean_pinball_loss`                  ``alpha``
+:func:`metrics.d2_tweedie_score`                   ``power``
+:func:`metrics.d2_pinball_score`                   ``alpha``
+==============================================     ==================================
+
 
 Usage examples:
 
@@ -159,18 +178,6 @@ the :func:`fbeta_score` function::
     >>> grid = GridSearchCV(LinearSVC(dual="auto"), param_grid={'C': [1, 10]},
     ...                     scoring=ftwo_scorer, cv=5)
 
-==============================================     ==================================
-Function                                           User settable parameter name
-==============================================     ==================================
-**Classification**
-:func:`metrics.fbeta_score`                        implements parameter ``beta``
-
-**Regression**      
-:func:`metrics.mean_tweedie_deviance`              implements parameter ``power``
-:func:`metrics.mean_pinball_loss`                  implements parameter ``alpha``
-:func:`metrics.d2_tweedie_score`                   implements parameter ``power``
-:func:`metrics.d2_pinball_score`                   implements parameter ``alpha``
-==============================================     ==================================
 
 |details-start|
 **Custom scorer objects**

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -96,6 +96,7 @@ Scoring                                Function                                 
 'neg_mean_squared_error'               :func:`metrics.mean_squared_error`
 'neg_root_mean_squared_error'          :func:`metrics.root_mean_squared_error`
 'neg_mean_squared_log_error'           :func:`metrics.mean_squared_log_error`
+'neg_root_mean_squared_log_error'      :func:`metrics.root_mean_squared_log_error`
 'neg_median_absolute_error'            :func:`metrics.median_absolute_error`
 'r2'                                   :func:`metrics.r2_score`
 'neg_mean_poisson_deviance'            :func:`metrics.mean_poisson_deviance`
@@ -109,18 +110,18 @@ their callable needs to be passed to :func:`make_scorer` together with the
 value of the user-settable parameters. See :ref:`scoring` for more
 details on :func:`make_scorer` usage.
 
-==============================================     ==================================
-Function                                           User-settable parameter name
-==============================================     ==================================
+=====================================  =========  ==============================================
+Function                               Parameter  Example usage
+=====================================  =========  ==============================================
 **Classification**
-:func:`metrics.fbeta_score`                        ``beta``
+:func:`metrics.fbeta_score`            ``beta``   ``make_scorer(fbeta_score, beta=2)``
 
 **Regression**
-:func:`metrics.mean_tweedie_deviance`              ``power``
-:func:`metrics.mean_pinball_loss`                  ``alpha``
-:func:`metrics.d2_tweedie_score`                   ``power``
-:func:`metrics.d2_pinball_score`                   ``alpha``
-==============================================     ==================================
+:func:`metrics.mean_tweedie_deviance`  ``power``  ``make_scorer(mean_tweedie_deviance, power=1)``
+:func:`metrics.mean_pinball_loss`      ``alpha``  ``make_scorer(mean_pinball_loss, alpha=0.95)``
+:func:`metrics.d2_tweedie_score`       ``power``  ``make_scorer(d2_tweedie_score, power=1)``
+:func:`metrics.d2_pinball_score`       ``alpha``  ``make_scorer(d2_pinball_score, alpha=0.95)``
+=====================================  =========  ===============================================
 
 
 Usage examples:
@@ -156,9 +157,6 @@ measuring a prediction error given ground truth and prediction:
   into a scorer object using :func:`make_scorer`, set
   the ``greater_is_better`` parameter to ``False`` (``True`` by default; see the
   parameter description below).
-
-Metrics available for various machine learning tasks are detailed in the table
-below.
 
 Many metrics are not given names to be used as ``scoring`` values,
 sometimes because they require additional parameters, such as

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -117,9 +117,9 @@ Function                               Parameter  Example usage
 :func:`metrics.fbeta_score`            ``beta``   ``make_scorer(fbeta_score, beta=2)``
 
 **Regression**
-:func:`metrics.mean_tweedie_deviance`  ``power``  ``make_scorer(mean_tweedie_deviance, power=1)``
+:func:`metrics.mean_tweedie_deviance`  ``power``  ``make_scorer(mean_tweedie_deviance, power=1.5)``
 :func:`metrics.mean_pinball_loss`      ``alpha``  ``make_scorer(mean_pinball_loss, alpha=0.95)``
-:func:`metrics.d2_tweedie_score`       ``power``  ``make_scorer(d2_tweedie_score, power=1)``
+:func:`metrics.d2_tweedie_score`       ``power``  ``make_scorer(d2_tweedie_score, power=1.5)``
 :func:`metrics.d2_pinball_score`       ``alpha``  ``make_scorer(d2_pinball_score, alpha=0.95)``
 =====================================  =========  ==============================================
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -160,22 +160,16 @@ the :func:`fbeta_score` function::
     ...                     scoring=ftwo_scorer, cv=5)
 
 ==============================================     ==================================
-Function                                           Comment
+Function                                           User settable parameter name
 ==============================================     ==================================
 **Classification**
 :func:`metrics.fbeta_score`                        implements parameter ``beta``
-:func:`metrics.hamming_loss`
-:func:`metrics.zero_one_loss`
 
 **Regression**      
-:func:`metrics.root_mean_squared_log_error`
-:func:`metrics.mean_poisson_deviance`
-:func:`metrics.mean_gamma_deviance`
 :func:`metrics.mean_tweedie_deviance`              implements parameter ``power``
 :func:`metrics.mean_pinball_loss`                  implements parameter ``alpha``
 :func:`metrics.d2_tweedie_score`                   implements parameter ``power``
 :func:`metrics.d2_pinball_score`                   implements parameter ``alpha``
-:func:`metrics.d2_absolute_error_score`            
 ==============================================     ==================================
 
 |details-start|

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -96,15 +96,11 @@ Scoring                                Function                                 
 'neg_mean_squared_error'               :func:`metrics.mean_squared_error`
 'neg_root_mean_squared_error'          :func:`metrics.root_mean_squared_error`
 'neg_mean_squared_log_error'           :func:`metrics.mean_squared_log_error`
-'neg_root_mean_squared_log_error'      :func:`metrics.root_mean_squared_log_error`
 'neg_median_absolute_error'            :func:`metrics.median_absolute_error`
 'r2'                                   :func:`metrics.r2_score`
 'neg_mean_poisson_deviance'            :func:`metrics.mean_poisson_deviance`
 'neg_mean_gamma_deviance'              :func:`metrics.mean_gamma_deviance`
 'neg_mean_absolute_percentage_error'   :func:`metrics.mean_absolute_percentage_error`
-'d2_absolute_error_score'              :func:`metrics.d2_absolute_error_score`
-'d2_pinball_score'                     :func:`metrics.d2_pinball_score`
-'d2_tweedie_score'                     :func:`metrics.d2_tweedie_score`
 ====================================   ==============================================     ==================================
 
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -104,26 +104,6 @@ Scoring                                Function                                 
 'neg_mean_absolute_percentage_error'   :func:`metrics.mean_absolute_percentage_error`
 ====================================   ==============================================     ==================================
 
-The following metrics functions are not implemented as named
-scorers. They cannot be passed to the ``scoring`` parameters; instead
-their callable needs to be passed to :func:`make_scorer` together with the
-value of the user-settable parameters. See :ref:`scoring` for more
-details on :func:`make_scorer` usage.
-
-=====================================  =========  ==============================================
-Function                               Parameter  Example usage
-=====================================  =========  ==============================================
-**Classification**
-:func:`metrics.fbeta_score`            ``beta``   ``make_scorer(fbeta_score, beta=2)``
-
-**Regression**
-:func:`metrics.mean_tweedie_deviance`  ``power``  ``make_scorer(mean_tweedie_deviance, power=1.5)``
-:func:`metrics.mean_pinball_loss`      ``alpha``  ``make_scorer(mean_pinball_loss, alpha=0.95)``
-:func:`metrics.d2_tweedie_score`       ``power``  ``make_scorer(d2_tweedie_score, power=1.5)``
-:func:`metrics.d2_pinball_score`       ``alpha``  ``make_scorer(d2_pinball_score, alpha=0.95)``
-=====================================  =========  ==============================================
-
-
 Usage examples:
 
     >>> from sklearn import svm, datasets
@@ -146,24 +126,25 @@ Usage examples:
 Defining your scoring strategy from metric functions
 -----------------------------------------------------
 
-The module :mod:`sklearn.metrics` also exposes a set of simple functions
-measuring a prediction error given ground truth and prediction:
-
-- functions ending with ``_score`` return a value to
-  maximize, the higher the better.
-
-- functions ending with ``_error``, ``_loss``, or ``_deviance`` return a
-  value to minimize, the lower the better.  When converting
-  into a scorer object using :func:`make_scorer`, set
-  the ``greater_is_better`` parameter to ``False`` (``True`` by default; see the
-  parameter description below).
-
-Many metrics are not given names to be used as ``scoring`` values,
+The following metrics functions are not implemented as named scorers,
 sometimes because they require additional parameters, such as
-:func:`fbeta_score`. In such cases, you need to generate an appropriate
-scoring object.  The simplest way to generate a callable object for scoring
-is by using :func:`make_scorer`. That function converts metrics
-into callables that can be used for model evaluation.
+:func:`fbeta_score`. They cannot be passed to the ``scoring``
+parameters; instead their callable needs to be passed to
+:func:`make_scorer` together with the value of the user-settable
+parameters.
+
+=====================================  =========  ==============================================
+Function                               Parameter  Example usage
+=====================================  =========  ==============================================
+**Classification**
+:func:`metrics.fbeta_score`            ``beta``   ``make_scorer(fbeta_score, beta=2)``
+
+**Regression**
+:func:`metrics.mean_tweedie_deviance`  ``power``  ``make_scorer(mean_tweedie_deviance, power=1.5)``
+:func:`metrics.mean_pinball_loss`      ``alpha``  ``make_scorer(mean_pinball_loss, alpha=0.95)``
+:func:`metrics.d2_tweedie_score`       ``power``  ``make_scorer(d2_tweedie_score, power=1.5)``
+:func:`metrics.d2_pinball_score`       ``alpha``  ``make_scorer(d2_pinball_score, alpha=0.95)``
+=====================================  =========  ==============================================
 
 One typical use case is to wrap an existing metric function from the library
 with non-default values for its parameters, such as the ``beta`` parameter for
@@ -175,6 +156,18 @@ the :func:`fbeta_score` function::
     >>> from sklearn.svm import LinearSVC
     >>> grid = GridSearchCV(LinearSVC(dual="auto"), param_grid={'C': [1, 10]},
     ...                     scoring=ftwo_scorer, cv=5)
+
+The module :mod:`sklearn.metrics` also exposes a set of simple functions
+measuring a prediction error given ground truth and prediction:
+
+- functions ending with ``_score`` return a value to
+  maximize, the higher the better.
+
+- functions ending with ``_error``, ``_loss``, or ``_deviance`` return a
+  value to minimize, the lower the better.  When converting
+  into a scorer object using :func:`make_scorer`, set
+  the ``greater_is_better`` parameter to ``False`` (``True`` by default; see the
+  parameter description below).
 
 
 |details-start|

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -121,7 +121,7 @@ Function                               Parameter  Example usage
 :func:`metrics.mean_pinball_loss`      ``alpha``  ``make_scorer(mean_pinball_loss, alpha=0.95)``
 :func:`metrics.d2_tweedie_score`       ``power``  ``make_scorer(d2_tweedie_score, power=1)``
 :func:`metrics.d2_pinball_score`       ``alpha``  ``make_scorer(d2_pinball_score, alpha=0.95)``
-=====================================  =========  ===============================================
+=====================================  =========  ==============================================
 
 
 Usage examples:

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -136,13 +136,13 @@ measuring a prediction error given ground truth and prediction:
 - functions ending with ``_score`` return a value to
   maximize, the higher the better.
 
-- functions ending with ``_error`` or ``_loss`` return a
+- functions ending with ``_error``, ``_loss``, or ``_deviance`` return a
   value to minimize, the lower the better.  When converting
   into a scorer object using :func:`make_scorer`, set
   the ``greater_is_better`` parameter to ``False`` (``True`` by default; see the
   parameter description below).
 
-Metrics available for various machine learning tasks are detailed in sections
+Metrics available for various machine learning tasks are detailed in the table
 below.
 
 Many metrics are not given names to be used as ``scoring`` values,
@@ -163,6 +163,24 @@ the :func:`fbeta_score` function::
     >>> grid = GridSearchCV(LinearSVC(dual="auto"), param_grid={'C': [1, 10]},
     ...                     scoring=ftwo_scorer, cv=5)
 
+==============================================     ==================================
+Function                                           Comment
+==============================================     ==================================
+**Classification**
+:func:`metrics.fbeta_score`                        implements parameter ``beta``
+:func:`metrics.hamming_loss`
+:func:`metrics.zero_one_loss`
+
+**Regression**      
+:func:`metrics.root_mean_squared_log_error`
+:func:`metrics.mean_poisson_deviance`
+:func:`metrics.mean_gamma_deviance`
+:func:`metrics.mean_tweedie_deviance`              implements parameter ``power``
+:func:`metrics.mean_pinball_loss`                  implements parameter ``alpha``
+:func:`metrics.d2_tweedie_score`                   implements parameter ``power``
+:func:`metrics.d2_pinball_score`                   implements parameter ``alpha``
+:func:`metrics.d2_absolute_error_score`            
+==============================================     ==================================
 
 |details-start|
 **Custom scorer objects**


### PR DESCRIPTION

#### Reference Issues/PRs

Related to #28671

#### What does this implement/fix? Explain your changes.

Table of scorer names currently in 3.3.1.1. includes also some that haven't been implemented / can't be passed as strings to the `scoring` parameter directly. These have now been removed from the table; a new table has been created in 3.3.1.2. (where the usage of `make_scorer` is explained) including the scoring functions which need to be wrapped with `make_scorer`.

#### Any other comments?

