### PR TITLE
BLD Use NPY_NO_DEPRECATED_API in meson.build to mirror setup.py

### DIFF
--- a/sklearn/meson.build
+++ b/sklearn/meson.build
@@ -58,7 +58,7 @@ inc_np = include_directories(incdir_numpy)
 # Don't use the deprecated NumPy C API. Define this to a fixed version instead of
 # NPY_API_VERSION in order not to break compilation for released SciPy versions
 # when NumPy introduces a new deprecation.
-numpy_no_deprecated_api = ['-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION']
+numpy_no_deprecated_api = ['-DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION']
 np_dep = declare_dependency(include_directories: inc_np, compile_args: numpy_no_deprecated_api)
 
 openmp_dep = dependency('OpenMP', language: 'c', required: false)

--- a/sklearn/meson.build
+++ b/sklearn/meson.build
@@ -55,7 +55,11 @@ print(incdir)
 endif
 
 inc_np = include_directories(incdir_numpy)
-np_dep = declare_dependency(include_directories: inc_np)
+# Don't use the deprecated NumPy C API. Define this to a fixed version instead of
+# NPY_API_VERSION in order not to break compilation for released SciPy versions
+# when NumPy introduces a new deprecation.
+numpy_no_deprecated_api = ['-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION']
+np_dep = declare_dependency(include_directories: inc_np, compile_args: numpy_no_deprecated_api)
 
 openmp_dep = dependency('OpenMP', language: 'c', required: false)
 


### PR DESCRIPTION
Looks like this was not ported from `setup.py` which is likely an oversight. It is not clear to me what the impact is to be fully honest if any, for example on the released scikit-learn 1.5 wheels.

Probably more details are available at [here](https://numpy.org/doc/stable/reference/c-api/deprecations.html) and [here](https://numpy.org/doc/stable/dev/depending_on_numpy.html).

The comment is from Scipy `meson.build`, feel free to suggest improvements.

This was noticed in https://github.com/scikit-learn/scikit-learn/pull/29352, see in particular https://github.com/scikit-learn/scikit-learn/pull/29352#discussion_r1657065973.