### PR TITLE
CI Use hashes to pin most Github actions

### DIFF
--- a/.github/workflows/artifact-redirector.yml
+++ b/.github/workflows/artifact-redirector.yml
@@ -15,7 +15,7 @@ jobs:
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step
-        uses: larsoner/circleci-artifacts-redirector-action@master
+        uses: larsoner/circleci-artifacts-redirector-action@4e13a10d89177f4bfc8007a7064bdbeda848d8d1 # v1.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           api-token: ${{ secrets.CIRCLECI_TOKEN }}

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           echo "TAGGED_MILESTONE=${{ github.event.pull_request.milestone.title }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: '0'
       - name: Check the changelog entry

--- a/.github/workflows/check-sdist.yml
+++ b/.github/workflows/check-sdist.yml
@@ -11,8 +11,8 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: '3.9'
       - name: Install dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/cuda-gpu-ci.yml
+++ b/.github/workflows/cuda-gpu-ci.yml
@@ -14,17 +14,17 @@ jobs:
       group: cuda-gpu-runner-group
     name: Run Array API unit tests
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@b64ffcaf5b410884ad320a9cfac8866006a109aa # v4.8.0
         with:
           python-version: '3.12'
       - name: Checkout main repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - run: |
           git fetch origin +refs/pull/${{ inputs.pr_id }}/head:pr-${{ inputs.pr_id }}
           git checkout pr-${{ inputs.pr_id }}
       - name: Cache conda environment
         id: cache-conda
-        uses: actions/cache@v3
+        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
         with:
           path: ~/conda
           key: ${{ runner.os }}-build-${{ hashFiles('build_tools/github/create_gpu_environment.sh') }}-${{ hashFiles('build_tools/github/pylatest_conda_forge_cuda_array-api_linux-64_conda.lock') }}

--- a/.github/workflows/label-blank-issue.yml
+++ b/.github/workflows/label-blank-issue.yml
@@ -8,7 +8,7 @@ jobs:
   label-blank-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: andymckay/labeler@1.0.4
+      - uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # v1.0.4
         with:
           add-labels: "Needs Triage"
           ignore-if-labeled: true

--- a/.github/workflows/labeler-module.yml
+++ b/.github/workflows/labeler-module.yml
@@ -14,7 +14,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: thomasjpfan/labeler@v2.5.1
+    - uses: thomasjpfan/labeler@3d528cd5d18871d09b85ac5d9fb1addf7b68753f # v2.5.1
       continue-on-error: true
       if: github.repository == 'scikit-learn/scikit-learn'
       with:
@@ -25,7 +25,7 @@ jobs:
   triage_file_extensions:
     runs-on: ubuntu-latest
     steps:
-    - uses: thomasjpfan/labeler@v2.5.1
+    - uses: thomasjpfan/labeler@3d528cd5d18871d09b85ac5d9fb1addf7b68753f # v2.5.1
       continue-on-error: true
       if: github.repository == 'scikit-learn/scikit-learn'
       with:

--- a/.github/workflows/labeler-title-regex.yml
+++ b/.github/workflows/labeler-title-regex.yml
@@ -15,8 +15,8 @@ jobs:
   labeler:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+    - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
         python-version: '3.9'
     - name: Install PyGithub

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: 3.11
 
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload Artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: lint-log
           path: |
@@ -72,10 +72,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: 3.11
 
@@ -84,7 +84,7 @@ jobs:
 
       - name: Download artifact
         id: download-artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: lint-log
 

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -18,8 +18,8 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+    - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
         python-version: '3.8'
     - name: Install dependencies

--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -33,7 +33,7 @@ jobs:
             update_script_args: "--select-tag cuda"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Generate lock files
         run: |
           source build_tools/shared.sh
@@ -46,7 +46,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
           push-to-fork: scikit-learn-bot/scikit-learn

--- a/.github/workflows/update_tracking_issue.yml
+++ b/.github/workflows/update_tracking_issue.yml
@@ -26,8 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'scikit-learn/scikit-learn' && github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: '3.9'
       - name: Update tracking issue on GitHub

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout scikit-learn
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -117,10 +117,10 @@ jobs:
 
     steps:
       - name: Checkout scikit-learn
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: "3.11" # update once build dependencies are available
 
@@ -175,7 +175,7 @@ jobs:
         run: bash build_tools/wheels/build_wheels.sh
 
       - name: Store artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           path: wheelhouse/*.whl
 
@@ -197,10 +197,10 @@ jobs:
 
     steps:
       - name: Checkout scikit-learn
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
           python-version: "3.9" # update once build dependencies are available
 
@@ -215,7 +215,7 @@ jobs:
           SKLEARN_SKIP_NETWORK_TESTS: 1
 
       - name: Store artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           path: dist/*.tar.gz
 
@@ -224,21 +224,21 @@ jobs:
     name: Upload to Anaconda
     runs-on: ubuntu-latest
     environment: upload_anaconda
-    needs: [build_wheels, build_sdist]
+    needs: [ build_wheels, build_sdist ]
     # The artifacts cannot be uploaded on PRs
     if: github.event_name != 'pull_request'
 
     steps:
       - name: Checkout scikit-learn
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           path: dist
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
 
       - name: Upload artifacts
         env:


### PR DESCRIPTION
This will allow the Dependabot PR https://github.com/scikit-learn/scikit-learn/pull/29203 to update commit hashes with human readable comment instead of only major version.

I added the `major.minor.patch` manually based on each project release/tags. After that I used https://github.com/mheap/pin-github-action to transform into commit hashes. I double-checked everything looked allright:

Side comment: there are still 3 actions without commit hash because I am not quite sure how to do it. They have many actions in the same repo: https://github.com/github/codeql-action
```
❯ git grep -P 'uses:.+@v\d' .github/workflows/
.github/workflows/codeql.yml:      uses: github/codeql-action/init@v3
.github/workflows/codeql.yml:      uses: github/codeql-action/autobuild@v3
.github/workflows/codeql.yml:      uses: github/codeql-action/analyze@v3
```
