### PR TITLE
CI Fixes pull request pull for gpu build

### DIFF
--- a/.github/workflows/cuda-gpu-ci.yml
+++ b/.github/workflows/cuda-gpu-ci.yml
@@ -18,7 +18,9 @@ jobs:
         with:
           python-version: '3.12'
       - name: Checkout main repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          ref: pull/${{ inputs.pr_id }}/head
       - name: Checkout a particular Pull Request
         if: inputs.pr_id
         env:

--- a/.github/workflows/cuda-gpu-ci.yml
+++ b/.github/workflows/cuda-gpu-ci.yml
@@ -21,13 +21,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: pull/${{ inputs.pr_id }}/head
-      - name: Checkout a particular Pull Request
-        if: inputs.pr_id
-        env:
-          PR_ID: ${{ inputs.pr_id }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh pr checkout ${{ env.PR_ID }}
       - name: Cache conda environment
         id: cache-conda
         uses: actions/cache@v3


### PR DESCRIPTION
The image does not have `gh` installed. With this PR, we checkout the PR directly with `actions/checkout`.