### PR TITLE
MAINT Clean up deprecations for 1.6: log_logistic

### DIFF
--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -11,7 +11,6 @@ import numpy as np
 from scipy import linalg, sparse
 
 from ..utils._param_validation import Interval, StrOptions, validate_params
-from ..utils.deprecation import deprecated
 from ._array_api import _is_numpy_namespace, device, get_namespace
 from .sparsefuncs_fast import csr_row_norms
 from .validation import check_array, check_random_state
@@ -903,46 +902,6 @@ def svd_flip(u, v, u_based_decision=True):
             u *= signs[np.newaxis, :]
         v *= signs[:, np.newaxis]
     return u, v
-
-
-# TODO(1.6): remove
-@deprecated(  # type: ignore
-    "The function `log_logistic` is deprecated and will be removed in 1.6. "
-    "Use `-np.logaddexp(0, -x)` instead."
-)
-def log_logistic(X, out=None):
-    """Compute the log of the logistic function, ``log(1 / (1 + e ** -x))``.
-
-    This implementation is numerically stable and uses `-np.logaddexp(0, -x)`.
-
-    For the ordinary logistic function, use ``scipy.special.expit``.
-
-    Parameters
-    ----------
-    X : array-like of shape (M, N) or (M,)
-        Argument to the logistic function.
-
-    out : array-like of shape (M, N) or (M,), default=None
-        Preallocated output array.
-
-    Returns
-    -------
-    out : ndarray of shape (M, N) or (M,)
-        Log of the logistic function evaluated at every point in x.
-
-    Notes
-    -----
-    See the blog post describing this implementation:
-    http://fa.bianp.net/blog/2013/numerical-optimizers-for-logistic-regression/
-    """
-    X = check_array(X, dtype=np.float64, ensure_2d=False)
-
-    if out is None:
-        out = np.empty_like(X)
-
-    np.logaddexp(0, -X, out=out)
-    out *= -1
-    return out
 
 
 def softmax(X, copy=True):

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -6,7 +6,6 @@ import pytest
 from scipy import linalg, sparse
 from scipy.linalg import eigh
 from scipy.sparse.linalg import eigsh
-from scipy.special import expit
 
 from sklearn.datasets import make_low_rank_matrix, make_sparse_spd_matrix
 from sklearn.utils import gen_batches
@@ -27,7 +26,6 @@ from sklearn.utils.extmath import (
     _safe_accumulator_op,
     cartesian,
     density,
-    log_logistic,
     randomized_svd,
     row_norms,
     safe_sparse_dot,
@@ -670,22 +668,6 @@ def test_cartesian_mix_types(arrays, output_dtype):
     output = cartesian(arrays)
 
     assert output.dtype == output_dtype
-
-
-# TODO(1.6): remove this test
-def test_logistic_sigmoid():
-    # Check correctness and robustness of logistic sigmoid implementation
-    def naive_log_logistic(x):
-        return np.log(expit(x))
-
-    x = np.linspace(-2, 2, 50)
-    warn_msg = "`log_logistic` is deprecated and will be removed"
-    with pytest.warns(FutureWarning, match=warn_msg):
-        assert_array_almost_equal(log_logistic(x), naive_log_logistic(x))
-
-    extreme_x = np.array([-100.0, 100.0])
-    with pytest.warns(FutureWarning, match=warn_msg):
-        assert_array_almost_equal(log_logistic(extreme_x), [-100, 0])
 
 
 @pytest.fixture()


### PR DESCRIPTION
removed deprecated `log_logistic` function.