### PR TITLE
MAINT Clean up deprecations for 1.5: delayed import path

### DIFF
--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -23,7 +23,6 @@ import threadpoolctl
 import sklearn
 
 from ..externals._packaging.version import parse as parse_version
-from .deprecation import deprecated
 
 _IS_PYPY = platform.python_implementation() == "PyPy"
 _IS_32BIT = 8 * struct.calcsize("P") == 32
@@ -132,16 +131,6 @@ def threadpool_info():
 
 
 threadpool_info.__doc__ = threadpoolctl.threadpool_info.__doc__
-
-
-@deprecated(
-    "The function `delayed` has been moved from `sklearn.utils.fixes` to "
-    "`sklearn.utils.parallel`. This import path will be removed in 1.5."
-)
-def delayed(function):
-    from sklearn.utils.parallel import delayed
-
-    return delayed(function)
 
 
 # TODO: Remove when SciPy 1.11 is the minimum supported version

--- a/sklearn/utils/tests/test_fixes.py
+++ b/sklearn/utils/tests/test_fixes.py
@@ -7,11 +7,7 @@ import numpy as np
 import pytest
 
 from sklearn.utils._testing import assert_array_equal
-from sklearn.utils.fixes import (
-    _object_dtype_isnan,
-    _smallest_admissible_index_dtype,
-    delayed,
-)
+from sklearn.utils.fixes import _object_dtype_isnan, _smallest_admissible_index_dtype
 
 
 @pytest.mark.parametrize("dtype, val", ([object, 1], [object, "a"], [float, 1]))
@@ -23,17 +19,6 @@ def test_object_dtype_isnan(dtype, val):
     mask = _object_dtype_isnan(X)
 
     assert_array_equal(mask, expected_mask)
-
-
-def test_delayed_deprecation():
-    """Check that we issue the FutureWarning regarding the deprecation of delayed."""
-
-    def func(x):
-        return x
-
-    warn_msg = "The function `delayed` has been moved from `sklearn.utils.fixes`"
-    with pytest.warns(FutureWarning, match=warn_msg):
-        delayed(func)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
removed deprecated import path for the ``delayed`` function.