### PR TITLE
BLD Fix build dependency in meson build

### DIFF
--- a/sklearn/cluster/_hdbscan/meson.build
+++ b/sklearn/cluster/_hdbscan/meson.build
@@ -1,5 +1,5 @@
 cluster_hdbscan_extension_metadata = {
-  '_linkage': {'sources': ['_linkage.pyx']},
+  '_linkage': {'sources': ['_linkage.pyx'] + metrics_cython_tree},
   '_reachability': {'sources': ['_reachability.pyx']},
   '_tree': {'sources': ['_tree.pyx']}
 }

--- a/sklearn/cluster/meson.build
+++ b/sklearn/cluster/meson.build
@@ -1,8 +1,8 @@
 cluster_extension_metadata = {
   '_dbscan_inner':
-    {'sources': ['_dbscan_inner.pyx'],'override_options': ['cython_language=cpp']},
+    {'sources': ['_dbscan_inner.pyx'], 'override_options': ['cython_language=cpp']},
   '_hierarchical_fast':
-    {'sources': ['_hierarchical_fast.pyx'], 'override_options': ['cython_language=cpp']},
+    {'sources': ['_hierarchical_fast.pyx'] + metrics_cython_tree, 'override_options': ['cython_language=cpp']},
   '_k_means_common':
     {'sources': ['_k_means_common.pyx']},
   '_k_means_lloyd':

--- a/sklearn/metrics/meson.build
+++ b/sklearn/metrics/meson.build
@@ -14,6 +14,7 @@ _dist_metrics_pxd = custom_target(
   install_dir: sklearn_dir / 'metrics',
   install: true,
 )
+metrics_cython_tree += [_dist_metrics_pxd]
 
 _dist_metrics_pyx = custom_target(
   '_dist_metrics_pyx',
@@ -24,7 +25,7 @@ _dist_metrics_pyx = custom_target(
 
 _dist_metrics = py.extension_module(
   '_dist_metrics',
-  [_dist_metrics_pyx, _dist_metrics_pxd, utils_cython_tree, metrics_cython_tree],
+  [_dist_metrics_pyx, utils_cython_tree, metrics_cython_tree],
   dependencies: [np_dep],
   cython_args: cython_args,
   subdir: 'sklearn/metrics',


### PR DESCRIPTION
This was seen from time to time in the no-OpenMP build e.g. in https://github.com/scikit-learn/scikit-learn/pull/28757#issuecomment-2034059380, see [build log](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=65516&view=logs&jobId=e6d5b7c0-0dfd-5ddf-13d5-c71bebf56ce2&j=e6d5b7c0-0dfd-5ddf-13d5-c71bebf56ce2&t=83107d01-18db-5293-bb0f-49ac2bf2f625) and more recently in `main` CI [build log](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=65630&view=logs&jobId=e6d5b7c0-0dfd-5ddf-13d5-c71bebf56ce2&j=e6d5b7c0-0dfd-5ddf-13d5-c71bebf56ce2&t=83107d01-18db-5293-bb0f-49ac2bf2f625). The error looks like this:
```
  [60/249] Compiling Cython source /Users/runner/work/1/s/sklearn/cluster/_hdbscan/_linkage.pyx
  FAILED: sklearn/cluster/_hdbscan/_linkage.cpython-312-darwin.so.p/sklearn/cluster/_hdbscan/_linkage.pyx.c
  cython -M --fast-fail -3 '-X language_level=3' '-X boundscheck=False' '-X wraparound=False' '-X initializedcheck=False' '-X nonecheck=False' '-X cdivision=True' '-X profile=False' --include-dir /Users/runner/work/1/s/build/cp312 /Users/runner/work/1/s/sklearn/cluster/_hdbscan/_linkage.pyx -o sklearn/cluster/_hdbscan/_linkage.cpython-312-darwin.so.p/sklearn/cluster/_hdbscan/_linkage.pyx.c

  Error compiling Cython file:
  ------------------------------------------------------------
  ...

  cimport numpy as cnp
  from libc.float cimport DBL_MAX

  import numpy as np
  from ...metrics._dist_metrics cimport DistanceMetric64
  ^
  ------------------------------------------------------------

  /Users/runner/work/1/s/sklearn/cluster/_hdbscan/_linkage.pyx:38:0: 'sklearn/metrics/_dist_metrics.pxd' not found
  [61/249] Compiling Cython source /Users/runner/work/1/s/sklearn/utils/_isfinite.pyx
  [62/249] Compiling Cython source /Users/runner/work/1/s/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
  [63/249] Compiling C++ object sklearn/utils/_vector_sentinel.cpython-312-darwin.so.p/meson-generated_sklearn_utils__vector_sentinel.pyx.cpp.o
  [64/249] Compiling C++ object sklearn/utils/_fast_dict.cpython-312-darwin.so.p/meson-generated_sklearn_utils__fast_dict.pyx.cpp.o
  ninja: build stopped: subcommand failed.
  error: subprocess-exited-with-error
  
  × Preparing editable metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  full command: /usr/local/miniconda/envs/testvenv/bin/python /usr/local/miniconda/envs/testvenv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py prepare_metadata_for_build_editable /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpagbgst0x
  cwd: /Users/runner/work/1/s
  Preparing editable metadata (pyproject.toml): finished with status 'error'
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

The root cause is likely that the dependency are not correctly defined in the `meson.build` files. This is not detected by `ninja -C build/cp312 -t missingdeps` maybe because this is a ninja template `.pxd.tp` rather than a `.pxd` file?

Here are the two files that need it `_dist_metrics.pxd`:
```
❯ git grep -P 'from.*metrics.+import' -- **/*.pyx **/*.pxd
sklearn/cluster/_hdbscan/_linkage.pyx:from ...metrics._dist_metrics cimport DistanceMetric64
sklearn/cluster/_hierarchical_fast.pyx:from ..metrics._dist_metrics cimport DistanceMetric64
```

I have not been able to reproduce locally so I don't know for sure that this fixes the problem, but looking at the generated `ninja.build` file, it does seem like `_dist_metrics_pxd` will be a dependency of the two files that need it.