### PR TITLE
MAINT fix redirected link for `Matthews Correlation Coefficient`

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -967,8 +967,8 @@ def matthews_corrcoef(y_true, y_pred, *, sample_weight=None):
        accuracy of prediction algorithms for classification: an overview.
        <10.1093/bioinformatics/16.5.412>`
 
-    .. [2] `Wikipedia entry for the Matthews Correlation Coefficient
-       <https://en.wikipedia.org/wiki/Matthews_correlation_coefficient>`_.
+    .. [2] `Wikipedia entry for the Matthews Correlation Coefficient (phi coefficient)
+       <https://en.wikipedia.org/wiki/Phi_coefficient>`_.
 
     .. [3] `Gorodkin, (2004). Comparing two K-category assignments by a
         K-category correlation coefficient


### PR DESCRIPTION
#### Reference Issues/PRs
No issue.

#### What does this implement/fix? Explain your changes.
The Wikipedia link <https://en.wikipedia.org/wiki/Matthews_correlation_coefficient> is automatically redirected to
<https://en.wikipedia.org/wiki/Phi_coefficient>.
This PR proposes to update this link too in order to avoid an invalidated link in the future.

#### Any other comments?
