### PR TITLE
Fix-formatting-rf

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1825,7 +1825,6 @@ class RandomForestRegressor(ForestRegressor):
     References
     ----------
     .. [1] L. Breiman, "Random Forests", Machine Learning, 45(1), 5-32, 2001.
-
     .. [2] P. Geurts, D. Ernst., and L. Wehenkel, "Extremely randomized
            trees", Machine Learning, 63(1), 3-42, 2006.
 


### PR DESCRIPTION
Fixes a formatting error in the help of the RandomForestRegressor:

![image](https://github.com/user-attachments/assets/96e10679-2255-4942-98a2-fb9abc304296)
