### PR TITLE
MAINT Pin the ruff version on CI linters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           command: |
             source build_tools/shared.sh
             # Include pytest compatibility with mypy
-            pip install pytest ruff $(get_dep mypy min) $(get_dep black min) cython-lint
+            pip install pytest $(get_dep ruff min) $(get_dep mypy min) $(get_dep black min) cython-lint
       - run:
           name: linting
           command: ./build_tools/linting.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           source build_tools/shared.sh
           # Include pytest compatibility with mypy
-          pip install pytest ruff $(get_dep mypy min) $(get_dep black min) cython-lint
+          pip install pytest $(get_dep ruff min) $(get_dep mypy min) $(get_dep black min) cython-lint
           # we save the versions of the linters to be used in the error message later.
           python -c "from importlib.metadata import version; print(f\"ruff={version('ruff')}\")" >> /tmp/versions.txt
           python -c "from importlib.metadata import version; print(f\"mypy={version('mypy')}\")" >> /tmp/versions.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
     - bash: |
         source build_tools/shared.sh
         # Include pytest compatibility with mypy
-        pip install pytest ruff $(get_dep mypy min) $(get_dep black min) cython-lint
+        pip install pytest $(get_dep ruff min) $(get_dep mypy min) $(get_dep black min) cython-lint
       displayName: Install linters
     - bash: |
         ./build_tools/linting.sh


### PR DESCRIPTION
Ruff recently started to complain on PRs for files unrelated to the changed files so I suppose this is because of a change introduce on a new version.

Let's pin it to a specific version to avoid this kind of disruption.