### PR TITLE
CI Update upload-artifact and download-artifact to v4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload Artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: lint-log
           path: |
@@ -84,7 +84,7 @@ jobs:
 
       - name: Download artifact
         id: download-artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: lint-log
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -175,8 +175,9 @@ jobs:
         run: bash build_tools/wheels/build_wheels.sh
 
       - name: Store artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
+          name: cibw-wheels-cp${{ matrix.python }}-${{ matrix.platform_id }}
           path: wheelhouse/*.whl
 
   update-tracker:
@@ -215,8 +216,9 @@ jobs:
           SKLEARN_SKIP_NETWORK_TESTS: 1
 
       - name: Store artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
+          name: cibw-sdist
           path: dist/*.tar.gz
 
   # Upload the wheels and the source distribution
@@ -233,9 +235,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
+          pattern: cibw-*
           path: dist
+          merge-multiple: true
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Followed https://learn.scientific-python.org/development/guides/gha-wheels for wheel workflow. 
This will be tested in this PR with the `[cd build gh]` comment. Actually the "Upload to Anaconda" is skipped but I triggered in on my fork and everything looks fine, see https://github.com/lesteve/scikit-learn/actions/runs/9414784335.

The lint workflow is probably fine because there is a single artifact.

For more details about the v3 -> v4 upgrade: https://github.blog/2024-02-12-get-started-with-v4-of-github-actions-artifacts/#compatibility

Context: Dependabot PR https://github.com/scikit-learn/scikit-learn/pull/29203