### PR TITLE
MNT ignore .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ sklearn-env/
 
 # Default JupyterLite content
 jupyterlite_contents
+
+# file recognised by vscode IDEs containing env variables
+.env


### PR DESCRIPTION
This file is recognised by vscode IDEs and needed to put `SCIPY_ARRAY_API=1` in it.

cc @StefanieSenger @ogrisel 