### PR TITLE
Fix __array__ requires a copy param

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -808,7 +808,7 @@ class _NotAnArray:
     def __init__(self, data):
         self.data = np.asarray(data)
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         return self.data
 
     def __array_function__(self, func, types, args, kwargs):


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/28868

From numpy: 
```
DeprecationWarning: __array__ implementation doesn't accept a copy keyword, so passing
copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments.
```