### PR TITLE
Fix seed sensitivity of test_fastica_eigh_low_rank_warning

### DIFF
--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -169,7 +169,7 @@ Changelog
 ............................
 
 - |Fix| Increase rank defficiency threshold in the whitening step of
-  :class:`decomposition.FastICA` with `whiten_solver="eigh"` to improvement
+  :class:`decomposition.FastICA` with `whiten_solver="eigh"` to improve the
   platform-agnosticity of the estimator. :pr:`29612` by :user:`Olivier Grisel
   <ogrisel>`.
 

--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -165,6 +165,14 @@ Changelog
   and automatic retries in case of HTTP errors. :pr:`29354` by :user:`Olivier
   Grisel <ogrisel>`.
 
+:mod:`sklearn.decomposition`
+............................
+
+- |Fix| Increase rank defficiency threshold in the whitening step of
+  :class:`decomposition.FastICA` with `whiten_solver="eigh"` to improvement
+  platform-agnosticity of the estimator. :pr:`29612` by :user:`Olivier Grisel
+  <ogrisel>`.
+
 :mod:`sklearn.discriminant_analysis`
 ....................................
 

--- a/sklearn/decomposition/_fastica.py
+++ b/sklearn/decomposition/_fastica.py
@@ -605,7 +605,7 @@ class FastICA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
                 # Faster when num_samples >> n_features
                 d, u = linalg.eigh(XT.dot(X))
                 sort_indices = np.argsort(d)[::-1]
-                eps = np.finfo(d.dtype).eps
+                eps = np.finfo(d.dtype).eps * 10
                 degenerate_idx = d < eps
                 if np.any(degenerate_idx):
                     warnings.warn(

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -446,8 +446,11 @@ def test_fastica_eigh_low_rank_warning(global_random_seed):
     rng = np.random.RandomState(global_random_seed)
     A = rng.randn(10, 2)
     X = A @ A.T
+    # Use a large max_iter to avoid ConvergenceWarning before getting the
+    # singular values warning.
+    max_iter = 10_000
     ica = FastICA(
-        random_state=0, whiten="unit-variance", whiten_solver="eigh", max_iter=1000
+        random_state=0, whiten="unit-variance", whiten_solver="eigh", max_iter=max_iter
     )
     msg = "There are some small singular values"
     with pytest.warns(UserWarning, match=msg):

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -13,7 +13,7 @@ from scipy import stats
 from sklearn.decomposition import PCA, FastICA, fastica
 from sklearn.decomposition._fastica import _gs_decorrelation
 from sklearn.exceptions import ConvergenceWarning
-from sklearn.utils._testing import assert_allclose
+from sklearn.utils._testing import assert_allclose, ignore_warnings
 
 
 def center_and_norm(x, axis=-1):
@@ -446,12 +446,12 @@ def test_fastica_eigh_low_rank_warning(global_random_seed):
     rng = np.random.RandomState(global_random_seed)
     A = rng.randn(10, 2)
     X = A @ A.T
-    # Use a large max_iter to avoid ConvergenceWarning before getting the
-    # singular values warning.
-    max_iter = 10_000
-    ica = FastICA(
-        random_state=0, whiten="unit-variance", whiten_solver="eigh", max_iter=max_iter
-    )
+    ica = FastICA(random_state=0, whiten="unit-variance", whiten_solver="eigh")
     msg = "There are some small singular values"
+
     with pytest.warns(UserWarning, match=msg):
-        ica.fit(X)
+        with ignore_warnings(category=ConvergenceWarning):
+            # The FastICA solver may not converge for some data with specific
+            # random seed but this will happen after the whiten step so this is
+            # not want we want to test here.
+            ica.fit(X)

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -452,6 +452,6 @@ def test_fastica_eigh_low_rank_warning(global_random_seed):
     with pytest.warns(UserWarning, match=msg):
         with ignore_warnings(category=ConvergenceWarning):
             # The FastICA solver may not converge for some data with specific
-            # random seed but this will happen after the whiten step so this is
+            # random seeds but this happens after the whiten step so this is
             # not want we want to test here.
             ica.fit(X)

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -446,7 +446,9 @@ def test_fastica_eigh_low_rank_warning(global_random_seed):
     rng = np.random.RandomState(global_random_seed)
     A = rng.randn(10, 2)
     X = A @ A.T
-    ica = FastICA(random_state=0, whiten="unit-variance", whiten_solver="eigh")
+    ica = FastICA(
+        random_state=0, whiten="unit-variance", whiten_solver="eigh", max_iter=1000
+    )
     msg = "There are some small singular values"
     with pytest.warns(UserWarning, match=msg):
         ica.fit(X)


### PR DESCRIPTION
As originally reported in #26802 and more recently in #29609.

I cannot reproduce on my local setup, so let's try via the CI triggered by this draft PR.

EDIT: the `ConvergenceWarning` happens later (in the fast ica solver itself) while the expected `UserWarning` should be raised earlier, in the whitening step, irrespective of whether `FastICA` converges or not. I therefore think that the cause of the problem is that our eps-based detection of rank deficient case is too low to be platform agnostic.

Fixes #26802.