### PR TITLE
MAINT Add project.urls to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,11 @@ classifiers=[
 ]
 
 [project.urls]
-HomePage = "https://scikit-learn.org"
-Repository = "https://github.com/scikit-learn/scikit-learn"
-DownloadURL = "https://pypi.org/project/scikit-learn/#files"
-Issues = "https://github.com/scikit-learn/scikit-learn/issues"
-Changelog = "https://scikit-learn.org/stable/whats_new"
+homepage = "https://scikit-learn.org"
+source = "https://github.com/scikit-learn/scikit-learn"
+download = "https://pypi.org/project/scikit-learn/#files"
+tracker = "https://github.com/scikit-learn/scikit-learn/issues"
+"release notes" = "https://scikit-learn.org/stable/whats_new"
 
 [project.optional-dependencies]
 build = ["numpy>=1.19.5", "scipy>=1.6.0", "cython>=3.0.9", "meson-python>=0.15.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,13 @@ classifiers=[
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
+[project.urls]
+HomePage = "https://scikit-learn.org"
+Repository = "https://github.com/scikit-learn/scikit-learn"
+DownloadURL = "https://pypi.org/project/scikit-learn/#files"
+Issues = "https://github.com/scikit-learn/scikit-learn/issues"
+Changelog = "https://scikit-learn.org/stable/whats_new"
+
 [project.optional-dependencies]
 build = ["numpy>=1.19.5", "scipy>=1.6.0", "cython>=3.0.9", "meson-python>=0.15.0"]
 install = ["numpy>=1.19.5", "scipy>=1.6.0", "joblib>=1.2.0", "threadpoolctl>=2.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,9 @@ name = "scikit-learn"
 version = "1.5.dev0"
 description = "A set of python modules for machine learning and data mining"
 readme = "README.rst"
+maintainers = [
+    {name = "scikit-learn developers", email="scikit-learn@python.org"},
+]
 dependencies = [
   "numpy>=1.19.5",
   "scipy>=1.6.0",

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ DISTNAME = "scikit-learn"
 DESCRIPTION = "A set of python modules for machine learning and data mining"
 with open("README.rst") as f:
     LONG_DESCRIPTION = f.read()
-MAINTAINER = "Andreas Mueller"
-MAINTAINER_EMAIL = "amueller@ais.uni-bonn.de"
+MAINTAINER = "scikit-learn developers"
+MAINTAINER_EMAIL = "scikit-learn@python.org"
 URL = "https://scikit-learn.org"
 DOWNLOAD_URL = "https://pypi.org/project/scikit-learn/#files"
 LICENSE = "new BSD"


### PR DESCRIPTION
This adds some metadata that are in the current sdist generated in setup.py and are not there anymore with Meson.

In the comparison done in https://github.com/scikit-learn/scikit-learn/pull/28757#issuecomment-2034638954, the only meaningful difference is in PKG-INFO.

After reordering2 the diff is like this:
```diff
--- PKG-INFO-setup-reordered	2024-04-03 16:02:02.434567837 +0200
+++ PKG-INFO-meson	2024-04-03 15:20:17.792383000 +0200
@@ -2,10 +2,6 @@
 Name: scikit-learn
 Version: 1.5.dev0
 Summary: A set of python modules for machine learning and data mining
-Home-page: https://scikit-learn.org
-Download-URL: https://pypi.org/project/scikit-learn/#files
-Maintainer: Andreas Mueller
-Maintainer-email: amueller@ais.uni-bonn.de
 License: new BSD
 Classifier: Intended Audience :: Science/Research
 Classifier: Intended Audience :: Developers
@@ -27,7 +23,6 @@
 Classifier: Programming Language :: Python :: Implementation :: CPython
 Classifier: Programming Language :: Python :: Implementation :: PyPy
 Requires-Python: >=3.9
-License-File: COPYING
 Requires-Dist: numpy>=1.19.5
 Requires-Dist: scipy>=1.6.0
 Requires-Dist: joblib>=1.2.0

```

I think Maintainer does not make too much sense and Andy's email is probably not valid anymore.

I added `project.urls` that are used for the "Project links" on PyPI left-hand-side panel. See for example for numpy:
https://github.com/numpy/numpy/blob/ffb23cd626bc1f7d09aed257e28142346661a915/pyproject.toml#L54-L60

https://pypi.org/project/numpy/
![image](https://github.com/scikit-learn/scikit-learn/assets/1680079/0cd139f5-e7d6-4cbc-b7a5-fd37a8c6be7a)

Comments:
- I am not too sure Changelog is needed and it goes to the generic changelog page you then have to chose the version you care about, maybe good enough? ... also numpy has it
- We had only DownloadURL and Homepage in our setup.py, not sure where the others are coming in https://pypi.org/project/numpy/, I added others to roughly mirror what we have currently in our PyPI project page and following https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls