### PR TITLE
FIX always return None as device when array API dispatch is disabled

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -23,12 +23,20 @@ Version 1.5.1
 Changelog
 ---------
 
+:mod:`sklearn.metrics`
+......................
+
+- |Fix| Fix a regression in :func:`metrics.r2_score`. Passing torch CPU tensors
+  with array API dispatched disabled would complain about non-CPU devices
+  instead of implicitly converting those inputs as regular NumPy arrays.
+  :pr:`29119` by :user:`Olivier Grisel`.
+
 :mod:`sklearn.model_selection`
 ..............................
 
 - |Fix| Fix a regression in :class:`model_selection.GridSearchCV` for parameter
   grids that have heterogeneous parameter values.
-  :pr:`29078` by :user:`Loïc Estève <lesteve>`
+  :pr:`29078` by :user:`Loïc Estève <lesteve>`.
 
 
 .. _changes_1_5:

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -568,10 +568,15 @@ def get_namespace_and_device(*array_list, remove_none=True, remove_types=(str,))
 
     skip_remove_kwargs = dict(remove_none=False, remove_types=[])
 
-    return (
-        *get_namespace(*array_list, **skip_remove_kwargs),
-        device(*array_list, **skip_remove_kwargs),
-    )
+    xp, is_array_api = get_namespace(*array_list, **skip_remove_kwargs)
+    if is_array_api:
+        return (
+            xp,
+            is_array_api,
+            device(*array_list, **skip_remove_kwargs),
+        )
+    else:
+        return xp, False, None
 
 
 def _expit(X, xp=None):

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -22,6 +22,7 @@ from sklearn.utils._array_api import (
     _ravel,
     device,
     get_namespace,
+    get_namespace_and_device,
     indexing_dtype,
     supported_float_dtypes,
     yield_namespace_device_dtype_combinations,
@@ -540,3 +541,28 @@ def test_isin(
         )
 
     assert_array_equal(_convert_to_numpy(result, xp=xp), expected)
+
+
+def test_get_namespace_and_device():
+    # a library with custom Device objects
+    torch = pytest.importorskip("torch")
+    xp_torch = pytest.importorskip("array_api_compat.torch")
+    some_torch_tensor = torch.arange(3, device="cpu")
+    some_numpy_array = numpy.arange(3)
+
+    # When dispatch is disabled, get_namespace_and_device should return the
+    # default NumPy wrapper namespace and no device. Our code will handle such
+    # inputs via the usual __array__ interface without attempting to dispatch
+    # via the array API.
+    namespace, is_array_api, device = get_namespace_and_device(some_torch_tensor)
+    assert namespace is get_namespace(some_numpy_array)[0]
+    assert not is_array_api
+    assert device is None
+
+    # Otherwise, expose the torch namespace and device via array API compat
+    # wrapper.
+    with config_context(array_api_dispatch=True):
+        namespace, is_array_api, device = get_namespace_and_device(some_torch_tensor)
+        assert namespace is xp_torch
+        assert is_array_api
+        assert device == some_torch_tensor.device

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -544,7 +544,7 @@ def test_isin(
 
 
 def test_get_namespace_and_device():
-    # a library with custom Device objects
+    # Use torch as a library with custom Device objects:
     torch = pytest.importorskip("torch")
     xp_torch = pytest.importorskip("array_api_compat.torch")
     some_torch_tensor = torch.arange(3, device="cpu")


### PR DESCRIPTION
Fixes #29107.

I manually checked that it fixes the problem described in the original report. I think the new unit test is good enough as non-regression test.

