### PR TITLE
DOC Update warm start example in ensemble user guide

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -603,7 +603,21 @@ fitted model.
 
 ::
 
-  >>> _ = est.set_params(n_estimators=200, warm_start=True)  # set warm_start and new nr of trees
+  >>> import numpy as np
+  >>> from sklearn.metrics import mean_squared_error
+  >>> from sklearn.datasets import make_friedman1
+  >>> from sklearn.ensemble import GradientBoostingRegressor
+
+  >>> X, y = make_friedman1(n_samples=1200, random_state=0, noise=1.0)
+  >>> X_train, X_test = X[:200], X[200:]
+  >>> y_train, y_test = y[:200], y[200:]
+  >>> est = GradientBoostingRegressor(
+  ...     n_estimators=100, learning_rate=0.1, max_depth=1, random_state=0,
+  ...     loss='squared_error'
+  ... ).fit(X_train, y_train)
+  >>> mean_squared_error(y_test, est.predict(X_test))
+  5.00...
+  >>> _ = est.set_params(n_estimators=200, warm_start=True)  # set warm_start and increase num of trees
   >>> _ = est.fit(X_train, y_train) # fit additional 100 trees to est
   >>> mean_squared_error(y_test, est.predict(X_test))
   3.84...

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -614,7 +614,8 @@ fitted model.
   >>> est = GradientBoostingRegressor(
   ...     n_estimators=100, learning_rate=0.1, max_depth=1, random_state=0,
   ...     loss='squared_error'
-  ... ).fit(X_train, y_train)
+  ... )
+  >>> est = est.fit(X_train, y_train)  # fit with 100 trees
   >>> mean_squared_error(y_test, est.predict(X_test))
   5.00...
   >>> _ = est.set_params(n_estimators=200, warm_start=True)  # set warm_start and increase num of trees


### PR DESCRIPTION
#### Reference Issues/PRs



#### What does this implement/fix? Explain your changes.
The [warm start example](https://scikit-learn.org/dev/modules/ensemble.html#fitting-additional-weak-learners) in ensemble.rst is a continuation from the [regression](https://scikit-learn.org/dev/modules/ensemble.html#regression) example above. The regression example is now hidden in a dropdown, so its not immediately obvious what `est` is and that `n_estimators` was initially set to 100. Also even when the regression section is expanded, the code example is not immediately above (there is a plot).

This section is also linked to in docstrings (#24579) so some users are sent directly here, without reading above.

This copies the regression example to the start, so the code block is runnable in isolation.

There is now a bit of repetition, but couldn't think of a better solution, happy to change though.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
