### PR TITLE
DOC Add warm start section for tree ensembles

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -1264,7 +1264,7 @@ final number of estimators is equal to ``n``.
 ::
 
   >>> clf = RandomForestClassifier(n_estimators=20)  # set `n_estimators` to 10 + 10
-  >>> clf.fit(X, y)  # fit `estimators_` will be the same as the classifier above
+  >>> _ = clf.fit(X, y)  # fit `estimators_` will be the same as the classifier above
 
 Note that this differs from the usual behavior of :term:`random_state` in that it does
 *not* result in the same result across different calls.

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -1262,7 +1262,7 @@ final number of estimators is equal to ``n``.
   >>> clf.fit(X, y)  # fit `estimators_` will be the same as the classifier above
 
 Note that this differs from the usual behavior of :term:`random_state` in that it does
-*not* result in the same results across different calls.
+*not* result in the same result across different calls.
 
 .. _bagging:
 

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -1248,8 +1248,13 @@ RandomForest, Extra-Trees and :class:`RandomTreesEmbedding` estimators all suppo
   >>> X, y = make_classification(n_samples=100, random_state=1)
   >>> clf = RandomForestClassifier(n_estimators=10)
   >>> clf = clf.fit(X, y)  # fit with 10 trees
-  >>> _ = clf.set_params(n_estimators=20, warm_start=True) # set warm_start and increase num of estimators
+  >>> len(clf.estimators_)
+  10
+  >>> # set warm_start and increase num of estimators
+  >>> _ = clf.set_params(n_estimators=20, warm_start=True)
   >>> _ = clf.fit(X, y) # fit additional 10 trees
+  >>> len(clf.estimators_)
+  20
 
 When ``random_state`` is also set, the internal random state is also preserved
 between ``fit`` calls. This means that training a model once with ``n`` estimators is

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -1232,6 +1232,25 @@ estimation.
    representations of feature space, also these approaches focus also on
    dimensionality reduction.
 
+.. _tree_ensemble_warm_start:
+
+Fitting additional trees
+------------------------
+
+RandomForest, Extra-Trees and :class:`RandomTreesEmbedding` estimators all support
+``warm_start=True`` which allows you to add more trees to an already fitted model.
+
+::
+
+  >>> from sklearn.datasets import make_classification
+  >>> from sklearn.ensemble import RandomForestClassifier
+
+  >>> X, y = make_classification(n_samples=100, random_state=1)
+  >>> clf = RandomForestClassifier(n_estimators=10)
+  >>> clf = clf.fit(X, y)  # fit with 10 trees
+  >>> _ = clf.set_params(n_estimators=20, warm_start=True) # set warm_start and increase num of estimators
+  >>> _ = clf.fit(X, y) # fit additional 10 trees
+
 .. _bagging:
 
 Bagging meta-estimator

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -1264,7 +1264,7 @@ final number of estimators is equal to ``n``.
 ::
 
   >>> clf = RandomForestClassifier(n_estimators=20)  # set `n_estimators` to 10 + 10
-  >>> _ = clf.fit(X, y)  # fit `estimators_` will be the same as the classifier above
+  >>> _ = clf.fit(X, y)  # fit `estimators_` will be the same as `clf` above
 
 Note that this differs from the usual behavior of :term:`random_state` in that it does
 *not* result in the same result across different calls.

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -1251,6 +1251,19 @@ RandomForest, Extra-Trees and :class:`RandomTreesEmbedding` estimators all suppo
   >>> _ = clf.set_params(n_estimators=20, warm_start=True) # set warm_start and increase num of estimators
   >>> _ = clf.fit(X, y) # fit additional 10 trees
 
+When ``random_state`` is also set, the internal random state is also preserved
+between ``fit`` calls. This means that training a model once with ``n`` estimators is
+the same as building the model iteratively via multiple ``fit`` calls, where the
+final number of estimators is equal to ``n``.
+
+::
+
+  >>> clf = RandomForestClassifier(n_estimators=20)  # set `n_estimators` to 10 + 10
+  >>> clf.fit(X, y)  # fit `estimators_` will be the same as the classifier above
+
+Note that this differs from the usual behavior of :term:`random_state` in that it does
+*not* result in the same results across different calls.
+
 .. _bagging:
 
 Bagging meta-estimator

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1308,7 +1308,7 @@ class RandomForestClassifier(ForestClassifier):
         When set to ``True``, reuse the solution of the previous call to fit
         and add more estimators to the ensemble, otherwise, just fit a whole
         new forest. See :term:`Glossary <warm_start>` and
-        :ref:`gradient_boosting_warm_start` for details.
+        :ref:`tree_ensemble_warm_start` for details.
 
     class_weight : {"balanced", "balanced_subsample"}, dict or list of dicts, \
             default=None
@@ -1710,7 +1710,7 @@ class RandomForestRegressor(ForestRegressor):
         When set to ``True``, reuse the solution of the previous call to fit
         and add more estimators to the ensemble, otherwise, just fit a whole
         new forest. See :term:`Glossary <warm_start>` and
-        :ref:`gradient_boosting_warm_start` for details.
+        :ref:`tree_ensemble_warm_start` for details.
 
     ccp_alpha : non-negative float, default=0.0
         Complexity parameter used for Minimal Cost-Complexity Pruning. The
@@ -2049,7 +2049,7 @@ class ExtraTreesClassifier(ForestClassifier):
         When set to ``True``, reuse the solution of the previous call to fit
         and add more estimators to the ensemble, otherwise, just fit a whole
         new forest. See :term:`Glossary <warm_start>` and
-        :ref:`gradient_boosting_warm_start` for details.
+        :ref:`tree_ensemble_warm_start` for details.
 
     class_weight : {"balanced", "balanced_subsample"}, dict or list of dicts, \
             default=None
@@ -2434,7 +2434,7 @@ class ExtraTreesRegressor(ForestRegressor):
         When set to ``True``, reuse the solution of the previous call to fit
         and add more estimators to the ensemble, otherwise, just fit a whole
         new forest. See :term:`Glossary <warm_start>` and
-        :ref:`gradient_boosting_warm_start` for details.
+        :ref:`tree_ensemble_warm_start` for details.
 
     ccp_alpha : non-negative float, default=0.0
         Complexity parameter used for Minimal Cost-Complexity Pruning. The
@@ -2727,7 +2727,7 @@ class RandomTreesEmbedding(TransformerMixin, BaseForest):
         When set to ``True``, reuse the solution of the previous call to fit
         and add more estimators to the ensemble, otherwise, just fit a whole
         new forest. See :term:`Glossary <warm_start>` and
-        :ref:`gradient_boosting_warm_start` for details.
+        :ref:`tree_ensemble_warm_start` for details.
 
     Attributes
     ----------


### PR DESCRIPTION
#### Reference Issues/PRs
closes #22041

#### What does this implement/fix? Explain your changes.
* Add warm start section for tree ensembles. Currently there is only one for gradient boosted trees and we link to this one from the tree ensemble estimators (#24579), which is confusing. I thought about making a single section and talk about both ensemble and gradient boosted trees but thought it didn't fit with `ensemble.rst` page as its currently divided into sections for each estimator type.
* Include info about using warm start with random state (#22041). I thought about adding this section in the docstrings (with `warm_start` param or at the end) of the 6 estimators but thought this was better as we can give an example as well. Happy to change though.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
