### PR TITLE
ENH Implement partial fitting for `NearestCentroid`

### DIFF
--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -16,7 +16,7 @@ from ..preprocessing import LabelEncoder
 from ..utils._param_validation import Interval, StrOptions
 from ..utils.multiclass import check_classification_targets
 from ..utils.sparsefuncs import csc_median_axis_0
-from ..utils.validation import check_is_fitted
+from ..utils.validation import check_is_fitted, column_or_1d
 
 
 class NearestCentroid(ClassifierMixin, BaseEstimator):
@@ -120,6 +120,37 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
             Note that centroid shrinking cannot be used with sparse matrices.
         y : array-like of shape (n_samples,)
             Target values.
+
+        Returns
+        -------
+        self : object
+            Fitted estimator.
+        """
+        X, y = self._validate_data(X, y, accept_sparse=True)
+        y = column_or_1d(y, warn=True)
+        return self._partial_fit(X, y, np.unique(y), _refit=True)
+    def _partial_fit(self, X, y, classes=None, _refit=False):
+        """
+        Actual implementation of the Nearest Centroid fitting.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            Training vector, where `n_samples` is the number of samples and
+            `n_features` is the number of features.
+            Note that centroid shrinking cannot be used with sparse matrices.
+
+        y : array-like of shape (n_samples,)
+            Target values.
+
+        classes : array-like of shape (n_classes,), optional (default=None)
+            List of all the classes that can possibly appear in the `y` vector.
+            Must be provided at the first call to `partial_fit`, can be omitted
+            in subsequent calls.
+
+        _refit : bool, optional (default=False)
+            If True, act as though this were the first time we called
+            `_partial_fit` (i.e. throw away any past fitting and start over).
 
         Returns
         -------

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -5,6 +5,7 @@ Nearest Centroid Classification
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import warnings
 from numbers import Real
 
 import numpy as np
@@ -14,7 +15,10 @@ from ..base import BaseEstimator, ClassifierMixin, _fit_context
 from ..metrics.pairwise import pairwise_distances_argmin
 from ..preprocessing import LabelEncoder
 from ..utils._param_validation import Interval, StrOptions
-from ..utils.multiclass import check_classification_targets
+from ..utils.multiclass import (
+    _check_partial_fit_first_call,
+    check_classification_targets,
+)
 from ..utils.sparsefuncs import csc_median_axis_0
 from ..utils.validation import check_is_fitted, column_or_1d
 
@@ -188,72 +192,145 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
         self : object
             Fitted estimator.
         """
+        if self.metric == "precomputed":
+            raise ValueError('Metric "precomputed" is not supported.')
+
         # If X is sparse and the metric is "manhattan", store it in a csc
         # format is easier to calculate the median.
         if self.metric == "manhattan":
             X, y = self._validate_data(X, y, accept_sparse=["csc"])
         else:
             X, y = self._validate_data(X, y, accept_sparse=["csr", "csc"])
-        is_X_sparse = sp.issparse(X)
-        if is_X_sparse and self.shrink_threshold:
-            raise ValueError("threshold shrinking not supported for sparse input")
+
+        X_is_sparse = sp.issparse(X)
+
+        if X_is_sparse and self.shrink_threshold:
+            raise ValueError("Threshold shrinking not supported for sparse input")
         check_classification_targets(y)
 
         n_samples, n_features = X.shape
-        le = LabelEncoder()
-        y_ind = le.fit_transform(y)
-        self.classes_ = classes = le.classes_
-        n_classes = classes.size
-        if n_classes < 2:
-            raise ValueError(
-                "The number of classes has to be greater than one; got %d class"
-                % (n_classes)
+
+        if _refit or _check_partial_fit_first_call(self, classes):
+            if self.metric != "euclidean":
+                warnings.warn(
+                    "Averaging for metrics other than "
+                    "euclidean and manhattan not supported. "
+                    "The average is set to be the mean."
+                )
+
+            self.true_classes_ = np.asarray(classes)
+
+            # Mask mapping each class to its members.
+            self.true_centroids_ = np.zeros(
+                (self.true_classes_.size, n_features), dtype=np.float64
             )
 
-        # Mask mapping each class to its members.
-        self.centroids_ = np.empty((n_classes, n_features), dtype=np.float64)
-        # Number of clusters in each class.
-        nk = np.zeros(n_classes)
+            # Number of clusters in each class.
+            self.nk_ = np.zeros(self.true_classes_.size)
+
+            if self.shrink_threshold:
+                self.ssd_ = np.zeros(
+                    (self.true_classes_.size, n_features), dtype=np.float64
+                )
+                self.dataset_centroid_ = np.mean(X, axis=0)
+
+        le = LabelEncoder()
+        le.fit(self.true_classes_)
+        y_ind = le.transform(y)
+
+        self.classes_ = le.classes_
+        n_classes = self.classes_.size
+
+        if n_classes < 2:
+            raise ValueError(
+                f"The number of classes has to be greater than one; got {n_classes}"
+            )
+
+        if self.shrink_threshold:
+            old_nk = self.nk_.copy()
+            old_centroids = self.true_centroids_.copy()
 
         for cur_class in range(n_classes):
             center_mask = y_ind == cur_class
-            nk[cur_class] = np.sum(center_mask)
-            if is_X_sparse:
+
+            if X[center_mask].size == 0:
+                continue
+
+            if X_is_sparse:
                 center_mask = np.where(center_mask)[0]
 
             if self.metric == "manhattan":
+                self.nk_[cur_class] += np.sum(center_mask)
+
                 # NumPy does not calculate median of sparse matrices.
-                if not is_X_sparse:
-                    self.centroids_[cur_class] = np.median(X[center_mask], axis=0)
+                if not X_is_sparse:
+                    self.true_centroids_[cur_class] = np.median(X[center_mask], axis=0)
                 else:
-                    self.centroids_[cur_class] = csc_median_axis_0(X[center_mask])
-            else:  # metric == "euclidean"
-                self.centroids_[cur_class] = X[center_mask].mean(axis=0)
+                    self.true_centroids_[cur_class] = csc_median_axis_0(X[center_mask])
+            else:
+                # Update each centroid weighted by the number of samples
+                self.true_centroids_[cur_class] = (
+                    X[center_mask].mean(axis=0) * np.sum(center_mask)
+                    + self.true_centroids_[cur_class] * self.nk_[cur_class]
+                )
+                self.nk_[cur_class] += np.sum(center_mask)
+                self.true_centroids_[cur_class] /= self.nk_[cur_class]
+
+        # Filtering out centroids without any data
+        self.classes_ = self.true_classes_[self.nk_ != 0]
+        self.centroids_ = self.true_centroids_[self.nk_ != 0]
 
         if self.shrink_threshold:
             if np.all(np.ptp(X, axis=0) == 0):
                 raise ValueError("All features have zero variance. Division by zero.")
-            dataset_centroid_ = np.mean(X, axis=0)
+
+            n_total = np.sum(self.nk_)
+            self.dataset_centroid_ = (
+                self.dataset_centroid_ * old_nk.sum(axis=0) + np.sum(X, axis=0)
+            ) / n_total
+
+            # Update sum of square distances of each class
+            for cur_class in range(n_classes):
+                n_old = old_nk[cur_class]
+                n_new = self.nk_[cur_class] - n_old
+                if n_new == 0:
+                    continue
+                center_mask = y_ind == cur_class
+                old_ssd = self.ssd_[cur_class]
+                new_ssd = (X[center_mask] - X[center_mask].mean(axis=0)) ** 2
+                new_ssd = new_ssd.sum(axis=0)
+                self.ssd_[cur_class] = (
+                    old_ssd
+                    + new_ssd
+                    + (n_old / float(n_new * (n_new + n_old)))
+                    * (
+                        n_new * old_centroids[cur_class]
+                        - n_new * X[center_mask].mean(axis=0)
+                    )
+                    ** 2
+                )
 
             # m parameter for determining deviation
-            m = np.sqrt((1.0 / nk) - (1.0 / n_samples))
+            m = np.sqrt((1.0 / self.nk_) - (1.0 / np.sum(self.nk_)))
+
             # Calculate deviation using the standard deviation of centroids.
-            variance = (X - self.centroids_[y_ind]) ** 2
-            variance = variance.sum(axis=0)
-            s = np.sqrt(variance / (n_samples - n_classes))
+            ssd = self.ssd_.sum(axis=0)
+            s = np.sqrt(ssd / (n_total - n_classes))
             s += np.median(s)  # To deter outliers from affecting the results.
-            mm = m.reshape(len(m), 1)  # Reshape to allow broadcasting.
-            ms = mm * s
-            deviation = (self.centroids_ - dataset_centroid_) / ms
+            ms = m.reshape(-1, 1) * s  # Reshape to allow broadcasting.
+            deviation = (self.true_centroids_ - self.dataset_centroid_) / ms
+
             # Soft thresholding: if the deviation crosses 0 during shrinking,
             # it becomes zero.
             signs = np.sign(deviation)
             deviation = np.abs(deviation) - self.shrink_threshold
             np.clip(deviation, 0, None, out=deviation)
             deviation *= signs
+
             # Now adjust the centroids using the deviation
             msd = ms * deviation
-            self.centroids_ = dataset_centroid_[np.newaxis, :] + msd
+            self.centroids_ = self.dataset_centroid_[np.newaxis, :] + msd
+
         return self
 
     def predict(self, X):

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -129,6 +129,37 @@ class NearestCentroid(ClassifierMixin, BaseEstimator):
         X, y = self._validate_data(X, y, accept_sparse=True)
         y = column_or_1d(y, warn=True)
         return self._partial_fit(X, y, np.unique(y), _refit=True)
+
+    def partial_fit(self, X, y, classes=None):
+        """Incremental fit on a batch of samples.
+
+        This method is expected to be called several times consecutively
+        on different chunks of a dataset so as to implement out-of-core
+        or online learning.
+        This is especially useful when the whole dataset is too big to fit in
+        memory at once.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            Training vector, where `n_samples` is the number of samples and
+            `n_features` is the number of features.
+            Note that centroid shrinking cannot be used with sparse matrices.
+
+        y : array-like of shape (n_samples,)
+            Target values (integers).
+
+        classes : array-like of shape (n_classes,), optional (default=None)
+            List of all the classes that can possibly appear in the `y` vector.
+            Must be provided at the first call to `partial_fit`, can be omitted
+            in subsequent calls.
+        """
+        if self.metric == "manhattan":
+            raise ValueError(
+                "Partial fitting with 'manhattan' metric is not supported."
+            )
+        return self._partial_fit(X, y, classes, _refit=False)
+
     def _partial_fit(self, X, y, classes=None, _refit=False):
         """
         Actual implementation of the Nearest Centroid fitting.

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -159,3 +159,40 @@ def test_features_zero_var():
     clf = NearestCentroid(shrink_threshold=0.1)
     with pytest.raises(ValueError):
         clf.fit(X, y)
+
+
+def test_partial_fit():
+    # Test the partial fitting
+
+    clf = NearestCentroid()
+
+    clf.partial_fit(X[:3], y[:3], classes=[-1, 1])
+    clf_partial_pred = clf.predict(T)
+    assert not np.array_equal(clf_partial_pred, true_result)
+
+    clf.partial_fit(X[3:], y[3:])
+    clf_complete_pred = clf.predict(T)
+    assert_array_equal(clf_complete_pred, true_result)
+    assert not np.array_equal(clf_complete_pred, clf_partial_pred)
+
+    clf_fit = NearestCentroid()
+    clf_fit = clf_fit.fit(X, y)
+    assert_array_equal(clf_fit.predict(T), clf_complete_pred)
+
+
+def test_partial_shrinkage_correct():
+    # Ensure that the shrinking is correct.
+    # The expected result is calculated by R (pamr),
+    # which is implemented by the author of the original paper.
+    # (One need to modify the code to output the new centroid in pamr.predict)
+
+    X = np.array([[0, 1], [1, 0], [1, 1], [2, 0], [6, 8]])
+    y = np.array([1, 1, 2, 2, 2])
+    clf = NearestCentroid(shrink_threshold=0.1)
+    clf.partial_fit(X[:3], y[:3], classes=[1, 2])
+    expected_result = np.array([[0.55773503, 0.55773503], [0.88452995, 0.88452995]])
+    np.testing.assert_array_almost_equal(clf.centroids_, expected_result)
+
+    clf.partial_fit(X[3:], y[3:])
+    expected_result = np.array([[0.7787310, 0.8545292], [2.814179, 2.763647]])
+    np.testing.assert_array_almost_equal(clf.centroids_, expected_result)


### PR DESCRIPTION
This is mostly a copy of #19262; credit goes to its author (now shown as @ghost) and @Robinspecteur.

I advise reviewing commit-by-commit.

This is my first contribution!

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Closes #12952. Supercedes #19262.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

This implements partial fitting for `.neighbors.NearestCentroid`.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
