### PR TITLE
DOC: make it explicit that `groups` is used to perform the split in `GridSearch CV`

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -908,7 +908,9 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             If a fit parameter is an array-like whose length is equal to
             `num_samples` then it will be split across CV groups along with `X`
             and `y`. For example, the :term:`sample_weight` parameter is split
-            because `len(sample_weights) = len(X)`.
+            because `len(sample_weights) = len(X)`. However, this behavior does
+            not apply to `groups` which is used *to perform the split* and determines
+            which samples are assigned to the same split.
 
         Returns
         -------

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -906,11 +906,13 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             and the CV splitter.
 
             If a fit parameter is an array-like whose length is equal to
-            `num_samples` then it will be split across CV groups along with `X`
-            and `y`. For example, the :term:`sample_weight` parameter is split
-            because `len(sample_weights) = len(X)`. However, this behavior does
-            not apply to `groups` which is used *to perform the split* and determines
-            which samples are assigned to the same split.
+            `num_samples` then it will be split by cross-validation along with
+            `X` and `y`. For example, the :term:`sample_weight` parameter is
+            split because `len(sample_weights) = len(X)`. However, this behavior
+            does not apply to `groups` which is passed to the splitter configured
+            via the `cv` parameter of the constructor. Thus, `groups` is used
+            *to perform the split* and determines which samples are
+            assigned to the each side of the a split.
 
         Returns
         -------


### PR DESCRIPTION
Closes #29917
Added a clarification about `groups` in `GridSearchCV.fit(X, y, groups=groups)`: the arg determines how the dataset is split.

