### PR TITLE
DOC Point users to miniforge as the way to get conda

### DIFF
--- a/doc/install_instructions_conda.rst
+++ b/doc/install_instructions_conda.rst
@@ -1,7 +1,6 @@
-Install conda using the `Anaconda or miniconda installers
-<https://docs.conda.io/projects/conda/en/latest/user-guide/install/>`__ or the
+Install conda using the
 `miniforge installers <https://github.com/conda-forge/miniforge#miniforge>`__ (no
-administrator permission required for any of those). Then run:
+administrator permission required). Then run:
 
 .. prompt:: bash
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This changes the conda based install instruction in the docs to link to miniforge as the only way to get conda installed.

The link we had to anaconda was broken, so we needed to edit this somehow. But I discovered this only after making my change. The original motivation for the change was to point people towards an installer that is a good match for anyone, independent of what they use it for. The `defaults` channel is not a good match for everyone, as you need al icense if you work in a large organisation. Given the restrictions that exist for anaconda and the defaults channel, should we point somewhere that has less (none?) restrictions? Is the miniforge page friendly enough to be useful to everyone (maybe people are put off because it looks not polished enough?)?

What do people think?

If there is support for the change I will double check that this PR removes all occurrences. 