### PR TITLE
FIX min_value and max_value not indexed when features are removed

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.impute/29451.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.impute/29451.fix.rst
@@ -1,0 +1,4 @@
+- When `min_value` and `max_value` are array-like and some features are dropped due to
+  `keep_empty_features=False`, :class:`impute.IterativeImputer` no longer raises an error and
+  now indexes correctly.
+  By :user:`Guntitat Sawadwuthikul <gunsodo>`

--- a/doc/whats_new/upcoming_changes/sklearn.impute/29451.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.impute/29451.fix.rst
@@ -1,4 +1,4 @@
 - When `min_value` and `max_value` are array-like and some features are dropped due to
-  `keep_empty_features=False`, :class:`impute.IterativeImputer` no longer raises an error and
-  now indexes correctly.
+  `keep_empty_features=False`, :class:`impute.IterativeImputer` no longer raises an
+  error and now indexes correctly.
   By :user:`Guntitat Sawadwuthikul <gunsodo>`

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -26,6 +26,7 @@ from ..utils.metadata_routing import (
 from ..utils.validation import (
     FLOAT_DTYPES,
     _check_feature_names_in,
+    _num_samples,
     check_is_fitted,
     validate_data,
 )
@@ -697,8 +698,12 @@ class IterativeImputer(_BaseImputer):
         limit: ndarray, shape(n_features,)
             Array of limits, one for each feature.
         """
-        n_features_in = len(is_empty_feature)
-        if limit is not None and not np.isscalar(limit) and len(limit) != n_features_in:
+        n_features_in = _num_samples(is_empty_feature)
+        if (
+            limit is not None
+            and not np.isscalar(limit)
+            and _num_samples(limit) != n_features_in
+        ):
             raise ValueError(
                 f"'{limit_type}_value' should be of shape ({n_features_in},) when an"
                 f" array-like is provided. Got {len(limit)}, instead."

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -695,7 +695,7 @@ class IterativeImputer(_BaseImputer):
         limit = limit_bound if limit is None else limit
         if np.isscalar(limit):
             limit = np.full(n_features, limit)
-        limit = check_array(limit, force_all_finite=False, copy=False, ensure_2d=False)
+        limit = check_array(limit, ensure_all_finite=False, copy=False, ensure_2d=False)
         return limit
 
     @_fit_context(

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -774,8 +774,17 @@ class IterativeImputer(_BaseImputer):
             self.n_iter_ = 0
             return super()._concatenate_indicator(Xt, X_indicator)
 
-        self._min_value = self._validate_limit(self.min_value, "min", X.shape[1])
-        self._max_value = self._validate_limit(self.max_value, "max", X.shape[1])
+        self._min_value = self._validate_limit(
+            self.min_value, "min", complete_mask.shape[1]
+        )
+        self._max_value = self._validate_limit(
+            self.max_value, "max", complete_mask.shape[1]
+        )
+
+        # Make sure to remove the empty feature elements from the bounds
+        nonempty_feature_mask = np.logical_not(np.all(complete_mask, axis=0))
+        self._min_value = self._min_value[nonempty_feature_mask]
+        self._max_value = self._max_value[nonempty_feature_mask]
 
         if not np.all(np.greater(self._max_value, self._min_value)):
             raise ValueError("One (or more) features have min_value >= max_value.")

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -756,19 +756,18 @@ class IterativeImputer(_BaseImputer):
             X, in_fit=True
         )
 
+        n_features_in = complete_mask.shape[1]
         err_msg = (
-            "'{}' should be of shape ({},) when an array-like is provided. "
-            "Got {}, instead."
+            f"should be of shape ({n_features_in},) when an array-like is provided. "
         )
 
-        n_features_in = complete_mask.shape[1]
         if (
             self.min_value is not None
             and not np.isscalar(self.min_value)
             and len(self.min_value) != n_features_in
         ):
             raise ValueError(
-                err_msg.format("min_value", n_features_in, len(self.min_value))
+                f"'min_value' {err_msg}. Got {len(self.min_value)}, instead."
             )
         if (
             self.max_value is not None
@@ -776,7 +775,7 @@ class IterativeImputer(_BaseImputer):
             and len(self.max_value) != n_features_in
         ):
             raise ValueError(
-                err_msg.format("max_value", n_features_in, len(self.max_value))
+                f"'max_value' {err_msg}. Got {len(self.max_value)}, instead."
             )
 
         super()._fit_indicator(complete_mask)

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1013,6 +1013,7 @@ def test_iterative_imputer_min_max_array_like(min_value, max_value, correct_outp
         (100, 0, "min_value >= max_value."),
         (np.inf, -np.inf, "min_value >= max_value."),
         ([-5, 5], [100, 200, 0], "_value' should be of shape"),
+        ([-5, 5, 5], [100, 200], "_value' should be of shape"),
     ],
 )
 def test_iterative_imputer_catch_min_max_error(min_value, max_value, err_msg):

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1559,13 +1559,13 @@ def test_iterative_imputer_min_max_value_remove_empty(
         keep_empty_features=False,
     )
 
-    X_no_missing = X[:, [i for i in range(X.shape[1]) if i != missing_column]]
+    X_without_missing_column = np.delete(X, missing_column, axis=1)
     X_imputed = imputer.fit_transform(X)
 
-    assert X_imputed.shape == X_no_missing.shape
+    assert X_imputed.shape == X_without_missing_column.shape
 
-    assert_allclose(np.min(X_imputed[np.isnan(X_no_missing)]), min_value)
-    assert_allclose(np.max(X_imputed[np.isnan(X_no_missing)]), max_value)
+    assert np.min(X_imputed[np.isnan(X_without_missing_column)]) == min_value
+    assert np.max(X_imputed[np.isnan(X_without_missing_column)]) == max_value
 
 
 @pytest.mark.parametrize("keep_empty_features", [True, False])

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1556,8 +1556,8 @@ def test_iterative_imputer_min_max_value_remove_empty():
 
     X_without_missing_column = np.delete(X, 2, axis=1)
     assert X_imputed.shape == X_without_missing_column.shape
-    assert np.min(X_imputed[np.isnan(X_without_missing_column)]) == 4
-    assert np.max(X_imputed[np.isnan(X_without_missing_column)]) == 5
+    assert np.min(X_imputed[np.isnan(X_without_missing_column)]) == pytest.approx(4)
+    assert np.max(X_imputed[np.isnan(X_without_missing_column)]) == pytest.approx(5)
 
     # Intentionally make column 3 as a missing column, then the bound of the imputed
     # value of column 2 should be (3.5, 6)
@@ -1578,10 +1578,10 @@ def test_iterative_imputer_min_max_value_remove_empty():
         keep_empty_features=False,
     ).fit_transform(X)
 
-    X_without_missing_column = np.delete(X, 3, axis=1)
+    X_without_missing_column = X[:, :3]
     assert X_imputed.shape == X_without_missing_column.shape
-    assert np.min(X_imputed[np.isnan(X_without_missing_column)]) == 3.5
-    assert np.max(X_imputed[np.isnan(X_without_missing_column)]) == 6
+    assert np.min(X_imputed[np.isnan(X_without_missing_column)]) == pytest.approx(3.5)
+    assert np.max(X_imputed[np.isnan(X_without_missing_column)]) == pytest.approx(6)
 
 
 @pytest.mark.parametrize("keep_empty_features", [True, False])

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1538,11 +1538,15 @@ def test_iterative_imputer_constant_fill_value():
 def test_iterative_imputer_min_max_value_remove_empty(
     missing_column, check_column, min_value, max_value
 ):
-    """Check that we properly apply the empty feature mask to
-    `min_value` and `max_value.
+    """Check that we properly apply the empty feature mask to `min_value` and
+    `max_value`.
+
+    Non-regression test for https://github.com/scikit-learn/scikit-learn/issues/29355
     """
-    X = np.array([[1, 2, -1, -1], [4, 5, 6, 6], [7, 8, -1, -1], [10, 11, 12, 12]])
-    X[:, missing_column] = -1
+    X = np.array(
+        [[1, 2, np.nan, np.nan], [4, 5, 6, 6], [7, 8, np.nan, np.nan], [10, 11, 12, 12]]
+    )
+    X[:, missing_column] = np.nan
 
     min_value_array = [-np.inf] * 4
     max_value_array = [np.inf] * 4
@@ -1550,7 +1554,6 @@ def test_iterative_imputer_min_max_value_remove_empty(
     max_value_array[check_column] = max_value
 
     imputer = IterativeImputer(
-        missing_values=-1,
         min_value=min_value_array,
         max_value=max_value_array,
         keep_empty_features=False,
@@ -1561,8 +1564,8 @@ def test_iterative_imputer_min_max_value_remove_empty(
 
     assert X_imputed.shape == X_no_missing.shape
 
-    assert_allclose(np.min(X_imputed[X_no_missing == -1]), min_value)
-    assert_allclose(np.max(X_imputed[X_no_missing == -1]), max_value)
+    assert_allclose(np.min(X_imputed[np.isnan(X_no_missing)]), min_value)
+    assert_allclose(np.max(X_imputed[np.isnan(X_no_missing)]), max_value)
 
 
 @pytest.mark.parametrize("keep_empty_features", [True, False])

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1530,7 +1530,7 @@ def test_iterative_imputer_constant_fill_value():
 
 
 @pytest.mark.parametrize(
-    "missing_column,check_column,min_value,max_value",
+    "missing_column, check_column, min_value, max_value",
     [
         (2, 3, 4, 5),
         (3, 2, 3.5, 6),


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #29355.

#### What does this implement/fix? Explain your changes.

- Check the shape of the `min_value` and `max_value` with the original number of features (before dropping those empty ones)
- Apply the feature mask to `min_value` and `max_value` to remove the empty features

@lesteve Please let me know if this does not align with your suggestion.
