### PR TITLE
FEA TargetEncoder should respect sample_weights

### DIFF
--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -88,6 +88,12 @@ Changelog
   whether to raise an exception if a subset of the scorers in multimetric scoring fails
   or to return an error code. :pr:`28992` by :user:`Stefanie Senger <StefanieSenger>`.
 
+:mod:`sklearn.preprocessing`
+...........................
+
+- |Feature| :class:`preprocessing.Target_encoder` now supports the `sample_weight`
+  parameter in the `fit` and `fit_transform` methods. :pr:`29110`
+  by :user: `Duarte São José <DuarteSJ>` and `Miguel Parece <MiguelParece>`.
 Thanks to everyone who has contributed to the maintenance and improvement of
 the project since version 1.5, including:
 

--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -89,11 +89,12 @@ Changelog
   or to return an error code. :pr:`28992` by :user:`Stefanie Senger <StefanieSenger>`.
 
 :mod:`sklearn.preprocessing`
-...........................
+............................
 
 - |Feature| :class:`preprocessing.Target_encoder` now supports the `sample_weight`
   parameter in the `fit` and `fit_transform` methods. :pr:`29110`
   by :user: `Duarte São José <DuarteSJ>` and `Miguel Parece <MiguelParece>`.
+
 Thanks to everyone who has contributed to the maintenance and improvement of
 the project since version 1.5, including:
 

--- a/sklearn/preprocessing/_target_encoder.py
+++ b/sklearn/preprocessing/_target_encoder.py
@@ -436,10 +436,7 @@ class TargetEncoder(OneToOneFeatureMixin, _BaseEncoder):
     ):
         """Learn target encodings."""
         if sample_weight is None:
-            sample_weight = np.ones_like(y, dtype=np.float64)
-        # TODO: This shouldnt be necessary,
-        # find where y is being casted to int prior to this
-        y = y.astype(np.float64)
+            sample_weight = np.ones_like(y)
         if self.smooth == "auto":
             if sample_weight is None:
                 y_variance = np.var(y)

--- a/sklearn/preprocessing/_target_encoder.py
+++ b/sklearn/preprocessing/_target_encoder.py
@@ -435,8 +435,6 @@ class TargetEncoder(OneToOneFeatureMixin, _BaseEncoder):
         self, X_ordinal, y, n_categories, target_mean, sample_weight=None
     ):
         """Learn target encodings."""
-        if sample_weight is None:
-            sample_weight = np.ones_like(y)
         if self.smooth == "auto":
             if sample_weight is None:
                 y_variance = np.var(y)
@@ -444,6 +442,11 @@ class TargetEncoder(OneToOneFeatureMixin, _BaseEncoder):
                 y_variance = np.sum(sample_weight * (y - target_mean) ** 2) / (
                     np.sum(sample_weight)
                 )
+
+            # Maybe leave `sample_weight` as None so as to make
+            # _target_encoder_fast.pyx more efficient
+            if sample_weight is None:
+                sample_weight = np.ones_like(y)
 
             encodings = _fit_encoding_fast_auto_smooth(
                 X_ordinal,
@@ -454,6 +457,11 @@ class TargetEncoder(OneToOneFeatureMixin, _BaseEncoder):
                 y_variance,
             )
         else:
+            # Maybe leave `sample_weight` as None so as to make
+            # _target_encoder_fast.pyx more efficient
+            if sample_weight is None:
+                sample_weight = np.ones_like(y)
+
             encodings = _fit_encoding_fast(
                 X_ordinal,
                 y,

--- a/sklearn/preprocessing/_target_encoder.py
+++ b/sklearn/preprocessing/_target_encoder.py
@@ -248,7 +248,7 @@ class TargetEncoder(OneToOneFeatureMixin, _BaseEncoder):
 
         y : array-like of shape (n_samples,)
             The target data used to encode the categories.
-        
+
         sample_weight : ndarray of shape (n_samples,)
             Contains weight values to be associated with each sample.
 
@@ -437,11 +437,9 @@ class TargetEncoder(OneToOneFeatureMixin, _BaseEncoder):
         """Learn target encodings."""
         if sample_weight is None:
             sample_weight = np.ones_like(y, dtype=np.float64)
-            # TODO: This isn't very efficient, maybe we should be able to pass None to _fit_encoding_fast
-
-        y = y.astype(
-            np.float64
-        )  # TODO: This shouldnt be necessary, find where y is being casted to int prior to this
+        # TODO: This shouldnt be necessary,
+        # find where y is being casted to int prior to this
+        y = y.astype(np.float64)
         if self.smooth == "auto":
             if sample_weight is None:
                 y_variance = np.var(y)

--- a/sklearn/preprocessing/_target_encoder_fast.pyx
+++ b/sklearn/preprocessing/_target_encoder_fast.pyx
@@ -17,7 +17,6 @@ ctypedef fused Y_DTYPE:
     float32_t
 
 
-
 def _fit_encoding_fast(
     INT_DTYPE[:, ::1] X_int,
     const Y_DTYPE[:] y,

--- a/sklearn/preprocessing/_target_encoder_fast.pyx
+++ b/sklearn/preprocessing/_target_encoder_fast.pyx
@@ -17,9 +17,11 @@ ctypedef fused Y_DTYPE:
     float32_t
 
 
+
 def _fit_encoding_fast(
     INT_DTYPE[:, ::1] X_int,
     const Y_DTYPE[:] y,
+    const Y_DTYPE[:] sample_weight,
     int64_t[::1] n_categories,
     double smooth,
     double y_mean,
@@ -65,8 +67,8 @@ def _fit_encoding_fast(
                 # -1 are unknown categories, which are not counted
                 if X_int_tmp == -1:
                     continue
-                sums[X_int_tmp] += y[sample_idx]
-                counts[X_int_tmp] += 1.0
+                sums[X_int_tmp] += y[sample_idx] * sample_weight[sample_idx]
+                counts[X_int_tmp] += sample_weight[sample_idx]
 
             for cat_idx in range(n_cats):
                 if counts[cat_idx] == 0:
@@ -80,6 +82,7 @@ def _fit_encoding_fast(
 def _fit_encoding_fast_auto_smooth(
     INT_DTYPE[:, ::1] X_int,
     const Y_DTYPE[:] y,
+    const Y_DTYPE[:] sample_weight,
     int64_t[::1] n_categories,
     double y_mean,
     double y_variance,
@@ -99,7 +102,7 @@ def _fit_encoding_fast_auto_smooth(
         int n_features = X_int.shape[1]
         int64_t max_n_cats = np.max(n_categories)
         double[::1] means = np.empty(max_n_cats, dtype=np.float64)
-        int64_t[::1] counts = np.empty(max_n_cats, dtype=np.int64)
+        double[::1] weighted_counts = np.empty(max_n_cats, dtype=np.float64)
         double[::1] sum_of_squared_diffs = np.empty(max_n_cats, dtype=np.float64)
         double lambda_
         list encodings = []
@@ -124,21 +127,21 @@ def _fit_encoding_fast_auto_smooth(
 
             for cat_idx in range(n_cats):
                 means[cat_idx] = 0.0
-                counts[cat_idx] = 0
+                weighted_counts[cat_idx] = 0.0
                 sum_of_squared_diffs[cat_idx] = 0.0
 
-            # first pass to compute the mean
+            # first pass to compute the weighted mean
             for sample_idx in range(n_samples):
                 X_int_tmp = X_int[sample_idx, feat_idx]
 
                 # -1 are unknown categories, which are not counted
                 if X_int_tmp == -1:
                     continue
-                counts[X_int_tmp] += 1
-                means[X_int_tmp] += y[sample_idx]
+                weighted_counts[X_int_tmp] += sample_weight[sample_idx]
+                means[X_int_tmp] += y[sample_idx] * sample_weight[sample_idx]
 
             for cat_idx in range(n_cats):
-                means[cat_idx] /= counts[cat_idx]
+                means[cat_idx] /= weighted_counts[cat_idx]
 
             # second pass to compute the sum of squared differences
             for sample_idx in range(n_samples):
@@ -146,13 +149,13 @@ def _fit_encoding_fast_auto_smooth(
                 if X_int_tmp == -1:
                     continue
                 diff = y[sample_idx] - means[X_int_tmp]
-                sum_of_squared_diffs[X_int_tmp] += diff * diff
+                sum_of_squared_diffs[X_int_tmp] += diff * diff * sample_weight[sample_idx]
 
             for cat_idx in range(n_cats):
                 lambda_ = (
-                    y_variance * counts[cat_idx] /
-                    (y_variance * counts[cat_idx] + sum_of_squared_diffs[cat_idx] /
-                     counts[cat_idx])
+                    y_variance * weighted_counts[cat_idx] /
+                    (y_variance * weighted_counts[cat_idx] + sum_of_squared_diffs[cat_idx] /
+                     weighted_counts[cat_idx])
                 )
                 if isnan(lambda_):
                     # A nan can happen when:

--- a/sklearn/preprocessing/_target_encoder_fast.pyx
+++ b/sklearn/preprocessing/_target_encoder_fast.pyx
@@ -15,12 +15,17 @@ ctypedef fused Y_DTYPE:
     int32_t
     float64_t
     float32_t
+ctypedef fused W_DTYPE:
+    int64_t
+    int32_t
+    float64_t
+    float32_t
 
 
 def _fit_encoding_fast(
     INT_DTYPE[:, ::1] X_int,
     const Y_DTYPE[:] y,
-    const Y_DTYPE[:] sample_weight,
+    const W_DTYPE[:] sample_weight,
     int64_t[::1] n_categories,
     double smooth,
     double y_mean,
@@ -81,7 +86,7 @@ def _fit_encoding_fast(
 def _fit_encoding_fast_auto_smooth(
     INT_DTYPE[:, ::1] X_int,
     const Y_DTYPE[:] y,
-    const Y_DTYPE[:] sample_weight,
+    const W_DTYPE[:] sample_weight,
     int64_t[::1] n_categories,
     double y_mean,
     double y_variance,

--- a/sklearn/preprocessing/tests/test_target_encoder.py
+++ b/sklearn/preprocessing/tests/test_target_encoder.py
@@ -22,32 +22,72 @@ from sklearn.preprocessing import (
 )
 
 
-def _encode_target(X_ordinal, y_numeric, n_categories, smooth):
+def _encode_target(X_ordinal, y_numeric, n_categories, smooth, sample_weight=None):
     """Simple Python implementation of target encoding."""
     cur_encodings = np.zeros(n_categories, dtype=np.float64)
-    y_mean = np.mean(y_numeric)
+    if sample_weight is not None:
+        y_mean = np.average(y_numeric, weights=sample_weight)
+    else:
+        y_mean = np.mean(y_numeric)
 
     if smooth == "auto":
-        y_variance = np.var(y_numeric)
+        if sample_weight is not None:
+            y_variance = np.sum(sample_weight * (y_numeric - y_mean) ** 2) / np.sum(
+                sample_weight
+            )
+        else:
+            y_variance = np.var(y_numeric)
+
         for c in range(n_categories):
-            y_subset = y_numeric[X_ordinal == c]
-            n_i = y_subset.shape[0]
+            mask = X_ordinal == c
+            y_subset = y_numeric[mask]
 
-            if n_i == 0:
-                cur_encodings[c] = y_mean
-                continue
+            if sample_weight is not None:
+                weights_subset = sample_weight[mask]
 
-            y_subset_variance = np.var(y_subset)
+                n_i = np.sum(weights_subset)
+
+                if n_i == 0:
+                    cur_encodings[c] = y_mean
+                    continue
+
+                y_subset_mean = np.average(y_subset, weights=weights_subset, axis=0)
+
+                y_subset_variance = np.sum(
+                    weights_subset * (y_subset - y_subset_mean) ** 2
+                ) / (np.sum(weights_subset))
+
+            else:
+                n_i = y_subset.shape[0]
+
+                if n_i == 0:
+                    cur_encodings[c] = y_mean
+                    continue
+
+                y_subset_mean = np.mean(y_subset)
+                y_subset_variance = np.var(y_subset)
+
             m = y_subset_variance / y_variance
             lambda_ = n_i / (n_i + m)
 
-            cur_encodings[c] = lambda_ * np.mean(y_subset) + (1 - lambda_) * y_mean
+            # ni = y_variance * counts[cat_idx]
+            #  m = sum_of_squared_diffs[cat_idx] /
+            #           counts[cat_idx])
+
+            cur_encodings[c] = lambda_ * y_subset_mean + (1 - lambda_) * y_mean
         return cur_encodings
+
     else:  # float
         for c in range(n_categories):
-            y_subset = y_numeric[X_ordinal == c]
-            current_sum = np.sum(y_subset) + y_mean * smooth
-            current_cnt = y_subset.shape[0] + smooth
+            mask = X_ordinal == c
+            y_subset = y_numeric[mask]
+            if sample_weight is not None:
+                weights_subset = sample_weight[mask]
+                current_sum = np.sum(y_subset * weights_subset) + y_mean * smooth
+                current_cnt = np.sum(weights_subset) + smooth
+            else:
+                current_sum = np.sum(y_subset) + y_mean * smooth
+                current_cnt = y_subset.shape[0] + smooth
             cur_encodings[c] = current_sum / current_cnt
         return cur_encodings
 
@@ -61,9 +101,12 @@ def _encode_target(X_ordinal, y_numeric, n_categories, smooth):
         ("auto", 3),
     ],
 )
+@pytest.mark.parametrize("sample_weight", [None, np.random.RandomState(42).rand(90)])
 @pytest.mark.parametrize("smooth", [5.0, "auto"])
 @pytest.mark.parametrize("target_type", ["binary", "continuous"])
-def test_encoding(categories, unknown_value, global_random_seed, smooth, target_type):
+def test_encoding(
+    categories, unknown_value, global_random_seed, smooth, target_type, sample_weight
+):
     """Check encoding for binary and continuous targets.
 
     Compare the values returned by `TargetEncoder.fit_transform` against the
@@ -117,7 +160,14 @@ def test_encoding(categories, unknown_value, global_random_seed, smooth, target_
 
     for train_idx, test_idx in cv.split(X_train_int_array, y_train):
         X_, y_ = X_train_int_array[train_idx, 0], y_numeric[train_idx]
-        cur_encodings = _encode_target(X_, y_, n_categories, smooth)
+        if sample_weight is not None:
+            sample_weight_ = sample_weight[train_idx]
+            cur_encodings = _encode_target(
+                X_, y_, n_categories, smooth, sample_weight=sample_weight_
+            )
+        else:
+            cur_encodings = _encode_target(X_, y_, n_categories, smooth)
+
         expected_X_fit_transform[test_idx, 0] = cur_encodings[
             X_train_int_array[test_idx, 0]
         ]
@@ -131,10 +181,12 @@ def test_encoding(categories, unknown_value, global_random_seed, smooth, target_
         random_state=global_random_seed,
     )
 
-    X_fit_transform = target_encoder.fit_transform(X_train, y_train)
+    X_fit_transform = target_encoder.fit_transform(X_train, y_train, sample_weight)
 
     assert target_encoder.target_type_ == target_type
+
     assert_allclose(X_fit_transform, expected_X_fit_transform)
+
     assert len(target_encoder.encodings_) == 1
     if target_type == "binary":
         assert_array_equal(target_encoder.classes_, target_names)
@@ -142,10 +194,19 @@ def test_encoding(categories, unknown_value, global_random_seed, smooth, target_
         assert target_encoder.classes_ is None
 
     # compute encodings for all data to validate `transform`
-    y_mean = np.mean(y_numeric)
-    expected_encodings = _encode_target(
-        X_train_int_array[:, 0], y_numeric, n_categories, smooth
+    y_mean = (
+        np.average(y_numeric, weights=sample_weight)
+        if sample_weight is not None
+        else np.mean(y_numeric)
     )
+    expected_encodings = _encode_target(
+        X_train_int_array[:, 0],
+        y_numeric,
+        n_categories,
+        smooth,
+        sample_weight=sample_weight,
+    )
+
     assert_allclose(target_encoder.encodings_[0], expected_encodings)
     assert target_encoder.target_mean_ == pytest.approx(y_mean)
 

--- a/sklearn/preprocessing/tests/test_target_encoder.py
+++ b/sklearn/preprocessing/tests/test_target_encoder.py
@@ -47,10 +47,6 @@ def _encode_target(X_ordinal, y_numeric, n_categories, smooth, sample_weight=Non
 
                 n_i = np.sum(weights_subset)
 
-                if n_i == 0:
-                    cur_encodings[c] = y_mean
-                    continue
-
                 y_subset_mean = np.average(y_subset, weights=weights_subset, axis=0)
 
                 y_subset_variance = np.sum(
@@ -69,10 +65,6 @@ def _encode_target(X_ordinal, y_numeric, n_categories, smooth, sample_weight=Non
 
             m = y_subset_variance / y_variance
             lambda_ = n_i / (n_i + m)
-
-            # ni = y_variance * counts[cat_idx]
-            #  m = sum_of_squared_diffs[cat_idx] /
-            #           counts[cat_idx])
 
             cur_encodings[c] = lambda_ * y_subset_mean + (1 - lambda_) * y_mean
         return cur_encodings


### PR DESCRIPTION
This commit updates the TargetEncoder to respect sample_weights. This Fixes #28881 and modifies the files: _target_encoder.py, _target_encoder_fast.pyx, and test_target_encoder.py.