### PR TITLE
FIX workaround to remove the left sidebar on some page

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -310,7 +310,18 @@ html_static_path = ["images", "css", "js"]
 # html_last_updated_fmt = '%b %d, %Y'
 
 # Custom sidebar templates, maps document names to template names.
-# html_sidebars = {}
+# workaround for removing the left sidebar on pages without TOC
+html_sidebars = {
+    "install.html": [],
+    "getting_started.html": [],
+    "glossary.html": [],
+    "faq.html": [],
+    "support.html": [],
+    "related_projects.html": [],
+    "roadmap.html": [],
+    "governance.html": [],
+    "about.html": [],
+}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -310,7 +310,9 @@ html_static_path = ["images", "css", "js"]
 # html_last_updated_fmt = '%b %d, %Y'
 
 # Custom sidebar templates, maps document names to template names.
-# workaround for removing the left sidebar on pages without TOC
+# Workaround for removing the left sidebar on pages without TOC
+# A better solution would be to follow the merge of:
+# https://github.com/pydata/pydata-sphinx-theme/pull/1682
 html_sidebars = {
     "install.html": [],
     "getting_started.html": [],

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -314,15 +314,15 @@ html_static_path = ["images", "css", "js"]
 # A better solution would be to follow the merge of:
 # https://github.com/pydata/pydata-sphinx-theme/pull/1682
 html_sidebars = {
-    "install.html": [],
-    "getting_started.html": [],
-    "glossary.html": [],
-    "faq.html": [],
-    "support.html": [],
-    "related_projects.html": [],
-    "roadmap.html": [],
-    "governance.html": [],
-    "about.html": [],
+    "install": [],
+    "getting_started": [],
+    "glossary": [],
+    "faq": [],
+    "support": [],
+    "related_projects": [],
+    "roadmap": [],
+    "governance": [],
+    "about": [],
 }
 
 # Additional templates that should be rendered to pages, maps page names to


### PR DESCRIPTION
I think that we can go around the issue reported here: https://github.com/pydata/pydata-sphinx-theme/issues/1662

We can suppress the left sidebar with the following configuration.