### PR TITLE
CI Enable Dependabot and use full length commit SHA for PyPI publishing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    labels:
+      - "Build / CI"
+      - "dependencies"
+    reviewers:
+      - "scikit-learn/core-devs"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,11 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
+  # Maintain dependencies for GitHub Actions as recommended in SPEC8:
+  # https://github.com/scientific-python/specs/pull/325
+  # At the time of writing, release critical workflows such as
+  # pypa/gh-action-pypi-publish should use hash-based versioning for security
+  # reasons. This strategy may be generalized to all other github actions
+  # in the future.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -39,10 +39,13 @@ jobs:
       run: |
         python build_tools/github/check_wheels.py
     - name: Publish package to TestPyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.5
+      uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # v1.8.14
       with:
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
+        print-hash: true
       if: ${{ github.event.inputs.pypi_repo == 'testpypi' }}
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.5
+      uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # v1.8.14
       if: ${{ github.event.inputs.pypi_repo == 'pypi' }}
+      with:
+        print-hash: true


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

None that I'm aware of.


#### What does this implement/fix? Explain your changes.

At the 2024 Scientific Python Developer Summit, work on SPEC 08 (https://github.com/scientific-python/summit-2024/issues/9) includes trying to harden publishing security by pinning GitHub Action workflows to commit hashes.

This PR does three things:

* Update the publishing GitHub Action to the latest release.
* Pin the GitHub Action at the full commit SHA as recommended.
* Add Dependabot to update GitHub Actions _only_ as a group in a monthly PR so that maintainers never need to update the hashes by themselves. c.f. https://github.com/scikit-hep/pyhf/pull/2478 as an example of what this looks like.
   - Note that [Dependabot does not run on forks by default](https://github.blog/changelog/2022-11-07-dependabot-pull-requests-off-by-default-for-forks/).

Pinning should be done throughout the publishing workflow, but this PR only implements it for the publishing state to start off and get agreement here first.

#### Any other comments?

cc @thomasjpfan @betatim given discussion at the summit

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
