### PR TITLE
MAINT Clean up deprecations for 1.5: in inspection._partial_dependence

### DIFF
--- a/doc/modules/partial_dependence.rst
+++ b/doc/modules/partial_dependence.rst
@@ -108,7 +108,7 @@ the plots, you can use the
     >>> results = partial_dependence(clf, X, [0])
     >>> results["average"]
     array([[ 2.466...,  2.466..., ...
-    >>> results["values"]
+    >>> results["grid_values"]
     [array([-1.624..., -1.592..., ...
 
 The values at which the partial dependence should be evaluated are directly

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -528,14 +528,6 @@ def partial_dependence(
             `method` is 'recursion').
             Only available when `kind='average'` or `kind='both'`.
 
-        values : seq of 1d ndarrays
-            The values with which the grid has been created.
-
-            .. deprecated:: 1.3
-                The key `values` has been deprecated in 1.3 and will be removed
-                in 1.5 in favor of `grid_values`. See `grid_values` for details
-                about the `values` attribute.
-
         grid_values : seq of 1d ndarrays
             The values with which the grid has been created. The generated
             grid is a cartesian product of the arrays in `grid_values` where
@@ -716,15 +708,7 @@ def partial_dependence(
     averaged_predictions = averaged_predictions.reshape(
         -1, *[val.shape[0] for val in values]
     )
-    pdp_results = Bunch()
-
-    msg = (
-        "Key: 'values', is deprecated in 1.3 and will be removed in 1.5. "
-        "Please use 'grid_values' instead."
-    )
-    pdp_results._set_deprecated(
-        values, new_key="grid_values", deprecated_key="values", warning_message=msg
-    )
+    pdp_results = Bunch(grid_values=values)
 
     if kind == "average":
         pdp_results["average"] = averaged_predictions

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -2,8 +2,6 @@
 Testing for the partial dependence module.
 """
 
-import warnings
-
 import numpy as np
 import pytest
 
@@ -913,34 +911,6 @@ def test_partial_dependence_sample_weight_with_recursion():
         partial_dependence(
             est, X, features=[0], method="recursion", sample_weight=sample_weight
         )
-
-
-# TODO(1.5): Remove when bunch values is deprecated in 1.5
-def test_partial_dependence_bunch_values_deprecated():
-    """Test that deprecation warning is raised when values is accessed."""
-
-    est = LogisticRegression()
-    (X, y), _ = binary_classification_data
-    est.fit(X, y)
-
-    pdp_avg = partial_dependence(est, X=X, features=[1, 2], kind="average")
-
-    msg = (
-        "Key: 'values', is deprecated in 1.3 and will be "
-        "removed in 1.5. Please use 'grid_values' instead"
-    )
-
-    with warnings.catch_warnings():
-        # Does not raise warnings with "grid_values"
-        warnings.simplefilter("error", FutureWarning)
-        grid_values = pdp_avg["grid_values"]
-
-    with pytest.warns(FutureWarning, match=msg):
-        # Warns for "values"
-        values = pdp_avg["values"]
-
-    # "values" and "grid_values" are the same object
-    assert values is grid_values
 
 
 def test_mixed_type_categorical():


### PR DESCRIPTION
Removed deprecated key `values` of the result Bunch of `partial_dependence`.