### PR TITLE
Deprecate  `cv_values_` in favour of `cv_results_` in `RidgeCV` estimators

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -352,6 +352,10 @@ Changelog
   :class:`linear_model.SGDOneClassSVM`. Pass `average=False` instead.
   :pr:`28582` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
+- |API| `store_cv_values` and `cv_values_` and  deprecated in favor of
+  `store_cv_results` and `cv_results_` in `RidgeCV` and `RidgeClassifierCV`.
+  :pr:`28915` by :user:`Lucy Liu <lucyleeow>`.
+
 :mod:`sklearn.manifold`
 .......................
 

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -352,7 +352,7 @@ Changelog
   :class:`linear_model.SGDOneClassSVM`. Pass `average=False` instead.
   :pr:`28582` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
-- |API| `store_cv_values` and `cv_values_` and  deprecated in favor of
+- |API| `store_cv_values` and `cv_values_` deprecated in favor of
   `store_cv_results` and `cv_results_` in `RidgeCV` and `RidgeClassifierCV`.
   :pr:`28915` by :user:`Lucy Liu <lucyleeow>`.
 

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -352,7 +352,7 @@ Changelog
   :class:`linear_model.SGDOneClassSVM`. Pass `average=False` instead.
   :pr:`28582` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
-- |API| `store_cv_values` and `cv_values_` deprecated in favor of
+- |API| `store_cv_values` and `cv_values_` are deprecated in favor of
   `store_cv_results` and `cv_results_` in `RidgeCV` and `RidgeClassifierCV`.
   :pr:`28915` by :user:`Lucy Liu <lucyleeow>`.
 

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -31,6 +31,7 @@ from ..utils import (
     check_scalar,
     column_or_1d,
     compute_sample_weight,
+    deprecated,
 )
 from ..utils._array_api import (
     _is_numpy_namespace,
@@ -39,7 +40,7 @@ from ..utils._array_api import (
     get_namespace,
     get_namespace_and_device,
 )
-from ..utils._param_validation import Interval, StrOptions, validate_params
+from ..utils._param_validation import Hidden, Interval, StrOptions, validate_params
 from ..utils.extmath import row_norms, safe_sparse_dot
 from ..utils.fixes import _sparse_linalg_cg
 from ..utils.metadata_routing import (
@@ -1731,7 +1732,7 @@ class _RidgeGCV(LinearModel):
         scoring=None,
         copy_X=True,
         gcv_mode=None,
-        store_cv_values=False,
+        store_cv_results=False,
         is_clf=False,
         alpha_per_target=False,
     ):
@@ -1740,7 +1741,7 @@ class _RidgeGCV(LinearModel):
         self.scoring = scoring
         self.copy_X = copy_X
         self.gcv_mode = gcv_mode
-        self.store_cv_values = store_cv_values
+        self.store_cv_results = store_cv_results
         self.is_clf = is_clf
         self.alpha_per_target = alpha_per_target
 
@@ -2135,8 +2136,8 @@ class _RidgeGCV(LinearModel):
         n_y = 1 if len(y.shape) == 1 else y.shape[1]
         n_alphas = 1 if np.ndim(self.alphas) == 0 else len(self.alphas)
 
-        if self.store_cv_values:
-            self.cv_values_ = np.empty((n_samples * n_y, n_alphas), dtype=X.dtype)
+        if self.store_cv_results:
+            self.cv_results_ = np.empty((n_samples * n_y, n_alphas), dtype=X.dtype)
 
         best_coef, best_score, best_alpha = None, None, None
 
@@ -2145,12 +2146,12 @@ class _RidgeGCV(LinearModel):
             if scorer is None:
                 squared_errors = (c / G_inverse_diag) ** 2
                 alpha_score = self._score_without_scorer(squared_errors=squared_errors)
-                if self.store_cv_values:
-                    self.cv_values_[:, i] = squared_errors.ravel()
+                if self.store_cv_results:
+                    self.cv_results_[:, i] = squared_errors.ravel()
             else:
                 predictions = y - (c / G_inverse_diag)
-                if self.store_cv_values:
-                    self.cv_values_[:, i] = predictions.ravel()
+                if self.store_cv_results:
+                    self.cv_results_[:, i] = predictions.ravel()
 
                 score_params = score_params or {}
                 alpha_score = self._score(
@@ -2193,12 +2194,12 @@ class _RidgeGCV(LinearModel):
             X_offset += X_mean * X_scale
         self._set_intercept(X_offset, y_offset, X_scale)
 
-        if self.store_cv_values:
+        if self.store_cv_results:
             if len(y.shape) == 1:
-                cv_values_shape = n_samples, n_alphas
+                cv_results_shape = n_samples, n_alphas
             else:
-                cv_values_shape = n_samples, n_y, n_alphas
-            self.cv_values_ = self.cv_values_.reshape(cv_values_shape)
+                cv_results_shape = n_samples, n_y, n_alphas
+            self.cv_results_ = self.cv_results_.reshape(cv_results_shape)
 
         return self
 
@@ -2258,8 +2259,9 @@ class _BaseRidgeCV(LinearModel):
         "scoring": [StrOptions(set(get_scorer_names())), callable, None],
         "cv": ["cv_object"],
         "gcv_mode": [StrOptions({"auto", "svd", "eigen"}), None],
-        "store_cv_values": ["boolean"],
+        "store_cv_results": ["boolean", None],
         "alpha_per_target": ["boolean"],
+        "store_cv_values": ["boolean", Hidden(StrOptions({"deprecated"}))],
     }
 
     def __init__(
@@ -2270,16 +2272,18 @@ class _BaseRidgeCV(LinearModel):
         scoring=None,
         cv=None,
         gcv_mode=None,
-        store_cv_values=False,
+        store_cv_results=None,
         alpha_per_target=False,
+        store_cv_values="deprecated",
     ):
         self.alphas = alphas
         self.fit_intercept = fit_intercept
         self.scoring = scoring
         self.cv = cv
         self.gcv_mode = gcv_mode
-        self.store_cv_values = store_cv_values
+        self.store_cv_results = store_cv_results
         self.alpha_per_target = alpha_per_target
+        self.store_cv_values = store_cv_values
 
     def fit(self, X, y, sample_weight=None, **params):
         """Fit Ridge regression model with cv.
@@ -2322,6 +2326,28 @@ class _BaseRidgeCV(LinearModel):
         """
         _raise_for_params(params, self, "fit")
         cv = self.cv
+
+        # TODO(1.7): Remove in 1.7
+        # Also change `store_cv_results` default back to False
+        if self.store_cv_values != "deprecated":
+            if self.store_cv_results is not None:
+                raise ValueError(
+                    "Both 'store_cv_values' and 'store_cv_results' were set. "
+                    "'store_cv_values' was deprecated in version 1.5 and will be "
+                    "removed in 1.7. To avoid this error, only set 'store_cv_results'."
+                )
+            warnings.warn(
+                (
+                    "'store_cv_values' was renamed to 'store_cv_results' in version "
+                    " 1.5 and will be removed in 1.7."
+                ),
+                FutureWarning,
+            )
+            self._store_cv_results = self.store_cv_values
+        elif self.store_cv_results is None:
+            self._store_cv_results = False
+        else:
+            self._store_cv_results = self.store_cv_results
 
         # `_RidgeGCV` does not work for alpha = 0
         if cv is None:
@@ -2368,7 +2394,7 @@ class _BaseRidgeCV(LinearModel):
                 fit_intercept=self.fit_intercept,
                 scoring=self.scoring,
                 gcv_mode=self.gcv_mode,
-                store_cv_values=self.store_cv_values,
+                store_cv_results=self._store_cv_results,
                 is_clf=is_classifier(self),
                 alpha_per_target=self.alpha_per_target,
             )
@@ -2380,11 +2406,11 @@ class _BaseRidgeCV(LinearModel):
             )
             self.alpha_ = estimator.alpha_
             self.best_score_ = estimator.best_score_
-            if self.store_cv_values:
-                self.cv_values_ = estimator.cv_values_
+            if self._store_cv_results:
+                self.cv_results_ = estimator.cv_results_
         else:
-            if self.store_cv_values:
-                raise ValueError("cv!=None and store_cv_values=True are incompatible")
+            if self._store_cv_results:
+                raise ValueError("cv!=None and store_cv_results=True are incompatible")
             if self.alpha_per_target:
                 raise ValueError("cv!=None and alpha_per_target=True are incompatible")
 
@@ -2444,6 +2470,16 @@ class _BaseRidgeCV(LinearModel):
 
     def _get_scorer(self):
         return check_scoring(self, scoring=self.scoring, allow_none=True)
+
+    # TODO(1.7): Remove
+    # mypy error: Decorated property not supported
+    @deprecated(  # type: ignore
+        "Attribute `cv_values_` is deprecated in version 1.5 and will be removed "
+        "in 1.7."
+    )
+    @property
+    def cv_values_(self):
+        return self.cv_results_
 
 
 class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
@@ -2506,11 +2542,24 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         The 'auto' mode is the default and is intended to pick the cheaper
         option of the two depending on the shape of the training data.
 
-    store_cv_values : bool, default=False
+    store_cv_results : bool, default=False
         Flag indicating if the cross-validation values corresponding to
         each alpha should be stored in the ``cv_values_`` attribute (see
         below). This flag is only compatible with ``cv=None`` (i.e. using
         Leave-One-Out Cross-Validation).
+
+        .. versionchanged:: 1.5
+            Parameter name changed from `store_cv_values` to `store_cv_results`.
+
+    store_cv_values : bool
+        Flag indicating if the cross-validation values corresponding to
+        each alpha should be stored in the ``cv_values_`` attribute (see
+        below). This flag is only compatible with ``cv=None`` (i.e. using
+        Leave-One-Out Cross-Validation).
+
+        .. deprecated:: 1.5
+            `store_cv_values` is deprecated in version 1.5 in favor of
+            `store_cv_results` and will be removed in version 1.7.
 
     alpha_per_target : bool, default=False
         Flag indicating whether to optimize the alpha value (picked from the
@@ -2523,13 +2572,23 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
 
     Attributes
     ----------
-    cv_values_ : ndarray of shape (n_samples, n_alphas) or \
+    cv_results_ : ndarray of shape (n_samples, n_alphas) or \
             shape (n_samples, n_targets, n_alphas), optional
         Cross-validation values for each alpha (only available if
-        ``store_cv_values=True`` and ``cv=None``). After ``fit()`` has been
+        ``store_cv_results=True`` and ``cv=None``). After ``fit()`` has been
         called, this attribute will contain the mean squared errors if
         `scoring is None` otherwise it will contain standardized per point
         prediction values.
+
+        .. versionchanged:: 1.5
+            `cv_values_` changed to `cv_results_`.
+
+    cv_values_ : ndarray of shape (n_samples, n_alphas) or \
+            shape (n_samples, n_targets, n_alphas), optional
+
+        .. deprecated:: 1.5
+            `cv_values_` is deprecated in version 1.5 in favor of
+            `cv_results_` and will be removed in version 1.7.
 
     coef_ : ndarray of shape (n_features) or (n_targets, n_features)
         Weight vector(s).
@@ -2670,19 +2729,41 @@ class RidgeClassifierCV(_RidgeClassifierMixin, _BaseRidgeCV):
         weights inversely proportional to class frequencies in the input data
         as ``n_samples / (n_classes * np.bincount(y))``.
 
-    store_cv_values : bool, default=False
+    store_cv_results : bool, default=False
+        Flag indicating if the cross-validation results corresponding to
+        each alpha should be stored in the ``cv_results_`` attribute (see
+        below). This flag is only compatible with ``cv=None`` (i.e. using
+        Leave-One-Out Cross-Validation).
+
+        .. versionchanged:: 1.5
+            Parameter name changed from `store_cv_values` to `store_cv_results`.
+
+    store_cv_values : bool
         Flag indicating if the cross-validation values corresponding to
         each alpha should be stored in the ``cv_values_`` attribute (see
         below). This flag is only compatible with ``cv=None`` (i.e. using
         Leave-One-Out Cross-Validation).
 
+        .. deprecated:: 1.5
+            `store_cv_values` is deprecated in version 1.5 in favor of
+            `store_cv_results` and will be removed in version 1.7.
+
     Attributes
     ----------
-    cv_values_ : ndarray of shape (n_samples, n_targets, n_alphas), optional
-        Cross-validation values for each alpha (only if ``store_cv_values=True`` and
+    cv_results_ : ndarray of shape (n_samples, n_targets, n_alphas), optional
+        Cross-validation results for each alpha (only if ``store_cv_results=True`` and
         ``cv=None``). After ``fit()`` has been called, this attribute will
         contain the mean squared errors if `scoring is None` otherwise it
         will contain standardized per point prediction values.
+
+        .. versionchanged:: 1.5
+            `cv_values_` changed to `cv_results_`.
+
+    cv_values_ : ndarray of shape (n_samples, n_targets, n_alphas), optional
+
+        .. deprecated:: 1.5
+            `cv_values_` is deprecated in version 1.5 in favor of
+            `cv_results_` and will be removed in version 1.7.
 
     coef_ : ndarray of shape (1, n_features) or (n_targets, n_features)
         Coefficient of the features in the decision function.
@@ -2752,13 +2833,15 @@ class RidgeClassifierCV(_RidgeClassifierMixin, _BaseRidgeCV):
         scoring=None,
         cv=None,
         class_weight=None,
-        store_cv_values=False,
+        store_cv_results=None,
+        store_cv_values="deprecated",
     ):
         super().__init__(
             alphas=alphas,
             fit_intercept=fit_intercept,
             scoring=scoring,
             cv=cv,
+            store_cv_results=store_cv_results,
             store_cv_values=store_cv_values,
         )
         self.class_weight = class_weight

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2333,13 +2333,13 @@ class _BaseRidgeCV(LinearModel):
             if self.store_cv_results is not None:
                 raise ValueError(
                     "Both 'store_cv_values' and 'store_cv_results' were set. "
-                    "'store_cv_values' was deprecated in version 1.5 and will be "
+                    "'store_cv_values' is deprecated in version 1.5 and will be "
                     "removed in 1.7. To avoid this error, only set 'store_cv_results'."
                 )
             warnings.warn(
                 (
-                    "'store_cv_values' was renamed to 'store_cv_results' in version "
-                    " 1.5 and will be removed in 1.7."
+                    "'store_cv_values' is deprecated in version 1.5 and will be "
+                    "removed in 1.7. Use 'store_cv_results' instead."
                 ),
                 FutureWarning,
             )
@@ -2475,7 +2475,7 @@ class _BaseRidgeCV(LinearModel):
     # mypy error: Decorated property not supported
     @deprecated(  # type: ignore
         "Attribute `cv_values_` is deprecated in version 1.5 and will be removed "
-        "in 1.7."
+        "in 1.7. Use `cv_results_` instead."
     )
     @property
     def cv_values_(self):
@@ -2551,6 +2551,15 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         .. versionchanged:: 1.5
             Parameter name changed from `store_cv_values` to `store_cv_results`.
 
+    alpha_per_target : bool, default=False
+        Flag indicating whether to optimize the alpha value (picked from the
+        `alphas` parameter list) for each target separately (for multi-output
+        settings: multiple prediction targets). When set to `True`, after
+        fitting, the `alpha_` attribute will contain a value for each target.
+        When set to `False`, a single alpha is used for all targets.
+
+        .. versionadded:: 0.24
+
     store_cv_values : bool
         Flag indicating if the cross-validation values corresponding to
         each alpha should be stored in the ``cv_values_`` attribute (see
@@ -2560,15 +2569,6 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         .. deprecated:: 1.5
             `store_cv_values` is deprecated in version 1.5 in favor of
             `store_cv_results` and will be removed in version 1.7.
-
-    alpha_per_target : bool, default=False
-        Flag indicating whether to optimize the alpha value (picked from the
-        `alphas` parameter list) for each target separately (for multi-output
-        settings: multiple prediction targets). When set to `True`, after
-        fitting, the `alpha_` attribute will contain a value for each target.
-        When set to `False`, a single alpha is used for all targets.
-
-        .. versionadded:: 0.24
 
     Attributes
     ----------
@@ -2582,13 +2582,6 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
 
         .. versionchanged:: 1.5
             `cv_values_` changed to `cv_results_`.
-
-    cv_values_ : ndarray of shape (n_samples, n_alphas) or \
-            shape (n_samples, n_targets, n_alphas), optional
-
-        .. deprecated:: 1.5
-            `cv_values_` is deprecated in version 1.5 in favor of
-            `cv_results_` and will be removed in version 1.7.
 
     coef_ : ndarray of shape (n_features) or (n_targets, n_features)
         Weight vector(s).
@@ -2758,12 +2751,6 @@ class RidgeClassifierCV(_RidgeClassifierMixin, _BaseRidgeCV):
 
         .. versionchanged:: 1.5
             `cv_values_` changed to `cv_results_`.
-
-    cv_values_ : ndarray of shape (n_samples, n_targets, n_alphas), optional
-
-        .. deprecated:: 1.5
-            `cv_values_` is deprecated in version 1.5 in favor of
-            `cv_results_` and will be removed in version 1.7.
 
     coef_ : ndarray of shape (1, n_features) or (n_targets, n_features)
         Coefficient of the features in the decision function.

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2259,7 +2259,7 @@ class _BaseRidgeCV(LinearModel):
         "scoring": [StrOptions(set(get_scorer_names())), callable, None],
         "cv": ["cv_object"],
         "gcv_mode": [StrOptions({"auto", "svd", "eigen"}), None],
-        "store_cv_results": ["boolean", None],
+        "store_cv_results": ["boolean", Hidden(None)],
         "alpha_per_target": ["boolean"],
         "store_cv_values": ["boolean", Hidden(StrOptions({"deprecated"}))],
     }

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -2231,7 +2231,7 @@ def test_ridge_store_cv_values_deprecated():
     """Check `store_cv_values` parameter deprecated."""
     X, y = make_regression(n_samples=6, random_state=42)
     ridge = RidgeCV(store_cv_values=True)
-    msg = "'store_cv_values' was renamed to 'store_cv_results'"
+    msg = "'store_cv_values' is deprecated"
     with pytest.warns(FutureWarning, match=msg):
         ridge.fit(X, y)
 

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -920,15 +920,15 @@ def test_ridge_gcv_sample_weights(
     X_gcv = X_container(X)
     gcv_ridge = RidgeCV(
         alphas=alphas,
-        store_cv_values=True,
+        store_cv_results=True,
         gcv_mode=gcv_mode,
         fit_intercept=fit_intercept,
     )
     gcv_ridge.fit(X_gcv, y, sample_weight=sample_weight)
     if len(y_shape) == 2:
-        gcv_errors = gcv_ridge.cv_values_[:, :, alphas.index(kfold.alpha_)]
+        gcv_errors = gcv_ridge.cv_results_[:, :, alphas.index(kfold.alpha_)]
     else:
-        gcv_errors = gcv_ridge.cv_values_[:, alphas.index(kfold.alpha_)]
+        gcv_errors = gcv_ridge.cv_results_[:, alphas.index(kfold.alpha_)]
 
     assert kfold.alpha_ == pytest.approx(gcv_ridge.alpha_)
     assert_allclose(gcv_errors, kfold_errors, rtol=1e-3)
@@ -1034,15 +1034,15 @@ def _test_ridge_cv(sparse_container):
 @pytest.mark.parametrize(
     "ridge, make_dataset",
     [
-        (RidgeCV(store_cv_values=False), make_regression),
-        (RidgeClassifierCV(store_cv_values=False), make_classification),
+        (RidgeCV(store_cv_results=False), make_regression),
+        (RidgeClassifierCV(store_cv_results=False), make_classification),
     ],
 )
-def test_ridge_gcv_cv_values_not_stored(ridge, make_dataset):
-    # Check that `cv_values_` is not stored when store_cv_values is False
+def test_ridge_gcv_cv_results_not_stored(ridge, make_dataset):
+    # Check that `cv_results_` is not stored when store_cv_results is False
     X, y = make_dataset(n_samples=6, random_state=42)
     ridge.fit(X, y)
-    assert not hasattr(ridge, "cv_values_")
+    assert not hasattr(ridge, "cv_results_")
 
 
 @pytest.mark.parametrize(
@@ -1053,7 +1053,7 @@ def test_ridge_gcv_cv_values_not_stored(ridge, make_dataset):
 def test_ridge_best_score(ridge, make_dataset, cv):
     # check that the best_score_ is store
     X, y = make_dataset(n_samples=6, random_state=42)
-    ridge.set_params(store_cv_values=False, cv=cv)
+    ridge.set_params(store_cv_results=False, cv=cv)
     ridge.fit(X, y)
     assert hasattr(ridge, "best_score_")
     assert isinstance(ridge.best_score_, float)
@@ -1090,27 +1090,27 @@ def test_ridge_cv_individual_penalties():
         Ridge(alpha=ridge_cv.alpha_).fit(X, y).coef_, ridge_cv.coef_
     )
 
-    # Test shape of alpha_ and cv_values_
-    ridge_cv = RidgeCV(alphas=alphas, alpha_per_target=True, store_cv_values=True).fit(
+    # Test shape of alpha_ and cv_results_
+    ridge_cv = RidgeCV(alphas=alphas, alpha_per_target=True, store_cv_results=True).fit(
         X, y
     )
     assert ridge_cv.alpha_.shape == (n_targets,)
     assert ridge_cv.best_score_.shape == (n_targets,)
-    assert ridge_cv.cv_values_.shape == (n_samples, len(alphas), n_targets)
+    assert ridge_cv.cv_results_.shape == (n_samples, len(alphas), n_targets)
 
     # Test edge case of there being only one alpha value
-    ridge_cv = RidgeCV(alphas=1, alpha_per_target=True, store_cv_values=True).fit(X, y)
+    ridge_cv = RidgeCV(alphas=1, alpha_per_target=True, store_cv_results=True).fit(X, y)
     assert ridge_cv.alpha_.shape == (n_targets,)
     assert ridge_cv.best_score_.shape == (n_targets,)
-    assert ridge_cv.cv_values_.shape == (n_samples, n_targets, 1)
+    assert ridge_cv.cv_results_.shape == (n_samples, n_targets, 1)
 
     # Test edge case of there being only one target
-    ridge_cv = RidgeCV(alphas=alphas, alpha_per_target=True, store_cv_values=True).fit(
+    ridge_cv = RidgeCV(alphas=alphas, alpha_per_target=True, store_cv_results=True).fit(
         X, y[:, 0]
     )
     assert np.isscalar(ridge_cv.alpha_)
     assert np.isscalar(ridge_cv.best_score_)
-    assert ridge_cv.cv_values_.shape == (n_samples, len(alphas))
+    assert ridge_cv.cv_results_.shape == (n_samples, len(alphas))
 
     # Try with a custom scoring function
     ridge_cv = RidgeCV(alphas=alphas, alpha_per_target=True, scoring="r2").fit(X, y)
@@ -1444,7 +1444,7 @@ def test_class_weights_cv():
 @pytest.mark.parametrize(
     "scoring", [None, "neg_mean_squared_error", _mean_squared_error_callable]
 )
-def test_ridgecv_store_cv_values(scoring):
+def test_ridgecv_store_cv_results(scoring):
     rng = np.random.RandomState(42)
 
     n_samples = 8
@@ -1455,26 +1455,26 @@ def test_ridgecv_store_cv_values(scoring):
 
     scoring_ = make_scorer(scoring) if callable(scoring) else scoring
 
-    r = RidgeCV(alphas=alphas, cv=None, store_cv_values=True, scoring=scoring_)
+    r = RidgeCV(alphas=alphas, cv=None, store_cv_results=True, scoring=scoring_)
 
     # with len(y.shape) == 1
     y = rng.randn(n_samples)
     r.fit(x, y)
-    assert r.cv_values_.shape == (n_samples, n_alphas)
+    assert r.cv_results_.shape == (n_samples, n_alphas)
 
     # with len(y.shape) == 2
     n_targets = 3
     y = rng.randn(n_samples, n_targets)
     r.fit(x, y)
-    assert r.cv_values_.shape == (n_samples, n_targets, n_alphas)
+    assert r.cv_results_.shape == (n_samples, n_targets, n_alphas)
 
-    r = RidgeCV(cv=3, store_cv_values=True, scoring=scoring)
-    with pytest.raises(ValueError, match="cv!=None and store_cv_values"):
+    r = RidgeCV(cv=3, store_cv_results=True, scoring=scoring)
+    with pytest.raises(ValueError, match="cv!=None and store_cv_results"):
         r.fit(x, y)
 
 
 @pytest.mark.parametrize("scoring", [None, "accuracy", _accuracy_callable])
-def test_ridge_classifier_cv_store_cv_values(scoring):
+def test_ridge_classifier_cv_store_cv_results(scoring):
     x = np.array([[-1.0, -1.0], [-1.0, 0], [-0.8, -1.0], [1.0, 1.0], [1.0, 0.0]])
     y = np.array([1, 1, 1, -1, -1])
 
@@ -1485,13 +1485,13 @@ def test_ridge_classifier_cv_store_cv_values(scoring):
     scoring_ = make_scorer(scoring) if callable(scoring) else scoring
 
     r = RidgeClassifierCV(
-        alphas=alphas, cv=None, store_cv_values=True, scoring=scoring_
+        alphas=alphas, cv=None, store_cv_results=True, scoring=scoring_
     )
 
     # with len(y.shape) == 1
     n_targets = 1
     r.fit(x, y)
-    assert r.cv_values_.shape == (n_samples, n_targets, n_alphas)
+    assert r.cv_results_.shape == (n_samples, n_targets, n_alphas)
 
     # with len(y.shape) == 2
     y = np.array(
@@ -1499,7 +1499,7 @@ def test_ridge_classifier_cv_store_cv_values(scoring):
     ).transpose()
     n_targets = y.shape[1]
     r.fit(x, y)
-    assert r.cv_values_.shape == (n_samples, n_targets, n_alphas)
+    assert r.cv_results_.shape == (n_samples, n_targets, n_alphas)
 
 
 @pytest.mark.parametrize("Estimator", [RidgeCV, RidgeClassifierCV])
@@ -2225,6 +2225,31 @@ def test_ridge_sample_weight_consistency(
     if fit_intercept:
         assert_allclose(reg1.intercept_, reg2.intercept_)
 
+
+# TODO(1.7): Remove
+def test_ridge_store_cv_values_deprecated():
+    """Check `store_cv_values` parameter deprecated."""
+    X, y = make_regression(n_samples=6, random_state=42)
+    ridge = RidgeCV(store_cv_values=True)
+    msg = "'store_cv_values' was renamed to 'store_cv_results'"
+    with pytest.warns(FutureWarning, match=msg):
+        ridge.fit(X, y)
+
+    # Error when both set
+    ridge = RidgeCV(store_cv_results=True, store_cv_values=True)
+    msg = "Both 'store_cv_values' and 'store_cv_results' were"
+    with pytest.raises(ValueError, match=msg):
+        ridge.fit(X, y)
+
+
+def test_ridge_cv_values_deprecated():
+    """Check `cv_values_` deprecated."""
+    X, y = make_regression(n_samples=6, random_state=42)
+    ridge = RidgeCV(store_cv_results=True)
+    msg = "Attribute `cv_values_` is deprecated"
+    with pytest.warns(FutureWarning, match=msg):
+        ridge.fit(X, y)
+        ridge.cv_values_
 
 # Metadata Routing Tests
 # ======================

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -2251,6 +2251,7 @@ def test_ridge_cv_values_deprecated():
         ridge.fit(X, y)
         ridge.cv_values_
 
+
 # Metadata Routing Tests
 # ======================
 


### PR DESCRIPTION
#### Reference Issues/PRs

closes #7206

#### What does this implement/fix? Explain your changes.
Deprecate `cv_values_` and `store_cv_values` in `RidgeCV` and `RidgeClassifierCV`

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
