### PR TITLE
MAINT Add user-friendly error when build dependencies are not satifisfied

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ inplace:
 	$(PYTHON) setup.py build_ext -i
 
 dev-meson:
-	pip install --verbose --no-build-isolation --editable . --config-settings editable-verbose=true
+	pip install --verbose --no-build-isolation --editable . --check-build-dependencies --config-settings editable-verbose=true
 
 clean-meson:
 	pip uninstall -y scikit-learn

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -140,11 +140,15 @@ scikit_learn_install() {
            # toolchain
            ADDITIONAL_PIP_OPTIONS='-Csetup-args=--vsenv'
         fi
+        # TODO Always add --check-build-dependencies when all CI builds have
+        # pip >= 22.1.1. At the time of writing, two CI builds (debian32_atlas and
+        # ubuntu_atlas) have an older pip
+        if pip install --help | grep check-build-dependencies; then
+            ADDITIONAL_PIP_OPTIONS="$ADDITIONAL_PIP_OPTIONS --check-build-dependencies"
+        fi
         # Use the pre-installed build dependencies and build directly in the
         # current environment.
-        pip install --verbose --no-build-isolation --editable . \
-            --check-build-dependencies \
-            $ADDITIONAL_PIP_OPTIONS
+        pip install --verbose --no-build-isolation --editable . $ADDITIONAL_PIP_OPTIONS
     fi
 
     ccache -s || echo "ccache not installed, skipping ccache statistics"

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -142,7 +142,9 @@ scikit_learn_install() {
         fi
         # Use the pre-installed build dependencies and build directly in the
         # current environment.
-        pip install --verbose --no-build-isolation --editable . $ADDITIONAL_PIP_OPTIONS
+        pip install --verbose --no-build-isolation --editable . \
+            --check-build-dependencies \
+            $ADDITIONAL_PIP_OPTIONS
     fi
 
     ccache -s || echo "ccache not installed, skipping ccache statistics"

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -99,6 +99,7 @@ feature, code or documentation improvement).
 
      pip install --editable . \
         --verbose --no-build-isolation \
+        --check-build-dependencies \
         --config-settings editable-verbose=true
 
 #. Check that the installed scikit-learn has a version number ending with


### PR DESCRIPTION
This is an arguably simpler alternative to https://github.com/scikit-learn/scikit-learn/pull/28721 which is adding checks inside `meson.build` which is a bit cumbersome.

The downside of this PR is that checks are only done when using `--check-build-dependencies` in the `pip` command, which is easy to forget and makes the `pip` command even longer and harder to remember. If you forget to pass `--check-build-dependencies`, you may have hard to diagnose compilation errors for example because cython is slightly too old (we want the latest release 3.0.10 at the time of writing).

Personally I would slightly lean towards #28721 since you can build scikit-learn via `meson` without going throug `pip` (`meson setup build` + `ninja -C build` + add `build` folder to `PYTHONPATH`). At the same time I would agree that 99% of the usage go through `pip` right now, so this is probably good enough.

cc @jeremiedbb who was not a fan of #28721 approach.

