### PR TITLE
MAINT redirect the URL of the machine learning map

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -436,6 +436,7 @@ redirects = {
     "contents": "index",
     "preface": "index",
     "modules/classes": "api/index",
+    "tutorial/machine_learning_map/index": "machine_learning_map",
     "auto_examples/feature_selection/plot_permutation_test_for_classification": (
         "auto_examples/model_selection/plot_permutation_tests_for_classification"
     ),


### PR DESCRIPTION
Currently, Google is still reporting the address of the machine learning map to: https://scikit-learn.org/stable/tutorial/machine_learning_map/index.html

This page has moved to: https://scikit-learn.org/stable/machine_learning_map.html

Since the machine learning map is one the most visited entry point, I think that we should make a redirection.