### PR TITLE
MAINT Clean up deprecations for 1.5: in make_sparse_coded_signal

### DIFF
--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -1466,7 +1466,6 @@ def make_low_rank_matrix(
         "n_features": [Interval(Integral, 1, None, closed="left")],
         "n_nonzero_coefs": [Interval(Integral, 1, None, closed="left")],
         "random_state": ["random_state"],
-        "data_transposed": ["boolean", Hidden(StrOptions({"deprecated"}))],
     },
     prefer_skip_nested_validation=True,
 )
@@ -1477,13 +1476,12 @@ def make_sparse_coded_signal(
     n_features,
     n_nonzero_coefs,
     random_state=None,
-    data_transposed="deprecated",
 ):
     """Generate a signal as a sparse combination of dictionary elements.
 
-    Returns a matrix `Y = DX`, such that `D` is of shape `(n_features, n_components)`,
-    `X` is of shape `(n_components, n_samples)` and each column of `X` has exactly
-    `n_nonzero_coefs` non-zero elements.
+    Returns matrices `Y`, `D` and `X` such that `Y = XD` where `X` is of shape
+    `(n_samples, n_components)`, `D` is of shape `(n_components, n_features)`, and
+    each row of `X` has exactly `n_nonzero_coefs` non-zero elements.
 
     Read more in the :ref:`User Guide <sample_generators>`.
 
@@ -1506,33 +1504,17 @@ def make_sparse_coded_signal(
         for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
 
-    data_transposed : bool, default=False
-        By default, Y, D and X are not transposed.
-
-        .. versionadded:: 1.1
-
-        .. versionchanged:: 1.3
-            Default value changed from True to False.
-
-        .. deprecated:: 1.3
-            `data_transposed` is deprecated and will be removed in 1.5.
-
     Returns
     -------
-    data : ndarray of shape (n_features, n_samples) or (n_samples, n_features)
-        The encoded signal (Y). The shape is `(n_samples, n_features)` if
-        `data_transposed` is False, otherwise it's `(n_features, n_samples)`.
+    data : ndarray of shape (n_samples, n_features)
+        The encoded signal (Y).
 
-    dictionary : ndarray of shape (n_features, n_components) or \
-            (n_components, n_features)
-        The dictionary with normalized components (D). The shape is
-        `(n_components, n_features)` if `data_transposed` is False, otherwise it's
-        `(n_features, n_components)`.
+    dictionary : ndarray of shape (n_components, n_features)
+        The dictionary with normalized components (D).
 
-    code : ndarray of shape (n_components, n_samples) or (n_samples, n_components)
+    code : ndarray of shape (n_samples, n_components)
         The sparse code such that each column of this matrix has exactly
-        n_nonzero_coefs non-zero items (X). The shape is `(n_samples, n_components)`
-        if `data_transposed` is False, otherwise it's `(n_components, n_samples)`.
+        n_nonzero_coefs non-zero items (X).
 
     Examples
     --------
@@ -1568,19 +1550,8 @@ def make_sparse_coded_signal(
     # encode signal
     Y = np.dot(D, X)
 
-    # TODO(1.5) remove data_transposed
-    # raise warning if data_transposed is not passed explicitly
-    if data_transposed != "deprecated":
-        warnings.warn(
-            "data_transposed was deprecated in version 1.3 and will be removed in 1.5.",
-            FutureWarning,
-        )
-    else:
-        data_transposed = False
-
-    # transpose if needed
-    if not data_transposed:
-        Y, D, X = Y.T, D.T, X.T
+    # Transpose to have shapes consistent with the rest of the API
+    Y, D, X = Y.T, D.T, X.T
 
     return map(np.squeeze, (Y, D, X))
 

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -33,7 +33,6 @@ from sklearn.utils._testing import (
     assert_almost_equal,
     assert_array_almost_equal,
     assert_array_equal,
-    ignore_warnings,
 )
 from sklearn.utils.validation import assert_all_finite
 
@@ -498,41 +497,6 @@ def test_make_sparse_coded_signal():
         assert len(np.flatnonzero(row)) == 3, "Non-zero coefs mismatch"
     assert_allclose(Y, X @ D)
     assert_allclose(np.sqrt((D**2).sum(axis=1)), np.ones(D.shape[0]))
-
-
-# TODO(1.5): remove
-@ignore_warnings(category=FutureWarning)
-def test_make_sparse_coded_signal_transposed():
-    Y, D, X = make_sparse_coded_signal(
-        n_samples=5,
-        n_components=8,
-        n_features=10,
-        n_nonzero_coefs=3,
-        random_state=0,
-        data_transposed=True,
-    )
-    assert Y.shape == (10, 5), "Y shape mismatch"
-    assert D.shape == (10, 8), "D shape mismatch"
-    assert X.shape == (8, 5), "X shape mismatch"
-    for col in X.T:
-        assert len(np.flatnonzero(col)) == 3, "Non-zero coefs mismatch"
-    assert_allclose(Y, D @ X)
-    assert_allclose(np.sqrt((D**2).sum(axis=0)), np.ones(D.shape[1]))
-
-
-# TODO(1.5): remove
-def test_make_sparse_code_signal_deprecation_warning():
-    """Check the message for future deprecation."""
-    warn_msg = "data_transposed was deprecated in version 1.3"
-    with pytest.warns(FutureWarning, match=warn_msg):
-        make_sparse_coded_signal(
-            n_samples=1,
-            n_components=1,
-            n_features=1,
-            n_nonzero_coefs=1,
-            random_state=0,
-            data_transposed=True,
-        )
 
 
 def test_make_sparse_uncorrelated():


### PR DESCRIPTION
remove deprecated `data_transposed` param from `make_sparse_coded_signal`.