### PR TITLE
CI Use correct Python version in lock-file update script for Debian 32bit build

### DIFF
--- a/build_tools/update_environments_and_lock_files.py
+++ b/build_tools/update_environments_and_lock_files.py
@@ -420,7 +420,7 @@ build_metadata_list = [
             "cython": "min",
         },
         # same Python version as in debian-32 build
-        "python_version": "3.9.2",
+        "python_version": "3.11.2",
     },
     {
         "name": "ubuntu_atlas",


### PR DESCRIPTION
This is the Python version that is used to create a conda environment with `pip-tools` and generate the `debian_atlas_32bit_lock.txt` from `debian_atlas_32bit_requirements.txt`. This does not really matter unless for some packages you have different package versions available for different Python versions, which I guess is quite rare.

I double-checked that I could run the lock-file update script locally.