### PR TITLE
MAINT do not allow for NumPy >= 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -279,6 +279,11 @@ def setup_package():
         **extra_setuptools_args,
     )
 
+    # Overwrite the dependencies to not allow for NumPy >= 2.0
+    metadata["install_requires"] = [
+        f"{dep},<2.0" for dep in metadata["install_requires"] if dep.startswith("numpy")
+    ]
+
     commands = [arg for arg in sys.argv[1:] if not arg.startswith("-")]
     if all(
         command in ("egg_info", "dist_info", "clean", "check") for command in commands


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #29630

#### What does this implement/fix? Explain your changes.
Add constraints for supported versions of numpy for older versions of sklearn.

#### Any other comments?
cherry-pick of 02254cd8f3bb4d17d7cbeb920be8275c4d52d18a