### PR TITLE
MAINT Clean-up some testing utils

### DIFF
--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -264,9 +264,7 @@ def test_lasso_cv():
     )
     # check that they also give a similar MSE
     mse_lars = interpolate.interp1d(lars.cv_alphas_, lars.mse_path_.T)
-    np.testing.assert_approx_equal(
-        mse_lars(clf.alphas_[5]).mean(), clf.mse_path_[5].mean(), significant=2
-    )
+    assert_allclose(mse_lars(clf.alphas_[5]).mean(), clf.mse_path_[5].mean(), rtol=1e-2)
 
     # test set
     assert clf.score(X_test, y_test) > 0.99

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -327,8 +327,8 @@ def test_set_params():
 
     # we don't currently catch if the things in pipeline are estimators
     # bad_pipeline = Pipeline([("bad", NoEstimator())])
-    # assert_raises(AttributeError, bad_pipeline.set_params,
-    #               bad__stupid_param=True)
+    # with pytest.raises(AttributeError):
+    #    bad_pipeline.set_params(bad__stupid_param=True)
 
 
 def test_set_params_passes_all_parameters():

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -164,48 +164,6 @@ class _IgnoreWarnings:
         self.log[:] = []
 
 
-def assert_raise_message(exceptions, message, function, *args, **kwargs):
-    """Helper function to test the message raised in an exception.
-
-    Given an exception, a callable to raise the exception, and
-    a message string, tests that the correct exception is raised and
-    that the message is a substring of the error thrown. Used to test
-    that the specific message thrown during an exception is correct.
-
-    Parameters
-    ----------
-    exceptions : exception or tuple of exception
-        An Exception object.
-
-    message : str
-        The error message or a substring of the error message.
-
-    function : callable
-        Callable object to raise error.
-
-    *args : the positional arguments to `function`.
-
-    **kwargs : the keyword arguments to `function`.
-    """
-    try:
-        function(*args, **kwargs)
-    except exceptions as e:
-        error_message = str(e)
-        if message not in error_message:
-            raise AssertionError(
-                "Error message does not include the expected"
-                " string: %r. Observed error message: %r" % (message, error_message)
-            )
-    else:
-        # concatenate exception names
-        if isinstance(exceptions, tuple):
-            names = " or ".join(e.__name__ for e in exceptions)
-        else:
-            names = exceptions.__name__
-
-        raise AssertionError("%s not raised by %s" % (names, function.__name__))
-
-
 def assert_allclose(
     actual, desired, rtol=None, atol=0.0, equal_nan=True, err_msg="", verbose=True
 ):

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -20,7 +20,6 @@ from dataclasses import dataclass
 from functools import wraps
 from inspect import signature
 from subprocess import STDOUT, CalledProcessError, TimeoutExpired, check_output
-from unittest import TestCase
 
 import joblib
 import numpy as np
@@ -28,7 +27,6 @@ import scipy as sp
 from numpy.testing import assert_allclose as np_assert_allclose
 from numpy.testing import (
     assert_almost_equal,
-    assert_approx_equal,
     assert_array_almost_equal,
     assert_array_equal,
     assert_array_less,
@@ -52,29 +50,17 @@ from sklearn.utils.validation import (
 )
 
 __all__ = [
-    "assert_raises",
-    "assert_raises_regexp",
     "assert_array_equal",
     "assert_almost_equal",
     "assert_array_almost_equal",
     "assert_array_less",
-    "assert_approx_equal",
     "assert_allclose",
     "assert_run_python_script_without_output",
     "assert_no_warnings",
     "SkipTest",
 ]
 
-_dummy = TestCase("__init__")
-assert_raises = _dummy.assertRaises
 SkipTest = unittest.case.SkipTest
-assert_dict_equal = _dummy.assertDictEqual
-
-assert_raises_regex = _dummy.assertRaisesRegex
-# assert_raises_regexp is deprecated in Python 3.4 in favor of
-# assert_raises_regex but lets keep the backward compat in scikit-learn with
-# the old name for now
-assert_raises_regexp = assert_raises_regex
 
 
 def ignore_warnings(obj=None, category=Warning):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -75,7 +75,6 @@ from ._testing import (
     assert_array_almost_equal,
     assert_array_equal,
     assert_array_less,
-    assert_raise_message,
     create_memmap_backed_data,
     ignore_warnings,
     raises,
@@ -1489,9 +1488,8 @@ def check_fit2d_predict1d(name, estimator_orig):
 
     for method in ["predict", "transform", "decision_function", "predict_proba"]:
         if hasattr(estimator, method):
-            assert_raise_message(
-                ValueError, "Reshape your data", getattr(estimator, method), X[0]
-            )
+            with raises(ValueError, match="Reshape your data"):
+                getattr(estimator, method)(X[0])
 
 
 def _apply_on_subsets(func, X):

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -17,7 +17,6 @@ from sklearn.utils._testing import (
     assert_allclose,
     assert_allclose_dense_sparse,
     assert_no_warnings,
-    assert_raise_message,
     assert_run_python_script_without_output,
     check_docstring_parameters,
     create_memmap_backed_data,
@@ -64,29 +63,6 @@ def test_assert_allclose_dense_sparse(csr_container):
     B = csr_container(np.ones((1, 5)))
     with pytest.raises(AssertionError, match="Arrays are not equal"):
         assert_allclose_dense_sparse(B, A)
-
-
-def test_assert_raise_message():
-    def _raise_ValueError(message):
-        raise ValueError(message)
-
-    def _no_raise():
-        pass
-
-    assert_raise_message(ValueError, "test", _raise_ValueError, "test")
-
-    with pytest.raises(AssertionError):
-        assert_raise_message(ValueError, "something else", _raise_ValueError, "test")
-
-    with pytest.raises(ValueError):
-        assert_raise_message(TypeError, "something else", _raise_ValueError, "test")
-
-    with pytest.raises(AssertionError):
-        assert_raise_message(ValueError, "test", _no_raise)
-
-    # multiple exceptions in a tuple
-    with pytest.raises(AssertionError):
-        assert_raise_message((ValueError, AttributeError), "test", _no_raise)
 
 
 def test_ignore_warning():

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -18,8 +18,6 @@ from sklearn.utils._testing import (
     assert_allclose_dense_sparse,
     assert_no_warnings,
     assert_raise_message,
-    assert_raises,
-    assert_raises_regex,
     assert_run_python_script_without_output,
     check_docstring_parameters,
     create_memmap_backed_data,
@@ -68,12 +66,6 @@ def test_assert_allclose_dense_sparse(csr_container):
         assert_allclose_dense_sparse(B, A)
 
 
-def test_assert_raises_msg():
-    with assert_raises_regex(AssertionError, "Hello world"):
-        with assert_raises(ValueError, msg="Hello world"):
-            pass
-
-
 def test_assert_raise_message():
     def _raise_ValueError(message):
         raise ValueError(message)
@@ -83,34 +75,18 @@ def test_assert_raise_message():
 
     assert_raise_message(ValueError, "test", _raise_ValueError, "test")
 
-    assert_raises(
-        AssertionError,
-        assert_raise_message,
-        ValueError,
-        "something else",
-        _raise_ValueError,
-        "test",
-    )
+    with pytest.raises(AssertionError):
+        assert_raise_message(ValueError, "something else", _raise_ValueError, "test")
 
-    assert_raises(
-        ValueError,
-        assert_raise_message,
-        TypeError,
-        "something else",
-        _raise_ValueError,
-        "test",
-    )
+    with pytest.raises(ValueError):
+        assert_raise_message(TypeError, "something else", _raise_ValueError, "test")
 
-    assert_raises(AssertionError, assert_raise_message, ValueError, "test", _no_raise)
+    with pytest.raises(AssertionError):
+        assert_raise_message(ValueError, "test", _no_raise)
 
     # multiple exceptions in a tuple
-    assert_raises(
-        AssertionError,
-        assert_raise_message,
-        (ValueError, AttributeError),
-        "test",
-        _no_raise,
-    )
+    with pytest.raises(AssertionError):
+        assert_raise_message((ValueError, AttributeError), "test", _no_raise)
 
 
 def test_ignore_warning():


### PR DESCRIPTION
- `assert_approx_equal` is not recommended. I replaced the last occurence by an `assert_allclose`.
- `assert_raises` and `assert_raises_regex` are not used anywhere anymore.
- `assert_raise_message`. I replaced the last occurrence in estimator_checks.
- `assert_dict_equal` is not used anywhere. I didn't even know we had that :)

Since they were available from the private module `utils._testing.py`, and not documented, I believe we can remove it without deprecation. Do you agree ?
