### PR TITLE
Fix typo in advanced_installation.rst

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -52,7 +52,7 @@ feature, code or documentation improvement).
 
    .. prompt:: bash $
 
-     git clone git://github.com/scikit-learn/scikit-learn.git  # add --depth 1 if your connection is slow
+     git clone git@github.com:scikit-learn/scikit-learn.git  # add --depth 1 if your connection is slow
      cd scikit-learn
 
    If you plan on submitting a pull-request, you should clone from your fork


### PR DESCRIPTION
The current link in the advanced installation guide is outdated/broken and yields a timeout when cloning. This PR updates the link to the SSH clone link. This might still fail for users who have not set up SSH, the alternative would be to add the https clone link as well (https://github.com/scikit-learn/scikit-learn.git).

Using the SSH link would be consistent with the developer docs (https://scikit-learn.org/dev/developers/contributing.html#contributing-code).