### PR TITLE
DOC Add quantile loss to user guide on HGBT regression

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -103,7 +103,8 @@ Available losses for **regression** are:
 - 'squared_error', which is the default loss;
 - 'absolute_error', which is less sensitive to outliers than the squared error;
 - 'poisson', which is well suited to model counts and frequencies;
-- 'quantile' that allows for estimating prediction intervals.
+- 'quantile', which allows for estimating a conditional quantile that can later
+  be used to predict confidence intervals.
 
 For **classification**, 'log_loss' is the only option. For binary classification
 it uses the binary log loss, also known as binomial deviance or binary

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -98,14 +98,19 @@ controls the number of iterations of the boosting process::
   >>> clf.score(X_test, y_test)
   0.8965
 
-Available losses for regression are 'squared_error',
-'absolute_error', which is less sensitive to outliers, and
-'poisson', which is well suited to model counts and frequencies. For
-classification, 'log_loss' is the only option. For binary classification it uses the
-binary log loss, also known as binomial deviance or binary cross-entropy. For
-`n_classes >= 3`, it uses the multi-class log loss function, with multinomial deviance
-and categorical cross-entropy as alternative names. The appropriate loss version is
-selected based on :term:`y` passed to :term:`fit`.
+Available losses for **regression** are:
+
+- 'squared_error', which is the default loss;
+- 'absolute_error', which is less sensitive to outliers than the squared error;
+- 'poisson', which is well suited to model counts and frequencies;
+- 'quantile' that allows for estimating prediction intervals.
+
+For **classification**, 'log_loss' is the only option. For binary classification
+it uses the binary log loss, also known as binomial deviance or binary
+cross-entropy. For `n_classes >= 3`, it uses the multi-class log loss function,
+with multinomial deviance and categorical cross-entropy as alternative names.
+The appropriate loss version is selected based on :term:`y` passed to
+:term:`fit`.
 
 The size of the trees can be controlled through the ``max_leaf_nodes``,
 ``max_depth``, and ``min_samples_leaf`` parameters.

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -102,9 +102,10 @@ Available losses for **regression** are:
 
 - 'squared_error', which is the default loss;
 - 'absolute_error', which is less sensitive to outliers than the squared error;
+- 'gamma', which is well suited to model strictly positive outcomes;
 - 'poisson', which is well suited to model counts and frequencies;
 - 'quantile', which allows for estimating a conditional quantile that can later
-  be used to predict confidence intervals.
+  be used to obtain prediction intervals.
 
 For **classification**, 'log_loss' is the only option. For binary classification
 it uses the binary log loss, also known as binomial deviance or binary


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Follows #28652.

#### What does this implement/fix? Explain your changes.

As mentioned in https://github.com/scikit-learn/scikit-learn/pull/28652#discussion_r1537489269, the description of HGBT regression losses was missing the quantile loss. This PR fixes the issue.

#### Any other comments?

In the same [comment](https://github.com/scikit-learn/scikit-learn/pull/28652#discussion_r1537489269) it is mentioned that
> [...] some overhaul and entanglement of the different GBTs would be very good. It‘s hard to speak about newton boosting (HGBT), when the original GBT is not yet introduced.

For a follow-up PR maybe we can consider refactoring the narrative to first introduce common mathematical aspects of GBT models and then the HGBT version. WDYT?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
