### PR TITLE
MAINT Support `sort_dicts` and `underscore_numbers` args

### DIFF
--- a/sklearn/utils/_pprint.py
+++ b/sklearn/utils/_pprint.py
@@ -68,6 +68,7 @@ BaseEstimator.__repr__ for pretty-printing estimators"""
 
 import inspect
 import pprint
+import sys
 
 from .._config import get_config
 from ..base import BaseEstimator
@@ -174,10 +175,24 @@ class _EstimatorPrettyPrinter(pprint.PrettyPrinter):
         stream=None,
         *,
         compact=False,
+        sort_dicts=True,
+        underscore_numbers=False,
         indent_at_name=True,
         n_max_elements_to_show=None,
     ):
-        super().__init__(indent, width, depth, stream, compact=compact)
+        super().__init__(
+            indent,
+            width,
+            depth,
+            stream,
+            compact=compact,
+            sort_dicts=sort_dicts,
+            **(
+                {}
+                if sys.version_info < (3, 10)
+                else {"underscore_numbers": underscore_numbers}
+            ),
+        )
         self._indent_at_name = indent_at_name
         if self._indent_at_name:
             self._indent_per_level = 1  # ignore indent param
@@ -189,7 +204,13 @@ class _EstimatorPrettyPrinter(pprint.PrettyPrinter):
 
     def format(self, object, context, maxlevels, level):
         return _safe_repr(
-            object, context, maxlevels, level, changed_only=self._changed_only
+            object,
+            context,
+            maxlevels,
+            level,
+            sort_dicts=self._sort_dicts,
+            underscore_numbers=getattr(self, "_underscore_numbers", False),
+            changed_only=self._changed_only,
         )
 
     def _pprint_estimator(self, object, stream, indent, allowance, context, level):
@@ -202,9 +223,12 @@ class _EstimatorPrettyPrinter(pprint.PrettyPrinter):
         else:
             params = object.get_params(deep=False)
 
-        self._format_params(
-            sorted(params.items()), stream, indent, allowance + 1, context, level
-        )
+        if self._sort_dicts:
+            items = sorted(params.items(), key=pprint._safe_tuple)
+        else:
+            items = params.items()
+
+        self._format_params(items, stream, indent, allowance + 1, context, level)
         stream.write(")")
 
     def _format_dict_items(self, items, stream, indent, allowance, context, level):
@@ -352,15 +376,29 @@ class _EstimatorPrettyPrinter(pprint.PrettyPrinter):
     _dispatch[KeyValTuple.__repr__] = _pprint_key_val_tuple
 
 
-def _safe_repr(object, context, maxlevels, level, changed_only=False):
+def _safe_repr(
+    object,
+    context,
+    maxlevels,
+    level,
+    sort_dicts,
+    underscore_numbers,
+    changed_only=False,
+):
     """Same as the builtin _safe_repr, with added support for Estimator
     objects."""
     typ = type(object)
-
     if typ in pprint._builtin_scalars:
         return repr(object), True, False
 
     r = getattr(typ, "__repr__", None)
+
+    if issubclass(typ, int) and r is int.__repr__:
+        if underscore_numbers:
+            return f"{object:_d}", True, False
+        else:
+            return repr(object), True, False
+
     if issubclass(typ, dict) and r is dict.__repr__:
         if not object:
             return "{}", True, False
@@ -376,13 +414,28 @@ def _safe_repr(object, context, maxlevels, level, changed_only=False):
         append = components.append
         level += 1
         saferepr = _safe_repr
-        items = sorted(object.items(), key=pprint._safe_tuple)
+        if sort_dicts:
+            items = sorted(object.items(), key=pprint._safe_tuple)
+        else:
+            items = object.items()
         for k, v in items:
             krepr, kreadable, krecur = saferepr(
-                k, context, maxlevels, level, changed_only=changed_only
+                k,
+                context,
+                maxlevels,
+                level,
+                sort_dicts,
+                underscore_numbers,
+                changed_only=changed_only,
             )
             vrepr, vreadable, vrecur = saferepr(
-                v, context, maxlevels, level, changed_only=changed_only
+                v,
+                context,
+                maxlevels,
+                level,
+                sort_dicts,
+                underscore_numbers,
+                changed_only=changed_only,
             )
             append("%s: %s" % (krepr, vrepr))
             readable = readable and kreadable and vreadable
@@ -417,7 +470,13 @@ def _safe_repr(object, context, maxlevels, level, changed_only=False):
         level += 1
         for o in object:
             orepr, oreadable, orecur = _safe_repr(
-                o, context, maxlevels, level, changed_only=changed_only
+                o,
+                context,
+                maxlevels,
+                level,
+                sort_dicts,
+                underscore_numbers,
+                changed_only=changed_only,
             )
             append(orepr)
             if not oreadable:
@@ -444,13 +503,28 @@ def _safe_repr(object, context, maxlevels, level, changed_only=False):
         append = components.append
         level += 1
         saferepr = _safe_repr
-        items = sorted(params.items(), key=pprint._safe_tuple)
+        if sort_dicts:
+            items = sorted(params.items(), key=pprint._safe_tuple)
+        else:
+            items = params.items()
         for k, v in items:
             krepr, kreadable, krecur = saferepr(
-                k, context, maxlevels, level, changed_only=changed_only
+                k,
+                context,
+                maxlevels,
+                level,
+                sort_dicts,
+                underscore_numbers,
+                changed_only=changed_only,
             )
             vrepr, vreadable, vrecur = saferepr(
-                v, context, maxlevels, level, changed_only=changed_only
+                v,
+                context,
+                maxlevels,
+                level,
+                sort_dicts,
+                underscore_numbers,
+                changed_only=changed_only,
             )
             append("%s=%s" % (krepr.strip("'"), vrepr))
             readable = readable and kreadable and vreadable

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from pprint import PrettyPrinter
 
 import numpy as np
@@ -697,3 +698,20 @@ def test_complexity_print_changed_only():
         nb_repr_print_changed_only_true = DummyEstimator.nb_times_repr_called
 
     assert nb_repr_print_changed_only_false == nb_repr_print_changed_only_true
+
+
+def test_do_not_sort_dicts():
+    pp = _EstimatorPrettyPrinter(sort_dicts=False)
+
+    d = dict.fromkeys("cba")
+    assert pp.pformat(d) == "{'c': None, 'b': None, 'a': None}"
+    assert pp.pformat([d, d]) == (
+        "[{'c': None, 'b': None, 'a': None}, {'c': None, 'b': None, 'a': None}]"
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
+def test_underscore_numbers():
+    pp = _EstimatorPrettyPrinter(underscore_numbers=True)
+
+    assert pp.pformat(1234567) == "1_234_567"


### PR DESCRIPTION
#### Reference Issues/PRs

I've been looking at scikit-learn and built-in pretty-printing code a lot lately, so I decided to make a few fixes/enhancements. ~Happy to open an issue, if it helps.~

#### What does this implement/fix? Explain your changes.

* Add support for `sort_dicts` (added to built-in `pprint.PrettyPrinter` in Python 3.8)
* Add support for `underscore_numbers` (added to built-in `pprint.PrettyPrinter` in Python 3.10)
  * This is a bit more messy, because scikit-learn is still running on 3.9 for now, despite being outside the window as per https://scientific-python.org/specs/spec-0000/. I've tried to make it more robust. Note that the base `pprint.PrettyPrinter` defines `_builtin_scalars`, so you don't actually need to worry about the `int` formatting logic getting hit before 3.10; you just need to make sure the `super()` call is not invalid.

#### Any other comments?

Initially, I wasn't going to add tests for `sort_dicts` and `underscore_numbers`, because base `pprint.PrettyPrinter` functionality doesn't seem to be tested for the most part. However, it wasn't meeting coverage thresholds for added code, so I copied over a couple added tests. Still don't think the `underscore_numbers` test will get run in CI, though...