### PR TITLE
DOC Added reference to documentation for SpectralBiclustering class

### DIFF
--- a/sklearn/cluster/_bicluster.py
+++ b/sklearn/cluster/_bicluster.py
@@ -373,6 +373,9 @@ class SpectralBiclustering(BaseSpectral):
     biclusters. The outer product of the corresponding row and column
     label vectors gives this checkerboard structure.
 
+    In order to learn more about the SpectralBiclustering class go to:
+    :ref:`sphx_glr_auto_examples_bicluster_plot_spectral_biclustering.py`
+
     Read more in the :ref:`User Guide <spectral_biclustering>`.
 
     Parameters


### PR DESCRIPTION

#### Reference Issues/PRs
Add links to examples from the docstrings and user guides #26927


#### What does this implement/fix? Explain your changes.

Added a reference to the documentation in example/bicluster/plot_spectral_biclustering.py for the SpectralBiclustering class. 
#### Any other comments?

This is a pull request done for the course TDDE51 group 6

