### PR TITLE
CI Fix wheel builder on osx

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -90,16 +90,16 @@ jobs:
             manylinux_image: manylinux2014
 
           # MacOS x86_64
-          - os: macos-latest
+          - os: macos-13
             python: 39
             platform_id: macosx_x86_64
-          - os: macos-latest
+          - os: macos-13
             python: 310
             platform_id: macosx_x86_64
-          - os: macos-latest
+          - os: macos-13
             python: 311
             platform_id: macosx_x86_64
-          - os: macos-latest
+          - os: macos-13
             python: 312
             platform_id: macosx_x86_64
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -90,16 +90,16 @@ jobs:
             manylinux_image: manylinux2014
 
           # MacOS x86_64
-          - os: macos-13
+          - os: macos-12
             python: 39
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-12
             python: 310
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-12
             python: 311
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-12
             python: 312
             platform_id: macosx_x86_64
 


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/28884

According to https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories, `macos-latest` is now equivalent to `macos-14` which is arm64.

I tried to use the `macos-13` image but it was not successful. There was an image update yesterday and it looks unavailable (see https://github.com/actions/runner-images?tab=readme-ov-file#available-images). So I used `macos-12`.

We can wait a bit to see if `macos-13` is available again but I wouldn't wait to long because we'll need the wheel builder for the release.

EDIT: `macos-latest` was actually `macos-12` (as can been seen in https://github.com/scikit-learn/scikit-learn/actions/runs/8810696001/job/24183468048, "Set up jobs" -> "Runner image"), so no need to wait.