### PR TITLE
Fix package name for sklearn-doc in Debian/Ubuntu

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -255,14 +255,14 @@ Debian/Ubuntu
 
 The Debian/Ubuntu package is split in three different packages called
 ``python3-sklearn`` (python modules), ``python3-sklearn-lib`` (low-level
-implementations and bindings), ``python3-sklearn-doc`` (documentation).
+implementations and bindings), ``python-sklearn-doc`` (documentation).
 Note that scikit-learn requires Python 3, hence the need to use the `python3-`
 suffixed package names.
 Packages can be installed using ``apt-get``:
 
 .. prompt:: bash
 
-  sudo apt-get install python3-sklearn python3-sklearn-lib python3-sklearn-doc
+  sudo apt-get install python3-sklearn python3-sklearn-lib python-sklearn-doc
 
 
 Fedora


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Remove "3" from package-name, as the documentation-package is just called ``python-sklearn-doc`` in Debian and Ubuntu.

#### Any other comments?

Minor issue
