### PR TITLE
MAINT Clean up deprecations for 1.5: in graphical_lasso

### DIFF
--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -222,7 +222,6 @@ def alpha_max(emp_cov):
 @validate_params(
     {
         "emp_cov": ["array-like"],
-        "cov_init": ["array-like", None],
         "return_costs": ["boolean"],
         "return_n_iter": ["boolean"],
     },
@@ -232,7 +231,6 @@ def graphical_lasso(
     emp_cov,
     alpha,
     *,
-    cov_init=None,
     mode="cd",
     tol=1e-4,
     enet_tol=1e-4,
@@ -258,14 +256,6 @@ def graphical_lasso(
         The regularization parameter: the higher alpha, the more
         regularization, the sparser the inverse covariance.
         Range is (0, inf].
-
-    cov_init : array of shape (n_features, n_features), default=None
-        The initial guess for the covariance. If None, then the empirical
-        covariance is used.
-
-        .. deprecated:: 1.3
-           `cov_init` is deprecated in 1.3 and will be removed in 1.5.
-           It currently has no effect.
 
     mode : {'cd', 'lars'}, default='cd'
         The Lasso solver to use: coordinate descent or LARS. Use LARS for
@@ -347,16 +337,6 @@ def graphical_lasso(
            [ 0.21...,  0.22..., -0.08...],
            [-0.20..., -0.08...,  0.23...]])
     """
-
-    if cov_init is not None:
-        warnings.warn(
-            (
-                "The cov_init parameter is deprecated in 1.3 and will be removed in "
-                "1.5. It does not have any effect."
-            ),
-            FutureWarning,
-        )
-
     model = GraphicalLasso(
         alpha=alpha,
         mode=mode,

--- a/sklearn/covariance/tests/test_graphical_lasso.py
+++ b/sklearn/covariance/tests/test_graphical_lasso.py
@@ -263,20 +263,6 @@ def test_graphical_lasso_cv_scores():
     )
 
 
-# TODO(1.5): remove in 1.5
-def test_graphical_lasso_cov_init_deprecation():
-    """Check that we raise a deprecation warning if providing `cov_init` in
-    `graphical_lasso`."""
-    rng, dim, n_samples = np.random.RandomState(0), 20, 100
-    prec = make_sparse_spd_matrix(dim, alpha=0.95, random_state=0)
-    cov = linalg.inv(prec)
-    X = rng.multivariate_normal(np.zeros(dim), cov, size=n_samples)
-
-    emp_cov = empirical_covariance(X)
-    with pytest.warns(FutureWarning, match="cov_init parameter is deprecated"):
-        graphical_lasso(emp_cov, alpha=0.1, cov_init=emp_cov)
-
-
 @pytest.mark.usefixtures("enable_slep006")
 def test_graphical_lasso_cv_scores_with_routing(global_random_seed):
     """Check that `GraphicalLassoCV` internally dispatches metadata to


### PR DESCRIPTION
removed deprecated `cov_init` param of `graphical_lasso`.