### PR TITLE
MAINT Replace ruff deprecated --show-source argument

### DIFF
--- a/build_tools/get_comment.py
+++ b/build_tools/get_comment.py
@@ -117,7 +117,7 @@ def get_message(log_file, repo, pr_number, sha, run_id, details, versions):
         end="Problems detected by ruff",
         title="`ruff`",
         message=(
-            "`ruff` detected issues. Please run `ruff --fix --show-source .` "
+            "`ruff` detected issues. Please run `ruff --fix --output-format=full .` "
             "locally, fix the remaining issues, and push the changes. "
             "Here you can see the detected issues. Note that the installed "
             f"`ruff` version is `ruff={versions['ruff']}`."

--- a/build_tools/linting.sh
+++ b/build_tools/linting.sh
@@ -23,7 +23,7 @@ else
 fi
 
 echo -e "### Running ruff ###\n"
-ruff check --show-source .
+ruff check --output-format=full .
 status=$?
 if [[ $status -eq 0 ]]
 then


### PR DESCRIPTION
```
❯ ruff --show-source .       
warning: The `--show-source` argument is deprecated. Use `--output-format=full` instead.
```

Here is one [CI build log](https://github.com/scikit-learn/scikit-learn/actions/runs/8613831611/job/23605989183?pr=28681) that shows the same warning.
