### PR TITLE
DOC Fix Definitions of False Positive and False Negative in Fowlkes-Mallows scores

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -1791,20 +1791,25 @@ homogeneous but not complete::
 Fowlkes-Mallows scores
 ----------------------
 
-The Fowlkes-Mallows index (:func:`sklearn.metrics.fowlkes_mallows_score`) can be
-used when the ground truth class assignments of the samples is known. The
-Fowlkes-Mallows score FMI is defined as the geometric mean of the
-pairwise precision and recall:
+The original Fowlkes-Mallows index (FMI) was intended to measure the similarity
+between two clustering results, which is inherently an unsupervised comparison.
+The supervised adaptation of the Fowlkes-Mallows index
+(as implemented in :func:`sklearn.metrics.fowlkes_mallows_score`) can be used
+when the ground truth class assignments of the samples are known.
+The FMI is defined as the geometric mean of the pairwise precision and recall:
 
 .. math:: \text{FMI} = \frac{\text{TP}}{\sqrt{(\text{TP} + \text{FP}) (\text{TP} + \text{FN})}}
 
-Where ``TP`` is the number of **True Positive** (i.e. the number of pair
-of points that belong to the same clusters in both the true labels and the
-predicted labels), ``FP`` is the number of **False Positive** (i.e. the number
-of pair of points that belong to the same clusters in the predicted labels and not
-in the true labels) and ``FN`` is the number of **False Negative** (i.e. the
-number of pair of points that belong to the same clusters in the true
-labels and not in the predicted labels).
+In the above formula:
+
+* ``TP`` (**True Positive**): The number of pairs of points that are clustered together
+  both in the true labels and in the predicted labels.
+
+* ``FP`` (**False Positive**): The number of pairs of points that are clustered together
+  in the predicted labels but not in the true labels.
+
+* ``FN`` (**False Negative**): The number of pairs of points that are clustered together
+  in the true labels but not in the predicted labels.
 
 The score ranges from 0 to 1. A high value indicates a good similarity
 between two clusters.

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -1801,10 +1801,10 @@ pairwise precision and recall:
 Where ``TP`` is the number of **True Positive** (i.e. the number of pair
 of points that belong to the same clusters in both the true labels and the
 predicted labels), ``FP`` is the number of **False Positive** (i.e. the number
-of pair of points that belong to the same clusters in the true labels and not
-in the predicted labels) and ``FN`` is the number of **False Negative** (i.e. the
-number of pair of points that belongs in the same clusters in the predicted
-labels and not in the true labels).
+of pair of points that belong to the same clusters in the predicted labels and not
+in the true labels) and ``FN`` is the number of **False Negative** (i.e. the
+number of pair of points that belong to the same clusters in the true
+labels and not in the predicted labels).
 
 The score ranges from 0 to 1. A high value indicates a good similarity
 between two clusters.

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -1188,7 +1188,7 @@ def fowlkes_mallows_score(labels_true, labels_pred, *, sparse=False):
     points that belongs in the same clusters in both ``labels_true`` and
     ``labels_pred``), ``FP`` is the number of **False Positive** (i.e. the
     number of pairs of points that belong to the same cluster in
-    ``labels_pred`` and not in ``labels_true``) and ``FN`` is the number of
+    ``labels_pred`` but not in ``labels_true``) and ``FN`` is the number of
     **False Negative** (i.e. the number of pairs of points that belong to the
     same cluster in ``labels_true`` but not in ``labels_pred``).
 

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -1188,9 +1188,9 @@ def fowlkes_mallows_score(labels_true, labels_pred, *, sparse=False):
     points that belongs in the same clusters in both ``labels_true`` and
     ``labels_pred``), ``FP`` is the number of **False Positive** (i.e. the
     number of pair of points that belongs in the same clusters in
-    ``labels_true`` and not in ``labels_pred``) and ``FN`` is the number of
+    ``labels_pred`` and not in ``labels_true``) and ``FN`` is the number of
     **False Negative** (i.e. the number of pair of points that belongs in the
-    same clusters in ``labels_pred`` and not in ``labels_True``).
+    same clusters in ``labels_true`` and not in ``labels_pred``).
 
     The score ranges from 0 to 1. A high value indicates a good similarity
     between two clusters.

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -1187,10 +1187,10 @@ def fowlkes_mallows_score(labels_true, labels_pred, *, sparse=False):
     Where ``TP`` is the number of **True Positive** (i.e. the number of pair of
     points that belongs in the same clusters in both ``labels_true`` and
     ``labels_pred``), ``FP`` is the number of **False Positive** (i.e. the
-    number of pair of points that belongs in the same clusters in
+    number of pairs of points that belong to the same cluster in
     ``labels_pred`` and not in ``labels_true``) and ``FN`` is the number of
-    **False Negative** (i.e. the number of pair of points that belongs in the
-    same clusters in ``labels_true`` and not in ``labels_pred``).
+    **False Negative** (i.e. the number of pairs of points that belong to the
+    same cluster in ``labels_true`` but not in ``labels_pred``).
 
     The score ranges from 0 to 1. A high value indicates a good similarity
     between two clusters.

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -1184,8 +1184,8 @@ def fowlkes_mallows_score(labels_true, labels_pred, *, sparse=False):
 
         FMI = TP / sqrt((TP + FP) * (TP + FN))
 
-    Where ``TP`` is the number of **True Positive** (i.e. the number of pair of
-    points that belongs in the same clusters in both ``labels_true`` and
+    Where ``TP`` is the number of **True Positive** (i.e. the number of pairs of
+    points that belong to the same cluster in both ``labels_true`` and
     ``labels_pred``), ``FP`` is the number of **False Positive** (i.e. the
     number of pairs of points that belong to the same cluster in
     ``labels_pred`` but not in ``labels_true``) and ``FN`` is the number of


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR addresses an issue where the definitions of false positive and false negative are incorrectly swapped in the documentation of the Fowlkes-Mallows scores [function docstring](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.fowlkes_mallows_score.html) and [user guide](https://scikit-learn.org/stable/modules/clustering.html#fowlkes-mallows-scores).

##### Current Definition

- False Positive: the number of pair of points that belong to the same clusters in the **true labels** and not in the **predicted labels**
- False Negative: the number of pair of points that belongs in the same clusters in the **predicted labels** and not in the **true labels**

##### Changes Made

- False Positive: the number of pair of points that belong to the same clusters in the **predicted labels** and not in the **true labels**
- False Negative: the number of pair of points that belong to the same clusters in the **true labels** and not in the **predicted labels**



#### Impact:

This fix will prevent misunderstandings for users trying to implement and interpret clustering results using Fowlkes-Mallows scores.
