### PR TITLE
MAINT use properly the metadata from OpenML

### DIFF
--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -10,6 +10,7 @@ from os.path import join
 from tempfile import TemporaryDirectory
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 from warnings import warn
 
@@ -29,12 +30,10 @@ from ._arff_parser import load_arff_from_gzip_file
 
 __all__ = ["fetch_openml"]
 
-_OPENML_PREFIX = "https://api.openml.org/"
-_SEARCH_NAME = "api/v1/json/data/list/data_name/{}/limit/2"
-_DATA_INFO = "api/v1/json/data/{}"
-_DATA_FEATURES = "api/v1/json/data/features/{}"
-_DATA_QUALITIES = "api/v1/json/data/qualities/{}"
-_DATA_FILE = "data/v1/download/{}"
+_SEARCH_NAME = "https://api.openml.org/api/v1/json/data/list/data_name/{}/limit/2"
+_DATA_INFO = "https://api.openml.org/api/v1/json/data/{}"
+_DATA_FEATURES = "https://api.openml.org/api/v1/json/data/features/{}"
+_DATA_QUALITIES = "https://api.openml.org/api/v1/json/data/qualities/{}"
 
 OpenmlQualitiesType = List[Dict[str, str]]
 OpenmlFeaturesType = List[Dict[str, str]]
@@ -116,16 +115,16 @@ def _retry_on_network_error(
 
 
 def _open_openml_url(
-    openml_path: str, data_home: Optional[str], n_retries: int = 3, delay: float = 1.0
+    url: str, data_home: Optional[str], n_retries: int = 3, delay: float = 1.0
 ):
     """
     Returns a resource from OpenML.org. Caches it to data_home if required.
 
     Parameters
     ----------
-    openml_path : str
-        OpenML URL that will be accessed. This will be prefixes with
-        _OPENML_PREFIX.
+    url : str
+        OpenML URL that will be accessed. We parse the URL to get the path and
+        replicate the tree structure on the local cache.
 
     data_home : str
         Directory to which the files will be cached. If None, no caching will
@@ -147,7 +146,7 @@ def _open_openml_url(
     def is_gzip_encoded(_fsrc):
         return _fsrc.info().get("Content-Encoding", "") == "gzip"
 
-    req = Request(_OPENML_PREFIX + openml_path)
+    req = Request(url)
     req.add_header("Accept-encoding", "gzip")
 
     if data_home is None:
@@ -156,6 +155,7 @@ def _open_openml_url(
             return gzip.GzipFile(fileobj=fsrc, mode="rb")
         return fsrc
 
+    openml_path = urlparse(url).path[1:]  # remove leading slash
     local_path = _get_local_path(openml_path, data_home)
     dir_name, file_name = os.path.split(local_path)
     if not os.path.exists(local_path):
@@ -1123,7 +1123,7 @@ def fetch_openml(
         shape = None
 
     # obtain the data
-    url = _DATA_FILE.format(data_description["file_id"])
+    url = data_description["url"]
     bunch = _download_data_to_bunch(
         url,
         return_sparse,


### PR DESCRIPTION
This PR improve the code in `_openml.py` to use the `json` file from OpenML. In this case, it helps at transitioning from ARFF file to parquet file. It also makes it easier for transitioning from v1 API to the future v2.