### PR TITLE
MAINT Update pyodide to 0.26.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,9 +105,9 @@ jobs:
     # Need to match Python version and Emscripten version for the correct
     # Pyodide version. For example, for Pyodide version 0.25.1, see
     # https://github.com/pyodide/pyodide/blob/0.25.1/Makefile.envs
-    PYODIDE_VERSION: '0.25.1'
-    EMSCRIPTEN_VERSION: '3.1.46'
-    PYTHON_VERSION: '3.11.3'
+    PYODIDE_VERSION: '0.26.0'
+    EMSCRIPTEN_VERSION: '3.1.58'
+    PYTHON_VERSION: '3.12.1'
 
   dependsOn: [git_commit, linting]
   condition: |

--- a/doc/jupyter-lite.json
+++ b/doc/jupyter-lite.json
@@ -3,7 +3,7 @@
   "jupyter-config-data": {
     "litePluginSettings": {
       "@jupyterlite/pyodide-kernel-extension:kernel": {
-        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide.js"
+        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.26.0/full/pyodide.js"
       }
     }
   }


### PR DESCRIPTION
Currently, the scikit-learn version on `pyodide` is `1.3.1`. This PR updates `pyodide` to 0.26.0, which should have 1.4.0.

I do not think https://github.com/pyodide/pyodide/commit/ff3942e942cda1e538a6f83247ebfb0f93cecbd5 is released yet to include 1.5.0