### PR TITLE
ENH Adjust estimator representation beyond `maxlevels`

### DIFF
--- a/sklearn/utils/_pprint.py
+++ b/sklearn/utils/_pprint.py
@@ -427,7 +427,7 @@ def _safe_repr(object, context, maxlevels, level, changed_only=False):
     if issubclass(typ, BaseEstimator):
         objid = id(object)
         if maxlevels and level >= maxlevels:
-            return "{...}", False, objid in context
+            return f"{typ.__name__}(...)", False, objid in context
         if objid in context:
             return pprint._recursion(object), False, True
         context[objid] = 1

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -2,6 +2,7 @@ import re
 from pprint import PrettyPrinter
 
 import numpy as np
+import pytest
 
 from sklearn.utils._pprint import _EstimatorPrettyPrinter
 from sklearn.linear_model import LogisticRegressionCV
@@ -346,12 +347,22 @@ RFE(estimator=RFE(estimator=RFE(estimator=RFE(estimator=RFE(estimator=RFE(estima
     assert rfe.__repr__() == expected
 
 
-def test_depth(print_changed_only_false):
-    pp = _EstimatorPrettyPrinter(depth=1)
+@pytest.mark.parametrize(
+    ("print_changed_only", "expected"),
+    [
+        (True, "RFE(estimator=RFE(...))"),
+        (
+            False,
+            "RFE(estimator=RFE(...), n_features_to_select=None, step=1, verbose=0)",
+        ),
+    ],
+)
+def test_depth(print_changed_only, expected):
+    with config_context(print_changed_only=print_changed_only):
+        pp = _EstimatorPrettyPrinter(depth=1)
 
-    rfe = RFE(RFE(RFE(RFE(RFE(LogisticRegression())))))
-    expected = "RFE(estimator=RFE(...), n_features_to_select=None, step=1, verbose=0)"
-    assert pp.pformat(rfe) == expected
+        rfe = RFE(RFE(RFE(RFE(RFE(LogisticRegression())))))
+        assert pp.pformat(rfe) == expected
 
 
 def test_gridsearch(print_changed_only_false):

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -357,7 +357,7 @@ RFE(estimator=RFE(estimator=RFE(estimator=RFE(estimator=RFE(estimator=RFE(estima
         ),
     ],
 )
-def test_depth(print_changed_only, expected):
+def test_print_estimator_max_depth(print_changed_only, expected):
     with config_context(print_changed_only=print_changed_only):
         pp = _EstimatorPrettyPrinter(depth=1)
 

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -346,6 +346,14 @@ RFE(estimator=RFE(estimator=RFE(estimator=RFE(estimator=RFE(estimator=RFE(estima
     assert rfe.__repr__() == expected
 
 
+def test_depth(print_changed_only_false):
+    pp = _EstimatorPrettyPrinter(depth=1)
+
+    rfe = RFE(RFE(RFE(RFE(RFE(LogisticRegression())))))
+    expected = "RFE(estimator=RFE(...), n_features_to_select=None, step=1, verbose=0)"
+    assert pp.pformat(rfe) == expected
+
+
 def test_gridsearch(print_changed_only_false):
     # render a gridsearch
     param_grid = [


### PR DESCRIPTION
#### Reference Issues/PRs

Resolves #29421

#### What does this implement/fix? Explain your changes.

* Don't print the estimator like a dict (`{...}`) beyond `maxlevels`

#### Any other comments?

None