### PR TITLE
ENH Add array_api compatibility to `max_error`

### DIFF
--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -114,6 +114,7 @@ Metrics
 
 - :func:`sklearn.metrics.accuracy_score`
 - :func:`sklearn.metrics.d2_tweedie_score`
+- :func:`sklearn.metrics.max_error`
 - :func:`sklearn.metrics.mean_absolute_error`
 - :func:`sklearn.metrics.mean_squared_error`
 - :func:`sklearn.metrics.mean_tweedie_deviance`

--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -33,7 +33,7 @@ See :ref:`array_api` for more details.
 **Functions:**
 
 - :func:`sklearn.metrics.d2_tweedie_score` :pr:`29207` by :user:`Emily Chen <EmilyXinyi>`;
-- :func:`sklearn.metrics.max_error` :pr:`` by :user:`Edoardo Abati <EdAbati>`;
+- :func:`sklearn.metrics.max_error` :pr:`29212` by :user:`Edoardo Abati <EdAbati>`;
 - :func:`sklearn.metrics.mean_absolute_error` :pr:`27736` by :user:`Edoardo Abati <EdAbati>`;
 - :func:`sklearn.metrics.mean_squared_error` :pr:`29142` by :user:`Yaroslav Korobko <Tialo>`;
 - :func:`sklearn.metrics.mean_tweedie_deviance` :pr:`28106` by :user:`Thomas Li <lithomas1>`;

--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -33,12 +33,12 @@ See :ref:`array_api` for more details.
 **Functions:**
 
 - :func:`sklearn.metrics.d2_tweedie_score` :pr:`29207` by :user:`Emily Chen <EmilyXinyi>`;
+- :func:`sklearn.metrics.max_error` :pr:`` by :user:`Edoardo Abati <EdAbati>`;
 - :func:`sklearn.metrics.mean_absolute_error` :pr:`27736` by :user:`Edoardo Abati <EdAbati>`;
 - :func:`sklearn.metrics.mean_squared_error` :pr:`29142` by :user:`Yaroslav Korobko <Tialo>`;
 - :func:`sklearn.metrics.mean_tweedie_deviance` :pr:`28106` by :user:`Thomas Li <lithomas1>`;
 - :func:`sklearn.metrics.pairwise.cosine_similarity` :pr:`29014` by :user:`Edoardo Abati <EdAbati>`.
 - :func:`sklearn.metrics.pairwise.paired_cosine_distances` :pr:`29112` by :user:`Edoardo Abati <EdAbati>`.
-
 
 **Classes:**
 

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1290,10 +1290,11 @@ def max_error(y_true, y_pred):
     >>> max_error(y_true, y_pred)
     1
     """
+    xp, _ = get_namespace(y_true, y_pred)
     y_type, y_true, y_pred, _ = _check_reg_targets(y_true, y_pred, None)
     if y_type == "continuous-multioutput":
         raise ValueError("Multioutput not supported in max_error")
-    return np.max(np.abs(y_true - y_pred))
+    return xp.max(xp.abs(y_true - y_pred))
 
 
 def _mean_tweedie_deviance(y_true, y_pred, sample_weight, power):

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1830,17 +1830,11 @@ def check_array_api_regression_metric(metric, array_namespace, device, dtype_nam
     y_true_np = np.array([2, 0, 1, 4], dtype=dtype_name)
     y_pred_np = np.array([0.5, 0.5, 2, 2], dtype=dtype_name)
 
-    check_array_api_metric(
-        metric,
-        array_namespace,
-        device,
-        dtype_name,
-        a_np=y_true_np,
-        b_np=y_pred_np,
-        sample_weight=None,
-    )
+    metric_kwargs = {}
+    metric_params = signature(metric).parameters
 
-    sample_weight = np.array([0.1, 2.0, 1.5, 0.5], dtype=dtype_name)
+    if "sample_weight" in metric_params:
+        metric_kwargs["sample_weight"] = None
 
     check_array_api_metric(
         metric,
@@ -1849,8 +1843,23 @@ def check_array_api_regression_metric(metric, array_namespace, device, dtype_nam
         dtype_name,
         a_np=y_true_np,
         b_np=y_pred_np,
-        sample_weight=sample_weight,
+        **metric_kwargs,
     )
+
+    if "sample_weight" in metric_params:
+        metric_kwargs["sample_weight"] = np.array(
+            [0.1, 2.0, 1.5, 0.5], dtype=dtype_name
+        )
+
+        check_array_api_metric(
+            metric,
+            array_namespace,
+            device,
+            dtype_name,
+            a_np=y_true_np,
+            b_np=y_pred_np,
+            **metric_kwargs,
+        )
 
 
 def check_array_api_regression_metric_multioutput(
@@ -1946,6 +1955,7 @@ array_api_metric_checkers = {
         check_array_api_regression_metric,
     ],
     paired_cosine_distances: [check_array_api_metric_pairwise],
+    max_error: [check_array_api_regression_metric],
 }
 
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1827,7 +1827,7 @@ def check_array_api_multiclass_classification_metric(
 
 
 def check_array_api_regression_metric(metric, array_namespace, device, dtype_name):
-    y_true_np = np.array([2, 0, 1, 4], dtype=dtype_name)
+    y_true_np = np.array([2.0, 0.0, 1.0, 4.0], dtype=dtype_name)
     y_pred_np = np.array([0.5, 0.5, 2, 2], dtype=dtype_name)
 
     metric_kwargs = {}


### PR DESCRIPTION
#### Reference Issues/PRs

Towards https://github.com/scikit-learn/scikit-learn/issues/26024

#### What does this implement/fix? Explain your changes.

It makes the `max_error` implementation compatible and tested with the Array API.
