### PR TITLE
Make the array API check strict for unit tests

### DIFF
--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -86,11 +86,20 @@ def yield_namespace_device_dtype_combinations(include_numpy_namespaces=True):
             yield array_namespace, None, None
 
 
-def _check_array_api_dispatch(array_api_dispatch):
-    """Check that array_api_compat is installed and NumPy version is compatible.
+def _check_array_api_dispatch(array_api_dispatch, strict=False):
+    """Check that required dependencies are installed in new enough versions.
 
-    array_api_compat follows NEP29, which has a higher minimum NumPy version than
-    scikit-learn.
+    We need the array_api_compat package as well as new enough versions of
+    NumPy and SciPy.
+
+    Parameters
+    ----------
+    array_api_dispatch : bool
+        Enable or disable array API checks.
+
+    strict : bool, default=False
+        Do not allow any slack in the configuration of SciPy. Warnings are
+        raised as errors.
     """
     if array_api_dispatch:
         try:
@@ -109,16 +118,22 @@ def _check_array_api_dispatch(array_api_dispatch):
                 " the API specification"
             )
         if os.environ.get("SCIPY_ARRAY_API") != "1":
-            warnings.warn(
+            message = (
                 (
-                    "Some scikit-learn array API features might rely on enabling "
+                    "Some scikit-learn array API features rely on enabling "
                     "SciPy's own support for array API to function properly. "
                     "Please set the SCIPY_ARRAY_API=1 environment variable "
                     "before importing sklearn or scipy. More details at: "
                     "https://docs.scipy.org/doc/scipy/dev/api-dev/array_api.html"
                 ),
-                UserWarning,
             )
+            if strict:
+                raise RuntimeError(message)
+            else:
+                warnings.warn(
+                    message,
+                    UserWarning,
+                )
 
 
 def _single_array_device(array):

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -119,13 +119,11 @@ def _check_array_api_dispatch(array_api_dispatch, misconfigured_scipy="warn"):
 
         if not scipy._lib._array_api.SCIPY_ARRAY_API:
             message = (
-                (
-                    "Some scikit-learn array API features rely on enabling "
-                    "SciPy's own support for array API to function properly. "
-                    "Please set the SCIPY_ARRAY_API=1 environment variable "
-                    "before importing sklearn or scipy. More details at: "
-                    "https://docs.scipy.org/doc/scipy/dev/api-dev/array_api.html"
-                ),
+                "Some scikit-learn array API features rely on enabling "
+                "SciPy's own support for array API to function properly. "
+                "Please set the SCIPY_ARRAY_API=1 environment variable "
+                "before importing sklearn or scipy. More details at: "
+                "https://docs.scipy.org/doc/scipy/dev/api-dev/array_api.html"
             )
             if misconfigured_scipy == "raise":
                 raise RuntimeError(message)

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -295,7 +295,7 @@ def set_random_state(estimator, random_state=0):
 
 
 try:
-    _check_array_api_dispatch(True, misconfigured_scipy="raise")
+    _check_array_api_dispatch(True)
     ARRAY_API_COMPAT_FUNCTIONAL = True
 except ImportError:
     ARRAY_API_COMPAT_FUNCTIONAL = False
@@ -987,6 +987,7 @@ class MinimalTransformer:
 
 
 def _array_api_for_tests(array_namespace, device):
+    _check_array_api_dispatch(True, misconfigured_scipy="raise")
     try:
         array_mod = importlib.import_module(array_namespace)
     except ModuleNotFoundError:

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -295,7 +295,7 @@ def set_random_state(estimator, random_state=0):
 
 
 try:
-    _check_array_api_dispatch(True)
+    _check_array_api_dispatch(True, strict=True)
     ARRAY_API_COMPAT_FUNCTIONAL = True
 except ImportError:
     ARRAY_API_COMPAT_FUNCTIONAL = False

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -295,7 +295,7 @@ def set_random_state(estimator, random_state=0):
 
 
 try:
-    _check_array_api_dispatch(True, strict=True)
+    _check_array_api_dispatch(True, misconfigured_scipy="raise")
     ARRAY_API_COMPAT_FUNCTIONAL = True
 except ImportError:
     ARRAY_API_COMPAT_FUNCTIONAL = False

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -1,9 +1,9 @@
-import os
 import re
 from functools import partial
 
 import numpy
 import pytest
+import scipy
 from numpy.testing import assert_allclose
 
 from sklearn._config import config_context
@@ -91,12 +91,8 @@ def test_get_namespace_array_api(monkeypatch):
         with pytest.raises(TypeError):
             xp_out, is_array_api_compliant = get_namespace(X_xp, X_np)
 
-        def mock_getenv(key):
-            if key == "SCIPY_ARRAY_API":
-                return "0"
-
-        monkeypatch.setattr("os.environ.get", mock_getenv)
-        assert os.environ.get("SCIPY_ARRAY_API") != "1"
+        monkeypatch.setattr("scipy._lib._array_api.SCIPY_ARRAY_API", False)
+        assert not scipy._lib._array_api.SCIPY_ARRAY_API
         with pytest.warns(
             UserWarning,
             match="enabling SciPy's own support for array API to function properly. ",


### PR DESCRIPTION
This means tests will not run and raise an error if one of the (possibly) optional dependencies is not installed or configured properly.

The idea is to keep the check flexible when it is used to check if we can run user code, but make it strict when running unit tests. For user code we don't know if we need the array API features of SciPy, so setting the environment variable is recommended but not required. For our unit tests we know we will test code that needs it and the warning is easily lost (by default hidden) and the error message you see regarding the failed test is not helpful for tracking down what you need to do to fix it.

Follow up to https://github.com/scikit-learn/scikit-learn/issues/29549