### PR TITLE
MAINT Remove unused check-manifest config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,35 +26,6 @@ exclude=
 [mypy-joblib.*]
 follow_imports = skip
 
-[check-manifest]
-# ignore files missing in VCS
-ignore =
-    sklearn/_loss/_loss.pyx
-    sklearn/linear_model/_sag_fast.pyx
-    sklearn/linear_model/_sgd_fast.pyx
-    sklearn/utils/_seq_dataset.pyx
-    sklearn/utils/_seq_dataset.pxd
-    sklearn/utils/_weight_vector.pyx
-    sklearn/utils/_weight_vector.pxd
-    sklearn/metrics/_dist_metrics.pyx
-    sklearn/metrics/_dist_metrics.pxd
-    sklearn/metrics/_pairwise_distances_reduction/_argkmin.pxd
-    sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx
-    sklearn/metrics/_pairwise_distances_reduction/_argkmin_classmode.pyx
-    sklearn/metrics/_pairwise_distances_reduction/_base.pxd
-    sklearn/metrics/_pairwise_distances_reduction/_base.pyx
-    sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pxd
-    sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx
-    sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pxd
-    sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pyx
-    sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pxd
-    sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx
-    sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors_classmode.pyx
-    sklearn/neighbors/_ball_tree.pyx
-    sklearn/neighbors/_binary_tree.pxi
-    sklearn/neighbors/_kd_tree.pyx
-
-
 [codespell]
 skip = ./.git,./.mypy_cache,./sklearn/feature_extraction/_stop_words.py,./doc/_build,./doc/auto_examples,./doc/modules/generated
 ignore-words = build_tools/codespell_ignore_words.txt


### PR DESCRIPTION
This is not used since we switched to `check-sdist` (and away from `check-manifest`) in #28757