### PR TITLE
BLD Improve make clean for edge case situations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ clean: clean-meson
 
 clean-meson:
 	pip uninstall -y scikit-learn
-  # It seems in some cases (e.g. weird compilation errors when switching
-  # between numpy<2 and numpy>=2) removing the folder avoids weird compilation
-  # errors. For some reason ninja clean -C $(DEFAULT_MESON_BUILD_DIR) is not
-  # enough
+	# It seems in some cases (e.g. weird compilation errors when switching
+	# between numpy<2 and numpy>=2) removing the folder avoids weird compilation
+	# errors. For some reason ninja clean -C $(DEFAULT_MESON_BUILD_DIR) is not
+	# enough
 	rm -rf $(DEFAULT_MESON_BUILD_DIR)
 
 dev-setuptools:

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ clean: clean-meson
 
 clean-meson:
 	pip uninstall -y scikit-learn
-	# It seems in some cases (e.g. weird compilation errors when switching
-	# between numpy<2 and numpy>=2) removing the folder avoids weird compilation
-	# errors. For some reason ninja clean -C $(DEFAULT_MESON_BUILD_DIR) is not
+	# It seems in some cases removing the folder avoids weird compilation
+	# errors (e.g. when switching from numpy>=2 to numpy<2). For some 
+	# reason ninja clean -C $(DEFAULT_MESON_BUILD_DIR) is not
 	# enough
 	rm -rf $(DEFAULT_MESON_BUILD_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # simple makefile to simplify repetitive build env management tasks under posix
 
 PYTHON ?= python
+DEFAULT_MESON_BUILD_DIR = build/cp$(shell python -c 'import sys; print(f"{sys.version_info.major}{sys.version_info.minor}")' )
 
 all:
 	@echo "Please use 'make <target>' where <target> is one of"
@@ -21,6 +22,11 @@ clean: clean-meson
 
 clean-meson:
 	pip uninstall -y scikit-learn
+  # It seems in some cases (e.g. weird compilation errors when switching
+  # between numpy<2 and numpy>=2) removing the folder avoids weird compilation
+  # errors. For some reason ninja clean -C $(DEFAULT_MESON_BUILD_DIR) is not
+  # enough
+	rm -rf $(DEFAULT_MESON_BUILD_DIR)
 
 dev-setuptools:
 	$(PYTHON) setup.py build_ext -i


### PR DESCRIPTION
So it turns out a better `make clean` is needed as was discussed around https://github.com/scikit-learn/scikit-learn/pull/29296#discussion_r1647594693

When using meson editable mode and switching between numpy<2 and numpy>=2 in the same environment, you can get weird build errors and the way to get out of it is to delete the meson build folder

Removing the default meson build folder `meson/cp312` if you are using Python 3.12 seems to be the simplest solution. I tried `ninja clean -C build/cp312` which is a softer clean (my personal newbie understanding).

cc @rgommers for visibility or in case off the top of your head this seems like something that should just work in principle. This is completely fine to use this work-around to be honest. It could well be the case that there are some issues with our `meson.build` files, hard to tell ...

I am able to reproduce with a snippet like this
```bash
git clone https://github.com/scikit-learn/scikit-learn --depth 1
cd scikit-learn

conda create -n testenv meson-python cython 'numpy>=2' scipy -y
conda activate testenv

# just to make sure to start from scratch
rm -rf build

# Build with numpy>=2
pip install --verbose --no-build-isolation --editable . --check-build-dependencies --config-settings editable-verbose=true
# works fine
python -c 'import sklearn'

# install numpy<2
conda install 'numpy<2' -y
# compilation error
python -c 'import sklearn'
```

With the output:
```
meson-python: building scikit-learn: /home/lesteve/micromamba/envs/scikit-learn-dev/bin/ninja
[1/34] Compiling C++ object sklearn/utils/_vector...enerated_sklearn_utils__vector_sentinel.pyx.cpp.o
FAILED: sklearn/utils/_vector_sentinel.cpython-312-x86_64-linux-gnu.so.p/meson-generated_sklearn_utils__vector_sentinel.pyx.cpp.o 
ccache c++ -Isklearn/utils/_vector_sentinel.cpython-312-x86_64-linux-gnu.so.p -Isklearn/utils -I../../sklearn/utils -I../../../../micromamba/envs/scikit-learn-dev/lib/python3.12/site-packages/numpy/_core/include -Isklearn -I/home/lesteve/micromamba/envs/scikit-learn-dev/include/python3.12 -fvisibility=hidden -fvisibility-inlines-hidden -fdiagnostics-color=always -DNDEBUG -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++14 -O3 -fPIC -DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION -MD -MQ sklearn/utils/_vector_sentinel.cpython-312-x86_64-linux-gnu.so.p/meson-generated_sklearn_utils__vector_sentinel.pyx.cpp.o -MF sklearn/utils/_vector_sentinel.cpython-312-x86_64-linux-gnu.so.p/meson-generated_sklearn_utils__vector_sentinel.pyx.cpp.o.d -o sklearn/utils/_vector_sentinel.cpython-312-x86_64-linux-gnu.so.p/meson-generated_sklearn_utils__vector_sentinel.pyx.cpp.o -c sklearn/utils/_vector_sentinel.cpython-312-x86_64-linux-gnu.so.p/sklearn/utils/_vector_sentinel.pyx.cpp
sklearn/utils/_vector_sentinel.cpython-312-x86_64-linux-gnu.so.p/sklearn/utils/_vector_sentinel.pyx.cpp:1239:10: fatal error: numpy/arrayobject.h: No such file or directory
 1239 | #include "numpy/arrayobject.h"
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```
@betatim likely bumped into a similar issue but the compilation error was different:
```
sklearn/utils/_vector_sentinel.cpython-310-darwin.so.p/sklearn/utils/_vector_sentinel.pyx.cpp:4799:13: error: use of undeclared identifier 'PyDataType_ELSIZE'
    __pyx_r = PyDataType_ELSIZE(__pyx_v_self);
              ^
  sklearn/utils/_vector_sentinel.cpython-310-darwin.so.p/sklearn/utils/_vector_sentinel.pyx.cpp:4833:13: error: use of undeclared identifier 'PyDataType_ALIGNMENT'
    __pyx_r = PyDataType_ALIGNMENT(__pyx_v_self);
```

