### PR TITLE
MAINT Use python3 rather than python in build script shebang

### DIFF
--- a/sklearn/_build_utils/version.py
+++ b/sklearn/_build_utils/version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Extract version number from __init__.py"""
 
 import os


### PR DESCRIPTION
`python` does not necessarily exists and I think `python3` always exist. I got a build error when trying to build inside the Debian 32 container with system Python:

```
docker run -it i386/debian:11.2 bash -c 'apt-get update; apt-get install python3 -y; /usr/bin/env python'
```

This is also what is used by the equivalent version script for [Numpy](https://github.com/numpy/numpy/blob/main/numpy/_build_utils/gitversion.py).

Although I was not able to reproduce I believe this is what is happening in the recent Termux issue https://github.com/scikit-learn/scikit-learn/issues/29367
```
  ../meson.build:4:11: ERROR: Could not execute command `/usr/bin/env python /data/data/com.termux/files/usr/tmp/pip-install-2c1ik6pc/scikit-learn_e619a22e86e14479a9431ce3a7de84a1/sklearn/_build_utils/version.py`.
````

Edit: also maybe in the RaspberryPi wheels issue: https://github.com/scikit-learn/scikit-learn/discussions/29430