### PR TITLE
ENH fetch_file to fetch data files by URL with retries, checksuming and local caching

### DIFF
--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -120,8 +120,8 @@ Changelog
 
 - |Feature| :func:`datasets.fetch_file` allows downloading arbitrary data-file
   from the web. It handles local caching, integrity checks with SHA256 digests
-  and automatic retries in case of HTTP errors. :pr:`Olivier Grisel <ogrisel>`
-  by :user:`Olivier Grisel <ogrisel>`.
+  and automatic retries in case of HTTP errors. :pr:`29354` by :user:`Olivier
+  Grisel <ogrisel>`.
 
 :mod:`sklearn.discriminant_analysis`
 ....................................

--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -114,6 +114,15 @@ Changelog
   on the input data.
   :pr:`29124` by :user:`Yao Xiao <Charlie-XIAO>`.
 
+
+:mod:`sklearn.datasets`
+.......................
+
+- |Feature| :func:`datasets.fetch_file` allows downloading arbitrary data-file
+  from the web. It handles local caching, integrity checks with SHA256 digests
+  and automatic retries in case of HTTP errors. :pr:`Olivier Grisel <ogrisel>`
+  by :user:`Olivier Grisel <ogrisel>`.
+
 :mod:`sklearn.discriminant_analysis`
 ....................................
 

--- a/examples/applications/plot_time_series_lagged_features.py
+++ b/examples/applications/plot_time_series_lagged_features.py
@@ -24,7 +24,8 @@ engineering.
 # step in a convenience tool such as `sklearn.datasets.fetch_openml`.
 #
 # The URL of the parquet file can be found in the JSON description of the
-# Bike Sharing Demand v7 dataset on openml.org.
+# Bike Sharing Demand v7 dataset on openml.org
+# (https://openml.org/search?type=data&status=active&id=44063).
 import numpy as np
 import polars as pl
 

--- a/examples/applications/plot_time_series_lagged_features.py
+++ b/examples/applications/plot_time_series_lagged_features.py
@@ -434,4 +434,3 @@ plt.show()
 # can be used to extend scikit-learn estimators by making use of recursive time
 # series forecasting, that enables dynamic predictions of future values.
 
-# %%

--- a/examples/applications/plot_time_series_lagged_features.py
+++ b/examples/applications/plot_time_series_lagged_features.py
@@ -21,7 +21,7 @@ engineering.
 #
 # We start by loading the data from the OpenML repository as a raw parquet file
 # to illustrate how to work with an arbitrary parquet file instead of hiding this
-# step in a convenience too such as `sklearn.datasets.fetch_openml`.
+# step in a convenience tool such as `sklearn.datasets.fetch_openml`.
 #
 # The URL of the parquet file can be found in the JSON description of the
 # Bike Sharing Demand v7 dataset on openml.org.
@@ -39,7 +39,7 @@ bike_sharing_data_file = fetch_file(
 bike_sharing_data_file
 
 # %%
-# We load the parquet file with Polars for feature engineering. Polas
+# We load the parquet file with Polars for feature engineering. Polars
 # automatically caches common subexpressions which are reused in multiple
 # expressions (like `pl.col("count").shift(1)` below). See
 # https://docs.pola.rs/user-guide/lazy/optimizations/ for more information.

--- a/examples/applications/plot_time_series_lagged_features.py
+++ b/examples/applications/plot_time_series_lagged_features.py
@@ -19,26 +19,31 @@ engineering.
 # Analyzing the Bike Sharing Demand dataset
 # -----------------------------------------
 #
-# We start by loading the data from the OpenML repository
-# as a pandas dataframe. This will be replaced with Polars
-# once `fetch_openml` adds a native support for it.
-# We convert to Polars for feature engineering, as it automatically caches
-# common subexpressions which are reused in multiple expressions
-# (like `pl.col("count").shift(1)` below). See
-# https://docs.pola.rs/user-guide/lazy/optimizations/ for more information.
-
+# We start by loading the data from the OpenML repository as a raw parquet file
+# to illustrate how to work with arbitrary parquet file instead of hiding this
+# step in a convenience too such as `sklearn.datasets.fetch_openml`.
 import numpy as np
 import polars as pl
 
-from sklearn.datasets import fetch_openml
+from sklearn.datasets import fetch_file
 
 pl.Config.set_fmt_str_lengths(20)
 
-bike_sharing = fetch_openml(
-    "Bike_Sharing_Demand", version=2, as_frame=True, parser="pandas"
+# Direct download of the parquet file of the Bike Sharing Demand v7 dataset on
+# openml.org:
+bike_sharing_data_file = fetch_file(
+    "https://openml1.win.tue.nl/datasets/0004/44063/dataset_44063.pq",
+    sha256="d120af76829af0d256338dc6dd4be5df4fd1f35bf3a283cab66a51c1c6abd06a",
 )
-df = bike_sharing.frame
-df = pl.DataFrame({col: df[col].to_numpy() for col in df.columns})
+bike_sharing_data_file
+
+# %%
+# We load the parquet file with Polars for feature engineering, as it
+# automatically caches common subexpressions which are reused in multiple
+# expressions (like `pl.col("count").shift(1)` below). See
+# https://docs.pola.rs/user-guide/lazy/optimizations/ for more information.
+
+df = pl.read_parquet(bike_sharing_data_file)
 
 # %%
 # Next, we take a look at the statistical summary of the dataset
@@ -423,3 +428,5 @@ plt.show()
 # by `sktime <https://www.sktime.net/en/latest/users.html>`_
 # can be used to extend scikit-learn estimators by making use of recursive time
 # series forecasting, that enables dynamic predictions of future values.
+
+# %%

--- a/examples/applications/plot_time_series_lagged_features.py
+++ b/examples/applications/plot_time_series_lagged_features.py
@@ -24,8 +24,11 @@ engineering.
 # step in a convenience tool such as `sklearn.datasets.fetch_openml`.
 #
 # The URL of the parquet file can be found in the JSON description of the
-# Bike Sharing Demand v7 dataset on openml.org
+# Bike Sharing Demand dataset with id 44063 on openml.org
 # (https://openml.org/search?type=data&status=active&id=44063).
+#
+# The `sha256` hash of the file is also provided to ensure the integrity of the
+# downloaded file.
 import numpy as np
 import polars as pl
 

--- a/examples/applications/plot_time_series_lagged_features.py
+++ b/examples/applications/plot_time_series_lagged_features.py
@@ -20,8 +20,11 @@ engineering.
 # -----------------------------------------
 #
 # We start by loading the data from the OpenML repository as a raw parquet file
-# to illustrate how to work with arbitrary parquet file instead of hiding this
+# to illustrate how to work with an arbitrary parquet file instead of hiding this
 # step in a convenience too such as `sklearn.datasets.fetch_openml`.
+#
+# The URL of the parquet file can be found in the JSON description of the
+# Bike Sharing Demand v7 dataset on openml.org.
 import numpy as np
 import polars as pl
 
@@ -29,8 +32,6 @@ from sklearn.datasets import fetch_file
 
 pl.Config.set_fmt_str_lengths(20)
 
-# Direct download of the parquet file of the Bike Sharing Demand v7 dataset on
-# openml.org:
 bike_sharing_data_file = fetch_file(
     "https://openml1.win.tue.nl/datasets/0004/44063/dataset_44063.pq",
     sha256="d120af76829af0d256338dc6dd4be5df4fd1f35bf3a283cab66a51c1c6abd06a",
@@ -38,7 +39,7 @@ bike_sharing_data_file = fetch_file(
 bike_sharing_data_file
 
 # %%
-# We load the parquet file with Polars for feature engineering, as it
+# We load the parquet file with Polars for feature engineering. Polas
 # automatically caches common subexpressions which are reused in multiple
 # expressions (like `pl.col("count").shift(1)` below). See
 # https://docs.pola.rs/user-guide/lazy/optimizations/ for more information.

--- a/examples/applications/plot_time_series_lagged_features.py
+++ b/examples/applications/plot_time_series_lagged_features.py
@@ -433,4 +433,3 @@ plt.show()
 # by `sktime <https://www.sktime.net/en/latest/users.html>`_
 # can be used to extend scikit-learn estimators by making use of recursive time
 # series forecasting, that enables dynamic predictions of future values.
-

--- a/sklearn/datasets/__init__.py
+++ b/sklearn/datasets/__init__.py
@@ -4,6 +4,7 @@ import textwrap
 
 from ._base import (
     clear_data_home,
+    fetch_file,
     get_data_home,
     load_breast_cancer,
     load_diabetes,
@@ -57,6 +58,7 @@ __all__ = [
     "dump_svmlight_file",
     "fetch_20newsgroups",
     "fetch_20newsgroups_vectorized",
+    "fetch_file",
     "fetch_lfw_pairs",
     "fetch_lfw_people",
     "fetch_olivetti_faces",

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1572,7 +1572,7 @@ def _derive_folder_and_filename_from_url(url):
 def fetch_file(
     url, folder=None, local_filename=None, sha256=None, n_retries=3, delay=1
 ):
-    """Fetch a file from the web.
+    """Fetch a file from the web if not already present in the local folder.
 
     If the file already exists locally (and the SHA256 checksums match when
     provided), the path to the local file is returned without re-downloading.

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1538,11 +1538,10 @@ def _filter_filename(value, filter_dots=True):
     """
     value = unicodedata.normalize("NFKD", value).lower()
     if filter_dots:
-        value = re.sub(r"[^\w\s-]", "_", value)
+        value = re.sub(r"[^\w\s-]+", "_", value)
     else:
-        value = re.sub(r"[^.\w\s-]", "_", value)
-    value = re.sub(r"_+", "_", value)
-    value = re.sub(r"-+", "-", value)
+        value = re.sub(r"[^.\w\s-]+", "_", value)
+    value = re.sub(r"[\s-]+", "-", value)
     return value.strip("-_.")
 
 

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1483,7 +1483,7 @@ def _fetch_remote(remote, dirname=None, n_retries=3, delay=1):
             return file_path
         else:
             warnings.warn(
-                f"SHA256 checksum of existing local file at {str(file_path)} "
+                f"SHA256 checksum of existing local file {file_path.name} "
                 f"({checksum}) differs from expected ({remote.checksum}): "
                 f"re-downloading from {remote.url} ."
             )

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1531,13 +1531,10 @@ def _slugify(value):
     Adapted from
     https://github.com/django/django/blob/master/django/utils/text.py
 
-    Convert to ASCII if 'allow_unicode' is False. Convert spaces or repeated
-    dashes to single dashes. Remove characters that aren't alphanumerics,
-    underscores, or hyphens. Convert to lowercase. Also strip leading and
+    Convert to ASCII, convert spaces or repeated dashes to single dashes.
+    Replace characters that aren't alphanumerics, underscores, hyphens or
+    periods by underscores. Convert to lowercase. Also strip leading and
     trailing whitespace, dashes, and underscores.
-
-    Note: this version keeps "." characters unchanged contrary to the django
-    version and replace other un-authorized characters by "_".
     """
     value = (
         unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii")

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1528,7 +1528,7 @@ def _fetch_remote(remote, dirname=None, n_retries=3, delay=1):
 def _filter_filename(value, filter_dots=True):
     """Derive a name that is safe to use as filename from the given string.
 
-    Adapted from
+    Adapted from the `slugify` function of django:
     https://github.com/django/django/blob/master/django/utils/text.py
 
     Convert spaces or repeated dashes to single dashes. Replace characters that

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1499,7 +1499,7 @@ def _fetch_remote(remote, dirname=None, n_retries=3, delay=1):
     temp_file = NamedTemporaryFile(
         prefix=remote.filename + ".part_", dir=folder_path, delete=False
     )
-    # Note that Python 3.12's `delete_on_close=True` is ignored as we set 
+    # Note that Python 3.12's `delete_on_close=True` is ignored as we set
     # `delete=False` explicitly. So after this line the empty temporary file still
     # exists on disk to make sure that it's uniquely reserved for this specific call of
     # `_fetch_remote` and therefore it protects against any corruption by parallel

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1580,8 +1580,10 @@ def fetch_file(
 ):
     """Fetch a file from the web.
 
-    If the file already exists locally and the SHA256 checksums match, the path
-    to the local file is returned without re-downloading.
+    If the file already exists locally (and the SHA256 checksums match when
+    provided), the path to the local file is returned without re-downloading.
+
+    .. versionadded:: 1.6
 
     Parameters
     ----------

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1508,9 +1508,8 @@ def _fetch_remote(remote, dirname=None, n_retries=3, delay=1):
         checksum = _sha256(temp_file_path)
         if remote.checksum is not None and remote.checksum != checksum:
             raise OSError(
-                f"{remote.filename} has an SHA256 checksum ({checksum}) "
-                f"differing from expected ({remote.checksum}), "
-                "file may be corrupted."
+                f"The SHA256 checksum of {remote.filename} ({checksum}) "
+                f"differs from expected ({remote.checksum})."
             )
     except BaseException:
         temp_file.close()

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1520,7 +1520,7 @@ def _fetch_remote(remote, dirname=None, n_retries=3, delay=1):
                 f"The SHA256 checksum of {remote.filename} ({checksum}) "
                 f"differs from expected ({remote.checksum})."
             )
-    except Exception:
+    except (Exception, KeyboardInterrupt):
         os.unlink(temp_file.name)
         raise
 

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1499,6 +1499,11 @@ def _fetch_remote(remote, dirname=None, n_retries=3, delay=1):
     temp_file = NamedTemporaryFile(
         prefix=remote.filename + ".part_", dir=folder_path, delete=False
     )
+    # Note that Python 3.12's `delete_on_close=True` is ignored as we set 
+    # `delete=False` explicitly. So after this line the empty temporary file still
+    # exists on disk to make sure that it's uniquely reserved for this specific call of
+    # `_fetch_remote` and therefore it protects against any corruption by parallel
+    # calls.
     temp_file.close()
     try:
         temp_file_path = Path(temp_file.name)

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1491,6 +1491,7 @@ def _fetch_remote(remote, dirname=None, n_retries=3, delay=1):
     temp_file = NamedTemporaryFile(
         prefix=remote.filename + ".part_", dir=folder_path, delete=False
     )
+    temp_file.close()
     try:
         temp_file_path = Path(temp_file.name)
         while True:
@@ -1512,7 +1513,6 @@ def _fetch_remote(remote, dirname=None, n_retries=3, delay=1):
                 f"differs from expected ({remote.checksum})."
             )
     except BaseException:
-        temp_file.close()
         os.unlink(temp_file.name)
         raise
 

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1525,7 +1525,7 @@ def _fetch_remote(remote, dirname=None, n_retries=3, delay=1):
     return file_path
 
 
-def _slugify(value, allow_unicode=False):
+def _slugify(value):
     """Derive a name that is safe to use as filename from the given string.
 
     Adapted from
@@ -1539,15 +1539,9 @@ def _slugify(value, allow_unicode=False):
     Note: this version keeps "." characters unchanged contrary to the django
     version and replace other un-authorized characters by "_".
     """
-    value = str(value)
-    if allow_unicode:
-        value = unicodedata.normalize("NFKC", value)
-    else:
-        value = (
-            unicodedata.normalize("NFKD", value)
-            .encode("ascii", "ignore")
-            .decode("ascii")
-        )
+    value = (
+        unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii")
+    )
     value = re.sub(r"[^.\w\s-]", "_", value.lower())
     value = re.sub(r"_+", "_", value)
     return re.sub(r"[-\s]+", "-", value).strip("-_")

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -406,6 +406,12 @@ def test_derive_folder_and_filename_from_url():
     assert filename == "file.tar.gz"
 
     folder, filename = _derive_folder_and_filename_from_url(
+        "https://example.com/نمونه نماینده.data"
+    )
+    assert folder == "example.com"
+    assert filename == "نمونه نماینده.data"
+
+    folder, filename = _derive_folder_and_filename_from_url(
         "https://example.com/path/to/file.tar.gz"
     )
     assert folder == "example.com/path_to"
@@ -430,6 +436,31 @@ def test_derive_folder_and_filename_from_url():
     )
     assert folder == "example.com/path_to"
     assert filename == "data.json"
+
+    folder, filename = _derive_folder_and_filename_from_url(
+        "https://example.com//some_file.txt"
+    )
+    assert folder == "example.com"
+    assert filename == "some_file.txt"
+
+    folder, filename = _derive_folder_and_filename_from_url(
+        "https://example.com/!.'.,/some_file.txt"
+    )
+    assert folder == "example.com"
+    assert filename == "some_file.txt"
+
+    folder, filename = _derive_folder_and_filename_from_url(
+        "https://example.com/a/!.'.,/b/some_file.txt"
+    )
+    assert folder == "example.com/a_b"
+    assert filename == "some_file.txt"
+
+    folder, filename = _derive_folder_and_filename_from_url("https://example.com/!.'.,")
+    assert folder == "example.com"
+    assert filename == "downloaded_file"
+
+    with pytest.raises(ValueError, match="Invalid URL"):
+        _derive_folder_and_filename_from_url("https:/../")
 
 
 def _mock_urlretrieve(server_side):

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -412,7 +412,7 @@ def test_derive_folder_and_filename_from_url():
     assert filename == "نمونه-نماینده.data"
 
     folder, filename = _derive_folder_and_filename_from_url(
-        "https://example.com/path/to/file.tar.gz"
+        "https://example.com/path/to/.file.tar.gz"
     )
     assert folder == "example.com/path_to"
     assert filename == "file.tar.gz"
@@ -432,13 +432,19 @@ def test_derive_folder_and_filename_from_url():
     assert filename == "data.json"
 
     folder, filename = _derive_folder_and_filename_from_url(
-        "https://example.com/path/@@to/data.json#anchor"
+        "https://example.com/path/@@to._/-_.data.json.#anchor"
     )
     assert folder == "example.com/path_to"
     assert filename == "data.json"
 
     folder, filename = _derive_folder_and_filename_from_url(
         "https://example.com//some_file.txt"
+    )
+    assert folder == "example.com"
+    assert filename == "some_file.txt"
+
+    folder, filename = _derive_folder_and_filename_from_url(
+        "https://example.com/../some_file.txt"
     )
     assert folder == "example.com"
     assert filename == "some_file.txt"

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -409,7 +409,7 @@ def test_derive_folder_and_filename_from_url():
         "https://example.com/نمونه نماینده.data"
     )
     assert folder == "example.com"
-    assert filename == "نمونه نماینده.data"
+    assert filename == "نمونه-نماینده.data"
 
     folder, filename = _derive_folder_and_filename_from_url(
         "https://example.com/path/to/file.tar.gz"
@@ -432,7 +432,7 @@ def test_derive_folder_and_filename_from_url():
     assert filename == "data.json"
 
     folder, filename = _derive_folder_and_filename_from_url(
-        "https://example.com/path/@to/data.json#anchor"
+        "https://example.com/path/@@to/data.json#anchor"
     )
     assert folder == "example.com/path_to"
     assert filename == "data.json"

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -602,7 +602,7 @@ def test_fetch_file_with_sha256(monkeypatch, tmpdir):
     assert urlretrieve_mock.call_count == 1
 
     # Corrupting the local data should yield a warning and trigger a new download:
-    fetched_file_path.write_text("corruped contents", encoding="utf-8")
+    fetched_file_path.write_text("corrupted contents", encoding="utf-8")
     expected_msg = (
         r"SHA256 checksum of existing local file data.jsonl "
         rf"\(.*\) differs from expected \({expected_sha256}\): "

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -567,7 +567,7 @@ def test_fetch_file_with_sha256(monkeypatch, tmpdir):
     # Corrupting the local data should yield a warning and trigger a new download:
     fetched_file_path.write_text("corruped contents", encoding="utf-8")
     expected_msg = (
-        r"SHA256 checksum of existing local file at .*client_side/data.jsonl "
+        r"SHA256 checksum of existing local file at .*data.jsonl "
         rf"\(.*\) differs from expected \({expected_sha256}\): "
         r"re-downloading from https://example.com/data.jsonl \."
     )

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -619,6 +619,3 @@ def test_fetch_file_with_sha256(monkeypatch, tmpdir):
                 folder=client_side,
                 sha256=non_matching_sha256,
             )
-        # The local file should not have been deleted.
-        assert client_side.join("data.jsonl").read_text(encoding="utf-8") == server_data
-        assert urlretrieve_mock.call_count == 3

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -412,7 +412,7 @@ def test_derive_folder_and_filename_from_url():
     assert filename == "نمونه-نماینده.data"
 
     folder, filename = _derive_folder_and_filename_from_url(
-        "https://example.com/path/to/.file.tar.gz"
+        "https://example.com/path/to-/.file.tar.gz"
     )
     assert folder == "example.com/path_to"
     assert filename == "file.tar.gz"
@@ -444,9 +444,9 @@ def test_derive_folder_and_filename_from_url():
     assert filename == "some_file.txt"
 
     folder, filename = _derive_folder_and_filename_from_url(
-        "https://example.com/../some_file.txt"
+        "http://example/../some_file.txt"
     )
-    assert folder == "example.com"
+    assert folder == "example"
     assert filename == "some_file.txt"
 
     folder, filename = _derive_folder_and_filename_from_url(

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -567,7 +567,7 @@ def test_fetch_file_with_sha256(monkeypatch, tmpdir):
     # Corrupting the local data should yield a warning and trigger a new download:
     fetched_file_path.write_text("corruped contents", encoding="utf-8")
     expected_msg = (
-        r"SHA256 checksum of existing local file at .*data.jsonl "
+        r"SHA256 checksum of existing local file data.jsonl "
         rf"\(.*\) differs from expected \({expected_sha256}\): "
         r"re-downloading from https://example.com/data.jsonl \."
     )

--- a/sklearn/datasets/tests/test_base.py
+++ b/sklearn/datasets/tests/test_base.py
@@ -28,6 +28,7 @@ from sklearn.datasets import (
 )
 from sklearn.datasets._base import (
     RemoteFileMetadata,
+    _derive_folder_and_filename_from_url,
     _fetch_remote,
     load_csv_data,
     load_gzip_compressed_csv_data,
@@ -391,3 +392,37 @@ def test_fetch_remote_raise_warnings_with_invalid_url(monkeypatch):
         for r in record:
             assert str(r.message) == f"Retry downloading from url: {url}"
         assert len(record) == 3
+
+
+def test_derive_folder_and_filename_from_url():
+    folder, filename = _derive_folder_and_filename_from_url(
+        "https://example.com/file.tar.gz"
+    )
+    assert folder == "example.com"
+    assert filename == "file.tar.gz"
+
+    folder, filename = _derive_folder_and_filename_from_url(
+        "https://example.com/path/to/file.tar.gz"
+    )
+    assert folder == "example.com/path_to"
+    assert filename == "file.tar.gz"
+
+    folder, filename = _derive_folder_and_filename_from_url("https://example.com/")
+    assert folder == "example.com"
+    assert filename == "downloaded_file"
+
+    folder, filename = _derive_folder_and_filename_from_url("https://example.com")
+    assert folder == "example.com"
+    assert filename == "downloaded_file"
+
+    folder, filename = _derive_folder_and_filename_from_url(
+        "https://example.com/path/@to/data.json?param=value"
+    )
+    assert folder == "example.com/path_to"
+    assert filename == "data.json"
+
+    folder, filename = _derive_folder_and_filename_from_url(
+        "https://example.com/path/@to/data.json#anchor"
+    )
+    assert folder == "example.com/path_to"
+    assert filename == "data.json"


### PR DESCRIPTION
The goal of this helper would be to make it possible to have education examples that download and cache datafiles that are then manually loaded with functions such as `pandas.read_csv`, `pandas.read_parquet` and so on.

The goal is to avoid inducing the readers of scikit-learn examples that machine learning is only about working with benchmark data wrapped as a `Bunch` object fetched by magic helpers such as `fetch_openml` that hide how to properly load a parquet file or specify non-default parameters to `read_csv`.

## TODO

- [x] write more tests;
- [x] upgrade at least one example to show how to use it, for instance with a parquet file from openml.org