### PR TITLE
BLD Include COPYING in wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "threadpoolctl>=3.1.0",
 ]
 requires-python = ">=3.9"
-license = {text = "new BSD"}
+license = {file = "COPYING"}
 classifiers=[
   "Intended Audience :: Science/Research",
   "Intended Audience :: Developers",


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/29518

I don't know how bad it is that we didn't include it in the wheels of 1.5.0 and 1.5.1...

I checked and it was included in the sdist.
I checked that with this PR, the command `python -m build --wheel` produces a wheel containing the `COPYING` file in the `dist-info` directory.

We should maybe check if we're not missing other things.

cc/ @lesteve 