### PR TITLE
CI Only use wheels when installing from scientific-python-nightly-wheels

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -85,7 +85,7 @@ python_environment_install_and_activate() {
         # install them from scientific-python-nightly-wheels
         dev_anaconda_url=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
         dev_packages="numpy scipy Cython"
-        pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url $dev_packages
+        pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url $dev_packages --only-binary :all:
     fi
 
     if [[ "$DISTRIB" == "conda-pip-scipy-dev" ]]; then

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -92,7 +92,7 @@ python_environment_install_and_activate() {
         echo "Installing development dependency wheels"
         dev_anaconda_url=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
         dev_packages="numpy scipy pandas Cython"
-        pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url $dev_packages
+        pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url $dev_packages --only-binary :all:
 
         check_packages_dev_version $dev_packages
 

--- a/build_tools/wheels/build_wheels.sh
+++ b/build_tools/wheels/build_wheels.sh
@@ -53,7 +53,7 @@ if [[ "$CIBW_FREE_THREADED_SUPPORT" =~ [tT]rue ]]; then
     # Numpy, scipy, Cython only have free-threaded wheels on scientific-python-nightly-wheels
     # TODO: remove this after CPython 3.13 is released (scheduled October 2024)
     # and our dependencies have free-threaded wheels on PyPI
-    export CIBW_BUILD_FRONTEND='pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" --no-binary :all:'
+    export CIBW_BUILD_FRONTEND='pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" --only-binary :all:'
 fi
 
 # The version of the built dependencies are specified

--- a/build_tools/wheels/build_wheels.sh
+++ b/build_tools/wheels/build_wheels.sh
@@ -53,7 +53,7 @@ if [[ "$CIBW_FREE_THREADED_SUPPORT" =~ [tT]rue ]]; then
     # Numpy, scipy, Cython only have free-threaded wheels on scientific-python-nightly-wheels
     # TODO: remove this after CPython 3.13 is released (scheduled October 2024)
     # and our dependencies have free-threaded wheels on PyPI
-    export CIBW_BUILD_FRONTEND='pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"'
+    export CIBW_BUILD_FRONTEND='pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" --no-binary :all:'
 fi
 
 # The version of the built dependencies are specified

--- a/build_tools/wheels/cibw_before_test.sh
+++ b/build_tools/wheels/cibw_before_test.sh
@@ -6,5 +6,5 @@ set -x
 FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
 if [[ $FREE_THREADED_BUILD == "True" ]]; then
     # TODO: remove when numpy, scipy and pandas have releases with free-threaded wheels
-    python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy scipy pandas
+    python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy scipy pandas --only-binary :all:
 fi


### PR DESCRIPTION
Fix #29583.

Basically we always want to use wheels and not compile from source. If a wheel is not available we would rather fail early and report upstream that their wheel is not available. I suspect this happens actually super rarely.

I am not worried about edge cases where a wheel is missing and it's useful to have the fall-back to compile from source. I would suggest we use `--only-binary :all:` for now and if we notice this is happening too often we can always use `--prefer-binary` instead.

Compiling from source can fail with a weird error that is generally not that straightforward to diagnose as in #29583. When it does succeed it takes a lot of time.
