### PR TITLE
DOC Mention the renaming of check_estimator_sparse_data in 1.5 changelog

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -527,6 +527,11 @@ Changelog
   `axis=0` and supports indexing polars Series.
   :pr:`28521` by :user:`Yao Xiao <Charlie-XIAO>`.
 
+- |API| :func:`utils.estimator_checks.check_estimator_sparse_data` was split into two
+  functions: :func:`utils.estimator_checks.check_estimator_sparse_matrix` and
+  :func:`utils.estimator_checks.check_estimator_sparse_array`.
+  :pr:`27576` by :user:`Stefanie Senger <StefanieSenger>`.
+
 .. rubric:: Code and documentation contributors
 
 Thanks to everyone who has contributed to the maintenance and improvement of


### PR DESCRIPTION
closes #28966 

This estimator check was split into 2 checks, one for sparse matrices and one for sparse arrays. It's not a public tool so I think that it's fine that it was done without deprecation, but since it's used by third party developers, we should at least mention it in the changelog.