### PR TITLE
DOC Clarify when `class_of_interest` required in `DecisionBoundaryDisplay`

### DIFF
--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -260,9 +260,9 @@ class DecisionBoundaryDisplay:
         class_of_interest : int, float, bool or str, default=None
             The class considered when plotting the decision. If None,
             `estimator.classes_[1]` is considered as the positive class
-            for binary classifiers. For multiclass classifiers, when
-            `response_method` is 'predict_proba' or 'decision_function',
-            an explicit value for `class_of_interest` is mandatory.
+            for binary classifiers. Must have an explicit value for
+            multiclass classifiers when `response_method` is 'predict_proba'
+            or 'decision_function'.
 
             .. versionadded:: 1.4
 

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -33,8 +33,8 @@ def _check_boundary_response_method(estimator, response_method, class_of_interes
         :term:`decision_function`, :term:`predict_proba`, :term:`predict`.
 
     class_of_interest : int, float, bool, str or None
-        The class considered when plotting the decision. If the label is specified, it
-        is then possible to plot the decision boundary in multiclass settings.
+        The class considered when plotting the decision. Cannot be None if
+        multiclass and `response_method` is 'predict_proba' or 'decision_function'.
 
         .. versionadded:: 1.4
 
@@ -260,7 +260,8 @@ class DecisionBoundaryDisplay:
         class_of_interest : int, float, bool or str, default=None
             The class considered when plotting the decision. If None,
             `estimator.classes_[1]` is considered as the positive class
-            for binary classifiers. For multiclass classifiers, passing
+            for binary classifiers. For multiclass classifiers, when
+            `response_method` is 'predict_proba' or 'decision_function',
             an explicit value for `class_of_interest` is mandatory.
 
             .. versionadded:: 1.4


### PR DESCRIPTION


#### Reference Issues/PRs



#### What does this implement/fix? Explain your changes.
Clarify when `class_of_interest` required in `DecisionBoundaryDisplay` in the multiclass case.

#### Any other comments?
cc @glemaitre 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
