### PR TITLE
BLD Add missing OpenMP dependencies in relevant meson.build

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -20,6 +20,14 @@ Version 1.5.2
 
 **release date of 1.5.2**
 
+Changes impacting many modules
+------------------------------
+
+- |Fix| Fixed performance regression in a few Cython modules in
+  `sklearn._loss`, `sklearn.manifold`, `sklearn.metrics` and `sklearn.utils`,
+  which were built without OpenMP support.
+  :pr:`29694` by :user:`Loïc Estèvce <lesteve>`.
+
 Changelog
 ---------
 

--- a/sklearn/_loss/meson.build
+++ b/sklearn/_loss/meson.build
@@ -17,6 +17,7 @@ _loss_pyx = custom_target(
 py.extension_module(
   '_loss',
   _loss_pyx,
+  dependencies: [openmp_dep],
   cython_args: cython_args,
   install: true,
   subdir: 'sklearn/_loss',

--- a/sklearn/manifold/meson.build
+++ b/sklearn/manifold/meson.build
@@ -9,7 +9,7 @@ py.extension_module(
 py.extension_module(
   '_barnes_hut_tsne',
   '_barnes_hut_tsne.pyx',
-  dependencies: [np_dep],
+  dependencies: [np_dep, openmp_dep],
   cython_args: cython_args,
   subdir: 'sklearn/manifold',
   install: true

--- a/sklearn/metrics/_pairwise_distances_reduction/meson.build
+++ b/sklearn/metrics/_pairwise_distances_reduction/meson.build
@@ -172,7 +172,7 @@ _argkmin_classmode_pyx = custom_target(
 _argkmin_classmode = py.extension_module(
   '_argkmin_classmode',
   _argkmin_classmode_pyx,
-  dependencies: [np_dep],
+  dependencies: [np_dep, openmp_dep],
   override_options: ['cython_language=cpp'],
   cython_args: cython_args,
   # XXX: for some reason -fno-sized-deallocation is needed otherwise there is
@@ -199,7 +199,7 @@ _radius_neighbors_classmode_pyx = custom_target(
 _radius_neighbors_classmode = py.extension_module(
   '_radius_neighbors_classmode',
   _radius_neighbors_classmode_pyx,
-  dependencies: [np_dep],
+  dependencies: [np_dep, openmp_dep],
   override_options: ['cython_language=cpp'],
   cython_args: cython_args,
   subdir: 'sklearn/metrics/_pairwise_distances_reduction',

--- a/sklearn/metrics/meson.build
+++ b/sklearn/metrics/meson.build
@@ -41,6 +41,7 @@ _dist_metrics = py.extension_module(
 py.extension_module(
   '_pairwise_fast',
   ['_pairwise_fast.pyx', metrics_cython_tree],
+  dependencies: [openmp_dep],
   cython_args: cython_args,
   subdir: 'sklearn/metrics',
   install: true

--- a/sklearn/utils/meson.build
+++ b/sklearn/utils/meson.build
@@ -18,7 +18,7 @@ utils_extension_metadata = {
   'sparsefuncs_fast':
     {'sources': ['sparsefuncs_fast.pyx']},
   '_cython_blas': {'sources': ['_cython_blas.pyx']},
-  'arrayfuncs': {'sources': ['arrayfuncs.pyx']},
+  'arrayfuncs': {'sources': ['arrayfuncs.pyx'], 'dependencies': [openmp_dep]},
   'murmurhash': {
       'sources': ['murmurhash.pyx', 'src' / 'MurmurHash3.cpp'],
   },


### PR DESCRIPTION
Fix https://github.com/scikit-learn/scikit-learn/issues/29665

This may be a good enough reason for a 1.5.2?

I checked that the OpenMP dependencies were added for the relevant `meson.build` with this grep pattern, let me know if you have a better idea:
```
❯ git grep -Pl 'cython.*parallel' -- **/*.pyx*
sklearn/_loss/_loss.pyx.tp
sklearn/cluster/_k_means_common.pyx
sklearn/cluster/_k_means_elkan.pyx
sklearn/cluster/_k_means_lloyd.pyx
sklearn/cluster/_k_means_minibatch.pyx
sklearn/ensemble/_hist_gradient_boosting/_binning.pyx
sklearn/ensemble/_hist_gradient_boosting/_gradient_boosting.pyx
sklearn/ensemble/_hist_gradient_boosting/_predictor.pyx
sklearn/ensemble/_hist_gradient_boosting/histogram.pyx
sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
sklearn/manifold/_barnes_hut_tsne.pyx
sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx.tp
sklearn/metrics/_pairwise_distances_reduction/_argkmin_classmode.pyx.tp
sklearn/metrics/_pairwise_distances_reduction/_base.pyx.tp
sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx.tp
sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors_classmode.pyx.tp
sklearn/metrics/_pairwise_fast.pyx
sklearn/utils/arrayfuncs.pyx
```

I also checked whether omp was present in the `ldd` output of 1.4.1 .so files (1.4.1 wheels have been built with setuptools) and compare with the 1.5.1 one (1.5.1 wheels have been built with meson). This does match the missing openmp_dep.