### PR TITLE
DEBUG coverage warning [azure parallel]

### DIFF
--- a/build_tools/azure/combine_coverage_reports.sh
+++ b/build_tools/azure/combine_coverage_reports.sh
@@ -12,6 +12,7 @@ activate_environment
 pushd $TEST_DIR
 coverage combine --append
 coverage xml
+coverage report  # for debugging purposes
 popd
 
 # Copy the combined coverage file to the root of the repository:


### PR DESCRIPTION
Investigate the warning raised at the end of a pytest run on our CI:

```
/usr/share/miniconda/envs/testvenv/lib/python3.11/site-packages/coverage/inorout.py:519: CoverageWarning: Module sklearn was previously imported, but not measured (module-not-measured)
  self.warn(msg, slug="module-not-measured")
```