### PR TITLE
MAINT Clean up deprecations for 1.5: in linear_model._bayes

### DIFF
--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -5,7 +5,6 @@ Various bayesian regression
 # Authors: V. Michel, F. Pedregosa, A. Gramfort
 # License: BSD 3 clause
 
-import warnings
 from math import log
 from numbers import Integral, Real
 
@@ -15,54 +14,10 @@ from scipy.linalg import pinvh
 
 from ..base import RegressorMixin, _fit_context
 from ..utils import _safe_indexing
-from ..utils._param_validation import Hidden, Interval, StrOptions
+from ..utils._param_validation import Interval
 from ..utils.extmath import fast_logdet
 from ..utils.validation import _check_sample_weight
 from ._base import LinearModel, _preprocess_data, _rescale_data
-
-
-# TODO(1.5) Remove
-def _deprecate_n_iter(n_iter, max_iter):
-    """Deprecates n_iter in favour of max_iter. Checks if the n_iter has been
-    used instead of max_iter and generates a deprecation warning if True.
-
-    Parameters
-    ----------
-    n_iter : int,
-        Value of n_iter attribute passed by the estimator.
-
-    max_iter : int, default=None
-        Value of max_iter attribute passed by the estimator.
-        If `None`, it corresponds to `max_iter=300`.
-
-    Returns
-    -------
-    max_iter : int,
-        Value of max_iter which shall further be used by the estimator.
-
-    Notes
-    -----
-    This function should be completely removed in 1.5.
-    """
-    if n_iter != "deprecated":
-        if max_iter is not None:
-            raise ValueError(
-                "Both `n_iter` and `max_iter` attributes were set. Attribute"
-                " `n_iter` was deprecated in version 1.3 and will be removed in"
-                " 1.5. To avoid this error, only set the `max_iter` attribute."
-            )
-        warnings.warn(
-            (
-                "'n_iter' was renamed to 'max_iter' in version 1.3 and "
-                "will be removed in 1.5"
-            ),
-            FutureWarning,
-        )
-        max_iter = n_iter
-    elif max_iter is None:
-        max_iter = 300
-    return max_iter
-
 
 ###############################################################################
 # BayesianRidge regression
@@ -132,13 +87,6 @@ class BayesianRidge(RegressorMixin, LinearModel):
 
     verbose : bool, default=False
         Verbose mode when fitting the model.
-
-    n_iter : int
-        Maximum number of iterations. Should be greater than or equal to 1.
-
-        .. deprecated:: 1.3
-           `n_iter` is deprecated in 1.3 and will be removed in 1.5. Use
-           `max_iter` instead.
 
     Attributes
     ----------
@@ -219,7 +167,7 @@ class BayesianRidge(RegressorMixin, LinearModel):
     """
 
     _parameter_constraints: dict = {
-        "max_iter": [Interval(Integral, 1, None, closed="left"), None],
+        "max_iter": [Interval(Integral, 1, None, closed="left")],
         "tol": [Interval(Real, 0, None, closed="neither")],
         "alpha_1": [Interval(Real, 0, None, closed="left")],
         "alpha_2": [Interval(Real, 0, None, closed="left")],
@@ -231,16 +179,12 @@ class BayesianRidge(RegressorMixin, LinearModel):
         "fit_intercept": ["boolean"],
         "copy_X": ["boolean"],
         "verbose": ["verbose"],
-        "n_iter": [
-            Interval(Integral, 1, None, closed="left"),
-            Hidden(StrOptions({"deprecated"})),
-        ],
     }
 
     def __init__(
         self,
         *,
-        max_iter=None,  # TODO(1.5): Set to 300
+        max_iter=300,
         tol=1.0e-3,
         alpha_1=1.0e-6,
         alpha_2=1.0e-6,
@@ -252,7 +196,6 @@ class BayesianRidge(RegressorMixin, LinearModel):
         fit_intercept=True,
         copy_X=True,
         verbose=False,
-        n_iter="deprecated",  # TODO(1.5): Remove
     ):
         self.max_iter = max_iter
         self.tol = tol
@@ -266,7 +209,6 @@ class BayesianRidge(RegressorMixin, LinearModel):
         self.fit_intercept = fit_intercept
         self.copy_X = copy_X
         self.verbose = verbose
-        self.n_iter = n_iter
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X, y, sample_weight=None):
@@ -290,8 +232,6 @@ class BayesianRidge(RegressorMixin, LinearModel):
         self : object
             Returns the instance itself.
         """
-        max_iter = _deprecate_n_iter(self.n_iter, self.max_iter)
-
         X, y = self._validate_data(X, y, dtype=[np.float64, np.float32], y_numeric=True)
         dtype = X.dtype
 
@@ -343,7 +283,7 @@ class BayesianRidge(RegressorMixin, LinearModel):
         eigen_vals_ = S**2
 
         # Convergence loop of the bayesian ridge regression
-        for iter_ in range(max_iter):
+        for iter_ in range(self.max_iter):
             # update posterior mean coef_ based on alpha_ and lambda_ and
             # compute corresponding rmse
             coef_, rmse_ = self._update_coef_(
@@ -540,13 +480,6 @@ class ARDRegression(RegressorMixin, LinearModel):
     verbose : bool, default=False
         Verbose mode when fitting the model.
 
-    n_iter : int
-        Maximum number of iterations.
-
-        .. deprecated:: 1.3
-           `n_iter` is deprecated in 1.3 and will be removed in 1.5. Use
-           `max_iter` instead.
-
     Attributes
     ----------
     coef_ : array-like of shape (n_features,)
@@ -624,7 +557,7 @@ class ARDRegression(RegressorMixin, LinearModel):
     """
 
     _parameter_constraints: dict = {
-        "max_iter": [Interval(Integral, 1, None, closed="left"), None],
+        "max_iter": [Interval(Integral, 1, None, closed="left")],
         "tol": [Interval(Real, 0, None, closed="left")],
         "alpha_1": [Interval(Real, 0, None, closed="left")],
         "alpha_2": [Interval(Real, 0, None, closed="left")],
@@ -635,16 +568,12 @@ class ARDRegression(RegressorMixin, LinearModel):
         "fit_intercept": ["boolean"],
         "copy_X": ["boolean"],
         "verbose": ["verbose"],
-        "n_iter": [
-            Interval(Integral, 1, None, closed="left"),
-            Hidden(StrOptions({"deprecated"})),
-        ],
     }
 
     def __init__(
         self,
         *,
-        max_iter=None,  # TODO(1.5): Set to 300
+        max_iter=300,
         tol=1.0e-3,
         alpha_1=1.0e-6,
         alpha_2=1.0e-6,
@@ -655,7 +584,6 @@ class ARDRegression(RegressorMixin, LinearModel):
         fit_intercept=True,
         copy_X=True,
         verbose=False,
-        n_iter="deprecated",  # TODO(1.5): Remove
     ):
         self.max_iter = max_iter
         self.tol = tol
@@ -668,7 +596,6 @@ class ARDRegression(RegressorMixin, LinearModel):
         self.threshold_lambda = threshold_lambda
         self.copy_X = copy_X
         self.verbose = verbose
-        self.n_iter = n_iter
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X, y):
@@ -689,8 +616,6 @@ class ARDRegression(RegressorMixin, LinearModel):
         self : object
             Fitted estimator.
         """
-        max_iter = _deprecate_n_iter(self.n_iter, self.max_iter)
-
         X, y = self._validate_data(
             X, y, dtype=[np.float64, np.float32], y_numeric=True, ensure_min_samples=2
         )
@@ -738,7 +663,7 @@ class ARDRegression(RegressorMixin, LinearModel):
             else self._update_sigma_woodbury
         )
         # Iterative procedure of ARDRegression
-        for iter_ in range(max_iter):
+        for iter_ in range(self.max_iter):
             sigma_ = update_sigma(X, alpha_, lambda_, keep_lambda)
             coef_ = update_coeff(X, y, coef_, alpha_, keep_lambda, sigma_)
 

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -297,33 +297,3 @@ def test_dtype_correctness(Estimator):
     coef_32 = model.fit(X.astype(np.float32), y).coef_
     coef_64 = model.fit(X.astype(np.float64), y).coef_
     np.testing.assert_allclose(coef_32, coef_64, rtol=1e-4)
-
-
-# TODO(1.5) remove
-@pytest.mark.parametrize("Estimator", [BayesianRidge, ARDRegression])
-def test_bayesian_ridge_ard_n_iter_deprecated(Estimator):
-    """Check the deprecation warning of `n_iter`."""
-    depr_msg = (
-        "'n_iter' was renamed to 'max_iter' in version 1.3 and will be removed in 1.5"
-    )
-    X, y = diabetes.data, diabetes.target
-    model = Estimator(n_iter=5)
-
-    with pytest.warns(FutureWarning, match=depr_msg):
-        model.fit(X, y)
-
-
-# TODO(1.5) remove
-@pytest.mark.parametrize("Estimator", [BayesianRidge, ARDRegression])
-def test_bayesian_ridge_ard_max_iter_and_n_iter_both_set(Estimator):
-    """Check that a ValueError is raised when both `max_iter` and `n_iter` are set."""
-    err_msg = (
-        "Both `n_iter` and `max_iter` attributes were set. Attribute"
-        " `n_iter` was deprecated in version 1.3 and will be removed in"
-        " 1.5. To avoid this error, only set the `max_iter` attribute."
-    )
-    X, y = diabetes.data, diabetes.target
-    model = Estimator(n_iter=5, max_iter=5)
-
-    with pytest.raises(ValueError, match=err_msg):
-        model.fit(X, y)


### PR DESCRIPTION
Remove deprecated `n_iter` in `BayesianRidge` and `ARDRegression`.