### PR TITLE
ENH add aligned numpy allocator

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -42,6 +42,10 @@ from sklearn.preprocessing import FunctionTransformer, LabelEncoder, OrdinalEnco
 from sklearn.utils import check_random_state, compute_sample_weight, resample
 from sklearn.utils._dataframe import is_pandas_df
 from sklearn.utils._missing import is_scalar_nan
+from sklearn.utils._numpy_aligned_allocator import (
+    set_aligned_allocation,
+    set_numpy_default_allocation,
+)
 from sklearn.utils._openmp_helpers import _openmp_effective_n_threads
 from sklearn.utils._param_validation import Interval, RealNotInt, StrOptions
 from sklearn.utils.multiclass import check_classification_targets
@@ -563,6 +567,9 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         acc_compute_hist_time = 0.0  # time spent computing histograms
         # time spent predicting X for gradient and hessians update
         acc_prediction_time = 0.0
+
+        set_aligned_allocation()
+
         X, known_categories = self._preprocess_X(X, reset=True)
         y = _check_y(y, estimator=self)
         y = self._encode_y(y)
@@ -1068,6 +1075,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         self.train_score_ = np.asarray(self.train_score_)
         self.validation_score_ = np.asarray(self.validation_score_)
         del self._in_fit  # hard delete so we're sure it can't be used anymore
+        set_numpy_default_allocation()
         return self
 
     def _is_fitted(self):

--- a/sklearn/utils/_numpy_aligned_allocator.pyx
+++ b/sklearn/utils/_numpy_aligned_allocator.pyx
@@ -1,0 +1,11 @@
+cdef extern from "src/numpy_allocator.h":
+    void c_set_aligned_allocation()
+    void c_set_numpy_default_allocation()
+
+
+def set_aligned_allocation():
+    c_set_aligned_allocation()
+
+
+def set_numpy_default_allocation():
+    c_set_numpy_default_allocation()

--- a/sklearn/utils/_numpy_aligned_allocator.pyx
+++ b/sklearn/utils/_numpy_aligned_allocator.pyx
@@ -1,3 +1,7 @@
+cimport numpy as cnp
+cnp.import_array()  # very important, segfault without it!
+
+
 cdef extern from "src/numpy_allocator.h":
     void c_set_aligned_allocation()
     void c_set_numpy_default_allocation()

--- a/sklearn/utils/meson.build
+++ b/sklearn/utils/meson.build
@@ -33,6 +33,10 @@ utils_extension_metadata = {
     {'sources': [cython_gen_cpp.process('_vector_sentinel.pyx')],
      'dependencies': [np_dep]},
   '_isfinite': {'sources': [cython_gen.process('_isfinite.pyx')]},
+  '_numpy_aligned_allocator': {
+    'sources': [cython_gen.process('_numpy_aligned_allocator.pyx'), 'src' / 'numpy_allocator.h'],
+    'dependencies': [np_dep]
+  }
 }
 
 foreach ext_name, ext_dict : utils_extension_metadata

--- a/sklearn/utils/src/numpy_allocator.h
+++ b/sklearn/utils/src/numpy_allocator.h
@@ -1,0 +1,85 @@
+/* See https://docs.python.org/3/extending/extending.html */
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+/* We need at least numpy 1.22 */
+#define NPY_TARGET_VERSION NPY_2_0_API_VERSION
+#include "numpy/arrayobject.h"
+
+#include <stdlib.h>  /* memory allocation */
+#include <string.h>  /* memset */
+
+
+static inline void *
+aligned_64_malloc(void *ctx, size_t size)
+{
+    size_t rest = size % 64;
+    if (rest > 0) {
+        size += 64 - rest;  /* allocate a bit more than we need */
+    }
+    return aligned_alloc(64, size);
+}
+
+
+static inline void *
+aligned_64_calloc(void *ctx, size_t nelem, size_t elsize)
+{
+    size_t size = nelem * elsize;
+    void *x = aligned_64_malloc(ctx, size);
+    if (x != NULL) {
+        size_t rest = size % 64;
+        if (rest > 0) {
+            size += 64 - rest;
+        }
+        memset(x, 0, size);
+    }
+    return x;
+}
+
+
+static inline void *
+std_realloc(void *ctx, void *ptr, size_t new_size)
+{
+    /* TODO: Do we need aligned realloc? */
+    return realloc(ptr, new_size);
+}
+
+static inline void
+std_free(void *ctx, void *ptr, size_t size)
+{
+    /* TODO: Deal with MSCV incompatibility of aligned_alloc. */
+    free(ptr);
+}
+
+
+static PyDataMem_Handler aligned_handler = {
+    "aligned_allocator",    /* name */
+    1,                      /* version */
+    {
+        NULL,               /* ctx */
+        aligned_64_malloc,  /* malloc */
+        aligned_64_calloc,  /* calloc */
+        std_realloc,        /* realloc */
+        std_free            /* free */
+    }
+};
+
+
+static inline void
+c_set_aligned_allocation()
+{
+    /* Name must be "mem_handler". */
+    PyObject *aligned_handler_obj = PyCapsule_New(&aligned_handler, "mem_handler", NULL);
+    if (aligned_handler_obj == NULL) {
+        return;
+    }
+    PyObject *old = PyDataMem_SetHandler(aligned_handler_obj);
+    Py_DECREF(aligned_handler_obj);
+};
+
+
+static inline void
+c_set_numpy_default_allocation()
+{
+    PyDataMem_SetHandler(NULL);
+};

--- a/sklearn/utils/tests/test_numpy_aligned_allocator.py
+++ b/sklearn/utils/tests/test_numpy_aligned_allocator.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+from sklearn.utils._numpy_aligned_allocator import (
+    set_aligned_allocation,
+    set_numpy_default_allocation,
+)
+
+
+def test_change_numpy_allocator():
+    # A no-op
+    set_numpy_default_allocation()
+    np.arange(3)
+    # Change to aligned allocator
+    set_aligned_allocation()
+    np.arange(3)
+    # Change back to default
+    set_numpy_default_allocation()
+    np.arange(3)


### PR DESCRIPTION
#### Reference Issues/PRs
None


#### What does this implement/fix? Explain your changes.
This PR adds a numpy allocator for aligned memory in order to evaluate the performance impact (mainly on HGBT).

LightGBM uses aligned allocation, see
- https://github.com/microsoft/LightGBM/blob/master/include/LightGBM/utils/common.h#L42-L56
- https://github.com/microsoft/LightGBM/blob/41ba9e8f00c89d72e5cb71c964722ce1ed4d8445/include/LightGBM/utils/common.h#L909.

Numpy allocator C-API, see
- https://numpy.org/doc/stable/reference/c-api/data_memory.html
- https://numpy.org/neps/nep-0049.html
- https://github.com/numpy/numpy/issues/27327

#### Any other comments?
While https://github.com/numpy/numpy/issues/27327 works perfectly fine locally, this PR results in a segmentation fault.
