### PR TITLE
DOC: add link plot stock market to manifold learning documentation

### DIFF
--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -108,6 +108,10 @@ from the data itself, without the use of predetermined classifications.
 * See :ref:`sphx_glr_auto_examples_manifold_plot_compare_methods.py` for an example of
   dimensionality reduction on a toy "S-curve" dataset.
 
+* See :ref:`sphx_glr_auto_examples_plot_stock_market.py` for an example of
+  Manifold learning to retrieve 2D embedding on stock market dataset.
+
+
 The manifold learning implementations available in scikit-learn are
 summarized below
 

--- a/doc/modules/manifold.rst
+++ b/doc/modules/manifold.rst
@@ -108,9 +108,9 @@ from the data itself, without the use of predetermined classifications.
 * See :ref:`sphx_glr_auto_examples_manifold_plot_compare_methods.py` for an example of
   dimensionality reduction on a toy "S-curve" dataset.
 
-* See :ref:`sphx_glr_auto_examples_plot_stock_market.py` for an example of
-  Manifold learning to retrieve 2D embedding on stock market dataset.
-
+* See :ref:`sphx_glr_auto_examples_applications_plot_stock_market.py` for an example of
+  using manifold learning to map the stock market structure based on historical stock
+  prices.
 
 The manifold learning implementations available in scikit-learn are
 summarized below


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

add link plot_stock_market towards -#26927
