### PR TITLE
MAINT Clean up deprecations for 1.6: in MiniBatchDictionaryLearning

### DIFF
--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -728,9 +728,6 @@ def dict_learning_online(
 
         .. versionadded:: 1.1
 
-        .. versionchanged:: 1.6
-           `max_iter=None` is no longer valid.
-
     return_code : bool, default=True
         Whether to also return the code U or just the dictionary `V`.
 
@@ -1728,9 +1725,6 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
         stopping independently of any early stopping criterion heuristics.
 
         .. versionadded:: 1.1
-
-        .. versionchanged:: 1.6
-           `max_iter=None` is no longer valid.
 
     fit_algorithm : {'lars', 'cd'}, default='lars'
         The algorithm used:

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -7,7 +7,6 @@ import itertools
 import sys
 import time
 from numbers import Integral, Real
-from warnings import warn
 
 import numpy as np
 from joblib import effective_n_jobs
@@ -21,7 +20,7 @@ from ..base import (
 )
 from ..linear_model import Lars, Lasso, LassoLars, orthogonal_mp_gram
 from ..utils import check_array, check_random_state, gen_batches, gen_even_slices
-from ..utils._param_validation import Hidden, Interval, StrOptions, validate_params
+from ..utils._param_validation import Interval, StrOptions, validate_params
 from ..utils.extmath import randomized_svd, row_norms, svd_flip
 from ..utils.parallel import Parallel, delayed
 from ..utils.validation import check_is_fitted, validate_data
@@ -729,9 +728,8 @@ def dict_learning_online(
 
         .. versionadded:: 1.1
 
-        .. deprecated:: 1.4
-           `max_iter=None` is deprecated in 1.4 and will be removed in 1.6.
-           Use the default value (i.e. `100`) instead.
+        .. versionchanged:: 1.6
+           `max_iter=None` is no longer valid.
 
     return_code : bool, default=True
         Whether to also return the code U or just the dictionary `V`.
@@ -857,17 +855,6 @@ def dict_learning_online(
     >>> np.mean(np.sum((X_hat - X) ** 2, axis=1) / np.sum(X ** 2, axis=1))
     np.float64(0.05...)
     """
-    # TODO(1.6): remove in 1.6
-    if max_iter is None:
-        warn(
-            (
-                "`max_iter=None` is deprecated in version 1.4 and will be removed in "
-                "version 1.6. Use the default value (i.e. `100`) instead."
-            ),
-            FutureWarning,
-        )
-        max_iter = 100
-
     transform_algorithm = "lasso_" + method
 
     est = MiniBatchDictionaryLearning(
@@ -1742,9 +1729,8 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
 
         .. versionadded:: 1.1
 
-        .. deprecated:: 1.4
-           `max_iter=None` is deprecated in 1.4 and will be removed in 1.6.
-           Use the default value (i.e. `1_000`) instead.
+        .. versionchanged:: 1.6
+           `max_iter=None` is no longer valid.
 
     fit_algorithm : {'lars', 'cd'}, default='lars'
         The algorithm used:
@@ -1926,7 +1912,7 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
     _parameter_constraints: dict = {
         "n_components": [Interval(Integral, 1, None, closed="left"), None],
         "alpha": [Interval(Real, 0, None, closed="left")],
-        "max_iter": [Interval(Integral, 0, None, closed="left"), Hidden(None)],
+        "max_iter": [Interval(Integral, 0, None, closed="left")],
         "fit_algorithm": [StrOptions({"cd", "lars"})],
         "n_jobs": [None, Integral],
         "batch_size": [Interval(Integral, 1, None, closed="left")],
@@ -2202,19 +2188,6 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
         )
         self._B = np.zeros((n_features, self._n_components), dtype=X_train.dtype)
 
-        # TODO(1.6): remove in 1.6
-        if self.max_iter is None:
-            warn(
-                (
-                    "`max_iter=None` is deprecated in version 1.4 and will be removed"
-                    " in version 1.6. Use the default value (i.e. `1_000`) instead."
-                ),
-                FutureWarning,
-            )
-            max_iter = 1_000
-        else:
-            max_iter = self.max_iter
-
         # Attributes to monitor the convergence
         self._ewa_cost = None
         self._ewa_cost_min = None
@@ -2223,7 +2196,7 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
         batches = gen_batches(n_samples, self._batch_size)
         batches = itertools.cycle(batches)
         n_steps_per_iter = int(np.ceil(n_samples / self._batch_size))
-        n_steps = max_iter * n_steps_per_iter
+        n_steps = self.max_iter * n_steps_per_iter
 
         i = -1  # to allow max_iter = 0
 

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -368,9 +368,8 @@ class MiniBatchSparsePCA(_BaseSparsePCA):
 
         .. versionadded:: 1.2
 
-        .. deprecated:: 1.4
-           `max_iter=None` is deprecated in 1.4 and will be removed in 1.6.
-           Use the default value (i.e. `100`) instead.
+        .. versionchanged:: 1.6
+           `max_iter=None` is no longer valid.
 
     callback : callable, default=None
         Callable that gets invoked every five iterations.
@@ -478,7 +477,7 @@ class MiniBatchSparsePCA(_BaseSparsePCA):
 
     _parameter_constraints: dict = {
         **_BaseSparsePCA._parameter_constraints,
-        "max_iter": [Interval(Integral, 0, None, closed="left"), Hidden(None)],
+        "max_iter": [Interval(Integral, 0, None, closed="left")],
         "callback": [None, callable],
         "batch_size": [Interval(Integral, 1, None, closed="left")],
         "shuffle": ["boolean"],

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -368,9 +368,6 @@ class MiniBatchSparsePCA(_BaseSparsePCA):
 
         .. versionadded:: 1.2
 
-        .. versionchanged:: 1.6
-           `max_iter=None` is no longer valid.
-
     callback : callable, default=None
         Callable that gets invoked every five iterations.
 

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -15,7 +15,7 @@ from ..base import (
 )
 from ..linear_model import ridge_regression
 from ..utils import check_random_state
-from ..utils._param_validation import Hidden, Interval, StrOptions
+from ..utils._param_validation import Interval, StrOptions
 from ..utils.extmath import svd_flip
 from ..utils.validation import check_array, check_is_fitted, validate_data
 from ._dict_learning import MiniBatchDictionaryLearning, dict_learning

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -972,12 +972,3 @@ def test_cd_work_on_joblib_memmapped_data(monkeypatch):
 
     # This must run and complete without error.
     dict_learner.fit(X_train)
-
-
-# TODO(1.6): remove in 1.6
-def test_xxx():
-    warn_msg = "`max_iter=None` is deprecated in version 1.4 and will be removed"
-    with pytest.warns(FutureWarning, match=warn_msg):
-        MiniBatchDictionaryLearning(max_iter=None, random_state=0).fit(X)
-    with pytest.warns(FutureWarning, match=warn_msg):
-        dict_learning_online(X, max_iter=None, random_state=0)

--- a/sklearn/decomposition/tests/test_sparse_pca.py
+++ b/sklearn/decomposition/tests/test_sparse_pca.py
@@ -272,18 +272,6 @@ def test_spca_feature_names_out(SPCA):
     assert_array_equal([f"{estimator_name}{i}" for i in range(4)], names)
 
 
-# TODO(1.6): remove in 1.6
-def test_spca_max_iter_None_deprecation():
-    """Check that we raise a warning for the deprecation of `max_iter=None`."""
-    rng = np.random.RandomState(0)
-    n_samples, n_features = 12, 10
-    X = rng.randn(n_samples, n_features)
-
-    warn_msg = "`max_iter=None` is deprecated in version 1.4 and will be removed"
-    with pytest.warns(FutureWarning, match=warn_msg):
-        MiniBatchSparsePCA(max_iter=None).fit(X)
-
-
 def test_spca_early_stopping(global_random_seed):
     """Check that `tol` and `max_no_improvement` act as early stopping."""
     rng = np.random.RandomState(global_random_seed)


### PR DESCRIPTION
removed `max_iter=None` from MiniBatchDictionaryLearning and related estimators/functions