### PR TITLE
EXA Use tick_labels in boxplot for matplotlib>=3.9

### DIFF
--- a/examples/ensemble/plot_gradient_boosting_regression.py
+++ b/examples/ensemble/plot_gradient_boosting_regression.py
@@ -21,6 +21,7 @@ showcasing some other advantages of
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -28,6 +29,7 @@ from sklearn import datasets, ensemble
 from sklearn.inspection import permutation_importance
 from sklearn.metrics import mean_squared_error
 from sklearn.model_selection import train_test_split
+from sklearn.utils.fixes import parse_version
 
 # %%
 # Load the data
@@ -145,11 +147,18 @@ result = permutation_importance(
 )
 sorted_idx = result.importances_mean.argsort()
 plt.subplot(1, 2, 2)
-plt.boxplot(
-    result.importances[sorted_idx].T,
-    vert=False,
-    labels=np.array(diabetes.feature_names)[sorted_idx],
+
+# labels has been renamed to tick_labels in matplotlib 3.9.
+# This code can be simplified when scikit-learn minimum supported version is 3.9
+tick_labels_parameter_name = (
+    "tick_labels"
+    if parse_version(matplotlib.__version__) >= parse_version("3.9")
+    else "labels"
 )
+tick_labels_dict = {
+    tick_labels_parameter_name: np.array(diabetes.feature_names)[sorted_idx]
+}
+plt.boxplot(result.importances[sorted_idx].T, vert=False, **tick_labels_dict)
 plt.title("Permutation Importance (test set)")
 fig.tight_layout()
 plt.show()

--- a/examples/ensemble/plot_gradient_boosting_regression.py
+++ b/examples/ensemble/plot_gradient_boosting_regression.py
@@ -148,8 +148,11 @@ result = permutation_importance(
 sorted_idx = result.importances_mean.argsort()
 plt.subplot(1, 2, 2)
 
-# labels has been renamed to tick_labels in matplotlib 3.9.
-# This code can be simplified when scikit-learn minimum supported version is 3.9
+# `labels` argument in boxplot is deprecated in matplotlib 3.9 and has been
+# renamed to `tick_labels`. The following code handles this, but as a
+# scikit-learn user you probably can write simpler code by using `labels=...`
+# (matplotlib < 3.9) or `tick_labels=...` (matplotlib >= 3.9).
+# Once the minimum matplotlib version is 3.9, the following code can be simplified
 tick_labels_parameter_name = (
     "tick_labels"
     if parse_version(matplotlib.__version__) >= parse_version("3.9")

--- a/examples/ensemble/plot_gradient_boosting_regression.py
+++ b/examples/ensemble/plot_gradient_boosting_regression.py
@@ -152,7 +152,6 @@ plt.subplot(1, 2, 2)
 # renamed to `tick_labels`. The following code handles this, but as a
 # scikit-learn user you probably can write simpler code by using `labels=...`
 # (matplotlib < 3.9) or `tick_labels=...` (matplotlib >= 3.9).
-# Once the minimum matplotlib version is 3.9, the following code can be simplified
 tick_labels_parameter_name = (
     "tick_labels"
     if parse_version(matplotlib.__version__) >= parse_version("3.9")

--- a/examples/inspection/plot_permutation_importance_multicollinear.py
+++ b/examples/inspection/plot_permutation_importance_multicollinear.py
@@ -36,8 +36,11 @@ def plot_permutation_importance(clf, X, y, ax):
     result = permutation_importance(clf, X, y, n_repeats=10, random_state=42, n_jobs=2)
     perm_sorted_idx = result.importances_mean.argsort()
 
-    # labels has been renamed to tick_labels in matplotlib 3.9.
-    # This code can be simplified when scikit-learn minimum supported version is 3.9
+    # `labels` argument in boxplot is deprecated in matplotlib 3.9 and has been
+    # renamed to `tick_labels`. The following code handles this, but as a
+    # scikit-learn user you probably can write simpler code by using `labels=...`
+    # (matplotlib < 3.9) or `tick_labels=...` (matplotlib >= 3.9).
+    # Once the minimum matplotlib version is 3.9, the following code can be simplified
     tick_labels_parameter_name = (
         "tick_labels"
         if parse_version(matplotlib.__version__) >= parse_version("3.9")

--- a/examples/inspection/plot_permutation_importance_multicollinear.py
+++ b/examples/inspection/plot_permutation_importance_multicollinear.py
@@ -40,7 +40,6 @@ def plot_permutation_importance(clf, X, y, ax):
     # renamed to `tick_labels`. The following code handles this, but as a
     # scikit-learn user you probably can write simpler code by using `labels=...`
     # (matplotlib < 3.9) or `tick_labels=...` (matplotlib >= 3.9).
-    # Once the minimum matplotlib version is 3.9, the following code can be simplified
     tick_labels_parameter_name = (
         "tick_labels"
         if parse_version(matplotlib.__version__) >= parse_version("3.9")

--- a/examples/inspection/plot_permutation_importance_multicollinear.py
+++ b/examples/inspection/plot_permutation_importance_multicollinear.py
@@ -26,18 +26,25 @@ picking a threshold, and keeping a single feature from each cluster.
 # ------------------------------------------------------
 #
 # First, we define a function to ease the plotting:
+import matplotlib
+
 from sklearn.inspection import permutation_importance
+from sklearn.utils.fixes import parse_version
 
 
 def plot_permutation_importance(clf, X, y, ax):
     result = permutation_importance(clf, X, y, n_repeats=10, random_state=42, n_jobs=2)
     perm_sorted_idx = result.importances_mean.argsort()
 
-    ax.boxplot(
-        result.importances[perm_sorted_idx].T,
-        vert=False,
-        labels=X.columns[perm_sorted_idx],
+    # labels has been renamed to tick_labels in matplotlib 3.9.
+    # This code can be simplified when scikit-learn minimum supported version is 3.9
+    tick_labels_parameter_name = (
+        "tick_labels"
+        if parse_version(matplotlib.__version__) >= parse_version("3.9")
+        else "labels"
     )
+    tick_labels_dict = {tick_labels_parameter_name: X.columns[perm_sorted_idx]}
+    ax.boxplot(result.importances[perm_sorted_idx].T, vert=False, **tick_labels_dict)
     ax.axvline(x=0, color="k", linestyle="--")
     return ax
 

--- a/examples/release_highlights/plot_release_highlights_0_22_0.py
+++ b/examples/release_highlights/plot_release_highlights_0_22_0.py
@@ -124,7 +124,6 @@ sorted_idx = result.importances_mean.argsort()
 # renamed to `tick_labels`. The following code handles this, but as a
 # scikit-learn user you probably can write simpler code by using `labels=...`
 # (matplotlib < 3.9) or `tick_labels=...` (matplotlib >= 3.9).
-# Once the minimum matplotlib version is 3.9, the following code can be simplified
 tick_labels_parameter_name = (
     "tick_labels"
     if parse_version(matplotlib.__version__) >= parse_version("3.9")

--- a/examples/release_highlights/plot_release_highlights_0_22_0.py
+++ b/examples/release_highlights/plot_release_highlights_0_22_0.py
@@ -34,6 +34,7 @@ or with conda::
 # `plot_confusion_matrix`. Read more about this new API in the
 # :ref:`User Guide <visualizations>`.
 
+import matplotlib
 import matplotlib.pyplot as plt
 
 from sklearn.datasets import make_classification
@@ -43,6 +44,7 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import RocCurveDisplay
 from sklearn.model_selection import train_test_split
 from sklearn.svm import SVC
+from sklearn.utils.fixes import parse_version
 
 X, y = make_classification(random_state=0)
 X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
@@ -117,9 +119,16 @@ result = permutation_importance(rf, X, y, n_repeats=10, random_state=0, n_jobs=2
 
 fig, ax = plt.subplots()
 sorted_idx = result.importances_mean.argsort()
-ax.boxplot(
-    result.importances[sorted_idx].T, vert=False, labels=feature_names[sorted_idx]
+
+# labels has been renamed to tick_labels in matplotlib 3.9.
+# This code can be simplified when scikit-learn minimum supported version is 3.9
+tick_labels_parameter_name = (
+    "tick_labels"
+    if parse_version(matplotlib.__version__) >= parse_version("3.9")
+    else "labels"
 )
+tick_labels_dict = {tick_labels_parameter_name: feature_names[sorted_idx]}
+ax.boxplot(result.importances[sorted_idx].T, vert=False, **tick_labels_dict)
 ax.set_title("Permutation Importance of each feature")
 ax.set_ylabel("Features")
 fig.tight_layout()

--- a/examples/release_highlights/plot_release_highlights_0_22_0.py
+++ b/examples/release_highlights/plot_release_highlights_0_22_0.py
@@ -120,8 +120,11 @@ result = permutation_importance(rf, X, y, n_repeats=10, random_state=0, n_jobs=2
 fig, ax = plt.subplots()
 sorted_idx = result.importances_mean.argsort()
 
-# labels has been renamed to tick_labels in matplotlib 3.9.
-# This code can be simplified when scikit-learn minimum supported version is 3.9
+# `labels` argument in boxplot is deprecated in matplotlib 3.9 and has been
+# renamed to `tick_labels`. The following code handles this, but as a
+# scikit-learn user you probably can write simpler code by using `labels=...`
+# (matplotlib < 3.9) or `tick_labels=...` (matplotlib >= 3.9).
+# Once the minimum matplotlib version is 3.9, the following code can be simplified
 tick_labels_parameter_name = (
     "tick_labels"
     if parse_version(matplotlib.__version__) >= parse_version("3.9")


### PR DESCRIPTION
Make the examples run without DeprecationWarning for matplotlib>=3.9, see https://github.com/scikit-learn/scikit-learn/issues/29434.
