### PR TITLE
CI Update Pyodide to 0.25.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,9 +126,8 @@ jobs:
     # Need to match Python version and Emscripten version for the correct
     # Pyodide version. For example, for Pyodide version 0.25.0, see
     # https://github.com/pyodide/pyodide/blob/0.25.0/Makefile.envs
-    PYODIDE_VERSION: '0.25.0'
+    PYODIDE_VERSION: '0.25.1'
     EMSCRIPTEN_VERSION: '3.1.46'
-    PYTHON_VERSION: '3.11.3'
 
   dependsOn: [git_commit, linting]
   condition: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,8 +124,8 @@ jobs:
     vmImage: ubuntu-22.04
   variables:
     # Need to match Python version and Emscripten version for the correct
-    # Pyodide version. For example, for Pyodide version 0.25.0, see
-    # https://github.com/pyodide/pyodide/blob/0.25.0/Makefile.envs
+    # Pyodide version. For example, for Pyodide version 0.25.1, see
+    # https://github.com/pyodide/pyodide/blob/0.25.1/Makefile.envs
     PYODIDE_VERSION: '0.25.1'
     EMSCRIPTEN_VERSION: '3.1.46'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,6 +128,7 @@ jobs:
     # https://github.com/pyodide/pyodide/blob/0.25.1/Makefile.envs
     PYODIDE_VERSION: '0.25.1'
     EMSCRIPTEN_VERSION: '3.1.46'
+    PYTHON_VERSION: '3.11.3'
 
   dependsOn: [git_commit, linting]
   condition: |


### PR DESCRIPTION
Pyodide build has been failing for a few days e.g. this [build log](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=65554&view=logs&jobId=6fac3219-cc32-5595-eb73-7f086a643b12&j=6fac3219-cc32-5595-eb73-7f086a643b12&t=6856d197-9931-5ad8-f897-5714e4bdfa31)

Similar issue was seen in numpy https://github.com/numpy/numpy/issues/26164 and has been fixed in Pyodide 0.25.1.

Traceback:
```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/pyodide_build/pypabuild.py", line 71, in _runner
    env["BUILD_ENV_SCRIPTS_DIR"] = isolated_build_env._scripts_dir
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: '_DefaultIsolatedEnv' object has no attribute '_scripts_dir'
```