### PR TITLE
Raise RuntimeError instead of a warning when using array API without setting SCIPY_ARRAY_API=1

### DIFF
--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -6,7 +6,6 @@
 import itertools
 import math
 import os
-import warnings
 from functools import wraps
 
 import numpy
@@ -120,15 +119,11 @@ def _check_array_api_dispatch(array_api_dispatch):
             )
 
         if os.environ.get("SCIPY_ARRAY_API") != "1":
-            warnings.warn(
-                (
-                    "Some scikit-learn array API features might rely on enabling "
-                    "SciPy's own support for array API to function properly. "
-                    "Please set the SCIPY_ARRAY_API=1 environment variable "
-                    "before importing sklearn or scipy. More details at: "
-                    "https://docs.scipy.org/doc/scipy/dev/api-dev/array_api.html"
-                ),
-                UserWarning,
+            raise RuntimeError(
+                "Scikit-learn array API support was enabled but scipy's own support is "
+                "not enabled. Please set the SCIPY_ARRAY_API=1 environment variable "
+                "before importing sklearn or scipy. More details at: "
+                "https://docs.scipy.org/doc/scipy/dev/api-dev/array_api.html"
             )
 
 

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -96,11 +96,11 @@ def test_get_namespace_array_api(monkeypatch):
 
         monkeypatch.setattr("os.environ.get", mock_getenv)
         assert os.environ.get("SCIPY_ARRAY_API") != "1"
-        with pytest.warns(
-            UserWarning,
-            match="enabling SciPy's own support for array API to function properly. ",
+        with pytest.raises(
+            RuntimeError,
+            match="scipy's own support is not enabled.",
         ):
-            xp_out, is_array_api_compliant = get_namespace(X_xp)
+            get_namespace(X_xp)
 
 
 @pytest.mark.parametrize("array_api", ["numpy", "array_api_strict"])
@@ -566,7 +566,6 @@ def test_get_namespace_and_device():
 def test_count_nonzero(
     array_namespace, device_, dtype_name, csr_container, axis, sample_weight_type
 ):
-
     from sklearn.utils.sparsefuncs import count_nonzero as sparse_count_nonzero
 
     xp = _array_api_for_tests(array_namespace, device_)


### PR DESCRIPTION
Fixes the UX problem described in #29549 by raising an exception instead of a warning.

In particular the warning is invisible when running pytest and is leading to a non-explicit error. @adrinjalali faced it again recently triggering this PR.

The alternative would be to skip individual scikit-learn tests where we know that scipy array API support is actually needed but this would require extra care when reviewing array API PRs.