### PR TITLE
DOC Removing warnings from plot_iris_dtc

### DIFF
--- a/examples/tree/plot_iris_dtc.py
+++ b/examples/tree/plot_iris_dtc.py
@@ -66,7 +66,6 @@ for pairidx, pair in enumerate([[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]])
             X[idx, 1],
             c=color,
             label=iris.target_names[i],
-            cmap=plt.cm.RdYlBu,
             edgecolor="black",
             s=15,
         )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

Addresses #29055 (plot_iris_dtc)
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Remove warnings from example page.


#### Any other comments?

According to [matplotlib docs](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.scatter.html) :

> cmapstr or [Colormap](https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.Colormap.html#matplotlib.colors.Colormap), default: [rcParams["image.cmap"]](https://matplotlib.org/stable/users/explain/customizing.html?highlight=image.cmap#matplotlibrc-sample) (default: 'viridis')
The Colormap instance or registered colormap name used to map scalar data to colors.
**This parameter is ignored if c is RGB(A).**


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
