### PR TITLE
DOC fix digits dataset link

### DIFF
--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -76,7 +76,7 @@ Loading an example dataset
 
 `scikit-learn` comes with a few standard datasets, for instance the
 `iris <https://en.wikipedia.org/wiki/Iris_flower_data_set>`_ and `digits
-<https://archive.ics.uci.edu/ml/datasets/Pen-Based+Recognition+of+Handwritten+Digits>`_
+<http://archive.ics.uci.edu/dataset/81/pen+based+recognition+of+handwritten+digits>`_
 datasets for classification and the `diabetes dataset
 <https://www4.stat.ncsu.edu/~boos/var.select/diabetes.html>`_ for regression.
 

--- a/doc/tutorial/basic/tutorial.rst
+++ b/doc/tutorial/basic/tutorial.rst
@@ -76,7 +76,7 @@ Loading an example dataset
 
 `scikit-learn` comes with a few standard datasets, for instance the
 `iris <https://en.wikipedia.org/wiki/Iris_flower_data_set>`_ and `digits
-<http://archive.ics.uci.edu/dataset/81/pen+based+recognition+of+handwritten+digits>`_
+<https://archive.ics.uci.edu/dataset/81/pen+based+recognition+of+handwritten+digits>`_
 datasets for classification and the `diabetes dataset
 <https://www4.stat.ncsu.edu/~boos/var.select/diabetes.html>`_ for regression.
 

--- a/examples/datasets/plot_digits_last_image.py
+++ b/examples/datasets/plot_digits_last_image.py
@@ -9,7 +9,7 @@ In order to utilize an 8x8 figure like this, we'd have to
 first transform it into a feature vector with length 64.
 
 See `here
-<http://archive.ics.uci.edu/dataset/81/pen+based+recognition+of+handwritten+digits>`_
+<https://archive.ics.uci.edu/dataset/81/pen+based+recognition+of+handwritten+digits>`_
 for more information about this dataset.
 
 """

--- a/examples/datasets/plot_digits_last_image.py
+++ b/examples/datasets/plot_digits_last_image.py
@@ -9,7 +9,7 @@ In order to utilize an 8x8 figure like this, we'd have to
 first transform it into a feature vector with length 64.
 
 See `here
-<https://archive.ics.uci.edu/ml/datasets/Pen-Based+Recognition+of+Handwritten+Digits>`_
+<http://archive.ics.uci.edu/dataset/81/pen+based+recognition+of+handwritten+digits>`_
 for more information about this dataset.
 
 """


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Because digits reference [link](https://archive.ics.uci.edu/ml/datasets/Pen-Based+Recognition+of+Handwritten+Digits) is broken, [fixed](https://archive.ics.uci.edu/dataset/81/pen+based+recognition+of+handwritten+digits) it.

#### Any other comments?

old website screenshot

<img width="1351" alt="Screenshot 2024-06-03 at 1 42 18" src="https://github.com/scikit-learn/scikit-learn/assets/31843888/8c236789-7950-4b3e-9151-6475a4719d53">

current one

<img width="1165" alt="Screenshot 2024-06-03 at 1 57 58" src="https://github.com/scikit-learn/scikit-learn/assets/31843888/43b05f2d-354e-4396-ae09-a5afb306ed94">