### PR TITLE
MAINT upload wheels to scientific-python-nightly-wheels on workflow_dispatch

### DIFF
--- a/build_tools/github/upload_anaconda.sh
+++ b/build_tools/github/upload_anaconda.sh
@@ -4,7 +4,9 @@ set -e
 set -x
 
 # Note: build_wheels.sh has the same branch (only for NumPy 2.0 transition)
-if [[ "$GITHUB_EVENT_NAME" == "schedule" || "$CIRRUS_CRON" == "nightly" ]]; then
+if [[ "$GITHUB_EVENT_NAME" == "schedule" \
+        || "$GITHUB_EVENT_NAME" == "workflow_dispatch" \
+        || "$CIRRUS_CRON" == "nightly" ]]; then
     ANACONDA_ORG="scientific-python-nightly-wheels"
     ANACONDA_TOKEN="$SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN"
 else

--- a/build_tools/wheels/build_wheels.sh
+++ b/build_tools/wheels/build_wheels.sh
@@ -50,7 +50,9 @@ if [[ $(uname) == "Darwin" ]]; then
 fi
 
 
-if [[ "$GITHUB_EVENT_NAME" == "schedule" || "$CIRRUS_CRON" == "nightly" ]]; then
+if [[ "$GITHUB_EVENT_NAME" == "schedule" \
+        || "$GITHUB_EVENT_NAME" == "workflow_dispatch" \
+        || "$CIRRUS_CRON" == "nightly" ]]; then
     # Nightly build:  See also `../github/upload_anaconda.sh` (same branching).
     # To help with NumPy 2.0 transition, ensure that we use the NumPy 2.0
     # nightlies.  This lives on the edge and opts-in to all pre-releases.


### PR DESCRIPTION
Tackling https://github.com/scikit-learn/scikit-learn/pull/29297#issuecomment-2178540610

I have updated `build_wheels.sh`, not sure this is actually needed but given the comment I thought I would keep code in sync.

Side-comment: the build against dev dependencies can be cleaned-up now that numpy 2 has been released but let's leave this for another day, because you know wayyyyyy too much CI stuff these days