### PR TITLE
CI Use git to fetch the branch of the PR for the CUDA GPU CI

### DIFF
--- a/.github/workflows/cuda-gpu-ci.yml
+++ b/.github/workflows/cuda-gpu-ci.yml
@@ -19,8 +19,9 @@ jobs:
           python-version: '3.12'
       - name: Checkout main repository
         uses: actions/checkout@v4
-        with:
-          ref: pull/${{ inputs.pr_id }}/head
+      - run: |
+          git fetch origin +refs/pull/${{ inputs.pr_id }}/head:pr-${{ inputs.pr_id }}
+          git checkout pr-${{ inputs.pr_id }}
       - name: Cache conda environment
         id: cache-conda
         uses: actions/cache@v3


### PR DESCRIPTION
In an attempt to fix 

```
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/pull/27369/head*:refs/remotes/origin/pull/27369/head* +refs/tags/pull/27369/head*:refs/tags/pull/27369/head*
  The process '/usr/bin/git' failed with exit code 1
  Waiting 16 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/pull/27369/head*:refs/remotes/origin/pull/27369/head* +refs/tags/pull/27369/head*:refs/tags/pull/27369/head*
  The process '/usr/bin/git' failed with exit code 1
  Waiting 16 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/pull/27369/head*:refs/remotes/origin/pull/27369/head* +refs/tags/pull/27369/head*:refs/tags/pull/27369/head*
  Error: The process '/usr/bin/git' failed with exit code 1
```

e.g. in https://github.com/scikit-learn/scikit-learn/actions/runs/9382523260/job/25834126765

I tested the change on my fork and it seems to work.

/cc @lesteve @thomasjpfan @betatim.