### PR TITLE
DOC: typo lar not lars

### DIFF
--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -273,7 +273,7 @@ def lars_path_gram(
 
     (1 / (2 * n_samples)) * ||y - Xw||^2_2 + alpha * ||w||_1
 
-    in the case of method='lars', the objective function is only known in
+    in the case of method='lar', the objective function is only known in
     the form of an implicit equation (see discussion in [1])
 
     Read more in the :ref:`User Guide <least_angle_regression>`.
@@ -432,7 +432,7 @@ def _lars_path_solver(
 
     (1 / (2 * n_samples)) * ||y - Xw||^2_2 + alpha * ||w||_1
 
-    in the case of method='lars', the objective function is only known in
+    in the case of method='lar', the objective function is only known in
     the form of an implicit equation (see discussion in [1])
 
     Read more in the :ref:`User Guide <least_angle_regression>`.


### PR DESCRIPTION
The expected argument is `'lar'` not `'lars'`, fix the typo in the docstrings.

-----

Is there a particular reason, why the correct argument is `'lar'` and not `'lars'`? All the methods and the abbreviation on [Wikipedia](https://en.wikipedia.org/wiki/Least-angle_regression) are LARS. To me, `method='lar'` always comes as a surprise.
If there is no particular reason, I would suggest allowing `'lars'` as a synonym for `'lar'` and deprecating `'lar'` in the long run.