### PR TITLE
API Deprecate utils.parallel_backend and utils.register_parallel_backend

### DIFF
--- a/build_tools/linting.sh
+++ b/build_tools/linting.sh
@@ -89,7 +89,7 @@ else
 fi
 
 # Check for joblib.delayed and joblib.Parallel imports
-
+# TODO(1.7): remove ":!sklearn/utils/_joblib.py"
 echo -e "### Checking for joblib imports ###\n"
 joblib_status=0
 joblib_delayed_import="$(git grep -l -A 10 -E "joblib import.+delayed" -- "*.py" ":!sklearn/utils/_joblib.py" ":!sklearn/utils/parallel.py")"

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -432,7 +432,7 @@ Changelog
 - |API| :class:`utils.parallel_backend` and :func:`utils.register_parallel_backend` are
   deprecated and will be removed in version 1.7. Use `joblib.parallel_backend` and
   `joblib.register_parallel_backend` instead.
-  :pr:`28846` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+  :pr:`28847` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 - |API| Raise informative warning message in :func:`type_of_target` when
   represented as bytes. For classifiers and classification metrics, labels encoded

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -429,6 +429,11 @@ Changelog
 - |API| :func:`utils.tosequence` is deprecated and will be removed in version 1.7.
   :pr:`28763` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+- |API| :class:`utils.parallel_backend` and :func:`utils.register_parallel_backend` are
+  deprecated and will be removed in version 1.7. Use `joblib.parallel_backend` and
+  `joblib.register_parallel_backend` instead.
+  :pr:`28846` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
 - |API| Raise informative warning message in :func:`type_of_target` when
   represented as bytes. For classifiers and classification metrics, labels encoded
   as bytes is deprecated and will raise an error in v1.6.

--- a/sklearn/inspection/tests/test_permutation_importance.py
+++ b/sklearn/inspection/tests/test_permutation_importance.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from joblib import parallel_backend
 from numpy.testing import assert_allclose
 
 from sklearn.compose import ColumnTransformer
@@ -22,7 +23,6 @@ from sklearn.metrics import (
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import KBinsDiscretizer, OneHotEncoder, StandardScaler, scale
-from sklearn.utils import parallel_backend
 from sklearn.utils._testing import _convert_container
 
 

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -51,6 +51,7 @@ with warnings.catch_warnings():
     )
 
 # functions to ignore args / docstring of
+# TODO(1.7): remove "sklearn.utils._joblib"
 _DOCSTRING_IGNORES = [
     "sklearn.utils.deprecation.load_mlcomp",
     "sklearn.pipeline.make_pipeline",

--- a/sklearn/utils/__init__.py
+++ b/sklearn/utils/__init__.py
@@ -42,13 +42,16 @@ from .validation import (
     indexable,
 )
 
-# Do not deprecate parallel_backend and register_parallel_backend as they are
-# needed to tune `scikit-learn` behavior and have different effect if called
-# from the vendored version or or the site-package version. The other are
-# utilities that are independent of scikit-learn so they are not part of
-# scikit-learn public API.
-parallel_backend = _joblib.parallel_backend
-register_parallel_backend = _joblib.register_parallel_backend
+# TODO(1.7): remove parallel_backend and register_parallel_backend
+msg = "deprecated in 1.5 to be removed in 1.7. Use joblib.{} instead."
+register_parallel_backend = deprecated(msg)(_joblib.register_parallel_backend)
+
+
+# if a class, deprecated will change the object in _joblib module so we need to subclass
+@deprecated(msg)
+class parallel_backend(_joblib.parallel_backend):
+    pass
+
 
 __all__ = [
     "murmurhash3_32",

--- a/sklearn/utils/_joblib.py
+++ b/sklearn/utils/_joblib.py
@@ -1,3 +1,5 @@
+# TODO(1.7): remove this file
+
 import warnings as _warnings
 
 with _warnings.catch_warnings():

--- a/sklearn/utils/tests/test_utils.py
+++ b/sklearn/utils/tests/test_utils.py
@@ -1,5 +1,6 @@
 import warnings
 
+import joblib
 import numpy as np
 import pytest
 
@@ -7,11 +8,13 @@ from sklearn.utils import (
     check_random_state,
     column_or_1d,
     deprecated,
+    parallel_backend,
+    register_parallel_backend,
     safe_mask,
     tosequence,
 )
 from sklearn.utils._missing import is_scalar_nan
-from sklearn.utils._testing import assert_array_equal, assert_no_warnings
+from sklearn.utils._testing import assert_array_equal
 from sklearn.utils.fixes import CSR_CONTAINERS
 from sklearn.utils.validation import _is_polars_df
 
@@ -136,19 +139,6 @@ def dummy_func():
     pass
 
 
-def test_deprecation_joblib_api(tmpdir):
-    # Only parallel_backend and register_parallel_backend are not deprecated in
-    # sklearn.utils
-    from sklearn.utils import parallel_backend, register_parallel_backend
-
-    assert_no_warnings(parallel_backend, "loky", None)
-    assert_no_warnings(register_parallel_backend, "failing", None)
-
-    from sklearn.utils._joblib import joblib
-
-    del joblib.parallel.BACKENDS["failing"]
-
-
 def test__is_polars_df():
     """Check that _is_polars_df return False for non-dataframe objects."""
 
@@ -170,3 +160,14 @@ def test_is_pypy_deprecated():
 def test_tosequence_deprecated():
     with pytest.warns(FutureWarning, match="tosequence was deprecated in 1.5"):
         tosequence([1, 2, 3])
+
+
+# TODO(1.7): remove
+def test_parallel_backend_deprecated():
+    with pytest.warns(FutureWarning, match="parallel_backend is deprecated"):
+        parallel_backend("loky", None)
+
+    with pytest.warns(FutureWarning, match="register_parallel_backend is deprecated"):
+        register_parallel_backend("a_backend", None)
+
+    del joblib.parallel.BACKENDS["a_backend"]


### PR DESCRIPTION
No longer useful since we don't vendor joblib anymore (it's been a while now 😄).