### PR TITLE
DOC Mention that Meson is the main supported way to build scikit-learn

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -99,9 +99,9 @@ From scikit-learn 1.5 onwards, Meson is the main supported way to build
 scikit-learn, see :ref:`Building from source <install_bleeding_edge>` for more
 details.
 
-Unless we discover a major blocker, we intend to keep testing setuptools
-support until v1.6 and officially remove setuptools support when scikit-learn
-1.6 is released.
+Unless we discover a major blocker, scikit-learn 1.5 releases will support
+building scikit-learn with setuptools and scikit-learn 1.6 will drop setuptools
+support.
 
 Meson support for building scikit-learn was added in :pr:`28040` by :user:`Loïc
 Estève <lesteve>`

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -95,12 +95,16 @@ See :ref:`array_api` for more details.
 Support for building with Meson
 -------------------------------
 
-Meson is now supported as a build backend, see :ref:`Building from source
-<install_bleeding_edge>` for more details.
+From scikit-learn 1.5 onwards, Meson is the main supported way to build
+scikit-learn, see :ref:`Building from source <install_bleeding_edge>` for more
+details.
 
-:pr:`28040` by :user:`Loïc Estève <lesteve>`
+Unless we discover a major blocker, we intend to keep testing setuptools
+support until v1.6 and officially remove setuptools support when scikit-learn
+1.6 is released.
 
-TODO Fill more details before the 1.5 release, when the Meson story has settled down.
+Meson support for building scikit-learn was added in :pr:`28040` by :user:`Loïc
+Estève <lesteve>`
 
 Metadata Routing
 ----------------

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -100,8 +100,8 @@ scikit-learn, see :ref:`Building from source <install_bleeding_edge>` for more
 details.
 
 Unless we discover a major blocker, scikit-learn 1.5 releases will support
-building scikit-learn with setuptools and scikit-learn 1.6 will drop setuptools
-support.
+building scikit-learn with setuptools and setuptools support will be dropped in
+scikit-learn 1.6.
 
 Meson support for building scikit-learn was added in :pr:`28040` by :user:`Loïc
 Estève <lesteve>`

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -99,9 +99,9 @@ From scikit-learn 1.5 onwards, Meson is the main supported way to build
 scikit-learn, see :ref:`Building from source <install_bleeding_edge>` for more
 details.
 
-Unless we discover a major blocker, scikit-learn 1.5 releases will support
-building scikit-learn with setuptools and setuptools support will be dropped in
-scikit-learn 1.6.
+Unless we discover a major blocker, setuptools support will be dropped in
+scikit-learn 1.6. The 1.5.x releases will support building scikit-learn with
+setuptools.
 
 Meson support for building scikit-learn was added in :pr:`28040` by :user:`Loïc
 Estève <lesteve>`


### PR DESCRIPTION
This fills a TODO in the changelog about Meson.

The wording + strategy is up for debate. I know scipy moved `setup.py` to `_setup.py` (without testing it not 100% sure) so that at least people relying on it had to make an explicit step and realise this was deprecated.