### PR TITLE
MAINT Avoid RuntimeWarning about invalid value in cast

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -422,7 +422,7 @@ def _yield_masked_array_for_each_param(candidate_params):
 
         # Use one MaskedArray and mask all the places where the param is not
         # applicable for that candidate (which may not contain all the params).
-        ma = MaskedArray(np.empty(n_candidates), mask=True, dtype=arr_dtype)
+        ma = MaskedArray(np.empty(n_candidates, dtype=arr_dtype), mask=True)
         for index, value in param_result.items():
             # Setting the value at an index unmasks that index
             ma[index] = value

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -2864,3 +2864,11 @@ def test_yield_masked_array_for_each_param(candidate_params, expected):
         assert value.dtype == expected_value.dtype
         np.testing.assert_array_equal(value, expected_value)
         np.testing.assert_array_equal(value.mask, expected_value.mask)
+
+
+def test_yield_masked_array_no_runtime_warning():
+    # non-regression test for https://github.com/scikit-learn/scikit-learn/issues/29929
+    candidate_params = [{"param": i} for i in range(1000)]
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        list(_yield_masked_array_for_each_param(candidate_params))


### PR DESCRIPTION
Fix #29929.

I implemented my suggestion in https://github.com/scikit-learn/scikit-learn/issues/29929#issuecomment-2378979053 and added a simple unit test.

The unit test seems to fail on `main` consistently. Note that this relies on the values of `np.empty` so this is not fully deterministic but on my machine it seems like the following snippet consistently produces a warning:

```py
import numpy as np

np.empty(1000).astype(np.int64)
```

A more realistic snippet that gives the warning is below. On my machine this produces a RuntimeWarning roughly 3-4 times out of 10 but takes a lot longer than the unit test (each run takes maybe ~2 seconds).
 
```py
import numpy as np

from sklearn.linear_model import LogisticRegression
from sklearn.model_selection import GridSearchCV
from sklearn.datasets import make_classification

X, y = make_classification(n_samples=10)
lr = LogisticRegression()
grid = GridSearchCV(lr, cv=2, param_grid={'max_iter': range(40, 240)})
grid.fit(X, y)
```