### PR TITLE
Copyedit species names in species distribution modeling example

### DIFF
--- a/examples/applications/plot_species_distribution_modeling.py
+++ b/examples/applications/plot_species_distribution_modeling.py
@@ -17,13 +17,13 @@ to plot the coast lines and national boundaries of South America.
 
 The two species are:
 
- - `"Bradypus variegatus"
-   <http://www.iucnredlist.org/details/3038/0>`_ ,
-   the Brown-throated Sloth.
+ - `Bradypus variegatus
+   <http://www.iucnredlist.org/details/3038/0>`_,
+   the brown-throated sloth.
 
- - `"Microryzomys minutus"
-   <http://www.iucnredlist.org/details/13408/0>`_ ,
-   also known as the Forest Small Rice Rat, a rodent that lives in Peru,
+ - `Microryzomys minutus
+   <http://www.iucnredlist.org/details/13408/0>`_,
+   also known as the forest small rice rat, a rodent that lives in Peru,
    Colombia, Ecuador, Peru, and Venezuela.
 
 References


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Made two copyedit changes to the `applications/plot_species_distribution_modeling` example documentation:
- Uncapitalize the species' common names
- Remove the quotes around the Latin names. Ideally I would put them in italics but reStructuredText doesn't readily support nesting hyperlinks and italics, though there is a [possible workaround].

#### Any other comments?
There is a [possible workaround] for nesting italics inside a link that involves substituting the text. We would have to do it for both Latin names. I feel like this would excessively clutter the source code, but I am opening to doing it in this PR before it is merged.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
[possible workaround]: https://stackoverflow.com/a/10766650