### PR TITLE
ENH add possibility to have a callable for verbose_feature_names_out of ColumnTransformer

### DIFF
--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -143,6 +143,12 @@ Changelog
   on the input data.
   :pr:`29124` by :user:`Yao Xiao <Charlie-XIAO>`.
 
+:mod:`sklearn.compose`
+......................
+
+- |Enhancement| :func:`sklearn.compose.ColumnTransformer` `verbose_feature_names_out`
+  now accepts string format or callable to generate feature names. :pr:`28934` by
+  :user:`Marc Bresson <MarcBresson>`.
 
 :mod:`sklearn.datasets`
 .......................

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -673,10 +673,14 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             feature_names_out_callable = self.verbose_feature_names_out
         elif isinstance(self.verbose_feature_names_out, str):
             feature_names_out_callable = partial(
-                _feature_names_out, str_format=self.verbose_feature_names_out
+                _feature_names_out_with_str_format,
+                str_format=self.verbose_feature_names_out,
             )
         elif self.verbose_feature_names_out is True:
-            feature_names_out_callable = _feature_names_out
+            feature_names_out_callable = partial(
+                _feature_names_out_with_str_format,
+                str_format="{transformer_name}__{feature_name}",
+            )
 
         if feature_names_out_callable is not None:
             # Prefix the feature names out with the transformers name
@@ -1676,11 +1680,9 @@ def _with_dtype_warning_enabled_set_to(warning_enabled, transformers):
     return result
 
 
-def _feature_names_out(
-    transformer_name: str, feature_name: str, str_format: str | None = None
+def _feature_names_out_with_str_format(
+    transformer_name: str, feature_name: str, str_format: str
 ) -> str:
-    if str_format is None:
-        str_format = "{transformer_name}__{feature_name}"
     return str_format.format(
         transformer_name=transformer_name, feature_name=feature_name
     )

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -133,7 +133,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         If True, the time elapsed while fitting each transformer will be
         printed as it is completed.
 
-    verbose_feature_names_out : bool | str | Callable[[str, str], str], default=True
+    verbose_feature_names_out : bool, str or Callable[[str, str], str], default=True
         If True, :meth:`ColumnTransformer.get_feature_names_out` will prefix
         all feature names with the name of the transformer that generated that
         feature. It is equivalent to setting
@@ -155,7 +155,6 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
 
         .. versionchanged:: 1.6
             `verbose_feature_names_out` can be a callable or a string to be formatted.
-
 
     force_int_remainder_cols : bool, default=True
         Force the columns of the last entry of `transformers_`, which

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -8,8 +8,8 @@ different columns.
 # SPDX-License-Identifier: BSD-3-Clause
 import warnings
 from collections import Counter, UserList
-from itertools import chain
 from functools import partial
+from itertools import chain
 from numbers import Integral, Real
 
 import numpy as np

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -134,22 +134,23 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         printed as it is completed.
 
     verbose_feature_names_out : bool, str or Callable[[str, str], str], default=True
-        If True, :meth:`ColumnTransformer.get_feature_names_out` will prefix
-        all feature names with the name of the transformer that generated that
-        feature. It is equivalent to setting
-        `verbose_feature_names_out="{transformer_name}__{feature_name}"`.
-        If False, :meth:`ColumnTransformer.get_feature_names_out` will not
-        prefix any feature names and will error if feature names are not
-        unique.
-        If Callable[[str, str], str], :meth:`ColumnTransformer.get_feature_names_out`
-        will rename all the features using the name of the transformer. The
-        first argument of the callable is the transformer name and the
-        second argument is the feature name. The returned string will be the
-        new feature name.
-        If str, it must be a string ready for formatting. The given string will
-        be formatted using two field names: transformer_name and feature_name.
-        e.g. "{feature_name}__{transformer_name}".
-        See str.format method from the standard library for more info.
+
+        - If True, :meth:`ColumnTransformer.get_feature_names_out` will prefix
+          all feature names with the name of the transformer that generated that
+          feature. It is equivalent to setting
+          `verbose_feature_names_out="{transformer_name}__{feature_name}"`.
+        - If False, :meth:`ColumnTransformer.get_feature_names_out` will not
+          prefix any feature names and will error if feature names are not
+          unique.
+        - If ``Callable[[str, str], str]``,
+          :meth:`ColumnTransformer.get_feature_names_out` will rename all the features
+          using the name of the transformer. The first argument of the callable is the
+          transformer name and the second argument is the feature name. The returned
+          string will be the new feature name.
+        - If ``str``, it must be a string ready for formatting. The given string will
+          be formatted using two field names: ``transformer_name`` and ``feature_name``.
+          e.g. ``"{feature_name}__{transformer_name}"``. See :meth:`str.format` method
+          from the standard library for more info.
 
         .. versionadded:: 1.0
 

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -148,11 +148,12 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         new feature name.
         If str, it must be a string ready for formatting. The given string will
         be formatted using two field names: transformer_name and feature_name.
+        e.g. "{feature_name}__{transformer_name}".
         See str.format method from the standard library for more info.
 
         .. versionadded:: 1.0
 
-        .. versionchanged:: 1.X
+        .. versionchanged:: 1.6
             `verbose_feature_names_out` can be a callable or a string to be formatted.
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### What does this implement?

This brings the possibility to pass a callable to the `verbose_feature_names_out` parameter of `ColumnTransformer`. Instead of the new feature name being "transormer_name__feature_name", we could have "feature_name$this is amazing$TRANSFORMER_NAME".

#### Any other comments?

I have a few questions:

- How do you type sklearn as there are no stub files ?
- What is the version number I should put in `.. versionchanged` ?

In advance, thank you for your time.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
