### PR TITLE
DOC Add link to examples_manifold_plot_compare_methods.py to manifold.MDS docstring

### DIFF
--- a/sklearn/manifold/_mds.py
+++ b/sklearn/manifold/_mds.py
@@ -501,9 +501,6 @@ class MDS(BaseEstimator):
     LocallyLinearEmbedding : Manifold learning using Locally Linear Embedding.
     SpectralEmbedding : Spectral embedding for non-linear dimensionality.
 
-    For a comparison of manifold learning techniques,
-        see :ref:`sphx_glr_auto_examples_manifold_plot_compare_methods.py`.
-
     References
     ----------
     .. [1] "Nonmetric multidimensional scaling: a numerical method" Kruskal, J.
@@ -529,6 +526,9 @@ class MDS(BaseEstimator):
 
     For a more detailed example of usage, see
     :ref:`sphx_glr_auto_examples_manifold_plot_mds.py`.
+
+    For a comparison of manifold learning techniques, see
+     :ref:`sphx_glr_auto_examples_manifold_plot_compare_methods.py`.
     """
 
     _parameter_constraints: dict = {

--- a/sklearn/manifold/_mds.py
+++ b/sklearn/manifold/_mds.py
@@ -90,6 +90,20 @@ def _smacof_single(
     n_iter : int
         The number of iterations corresponding to the best stress.
 
+    See Also
+    --------
+    sklearn.decomposition.PCA : Principal component analysis that is a linear
+        dimensionality reduction method.
+    sklearn.decomposition.KernelPCA : Non-linear dimensionality reduction using
+        kernels and PCA.
+    Isomap : Non-linear dimensionality reduction through Isometric Mapping.
+    TSNE : T-distributed Stochastic Neighbor Embedding.
+    LocallyLinearEmbedding : Manifold learning using Locally Linear Embedding.
+    SpectralEmbedding : Spectral embedding for non-linear dimensionality.
+
+    For a comparison of dimensionality reduction techniques, 
+    see :ref:`sphx_glr_auto_examples_manifold_plot_compare_methods.py`.
+
     References
     ----------
     .. [1] "Nonmetric multidimensional scaling: a numerical method" Kruskal, J.

--- a/sklearn/manifold/_mds.py
+++ b/sklearn/manifold/_mds.py
@@ -90,20 +90,6 @@ def _smacof_single(
     n_iter : int
         The number of iterations corresponding to the best stress.
 
-    See Also
-    --------
-    sklearn.decomposition.PCA : Principal component analysis that is a linear
-        dimensionality reduction method.
-    sklearn.decomposition.KernelPCA : Non-linear dimensionality reduction using
-        kernels and PCA.
-    Isomap : Non-linear dimensionality reduction through Isometric Mapping.
-    TSNE : T-distributed Stochastic Neighbor Embedding.
-    LocallyLinearEmbedding : Manifold learning using Locally Linear Embedding.
-    SpectralEmbedding : Spectral embedding for non-linear dimensionality.
-
-    For a comparison of dimensionality reduction techniques, 
-    see :ref:`sphx_glr_auto_examples_manifold_plot_compare_methods.py`.
-
     References
     ----------
     .. [1] "Nonmetric multidimensional scaling: a numerical method" Kruskal, J.
@@ -515,6 +501,9 @@ class MDS(BaseEstimator):
     LocallyLinearEmbedding : Manifold learning using Locally Linear Embedding.
     SpectralEmbedding : Spectral embedding for non-linear dimensionality.
 
+    For a comparison of manifold learning techniques, 
+        see :ref:`sphx_glr_auto_examples_manifold_plot_compare_methods.py`.
+    
     References
     ----------
     .. [1] "Nonmetric multidimensional scaling: a numerical method" Kruskal, J.

--- a/sklearn/manifold/_mds.py
+++ b/sklearn/manifold/_mds.py
@@ -501,9 +501,9 @@ class MDS(BaseEstimator):
     LocallyLinearEmbedding : Manifold learning using Locally Linear Embedding.
     SpectralEmbedding : Spectral embedding for non-linear dimensionality.
 
-    For a comparison of manifold learning techniques, 
+    For a comparison of manifold learning techniques,
         see :ref:`sphx_glr_auto_examples_manifold_plot_compare_methods.py`.
-    
+
     References
     ----------
     .. [1] "Nonmetric multidimensional scaling: a numerical method" Kruskal, J.

--- a/sklearn/manifold/_mds.py
+++ b/sklearn/manifold/_mds.py
@@ -527,8 +527,8 @@ class MDS(BaseEstimator):
     >>> X_transformed.shape
     (100, 2)
 
-    For a more detailed example of usage, see:
-    :ref:`sphx_glr_auto_examples_manifold_plot_mds.py`
+    For a more detailed example of usage, see
+    :ref:`sphx_glr_auto_examples_manifold_plot_mds.py`.
     """
 
     _parameter_constraints: dict = {

--- a/sklearn/manifold/_mds.py
+++ b/sklearn/manifold/_mds.py
@@ -528,7 +528,7 @@ class MDS(BaseEstimator):
     :ref:`sphx_glr_auto_examples_manifold_plot_mds.py`.
 
     For a comparison of manifold learning techniques, see
-     :ref:`sphx_glr_auto_examples_manifold_plot_compare_methods.py`.
+    :ref:`sphx_glr_auto_examples_manifold_plot_compare_methods.py`.
     """
 
     _parameter_constraints: dict = {


### PR DESCRIPTION
References issue #26927.

This PR aims to improve documentation by including a link to an example file that compares dimensionality reduction techniques to the doc string of the manifold.MDS class.


# Other Comments

Consider the below proposal for 
1. a new use of the See Also section, and of 
2. a new convention for where in doc strings to place links to example files. 

## Observations
1. There is not consensus by maintainers about where in the doc string developers should place links to an example files.
    - The creator of the referenced issue, 26927 , made an example PR wherein the link is [in the main section of the doc string](https://github.com/scikit-learn/scikit-learn/pull/26926/files). The link is in the [same location](https://github.com/scikit-learn/scikit-learn/blob/ede02b4d000d3f9334940cf5c81155f9dc070e77/sklearn/utils/validation.py#L1663) in the latest version of main.
    - The most recent (as of 2023-09-25) PR originally placed the link [in the main section](https://github.com/scikit-learn/scikit-learn/pull/29636/commits/0ec7dce3c2cc4c713b7f4d0c4a2f45d18f787ef4) but was [advised](https://github.com/scikit-learn/scikit-learn/pull/29636#discussion_r1720754057) to move it to the examples section. After the move, the PR was approved.
    - Another recent PR originally placed the link [in the See Also section](https://github.com/scikit-learn/scikit-learn/pull/29602/commits/4719df73a08405493f56afdf2b979ffa16a4d1f9) but was [advised](https://github.com/scikit-learn/scikit-learn/pull/29602#pullrequestreview-2212369669) to move the link to the main section. After the move, the PR was approved. The link is still [in the main section](https://github.com/scikit-learn/scikit-learn/blob/ede02b4d000d3f9334940cf5c81155f9dc070e77/sklearn/covariance/_graph_lasso.py#L395).

2. The Developer's Guide says that example files might 
    - demonstrate use
    - compare different algorithms
    - et cetera.
3. The See Also section of doc strings is [meant to be](https://github.com/scikit-learn/scikit-learn/blob/ede02b4d000d3f9334940cf5c81155f9dc070e77/doc/developers/contributing.rst?plain=1#L774) a list of FCMs (functions/classes/methods) for similar algorithms.
4. Personally, I would appreciate finding link to detailed examples in the Examples section of doc strings just below the code snippet examples (in case the code snippets are not enough).
5. Personally, I would appreciate finding a link to an example file that compares similar algorithms in the doc string just after the list of similar algorithms.
6. Personally, I do not look for examples OR comparisons in the main section of a doc string; I look there for a simple statement of what the FCM does. (cf. @adrinjalali 's [response](https://github.com/scikit-learn/scikit-learn/issues/26927#issuecomment-2270981860) to @ArturoAmorQ about prominent content.) 

## Opinion  
I would make the following convention for this meta-issue #26927:
1. If an example file gives a demonstration of an FMC with a level of detail beyond that available in the code snippets, then the link to the example file goes at the bottom of the Examples section of the doc string for the FMC with the wording "For a more detailed example, see ..."
2. If an example file gives a comparison of related FMCs, then the link to the example file goes at the bottom of the Also See section of the doc string of the FMC with the wording "For a comparison of similar algorithms, see ...".

## Trade-offs
1. The See Also sections are, as of now, consistently and cleanly lists of related FCMs. My suggestion introduces a new use for the section, reducing consistency of use of the section.
2. This (meta)-issue is inviting to first time contributors (like myself). Adding too many details will make it less inviting. 
3. In trying to put a link in the Also See section, I have found that [some](https://github.com/scikit-learn/scikit-learn/pull/29714/checks?check_run_id=29251364582) of the GitHub checks do not pass. 