### PR TITLE
FIX Accept d2_absolute_error_score as named scorer

### DIFF
--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -45,6 +45,7 @@ from . import (
     balanced_accuracy_score,
     brier_score_loss,
     class_likelihood_ratios,
+    d2_absolute_error_score,
     explained_variance_score,
     f1_score,
     jaccard_score,
@@ -727,6 +728,7 @@ neg_mean_poisson_deviance_scorer = make_scorer(
 neg_mean_gamma_deviance_scorer = make_scorer(
     mean_gamma_deviance, greater_is_better=False
 )
+d2_absolute_error_scorer = make_scorer(d2_absolute_error_score)
 
 # Standard Classification Scores
 accuracy_scorer = make_scorer(accuracy_score)
@@ -819,6 +821,7 @@ _SCORERS = dict(
     neg_root_mean_squared_log_error=neg_root_mean_squared_log_error_scorer,
     neg_mean_poisson_deviance=neg_mean_poisson_deviance_scorer,
     neg_mean_gamma_deviance=neg_mean_gamma_deviance_scorer,
+    d2_absolute_error_score=d2_absolute_error_scorer,
     accuracy=accuracy_scorer,
     top_k_accuracy=top_k_accuracy_scorer,
     roc_auc=roc_auc_scorer,

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -65,6 +65,7 @@ from sklearn.utils._testing import (
 from sklearn.utils.metadata_routing import MetadataRouter
 
 REGRESSION_SCORERS = [
+    "d2_absolute_error_score",
     "explained_variance",
     "r2",
     "neg_mean_absolute_error",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Follow-up from #28750. See also #22118.

#### What does this implement/fix? Explain your changes.

As mentioned in https://github.com/scikit-learn/scikit-learn/pull/28750#discussion_r1559183331,   accepting `d2_absolute_error_score` as a named scorer (a string to be passed to scoring) could be a common enough practice to be worth the shortcut. In fact, such possibility is already documented in [model_evaluation.rst L105](https://github.com/scikit-learn/scikit-learn/blob/d1d1596fac19d688a637690134d71fc460f5f0dd/doc/modules/model_evaluation.rst?plain=1#L105).

#### Any other comments?

Snippet for testing:

```python
from sklearn.datasets import load_diabetes
from sklearn.linear_model import LinearRegression
from sklearn.model_selection import cross_val_score

X, y = load_diabetes(return_X_y=True)
model = LinearRegression()
cross_val_score(model, X, y, scoring="d2_absolute_error_score")
```

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
