### PR TITLE
Fix use metric_kwargs in check_array_api_metric_pairwise

### DIFF
--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1898,12 +1898,24 @@ def check_array_api_metric_pairwise(metric, array_namespace, device, dtype_name)
     if "dense_output" in signature(metric).parameters:
         metric_kwargs["dense_output"] = False
         check_array_api_metric(
-            metric, array_namespace, device, dtype_name, a_np=X_np, b_np=Y_np
+            metric,
+            array_namespace,
+            device,
+            dtype_name,
+            a_np=X_np,
+            b_np=Y_np,
+            **metric_kwargs,
         )
         metric_kwargs["dense_output"] = True
 
     check_array_api_metric(
-        metric, array_namespace, device, dtype_name, a_np=X_np, b_np=Y_np
+        metric,
+        array_namespace,
+        device,
+        dtype_name,
+        a_np=X_np,
+        b_np=Y_np,
+        **metric_kwargs,
     )
 
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
As discussed [here](https://github.com/scikit-learn/scikit-learn/pull/29036#pullrequestreview-2063865000), we need to pass `metrics_kwargs` when using the check_array_api_metric_pairwise. 

cc @OmarManzoor @betatim 