### PR TITLE
FIX change writeability only if not already writeable

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -34,7 +34,7 @@ Changelog
 ....................
 
 - |Fix| Fix a regression in :func:`utils.validation.check_array` that may have caused
-   it to raise an unexpected error about writeability on pandas dataframes.
+  it to raise an unexpected error about writeability on pandas dataframes.
   :pr:`19103` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 .. _changes_1_5:

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -30,6 +30,12 @@ Changelog
   grids that have heterogeneous parameter values.
   :pr:`29078` by :user:`Loïc Estève <lesteve>`
 
+:mod:`sklearn.utils`
+....................
+
+- |Fix| Fix a regression in :func:`utils.validation.check_array` that may caused it to
+  raise an unexpected error about writeability on pandas dataframes.
+  :pr:`19103` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 .. _changes_1_5:
 

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -33,8 +33,8 @@ Changelog
 :mod:`sklearn.utils`
 ....................
 
-- |Fix| Fix a regression in :func:`utils.validation.check_array` that may caused it to
-  raise an unexpected error about writeability on pandas dataframes.
+- |Fix| Fix a regression in :func:`utils.validation.check_array` that may have caused
+   it to raise an unexpected error about writeability on pandas dataframes.
   :pr:`19103` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
 
 .. _changes_1_5:

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1100,7 +1100,11 @@ def check_array(
     # See https://pandas.pydata.org/docs/dev/user_guide/copy_on_write.html#read-only-numpy-arrays
     # for more details about pandas copy-on-write mechanism, that is enabled by
     # default in pandas 3.0.0.dev.
-    if _is_pandas_df_or_series(array_orig) and hasattr(array, "flags"):
+    if (
+        _is_pandas_df_or_series(array_orig)
+        and hasattr(array, "flags")
+        and not array.flags.writeable
+    ):
         array.flags.writeable = True
 
     return array


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/28899

This is a quick and easy fix for the regression reported in #28899. The issue is that setting the flag is not always possible, even if the new value is the same as the old value, which is the case there.

I haven't been able to make a simpler reproducer and I'm not sure that we want to add a test using this complex reproducer, but maybe we don't need a test given that the fix is pretty straightforward.

Note that the lines of code involved cause other issues that can't be fixed as easily, see https://github.com/scikit-learn/scikit-learn/pull/29018#issuecomment-2127171954. For that, there's ongoing work in https://github.com/scikit-learn/scikit-learn/pull/29018, but the changes are bigger and may not fit in a bug-fix release.