### PR TITLE
CI Use bot token for adding CUDA CI label

### DIFF
--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -6,10 +6,6 @@ on:
   schedule:
     - cron: '0 5 * * 1'
 
-# In order to add the "CUDA CI" label we need to have write permissions for PRs
-permissions:
-  pull-requests: write
-
 jobs:
   update_lock_files:
     if: github.repository == 'scikit-learn/scikit-learn'
@@ -66,7 +62,7 @@ jobs:
       - name: Trigger additional tests
         if: steps.cpr.outputs.pull-request-number != '' && matrix.name == 'array-api'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         run: |
           gh pr edit ${{steps.cpr.outputs.pull-request-number}} --add-label "CUDA CI"
 


### PR DESCRIPTION
Fix #29781

Together with adding scikit-learn-bot to the Contributor Experience (aka Triage) team.