### PR TITLE
CI Move CUDA CI to `pull_request` trigger

### DIFF
--- a/.github/workflows/cuda-gpu-ci.yml
+++ b/.github/workflows/cuda-gpu-ci.yml
@@ -1,31 +1,33 @@
 name: CUDA GPU
-on:
-  workflow_dispatch:
-    inputs:
-      commit_hash:
-        description: Commit hash to test
-        required: true
 
-permissions: read-all
+# Only run this workflow when a Pull Request is labeled with the
+# 'CUDA CI' label.
+on:
+  pull_request:
+    types:
+      - labeled
+
+# In order to remove the "CUDA CI" label we need to have write permissions for PRs
+permissions:
+  pull-requests: write
 
 jobs:
   tests:
+    if: contains(github.event.pull_request.labels.*.name, 'CUDA CI')
     runs-on:
       group: cuda-gpu-runner-group
     name: Run Array API unit tests
     steps:
+      - uses: actions-ecosystem/action-remove-labels@v1.3.0
+        with:
+          labels: CUDA CI
       - uses: actions/setup-python@v5
         with:
           # XXX: The 3.12.4 release of Python on GitHub Actions is corrupted:
           # https://github.com/actions/setup-python/issues/886
           python-version: '3.12.3'
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.commit_hash }}
-      - name: PRs associated with commit
-        run: |
-          echo "This commit belongs to PR(s):"
-          git ls-remote origin 'pull/*/head' | grep -F -f <(git rev-parse HEAD) | awk -F'/' '{print $3}'
+      - name: Checkout main repository
+        uses: actions/checkout@v4
       - name: Cache conda environment
         id: cache-conda
         uses: actions/cache@v4
@@ -41,6 +43,7 @@ jobs:
           conda activate sklearn
           pip install --verbose --no-build-isolation --config-settings editable-verbose=true --editable .
       - name: Run array API tests
+        id: tests
         run: |
           source "${HOME}/conda/etc/profile.d/conda.sh"
           conda activate sklearn

--- a/.github/workflows/cuda-gpu-ci.yml
+++ b/.github/workflows/cuda-gpu-ci.yml
@@ -16,6 +16,9 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'CUDA CI')
     runs-on:
       group: cuda-gpu-runner-group
+    # Set this high enough so that the tests can comforatble run. We set a
+    # timeout to make abusing this workflow less attractive.
+    timeout-minutes: 20
     name: Run Array API unit tests
     steps:
       - uses: actions-ecosystem/action-remove-labels@v1

--- a/.github/workflows/cuda-gpu-ci.yml
+++ b/.github/workflows/cuda-gpu-ci.yml
@@ -18,7 +18,7 @@ jobs:
       group: cuda-gpu-runner-group
     name: Run Array API unit tests
     steps:
-      - uses: actions-ecosystem/action-remove-labels@v1.3.0
+      - uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: CUDA CI
       - uses: actions/setup-python@v5

--- a/.github/workflows/cuda-gpu-ci.yml
+++ b/.github/workflows/cuda-gpu-ci.yml
@@ -43,7 +43,6 @@ jobs:
           conda activate sklearn
           pip install --verbose --no-build-isolation --config-settings editable-verbose=true --editable .
       - name: Run array API tests
-        id: tests
         run: |
           source "${HOME}/conda/etc/profile.d/conda.sh"
           conda activate sklearn

--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -6,9 +6,9 @@ on:
   schedule:
     - cron: '0 5 * * 1'
 
-# XXX Set the right permissions, per step??
-# Can we set read only at the global level here and then elevate to write for some steps?
-#permissions: read-all
+# In order to add the "CUDA CI" label we need to have write permissions for PRs
+permissions:
+  pull-requests: write
 
 jobs:
   update_lock_files:
@@ -68,7 +68,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh workflow run .github/workflows/cuda-gpu-ci.yml -f commit_hash=`git rev-parse HEAD`
+          gh pr edit ${{steps.cpr.outputs.pull-request-number}} --add-label "CUDA CI"
 
       - name: Check Pull Request
         if: steps.cpr.outputs.pull-request-number != ''


### PR DESCRIPTION
This modifies the CUDA CI workflow so that it runs with a `pull_request` trigger, if the PR has the `CUDA CI` label. When the workflow runs, it removes the label. Each time the label is added the workflow runs.

This improves the security of our workflows, for example by having a cache that is isolated from other branches. The current manual workflow trigger would execute the workflow in the context of the `main` branch instead.

There is currently no check that no new commit was pushed between the moment the label was applied and the checkout happens.

It is not clear to me if the workflow will start to run (-> cost us CI minutes) if a label is applied to a PR but the label does not match "CUDA CI". It looks like the CI run will be skipped immediately: https://github.com/betatim/scikit-learn-ci/pull/6

todo:
* [x] decide label name, currently "CUDA CI".
* [x] add a timeout for the job https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes
* [x] test whether or not the workflow triggers when labelling with "Foo Bar". Use https://github.com/betatim/scikit-learn-ci/ for test
* [x] discuss workflow permissions, is this the minimal set?
* [x] do we want to rely on an external workflow to remove the label or make a short python script that calls the REST API? (can't use `gh` as that isn't installed in the CUDA VM image :()

This follows on from #29245