### PR TITLE
MAINT remove wrong redirection machine learning map

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -463,7 +463,6 @@ redirects = {
     "auto_examples/exercises/plot_cv_digits.py": (
         "auto_examples/model_selection/plot_nested_cross_validation_iris.py"
     ),
-    "tutorial/machine_learning_map/index.html": "machine_learning_map/index.html",
 }
 html_context["redirects"] = redirects
 for old_link in redirects:


### PR DESCRIPTION
While proposing #29879, I missed that one of the current redirection was intending already to redirect the machine learning map webpage. However, the link is not proper (it should not include ".html"). So we can remove it and backport this PR for 1.5.X.