### PR TITLE
DOC Update doc for `min_samples` in HDBSCAN

### DIFF
--- a/sklearn/cluster/_hdbscan/_reachability.pyx
+++ b/sklearn/cluster/_hdbscan/_reachability.pyx
@@ -62,8 +62,8 @@ def mutual_reachability_graph(
         `CSR` format.
 
     min_samples : int, default=5
-        The number of points in a neighbourhood for a point to be considered
-        a core point.
+        The parameter `k` used to calculate the distance between a point
+        `x_p` and its k-th nearest neighbor.
 
     max_distance : float, default=0.0
         The distance which `np.inf` is replaced with. When the true mutual-

--- a/sklearn/cluster/_hdbscan/hdbscan.py
+++ b/sklearn/cluster/_hdbscan/hdbscan.py
@@ -441,8 +441,8 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
         as noise.
 
     min_samples : int, default=None
-        The number of samples in a neighborhood for a point
-        to be considered as a core point. This includes the point itself.
+        The parameter `k` used to calculate the distance between a point
+        `x_p` and its k-th nearest neighbor.
         When `None`, defaults to `min_cluster_size`.
 
     cluster_selection_epsilon : float, default=0.0


### PR DESCRIPTION
#### Reference Issues/PRs
Fix #28976.

#### What does this implement/fix? Explain your changes.
Clarify the role of the argument `min_samples` when computing the core distance, needed to calculate the mutual reachability distance in the clustering algorithm HDBSCAN.
