### PR TITLE
[WIP] Add ReducedRankRegression estimator (Resolves#10796)

### DIFF
--- a/sklearn/cross_decomposition/__init__.py
+++ b/sklearn/cross_decomposition/__init__.py
@@ -1,3 +1,3 @@
-from ._pls import CCA, PLSSVD, PLSCanonical, PLSRegression
+from ._pls import CCA, PLSSVD, PLSCanonical, PLSRegression, ReducedRankRegression
 
-__all__ = ["PLSCanonical", "PLSRegression", "PLSSVD", "CCA"]
+__all__ = ["PLSCanonical", "PLSRegression", "PLSSVD", "CCA", "ReducedRankRegression"]

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -20,6 +20,7 @@ from ..base import (
     TransformerMixin,
     _fit_context,
 )
+from ..decomposition import PCA
 from ..exceptions import ConvergenceWarning
 from ..linear_model import Ridge
 from ..utils import check_array, check_consistent_length
@@ -243,12 +244,11 @@ class ReducedRankRegression(Ridge):
     >>> Y_pred = rrr.predict(X)
     """
 
-    from ..decomposition import PCA
 
     _parameter_constraints: dict = {
     "rank": [Interval(Integral, 1, None, closed="left")],
     "alpha": [Interval(Real, 0, None, closed="left"), np.ndarray],
-    "ridge_params_dict": ["dict"],
+    #"ridge_params_dict": ["dict"], # TODO: add validation for Ridge parameters dict argument?
     }
 
     def __init__(self, rank=2, alpha=0, ridge_params_dict=None): # default full rank


### PR DESCRIPTION
I've added a ReducedRankRegression estimator (resolves #10796) . It seems to be behaving as expected, as shown below.  
![rr_reg](https://github.com/scikit-learn/scikit-learn/assets/49578591/ccf54928-6508-4eb7-9cd9-2d3f15804f6a)
I did this by extending `sklearn.linearmodel.Ridge` because I thought it'd be nice to optionally apply a ridge penalty too. 

Where I'm stuck is on how to handle some tests: I'm currently failing a few of them because reduced rank regression (specifically the underlying SVD operation) don't work (and are pointless) when there is only one target to predict. Any guidance on what to do here is appreciated.

Also if inheriting from an existing estimator is inappropriate, I can implement more of the functionality myself. This is my first contribution attempt so still getting familiar with the codebase...


