### PR TITLE
FIX fix regression in gridsearchcv when parameter grids have estimators as values

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -38,6 +38,10 @@ Changelog
   grids that have heterogeneous parameter values.
   :pr:`29078` by :user:`Loïc Estève <lesteve>`.
 
+- |Fix| Fix a regression in :class:`model_selection.GridSearchCV` for parameter
+  grids that have estimators as parameter values.
+  :pr:`29179` by :user:`Marco Gorelli<MarcoGorelli>`.
+
 
 .. _changes_1_5:
 

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1089,11 +1089,15 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         for key, param_result in param_results.items():
             param_list = list(param_result.values())
             try:
-                arr_dtype = np.array(param_list).dtype
+                arr_dtype = np.result_type(*param_list)
             except (TypeError, ValueError):
                 arr_dtype = np.dtype(object)
-            if arr_dtype.kind == "U":
-                arr_dtype = object
+            else:
+                if np.array(param_list).dtype == object:
+                    # `np.result_type` might get thrown off by `.dtype` properties
+                    # (which some estimators have), so we check against the `dtype`
+                    # resulting from constructing an array.
+                    arr_dtype = object
             if len(param_list) == n_candidates and arr_dtype != object:
                 # Exclude `object` else the numpy constructor might infer a list of
                 # tuples to be a 2d array.

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1097,7 +1097,8 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
                     # `np.result_type` might get thrown off by `.dtype` properties
                     # (which some estimators have), so we check against the `dtype`
                     # resulting from constructing an array.
-                    arr_dtype = object
+                    # https://github.com/scikit-learn/scikit-learn/issues/29157
+                    arr_dtype = np.dtype(object)
             if len(param_list) == n_candidates and arr_dtype != object:
                 # Exclude `object` else the numpy constructor might infer a list of
                 # tuples to be a 2d array.

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1095,6 +1095,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
                         message="in the future the `.dtype` attribute",
                         category=DeprecationWarning,
                     )
+                    # Warning raised by NumPy 1.20+
                     arr_dtype = np.result_type(*param_list)
             except (TypeError, ValueError):
                 arr_dtype = np.dtype(object)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -10,7 +10,6 @@ parameters of an estimator.
 #         Raghav RV <rvraghav93@gmail.com>
 # License: BSD 3 clause
 
-import functools
 import numbers
 import operator
 import time
@@ -1094,13 +1093,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             except (TypeError, ValueError):
                 arr_dtype = np.dtype(object)
             else:
-                if (
-                    functools.reduce(
-                        lambda x, y: np.promote_types(x, y),
-                        (np.min_scalar_type(x) for x in param_list),
-                    )
-                    == object
-                ):
+                if any(np.min_scalar_type(x) == object for x in param_list):
                     # `np.result_type` might get thrown off by `.dtype` properties
                     # (which some estimators have).
                     # If finding the result dtype this way would give object,

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1089,7 +1089,13 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         for key, param_result in param_results.items():
             param_list = list(param_result.values())
             try:
-                arr_dtype = np.result_type(*param_list)
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore",
+                        message="in the future the `.dtype` attribute",
+                        category=DeprecationWarning,
+                    )
+                    arr_dtype = np.result_type(*param_list)
             except (TypeError, ValueError):
                 arr_dtype = np.dtype(object)
             else:

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1089,8 +1089,10 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         for key, param_result in param_results.items():
             param_list = list(param_result.values())
             try:
-                arr_dtype = np.result_type(*param_list)
+                arr_dtype = np.array(param_list).dtype
             except (TypeError, ValueError):
+                arr_dtype = np.dtype(object)
+            if arr_dtype.kind == "U":
                 arr_dtype = object
             if len(param_list) == n_candidates and arr_dtype != object:
                 # Exclude `object` else the numpy constructor might infer a list of

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -10,6 +10,7 @@ parameters of an estimator.
 #         Raghav RV <rvraghav93@gmail.com>
 # License: BSD 3 clause
 
+import functools
 import numbers
 import operator
 import time
@@ -1093,10 +1094,17 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             except (TypeError, ValueError):
                 arr_dtype = np.dtype(object)
             else:
-                if np.array(param_list).dtype == object:
+                if (
+                    functools.reduce(
+                        lambda x, y: np.promote_types(x, y),
+                        (np.min_scalar_type(x) for x in param_list),
+                    )
+                    == object
+                ):
                     # `np.result_type` might get thrown off by `.dtype` properties
-                    # (which some estimators have), so we check against the `dtype`
-                    # resulting from constructing an array.
+                    # (which some estimators have).
+                    # If finding the result dtype this way would give object,
+                    # then we use object.
                     # https://github.com/scikit-learn/scikit-learn/issues/29157
                     arr_dtype = np.dtype(object)
             if len(param_list) == n_candidates and arr_dtype != object:

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -2687,6 +2687,10 @@ def test_cv_results_dtype_issue_29074():
         assert grid_search.cv_results_[f"param_{param}"].dtype == object
 
 
+@pytest.mark.filterwarnings(
+    "ignore:in the future the `.dtype` attribute of a given datatype object must "
+    "be a valid dtype instance:DeprecationWarning"
+)
 def test_search_with_estimators():
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame(
@@ -2715,12 +2719,5 @@ def test_search_with_estimators():
         ]
     }
     grid_search = GridSearchCV(pipe, grid_params, cv=2)
-    with pytest.warns(
-        DeprecationWarning,
-        match=(
-            "in the future the `.dtype` attribute of a given datatype object must be "
-            "a valid dtype instance"
-        ),
-    ):
-        grid_search.fit(X, y)
+    grid_search.fit(X, y)
     assert grid_search.cv_results_["param_enc__enc"].dtype == object

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -2688,6 +2688,7 @@ def test_cv_results_dtype_issue_29074():
 
 
 def test_search_with_estimators_issue_29157():
+    """Check cv_results_ for estimators with a `dtype` parameter, e.g. OneHotEncoder."""
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame(
         {

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -2691,7 +2691,7 @@ def test_cv_results_dtype_issue_29074():
     "ignore:in the future the `.dtype` attribute of a given datatype object must "
     "be a valid dtype instance:DeprecationWarning"
 )
-def test_search_with_estimators():
+def test_search_with_estimators_issue_29157():
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame(
         {

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -2719,7 +2719,7 @@ def test_search_with_estimators():
         DeprecationWarning,
         match=(
             "in the future the `.dtype` attribute of a given datatype object must be "
-            "a valid dtype instance",
+            "a valid dtype instance"
         ),
     ):
         grid_search.fit(X, y)

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -2521,7 +2521,8 @@ def test_search_with_2d_array():
     data_target = [0, 0, 1, 0, 1]
     random_search.fit(data_train, data_target)
     result = random_search.cv_results_["param_vect__ngram_range"]
-    expected_data = np.array([[1, 2], [1, 2], [1, 1]])
+    expected_data = np.empty(3, dtype=object)
+    expected_data[:] = [(1, 2), (1, 2), (1, 1)]
     np.testing.assert_array_equal(result.data, expected_data)
 
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -2687,10 +2687,6 @@ def test_cv_results_dtype_issue_29074():
         assert grid_search.cv_results_[f"param_{param}"].dtype == object
 
 
-@pytest.mark.filterwarnings(
-    "ignore:in the future the `.dtype` attribute of a given datatype object must "
-    "be a valid dtype instance:DeprecationWarning"
-)
 def test_search_with_estimators():
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame(

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -11,7 +11,6 @@ from itertools import chain, product
 from types import GeneratorType
 
 import numpy as np
-import pandas as pd
 import pytest
 from scipy.stats import bernoulli, expon, uniform
 
@@ -2689,6 +2688,7 @@ def test_cv_results_dtype_issue_29074():
 
 
 def test_search_with_estimators():
+    pd = pytest.importorskip("pandas")
     df = pd.DataFrame(
         {
             "numeric_1": [1, 2, 3, 4, 5],


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

closes #29157


#### What does this implement/fix? Explain your changes.

Fixes regression. Constructs array, and gets the dtype from there, as suggested [here](https://github.com/scikit-learn/scikit-learn/issues/29157#issuecomment-2147467117), but sets `'U'` kinds to `object` in keeping with [this comment](https://github.com/scikit-learn/scikit-learn/pull/28352#discussion_r1509648638)

Per discussion in #29157, alternatives to creating an array may not be acceptable

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
