### PR TITLE
MAINT Clean up deprecations for 1.6: in NMF

### DIFF
--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -24,7 +24,6 @@ from ..base import (
 from ..exceptions import ConvergenceWarning
 from ..utils import check_array, check_random_state, gen_batches, metadata_routing
 from ..utils._param_validation import (
-    Hidden,
     Interval,
     StrOptions,
     validate_params,
@@ -908,7 +907,7 @@ def non_negative_factorization(
     X,
     W=None,
     H=None,
-    n_components="warn",
+    n_components="auto",
     *,
     init=None,
     update_H=True,
@@ -978,14 +977,16 @@ def non_negative_factorization(
         If `update_H=False`, it is used as a constant, to solve for W only.
         If `None`, uses the initialisation method specified in `init`.
 
-    n_components : int or {'auto'} or None, default=None
-        Number of components, if n_components is not set all features
-        are kept.
+    n_components : int or {'auto'} or None, default='auto'
+        Number of components. If `None`, all features are kept.
         If `n_components='auto'`, the number of components is automatically inferred
         from `W` or `H` shapes.
 
         .. versionchanged:: 1.4
             Added `'auto'` value.
+
+        .. versionchanged:: 1.6
+            Default value changed from `None` to `'auto'`.
 
     init : {'random', 'nndsvd', 'nndsvda', 'nndsvdar', 'custom'}, default=None
         Method used to initialize the procedure.
@@ -1144,7 +1145,6 @@ class _BaseNMF(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator,
             Interval(Integral, 1, None, closed="left"),
             None,
             StrOptions({"auto"}),
-            Hidden(StrOptions({"warn"})),
         ],
         "init": [
             StrOptions({"random", "nndsvd", "nndsvda", "nndsvdar", "custom"}),
@@ -1165,7 +1165,7 @@ class _BaseNMF(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator,
 
     def __init__(
         self,
-        n_components="warn",
+        n_components="auto",
         *,
         init=None,
         beta_loss="frobenius",
@@ -1191,16 +1191,6 @@ class _BaseNMF(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator,
     def _check_params(self, X):
         # n_components
         self._n_components = self.n_components
-        if self.n_components == "warn":
-            warnings.warn(
-                (
-                    "The default value of `n_components` will change from `None` to"
-                    " `'auto'` in 1.6. Set the value of `n_components` to `None`"
-                    " explicitly to suppress the warning."
-                ),
-                FutureWarning,
-            )
-            self._n_components = None  # Keeping the old default value
         if self._n_components is None:
             self._n_components = X.shape[1]
 
@@ -1388,14 +1378,16 @@ class NMF(_BaseNMF):
 
     Parameters
     ----------
-    n_components : int or {'auto'} or None, default=None
-        Number of components, if n_components is not set all features
-        are kept.
+    n_components : int or {'auto'} or None, default='auto'
+        Number of components. If `None`, all features are kept.
         If `n_components='auto'`, the number of components is automatically inferred
         from W or H shapes.
 
         .. versionchanged:: 1.4
             Added `'auto'` value.
+
+        .. versionchanged:: 1.6
+            Default value changed from `None` to `'auto'`.
 
     init : {'random', 'nndsvd', 'nndsvda', 'nndsvdar', 'custom'}, default=None
         Method used to initialize the procedure.
@@ -1558,7 +1550,7 @@ class NMF(_BaseNMF):
 
     def __init__(
         self,
-        n_components="warn",
+        n_components="auto",
         *,
         init=None,
         solver="cd",
@@ -1826,14 +1818,16 @@ class MiniBatchNMF(_BaseNMF):
 
     Parameters
     ----------
-    n_components : int or {'auto'} or None, default=None
-        Number of components, if `n_components` is not set all features
-        are kept.
+    n_components : int or {'auto'} or None, default='auto'
+        Number of components. If `None`, all features are kept.
         If `n_components='auto'`, the number of components is automatically inferred
         from W or H shapes.
 
         .. versionchanged:: 1.4
             Added `'auto'` value.
+
+        .. versionchanged:: 1.6
+            Default value changed from `None` to `'auto'`.
 
     init : {'random', 'nndsvd', 'nndsvda', 'nndsvdar', 'custom'}, default=None
         Method used to initialize the procedure.
@@ -1998,7 +1992,7 @@ class MiniBatchNMF(_BaseNMF):
 
     def __init__(
         self,
-        n_components="warn",
+        n_components="auto",
         *,
         init=None,
         batch_size=1024,

--- a/sklearn/decomposition/tests/test_nmf.py
+++ b/sklearn/decomposition/tests/test_nmf.py
@@ -43,11 +43,9 @@ def test_initialize_nn_output():
         assert not ((W < 0).any() or (H < 0).any())
 
 
-# TODO(1.6): remove the warning filter for `n_components`
 @pytest.mark.filterwarnings(
     r"ignore:The multiplicative update \('mu'\) solver cannot update zeros present in"
     r" the initialization",
-    "ignore:The default value of `n_components` will change",
 )
 def test_parameter_checking():
     # Here we only check for invalid parameter values that are not already
@@ -270,8 +268,6 @@ def test_nmf_inverse_transform(solver):
     assert_array_almost_equal(A, A_new, decimal=2)
 
 
-# TODO(1.6): remove the warning filter
-@pytest.mark.filterwarnings("ignore:The default value of `n_components` will change")
 def test_mbnmf_inverse_transform():
     # Test that MiniBatchNMF.transform followed by MiniBatchNMF.inverse_transform
     # is close to the identity
@@ -349,8 +345,6 @@ def test_nmf_sparse_transform(Estimator, solver, csc_container):
     assert_allclose(A_fit_tr, A_tr, atol=1e-1)
 
 
-# TODO(1.6): remove the warning filter
-@pytest.mark.filterwarnings("ignore:The default value of `n_components` will change")
 @pytest.mark.parametrize("init", ["random", "nndsvd"])
 @pytest.mark.parametrize("solver", ("cd", "mu"))
 @pytest.mark.parametrize("alpha_W", (0.0, 1.0))
@@ -621,8 +615,6 @@ def test_nmf_negative_beta_loss(csr_container):
         _assert_nmf_no_nan(X_csr, beta_loss)
 
 
-# TODO(1.6): remove the warning filter
-@pytest.mark.filterwarnings("ignore:The default value of `n_components` will change")
 @pytest.mark.parametrize("beta_loss", [-0.5, 0.0])
 def test_minibatch_nmf_negative_beta_loss(beta_loss):
     """Check that an error is raised if beta_loss < 0 and X contains zeros."""
@@ -779,8 +771,6 @@ def test_nmf_underflow():
     assert_almost_equal(res, ref)
 
 
-# TODO(1.6): remove the warning filter
-@pytest.mark.filterwarnings("ignore:The default value of `n_components` will change")
 @pytest.mark.parametrize(
     "dtype_in, dtype_out",
     [
@@ -812,8 +802,6 @@ def test_nmf_dtype_match(Estimator, solver, dtype_in, dtype_out):
     assert nmf.components_.dtype == dtype_out
 
 
-# TODO(1.6): remove the warning filter
-@pytest.mark.filterwarnings("ignore:The default value of `n_components` will change")
 @pytest.mark.parametrize(
     ["Estimator", "solver"],
     [[NMF, {"solver": "cd"}], [NMF, {"solver": "mu"}], [MiniBatchNMF, {}]],
@@ -830,8 +818,6 @@ def test_nmf_float32_float64_consistency(Estimator, solver):
     assert_allclose(W32, W64, atol=1e-5)
 
 
-# TODO(1.6): remove the warning filter
-@pytest.mark.filterwarnings("ignore:The default value of `n_components` will change")
 @pytest.mark.parametrize("Estimator", [NMF, MiniBatchNMF])
 def test_nmf_custom_init_dtype_error(Estimator):
     # Check that an error is raise if custom H and/or W don't have the same
@@ -921,8 +907,6 @@ def test_feature_names_out():
     assert_array_equal([f"nmf{i}" for i in range(3)], names)
 
 
-# TODO(1.6): remove the warning filter
-@pytest.mark.filterwarnings("ignore:The default value of `n_components` will change")
 def test_minibatch_nmf_verbose():
     # Check verbose mode of MiniBatchNMF for better coverage.
     A = np.random.RandomState(0).random_sample((100, 10))
@@ -992,17 +976,6 @@ def test_nmf_non_negative_factorization_n_components_auto():
     )
     assert H.shape == H_init.shape
     assert W.shape == W_init.shape
-
-
-# TODO(1.6): remove
-def test_nmf_n_components_default_value_warning():
-    rng = np.random.RandomState(0)
-    X = rng.random_sample((6, 5))
-    H = rng.random_sample((2, 5))
-    with pytest.warns(
-        FutureWarning, match="The default value of `n_components` will change from"
-    ):
-        non_negative_factorization(X, H=H)
 
 
 def test_nmf_n_components_auto_no_h_update():


### PR DESCRIPTION
Changed default value of n_components from None to "auto" in NMF and related estimators/functions