### PR TITLE
Add separate_avg parameter for classification_report function in sklearn/metrics/_classification.py

### DIFF
--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -139,6 +139,16 @@ Changelog
     :pr:`123456` by :user:`Joe Bloggs <joeongithub>`.
     where 123455 is the *pull request* number, not the issue number.
 
+:mod:`sklearn.metrics`
+......................
+
+- |Enhancement| The `classification_report` function now includes a new parameter
+  `separate_avg` (default: `True`). This allows for the separation of class-wise
+  metrics from average metrics in the output dictionary when `output_dict=True`,
+  preventing potential conflicts between class names and average metrics such as
+  "accuracy" or "macro avg". Backward compatibility is maintained by setting
+  `separate_avg=False`. :pr:`29668` by :user:`Anuraag Pandhi <Anumon6395>`.
+
 :mod:`sklearn.base`
 ...................
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2629,7 +2629,7 @@ def classification_report(
               'label 1': {'precision': 0.5, 'recall': 1.0, 'f1-score': 0.67, 'support': 1},
               'label 2': { ... },
               ...,
-              'averages': {'macro avg': {...}, 'weighted avg': {...}}  # New structure when separate_avg=True
+              'averages': {'macro avg': {...}, 'weighted avg': {...}}
             }
 
     See Also
@@ -2718,24 +2718,31 @@ def classification_report(
         )
         avg = [avg_p, avg_r, avg_f1, np.sum(s)]
 
-        if output_dict:
-            if separate_avg:
-                averages[line_heading] = dict(zip(headers, [float(i) for i in avg]))
-            else:
-                report_dict[line_heading] = dict(zip(headers, [float(i) for i in avg]))
+    if output_dict:
+        if separate_avg:
+            averages[line_heading] = dict(
+                zip(headers, [float(i) for i in avg])
+            )
         else:
-            if line_heading == "accuracy":
-                row_fmt_accuracy = (
-                    "{:>{width}s} "
-                    + " {:>9.{digits}}" * 2
-                    + " {:>9.{digits}f}"
-                    + " {:>9}\n"
-                )
-                report += row_fmt_accuracy.format(
-                    line_heading, "", "", *avg[2:], width=width, digits=digits
-                )
-            else:
-                report += row_fmt.format(line_heading, *avg, width=width, digits=digits)
+            report_dict[line_heading] = dict(
+                zip(headers, [float(i) for i in avg])
+            )
+    else:
+        if line_heading == "accuracy":
+            row_fmt_accuracy = (
+                "{:>{width}s} "
+                + " {:>9.{digits}}" * 2
+                + " {:>9.{digits}f}"
+                + " {:>9}\n"
+            )
+            report += row_fmt_accuracy.format(
+                line_heading, "", "", *avg[2:], width=width, digits=digits
+            )
+        else:
+            report += row_fmt.format(
+                line_heading, *avg, width=width, digits=digits
+            )
+
 
     if output_dict:
         if separate_avg:

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2773,13 +2773,9 @@ def classification_report(
 
     if output_dict:
         if separate_avg:
-            averages[line_heading] = dict(
-                zip(headers, [float(i) for i in avg])
-            )
+            averages[line_heading] = dict(zip(headers, [float(i) for i in avg]))
         else:
-            report_dict[line_heading] = dict(
-                zip(headers, [float(i) for i in avg])
-            )
+            report_dict[line_heading] = dict(zip(headers, [float(i) for i in avg]))
     else:
         if line_heading == "accuracy":
             row_fmt_accuracy = (
@@ -2792,9 +2788,7 @@ def classification_report(
                 line_heading, "", "", *avg[2:], width=width, digits=digits
             )
         else:
-            report += row_fmt.format(
-                line_heading, *avg, width=width, digits=digits
-            )
+            report += row_fmt.format(line_heading, *avg, width=width, digits=digits)
 
     if output_dict:
         if separate_avg:

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2655,8 +2655,8 @@ def classification_report(
         support for each class.
     confusion_matrix: Compute confusion matrix to evaluate the accuracy of a
         classification.
-        multilabel_confusion_matrix: Compute a confusion matrix for each class or sample.
-    
+    multilabel_confusion_matrix: Compute a confusion matrix for each class or sample.
+
     Examples
     --------
     >>> from sklearn.metrics import classification_report

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2743,7 +2743,6 @@ def classification_report(
                 line_heading, *avg, width=width, digits=digits
             )
 
-
     if output_dict:
         if separate_avg:
             report_dict["averages"] = averages

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2570,7 +2570,7 @@ def classification_report(
     digits=2,
     output_dict=False,
     zero_division="warn",
-    separate_avg=True, 
+    separate_avg=True,
 ):
     """Build a text report showing the main classification metrics.
 
@@ -2609,7 +2609,7 @@ def classification_report(
 
         .. versionadded:: 1.3
            `np.nan` option was added.
-           
+
     separate_avg : bool, default=True
         If True, average metrics (such as "macro avg", "weighted avg", etc.)
         will be separated from the class-wise metrics and placed under a new
@@ -2631,7 +2631,7 @@ def classification_report(
                          'support':1},
              'label 2': { ... },
               ...,
-              'averages': {'macro avg': {...}, 
+              'averages': {'macro avg': {...},
                            'weighted avg': {...}}
             }
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -203,7 +203,7 @@ def test_classification_report_dict_separate_avg():
     y_true = [0, 1, 2, 2, 2, 0]
     y_pred = [0, 0, 2, 2, 1, 0]
     target_names = ['class 0', 'class 1', 'class 2']
-    
+
     report = classification_report(
         y_true, y_pred, target_names=target_names, output_dict=True,
         separate_avg=True

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -197,16 +197,16 @@ def test_classification_report_output_dict_empty_input():
             for metric in expected_report[key]:
                 assert_almost_equal(expected_report[key][metric], report[key][metric])
 
+
 def test_classification_report_dict_separate_avg():
     # Test to ensure classification_report separates averages when
     # separate_avg=True
     y_true = [0, 1, 2, 2, 2, 0]
     y_pred = [0, 0, 2, 2, 1, 0]
-    target_names = ['class 0', 'class 1', 'class 2']
+    target_names = ["class 0", "class 1", "class 2"]
 
     report = classification_report(
-        y_true, y_pred, target_names=target_names, output_dict=True,
-        separate_avg=True
+        y_true, y_pred, target_names=target_names, output_dict=True, separate_avg=True
     )
 
     assert "averages" in report
@@ -227,12 +227,12 @@ def test_classification_report_dict_separate_avg():
 
     # Also test for separate_avg=False to ensure backward compatibility
     report_no_separate = classification_report(
-        y_true, y_pred, target_names=target_names, output_dict=True,
-        separate_avg=False
+        y_true, y_pred, target_names=target_names, output_dict=True, separate_avg=False
     )
     assert "averages" not in report_no_separate
     assert "macro avg" in report_no_separate
     assert "weighted avg" in report_no_separate
+
 
 @pytest.mark.parametrize("zero_division", ["warn", 0, 1, np.nan])
 def test_classification_report_zero_division_warning(zero_division):

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -197,6 +197,33 @@ def test_classification_report_output_dict_empty_input():
             for metric in expected_report[key]:
                 assert_almost_equal(expected_report[key][metric], report[key][metric])
 
+def test_classification_report_dict_separate_avg():
+    # Test to ensure classification_report separates averages when separate_avg=True
+    y_true = [0, 1, 2, 2, 2, 0]
+    y_pred = [0, 0, 2, 2, 1, 0]
+    target_names = ['class 0', 'class 1', 'class 2']
+    
+    report = classification_report(y_true, y_pred, target_names=target_names, output_dict=True, separate_avg=True)
+
+    assert "averages" in report
+    assert "macro avg" in report["averages"]
+    assert "weighted avg" in report["averages"]
+    assert "class 0" in report
+    assert "class 1" in report
+    assert "class 2" in report
+    assert "macro avg" not in report  # Ensure macro avg is not at the top level
+    assert "weighted avg" not in report  # Ensure weighted avg is not at the top level
+
+    # Check the correctness of the average metrics
+    assert report["averages"]["macro avg"]["precision"] is not None
+    assert report["averages"]["macro avg"]["recall"] is not None
+    assert report["averages"]["macro avg"]["f1-score"] is not None
+
+    # Also test for separate_avg=False to ensure backward compatibility
+    report_no_separate = classification_report(y_true, y_pred, target_names=target_names, output_dict=True, separate_avg=False)
+    assert "averages" not in report_no_separate
+    assert "macro avg" in report_no_separate
+    assert "weighted avg" in report_no_separate
 
 @pytest.mark.parametrize("zero_division", ["warn", 0, 1, np.nan])
 def test_classification_report_zero_division_warning(zero_division):

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -198,12 +198,16 @@ def test_classification_report_output_dict_empty_input():
                 assert_almost_equal(expected_report[key][metric], report[key][metric])
 
 def test_classification_report_dict_separate_avg():
-    # Test to ensure classification_report separates averages when separate_avg=True
+    # Test to ensure classification_report separates averages when
+    # separate_avg=True
     y_true = [0, 1, 2, 2, 2, 0]
     y_pred = [0, 0, 2, 2, 1, 0]
     target_names = ['class 0', 'class 1', 'class 2']
     
-    report = classification_report(y_true, y_pred, target_names=target_names, output_dict=True, separate_avg=True)
+    report = classification_report(
+        y_true, y_pred, target_names=target_names, output_dict=True,
+        separate_avg=True
+    )
 
     assert "averages" in report
     assert "macro avg" in report["averages"]
@@ -211,8 +215,10 @@ def test_classification_report_dict_separate_avg():
     assert "class 0" in report
     assert "class 1" in report
     assert "class 2" in report
-    assert "macro avg" not in report  # Ensure macro avg is not at the top level
-    assert "weighted avg" not in report  # Ensure weighted avg is not at the top level
+
+    # Ensure macro avg and weighted avg are not at the top level
+    assert "macro avg" not in report
+    assert "weighted avg" not in report
 
     # Check the correctness of the average metrics
     assert report["averages"]["macro avg"]["precision"] is not None
@@ -220,7 +226,10 @@ def test_classification_report_dict_separate_avg():
     assert report["averages"]["macro avg"]["f1-score"] is not None
 
     # Also test for separate_avg=False to ensure backward compatibility
-    report_no_separate = classification_report(y_true, y_pred, target_names=target_names, output_dict=True, separate_avg=False)
+    report_no_separate = classification_report(
+        y_true, y_pred, target_names=target_names, output_dict=True,
+        separate_avg=False
+    )
     assert "averages" not in report_no_separate
     assert "macro avg" in report_no_separate
     assert "weighted avg" in report_no_separate


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #29205

#### What does this implement/fix? Explain your changes.
This pull request addresses the issue in the classification_report function in _classification.py where class names could potentially conflict with average metric names (e.g., "accuracy", "macro avg", "weighted avg") when output_dict=True.

#### Changes Implemented:

Introduced a new separate_avg parameter (default: True) in the classification_report function.
When separate_avg=True, the function now separates average metrics into a distinct "averages" key in the output dictionary. This manages conflicts between class names and average metrics.
Updated the validate_params decorator to include the new parameter.
Included backward compatibility by maintaining the original structure of the output dictionary when separate_avg=False.

#### Any other comments?
This solution focuses on avoiding API-breaking changes while resolving the issue. A new test case has been added to verify the correct behavior of the classification_report function with the separate_avg parameter.