### PR TITLE
Replace PYODIDE_PACKAGE_ABI with PYODIDE

### DIFF
--- a/sklearn/_build_utils/openmp_helpers.py
+++ b/sklearn/_build_utils/openmp_helpers.py
@@ -34,7 +34,7 @@ def get_openmp_flag():
 
 def check_openmp_support():
     """Check whether OpenMP test code can be compiled and run"""
-    if "PYODIDE_PACKAGE_ABI" in os.environ:
+    if "PYODIDE" in os.environ:
         # Pyodide doesn't support OpenMP
         return False
 

--- a/sklearn/_build_utils/pre_build_helpers.py
+++ b/sklearn/_build_utils/pre_build_helpers.py
@@ -60,7 +60,7 @@ def compile_test_program(code, extra_preargs=None, extra_postargs=None):
 
 def basic_check_build():
     """Check basic compilation and linking of C code"""
-    if "PYODIDE_PACKAGE_ABI" in os.environ:
+    if "PYODIDE" in os.environ:
         # The following check won't work in pyodide
         return
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Pyodide is planning to remove the `PYODIDE_PACKAGE_ABI` env variable. This variable has been deprecated for a very long time. This PR replaces all appearance of `PYODIDE_PACKAGE_ABI` with `PYODIDE` env variable, which Pyodide now recommends when checking if the build is targeting Pyodide.