### PR TITLE
FIX missing force_writeable in KernelCenterer.transform

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2435,7 +2435,11 @@ class KernelCenterer(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEsti
         xp, _ = get_namespace(K)
 
         K = self._validate_data(
-            K, copy=copy, dtype=_array_api.supported_float_dtypes(xp), reset=False
+            K,
+            copy=copy,
+            force_writeable=True,
+            dtype=_array_api.supported_float_dtypes(xp),
+            reset=False,
         )
 
         K_pred_cols = (xp.sum(K, axis=1) / self.K_fit_rows_.shape[0])[:, None]


### PR DESCRIPTION
Fix the CI failure on `main` described here: https://github.com/scikit-learn/scikit-learn/issues/29325#issuecomment-2181967547 caused by the recently concurrently merged fixes in  #29018 and #29100.

/cc @jeremiedbb @lesteve.

Fixes #29326 
Fixes #29325 
Fixes #29324 
Fixes #29323
