### PR TITLE
Add automatic conversion from `pydata/sparse` to scipy sparse counterparts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ tests = [
     "pyarrow>=12.0.0",
     "numpydoc>=1.2.0",
     "pooch>=1.6.0",
+    "sparse>=0.15.1",
 ]
 maintenance = ["conda-lock==2.5.6"]
 

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -35,6 +35,7 @@ dependent_packages = {
     "pyamg": ("4.0.0", "tests"),
     "polars": ("0.19.12", "docs, tests"),
     "pyarrow": ("12.0.0", "tests"),
+    "sparse": ("0.15.1", "tests"),
     "sphinx": ("6.0.0", "docs"),
     "sphinx-copybutton": ("0.5.2", "docs"),
     "sphinx-gallery": ("0.15.0", "docs"),

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -10,6 +10,7 @@ from tempfile import NamedTemporaryFile
 import numpy as np
 import pytest
 import scipy.sparse as sp
+import sparse as pydata_sparse
 from pytest import importorskip
 
 import sklearn
@@ -2124,3 +2125,13 @@ def test__is_polars_df():
             self.schema = ["a", "b"]
 
     assert not _is_polars_df(LooksLikePolars())
+
+
+def test_pydata_sparse_dispatch():
+    arr = np.array([[-2, 0], [2, 2], [-1, 1], [2, 3]])
+
+    sp_graph = pydata_sparse.COO.from_numpy(arr)
+    neigh = sklearn.cluster.KMeans(n_clusters=2)
+    labels = neigh.fit_predict(sp_graph)
+
+    assert_array_equal(labels, [1, 0, 1, 0])

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -961,6 +961,9 @@ def check_array(
                             "numeric type."
                         )
 
+    if _is_pydata_spmatrix(array):
+        array = array.to_scipy_sparse()
+
     if sp.issparse(array):
         _ensure_no_complex_data(array)
         array = _ensure_sparse_format(
@@ -2515,3 +2518,11 @@ def _to_object_array(sequence):
     out = np.empty(len(sequence), dtype=object)
     out[:] = sequence
     return out
+
+
+def _is_pydata_spmatrix(m) -> bool:
+    """
+    Check whether object is pydata/sparse matrix, avoiding importing the module.
+    """
+    base_cls = getattr(sys.modules.get("sparse"), "SparseArray", None)
+    return base_cls is not None and isinstance(m, base_cls)


### PR DESCRIPTION
Hi!

This PR adds a simple `scipy.sparse` dispatch for https://github.com/pydata/sparse (transforming `pydata/sparse` arrays to `scipy.sparse` matrices).

Same efforts to support `pydata/sparse` input and convert to `scipy.sparse` were completed in `scipy.sparse.linalg` and `scipy.sparse.csgraph`:
- https://github.com/scipy/scipy/pull/19796
- https://github.com/scipy/scipy/pull/20485
