### PR TITLE
EXA Fix axis scaling in example `plot_ica_vs_pca.py`

### DIFF
--- a/examples/decomposition/plot_ica_vs_pca.py
+++ b/examples/decomposition/plot_ica_vs_pca.py
@@ -81,11 +81,11 @@ def plot_samples(S, axis_list=None):
                 label=label,
             )
 
-    plt.hlines(0, -5, 5, color='black', linewidth=0.5)
-    plt.vlines(0, -3, 3, color='black', linewidth=0.5)
+    plt.hlines(0, -5, 5, color="black", linewidth=0.5)
+    plt.vlines(0, -3, 3, color="black", linewidth=0.5)
     plt.xlim(-5, 5)
     plt.ylim(-3, 3)
-    plt.gca().set_aspect('equal')
+    plt.gca().set_aspect("equal")
     plt.xlabel("x")
     plt.ylabel("y")
 

--- a/examples/decomposition/plot_ica_vs_pca.py
+++ b/examples/decomposition/plot_ica_vs_pca.py
@@ -81,10 +81,11 @@ def plot_samples(S, axis_list=None):
                 label=label,
             )
 
-    plt.hlines(0, -3, 3)
-    plt.vlines(0, -3, 3)
-    plt.xlim(-3, 3)
+    plt.hlines(0, -5, 5, color='black', linewidth=0.5)
+    plt.vlines(0, -3, 3, color='black', linewidth=0.5)
+    plt.xlim(-5, 5)
     plt.ylim(-3, 3)
+    plt.gca().set_aspect('equal')
     plt.xlabel("x")
     plt.ylabel("y")
 
@@ -97,7 +98,7 @@ plt.title("True Independent Sources")
 axis_list = [(pca.components_.T, "orange", "PCA"), (ica.mixing_, "red", "ICA")]
 plt.subplot(2, 2, 2)
 plot_samples(X / np.std(X), axis_list=axis_list)
-legend = plt.legend(loc="lower right")
+legend = plt.legend(loc="upper left")
 legend.set_zorder(100)
 
 plt.title("Observations")

--- a/examples/decomposition/plot_ica_vs_pca.py
+++ b/examples/decomposition/plot_ica_vs_pca.py
@@ -67,8 +67,7 @@ def plot_samples(S, axis_list=None):
     )
     if axis_list is not None:
         for axis, color, label in axis_list:
-            axis /= axis.std()
-            x_axis, y_axis = axis
+            x_axis, y_axis = axis / axis.std()
             plt.quiver(
                 (0, 0),
                 (0, 0),
@@ -104,7 +103,7 @@ legend.set_zorder(100)
 plt.title("Observations")
 
 plt.subplot(2, 2, 3)
-plot_samples(S_pca_ / np.std(S_pca_, axis=0))
+plot_samples(S_pca_ / np.std(S_pca_))
 plt.title("PCA recovered signals")
 
 plt.subplot(2, 2, 4)


### PR DESCRIPTION
In this example the axes of the plots are distorted. As a consequence the plotted ICA and PCA components are incorrect. It can be easily seen in 
https://scikit-learn.org/stable/auto_examples/decomposition/plot_ica_vs_pca.html#sphx-glr-auto-examples-decomposition-plot-ica-vs-pca-py
that the ICA components (red arrows) should be aligned with the data-generating components in the upper right plot, which is not the case. Similarly, the PCA components (orange arrows) are off too. Simply fixing the axis scaling fixes this issue, and plots the components correctly.