### PR TITLE
TST remove unnecessary check from check_classifiers_predictions

### DIFF
--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -182,7 +182,7 @@ INIT_PARAMS = {
     DictionaryLearning: dict(max_iter=20, transform_algorithm="lasso_lars"),
     # the default strategy prior would output constant predictions and fail
     # for check_classifiers_predictions
-    DummyClassifier: dict(strategy="stratified"),
+    DummyClassifier: [dict(strategy="stratified"), dict(strategy="most_frequent")],
     ElasticNetCV: dict(max_iter=5, cv=3),
     ElasticNet: dict(max_iter=5),
     ExtraTreesClassifier: dict(n_estimators=5),

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2842,12 +2842,6 @@ def check_classifiers_predictions(X, y, name, classifier_orig):
                 ),
             )
 
-    # training set performance
-    if name != "ComplementNB":
-        # This is a pathological data set for ComplementNB.
-        # For some specific cases 'ComplementNB' predicts less classes
-        # than expected
-        assert_array_equal(np.unique(y), np.unique(y_pred))
     assert_array_equal(
         classes,
         classifier.classes_,


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/21921

The check was related to performance, which is tested in other places, and this was the only thing failing with `DummyClassifier(strategy="most_frequent")`.

cc @ogrisel @glemaitre since you talked about this on the issue.