### PR TITLE
CI Use Meson to build sdist

### DIFF
--- a/build_tools/github/build_source.sh
+++ b/build_tools/github/build_source.sh
@@ -11,10 +11,10 @@ python -m venv build_env
 source build_env/bin/activate
 
 python -m pip install numpy scipy cython
-python -m pip install twine
+python -m pip install twine build
 
 cd scikit-learn/scikit-learn
-python setup.py sdist
+python -m build --sdist
 
 # Check whether the source distribution will render correctly
 twine check dist/*.tar.gz


### PR DESCRIPTION
I am guessing this is the sdist that eventually gets uploaded to PyPI?

I trigger the Wheel build to make sure it works.

Edit: Meson is indeed used to build the sdist according to the
[build log](https://github.com/scikit-learn/scikit-learn/actions/runs/8701777872/job/23864451425?pr=28844)
```
* Building sdist...
+ meson setup /home/runner/work/scikit-learn/scikit-learn /home/runner/work/scikit-learn/scikit-learn/.mesonpy-h6ifstfg -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md --native-file=/home/runner/work/scikit-learn/scikit-learn/.mesonpy-h6ifstfg/meson-python-native-file.ini
The Meson build system
```