### PR TITLE
MAINT cleanup utils.__init__: deprecate tosequence

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -336,7 +336,7 @@ Changelog
 ....................
 
 - |API| :func:`utils.tosequence` is deprecated and will be removed in version 1.7.
-  :pr:`28762` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+  :pr:`287623` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 .. rubric:: Code and documentation contributors
 

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -332,6 +332,12 @@ Changelog
   given the split condition.
   :pr:`28552` by :user:`Adam Li <adam2392>`.
 
+:mod:`sklearn.utils`
+....................
+
+- |API| :func:`utils.tosequence` is deprecated and will be removed in version 1.7.
+  :pr:`28762` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
 .. rubric:: Code and documentation contributors
 
 Thanks to everyone who has contributed to the maintenance and improvement of

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -336,7 +336,7 @@ Changelog
 ....................
 
 - |API| :func:`utils.tosequence` is deprecated and will be removed in version 1.7.
-  :pr:`287623` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+  :pr:`28763` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 .. rubric:: Code and documentation contributors
 

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -22,7 +22,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import scale
 from sklearn.svm import NuSVR
-from sklearn.utils import check_random_state, tosequence
+from sklearn.utils import check_random_state
 from sklearn.utils._mocking import NoSampleWeightWrapper
 from sklearn.utils._param_validation import InvalidParameterError
 from sklearn.utils._testing import (
@@ -529,10 +529,10 @@ def test_symbol_labels():
     # Test with non-integer class labels.
     clf = GradientBoostingClassifier(n_estimators=100, random_state=1)
 
-    symbol_y = tosequence(map(str, y))
+    symbol_y = list(map(str, y))
 
     clf.fit(X, symbol_y)
-    assert_array_equal(clf.predict(T), tosequence(map(str, true_result)))
+    assert_array_equal(clf.predict(T), list(map(str, true_result)))
     assert 100 == len(clf.estimators_)
 
 

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -86,6 +86,8 @@ _IS_32BIT = 8 * struct.calcsize("P") == 32
 _IS_WASM = platform.machine() in ["wasm32", "wasm64"]
 
 
+# TODO(1.7): remove tosequence
+@deprecated("tosequence was deprecated in 1.5 and will be removed in 1.7")
 def tosequence(x):
     """Cast iterable x to a Sequence, avoiding a copy if possible.
 

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -8,6 +8,7 @@ from sklearn.utils import (
     column_or_1d,
     deprecated,
     safe_mask,
+    tosequence,
 )
 from sklearn.utils._missing import is_scalar_nan
 from sklearn.utils._testing import assert_array_equal, assert_no_warnings
@@ -157,3 +158,9 @@ def test__is_polars_df():
             self.schema = ["a", "b"]
 
     assert not _is_polars_df(LooksLikePolars())
+
+
+# TODO(1.7): remove
+def test_tosequence_deprecated():
+    with pytest.warns(FutureWarning, match="tosequence was deprecated in 1.5"):
+        tosequence([1, 2, 3])


### PR DESCRIPTION
Extracted from https://github.com/scikit-learn/scikit-learn/pull/26686 to ease the reviews. The end goal is to clean the `utils.__init__` module as explained in the linked PR.

The only current usage of `tosequence` is in a single test, to turn a `map` into a `list`. I don't think we really need to keep it in the codebase. It's not a public function but since it's available from `sklearn.utils` and doesn't have a leading underscore, let's be extra safe and follow the deprecation cycle, unless you think otherwise and I'll be happy to just remove it right away :)