### PR TITLE
ENH use error_score='raise' in test_array_api_search_cv_classifier

### DIFF
--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -2780,6 +2780,7 @@ def test_array_api_search_cv_classifier(SearchCV, array_namespace, device, dtype
             LinearDiscriminantAnalysis(),
             {"tol": [1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7]},
             cv=2,
+            error_score="raise",
         )
         searcher.fit(X_xp, y_xp)
         searcher.score(X_xp, y_xp)


### PR DESCRIPTION
Do not hide the cause exception under a `ValueError` when running `test_array_api_search_cv_classifier`.

Found via the #29647 draft PR.