### PR TITLE
CI Add CPython 3.13 free-threaded manylinux wheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -90,6 +90,7 @@ jobs:
             python: 313t
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
+            # TODO: remove next line when Python 3.13 is released
             prerelease_pythons: True
             free_threaded_support: True
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -86,6 +86,12 @@ jobs:
             python: 312
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 313t
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+            prerelease_pythons: True
+            free_threaded_support: True
 
           # MacOS x86_64
           - os: macos-12
@@ -154,7 +160,8 @@ jobs:
 
       - name: Build and test wheels
         env:
-          CIBW_PRERELEASE_PYTHONS: ${{ matrix.prerelease }}
+          CIBW_PRERELEASE_PYTHONS: ${{ matrix.prerelease_pythons }}
+          CIBW_FREE_THREADED_SUPPORT: ${{ matrix.free_threaded_support }}
           CIBW_ENVIRONMENT: SKLEARN_SKIP_NETWORK_TESTS=1
             SKLEARN_BUILD_PARALLEL=3
           CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
@@ -167,7 +174,8 @@ jobs:
           CIBW_CONFIG_SETTINGS_WINDOWS: "setup-args=--vsenv"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: bash build_tools/github/repair_windows_wheels.sh {wheel} {dest_dir}
           CIBW_BEFORE_TEST_WINDOWS: bash build_tools/github/build_minimal_windows_image.sh ${{ matrix.python }}
-          CIBW_TEST_REQUIRES: pytest pandas
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_BEFORE_TEST: bash {project}/build_tools/wheels/cibw_before_test.sh
           CIBW_TEST_COMMAND: bash {project}/build_tools/wheels/test_wheels.sh
           CIBW_TEST_COMMAND_WINDOWS: bash {project}/build_tools/github/test_windows_wheels.sh ${{ matrix.python }}
           CIBW_BUILD_VERBOSITY: 1

--- a/build_tools/wheels/build_wheels.sh
+++ b/build_tools/wheels/build_wheels.sh
@@ -59,6 +59,13 @@ if [[ "$GITHUB_EVENT_NAME" == "schedule" || "$CIRRUS_CRON" == "nightly" ]]; then
     export CIBW_BUILD_FRONTEND='pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"'
 fi
 
+if [[ "$CIBW_FREE_THREADED_SUPPORT" =~ [tT]rue ]]; then
+    # Numpy, scipy, Cython only have free-threaded wheels on scientific-python-nightly-wheels
+    # TODO: remove this after CPython 3.13 is released (scheduled October 2024)
+    # and our dependencies have free-threaded wheels on PyPI
+    export CIBW_BUILD_FRONTEND='pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"'
+fi
+
 # The version of the built dependencies are specified
 # in the pyproject.toml file, while the tests are run
 # against the most recent version of the dependencies

--- a/build_tools/wheels/cibw_before_test.sh
+++ b/build_tools/wheels/cibw_before_test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+set -x
+
+FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
+if [[ $FREE_THREADED_BUILD == "True" ]]; then
+    # TODO: remove when numpy and scipy have releases with free-threaded wheels
+    python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy scipy
+else
+    # There is no pandas free-threaded wheel at the time of writing, so we only
+    # install pandas in other builds
+    # TODO: adapt when there is a pandas free-threaded wheel
+    python -m pip install pandas
+fi

--- a/build_tools/wheels/test_wheels.sh
+++ b/build_tools/wheels/test_wheels.sh
@@ -6,6 +6,14 @@ set -x
 python -c "import joblib; print(f'Number of cores (physical): \
 {joblib.cpu_count()} ({joblib.cpu_count(only_physical_cores=True)})')"
 
+FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
+if [[ $FREE_THREADED_BUILD == "True" ]]; then
+    # TODO: delete when importing numpy no longer enables the GIL
+    # setting to zero ensures the GIL is disabled while running the
+    # tests under free-threaded python
+    export PYTHON_GIL=0
+fi
+
 # Test that there are no links to system libraries in the
 # threadpoolctl output section of the show_versions output:
 python -c "import sklearn; sklearn.show_versions()"


### PR DESCRIPTION
This adds a CPython 3.13 free-threaded manylinux wheel.

I haven't thought too much about it, but if we merge this PR, there may be a risk that we upload a CPython 3.13 free-thread wheel to PyPI by mistake. CPython 3.13 is supposed to be schedule in October 2024 and scikit-learn 1.6 release will probably happen November/December 2024, so we may be fine based on this.

Related to #28978.