### PR TITLE
CI Use Meson for Pyodide build

### DIFF
--- a/build_tools/azure/emscripten.meson.cross
+++ b/build_tools/azure/emscripten.meson.cross
@@ -1,0 +1,15 @@
+# compiler paths are omitted intentionally so we can override the compiler using environment variables
+[binaries]
+exe_wrapper = 'node'
+pkgconfig = 'pkg-config'
+
+[properties]
+needs_exe_wrapper = true
+skip_sanity_check = true
+longdouble_format = 'IEEE_QUAD_LE' # for numpy
+
+[host_machine]
+system = 'emscripten'
+cpu_family = 'wasm32'
+cpu = 'wasm'
+endian = 'little'

--- a/build_tools/azure/install_pyodide.sh
+++ b/build_tools/azure/install_pyodide.sh
@@ -11,7 +11,7 @@ cd -
 
 pip install pyodide-build==$PYODIDE_VERSION pyodide-cli
 
-pyodide build
+pyodide build -Csetup-args="--cross-file=$PWD/build_tools/azure/emscripten.meson.cross"
 
 ls -ltrh dist
 


### PR DESCRIPTION
I took the meson cross-compilation file from Numpy https://github.com/numpy/numpy/pull/25894 and https://github.com/numpy/numpy/pull/24603.

I have triggered a Pyodide build to see whether that passes.

Edit: Meson is indeed used for building see [build log](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=65867&view=logs&j=6fac3219-cc32-5595-eb73-7f086a643b12&t=6856d197-9931-5ad8-f897-5714e4bdfa31)
```
+ meson setup /home/vsts/work/1/s /home/vsts/work/1/s/.mesonpy-379d495u -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md --cross-file=/home/vsts/work/1/s/build_tools/azure/emscripten.meson.cross --native-file=/home/vsts/work/1/s/.mesonpy-379d495u/meson-python-native-file.ini
The Meson build system
Version: 1.4.0
```