### PR TITLE
Add Feature: Ensure RandomizedSearchCV (and other optimizers) skips duplicated hyperparameter combinations #29794

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -21,7 +21,7 @@ from numpy.ma import MaskedArray
 from scipy.stats import rankdata
 
 from ..base import BaseEstimator, MetaEstimatorMixin, _fit_context, clone, is_classifier
-from ..exceptions import NotFittedError
+from ..exceptions import NotFittedError, ConvergenceWarning
 from ..metrics import check_scoring
 from ..metrics._scorer import (
     _check_multimetric_scoring,
@@ -294,6 +294,8 @@ class ParameterSampler:
         self.n_iter = n_iter
         self.random_state = random_state
         self.param_distributions = param_distributions
+        self.param_history = set()
+        self.max_tries_new_param_combination = 10
 
     def _is_all_lists(self):
         return all(
@@ -329,12 +331,27 @@ class ParameterSampler:
                 # Always sort the keys of a dictionary, for reproducibility
                 items = sorted(dist.items())
                 params = dict()
-                for k, v in items:
-                    if hasattr(v, "rvs"):
-                        params[k] = v.rvs(random_state=rng)
-                    else:
-                        params[k] = v[rng.randint(len(v))]
-                yield params
+                for _ in range(self.max_tries_new_param_combination):
+                    for k, v in items:
+                        if hasattr(v, "rvs"):
+                            params[k] = v.rvs(random_state=rng)
+                        else:
+                            params[k] = v[rng.randint(len(v))]
+            
+                    param_tuple = tuple(sorted(params.items()))
+                    is_new_param_combination = param_tuple not in self.param_history
+                    if is_new_param_combination:
+                        self.param_history.add(param_tuple)
+                        print(f"{params=}")
+                        yield params
+                        break
+                else:
+                    warnings.warn(
+                        "The total space of possible combination of parameters is smaller "
+                        f"or really close to the number of iterations provided ({self.n_iter})."
+                        "Search stoped before reaching that number."
+                        "For exhaustive searches, GridSearch may be a better option ",
+                        ConvergenceWarning)
 
     def __len__(self):
         """Number of points that will be sampled."""

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -21,7 +21,7 @@ from numpy.ma import MaskedArray
 from scipy.stats import rankdata
 
 from ..base import BaseEstimator, MetaEstimatorMixin, _fit_context, clone, is_classifier
-from ..exceptions import NotFittedError, ConvergenceWarning
+from ..exceptions import ConvergenceWarning, NotFittedError
 from ..metrics import check_scoring
 from ..metrics._scorer import (
     _check_multimetric_scoring,
@@ -337,7 +337,7 @@ class ParameterSampler:
                             params[k] = v.rvs(random_state=rng)
                         else:
                             params[k] = v[rng.randint(len(v))]
-            
+
                     param_tuple = tuple(sorted(params.items()))
                     is_new_param_combination = param_tuple not in self.param_history
                     if is_new_param_combination:
@@ -347,11 +347,13 @@ class ParameterSampler:
                         break
                 else:
                     warnings.warn(
-                        "The total space of possible combination of parameters is smaller "
-                        f"or really close to the number of iterations provided ({self.n_iter})."
-                        "Search stoped before reaching that number."
-                        "For exhaustive searches, GridSearch may be a better option ",
-                        ConvergenceWarning)
+                        "The total space of possible combination of parameters "
+                        "is smaller or really close to the number of iterations "
+                        f"provided ({self.n_iter}). Search stoped before reaching "
+                        "that number.For exhaustive searches, GridSearch may be "
+                        " a better option ",
+                        ConvergenceWarning,
+                    )
 
     def __len__(self):
         """Number of points that will be sampled."""


### PR DESCRIPTION
Modified the ParameterSampler class.

Added to attributes:
- param_history: A set with the already yielded combinations of parameters.
- max_tries_new_param_combination: maximum attempts to try to find a new value

on the __iter__ method:
Only new params while be yielded, checking if a param combination already was yielded in the past using the self.param_history parameter


Considerations/Pending:
- This self.param_history could grow and lead to unnecessary memory use in cases where duplicates are very unlikely.
- Right now I hard-coded the self.max_tries_new_param_combination to 10 in the __init__ method, should it be a optional parameter ?


Originated from #29794


