### PR TITLE
DOC Fixed Git Documentation Link

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -363,7 +363,7 @@ line
 
 .. topic:: Learning Git
 
-    The `Git documentation <https://git-scm.com/documentation>`_ and
+    The `Git documentation <https://git-scm.com/doc>`_ and
     http://try.github.io are excellent resources to get started with git,
     and understanding all of the commands shown here.
 


### PR DESCRIPTION
 noticed that the link was broken on this page: https://scikit-learn.org/dev/developers/contributing.html#how-to-contribute

under **"Learning Git"** section



@lesteve