### PR TITLE
MAINT Clean-up some old warning filters

### DIFF
--- a/sklearn/cluster/tests/test_spectral.py
+++ b/sklearn/cluster/tests/test_spectral.py
@@ -215,23 +215,6 @@ def test_discretize(n_samples, coo_container):
         assert adjusted_rand_score(y_true, y_pred) > 0.8
 
 
-# TODO: Remove when pyamg does replaces sp.rand call with np.random.rand
-# https://github.com/scikit-learn/scikit-learn/issues/15913
-@pytest.mark.filterwarnings(
-    "ignore:scipy.rand is deprecated:DeprecationWarning:pyamg.*"
-)
-# TODO: Remove when pyamg removes the use of np.float
-@pytest.mark.filterwarnings(
-    "ignore:`np.float` is a deprecated alias:DeprecationWarning:pyamg.*"
-)
-# TODO: Remove when pyamg removes the use of pinv2
-@pytest.mark.filterwarnings(
-    "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
-)
-# TODO: Remove when pyamg removes the use of np.find_common_type
-@pytest.mark.filterwarnings(
-    "ignore:np.find_common_type is deprecated:DeprecationWarning:pyamg.*"
-)
 def test_spectral_clustering_with_arpack_amg_solvers():
     # Test that spectral_clustering is the same for arpack and amg solver
     # Based on toy example from plot_segmentation_toy.py

--- a/sklearn/decomposition/tests/test_factor_analysis.py
+++ b/sklearn/decomposition/tests/test_factor_analysis.py
@@ -9,15 +9,9 @@ import pytest
 from sklearn.decomposition import FactorAnalysis
 from sklearn.decomposition._factor_analysis import _ortho_rotation
 from sklearn.exceptions import ConvergenceWarning
-from sklearn.utils._testing import (
-    assert_almost_equal,
-    assert_array_almost_equal,
-    ignore_warnings,
-)
+from sklearn.utils._testing import assert_almost_equal, assert_array_almost_equal
 
 
-# Ignore warnings from switching to more power iterations in randomized_svd
-@ignore_warnings
 def test_factor_analysis(global_random_seed):
     # Test FactorAnalysis ability to recover the data covariance structure
     rng = np.random.RandomState(global_random_seed)

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -878,8 +878,6 @@ def test_random_trees_dense_equal():
     assert_array_equal(X_transformed_sparse.toarray(), X_transformed_dense)
 
 
-# Ignore warnings from switching to more power iterations in randomized_svd
-@ignore_warnings
 def test_random_hasher():
     # test random forest hashing on circles dataset
     # make sure that it is linearly separable.

--- a/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
@@ -42,7 +42,6 @@ def clf_diabetes(diabetes):
     return clf
 
 
-@pytest.mark.filterwarnings("ignore:A Bunch will be returned")
 @pytest.mark.parametrize("grid_resolution", [10, 20])
 def test_plot_partial_dependence(grid_resolution, pyplot, clf_diabetes, diabetes):
     # Test partial dependence plot function.
@@ -114,7 +113,6 @@ def test_plot_partial_dependence(grid_resolution, pyplot, clf_diabetes, diabetes
     assert ax.get_ylabel() == diabetes.feature_names[2]
 
 
-@pytest.mark.filterwarnings("ignore:A Bunch will be returned")
 @pytest.mark.parametrize(
     "kind, centered, subsample, shape",
     [
@@ -164,7 +162,6 @@ def test_plot_partial_dependence_kind(
         assert all([ln._y[0] != 0.0 for ln in disp.lines_.ravel() if ln is not None])
 
 
-@pytest.mark.filterwarnings("ignore:A Bunch will be returned")
 @pytest.mark.parametrize(
     "input_type, feature_names_type",
     [
@@ -252,7 +249,6 @@ def test_plot_partial_dependence_str_features(
     assert ax.get_ylabel() == "bmi"
 
 
-@pytest.mark.filterwarnings("ignore:A Bunch will be returned")
 def test_plot_partial_dependence_custom_axes(pyplot, clf_diabetes, diabetes):
     grid_resolution = 25
     fig, (ax1, ax2) = pyplot.subplots(1, 2)
@@ -288,7 +284,6 @@ def test_plot_partial_dependence_custom_axes(pyplot, clf_diabetes, diabetes):
     assert ax.get_ylabel() == "bmi"
 
 
-@pytest.mark.filterwarnings("ignore:A Bunch will be returned")
 @pytest.mark.parametrize(
     "kind, lines", [("average", 1), ("individual", 50), ("both", 51)]
 )
@@ -329,7 +324,6 @@ def test_plot_partial_dependence_passing_numpy_axes(
     assert len(disp2.axes_[0, 1].get_lines()) == 2 * lines
 
 
-@pytest.mark.filterwarnings("ignore:A Bunch will be returned")
 @pytest.mark.parametrize("nrows, ncols", [(2, 2), (3, 1)])
 def test_plot_partial_dependence_incorrent_num_axes(
     pyplot, clf_diabetes, diabetes, nrows, ncols
@@ -364,7 +358,6 @@ def test_plot_partial_dependence_incorrent_num_axes(
             disp.plot(ax=ax_format)
 
 
-@pytest.mark.filterwarnings("ignore:A Bunch will be returned")
 def test_plot_partial_dependence_with_same_axes(pyplot, clf_diabetes, diabetes):
     # The first call to plot_partial_dependence will create two new axes to
     # place in the space of the passed in axes, which results in a total of
@@ -404,7 +397,6 @@ def test_plot_partial_dependence_with_same_axes(pyplot, clf_diabetes, diabetes):
         )
 
 
-@pytest.mark.filterwarnings("ignore:A Bunch will be returned")
 def test_plot_partial_dependence_feature_name_reuse(pyplot, clf_diabetes, diabetes):
     # second call to plot does not change the feature names from the first
     # call
@@ -426,7 +418,6 @@ def test_plot_partial_dependence_feature_name_reuse(pyplot, clf_diabetes, diabet
         assert ax.get_xlabel() == feature_names[i]
 
 
-@pytest.mark.filterwarnings("ignore:A Bunch will be returned")
 def test_plot_partial_dependence_multiclass(pyplot):
     grid_resolution = 25
     clf_int = GradientBoostingClassifier(n_estimators=10, random_state=1)
@@ -480,7 +471,6 @@ def test_plot_partial_dependence_multiclass(pyplot):
 multioutput_regression_data = make_regression(n_samples=50, n_targets=2, random_state=0)
 
 
-@pytest.mark.filterwarnings("ignore:A Bunch will be returned")
 @pytest.mark.parametrize("target", [0, 1])
 def test_plot_partial_dependence_multioutput(pyplot, target):
     # Test partial dependence plot function on multi-output input.
@@ -506,7 +496,6 @@ def test_plot_partial_dependence_multioutput(pyplot, target):
         assert ax.get_xlabel() == f"x{i}"
 
 
-@pytest.mark.filterwarnings("ignore:A Bunch will be returned")
 def test_plot_partial_dependence_dataframe(pyplot, clf_diabetes, diabetes):
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame(diabetes.data, columns=diabetes.feature_names)
@@ -525,7 +514,6 @@ def test_plot_partial_dependence_dataframe(pyplot, clf_diabetes, diabetes):
 dummy_classification_data = make_classification(random_state=0)
 
 
-@pytest.mark.filterwarnings("ignore:A Bunch will be returned")
 @pytest.mark.parametrize(
     "data, params, err_msg",
     [
@@ -619,7 +607,6 @@ def test_plot_partial_dependence_error(pyplot, data, params, err_msg):
         PartialDependenceDisplay.from_estimator(estimator, X, **params)
 
 
-@pytest.mark.filterwarnings("ignore:A Bunch will be returned")
 @pytest.mark.parametrize(
     "params, err_msg",
     [
@@ -982,7 +969,6 @@ def test_partial_dependence_kind_error(
         )
 
 
-@pytest.mark.filterwarnings("ignore:A Bunch will be returned")
 @pytest.mark.parametrize(
     "line_kw, pd_line_kw, ice_lines_kw, expected_colors",
     [

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -480,7 +480,6 @@ class NoPredictProbaNoDecisionFunction(ClassifierMixin, BaseEstimator):
         return self
 
 
-@pytest.mark.filterwarnings("ignore:A Bunch will be returned")
 @pytest.mark.parametrize(
     "estimator, params, err_msg",
     [

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -117,20 +117,16 @@ def test_all_precomputed():
             assert_array_almost_equal(expected, got)
 
 
-@pytest.mark.filterwarnings("ignore: `rcond` parameter will change")
-# numpy deprecation
 def test_lars_lstsq():
     # Test that Lars gives least square solution at the end
     # of the path
     X1 = 3 * X  # use un-normalized dataset
     clf = linear_model.LassoLars(alpha=0.0)
     clf.fit(X1, y)
-    coef_lstsq = np.linalg.lstsq(X1, y, rcond=None)[0]
+    coef_lstsq = np.linalg.lstsq(X1, y)[0]
     assert_array_almost_equal(clf.coef_, coef_lstsq)
 
 
-@pytest.mark.filterwarnings("ignore:`rcond` parameter will change")
-# numpy deprecation
 def test_lasso_gives_lstsq_solution():
     # Test that Lars Lasso gives least square solution at the end
     # of the path

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -404,7 +404,6 @@ def test_lars_n_nonzero_coefs(verbose=False):
     assert len(lars.alphas_) == 7
 
 
-@ignore_warnings
 def test_multitarget():
     # Assure that estimators receiving multidimensional y do the right thing
     Y = np.vstack([y, y**2]).T

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -125,7 +125,7 @@ def test_lars_lstsq():
     X1 = 3 * X  # use un-normalized dataset
     clf = linear_model.LassoLars(alpha=0.0)
     clf.fit(X1, y)
-    coef_lstsq = np.linalg.lstsq(X1, y, rcond=None)[0]
+    coef_lstsq = np.linalg.lstsq(X1, y)[0]
     assert_array_almost_equal(clf.coef_, coef_lstsq)
 
 

--- a/sklearn/linear_model/tests/test_least_angle.py
+++ b/sklearn/linear_model/tests/test_least_angle.py
@@ -117,16 +117,20 @@ def test_all_precomputed():
             assert_array_almost_equal(expected, got)
 
 
+# TODO: remove warning filter when numpy min version >= 2.0.0
+@pytest.mark.filterwarnings("ignore: `rcond` parameter will change")
 def test_lars_lstsq():
     # Test that Lars gives least square solution at the end
     # of the path
     X1 = 3 * X  # use un-normalized dataset
     clf = linear_model.LassoLars(alpha=0.0)
     clf.fit(X1, y)
-    coef_lstsq = np.linalg.lstsq(X1, y)[0]
+    coef_lstsq = np.linalg.lstsq(X1, y, rcond=None)[0]
     assert_array_almost_equal(clf.coef_, coef_lstsq)
 
 
+# TODO: remove warning filter when numpy min version >= 2.0.0
+@pytest.mark.filterwarnings("ignore: `rcond` parameter will change")
 def test_lasso_gives_lstsq_solution():
     # Test that Lars Lasso gives least square solution at the end
     # of the path

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -1365,7 +1365,6 @@ def test_elasticnet_convergence(klass):
             assert_almost_equal(cd.coef_, sgd.coef_, decimal=2, err_msg=err_msg)
 
 
-@ignore_warnings
 @pytest.mark.parametrize("klass", [SGDRegressor, SparseSGDRegressor])
 def test_partial_fit(klass):
     third = X.shape[0] // 3

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -25,7 +25,6 @@ from sklearn.utils._testing import (
     assert_almost_equal,
     assert_array_almost_equal,
     assert_array_equal,
-    ignore_warnings,
 )
 
 

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -244,22 +244,6 @@ def test_spectral_embedding_callable_affinity(sparse_container, seed=36):
     _assert_equal_with_sign_flipping(embed_rbf, embed_callable, 0.05)
 
 
-# TODO: Remove when pyamg does replaces sp.rand call with np.random.rand
-# https://github.com/scikit-learn/scikit-learn/issues/15913
-@pytest.mark.filterwarnings(
-    "ignore:scipy.rand is deprecated:DeprecationWarning:pyamg.*"
-)
-# TODO: Remove when pyamg removes the use of np.float
-@pytest.mark.filterwarnings(
-    "ignore:`np.float` is a deprecated alias:DeprecationWarning:pyamg.*"
-)
-# TODO: Remove when pyamg removes the use of pinv2
-@pytest.mark.filterwarnings(
-    "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
-)
-@pytest.mark.filterwarnings(
-    "ignore:np.find_common_type is deprecated:DeprecationWarning:pyamg.*"
-)
 @pytest.mark.skipif(
     not pyamg_available, reason="PyAMG is required for the tests in this function."
 )
@@ -319,27 +303,6 @@ def test_spectral_embedding_amg_solver(dtype, coo_container, seed=36):
             se_amg.fit_transform(affinity)
 
 
-# TODO: Remove filterwarnings when pyamg does replaces sp.rand call with
-# np.random.rand:
-# https://github.com/scikit-learn/scikit-learn/issues/15913
-@pytest.mark.filterwarnings(
-    "ignore:scipy.rand is deprecated:DeprecationWarning:pyamg.*"
-)
-# TODO: Remove when pyamg removes the use of np.float
-@pytest.mark.filterwarnings(
-    "ignore:`np.float` is a deprecated alias:DeprecationWarning:pyamg.*"
-)
-# TODO: Remove when pyamg removes the use of pinv2
-@pytest.mark.filterwarnings(
-    "ignore:scipy.linalg.pinv2 is deprecated:DeprecationWarning:pyamg.*"
-)
-@pytest.mark.skipif(
-    not pyamg_available, reason="PyAMG is required for the tests in this function."
-)
-# TODO: Remove when pyamg removes the use of np.find_common_type
-@pytest.mark.filterwarnings(
-    "ignore:np.find_common_type is deprecated:DeprecationWarning:pyamg.*"
-)
 @pytest.mark.parametrize("dtype", (np.float32, np.float64))
 def test_spectral_embedding_amg_solver_failure(dtype, seed=36):
     # Non-regression test for amg solver failure (issue #13393 on github)
@@ -360,7 +323,6 @@ def test_spectral_embedding_amg_solver_failure(dtype, seed=36):
         _assert_equal_with_sign_flipping(embedding, new_embedding, tol=0.05)
 
 
-@pytest.mark.filterwarnings("ignore:the behavior of nmi will change in version 0.22")
 def test_pipeline_spectral_clustering(seed=36):
     # Test using pipeline to do spectral clustering
     random_state = np.random.RandomState(seed)
@@ -509,10 +471,6 @@ def test_error_pyamg_not_available():
         se_precomp.fit_transform(S)
 
 
-# TODO: Remove when pyamg removes the use of np.find_common_type
-@pytest.mark.filterwarnings(
-    "ignore:np.find_common_type is deprecated:DeprecationWarning:pyamg.*"
-)
 @pytest.mark.parametrize("solver", ["arpack", "amg", "lobpcg"])
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 def test_spectral_eigen_tol_auto(monkeypatch, solver, csr_container):

--- a/sklearn/manifold/tests/test_spectral_embedding.py
+++ b/sklearn/manifold/tests/test_spectral_embedding.py
@@ -303,6 +303,9 @@ def test_spectral_embedding_amg_solver(dtype, coo_container, seed=36):
             se_amg.fit_transform(affinity)
 
 
+@pytest.mark.skipif(
+    not pyamg_available, reason="PyAMG is required for the tests in this function."
+)
 @pytest.mark.parametrize("dtype", (np.float32, np.float64))
 def test_spectral_embedding_amg_solver_failure(dtype, seed=36):
     # Non-regression test for amg solver failure (issue #13393 on github)

--- a/sklearn/metrics/cluster/tests/test_common.py
+++ b/sklearn/metrics/cluster/tests/test_common.py
@@ -96,8 +96,6 @@ def test_symmetric_non_symmetric_union():
     )
 
 
-# 0.22 AMI and NMI changes
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize(
     "metric_name, y1, y2", [(name, y1, y2) for name in SYMMETRIC_METRICS]
 )
@@ -114,8 +112,6 @@ def test_non_symmetry(metric_name, y1, y2):
     assert metric(y1, y2) != pytest.approx(metric(y2, y1))
 
 
-# 0.22 AMI and NMI changes
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("metric_name", NORMALIZED_METRICS)
 def test_normalized_output(metric_name):
     upper_bound_1 = [0, 0, 0, 1, 1, 1]
@@ -135,8 +131,6 @@ def test_normalized_output(metric_name):
     assert not (score < 0).any()
 
 
-# 0.22 AMI and NMI changes
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("metric_name", chain(SUPERVISED_METRICS, UNSUPERVISED_METRICS))
 def test_permute_labels(metric_name):
     # All clustering metrics do not change score due to permutations of labels
@@ -156,8 +150,6 @@ def test_permute_labels(metric_name):
         assert_allclose(score_1, metric(X, 1 - y_pred))
 
 
-# 0.22 AMI and NMI changes
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("metric_name", chain(SUPERVISED_METRICS, UNSUPERVISED_METRICS))
 # For all clustering metrics Input parameters can be both
 # in the form of arrays lists, positive, negative or string

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -551,7 +551,6 @@ def test_supervised_cluster_scorers():
         assert_almost_equal(score1, score2)
 
 
-@ignore_warnings
 def test_raises_on_score_list():
     # Test that when a list of scores is returned, we raise proper errors.
     X, y = make_blobs(random_state=0)
@@ -566,7 +565,6 @@ def test_raises_on_score_list():
         grid_search.fit(X, y)
 
 
-@ignore_warnings
 def test_classification_scorer_sample_weight():
     # Test that classification scorers support sample_weight or raise sensible
     # errors
@@ -626,7 +624,6 @@ def test_classification_scorer_sample_weight():
             )
 
 
-@ignore_warnings
 def test_regression_scorer_sample_weight():
     # Test that regression scorers support sample_weight or raise sensible
     # errors

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -273,7 +273,6 @@ def test_SearchCV_with_fit_params(SearchCV):
     searcher.fit(X, y, spam=np.ones(10), eggs=np.zeros(10))
 
 
-@ignore_warnings
 def test_grid_search_no_score():
     # Test grid-search on classifier that has no score function.
     clf = LinearSVC(random_state=0)
@@ -812,7 +811,6 @@ def test_y_as_list():
     assert hasattr(grid_search, "cv_results_")
 
 
-@ignore_warnings
 def test_pandas_input():
     # check cross_val_score doesn't destroy pandas dataframe
     types = [(MockDataFrame, MockDataFrame)]

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -769,7 +769,6 @@ def test_group_shuffle_split_default_test_size(train_size, exp_train, exp_test):
     assert len(X_test) == exp_test
 
 
-@ignore_warnings
 def test_stratified_shuffle_split_init():
     X = np.arange(7)
     y = np.asarray([0, 1, 1, 1, 2, 2, 2])
@@ -1147,7 +1146,6 @@ def test_leave_one_p_group_out_error_on_fewer_number_of_groups():
         next(LeavePGroupsOut(n_groups=3).split(X, y, groups))
 
 
-@ignore_warnings
 def test_repeated_cv_value_errors():
     # n_repeats is not integer or <= 0
     for cv in (RepeatedKFold, RepeatedStratifiedKFold):
@@ -1419,7 +1417,6 @@ def test_train_test_split_32bit_overflow():
     assert y_train.size + y_test.size == big_number
 
 
-@ignore_warnings
 def test_train_test_split_pandas():
     # check train_test_split doesn't destroy pandas dataframe
     types = [MockDataFrame]

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -620,7 +620,6 @@ def test_cross_val_score_predict_groups():
             cross_val_predict(estimator=clf, X=X, y=y, cv=cv)
 
 
-@pytest.mark.filterwarnings("ignore: Using or importing the ABCs from")
 def test_cross_val_score_pandas():
     # check cross_val_score doesn't destroy pandas dataframe
     types = [(MockDataFrame, MockDataFrame)]
@@ -1116,8 +1115,6 @@ def test_cross_val_predict_input_types(coo_container):
     assert_array_equal(predictions.shape, (150,))
 
 
-@pytest.mark.filterwarnings("ignore: Using or importing the ABCs from")
-# python3.7 deprecation warnings in pandas via matplotlib :-/
 def test_cross_val_predict_pandas():
     # check cross_val_score doesn't destroy pandas dataframe
     types = [(MockDataFrame, MockDataFrame)]
@@ -2074,7 +2071,6 @@ def test_score_memmap():
                 sleep(1.0)
 
 
-@pytest.mark.filterwarnings("ignore: Using or importing the ABCs from")
 def test_permutation_test_score_pandas():
     # check permutation_test_score doesn't destroy pandas dataframe
     types = [(MockDataFrame, MockDataFrame)]

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -143,7 +143,6 @@ def test_label_binarizer_pandas_nullable(dtype, unique_first):
     assert_array_equal(y_out, [[1], [0]])
 
 
-@ignore_warnings
 def test_label_binarizer_errors():
     # Check that invalid arguments yield ValueError
     one_class = np.array([0, 0, 0, 0])

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -19,7 +19,6 @@ from sklearn.utils._array_api import (
 from sklearn.utils._testing import (
     _array_api_for_tests,
     assert_array_equal,
-    ignore_warnings,
 )
 from sklearn.utils.fixes import (
     COO_CONTAINERS,

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -71,10 +71,6 @@ _METHODS_IGNORE_NONE_Y = [
 ]
 
 
-# numpydoc 0.8.0's docscrape tool raises because of collections.abc under
-# Python 3.7
-@pytest.mark.filterwarnings("ignore::FutureWarning")
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_docstring_parameters():
     # Test module docstring formatting
 

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -698,7 +698,6 @@ class DummyClassifierWithFitParams(DummyClassifier):
         return super().fit(X, y, sample_weight)
 
 
-@pytest.mark.filterwarnings("ignore:`n_features_in_` is deprecated")
 @pytest.mark.parametrize(
     "estimator, dataset",
     [

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1543,7 +1543,6 @@ def test_explicit_sparse_zeros(tree_type, csc_container, csr_container):
             assert_array_almost_equal(s.predict_proba(X1), d.predict_proba(X2))
 
 
-@ignore_warnings
 def check_raise_error_on_1d_input(name):
     TreeEstimator = ALL_TREES[name]
 

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -413,7 +413,6 @@ def test_check_classification_targets():
                 check_classification_targets(example)
 
 
-# @ignore_warnings
 def test_type_of_target():
     for group, group_examples in EXAMPLES.items():
         for example in group_examples:


### PR DESCRIPTION
Many warning filters from old deprecations have not been cleaned-up.
I also removed occurences of the ignore_warnings decorator that have been there for a while but the test doesn't actually emit any warning anymore.