### PR TITLE
Fix mixed dense/sparse array API namespace inspection

### DIFF
--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -56,6 +56,12 @@ See :ref:`array_api` for more details.
   compatible inputs when their base estimators do. :pr:`27096` by :user:`Tim
   Head <betatim>` and :user:`Olivier Grisel <ogrisel>`.
 
+Other changes impacting array API support in general:
+
+- |Fix| func:`validation.check_array` now accepts scipy sparse inputs without error
+  even when array API dispatch is enabled.
+  :pr:`29466` by :user:`Olivier Grisel <ogrisel>`.
+
 Metadata Routing
 ----------------
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -2018,6 +2018,16 @@ def test_check_array_array_api_has_non_finite(array_namespace):
             check_array(X_inf)
 
 
+@skip_if_array_api_compat_not_configured
+def test_check_array_on_sparse_inputs_with_array_api_enabled():
+    X_sp = sp.csr_array([[0, 1, 0], [1, 0, 1]])
+    with config_context(array_api_dispatch=True):
+        assert sp.issparse(check_array(X_sp, accept_sparse=True))
+
+        with pytest.raises(TypeError):
+            check_array(X_sp)
+
+
 @pytest.mark.parametrize(
     "extension_dtype, regular_dtype",
     [


### PR DESCRIPTION
Fixes #29452.

I think this is the most natural way to handle mixed dense and sparse array inputs: rely on the caller code to handle sparse data in specific code branch and let `get_namespace` ignore those, unless the input data is all-sparse, in which case we return the numpy namespace to avoid errors.

The alternative would be to:

- accept all-sparse and mixed scipy sparse / numpy inputs;
- reject mixed scipy sparse / non-numpy inputs.

However the latter introduces some asymetry and I am not sure it's justified and the code would be more complex. So unless we have a good reason to chose the second option, I find the option implemented in this PR leaner.