### PR TITLE
ENH make check_is_fitted to always pass on stateless estimators

### DIFF
--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -353,6 +353,11 @@ Changelog
   calling :func:`utils.validation.check_non_negative`.
   :pr:`29540` by :user:`Tamara Atanasoska <tamaraatanasoska>`.
 
+- |Enhancement| :func:`utils.validation.check_is_fitted` now passes on stateless
+  estimators. An estimator can indicate it's stateless by setting the `requires_fit`
+  tag. See :ref:`estimator_tags` for more information.
+  :pr:`29880` by `Adrin Jalali`_.
+
 - |API| the `assert_all_finite` parameter of functions :func:`utils.check_array`,
   :func:`utils.check_X_y`, :func:`utils.as_float_array` is renamed into
   `ensure_all_finite`. `force_all_finite` will be removed in 1.8.

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -863,7 +863,10 @@ class OneToOneFeatureMixin:
         feature_names_out : ndarray of str objects
             Same as input features.
         """
-        check_is_fitted(self, "n_features_in_")
+        # Note that passing attributes="n_features_in_" forces check_is_fitted
+        # to check if the attribute is present. Otherwise it will pass on
+        # stateless estimators (requires_fit=False)
+        check_is_fitted(self, attributes="n_features_in_")
         return _check_feature_names_in(self, input_features)
 
 

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -747,7 +747,10 @@ class AdditiveChi2Sampler(TransformerMixin, BaseEstimator):
         feature_names_out : ndarray of str objects
             Transformed feature names.
         """
-        check_is_fitted(self, "n_features_in_")
+        # Note that passing attributes="n_features_in_" forces check_is_fitted
+        # to check if the attribute is present. Otherwise it will pass on this
+        # stateless estimator (requires_fit=False)
+        check_is_fitted(self, attributes="n_features_in_")
         input_features = _check_feature_names_in(
             self, input_features, generate_names=True
         )

--- a/sklearn/utils/_tags.py
+++ b/sklearn/utils/_tags.py
@@ -180,6 +180,8 @@ class RegressorTags:
 class Tags:
     """Tags for the estimator.
 
+    See :ref:`estimator_tags` for more information.
+
     Parameters
     ----------
     target_tags : :class:`TargetTags`

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -894,6 +894,21 @@ def test_check_is_fitted_with_is_fitted():
     check_is_fitted(Estimator().fit())
 
 
+def test_check_is_fitted_stateless():
+    """Check that check_is_fitted passes for stateless estimators."""
+
+    class StatelessEstimator(BaseEstimator):
+        def fit(self, **kwargs):
+            return self  # pragma: no cover
+
+        def __sklearn_tags__(self):
+            tags = super().__sklearn_tags__()
+            tags.requires_fit = False
+            return tags
+
+    check_is_fitted(StatelessEstimator())
+
+
 def test_check_is_fitted():
     # Check is TypeError raised when non estimator instance passed
     with pytest.raises(TypeError):

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1656,13 +1656,17 @@ def check_is_fitted(estimator, attributes=None, *, msg=None, all_or_any=all):
 
     Checks if the estimator is fitted by verifying the presence of
     fitted attributes (ending with a trailing underscore) and otherwise
-    raises a NotFittedError with the given message.
+    raises a :class:`~sklearn.exceptions.NotFittedError` with the given message.
 
     If an estimator does not set any attributes with a trailing underscore, it
     can define a ``__sklearn_is_fitted__`` method returning a boolean to
     specify if the estimator is fitted or not. See
     :ref:`sphx_glr_auto_examples_developing_estimators_sklearn_is_fitted.py`
     for an example on how to use the API.
+
+    This fuction will pass if an estimator is stateless. An estimator can indicate it's
+    stateless by setting the `requires_fit` tag. See :ref:`estimator_tags` for more
+    information.
 
     Parameters
     ----------
@@ -1723,6 +1727,11 @@ def check_is_fitted(estimator, attributes=None, *, msg=None, all_or_any=all):
 
     if not hasattr(estimator, "fit"):
         raise TypeError("%s is not an estimator instance." % (estimator))
+
+    tags = get_tags(estimator)
+
+    if not tags.requires_fit:
+        return
 
     if not _is_fitted(estimator, attributes, all_or_any):
         raise NotFittedError(msg % {"name": type(estimator).__name__})

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1664,9 +1664,10 @@ def check_is_fitted(estimator, attributes=None, *, msg=None, all_or_any=all):
     :ref:`sphx_glr_auto_examples_developing_estimators_sklearn_is_fitted.py`
     for an example on how to use the API.
 
-    This fuction will pass if an estimator is stateless. An estimator can indicate it's
-    stateless by setting the `requires_fit` tag. See :ref:`estimator_tags` for more
-    information.
+    If no `attributes` are passed, this fuction will pass if an estimator is stateless.
+    An estimator can indicate it's stateless by setting the `requires_fit` tag. See
+    :ref:`estimator_tags` for more information. Note that the `requires_fit` tag
+    is ignored if `attributes` are passed.
 
     Parameters
     ----------
@@ -1730,7 +1731,7 @@ def check_is_fitted(estimator, attributes=None, *, msg=None, all_or_any=all):
 
     tags = get_tags(estimator)
 
-    if not tags.requires_fit:
+    if not tags.requires_fit and attributes is None:
         return
 
     if not _is_fitted(estimator, attributes, all_or_any):


### PR DESCRIPTION
This makes `check_is_fitted` pass on stateless estimators.

cc @glemaitre @OmarManzoor 