### PR TITLE
Automatically validate data for `multioutput_only` tag.

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -20,9 +20,7 @@ from .utils._estimator_html_repr import _HTMLDocumentationLinkMixin, estimator_h
 from .utils._metadata_requests import _MetadataRequester, _routing_enabled
 from .utils._param_validation import validate_parameter_constraints
 from .utils._set_output import _SetOutputMixin
-from .utils._tags import (
-    _DEFAULT_TAGS,
-)
+from .utils._tags import _DEFAULT_TAGS, _safe_tags
 from .utils.fixes import _IS_32BIT
 from .utils.validation import (
     _check_feature_names_in,
@@ -624,8 +622,8 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
         check_X_params = {**default_check_params, **check_params}
         check_y_params = {
             **default_check_params,
-            "multi_output": tags.get("multioutput", False),
-            "ensure_2d": tags.get("multioutput_only", False),
+            "multi_output": _safe_tags(self, key="multioutput"),
+            "ensure_2d": _safe_tags(self, key="multioutput_only"),
             **check_params,
         }
 

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -607,7 +607,8 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
         """
         self._check_feature_names(X, reset=reset)
 
-        if y is None and self._get_tags()["requires_y"]:
+        tags = self._get_tags()
+        if y is None and tags["requires_y"]:
             raise ValueError(
                 f"This {self.__class__.__name__} estimator "
                 "requires y to be passed, but the target y is None."
@@ -620,7 +621,13 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
             raise ValueError("Validation should be done on X, y or both.")
 
         default_check_params = {"estimator": self}
-        check_params = {**default_check_params, **check_params}
+        check_X_params = {**default_check_params, **check_params}
+        check_y_params = {
+            **default_check_params,
+            "multi_output": tags.get("multioutput", False),
+            "ensure_2d": tags.get("multioutput_only", False),
+            **check_params,
+        }
 
         if not cast_to_ndarray:
             if not no_val_X and no_val_y:
@@ -630,9 +637,9 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
             else:
                 out = X, y
         elif not no_val_X and no_val_y:
-            out = check_array(X, input_name="X", **check_params)
+            out = check_array(X, input_name="X", **check_X_params)
         elif no_val_X and not no_val_y:
-            out = _check_y(y, **check_params)
+            out = _check_y(y, **check_y_params)
         else:
             if validate_separately:
                 # We need this because some estimators validate X and y

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -103,8 +103,7 @@ def test_multi_target_regression_one_target():
     # Test multi target regression raises
     X, y = datasets.make_regression(n_targets=1, random_state=0)
     rgr = MultiOutputRegressor(GradientBoostingRegressor(random_state=0))
-    msg = "at least two dimensions"
-    with pytest.raises(ValueError, match=msg):
+    with pytest.raises(ValueError, match="Expected 2D array, got 1D array instead"):
         rgr.fit(X, y)
 
 
@@ -456,7 +455,7 @@ def test_multi_output_exceptions():
     # ValueError when y is continuous
     msg = "Unknown label type"
     with pytest.raises(ValueError, match=msg):
-        moc.fit(X, X[:, 1])
+        moc.fit(X, X)
 
 
 @pytest.mark.parametrize("response_method", ["predict_proba", "predict"])

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1388,14 +1388,14 @@ def check_X_y(
     return X, y
 
 
-def _check_y(y, multi_output=False, y_numeric=False, estimator=None):
+def _check_y(y, multi_output=False, y_numeric=False, estimator=None, ensure_2d=False):
     """Isolated part of check_X_y dedicated to y validation"""
     if multi_output:
         y = check_array(
             y,
             accept_sparse="csr",
             ensure_all_finite=True,
-            ensure_2d=False,
+            ensure_2d=ensure_2d,
             dtype=None,
             input_name="y",
             estimator=estimator,


### PR DESCRIPTION
This PR adds automatic validation of data `(X, y)` to verify `y` is multi-output if the estimator has the tag `multioutput_only` and update tests accordingly.