### PR TITLE
FIX add long long for int32/int64 windows compat in NumPy 2.0

### DIFF
--- a/sklearn/utils/arrayfuncs.pyx
+++ b/sklearn/utils/arrayfuncs.pyx
@@ -16,6 +16,7 @@ ctypedef fused real_numeric:
     short
     int
     long
+    long long
     float
     double
 

--- a/sklearn/utils/tests/test_arrayfuncs.py
+++ b/sklearn/utils/tests/test_arrayfuncs.py
@@ -26,7 +26,9 @@ def test_min_pos_no_positive(dtype):
     assert min_pos(X) == np.finfo(dtype).max
 
 
-@pytest.mark.parametrize("dtype", [np.int16, np.int32, np.float32, np.float64])
+@pytest.mark.parametrize(
+    "dtype", [np.int16, np.int32, np.int64, np.float32, np.float64]
+)
 @pytest.mark.parametrize("value", [0, 1.5, -1])
 def test_all_with_any_reduction_axis_1(dtype, value):
     # Check that return value is False when there is no row equal to `value`


### PR DESCRIPTION
closes #29028 

Since NumPy 2.0 will switch from `long` to `long long` for Windows machine, then it seems that we have trigger a non-matching type as shown here: https://github.com/conda-forge/scikit-learn-feedstock/pull/259#issuecomment-2114181905

This should fix it.