### PR TITLE
Fix ImportError: add InconsistentVersionWarning to __all__ in exception.py

### DIFF
--- a/sklearn/exceptions.py
+++ b/sklearn/exceptions.py
@@ -14,6 +14,7 @@ __all__ = [
     "UndefinedMetricWarning",
     "PositiveSpectrumWarning",
     "UnsetMetadataPassedError",
+    "InconsistentVersionWarning",
 ]
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #29902 

#### Changes Explained
This PR fixes an `ImportError` where `InconsistentVersionWarning` could not be imported from sklearn.exceptions. The issue occurred because `InconsistentVersionWarning` was not included in the `__all__` list in the `exceptions.py` module.

To fix this, I have added `InconsistentVersionWarning` to the `__all__` list, ensuring that it can be imported correctly.
