### PR TITLE
CI Fix build nightly wheels upload

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -258,6 +258,6 @@ jobs:
           # Secret variables need to be mapped to environment variables explicitly
           SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN }}
           SCIKIT_LEARN_STAGING_UPLOAD_TOKEN: ${{ secrets.SCIKIT_LEARN_STAGING_UPLOAD_TOKEN }}
-          ARTIFACTS_PATH: dist/artifact
+          ARTIFACTS_PATH: dist
         # Force a replacement if the remote file already exists
         run: bash build_tools/github/upload_anaconda.sh


### PR DESCRIPTION
Fix #29293. Probaly the v3 -> v4 artifact actions update changed the path ...

I tested this on my fork with a simpler setup only sdist and making sure that `ls $ARTIFACTS_PATH/*` shows something and it does, see [build log](https://github.com/lesteve/scikit-learn/actions/runs/9576284538/job/26402546972). There is no staightforward way to test in this PR, `[cd build gh]` will skip the upload step since the upload step is skipped inside a PR.

Previously in #29211, during my testing on my fork, I kind of I expected the workflow to fail because anaconda_upload would fail without token, but I did not think of checking that `ls $ARTIFACTS_PATH/*` was showing something oh well :sweat_smile: 

Side-comment: in an ideal world we have an automated issue when the nightly wheels upload fails ...