### PR TITLE
CI Merge main in the PR branch prior to running CUDA array API tests

### DIFF
--- a/.github/workflows/cuda-gpu-ci.yml
+++ b/.github/workflows/cuda-gpu-ci.yml
@@ -22,6 +22,7 @@ jobs:
       - run: |
           git fetch origin +refs/pull/${{ inputs.pr_id }}/head:pr-${{ inputs.pr_id }}
           git checkout pr-${{ inputs.pr_id }}
+          git merge main
       - name: Cache conda environment
         id: cache-conda
         uses: actions/cache@v3


### PR DESCRIPTION
Towards #24491.

If we don't merge `main`, we test the state of a possibly very old PR that lacks some workflow files, e.g.:

https://github.com/scikit-learn/scikit-learn/actions/runs/9387170860/job/25849452469

after (manually) merging, testing the same PR (#27369) works:

https://github.com/scikit-learn/scikit-learn/actions/runs/9387261905

So better merge by default.

As usual, it's not possible to test this workflow change without merging it to `main` first...