### PR TITLE
BLD Use work-around for partial recompilation when building with Meson

### DIFF
--- a/sklearn/_loss/meson.build
+++ b/sklearn/_loss/meson.build
@@ -8,7 +8,9 @@ _loss_pyx = custom_target(
   output: '_loss.pyx',
   input: '_loss.pyx.tp',
   command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
-  # TODO comment work-around
+  # TODO in principle this should go in py.exension_module below. This is
+  # temporary work-around for dependency issue with .pyx.tp files. For more
+  # details, see https://github.com/mesonbuild/meson/issues/13212
   depends: _loss_cython_tree,
 )
 

--- a/sklearn/_loss/meson.build
+++ b/sklearn/_loss/meson.build
@@ -8,11 +8,13 @@ _loss_pyx = custom_target(
   output: '_loss.pyx',
   input: '_loss.pyx.tp',
   command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+  # TODO comment work-around
+  depends: _loss_cython_tree,
 )
 
 py.extension_module(
   '_loss',
-  [_loss_pyx, _loss_cython_tree],
+  _loss_pyx,
   cython_args: cython_args,
   install: true,
   subdir: 'sklearn/_loss',

--- a/sklearn/linear_model/meson.build
+++ b/sklearn/linear_model/meson.build
@@ -20,7 +20,9 @@ foreach name: name_list
     output: name + '.pyx',
     input: name + '.pyx.tp',
     command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
-    # TODO comment work-around
+    # TODO in principle this should go in py.exension_module below. This is
+    # temporary work-around for dependency issue with .pyx.tp files. For more
+    # details, see https://github.com/mesonbuild/meson/issues/13212
     depends: [linear_model_cython_tree, utils_cython_tree],
   )
   py.extension_module(

--- a/sklearn/linear_model/meson.build
+++ b/sklearn/linear_model/meson.build
@@ -19,11 +19,13 @@ foreach name: name_list
     name + '_pyx',
     output: name + '.pyx',
     input: name + '.pyx.tp',
-    command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@']
+    command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+    # TODO comment work-around
+    depends: [linear_model_cython_tree, utils_cython_tree],
   )
   py.extension_module(
     name,
-    [pyx, linear_model_cython_tree, utils_cython_tree],
+    pyx,
     cython_args: cython_args,
     subdir: 'sklearn/linear_model',
     install: true

--- a/sklearn/metrics/_pairwise_distances_reduction/meson.build
+++ b/sklearn/metrics/_pairwise_distances_reduction/meson.build
@@ -34,7 +34,7 @@ _datasets_pair_pyx = custom_target(
   # TODO in principle this should go in py.exension_module below. This is
   # temporary work-around for dependency issue with .pyx.tp files. For more
   # details, see https://github.com/mesonbuild/meson/issues/13212
-  depends: [_pairwise_distances_reduction_cython_tree, utils_cython_tree],
+  depends: [_datasets_pair_pxd, _pairwise_distances_reduction_cython_tree, utils_cython_tree],
 )
 _datasets_pair = py.extension_module(
   '_datasets_pair',

--- a/sklearn/metrics/_pairwise_distances_reduction/meson.build
+++ b/sklearn/metrics/_pairwise_distances_reduction/meson.build
@@ -31,11 +31,12 @@ _datasets_pair_pyx = custom_target(
   output: '_datasets_pair.pyx',
   input: '_datasets_pair.pyx.tp',
   command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+  # TODO comment work-around
+  depends: [_pairwise_distances_reduction_cython_tree, utils_cython_tree],
 )
 _datasets_pair = py.extension_module(
   '_datasets_pair',
-  [_datasets_pair_pxd, _datasets_pair_pyx,
-   _pairwise_distances_reduction_cython_tree, utils_cython_tree],
+  _datasets_pair_pyx,
   dependencies: [np_dep, openmp_dep],
   override_options: ['cython_language=cpp'],
   cython_args: cython_args,
@@ -54,12 +55,13 @@ _base_pyx = custom_target(
   output: '_base.pyx',
   input: '_base.pyx.tp',
   command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+  # TODO comment work-around
+  depends: [_base_pxd, _pairwise_distances_reduction_cython_tree,
+            _datasets_pair_pxd, utils_cython_tree],
 )
 _base = py.extension_module(
   '_base',
-  [_base_pxd, _base_pyx,
-   _pairwise_distances_reduction_cython_tree,
-   _datasets_pair_pxd, utils_cython_tree],
+  _base_pyx,
   dependencies: [np_dep, openmp_dep],
   override_options: ['cython_language=cpp'],
   cython_args: cython_args,
@@ -78,11 +80,14 @@ _middle_term_computer_pyx = custom_target(
   output: '_middle_term_computer.pyx',
   input: '_middle_term_computer.pyx.tp',
   command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+  # TODO comment work-around
+  depends: [_middle_term_computer_pxd,
+            _pairwise_distances_reduction_cython_tree,
+            utils_cython_tree],
 )
 _middle_term_computer = py.extension_module(
   '_middle_term_computer',
-  [_middle_term_computer_pxd, _middle_term_computer_pyx,
-   _pairwise_distances_reduction_cython_tree, utils_cython_tree],
+  _middle_term_computer_pyx,
   dependencies: [np_dep, openmp_dep],
   override_options: ['cython_language=cpp'],
   cython_args: cython_args,
@@ -101,13 +106,14 @@ _argkmin_pyx = custom_target(
     output: '_argkmin.pyx',
     input: '_argkmin.pyx.tp',
     command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
-  )
+    # TODO comment work-around
+    depends: [_argkmin_pxd,
+              _pairwise_distances_reduction_cython_tree,
+              _datasets_pair_pxd, _base_pxd, _middle_term_computer_pxd],
+      )
 _argkmin = py.extension_module(
     '_argkmin',
-    [_argkmin_pxd, _argkmin_pyx,
-     _pairwise_distances_reduction_cython_tree,
-     _datasets_pair_pxd, _base_pxd, _middle_term_computer_pxd,
-     utils_cython_tree],
+    _argkmin_pyx,
     dependencies: [np_dep, openmp_dep],
     override_options: ['cython_language=cpp'],
     cython_args: cython_args,
@@ -126,12 +132,14 @@ _radius_neighbors_pyx = custom_target(
     output: '_radius_neighbors.pyx',
     input: '_radius_neighbors.pyx.tp',
     command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
-  )
+    # TODO comment work-around
+    depends: [_radius_neighbors_pxd,
+              _datasets_pair_pxd, _base_pxd, _middle_term_computer_pxd,
+              _pairwise_distances_reduction_cython_tree, utils_cython_tree],
+)
 _radius_neighbors = py.extension_module(
     '_radius_neighbors',
-    [_radius_neighbors_pxd, _radius_neighbors_pyx,
-     _datasets_pair_pxd, _base_pxd, _middle_term_computer_pxd,
-     _pairwise_distances_reduction_cython_tree, utils_cython_tree],
+    _radius_neighbors_pyx,
     dependencies: [np_dep, openmp_dep],
     override_options: ['cython_language=cpp'],
     cython_args: cython_args,
@@ -144,12 +152,14 @@ _argkmin_classmode_pyx = custom_target(
   output: '_argkmin_classmode.pyx',
   input: '_argkmin_classmode.pyx.tp',
   command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+  # TODO comment work-around
+  depends: [_classmode_pxd,
+            _argkmin_pxd, _pairwise_distances_reduction_cython_tree,
+            _datasets_pair_pxd, _base_pxd, _middle_term_computer_pxd, utils_cython_tree],
 )
 _argkmin_classmode = py.extension_module(
   '_argkmin_classmode',
-  [_argkmin_classmode_pyx, _classmode_pxd,
-   _argkmin_pxd, _pairwise_distances_reduction_cython_tree,
-   _datasets_pair_pxd, _base_pxd, _middle_term_computer_pxd, utils_cython_tree],
+  _argkmin_classmode_pyx,
   dependencies: [np_dep],
   override_options: ['cython_language=cpp'],
   cython_args: cython_args,
@@ -166,13 +176,15 @@ _radius_neighbors_classmode_pyx = custom_target(
   output: '_radius_neighbors_classmode.pyx',
   input: '_radius_neighbors_classmode.pyx.tp',
   command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+  # TODO comment work-around
+  depends: [_classmode_pxd,
+            _middle_term_computer_pxd, _radius_neighbors_pxd,
+            _pairwise_distances_reduction_cython_tree,
+            _datasets_pair_pxd, _base_pxd, utils_cython_tree],
 )
 _radius_neighbors_classmode = py.extension_module(
   '_radius_neighbors_classmode',
-  [_radius_neighbors_classmode_pyx, _classmode_pxd,
-  _middle_term_computer_pxd, _radius_neighbors_pxd,
-  _pairwise_distances_reduction_cython_tree,
-  _datasets_pair_pxd, _base_pxd, utils_cython_tree],
+  _radius_neighbors_classmode_pyx,
   dependencies: [np_dep],
   override_options: ['cython_language=cpp'],
   cython_args: cython_args,

--- a/sklearn/metrics/_pairwise_distances_reduction/meson.build
+++ b/sklearn/metrics/_pairwise_distances_reduction/meson.build
@@ -31,7 +31,9 @@ _datasets_pair_pyx = custom_target(
   output: '_datasets_pair.pyx',
   input: '_datasets_pair.pyx.tp',
   command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
-  # TODO comment work-around
+  # TODO in principle this should go in py.exension_module below. This is
+  # temporary work-around for dependency issue with .pyx.tp files. For more
+  # details, see https://github.com/mesonbuild/meson/issues/13212
   depends: [_pairwise_distances_reduction_cython_tree, utils_cython_tree],
 )
 _datasets_pair = py.extension_module(
@@ -55,7 +57,9 @@ _base_pyx = custom_target(
   output: '_base.pyx',
   input: '_base.pyx.tp',
   command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
-  # TODO comment work-around
+  # TODO in principle this should go in py.exension_module below. This is
+  # temporary work-around for dependency issue with .pyx.tp files. For more
+  # details, see https://github.com/mesonbuild/meson/issues/13212
   depends: [_base_pxd, _pairwise_distances_reduction_cython_tree,
             _datasets_pair_pxd, utils_cython_tree],
 )
@@ -80,7 +84,9 @@ _middle_term_computer_pyx = custom_target(
   output: '_middle_term_computer.pyx',
   input: '_middle_term_computer.pyx.tp',
   command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
-  # TODO comment work-around
+  # TODO in principle this should go in py.exension_module below. This is
+  # temporary work-around for dependency issue with .pyx.tp files. For more
+  # details, see https://github.com/mesonbuild/meson/issues/13212
   depends: [_middle_term_computer_pxd,
             _pairwise_distances_reduction_cython_tree,
             utils_cython_tree],
@@ -106,7 +112,9 @@ _argkmin_pyx = custom_target(
     output: '_argkmin.pyx',
     input: '_argkmin.pyx.tp',
     command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
-    # TODO comment work-around
+    # TODO in principle this should go in py.exension_module below. This is
+    # temporary work-around for dependency issue with .pyx.tp files. For more
+    # details, see https://github.com/mesonbuild/meson/issues/13212
     depends: [_argkmin_pxd,
               _pairwise_distances_reduction_cython_tree,
               _datasets_pair_pxd, _base_pxd, _middle_term_computer_pxd],
@@ -132,7 +140,9 @@ _radius_neighbors_pyx = custom_target(
     output: '_radius_neighbors.pyx',
     input: '_radius_neighbors.pyx.tp',
     command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
-    # TODO comment work-around
+    # TODO in principle this should go in py.exension_module below. This is
+    # temporary work-around for dependency issue with .pyx.tp files. For more
+    # details, see https://github.com/mesonbuild/meson/issues/13212
     depends: [_radius_neighbors_pxd,
               _datasets_pair_pxd, _base_pxd, _middle_term_computer_pxd,
               _pairwise_distances_reduction_cython_tree, utils_cython_tree],
@@ -152,7 +162,9 @@ _argkmin_classmode_pyx = custom_target(
   output: '_argkmin_classmode.pyx',
   input: '_argkmin_classmode.pyx.tp',
   command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
-  # TODO comment work-around
+  # TODO in principle this should go in py.exension_module below. This is
+  # temporary work-around for dependency issue with .pyx.tp files. For more
+  # details, see https://github.com/mesonbuild/meson/issues/13212
   depends: [_classmode_pxd,
             _argkmin_pxd, _pairwise_distances_reduction_cython_tree,
             _datasets_pair_pxd, _base_pxd, _middle_term_computer_pxd, utils_cython_tree],
@@ -176,7 +188,9 @@ _radius_neighbors_classmode_pyx = custom_target(
   output: '_radius_neighbors_classmode.pyx',
   input: '_radius_neighbors_classmode.pyx.tp',
   command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
-  # TODO comment work-around
+  # TODO in principle this should go in py.exension_module below. This is
+  # temporary work-around for dependency issue with .pyx.tp files. For more
+  # details, see https://github.com/mesonbuild/meson/issues/13212
   depends: [_classmode_pxd,
             _middle_term_computer_pxd, _radius_neighbors_pxd,
             _pairwise_distances_reduction_cython_tree,

--- a/sklearn/metrics/meson.build
+++ b/sklearn/metrics/meson.build
@@ -22,12 +22,14 @@ _dist_metrics_pyx = custom_target(
   '_dist_metrics_pyx',
   output: '_dist_metrics.pyx',
   input: '_dist_metrics.pyx.tp',
-  command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@']
+  command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+  # TODO comment work-around
+  depends: metrics_cython_tree,
 )
 
 _dist_metrics = py.extension_module(
   '_dist_metrics',
-  [_dist_metrics_pyx, metrics_cython_tree],
+  _dist_metrics_pyx,
   dependencies: [np_dep],
   cython_args: cython_args,
   subdir: 'sklearn/metrics',

--- a/sklearn/metrics/meson.build
+++ b/sklearn/metrics/meson.build
@@ -23,7 +23,9 @@ _dist_metrics_pyx = custom_target(
   output: '_dist_metrics.pyx',
   input: '_dist_metrics.pyx.tp',
   command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
-  # TODO comment work-around
+  # TODO in principle this should go in py.exension_module below. This is
+  # temporary work-around for dependency issue with .pyx.tp files. For more
+  # details, see https://github.com/mesonbuild/meson/issues/13212
   depends: metrics_cython_tree,
 )
 

--- a/sklearn/neighbors/meson.build
+++ b/sklearn/neighbors/meson.build
@@ -21,7 +21,9 @@ foreach name: name_list
     output: name + '.pyx',
     input: name + '.pyx.tp',
     command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
-    # TODO comment work-around
+    # TODO in principle this should go in py.exension_module below. This is
+    # temporary work-around for dependency issue with .pyx.tp files. For more
+    # details, see https://github.com/mesonbuild/meson/issues/13212
     depends: [neighbors_cython_tree, utils_cython_tree, metrics_cython_tree],
   )
   py.extension_module(

--- a/sklearn/neighbors/meson.build
+++ b/sklearn/neighbors/meson.build
@@ -20,11 +20,13 @@ foreach name: name_list
     name + '_pyx',
     output: name + '.pyx',
     input: name + '.pyx.tp',
-    command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@']
+    command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+    # TODO comment work-around
+    depends: [neighbors_cython_tree, utils_cython_tree, metrics_cython_tree],
   )
   py.extension_module(
     name,
-    [pyx, neighbors_cython_tree, utils_cython_tree, metrics_cython_tree],
+    pyx,
     dependencies: [np_dep],
     cython_args: cython_args,
     subdir: 'sklearn/neighbors',

--- a/sklearn/utils/meson.build
+++ b/sklearn/utils/meson.build
@@ -62,11 +62,13 @@ foreach name: util_extension_names
     name + '_pyx',
     output: name + '.pyx',
     input: name + '.pyx.tp',
-    command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@']
+    command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+    # TODO comment work-around
+    depends: [pxd, utils_cython_tree],
   )
   py.extension_module(
     name,
-    [pxd, pyx, utils_cython_tree],
+    pyx,
     cython_args: cython_args,
     subdir: 'sklearn/utils',
     install: true

--- a/sklearn/utils/meson.build
+++ b/sklearn/utils/meson.build
@@ -63,7 +63,9 @@ foreach name: util_extension_names
     output: name + '.pyx',
     input: name + '.pyx.tp',
     command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
-    # TODO comment work-around
+    # TODO in principle this should go in py.exension_module below. This is
+    # temporary work-around for dependency issue with .pyx.tp files. For more
+    # details, see https://github.com/mesonbuild/meson/issues/13212
     depends: [pxd, utils_cython_tree],
   )
   py.extension_module(


### PR DESCRIPTION
Fix #28837 

This fixes the reproducer in #28837, the behaviour with this PR is the expected one:
```
meson setup build/test
# Start from a built project
ninja -C build/test

# ninja is timestamp-based to touching this pxd will cause things to rebuild
touch sklearn/utils/_typedefs.pxd
# 177 targets need to be rebuilt, this is expected
ninja -C build/test

# "no work to do" as expected, i.e. no recompilation happens 
ninja -C build/test
```

The work-around was suggested by @rgommers in https://github.com/mesonbuild/meson/issues/13212 :pray:.