### PR TITLE
BLD Fix another meson.build dependency

### DIFF
--- a/sklearn/neighbors/meson.build
+++ b/sklearn/neighbors/meson.build
@@ -24,7 +24,7 @@ foreach name: name_list
   )
   py.extension_module(
     name,
-    [pyx, neighbors_cython_tree, utils_cython_tree],
+    [pyx, neighbors_cython_tree, utils_cython_tree, metrics_cython_tree],
     dependencies: [np_dep],
     cython_args: cython_args,
     subdir: 'sklearn/neighbors',


### PR DESCRIPTION
Yet another instance of https://github.com/scikit-learn/scikit-learn/issues/28820

One way to reproduce locally is to start a build from scratch and build specific files that are missing dependencies:
```
rm -rf my-build
meson setup my-build
ninja -C my-build \
    sklearn/neighbors/_kd_tree.cpython-312-x86_64-linux-gnu.so.p/sklearn/neighbors/_kd_tree.pyx.c
```

On `main` you get the following error: 
```
FAILED: sklearn/neighbors/_kd_tree.cpython-312-x86_64-linux-gnu.so.p/sklearn/neighbors/_kd_tree.pyx.c 
cython -M --fast-fail -3 '-X language_level=3' '-X boundscheck=False' '-X wraparound=False' '-X initializedcheck=False' '-X nonecheck=False' '-X cdivision=True' '-X profile=False' --include-dir /home/lesteve/dev/scikit-learn/my-build sklearn/neighbors/_kd_tree.pyx -o sklearn/neighbors/_kd_tree.cpython-312-x86_64-linux-gnu.so.p/sklearn/neighbors/_kd_tree.pyx.c

Error compiling Cython file:
------------------------------------------------------------
...
from libc.string cimport memcpy

import numpy as np
import warnings

from ..metrics._dist_metrics cimport (
^
------------------------------------------------------------

sklearn/neighbors/_binary_tree.pxi:148:0: 'sklearn/metrics/_dist_metrics.pxd' not found
```