### PR TITLE
Make GroupKFold use a stable sort

### DIFF
--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -342,7 +342,7 @@ Changelog
   :pr:`29402` by :user:`Anurag Varma <Anurag-Varma>`.
 
 - |Fix| Make GroupKFold use a stable sort to ensure reproducability with ties in group size. 
-  This may result in different groupings than previous versions, but will now be reprodcable.
+  This may result in different groupings than previous versions, but will now be reproducible across different machines and runs.
   :pr:`29496` by :user:`Jake Blitch <blitchj>`.
 
 :mod:`sklearn.neighbors`

--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -341,6 +341,10 @@ Changelog
   is called without a `y` argument
   :pr:`29402` by :user:`Anurag Varma <Anurag-Varma>`.
 
+- |Fix| Make GroupKFold use a stable sort to ensure reproducability with ties in group size. 
+  This may result in different groupings than previous versions, but will now be reprodcable.
+  :pr:`29496` by :user:`Jake Blitch <blitchj>`.
+
 :mod:`sklearn.neighbors`
 ........................
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -610,7 +610,7 @@ class GroupKFold(GroupsConsumerMixin, _BaseKFold):
         n_samples_per_group = np.bincount(groups)
 
         # Distribute the most frequent groups first
-        indices = np.argsort(n_samples_per_group)[::-1]
+        indices = np.argsort(n_samples_per_group, kind="stable")[::-1]
         n_samples_per_group = n_samples_per_group[indices]
 
         # Total weight of each fold

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -2083,7 +2083,7 @@ def test_group_kfold_is_stable_with_ties(folds, n_groups, group_size):
 
     split = [a for a in gkf.split(X, groups=groups)]
     for i, (_, test) in enumerate(split):
-        expected = X[(n_groups - 1 - groups) % folds == i]
+        expected = X[groups[::-1] % folds == i]
         assert_array_equal(test, expected)
 
 

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -2083,6 +2083,7 @@ def test_group_kfold_is_stable_with_ties(folds, n_groups, group_size):
 
     split = [a for a in gkf.split(X, groups=groups)]
     for i, (_, test) in enumerate(split):
+        # GroupKFold reverses sort, expect groups dealt in reverse
         expected = X[groups[::-1] % folds == i]
         assert_array_equal(test, expected)
 

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -2093,7 +2093,7 @@ def test_stratified_splitter_without_y(cv):
         ),
     ],
 )
-def test_group_k_fold_is_stable_tied(folds, n_groups, group_size, expected):
+def test_group_kfold_is_stable_with_ties(folds, n_groups, group_size, expected):
     """Verify groups are assigned based on a stable sort, with ties."""
     groups = np.repeat(np.arange(n_groups), group_size)
     X = np.arange(n_groups * group_size)

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -2,7 +2,7 @@
 
 import re
 import warnings
-from itertools import combinations, combinations_with_replacement, permutations, chain
+from itertools import chain, combinations, combinations_with_replacement, permutations
 
 import numpy as np
 import pytest

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -2104,7 +2104,7 @@ def test_group_k_fold_is_stable_tied(folds, n_groups, group_size, expected):
         assert_array_equal(train, np.array(expected[i]))
 
 
-def test_group_k_fold_is_stable_no_tied():
+def test_group_kfold_with_no_ties():
     """Verify groups are assigned based on a stable sort, without ties."""
     groups = np.array(list(chain.from_iterable([[i] * i for i in range(1, 10)])))
     X = np.arange(len(groups))

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -2068,40 +2068,23 @@ def test_stratified_splitter_without_y(cv):
 
 
 @pytest.mark.parametrize(
-    "folds,n_groups,group_size,expected",
+    "folds,n_groups,group_size",
     [
-        (
-            333,
-            333,
-            1,
-            [[j for j in range(333) if j != i] for i in reversed(range(333))],
-        ),
-        (
-            2,
-            41,
-            5,
-            [
-                list(
-                    chain.from_iterable(
-                        [range(10 * i + 5, 10 * i + 10) for i in range(20)]
-                    )
-                ),
-                list(
-                    chain.from_iterable([range(10 * i, 10 * i + 5) for i in range(21)])
-                ),
-            ],
-        ),
+        (333, 333, 1),
+        (2, 41, 5),
+        (3, 5, 16),
     ],
 )
-def test_group_kfold_is_stable_with_ties(folds, n_groups, group_size, expected):
+def test_group_kfold_is_stable_with_ties(folds, n_groups, group_size):
     """Verify groups are assigned based on a stable sort, with ties."""
     groups = np.repeat(np.arange(n_groups), group_size)
     X = np.arange(n_groups * group_size)
     gkf = GroupKFold(folds)
 
     split = [a for a in gkf.split(X, groups=groups)]
-    for i, (train, _) in enumerate(split):
-        assert_array_equal(train, np.array(expected[i]))
+    for i, (_, test) in enumerate(split):
+        expected = X[(n_groups - 1 - groups) % folds == i]
+        assert_array_equal(test, expected)
 
 
 def test_group_kfold_with_no_ties():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes: #29495


#### What does this implement/fix? Explain your changes.
Use stable sort in GroupKFold

#### Any other comments?
This does not reproduce the current results. But the current results aren't perfectly reproducible; however, they are likely to get the same sort on the same machine. It may be best to either consider this a breaking change as the new sort is different from the old. Or instead extend GroupKFold with a StableGroupKFold or add a stable parameter to GroupKFold.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
