### PR TITLE
MAINT Clean up deprecations for 1.5: in LinearSV*

### DIFF
--- a/benchmarks/bench_mnist.py
+++ b/benchmarks/bench_mnist.py
@@ -84,10 +84,10 @@ ESTIMATORS = {
     "ExtraTrees": ExtraTreesClassifier(),
     "RandomForest": RandomForestClassifier(),
     "Nystroem-SVM": make_pipeline(
-        Nystroem(gamma=0.015, n_components=1000), LinearSVC(C=100, dual="auto")
+        Nystroem(gamma=0.015, n_components=1000), LinearSVC(C=100)
     ),
     "SampledRBF-SVM": make_pipeline(
-        RBFSampler(gamma=0.015, n_components=1000), LinearSVC(C=100, dual="auto")
+        RBFSampler(gamma=0.015, n_components=1000), LinearSVC(C=100)
     ),
     "LogisticRegression-SAG": LogisticRegression(solver="sag", tol=1e-1, C=1e4),
     "LogisticRegression-SAGA": LogisticRegression(solver="saga", tol=1e-1, C=1e4),

--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -340,7 +340,7 @@ the actual learning. The recommended way to do this in scikit-learn is
 to use a :class:`~pipeline.Pipeline`::
 
   clf = Pipeline([
-    ('feature_selection', SelectFromModel(LinearSVC(dual="auto", penalty="l1"))),
+    ('feature_selection', SelectFromModel(LinearSVC(penalty="l1"))),
     ('classification', RandomForestClassifier())
   ])
   clf.fit(X, y)

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -155,7 +155,7 @@ the :func:`fbeta_score` function::
     >>> ftwo_scorer = make_scorer(fbeta_score, beta=2)
     >>> from sklearn.model_selection import GridSearchCV
     >>> from sklearn.svm import LinearSVC
-    >>> grid = GridSearchCV(LinearSVC(dual="auto"), param_grid={'C': [1, 10]},
+    >>> grid = GridSearchCV(LinearSVC(), param_grid={'C': [1, 10]},
     ...                     scoring=ftwo_scorer, cv=5)
 
 The module :mod:`sklearn.metrics` also exposes a set of simple functions
@@ -308,7 +308,7 @@ parameter:
     >>> from sklearn.metrics import confusion_matrix
     >>> # A sample toy binary classification dataset
     >>> X, y = datasets.make_classification(n_classes=2, random_state=0)
-    >>> svm = LinearSVC(dual="auto", random_state=0)
+    >>> svm = LinearSVC(random_state=0)
     >>> def confusion_matrix_scorer(clf, X, y):
     ...      y_pred = clf.predict(X)
     ...      cm = confusion_matrix(y, y_pred)
@@ -1148,7 +1148,7 @@ with a svm classifier in a binary class problem::
   >>> from sklearn.metrics import hinge_loss
   >>> X = [[0], [1]]
   >>> y = [-1, 1]
-  >>> est = svm.LinearSVC(dual="auto", random_state=0)
+  >>> est = svm.LinearSVC(random_state=0)
   >>> est.fit(X, y)
   LinearSVC(dual='auto', random_state=0)
   >>> pred_decision = est.decision_function([[-2], [3], [0.5]])
@@ -1163,7 +1163,7 @@ with a svm classifier in a multiclass problem::
   >>> X = np.array([[0], [1], [2], [3]])
   >>> Y = np.array([0, 1, 2, 3])
   >>> labels = np.array([0, 1, 2, 3])
-  >>> est = svm.LinearSVC(dual="auto")
+  >>> est = svm.LinearSVC()
   >>> est.fit(X, Y)
   LinearSVC(dual='auto')
   >>> pred_decision = est.decision_function([[-1], [2], [3]])

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -1150,7 +1150,7 @@ with a svm classifier in a binary class problem::
   >>> y = [-1, 1]
   >>> est = svm.LinearSVC(random_state=0)
   >>> est.fit(X, y)
-  LinearSVC(dual='auto', random_state=0)
+  LinearSVC(random_state=0)
   >>> pred_decision = est.decision_function([[-2], [3], [0.5]])
   >>> pred_decision
   array([-2.18...,  2.36...,  0.09...])
@@ -1165,7 +1165,7 @@ with a svm classifier in a multiclass problem::
   >>> labels = np.array([0, 1, 2, 3])
   >>> est = svm.LinearSVC()
   >>> est.fit(X, Y)
-  LinearSVC(dual='auto')
+  LinearSVC()
   >>> pred_decision = est.decision_function([[-1], [2], [3]])
   >>> y_true = [0, 2, 3]
   >>> hinge_loss(y_true, pred_decision, labels=labels)

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -201,7 +201,7 @@ Below is an example of multiclass learning using OvR::
   >>> from sklearn.multiclass import OneVsRestClassifier
   >>> from sklearn.svm import LinearSVC
   >>> X, y = datasets.load_iris(return_X_y=True)
-  >>> OneVsRestClassifier(LinearSVC(dual="auto", random_state=0)).fit(X, y).predict(X)
+  >>> OneVsRestClassifier(LinearSVC(random_state=0)).fit(X, y).predict(X)
   array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
          0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -253,7 +253,7 @@ Below is an example of multiclass learning using OvO::
   >>> from sklearn.multiclass import OneVsOneClassifier
   >>> from sklearn.svm import LinearSVC
   >>> X, y = datasets.load_iris(return_X_y=True)
-  >>> OneVsOneClassifier(LinearSVC(dual="auto", random_state=0)).fit(X, y).predict(X)
+  >>> OneVsOneClassifier(LinearSVC(random_state=0)).fit(X, y).predict(X)
   array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
          0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -311,8 +311,7 @@ Below is an example of multiclass learning using Output-Codes::
   >>> from sklearn.multiclass import OutputCodeClassifier
   >>> from sklearn.svm import LinearSVC
   >>> X, y = datasets.load_iris(return_X_y=True)
-  >>> clf = OutputCodeClassifier(LinearSVC(dual="auto", random_state=0),
-  ...                            code_size=2, random_state=0)
+  >>> clf = OutputCodeClassifier(LinearSVC(random_state=0), code_size=2, random_state=0)
   >>> clf.fit(X, y).predict(X)
   array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -144,9 +144,9 @@ function of shape ``(n_samples, n_classes)``.
 On the other hand, :class:`LinearSVC` implements "one-vs-the-rest"
 multi-class strategy, thus training `n_classes` models.
 
-    >>> lin_clf = svm.LinearSVC(dual="auto")
+    >>> lin_clf = svm.LinearSVC()
     >>> lin_clf.fit(X, Y)
-    LinearSVC(dual='auto')
+    LinearSVC()
     >>> dec = lin_clf.decision_function([[1]])
     >>> dec.shape[1]
     4

--- a/examples/calibration/plot_calibration_curve.py
+++ b/examples/calibration/plot_calibration_curve.py
@@ -222,7 +222,7 @@ class NaivelyCalibratedLinearSVC(LinearSVC):
 # %%
 
 lr = LogisticRegression(C=1.0)
-svc = NaivelyCalibratedLinearSVC(max_iter=10_000, dual="auto")
+svc = NaivelyCalibratedLinearSVC(max_iter=10_000)
 svc_isotonic = CalibratedClassifierCV(svc, cv=2, method="isotonic")
 svc_sigmoid = CalibratedClassifierCV(svc, cv=2, method="sigmoid")
 

--- a/examples/calibration/plot_compare_calibration.py
+++ b/examples/calibration/plot_compare_calibration.py
@@ -107,7 +107,7 @@ lr = LogisticRegressionCV(
     Cs=np.logspace(-6, 6, 101), cv=10, scoring="neg_log_loss", max_iter=1_000
 )
 gnb = GaussianNB()
-svc = NaivelyCalibratedLinearSVC(C=1.0, dual="auto")
+svc = NaivelyCalibratedLinearSVC(C=1.0)
 rfc = RandomForestClassifier(random_state=42)
 
 clf_list = [

--- a/examples/feature_selection/plot_feature_selection.py
+++ b/examples/feature_selection/plot_feature_selection.py
@@ -77,7 +77,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import MinMaxScaler
 from sklearn.svm import LinearSVC
 
-clf = make_pipeline(MinMaxScaler(), LinearSVC(dual="auto"))
+clf = make_pipeline(MinMaxScaler(), LinearSVC())
 clf.fit(X_train, y_train)
 print(
     "Classification accuracy without selecting features: {:.3f}".format(
@@ -90,9 +90,7 @@ svm_weights /= svm_weights.sum()
 
 # %%
 # After univariate feature selection
-clf_selected = make_pipeline(
-    SelectKBest(f_classif, k=4), MinMaxScaler(), LinearSVC(dual="auto")
-)
+clf_selected = make_pipeline(SelectKBest(f_classif, k=4), MinMaxScaler(), LinearSVC())
 clf_selected.fit(X_train, y_train)
 print(
     "Classification accuracy after univariate feature selection: {:.3f}".format(

--- a/examples/feature_selection/plot_feature_selection_pipeline.py
+++ b/examples/feature_selection/plot_feature_selection_pipeline.py
@@ -46,7 +46,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.svm import LinearSVC
 
 anova_filter = SelectKBest(f_classif, k=3)
-clf = LinearSVC(dual="auto")
+clf = LinearSVC()
 anova_svm = make_pipeline(anova_filter, clf)
 anova_svm.fit(X_train, y_train)
 

--- a/examples/kernel_approximation/plot_scalable_poly_kernels.py
+++ b/examples/kernel_approximation/plot_scalable_poly_kernels.py
@@ -85,7 +85,7 @@ from sklearn.svm import LinearSVC
 
 results = {}
 
-lsvm = LinearSVC(dual="auto")
+lsvm = LinearSVC()
 start = time.time()
 lsvm.fit(X_train, y_train)
 lsvm_time = time.time() - start
@@ -126,7 +126,7 @@ for n_components in N_COMPONENTS:
     for _ in range(n_runs):
         pipeline = make_pipeline(
             PolynomialCountSketch(n_components=n_components, degree=4),
-            LinearSVC(dual="auto"),
+            LinearSVC(),
         )
 
         start = time.time()

--- a/examples/miscellaneous/plot_kernel_approximation.py
+++ b/examples/miscellaneous/plot_kernel_approximation.py
@@ -72,7 +72,7 @@ data_test, targets_test = (data[n_samples // 2 :], digits.target[n_samples // 2 
 
 # Create a classifier: a support vector classifier
 kernel_svm = svm.SVC(gamma=0.2)
-linear_svm = svm.LinearSVC(dual="auto", random_state=42)
+linear_svm = svm.LinearSVC(random_state=42)
 
 # create pipeline from kernel approximation
 # and linear svm
@@ -81,14 +81,14 @@ feature_map_nystroem = Nystroem(gamma=0.2, random_state=1)
 fourier_approx_svm = pipeline.Pipeline(
     [
         ("feature_map", feature_map_fourier),
-        ("svm", svm.LinearSVC(dual="auto", random_state=42)),
+        ("svm", svm.LinearSVC(random_state=42)),
     ]
 )
 
 nystroem_approx_svm = pipeline.Pipeline(
     [
         ("feature_map", feature_map_nystroem),
-        ("svm", svm.LinearSVC(dual="auto", random_state=42)),
+        ("svm", svm.LinearSVC(random_state=42)),
     ]
 )
 

--- a/examples/model_selection/plot_det.py
+++ b/examples/model_selection/plot_det.py
@@ -66,7 +66,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.svm import LinearSVC
 
 classifiers = {
-    "Linear SVM": make_pipeline(StandardScaler(), LinearSVC(C=0.025, dual="auto")),
+    "Linear SVM": make_pipeline(StandardScaler(), LinearSVC(C=0.025)),
     "Random Forest": RandomForestClassifier(
         max_depth=5, n_estimators=10, max_features=1
     ),

--- a/examples/model_selection/plot_grid_search_refit_callable.py
+++ b/examples/model_selection/plot_grid_search_refit_callable.py
@@ -81,7 +81,7 @@ def best_low_complexity(cv_results):
 pipe = Pipeline(
     [
         ("reduce_dim", PCA(random_state=42)),
-        ("classify", LinearSVC(random_state=42, C=0.01, dual="auto")),
+        ("classify", LinearSVC(random_state=42, C=0.01)),
     ]
 )
 

--- a/examples/model_selection/plot_precision_recall.py
+++ b/examples/model_selection/plot_precision_recall.py
@@ -125,9 +125,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.svm import LinearSVC
 
-classifier = make_pipeline(
-    StandardScaler(), LinearSVC(random_state=random_state, dual="auto")
-)
+classifier = make_pipeline(StandardScaler(), LinearSVC(random_state=random_state))
 classifier.fit(X_train, y_train)
 
 # %%
@@ -191,7 +189,7 @@ X_train, X_test, Y_train, Y_test = train_test_split(
 from sklearn.multiclass import OneVsRestClassifier
 
 classifier = OneVsRestClassifier(
-    make_pipeline(StandardScaler(), LinearSVC(random_state=random_state, dual="auto"))
+    make_pipeline(StandardScaler(), LinearSVC(random_state=random_state))
 )
 classifier.fit(X_train, Y_train)
 y_score = classifier.decision_function(X_test)

--- a/examples/preprocessing/plot_discretization_classification.py
+++ b/examples/preprocessing/plot_discretization_classification.py
@@ -68,7 +68,7 @@ classifiers = [
         {"logisticregression__C": np.logspace(-1, 1, 3)},
     ),
     (
-        make_pipeline(StandardScaler(), LinearSVC(random_state=0, dual="auto")),
+        make_pipeline(StandardScaler(), LinearSVC(random_state=0)),
         {"linearsvc__C": np.logspace(-1, 1, 3)},
     ),
     (
@@ -86,7 +86,7 @@ classifiers = [
         make_pipeline(
             StandardScaler(),
             KBinsDiscretizer(encode="onehot", random_state=0),
-            LinearSVC(random_state=0, dual="auto"),
+            LinearSVC(random_state=0),
         ),
         {
             "kbinsdiscretizer__n_bins": np.arange(5, 8),

--- a/examples/svm/plot_iris_svc.py
+++ b/examples/svm/plot_iris_svc.py
@@ -50,7 +50,7 @@ y = iris.target
 C = 1.0  # SVM regularization parameter
 models = (
     svm.SVC(kernel="linear", C=C),
-    svm.LinearSVC(C=C, max_iter=10000, dual="auto"),
+    svm.LinearSVC(C=C, max_iter=10000),
     svm.SVC(kernel="rbf", gamma=0.7, C=C),
     svm.SVC(kernel="poly", degree=3, gamma="auto", C=C),
 )

--- a/examples/svm/plot_linearsvc_support_vectors.py
+++ b/examples/svm/plot_linearsvc_support_vectors.py
@@ -21,7 +21,7 @@ X, y = make_blobs(n_samples=40, centers=2, random_state=0)
 plt.figure(figsize=(10, 5))
 for i, C in enumerate([1, 100]):
     # "hinge" is the standard SVM loss
-    clf = LinearSVC(C=C, loss="hinge", random_state=42, dual="auto").fit(X, y)
+    clf = LinearSVC(C=C, loss="hinge", random_state=42).fit(X, y)
     # obtain the support vectors through the decision function
     decision_function = clf.decision_function(X)
     # we can also calculate the decision function manually

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -280,7 +280,7 @@ class CalibratedClassifierCV(ClassifierMixin, MetaEstimatorMixin, BaseEstimator)
         if self.estimator is None:
             # we want all classifiers that don't expose a random_state
             # to be deterministic (and we don't want to expose this one).
-            estimator = LinearSVC(random_state=0, dual="auto")
+            estimator = LinearSVC(random_state=0)
             if _routing_enabled():
                 estimator.set_fit_request(sample_weight=True)
         else:

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -556,7 +556,7 @@ class StackingClassifier(_RoutingNotSupportedMixin, ClassifierMixin, _BaseStacki
     >>> estimators = [
     ...     ('rf', RandomForestClassifier(n_estimators=10, random_state=42)),
     ...     ('svr', make_pipeline(StandardScaler(),
-    ...                           LinearSVC(dual="auto", random_state=42)))
+    ...                           LinearSVC(random_state=42)))
     ... ]
     >>> clf = StackingClassifier(
     ...     estimators=estimators, final_estimator=LogisticRegression()
@@ -900,7 +900,7 @@ class StackingRegressor(_RoutingNotSupportedMixin, RegressorMixin, _BaseStacking
     >>> X, y = load_diabetes(return_X_y=True)
     >>> estimators = [
     ...     ('lr', RidgeCV()),
-    ...     ('svr', LinearSVR(dual="auto", random_state=42))
+    ...     ('svr', LinearSVR(random_state=42))
     ... ]
     >>> reg = StackingRegressor(
     ...     estimators=estimators,

--- a/sklearn/ensemble/tests/test_common.py
+++ b/sklearn/ensemble/tests/test_common.py
@@ -34,7 +34,7 @@ X_r, y_r = load_diabetes(return_X_y=True)
             StackingClassifier(
                 estimators=[
                     ("lr", LogisticRegression()),
-                    ("svm", LinearSVC(dual="auto")),
+                    ("svm", LinearSVC()),
                     ("rf", RandomForestClassifier(n_estimators=5, max_depth=3)),
                 ],
                 cv=2,
@@ -45,7 +45,7 @@ X_r, y_r = load_diabetes(return_X_y=True)
             VotingClassifier(
                 estimators=[
                     ("lr", LogisticRegression()),
-                    ("svm", LinearSVC(dual="auto")),
+                    ("svm", LinearSVC()),
                     ("rf", RandomForestClassifier(n_estimators=5, max_depth=3)),
                 ]
             ),
@@ -55,7 +55,7 @@ X_r, y_r = load_diabetes(return_X_y=True)
             StackingRegressor(
                 estimators=[
                     ("lr", LinearRegression()),
-                    ("svm", LinearSVR(dual="auto")),
+                    ("svm", LinearSVR()),
                     ("rf", RandomForestRegressor(n_estimators=5, max_depth=3)),
                 ],
                 cv=2,
@@ -66,7 +66,7 @@ X_r, y_r = load_diabetes(return_X_y=True)
             VotingRegressor(
                 estimators=[
                     ("lr", LinearRegression()),
-                    ("svm", LinearSVR(dual="auto")),
+                    ("svm", LinearSVR()),
                     ("rf", RandomForestRegressor(n_estimators=5, max_depth=3)),
                 ]
             ),

--- a/sklearn/ensemble/tests/test_stacking.py
+++ b/sklearn/ensemble/tests/test_stacking.py
@@ -69,7 +69,7 @@ def test_stacking_classifier_iris(cv, final_estimator, passthrough):
     X_train, X_test, y_train, y_test = train_test_split(
         scale(X_iris), y_iris, stratify=y_iris, random_state=42
     )
-    estimators = [("lr", LogisticRegression()), ("svc", LinearSVC(dual="auto"))]
+    estimators = [("lr", LogisticRegression()), ("svc", LinearSVC())]
     clf = StackingClassifier(
         estimators=estimators,
         final_estimator=final_estimator,
@@ -121,7 +121,7 @@ def test_stacking_classifier_drop_column_binary_classification():
     assert X_trans.shape[1] == 2
 
     # LinearSVC does not implement 'predict_proba' and will not drop one column
-    estimators = [("lr", LogisticRegression()), ("svc", LinearSVC(dual="auto"))]
+    estimators = [("lr", LogisticRegression()), ("svc", LinearSVC())]
     clf.set_params(estimators=estimators)
 
     clf.fit(X_train, y_train)
@@ -135,10 +135,10 @@ def test_stacking_classifier_drop_estimator():
     X_train, X_test, y_train, _ = train_test_split(
         scale(X_iris), y_iris, stratify=y_iris, random_state=42
     )
-    estimators = [("lr", "drop"), ("svc", LinearSVC(dual="auto", random_state=0))]
+    estimators = [("lr", "drop"), ("svc", LinearSVC(random_state=0))]
     rf = RandomForestClassifier(n_estimators=10, random_state=42)
     clf = StackingClassifier(
-        estimators=[("svc", LinearSVC(dual="auto", random_state=0))],
+        estimators=[("svc", LinearSVC(random_state=0))],
         final_estimator=rf,
         cv=5,
     )
@@ -157,10 +157,10 @@ def test_stacking_regressor_drop_estimator():
     X_train, X_test, y_train, _ = train_test_split(
         scale(X_diabetes), y_diabetes, random_state=42
     )
-    estimators = [("lr", "drop"), ("svr", LinearSVR(dual="auto", random_state=0))]
+    estimators = [("lr", "drop"), ("svr", LinearSVR(random_state=0))]
     rf = RandomForestRegressor(n_estimators=10, random_state=42)
     reg = StackingRegressor(
-        estimators=[("svr", LinearSVR(dual="auto", random_state=0))],
+        estimators=[("svr", LinearSVR(random_state=0))],
         final_estimator=rf,
         cv=5,
     )
@@ -188,7 +188,7 @@ def test_stacking_regressor_diabetes(cv, final_estimator, predict_params, passth
     X_train, X_test, y_train, _ = train_test_split(
         scale(X_diabetes), y_diabetes, random_state=42
     )
-    estimators = [("lr", LinearRegression()), ("svr", LinearSVR(dual="auto"))]
+    estimators = [("lr", LinearRegression()), ("svr", LinearSVR())]
     reg = StackingRegressor(
         estimators=estimators,
         final_estimator=final_estimator,
@@ -226,7 +226,7 @@ def test_stacking_regressor_sparse_passthrough(sparse_container):
     X_train, X_test, y_train, _ = train_test_split(
         sparse_container(scale(X_diabetes)), y_diabetes, random_state=42
     )
-    estimators = [("lr", LinearRegression()), ("svr", LinearSVR(dual="auto"))]
+    estimators = [("lr", LinearRegression()), ("svr", LinearSVR())]
     rf = RandomForestRegressor(n_estimators=10, random_state=42)
     clf = StackingRegressor(
         estimators=estimators, final_estimator=rf, cv=5, passthrough=True
@@ -246,7 +246,7 @@ def test_stacking_classifier_sparse_passthrough(sparse_container):
     X_train, X_test, y_train, _ = train_test_split(
         sparse_container(scale(X_iris)), y_iris, random_state=42
     )
-    estimators = [("lr", LogisticRegression()), ("svc", LinearSVC(dual="auto"))]
+    estimators = [("lr", LogisticRegression()), ("svc", LinearSVC())]
     rf = RandomForestClassifier(n_estimators=10, random_state=42)
     clf = StackingClassifier(
         estimators=estimators, final_estimator=rf, cv=5, passthrough=True
@@ -319,7 +319,7 @@ class NoWeightClassifier(ClassifierMixin, BaseEstimator):
             {
                 "estimators": [
                     ("lr", LogisticRegression()),
-                    ("cor", LinearSVC(dual="auto", max_iter=50_000)),
+                    ("cor", LinearSVC(max_iter=50_000)),
                 ],
                 "final_estimator": NoWeightClassifier(),
             },
@@ -349,7 +349,7 @@ def test_stacking_classifier_error(y, params, type_err, msg_err):
             {
                 "estimators": [
                     ("lr", LinearRegression()),
-                    ("cor", LinearSVR(dual="auto")),
+                    ("cor", LinearSVR()),
                 ],
                 "final_estimator": NoWeightRegressor(),
             },
@@ -371,7 +371,7 @@ def test_stacking_regressor_error(y, params, type_err, msg_err):
             StackingClassifier(
                 estimators=[
                     ("lr", LogisticRegression(random_state=0)),
-                    ("svm", LinearSVC(dual="auto", random_state=0)),
+                    ("svm", LinearSVC(random_state=0)),
                 ]
             ),
             X_iris[:100],
@@ -381,7 +381,7 @@ def test_stacking_regressor_error(y, params, type_err, msg_err):
             StackingRegressor(
                 estimators=[
                     ("lr", LinearRegression()),
-                    ("svm", LinearSVR(dual="auto", random_state=0)),
+                    ("svm", LinearSVR(random_state=0)),
                 ]
             ),
             X_diabetes,
@@ -415,7 +415,7 @@ def test_stacking_classifier_stratify_default():
     clf = StackingClassifier(
         estimators=[
             ("lr", LogisticRegression(max_iter=10_000)),
-            ("svm", LinearSVC(dual="auto", max_iter=10_000)),
+            ("svm", LinearSVC(max_iter=10_000)),
         ]
     )
     # since iris is not shuffled, a simple k-fold would not contain the
@@ -430,7 +430,7 @@ def test_stacking_classifier_stratify_default():
             StackingClassifier(
                 estimators=[
                     ("lr", LogisticRegression()),
-                    ("svm", LinearSVC(dual="auto", random_state=42)),
+                    ("svm", LinearSVC(random_state=42)),
                 ],
                 final_estimator=LogisticRegression(),
                 cv=KFold(shuffle=True, random_state=42),
@@ -441,7 +441,7 @@ def test_stacking_classifier_stratify_default():
             StackingRegressor(
                 estimators=[
                     ("lr", LinearRegression()),
-                    ("svm", LinearSVR(dual="auto", random_state=42)),
+                    ("svm", LinearSVR(random_state=42)),
                 ],
                 final_estimator=LinearRegression(),
                 cv=KFold(shuffle=True, random_state=42),
@@ -498,7 +498,7 @@ def test_stacking_classifier_sample_weight_fit_param():
             StackingClassifier(
                 estimators=[
                     ("lr", LogisticRegression()),
-                    ("svm", LinearSVC(dual="auto", random_state=42)),
+                    ("svm", LinearSVC(random_state=42)),
                 ],
                 final_estimator=LogisticRegression(),
             ),
@@ -508,7 +508,7 @@ def test_stacking_classifier_sample_weight_fit_param():
             StackingRegressor(
                 estimators=[
                     ("lr", LinearRegression()),
-                    ("svm", LinearSVR(dual="auto", random_state=42)),
+                    ("svm", LinearSVR(random_state=42)),
                 ],
                 final_estimator=LinearRegression(),
             ),
@@ -614,7 +614,7 @@ def test_stacking_prefit(Stacker, Estimator, stack_method, final_estimator, X, y
             StackingRegressor(
                 estimators=[
                     ("lr", LinearRegression()),
-                    ("svm", LinearSVR(dual="auto")),
+                    ("svm", LinearSVR()),
                 ],
                 cv="prefit",
             ),
@@ -780,7 +780,7 @@ def test_stacking_classifier_multilabel_auto_predict(stack_method, passthrough):
             StackingClassifier(
                 estimators=[
                     ("lr", LogisticRegression(random_state=0)),
-                    ("svm", LinearSVC(dual="auto", random_state=0)),
+                    ("svm", LinearSVC(random_state=0)),
                 ]
             ),
             iris.feature_names,
@@ -800,7 +800,7 @@ def test_stacking_classifier_multilabel_auto_predict(stack_method, passthrough):
                 estimators=[
                     ("lr", LogisticRegression(random_state=0)),
                     ("other", "drop"),
-                    ("svm", LinearSVC(dual="auto", random_state=0)),
+                    ("svm", LinearSVC(random_state=0)),
                 ]
             ),
             iris.feature_names,
@@ -815,7 +815,7 @@ def test_stacking_classifier_multilabel_auto_predict(stack_method, passthrough):
             StackingRegressor(
                 estimators=[
                     ("lr", LinearRegression()),
-                    ("svm", LinearSVR(dual="auto", random_state=0)),
+                    ("svm", LinearSVR(random_state=0)),
                 ]
             ),
             diabetes.feature_names,

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -936,7 +936,7 @@ def test_count_vectorizer_pipeline_grid_selection():
         data, target, test_size=0.2, random_state=0
     )
 
-    pipeline = Pipeline([("vect", CountVectorizer()), ("svc", LinearSVC(dual="auto"))])
+    pipeline = Pipeline([("vect", CountVectorizer()), ("svc", LinearSVC())])
 
     parameters = {
         "vect__ngram_range": [(1, 1), (1, 2)],
@@ -972,7 +972,7 @@ def test_vectorizer_pipeline_grid_selection():
         data, target, test_size=0.1, random_state=0
     )
 
-    pipeline = Pipeline([("vect", TfidfVectorizer()), ("svc", LinearSVC(dual="auto"))])
+    pipeline = Pipeline([("vect", TfidfVectorizer()), ("svc", LinearSVC())])
 
     parameters = {
         "vect__ngram_range": [(1, 1), (1, 2)],
@@ -1006,7 +1006,7 @@ def test_vectorizer_pipeline_cross_validation():
     # label junk food as -1, the others as +1
     target = [-1] * len(JUNK_FOOD_DOCS) + [1] * len(NOTJUNK_FOOD_DOCS)
 
-    pipeline = Pipeline([("vect", TfidfVectorizer()), ("svc", LinearSVC(dual="auto"))])
+    pipeline = Pipeline([("vect", TfidfVectorizer()), ("svc", LinearSVC())])
 
     cv_scores = cross_val_score(pipeline, data, target, cv=3)
     assert_array_equal(cv_scores, [1.0, 1.0, 1.0])

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -408,7 +408,7 @@ def test_partial_fit():
 
 
 def test_calling_fit_reinitializes():
-    est = LinearSVC(dual="auto", random_state=0)
+    est = LinearSVC(random_state=0)
     transformer = SelectFromModel(estimator=est)
     transformer.fit(data, y)
     transformer.set_params(estimator__C=100)

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -464,7 +464,7 @@ def test_rfe_wrapped_estimator(importance_getter, selector, expected_n_features)
     # Non-regression test for
     # https://github.com/scikit-learn/scikit-learn/issues/15312
     X, y = make_friedman1(n_samples=50, n_features=10, random_state=0)
-    estimator = LinearSVR(dual="auto", random_state=0)
+    estimator = LinearSVR(random_state=0)
 
     log_estimator = TransformedTargetRegressor(
         regressor=estimator, func=np.log, inverse_func=np.exp
@@ -486,7 +486,7 @@ def test_rfe_wrapped_estimator(importance_getter, selector, expected_n_features)
 @pytest.mark.parametrize("Selector", [RFE, RFECV])
 def test_rfe_importance_getter_validation(importance_getter, err_type, Selector):
     X, y = make_friedman1(n_samples=50, n_features=10, random_state=42)
-    estimator = LinearSVR(dual="auto")
+    estimator = LinearSVR()
     log_estimator = TransformedTargetRegressor(
         regressor=estimator, func=np.log, inverse_func=np.exp
     )

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -968,13 +968,13 @@ class Nystroem(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator)
     >>> from sklearn.kernel_approximation import Nystroem
     >>> X, y = datasets.load_digits(n_class=9, return_X_y=True)
     >>> data = X / 16.
-    >>> clf = svm.LinearSVC(dual="auto")
+    >>> clf = svm.LinearSVC()
     >>> feature_map_nystroem = Nystroem(gamma=.2,
     ...                                 random_state=1,
     ...                                 n_components=300)
     >>> data_transformed = feature_map_nystroem.fit_transform(data)
     >>> clf.fit(data_transformed, y)
-    LinearSVC(dual='auto')
+    LinearSVC()
     >>> clf.score(data_transformed, y)
     0.9987...
     """

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -3061,9 +3061,9 @@ def hinge_loss(y_true, pred_decision, *, labels=None, sample_weight=None):
     >>> from sklearn.metrics import hinge_loss
     >>> X = [[0], [1]]
     >>> y = [-1, 1]
-    >>> est = svm.LinearSVC(dual="auto", random_state=0)
+    >>> est = svm.LinearSVC(random_state=0)
     >>> est.fit(X, y)
-    LinearSVC(dual='auto', random_state=0)
+    LinearSVC(random_state=0)
     >>> pred_decision = est.decision_function([[-2], [3], [0.5]])
     >>> pred_decision
     array([-2.18...,  2.36...,  0.09...])
@@ -3076,9 +3076,9 @@ def hinge_loss(y_true, pred_decision, *, labels=None, sample_weight=None):
     >>> X = np.array([[0], [1], [2], [3]])
     >>> Y = np.array([0, 1, 2, 3])
     >>> labels = np.array([0, 1, 2, 3])
-    >>> est = svm.LinearSVC(dual="auto")
+    >>> est = svm.LinearSVC()
     >>> est.fit(X, Y)
-    LinearSVC(dual='auto')
+    LinearSVC()
     >>> pred_decision = est.decision_function([[-1], [2], [3]])
     >>> y_true = [0, 2, 3]
     >>> hinge_loss(y_true, pred_decision, labels=labels)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -276,7 +276,7 @@ def test_check_scoring_and_check_multimetric_scoring(scoring):
     # To make sure the check_scoring is correctly applied to the constituent
     # scorers
 
-    estimator = LinearSVC(dual="auto", random_state=0)
+    estimator = LinearSVC(random_state=0)
     estimator.fit([[1], [2], [3]], [1, 1, 0])
 
     scorers = _check_multimetric_scoring(estimator, scoring)
@@ -337,12 +337,12 @@ def test_check_scoring_gridsearchcv():
     # test that check_scoring works on GridSearchCV and pipeline.
     # slightly redundant non-regression test.
 
-    grid = GridSearchCV(LinearSVC(dual="auto"), param_grid={"C": [0.1, 1]}, cv=3)
+    grid = GridSearchCV(LinearSVC(), param_grid={"C": [0.1, 1]}, cv=3)
     scorer = check_scoring(grid, scoring="f1")
     assert isinstance(scorer, _Scorer)
     assert scorer._response_method == "predict"
 
-    pipe = make_pipeline(LinearSVC(dual="auto"))
+    pipe = make_pipeline(LinearSVC())
     scorer = check_scoring(pipe, scoring="f1")
     assert isinstance(scorer, _Scorer)
     assert scorer._response_method == "predict"
@@ -384,7 +384,7 @@ def test_classification_binary_scores(scorer_name, metric):
     # binary classification.
     X, y = make_blobs(random_state=0, centers=2)
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
-    clf = LinearSVC(dual="auto", random_state=0)
+    clf = LinearSVC(random_state=0)
     clf.fit(X_train, y_train)
 
     score = get_scorer(scorer_name)(clf, X_test, y_test)
@@ -434,7 +434,7 @@ def test_custom_scorer_pickling():
     # test that custom scorer can be pickled
     X, y = make_blobs(random_state=0, centers=2)
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
-    clf = LinearSVC(dual="auto", random_state=0)
+    clf = LinearSVC(random_state=0)
     clf.fit(X_train, y_train)
 
     scorer = make_scorer(fbeta_score, beta=2)
@@ -532,7 +532,7 @@ def test_thresholded_scorers_multilabel_indicator_data():
     assert_almost_equal(score1, score2)
 
     # Multilabel decision function
-    clf = OneVsRestClassifier(LinearSVC(dual="auto", random_state=0))
+    clf = OneVsRestClassifier(LinearSVC(random_state=0))
     clf.fit(X_train, y_train)
     score1 = get_scorer("roc_auc")(clf, X_test, y_test)
     score2 = roc_auc_score(y_test, clf.decision_function(X_test))

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -259,10 +259,10 @@ def test_SearchCV_with_fit_params(SearchCV):
 @ignore_warnings
 def test_grid_search_no_score():
     # Test grid-search on classifier that has no score function.
-    clf = LinearSVC(dual="auto", random_state=0)
+    clf = LinearSVC(random_state=0)
     X, y = make_blobs(random_state=0, centers=2)
     Cs = [0.1, 1, 10]
-    clf_no_score = LinearSVCNoScore(dual="auto", random_state=0)
+    clf_no_score = LinearSVCNoScore(random_state=0)
     grid_search = GridSearchCV(clf, {"C": Cs}, scoring="accuracy")
     grid_search.fit(X, y)
 
@@ -283,13 +283,13 @@ def test_grid_search_no_score():
 
 def test_grid_search_score_method():
     X, y = make_classification(n_samples=100, n_classes=2, flip_y=0.2, random_state=0)
-    clf = LinearSVC(dual="auto", random_state=0)
+    clf = LinearSVC(random_state=0)
     grid = {"C": [0.1]}
 
     search_no_scoring = GridSearchCV(clf, grid, scoring=None).fit(X, y)
     search_accuracy = GridSearchCV(clf, grid, scoring="accuracy").fit(X, y)
     search_no_score_method_auc = GridSearchCV(
-        LinearSVCNoScore(dual="auto"), grid, scoring="roc_auc"
+        LinearSVCNoScore(), grid, scoring="roc_auc"
     ).fit(X, y)
     search_auc = GridSearchCV(clf, grid, scoring="roc_auc").fit(X, y)
 
@@ -317,7 +317,7 @@ def test_grid_search_groups():
     X, y = make_classification(n_samples=15, n_classes=2, random_state=0)
     groups = rng.randint(0, 3, 15)
 
-    clf = LinearSVC(dual="auto", random_state=0)
+    clf = LinearSVC(random_state=0)
     grid = {"C": [1]}
 
     group_cvs = [
@@ -346,7 +346,7 @@ def test_classes__property():
     y = np.array([0] * 5 + [1] * 5)
     Cs = [0.1, 1, 10]
 
-    grid_search = GridSearchCV(LinearSVC(dual="auto", random_state=0), {"C": Cs})
+    grid_search = GridSearchCV(LinearSVC(random_state=0), {"C": Cs})
     grid_search.fit(X, y)
     assert_array_equal(grid_search.best_estimator_.classes_, grid_search.classes_)
 
@@ -356,13 +356,11 @@ def test_classes__property():
     assert not hasattr(grid_search, "classes_")
 
     # Test that the grid searcher has no classes_ attribute before it's fit
-    grid_search = GridSearchCV(LinearSVC(dual="auto", random_state=0), {"C": Cs})
+    grid_search = GridSearchCV(LinearSVC(random_state=0), {"C": Cs})
     assert not hasattr(grid_search, "classes_")
 
     # Test that the grid searcher has no classes_ attribute without a refit
-    grid_search = GridSearchCV(
-        LinearSVC(dual="auto", random_state=0), {"C": Cs}, refit=False
-    )
+    grid_search = GridSearchCV(LinearSVC(random_state=0), {"C": Cs}, refit=False)
     grid_search.fit(X, y)
     assert not hasattr(grid_search, "classes_")
 
@@ -426,7 +424,7 @@ def test_grid_search_error():
     # Test that grid search will capture errors on data with different length
     X_, y_ = make_classification(n_samples=200, n_features=100, random_state=0)
 
-    clf = LinearSVC(dual="auto")
+    clf = LinearSVC()
     cv = GridSearchCV(clf, {"C": [0.1, 1.0]})
     with pytest.raises(ValueError):
         cv.fit(X_[:180], y_)
@@ -500,14 +498,14 @@ def test_grid_search_sparse(csr_container):
     # Test that grid search works with both dense and sparse matrices
     X_, y_ = make_classification(n_samples=200, n_features=100, random_state=0)
 
-    clf = LinearSVC(dual="auto")
+    clf = LinearSVC()
     cv = GridSearchCV(clf, {"C": [0.1, 1.0]})
     cv.fit(X_[:180], y_[:180])
     y_pred = cv.predict(X_[180:])
     C = cv.best_estimator_.C
 
     X_ = csr_container(X_)
-    clf = LinearSVC(dual="auto")
+    clf = LinearSVC()
     cv = GridSearchCV(clf, {"C": [0.1, 1.0]})
     cv.fit(X_[:180].tocoo(), y_[:180])
     y_pred2 = cv.predict(X_[180:])
@@ -521,14 +519,14 @@ def test_grid_search_sparse(csr_container):
 def test_grid_search_sparse_scoring(csr_container):
     X_, y_ = make_classification(n_samples=200, n_features=100, random_state=0)
 
-    clf = LinearSVC(dual="auto")
+    clf = LinearSVC()
     cv = GridSearchCV(clf, {"C": [0.1, 1.0]}, scoring="f1")
     cv.fit(X_[:180], y_[:180])
     y_pred = cv.predict(X_[180:])
     C = cv.best_estimator_.C
 
     X_ = csr_container(X_)
-    clf = LinearSVC(dual="auto")
+    clf = LinearSVC()
     cv = GridSearchCV(clf, {"C": [0.1, 1.0]}, scoring="f1")
     cv.fit(X_[:180], y_[:180])
     y_pred2 = cv.predict(X_[180:])
@@ -638,7 +636,7 @@ def test_refit_callable():
         # clf.cv_results_.
         X, y = make_classification(n_samples=100, n_features=4, random_state=42)
         clf = GridSearchCV(
-            LinearSVC(dual="auto", random_state=42),
+            LinearSVC(random_state=42),
             {"C": [0.01, 0.1, 1]},
             scoring="precision",
             refit=True,
@@ -655,7 +653,7 @@ def test_refit_callable():
 
     X, y = make_classification(n_samples=100, n_features=4, random_state=42)
     clf = GridSearchCV(
-        LinearSVC(dual="auto", random_state=42),
+        LinearSVC(random_state=42),
         {"C": [0.01, 0.1, 1]},
         scoring="precision",
         refit=refit_callable,
@@ -682,7 +680,7 @@ def test_refit_callable_invalid_type():
     X, y = make_classification(n_samples=100, n_features=4, random_state=42)
 
     clf = GridSearchCV(
-        LinearSVC(dual="auto", random_state=42),
+        LinearSVC(random_state=42),
         {"C": [0.1, 1]},
         scoring="precision",
         refit=refit_callable_invalid_type,
@@ -708,7 +706,7 @@ def test_refit_callable_out_bound(out_bound_value, search_cv):
     X, y = make_classification(n_samples=100, n_features=4, random_state=42)
 
     clf = search_cv(
-        LinearSVC(dual="auto", random_state=42),
+        LinearSVC(random_state=42),
         {"C": [0.1, 1]},
         scoring="precision",
         refit=refit_callable_out_bound,
@@ -734,7 +732,7 @@ def test_refit_callable_multi_metric():
     X, y = make_classification(n_samples=100, n_features=4, random_state=42)
     scoring = {"Accuracy": make_scorer(accuracy_score), "prec": "precision"}
     clf = GridSearchCV(
-        LinearSVC(dual="auto", random_state=42),
+        LinearSVC(random_state=42),
         {"C": [0.01, 0.1, 1]},
         scoring=scoring,
         refit=refit_callable,
@@ -1407,7 +1405,7 @@ def test_search_cv_results_none_param():
 
 @ignore_warnings()
 def test_search_cv_timing():
-    svc = LinearSVC(dual="auto", random_state=0)
+    svc = LinearSVC(random_state=0)
 
     X = [
         [
@@ -1449,7 +1447,7 @@ def test_search_cv_timing():
 def test_grid_search_correct_score_results():
     # test that correct scores are used
     n_splits = 3
-    clf = LinearSVC(dual="auto", random_state=0)
+    clf = LinearSVC(random_state=0)
     X, y = make_blobs(random_state=0, centers=2)
     Cs = [0.1, 1, 10]
     for score in ["f1", "roc_auc"]:
@@ -1788,7 +1786,7 @@ def test_stochastic_gradient_loss_param():
 def test_search_train_scores_set_to_false():
     X = np.arange(6).reshape(6, -1)
     y = [0, 0, 0, 1, 1, 1]
-    clf = LinearSVC(dual="auto", random_state=0)
+    clf = LinearSVC(random_state=0)
 
     gs = GridSearchCV(clf, param_grid={"C": [0.1, 0.2]}, cv=3)
     gs.fit(X, y)
@@ -1801,7 +1799,7 @@ def test_grid_search_cv_splits_consistency():
     X, y = make_classification(n_samples=n_samples, random_state=0)
 
     gs = GridSearchCV(
-        LinearSVC(dual="auto", random_state=0),
+        LinearSVC(random_state=0),
         param_grid={"C": [0.1, 0.2, 0.3]},
         cv=OneTimeSplitter(n_splits=n_splits, n_samples=n_samples),
         return_train_score=True,
@@ -1809,7 +1807,7 @@ def test_grid_search_cv_splits_consistency():
     gs.fit(X, y)
 
     gs2 = GridSearchCV(
-        LinearSVC(dual="auto", random_state=0),
+        LinearSVC(random_state=0),
         param_grid={"C": [0.1, 0.2, 0.3]},
         cv=KFold(n_splits=n_splits),
         return_train_score=True,
@@ -1822,7 +1820,7 @@ def test_grid_search_cv_splits_consistency():
         GeneratorType,
     )
     gs3 = GridSearchCV(
-        LinearSVC(dual="auto", random_state=0),
+        LinearSVC(random_state=0),
         param_grid={"C": [0.1, 0.2, 0.3]},
         cv=KFold(n_splits=n_splits, shuffle=True, random_state=0).split(X, y),
         return_train_score=True,
@@ -1830,7 +1828,7 @@ def test_grid_search_cv_splits_consistency():
     gs3.fit(X, y)
 
     gs4 = GridSearchCV(
-        LinearSVC(dual="auto", random_state=0),
+        LinearSVC(random_state=0),
         param_grid={"C": [0.1, 0.2, 0.3]},
         cv=KFold(n_splits=n_splits, shuffle=True, random_state=0),
         return_train_score=True,
@@ -1866,7 +1864,7 @@ def test_grid_search_cv_splits_consistency():
 
     # Check consistency of folds across the parameters
     gs = GridSearchCV(
-        LinearSVC(dual="auto", random_state=0),
+        LinearSVC(random_state=0),
         param_grid={"C": [0.1, 0.1, 0.2, 0.2]},
         cv=KFold(n_splits=n_splits, shuffle=True),
         return_train_score=True,
@@ -2090,7 +2088,7 @@ def test_callable_multimetric_confusion_matrix():
         return {"tn": cm[0, 0], "fp": cm[0, 1], "fn": cm[1, 0], "tp": cm[1, 1]}
 
     X, y = make_classification(n_samples=40, n_features=4, random_state=42)
-    est = LinearSVC(dual="auto", random_state=42)
+    est = LinearSVC(random_state=42)
     search = GridSearchCV(est, {"C": [0.1, 1]}, scoring=custom_scorer, refit="fp")
 
     search.fit(X, y)
@@ -2114,7 +2112,7 @@ def test_callable_multimetric_same_as_list_of_strings():
         }
 
     X, y = make_classification(n_samples=40, n_features=4, random_state=42)
-    est = LinearSVC(dual="auto", random_state=42)
+    est = LinearSVC(random_state=42)
     search_callable = GridSearchCV(
         est, {"C": [0.1, 1]}, scoring=custom_scorer, refit="recall"
     )
@@ -2137,7 +2135,7 @@ def test_callable_single_metric_same_as_single_string():
         return recall_score(y, y_pred)
 
     X, y = make_classification(n_samples=40, n_features=4, random_state=42)
-    est = LinearSVC(dual="auto", random_state=42)
+    est = LinearSVC(random_state=42)
     search_callable = GridSearchCV(
         est, {"C": [0.1, 1]}, scoring=custom_scorer, refit=True
     )
@@ -2165,7 +2163,7 @@ def test_callable_multimetric_error_on_invalid_key():
 
     X, y = make_classification(n_samples=40, n_features=4, random_state=42)
     clf = GridSearchCV(
-        LinearSVC(dual="auto", random_state=42),
+        LinearSVC(random_state=42),
         {"C": [0.1, 1]},
         scoring=bad_scorer,
         refit="good_name",
@@ -2447,7 +2445,7 @@ def test_search_cv_verbose_3(capsys, return_train_score):
     """Check that search cv with verbose>2 shows the score for single
     metrics. non-regression test for #19658."""
     X, y = make_classification(n_samples=100, n_classes=2, flip_y=0.2, random_state=0)
-    clf = LinearSVC(dual="auto", random_state=0)
+    clf = LinearSVC(random_state=0)
     grid = {"C": [0.1]}
 
     GridSearchCV(
@@ -2478,7 +2476,7 @@ def test_search_estimator_param(SearchCV, param_search):
     # test that SearchCV object doesn't change the object given in the parameter grid
     X, y = make_classification(random_state=42)
 
-    params = {"clf": [LinearSVC(dual="auto")], "clf__C": [0.01]}
+    params = {"clf": [LinearSVC()], "clf__C": [0.01]}
     orig_C = params["clf"][0].C
 
     pipe = Pipeline([("trs", MinimalTransformer()), ("clf", None)])
@@ -2543,7 +2541,7 @@ def test_multi_metric_search_forwards_metadata(SearchCV, param_search):
     score_weights = rng.rand(n_samples)
     score_metadata = rng.rand(n_samples)
 
-    est = LinearSVC(dual="auto")
+    est = LinearSVC()
     param_grid_search = {param_search: {"C": [1]}}
 
     scorer_registry = _Registry()
@@ -2577,7 +2575,7 @@ def test_score_rejects_params_with_no_routing_enabled(SearchCV, param_search):
     """*SearchCV should reject **params when metadata routing is not enabled
     since this is added only when routing is enabled."""
     X, y = make_classification(random_state=42)
-    est = LinearSVC(dual="auto")
+    est = LinearSVC()
     param_grid_search = {param_search: {"C": [1]}}
 
     gs = SearchCV(est, cv=2, **param_grid_search).fit(X, y)

--- a/sklearn/model_selection/tests/test_successive_halving.py
+++ b/sklearn/model_selection/tests/test_successive_halving.py
@@ -732,7 +732,7 @@ def test_groups_support(Est):
     X, y = make_classification(n_samples=50, n_classes=2, random_state=0)
     groups = rng.randint(0, 3, 50)
 
-    clf = LinearSVC(dual="auto", random_state=0)
+    clf = LinearSVC(random_state=0)
     grid = {"C": [1]}
 
     group_cvs = [

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -2403,7 +2403,7 @@ def test_callable_multimetric_confusion_matrix_cross_validate():
         return {"tn": cm[0, 0], "fp": cm[0, 1], "fn": cm[1, 0], "tp": cm[1, 1]}
 
     X, y = make_classification(n_samples=40, n_features=4, random_state=42)
-    est = LinearSVC(dual="auto", random_state=42)
+    est = LinearSVC(random_state=42)
     est.fit(X, y)
     cv_results = cross_validate(est, X, y, cv=5, scoring=custom_scorer)
 

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -738,7 +738,7 @@ class OneVsOneClassifier(MetaEstimatorMixin, ClassifierMixin, BaseEstimator):
     >>> X_train, X_test, y_train, y_test = train_test_split(
     ...     X, y, test_size=0.33, shuffle=True, random_state=0)
     >>> clf = OneVsOneClassifier(
-    ...     LinearSVC(dual="auto", random_state=0)).fit(X_train, y_train)
+    ...     LinearSVC(random_state=0)).fit(X_train, y_train)
     >>> clf.predict(X_test[:10])
     array([2, 1, 0, 2, 0, 2, 0, 1, 1, 1])
     """

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -213,10 +213,10 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
     >>> from sklearn.datasets import make_classification
     >>> X, y = make_classification(n_features=4, random_state=0)
     >>> clf = make_pipeline(StandardScaler(),
-    ...                     LinearSVC(dual="auto", random_state=0, tol=1e-5))
+    ...                     LinearSVC(random_state=0, tol=1e-5))
     >>> clf.fit(X, y)
     Pipeline(steps=[('standardscaler', StandardScaler()),
-                    ('linearsvc', LinearSVC(dual='auto', random_state=0, tol=1e-05))])
+                    ('linearsvc', LinearSVC(random_state=0, tol=1e-05))])
 
     >>> print(clf.named_steps['linearsvc'].coef_)
     [[0.141...   0.526... 0.679... 0.493...]]

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -1,11 +1,10 @@
-import warnings
 from numbers import Integral, Real
 
 import numpy as np
 
 from ..base import BaseEstimator, OutlierMixin, RegressorMixin, _fit_context
 from ..linear_model._base import LinearClassifierMixin, LinearModel, SparseCoefMixin
-from ..utils._param_validation import Hidden, Interval, StrOptions
+from ..utils._param_validation import Interval, StrOptions
 from ..utils.multiclass import check_classification_targets
 from ..utils.validation import _num_samples
 from ._base import BaseLibSVM, BaseSVC, _fit_liblinear, _get_liblinear_solver_type
@@ -26,16 +25,6 @@ def _validate_dual_parameter(dual, loss, penalty, multi_class, X):
                 return False
             except ValueError:  # primal not supported by the combination
                 return True
-    # TODO 1.5
-    elif dual == "warn":
-        warnings.warn(
-            (
-                "The default value of `dual` will change from `True` to `'auto'` in"
-                " 1.5. Set the value of `dual` explicitly to suppress the warning."
-            ),
-            FutureWarning,
-        )
-        return True
     else:
         return dual
 
@@ -70,7 +59,7 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
         square of the hinge loss. The combination of ``penalty='l1'``
         and ``loss='hinge'`` is not supported.
 
-    dual : "auto" or bool, default=True
+    dual : "auto" or bool, default="auto"
         Select the algorithm to either solve the dual or primal
         optimization problem. Prefer dual=False when n_samples > n_features.
         `dual="auto"` will choose the value of the parameter automatically,
@@ -241,7 +230,7 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
     _parameter_constraints: dict = {
         "penalty": [StrOptions({"l1", "l2"})],
         "loss": [StrOptions({"hinge", "squared_hinge"})],
-        "dual": ["boolean", StrOptions({"auto"}), Hidden(StrOptions({"warn"}))],
+        "dual": ["boolean", StrOptions({"auto"})],
         "tol": [Interval(Real, 0.0, None, closed="neither")],
         "C": [Interval(Real, 0.0, None, closed="neither")],
         "multi_class": [StrOptions({"ovr", "crammer_singer"})],
@@ -258,7 +247,7 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
         penalty="l2",
         loss="squared_hinge",
         *,
-        dual="warn",
+        dual="auto",
         tol=1e-4,
         C=1.0,
         multi_class="ovr",
@@ -423,7 +412,7 @@ class LinearSVR(RegressorMixin, LinearModel):
         `intercept_scaling`. This scaling allows the intercept term to have a
         different regularization behavior compared to the other features.
 
-    dual : "auto" or bool, default=True
+    dual : "auto" or bool, default="auto"
         Select the algorithm to either solve the dual or primal
         optimization problem. Prefer dual=False when n_samples > n_features.
         `dual="auto"` will choose the value of the parameter automatically,
@@ -498,10 +487,10 @@ class LinearSVR(RegressorMixin, LinearModel):
     >>> from sklearn.datasets import make_regression
     >>> X, y = make_regression(n_features=4, random_state=0)
     >>> regr = make_pipeline(StandardScaler(),
-    ...                      LinearSVR(dual="auto", random_state=0, tol=1e-5))
+    ...                      LinearSVR(random_state=0, tol=1e-5))
     >>> regr.fit(X, y)
     Pipeline(steps=[('standardscaler', StandardScaler()),
-                    ('linearsvr', LinearSVR(dual='auto', random_state=0, tol=1e-05))])
+                    ('linearsvr', LinearSVR(random_state=0, tol=1e-05))])
 
     >>> print(regr.named_steps['linearsvr'].coef_)
     [18.582... 27.023... 44.357... 64.522...]
@@ -518,7 +507,7 @@ class LinearSVR(RegressorMixin, LinearModel):
         "loss": [StrOptions({"epsilon_insensitive", "squared_epsilon_insensitive"})],
         "fit_intercept": ["boolean"],
         "intercept_scaling": [Interval(Real, 0, None, closed="neither")],
-        "dual": ["boolean", StrOptions({"auto"}), Hidden(StrOptions({"warn"}))],
+        "dual": ["boolean", StrOptions({"auto"})],
         "verbose": ["verbose"],
         "random_state": ["random_state"],
         "max_iter": [Interval(Integral, 0, None, closed="left")],
@@ -533,7 +522,7 @@ class LinearSVR(RegressorMixin, LinearModel):
         loss="epsilon_insensitive",
         fit_intercept=True,
         intercept_scaling=1.0,
-        dual="warn",
+        dual="auto",
         verbose=0,
         random_state=None,
         max_iter=1000,

--- a/sklearn/svm/tests/test_sparse.py
+++ b/sklearn/svm/tests/test_sparse.py
@@ -242,8 +242,8 @@ def test_linearsvc(lil_container, dok_container):
     X_sp = lil_container(X)
     X2_sp = dok_container(X2)
 
-    clf = svm.LinearSVC(dual="auto", random_state=0).fit(X, Y)
-    sp_clf = svm.LinearSVC(dual="auto", random_state=0).fit(X_sp, Y)
+    clf = svm.LinearSVC(random_state=0).fit(X, Y)
+    sp_clf = svm.LinearSVC(random_state=0).fit(X_sp, Y)
 
     assert sp_clf.fit_intercept
 
@@ -264,8 +264,8 @@ def test_linearsvc_iris(csr_container):
     # Test the sparse LinearSVC with the iris dataset
     iris_data_sp = csr_container(iris.data)
 
-    sp_clf = svm.LinearSVC(dual="auto", random_state=0).fit(iris_data_sp, iris.target)
-    clf = svm.LinearSVC(dual="auto", random_state=0).fit(iris.data, iris.target)
+    sp_clf = svm.LinearSVC(random_state=0).fit(iris_data_sp, iris.target)
+    clf = svm.LinearSVC(random_state=0).fit(iris.data, iris.target)
 
     assert clf.fit_intercept == sp_clf.fit_intercept
 
@@ -295,7 +295,7 @@ def test_weight(csr_container):
     X_ = csr_container(X_)
     for clf in (
         linear_model.LogisticRegression(),
-        svm.LinearSVC(dual="auto", random_state=0),
+        svm.LinearSVC(random_state=0),
         svm.SVC(),
     ):
         clf.set_params(class_weight={0: 5})

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -4,7 +4,6 @@ Testing for Support Vector Machine module (sklearn.svm)
 TODO: remove hard coded numerical results when possible
 """
 
-
 import numpy as np
 import pytest
 from numpy.testing import (
@@ -226,8 +225,8 @@ def test_svr():
         svm.NuSVR(kernel="linear", nu=0.4, C=1.0),
         svm.NuSVR(kernel="linear", nu=0.4, C=10.0),
         svm.SVR(kernel="linear", C=10.0),
-        svm.LinearSVR(dual="auto", C=10.0),
-        svm.LinearSVR(dual="auto", C=10.0),
+        svm.LinearSVR(C=10.0),
+        svm.LinearSVR(C=10.0),
     ):
         clf.fit(diabetes.data, diabetes.target)
         assert clf.score(diabetes.data, diabetes.target) > 0.02
@@ -235,14 +234,14 @@ def test_svr():
     # non-regression test; previously, BaseLibSVM would check that
     # len(np.unique(y)) < 2, which must only be done for SVC
     svm.SVR().fit(diabetes.data, np.ones(len(diabetes.data)))
-    svm.LinearSVR(dual="auto").fit(diabetes.data, np.ones(len(diabetes.data)))
+    svm.LinearSVR().fit(diabetes.data, np.ones(len(diabetes.data)))
 
 
 def test_linearsvr():
     # check that SVR(kernel='linear') and LinearSVC() give
     # comparable results
     diabetes = datasets.load_diabetes()
-    lsvr = svm.LinearSVR(C=1e3, dual="auto").fit(diabetes.data, diabetes.target)
+    lsvr = svm.LinearSVR(C=1e3).fit(diabetes.data, diabetes.target)
     score1 = lsvr.score(diabetes.data, diabetes.target)
 
     svr = svm.SVR(kernel="linear", C=1e3).fit(diabetes.data, diabetes.target)
@@ -259,12 +258,12 @@ def test_linearsvr_fit_sampleweight():
     diabetes = datasets.load_diabetes()
     n_samples = len(diabetes.target)
     unit_weight = np.ones(n_samples)
-    lsvr = svm.LinearSVR(dual="auto", C=1e3, tol=1e-12, max_iter=10000).fit(
+    lsvr = svm.LinearSVR(C=1e3, tol=1e-12, max_iter=10000).fit(
         diabetes.data, diabetes.target, sample_weight=unit_weight
     )
     score1 = lsvr.score(diabetes.data, diabetes.target)
 
-    lsvr_no_weight = svm.LinearSVR(dual="auto", C=1e3, tol=1e-12, max_iter=10000).fit(
+    lsvr_no_weight = svm.LinearSVR(C=1e3, tol=1e-12, max_iter=10000).fit(
         diabetes.data, diabetes.target
     )
     score2 = lsvr_no_weight.score(diabetes.data, diabetes.target)
@@ -278,7 +277,7 @@ def test_linearsvr_fit_sampleweight():
     # X = X1 repeated n1 times, X2 repeated n2 times and so forth
     random_state = check_random_state(0)
     random_weight = random_state.randint(0, 10, n_samples)
-    lsvr_unflat = svm.LinearSVR(dual="auto", C=1e3, tol=1e-12, max_iter=10000).fit(
+    lsvr_unflat = svm.LinearSVR(C=1e3, tol=1e-12, max_iter=10000).fit(
         diabetes.data, diabetes.target, sample_weight=random_weight
     )
     score3 = lsvr_unflat.score(
@@ -287,9 +286,7 @@ def test_linearsvr_fit_sampleweight():
 
     X_flat = np.repeat(diabetes.data, random_weight, axis=0)
     y_flat = np.repeat(diabetes.target, random_weight, axis=0)
-    lsvr_flat = svm.LinearSVR(dual="auto", C=1e3, tol=1e-12, max_iter=10000).fit(
-        X_flat, y_flat
-    )
+    lsvr_flat = svm.LinearSVR(C=1e3, tol=1e-12, max_iter=10000).fit(X_flat, y_flat)
     score4 = lsvr_flat.score(X_flat, y_flat)
 
     assert_almost_equal(score3, score4, 2)
@@ -489,7 +486,7 @@ def test_weight():
 
     for clf in (
         linear_model.LogisticRegression(),
-        svm.LinearSVC(dual="auto", random_state=0),
+        svm.LinearSVC(random_state=0),
         svm.SVC(),
     ):
         clf.set_params(class_weight={0: 0.1, 1: 10})
@@ -666,7 +663,7 @@ def test_auto_weight():
 
     for clf in (
         svm.SVC(kernel="linear"),
-        svm.LinearSVC(dual="auto", random_state=0),
+        svm.LinearSVC(random_state=0),
         LogisticRegression(),
     ):
         # check that score is better when class='balanced' is set.
@@ -689,7 +686,7 @@ def test_bad_input(lil_container):
         svm.SVC().fit(X, Y2)
 
     # Test with arrays that are non-contiguous.
-    for clf in (svm.SVC(), svm.LinearSVC(dual="auto", random_state=0)):
+    for clf in (svm.SVC(), svm.LinearSVC(random_state=0)):
         Xf = np.asfortranarray(X)
         assert not Xf.flags["C_CONTIGUOUS"]
         yf = np.ascontiguousarray(np.tile(Y, (2, 1)).T)
@@ -789,7 +786,7 @@ def test_linearsvc_parameters(loss, penalty, dual):
 
 def test_linearsvc():
     # Test basic routines using LinearSVC
-    clf = svm.LinearSVC(dual="auto", random_state=0).fit(X, Y)
+    clf = svm.LinearSVC(random_state=0).fit(X, Y)
 
     # by default should have intercept
     assert clf.fit_intercept
@@ -820,8 +817,8 @@ def test_linearsvc():
 
 def test_linearsvc_crammer_singer():
     # Test LinearSVC with crammer_singer multi-class svm
-    ovr_clf = svm.LinearSVC(dual="auto", random_state=0).fit(iris.data, iris.target)
-    cs_clf = svm.LinearSVC(dual="auto", multi_class="crammer_singer", random_state=0)
+    ovr_clf = svm.LinearSVC(random_state=0).fit(iris.data, iris.target)
+    cs_clf = svm.LinearSVC(multi_class="crammer_singer", random_state=0)
     cs_clf.fit(iris.data, iris.target)
 
     # similar prediction for ovr and crammer-singer:
@@ -843,10 +840,10 @@ def test_linearsvc_fit_sampleweight():
     # check correct result when sample_weight is 1
     n_samples = len(X)
     unit_weight = np.ones(n_samples)
-    clf = svm.LinearSVC(dual="auto", random_state=0).fit(X, Y)
-    clf_unitweight = svm.LinearSVC(
-        dual="auto", random_state=0, tol=1e-12, max_iter=1000
-    ).fit(X, Y, sample_weight=unit_weight)
+    clf = svm.LinearSVC(random_state=0).fit(X, Y)
+    clf_unitweight = svm.LinearSVC(random_state=0, tol=1e-12, max_iter=1000).fit(
+        X, Y, sample_weight=unit_weight
+    )
 
     # check if same as sample_weight=None
     assert_array_equal(clf_unitweight.predict(T), clf.predict(T))
@@ -857,17 +854,17 @@ def test_linearsvc_fit_sampleweight():
 
     random_state = check_random_state(0)
     random_weight = random_state.randint(0, 10, n_samples)
-    lsvc_unflat = svm.LinearSVC(
-        dual="auto", random_state=0, tol=1e-12, max_iter=1000
-    ).fit(X, Y, sample_weight=random_weight)
+    lsvc_unflat = svm.LinearSVC(random_state=0, tol=1e-12, max_iter=1000).fit(
+        X, Y, sample_weight=random_weight
+    )
 
     pred1 = lsvc_unflat.predict(T)
 
     X_flat = np.repeat(X, random_weight, axis=0)
     y_flat = np.repeat(Y, random_weight, axis=0)
-    lsvc_flat = svm.LinearSVC(
-        dual="auto", random_state=0, tol=1e-12, max_iter=1000
-    ).fit(X_flat, y_flat)
+    lsvc_flat = svm.LinearSVC(random_state=0, tol=1e-12, max_iter=1000).fit(
+        X_flat, y_flat
+    )
     pred2 = lsvc_flat.predict(T)
 
     assert_array_equal(pred1, pred2)
@@ -881,7 +878,6 @@ def test_crammer_singer_binary():
     for fit_intercept in (True, False):
         acc = (
             svm.LinearSVC(
-                dual="auto",
                 fit_intercept=fit_intercept,
                 multi_class="crammer_singer",
                 random_state=0,
@@ -896,7 +892,7 @@ def test_linearsvc_iris():
     # Test that LinearSVC gives plausible predictions on the iris dataset
     # Also, test symbolic class names (classes_).
     target = iris.target_names[iris.target]
-    clf = svm.LinearSVC(dual="auto", random_state=0).fit(iris.data, target)
+    clf = svm.LinearSVC(random_state=0).fit(iris.data, target)
     assert set(clf.classes_) == set(iris.target_names)
     assert np.mean(clf.predict(iris.data) == target) > 0.8
 
@@ -944,7 +940,7 @@ def test_dense_liblinear_intercept_handling(classifier=svm.LinearSVC):
 
 def test_liblinear_set_coef():
     # multi-class case
-    clf = svm.LinearSVC(dual="auto").fit(iris.data, iris.target)
+    clf = svm.LinearSVC().fit(iris.data, iris.target)
     values = clf.decision_function(iris.data)
     clf.coef_ = clf.coef_.copy()
     clf.intercept_ = clf.intercept_.copy()
@@ -955,7 +951,7 @@ def test_liblinear_set_coef():
     X = [[2, 1], [3, 1], [1, 3], [2, 3]]
     y = [0, 0, 1, 1]
 
-    clf = svm.LinearSVC(dual="auto").fit(X, y)
+    clf = svm.LinearSVC().fit(X, y)
     values = clf.decision_function(X)
     clf.coef_ = clf.coef_.copy()
     clf.intercept_ = clf.intercept_.copy()
@@ -987,7 +983,7 @@ def test_linearsvc_verbose():
     os.dup2(os.pipe()[1], 1)  # replace it
 
     # actual call
-    clf = svm.LinearSVC(dual="auto", verbose=1)
+    clf = svm.LinearSVC(verbose=1)
     clf.fit(X, Y)
 
     # stdout: restore
@@ -1071,7 +1067,7 @@ def test_consistent_proba():
 def test_linear_svm_convergence_warnings():
     # Test that warnings are raised if model does not converge
 
-    lsvc = svm.LinearSVC(dual="auto", random_state=0, max_iter=2)
+    lsvc = svm.LinearSVC(random_state=0, max_iter=2)
     warning_msg = "Liblinear failed to converge, increase the number of iterations."
     with pytest.warns(ConvergenceWarning, match=warning_msg):
         lsvc.fit(X, Y)
@@ -1080,7 +1076,7 @@ def test_linear_svm_convergence_warnings():
     assert isinstance(lsvc.n_iter_, int)
     assert lsvc.n_iter_ == 2
 
-    lsvr = svm.LinearSVR(dual="auto", random_state=0, max_iter=2)
+    lsvr = svm.LinearSVR(random_state=0, max_iter=2)
     with pytest.warns(ConvergenceWarning, match=warning_msg):
         lsvr.fit(iris.data, iris.target)
     assert isinstance(lsvr.n_iter_, int)
@@ -1096,7 +1092,7 @@ def test_svr_coef_sign():
     for svr in [
         svm.SVR(kernel="linear"),
         svm.NuSVR(kernel="linear"),
-        svm.LinearSVR(dual="auto"),
+        svm.LinearSVR(),
     ]:
         svr.fit(X, y)
         assert_array_almost_equal(
@@ -1107,7 +1103,7 @@ def test_svr_coef_sign():
 def test_lsvc_intercept_scaling_zero():
     # Test that intercept_scaling is ignored when fit_intercept is False
 
-    lsvc = svm.LinearSVC(dual="auto", fit_intercept=False)
+    lsvc = svm.LinearSVC(fit_intercept=False)
     lsvc.fit(X, Y)
     assert lsvc.intercept_ == 0.0
 

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -4,7 +4,6 @@ Testing for Support Vector Machine module (sklearn.svm)
 TODO: remove hard coded numerical results when possible
 """
 
-import re
 
 import numpy as np
 import pytest
@@ -1396,18 +1395,6 @@ def test_n_iter_libsvm(estimator, expected_n_iter_type, dataset):
     if estimator in [svm.SVC, svm.NuSVC]:
         n_classes = len(np.unique(y))
         assert n_iter.shape == (n_classes * (n_classes - 1) // 2,)
-
-
-# TODO(1.5): Remove
-@pytest.mark.parametrize("Estimator", [LinearSVR, LinearSVC])
-def test_dual_auto_deprecation_warning(Estimator):
-    svm = Estimator()
-    msg = (
-        "The default value of `dual` will change from `True` to `'auto'` in"
-        " 1.5. Set the value of `dual` explicitly to suppress the warning."
-    )
-    with pytest.warns(FutureWarning, match=re.escape(msg)):
-        svm.fit(X, Y)
 
 
 @pytest.mark.parametrize("loss", ["squared_hinge", "squared_epsilon_insensitive"])

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -156,7 +156,7 @@ def test_sample_weight(data, method, ensemble):
     X_train, y_train, sw_train = X[:n_samples], y[:n_samples], sample_weight[:n_samples]
     X_test = X[n_samples:]
 
-    estimator = LinearSVC(dual="auto", random_state=42)
+    estimator = LinearSVC(random_state=42)
     calibrated_clf = CalibratedClassifierCV(estimator, method=method, ensemble=ensemble)
     calibrated_clf.fit(X_train, y_train, sample_weight=sw_train)
     probs_with_sw = calibrated_clf.predict_proba(X_test)
@@ -177,7 +177,7 @@ def test_parallel_execution(data, method, ensemble):
     X, y = data
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
 
-    estimator = make_pipeline(StandardScaler(), LinearSVC(dual="auto", random_state=42))
+    estimator = make_pipeline(StandardScaler(), LinearSVC(random_state=42))
 
     cal_clf_parallel = CalibratedClassifierCV(
         estimator, method=method, n_jobs=2, ensemble=ensemble
@@ -206,7 +206,7 @@ def test_calibration_multiclass(method, ensemble, seed):
 
     # Test calibration for multiclass with classifier that implements
     # only decision function.
-    clf = LinearSVC(dual="auto", random_state=7)
+    clf = LinearSVC(random_state=7)
     X, y = make_blobs(
         n_samples=500, n_features=100, random_state=seed, centers=10, cluster_std=15.0
     )
@@ -338,7 +338,7 @@ def test_calibration_ensemble_false(data, method):
     # Test that `ensemble=False` is the same as using predictions from
     # `cross_val_predict` to train calibrator.
     X, y = data
-    clf = LinearSVC(dual="auto", random_state=7)
+    clf = LinearSVC(random_state=7)
 
     cal_clf = CalibratedClassifierCV(clf, method=method, cv=3, ensemble=False)
     cal_clf.fit(X, y)
@@ -427,7 +427,7 @@ def test_calibration_prob_sum(ensemble):
     # issue #7796
     num_classes = 2
     X, y = make_classification(n_samples=10, n_features=5, n_classes=num_classes)
-    clf = LinearSVC(dual="auto", C=1.0, random_state=7)
+    clf = LinearSVC(C=1.0, random_state=7)
     clf_prob = CalibratedClassifierCV(
         clf, method="sigmoid", cv=LeaveOneOut(), ensemble=ensemble
     )
@@ -445,7 +445,7 @@ def test_calibration_less_classes(ensemble):
     # class label
     X = np.random.randn(10, 5)
     y = np.arange(10)
-    clf = LinearSVC(dual="auto", C=1.0, random_state=7)
+    clf = LinearSVC(C=1.0, random_state=7)
     cal_clf = CalibratedClassifierCV(
         clf, method="sigmoid", cv=LeaveOneOut(), ensemble=ensemble
     )
@@ -542,8 +542,8 @@ def test_calibration_dict_pipeline(dict_data, dict_data_pipeline):
 @pytest.mark.parametrize(
     "clf, cv",
     [
-        pytest.param(LinearSVC(dual="auto", C=1), 2),
-        pytest.param(LinearSVC(dual="auto", C=1), "prefit"),
+        pytest.param(LinearSVC(C=1), 2),
+        pytest.param(LinearSVC(C=1), "prefit"),
     ],
 )
 def test_calibration_attributes(clf, cv):
@@ -567,7 +567,7 @@ def test_calibration_inconsistent_prefit_n_features_in():
     # Check that `n_features_in_` from prefit base estimator
     # is consistent with training set
     X, y = make_classification(n_samples=10, n_features=5, n_classes=2, random_state=7)
-    clf = LinearSVC(dual="auto", C=1).fit(X, y)
+    clf = LinearSVC(C=1).fit(X, y)
     calib_clf = CalibratedClassifierCV(clf, cv="prefit")
 
     msg = "X has 3 features, but LinearSVC is expecting 5 features as input."

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -225,10 +225,6 @@ def test_fit_docstring_attributes(name, Estimator):
         # default raises an error, perplexity must be less than n_samples
         est.set_params(perplexity=2)
 
-    # TODO(1.5): TO BE REMOVED for 1.5 (avoid FutureWarning)
-    if Estimator.__name__ in ("LinearSVC", "LinearSVR"):
-        est.set_params(dual="auto")
-
     # TODO(1.6): remove (avoid FutureWarning)
     if Estimator.__name__ in ("NMF", "MiniBatchNMF"):
         est.set_params(n_components="auto")

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -57,7 +57,7 @@ n_classes = 3
 
 
 def test_ovr_exceptions():
-    ovr = OneVsRestClassifier(LinearSVC(dual="auto", random_state=0))
+    ovr = OneVsRestClassifier(LinearSVC(random_state=0))
 
     # test predicting without fitting
     with pytest.raises(NotFittedError):
@@ -86,11 +86,11 @@ def test_check_classification_targets():
 
 def test_ovr_fit_predict():
     # A classifier which implements decision_function.
-    ovr = OneVsRestClassifier(LinearSVC(dual="auto", random_state=0))
+    ovr = OneVsRestClassifier(LinearSVC(random_state=0))
     pred = ovr.fit(iris.data, iris.target).predict(iris.data)
     assert len(ovr.estimators_) == n_classes
 
-    clf = LinearSVC(dual="auto", random_state=0)
+    clf = LinearSVC(random_state=0)
     pred2 = clf.fit(iris.data, iris.target).predict(iris.data)
     assert np.mean(iris.target == pred) == np.mean(iris.target == pred2)
 
@@ -258,7 +258,7 @@ def test_ovr_multiclass():
 
     for base_clf in (
         MultinomialNB(),
-        LinearSVC(dual="auto", random_state=0),
+        LinearSVC(random_state=0),
         LinearRegression(),
         Ridge(),
         ElasticNet(),
@@ -303,7 +303,7 @@ def test_ovr_binary():
         assert y_pred == 1
 
     for base_clf in (
-        LinearSVC(dual="auto", random_state=0),
+        LinearSVC(random_state=0),
         LinearRegression(),
         Ridge(),
         ElasticNet(),
@@ -321,7 +321,7 @@ def test_ovr_multilabel():
 
     for base_clf in (
         MultinomialNB(),
-        LinearSVC(dual="auto", random_state=0),
+        LinearSVC(random_state=0),
         LinearRegression(),
         Ridge(),
         ElasticNet(),
@@ -459,7 +459,7 @@ def test_ovr_single_label_decision_function():
 
 
 def test_ovr_gridsearch():
-    ovr = OneVsRestClassifier(LinearSVC(dual="auto", random_state=0))
+    ovr = OneVsRestClassifier(LinearSVC(random_state=0))
     Cs = [0.1, 0.5, 0.8]
     cv = GridSearchCV(ovr, {"estimator__C": Cs})
     cv.fit(iris.data, iris.target)
@@ -480,7 +480,7 @@ def test_ovr_pipeline():
 
 
 def test_ovo_exceptions():
-    ovo = OneVsOneClassifier(LinearSVC(dual="auto", random_state=0))
+    ovo = OneVsOneClassifier(LinearSVC(random_state=0))
     with pytest.raises(NotFittedError):
         ovo.predict([])
 
@@ -488,7 +488,7 @@ def test_ovo_exceptions():
 def test_ovo_fit_on_list():
     # Test that OneVsOne fitting works with a list of targets and yields the
     # same output as predict from an array
-    ovo = OneVsOneClassifier(LinearSVC(dual="auto", random_state=0))
+    ovo = OneVsOneClassifier(LinearSVC(random_state=0))
     prediction_from_array = ovo.fit(iris.data, iris.target).predict(iris.data)
     iris_data_list = [list(a) for a in iris.data]
     prediction_from_list = ovo.fit(iris_data_list, list(iris.target)).predict(
@@ -499,7 +499,7 @@ def test_ovo_fit_on_list():
 
 def test_ovo_fit_predict():
     # A classifier which implements decision_function.
-    ovo = OneVsOneClassifier(LinearSVC(dual="auto", random_state=0))
+    ovo = OneVsOneClassifier(LinearSVC(random_state=0))
     ovo.fit(iris.data, iris.target).predict(iris.data)
     assert len(ovo.estimators_) == n_classes * (n_classes - 1) / 2
 
@@ -565,7 +565,7 @@ def test_ovo_partial_fit_predict():
 def test_ovo_decision_function():
     n_samples = iris.data.shape[0]
 
-    ovo_clf = OneVsOneClassifier(LinearSVC(dual="auto", random_state=0))
+    ovo_clf = OneVsOneClassifier(LinearSVC(random_state=0))
     # first binary
     ovo_clf.fit(iris.data, iris.target == 0)
     decisions = ovo_clf.decision_function(iris.data)
@@ -610,7 +610,7 @@ def test_ovo_decision_function():
 
 
 def test_ovo_gridsearch():
-    ovo = OneVsOneClassifier(LinearSVC(dual="auto", random_state=0))
+    ovo = OneVsOneClassifier(LinearSVC(random_state=0))
     Cs = [0.1, 0.5, 0.8]
     cv = GridSearchCV(ovo, {"estimator__C": Cs})
     cv.fit(iris.data, iris.target)
@@ -660,7 +660,7 @@ def test_ovo_string_y():
     X = np.eye(4)
     y = np.array(["a", "b", "c", "d"])
 
-    ovo = OneVsOneClassifier(LinearSVC(dual="auto"))
+    ovo = OneVsOneClassifier(LinearSVC())
     ovo.fit(X, y)
     assert_array_equal(y, ovo.predict(X))
 
@@ -670,7 +670,7 @@ def test_ovo_one_class():
     X = np.eye(4)
     y = np.array(["a"] * 4)
 
-    ovo = OneVsOneClassifier(LinearSVC(dual="auto"))
+    ovo = OneVsOneClassifier(LinearSVC())
     msg = "when only one class"
     with pytest.raises(ValueError, match=msg):
         ovo.fit(X, y)
@@ -681,23 +681,21 @@ def test_ovo_float_y():
     X = iris.data
     y = iris.data[:, 0]
 
-    ovo = OneVsOneClassifier(LinearSVC(dual="auto"))
+    ovo = OneVsOneClassifier(LinearSVC())
     msg = "Unknown label type"
     with pytest.raises(ValueError, match=msg):
         ovo.fit(X, y)
 
 
 def test_ecoc_exceptions():
-    ecoc = OutputCodeClassifier(LinearSVC(dual="auto", random_state=0))
+    ecoc = OutputCodeClassifier(LinearSVC(random_state=0))
     with pytest.raises(NotFittedError):
         ecoc.predict([])
 
 
 def test_ecoc_fit_predict():
     # A classifier which implements decision_function.
-    ecoc = OutputCodeClassifier(
-        LinearSVC(dual="auto", random_state=0), code_size=2, random_state=0
-    )
+    ecoc = OutputCodeClassifier(LinearSVC(random_state=0), code_size=2, random_state=0)
     ecoc.fit(iris.data, iris.target).predict(iris.data)
     assert len(ecoc.estimators_) == n_classes * 2
 
@@ -708,7 +706,7 @@ def test_ecoc_fit_predict():
 
 
 def test_ecoc_gridsearch():
-    ecoc = OutputCodeClassifier(LinearSVC(dual="auto", random_state=0), random_state=0)
+    ecoc = OutputCodeClassifier(LinearSVC(random_state=0), random_state=0)
     Cs = [0.1, 0.5, 0.8]
     cv = GridSearchCV(ecoc, {"estimator__C": Cs})
     cv.fit(iris.data, iris.target)
@@ -721,7 +719,7 @@ def test_ecoc_float_y():
     X = iris.data
     y = iris.data[:, 0]
 
-    ovo = OutputCodeClassifier(LinearSVC(dual="auto"))
+    ovo = OutputCodeClassifier(LinearSVC())
     msg = "Unknown label type"
     with pytest.raises(ValueError, match=msg):
         ovo.fit(X, y)
@@ -749,7 +747,7 @@ def test_ecoc_delegate_sparse_base_estimator(csc_container):
         ecoc.predict(X_sp)
 
     # smoke test to check when sparse input should be supported
-    ecoc = OutputCodeClassifier(LinearSVC(dual="auto", random_state=0))
+    ecoc = OutputCodeClassifier(LinearSVC(random_state=0))
     ecoc.fit(X_sp, y).predict(X_sp)
     assert len(ecoc.estimators_) == 4
 

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -337,7 +337,7 @@ def test_multi_output_classification():
 
 def test_multiclass_multioutput_estimator():
     # test to check meta of meta estimators
-    svc = LinearSVC(dual="auto", random_state=0)
+    svc = LinearSVC(random_state=0)
     multi_class_svc = OneVsRestClassifier(svc)
     multi_target_svc = MultiOutputClassifier(multi_class_svc)
 
@@ -442,7 +442,7 @@ def test_multi_output_classification_partial_fit_sample_weights():
 def test_multi_output_exceptions():
     # NotFittedError when fit is not done but score, predict and
     # and predict_proba are called
-    moc = MultiOutputClassifier(LinearSVC(dual="auto", random_state=0))
+    moc = MultiOutputClassifier(LinearSVC(random_state=0))
     with pytest.raises(NotFittedError):
         moc.score(X, y)
 
@@ -478,7 +478,7 @@ def test_multi_output_delegate_predict_proba():
     assert hasattr(moc, "predict_proba")
 
     # A base estimator without `predict_proba` should raise an AttributeError
-    moc = MultiOutputClassifier(LinearSVC(dual="auto"))
+    moc = MultiOutputClassifier(LinearSVC())
     assert not hasattr(moc, "predict_proba")
 
     outer_msg = "'MultiOutputClassifier' has no attribute 'predict_proba'"
@@ -513,7 +513,7 @@ def test_classifier_chain_fit_and_predict_with_linear_svc(chain_method):
     # Fit classifier chain and verify predict performance using LinearSVC
     X, Y = generate_multilabel_dataset_with_correlations()
     classifier_chain = ClassifierChain(
-        LinearSVC(dual="auto"),
+        LinearSVC(),
         chain_method=chain_method,
     ).fit(X, Y)
 


### PR DESCRIPTION
Changed default value of the `dual` param of `LinearSV[CR]` from True to "auto".

I removed `dual="auto"` from all instantiations of these classes in the tests, doc, examples, benchs...
- it's the default value, no need to have it. It was added to avoid future warnings.
- to avoid accumulating param settings irrelevant to the thing that is tested, documented, ... It always makes me wonder why this or that param was set when reading tests, making them more complex that needed.
