### PR TITLE
fixed error that prevented parametrizing custom estimators that implements `__call__`

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -104,7 +104,10 @@ def _sample_func(x, y=1):
 
 
 class EstimatorStub:
-    """Dummy development stub for an estimator."""
+    """Dummy development stub for an estimator.
+    
+    This is to make sure a callable estimator passes common tests.
+    """
 
     def get_params(self, *, deep=True):
         return {}

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -111,7 +111,7 @@ class CallableEstimator(BaseEstimator):
     """
 
     def __call__(self):
-        pass
+        pass  # pragma: nocover
 
 
 @pytest.mark.parametrize(

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -20,6 +20,7 @@ import numpy as np
 import pytest
 
 import sklearn
+from sklearn.base import BaseEstimator
 from sklearn.cluster import (
     OPTICS,
     AffinityPropagation,
@@ -103,32 +104,14 @@ def _sample_func(x, y=1):
     pass
 
 
-class CallableEstimator:
+class CallableEstimator(BaseEstimator):
     """Dummy development stub for an estimator.
 
     This is to make sure a callable estimator passes common tests.
     """
 
-    def get_params(self, *, deep=True):
-        return {}
-
-    def set_params(self, **kwargs):
+    def __call__(self):
         pass
-
-    def fit(self, X, y=None):
-        return self
-
-    def fit_transform(self, X, y=None):
-        return self.fit(X, y).transform(X)
-
-    def transform(self, X):
-        return X
-
-    def __call__(self, X):
-        return self.transform(X)
-
-    def __str__(self):
-        return type(self).__name__
 
 
 @pytest.mark.parametrize(
@@ -150,7 +133,7 @@ class CallableEstimator:
                 "solver='newton-cg',warm_start=True)"
             ),
         ),
-        (CallableEstimator(), "CallableEstimator"),
+        (CallableEstimator(), "CallableEstimator()"),
     ],
 )
 def test_get_check_estimator_ids(val, expected):

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -103,7 +103,7 @@ def _sample_func(x, y=1):
     pass
 
 
-class EstimatorStub:
+class CallableEstimator:
     """Dummy development stub for an estimator.
     
     This is to make sure a callable estimator passes common tests.

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -150,7 +150,7 @@ class CallableEstimator:
                 "solver='newton-cg',warm_start=True)"
             ),
         ),
-        (EstimatorStub(), "EstimatorStub"),
+        (EstimatorStub(), "CallableEstimator"),
     ],
 )
 def test_get_check_estimator_ids(val, expected):

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -103,6 +103,31 @@ def _sample_func(x, y=1):
     pass
 
 
+class EstimatorStub:
+    """Dummy development stub for an estimator."""
+
+    def get_params(self, *, deep=True):
+        return {}
+
+    def set_params(self, **kwargs):
+        pass
+
+    def fit(self, X, y=None):
+        return self
+
+    def fit_transform(self, X, y=None):
+        return self.fit(X, y).transform(X)
+
+    def transform(self, X):
+        return X
+
+    def __call__(self, X):
+        return self.transform(X)
+
+    def __str__(self):
+        return type(self).__name__
+
+
 @pytest.mark.parametrize(
     "val, expected",
     [
@@ -122,6 +147,7 @@ def _sample_func(x, y=1):
                 "solver='newton-cg',warm_start=True)"
             ),
         ),
+        (EstimatorStub(), "EstimatorStub"),
     ],
 )
 def test_get_check_estimator_ids(val, expected):

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -105,7 +105,7 @@ def _sample_func(x, y=1):
 
 class CallableEstimator:
     """Dummy development stub for an estimator.
-    
+
     This is to make sure a callable estimator passes common tests.
     """
 
@@ -150,7 +150,7 @@ class CallableEstimator:
                 "solver='newton-cg',warm_start=True)"
             ),
         ),
-        (EstimatorStub(), "CallableEstimator"),
+        (CallableEstimator(), "CallableEstimator"),
     ],
 )
 def test_get_check_estimator_ids(val, expected):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -9,7 +9,7 @@ import warnings
 from contextlib import nullcontext
 from copy import deepcopy
 from functools import partial, wraps
-from inspect import signature
+from inspect import isfunction, signature
 from numbers import Integral, Real
 
 import joblib
@@ -405,13 +405,11 @@ def _get_check_estimator_ids(obj):
     --------
     check_estimator
     """
-    if callable(obj):
-        if not isinstance(obj, partial):
-            return obj.__name__
-
+    if isfunction(obj):
+        return obj.__name__
+    if isinstance(obj, partial):
         if not obj.keywords:
             return obj.func.__name__
-
         kwstring = ",".join(["{}={}".format(k, v) for k, v in obj.keywords.items()])
         return "{}({})".format(obj.func.__name__, kwstring)
     if hasattr(obj, "get_params"):


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #28859

#### What does this implement/fix? Explain your changes.

Replaced `if callable(obj)` with two separate checks `if isisfunction(obj)` and `if isinstance(obj, partial)`.
