### PR TITLE
TST workaround arpack-ng regression in [scipy-dev]

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1028,9 +1028,9 @@ def check_array_api_input_and_values(
 def _check_estimator_sparse_container(name, estimator_orig, sparse_type):
     rng = np.random.RandomState(0)
     X = rng.uniform(size=(40, 3))
-    X[X < 0.8] = 0
+    X[X < 0.6] = 0
     X = _enforce_estimator_tags_X(estimator_orig, X)
-    y = (4 * rng.uniform(size=40)).astype(int)
+    y = (4 * rng.uniform(size=X.shape[0])).astype(np.int32)
     # catch deprecation warnings
     with ignore_warnings(category=FutureWarning):
         estimator = clone(estimator_orig)


### PR DESCRIPTION
This should workaround the failure observed on our nightly `[scipy-dev]` CI: #29428 by avoiding running a PCA-based pipeline on zero data when running the `Halving*SearchCV` estimator on it.

See #29428 for details. The upstream regression is tracked in scipy/scipy#21137 and a fix should prospectively be included before the scipy 1.15.0 release.

However, it would be helpful not to trigger this problem in the scikit-learn common tests in the mean time to keep the scipy-dev CI green and avoid hiding potentially unrelated failures behind a failing nightly CI job.

Close https://github.com/scikit-learn/scikit-learn/issues/29422
Close https://github.com/scikit-learn/scikit-learn/issues/29423
Close https://github.com/scikit-learn/scikit-learn/issues/29424