### PR TITLE
CI Fix Assign workflow

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -19,6 +19,8 @@ jobs:
        && !github.event.issue.assignee
     steps:
       - run: |
+          # Using REST API directly because assigning through gh has some severe limitations. For more details, see
+          # https://github.com/scikit-learn/scikit-learn/issues/29395#issuecomment-2206776963
           echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
           curl -H "Authorization: token $GH_TOKEN" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' \
               https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - run: |
           echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
-          curl -H "Authorization: token ${{ github.token }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' \
+          curl -H "Authorization: token $GH_TOKEN" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' \
               https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
           gh issue edit $ISSUE --remove-label "help wanted"
         env:

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -20,7 +20,8 @@ jobs:
     steps:
       - run: |
           echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
-          gh issue edit $ISSUE --add-assignee ${{ github.event.comment.user.login }}
+          curl -H "Authorization: token ${{ github.token }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' \
+              https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees
           gh issue edit $ISSUE --remove-label "help wanted"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Fix #29395 

This uses the REST API rather than `gh` which only work for scikit-learn team members, see https://github.com/scikit-learn/scikit-learn/issues/29395#issuecomment-2206776963 for more details if you are really curious.

I tested this on my fork see https://github.com/lesteve/scikit-learn/issues/36 and this seems to work fine.

Regression introduced in https://github.com/scikit-learn/scikit-learn/pull/28031 (January 2 2024), it took us 6 months to realise. My feeling is that the assign workflow is not that useful in practice but oh well :shrug: 