### PR TITLE
MAINT Clean up deprecations for 1.5: in KMeans.predict

### DIFF
--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1070,7 +1070,7 @@ class _BaseKMeans(
         """
         return self.fit(X, sample_weight=sample_weight).labels_
 
-    def predict(self, X, sample_weight="deprecated"):
+    def predict(self, X):
         """Predict the closest cluster each sample in X belongs to.
 
         In the vector quantization literature, `cluster_centers_` is called
@@ -1082,14 +1082,6 @@ class _BaseKMeans(
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
             New data to predict.
 
-        sample_weight : array-like of shape (n_samples,), default=None
-            The weights for each observation in X. If None, all observations
-            are assigned equal weight.
-
-            .. deprecated:: 1.3
-               The parameter `sample_weight` is deprecated in version 1.3
-               and will be removed in 1.5.
-
         Returns
         -------
         labels : ndarray of shape (n_samples,)
@@ -1098,17 +1090,9 @@ class _BaseKMeans(
         check_is_fitted(self)
 
         X = self._check_test_data(X)
-        if not (isinstance(sample_weight, str) and sample_weight == "deprecated"):
-            warnings.warn(
-                (
-                    "'sample_weight' was deprecated in version 1.3 and "
-                    "will be removed in 1.5."
-                ),
-                FutureWarning,
-            )
-            sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
-        else:
-            sample_weight = _check_sample_weight(None, X, dtype=X.dtype)
+
+        # sample weights are not used by predict but cython helpers expect an array
+        sample_weight = np.ones(X.shape[0], dtype=X.dtype)
 
         labels = _labels_inertia_threadpool_limit(
             X,

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -201,19 +201,6 @@ def test_kmeans_convergence(algorithm, global_random_seed):
     assert km.n_iter_ < max_iter
 
 
-@pytest.mark.parametrize("Estimator", [KMeans, MiniBatchKMeans])
-def test_predict_sample_weight_deprecation_warning(Estimator):
-    X = np.random.rand(100, 2)
-    sample_weight = np.random.uniform(size=100)
-    kmeans = Estimator()
-    kmeans.fit(X, sample_weight=sample_weight)
-    warn_msg = (
-        "'sample_weight' was deprecated in version 1.3 and will be removed in 1.5."
-    )
-    with pytest.warns(FutureWarning, match=warn_msg):
-        kmeans.predict(X, sample_weight=sample_weight)
-
-
 @pytest.mark.parametrize("X_csr", X_as_any_csr)
 def test_minibatch_update_consistency(X_csr, global_random_seed):
     # Check that dense and sparse minibatch update give the same results


### PR DESCRIPTION
Removed deprecated ``sample_weight`` in ``*KMeans.predict``.