### PR TITLE
DOC Removing warnings from plot_logistic_multinomial examples

### DIFF
--- a/examples/linear_model/plot_logistic_multinomial.py
+++ b/examples/linear_model/plot_logistic_multinomial.py
@@ -46,9 +46,7 @@ for multi_class in ("multinomial", "ovr"):
     colors = "bry"
     for i, color in zip(clf.classes_, colors):
         idx = np.where(y == i)
-        plt.scatter(
-            X[idx, 0], X[idx, 1], c=color, cmap=plt.cm.Paired, edgecolor="black", s=20
-        )
+        plt.scatter(X[idx, 0], X[idx, 1], c=color, edgecolor="black", s=20)
 
     # Plot the three one-against-all classifiers
     xmin, xmax = plt.xlim()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

 Logistic Multinomial Examples (#29055)


#### What does this implement/fix? Explain your changes.

Removing warnings from Logistic Multinomial Examples (#29055)

#### Any other comments?

According to [matplotlib docs](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.scatter.html) :

> cmapstr or [Colormap](https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.Colormap.html#matplotlib.colors.Colormap), default:[rcParams["image.cmap"]](https://matplotlib.org/stable/users/explain/customizing.html?>highlight=image.cmap#matplotlibrc-sample) (default: 'viridis')
>The Colormap instance or registered colormap name used to map scalar data to colors.
>This parameter is ignored if c is RGB(A).

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
