### PR TITLE
TST Add test to check docstring consistency of stacking estimators

### DIFF
--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -558,7 +558,8 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
         .. versionadded:: 1.0
 
     final_estimator_ : estimator
-        The final classifier, fitted on the output of `estimators_`.
+        The classifier fit on the output of `estimators_` and responsible for
+        final predictions.
 
     stack_method_ : list of str
         The method used by each base estimator.
@@ -956,7 +957,8 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
         .. versionadded:: 1.0
 
     final_estimator_ : estimator
-        The final regressor, fitted on the output of `estimators_`.
+        The regressor fit on the output of `estimators_` and responsible for
+        final predictions.
 
     stack_method_ : list of str
         The method used by each base estimator.

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -477,7 +477,7 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
         * integer, to specify the number of folds in a (Stratified) KFold,
         * An object to be used as a cross-validation generator,
         * An iterable yielding train, test splits,
-        * `"prefit"` to assume the `estimators` are prefit. In this case, the
+        * "prefit", to assume the `estimators` are prefit. In this case, the
           estimators will not be refitted.
 
         For integer/None inputs, if the estimator is a classifier and y is
@@ -517,9 +517,9 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
           will raise an error.
 
     n_jobs : int, default=None
-        The number of jobs to run in parallel all `estimators` `fit`.
+        The number of jobs to run in parallel for `fit` of all `estimators`.
         `None` means 1 unless in a `joblib.parallel_backend` context. -1 means
-        using all processors. See Glossary for more details.
+        using all processors. See :term:`Glossary <n_jobs>` for more details.
 
     passthrough : bool, default=False
         When False, only the predictions of estimators will be used as
@@ -547,7 +547,7 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
 
     n_features_in_ : int
         Number of features seen during :term:`fit`. Only defined if the
-        underlying classifier exposes such an attribute when fit.
+        underlying estimator exposes such an attribute when fit.
 
         .. versionadded:: 0.24
 
@@ -889,8 +889,9 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
         * None, to use the default 5-fold cross validation,
         * integer, to specify the number of folds in a (Stratified) KFold,
         * An object to be used as a cross-validation generator,
-        * An iterable yielding train, test splits.
-        * "prefit" to assume the `estimators` are prefit, and skip cross validation
+        * An iterable yielding train, test splits,
+        * "prefit", to assume the `estimators` are prefit. In this case, the
+          estimators will not be refitted.
 
         For integer/None inputs, if the estimator is a classifier and y is
         either binary or multiclass,
@@ -920,7 +921,7 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
     n_jobs : int, default=None
         The number of jobs to run in parallel for `fit` of all `estimators`.
         `None` means 1 unless in a `joblib.parallel_backend` context. -1 means
-        using all processors. See Glossary for more details.
+        using all processors. See :term:`Glossary <n_jobs>` for more details.
 
     passthrough : bool, default=False
         When False, only the predictions of estimators will be used as
@@ -933,7 +934,7 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
 
     Attributes
     ----------
-    estimators_ : list of estimator
+    estimators_ : list of estimators
         The elements of the `estimators` parameter, having been fitted on the
         training data. If an estimator has been set to `'drop'`, it
         will not appear in `estimators_`. When `cv="prefit"`, `estimators_`
@@ -944,7 +945,7 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
 
     n_features_in_ : int
         Number of features seen during :term:`fit`. Only defined if the
-        underlying regressor exposes such an attribute when fit.
+        underlying estimator exposes such an attribute when fit.
 
         .. versionadded:: 0.24
 
@@ -955,7 +956,7 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
         .. versionadded:: 1.0
 
     final_estimator_ : estimator
-        The regressor to stacked the base estimators fitted.
+        The regressor to stack the base estimators fitted.
 
     stack_method_ : list of str
         The method used by each base estimator.

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -477,7 +477,7 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
         * integer, to specify the number of folds in a (Stratified) KFold,
         * An object to be used as a cross-validation generator,
         * An iterable yielding train, test splits,
-        * "prefit", to assume the `estimators` are prefit. In this case, the
+        * `"prefit"`, to assume the `estimators` are prefit. In this case, the
           estimators will not be refitted.
 
         For integer/None inputs, if the estimator is a classifier and y is
@@ -558,7 +558,7 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
         .. versionadded:: 1.0
 
     final_estimator_ : estimator
-        The classifier which predicts given the output of `estimators_`.
+        The final classifier, fitted on the output of `estimators_`.
 
     stack_method_ : list of str
         The method used by each base estimator.
@@ -890,7 +890,7 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
         * integer, to specify the number of folds in a (Stratified) KFold,
         * An object to be used as a cross-validation generator,
         * An iterable yielding train, test splits,
-        * "prefit", to assume the `estimators` are prefit. In this case, the
+        * `"prefit"`, to assume the `estimators` are prefit. In this case, the
           estimators will not be refitted.
 
         For integer/None inputs, if the estimator is a classifier and y is
@@ -956,7 +956,7 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
         .. versionadded:: 1.0
 
     final_estimator_ : estimator
-        The regressor to stack the base estimators fitted.
+        The final regressor, fitted on the output of `estimators_`.
 
     stack_method_ : list of str
         The method used by each base estimator.

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -15,6 +15,7 @@ import sklearn
 from sklearn import metrics
 from sklearn.datasets import make_classification
 
+from sklearn.ensemble import StackingClassifier, StackingRegressor
 # make it possible to discover experimental estimators when calling `all_estimators`
 from sklearn.experimental import (
     enable_halving_search_cv,  # noqa
@@ -29,6 +30,7 @@ from sklearn.utils._testing import (
     assert_docstring_consistency,
     check_docstring_parameters,
     ignore_warnings,
+    skip_if_no_numpydoc,
 )
 from sklearn.utils.deprecation import _is_deprecated
 from sklearn.utils.estimator_checks import (
@@ -326,12 +328,9 @@ def _get_all_fitted_attributes(estimator):
     return [k for k in fit_attr if k.endswith("_") and not k.startswith("_")]
 
 
+@skip_if_no_numpydoc
 def test_precision_recall_f_score_docstring_consistency():
     """Check docstrings parameters of related metrics are consistent."""
-    pytest.importorskip(
-        "numpydoc",
-        reason="numpydoc is required to test the docstrings",
-    )
     assert_docstring_consistency(
         [
             metrics.precision_recall_fscore_support,
@@ -346,4 +345,15 @@ def test_precision_recall_f_score_docstring_consistency():
         # "zero_division" - the reason for zero division differs between f scores,
         # precison and recall.
         exclude_params=["average", "zero_division"],
+    )
+
+
+@skip_if_no_numpydoc
+def test_stacking_classifier_regressor_docstring_consistency():
+    """Check docstrings parameters stacking estimators are consistent."""
+    assert_docstring_consistency(
+        [StackingClassifier, StackingRegressor],
+        include_params=["cv", "n_jobs", "passthrough", "verbose"],
+        include_attrs=True,
+        exclude_attrs=["final_estimator_"],
     )

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -14,8 +14,8 @@ import pytest
 import sklearn
 from sklearn import metrics
 from sklearn.datasets import make_classification
-
 from sklearn.ensemble import StackingClassifier, StackingRegressor
+
 # make it possible to discover experimental estimators when calling `all_estimators`
 from sklearn.experimental import (
     enable_halving_search_cv,  # noqa

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -300,7 +300,7 @@ def set_random_state(estimator, random_state=0):
 
 def _is_numpydoc():
     try:
-        import numpydoc
+        import numpydoc  # noqa
     except (ImportError, AssertionError):
         return False
     else:

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -298,6 +298,15 @@ def set_random_state(estimator, random_state=0):
         estimator.set_params(random_state=random_state)
 
 
+def _is_numpydoc():
+    try:
+        import numpydoc
+    except (ImportError, AssertionError):
+        return False
+    else:
+        return True
+
+
 try:
     _check_array_api_dispatch(True)
     ARRAY_API_COMPAT_FUNCTIONAL = True
@@ -341,6 +350,10 @@ try:
 
     if_safe_multiprocessing_with_blas = pytest.mark.skipif(
         sys.platform == "darwin", reason="Possible multi-process bug with some BLAS"
+    )
+    skip_if_no_numpydoc = pytest.mark.skipif(
+        not _is_numpydoc(),
+        reason="numpydoc is required to test the docstrings",
     )
 except ImportError:
     pass

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -22,6 +22,7 @@ from sklearn.utils._testing import (
     ignore_warnings,
     raises,
     set_random_state,
+    skip_if_no_numpydoc,
     turn_warnings_into_errors,
 )
 from sklearn.utils.deprecation import deprecated
@@ -399,12 +400,8 @@ class MockMetaEstimator:
         """Incorrect docstring but should not be tested"""
 
 
+@skip_if_no_numpydoc
 def test_check_docstring_parameters():
-    pytest.importorskip(
-        "numpydoc",
-        reason="numpydoc is required to test the docstrings",
-        minversion="1.2.0",
-    )
     incorrect = check_docstring_parameters(f_ok)
     assert incorrect == []
     incorrect = check_docstring_parameters(f_ok, ignore=["b"])
@@ -608,16 +605,14 @@ def f_three(a, b):  # pragma: no cover
     pass
 
 
+@skip_if_no_numpydoc
 def test_assert_docstring_consistency_object_type():
     """Check error raised when `objects` incorrect type."""
-    pytest.importorskip(
-        "numpydoc",
-        reason="numpydoc is required to test the docstrings",
-    )
     with pytest.raises(TypeError, match="All 'objects' must be one of"):
         assert_docstring_consistency(["string", f_one])
 
 
+@skip_if_no_numpydoc
 @pytest.mark.parametrize(
     "objects, kwargs, error",
     [
@@ -635,14 +630,11 @@ def test_assert_docstring_consistency_object_type():
 )
 def test_assert_docstring_consistency_arg_checks(objects, kwargs, error):
     """Check `assert_docstring_consistency` argument checking correct."""
-    pytest.importorskip(
-        "numpydoc",
-        reason="numpydoc is required to test the docstrings",
-    )
     with pytest.raises(TypeError, match=error):
         assert_docstring_consistency(objects, **kwargs)
 
 
+@skip_if_no_numpydoc
 @pytest.mark.parametrize(
     "objects, kwargs, error, warn",
     [
@@ -691,10 +683,6 @@ def test_assert_docstring_consistency_arg_checks(objects, kwargs, error):
 )
 def test_assert_docstring_consistency(objects, kwargs, error, warn):
     """Check `assert_docstring_consistency` gives correct results."""
-    pytest.importorskip(
-        "numpydoc",
-        reason="numpydoc is required to test the docstrings",
-    )
     if error:
         with pytest.raises(AssertionError, match=error):
             assert_docstring_consistency(objects, **kwargs)
@@ -745,12 +733,9 @@ def f_six(labels):  # pragma: no cover
     pass
 
 
+@skip_if_no_numpydoc
 def test_assert_docstring_consistency_error_msg():
     """Check `assert_docstring_consistency` difference message."""
-    pytest.importorskip(
-        "numpydoc.docscrape",
-        reason="numpydoc is required to test the docstrings",
-    )
     msg = r"""The description of Parameter 'labels' is inconsistent between
 \['f_four'\] and \['f_five'\] and \['f_six'\]:
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Follow on from  #28678

#### What does this implement/fix? Explain your changes.
* Add test checking for parameter and attribute consistency for `StackingClassifier` and `StackingRegressor`
* Add (back) `skip_if_no_numpydoc` decorator. I think if we are to add more of these tests it makes sense to have this decorator, instead of adding the `importskip` to so many tests.

#### Any other comments?
Mentioned here: https://github.com/scikit-learn/scikit-learn/pull/28678#discussion_r1743518503 but I wonder if these tests would make more sense living with their respective estimator tests..? Or in a file by themselves..?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
