### PR TITLE
FIX RidgeCV works with multioutput and sample-weight non-default score

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2248,12 +2248,7 @@ class _RidgeGCV(LinearModel):
                     ]
                 )
             else:
-                _score = scorer(
-                    identity_estimator,
-                    predictions.ravel(),
-                    y.ravel(),
-                    **score_params,
-                )
+                _score = scorer(identity_estimator, predictions, y, **score_params)
 
         return _score
 

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -2252,6 +2252,16 @@ def test_ridge_cv_values_deprecated():
         ridge.cv_values_
 
 
+def test_ridge_cv_multioutput_sample_weight():
+    """Check that `RidgeCV` works properly with multioutput and sample_weight
+    when `scoring != None`."""
+    X, y = make_regression(n_targets=2, random_state=42)
+    sample_weight = np.ones(shape=(X.shape[0],))
+
+    ridge_cv = RidgeCV(scoring="neg_mean_squared_error")
+    ridge_cv.fit(X, y, sample_weight=sample_weight)
+
+
 # Metadata Routing Tests
 # ======================
 


### PR DESCRIPTION
This PR is fixing the following case:

- `RidgeCV` with `scoring != None`
- Passing some `sample_weight`
- `y` should be multioutput

As stated in https://github.com/scikit-learn/scikit-learn/pull/29842#issuecomment-2357004519, there is a bug. Previous to metadata routing, we did not use `sample_weight` for the scoring and we never encounter this bug.