### PR TITLE
TST Make test_neighbors_metric robust to rng

### DIFF
--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1644,7 +1644,13 @@ def test_nearest_neighbors_validate_params():
     + DISTANCE_METRIC_OBJS,
 )
 def test_neighbors_metrics(
-    global_dtype, global_random_seed, metric, n_samples=20, n_features=3, n_query_pts=2, n_neighbors=5
+    global_dtype,
+    global_random_seed,
+    metric,
+    n_samples=20,
+    n_features=3,
+    n_query_pts=2,
+    n_neighbors=5,
 ):
     rng = np.random.RandomState(global_random_seed)
 
@@ -1699,8 +1705,8 @@ def test_neighbors_metrics(
         brute_dst, brute_idx = results["brute"]
         ball_tree_dst, ball_tree_idx = results["ball_tree"]
 
-        # The returned distances are always in float64 regardless of the input dtype
-        # We need to adjust the tolerance w.r.t the input dtype
+        # The returned distances are always in float64 regardless of the input dtype
+        # We need to adjust the tolerance w.r.t the input dtype
         rtol = 1e-7 if global_dtype == np.float64 else 1e-4
 
         assert_allclose(brute_dst, ball_tree_dst, rtol=rtol)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1644,8 +1644,10 @@ def test_nearest_neighbors_validate_params():
     + DISTANCE_METRIC_OBJS,
 )
 def test_neighbors_metrics(
-    global_dtype, metric, n_samples=20, n_features=3, n_query_pts=2, n_neighbors=5
+    global_dtype, global_random_seed, metric, n_samples=20, n_features=3, n_query_pts=2, n_neighbors=5
 ):
+    rng = np.random.RandomState(global_random_seed)
+
     metric = _parse_metric(metric, global_dtype)
 
     # Test computing the neighbors for various metrics
@@ -1697,15 +1699,19 @@ def test_neighbors_metrics(
         brute_dst, brute_idx = results["brute"]
         ball_tree_dst, ball_tree_idx = results["ball_tree"]
 
-        assert_allclose(brute_dst, ball_tree_dst)
+        # The returned distances are always in float64 regardless of the input dtype
+        # We need to adjust the tolerance w.r.t the input dtype
+        rtol = 1e-7 if global_dtype == np.float64 else 1e-4
+
+        assert_allclose(brute_dst, ball_tree_dst, rtol=rtol)
         assert_array_equal(brute_idx, ball_tree_idx)
 
         if not exclude_kd_tree:
             kd_tree_dst, kd_tree_idx = results["kd_tree"]
-            assert_allclose(brute_dst, kd_tree_dst)
+            assert_allclose(brute_dst, kd_tree_dst, rtol=rtol)
             assert_array_equal(brute_idx, kd_tree_idx)
 
-            assert_allclose(ball_tree_dst, kd_tree_dst)
+            assert_allclose(ball_tree_dst, kd_tree_dst, rtol=rtol)
             assert_array_equal(ball_tree_idx, kd_tree_idx)
 
 


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/28878

It looked like the test was deterministic but it was in fact consuming a random state defined outside of the test, which can end up being in a different state between 2 runs depending on the collection of tests when they run in parallel.

In addition, the tolerance used was always the tolerance for float64 because the distances are always computed in float64. But the tolerance should be adjusted based on the input dtype.
