### PR TITLE
MAINT Use Pyodide venv rather than js wrapper script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,11 +124,11 @@ jobs:
     vmImage: ubuntu-22.04
   variables:
     # Need to match Python version and Emscripten version for the correct
-    # Pyodide version. For example, for Pyodide version 0.25.1, see
-    # https://github.com/pyodide/pyodide/blob/0.25.1/Makefile.envs
-    PYODIDE_VERSION: '0.25.1'
-    EMSCRIPTEN_VERSION: '3.1.46'
-    PYTHON_VERSION: '3.11.3'
+    # Pyodide version. For example, for Pyodide version 0.26.0, see
+    # https://github.com/pyodide/pyodide/blob/0.26.0/Makefile.envs
+    PYODIDE_VERSION: '0.26.0'
+    EMSCRIPTEN_VERSION: '3.1.58'
+    PYTHON_VERSION: '3.12.1'
 
   dependsOn: [git_commit, linting]
   condition: |

--- a/build_tools/azure/install_pyodide.sh
+++ b/build_tools/azure/install_pyodide.sh
@@ -17,4 +17,7 @@ ls -ltrh dist
 
 # The Pyodide js library is needed by build_tools/azure/test_script_pyodide.sh
 # to run tests inside Pyodide
-npm install pyodide@$PYODIDE_VERSION
+# npm install pyodide@$PYODIDE_VERSION
+pyodide venv .pyodide-venv
+source .pyodide-venv/bin/activate
+pip install dist/*.whl

--- a/build_tools/azure/test_script_pyodide.sh
+++ b/build_tools/azure/test_script_pyodide.sh
@@ -10,6 +10,7 @@ set -ex
 source .pyodide-venv/bin/activate
 which pip
 pip install pytest
+df -h
 cd /tmp
 which pytest
 python -c 'import sklearn; print(sklearn.__file__)'

--- a/build_tools/azure/test_script_pyodide.sh
+++ b/build_tools/azure/test_script_pyodide.sh
@@ -7,5 +7,6 @@ set -e
 # (2023-09-27) there is an issue with scipy.linalg in a Pyodide venv, see
 # https://github.com/pyodide/pyodide/issues/3865 for more details.
 # node build_tools/azure/pytest-pyodide.js --pyargs sklearn --durations 20 --showlocals
+source .pyodide-venv/bin/activate
 pip install pytest
 pytest --pyargs sklearn --durations 20 --showlocals

--- a/build_tools/azure/test_script_pyodide.sh
+++ b/build_tools/azure/test_script_pyodide.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 # We are using a pytest js wrapper script to run tests inside Pyodide. Maybe
 # one day we can use a Pyodide venv instead but at the time of writing
@@ -8,5 +8,9 @@ set -e
 # https://github.com/pyodide/pyodide/issues/3865 for more details.
 # node build_tools/azure/pytest-pyodide.js --pyargs sklearn --durations 20 --showlocals
 source .pyodide-venv/bin/activate
+which pip
 pip install pytest
+cd /tmp
+which pytest
+python -c 'import sklearn; print(sklearn.__file__)'
 pytest --pyargs sklearn --durations 20 --showlocals

--- a/build_tools/azure/test_script_pyodide.sh
+++ b/build_tools/azure/test_script_pyodide.sh
@@ -7,4 +7,5 @@ set -e
 # (2023-09-27) there is an issue with scipy.linalg in a Pyodide venv, see
 # https://github.com/pyodide/pyodide/issues/3865 for more details.
 # node build_tools/azure/pytest-pyodide.js --pyargs sklearn --durations 20 --showlocals
+pip install pytest
 pytest --pyargs sklearn --durations 20 --showlocals

--- a/build_tools/azure/test_script_pyodide.sh
+++ b/build_tools/azure/test_script_pyodide.sh
@@ -6,4 +6,5 @@ set -e
 # one day we can use a Pyodide venv instead but at the time of writing
 # (2023-09-27) there is an issue with scipy.linalg in a Pyodide venv, see
 # https://github.com/pyodide/pyodide/issues/3865 for more details.
-node build_tools/azure/pytest-pyodide.js --pyargs sklearn --durations 20 --showlocals
+# node build_tools/azure/pytest-pyodide.js --pyargs sklearn --durations 20 --showlocals
+pytest --pyargs sklearn --durations 20 --showlocals


### PR DESCRIPTION
The issue with library loading in Pyodide with `scipy.linalg` may have gone away https://github.com/pyodide/pyodide/issues/3865#issuecomment-2143698995. Let's see what CI has to say about this ...