### PR TITLE
DOC Take SPHINXOPTS from the command-line environment

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -T
+SPHINXOPTS   ?= -T
 SPHINXBUILD  ?= sphinx-build
 PAPER         =
 BUILDDIR      = _build
@@ -66,6 +66,7 @@ clean:
 # https://github.com/scikit-learn/scikit-learn/pull/25809
 html: SPHINX_NUMJOBS ?= 1
 html:
+	@echo $(ALLSPHINXOPTS)
 	# These two lines make the build a bit more lengthy, and the
 	# the embedding of images more robust
 	rm -rf $(BUILDDIR)/html/_images


### PR DESCRIPTION
This allows `spin doc --no-plot` to work, but it also means that when you use `spin doc --no-plot` the options passed to `sphinx-build` will be quite different from what we normally use. For example `-j auto` and `-W` will be added.

So in summary I am not sure that this is the fix we want to merge.

The "right" way for spin to act would probably be something like parsing the `Makefile` to find out the default values of `SPHINXOPTS` and then use that [instead of its hardcoded value](https://github.com/scientific-python/spin/blob/d624569c265f1e3905ee938d588cbd696600572d/spin/cmds/meson.py#L918C1-L918C46). However that is probably quite complex to do.

An idea from @lesteve is that we could redefine what `spin doc` does ourselves. So that it does mostly what `spin` does, but then customise it a bit. 

xref #29742