### PR TITLE
MAINT: Remove __SKLEARN_SETUP__ from __init__.py

### DIFF
--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -19,7 +19,6 @@
 import logging
 import os
 import random
-import sys
 
 from ._config import config_context, get_config, set_config
 
@@ -59,87 +58,73 @@ os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "True")
 # https://github.com/ContinuumIO/anaconda-issues/issues/11294
 os.environ.setdefault("KMP_INIT_AT_FORK", "FALSE")
 
+# `_distributor_init` allows distributors to run custom init code.
+# For instance, for the Windows wheel, this is used to pre-load the
+# vcomp shared library runtime for OpenMP embedded in the sklearn/.libs
+# sub-folder.
+# It is necessary to do this prior to importing show_versions as the
+# later is linked to the OpenMP runtime to make it possible to introspect
+# it and importing it first would fail if the OpenMP dll cannot be found.
+from . import (  # noqa: F401 E402
+    __check_build,
+    _distributor_init,
+)
+from .base import clone  # noqa: E402
+from .utils._show_versions import show_versions  # noqa: E402
+
+__all__ = [
+    "calibration",
+    "cluster",
+    "covariance",
+    "cross_decomposition",
+    "datasets",
+    "decomposition",
+    "dummy",
+    "ensemble",
+    "exceptions",
+    "experimental",
+    "externals",
+    "feature_extraction",
+    "feature_selection",
+    "gaussian_process",
+    "inspection",
+    "isotonic",
+    "kernel_approximation",
+    "kernel_ridge",
+    "linear_model",
+    "manifold",
+    "metrics",
+    "mixture",
+    "model_selection",
+    "multiclass",
+    "multioutput",
+    "naive_bayes",
+    "neighbors",
+    "neural_network",
+    "pipeline",
+    "preprocessing",
+    "random_projection",
+    "semi_supervised",
+    "svm",
+    "tree",
+    "discriminant_analysis",
+    "impute",
+    "compose",
+    # Non-modules:
+    "clone",
+    "get_config",
+    "set_config",
+    "config_context",
+    "show_versions",
+]
+
+_BUILT_WITH_MESON = False
 try:
-    # This variable is injected in the __builtins__ by the build
-    # process. It is used to enable importing subpackages of sklearn when
-    # the binaries are not built
-    # mypy error: Cannot determine type of '__SKLEARN_SETUP__'
-    __SKLEARN_SETUP__  # type: ignore
-except NameError:
-    __SKLEARN_SETUP__ = False
+    import sklearn._built_with_meson  # noqa: F401
 
-if __SKLEARN_SETUP__:
-    sys.stderr.write("Partial import of sklearn during the build process.\n")
-    # We are not importing the rest of scikit-learn during the build
-    # process, as it may not be compiled yet
-else:
-    # `_distributor_init` allows distributors to run custom init code.
-    # For instance, for the Windows wheel, this is used to pre-load the
-    # vcomp shared library runtime for OpenMP embedded in the sklearn/.libs
-    # sub-folder.
-    # It is necessary to do this prior to importing show_versions as the
-    # later is linked to the OpenMP runtime to make it possible to introspect
-    # it and importing it first would fail if the OpenMP dll cannot be found.
-    from . import (
-        __check_build,  # noqa: F401
-        _distributor_init,  # noqa: F401
-    )
-    from .base import clone
-    from .utils._show_versions import show_versions
-
-    __all__ = [
-        "calibration",
-        "cluster",
-        "covariance",
-        "cross_decomposition",
-        "datasets",
-        "decomposition",
-        "dummy",
-        "ensemble",
-        "exceptions",
-        "experimental",
-        "externals",
-        "feature_extraction",
-        "feature_selection",
-        "gaussian_process",
-        "inspection",
-        "isotonic",
-        "kernel_approximation",
-        "kernel_ridge",
-        "linear_model",
-        "manifold",
-        "metrics",
-        "mixture",
-        "model_selection",
-        "multiclass",
-        "multioutput",
-        "naive_bayes",
-        "neighbors",
-        "neural_network",
-        "pipeline",
-        "preprocessing",
-        "random_projection",
-        "semi_supervised",
-        "svm",
-        "tree",
-        "discriminant_analysis",
-        "impute",
-        "compose",
-        # Non-modules:
-        "clone",
-        "get_config",
-        "set_config",
-        "config_context",
-        "show_versions",
-    ]
-
-    _BUILT_WITH_MESON = False
-    try:
-        import sklearn._built_with_meson  # noqa: F401
-
-        _BUILT_WITH_MESON = True
-    except ModuleNotFoundError:
-        pass
+    _BUILT_WITH_MESON = True
+except ModuleNotFoundError:
+    pass
 
 
 def setup_module(module):


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Previous `__SKLEARN_SETUP__` was set by `setup.py` so we can import sklearn without fulling building the library. With the move to `meson`, I do not think it is required anymore.

#### Any other comments?
CC @lesteve 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
