### PR TITLE
DOC add MLJAR AutoML and supertree in related projects

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -61,7 +61,7 @@ enhance the functionality of scikit-learn's estimators.
   It incorporates multiple modeling libraries under one API, and
   the objects that EvalML creates use an sklearn-compatible API.
 
-- `MLJAR AutoML <https://github.com/mljar/supervised>`_
+- `MLJAR AutoML <https://github.com/mljar/mljar-supervised>`_
   Python package for AutoML on Tabular Data with Feature Engineering, 
   Hyper-Parameters Tuning, Explanations and Automatic Documentation.
 

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -61,6 +61,10 @@ enhance the functionality of scikit-learn's estimators.
   It incorporates multiple modeling libraries under one API, and
   the objects that EvalML creates use an sklearn-compatible API.
 
+- `MLJAR AutoML <https://github.com/mljar/supervised>`_
+  Python package for AutoML on Tabular Data with Feature Engineering, 
+  Hyper-Parameters Tuning, Explanations and Automatic Documentation.
+
 **Experimentation and model registry frameworks**
 
 - `MLFlow <https://mlflow.org/>`_ MLflow is an open source platform to manage the ML
@@ -97,6 +101,11 @@ enhance the functionality of scikit-learn's estimators.
 - `yellowbrick <https://github.com/DistrictDataLabs/yellowbrick>`_ A suite of
   custom matplotlib visualizers for scikit-learn estimators to support visual feature
   analysis, model selection, evaluation, and diagnostics.
+
+- `supertree <https://github.com/mljar/supertree>`_
+  Python package designed to visualize decision trees in an interactive 
+  and user-friendly way within Jupyter Notebooks, Jupyter Lab, 
+  Google Colab, and any other notebooks that support HTML rendering.
 
 **Model selection**
 

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -102,11 +102,6 @@ enhance the functionality of scikit-learn's estimators.
   custom matplotlib visualizers for scikit-learn estimators to support visual feature
   analysis, model selection, evaluation, and diagnostics.
 
-- `supertree <https://github.com/mljar/supertree>`_
-  Python package designed to visualize decision trees in an interactive 
-  and user-friendly way within Jupyter Notebooks, Jupyter Lab, 
-  Google Colab, and any other notebooks that support HTML rendering.
-
 **Model selection**
 
 - `scikit-optimize <https://scikit-optimize.github.io/>`_


### PR DESCRIPTION
Hi Scikit-learn Team,

I made changes in `doc/related_projects.rst` file. I've added two projects that I maintain:
- MLJAR AutoML https://github.com/mljar/mljar-supervised - it is AutoML framework which heavily depends on scikit-learn (thank you!) 
- `supertree` https://github.com/mljar/supertree - it is a package for interactive visualization of tree based models from scikit-learn, I believe it will be huge improvement for scikit-learn tree huggers

All the best,
Piotr