### PR TITLE
MAINT Clean up deprecations for 1.6: in HDBSCAN

### DIFF
--- a/sklearn/cluster/_hdbscan/hdbscan.py
+++ b/sklearn/cluster/_hdbscan/hdbscan.py
@@ -492,13 +492,11 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
         :class:`~sklearn.neighbors.BallTree`, then it resolves to use the
         `"brute"` algorithm.
 
-        .. deprecated:: 1.4
-           The `'kdtree'` option was deprecated in version 1.4,
-           and will be renamed to `'kd_tree'` in 1.6.
+        .. versionchanged:: 1.6
+           The `'kdtree'` option was renamed to `'kd_tree'`.
 
-        .. deprecated:: 1.4
-           The `'balltree'` option was deprecated in version 1.4,
-           and will be renamed to `'ball_tree'` in 1.6.
+        .. versionchanged:: 1.6
+           The `'balltree'` option was renamed to `'ball_tree'`.
 
     leaf_size : int, default=40
         Leaf size for trees responsible for fast nearest neighbour queries when
@@ -661,13 +659,7 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
         ],
         "metric_params": [dict, None],
         "alpha": [Interval(Real, left=0, right=None, closed="neither")],
-        # TODO(1.6): Remove "kdtree" and "balltree"  option
-        "algorithm": [
-            StrOptions(
-                {"auto", "brute", "kd_tree", "ball_tree", "kdtree", "balltree"},
-                deprecated={"kdtree", "balltree"},
-            ),
-        ],
+        "algorithm": [StrOptions({"auto", "brute", "kd_tree", "ball_tree"})],
         "leaf_size": [Interval(Integral, left=1, right=None, closed="left")],
         "n_jobs": [Integral, None],
         "cluster_selection_method": [StrOptions({"eom", "leaf"})],
@@ -805,30 +797,6 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
                 f"min_samples ({self._min_samples}) must be at most the number of"
                 f" samples in X ({X.shape[0]})"
             )
-
-        # TODO(1.6): Remove
-        if self.algorithm == "kdtree":
-            warn(
-                (
-                    "`algorithm='kdtree'`has been deprecated in 1.4 and will be renamed"
-                    " to'kd_tree'`in 1.6. To keep the past behaviour, set"
-                    " `algorithm='kd_tree'`."
-                ),
-                FutureWarning,
-            )
-            self.algorithm = "kd_tree"
-
-        # TODO(1.6): Remove
-        if self.algorithm == "balltree":
-            warn(
-                (
-                    "`algorithm='balltree'`has been deprecated in 1.4 and will be"
-                    " renamed to'ball_tree'`in 1.6. To keep the past behaviour, set"
-                    " `algorithm='ball_tree'`."
-                ),
-                FutureWarning,
-            )
-            self.algorithm = "ball_tree"
 
         mst_func = None
         kwargs = dict(

--- a/sklearn/cluster/_hdbscan/hdbscan.py
+++ b/sklearn/cluster/_hdbscan/hdbscan.py
@@ -492,12 +492,6 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
         :class:`~sklearn.neighbors.BallTree`, then it resolves to use the
         `"brute"` algorithm.
 
-        .. versionchanged:: 1.6
-           The `'kdtree'` option was renamed to `'kd_tree'`.
-
-        .. versionchanged:: 1.6
-           The `'balltree'` option was renamed to `'ball_tree'`.
-
     leaf_size : int, default=40
         Leaf size for trees responsible for fast nearest neighbour queries when
         a KDTree or a BallTree are used as core-distance algorithms. A large

--- a/sklearn/cluster/tests/test_hdbscan.py
+++ b/sklearn/cluster/tests/test_hdbscan.py
@@ -546,26 +546,6 @@ def test_labelling_thresholding():
     assert sum(num_noise) == sum(labels == -1)
 
 
-# TODO(1.6): Remove
-def test_hdbscan_warning_on_deprecated_algorithm_name():
-    # Test that warning message is shown when algorithm='kdtree'
-    msg = (
-        "`algorithm='kdtree'`has been deprecated in 1.4 and will be renamed"
-        " to'kd_tree'`in 1.6. To keep the past behaviour, set `algorithm='kd_tree'`."
-    )
-    with pytest.warns(FutureWarning, match=msg):
-        HDBSCAN(algorithm="kdtree").fit(X)
-
-    # Test that warning message is shown when algorithm='balltree'
-    msg = (
-        "`algorithm='balltree'`has been deprecated in 1.4 and will be renamed"
-        " to'ball_tree'`in 1.6. To keep the past behaviour, set"
-        " `algorithm='ball_tree'`."
-    )
-    with pytest.warns(FutureWarning, match=msg):
-        HDBSCAN(algorithm="balltree").fit(X)
-
-
 @pytest.mark.parametrize("store_centers", ["centroid", "medoid"])
 def test_hdbscan_error_precomputed_and_store_centers(store_centers):
     """Check that we raise an error if the centers are requested together with


### PR DESCRIPTION
removed deprecated (renamed) `kdtree` and `balltree` algorithm options.