### PR TITLE
MAINT Clean up deprecations for 1.5: in Displays

### DIFF
--- a/sklearn/model_selection/_plot.py
+++ b/sklearn/model_selection/_plot.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 
 from ..utils._optional_dependencies import check_matplotlib_support
@@ -16,7 +14,6 @@ class _BaseCurveDisplay:
         negate_score=False,
         score_name=None,
         score_type="test",
-        log_scale="deprecated",
         std_display_style="fill_between",
         line_kw=None,
         fill_between_kw=None,
@@ -108,25 +105,14 @@ class _BaseCurveDisplay:
 
         ax.legend()
 
-        # TODO(1.5): to be removed
-        if log_scale != "deprecated":
-            warnings.warn(
-                (
-                    "The `log_scale` parameter is deprecated as of version 1.3 "
-                    "and will be removed in 1.5. You can use display.ax_.set_xscale "
-                    "and display.ax_.set_yscale instead."
-                ),
-                FutureWarning,
-            )
-            xscale = "log" if log_scale else "linear"
+        # We found that a ratio, smaller or bigger than 5, between the largest and
+        # smallest gap of the x values is a good indicator to choose between linear
+        # and log scale.
+        if _interval_max_min_ratio(x_data) > 5:
+            xscale = "symlog" if x_data.min() <= 0 else "log"
         else:
-            # We found that a ratio, smaller or bigger than 5, between the largest and
-            # smallest gap of the x values is a good indicator to choose between linear
-            # and log scale.
-            if _interval_max_min_ratio(x_data) > 5:
-                xscale = "symlog" if x_data.min() <= 0 else "log"
-            else:
-                xscale = "linear"
+            xscale = "linear"
+
         ax.set_xscale(xscale)
         ax.set_ylabel(f"{score_name}")
 
@@ -226,7 +212,6 @@ class LearningCurveDisplay(_BaseCurveDisplay):
         negate_score=False,
         score_name=None,
         score_type="both",
-        log_scale="deprecated",
         std_display_style="fill_between",
         line_kw=None,
         fill_between_kw=None,
@@ -259,13 +244,6 @@ class LearningCurveDisplay(_BaseCurveDisplay):
             The type of score to plot. Can be one of `"test"`, `"train"`, or
             `"both"`.
 
-        log_scale : bool, default="deprecated"
-            Whether or not to use a logarithmic scale for the x-axis.
-
-            .. deprecated:: 1.3
-               `log_scale` is deprecated in 1.3 and will be removed in 1.5.
-               Use `display.ax_.set_xscale` and `display.ax_.set_yscale` instead.
-
         std_display_style : {"errorbar", "fill_between"} or None, default="fill_between"
             The style used to display the score standard deviation around the
             mean score. If None, no standard deviation representation is
@@ -294,7 +272,6 @@ class LearningCurveDisplay(_BaseCurveDisplay):
             negate_score=negate_score,
             score_name=score_name,
             score_type=score_type,
-            log_scale=log_scale,
             std_display_style=std_display_style,
             line_kw=line_kw,
             fill_between_kw=fill_between_kw,
@@ -326,7 +303,6 @@ class LearningCurveDisplay(_BaseCurveDisplay):
         negate_score=False,
         score_name=None,
         score_type="both",
-        log_scale="deprecated",
         std_display_style="fill_between",
         line_kw=None,
         fill_between_kw=None,
@@ -451,13 +427,6 @@ class LearningCurveDisplay(_BaseCurveDisplay):
             The type of score to plot. Can be one of `"test"`, `"train"`, or
             `"both"`.
 
-        log_scale : bool, default="deprecated"
-            Whether or not to use a logarithmic scale for the x-axis.
-
-            .. deprecated:: 1.3
-               `log_scale` is deprecated in 1.3 and will be removed in 1.5.
-               Use `display.ax_.xscale` and `display.ax_.yscale` instead.
-
         std_display_style : {"errorbar", "fill_between"} or None, default="fill_between"
             The style used to display the score standard deviation around the
             mean score. If `None`, no representation of the standard deviation
@@ -525,7 +494,6 @@ class LearningCurveDisplay(_BaseCurveDisplay):
             ax=ax,
             negate_score=negate_score,
             score_type=score_type,
-            log_scale=log_scale,
             std_display_style=std_display_style,
             line_kw=line_kw,
             fill_between_kw=fill_between_kw,
@@ -694,7 +662,6 @@ class ValidationCurveDisplay(_BaseCurveDisplay):
             negate_score=negate_score,
             score_name=score_name,
             score_type=score_type,
-            log_scale="deprecated",
             std_display_style=std_display_style,
             line_kw=line_kw,
             fill_between_kw=fill_between_kw,

--- a/sklearn/model_selection/tests/test_plot.py
+++ b/sklearn/model_selection/tests/test_plot.py
@@ -526,29 +526,6 @@ def test_curve_display_plot_kwargs(pyplot, data, CurveDisplay, specific_params):
     assert display.errorbar_[0].lines[0].get_color() == "red"
 
 
-# TODO(1.5): to be removed
-def test_learning_curve_display_deprecate_log_scale(data, pyplot):
-    """Check that we warn for the deprecated parameter `log_scale`."""
-    X, y = data
-    estimator = DecisionTreeClassifier(random_state=0)
-
-    with pytest.warns(FutureWarning, match="`log_scale` parameter is deprecated"):
-        display = LearningCurveDisplay.from_estimator(
-            estimator, X, y, train_sizes=[0.3, 0.6, 0.9], log_scale=True
-        )
-
-    assert display.ax_.get_xscale() == "log"
-    assert display.ax_.get_yscale() == "linear"
-
-    with pytest.warns(FutureWarning, match="`log_scale` parameter is deprecated"):
-        display = LearningCurveDisplay.from_estimator(
-            estimator, X, y, train_sizes=[0.3, 0.6, 0.9], log_scale=False
-        )
-
-    assert display.ax_.get_xscale() == "linear"
-    assert display.ax_.get_yscale() == "linear"
-
-
 @pytest.mark.parametrize(
     "param_range, xscale",
     [([5, 10, 15], "linear"), ([-50, 5, 50, 500], "symlog"), ([5, 50, 500], "log")],


### PR DESCRIPTION
removed deprecated `log_scale` param in Displays.