### PR TITLE
DOC Remove unneeded html_show_search_summary since True is the default

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -456,9 +456,6 @@ for old_link in redirects:
 # See https://github.com/scikit-learn/scikit-learn/pull/22550
 html_context["is_devrelease"] = parsed_version.is_devrelease
 
-# Not showing the search summary makes the search page load faster.
-html_show_search_summary = True
-
 
 # -- Options for LaTeX output ------------------------------------------------
 latex_elements = {


### PR DESCRIPTION
`html_show_search_summary` is True by default ([source](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_show_search_summary)).

Also this removes the confusing comment above that does not match the code ...