### PR TITLE
MAINT Protect CUDA GPU workflow against timed commits

### DIFF
--- a/.github/workflows/cuda-gpu-ci.yml
+++ b/.github/workflows/cuda-gpu-ci.yml
@@ -19,12 +19,26 @@ jobs:
           # XXX: The 3.12.4 release of Python on GitHub Actions is corrupted:
           # https://github.com/actions/setup-python/issues/886
           python-version: '3.12.3'
-      - name: Checkout main repository
-        uses: actions/checkout@v4
-      - run: |
-          git fetch origin +refs/pull/${{ inputs.pr_id }}/head:pr-${{ inputs.pr_id }}
-          git checkout pr-${{ inputs.pr_id }}
-          echo "Checked out commit $(git rev-parse HEAD)"
+      - name: Get PR Info
+        id: pr
+        env:
+          PR_NUMBER: ${{ inputs.pr_id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          REPO_UPDATE_AT: ${{ github.event.repository.updated_at }}
+        run: |
+          pr="$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${GH_REPO}/pulls/${PR_NUMBER})"
+          head_sha="$(echo "$pr" | jq -r .head.sha)"
+          updated_at="$(echo "$pr" | jq -r .updated_at)"
+
+          # Check that the PR was not updated since the start of the workflow
+          # to protect against timed commit attacks.
+          if [[ $(date -d $updated_at) > $(date -d $REPO_UPDATE_AT) ]]; exit 1; fi
+
+          echo "head_sha=$head_sha" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
       - name: Cache conda environment
         id: cache-conda
         uses: actions/cache@v4

--- a/.github/workflows/cuda-gpu-ci.yml
+++ b/.github/workflows/cuda-gpu-ci.yml
@@ -2,8 +2,8 @@ name: CUDA GPU
 on:
   workflow_dispatch:
     inputs:
-      pr_id:
-        description: Test the contents of this Pull Request
+      commit_hash:
+        description: Commit hash to test
         required: true
 
 permissions: read-all
@@ -19,26 +19,13 @@ jobs:
           # XXX: The 3.12.4 release of Python on GitHub Actions is corrupted:
           # https://github.com/actions/setup-python/issues/886
           python-version: '3.12.3'
-      - name: Get PR Info
-        id: pr
-        env:
-          PR_NUMBER: ${{ inputs.pr_id }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          REPO_UPDATE_AT: ${{ github.event.repository.updated_at }}
-        run: |
-          pr="$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${GH_REPO}/pulls/${PR_NUMBER})"
-          head_sha="$(echo "$pr" | jq -r .head.sha)"
-          updated_at="$(echo "$pr" | jq -r .updated_at)"
-
-          # Check that the PR was not updated since the start of the workflow
-          # to protect against timed commit attacks.
-          if [[ $(date -d $updated_at) > $(date -d $REPO_UPDATE_AT) ]]; exit 1; fi
-
-          echo "head_sha=$head_sha" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         with:
-          ref: ${{ steps.pr.outputs.head_sha }}
+          ref: ${{ inputs.commit_hash }}
+      - name: PRs associated with commit
+        run: |
+          echo "This commit belongs to PR(s):"
+          git ls-remote origin 'pull/*/head' | grep -F -f <(git rev-parse HEAD) | awk -F'/' '{print $3}'
       - name: Cache conda environment
         id: cache-conda
         uses: actions/cache@v4

--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh workflow run .github/workflows/cuda-gpu-ci.yml -f pr_id=${{steps.cpr.outputs.pull-request-number}}
+          gh workflow run .github/workflows/cuda-gpu-ci.yml -f commit_hash=`git rev-parse HEAD`
 
       - name: Check Pull Request
         if: steps.cpr.outputs.pull-request-number != ''


### PR DESCRIPTION
This should prevent contributors to push malicious changes in their PR right after a maintainer has manually triggered on their PR.

I guess the only way to test that this works as expected to is to merge to `main` an trigger test build, although I could not find an exhaustive list of what triggers updates of the value of `github.event.repository.updated_at`.