### PR TITLE
MAINT Use CPU runner to build wheel + pass it to GPU runner

### DIFF
--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -8,8 +8,28 @@ on:
       - labeled
 
 jobs:
+  build_wheel:
+    if: contains(github.event.pull_request.labels.*.name, 'CUDA CI')
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.20.0
+        env:
+          CIBW_BUILD: cp312-manylinux_x86_64
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_ARCHS: x86_64
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels
+          path: ./wheelhouse/*.whl
+
   tests:
     if: contains(github.event.pull_request.labels.*.name, 'CUDA CI')
+    needs: [build_wheel]
     runs-on:
       group: cuda-gpu-runner-group
     # Set this high enough so that the tests can comforatble run. We set a
@@ -17,6 +37,11 @@ jobs:
     timeout-minutes: 20
     name: Run Array API unit tests
     steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-wheels
+          path: ~/dist
+
       - uses: actions/setup-python@v5
         with:
           # XXX: The 3.12.4 release of Python on GitHub Actions is corrupted:
@@ -37,10 +62,15 @@ jobs:
         run: |
           source "${HOME}/conda/etc/profile.d/conda.sh"
           conda activate sklearn
-          pip install --verbose --no-build-isolation --config-settings editable-verbose=true --editable .
+          pip install ~/dist/cibw-wheels/$(ls ~/dist/cibw-wheels)
+
       - name: Run array API tests
         run: |
           source "${HOME}/conda/etc/profile.d/conda.sh"
           conda activate sklearn
           python -c "import sklearn; sklearn.show_versions()"
-          SCIPY_ARRAY_API=1 pytest -k 'array_api'
+
+          # Move to temporary directory to make sure we import from the installed sklearn
+          mkdir tmp
+          cd tmp
+          SCIPY_ARRAY_API=1 pytest --pyargs sklearn -k 'array_api'

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -11,6 +11,7 @@ jobs:
   build_wheel:
     if: contains(github.event.pull_request.labels.*.name, 'CUDA CI')
     runs-on: "ubuntu-latest"
+    name: Build wheel for Pull Request
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -70,7 +70,6 @@ jobs:
           conda activate sklearn
           python -c "import sklearn; sklearn.show_versions()"
 
-          # Move to temporary directory to make sure we import from the installed sklearn
           SCIPY_ARRAY_API=1 pytest --pyargs sklearn -k 'array_api'
         # Run in /home/runner to not load sklearn from the checkout repo
         working-directory: /home/runner

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -71,6 +71,6 @@ jobs:
           python -c "import sklearn; sklearn.show_versions()"
 
           # Move to temporary directory to make sure we import from the installed sklearn
-          mkdir tmp
-          cd tmp
           SCIPY_ARRAY_API=1 pytest --pyargs sklearn -k 'array_api'
+        # Run in ~/dist to not use the sklearn that was checked out
+        working-directory: ~/dist

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -72,5 +72,5 @@ jobs:
 
           # Move to temporary directory to make sure we import from the installed sklearn
           SCIPY_ARRAY_API=1 pytest --pyargs sklearn -k 'array_api'
-        # Run in ~/dist to not use the sklearn that was checked out
-        working-directory: ~/dist
+        # Run in /home/runner to not load sklearn from the checkout repo
+        working-directory: /home/runner


### PR DESCRIPTION
Currently scikit-learn is compiled on the GPU runner, which takes [2m 24s](https://github.com/scikit-learn/scikit-learn/actions/runs/10451046790/job/28936627899?pr=29475) from the GPU runner.

This PR moves the scikit-learn builds a wheel using the CPU runner and then sends it to the GPU runner. On a testing repo, I measured that it took [4m 17s](https://github.com/thomasjpfan/scikit-learn-ci-wheel-move/actions/runs/10551424979/job/29228851277) to build the wheel. Although the total time is longer than using the GPU runner, I think saving the 2m 24s GPU time is worth it.