### PR TITLE
FIX Work around likely SIMD issue in tree export on 32bit OS

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -56,6 +56,13 @@ Changelog
   grids that have estimators as parameter values.
   :pr:`29179` by :user:`Marco Gorelli<MarcoGorelli>`.
 
+:mod:`sklearn.tree`
+...................
+
+- |Fix| Fix an issue in :func:`tree.export_graphviz` and :func:`tree.plot_tree`
+  that could potentially result in exception or wrong results on 32bit OSes.
+  :pr:`` by :user:`Loïc Estève<lesteve>`.
+
 :mod:`sklearn.utils`
 ....................
 

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -260,10 +260,10 @@ class _BaseTreeExporter:
             if tree.n_outputs != 1:
                 # Find max and min impurities for multi-output
                 # The next line uses -max(impurity) instead of min(-impurity)
-                # and -min(impurity) instead of max(-impurity) on purpose, to
-                # avoid what looks like an issue with SIMD on non memory
-                # aligned arrays on 32bit OS, for more details see
-                # https://github.com/scikit-learn/scikit-learn/issues/27506 for
+                # and -min(impurity) instead of max(-impurity) on purpose, in
+                # order to avoid what looks like an issue with SIMD on non
+                # memory aligned arrays on 32bit OS. For more details see
+                # https://github.com/scikit-learn/scikit-learn/issues/27506.
                 self.colors["bounds"] = (-np.max(tree.impurity), -np.min(tree.impurity))
             elif tree.n_classes[0] == 1 and len(np.unique(tree.value)) != 1:
                 # Find max and min values in leaf nodes for regression

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from ..base import is_classifier
 from ..utils._param_validation import HasMethods, Interval, StrOptions, validate_params
+from ..utils.fixes import _IS_32BIT
 from ..utils.validation import check_array, check_is_fitted
 from . import DecisionTreeClassifier, DecisionTreeRegressor, _criterion, _tree
 from ._reingold_tilford import Tree, buchheim
@@ -259,7 +260,12 @@ class _BaseTreeExporter:
             self.colors["rgb"] = _color_brew(tree.n_classes[0])
             if tree.n_outputs != 1:
                 # Find max and min impurities for multi-output
-                self.colors["bounds"] = (np.min(-tree.impurity), np.max(-tree.impurity))
+                # Avoid what looks like an issue with SIMD on non memory
+                # aligned arrays on 32bit OS, see
+                # https://github.com/scikit-learn/scikit-learn/issues/27506 for
+                # more details
+                minus_impurity = -1.0 * tree.impurity if _IS_32BIT else -tree.impurity
+                self.colors["bounds"] = (np.min(minus_impurity), np.max(minus_impurity))
             elif tree.n_classes[0] == 1 and len(np.unique(tree.value)) != 1:
                 # Find max and min values in leaf nodes for regression
                 self.colors["bounds"] = (np.min(tree.value), np.max(tree.value))


### PR DESCRIPTION
Fix #27506.

I have put @mr-c,@gspr and @sergiopasra as co-authors, thanks for your inputs on this tricky issue :pray:!

I tested the fix in the Docker image provided by @mr-c in https://github.com/scikit-learn/scikit-learn/issues/27506#issuecomment-2180942355 and it works

Note for Distro package managers the patch may not work directly because `_IS_32BIT` was moved from `sklearn.utils` to `sklearn.utils.fixes` . Honestly I am pretty sure that this code is not performance critical and that just using `-1.0 * tree.impurity` even on 64bit OS is a completely fine patch. After all this code was not SIMDed before using numpy 1.26 and nobody ever complained that it was slow ...

The main reason, I used `_IS_32BIT` is that it makes it more explicit and I hope that one day it can be cleaned up :crossed_fingers: