### PR TITLE
ENH Adding callable function option to bicluster method

### DIFF
--- a/sklearn/cluster/_bicluster.py
+++ b/sklearn/cluster/_bicluster.py
@@ -381,12 +381,13 @@ class SpectralBiclustering(BaseSpectral):
         The number of row and column clusters in the checkerboard
         structure.
 
-    method : {'bistochastic', 'scale', 'log'}, default='bistochastic'
+    method : {'bistochastic', 'scale', 'log'} or callable, default='bistochastic'
         Method of normalizing and converting singular vectors into
         biclusters. May be one of 'scale', 'bistochastic', or 'log'.
         The authors recommend using 'log'. If the data is sparse,
         however, log normalization will not work, which is why the
         default is 'bistochastic'.
+        Callable must take a 2D array and return a 2D array.
 
         .. warning::
            if `method='log'`, the data must not be sparse.
@@ -491,7 +492,7 @@ class SpectralBiclustering(BaseSpectral):
     _parameter_constraints: dict = {
         **BaseSpectral._parameter_constraints,
         "n_clusters": [Interval(Integral, 1, None, closed="left"), tuple],
-        "method": [StrOptions({"bistochastic", "scale", "log"})],
+        "method": [StrOptions({"bistochastic", "scale", "log"}), callable],
         "n_components": [Interval(Integral, 1, None, closed="left")],
         "n_best": [Interval(Integral, 1, None, closed="left")],
     }
@@ -558,7 +559,10 @@ class SpectralBiclustering(BaseSpectral):
 
     def _fit(self, X):
         n_sv = self.n_components
-        if self.method == "bistochastic":
+        if callable(self.method):
+            normalized_data = self.method(X)
+            n_sv += 1
+        elif self.method == "bistochastic":
             normalized_data = _bistochastic_normalize(X)
             n_sv += 1
         elif self.method == "scale":

--- a/sklearn/cluster/tests/test_bicluster.py
+++ b/sklearn/cluster/tests/test_bicluster.py
@@ -98,7 +98,7 @@ def test_spectral_biclustering(global_random_seed, csr_container):
     )
 
     non_default_params = {
-        "method": ["scale", "log"],
+        "method": ["scale", "log", lambda x: x / x.sum(axis=0)],
         "svd_method": ["arpack"],
         "n_svd_vecs": [20],
         "mini_batch": [True],


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR adds the option to provide your own custom callable to the SpectralBiclustering class 

#### Any other comments?
The current implementation is constrained to a few normalizations from the original work; other normalizations could be helpful to others.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
