### PR TITLE
FIX IterativeImputer skip iterative part if keep_empty_features is set to True

### DIFF
--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -147,6 +147,11 @@ Changelog
   computing the mean value for uniform weights.
   :pr:`29135` by :user:`Xuefeng Xu <xuefeng-xu>`.
 
+- |Fix| :class:`impute.IterativeImputer` Now gives same output 
+  when keep_empty_features is set to True, This is the same as when
+  keep_empty_features is to False.
+  :pr:`29414` by :user:`Anurag Varma <Anurag-Varma>`.
+
 :mod:`sklearn.linear_model`
 ...........................
 

--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -148,8 +148,8 @@ Changelog
   :pr:`29135` by :user:`Xuefeng Xu <xuefeng-xu>`.
 
 - |Fix| :class:`impute.IterativeImputer` Now gives same output 
-  when keep_empty_features is set to True, This is the same as when
-  keep_empty_features is to False.
+  when ``keep_empty_features=True`` compared to when
+  ``keep_empty_features=False`` on non-empty features.
   :pr:`29414` by :user:`Anurag Varma <Anurag-Varma>`.
 
 :mod:`sklearn.linear_model`

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -652,7 +652,10 @@ class IterativeImputer(_BaseImputer):
                 Xt = X
                 mask_missing_values[:, valid_mask] = True
             else:
-                mask_missing_values[:, valid_mask] = np.logical_or(mask_missing_values[:, valid_mask], np.all(np.isnan(X[:, valid_mask]), axis=0))
+                mask_missing_values[:, valid_mask] = np.logical_or(
+                    mask_missing_values[:, valid_mask],
+                    np.all(np.isnan(X[:, valid_mask]), axis=0),
+                )
                 Xt = X
 
         return Xt, X_filled, mask_missing_values, X_missing_mask

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -648,8 +648,12 @@ class IterativeImputer(_BaseImputer):
         else:
             # mark empty features as not missing and keep the original
             # imputation
-            mask_missing_values[:, valid_mask] = True
-            Xt = X
+            if np.any(np.all(np.isnan(X[:, valid_mask]), axis=0)):
+                Xt = X
+                mask_missing_values[:, valid_mask] = True
+            else:
+                mask_missing_values[:, valid_mask] = np.logical_or(mask_missing_values[:, valid_mask], np.all(np.isnan(X[:, valid_mask]), axis=0))
+                Xt = X
 
         return Xt, X_filled, mask_missing_values, X_missing_mask
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1538,9 +1538,7 @@ def test_iterative_imputer_keep_empty_features_different_input_x(keep_empty_feat
     """
     X = np.array([[np.nan, 0, 1], [2, np.nan, 3], [4, 5, np.nan]])
 
-    imputer = IterativeImputer(
-        keep_empty_features=keep_empty_features
-    )
+    imputer = IterativeImputer(keep_empty_features=keep_empty_features)
     X_imputed = imputer.fit_transform(X)
     assert X_imputed.shape == (3, 3)
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1531,16 +1531,19 @@ def test_iterative_imputer_keep_empty_features(initial_strategy):
     assert_allclose(X_imputed[:, 1], 0)
 
 
-@pytest.mark.parametrize("keep_empty_features", [True, False])
-def test_iterative_imputer_keep_empty_features_different_input_x(keep_empty_features):
-    """Check the behaviour of the iterative imputer with different keep_empty_features
-    and different input.
+def test_iterative_imputer_keep_empty_features_different_input_x():
+    """Check the behaviour of the iterative imputer with keep_empty_features of
+    True & False, and making sure that both are the same for the given input case.
     """
     X = np.array([[np.nan, 0, 1], [2, np.nan, 3], [4, 5, np.nan]])
 
-    imputer = IterativeImputer(keep_empty_features=keep_empty_features)
-    X_imputed = imputer.fit_transform(X)
-    assert X_imputed.shape == (3, 3)
+    imputer_True = IterativeImputer(keep_empty_features=True)
+    X_imputed_True = imputer_True.fit_transform(X)
+
+    imputer_False = IterativeImputer(keep_empty_features=False)
+    X_imputed_False = imputer_False.fit_transform(X)
+
+    assert_array_equal(X_imputed_True, X_imputed_False)
 
 
 def test_iterative_imputer_constant_fill_value():

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1531,6 +1531,20 @@ def test_iterative_imputer_keep_empty_features(initial_strategy):
     assert_allclose(X_imputed[:, 1], 0)
 
 
+@pytest.mark.parametrize("keep_empty_features", [True, False])
+def test_iterative_imputer_keep_empty_features_different_input_x(keep_empty_features):
+    """Check the behaviour of the iterative imputer with different keep_empty_features
+    and different input.
+    """
+    X = np.array([[np.nan, 0, 1], [2, np.nan, 3], [4, 5, np.nan]])
+
+    imputer = IterativeImputer(
+        keep_empty_features=keep_empty_features
+    )
+    X_imputed = imputer.fit_transform(X)
+    assert X_imputed.shape == (3, 3)
+
+
 def test_iterative_imputer_constant_fill_value():
     """Check that we propagate properly the parameter `fill_value`."""
     X = np.array([[-1, 2, 3, -1], [4, -1, 5, -1], [6, 7, -1, -1], [8, 9, 0, -1]])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #29375


#### What does this implement/fix? Explain your changes.
```python
            if np.any(np.all(np.isnan(X[:, valid_mask]), axis=0)):
                Xt = X
                mask_missing_values[:, valid_mask] = True
            else:
                mask_missing_values[:, valid_mask] = np.logical_or(mask_missing_values[:, valid_mask], np.all(np.isnan(X[:, valid_mask]), axis=0))
                Xt = X
```

Fixes the issues caused when keep_empty_features is set to 'True' and giving different output when compared to that of when set to 'False'. 

#### Any other comments?
After this change, it returns the same result for keep_empty_features set to 'True' or 'False'.

Added 1 new test case to cover the newly added code in if-else condition, by giving the input mentioned in the issue and checking if it's working or not.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
