### PR TITLE
MAINT Clean-up more unused Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,19 @@
 
 PYTHON ?= python
 
-clean-setuptools:
-	$(PYTHON) setup.py clean
-	rm -rf dist
-
-inplace-setuptools:
-	$(PYTHON) setup.py build_ext -i
-
 dev: dev-meson
 
 dev-meson:
 	pip install --verbose --no-build-isolation --editable . --check-build-dependencies --config-settings editable-verbose=true
 
+clean: clean-meson
+
 clean-meson:
 	pip uninstall -y scikit-learn
 
-clean: clean-meson
+dev-setuptools:
+	$(PYTHON) setup.py build_ext -i
+
+clean-setuptools:
+	$(PYTHON) setup.py clean
+	rm -rf dist

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,8 @@ dev: dev-meson
 
 dev-meson:
 	pip install --verbose --no-build-isolation --editable . --check-build-dependencies --config-settings editable-verbose=true
+
+clean-meson:
+	pip uninstall -y scikit-learn
+
+clean: clean-meson

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ all:
 	@echo "  dev-setuptools       build scikit-learn with setuptools (deprecated)"
 	@echo "  clean-setuptools     clean scikit-learn setuptools build (deprecated)"
 
+.PHONY: all
+
 dev: dev-meson
 
 dev-meson:

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ all:
 	@echo "Please use 'make <target>' where <target> is one of"
 	@echo "  dev                  build scikit-learn with Meson"
 	@echo "  clean                clean scikit-learn Meson build. Very rarely needed,"
-	@echo "                       one use case is when switching back to setuptools)"
-	@echo "  dev-setuptools       build scikit-learn with setuptools"
-	@echo "  clean-setuptools     clean scikit-learn setuptools build"
+	@echo "                       one use case is when switching back to setuptools"
+	@echo "  dev-setuptools       build scikit-learn with setuptools (deprecated)"
+	@echo "  clean-setuptools     clean scikit-learn setuptools build (deprecated)"
 
 dev: dev-meson
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,14 @@
 
 PYTHON ?= python
 
+all:
+	@echo "Please use 'make <target>' where <target> is one of"
+	@echo "  dev                  build scikit-learn with Meson"
+	@echo "  clean                clean scikit-learn Meson build. Very rarely needed,"
+	@echo "                       one use case is when switching back to setuptools)"
+	@echo "  dev-setuptools       build scikit-learn with setuptools"
+	@echo "  clean-setuptools     clean scikit-learn setuptools build"
+
 dev: dev-meson
 
 dev-meson:

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,14 @@
 
 PYTHON ?= python
 
-clean:
+clean-setuptools:
 	$(PYTHON) setup.py clean
 	rm -rf dist
 
-inplace:
+inplace-setuptools:
 	$(PYTHON) setup.py build_ext -i
+
+dev: dev-meson
 
 dev-meson:
 	pip install --verbose --no-build-isolation --editable . --check-build-dependencies --config-settings editable-verbose=true
-
-clean-meson:
-	pip uninstall -y scikit-learn

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,11 @@
 # simple makefile to simplify repetitive build env management tasks under posix
 
-# caution: testing won't work on windows, see README
-
 PYTHON ?= python
-CYTHON ?= cython
-PYTEST ?= pytest
-
-# skip doctests on 32bit python
-BITS := $(shell python -c 'import struct; print(8 * struct.calcsize("P"))')
-
-all: clean inplace test
 
 clean:
 	$(PYTHON) setup.py clean
 	rm -rf dist
 
-in: inplace # just a shortcut
 inplace:
 	$(PYTHON) setup.py build_ext -i
 
@@ -24,32 +14,3 @@ dev-meson:
 
 clean-meson:
 	pip uninstall -y scikit-learn
-
-test-code: in
-	$(PYTEST) --showlocals -v sklearn --durations=20
-test-sphinxext:
-	$(PYTEST) --showlocals -v doc/sphinxext/
-test-doc:
-ifeq ($(BITS),64)
-	$(PYTEST) $(shell find doc -name '*.rst' | sort)
-endif
-test-code-parallel: in
-	$(PYTEST) -n auto --showlocals -v sklearn --durations=20
-
-test-coverage:
-	rm -rf coverage .coverage
-	$(PYTEST) sklearn --showlocals -v --cov=sklearn --cov-report=html:coverage
-test-coverage-parallel:
-	rm -rf coverage .coverage .coverage.*
-	$(PYTEST) sklearn -n auto --showlocals -v --cov=sklearn --cov-report=html:coverage
-
-test: test-code test-sphinxext test-doc
-
-cython:
-	python setup.py build_src
-
-doc: inplace
-	$(MAKE) -C doc html
-
-doc-noplot: inplace
-	$(MAKE) -C doc html-noplot

--- a/build_tools/azure/test_docs.sh
+++ b/build_tools/azure/test_docs.sh
@@ -9,5 +9,6 @@ pwd
 which python
 which pytest
 
+# XXX: for some unknown reason python -m pytest fails here in the CI, can't
+# reproduce locally and not worth spending time on this
 pytest $(find doc -name '*.rst' | sort)
-python -m pytest $(find doc -name '*.rst' | sort)

--- a/build_tools/azure/test_docs.sh
+++ b/build_tools/azure/test_docs.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 source build_tools/shared.sh
 activate_environment
 
+pwd
+which python
+which pytest
+
+pytest $(find doc -name '*.rst' | sort)
 python -m pytest $(find doc -name '*.rst' | sort)

--- a/build_tools/azure/test_docs.sh
+++ b/build_tools/azure/test_docs.sh
@@ -2,10 +2,7 @@
 
 set -e
 
-if [[ "$DISTRIB" =~ ^conda.* ]]; then
-    source activate $VIRTUALENV
-elif [[ "$DISTRIB" == "ubuntu" || "$DISTRIB" == "pip-free-threaded" ]]; then
-    source $VIRTUALENV/bin/activate
-fi
+source build_tools/shared.sh
+activate_environment
 
 make test-doc

--- a/build_tools/azure/test_docs.sh
+++ b/build_tools/azure/test_docs.sh
@@ -5,4 +5,4 @@ set -e
 source build_tools/shared.sh
 activate_environment
 
-make test-doc
+python -m pytest $(find doc -name '*.rst' | sort)

--- a/build_tools/azure/test_docs.sh
+++ b/build_tools/azure/test_docs.sh
@@ -5,10 +5,6 @@ set -ex
 source build_tools/shared.sh
 activate_environment
 
-pwd
-which python
-which pytest
-
 # XXX: for some unknown reason python -m pytest fails here in the CI, can't
 # reproduce locally and not worth spending time on this
 pytest $(find doc -name '*.rst' | sort)

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -996,7 +996,7 @@ We expect code coverage of new features to be at least around 90%.
   To test code coverage, you need to install the `coverage
   <https://pypi.org/project/coverage/>`_ package in addition to `pytest`.
 
-  1. Run `make test-coverage`. The output lists for each file the line
+  1. Run `pytest --cov sklearn /path/to/tests`. The output lists for each file the line
      numbers that are not tested.
 
   2. Find a low hanging fruit, looking at which lines are not tested,


### PR DESCRIPTION
Follow-up of #29170 and preparing for #29012.
 
In rough order of controversy potential, from from 1 to 10 (from "no brainer"=1 to "super controversial"=10)
1. `make cython` controversy rating 1: never heard of it, not sure what it does, probably nobody uses it
2. `make test-*` removal controvery rating 1: and similar have been broken for a few years. In particular since the global random seed plugin, you need to install scikit-learn in your environment or use `python -m pytest` that adds current working directory to sys.path automatically, nobody has ever complained about this it seems until https://github.com/scikit-learn/scikit-learn/issues/29280 so I am guessing this is not used
3. `make doc`, `make doc-noplot` removal controversy rating 2: undocumented so people go to `doc` and do `make html` or`make html-noplot`
4. `all` removal controversy rating 3: I have a slight preference that people be explicit about what they want to do ... the `Makefile` will go away one day we use spin #29012. If there is a strong support for having the same behaviour as previously (build + test) I can put it back.

Other changes after @adrin's suggestion with higher controversy rating:
- add `dev` for `dev-meson` to have something less generic, controversy rating 3
- rename setuptools specific targets controversy rating 5: for example `clean-meson` rather than `clean`, `inplace-setuptools` rather than `inplace`
- probably other stuff I have forgotten