### PR TITLE
DOC add fetch_file into the API reference

### DIFF
--- a/doc/api_reference.py
+++ b/doc/api_reference.py
@@ -240,6 +240,7 @@ API_REFERENCE = {
                     "fetch_20newsgroups_vectorized",
                     "fetch_california_housing",
                     "fetch_covtype",
+                    "fetch_file",
                     "fetch_kddcup99",
                     "fetch_lfw_pairs",
                     "fetch_lfw_people",


### PR DESCRIPTION
When merging https://github.com/scikit-learn/scikit-learn/pull/29354, we forgot to add this new function to the API reference and it does not show in the list of public function.

This PR is fixing this issue.