### PR TITLE
Add note about pip system requirements for --config-settings

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -122,6 +122,10 @@ feature, code or documentation improvement).
     install` command once, `sklearn` will automatically be rebuilt when
     importing `sklearn`.
 
+    Note that `--config-settings` is only supported in `pip` version 23.1 or
+    later. To upgrade `pip` to a compatible version, run `pip install -U pip` or
+    `pip install pip==23.1`.
+
 Dependencies
 ------------
 

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -123,8 +123,7 @@ feature, code or documentation improvement).
     importing `sklearn`.
 
     Note that `--config-settings` is only supported in `pip` version 23.1 or
-    later. To upgrade `pip` to a compatible version, run `pip install -U pip` or
-    `pip install pip==23.1`.
+    later. To upgrade `pip` to a compatible version, run `pip install -U pip`.
 
 Dependencies
 ------------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
N/A

#### What does this implement/fix? Explain your changes.
Adds a note to the `developers/advanced_installation` documentation helping devs troubleshoot problems with the `pip install ... --config-settings editable-verbose=true` command. Specifically, if the developer's version of pip is <23.1, they will get an error like:
```
no such option: --config-settings
```

pip 23.1 adds support for the `--config-settings` option (see [their changelog][pip-changelog] for details), so this change encourages the developer to upgrade their version of pip to 23.1 or later.

#### Any other comments?
pip 23.1 deprecated `--build-option` and `--global-option` in favor of `--config-settings`. Should we mention this too?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
[pip-changelog]: https://pip.pypa.io/en/stable/news/#v23-1