### PR TITLE
Adding links for examples/cluster/plot_feature_agglomeration_vs_univariate_selection.py

### DIFF
--- a/examples/cluster/plot_feature_agglomeration_vs_univariate_selection.py
+++ b/examples/cluster/plot_feature_agglomeration_vs_univariate_selection.py
@@ -12,6 +12,8 @@ This example compares 2 dimensionality reduction strategies:
 Both methods are compared in a regression problem using
 a BayesianRidge as supervised estimator.
 
+See :ref:`sphx_glr_auto_examples_cluster_plot_feature_agglomeration_vs_univariate_selection.py`
+
 """
 
 # Authors: The scikit-learn developers


### PR DESCRIPTION
#### Reference Issues/PRs
References #26927

#### What does this implement/fix? Explain your changes.
This pull request links an example in examples/cluster/plot_feature_agglomeration_vs_univariate_selection.py

#### Changes Implemented:
Implements :ref:`sphx_glr_auto_examples_cluster_plot_feature_agglomeration_vs_univariate_selection.py`
