### PR TITLE
MAINT Clean up deprecations for 1.6: in AgglomerativeClustering

### DIFF
--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -803,9 +803,6 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
 
         .. versionadded:: 1.2
 
-        .. versionchanged:: 1.6
-           `metric=None` is no longer valid.
-
     memory : str or object with the joblib.Memory interface, default=None
         Used to cache the output of the computation of the tree.
         By default, no caching is done. If a string is given, it is the

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -803,9 +803,8 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
 
         .. versionadded:: 1.2
 
-        .. deprecated:: 1.4
-           `metric=None` is deprecated in 1.4 and will be removed in 1.6.
-           Let `metric` be the default value (i.e. `"euclidean"`) instead.
+        .. versionchanged:: 1.6
+           `metric=None` is no longer valid.
 
     memory : str or object with the joblib.Memory interface, default=None
         Used to cache the output of the computation of the tree.
@@ -939,7 +938,6 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
         "metric": [
             StrOptions(set(_VALID_METRICS) | {"precomputed"}),
             callable,
-            Hidden(None),
         ],
         "memory": [str, HasMethods("cache"), None],
         "connectivity": ["array-like", "sparse matrix", callable, None],
@@ -1008,20 +1006,6 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
         """
         memory = check_memory(self.memory)
 
-        # TODO(1.6): remove in 1.6
-        if self.metric is None:
-            warnings.warn(
-                (
-                    "`metric=None` is deprecated in version 1.4 and will be removed in "
-                    "version 1.6. Let `metric` be the default value "
-                    "(i.e. `'euclidean'`) instead."
-                ),
-                FutureWarning,
-            )
-            self._metric = "euclidean"
-        else:
-            self._metric = self.metric
-
         if not ((self.n_clusters is None) ^ (self.distance_threshold is None)):
             raise ValueError(
                 "Exactly one of n_clusters and "
@@ -1034,9 +1018,9 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
                 "compute_full_tree must be True if distance_threshold is set."
             )
 
-        if self.linkage == "ward" and self._metric != "euclidean":
+        if self.linkage == "ward" and self.metric != "euclidean":
             raise ValueError(
-                f"{self._metric} was provided as metric. Ward can only "
+                f"{self.metric} was provided as metric. Ward can only "
                 "work with euclidean distances."
             )
 
@@ -1070,7 +1054,7 @@ class AgglomerativeClustering(ClusterMixin, BaseEstimator):
         kwargs = {}
         if self.linkage != "ward":
             kwargs["linkage"] = self.linkage
-            kwargs["affinity"] = self._metric
+            kwargs["affinity"] = self.metric
 
         distance_threshold = self.distance_threshold
 

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -887,14 +887,3 @@ def test_precomputed_connectivity_metric_with_2_connected_components():
 
     assert_array_equal(clusterer.labels_, clusterer_precomputed.labels_)
     assert_array_equal(clusterer.children_, clusterer_precomputed.children_)
-
-
-# TODO(1.6): remove in 1.6
-@pytest.mark.parametrize(
-    "Agglomeration", [AgglomerativeClustering, FeatureAgglomeration]
-)
-def test_deprecation_warning_metric_None(Agglomeration):
-    X = np.array([[1, 2], [1, 4], [1, 0], [4, 2], [4, 4], [4, 0]])
-    warn_msg = "`metric=None` is deprecated in version 1.4 and will be removed"
-    with pytest.warns(FutureWarning, match=warn_msg):
-        Agglomeration(metric=None).fit(X)


### PR DESCRIPTION
removed deprecated `metric=None`.

I'm not sure what we want to do with the deprecated directive in the docstring. I changed it to a `versionchanged`. Should we just remove the directive ?