### PR TITLE
TST cleanup check_non_transformer_estimators_n_iter

### DIFF
--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -722,6 +722,13 @@ class PLSRegression(_PLS):
         self.y_scores_ = self._y_scores
         return self
 
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags._xfail_checks.update(
+            {"check_non_transformer_estimators_n_iter": "Test doesn't apply."}
+        )
+        return tags
+
 
 class PLSCanonical(_PLS):
     """Partial Least Squares transformer and regressor.
@@ -855,6 +862,13 @@ class PLSCanonical(_PLS):
             copy=copy,
         )
 
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags._xfail_checks.update(
+            {"check_non_transformer_estimators_n_iter": "Test doesn't apply."}
+        )
+        return tags
+
 
 class CCA(_PLS):
     """Canonical Correlation Analysis, also known as "Mode B" PLS.
@@ -964,6 +978,13 @@ class CCA(_PLS):
             tol=tol,
             copy=copy,
         )
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags._xfail_checks.update(
+            {"check_non_transformer_estimators_n_iter": "Test doesn't apply."}
+        )
+        return tags
 
 
 class PLSSVD(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
@@ -1176,3 +1197,10 @@ class PLSSVD(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
             `(X_transformed, Y_transformed)` otherwise.
         """
         return self.fit(X, y).transform(X, y)
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags._xfail_checks.update(
+            {"check_non_transformer_estimators_n_iter": "Test doesn't apply."}
+        )
+        return tags

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -722,13 +722,6 @@ class PLSRegression(_PLS):
         self.y_scores_ = self._y_scores
         return self
 
-    def __sklearn_tags__(self):
-        tags = super().__sklearn_tags__()
-        tags._xfail_checks.update(
-            {"check_non_transformer_estimators_n_iter": "Test doesn't apply."}
-        )
-        return tags
-
 
 class PLSCanonical(_PLS):
     """Partial Least Squares transformer and regressor.
@@ -862,13 +855,6 @@ class PLSCanonical(_PLS):
             copy=copy,
         )
 
-    def __sklearn_tags__(self):
-        tags = super().__sklearn_tags__()
-        tags._xfail_checks.update(
-            {"check_non_transformer_estimators_n_iter": "Test doesn't apply."}
-        )
-        return tags
-
 
 class CCA(_PLS):
     """Canonical Correlation Analysis, also known as "Mode B" PLS.
@@ -978,13 +964,6 @@ class CCA(_PLS):
             tol=tol,
             copy=copy,
         )
-
-    def __sklearn_tags__(self):
-        tags = super().__sklearn_tags__()
-        tags._xfail_checks.update(
-            {"check_non_transformer_estimators_n_iter": "Test doesn't apply."}
-        )
-        return tags
 
 
 class PLSSVD(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
@@ -1197,10 +1176,3 @@ class PLSSVD(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
             `(X_transformed, Y_transformed)` otherwise.
         """
         return self.fit(X, y).transform(X, y)
-
-    def __sklearn_tags__(self):
-        tags = super().__sklearn_tags__()
-        tags._xfail_checks.update(
-            {"check_non_transformer_estimators_n_iter": "Test doesn't apply."}
-        )
-        return tags

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1458,6 +1458,17 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
         """
         return np.log(self.predict_proba(X))
 
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags._xfail_checks.update(
+            {
+                "check_non_transformer_estimators_n_iter": (
+                    "n_iter_ cannot be easily accessed."
+                )
+            }
+        )
+        return tags
+
 
 class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstimator):
     """Logistic Regression CV (aka logit, MaxEnt) classifier.

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1251,6 +1251,13 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.array_api_support = True
+        tags._xfail_checks.update(
+            {
+                "check_non_transformer_estimators_n_iter": (
+                    "n_iter_ cannot be easily accessed."
+                )
+            }
+        )
         return tags
 
 
@@ -1567,6 +1574,17 @@ class RidgeClassifier(_RidgeClassifierMixin, _BaseRidge):
 
         super().fit(X, Y, sample_weight=sample_weight)
         return self
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags._xfail_checks.update(
+            {
+                "check_non_transformer_estimators_n_iter": (
+                    "n_iter_ cannot be easily accessed."
+                )
+            }
+        )
+        return tags
 
 
 def _check_gcv_mode(X, gcv_mode):

--- a/sklearn/semi_supervised/_self_training.py
+++ b/sklearn/semi_supervised/_self_training.py
@@ -632,3 +632,10 @@ class SelfTrainingClassifier(MetaEstimatorMixin, BaseEstimator):
             ),
         )
         return router
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags._xfail_checks.update(
+            {"check_non_transformer_estimators_n_iter": "n_iter_ can be 0."}
+        )
+        return tags

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -355,6 +355,9 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
             "check_sample_weights_invariance": (
                 "zero sample_weight is not equivalent to removing samples"
             ),
+            "check_non_transformer_estimators_n_iter": (
+                "n_iter_ cannot be easily accessed."
+            ),
         }
         return tags
 

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -498,6 +498,7 @@ PER_ESTIMATOR_CHECK_PARAMS: dict = {
     Isomap: {"check_dict_unchanged": dict(n_components=1)},
     KMeans: {"check_dict_unchanged": dict(max_iter=5, n_clusters=1, n_init=2)},
     KernelPCA: {"check_dict_unchanged": dict(n_components=1)},
+    LassoLars: {"check_non_transformer_estimators_n_iter": dict(alpha=0.0)},
     LatentDirichletAllocation: {
         "check_dict_unchanged": dict(batch_size=10, max_iter=5, n_components=1)
     },

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -3486,19 +3486,23 @@ def check_non_transformer_estimators_n_iter(name, estimator_orig):
     # Test that estimators that are not transformers with a parameter
     # max_iter, return the attribute of n_iter_ at least 1.
 
+    if not hasattr(estimator_orig, "max_iter"):
+        return
+
     estimator = clone(estimator_orig)
-    if hasattr(estimator, "max_iter"):
-        iris = load_iris()
-        X, y_ = iris.data, iris.target
-        y_ = _enforce_estimator_tags_y(estimator, y_)
+    iris = load_iris()
+    X, y_ = iris.data, iris.target
+    y_ = _enforce_estimator_tags_y(estimator, y_)
+    set_random_state(estimator, 0)
+    X = _enforce_estimator_tags_X(estimator_orig, X)
 
-        set_random_state(estimator, 0)
+    estimator.fit(X, y_)
 
-        X = _enforce_estimator_tags_X(estimator_orig, X)
-
-        estimator.fit(X, y_)
-
-        assert np.all(estimator.n_iter_ >= 1)
+    assert np.all(np.asarray(estimator.n_iter_) >= 1), (
+        "Estimators with a `max_iter` parameter, should expose an `n_iter_` attribute,"
+        " indicating the number of iterations that were executed. The values in the "
+        "`n_iter_` attribute should be greater or equal to 1."
+    )
 
 
 @ignore_warnings(category=FutureWarning)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -273,7 +273,6 @@ def _yield_transformer_checks(transformer):
         "Isomap",
         "KernelPCA",
         "LocallyLinearEmbedding",
-        "RandomizedLasso",
         "LogisticRegressionCV",
         "BisectingKMeans",
     ]
@@ -3487,30 +3486,7 @@ def check_non_transformer_estimators_n_iter(name, estimator_orig):
     # Test that estimators that are not transformers with a parameter
     # max_iter, return the attribute of n_iter_ at least 1.
 
-    # These models are dependent on external solvers like
-    # libsvm and accessing the iter parameter is non-trivial.
-    # SelfTrainingClassifier does not perform an iteration if all samples are
-    # labeled, hence n_iter_ = 0 is valid.
-    not_run_check_n_iter = [
-        "Ridge",
-        "RidgeClassifier",
-        "RandomizedLasso",
-        "LogisticRegressionCV",
-        "LinearSVC",
-        "LogisticRegression",
-        "SelfTrainingClassifier",
-    ]
-
-    # Tested in test_transformer_n_iter
-    not_run_check_n_iter += CROSS_DECOMPOSITION
-    if name in not_run_check_n_iter:
-        return
-
-    # LassoLars stops early for the default alpha=1.0 the iris dataset.
-    if name == "LassoLars":
-        estimator = clone(estimator_orig).set_params(alpha=0.0)
-    else:
-        estimator = clone(estimator_orig)
+    estimator = clone(estimator_orig)
     if hasattr(estimator, "max_iter"):
         iris = load_iris()
         X, y_ = iris.data, iris.target


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/14712

This cleans up `check_non_transformer_estimators_n_iter`. The test is a bit odd, since it kinda enforces a somewhat loose API, but it can be skipped I guess.

cc @Charlie-XIAO @glemaitre 