### PR TITLE
TST Relax `test_minibatch_sensible_reassign` to avoid CI failures with single global random seed 

### DIFF
--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -438,22 +438,29 @@ def test_minibatch_sensible_reassign(global_random_seed):
         n_clusters=20, batch_size=10, random_state=global_random_seed, init="random"
     ).fit(zeroed_X)
     # there should not be too many exact zero cluster centers
-    assert km.cluster_centers_.any(axis=1).sum() > 10
+    num_non_zero_clusters = km.cluster_centers_.any(axis=1).sum()
+    if num_non_zero_clusters <= 10:
+        raise ValueError(
+            f"Number of non-zero clusters is too small {num_non_zero_clusters=}"
+        )
 
     # do the same with batch-size > X.shape[0] (regression test)
     km = MiniBatchKMeans(
         n_clusters=20, batch_size=200, random_state=global_random_seed, init="random"
     ).fit(zeroed_X)
     # there should not be too many exact zero cluster centers
-    assert km.cluster_centers_.any(axis=1).sum() > 10
+    num_non_zero_clusters = km.cluster_centers_.any(axis=1).sum()
+    if num_non_zero_clusters <= 10:
+        raise ValueError(
+            f"Number of non-zero clusters is too small {num_non_zero_clusters=}"
+        )
 
     # do the same with partial_fit API
     km = MiniBatchKMeans(n_clusters=20, random_state=global_random_seed, init="random")
     for i in range(100):
         km.partial_fit(zeroed_X)
-
+    # there should not be too many exact zero cluster centers
     num_non_zero_clusters = km.cluster_centers_.any(axis=1).sum()
-    # Error with info
     if num_non_zero_clusters <= 10:
         raise ValueError(
             f"Number of non-zero clusters is too small {num_non_zero_clusters=}"

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -453,6 +453,7 @@ def test_minibatch_sensible_reassign(global_random_seed):
         km.partial_fit(zeroed_X)
     # there should not be too many exact zero cluster centers
     num_non_zero_clusters = km.cluster_centers_.any(axis=1).sum()
+    # Assert with info
     assert num_non_zero_clusters > 10, f"{num_non_zero_clusters=}"
 
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -2,6 +2,7 @@
 
 import re
 import sys
+import warnings
 from io import StringIO
 
 import numpy as np
@@ -453,6 +454,7 @@ def test_minibatch_sensible_reassign(global_random_seed):
         km.partial_fit(zeroed_X)
     # there should not be too many exact zero cluster centers
     num_non_zero_clusters = km.cluster_centers_.any(axis=1).sum()
+    warnings.warn("f{num_non_zero_clusters=}", category=RuntimeWarning)
     # Assert with info
     assert num_non_zero_clusters > 10, f"{num_non_zero_clusters=}"
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -438,7 +438,7 @@ def test_minibatch_sensible_reassign(global_random_seed):
     ).fit(zeroed_X)
     # there should not be too many exact zero cluster centers
     num_non_zero_clusters = km.cluster_centers_.any(axis=1).sum()
-    if num_non_zero_clusters <= 10:
+    if num_non_zero_clusters < 10:
         raise ValueError(
             f"Number of non-zero clusters is too small {num_non_zero_clusters=}"
         )
@@ -449,7 +449,7 @@ def test_minibatch_sensible_reassign(global_random_seed):
     ).fit(zeroed_X)
     # there should not be too many exact zero cluster centers
     num_non_zero_clusters = km.cluster_centers_.any(axis=1).sum()
-    if num_non_zero_clusters <= 10:
+    if num_non_zero_clusters < 10:
         raise ValueError(
             f"Number of non-zero clusters is too small {num_non_zero_clusters=}"
         )
@@ -460,7 +460,7 @@ def test_minibatch_sensible_reassign(global_random_seed):
         km.partial_fit(zeroed_X)
     # there should not be too many exact zero cluster centers
     num_non_zero_clusters = km.cluster_centers_.any(axis=1).sum()
-    if num_non_zero_clusters <= 10:
+    if num_non_zero_clusters < 10:
         raise ValueError(
             f"Number of non-zero clusters is too small {num_non_zero_clusters=}"
         )

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -428,6 +428,7 @@ def test_minibatch_sensible_reassign(global_random_seed):
     # check that identical initial clusters are reassigned
     # also a regression test for when there are more desired reassignments than
     # samples.
+    global_random_seed = 34
     zeroed_X, true_labels = make_blobs(
         n_samples=100, centers=5, random_state=global_random_seed
     )
@@ -451,7 +452,8 @@ def test_minibatch_sensible_reassign(global_random_seed):
     for i in range(100):
         km.partial_fit(zeroed_X)
     # there should not be too many exact zero cluster centers
-    assert km.cluster_centers_.any(axis=1).sum() > 10
+    num_non_zero_clusters = km.cluster_centers_.any(axis=1).sum()
+    assert num_non_zero_clusters > 10, f"{num_non_zero_clusters=}"
 
 
 @pytest.mark.parametrize(

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -438,10 +438,7 @@ def test_minibatch_sensible_reassign(global_random_seed):
     ).fit(zeroed_X)
     # there should not be too many exact zero cluster centers
     num_non_zero_clusters = km.cluster_centers_.any(axis=1).sum()
-    if num_non_zero_clusters < 10:
-        raise ValueError(
-            f"Number of non-zero clusters is too small {num_non_zero_clusters=}"
-        )
+    assert num_non_zero_clusters > 9, f"{num_non_zero_clusters=} is too small"
 
     # do the same with batch-size > X.shape[0] (regression test)
     km = MiniBatchKMeans(
@@ -449,10 +446,7 @@ def test_minibatch_sensible_reassign(global_random_seed):
     ).fit(zeroed_X)
     # there should not be too many exact zero cluster centers
     num_non_zero_clusters = km.cluster_centers_.any(axis=1).sum()
-    if num_non_zero_clusters < 10:
-        raise ValueError(
-            f"Number of non-zero clusters is too small {num_non_zero_clusters=}"
-        )
+    assert num_non_zero_clusters > 9, f"{num_non_zero_clusters=} is too small"
 
     # do the same with partial_fit API
     km = MiniBatchKMeans(n_clusters=20, random_state=global_random_seed, init="random")
@@ -460,10 +454,7 @@ def test_minibatch_sensible_reassign(global_random_seed):
         km.partial_fit(zeroed_X)
     # there should not be too many exact zero cluster centers
     num_non_zero_clusters = km.cluster_centers_.any(axis=1).sum()
-    if num_non_zero_clusters < 10:
-        raise ValueError(
-            f"Number of non-zero clusters is too small {num_non_zero_clusters=}"
-        )
+    assert num_non_zero_clusters > 9, f"{num_non_zero_clusters=} is too small"
 
 
 @pytest.mark.parametrize(

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -428,7 +428,6 @@ def test_minibatch_sensible_reassign(global_random_seed):
     # check that identical initial clusters are reassigned
     # also a regression test for when there are more desired reassignments than
     # samples.
-    global_random_seed = 34
     zeroed_X, true_labels = make_blobs(
         n_samples=100, centers=5, random_state=global_random_seed
     )

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -2,7 +2,6 @@
 
 import re
 import sys
-import warnings
 from io import StringIO
 
 import numpy as np
@@ -452,11 +451,13 @@ def test_minibatch_sensible_reassign(global_random_seed):
     km = MiniBatchKMeans(n_clusters=20, random_state=global_random_seed, init="random")
     for i in range(100):
         km.partial_fit(zeroed_X)
-    # there should not be too many exact zero cluster centers
+
     num_non_zero_clusters = km.cluster_centers_.any(axis=1).sum()
-    warnings.warn("f{num_non_zero_clusters=}", category=RuntimeWarning)
-    # Assert with info
-    assert num_non_zero_clusters > 10, f"{num_non_zero_clusters=}"
+    # Error with info
+    if num_non_zero_clusters <= 10:
+        raise ValueError(
+            f"Number of non-zero clusters is too small {num_non_zero_clusters=}"
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Close #29253.

Summarising my comments below, relaxing the check to be `> 9` instead of `> 10` makes the CI pass on all random seeds, see [Azure logs](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=67658&view=results) on PR commit https://github.com/scikit-learn/scikit-learn/pull/29278/commits/162684a1323ddad58295749f66dc3e30bb83eab6. I have not been able to reproduce the issue locally.



This issue has been seen in multiple CI builds from time to time e.g. https://github.com/scikit-learn/scikit-learn/issues/27967#issuecomment-1863791083 or https://github.com/scikit-learn/scikit-learn/issues/26802#issuecomment-2126728286