### PR TITLE
DOC add more developer doc in RidgeGCV

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1691,11 +1691,11 @@ class _IdentityClassifier(LinearClassifierMixin):
 class _RidgeGCV(LinearModel):
     """Ridge regression with built-in Leave-one-out Cross-Validation.
 
-    Let's briefly describe the advantage of this formulation.
-
-    Using a naive grid-search approach with a leave-one-out cross-validation requires to
-    fit `n_samples` models to compute the prediction error for each sample. Finally, one
-    needs to repeat this process for each alpha in the grid.
+    _RidgeGCV uses a Generalized Cross-Validation for model selection. 
+    
+    It's an efficient approximation of leave-one-out cross-validation (LOO-CV), where instead of computing multiple models by excluding one data point at a time, it uses an algebraic shortcut to approximate the LOO-CV error, making it faster and computationally more efficient.
+    
+    Using a naive grid-search approach with a leave-one-out cross-validation in contrast requires to fit `n_samples` models to compute the prediction error for each sample and then to repeat this process for each alpha in the grid.
 
     Here, the prediction error for each sample is computed by solving a **single**
     linear system (in other words a single model) via a matrix factorization (i.e.

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1691,11 +1691,17 @@ class _IdentityClassifier(LinearClassifierMixin):
 class _RidgeGCV(LinearModel):
     """Ridge regression with built-in Leave-one-out Cross-Validation.
 
-    _RidgeGCV uses a Generalized Cross-Validation for model selection. 
-    
-    It's an efficient approximation of leave-one-out cross-validation (LOO-CV), where instead of computing multiple models by excluding one data point at a time, it uses an algebraic shortcut to approximate the LOO-CV error, making it faster and computationally more efficient.
-    
-    Using a naive grid-search approach with a leave-one-out cross-validation in contrast requires to fit `n_samples` models to compute the prediction error for each sample and then to repeat this process for each alpha in the grid.
+    This class is not intended to be used directly. Use RidgeCV instead.
+
+    `_RidgeGCV` uses a Generalized Cross-Validation for model selection. It's an
+    efficient approximation of leave-one-out cross-validation (LOO-CV), where instead of
+    computing multiple models by excluding one data point at a time, it uses an
+    algebraic shortcut to approximate the LOO-CV error, making it faster and
+    computationally more efficient.
+
+    Using a naive grid-search approach with a leave-one-out cross-validation in contrast
+    requires to fit `n_samples` models to compute the prediction error for each sample
+    and then to repeat this process for each alpha in the grid.
 
     Here, the prediction error for each sample is computed by solving a **single**
     linear system (in other words a single model) via a matrix factorization (i.e.
@@ -1703,10 +1709,11 @@ class _RidgeGCV(LinearModel):
     we need to repeat this process for each alpha in the grid. The detailed complexity
     is further discussed in Sect. 4 in [1].
 
+    This algebraic approach is only applicable for regularized least squares
+    problems. It could potentially be extended to kernel ridge regression.
+
     See the Notes section and references for more details regarding the formulation
     and the linear system that is solved.
-
-    This class is not intended to be used directly. Use RidgeCV instead.
 
     Notes
     -----

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1691,6 +1691,21 @@ class _IdentityClassifier(LinearClassifierMixin):
 class _RidgeGCV(LinearModel):
     """Ridge regression with built-in Leave-one-out Cross-Validation.
 
+    Let's briefly describe the advantage of this formulation.
+
+    Using a naive grid-search approach with a leave-one-out cross-validation requires to
+    fit `n_samples` models to compute the prediction error for each sample. Finally, one
+    needs to repeat this process for each alpha in the grid.
+
+    Here, the prediction error for each sample is computed by solving a **single**
+    linear system (in other words a single model) via a matrix factorization (i.e.
+    eigendecomposition or SVD) solving the problem stated in the Notes section. Finally,
+    we need to repeat this process for each alpha in the grid. The detailed complexity
+    is further discussed in Sect. 4 in [1].
+
+    See the Notes section and references for more details regarding the formulation
+    and the linear system that is solved.
+
     This class is not intended to be used directly. Use RidgeCV instead.
 
     Notes
@@ -1725,8 +1740,8 @@ class _RidgeGCV(LinearModel):
 
     References
     ----------
-    http://cbcl.mit.edu/publications/ps/MIT-CSAIL-TR-2007-025.pdf
-    https://www.mit.edu/~9.520/spring07/Classes/rlsslides.pdf
+    [1] http://cbcl.mit.edu/publications/ps/MIT-CSAIL-TR-2007-025.pdf
+    [2] https://www.mit.edu/~9.520/spring07/Classes/rlsslides.pdf
     """
 
     def __init__(


### PR DESCRIPTION
When working on fixing a couple of issues in `RidgeCV` (eg. https://github.com/scikit-learn/scikit-learn/pull/29634), we find out that it is not particularly easy to understand the different code path and what is `_RidgeGCV` without going into details in the maths of the references.

I'm trying to provide a higher level explanation in the docstring of `_RidgeGCV` to have a quick overview of what is going on.