### PR TITLE
CI Trigger wheels build on workflow_dispatch

### DIFF
--- a/build_tools/github/check_build_trigger.sh
+++ b/build_tools/github/check_build_trigger.sh
@@ -7,6 +7,7 @@ COMMIT_MSG=$(git log --no-merges -1 --oneline)
 
 # The commit marker "[cd build]" or "[cd build gh]" will trigger the build when required
 if [[ "$GITHUB_EVENT_NAME" == schedule ||
+      "$GITHUB_EVENT_NAME" == workflow_dispatch ||
       "$COMMIT_MSG" =~ \[cd\ build\] ||
       "$COMMIT_MSG" =~ \[cd\ build\ gh\] ]]; then
     echo "build=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Follow-up of #29295 to be able to upload nightly wheels when we manually trigger the workflow like I just wanted. I realised that nothing happens because the check-trigger script does not take into account the `workflow_dispatch` workflow and the build wheels step is skipped, see [workflow](https://github.com/scikit-learn/scikit-learn/actions/runs/9577889453)

Tested on my fork (with simplified setup): https://github.com/lesteve/scikit-learn/actions/runs/9577944751