### PR TITLE
DOC add persistence methods table

### DIFF
--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -19,7 +19,7 @@ Model persistence
        * Custom estimators require more work to support
        * Original Python object is lost and cannot be reconstructed
    * - :ref:`skops_persistence`
-     - * Pickle free and more secure
+     - * More secure than `pickle` based formats
        * Contents can be partly validated without loading
      - * Not as fast as `pickle` based formats
        * Supports less types than `pickle` based formats

--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -4,6 +4,43 @@
 Model persistence
 =================
 
+.. list-table:: Summary of model persistence methods
+   :widths: 25 50 50
+   :header-rows: 1
+
+   * - Persistence method
+     - Pros
+     - Risks / Cons
+   * - :ref:`ONNX <onnx_persistence>`
+     - * Serve models without a Python environment
+       * Serving and training environments independent of one another
+       * Most secure option
+     - * Not all scikit-learn models are supported
+       * Custom estimators are hard to add
+       * Original Python object is lost and cannot be reconstructed
+   * - :ref:`skops_persistence`
+     - * Pickle free and more secure
+       * Contents can be partly validated without loading
+     - * Not as fast as `pickle` based formats
+       * Supports less types than `pickle` based formats
+   * - :mod:`pickle`
+     - * Native to Python
+       * Can serialize most Python objects
+       * Efficient memory usage with `protocol=5`
+     - * Loading can execute arbitrary code
+       * No memory mapping
+   * - :mod:`joblib`
+     - * Efficient memory usage with memory mapping
+       * Easy shortcuts for compression and decompression
+     - * Pickle based format
+       * Loading can execute arbitrary code
+   * - `cloudpickle`_
+     - * Serialize custom Python code
+       * Comparable loading efficiency as :mod:`pickle`
+     - * Pickle based format
+       * Loading can execute arbitrary code
+       * No forward compatibility guarantees
+
 After training a scikit-learn model, it is desirable to have a way to persist
 the model for future use without having to retrain. Based on your use-case,
 there are a few different ways to persist a scikit-learn model, and here we

--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -39,7 +39,7 @@ Model persistence
        * Loading can execute arbitrary code
        * Requires the same environment as the training environment
    * - `cloudpickle`_
-     - * Serialize custom Python code
+     - * Can serialize non-packaged, custom Python code
        * Comparable loading efficiency as :mod:`pickle`
      - * Pickle based format
        * Loading can execute arbitrary code

--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -29,7 +29,6 @@ Model persistence
        * Can serialize most Python objects
        * Efficient memory usage with `protocol=5`
      - * Loading can execute arbitrary code
-       * No memory mapping
        * Requires the same environment as the training environment
    * - :mod:`joblib`
      - * Efficient memory usage

--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -16,7 +16,7 @@ Model persistence
        * Serving and training environments independent of one another
        * Most secure option
      - * Not all scikit-learn models are supported
-       * Custom estimators are hard to add
+       * Custom estimators require more work to support
        * Original Python object is lost and cannot be reconstructed
    * - :ref:`skops_persistence`
      - * Pickle free and more secure

--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -23,23 +23,27 @@ Model persistence
        * Contents can be partly validated without loading
      - * Not as fast as `pickle` based formats
        * Supports less types than `pickle` based formats
+       * Requires the same environment as the training environment
    * - :mod:`pickle`
      - * Native to Python
        * Can serialize most Python objects
        * Efficient memory usage with `protocol=5`
      - * Loading can execute arbitrary code
        * No memory mapping
+       * Requires the same environment as the training environment
    * - :mod:`joblib`
      - * Efficient memory usage with memory mapping
        * Easy shortcuts for compression and decompression
      - * Pickle based format
        * Loading can execute arbitrary code
+       * Requires the same environment as the training environment
    * - `cloudpickle`_
      - * Serialize custom Python code
        * Comparable loading efficiency as :mod:`pickle`
      - * Pickle based format
        * Loading can execute arbitrary code
        * No forward compatibility guarantees
+       * Requires the same environment as the training environment
 
 After training a scikit-learn model, it is desirable to have a way to persist
 the model for future use without having to retrain. Based on your use-case,

--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -32,7 +32,7 @@ Model persistence
        * Requires the same environment as the training environment
    * - :mod:`joblib`
      - * Efficient memory usage
-     - * Supports memory mapping
+       * Supports memory mapping
        * Easy shortcuts for compression and decompression
      - * Pickle based format
        * Loading can execute arbitrary code

--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -32,7 +32,8 @@ Model persistence
        * No memory mapping
        * Requires the same environment as the training environment
    * - :mod:`joblib`
-     - * Efficient memory usage with memory mapping
+     - * Efficient memory usage
+     - * Supports memory mapping
        * Easy shortcuts for compression and decompression
      - * Pickle based format
        * Loading can execute arbitrary code

--- a/doc/model_persistence.rst
+++ b/doc/model_persistence.rst
@@ -40,7 +40,7 @@ Model persistence
        * Requires the same environment as the training environment
    * - `cloudpickle`_
      - * Can serialize non-packaged, custom Python code
-       * Comparable loading efficiency as :mod:`pickle`
+       * Comparable loading efficiency as :mod:`pickle` with `protocol=5`
      - * Pickle based format
        * Loading can execute arbitrary code
        * No forward compatibility guarantees


### PR DESCRIPTION
This adds a table to summarize persistence methods as suggested by @ogrisel (ref: https://github.com/scikit-learn/scikit-learn/pull/29011#issuecomment-2111855678)