### PR TITLE
CI Handle unchanged lock-file in workflow triggering on comment

### DIFF
--- a/build_tools/on_pr_comment_update_environments_and_lock_files.py
+++ b/build_tools/on_pr_comment_update_environments_and_lock_files.py
@@ -65,7 +65,8 @@ def main():
     execute_command(
         "git reset build_tools/on_pr_comment_update_environments_and_lock_files.py"
     )
-    execute_command(f'git commit -m "{marker}Update lock files"')
+    # Using --allow-empty to handle cases where the lock-file has not changed
+    execute_command(f'git commit --allow-empty -m "{marker}Update lock files"')
     execute_command("git push")
 
 


### PR DESCRIPTION
I find it slightly preferrable that an empty commit is pushed when lock-file has not changed. Otherwise you don't see any new commit and you wonder what has gone wrong.

cc @Charlie-XIAO.

Seen in https://github.com/scikit-learn/scikit-learn/pull/29765#issuecomment-2328624880.