### PR TITLE
BLD Remove confusing default Meson buildtype

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,6 @@ project(
   license: 'BSD-3',
   meson_version: '>= 1.1.0',
   default_options: [
-    'buildtype=debugoptimized',
     'c_std=c11',
     'cpp_std=c++14',
   ],


### PR DESCRIPTION
Close #29589.

This uses Ralf's suggestion in https://github.com/scikit-learn/scikit-learn/issues/29589#issuecomment-2258620940. This default buildtype is only used if you do `meson setup` + `ninja` which happens extremely rarely. We use editable install which goes through pip and thus meson-python and sets buildtype=release.