### PR TITLE
MNT remove author and license in GLM files

### DIFF
--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -36,11 +36,6 @@ policyholders.
 
 """
 
-# Authors: Christian Lorentzen <lorentzen.ch@gmail.com>
-#          Roman Yurchak <rth.yurchak@gmail.com>
-#          Olivier Grisel <olivier.grisel@ensta.org>
-# License: BSD 3 clause
-
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -1,5 +1,5 @@
 # Authors: The scikit-learn developers
-# License: BSD 3 clause
+# SPDX-License-Identifier: BSD-3-Clause
 """
 ======================================
 Poisson regression and non-normal loss

--- a/examples/linear_model/plot_poisson_regression_non_normal_loss.py
+++ b/examples/linear_model/plot_poisson_regression_non_normal_loss.py
@@ -1,3 +1,5 @@
+# Authors: The scikit-learn developers
+# License: BSD 3 clause
 """
 ======================================
 Poisson regression and non-normal loss

--- a/examples/linear_model/plot_tweedie_regression_insurance_claims.py
+++ b/examples/linear_model/plot_tweedie_regression_insurance_claims.py
@@ -37,11 +37,6 @@ helper functions for loading the data and visualizing results.
     <https://doi.org/10.2139/ssrn.3164764>`_
 """
 
-# Authors: Christian Lorentzen <lorentzen.ch@gmail.com>
-#          Roman Yurchak <rth.yurchak@gmail.com>
-#          Olivier Grisel <olivier.grisel@ensta.org>
-# License: BSD 3 clause
-
 # %%
 
 from functools import partial

--- a/examples/linear_model/plot_tweedie_regression_insurance_claims.py
+++ b/examples/linear_model/plot_tweedie_regression_insurance_claims.py
@@ -1,5 +1,5 @@
 # Authors: The scikit-learn developers
-# License: BSD 3 clause
+# SPDX-License-Identifier: BSD-3-Clause
 """
 ======================================
 Tweedie regression on insurance claims

--- a/examples/linear_model/plot_tweedie_regression_insurance_claims.py
+++ b/examples/linear_model/plot_tweedie_regression_insurance_claims.py
@@ -1,3 +1,5 @@
+# Authors: The scikit-learn developers
+# License: BSD 3 clause
 """
 ======================================
 Tweedie regression on insurance claims

--- a/sklearn/linear_model/_glm/__init__.py
+++ b/sklearn/linear_model/_glm/__init__.py
@@ -1,5 +1,3 @@
-# License: BSD 3 clause
-
 from .glm import (
     GammaRegressor,
     PoissonRegressor,

--- a/sklearn/linear_model/_glm/__init__.py
+++ b/sklearn/linear_model/_glm/__init__.py
@@ -1,5 +1,5 @@
 # Authors: The scikit-learn developers
-# License: BSD 3 clause
+# SPDX-License-Identifier: BSD-3-Clause
 from .glm import (
     GammaRegressor,
     PoissonRegressor,

--- a/sklearn/linear_model/_glm/__init__.py
+++ b/sklearn/linear_model/_glm/__init__.py
@@ -1,3 +1,5 @@
+# Authors: The scikit-learn developers
+# License: BSD 3 clause
 from .glm import (
     GammaRegressor,
     PoissonRegressor,

--- a/sklearn/linear_model/_glm/_newton_solver.py
+++ b/sklearn/linear_model/_glm/_newton_solver.py
@@ -2,9 +2,6 @@
 Newton solver for Generalized Linear Models
 """
 
-# Author: Christian Lorentzen <lorentzen.ch@gmail.com>
-# License: BSD 3 clause
-
 import warnings
 from abc import ABC, abstractmethod
 

--- a/sklearn/linear_model/_glm/_newton_solver.py
+++ b/sklearn/linear_model/_glm/_newton_solver.py
@@ -1,5 +1,5 @@
 # Authors: The scikit-learn developers
-# License: BSD 3 clause
+# SPDX-License-Identifier: BSD-3-Clause
 """
 Newton solver for Generalized Linear Models
 """

--- a/sklearn/linear_model/_glm/_newton_solver.py
+++ b/sklearn/linear_model/_glm/_newton_solver.py
@@ -1,3 +1,5 @@
+# Authors: The scikit-learn developers
+# License: BSD 3 clause
 """
 Newton solver for Generalized Linear Models
 """

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -2,10 +2,6 @@
 Generalized Linear Models with Exponential Dispersion Family
 """
 
-# Author: Christian Lorentzen <lorentzen.ch@gmail.com>
-# some parts and tricks stolen from other sklearn files.
-# License: BSD 3 clause
-
 from numbers import Integral, Real
 
 import numpy as np

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -1,3 +1,5 @@
+# Authors: The scikit-learn developers
+# License: BSD 3 clause
 """
 Generalized Linear Models with Exponential Dispersion Family
 """

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -1,5 +1,5 @@
 # Authors: The scikit-learn developers
-# License: BSD 3 clause
+# SPDX-License-Identifier: BSD-3-Clause
 """
 Generalized Linear Models with Exponential Dispersion Family
 """

--- a/sklearn/linear_model/_glm/tests/__init__.py
+++ b/sklearn/linear_model/_glm/tests/__init__.py
@@ -1,1 +1,0 @@
-# License: BSD 3 clause

--- a/sklearn/linear_model/_glm/tests/__init__.py
+++ b/sklearn/linear_model/_glm/tests/__init__.py
@@ -1,2 +1,2 @@
 # Authors: The scikit-learn developers
-# License: BSD 3 clause
+# SPDX-License-Identifier: BSD-3-Clause

--- a/sklearn/linear_model/_glm/tests/__init__.py
+++ b/sklearn/linear_model/_glm/tests/__init__.py
@@ -1,0 +1,2 @@
+# Authors: The scikit-learn developers
+# License: BSD 3 clause

--- a/sklearn/linear_model/_glm/tests/test_glm.py
+++ b/sklearn/linear_model/_glm/tests/test_glm.py
@@ -1,7 +1,3 @@
-# Authors: Christian Lorentzen <lorentzen.ch@gmail.com>
-#
-# License: BSD 3 clause
-
 import itertools
 import warnings
 from functools import partial

--- a/sklearn/linear_model/_glm/tests/test_glm.py
+++ b/sklearn/linear_model/_glm/tests/test_glm.py
@@ -1,5 +1,5 @@
 # Authors: The scikit-learn developers
-# License: BSD 3 clause
+# SPDX-License-Identifier: BSD-3-Clause
 import itertools
 import warnings
 from functools import partial

--- a/sklearn/linear_model/_glm/tests/test_glm.py
+++ b/sklearn/linear_model/_glm/tests/test_glm.py
@@ -1,3 +1,5 @@
+# Authors: The scikit-learn developers
+# License: BSD 3 clause
 import itertools
 import warnings
 from functools import partial


### PR DESCRIPTION
#### Reference Issues/PRs
Partially addresses #20813.

#### What does this implement/fix? Explain your changes.
I best start with my own authorship and remove all those info from GLMs.

#### Any other comments?
An alternative https://github.com/scikit-learn/scikit-learn/issues/20813#issuecomment-903774983 to removing is
```
# Authors: The scikit-learn developers.
# License: BSD 3 clause
```
