### PR TITLE
CI Update ruff invoke command

### DIFF
--- a/build_tools/get_comment.py
+++ b/build_tools/get_comment.py
@@ -116,10 +116,10 @@ def get_message(log_file, repo, pr_number, sha, run_id, details, versions):
         end="Problems detected by ruff",
         title="`ruff`",
         message=(
-            "`ruff` detected issues. Please run `ruff --fix --output-format=full .` "
-            "locally, fix the remaining issues, and push the changes. "
-            "Here you can see the detected issues. Note that the installed "
-            f"`ruff` version is `ruff={versions['ruff']}`."
+            "`ruff` detected issues. Please run "
+            "`ruff check --fix --output-format=full .` locally, fix the remaining "
+            "issues, and push the changes. Here you can see the detected issues. Note "
+            f"that the installed `ruff` version is `ruff={versions['ruff']}`."
         ),
         details=details,
     )


### PR DESCRIPTION
``warning: `ruff <path>` is deprecated. Use `ruff check <path>` instead.``