### PR TITLE
BLD Fix more build dependencies in meson build

### DIFF
--- a/sklearn/cluster/_hdbscan/meson.build
+++ b/sklearn/cluster/_hdbscan/meson.build
@@ -1,5 +1,5 @@
 cluster_hdbscan_extension_metadata = {
-  '_linkage': {'sources': ['_linkage.pyx'] + metrics_cython_tree},
+  '_linkage': {'sources': ['_linkage.pyx', metrics_cython_tree]},
   '_reachability': {'sources': ['_reachability.pyx']},
   '_tree': {'sources': ['_tree.pyx']}
 }

--- a/sklearn/cluster/meson.build
+++ b/sklearn/cluster/meson.build
@@ -17,7 +17,7 @@ cluster_extension_metadata = {
 foreach ext_name, ext_dict : cluster_extension_metadata
   py.extension_module(
     ext_name,
-    ext_dict.get('sources') + utils_cython_tree,
+    [ext_dict.get('sources'), utils_cython_tree],
     dependencies: [np_dep, openmp_dep],
     override_options : ext_dict.get('override_options', []),
     cython_args: cython_args,

--- a/sklearn/cluster/meson.build
+++ b/sklearn/cluster/meson.build
@@ -2,7 +2,8 @@ cluster_extension_metadata = {
   '_dbscan_inner':
     {'sources': ['_dbscan_inner.pyx'], 'override_options': ['cython_language=cpp']},
   '_hierarchical_fast':
-    {'sources': ['_hierarchical_fast.pyx'] + metrics_cython_tree, 'override_options': ['cython_language=cpp']},
+    {'sources': ['_hierarchical_fast.pyx', metrics_cython_tree],
+     'override_options': ['cython_language=cpp']},
   '_k_means_common':
     {'sources': ['_k_means_common.pyx']},
   '_k_means_lloyd':
@@ -16,7 +17,7 @@ cluster_extension_metadata = {
 foreach ext_name, ext_dict : cluster_extension_metadata
   py.extension_module(
     ext_name,
-    ext_dict.get('sources') + [utils_cython_tree],
+    ext_dict.get('sources') + utils_cython_tree,
     dependencies: [np_dep, openmp_dep],
     override_options : ext_dict.get('override_options', []),
     cython_args: cython_args,

--- a/sklearn/decomposition/meson.build
+++ b/sklearn/decomposition/meson.build
@@ -1,6 +1,6 @@
 py.extension_module(
   '_online_lda_fast',
-  '_online_lda_fast.pyx',
+  ['_online_lda_fast.pyx', utils_cython_tree],
   cython_args: cython_args,
   subdir: 'sklearn/decomposition',
   install: true

--- a/sklearn/feature_extraction/meson.build
+++ b/sklearn/feature_extraction/meson.build
@@ -1,6 +1,6 @@
 py.extension_module(
   '_hashing_fast',
-  '_hashing_fast.pyx',
+  ['_hashing_fast.pyx', utils_cython_tree],
   dependencies: [np_dep],
   override_options: ['cython_language=cpp'],
   cython_args: cython_args,

--- a/sklearn/linear_model/meson.build
+++ b/sklearn/linear_model/meson.build
@@ -6,7 +6,7 @@ linear_model_cython_tree = [
 
 py.extension_module(
   '_cd_fast',
-  '_cd_fast.pyx',
+  ['_cd_fast.pyx', utils_cython_tree],
   cython_args: cython_args,
   subdir: 'sklearn/linear_model',
   install: true
@@ -23,7 +23,7 @@ foreach name: name_list
   )
   py.extension_module(
     name,
-    [pyx, linear_model_cython_tree],
+    [pyx, linear_model_cython_tree, utils_cython_tree],
     cython_args: cython_args,
     subdir: 'sklearn/linear_model',
     install: true

--- a/sklearn/manifold/meson.build
+++ b/sklearn/manifold/meson.build
@@ -1,6 +1,6 @@
 py.extension_module(
   '_utils',
-  '_utils.pyx',
+  ['_utils.pyx', utils_cython_tree],
   cython_args: cython_args,
   subdir: 'sklearn/manifold',
   install: true

--- a/sklearn/meson.build
+++ b/sklearn/meson.build
@@ -141,7 +141,9 @@ py.extension_module(
 
 # Need for Cython cimports across subpackages to work, i.e. avoid errors like
 # relative cimport from non-package directory is not allowed
-fs.copyfile('__init__.py')
+sklearn_root_cython_tree = [
+  fs.copyfile('__init__.py')
+]
 
 sklearn_dir = py.get_install_dir() / 'sklearn'
 

--- a/sklearn/metrics/meson.build
+++ b/sklearn/metrics/meson.build
@@ -3,6 +3,8 @@
 metrics_cython_tree = [
   fs.copyfile('__init__.py')
 ]
+# Some metrics code cimports code from utils, we may as well copy all the necessary files
+metrics_cython_tree += utils_cython_tree
 
 _dist_metrics_pxd = custom_target(
   '_dist_metrics_pxd',
@@ -25,7 +27,7 @@ _dist_metrics_pyx = custom_target(
 
 _dist_metrics = py.extension_module(
   '_dist_metrics',
-  [_dist_metrics_pyx, utils_cython_tree, metrics_cython_tree],
+  [_dist_metrics_pyx, metrics_cython_tree],
   dependencies: [np_dep],
   cython_args: cython_args,
   subdir: 'sklearn/metrics',
@@ -34,7 +36,7 @@ _dist_metrics = py.extension_module(
 
 py.extension_module(
   '_pairwise_fast',
-  ['_pairwise_fast.pyx', utils_cython_tree, metrics_cython_tree],
+  ['_pairwise_fast.pyx', metrics_cython_tree],
   cython_args: cython_args,
   subdir: 'sklearn/metrics',
   install: true

--- a/sklearn/neighbors/meson.build
+++ b/sklearn/neighbors/meson.build
@@ -24,7 +24,7 @@ foreach name: name_list
   )
   py.extension_module(
     name,
-    [pyx, neighbors_cython_tree],
+    [pyx, neighbors_cython_tree, utils_cython_tree],
     dependencies: [np_dep],
     cython_args: cython_args,
     subdir: 'sklearn/neighbors',
@@ -42,7 +42,7 @@ neighbors_extension_metadata = {
 foreach ext_name, ext_dict : neighbors_extension_metadata
   py.extension_module(
     ext_name,
-    ext_dict.get('sources'),
+    ext_dict.get('sources') + utils_cython_tree,
     dependencies: ext_dict.get('dependencies'),
     override_options : ext_dict.get('override_options', []),
     cython_args: cython_args,

--- a/sklearn/neighbors/meson.build
+++ b/sklearn/neighbors/meson.build
@@ -42,7 +42,7 @@ neighbors_extension_metadata = {
 foreach ext_name, ext_dict : neighbors_extension_metadata
   py.extension_module(
     ext_name,
-    ext_dict.get('sources') + utils_cython_tree,
+    [ext_dict.get('sources'), utils_cython_tree],
     dependencies: ext_dict.get('dependencies'),
     override_options : ext_dict.get('override_options', []),
     cython_args: cython_args,

--- a/sklearn/preprocessing/meson.build
+++ b/sklearn/preprocessing/meson.build
@@ -1,6 +1,6 @@
 py.extension_module(
   '_csr_polynomial_expansion',
-  '_csr_polynomial_expansion.pyx',
+  ['_csr_polynomial_expansion.pyx', utils_cython_tree],
   cython_args: cython_args,
   subdir: 'sklearn/preprocessing',
   install: true
@@ -8,7 +8,7 @@ py.extension_module(
 
 py.extension_module(
   '_target_encoder_fast',
-  '_target_encoder_fast.pyx',
+  ['_target_encoder_fast.pyx', utils_cython_tree],
   override_options: ['cython_language=cpp'],
   cython_args: cython_args,
   subdir: 'sklearn/preprocessing',

--- a/sklearn/svm/meson.build
+++ b/sklearn/svm/meson.build
@@ -19,7 +19,7 @@ libsvm_skl = static_library(
 
 py.extension_module(
   '_libsvm',
-  ['_libsvm.pyx'],
+  ['_libsvm.pyx', utils_cython_tree],
   include_directories: [newrand_include, libsvm_include],
   link_with: libsvm_skl,
   cython_args: cython_args,
@@ -29,7 +29,7 @@ py.extension_module(
 
 py.extension_module(
   '_libsvm_sparse',
-  ['_libsvm_sparse.pyx'],
+  ['_libsvm_sparse.pyx', utils_cython_tree],
   include_directories: [newrand_include, libsvm_include],
   link_with: libsvm_skl,
   cython_args: cython_args,
@@ -44,7 +44,7 @@ liblinear_skl = static_library(
 
 py.extension_module(
   '_liblinear',
-  ['_liblinear.pyx'],
+  ['_liblinear.pyx', utils_cython_tree],
   include_directories: [newrand_include, liblinear_include],
   link_with: [liblinear_skl],
   cython_args: cython_args,

--- a/sklearn/tree/meson.build
+++ b/sklearn/tree/meson.build
@@ -16,7 +16,7 @@ tree_extension_metadata = {
 foreach ext_name, ext_dict : tree_extension_metadata
   py.extension_module(
     ext_name,
-    ext_dict.get('sources') + utils_cython_tree,
+    [ext_dict.get('sources'), utils_cython_tree],
     dependencies: [np_dep],
     override_options : ext_dict.get('override_options', []),
     cython_args: cython_args,

--- a/sklearn/tree/meson.build
+++ b/sklearn/tree/meson.build
@@ -16,7 +16,7 @@ tree_extension_metadata = {
 foreach ext_name, ext_dict : tree_extension_metadata
   py.extension_module(
     ext_name,
-    ext_dict.get('sources'),
+    ext_dict.get('sources') + utils_cython_tree,
     dependencies: [np_dep],
     override_options : ext_dict.get('override_options', []),
     cython_args: cython_args,

--- a/sklearn/utils/_seq_dataset.pxd.tp
+++ b/sklearn/utils/_seq_dataset.pxd.tp
@@ -19,6 +19,7 @@ dtypes = [('64', 'float64_t'),
 }}
 """Dataset abstractions for sequential data access."""
 
+1+1
 from ._typedefs cimport float32_t, float64_t, intp_t, uint32_t
 
 # SequentialDataset and its two concrete subclasses are (optionally randomized)

--- a/sklearn/utils/_seq_dataset.pxd.tp
+++ b/sklearn/utils/_seq_dataset.pxd.tp
@@ -19,7 +19,6 @@ dtypes = [('64', 'float64_t'),
 }}
 """Dataset abstractions for sequential data access."""
 
-1+1
 from ._typedefs cimport float32_t, float64_t, intp_t, uint32_t
 
 # SequentialDataset and its two concrete subclasses are (optionally randomized)

--- a/sklearn/utils/meson.build
+++ b/sklearn/utils/meson.build
@@ -1,6 +1,9 @@
 # utils is cimported from other subpackages so this is needed for the cimport
 # to work
 utils_cython_tree = [
+  # We add the root cython tree to make sure sklearn/__init__.py is copied
+  # early in the build
+  sklearn_root_cython_tree,
   fs.copyfile('__init__.py'),
   fs.copyfile('_cython_blas.pxd'),
   fs.copyfile('_heap.pxd'),
@@ -63,7 +66,7 @@ foreach name: util_extension_names
   )
   py.extension_module(
     name,
-    [pxd, pyx] + utils_cython_tree,
+    [pxd, pyx, utils_cython_tree],
     cython_args: cython_args,
     subdir: 'sklearn/utils',
     install: true

--- a/sklearn/utils/meson.build
+++ b/sklearn/utils/meson.build
@@ -38,7 +38,7 @@ utils_extension_metadata = {
 foreach ext_name, ext_dict : utils_extension_metadata
   py.extension_module(
     ext_name,
-    ext_dict.get('sources') + utils_cython_tree,
+    [ext_dict.get('sources'), utils_cython_tree],
     dependencies: ext_dict.get('dependencies', []),
     override_options : ext_dict.get('override_options', []),
     cython_args: cython_args,

--- a/sklearn/utils/meson.build
+++ b/sklearn/utils/meson.build
@@ -1,7 +1,7 @@
 # utils is cimported from other subpackages so this is needed for the cimport
 # to work
 utils_cython_tree = [
-  # We add the root cython tree to make sure sklearn/__init__.py is copied
+  # We add sklearn_root_cython_tree to make sure sklearn/__init__.py is copied
   # early in the build
   sklearn_root_cython_tree,
   fs.copyfile('__init__.py'),


### PR DESCRIPTION
Improves the situation for #28820. Since I am not able to reproduce the issue, I guess we will just have to wait and see if this kind of issues happen again after this is merged ...

I tested it for the cases that have been seen in the CI by running this kind of commands from an empty Meson build dir:
```
ninja -C build/cp312 sklearn/cluster/_hdbscan/_linkage.cpython-312-x86_64-linux-gnu.so.p/sklearn/cluster/_hdbscan/_linkage.pyx.c
```

I also added `utils_cython_tree` in all the places that cimport something from `utils`.
```
git grep -P 'from \.\..*utils.+cimport'
```

You can also check inputs are defined correctly by looking at the `ninja.build` file or with this kind of `ninja` commands:
```
❯ ninja -C build/cp312 -t inputs sklearn/cluster/_hdbscan/_linkage.cpython-312-x86_64-linux-gnu.so.p/sklearn/cluster/_hdbscan/_linkage.pyx.c
../../sklearn/__init__.py
../../sklearn/_build_utils/tempita.py
../../sklearn/metrics/__init__.py
../../sklearn/metrics/_dist_metrics.pxd.tp
../../sklearn/utils/__init__.py
../../sklearn/utils/_cython_blas.pxd
../../sklearn/utils/_heap.pxd
../../sklearn/utils/_openmp_helpers.pxd
../../sklearn/utils/_random.pxd
../../sklearn/utils/_seq_dataset.pxd.tp
../../sklearn/utils/_sorting.pxd
../../sklearn/utils/_typedefs.pxd
../../sklearn/utils/_vector_sentinel.pxd
../../sklearn/utils/_weight_vector.pxd.tp
/home/lesteve/dev/scikit-learn/sklearn/cluster/_hdbscan/_linkage.pyx
/home/lesteve/micromamba/envs/scikit-learn-dev/bin/python3.12
sklearn/__init__.py
sklearn/metrics/__init__.py
sklearn/metrics/_dist_metrics.pxd
sklearn/utils/__init__.py
sklearn/utils/_cython_blas.pxd
sklearn/utils/_heap.pxd
sklearn/utils/_openmp_helpers.pxd
sklearn/utils/_random.pxd
sklearn/utils/_seq_dataset.pxd
sklearn/utils/_sorting.pxd
sklearn/utils/_typedefs.pxd
sklearn/utils/_vector_sentinel.pxd
sklearn/utils/_weight_vector.pxd

```

Here you can check that cythonizing `sklearn/cluster/_hdbscan/_linkage.pyx` does depend on `sklearn/__init__.py`, `sklearn/utils/__init__.py`, `sklearn/metrics/__init__.py` and `utils`  + `metrics` `.pxd` files.
