### PR TITLE
DOC add links to examples/linear_model/plot_bayesian_ridge_curvefit.py

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -184,10 +184,6 @@ Ridge Complexity
 This method has the same order of complexity as
 :ref:`ordinary_least_squares`.
 
-.. topic:: Examples:
-
-  * :ref:`sphx_glr_auto_examples_linear_model_plot_bayesian_ridge_curvefit.py`
-
 .. FIXME:
 .. Not completely true: OLS is solved by an SVD, while Ridge is solved by
 .. the method of normal equations (Cholesky), there is a big flop difference

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -184,6 +184,10 @@ Ridge Complexity
 This method has the same order of complexity as
 :ref:`ordinary_least_squares`.
 
+.. topic:: Examples:
+
+  * :ref:`sphx_glr_auto_examples_linear_model_plot_bayesian_ridge_curvefit.py`
+
 .. FIXME:
 .. Not completely true: OLS is solved by an SVD, while Ridge is solved by
 .. the method of normal equations (Cholesky), there is a big flop difference

--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -31,6 +31,9 @@ class BayesianRidge(RegressorMixin, LinearModel):
     lambda (precision of the weights) and alpha (precision of the noise).
 
     Read more in the :ref:`User Guide <bayesian_regression>`.
+    For an intuitive visualization of how the sinusoid is approximated by
+    a polynomial using different pairs of initial values, see
+    :ref:`sphx_glr_auto_examples_linear_model_plot_bayesian_ridge_curvefit.py`.
 
     Parameters
     ----------

--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -32,7 +32,7 @@ class BayesianRidge(RegressorMixin, LinearModel):
 
     Read more in the :ref:`User Guide <bayesian_regression>`.
     For an intuitive visualization of how the sinusoid is approximated by
-    a polynomial using different pairs of initial values, see
+    a polynomial using different pairs of initial values,see
     :ref:`sphx_glr_auto_examples_linear_model_plot_bayesian_ridge_curvefit.py`.
 
     Parameters

--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -32,7 +32,7 @@ class BayesianRidge(RegressorMixin, LinearModel):
 
     Read more in the :ref:`User Guide <bayesian_regression>`.
     For an intuitive visualization of how the sinusoid is approximated by
-    a polynomial using different pairs of initial values,see
+    a polynomial using different pairs of initial values, see
     :ref:`sphx_glr_auto_examples_linear_model_plot_bayesian_ridge_curvefit.py`.
 
     Parameters


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->



#### What does this implement/fix? Explain your changes.
Towards [#26927](https://github.com/scikit-learn/scikit-learn/issues/26927), adds links to examples/linear_model/plot_bayesian_ridge_curvefit.py to help users understand how the sinusoid is approximated by a polynomial using different pairs of initial values

#### Any other comments?
cc [@adrinjalali](https://github.com/adrinjalali) for review, since it is outside of a sprint

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
