### PR TITLE
MNT remove unused mixin class in TransformedTargetRegressor

### DIFF
--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -18,17 +18,12 @@ from ..utils._metadata_requests import (
 )
 from ..utils._param_validation import HasMethods
 from ..utils._tags import _safe_tags
-from ..utils.metadata_routing import (
-    _RoutingNotSupportedMixin,
-)
 from ..utils.validation import check_is_fitted
 
 __all__ = ["TransformedTargetRegressor"]
 
 
-class TransformedTargetRegressor(
-    _RoutingNotSupportedMixin, RegressorMixin, BaseEstimator
-):
+class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
     """Meta-estimator to regress on a transformed target.
 
     Useful for applying a non-linear transformation to the target `y` in


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Removes an unused mixin class in `TransformedTargetRegressor` (`_RoutingNotSupportedMixin`), that happend to stay there by accident. There are no side effects to this, I think, because the only method the mixin has is overridden by the same method from TransformedTargetRegressor itself.