### PR TITLE
CI Add last failure date to automatic issue

### DIFF
--- a/maint_tools/update_tracking_issue.py
+++ b/maint_tools/update_tracking_issue.py
@@ -60,7 +60,7 @@ issue_repo = gh.get_repo(args.issue_repo)
 dt_now = datetime.now(tz=timezone.utc)
 date_str = dt_now.strftime("%b %d, %Y")
 title_query = "CI failed on {args.ci_name}"
-title = f"⚠️ {title_query} ⚠️ (last failure: {date_str})"
+title = f"⚠️ {title_query} (last failure: {date_str}) ⚠️"
 
 
 def get_issue():

--- a/maint_tools/update_tracking_issue.py
+++ b/maint_tools/update_tracking_issue.py
@@ -59,13 +59,14 @@ gh = Github(args.bot_github_token)
 issue_repo = gh.get_repo(args.issue_repo)
 dt_now = datetime.now(tz=timezone.utc)
 date_str = dt_now.strftime("%b %d, %Y")
-title = f"⚠️ CI failed on {args.ci_name} ⚠️"
+title_query = "CI failed on {args.ci_name}"
+title = f"⚠️ {title_query} ⚠️ (last failure: {date_str})"
 
 
 def get_issue():
     login = gh.get_user().login
     issues = gh.search_issues(
-        f"repo:{args.issue_repo} {title} in:title state:open author:{login}"
+        f"repo:{args.issue_repo} {title_query} in:title state:open author:{login}"
     )
     first_page = issues.get_page(0)
     # Return issue if it exist
@@ -95,7 +96,7 @@ def create_or_update_issue(body=""):
     else:
         # Update existing issue
         header = f"**CI is still failing on {link}** ({date_str})"
-        issue.edit(body=f"{header}\n{body}")
+        issue.edit(title=title, body=f"{header}\n{body}")
         print(f"Commented on issue: {args.issue_repo}#{issue.number}")
         sys.exit()
 


### PR DESCRIPTION
When I look at issues I always sort by "recently udpated":
https://github.com/scikit-learn/scikit-learn/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc

The automatically opened issues appear towards the top (whether they failed or not they are updated each day) and it would be great to be able to be able to judge quickly if this is a new issue or an old one that fails from time to time:
![image](https://github.com/scikit-learn/scikit-learn/assets/1680079/5a5ed2a9-b9f2-489b-8429-4c9893794b69)

I added the date of the last failure at the end of the issue title. I haven't tested it, but this looks like a minor change. Here is the PyGithub `Issue.edit` doc that shows you can edit the title and the body: https://pygithub.readthedocs.io/en/stable/github_objects/Issue.html#github.Issue.Issue.edit.
