### PR TITLE
FIX avoid warning in input validation with array_api_strict

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -95,7 +95,7 @@ def _assert_all_finite(
 ):
     """Like assert_all_finite, but only for ndarray."""
 
-    xp, _ = get_namespace(X)
+    xp, is_array_api = get_namespace(X)
 
     if _get_config()["assume_finite"]:
         return
@@ -103,7 +103,7 @@ def _assert_all_finite(
     X = xp.asarray(X)
 
     # for object dtype data, we only check for NaNs (GH-13254)
-    if X.dtype == np.dtype("object") and not allow_nan:
+    if not is_array_api and X.dtype == np.dtype("object") and not allow_nan:
         if _object_dtype_isnan(X).any():
             raise ValueError("Input contains NaN")
 


### PR DESCRIPTION
Here is a reproducer for the original problem fixed in this PR.

```python
In [11]: import numpy as np

In [12]: X = xp.asarray(np.random.randn(10000, 10))

In [13]: from sklearn.decomposition import PCA

In [14]: import sklearn

In [15]: sklearn.set_config(array_api_dispatch=True)

In [16]: PCA().fit(X).explained_variance_ratio_
/Users/ogrisel/code/scikit-learn/sklearn/utils/validation.py:106: UserWarning: You are comparing a array_api_strict dtype against a NumPy native dtype object, but you probably don't want to do this. array_api_strict dtype objects compare unequal to their NumPy equivalents. Such cross-library comparison is not supported by the standard.
  if X.dtype == np.dtype("object") and not allow_nan:
```

I don't think it's worth adding a non-regression test just for an annoying warning.