### PR TITLE
Avoid incorrect "Unsupported device for NumPy"; fixes #29107

### DIFF
--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -304,6 +304,7 @@ class _ArrayAPIWrapper:
 
 
 def _check_device_cpu(device):  # noqa
+    device = getattr(device, 'type', device)
     if device not in {"cpu", None}:
         raise ValueError(f"Unsupported device for NumPy: {device!r}")
 

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -304,7 +304,7 @@ class _ArrayAPIWrapper:
 
 
 def _check_device_cpu(device):  # noqa
-    device = getattr(device, 'type', device)
+    device = getattr(device, "type", device)
     if device not in {"cpu", None}:
         raise ValueError(f"Unsupported device for NumPy: {device!r}")
 


### PR DESCRIPTION
Avoids incorrect `ValueError: Unsupported device for NumPy: device(type='cpu')` by using `type` attr if available.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #29107


#### What does this implement/fix? Explain your changes.
Avoids incorrect `ValueError: Unsupported device for NumPy: device(type='cpu')`