### PR TITLE
MAINT Remove unused targets from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,13 @@
 PYTHON ?= python
 CYTHON ?= cython
 PYTEST ?= pytest
-CTAGS ?= ctags
 
 # skip doctests on 32bit python
 BITS := $(shell python -c 'import struct; print(8 * struct.calcsize("P"))')
 
 all: clean inplace test
 
-clean-ctags:
-	rm -f tags
-
-clean: clean-ctags
+clean:
 	$(PYTHON) setup.py clean
 	rm -rf dist
 
@@ -49,22 +45,11 @@ test-coverage-parallel:
 
 test: test-code test-sphinxext test-doc
 
-trailing-spaces:
-	find sklearn -name "*.py" -exec perl -pi -e 's/[ \t]*$$//' {} \;
-
 cython:
 	python setup.py build_src
-
-ctags:
-	# make tags for symbol based navigation in emacs and vim
-	# Install with: sudo apt-get install exuberant-ctags
-	$(CTAGS) --python-kinds=-i -R sklearn
 
 doc: inplace
 	$(MAKE) -C doc html
 
 doc-noplot: inplace
 	$(MAKE) -C doc html-noplot
-
-code-analysis:
-	build_tools/linting.sh


### PR DESCRIPTION
- `ctags`, no scikit-learn developers use this. This was a thing for code navigation before LSP (Language Server Protocol) existed, or most people switched to Visual Studio Code or similar.
- `trailing-spaces` or `code-analysis` are probably done through pre-commit with ruff.

Context (if you are curious): I am looking at what could be useful to implement with `spin`: #29012 and decided I may as well first remove unused targets from the `Makefile`.