### PR TITLE
DOC update KNNImputer `metric` parameter by describing the expected interface when passing a callable

### DIFF
--- a/sklearn/impute/_knn.py
+++ b/sklearn/impute/_knn.py
@@ -55,9 +55,9 @@ class KNNImputer(_BaseImputer):
 
         - 'nan_euclidean'
         - callable : a user-defined function which conforms to the definition
-          of ``_pairwise_callable(X, Y, *, missing_values=np.nan)``. The function
-          accepts two 1-D arrays, X and Y, and a `missing_values` keyword and 
-          returns a scalar distance value.
+          of ``func_metric(x, y, *, missing_values=np.nan)``. `x` and `y`
+          corresponds to a row (i.e. 1-D arrays) of `X` and `Y`, respectively.
+          The callable should returns a scalar distance value.
 
     copy : bool, default=True
         If True, a copy of X will be created. If False, imputation will

--- a/sklearn/impute/_knn.py
+++ b/sklearn/impute/_knn.py
@@ -55,9 +55,9 @@ class KNNImputer(_BaseImputer):
 
         - 'nan_euclidean'
         - callable : a user-defined function which conforms to the definition
-          of ``_pairwise_callable(X, Y, metric, **kwds)``. The function
-          accepts two arrays, X and Y, and a `missing_values` keyword in
-          `kwds` and returns a scalar distance value.
+          of ``_pairwise_callable(X, Y, *, missing_values=np.nan)``. The function
+          accepts two 1-D arrays, X and Y, and a `missing_values` keyword and 
+          returns a scalar distance value.
 
     copy : bool, default=True
         If True, a copy of X will be created. If False, imputation will


### PR DESCRIPTION
closes #29735

This PR update the documentation of KNNImputer and improve the description of the `metric` parameter when a callable is provided. It gives details regarding the expected interface