### PR TITLE
MAINT Clean up deprecations for 1.6: fit_params

### DIFF
--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -79,6 +79,14 @@ def _check_params_groups_deprecation(fit_params, params, groups, version):
 
     params = {} if params is None else params
 
+    _check_groups_routing_disabled(groups)
+
+    return params
+
+
+# TODO(SLEP6): To be removed when set_config(enable_metadata_routing=False) is not
+# possible.
+def _check_groups_routing_disabled(groups):
     if groups is not None and _routing_enabled():
         raise ValueError(
             "`groups` can only be passed if metadata routing is not enabled via"
@@ -86,8 +94,6 @@ def _check_params_groups_deprecation(fit_params, params, groups, version):
             " enabled, pass `groups` alongside other metadata via the `params` argument"
             " instead."
         )
-
-    return params
 
 
 @validate_params(
@@ -107,7 +113,6 @@ def _check_params_groups_deprecation(fit_params, params, groups, version):
         "cv": ["cv_object"],
         "n_jobs": [Integral, None],
         "verbose": ["verbose"],
-        "fit_params": [dict, None],
         "params": [dict, None],
         "pre_dispatch": [Integral, str],
         "return_train_score": ["boolean"],
@@ -127,7 +132,6 @@ def cross_validate(
     cv=None,
     n_jobs=None,
     verbose=0,
-    fit_params=None,
     params=None,
     pre_dispatch="2*n_jobs",
     return_train_score=False,
@@ -210,13 +214,6 @@ def cross_validate(
 
     verbose : int, default=0
         The verbosity level.
-
-    fit_params : dict, default=None
-        Parameters to pass to the fit method of the estimator.
-
-        .. deprecated:: 1.4
-            This parameter is deprecated and will be removed in version 1.6. Use
-            ``params`` instead.
 
     params : dict, default=None
         Parameters to pass to the underlying estimator's ``fit``, the scorer,
@@ -341,7 +338,7 @@ def cross_validate(
     >>> print(scores['train_r2'])
     [0.28009951 0.3908844  0.22784907]
     """
-    params = _check_params_groups_deprecation(fit_params, params, groups, "1.6")
+    _check_groups_routing_disabled(groups)
 
     X, y = indexable(X, y)
 
@@ -539,7 +536,6 @@ def _warn_or_raise_about_fit_failures(results, error_score):
         "cv": ["cv_object"],
         "n_jobs": [Integral, None],
         "verbose": ["verbose"],
-        "fit_params": [dict, None],
         "params": [dict, None],
         "pre_dispatch": [Integral, str, None],
         "error_score": [StrOptions({"raise"}), Real],
@@ -556,7 +552,6 @@ def cross_val_score(
     cv=None,
     n_jobs=None,
     verbose=0,
-    fit_params=None,
     params=None,
     pre_dispatch="2*n_jobs",
     error_score=np.nan,
@@ -629,13 +624,6 @@ def cross_val_score(
     verbose : int, default=0
         The verbosity level.
 
-    fit_params : dict, default=None
-        Parameters to pass to the fit method of the estimator.
-
-        .. deprecated:: 1.4
-            This parameter is deprecated and will be removed in version 1.6. Use
-            ``params`` instead.
-
     params : dict, default=None
         Parameters to pass to the underlying estimator's ``fit``, the scorer,
         and the CV splitter.
@@ -700,7 +688,6 @@ def cross_val_score(
         cv=cv,
         n_jobs=n_jobs,
         verbose=verbose,
-        fit_params=fit_params,
         params=params,
         pre_dispatch=pre_dispatch,
         error_score=error_score,
@@ -1024,7 +1011,6 @@ def _score(estimator, X_test, y_test, scorer, score_params, error_score="raise")
         "cv": ["cv_object"],
         "n_jobs": [Integral, None],
         "verbose": ["verbose"],
-        "fit_params": [dict, None],
         "params": [dict, None],
         "pre_dispatch": [Integral, str, None],
         "method": [
@@ -1049,7 +1035,6 @@ def cross_val_predict(
     cv=None,
     n_jobs=None,
     verbose=0,
-    fit_params=None,
     params=None,
     pre_dispatch="2*n_jobs",
     method="predict",
@@ -1123,13 +1108,6 @@ def cross_val_predict(
     verbose : int, default=0
         The verbosity level.
 
-    fit_params : dict, default=None
-        Parameters to pass to the fit method of the estimator.
-
-        .. deprecated:: 1.4
-            This parameter is deprecated and will be removed in version 1.6. Use
-            ``params`` instead.
-
     params : dict, default=None
         Parameters to pass to the underlying estimator's ``fit`` and the CV
         splitter.
@@ -1190,7 +1168,7 @@ def cross_val_predict(
     >>> lasso = linear_model.Lasso()
     >>> y_pred = cross_val_predict(lasso, X, y, cv=3)
     """
-    params = _check_params_groups_deprecation(fit_params, params, groups, "1.6")
+    _check_groups_routing_disabled(groups)
     X, y = indexable(X, y)
 
     if _routing_enabled():

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -2482,14 +2482,10 @@ def test_cross_validate_return_indices(global_random_seed):
 # ======================================================
 
 
-# TODO(1.6): remove `cross_validate` and `cross_val_predict` from this test in 1.6 and
-# `learning_curve` and `validation_curve` in 1.8
+# TODO(1.8): remove `learning_curve`, `validation_curve` and `permutation_test_score`.
 @pytest.mark.parametrize(
     "func, extra_args",
     [
-        (cross_validate, {}),
-        (cross_val_score, {}),
-        (cross_val_predict, {}),
         (learning_curve, {}),
         (permutation_test_score, {}),
         (validation_curve, {"param_name": "alpha", "param_range": np.array([1])}),


### PR DESCRIPTION
removed deprecated parameter `fit_params` of `cross_validate`, `cross_val_score` and `cross_val_predict`.