### PR TITLE
MAINT Directly cimport `stack` from Cython

### DIFF
--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -22,6 +22,7 @@ from libc.math cimport isnan
 from libcpp.vector cimport vector
 from libcpp.algorithm cimport pop_heap
 from libcpp.algorithm cimport push_heap
+from libcpp.stack cimport stack
 from libcpp cimport bool
 
 import struct
@@ -42,15 +43,6 @@ cdef extern from "numpy/arrayobject.h":
                                 cnp.npy_intp* strides,
                                 void* data, int flags, object obj)
     int PyArray_SetBaseObject(cnp.ndarray arr, PyObject* obj)
-
-cdef extern from "<stack>" namespace "std" nogil:
-    cdef cppclass stack[T]:
-        ctypedef T value_type
-        stack() except +
-        bint empty()
-        void pop()
-        void push(T&) except +  # Raise c++ exception for bad_alloc -> MemoryError
-        T& top()
 
 # =============================================================================
 # Types and constants


### PR DESCRIPTION
#### Reference Issues/PRs
n/a


#### What does this implement/fix? Explain your changes.
- directly imports the stack from Cython 3.0+

#### Any other comments?
Noticed this when I was hacking some of the Cython internal tree code. This should be an extremely quick review.