### PR TITLE
MNT fix copyright rule to handle \r\n endings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,7 @@ ignore=[
 ]
 
 [tool.ruff.lint.flake8-copyright]
-notice-rgx = "\\#\\ Authors:\\ The\\ scikit\\-learn\\ developers\\\n\\#\\ SPDX\\-License\\-Identifier:\\ BSD\\-3\\-Clause\\\n"
+notice-rgx = "\\#\\ Authors:\\ The\\ scikit\\-learn\\ developers\\\r?\\\n\\#\\ SPDX\\-License\\-Identifier:\\ BSD\\-3\\-Clause"
 
 [tool.ruff.lint.per-file-ignores]
 # It's fine not to put the import at the top of the file in the examples


### PR DESCRIPTION
I tested and it works with \r\n endings. Could you please confirm @Charlie-XIAO ?

xref: https://github.com/scikit-learn/scikit-learn/pull/29477#issuecomment-2245352357