### PR TITLE
DOC Reorder release steps

### DIFF
--- a/doc/developers/maintainer.rst.template
+++ b/doc/developers/maintainer.rst.template
@@ -132,13 +132,13 @@ Reference Steps
         * [ ] Upload the wheels and source tarball to PyPI
         * [ ] Update news and what's new date in main branch
         * [ ] Backport news and what's new date in release branch
+        {%- if key == "final" %}
+        * [ ] Update symlink for stable in https://github.com/scikit-learn/scikit-learn.github.io
+        {%- endif %}
         {%- if key != "rc" %}
         * [ ] Publish to https://github.com/scikit-learn/scikit-learn/releases
         {%- endif %}
         * [ ] Announce on mailing list and on Twitter, and LinkedIn
-        {%- if key == "final" %}
-        * [ ] Update symlink for stable in https://github.com/scikit-learn/scikit-learn.github.io
-        {%- endif %}
         {%- if key != "rc" %}
         * [ ] Update SECURITY.md in main branch
         {%- endif %}
@@ -202,6 +202,12 @@ Reference Steps
         git tag -a {{ version_full }}  # in the {{ version_short }}.X branch
         git push git@github.com:scikit-learn/scikit-learn.git {{ version_full }}
 
+      .. warning::
+
+        Don't use the github interface for publishing the release as a way to create the
+        tag because it will automatically send notifications to all users that follow
+        the repo even though the website isn't updated and wheels aren't uploaded yet.
+
     - Confirm that the bot has detected the tag on the conda-forge feedstock repository
       https://github.com/conda-forge/scikit-learn-feedstock. If not, submit a PR for the
       release, targeting the `{% if key == "rc" %}rc{% else %}main{% endif %}` branch.
@@ -223,7 +229,7 @@ Reference Steps
           rm -r dist
           python -m pip install -U wheelhouse_uploader twine
           python -m wheelhouse_uploader fetch \
-            --version 0.99.0rc1 --local-folder dist scikit-learn \
+            --version {{ version_full }} --local-folder dist scikit-learn \
             https://pypi.anaconda.org/scikit-learn-wheels-staging/simple/scikit-learn/
 
         These commands will download all the binary packages accumulated in the `staging
@@ -290,6 +296,13 @@ Reference Steps
         git add stable versionwarning.js
         git commit -m "Update stable to point to {{ version_short }}"
         git push origin main
+    {% endif %}
+
+    {% if key != "rc" %}
+    - Publish the release at https://github.com/scikit-learn/scikit-learn/releases and
+      announce it on the mailing list and social networks. Remember to add a link to the
+      changelog in the release note. Ideally, only perform this step once the package
+      is available both on PyPI and conda-forge and once the website is up to date.
     {% endif %}
 
     {% if key != "rc" %}

--- a/doc/developers/maintainer.rst.template
+++ b/doc/developers/maintainer.rst.template
@@ -87,38 +87,9 @@ Reference Steps
         git push --set-upstream upstream {{ version_short }}.X
     {% endif %}
 
-    - Create a PR from the `main` branch targeting the `{{ version_short }}.X` branch.
-      Copy the following release checklist to the description of this PR to track the
-      progress.
-
-      .. code-block:: markdown
-
-        * [ ] Update news and what's new date in main branch
-        * [ ] Backport news and what's new date in release branch
-        {%- if key == "rc" %}
-        * [ ] Update the sklearn dev0 version in main branch
-        {%- endif %}
-        * [ ] Set the version number in the release branch
-        * [ ] Check that the wheels for the release can be built successfully
-        * [ ] Merge the PR with `[cd build]` commit message to upload wheels to the staging repo
-        * [ ] Upload the wheels and source tarball to https://test.pypi.org
-        * [ ] Create tag on the main repo
-        * [ ] Confirm bot detected at https://github.com/conda-forge/scikit-learn-feedstock
-              and wait for merge
-        * [ ] Upload the wheels and source tarball to PyPI
-        {%- if key != "rc" %}
-        * [ ] Publish to https://github.com/scikit-learn/scikit-learn/releases
-        {%- endif %}
-        * [ ] Announce on mailing list and on Twitter, and LinkedIn
-        {%- if key == "final" %}
-        * [ ] Update symlink for stable in https://github.com/scikit-learn/scikit-learn.github.io
-        {%- endif %}
-        {%- if key != "rc" %}
-        * [ ] Update SECURITY.md in main branch
-        {%- endif %}
-
     {% if key != "rc" %}
-    - Rebase this PR from the `{{ version_short }}.X` branch:
+    - Create a new branch from the `main` branch, then start an interactive rebase from
+      `{{ version_short }}.X` to select the commits that need to be backported:
 
       .. prompt:: bash
 
@@ -142,6 +113,36 @@ Reference Steps
         necessary.
     {% endif %}
 
+    - Create a PR targeting the `{{ version_short }}.X` branch.
+      Copy the following release checklist to the description of this PR to track the
+      progress.
+
+      .. code-block:: markdown
+
+        {%- if key == "rc" %}
+        * [ ] Update the sklearn dev0 version in main branch
+        {%- endif %}
+        * [ ] Set the version number in the release branch
+        * [ ] Check that the wheels for the release can be built successfully
+        * [ ] Merge the PR with `[cd build]` commit message to upload wheels to the staging repo
+        * [ ] Upload the wheels and source tarball to https://test.pypi.org
+        * [ ] Create tag on the main repo
+        * [ ] Confirm bot detected at https://github.com/conda-forge/scikit-learn-feedstock
+              and wait for merge
+        * [ ] Upload the wheels and source tarball to PyPI
+        * [ ] Update news and what's new date in main branch
+        * [ ] Backport news and what's new date in release branch
+        {%- if key != "rc" %}
+        * [ ] Publish to https://github.com/scikit-learn/scikit-learn/releases
+        {%- endif %}
+        * [ ] Announce on mailing list and on Twitter, and LinkedIn
+        {%- if key == "final" %}
+        * [ ] Update symlink for stable in https://github.com/scikit-learn/scikit-learn.github.io
+        {%- endif %}
+        {%- if key != "rc" %}
+        * [ ] Update SECURITY.md in main branch
+        {%- endif %}
+
     {% if key == "rc" %}
     - Create a PR from `main` and targeting `main` to increment the dev0 `__version__`
       variable in `sklearn/__init__.py`. This means while we are in the release
@@ -154,34 +155,6 @@ Reference Steps
 
     - In the release branch, change the version number `__version__` in
       `sklearn/__init__.py` to `{{ version_full }}`.
-
-    {% if key != "rc" %}
-    - In the `main` branch, edit the corresponding file in the `doc/whats_new` directory
-      to update the release date
-      {%- if key == "final" %}, link the release highlights example,{% endif %}
-      and add the list of contributor names. Suppose that the tag of the last release in
-      the previous major/minor version is `{{ previous_tag }}`, then you can use the
-      following command to retrieve the list of contributor names:
-
-      .. prompt:: bash
-
-        git shortlog -s {{ previous_tag }}.. |
-          cut -f2- |
-          sort --ignore-case |
-          tr "\n" ";" |
-          sed "s/;/, /g;s/, $//" |
-          fold -s
-
-      Then cherry-pick it in the release branch.
-
-    - In the `main` branch, edit `doc/templates/index.html` to change the "News" section
-      in the landing page, along with the month of the release.
-      {%- if key == "final" %}
-      Do not forget to remove old entries (two years or three releases ago) and update
-      the "On-going development" entry.
-      {%- endif %}
-      Then cherry-pick it in the release branch.
-    {% endif %}
 
     - Trigger the wheel builder with the `[cd build]` commit marker. See also the
       `workflow runs of the wheel builder
@@ -217,7 +190,7 @@ Reference Steps
 
         In addition if on merging, the last commit, containing the `[cd build]` marker,
         is empty, the CD jobs won't be triggered. In this case, you can directly push
-        a commit with the marker in the `{{ version_short }}.X` to trigger them.
+        a commit with the marker in the `{{ version_short }}.X` branch to trigger them.
 
     - If the steps above went fine, proceed **with caution** to create a new tag for the
       release. This should be done only when you are almost certain that the release is
@@ -271,6 +244,34 @@ Reference Steps
         .. prompt:: bash
 
           twine upload dist/*
+
+    {% if key != "rc" %}
+    - In the `main` branch, edit the corresponding file in the `doc/whats_new` directory
+      to update the release date
+      {%- if key == "final" %}, link the release highlights example,{% endif %}
+      and add the list of contributor names. Suppose that the tag of the last release in
+      the previous major/minor version is `{{ previous_tag }}`, then you can use the
+      following command to retrieve the list of contributor names:
+
+      .. prompt:: bash
+
+        git shortlog -s {{ previous_tag }}.. |
+          cut -f2- |
+          sort --ignore-case |
+          tr "\n" ";" |
+          sed "s/;/, /g;s/, $//" |
+          fold -s
+
+      Then cherry-pick it in the release branch.
+
+    - In the `main` branch, edit `doc/templates/index.html` to change the "News" section
+      in the landing page, along with the month of the release.
+      {%- if key == "final" %}
+      Do not forget to remove old entries (two years or three releases ago) and update
+      the "On-going development" entry.
+      {%- endif %}
+      Then cherry-pick it in the release branch.
+    {% endif %}
 
     {% if key == "final" %}
     - Update the symlink for `stable` and the `latestStable` variable in

--- a/doc/developers/maintainer.rst.template
+++ b/doc/developers/maintainer.rst.template
@@ -119,7 +119,7 @@ Reference Steps
 
       .. code-block:: markdown
 
-        {%- if key == "rc" %}
+        {% if key == "rc" -%}
         * [ ] Update the sklearn dev0 version in main branch
         {%- endif %}
         * [ ] Set the version number in the release branch


### PR DESCRIPTION
Update the doc for making a release following 1.5.2 to reorder the steps a bit.

- update the news and whats new date only when the wheels are uploaded
- make the interactive rebase before creating the release PR

cc/ @glemaitre 