### PR TITLE
SLEP006 FEA Add metadata routing support for `AdaBoostClassifier` and `AdaBoostRegressor`

### DIFF
--- a/doc/metadata_routing.rst
+++ b/doc/metadata_routing.rst
@@ -278,6 +278,8 @@ Meta-estimators and functions supporting metadata routing:
 - :class:`sklearn.compose.ColumnTransformer`
 - :class:`sklearn.compose.TransformedTargetRegressor`
 - :class:`sklearn.covariance.GraphicalLassoCV`
+- :class:`sklearn.ensemble.AdaBoostClassifier`
+- :class:`sklearn.ensemble.AdaBoostRegressor`
 - :class:`sklearn.ensemble.StackingClassifier`
 - :class:`sklearn.ensemble.StackingRegressor`
 - :class:`sklearn.ensemble.VotingClassifier`
@@ -320,8 +322,6 @@ Meta-estimators and functions supporting metadata routing:
 
 Meta-estimators and tools not supporting metadata routing yet:
 
-- :class:`sklearn.ensemble.AdaBoostClassifier`
-- :class:`sklearn.ensemble.AdaBoostRegressor`
 - :class:`sklearn.feature_selection.RFE`
 - :class:`sklearn.feature_selection.RFECV`
 - :class:`sklearn.feature_selection.SequentialFeatureSelector`

--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -95,6 +95,10 @@ more details.
   for the `fit` method of its estimator and for its underlying CV splitter and scorer.
   :pr:`29266` by :user:`Adam Li <adam2392>`.
 
+- |Feature| :class:`ensemble.AdaBoostClassifier` and :class:`ensemble.AdaBoostRegressor`
+  now supports metadata routing.
+  :pr:`28494` by :user:`Adam Li <adam2392>`.
+
 Dropping support for building with setuptools
 ---------------------------------------------
 

--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -97,7 +97,7 @@ more details.
 
 - |Feature| :class:`ensemble.AdaBoostClassifier` and :class:`ensemble.AdaBoostRegressor`
   now supports metadata routing.
-  :pr:`28494` by :user:`Adam Li <adam2392>`.
+  :pr:`29472` by :user:`Adam Li <adam2392>`.
 
 Dropping support for building with setuptools
 ---------------------------------------------

--- a/sklearn/tests/test_metaestimators_metadata_routing.py
+++ b/sklearn/tests/test_metaestimators_metadata_routing.py
@@ -407,6 +407,40 @@ METAESTIMATORS: list = [
         ],
         "method_mapping": {"fit": ["fit", "score"]},
     },
+    {
+        "metaestimator": AdaBoostClassifier,
+        "estimator_name": "estimator",
+        "estimator": "classifier",
+        "X": X,
+        "y": y,
+        "preserves_metadata": True,
+        "estimator_routing_methods": [
+            "fit",
+            "predict",
+            "predict_proba",
+            "predict_log_proba",
+            "decision_function",
+            "score",
+        ],
+        "method_mapping": {"fit": ["fit", "score"]},
+    },
+        {
+        "metaestimator": AdaBoostRegressor,
+        "estimator_name": "estimator",
+        "estimator": "regressor",
+        "X": X,
+        "y": y,
+        "preserves_metadata": True,
+        "estimator_routing_methods": [
+            "fit",
+            "predict",
+            "predict_proba",
+            "predict_log_proba",
+            "decision_function",
+            "score",
+        ],
+        "method_mapping": {"fit": ["fit", "score"]},
+    },
 ]
 """List containing all metaestimators to be tested and their settings
 
@@ -446,8 +480,6 @@ The keys are as follows:
 METAESTIMATOR_IDS = [str(row["metaestimator"].__name__) for row in METAESTIMATORS]
 
 UNSUPPORTED_ESTIMATORS = [
-    AdaBoostClassifier(),
-    AdaBoostRegressor(),
     RFE(ConsumingClassifier()),
     RFECV(ConsumingClassifier()),
     SequentialFeatureSelector(ConsumingClassifier()),


### PR DESCRIPTION
#### Reference Issues/PRs
Towards: #22893 


#### What does this implement/fix? Explain your changes.
This is the final suite of estimators that needed metadata routing implemented.

`AdaBoost*` is a bit more complicated than other functions, or meta-estimators as they must pass sample_weight around internally. This means `fit_params` always contains `sample_weight`.

#### Any other comments?

I have a few questions:

1. when should we deprecate, or remove `sample_weight` in function signatures?
2. should all the methods including things like `staged_predict` have the `**params` signature get added?
3. Inside `get_metadata_routing`, do I have to define when the callee is the self? E.g. in `AdaBoostClassifier.predict_proba`, it calls `AdaBoostClassifier.decision_function`.
