### PR TITLE
Calculate exhaust `min_resource` with `n_iterations_` instead in Halving Search CVs

### DIFF
--- a/sklearn/model_selection/_search_successive_halving.py
+++ b/sklearn/model_selection/_search_successive_halving.py
@@ -271,16 +271,6 @@ class BaseSuccessiveHalving(BaseSearchCV):
         # last iterations evaluates less than `factor` candidates.
         n_required_iterations = 1 + floor(log(len(candidate_params), self.factor))
 
-        if self.min_resources == "exhaust":
-            # To exhaust the resources, we want to start with the biggest
-            # min_resources possible so that the last (required) iteration
-            # uses as many resources as possible
-            last_iteration = n_required_iterations - 1
-            self.min_resources_ = max(
-                self.min_resources_,
-                self.max_resources_ // self.factor**last_iteration,
-            )
-
         # n_possible_iterations is the number of iterations that we can
         # actually do starting from min_resources and without exceeding
         # max_resources. Depending on max_resources and the number of
@@ -294,6 +284,16 @@ class BaseSuccessiveHalving(BaseSearchCV):
             n_iterations = n_required_iterations
         else:
             n_iterations = min(n_possible_iterations, n_required_iterations)
+
+        if self.min_resources == "exhaust":
+            # To exhaust the resources, we want to start with the biggest
+            # min_resources possible so that the last (actual) iteration
+            # uses as many resources as possible
+            last_iteration = n_iterations - 1
+            self.min_resources_ = max(
+                self.min_resources_,
+                self.max_resources_ // self.factor**last_iteration,
+            )
 
         if self.verbose:
             print(f"n_iterations: {n_iterations}")

--- a/sklearn/model_selection/tests/test_successive_halving.py
+++ b/sklearn/model_selection/tests/test_successive_halving.py
@@ -220,14 +220,14 @@ def test_aggressive_elimination(
         # without enough resources, only one iteration can be done
         ("smallest", 30, 1, 1, [20]),
         # with exhaust: use as much resources as possible at the last iter
-        ("exhaust", "auto", 2, 2, [333, 999]),
-        ("exhaust", 1000, 2, 2, [333, 999]),
-        ("exhaust", 999, 2, 2, [333, 999]),
-        ("exhaust", 600, 2, 2, [200, 600]),
-        ("exhaust", 599, 2, 2, [199, 597]),
-        ("exhaust", 300, 2, 2, [100, 300]),
+        ("exhaust", "auto", 2, 4, [333, 999]),
+        ("exhaust", 1000, 2, 4, [333, 999]),
+        ("exhaust", 999, 2, 4, [333, 999]),
+        ("exhaust", 600, 2, 4, [200, 600]),
+        ("exhaust", 599, 2, 4, [199, 597]),
+        ("exhaust", 300, 2, 3, [100, 300]),
         ("exhaust", 60, 2, 2, [20, 60]),
-        ("exhaust", 50, 1, 1, [20]),
+        ("exhaust", 50, 1, 1, [50]),
         ("exhaust", 20, 1, 1, [20]),
     ],
 )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #27422. See also #28320


#### What does this implement/fix? Explain your changes.

In current implementation of finding the `min_resouces` when `min_resouces = 'exhaust'` is set,
the `min_resources` is calculated based on `n_required_iterations_`, which is equal to or larger than
the actual iterations run, `n_iterations_`. Such may cause the `min_resources` calculated does not as 'exhaust' as expected.

I have changed the calculation bases to the real iteration number run, `n_iterations_`, to make the `min_resources` more optimal.

As the example in #27422, `n_samples` = 1050, `factor` = 2, 160 params sets, `aggresive_elimination` is `False`:
* `n_required_iterations_`: 1 + floor(log(160, 2)) = 8
* `n_possible_iterations_`: 1 + floor(log(1050 // 20, 2)) = 6
* `n_iterations_`: min(`n_possible_iteration_`, `n_required_iterations_`) = 6

__Before modification:__
* `min_resources`: min(20,1050 // 2**(8-1)) = 20
* resources in each step: [20, 40, 80, 160, 320, 640]

__After modification:__
* `min_resources`: min(20, 1050 // 2**(6-1)) = 32
* resources in each step: [32, 64, 128, 256, 512, 1024]
which is more fit with the `n_samples` 1050.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
