### PR TITLE
BENCH Don't use setuptools based build commands

### DIFF
--- a/asv_benchmarks/asv.conf.json
+++ b/asv_benchmarks/asv.conf.json
@@ -20,10 +20,10 @@
 
     // Customizable commands for building, installing, and
     // uninstalling the project. See asv.conf.json documentation.
-    //
-    // "install_command": ["python -mpip install {wheel_file}"],
-    // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
-    // "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
+    "install_command": ["python -mpip install {wheel_file}"],
+    "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
+    "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
+
     // List of branches to benchmark. If not provided, defaults to "master
     // (for git) or "default" (for mercurial).
     "branches": ["main"],
@@ -72,12 +72,12 @@
     // those due to dependency changes.
     //
     "matrix": {
-        "numpy": ["1.25.2"],
-        "scipy": ["1.11.2"],
+        "numpy": ["2.0.0"],
+        "scipy": ["1.14.0"],
         "cython": ["3.0.10"],
         "joblib": ["1.3.2"],
         "threadpoolctl": ["3.2.0"],
-        "pandas": ["2.1.0"]
+        "pandas": ["2.2.2"]
     },
 
     // Combinations of libraries/python versions can be excluded/included


### PR DESCRIPTION
Fixes #29494

It looks like the default build commands have changed since https://github.com/scikit-learn/scikit-learn/pull/29352, so let's write them explicitly and not rely on the default.

Also take the opportunity to bump the dependencies for numpy 2.