### PR TITLE
Investigate impact of rejecting sparse inputs in `get_namespace`

### DIFF
--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -56,6 +56,10 @@ See :ref:`array_api` for more details.
   compatible inputs when their base estimators do. :pr:`27096` by :user:`Tim
   Head <betatim>` and :user:`Olivier Grisel <ogrisel>`.
 
+- |Fix| func:`validation.check_array` now accepts scipy sparse inputs without error
+  even when array API dispatch is enabled.
+  :pr:`29469` by :user:`Olivier Grisel <ogrisel>`.
+
 Metadata Routing
 ----------------
 

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -5,6 +5,7 @@ import math
 from functools import wraps
 
 import numpy
+import scipy.sparse as sp
 import scipy.special as special
 
 from .._config import get_config
@@ -528,6 +529,13 @@ def get_namespace(*arrays, remove_none=True, remove_types=(str,), xp=None):
         True if the arrays are containers that implement the Array API spec.
         Always False when array_api_dispatch=False.
     """
+    if any(sp.issparse(a) for a in arrays):
+        # Consistently reject scipy sparse arrays, whether or not array_api_dispatch
+        # is enabled.
+        raise ValueError(
+            "Scipy sparse arrays or matrices are not supported in get_namespace."
+        )
+
     array_api_dispatch = get_config()["array_api_dispatch"]
     if not array_api_dispatch:
         if xp is not None:

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -2018,6 +2018,16 @@ def test_check_array_array_api_has_non_finite(array_namespace):
             check_array(X_inf)
 
 
+@skip_if_array_api_compat_not_configured
+def test_check_array_on_sparse_inputs_with_array_api_enabled():
+    X_sp = sp.csr_array([[0, 1, 0], [1, 0, 1]])
+    with config_context(array_api_dispatch=True):
+        assert sp.issparse(check_array(X_sp, accept_sparse=True))
+
+        with pytest.raises(TypeError):
+            check_array(X_sp)
+
+
 @pytest.mark.parametrize(
     "extension_dtype, regular_dtype",
     [

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1670,7 +1670,6 @@ def check_non_negative(X, whom):
     whom : str
         Who passed X to this function.
     """
-    xp, _ = get_namespace(X)
     # avoid X.min() on sparse matrix since it also sorts the indices
     if sp.issparse(X):
         if X.format in ["lil", "dok"]:
@@ -1680,6 +1679,7 @@ def check_non_negative(X, whom):
         else:
             X_min = X.data.min()
     else:
+        xp, _ = get_namespace(X)
         X_min = xp.min(X)
 
     if X_min < 0:

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -838,7 +838,10 @@ def check_array(
             "https://numpy.org/doc/stable/reference/generated/numpy.matrix.html"
         )
 
-    xp, is_array_api_compliant = get_namespace(array)
+    if sp.issparse(array):
+        xp, is_array_api_compliant = None, False
+    else:
+        xp, is_array_api_compliant = get_namespace(array)
 
     # store reference to original array to check if copy is needed when
     # function returns
@@ -931,7 +934,7 @@ def check_array(
             )
         )
 
-    if dtype is not None and _is_numpy_namespace(xp):
+    if dtype is not None and xp is not None and _is_numpy_namespace(xp):
         # convert to dtype object to conform to Array API to be use `xp.isdtype` later
         dtype = np.dtype(dtype)
 


### PR DESCRIPTION
This is a draft PR to see the list of things that break if we consistently reject sparse inputs in `get_namespace` (whether or not `array_api_dispatch` is enabled).

This is based on the minimal fix for `check_array` submitted independently under #29469 as an alternative to #29466. See discussion in #29466 for context.

Note: I already updated `check_non_negative` as part of this PR but not `type_of_target` because it's much more involved.

But first let's run the CI to find other cases.