### PR TITLE
CI Don't run CUDA workflow on closed/merged PRs

### DIFF
--- a/.github/workflows/cuda-gpu-ci.yml
+++ b/.github/workflows/cuda-gpu-ci.yml
@@ -13,7 +13,10 @@ permissions:
 
 jobs:
   tests:
-    if: contains(github.event.pull_request.labels.*.name, 'CUDA CI')
+    if: |
+      github.event.pull_request.state == 'open' &&
+      github.event.pull_request.merged == false &&
+      contains(github.event.pull_request.labels.*.name, 'CUDA CI')
     runs-on:
       group: cuda-gpu-runner-group
     # Set this high enough so that the tests can comforatble run. We set a


### PR DESCRIPTION
After a PR has been merged or closed we do not really need the results of this workflow and it costs money to run it.

I think it makes sense to add this restriction, but maybe it isn't worth it? What do others think?

This is a follow up to #29376