### PR TITLE
FIX CalibratedClassifierCV with string targets

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -128,7 +128,7 @@ Changelog
     where 123455 is the *pull request* number, not the issue number.
 
 :mod:`sklearn.calibration`
-.........................
+..........................
 
 - |Fix| Fixed a regression in :class:`calibration.CalibratedClassifierCV` where
   an error was wrongly raised with string targets. 

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -127,6 +127,13 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123455 is the *pull request* number, not the issue number.
 
+:mod:`sklearn.calibration`
+.........................
+
+- |Fix| Fixed a regression in :class:`calibration.CalibratedClassifierCV` where
+  an error was wrongly raised with string targets. 
+  :pr:`28843` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
 :mod:`sklearn.cluster`
 ......................
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -388,9 +388,7 @@ class CalibratedClassifierCV(ClassifierMixin, MetaEstimatorMixin, BaseEstimator)
                 n_folds = self.cv.n_splits
             else:
                 n_folds = None
-            if n_folds and np.any(
-                [np.sum(y == class_) < n_folds for class_ in self.classes_]
-            ):
+            if n_folds and np.any(np.unique(y, return_counts=True)[1] < n_folds):
                 raise ValueError(
                     f"Requesting {n_folds}-fold "
                     "cross-validation but provided less than "

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -1088,3 +1088,14 @@ def test_float32_predict_proba(data):
     calibrator = CalibratedClassifierCV(model)
     # Does not raise an error
     calibrator.fit(*data)
+
+
+def test_error_less_class_samples_than_folds():
+    """Check that CalibratedClassifierCV works with string targets.
+
+    non-regression test for issue #28841.
+    """
+    X = np.random.normal(size=(20, 3))
+    y = ["a"] * 10 + ["b"] * 10
+
+    CalibratedClassifierCV(cv=3).fit(X, y)


### PR DESCRIPTION
Fixes #28841

By removing `_validate_data`, https://github.com/scikit-learn/scikit-learn/pull/19555 introduced a regression in `CalibratedClassifierCV`. This is due to how numpy behaves with element-wise comparison of arrays of strings.
```py
y = ["1", "1", "2", "2"]
c = np.array(["1", "2"])

# before, y was validated, hence was an array
np.array(y) == c[0]
# array([ True,  True, False, False])

# now, y is not validated, hence still a list
y == c[0]
# False
```
Surprisingly, the second one works with integers.

Using np.unique will work no matter what to count the number of occurrences.