### PR TITLE
TST check compatibility with metadata routing for *ThresholdClassifier*

### DIFF
--- a/sklearn/model_selection/_classification_threshold.py
+++ b/sklearn/model_selection/_classification_threshold.py
@@ -106,6 +106,14 @@ class BaseThresholdClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator
         self.estimator = estimator
         self.response_method = response_method
 
+    def _get_response_method(self):
+        """Define the response method."""
+        if self.response_method == "auto":
+            response_method = ["predict_proba", "decision_function"]
+        else:
+            response_method = self.response_method
+        return response_method
+
     @_fit_context(
         # *ThresholdClassifier*.estimator is not validated yet
         prefer_skip_nested_validation=False
@@ -139,11 +147,6 @@ class BaseThresholdClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator
             raise ValueError(
                 f"Only binary classification is supported. Unknown label type: {y_type}"
             )
-
-        if self.response_method == "auto":
-            self._response_method = ["predict_proba", "decision_function"]
-        else:
-            self._response_method = self.response_method
 
         self._fit(X, y, **params)
 
@@ -374,7 +377,7 @@ class FixedThresholdClassifier(BaseThresholdClassifier):
         y_score, _, response_method_used = _get_response_values_binary(
             self.estimator_,
             X,
-            self._response_method,
+            self._get_response_method(),
             pos_label=self.pos_label,
             return_response_method_used=True,
         )
@@ -954,7 +957,7 @@ class TunedThresholdClassifierCV(BaseThresholdClassifier):
         y_score, _ = _get_response_values_binary(
             self.estimator_,
             X,
-            self._response_method,
+            self._get_response_method(),
             pos_label=pos_label,
         )
 
@@ -995,6 +998,6 @@ class TunedThresholdClassifierCV(BaseThresholdClassifier):
         """Get the curve scorer based on the objective metric used."""
         scoring = check_scoring(self.estimator, scoring=self.scoring)
         curve_scorer = _CurveScorer.from_scorer(
-            scoring, self._response_method, self.thresholds
+            scoring, self._get_response_method(), self.thresholds
         )
         return curve_scorer

--- a/sklearn/tests/metadata_routing_common.py
+++ b/sklearn/tests/metadata_routing_common.py
@@ -194,7 +194,10 @@ class NonConsumingClassifier(ClassifierMixin, BaseEstimator):
         return self.predict(X)
 
     def predict(self, X):
-        return np.ones(len(X))
+        y_pred = np.empty(shape=(len(X),))
+        y_pred[: len(X) // 2] = 0
+        y_pred[len(X) // 2 :] = 1
+        return y_pred
 
 
 class NonConsumingRegressor(RegressorMixin, BaseEstimator):
@@ -257,13 +260,19 @@ class ConsumingClassifier(ClassifierMixin, BaseEstimator):
         record_metadata_not_default(
             self, "predict", sample_weight=sample_weight, metadata=metadata
         )
-        return np.zeros(shape=(len(X),), dtype="int8")
+        y_score = np.empty(shape=(len(X),), dtype="int8")
+        y_score[len(X) // 2 :] = 0
+        y_score[: len(X) // 2] = 1
+        return y_score
 
     def predict_proba(self, X, sample_weight="default", metadata="default"):
         record_metadata_not_default(
             self, "predict_proba", sample_weight=sample_weight, metadata=metadata
         )
-        return np.asarray([[0.0, 1.0]] * len(X))
+        y_proba = np.empty(shape=(len(X), 2))
+        y_proba[: len(X) // 2, :] = np.asarray([1.0, 0.0])
+        y_proba[len(X) // 2 :, :] = np.asarray([0.0, 1.0])
+        return y_proba
 
     def predict_log_proba(self, X, sample_weight="default", metadata="default"):
         pass  # pragma: no cover
@@ -278,7 +287,10 @@ class ConsumingClassifier(ClassifierMixin, BaseEstimator):
         record_metadata_not_default(
             self, "predict_proba", sample_weight=sample_weight, metadata=metadata
         )
-        return np.zeros(shape=(len(X),))
+        y_score = np.empty(shape=(len(X),))
+        y_score[len(X) // 2 :] = 0
+        y_score[: len(X) // 2] = 1
+        return y_score
 
     # uncomment when needed
     # def score(self, X, y, sample_weight="default", metadata="default"):

--- a/sklearn/tests/test_metaestimators_metadata_routing.py
+++ b/sklearn/tests/test_metaestimators_metadata_routing.py
@@ -41,10 +41,12 @@ from sklearn.linear_model import (
     RidgeCV,
 )
 from sklearn.model_selection import (
+    FixedThresholdClassifier,
     GridSearchCV,
     HalvingGridSearchCV,
     HalvingRandomSearchCV,
     RandomizedSearchCV,
+    TunedThresholdClassifierCV,
 )
 from sklearn.multiclass import (
     OneVsOneClassifier,
@@ -75,6 +77,7 @@ rng = np.random.RandomState(42)
 N, M = 100, 4
 X = rng.rand(N, M)
 y = rng.randint(0, 3, size=N)
+y_binary = (y >= 1).astype(int)
 classes = np.unique(y)
 y_multi = rng.randint(0, 3, size=(N, 3))
 classes_multi = [np.unique(y_multi[:, i]) for i in range(y_multi.shape[1])]
@@ -197,6 +200,24 @@ METAESTIMATORS: list = [
         "scorer_routing_methods": ["fit", "score"],
         "cv_name": "cv",
         "cv_routing_methods": ["fit"],
+    },
+    {
+        "metaestimator": FixedThresholdClassifier,
+        "estimator_name": "estimator",
+        "estimator": "classifier",
+        "X": X,
+        "y": y_binary,
+        "estimator_routing_methods": ["fit"],
+        "preserves_metadata": "subset",
+    },
+    {
+        "metaestimator": TunedThresholdClassifierCV,
+        "estimator_name": "estimator",
+        "estimator": "classifier",
+        "X": X,
+        "y": y_binary,
+        "estimator_routing_methods": ["fit"],
+        "preserves_metadata": "subset",
     },
     {
         "metaestimator": OneVsRestClassifier,


### PR DESCRIPTION
closes #29019 

Attempt to solve the issue when `TunedThresholdClassifierCV` is used within another meta-estimator and routing is on.

In this regard, I'm adding both `TunedThresholdClassifierCV` and `FixedThresholdClassifier` to the list of meta-estimator in the metadata routing test file.