### PR TITLE
ENH Add Array API compatibility to 'auc'

### DIFF
--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -140,6 +140,7 @@ Tools
 -----
 
 - :func:`model_selection.train_test_split`
+- :func:`utils.check_consistent_length`
 
 Coverage is expected to grow over time. Please follow the dedicated `meta-issue on GitHub
 <https://github.com/scikit-learn/scikit-learn/issues/22352>`_ to track progress.

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -16,7 +16,6 @@ from functools import partial
 from numbers import Integral, Real
 
 import numpy as np
-from scipy.integrate import trapezoid
 from scipy.sparse import csr_matrix, issparse
 from scipy.stats import rankdata
 
@@ -28,7 +27,7 @@ from ..utils import (
     check_consistent_length,
     column_or_1d,
 )
-from ..utils._array_api import get_namespace
+from ..utils._array_api import _trapezoid, get_namespace
 from ..utils._encode import _encode, _unique
 from ..utils._param_validation import Hidden, Interval, StrOptions, validate_params
 from ..utils.extmath import stable_cumsum
@@ -100,12 +99,7 @@ def auc(x, y):
         else:
             raise ValueError("x is neither increasing nor decreasing : {}.".format(x))
 
-    area = direction * trapezoid(y, x)
-    if isinstance(area, np.memmap):
-        # Reductions such as .sum used internally in trapezoid do not return a
-        # scalar by default for numpy.memmap instances contrary to
-        # regular numpy.ndarray instances.
-        area = area.dtype.type(area)
+    area = direction * _trapezoid(y, x)
     return area
 
 

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -28,6 +28,7 @@ from ..utils import (
     check_consistent_length,
     column_or_1d,
 )
+from ..utils._array_api import get_namespace
 from ..utils._encode import _encode, _unique
 from ..utils._param_validation import Hidden, Interval, StrOptions, validate_params
 from ..utils.extmath import stable_cumsum
@@ -79,6 +80,8 @@ def auc(x, y):
     >>> metrics.auc(fpr, tpr)
     np.float64(0.75)
     """
+    xp, _ = get_namespace(x, y)
+
     check_consistent_length(x, y)
     x = column_or_1d(x)
     y = column_or_1d(y)
@@ -90,9 +93,9 @@ def auc(x, y):
         )
 
     direction = 1
-    dx = np.diff(x)
-    if np.any(dx < 0):
-        if np.all(dx <= 0):
+    dx = xp.subtract(x[1:], x[:-1])
+    if xp.any(dx < 0):
+        if xp.all(dx <= 0):
             direction = -1
         else:
             raise ValueError("x is neither increasing nor decreasing : {}.".format(x))

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -1179,7 +1179,7 @@ def fowlkes_mallows_score(labels_true, labels_pred, *, sparse=False):
 
     .. versionadded:: 0.18
 
-    The Fowlkes-Mallows index (FMI) is defined as the geometric mean between of
+    The Fowlkes-Mallows index (FMI) is defined as the geometric mean of
     the precision and recall::
 
         FMI = TP / sqrt((TP + FP) * (TP + FN))

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -9,6 +9,7 @@ from sklearn._config import config_context
 from sklearn.datasets import make_multilabel_classification
 from sklearn.metrics import (
     accuracy_score,
+    auc,
     average_precision_score,
     balanced_accuracy_score,
     brier_score_loss,
@@ -1990,7 +1991,27 @@ def check_array_api_metric_pairwise(metric, array_namespace, device, dtype_name)
     )
 
 
+def check_array_api_regression_ranking(metric, array_namespace, device, dtype_name):
+    x_np = np.array([-1.1, -0.3, 0.4, 1.0, 4.0], dtype=dtype_name)
+    y_np = np.array([1.0, 0.5, -0.5, 2, 2], dtype=dtype_name)
+
+    metric_kwargs = {}
+
+    check_array_api_metric(
+        metric,
+        array_namespace,
+        device,
+        dtype_name,
+        a_np=x_np,
+        b_np=y_np,
+        **metric_kwargs,
+    )
+
+
 array_api_metric_checkers = {
+    auc: [
+        check_array_api_regression_ranking,
+    ],
     accuracy_score: [
         check_array_api_binary_classification_metric,
         check_array_api_multiclass_classification_metric,

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -530,10 +530,11 @@ def get_namespace(*arrays, remove_none=True, remove_types=(str,), xp=None):
     -------
     namespace : module
         Namespace shared by array objects. If any of the `arrays` are not arrays,
-        the namespace defaults to NumPy.
+        the namespace defaults to the NumPy namespace.
 
     is_array_api_compliant : bool
-        True if the arrays are containers that implement the Array API spec.
+        True if the arrays are containers that implement the array API spec (see
+        https://data-apis.org/array-api/latest/API_specification/).
         Always False when array_api_dispatch=False.
     """
     array_api_dispatch = get_config()["array_api_dispatch"]

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -1046,3 +1046,18 @@ def _modify_in_place_if_numpy(xp, func, *args, out=None, **kwargs):
     else:
         out = func(*args, **kwargs)
     return out
+
+
+def _trapezoid(y, x=None, dx=1.0, axis=None):
+    """Partial (one-dimensional) port of scipy.trapezoid to support the Array API."""
+    xp, _, device = get_namespace_and_device(x, y)
+
+    if size(y) < 2:
+        return xp.asarray(0, device=device, dtype=y.dtype)
+
+    if x is None:
+        d = dx
+    else:
+        d = xp.subtract(x[1:], x[:-1])
+
+    return xp.sum(d * (y[:-1] + y[1:]) / 2.0)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -34,6 +34,7 @@ from sklearn.utils import (
     check_X_y,
     deprecated,
 )
+from sklearn.utils._array_api import yield_namespace_device_dtype_combinations
 from sklearn.utils._mocking import (
     MockDataFrame,
     _MockEstimatorOnOffPrediction,
@@ -41,6 +42,7 @@ from sklearn.utils._mocking import (
 from sklearn.utils._testing import (
     SkipTest,
     TempMemmap,
+    _array_api_for_tests,
     _convert_container,
     assert_allclose,
     assert_allclose_dense_sparse,
@@ -985,23 +987,52 @@ def test_check_is_fitted_with_attributes(wrap):
 
 
 def test_check_consistent_length():
+    """Test that `check_consistent_length` raises on inconsistent lengths and wrong
+    input types trigger TypeErrors."""
     check_consistent_length([1], [2], [3], [4], [5])
     check_consistent_length([[1, 2], [[1, 2]]], [1, 2], ["a", "b"])
     check_consistent_length([1], (2,), np.array([3]), sp.csr_matrix((1, 2)))
     with pytest.raises(ValueError, match="inconsistent numbers of samples"):
         check_consistent_length([1, 2], [1])
+
     with pytest.raises(TypeError, match=r"got <\w+ 'int'>"):
         check_consistent_length([1, 2], 1)
     with pytest.raises(TypeError, match=r"got <\w+ 'object'>"):
         check_consistent_length([1, 2], object())
-
     with pytest.raises(TypeError):
         check_consistent_length([1, 2], np.array(1))
-
     # Despite ensembles having __len__ they must raise TypeError
     with pytest.raises(TypeError, match="Expected sequence or array-like"):
         check_consistent_length([1, 2], RandomForestRegressor())
     # XXX: We should have a test with a string, but what is correct behaviour?
+
+
+@pytest.mark.parametrize(
+    "array_namespace, device, _", yield_namespace_device_dtype_combinations()
+)
+def test_check_consistent_length_array_API(array_namespace, device, _):
+    """Test that check_consistent_length works with different array types."""
+    xp = _array_api_for_tests(array_namespace, device)
+
+    check_consistent_length(
+        xp.asarray([1], device=device),
+        xp.asarray([2], device=device),
+    )
+    if xp.__name__ == "numpy":
+        check_consistent_length(
+            xp.asarray([[1, 2], [1, 2]], device=device),
+            xp.asarray([1, 2], device=device),
+            xp.asarray(["a", "b"], device=device),
+        )
+    else:
+        check_consistent_length(
+            xp.asarray([[1, 2], [1, 2]], device=device),
+            xp.asarray([1, 2], device=device),
+        )
+    with pytest.raises(ValueError, match="inconsistent numbers of samples"):
+        check_consistent_length(
+            xp.asarray([1, 2], device=device), xp.asarray([1], device=device)
+        )
 
 
 def test_check_dataframe_fit_attribute():

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -465,10 +465,10 @@ def check_consistent_length(*arrays):
     >>> b = [2, 3, 4]
     >>> check_consistent_length(a, b)
     """
-
-    lengths = [_num_samples(X) for X in arrays if X is not None]
-    uniques = np.unique(lengths)
-    if len(uniques) > 1:
+    xp, _ = get_namespace(*arrays)
+    lengths = xp.asarray([_num_samples(X) for X in arrays if X is not None])
+    uniques = xp.unique_values(lengths)
+    if uniques.shape[0] > 1:
         raise ValueError(
             "Found input variables with inconsistent numbers of samples: %r"
             % [int(l) for l in lengths]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Adds to #26024

#### What does this implement/fix? Explain your changes.
The AUC metric is made to be array api compatible. The original implementation uses np.diff, which is not part of the array api standard. Here, it is a simple difference between two neighboring array elements in a one-dimensional array and thus is replaced by a simple difference of two array slices.
Furthermore, a one-dimensional version of scipy.integrate.trapezoid is implemented to be used in 'auc'.

#### Any other comments?
This PR includes the changes from #29519 and should be merged after it. The changes from #29519 are in a single commit which can be removed before this PR is merged.