### PR TITLE
Forgot to specify false for dual optimization in l1 loss

### DIFF
--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -333,7 +333,7 @@ the actual learning. The recommended way to do this in scikit-learn is
 to use a :class:`~pipeline.Pipeline`::
 
   clf = Pipeline([
-    ('feature_selection', SelectFromModel(LinearSVC(penalty="l1"))),
+    ('feature_selection', SelectFromModel(LinearSVC(penalty="l1", dual=False))),
     ('classification', RandomForestClassifier())
   ])
   clf.fit(X, y)


### PR DESCRIPTION
The author forgot to specify false for l1 loss.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Fix a small error

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
