### PR TITLE
DOC Fix `cosine_similarity` docstring return

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1651,7 +1651,7 @@ def cosine_similarity(X, Y=None, dense_output=True):
 
     Returns
     -------
-    similarities : ndarray of shape (n_samples_X, n_samples_Y)
+    similarities : ndarray or sparse matrix of shape (n_samples_X, n_samples_Y)
         Returns the cosine similarity between samples in X and Y.
 
     Examples


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
`cosine_similarity` returns ndarray or sparse matrix. Updated return type to reflect this.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
