### PR TITLE
MAINT Fix typo in parameter name input_dtye -> input_dtype

### DIFF
--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -334,12 +334,12 @@ class BaseSGD(SparseCoefMixin, BaseEstimator, metaclass=ABCMeta):
         return self._loss_function_
 
 
-def _prepare_fit_binary(est, y, i, input_dtye):
+def _prepare_fit_binary(est, y, i, input_dtype):
     """Initialization for fit_binary.
 
     Returns y, coef, intercept, average_coef, average_intercept.
     """
-    y_i = np.ones(y.shape, dtype=input_dtye, order="C")
+    y_i = np.ones(y.shape, dtype=input_dtype, order="C")
     y_i[y != est.classes_[i]] = -1.0
     average_intercept = 0
     average_coef = None
@@ -434,7 +434,7 @@ def fit_binary(
     # if average is not true, average_coef, and average_intercept will be
     # unused
     y_i, coef, intercept, average_coef, average_intercept = _prepare_fit_binary(
-        est, y, i, input_dtye=X.dtype
+        est, y, i, input_dtype=X.dtype
     )
     assert y_i.shape[0] == y.shape[0] == sample_weight.shape[0]
 


### PR DESCRIPTION
Regarding backward-compatibility, this is fine to change the parameter name, since this is a private function in a private module.