### PR TITLE
DOC Linked randomized_svd with Wikipedia prinicipal eigenvector example

### DIFF
--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -489,6 +489,7 @@ def randomized_svd(
 
     Examples
     --------
+    * :ref:`sphx_glr_auto_examples_applications_wikipedia_principal_eigenvector.py`
     >>> import numpy as np
     >>> from sklearn.utils.extmath import randomized_svd
     >>> a = np.array([[1, 2, 3, 5],


### PR DESCRIPTION
#### Reference Issues/PRs
#26927 

#### What does this implement/fix? Explain your changes.
Adds link between wikipedia_principal_eigenvector.py example in  sklearn.utils.extmath.randomized_svd 

#### Any other comments?
