### PR TITLE
TST enable testing for multiple instances in common tests

### DIFF
--- a/doc/sphinxext/allow_nan_estimators.py
+++ b/doc/sphinxext/allow_nan_estimators.py
@@ -4,7 +4,7 @@ from docutils import nodes
 from docutils.parsers.rst import Directive
 
 from sklearn.utils import all_estimators
-from sklearn.utils._test_common.instance_generator import _construct_instance
+from sklearn.utils._test_common.instance_generator import _construct_instances
 from sklearn.utils._testing import SkipTest
 
 
@@ -19,7 +19,10 @@ class AllowNanEstimators(Directive):
         lst = nodes.bullet_list()
         for name, est_class in all_estimators(type_filter=estimator_type):
             with suppress(SkipTest):
-                est = _construct_instance(est_class)
+                # Here we generate the text only for one instance. This directive
+                # should not be used for meta-estimators where tags depend on the
+                # sub-estimator.
+                est = next(_construct_instances(est_class))
 
             if est.__sklearn_tags__().input_tags.allow_nan:
                 module_name = ".".join(est_class.__module__.split(".")[:2])

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -28,7 +28,7 @@ from sklearn.cluster import (
 )
 from sklearn.compose import ColumnTransformer
 from sklearn.datasets import make_blobs
-from sklearn.exceptions import ConvergenceWarning, FitFailedWarning
+from sklearn.exceptions import ConvergenceWarning
 
 # make it possible to discover experimental estimators when calling `all_estimators`
 from sklearn.experimental import (
@@ -55,8 +55,6 @@ from sklearn.semi_supervised import LabelPropagation, LabelSpreading
 from sklearn.utils import all_estimators
 from sklearn.utils._tags import get_tags
 from sklearn.utils._test_common.instance_generator import (
-    _generate_pipeline,
-    _generate_search_cv_instances,
     _get_check_estimator_ids,
     _tested_estimators,
 )
@@ -132,7 +130,7 @@ def test_get_check_estimator_ids(val, expected):
     assert _get_check_estimator_ids(val) == expected
 
 
-@parametrize_with_checks(list(chain(_tested_estimators(), _generate_pipeline())))
+@parametrize_with_checks(list(_tested_estimators()))
 def test_estimators(estimator, check, request):
     # Common tests for estimator instances
     with ignore_warnings(
@@ -233,22 +231,6 @@ def test_class_support_removed():
         parametrize_with_checks([LogisticRegression])
 
 
-@parametrize_with_checks(list(_generate_search_cv_instances()))
-def test_search_cv(estimator, check, request):
-    # Common tests for SearchCV instances
-    # We have a separate test because those meta-estimators can accept a
-    # wide range of base estimators (classifiers, regressors, pipelines)
-    with ignore_warnings(
-        category=(
-            FutureWarning,
-            ConvergenceWarning,
-            UserWarning,
-            FitFailedWarning,
-        )
-    ):
-        check(estimator)
-
-
 @pytest.mark.parametrize(
     "estimator", _tested_estimators(), ids=_get_check_estimator_ids
 )
@@ -311,7 +293,6 @@ column_name_estimators = list(
     chain(
         _tested_estimators(),
         [make_pipeline(LogisticRegression(C=1))],
-        list(_generate_search_cv_instances()),
         _estimators_that_predict_in_fit(),
     )
 )
@@ -401,13 +382,7 @@ def test_estimators_do_not_raise_errors_in_init_or_set_params(Estimator):
 
 
 @pytest.mark.parametrize(
-    "estimator",
-    chain(
-        _tested_estimators(),
-        _generate_pipeline(),
-        _generate_search_cv_instances(),
-    ),
-    ids=_get_check_estimator_ids,
+    "estimator", list(_tested_estimators()), ids=_get_check_estimator_ids
 )
 def test_check_param_validation(estimator):
     if isinstance(estimator, FeatureUnion):

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -23,7 +23,7 @@ from sklearn.experimental import (
 from sklearn.linear_model import LogisticRegression
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.utils import all_estimators
-from sklearn.utils._test_common.instance_generator import _construct_instance
+from sklearn.utils._test_common.instance_generator import _construct_instances
 from sklearn.utils._testing import (
     _get_func_name,
     assert_docstring_consistency,
@@ -202,7 +202,9 @@ def test_fit_docstring_attributes(name, Estimator):
     elif Estimator.__name__ == "SparseCoder":
         est = _construct_sparse_coder(Estimator)
     else:
-        est = _construct_instance(Estimator)
+        # TODO(devtools): use _tested_estimators instead of all_estimators in the
+        # decorator
+        est = next(_construct_instances(Estimator))
 
     if Estimator.__name__ == "SelectKBest":
         est.set_params(k=2)

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -5,10 +5,10 @@
 import re
 import warnings
 from functools import partial
-from inspect import isfunction, signature
-from itertools import product
+from inspect import isfunction
 
 from sklearn import config_context
+from sklearn.base import clone
 from sklearn.calibration import CalibratedClassifierCV
 from sklearn.cluster import (
     HDBSCAN,
@@ -129,7 +129,7 @@ from sklearn.multioutput import (
 )
 from sklearn.neighbors import NeighborhoodComponentsAnalysis
 from sklearn.neural_network import BernoulliRBM, MLPClassifier, MLPRegressor
-from sklearn.pipeline import FeatureUnion, Pipeline, make_pipeline
+from sklearn.pipeline import FeatureUnion, Pipeline
 from sklearn.preprocessing import OneHotEncoder, StandardScaler, TargetEncoder
 from sklearn.random_projection import (
     GaussianRandomProjection,
@@ -143,7 +143,7 @@ from sklearn.semi_supervised import (
 from sklearn.svm import SVC, SVR, LinearSVC, LinearSVR, NuSVC, NuSVR, OneClassSVM
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.utils import all_estimators
-from sklearn.utils._testing import SkipTest, set_random_state
+from sklearn.utils._testing import SkipTest
 
 CROSS_DECOMPOSITION = ["PLSCanonical", "PLSRegression", "CCA", "PLSSVD"]
 
@@ -190,25 +190,102 @@ INIT_PARAMS = {
     GradientBoostingRegressor: dict(n_estimators=5),
     GraphicalLassoCV: dict(max_iter=5, cv=3),
     GraphicalLasso: dict(max_iter=5),
-    GridSearchCV: dict(
-        estimator=LogisticRegression(C=1), param_grid={"C": [1.0]}, cv=3
-    ),
-    HalvingGridSearchCV: dict(
-        estimator=Ridge(),
-        min_resources="smallest",
-        param_grid={"alpha": [0.1, 1.0]},
-        random_state=0,
-        cv=2,
-        error_score="raise",
-    ),
-    HalvingRandomSearchCV: dict(
-        estimator=Ridge(),
-        param_distributions={"alpha": [0.1, 1.0]},
-        min_resources="smallest",
-        cv=2,
-        error_score="raise",
-        random_state=0,
-    ),
+    GridSearchCV: [
+        dict(
+            cv=2,
+            error_score="raise",
+            estimator=Ridge(),
+            param_grid={"alpha": [0.1, 1.0]},
+        ),
+        dict(
+            cv=2,
+            error_score="raise",
+            estimator=LogisticRegression(),
+            param_grid={"C": [0.1, 1.0]},
+        ),
+        dict(
+            cv=2,
+            error_score="raise",
+            estimator=Pipeline(steps=[("pca", PCA()), ("ridge", Ridge())]),
+            param_grid={"ridge__alpha": [0.1, 1.0]},
+        ),
+        dict(
+            cv=2,
+            error_score="raise",
+            estimator=Pipeline(
+                steps=[("pca", PCA()), ("logisticregression", LogisticRegression())]
+            ),
+            param_grid={"logisticregression__C": [0.1, 1.0]},
+        ),
+    ],
+    HalvingGridSearchCV: [
+        dict(
+            cv=2,
+            error_score="raise",
+            estimator=Ridge(),
+            min_resources="smallest",
+            param_grid={"alpha": [0.1, 1.0]},
+            random_state=0,
+        ),
+        dict(
+            cv=2,
+            error_score="raise",
+            estimator=LogisticRegression(),
+            min_resources="smallest",
+            param_grid={"C": [0.1, 1.0]},
+            random_state=0,
+        ),
+        dict(
+            cv=2,
+            error_score="raise",
+            estimator=Pipeline(steps=[("pca", PCA()), ("ridge", Ridge())]),
+            min_resources="smallest",
+            param_grid={"ridge__alpha": [0.1, 1.0]},
+            random_state=0,
+        ),
+        dict(
+            cv=2,
+            error_score="raise",
+            estimator=Pipeline(
+                steps=[("pca", PCA()), ("logisticregression", LogisticRegression())]
+            ),
+            min_resources="smallest",
+            param_grid={"logisticregression__C": [0.1, 1.0]},
+            random_state=0,
+        ),
+    ],
+    HalvingRandomSearchCV: [
+        dict(
+            cv=2,
+            error_score="raise",
+            estimator=Ridge(),
+            param_distributions={"alpha": [0.1, 1.0]},
+            random_state=0,
+        ),
+        dict(
+            cv=2,
+            error_score="raise",
+            estimator=LogisticRegression(),
+            param_distributions={"C": [0.1, 1.0]},
+            random_state=0,
+        ),
+        dict(
+            cv=2,
+            error_score="raise",
+            estimator=Pipeline(steps=[("pca", PCA()), ("ridge", Ridge())]),
+            param_distributions={"ridge__alpha": [0.1, 1.0]},
+            random_state=0,
+        ),
+        dict(
+            cv=2,
+            error_score="raise",
+            estimator=Pipeline(
+                steps=[("pca", PCA()), ("logisticregression", LogisticRegression())]
+            ),
+            param_distributions={"logisticregression__C": [0.1, 1.0]},
+            random_state=0,
+        ),
+    ],
     HDBSCAN: dict(min_samples=1),
     # The default min_samples_leaf (20) isn't appropriate for small
     # datasets (only very shallow trees are built) that the checks use.
@@ -264,19 +341,53 @@ INIT_PARAMS = {
     PassiveAggressiveClassifier: dict(max_iter=5),
     PassiveAggressiveRegressor: dict(max_iter=5),
     Perceptron: dict(max_iter=5),
-    Pipeline: dict(steps=[("scaler", StandardScaler()), ("est", Ridge())]),
+    Pipeline: [
+        {"steps": [("scaler", StandardScaler()), ("final_estimator", Ridge())]},
+        {
+            "steps": [
+                ("scaler", StandardScaler()),
+                ("final_estimator", LogisticRegression()),
+            ]
+        },
+    ],
     PLSCanonical: dict(n_components=1, max_iter=5),
     PLSRegression: dict(n_components=1, max_iter=5),
     PLSSVD: dict(n_components=1),
     PoissonRegressor: dict(max_iter=5),
     RandomForestClassifier: dict(n_estimators=5),
     RandomForestRegressor: dict(n_estimators=5),
-    RandomizedSearchCV: dict(
-        estimator=LogisticRegression(C=1),
-        param_distributions={"C": [1.0]},
-        n_iter=5,
-        cv=3,
-    ),
+    RandomizedSearchCV: [
+        dict(
+            cv=2,
+            error_score="raise",
+            estimator=Ridge(),
+            param_distributions={"alpha": [0.1, 1.0]},
+            random_state=0,
+        ),
+        dict(
+            cv=2,
+            error_score="raise",
+            estimator=LogisticRegression(),
+            param_distributions={"C": [0.1, 1.0]},
+            random_state=0,
+        ),
+        dict(
+            cv=2,
+            error_score="raise",
+            estimator=Pipeline(steps=[("pca", PCA()), ("ridge", Ridge())]),
+            param_distributions={"ridge__alpha": [0.1, 1.0]},
+            random_state=0,
+        ),
+        dict(
+            cv=2,
+            error_score="raise",
+            estimator=Pipeline(
+                steps=[("pca", PCA()), ("logisticregression", LogisticRegression())]
+            ),
+            param_distributions={"logisticregression__C": [0.1, 1.0]},
+            random_state=0,
+        ),
+    ],
     RandomTreesEmbedding: dict(n_estimators=5),
     # `RANSACRegressor` will raise an error with any model other
     # than `LinearRegression` if we don't fix the `min_samples` parameter.
@@ -348,33 +459,31 @@ INIT_PARAMS = {
 }
 
 
+# This dictionary stores parameters for specific checks. It also enables running the
+# same check with multiple instances of the same estimator with different parameters.
+# The special key "*" allows to apply the parameters to all checks.
+CHECK_PARAMS = {
+    Pipeline: {"*": []},
+    GridSearchCV: {"*": []},
+    HalvingGridSearchCV: {"*": []},
+    RandomizedSearchCV: {"*": []},
+    HalvingRandomSearchCV: {"*": []},
+}
+
+
 def _tested_estimators(type_filter=None):
     for name, Estimator in all_estimators(type_filter=type_filter):
         try:
-            estimator = _construct_instance(Estimator)
+            for estimator in _construct_instances(Estimator):
+                yield estimator
         except SkipTest:
             continue
-
-        yield estimator
-
-
-def _generate_pipeline():
-    """Generator of simple pipeline to check compliance of the
-    :class:`~sklearn.pipeline.Pipeline` class.
-    """
-    for final_estimator in [Ridge(), LogisticRegression()]:
-        yield Pipeline(
-            steps=[
-                ("scaler", StandardScaler()),
-                ("final_estimator", final_estimator),
-            ]
-        )
 
 
 SKIPPED_ESTIMATORS = [SparseCoder]
 
 
-def _construct_instance(Estimator):
+def _construct_instances(Estimator):
     """Construct Estimator instance if possible."""
     if Estimator in SKIPPED_ESTIMATORS:
         msg = f"Can't instantiate estimator {Estimator.__name__}"
@@ -425,48 +534,28 @@ def _get_check_estimator_ids(obj):
             return re.sub(r"\s", "", str(obj))
 
 
-def _generate_search_cv_instances():
-    """Generator of `SearchCV` instances to check their compliance with scikit-learn."""
-    for SearchCV, (Estimator, param_grid) in product(
-        [
-            GridSearchCV,
-            HalvingGridSearchCV,
-            RandomizedSearchCV,
-            HalvingGridSearchCV,
-        ],
-        [
-            (Ridge, {"alpha": [0.1, 1.0]}),
-            (LogisticRegression, {"C": [0.1, 1.0]}),
-        ],
-    ):
-        init_params = signature(SearchCV).parameters
-        extra_params = (
-            {"min_resources": "smallest"} if "min_resources" in init_params else {}
-        )
-        search_cv = SearchCV(
-            Estimator(), param_grid, cv=2, error_score="raise", **extra_params
-        )
-        set_random_state(search_cv)
-        yield search_cv
+def _yield_instances_for_check(check, estimator_orig):
+    """Yield instances for a check.
 
-    for SearchCV, (Estimator, param_grid) in product(
-        [
-            GridSearchCV,
-            HalvingGridSearchCV,
-            RandomizedSearchCV,
-            HalvingRandomSearchCV,
-        ],
-        [
-            (Ridge, {"ridge__alpha": [0.1, 1.0]}),
-            (LogisticRegression, {"logisticregression__C": [0.1, 1.0]}),
-        ],
-    ):
-        init_params = signature(SearchCV).parameters
-        extra_params = (
-            {"min_resources": "smallest"} if "min_resources" in init_params else {}
-        )
-        search_cv = SearchCV(
-            make_pipeline(PCA(), Estimator()), param_grid, cv=2, **extra_params
-        ).set_params(error_score="raise")
-        set_random_state(search_cv)
-        yield search_cv
+    For most estimators, this is a no-op.
+
+    For estimators which have an entry in CHECK_PARAMS, this will yield
+    an estimator for each parameter set in CHECK_PARAMS[estimator].
+    """
+    if type(estimator_orig) not in CHECK_PARAMS:
+        return (estimator_orig,)
+
+    check_params = CHECK_PARAMS[type(estimator_orig)]
+
+    if "*" not in check_params and check not in check_params:
+        return (estimator_orig,)
+
+    if "*" in check_params:
+        param_set = check_params["*"]
+    else:
+        param_set = check_params[check]
+
+    for params in param_set:
+        estimator = clone(estimator_orig)
+        estimator.set_params(**params)
+        yield estimator

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -488,7 +488,6 @@ def _construct_instances(Estimator):
             param_sets = [param_sets]
         for params in param_sets:
             est = Estimator(**params)
-            est._init_params_set_by_construct_instance = params
             yield est
     else:
         yield Estimator()

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -3335,8 +3335,8 @@ def check_parameters_default_constructible(name, estimator_orig):
                     # nice way to check for it. We assume there's no VAR_POSITIONAL in
                     # the constructor parameters.
                     #
-                    # TODO(devtools): seaprate check that constructor doesn't have
-                    # *args.
+                    # TODO(devtools): separately check that the constructor doesn't 
+                    # have *args.
                     and p.kind != p.VAR_POSITIONAL
                     # these are parameters that don't have a default value and are
                     # required to construct the estimator.

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -3335,7 +3335,7 @@ def check_parameters_default_constructible(name, estimator_orig):
                     # nice way to check for it. We assume there's no VAR_POSITIONAL in
                     # the constructor parameters.
                     #
-                    # TODO(devtools): separately check that the constructor doesn't 
+                    # TODO(devtools): separately check that the constructor doesn't
                     # have *args.
                     and p.kind != p.VAR_POSITIONAL
                     # these are parameters that don't have a default value and are


### PR DESCRIPTION
This PR allows for creation of multiple instances from each estimator for all the tests. This further simplifies instance generation for tests.

There will be another PR allowing for multiple settings of estimators for individual tests.

cc @ogrisel since you were interested in this / dealing with similar issues

cc @glemaitre @OmarManzoor 