### PR TITLE
Update biclustering documentation new scipy algorithm (#29282)

### DIFF
--- a/doc/modules/biclustering.rst
+++ b/doc/modules/biclustering.rst
@@ -288,7 +288,8 @@ available:
 
 2. Assign biclusters from one set to another in a one-to-one fashion
    to maximize the sum of their similarities. This step is performed
-   using the Hungarian algorithm.
+   using :func:`scipy.optimize.linear_sum_assignment`, which uses a 
+   modified Jonker-Volgenant algorithm.
 
 3. The final sum of similarities is divided by the size of the larger
    set.

--- a/sklearn/metrics/cluster/_bicluster.py
+++ b/sklearn/metrics/cluster/_bicluster.py
@@ -57,8 +57,9 @@ def _pairwise_similarity(a, b, similarity):
 def consensus_score(a, b, *, similarity="jaccard"):
     """The similarity of two sets of biclusters.
 
-    Similarity between individual biclusters is computed. Then the best
-    matching between sets is found using a modified Jonker-Volgenant algorithm.
+    Similarity between individual biclusters is computed. Then the best  
+    matching between sets is found by solving a linear sum assignment problem,
+    using a modified Jonker-Volgenant algorithm.  
     The final score is the sum of similarities divided by the size of
     the larger set.
 

--- a/sklearn/metrics/cluster/_bicluster.py
+++ b/sklearn/metrics/cluster/_bicluster.py
@@ -101,7 +101,6 @@ def consensus_score(a, b, *, similarity="jaccard"):
     >>> consensus_score(a, b, similarity='jaccard')
     1.0
     """
-    pass
     if similarity == "jaccard":
         similarity = _jaccard
     matrix = _pairwise_similarity(a, b, similarity)

--- a/sklearn/metrics/cluster/_bicluster.py
+++ b/sklearn/metrics/cluster/_bicluster.py
@@ -58,7 +58,8 @@ def consensus_score(a, b, *, similarity="jaccard"):
     """The similarity of two sets of biclusters.
 
     Similarity between individual biclusters is computed. Then the
-    best matching between sets is found using the Hungarian algorithm.
+    best matching between sets is found using a modified 
+    Jonker-Volgenant algorithm.
     The final score is the sum of similarities divided by the size of
     the larger set.
 
@@ -83,13 +84,16 @@ def consensus_score(a, b, *, similarity="jaccard"):
        Consensus score, a non-negative value, sum of similarities
        divided by size of larger set.
 
+    See Also
+    --------
+    scipy.optimize.linear_sum_assignment : Solve the linear sum assignment problem.
+    
     References
     ----------
 
     * Hochreiter, Bodenhofer, et. al., 2010. `FABIA: factor analysis
       for bicluster acquisition
       <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2881408/>`__.
-
     Examples
     --------
     >>> from sklearn.metrics import consensus_score

--- a/sklearn/metrics/cluster/_bicluster.py
+++ b/sklearn/metrics/cluster/_bicluster.py
@@ -57,9 +57,8 @@ def _pairwise_similarity(a, b, similarity):
 def consensus_score(a, b, *, similarity="jaccard"):
     """The similarity of two sets of biclusters.
 
-    Similarity between individual biclusters is computed. Then the
-    best matching between sets is found using a modified
-    Jonker-Volgenant algorithm.
+    Similarity between individual biclusters is computed. Then the best
+    matching between sets is found using a modified Jonker-Volgenant algorithm.
     The final score is the sum of similarities divided by the size of
     the larger set.
 

--- a/sklearn/metrics/cluster/_bicluster.py
+++ b/sklearn/metrics/cluster/_bicluster.py
@@ -89,10 +89,10 @@ def consensus_score(a, b, *, similarity="jaccard"):
 
     References
     ----------
-
     * Hochreiter, Bodenhofer, et. al., 2010. `FABIA: factor analysis
       for bicluster acquisition
       <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2881408/>`__.
+
     Examples
     --------
     >>> from sklearn.metrics import consensus_score
@@ -101,6 +101,7 @@ def consensus_score(a, b, *, similarity="jaccard"):
     >>> consensus_score(a, b, similarity='jaccard')
     1.0
     """
+    pass
     if similarity == "jaccard":
         similarity = _jaccard
     matrix = _pairwise_similarity(a, b, similarity)

--- a/sklearn/metrics/cluster/_bicluster.py
+++ b/sklearn/metrics/cluster/_bicluster.py
@@ -57,9 +57,9 @@ def _pairwise_similarity(a, b, similarity):
 def consensus_score(a, b, *, similarity="jaccard"):
     """The similarity of two sets of biclusters.
 
-    Similarity between individual biclusters is computed. Then the best  
+    Similarity between individual biclusters is computed. Then the best
     matching between sets is found by solving a linear sum assignment problem,
-    using a modified Jonker-Volgenant algorithm.  
+    using a modified Jonker-Volgenant algorithm.
     The final score is the sum of similarities divided by the size of
     the larger set.
 

--- a/sklearn/metrics/cluster/_bicluster.py
+++ b/sklearn/metrics/cluster/_bicluster.py
@@ -58,7 +58,7 @@ def consensus_score(a, b, *, similarity="jaccard"):
     """The similarity of two sets of biclusters.
 
     Similarity between individual biclusters is computed. Then the
-    best matching between sets is found using a modified 
+    best matching between sets is found using a modified
     Jonker-Volgenant algorithm.
     The final score is the sum of similarities divided by the size of
     the larger set.
@@ -87,7 +87,7 @@ def consensus_score(a, b, *, similarity="jaccard"):
     See Also
     --------
     scipy.optimize.linear_sum_assignment : Solve the linear sum assignment problem.
-    
+
     References
     ----------
 


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #29282 


#### What does this implement/fix? Explain your changes.

Changes the documentation of the biclustering page and the `consensus_score` page to add references to SciPy's function (to make it clear it's not scikit-learn's implementation, and to prevent future changes from impacting it) and changes the references from the previous Hungarian method to the now modified Jonker-Volgenant algorithm. 

#### Any other comments?
I'm not sure if the way I've written it matches the rest of the documentation, or if the _See Also_ section should be there in this case. I also feel like there should be a reference to the previous Hungarian method in the biclustering page, because it's one of the first and easiest to understand methods for the assignment problem; however I don't really know how to write that in, or if the team agrees.
Feel free to change it up.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
