### PR TITLE
BLD Fix yet another meson.build dependency

### DIFF
--- a/sklearn/metrics/_pairwise_distances_reduction/meson.build
+++ b/sklearn/metrics/_pairwise_distances_reduction/meson.build
@@ -11,6 +11,11 @@
 # needed for the cimport to work
 _pairwise_distances_reduction_cython_tree = [
   fs.copyfile('__init__.py'),
+  # We are in a sub-module of metrics, so we always need to have
+  # sklearn/metrics/__init__.py copied to the build directory to avoid the
+  # error:
+  # relative cimport beyond main package is not allowed
+  metrics_cython_tree
 ]
 
 _classmode_pxd = fs.copyfile('_classmode.pxd')
@@ -30,7 +35,7 @@ _datasets_pair_pyx = custom_target(
 _datasets_pair = py.extension_module(
   '_datasets_pair',
   [_datasets_pair_pxd, _datasets_pair_pyx,
-    _pairwise_distances_reduction_cython_tree, utils_cython_tree],
+   _pairwise_distances_reduction_cython_tree, utils_cython_tree],
   dependencies: [np_dep, openmp_dep],
   override_options: ['cython_language=cpp'],
   cython_args: cython_args,


### PR DESCRIPTION
Another instance of #28820, issue seen in https://github.com/scikit-learn/scikit-learn/pull/29081#issuecomment-2126532754.

```
FAILED: sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.cpython-312-darwin.so.p/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.cpp
  cython -M --fast-fail -3 --cplus '-X language_level=3' '-X boundscheck=False' '-X wraparound=False' '-X initializedcheck=False' '-X nonecheck=False' '-X cdivision=True' '-X profile=False' --include-dir /Users/runner/work/1/s/build/cp312 sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx -o sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.cpython-312-darwin.so.p/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.cpp

  Error compiling Cython file:
  ------------------------------------------------------------
  ...
  from ...utils._typedefs cimport float64_t, float32_t, int32_t, intp_t
  ^
  ------------------------------------------------------------

  sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pxd:1:0: relative cimport beyond main package is not allowed
```

The error happened because `sklearn/metrics/__init__.py` was not copied when calling cython.

The error can be reproduce locally on `main` with:
```
rm -rf my-build
meson setup my-build
ninja -C my-build sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.cpython-312-x86_64-linux-gnu.so
```