### PR TITLE
MAINT Add Python 3.13 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -195,8 +195,9 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: bash build_tools/github/repair_windows_wheels.sh {wheel} {dest_dir}
           CIBW_BEFORE_TEST_WINDOWS: bash build_tools/github/build_minimal_windows_image.sh ${{ matrix.python }}
           CIBW_BEFORE_TEST: bash {project}/build_tools/wheels/cibw_before_test.sh
-          # TODO remove when pandas has python 3.13 wheels
-          CIBW_TEST_REQUIRES: ${{ matrix.python == '313' && 'pytest' || 'pytest pandas' }}
+          CIBW_TEST_REQUIRES: pytest pandas
+          # Test dependencies need to be installed in the Docker image
+          CIBW_TEST_REQUIRES_WINDOWS: ""
           CIBW_TEST_COMMAND: bash {project}/build_tools/wheels/test_wheels.sh
           CIBW_TEST_COMMAND_WINDOWS: bash {project}/build_tools/github/test_windows_wheels.sh ${{ matrix.python }}
           CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -196,7 +196,7 @@ jobs:
           CIBW_BEFORE_TEST_WINDOWS: bash build_tools/github/build_minimal_windows_image.sh ${{ matrix.python }}
           CIBW_BEFORE_TEST: bash {project}/build_tools/wheels/cibw_before_test.sh
           # TODO remove when pandas has python 3.13 wheels
-          CIBW_TEST_REQUIRES: ${{ matrix.python != "313" && "pytest pandas" || "pytest" }}
+          CIBW_TEST_REQUIRES: ${{ matrix.python == '313' && 'pytest' || 'pytest pandas' }}
           CIBW_TEST_COMMAND: bash {project}/build_tools/wheels/test_wheels.sh
           CIBW_TEST_COMMAND_WINDOWS: bash {project}/build_tools/github/test_windows_wheels.sh ${{ matrix.python }}
           CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -197,7 +197,7 @@ jobs:
           CIBW_BEFORE_TEST: bash {project}/build_tools/wheels/cibw_before_test.sh
           CIBW_TEST_REQUIRES: pytest pandas
           CIBW_TEST_COMMAND: bash {project}/build_tools/wheels/test_wheels.sh
-          CIBW_TEST_COMMAND_WINDOWS: bash {project}/build_tools/github/test_windows_wheels.sh ${{ matrix.python }}
+          CIBW_TEST_COMMAND_WINDOWS: bash {project}/build_tools/github/test_windows_wheels.sh ${{ matrix.python }} ${{ env.CIBW_TEST_REQUIRES }}
           CIBW_BUILD_VERBOSITY: 1
 
         run: bash build_tools/wheels/build_wheels.sh

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -65,6 +65,10 @@ jobs:
           - os: windows-latest
             python: 312
             platform_id: win_amd64
+          - os: windows-latest
+            python: 313
+            platform_id: win_amd64
+            prerelease_pythons: True
 
           # Linux 64 bit manylinux2014
           - os: ubuntu-latest
@@ -87,6 +91,12 @@ jobs:
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
           - os: ubuntu-latest
+            python: 313
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+            # TODO: remove next line when Python 3.13 is released
+            prerelease_pythons: True
+          - os: ubuntu-latest
             python: 313t
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
@@ -107,6 +117,11 @@ jobs:
           - os: macos-12
             python: 312
             platform_id: macosx_x86_64
+          - os: macos-12
+            python: 313
+            platform_id: macosx_x86_64
+            # TODO: remove next line when Python 3.13 is released
+            prerelease_pythons: True
 
           # MacOS arm64
           - os: macos-14
@@ -121,6 +136,11 @@ jobs:
           - os: macos-14
             python: 312
             platform_id: macosx_arm64
+          - os: macos-14
+            python: 313
+            platform_id: macosx_arm64
+            # TODO: remove next line when Python 3.13 is released
+            prerelease_pythons: True
 
     steps:
       - name: Checkout scikit-learn

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -195,9 +195,10 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: bash build_tools/github/repair_windows_wheels.sh {wheel} {dest_dir}
           CIBW_BEFORE_TEST_WINDOWS: bash build_tools/github/build_minimal_windows_image.sh ${{ matrix.python }}
           CIBW_BEFORE_TEST: bash {project}/build_tools/wheels/cibw_before_test.sh
-          CIBW_TEST_REQUIRES: pytest pandas
+          # TODO remove when pandas has python 3.13 wheels
+          CIBW_TEST_REQUIRES: ${{ matrix.python != "313" && "pytest pandas" || "pytest" }}
           CIBW_TEST_COMMAND: bash {project}/build_tools/wheels/test_wheels.sh
-          CIBW_TEST_COMMAND_WINDOWS: bash {project}/build_tools/github/test_windows_wheels.sh ${{ matrix.python }} ${{ env.CIBW_TEST_REQUIRES }}
+          CIBW_TEST_COMMAND_WINDOWS: bash {project}/build_tools/github/test_windows_wheels.sh ${{ matrix.python }}
           CIBW_BUILD_VERBOSITY: 1
 
         run: bash build_tools/wheels/build_wheels.sh

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -68,6 +68,7 @@ jobs:
           - os: windows-latest
             python: 313
             platform_id: win_amd64
+            # TODO: remove next line when Python 3.13 is released
             prerelease_pythons: True
 
           # Linux 64 bit manylinux2014
@@ -94,14 +95,10 @@ jobs:
             python: 313
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
-            # TODO: remove next line when Python 3.13 is released
-            prerelease_pythons: True
           - os: ubuntu-latest
             python: 313t
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
-            # TODO: remove next line when Python 3.13 is released
-            prerelease_pythons: True
             free_threaded_support: True
 
           # MacOS x86_64
@@ -120,8 +117,6 @@ jobs:
           - os: macos-12
             python: 313
             platform_id: macosx_x86_64
-            # TODO: remove next line when Python 3.13 is released
-            prerelease_pythons: True
 
           # MacOS arm64
           - os: macos-14
@@ -139,8 +134,6 @@ jobs:
           - os: macos-14
             python: 313
             platform_id: macosx_arm64
-            # TODO: remove next line when Python 3.13 is released
-            prerelease_pythons: True
 
     steps:
       - name: Checkout scikit-learn
@@ -196,7 +189,9 @@ jobs:
           CIBW_BEFORE_TEST_WINDOWS: bash build_tools/github/build_minimal_windows_image.sh ${{ matrix.python }}
           CIBW_BEFORE_TEST: bash {project}/build_tools/wheels/cibw_before_test.sh
           CIBW_TEST_REQUIRES: pytest pandas
-          # Test dependencies need to be installed in the Docker image
+          # On Windows, we use a custom Docker image and CIBW_TEST_REQUIRES_WINDOWS
+          # does not make sense because it would install dependencies in the host
+          # rather than inside the Docker image
           CIBW_TEST_REQUIRES_WINDOWS: ""
           CIBW_TEST_COMMAND: bash {project}/build_tools/wheels/test_wheels.sh
           CIBW_TEST_COMMAND_WINDOWS: bash {project}/build_tools/github/test_windows_wheels.sh ${{ matrix.python }}

--- a/build_tools/cirrus/arm_wheel.yml
+++ b/build_tools/cirrus/arm_wheel.yml
@@ -17,20 +17,19 @@ linux_arm64_wheel_task:
     BOT_GITHUB_TOKEN: ENCRYPTED[9b50205e2693f9e4ce9a3f0fcb897a259289062fda2f5a3b8aaa6c56d839e0854a15872f894a70fca337dd4787274e0f]
   matrix:
     # Only the latest Python version is tested
-    - env:
-        CIBW_BUILD: cp39-manylinux_aarch64
-        CIBW_TEST_SKIP: "*_aarch64"
-    - env:
-        CIBW_BUILD: cp310-manylinux_aarch64
-        CIBW_TEST_SKIP: "*_aarch64"
-    - env:
-        CIBW_BUILD: cp311-manylinux_aarch64
-        CIBW_TEST_SKIP: "*_aarch64"
+    # - env:
+    #     CIBW_BUILD: cp39-manylinux_aarch64
+    #     CIBW_TEST_SKIP: "*_aarch64"
+    # - env:
+    #     CIBW_BUILD: cp310-manylinux_aarch64
+    #     CIBW_TEST_SKIP: "*_aarch64"
+    # - env:
+    #     CIBW_BUILD: cp311-manylinux_aarch64
+    #     CIBW_TEST_SKIP: "*_aarch64"
     - env:
         CIBW_BUILD: cp312-manylinux_aarch64
     - env:
         CIBW_BUILD: cp313-manylinux_aarch64
-        CIBW_TEST_SKIP: "*_aarch64"
 
   cibuildwheel_script:
     - apt install -y python3 python-is-python3

--- a/build_tools/cirrus/arm_wheel.yml
+++ b/build_tools/cirrus/arm_wheel.yml
@@ -17,19 +17,20 @@ linux_arm64_wheel_task:
     BOT_GITHUB_TOKEN: ENCRYPTED[9b50205e2693f9e4ce9a3f0fcb897a259289062fda2f5a3b8aaa6c56d839e0854a15872f894a70fca337dd4787274e0f]
   matrix:
     # Only the latest Python version is tested
-    # - env:
-    #     CIBW_BUILD: cp39-manylinux_aarch64
-    #     CIBW_TEST_SKIP: "*_aarch64"
-    # - env:
-    #     CIBW_BUILD: cp310-manylinux_aarch64
-    #     CIBW_TEST_SKIP: "*_aarch64"
-    # - env:
-    #     CIBW_BUILD: cp311-manylinux_aarch64
-    #     CIBW_TEST_SKIP: "*_aarch64"
+    - env:
+        CIBW_BUILD: cp39-manylinux_aarch64
+        CIBW_TEST_SKIP: "*_aarch64"
+    - env:
+        CIBW_BUILD: cp310-manylinux_aarch64
+        CIBW_TEST_SKIP: "*_aarch64"
+    - env:
+        CIBW_BUILD: cp311-manylinux_aarch64
+        CIBW_TEST_SKIP: "*_aarch64"
     - env:
         CIBW_BUILD: cp312-manylinux_aarch64
     - env:
         CIBW_BUILD: cp313-manylinux_aarch64
+        CIBW_TEST_SKIP: "*_aarch64"
 
   cibuildwheel_script:
     - apt install -y python3 python-is-python3

--- a/build_tools/cirrus/arm_wheel.yml
+++ b/build_tools/cirrus/arm_wheel.yml
@@ -28,6 +28,9 @@ linux_arm64_wheel_task:
         CIBW_TEST_SKIP: "*_aarch64"
     - env:
         CIBW_BUILD: cp312-manylinux_aarch64
+    - env:
+        CIBW_BUILD: cp313-manylinux_aarch64
+        CIBW_TEST_SKIP: "*_aarch64"
 
   cibuildwheel_script:
     - apt install -y python3 python-is-python3

--- a/build_tools/cirrus/arm_wheel.yml
+++ b/build_tools/cirrus/arm_wheel.yml
@@ -30,6 +30,8 @@ linux_arm64_wheel_task:
         CIBW_BUILD: cp312-manylinux_aarch64
     - env:
         CIBW_BUILD: cp313-manylinux_aarch64
+        # TODO remove next line when Python 3.13 is relased and add
+        # CIBW_TEST_SKIP for Python 3.12 above
         CIBW_TEST_SKIP: "*_aarch64"
 
   cibuildwheel_script:

--- a/build_tools/github/Windows
+++ b/build_tools/github/Windows
@@ -8,6 +8,3 @@ ARG CIBW_TEST_REQUIRES
 # Copy and install the Windows wheel
 COPY $WHEEL_NAME $WHEEL_NAME
 RUN pip install $env:WHEEL_NAME
-
-# Install the testing dependencies
-RUN pip install $env:CIBW_TEST_REQUIRES.split(" ")

--- a/build_tools/github/Windows
+++ b/build_tools/github/Windows
@@ -3,7 +3,6 @@ ARG PYTHON_VERSION
 FROM winamd64/python:$PYTHON_VERSION-windowsservercore
 
 ARG WHEEL_NAME
-ARG CIBW_TEST_REQUIRES
 
 # Copy and install the Windows wheel
 COPY $WHEEL_NAME $WHEEL_NAME

--- a/build_tools/github/Windows
+++ b/build_tools/github/Windows
@@ -1,9 +1,0 @@
-# Get the Python version of the base image from a build argument
-ARG PYTHON_VERSION
-FROM winamd64/python:$PYTHON_VERSION-windowsservercore
-
-ARG WHEEL_NAME
-
-# Copy and install the Windows wheel
-COPY $WHEEL_NAME $WHEEL_NAME
-RUN pip install $env:WHEEL_NAME

--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -14,7 +14,7 @@ cp $WHEEL_PATH $WHEEL_NAME
 # Dot the Python version for identyfing the base Docker image
 PYTHON_VERSION=$(echo ${PYTHON_VERSION:0:1}.${PYTHON_VERSION:1:2})
 
-if [[ "$CIBW_PRERELEASE_PYTHONS" == "True" ]]; then
+if [[ "$CIBW_PRERELEASE_PYTHONS" =~ [tT]rue ]]; then
     PYTHON_VERSION="$PYTHON_VERSION-rc"
 fi
 # Build a minimal Windows Docker image for testing the wheels

--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -20,6 +20,5 @@ fi
 # Build a minimal Windows Docker image for testing the wheels
 docker build --build-arg PYTHON_VERSION=$PYTHON_VERSION \
              --build-arg WHEEL_NAME=$WHEEL_NAME \
-             --build-arg CIBW_TEST_REQUIRES="$CIBW_TEST_REQUIRES" \
              -f build_tools/github/Windows \
              -t scikit-learn/minimal-windows .

--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -12,8 +12,7 @@ WHEEL_NAME=$(basename $WHEEL_PATH)
 cp $WHEEL_PATH $WHEEL_NAME
 
 # Dot the Python version for identifying the base Docker image
-PYTHON_VERSION=$(echo ${PYTHON_VERSION:0:1}.${PYTHON_VERSION:1:2})
-PYTHON_DOCKER_IMAGE_PART=$PYTHON_VERSION
+PYTHON_DOCKER_IMAGE_PART=$(echo ${PYTHON_VERSION:0:1}.${PYTHON_VERSION:1:2})
 
 if [[ "$CIBW_PRERELEASE_PYTHONS" =~ [tT]rue ]]; then
     PYTHON_DOCKER_IMAGE_PART="${PYTHON_DOCKER_IMAGE_PART}-rc"
@@ -32,7 +31,7 @@ function exec_inside_container() {
 
 exec_inside_container "python -m pip install $MNT_FOLDER/$WHEEL_NAME"
 
-if [[ "$PYTHON_VERSION" == "3.13" ]]; then
+if [[ "$PYTHON_VERSION" == "313" ]]; then
     # TODO: remove when pandas has a release with python 3.13 wheels
     # First install numpy release
     exec_inside_container "python -m pip install numpy"

--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -16,7 +16,7 @@ PYTHON_VERSION=$(echo ${PYTHON_VERSION:0:1}.${PYTHON_VERSION:1:2})
 PYTHON_DOCKER_IMAGE_PART=$PYTHON_VERSION
 
 if [[ "$CIBW_PRERELEASE_PYTHONS" =~ [tT]rue ]]; then
-    PYTHON_DOCKER_IMAGE_PART="${PYTHON_DOCKER_IMAGE_TAG}-rc"
+    PYTHON_DOCKER_IMAGE_PART="${PYTHON_DOCKER_IMAGE_PART}-rc"
 fi
 
 # We could have all of the following logic in a Dockerfile but it's a lot

--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -11,14 +11,34 @@ WHEEL_NAME=$(basename $WHEEL_PATH)
 
 cp $WHEEL_PATH $WHEEL_NAME
 
-# Dot the Python version for identyfing the base Docker image
+# Dot the Python version for identifying the base Docker image
 PYTHON_VERSION=$(echo ${PYTHON_VERSION:0:1}.${PYTHON_VERSION:1:2})
 
 if [[ "$CIBW_PRERELEASE_PYTHONS" =~ [tT]rue ]]; then
     PYTHON_VERSION="$PYTHON_VERSION-rc"
 fi
-# Build a minimal Windows Docker image for testing the wheels
-docker build --build-arg PYTHON_VERSION=$PYTHON_VERSION \
-             --build-arg WHEEL_NAME=$WHEEL_NAME \
-             -f build_tools/github/Windows \
-             -t scikit-learn/minimal-windows .
+
+# We could have all of the following logic in a Dockerfile but it's a lot
+# easier to do it in bash rather than figure out how to do it in Powershell
+# inside the Dockerfile ...
+DOCKER_IMAGE="winamd64/python:$PYTHON_VERSION-windowsservercore"
+container_id=$(docker run -it -v $PWD:/mnt -d $DOCKER_IMAGE)
+
+function exec_inside_container() {
+    docker exec $container_id powershell -Command $1
+}
+
+exec_inside_container "python -m pip install /mnt/$WHEEL_NAME"
+
+if [[ "$PYTHON_VERSION" == "3.13" ]]; then
+    # TODO: remove when pandas has a release with python 3.13 wheels
+    # First install numpy release
+    exec_inside_container "python -m pip install numpy"
+    # Then install pandas-dev
+    exec_inside_container "python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas --only-binary :all:"
+fi
+
+exec_inside_container "python -m pip install $CIBW_TEST_REQUIRES"
+
+# Save container state to scikit-learn/minimal-windows image
+docker commit $container_id scikit-learn/minimal-windows

--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -13,15 +13,16 @@ cp $WHEEL_PATH $WHEEL_NAME
 
 # Dot the Python version for identifying the base Docker image
 PYTHON_VERSION=$(echo ${PYTHON_VERSION:0:1}.${PYTHON_VERSION:1:2})
+PYTHON_DOCKER_IMAGE_PART=$PYTHON_VERSION
 
 if [[ "$CIBW_PRERELEASE_PYTHONS" =~ [tT]rue ]]; then
-    PYTHON_VERSION="$PYTHON_VERSION-rc"
+    PYTHON_DOCKER_IMAGE_PART="${PYTHON_DOCKER_IMAGE_TAG}-rc"
 fi
 
 # We could have all of the following logic in a Dockerfile but it's a lot
 # easier to do it in bash rather than figure out how to do it in Powershell
 # inside the Dockerfile ...
-DOCKER_IMAGE="winamd64/python:$PYTHON_VERSION-windowsservercore"
+DOCKER_IMAGE="winamd64/python:${PYTHON_DOCKER_IMAGE_PART}-windowsservercore"
 MNT_FOLDER="C:/mnt"
 CONTAINER_ID=$(docker run -it -v "$(cygpath -w $PWD):$MNT_FOLDER" -d $DOCKER_IMAGE)
 

--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -22,13 +22,14 @@ fi
 # easier to do it in bash rather than figure out how to do it in Powershell
 # inside the Dockerfile ...
 DOCKER_IMAGE="winamd64/python:$PYTHON_VERSION-windowsservercore"
-container_id=$(docker run -it -v $PWD:/mnt -d $DOCKER_IMAGE)
+MNT_FOLDER="C:\mnt"
+container_id=$(docker run -it -v "$(cygpath -w $PWD):$MNT_FOLDER" -d $DOCKER_IMAGE)
 
 function exec_inside_container() {
     docker exec $container_id powershell -Command $1
 }
 
-exec_inside_container "python -m pip install /mnt/$WHEEL_NAME"
+exec_inside_container "python -m pip install $MNT_FOLDER/$WHEEL_NAME"
 
 if [[ "$PYTHON_VERSION" == "3.13" ]]; then
     # TODO: remove when pandas has a release with python 3.13 wheels

--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -22,11 +22,11 @@ fi
 # easier to do it in bash rather than figure out how to do it in Powershell
 # inside the Dockerfile ...
 DOCKER_IMAGE="winamd64/python:$PYTHON_VERSION-windowsservercore"
-MNT_FOLDER="C:\mnt"
-container_id=$(docker run -it -v "$(cygpath -w $PWD):$MNT_FOLDER" -d $DOCKER_IMAGE)
+MNT_FOLDER="C:/mnt"
+CONTAINER_ID=$(docker run -it -v "$(cygpath -w $PWD):$MNT_FOLDER" -d $DOCKER_IMAGE)
 
 function exec_inside_container() {
-    docker exec $container_id powershell -Command $1
+    docker exec $CONTAINER_ID powershell -Command $1
 }
 
 exec_inside_container "python -m pip install $MNT_FOLDER/$WHEEL_NAME"
@@ -41,5 +41,7 @@ fi
 
 exec_inside_container "python -m pip install $CIBW_TEST_REQUIRES"
 
-# Save container state to scikit-learn/minimal-windows image
-docker commit $container_id scikit-learn/minimal-windows
+# Save container state to scikit-learn/minimal-windows image. On Windows the
+# container needs to be stopped first.
+docker stop $CONTAINER_ID
+docker commit $CONTAINER_ID scikit-learn/minimal-windows

--- a/build_tools/github/test_windows_wheels.sh
+++ b/build_tools/github/test_windows_wheels.sh
@@ -25,4 +25,16 @@ docker exec $container_id \
 
 docker exec $container_id \
     -e SKLEARN_SKIP_NETWORK_TESTS=1 \
-    powershell -Command "pytest --pyargs sklearn"
+    powershell -Command "which python"
+
+docker exec $container_id \
+    -e SKLEARN_SKIP_NETWORK_TESTS=1 \
+    powershell -Command "which pytest"
+
+docker exec $container_id \
+    -e SKLEARN_SKIP_NETWORK_TESTS=1 \
+    powershell -Command "python -m pip list"
+
+docker exec $container_id \
+    -e SKLEARN_SKIP_NETWORK_TESTS=1 \
+    powershell -Command "python -m pytest --pyargs sklearn"

--- a/build_tools/github/test_windows_wheels.sh
+++ b/build_tools/github/test_windows_wheels.sh
@@ -25,14 +25,6 @@ docker exec $container_id \
 
 docker exec $container_id \
     -e SKLEARN_SKIP_NETWORK_TESTS=1 \
-    powershell -Command "which python"
-
-docker exec $container_id \
-    -e SKLEARN_SKIP_NETWORK_TESTS=1 \
-    powershell -Command "which pytest"
-
-docker exec $container_id \
-    -e SKLEARN_SKIP_NETWORK_TESTS=1 \
     powershell -Command "python -m pip list"
 
 docker exec $container_id \

--- a/build_tools/github/test_windows_wheels.sh
+++ b/build_tools/github/test_windows_wheels.sh
@@ -24,8 +24,8 @@ if [[ "$PYTHON_VERSION" == "313" ]]; then
 fi
 
 docker container run \
-        --rm scikit-learn/minimal-windows \
-        powershell -Command "python -m pip install $TEST_REQUIRES"
+    --rm scikit-learn/minimal-windows \
+    powershell -Command "python -m pip install $TEST_REQUIRES"
 
 docker container run \
     --rm scikit-learn/minimal-windows \

--- a/build_tools/github/test_windows_wheels.sh
+++ b/build_tools/github/test_windows_wheels.sh
@@ -23,10 +23,6 @@ docker container run \
 
 docker container run \
     --rm scikit-learn/minimal-windows \
-    powershell -Command "python -m pip install  -c 'import sklearn; sklearn.show_versions()'"
-
-docker container run \
-    --rm scikit-learn/minimal-windows \
     powershell -Command "python -c 'import sklearn; sklearn.show_versions()'"
 
 docker container run \

--- a/build_tools/github/test_windows_wheels.sh
+++ b/build_tools/github/test_windows_wheels.sh
@@ -5,27 +5,24 @@ set -x
 
 PYTHON_VERSION=$1
 
+container_id=$(docker run -it -d scikit-learn/minimal-windows)
+
 if [[ "$PYTHON_VERSION" == "313" ]]; then
     # TODO: remove when pandas has a release with python 3.13 wheels
     # First install numpy release
-    docker container run \
-        --rm scikit-learn/minimal-windows \
+    docker exec $container_id \
         powershell -Command "python -m pip install numpy"
     # Then install pandas-dev
-    docker container run \
-        --rm scikit-learn/minimal-windows \
+    docker exec $container_id \
         powershell -Command "python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas --only-binary :all:"
 fi
 
-docker container run \
-    --rm scikit-learn/minimal-windows \
+docker exec $container_id \
     powershell -Command "python -m pip install $CIBW_TEST_REQUIRES"
 
-docker container run \
-    --rm scikit-learn/minimal-windows \
+docker exec $container_id \
     powershell -Command "python -c 'import sklearn; sklearn.show_versions()'"
 
-docker container run \
+docker exec $container_id \
     -e SKLEARN_SKIP_NETWORK_TESTS=1 \
-    --rm scikit-learn/minimal-windows \
     powershell -Command "pytest --pyargs sklearn"

--- a/build_tools/github/test_windows_wheels.sh
+++ b/build_tools/github/test_windows_wheels.sh
@@ -3,7 +3,33 @@
 set -e
 set -x
 
+echo number of args: $#
 PYTHON_VERSION=$1
+shift
+TEST_REQUIRES=$*
+
+echo CIBW_TEST_REQUIRES: $CIBW_TEST_REQUIRES
+
+
+if [[ "$PYTHON_VERSION" == "313" ]]; then
+    # TODO: remove when pandas has a release with python 3.13 wheels
+    # First install numpy release
+    docker container run \
+        --rm scikit-learn/minimal-windows \
+        powershell -Command "python -m pip install numpy"
+    # Then install pandas-dev
+    docker container run \
+        --rm scikit-learn/minimal-windows \
+        powershell -Command "python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas --only-binary :all:"
+fi
+
+docker container run \
+        --rm scikit-learn/minimal-windows \
+        powershell -Command "python -m pip install $TEST_REQUIRES"
+
+docker container run \
+    --rm scikit-learn/minimal-windows \
+    powershell -Command "python -m pip install  -c 'import sklearn; sklearn.show_versions()'"
 
 docker container run \
     --rm scikit-learn/minimal-windows \

--- a/build_tools/github/test_windows_wheels.sh
+++ b/build_tools/github/test_windows_wheels.sh
@@ -24,8 +24,7 @@ docker exec $container_id \
     powershell -Command "python -c 'import sklearn; sklearn.show_versions()'"
 
 docker exec $container_id \
-    -e SKLEARN_SKIP_NETWORK_TESTS=1 \
-    powershell -Command "python -m pip list"
+    powershell -Command "python -m pip list" || echo pip list failed
 
 docker exec $container_id \
     -e SKLEARN_SKIP_NETWORK_TESTS=1 \

--- a/build_tools/github/test_windows_wheels.sh
+++ b/build_tools/github/test_windows_wheels.sh
@@ -3,13 +3,7 @@
 set -e
 set -x
 
-echo number of args: $#
 PYTHON_VERSION=$1
-shift
-TEST_REQUIRES=$*
-
-echo CIBW_TEST_REQUIRES: $CIBW_TEST_REQUIRES
-
 
 if [[ "$PYTHON_VERSION" == "313" ]]; then
     # TODO: remove when pandas has a release with python 3.13 wheels
@@ -25,7 +19,7 @@ fi
 
 docker container run \
     --rm scikit-learn/minimal-windows \
-    powershell -Command "python -m pip install $TEST_REQUIRES"
+    powershell -Command "python -m pip install $CIBW_TEST_REQUIRES"
 
 docker container run \
     --rm scikit-learn/minimal-windows \

--- a/build_tools/github/test_windows_wheels.sh
+++ b/build_tools/github/test_windows_wheels.sh
@@ -23,9 +23,7 @@ docker exec $container_id \
 docker exec $container_id \
     powershell -Command "python -c 'import sklearn; sklearn.show_versions()'"
 
-docker exec $container_id \
-    powershell -Command "python -m pip list" || echo pip list failed
-
-docker exec $container_id \
+docker exec \
     -e SKLEARN_SKIP_NETWORK_TESTS=1 \
+    $container_id \
     powershell -Command "python -m pytest --pyargs sklearn"

--- a/build_tools/github/test_windows_wheels.sh
+++ b/build_tools/github/test_windows_wheels.sh
@@ -5,25 +5,11 @@ set -x
 
 PYTHON_VERSION=$1
 
-container_id=$(docker run -it -d scikit-learn/minimal-windows)
-
-if [[ "$PYTHON_VERSION" == "313" ]]; then
-    # TODO: remove when pandas has a release with python 3.13 wheels
-    # First install numpy release
-    docker exec $container_id \
-        powershell -Command "python -m pip install numpy"
-    # Then install pandas-dev
-    docker exec $container_id \
-        powershell -Command "python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas --only-binary :all:"
-fi
-
-docker exec $container_id \
-    powershell -Command "python -m pip install $CIBW_TEST_REQUIRES"
-
-docker exec $container_id \
+docker container run \
+    --rm scikit-learn/minimal-windows \
     powershell -Command "python -c 'import sklearn; sklearn.show_versions()'"
 
-docker exec \
+docker container run \
     -e SKLEARN_SKIP_NETWORK_TESTS=1 \
-    $container_id \
-    powershell -Command "python -m pytest --pyargs sklearn"
+    --rm scikit-learn/minimal-windows \
+    powershell -Command "pytest --pyargs sklearn"

--- a/build_tools/wheels/cibw_before_test.sh
+++ b/build_tools/wheels/cibw_before_test.sh
@@ -4,13 +4,13 @@ set -e
 set -x
 
 FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
-PY_VERSION=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+PY_VERSION=$(python -c 'import sys; print(f"{sys.version_info.major}{sys.version_info.minor}")')
 
 if [[ $FREE_THREADED_BUILD == "True" ]]; then
     # TODO: remove when numpy, scipy and pandas have releases with free-threaded wheels
     python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy scipy pandas --only-binary :all:
 
-elif [[ "$PY_VERSION" == "3.13" ]]; then
+elif [[ "$PY_VERSION" == "313" ]]; then
     # TODO: remove when pandas has a release with python 3.13 wheels
     # First install numpy release
     python -m pip install numpy --only-binary :all:

--- a/build_tools/wheels/cibw_before_test.sh
+++ b/build_tools/wheels/cibw_before_test.sh
@@ -8,3 +8,12 @@ if [[ $FREE_THREADED_BUILD == "True" ]]; then
     # TODO: remove when numpy, scipy and pandas have releases with free-threaded wheels
     python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy scipy pandas --only-binary :all:
 fi
+
+env
+if [[ "$CIBW_BUILD" == cp313-* ]]; then
+    # TODO: remove when pandas has a release with python 3.13 wheels
+    # First install numpy release
+    python -m pip install numpy --only-binary :all:
+    # Then install pandas-dev
+    python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas --only-binary :all:
+fi

--- a/build_tools/wheels/cibw_before_test.sh
+++ b/build_tools/wheels/cibw_before_test.sh
@@ -4,13 +4,13 @@ set -e
 set -x
 
 FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
+PY_VERSION=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+
 if [[ $FREE_THREADED_BUILD == "True" ]]; then
     # TODO: remove when numpy, scipy and pandas have releases with free-threaded wheels
     python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy scipy pandas --only-binary :all:
-fi
 
-env
-if [[ "$CIBW_BUILD" == cp313-* ]]; then
+elif [[ "$PY_VERSION" == "3.13" ]]; then
     # TODO: remove when pandas has a release with python 3.13 wheels
     # First install numpy release
     python -m pip install numpy --only-binary :all:


### PR DESCRIPTION
One of the complications due to the fact that pandas does not have a release with Python 3.13 wheels (in contrary to numpy and scipy). For now I used pandas-dev to test the wheels.

The other complication is due to our custom Windows setup (we build a minimal Windows image to avoid relying on system OpenMP https://github.com/scikit-learn/scikit-learn/pull/18802) and run the tests in this image which has a few quirks (for example cibuildwheel does not know about it and install CIBW_TEST_REQUIRES inside the host).

Close #29292.
