### PR TITLE
DOC Add 1.4.2 to News

### DIFF
--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -169,7 +169,9 @@
         <li><strong>On-going development:</strong>
         <a href="whats_new/v1.5.html#version-1-5-0">scikit-learn 1.5 (Changelog)</a>
         </li>
-        <li><strong>February 2024.</strong> scikit-learn 1.4.1 is available for download (<a href="whats_new/v1.4.html#version-1-4-1">Changelog</a>).
+        <li><strong>April 2024.</strong> scikit-learn 1.4.2 is available for download (<a href="whats_new/v1.4.html#version-1-4-2">Changelog</a>).
+        </li>
+        <li><strong>February 2024.</strong> scikit-learn 1.4.1.post1 is available for download (<a href="whats_new/v1.4.html#version-1-4-1-post1">Changelog</a>).
         </li>
         <li><strong>January 2024.</strong> scikit-learn 1.4.0 is available for download (<a href="whats_new/v1.4.html#version-1-4-0">Changelog</a>).
         </li>


### PR DESCRIPTION
I only did it in the 1.4.2 release branch. Usually we do it in the main branch and backport in the release branch but I forgot this one.

This PR also switches 1.4.1 to 1.4.1.post1 as was done in 1.4.X for the 1.4.1.post1 release but was apparently also not done in main at the time as well.