### PR TITLE
add rename_label for classification_report

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2615,6 +2615,8 @@ def classification_report(
 
     y_type, y_true, y_pred = _check_targets(y_true, y_pred)
 
+    classification_report_values = {"accuracy", "weighted avg", "macro avg", "weighted avg"}
+
     if labels is None:
         labels = unique_labels(y_true, y_pred)
         labels_given = False
@@ -2626,9 +2628,8 @@ def classification_report(
         if target_names is None:
             target_names = np.array(["class " + label for label in labels])
         else:
-            target_names = np.array(["class " + target_name for target_name in target_names])
+            target_names = np.array(["class " + tn for tn in target_names])
 
-    
     # labelled micro average
     micro_is_accuracy = (y_type == "multiclass" or y_type == "binary") and (
         not labels_given or (set(labels) >= set(unique_labels(y_true, y_pred)))

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2500,6 +2500,7 @@ def classification_report(
     sample_weight=None,
     digits=2,
     output_dict=False,
+    rename_label=False,
     zero_division="warn",
 ):
     """Build a text report showing the main classification metrics.
@@ -2532,6 +2533,9 @@ def classification_report(
         If True, return output as dict.
 
         .. versionadded:: 0.20
+
+    rename_label: bool, default=False
+        if True, rename label's name and add ``class`` before that.
 
     zero_division : {"warn", 0.0, 1.0, np.nan}, default="warn"
         Sets the value to return when there is a zero division. If set to
@@ -2611,6 +2615,8 @@ def classification_report(
 
     y_type, y_true, y_pred = _check_targets(y_true, y_pred)
 
+    classification_report_values = {"accuracy", "weighted avg", "macro avg", "weighted avg"}
+
     if labels is None:
         labels = unique_labels(y_true, y_pred)
         labels_given = False
@@ -2618,6 +2624,13 @@ def classification_report(
         labels = np.asarray(labels)
         labels_given = True
 
+    if rename_label:
+        if target_names is None:
+            target_names = np.array(["class " + label for label in labels])
+        else:
+            target_names = np.array(["class " + target_name for target_name in target_names])
+
+    
     # labelled micro average
     micro_is_accuracy = (y_type == "multiclass" or y_type == "binary") and (
         not labels_given or (set(labels) >= set(unique_labels(y_true, y_pred)))

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2615,8 +2615,6 @@ def classification_report(
 
     y_type, y_true, y_pred = _check_targets(y_true, y_pred)
 
-    classification_report_values = {"accuracy", "weighted avg", "macro avg", "weighted avg"}
-
     if labels is None:
         labels = unique_labels(y_true, y_pred)
         labels_given = False

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2534,7 +2534,7 @@ def classification_report(
 
         .. versionadded:: 0.20
 
-    rename_label: bool, default=False
+    rename_label : bool, default=False
         if True, rename label's name and add ``class`` before that.
 
     zero_division : {"warn", 0.0, 1.0, np.nan}, default="warn"

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -103,6 +103,7 @@ def make_prediction(dataset=None, binary=False):
 ###############################################################################
 # Tests
 
+
 def test_classification_report_rename_output():
     iris = datasets.load_iris()
     y_true, y_pred, _ = make_prediction(dataset=iris, binary=False)

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -103,6 +103,70 @@ def make_prediction(dataset=None, binary=False):
 ###############################################################################
 # Tests
 
+def test_classification_report_rename_output():
+    iris = datasets.load_iris()
+    y_true, y_pred, _ = make_prediction(dataset=iris, binary=False)
+
+    # print classification report with class names
+    expected_report = {
+        "class setosa": {
+            "precision": 0.82608695652173914,
+            "recall": 0.79166666666666663,
+            "f1-score": 0.8085106382978724,
+            "support": 24,
+        },
+        "class versicolor": {
+            "precision": 0.33333333333333331,
+            "recall": 0.096774193548387094,
+            "f1-score": 0.15000000000000002,
+            "support": 31,
+        },
+        "class virginica": {
+            "precision": 0.41860465116279072,
+            "recall": 0.90000000000000002,
+            "f1-score": 0.57142857142857151,
+            "support": 20,
+        },
+        "macro avg": {
+            "f1-score": 0.5099797365754813,
+            "precision": 0.5260083136726211,
+            "recall": 0.596146953405018,
+            "support": 75,
+        },
+        "accuracy": 0.5333333333333333,
+        "weighted avg": {
+            "f1-score": 0.47310435663627154,
+            "precision": 0.5137535108414785,
+            "recall": 0.5333333333333333,
+            "support": 75,
+        },
+    }
+
+    report = classification_report(
+        y_true,
+        y_pred,
+        labels=np.arange(len(iris.target_names)),
+        target_names=iris.target_names,
+        output_dict=True,
+        rename_label=True,
+    )
+
+    # assert the 2 dicts are equal.
+    assert report.keys() == expected_report.keys()
+    for key in expected_report:
+        if key == "accuracy":
+            assert isinstance(report[key], float)
+            assert report[key] == expected_report[key]
+        else:
+            assert report[key].keys() == expected_report[key].keys()
+            for metric in expected_report[key]:
+                assert_almost_equal(expected_report[key][metric], report[key][metric])
+
+    assert isinstance(expected_report["class setosa"]["precision"], float)
+    assert isinstance(expected_report["macro avg"]["precision"], float)
+    assert isinstance(expected_report["class setosa"]["support"], int)
+    assert isinstance(expected_report["macro avg"]["support"], int)
+
 
 def test_classification_report_dictionary_output():
     # Test performance report with dictionary output


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
A fix for #29205 


#### What does this implement/fix? Explain your changes.
I add a boolean rename_label to classification_report that can rename the labels and add class prefix


#### Any other comments?
I'm not quite sure that should i generate error if there is a name conflict or not. if you think it's better to add error tell me to fix that

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
