### PR TITLE
MAINT switch to macOS 12 on Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -247,7 +247,7 @@ jobs:
 - template: build_tools/azure/posix.yml
   parameters:
     name: macOS
-    vmImage: macOS-11
+    vmImage: macOS-12
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
     # Runs when dependencies succeeded or skipped
     condition: |


### PR DESCRIPTION
macOS is deprecated and some builds started to fail with the following message:


```
This is a scheduled macOS-11 brownout. The macOS-11 environment is deprecated and will be removed on June 28th, 2024.
```

e.g. in https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=67635&view=logs&j=97641769-79fb-5590-9088-a30ce9b850b9