### PR TITLE
FIX #13117: implement fit methods in subclasses of LinearModelCV

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2074,9 +2074,17 @@ class LassoCV(RegressorMixin, LinearModelCV):
             selection=selection,
         )
 
-    @_fit_context(prefer_skip_nested_validation=True)
+    def _get_estimator(self):
+        return Lasso()
+
+    def _is_multitask(self):
+        return False
+
+    def _more_tags(self):
+        return {"multioutput": False}
+
     def fit(self, X, y, sample_weight=None, **params):
-        """Fit linear model with coordinate descent.
+        """Fit Lasso model with coordinate descent.
 
         Fit is on grid of alphas and best alpha estimated by cross-validation.
 
@@ -2114,15 +2122,6 @@ class LassoCV(RegressorMixin, LinearModelCV):
             Returns an instance of fitted model.
         """
         super().fit(X, y, sample_weight=sample_weight, **params)
-
-    def _get_estimator(self):
-        return Lasso()
-
-    def _is_multitask(self):
-        return False
-
-    def _more_tags(self):
-        return {"multioutput": False}
 
 
 class ElasticNetCV(RegressorMixin, LinearModelCV):
@@ -2354,9 +2353,17 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         self.random_state = random_state
         self.selection = selection
 
-    @_fit_context(prefer_skip_nested_validation=True)
+    def _get_estimator(self):
+        return ElasticNet()
+
+    def _is_multitask(self):
+        return False
+
+    def _more_tags(self):
+        return {"multioutput": False}
+
     def fit(self, X, y, sample_weight=None, **params):
-        """Fit linear model with coordinate descent.
+        """Fit ElasticNet model with coordinate descent.
 
         Fit is on grid of alphas and best alpha estimated by cross-validation.
 
@@ -2394,15 +2401,6 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
             Returns an instance of fitted model.
         """
         super().fit(X, y, sample_weight=sample_weight, **params)
-
-    def _get_estimator(self):
-        return ElasticNet()
-
-    def _is_multitask(self):
-        return False
-
-    def _more_tags(self):
-        return {"multioutput": False}
 
 
 ###############################################################################
@@ -3015,47 +3013,6 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         self.random_state = random_state
         self.selection = selection
 
-    @_fit_context(prefer_skip_nested_validation=True)
-    def fit(self, X, y, sample_weight=None, **params):
-        """Fit linear model with coordinate descent.
-
-        Fit is on grid of alphas and best alpha estimated by cross-validation.
-
-        Parameters
-        ----------
-        X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            Training data. Pass directly as Fortran-contiguous data
-            to avoid unnecessary memory duplication. If y is mono-output,
-            X can be sparse. Note that large sparse matrices and arrays
-            requiring `int64` indices are not accepted.
-
-        y : array-like of shape (n_samples, n_targets)
-            Target values.
-
-        sample_weight : float or array-like of shape (n_samples,), \
-                default=None
-            Sample weights used for fitting and evaluation of the weighted
-            mean squared error of each cv-fold. Note that the cross validated
-            MSE that is finally used to find the best model is the unweighted
-            mean over the (weighted) MSEs of each test fold.
-
-        **params : dict, default=None
-            Parameters to be passed to the CV splitter.
-
-            .. versionadded:: 1.4
-                Only available if `enable_metadata_routing=True`,
-                which can be set by using
-                ``sklearn.set_config(enable_metadata_routing=True)``.
-                See :ref:`Metadata Routing User Guide <metadata_routing>` for
-                more details.
-
-        Returns
-        -------
-        self : object
-            Returns an instance of fitted model.
-        """
-        super().fit(X, y, sample_weight=sample_weight, **params)
-
     def _get_estimator(self):
         return MultiTaskElasticNet()
 
@@ -3066,7 +3023,7 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         return {"multioutput_only": True}
 
     # This is necessary as LinearModelCV now supports sample_weight while
-    # MultiTaskElasticNet does not (yet).
+    # MultiTaskElasticNetCV does not (yet).
     def fit(self, X, y, **params):
         """Fit MultiTaskElasticNet model with coordinate descent.
 
@@ -3294,47 +3251,6 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
             selection=selection,
         )
 
-    @_fit_context(prefer_skip_nested_validation=True)
-    def fit(self, X, y, sample_weight=None, **params):
-        """Fit linear model with coordinate descent.
-
-        Fit is on grid of alphas and best alpha estimated by cross-validation.
-
-        Parameters
-        ----------
-        X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            Training data. Pass directly as Fortran-contiguous data
-            to avoid unnecessary memory duplication. If y is mono-output,
-            X can be sparse. Note that large sparse matrices and arrays
-            requiring `int64` indices are not accepted.
-
-        y : array-like of shape (n_samples, n_targets)
-            Target values.
-
-        sample_weight : float or array-like of shape (n_samples,), \
-                default=None
-            Sample weights used for fitting and evaluation of the weighted
-            mean squared error of each cv-fold. Note that the cross validated
-            MSE that is finally used to find the best model is the unweighted
-            mean over the (weighted) MSEs of each test fold.
-
-        **params : dict, default=None
-            Parameters to be passed to the CV splitter.
-
-            .. versionadded:: 1.4
-                Only available if `enable_metadata_routing=True`,
-                which can be set by using
-                ``sklearn.set_config(enable_metadata_routing=True)``.
-                See :ref:`Metadata Routing User Guide <metadata_routing>` for
-                more details.
-
-        Returns
-        -------
-        self : object
-            Returns an instance of fitted model.
-        """
-        super().fit(X, y, sample_weight=sample_weight, **params)
-
     def _get_estimator(self):
         return MultiTaskLasso()
 
@@ -3345,7 +3261,7 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
         return {"multioutput_only": True}
 
     # This is necessary as LinearModelCV now supports sample_weight while
-    # MultiTaskElasticNet does not (yet).
+    # MultiTaskLassoCV does not (yet).
     def fit(self, X, y, **params):
         """Fit MultiTaskLasso model with coordinate descent.
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2074,6 +2074,47 @@ class LassoCV(RegressorMixin, LinearModelCV):
             selection=selection,
         )
 
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X, y, sample_weight=None, **params):
+        """Fit linear model with coordinate descent.
+
+        Fit is on grid of alphas and best alpha estimated by cross-validation.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            Training data. Pass directly as Fortran-contiguous data
+            to avoid unnecessary memory duplication. If y is mono-output,
+            X can be sparse. Note that large sparse matrices and arrays
+            requiring `int64` indices are not accepted.
+
+        y : array-like of shape (n_samples,)
+            Target values.
+
+        sample_weight : float or array-like of shape (n_samples,), \
+                default=None
+            Sample weights used for fitting and evaluation of the weighted
+            mean squared error of each cv-fold. Note that the cross validated
+            MSE that is finally used to find the best model is the unweighted
+            mean over the (weighted) MSEs of each test fold.
+
+        **params : dict, default=None
+            Parameters to be passed to the CV splitter.
+
+            .. versionadded:: 1.4
+                Only available if `enable_metadata_routing=True`,
+                which can be set by using
+                ``sklearn.set_config(enable_metadata_routing=True)``.
+                See :ref:`Metadata Routing User Guide <metadata_routing>` for
+                more details.
+
+        Returns
+        -------
+        self : object
+            Returns an instance of fitted model.
+        """
+        super().fit(X, y, sample_weight=sample_weight, **params)
+
     def _get_estimator(self):
         return Lasso()
 
@@ -2312,6 +2353,47 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         self.positive = positive
         self.random_state = random_state
         self.selection = selection
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X, y, sample_weight=None, **params):
+        """Fit linear model with coordinate descent.
+
+        Fit is on grid of alphas and best alpha estimated by cross-validation.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            Training data. Pass directly as Fortran-contiguous data
+            to avoid unnecessary memory duplication. If y is mono-output,
+            X can be sparse. Note that large sparse matrices and arrays
+            requiring `int64` indices are not accepted.
+
+        y : array-like of shape (n_samples,)
+            Target values.
+
+        sample_weight : float or array-like of shape (n_samples,), \
+                default=None
+            Sample weights used for fitting and evaluation of the weighted
+            mean squared error of each cv-fold. Note that the cross validated
+            MSE that is finally used to find the best model is the unweighted
+            mean over the (weighted) MSEs of each test fold.
+
+        **params : dict, default=None
+            Parameters to be passed to the CV splitter.
+
+            .. versionadded:: 1.4
+                Only available if `enable_metadata_routing=True`,
+                which can be set by using
+                ``sklearn.set_config(enable_metadata_routing=True)``.
+                See :ref:`Metadata Routing User Guide <metadata_routing>` for
+                more details.
+
+        Returns
+        -------
+        self : object
+            Returns an instance of fitted model.
+        """
+        super().fit(X, y, sample_weight=sample_weight, **params)
 
     def _get_estimator(self):
         return ElasticNet()
@@ -2933,6 +3015,47 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         self.random_state = random_state
         self.selection = selection
 
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X, y, sample_weight=None, **params):
+        """Fit linear model with coordinate descent.
+
+        Fit is on grid of alphas and best alpha estimated by cross-validation.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            Training data. Pass directly as Fortran-contiguous data
+            to avoid unnecessary memory duplication. If y is mono-output,
+            X can be sparse. Note that large sparse matrices and arrays
+            requiring `int64` indices are not accepted.
+
+        y : array-like of shape (n_samples, n_targets)
+            Target values.
+
+        sample_weight : float or array-like of shape (n_samples,), \
+                default=None
+            Sample weights used for fitting and evaluation of the weighted
+            mean squared error of each cv-fold. Note that the cross validated
+            MSE that is finally used to find the best model is the unweighted
+            mean over the (weighted) MSEs of each test fold.
+
+        **params : dict, default=None
+            Parameters to be passed to the CV splitter.
+
+            .. versionadded:: 1.4
+                Only available if `enable_metadata_routing=True`,
+                which can be set by using
+                ``sklearn.set_config(enable_metadata_routing=True)``.
+                See :ref:`Metadata Routing User Guide <metadata_routing>` for
+                more details.
+
+        Returns
+        -------
+        self : object
+            Returns an instance of fitted model.
+        """
+        super().fit(X, y, sample_weight=sample_weight, **params)
+
     def _get_estimator(self):
         return MultiTaskElasticNet()
 
@@ -3170,6 +3293,47 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
             random_state=random_state,
             selection=selection,
         )
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def fit(self, X, y, sample_weight=None, **params):
+        """Fit linear model with coordinate descent.
+
+        Fit is on grid of alphas and best alpha estimated by cross-validation.
+
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            Training data. Pass directly as Fortran-contiguous data
+            to avoid unnecessary memory duplication. If y is mono-output,
+            X can be sparse. Note that large sparse matrices and arrays
+            requiring `int64` indices are not accepted.
+
+        y : array-like of shape (n_samples, n_targets)
+            Target values.
+
+        sample_weight : float or array-like of shape (n_samples,), \
+                default=None
+            Sample weights used for fitting and evaluation of the weighted
+            mean squared error of each cv-fold. Note that the cross validated
+            MSE that is finally used to find the best model is the unweighted
+            mean over the (weighted) MSEs of each test fold.
+
+        **params : dict, default=None
+            Parameters to be passed to the CV splitter.
+
+            .. versionadded:: 1.4
+                Only available if `enable_metadata_routing=True`,
+                which can be set by using
+                ``sklearn.set_config(enable_metadata_routing=True)``.
+                See :ref:`Metadata Routing User Guide <metadata_routing>` for
+                more details.
+
+        Returns
+        -------
+        self : object
+            Returns an instance of fitted model.
+        """
+        super().fit(X, y, sample_weight=sample_weight, **params)
 
     def _get_estimator(self):
         return MultiTaskLasso()

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2121,7 +2121,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
         self : object
             Returns an instance of fitted model.
         """
-        super().fit(X, y, sample_weight=sample_weight, **params)
+        return super().fit(X, y, sample_weight=sample_weight, **params)
 
 
 class ElasticNetCV(RegressorMixin, LinearModelCV):
@@ -2400,7 +2400,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         self : object
             Returns an instance of fitted model.
         """
-        super().fit(X, y, sample_weight=sample_weight, **params)
+        return super().fit(X, y, sample_weight=sample_weight, **params)
 
 
 ###############################################################################


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #13117
See also #13131

#### What does this implement/fix? Explain your changes.

As suggested in #13131 this PR implements `fit()` methods that just call `super()` in all subclasses of `LinearModelCV` just to have a better documentation (see original issue #13117 for context of the potential problems). This also opens up the way of slightly altering the docstrings so they are better tailored for the specific classes.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
