### PR TITLE
DOC reflect deprecations in 1.5 on API page

### DIFF
--- a/doc/api_reference.py
+++ b/doc/api_reference.py
@@ -1285,8 +1285,6 @@ API_REFERENCE = {
                 "autosummary": [
                     "parallel.Parallel",
                     "parallel.delayed",
-                    "parallel_backend",
-                    "register_parallel_backend",
                 ],
             },
         ],
@@ -1329,4 +1327,9 @@ DEPRECATED_API_REFERENCE = {
 }
 """
 
-DEPRECATED_API_REFERENCE = {}  # type: ignore
+DEPRECATED_API_REFERENCE = {
+    "1.7": [
+        "utils.parallel_backend",
+        "utils.register_parallel_backend",
+    ]
+}  # type: ignore


### PR DESCRIPTION
According to the [v1.5 changelog](https://scikit-learn.org/dev/whats_new/v1.5.html#sklearn-utils), `utils.parallel_backend` and `utils.register_parallel_backend` will be removed in v1.7. In case people are not familiar with the new web theme yet, the deprecated items will be moved to the bottom of the table on the [API index](https://output.circle-artifacts.com/output/job/9aa882bb-3166-4b30-b2d8-a5bf744ec82e/artifacts/0/doc/api/index.html) page and marked with a deprecation badge:

![image](https://github.com/scikit-learn/scikit-learn/assets/108576690/3de860d1-f1f0-47ce-ad9a-9e22db17b3a0)

and they will also be moved to the [recently deprecated](https://output.circle-artifacts.com/output/job/9aa882bb-3166-4b30-b2d8-a5bf744ec82e/artifacts/0/doc/api/deprecated.html) page:

![image](https://github.com/scikit-learn/scikit-learn/assets/108576690/e2aecad8-321b-4f47-81f4-24e190330b65)


Note that this PR also needs to be backported to the v1.5 branch.