### PR TITLE
DOC Add links to miscellaneous examples in docstrings

### DIFF
--- a/doc/modules/kernel_ridge.rst
+++ b/doc/modules/kernel_ridge.rst
@@ -55,6 +55,9 @@ dense model.
    :target: ../auto_examples/miscellaneous/plot_kernel_ridge_regression.html
    :align: center
 
+.. topic:: Examples
+
+    * :ref:`sphx_glr_auto_examples_miscellaneous_plot_kernel_ridge_regression.py`
 
 .. topic:: References:
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Issue [#26927](https://github.com/scikit-learn/scikit-learn/issues/26927)

#### This PR adds the [plot_kernel_ridge_regression.py link](https://github.com/scikit-learn/scikit-learn/blob/main/examples/miscellaneous/plot_kernel_ridge_regression.py) into [Kernel Ridge Regression](https://github.com/scikit-learn/scikit-learn/blob/main/doc/modules/kernel_ridge.rst).