### PR TITLE
TST Fix doctests to be compatible with scipy>=1.14

### DIFF
--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -211,6 +211,9 @@ def pytest_collection_modifyitems(config, items):
         reason = "Due to NEP 51 numpy scalar repr has changed in numpy 2"
         skip_doctests = True
 
+    if sp_version > parse_version("1.14"):
+        reason = "Scipy sparse matrix repr has changed in scipy 1.14"
+
     # Normally doctest has the entire module's scope. Here we set globs to an empty dict
     # to remove the module's scope:
     # https://docs.python.org/3/library/doctest.html#what-s-the-execution-context

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -211,8 +211,9 @@ def pytest_collection_modifyitems(config, items):
         reason = "Due to NEP 51 numpy scalar repr has changed in numpy 2"
         skip_doctests = True
 
-    if sp_version > parse_version("1.14"):
+    if sp_version < parse_version("1.14"):
         reason = "Scipy sparse matrix repr has changed in scipy 1.14"
+        skip_doctests = True
 
     # Normally doctest has the entire module's scope. Here we set globs to an empty dict
     # to remove the module's scope:

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -234,6 +234,9 @@ def grid_to_graph(
     >>> mask[[1, 2], [1, 2], :] = True
     >>> graph = grid_to_graph(*shape_img, mask=mask)
     >>> print(graph)
+    <COOrdinate sparse matrix of dtype 'int64'
+      with 2 stored elements and shape (2, 2)>
+      Coords	Values
       (0, 0)    1
       (1, 1)    1
     """

--- a/sklearn/utils/_indexing.py
+++ b/sklearn/utils/_indexing.py
@@ -478,8 +478,8 @@ def resample(*arrays, replace=True, n_samples=None, random_state=None, stratify=
              [1., 0.]])
 
       >>> X_sparse
-      <3x2 sparse matrix of type '<... 'numpy.float64'>'
-          with 4 stored elements in Compressed Sparse Row format>
+      <Compressed Sparse Row sparse matrix of dtype 'float64'
+          with 4 stored elements and shape (3, 2)>
 
       >>> X_sparse.toarray()
       array([[1., 0.],
@@ -616,8 +616,8 @@ def shuffle(*arrays, random_state=None, n_samples=None):
              [1., 0.]])
 
       >>> X_sparse
-      <3x2 sparse matrix of type '<... 'numpy.float64'>'
-          with 3 stored elements in Compressed Sparse Row format>
+      <Compressed Sparse Row sparse matrix of dtype 'float64'
+          with 3 stored elements and shape (3, 2)>
 
       >>> X_sparse.toarray()
       array([[0., 0.],

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -501,7 +501,7 @@ def indexable(*iterables):
     ...     [1, 2, 3], np.array([2, 3, 4]), None, csr_matrix([[5], [6], [7]])
     ... ]
     >>> indexable(*iterables)
-    [[1, 2, 3], array([2, 3, 4]), None, <3x1 sparse matrix ...>]
+    [[1, 2, 3], array([2, 3, 4]), None, <...Sparse...dtype 'int64'...shape (3, 1)>]
     """
 
     result = [_make_indexable(X) for X in iterables]
@@ -1503,8 +1503,8 @@ def check_symmetric(array, *, tol=1e-10, raise_warning=True, raise_exception=Fal
     >>> from scipy.sparse import csr_matrix
     >>> sparse_symmetric_array = csr_matrix(symmetric_array)
     >>> check_symmetric(sparse_symmetric_array)
-    <3x3 sparse matrix of type '<class 'numpy.int64'>'
-        with 6 stored elements in Compressed Sparse Row format>
+    <Compressed Sparse Row sparse matrix of dtype 'int64'
+        with 6 stored elements and shape (3, 3)>
     """
     if (array.ndim != 2) or (array.shape[0] != array.shape[1]):
         raise ValueError(


### PR DESCRIPTION
Seen in https://github.com/scikit-learn/scikit-learn/pull/29276,

Scipy 1.14 tweaked the sparse matrix `__repr__` making a few of our doctests fail.

This is only running the doctests for `scipy>=1.14` following what we already do with numpy (we are currently running the doctests only with `numpy<2` actually, we should probably update this to only run them with `numpy>=2`).

This is tested locally and will not be tested in the CI until we fix #29276.