### PR TITLE
DOC Remove warning from plot svm margin example

### DIFF
--- a/examples/svm/plot_svm_margin.py
+++ b/examples/svm/plot_svm_margin.py
@@ -63,7 +63,6 @@ for name, penalty in (("unreg", 1), ("reg", 0.05)):
         facecolors="none",
         zorder=10,
         edgecolors="k",
-        cmap=plt.get_cmap("RdBu"),
     )
     plt.scatter(
         X[:, 0], X[:, 1], c=Y, zorder=10, cmap=plt.get_cmap("RdBu"), edgecolors="k"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes plot svm margin example #29055 
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
I removed the cmap parameter from plt.scatter in order to fix the user warnings.


#### Any other comments?
I tested the code with the changes, and it ran as expected with no warnings.
The fix was implemented based on the relative matplotlib documentation: (https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.scatter.html) 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
