### PR TITLE
DOC improve rendering of items in LDA

### DIFF
--- a/sklearn/decomposition/_lda.py
+++ b/sklearn/decomposition/_lda.py
@@ -194,15 +194,14 @@ class LatentDirichletAllocation(
         In general, if the data size is large, the online update will be much
         faster than the batch update.
 
-        Valid options::
+        Valid options:
 
-            'batch': Batch variational Bayes method. Use all training data in
-                each EM update.
-                Old `components_` will be overwritten in each iteration.
-            'online': Online variational Bayes method. In each EM update, use
-                mini-batch of training data to update the ``components_``
-                variable incrementally. The learning rate is controlled by the
-                ``learning_decay`` and the ``learning_offset`` parameters.
+        - 'batch': Batch variational Bayes method. Use all training data in each EM
+          update. Old `components_` will be overwritten in each iteration.
+        - 'online': Online variational Bayes method. In each EM update, use mini-batch
+          of training data to update the ``components_`` variable incrementally. The
+          learning rate is controlled by the ``learning_decay`` and the
+          ``learning_offset`` parameters.
 
         .. versionchanged:: 0.20
             The default learning method is now ``"batch"``.


### PR DESCRIPTION
Quickly fixing the rendering of the `learning_method` parameter in the LDA documentation. We currently use a code block instead of a list of items.

<img width="731" alt="image" src="https://github.com/user-attachments/assets/706cf86e-9b27-4330-9890-accd890b951f">
