### PR TITLE
fix typo in documentation of MLPRegressor score method

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -808,7 +808,7 @@ class RegressorMixin:
         The coefficient of determination :math:`R^2` is defined as
         :math:`(1 - \\frac{u}{v})`, where :math:`u` is the residual
         sum of squares ``((y_true - y_pred)** 2).sum()`` and :math:`v`
-        is the total sum of squares ``((y_true - y_true.mean()) ** 2).sum()``.
+        is the total sum of squares ``((y_true - y_pred.mean()) ** 2).sum()``.
         The best possible score is 1.0 and it can be negative (because the
         model can be arbitrarily worse). A constant model that always predicts
         the expected value of `y`, disregarding the input features, would get


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

The `MLPRegressor` documentation at https://scikit-learn.org/stable/modules/generated/sklearn.neural_network.MLPRegressor.html#sklearn.neural_network.MLPRegressor says:

> v is the total sum of squares ((y_true - y_true.mean()) ** 2).sum()

This is probably supposed to be `y_true - y_pred`.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
