### PR TITLE
BLD Remove `build_utils/` from the built wheels, and associated Meson cleanups

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -42,7 +42,7 @@ if m_dep.found()
   add_project_link_arguments('-lm', language : 'c')
 endif
 
-tempita = files('sklearn/_build_utils/tempita.py')
+tempita = find_program('sklearn/_build_utils/tempita.py')
 
 py = import('python').find_installation(pure: false)
 

--- a/meson.build
+++ b/meson.build
@@ -47,7 +47,11 @@ tempita = find_program('sklearn/_build_utils/tempita.py')
 py = import('python').find_installation(pure: false)
 
 # Copy all the .py files to the install dir, rather than using
-# py.install_sources and needing to list them explicitely one by one
-install_subdir('sklearn', install_dir: py.get_install_dir())
+# py.install_sources and needing to list them explicitly one by one
+# Exclude the _build_utils directory, which is not needed at runtime
+install_subdir('sklearn',
+  install_dir: py.get_install_dir(),
+  exclude_directories: ['sklearn/_build_utils']
+)
 
 subdir('sklearn')

--- a/meson.build
+++ b/meson.build
@@ -51,7 +51,7 @@ py = import('python').find_installation(pure: false)
 # Exclude the _build_utils directory, which is not needed at runtime
 install_subdir('sklearn',
   install_dir: py.get_install_dir(),
-  exclude_directories: ['sklearn/_build_utils']
+  exclude_directories: ['_build_utils']
 )
 
 subdir('sklearn')

--- a/sklearn/_build_utils/tempita.py
+++ b/sklearn/_build_utils/tempita.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/sklearn/_loss/meson.build
+++ b/sklearn/_loss/meson.build
@@ -7,7 +7,7 @@ _loss_pyx = custom_target(
   '_loss_pyx',
   output: '_loss.pyx',
   input: '_loss.pyx.tp',
-  command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+  command: [tempita, '@INPUT@', '-o', '@OUTDIR@'],
   # TODO in principle this should go in py.exension_module below. This is
   # temporary work-around for dependency issue with .pyx.tp files. For more
   # details, see https://github.com/mesonbuild/meson/issues/13212

--- a/sklearn/linear_model/meson.build
+++ b/sklearn/linear_model/meson.build
@@ -18,7 +18,7 @@ foreach name: name_list
     name + '_pyx',
     output: name + '.pyx',
     input: name + '.pyx.tp',
-    command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+    command: [tempita, '@INPUT@', '-o', '@OUTDIR@'],
     # TODO in principle this should go in py.exension_module below. This is
     # temporary work-around for dependency issue with .pyx.tp files. For more
     # details, see https://github.com/mesonbuild/meson/issues/13212

--- a/sklearn/metrics/_pairwise_distances_reduction/meson.build
+++ b/sklearn/metrics/_pairwise_distances_reduction/meson.build
@@ -24,13 +24,13 @@ _datasets_pair_pxd = custom_target(
   '_datasets_pair_pxd',
   output: '_datasets_pair.pxd',
   input: '_datasets_pair.pxd.tp',
-  command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@']
+  command: [tempita, '@INPUT@', '-o', '@OUTDIR@']
 )
 _datasets_pair_pyx = custom_target(
   '_datasets_pair_pyx',
   output: '_datasets_pair.pyx',
   input: '_datasets_pair.pyx.tp',
-  command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+  command: [tempita, '@INPUT@', '-o', '@OUTDIR@'],
   # TODO in principle this should go in py.exension_module below. This is
   # temporary work-around for dependency issue with .pyx.tp files. For more
   # details, see https://github.com/mesonbuild/meson/issues/13212
@@ -50,13 +50,13 @@ _base_pxd = custom_target(
   '_base_pxd',
   output: '_base.pxd',
   input: '_base.pxd.tp',
-  command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@']
+  command: [tempita, '@INPUT@', '-o', '@OUTDIR@']
 )
 _base_pyx = custom_target(
   '_base_pyx',
   output: '_base.pyx',
   input: '_base.pyx.tp',
-  command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+  command: [tempita, '@INPUT@', '-o', '@OUTDIR@'],
   # TODO in principle this should go in py.exension_module below. This is
   # temporary work-around for dependency issue with .pyx.tp files. For more
   # details, see https://github.com/mesonbuild/meson/issues/13212
@@ -77,13 +77,13 @@ _middle_term_computer_pxd = custom_target(
   '_middle_term_computer_pxd',
   output: '_middle_term_computer.pxd',
   input: '_middle_term_computer.pxd.tp',
-  command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@']
+  command: [tempita, '@INPUT@', '-o', '@OUTDIR@']
 )
 _middle_term_computer_pyx = custom_target(
   '_middle_term_computer_pyx',
   output: '_middle_term_computer.pyx',
   input: '_middle_term_computer.pyx.tp',
-  command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+  command: [tempita, '@INPUT@', '-o', '@OUTDIR@'],
   # TODO in principle this should go in py.exension_module below. This is
   # temporary work-around for dependency issue with .pyx.tp files. For more
   # details, see https://github.com/mesonbuild/meson/issues/13212
@@ -105,13 +105,13 @@ _argkmin_pxd = custom_target(
     '_argkmin_pxd',
     output: '_argkmin.pxd',
     input: '_argkmin.pxd.tp',
-    command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@']
+    command: [tempita, '@INPUT@', '-o', '@OUTDIR@']
   )
 _argkmin_pyx = custom_target(
     '_argkmin_pyx',
     output: '_argkmin.pyx',
     input: '_argkmin.pyx.tp',
-    command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+    command: [tempita, '@INPUT@', '-o', '@OUTDIR@'],
     # TODO in principle this should go in py.exension_module below. This is
     # temporary work-around for dependency issue with .pyx.tp files. For more
     # details, see https://github.com/mesonbuild/meson/issues/13212
@@ -133,13 +133,13 @@ _radius_neighbors_pxd = custom_target(
     '_radius_neighbors_pxd',
     output: '_radius_neighbors.pxd',
     input: '_radius_neighbors.pxd.tp',
-    command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@']
+    command: [tempita, '@INPUT@', '-o', '@OUTDIR@']
   )
 _radius_neighbors_pyx = custom_target(
     '_radius_neighbors_pyx',
     output: '_radius_neighbors.pyx',
     input: '_radius_neighbors.pyx.tp',
-    command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+    command: [tempita, '@INPUT@', '-o', '@OUTDIR@'],
     # TODO in principle this should go in py.exension_module below. This is
     # temporary work-around for dependency issue with .pyx.tp files. For more
     # details, see https://github.com/mesonbuild/meson/issues/13212
@@ -161,7 +161,7 @@ _argkmin_classmode_pyx = custom_target(
   '_argkmin_classmode_pyx',
   output: '_argkmin_classmode.pyx',
   input: '_argkmin_classmode.pyx.tp',
-  command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+  command: [tempita, '@INPUT@', '-o', '@OUTDIR@'],
   # TODO in principle this should go in py.exension_module below. This is
   # temporary work-around for dependency issue with .pyx.tp files. For more
   # details, see https://github.com/mesonbuild/meson/issues/13212
@@ -187,7 +187,7 @@ _radius_neighbors_classmode_pyx = custom_target(
   '_radius_neighbors_classmode_pyx',
   output: '_radius_neighbors_classmode.pyx',
   input: '_radius_neighbors_classmode.pyx.tp',
-  command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+  command: [tempita, '@INPUT@', '-o', '@OUTDIR@'],
   # TODO in principle this should go in py.exension_module below. This is
   # temporary work-around for dependency issue with .pyx.tp files. For more
   # details, see https://github.com/mesonbuild/meson/issues/13212

--- a/sklearn/metrics/meson.build
+++ b/sklearn/metrics/meson.build
@@ -10,7 +10,7 @@ _dist_metrics_pxd = custom_target(
   '_dist_metrics_pxd',
   output: '_dist_metrics.pxd',
   input: '_dist_metrics.pxd.tp',
-  command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+  command: [tempita, '@INPUT@', '-o', '@OUTDIR@'],
   # Need to install the generated pxd because it is needed in other subpackages
   # Cython code, e.g. sklearn.cluster
   install_dir: sklearn_dir / 'metrics',
@@ -22,7 +22,7 @@ _dist_metrics_pyx = custom_target(
   '_dist_metrics_pyx',
   output: '_dist_metrics.pyx',
   input: '_dist_metrics.pyx.tp',
-  command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+  command: [tempita, '@INPUT@', '-o', '@OUTDIR@'],
   # TODO in principle this should go in py.exension_module below. This is
   # temporary work-around for dependency issue with .pyx.tp files. For more
   # details, see https://github.com/mesonbuild/meson/issues/13212

--- a/sklearn/neighbors/meson.build
+++ b/sklearn/neighbors/meson.build
@@ -2,7 +2,7 @@ _binary_tree_pxi = custom_target(
   '_binary_tree_pxi',
   output: '_binary_tree.pxi',
   input: '_binary_tree.pxi.tp',
-  command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+  command: [tempita, '@INPUT@', '-o', '@OUTDIR@'],
 )
 
 # .pyx is generated so this is needed to make Cython compilation work. The pxi
@@ -20,7 +20,7 @@ foreach name: name_list
     name + '_pyx',
     output: name + '.pyx',
     input: name + '.pyx.tp',
-    command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+    command: [tempita, '@INPUT@', '-o', '@OUTDIR@'],
     # TODO in principle this should go in py.exension_module below. This is
     # temporary work-around for dependency issue with .pyx.tp files. For more
     # details, see https://github.com/mesonbuild/meson/issues/13212

--- a/sklearn/utils/meson.build
+++ b/sklearn/utils/meson.build
@@ -54,7 +54,7 @@ foreach name: util_extension_names
     name + '_pxd',
     output: name + '.pxd',
     input: name + '.pxd.tp',
-    command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+    command: [tempita, '@INPUT@', '-o', '@OUTDIR@'],
   )
   utils_cython_tree += [pxd]
 
@@ -62,7 +62,7 @@ foreach name: util_extension_names
     name + '_pyx',
     output: name + '.pyx',
     input: name + '.pyx.tp',
-    command: [py, tempita, '@INPUT@', '-o', '@OUTDIR@'],
+    command: [tempita, '@INPUT@', '-o', '@OUTDIR@'],
     # TODO in principle this should go in py.exension_module below. This is
     # temporary work-around for dependency issue with .pyx.tp files. For more
     # details, see https://github.com/mesonbuild/meson/issues/13212


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Stemmed off from #29791

#### What does this implement/fix? Explain your changes.

This PR aims to remove the `sklearn/_build_utils/` folder from the wheel (while keeping it in the sdist to allow building wheels). The utility file `sklearn/_build_utils/tempita.py` seems to have created a runtime dependency on Cython in the PR linked above that aims to improve the Pyodide builds, because Cython is being imported at the time of running the test suite. I'm unsure how it works for the current builds with the `[pyodide]` commit marker, but either way: since the `_build_utils/` files are needed at just build time, it would make sense to remove them from the wheel artifacts.

This behaviour matches that of NumPy, where the contents of this folder have likely been inspired from back in #28040. The NumPy source distribution on PyPI includes this folder since it's needed at build-time to build wheels off of the sdist, but removes it from the wheel. There are a few more potential and possible Meson-related cleanups to do here but I am not too eager to push them in this PR to keep the diff small :)

In particular, here's a short summary of the changes:
- Replaced [`files()`](https://mesonbuild.com/Reference-manual_functions.html#files) with the more standard [`find_program()`](https://mesonbuild.com/Reference-manual_functions.html#find_program)
- Used the `exclude_directories:` keyword argument for [`install_subdir()`](https://mesonbuild.com/Reference-manual_functions.html#install_subdir) to remove the build utilities from the wheels from the installation
- Added a shebang at the top of the `tempita.py` CLI utility to invoke the `tempita` executable directly

#### Any other comments?

N/A

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
