### PR TITLE
array API support for mean_gamma_deviance

### DIFF
--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -115,6 +115,7 @@ Metrics
 - :func:`sklearn.metrics.accuracy_score`
 - :func:`sklearn.metrics.d2_tweedie_score`
 - :func:`sklearn.metrics.mean_absolute_error`
+- :func:`sklearn.metrics.mean_gamma_deviance`
 - :func:`sklearn.metrics.mean_squared_error`
 - :func:`sklearn.metrics.mean_tweedie_deviance`
 - :func:`sklearn.metrics.pairwise.cosine_similarity`

--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -34,6 +34,7 @@ See :ref:`array_api` for more details.
 
 - :func:`sklearn.metrics.d2_tweedie_score` :pr:`29207` by :user:`Emily Chen <EmilyXinyi>`;
 - :func:`sklearn.metrics.mean_absolute_error` :pr:`27736` by :user:`Edoardo Abati <EdAbati>`;
+- :func:`sklearn.metrics.mean_gamma_deviance` :pr:`29239` by :usser:`Emily Chen <EmilyXinyi>`;
 - :func:`sklearn.metrics.mean_squared_error` :pr:`29142` by :user:`Yaroslav Korobko <Tialo>`;
 - :func:`sklearn.metrics.mean_tweedie_deviance` :pr:`28106` by :user:`Thomas Li <lithomas1>`;
 - :func:`sklearn.metrics.pairwise.cosine_similarity` :pr:`29014` by :user:`Edoardo Abati <EdAbati>`.

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1411,7 +1411,7 @@ def mean_tweedie_deviance(y_true, y_pred, *, sample_weight=None, power=0):
             raise ValueError(message + "non-negative y and strictly positive y_pred.")
     elif power >= 2:
         # Gamma and Extreme stable distribution, y and y_pred > 0
-        if (y_true <= 0).any() or (y_pred <= 0).any():
+        if xp.any(y_true <= 0) or xp.any(y_pred <= 0):
             raise ValueError(message + "strictly positive y and y_pred.")
     else:  # pragma: nocover
         # Unreachable statement

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1852,6 +1852,31 @@ def check_array_api_regression_metric(metric, array_namespace, device, dtype_nam
         sample_weight=sample_weight,
     )
 
+def check_array_api_regression_metric_gamma(metric, array_namespace, device, dtype_name):
+    y_true_np = np.array([2, 0.1, 1, 4], dtype=dtype_name)
+    y_pred_np = np.array([0.5, 0.5, 2, 2], dtype=dtype_name)
+
+    check_array_api_metric(
+        metric,
+        array_namespace,
+        device,
+        dtype_name,
+        a_np=y_true_np,
+        b_np=y_pred_np,
+        sample_weight=None,
+    )
+
+    sample_weight = np.array([0.1, 2.0, 1.5, 0.5], dtype=dtype_name)
+
+    check_array_api_metric(
+        metric,
+        array_namespace,
+        device,
+        dtype_name,
+        a_np=y_true_np,
+        b_np=y_pred_np,
+        sample_weight=sample_weight,
+    )
 
 def check_array_api_regression_metric_multioutput(
     metric, array_namespace, device, dtype_name
@@ -1946,6 +1971,7 @@ array_api_metric_checkers = {
         check_array_api_regression_metric,
     ],
     paired_cosine_distances: [check_array_api_metric_pairwise],
+    mean_gamma_deviance: [check_array_api_regression_metric_gamma],
 }
 
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1827,35 +1827,6 @@ def check_array_api_multiclass_classification_metric(
 
 
 def check_array_api_regression_metric(metric, array_namespace, device, dtype_name):
-    y_true_np = np.array([2, 0, 1, 4], dtype=dtype_name)
-    y_pred_np = np.array([0.5, 0.5, 2, 2], dtype=dtype_name)
-
-    check_array_api_metric(
-        metric,
-        array_namespace,
-        device,
-        dtype_name,
-        a_np=y_true_np,
-        b_np=y_pred_np,
-        sample_weight=None,
-    )
-
-    sample_weight = np.array([0.1, 2.0, 1.5, 0.5], dtype=dtype_name)
-
-    check_array_api_metric(
-        metric,
-        array_namespace,
-        device,
-        dtype_name,
-        a_np=y_true_np,
-        b_np=y_pred_np,
-        sample_weight=sample_weight,
-    )
-
-
-def check_array_api_regression_metric_gamma(
-    metric, array_namespace, device, dtype_name
-):
     y_true_np = np.array([2, 0.1, 1, 4], dtype=dtype_name)
     y_pred_np = np.array([0.5, 0.5, 2, 2], dtype=dtype_name)
 
@@ -1975,7 +1946,7 @@ array_api_metric_checkers = {
         check_array_api_regression_metric,
     ],
     paired_cosine_distances: [check_array_api_metric_pairwise],
-    mean_gamma_deviance: [check_array_api_regression_metric_gamma],
+    mean_gamma_deviance: [check_array_api_regression_metric],
 }
 
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1852,7 +1852,10 @@ def check_array_api_regression_metric(metric, array_namespace, device, dtype_nam
         sample_weight=sample_weight,
     )
 
-def check_array_api_regression_metric_gamma(metric, array_namespace, device, dtype_name):
+
+def check_array_api_regression_metric_gamma(
+    metric, array_namespace, device, dtype_name
+):
     y_true_np = np.array([2, 0.1, 1, 4], dtype=dtype_name)
     y_pred_np = np.array([0.5, 0.5, 2, 2], dtype=dtype_name)
 
@@ -1877,6 +1880,7 @@ def check_array_api_regression_metric_gamma(metric, array_namespace, device, dty
         b_np=y_pred_np,
         sample_weight=sample_weight,
     )
+
 
 def check_array_api_regression_metric_multioutput(
     metric, array_namespace, device, dtype_name


### PR DESCRIPTION
#### Reference Issues/PRs
towards #26024 

#### What does this implement/fix? Explain your changes.
add array API support for `mean_gamma_deviance`

#### Any other comments?
`mean_gamma_deviance` is a special case of `mean_tweedie_deviance` where power=2 and both y_pred and y_true must be strictly positive. For this reason I have added the test case `check_array_api_regression_metric_gamma` (because the y_true in `check_array_api_regression_metric` contains 0 and I didn't want to change a test that is so widely used). I am not sure if this is the best way to approach this, so if there are any suggestions on how to do this better I would love to know. Thanks!! 