### PR TITLE
TST check that we support multioutput custom scorer in RidgeCV

### DIFF
--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -257,6 +257,11 @@ Changelog
   for the calculation of test scores.
   :pr:`29419` by :user:`Shruti Nath <snath-xoc>`.
 
+- |Fix| :class:`linear_model.RidgeCV` supports properly custom multioutput scorers by
+  letting the scorer managing the multioutput averaging. Previously, the predictions
+  and true targets where both squeezed to a 1d array before computing the error.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 - |API| Deprecates `copy_X` in :class:`linear_model.TheilSenRegressor` as the parameter
   has no effect. `copy_X` will be removed in 1.8.
   :pr:`29105` by :user:`Adam Li <adam2392>`.

--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -260,7 +260,7 @@ Changelog
 - |Fix| :class:`linear_model.RidgeCV` supports properly custom multioutput scorers by
   letting the scorer managing the multioutput averaging. Previously, the predictions
   and true targets where both squeezed to a 1d array before computing the error.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`.
+  :pr:`29884` by :user:`Guillaume Lemaitre <glemaitre>`.
 
 - |API| Deprecates `copy_X` in :class:`linear_model.TheilSenRegressor` as the parameter
   has no effect. `copy_X` will be removed in 1.8.


### PR DESCRIPTION
This is a follow-up of #29877 that is adding a test and an entry in the changelog to acknowledge a potential bug.

I raised the point here: https://github.com/scikit-learn/scikit-learn/pull/29877#issuecomment-2357652893