### PR TITLE
DOC update r2_score default in regression metrics tutorial

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -2230,9 +2230,6 @@ leads to a weighting of each individual score by the variance of the
 corresponding target variable. This setting quantifies the globally captured
 unscaled variance. If the target variables are of different scale, then this
 score puts more importance on explaining the higher variance variables.
-``multioutput='variance_weighted'`` is the default value for :func:`r2_score`
-for backward compatibility. This will be changed to ``uniform_average`` in the
-future.
 
 .. _r2_score:
 


### PR DESCRIPTION
> `multioutput='variance_weighted'` is the default value for `r2_score`
for backward compatibility. This will be changed to `uniform_average` in the
future.

The future is now! Er... checks watch... 8 years ago! Looks like this was changed in #7927 but we never updated the docs to match 😅 