### PR TITLE
DOC Remove mention of deprecated `multi_class` in `LogisticRegression`

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -1000,6 +1000,8 @@ logistic regression, see also `log-linear model
   | `ElasticNet`   | :math:`\frac{1 - \rho}{2}\|W\|_F^2 + \rho \|W\|_{1,1}`                           |
   +----------------+----------------------------------------------------------------------------------+
 
+.. _Logistic_regression_solvers:
+
 Solvers
 -------
 

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -1000,7 +1000,7 @@ logistic regression, see also `log-linear model
   | `ElasticNet`   | :math:`\frac{1 - \rho}{2}\|W\|_F^2 + \rho \|W\|_{1,1}`                           |
   +----------------+----------------------------------------------------------------------------------+
 
-.. _Logistic_regression_solvers:
+.. _logistic_regression_solvers:
 
 Solvers
 -------

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -937,7 +937,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
         .. seealso::
            Refer to the :ref:`User Guide <Logistic_regression>` for more
            information regarding :class:`LogisticRegression` and more specifically the
-           :ref:`Table <Logistic_regression_solvers>`
+           :ref:`Table <logistic_regression_solvers>`
            summarizing solver/penalty supports.
 
         .. versionadded:: 0.17

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -808,12 +808,6 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
     """
     Logistic Regression (aka logit, MaxEnt) classifier.
 
-    In the multiclass case, the training algorithm uses the one-vs-rest (OvR)
-    scheme if the 'multi_class' option is set to 'ovr', and uses the
-    cross-entropy loss if the 'multi_class' option is set to 'multinomial'.
-    (Currently the 'multinomial' option is supported only by the 'lbfgs',
-    'sag', 'saga' and 'newton-cg' solvers.)
-
     This class implements regularized logistic regression using the
     'liblinear' library, 'newton-cg', 'sag', 'saga' and 'lbfgs' solvers. **Note
     that regularization is applied by default**. It can handle both dense
@@ -826,6 +820,11 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
     supports both L1 and L2 regularization, with a dual formulation only for
     the L2 penalty. The Elastic-Net regularization is only supported by the
     'saga' solver.
+
+    For :term:`multiclass` problems, only 'newton-cg', 'sag', 'saga' and 'lbfgs'
+    handle multinomial loss. 'liblinear' and 'newton-cholesky' only handle binary
+    classification but can be extended to handle multiclass by using
+    :class:`~sklearn.multiclass.OneVsRestClassifier`.
 
     Read more in the :ref:`User Guide <logistic_regression>`.
 
@@ -904,11 +903,11 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
 
         - For small datasets, 'liblinear' is a good choice, whereas 'sag'
           and 'saga' are faster for large ones;
-        - For multiclass problems, only 'newton-cg', 'sag', 'saga' and
+        - For :term:`multiclass` problems, only 'newton-cg', 'sag', 'saga' and
           'lbfgs' handle multinomial loss;
         - 'liblinear' and 'newton-cholesky' can only handle binary classification
           by default. To apply a one-versus-rest scheme for the multiclass setting
-          one can wrapt it with the `OneVsRestClassifier`.
+          one can wrap it with the :class:`~sklearn.multiclass.OneVsRestClassifier`.
         - 'newton-cholesky' is a good choice for `n_samples` >> `n_features`,
           especially with one-hot encoded categorical features with rare
           categories. Be aware that the memory usage of this solver has a quadratic
@@ -936,9 +935,9 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
            a scaler from :mod:`sklearn.preprocessing`.
 
         .. seealso::
-           Refer to the User Guide for more information regarding
-           :class:`LogisticRegression` and more specifically the
-           :ref:`Table <Logistic_regression>`
+           Refer to the :ref:`User Guide <Logistic_regression>` for more
+           information regarding :class:`LogisticRegression` and more specifically the
+           :ref:`Table <Logistic_regression_solvers>`
            summarizing solver/penalty supports.
 
         .. versionadded:: 0.17
@@ -1550,7 +1549,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
           because it does not handle warm-starting.
         - 'liblinear' and 'newton-cholesky' can only handle binary classification
           by default. To apply a one-versus-rest scheme for the multiclass setting
-          one can wrapt it with the `OneVsRestClassifier`.
+          one can wrap it with the :class:`~sklearn.multiclass.OneVsRestClassifier`.
         - 'newton-cholesky' is a good choice for `n_samples` >> `n_features`,
           especially with one-hot encoded categorical features with rare
           categories. Be aware that the memory usage of this solver has a quadratic


### PR DESCRIPTION
#### Reference Issues/PRs
`multi_class` deprecated in #28703


#### What does this implement/fix? Explain your changes.
* Remove mention of deprecated `multi_class` in `LogisticRegression`. Also moves the section on multiclass down, as it seems to make sense to introduce the class first.
* Add some links to multiclass term, OvR class
* Amend (solver) 'Table' link to be directly to the section with the table

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
