### PR TITLE
MAINT: specify C17 as C standard in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project(
   meson_version: '>= 1.1.0',
   default_options: [
     'buildtype=debugoptimized',
-    'c_std=c99',
+    'c_std=c17',
     'cpp_std=c++14',
   ],
 )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#28977 

#### What does this implement/fix? Explain your changes.

Bumps the required C standard. Doing this as a PR to see how impactful it is in CI.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
