### PR TITLE
extreme_stable case for mean_tweedie_deviance

### DIFF
--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1301,12 +1301,14 @@ def _mean_tweedie_deviance(y_true, y_pred, sample_weight, power):
     """Mean Tweedie deviance regression loss."""
     xp, _ = get_namespace(y_true, y_pred)
     p = power
+    zero = xp.asarray(0, dtype=y_true.dtype)
     if p < 0:
         # 'Extreme stable', y any real number, y_pred > 0
         dev = 2 * (
-            xp.pow(xp.where(y_true > 0, y_true, 0), 2 - p) / ((1 - p) * (2 - p))
-            - y_true * xp.pow(y_pred, 1 - p) / (1 - p)
-            + xp.pow(y_pred, 2 - p) / (2 - p)
+            xp.pow(xp.where(y_true > 0, y_true, zero), xp.asarray(2 - p))
+            / ((1 - p) * (2 - p))
+            - y_true * xp.pow(y_pred, xp.asarray(1 - p)) / (1 - p)
+            + xp.pow(y_pred, xp.asarray(2 - p)) / (2 - p)
         )
     elif p == 0:
         # Normal distribution, y and y_pred any real number
@@ -1401,7 +1403,7 @@ def mean_tweedie_deviance(y_true, y_pred, *, sample_weight=None, power=0):
     message = f"Mean Tweedie deviance error with power={power} can only be used on "
     if power < 0:
         # 'Extreme stable', y any real number, y_pred > 0
-        if (y_pred <= 0).any():
+        if xp.any(y_pred <= 0):
             raise ValueError(message + "strictly positive y_pred.")
     elif power == 0:
         # Normal, y and y_pred can be any real number

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1321,9 +1321,9 @@ def _mean_tweedie_deviance(y_true, y_pred, sample_weight, power):
         dev = 2 * (xp.log(y_pred / y_true) + y_true / y_pred - 1)
     else:
         dev = 2 * (
-            xp.pow(y_true, 2 - p) / ((1 - p) * (2 - p))
-            - y_true * xp.pow(y_pred, 1 - p) / (1 - p)
-            + xp.pow(y_pred, 2 - p) / (2 - p)
+            xp.pow(y_true, xp.asarray(2 - p)) / ((1 - p) * (2 - p))
+            - y_true * xp.pow(y_pred, xp.asarray(1 - p)) / (1 - p)
+            + xp.pow(y_pred, xp.asarray(2 - p)) / (2 - p)
         )
     return float(_average(dev, weights=sample_weight))
 
@@ -1410,7 +1410,7 @@ def mean_tweedie_deviance(y_true, y_pred, *, sample_weight=None, power=0):
         pass
     elif 1 <= power < 2:
         # Poisson and compound Poisson distribution, y >= 0, y_pred > 0
-        if (y_true < 0).any() or (y_pred <= 0).any():
+        if xp.any(y_true < 0) or xp.any(y_pred <= 0):
             raise ValueError(message + "non-negative y and strictly positive y_pred.")
     elif power >= 2:
         # Gamma and Extreme stable distribution, y and y_pred > 0

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1831,7 +1831,6 @@ def check_array_api_multiclass_classification_metric(
 
 
 def check_array_api_regression_metric(metric, array_namespace, device, dtype_name):
-    func_name = metric.func.__name__ if isinstance(metric, partial) else metric.__name__
     y_true_np = np.array([2.0, 0.1, 1.0, 4.0], dtype=dtype_name)
     y_pred_np = np.array([0.5, 0.5, 2, 2], dtype=dtype_name)
 
@@ -1855,8 +1854,6 @@ def check_array_api_regression_metric(metric, array_namespace, device, dtype_nam
         metric_kwargs["sample_weight"] = np.array(
             [0.1, 2.0, 1.5, 0.5], dtype=dtype_name
         )
-    if func_name == "mean_tweedie_deviance":
-        metric_kwargs["power"] = -0.5
 
         check_array_api_metric(
             metric,
@@ -1945,6 +1942,7 @@ array_api_metric_checkers = {
         check_array_api_multiclass_classification_metric,
     ],
     mean_tweedie_deviance: [check_array_api_regression_metric],
+    partial(mean_tweedie_deviance, power=-0.5): [check_array_api_regression_metric],
     r2_score: [
         check_array_api_regression_metric,
         check_array_api_regression_metric_multioutput,

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1831,6 +1831,7 @@ def check_array_api_multiclass_classification_metric(
 
 
 def check_array_api_regression_metric(metric, array_namespace, device, dtype_name):
+    func_name = metric.func.__name__ if isinstance(metric, partial) else metric.__name__
     y_true_np = np.array([2.0, 0.1, 1.0, 4.0], dtype=dtype_name)
     y_pred_np = np.array([0.5, 0.5, 2, 2], dtype=dtype_name)
 
@@ -1854,6 +1855,8 @@ def check_array_api_regression_metric(metric, array_namespace, device, dtype_nam
         metric_kwargs["sample_weight"] = np.array(
             [0.1, 2.0, 1.5, 0.5], dtype=dtype_name
         )
+    if func_name == "mean_tweedie_deviance":
+        metric_kwargs["power"] = -0.5
 
         check_array_api_metric(
             metric,

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1943,6 +1943,7 @@ array_api_metric_checkers = {
     ],
     mean_tweedie_deviance: [check_array_api_regression_metric],
     partial(mean_tweedie_deviance, power=-0.5): [check_array_api_regression_metric],
+    partial(mean_tweedie_deviance, power=1.5): [check_array_api_regression_metric],
     r2_score: [
         check_array_api_regression_metric,
         check_array_api_regression_metric_multioutput,


### PR DESCRIPTION
#### Reference Issues/PRs
towards #26024 
related to #28106

#### What does this implement/fix? Explain your changes.
I noticed that for `mean_tweedie_deviance` we never check for extreme stable cases (power<0) so I added a test for it 😺 
Upon testing I also found some spots in the actual `mean_tweedie_deviance` method that we either have missed (still using np) or little errors that break unit tests so I fixed them. 

#### Any other comments?
Not sure how to update changelogs or if it's necessary to do that 