### PR TITLE
FIX 1d sparse array validation

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -68,7 +68,7 @@ Changes impacting many modules
   :pr:`28756` by :user:`Will Dean <wd60622>`.
 
 - |Fix| Raise `ValueError` with an informative error message when passing 1D
-  sparse arrays to methods that expect 1D sparse inputs.
+  sparse arrays to methods that expect 2D sparse inputs.
   :pr:`28988` by :user:`Olivier Grisel <ogrisel>`.
 
 Support for Array API

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -67,6 +67,10 @@ Changes impacting many modules
   :class:`pipeline.Pipeline` and :class:`preprocessing.KBinsDiscretizer`.
   :pr:`28756` by :user:`Will Dean <wd60622>`.
 
+- |Fix| Raise `ValueError` with an informative error message when passing 1D
+  sparse arrays to methods that expect 1D sparse inputs.
+  :pr:`28988` by :user:`Olivier Grisel <ogrisel>`.
+
 Support for Array API
 ---------------------
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -595,6 +595,10 @@ def test_standard_scaler_partial_fit_numerical_stability(sparse_container):
     scaler_incr = StandardScaler(with_mean=False)
 
     for chunk in X:
+        if chunk.ndim == 1:
+            # Sparse arrays can be 1D (in scipy 1.14 and later) while old
+            # sparse matrix instances are always 2D.
+            chunk = chunk.reshape(1, -1)
         scaler_incr = scaler_incr.partial_fit(chunk)
 
     # Regardless of magnitude, they must not differ more than of 6 digits

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -361,6 +361,14 @@ def test_check_array():
     with pytest.raises(ValueError, match="Expected 2D array, got scalar array instead"):
         check_array(10, ensure_2d=True)
 
+    # ensure_2d=True with 1d sparse array
+    if hasattr(sp, "csr_array"):
+        sparse_row = next(iter(sp.csr_array(X)))
+        if sparse_row.ndim == 1:
+            # In scipy 1.14 and later, sparse row is 1D while it was 2D before.
+            with pytest.raises(ValueError, match="Expected 2D input, got"):
+                check_array(sparse_row, accept_sparse=True, ensure_2d=True)
+
     # don't allow ndim > 3
     X_ndim = np.arange(8).reshape(2, 2, 2)
     with pytest.raises(ValueError):

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -973,6 +973,13 @@ def check_array(
             estimator_name=estimator_name,
             input_name=input_name,
         )
+        if ensure_2d and array.ndim < 2:
+            raise ValueError(
+                f"Expected 2D input, got input with shape {array.shape}.\n"
+                "Reshape your data either using array.reshape(-1, 1) if "
+                "your data has a single feature or array.reshape(1, -1) "
+                "if it contains a single sample."
+            )
     else:
         # If np.array(..) gives ComplexWarning, then we convert the warning
         # to an error. This is needed because specifying a non complex


### PR DESCRIPTION
Fixes #28974 and the exception raised by `check_array` for scipy 1.14+