### PR TITLE
FIX check_transformer_data_not_an_array for ColumnTransformer

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -1327,7 +1327,6 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             "check_estimators_nan_inf": "FIXME",
             "check_estimator_sparse_array": "FIXME",
             "check_estimator_sparse_matrix": "FIXME",
-            "check_transformer_data_not_an_array": "FIXME",
             "check_fit1d": "FIXME",
             "check_fit2d_predict1d": "FIXME",
             "check_complex_data": "FIXME",
@@ -1338,7 +1337,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
 
 def _check_X(X):
     """Use check_array only when necessary, e.g. on lists and other non-array-likes."""
-    if hasattr(X, "__array__") or hasattr(X, "__dataframe__") or sparse.issparse(X):
+    if (hasattr(X, "__array__") and hasattr(X, "shape")) or hasattr(X, "__dataframe__") or sparse.issparse(X):
         return X
     return check_array(X, ensure_all_finite="allow-nan", dtype=object)
 

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -1337,7 +1337,11 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
 
 def _check_X(X):
     """Use check_array only when necessary, e.g. on lists and other non-array-likes."""
-    if (hasattr(X, "__array__") and hasattr(X, "shape")) or hasattr(X, "__dataframe__") or sparse.issparse(X):
+    if (
+        (hasattr(X, "__array__") and hasattr(X, "shape"))
+        or hasattr(X, "__dataframe__")
+        or sparse.issparse(X)
+    ):
         return X
     return check_array(X, ensure_all_finite="allow-nan", dtype=object)
 

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -1327,7 +1327,6 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             "check_estimators_nan_inf": "FIXME",
             "check_estimator_sparse_array": "FIXME",
             "check_estimator_sparse_matrix": "FIXME",
-            "check_transformer_data_not_an_array": "FIXME",
             "check_fit1d": "FIXME",
             "check_fit2d_predict1d": "FIXME",
             "check_complex_data": "FIXME",
@@ -1338,7 +1337,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
 
 def _check_X(X):
     """Use check_array only when necessary, e.g. on lists and other non-array-likes."""
-    if hasattr(X, "__array__") or hasattr(X, "__dataframe__") or sparse.issparse(X):
+    if isinstance(X, np.ndarray) or hasattr(X, "__dataframe__") or sparse.issparse(X):
         return X
     return check_array(X, ensure_all_finite="allow-nan", dtype=object)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Removed the `_xfail.checks` from `ColumnTransformer` for the name of test `check_transformer_data_not_an_array`
by adding if `hasattr(X, shape)` to `_check_X`, after discussion with @glemaitre, @jeremiedbb 



#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
