### PR TITLE
MAINT | API Clean up deprecations for 1.6: in make_scorer

### DIFF
--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -330,7 +330,7 @@ Changelog
 
 - |API| The default value of the `response_method` parameter of
   :func:`metrics.make_scorer` will change from `None` to `"predict"` and `None` will be
-  removed in 1.8.
+  removed in 1.8. In the mean time, `None` is equivalent to `"predict"`.
   :pr:`30001` by :user:`Jérémie du Boisberranger <jeremiedb>`.
 
 :mod:`sklearn.model_selection`

--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -328,6 +328,10 @@ Changelog
   will be returned when `multioutput=uniform_average`.
   :pr:`29709` by :user:`Virgil Chan <virchan>`.
 
+- |API| The default value of the `response_method` parameter of
+  :func:`metrics.make_scorer` will change from `None` to `"predict"` and `None` will be
+  removed in 1.8.
+  :pr:`30001` by :user:`Jérémie du Boisberranger <jeremiedb>`.
 
 :mod:`sklearn.model_selection`
 ..............................

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -28,7 +28,7 @@ import numpy as np
 
 from ..base import is_regressor
 from ..utils import Bunch
-from ..utils._param_validation import HasMethods, StrOptions, validate_params
+from ..utils._param_validation import HasMethods, Hidden, StrOptions, validate_params
 from ..utils._response import _get_response_values
 from ..utils.metadata_routing import (
     MetadataRequest,
@@ -620,12 +620,15 @@ def _get_response_method_name(response_method):
             list,
             tuple,
             StrOptions({"predict", "predict_proba", "decision_function"}),
+            Hidden(StrOptions({"default"})),
         ],
         "greater_is_better": ["boolean"],
     },
     prefer_skip_nested_validation=True,
 )
-def make_scorer(score_func, *, response_method=None, greater_is_better=True, **kwargs):
+def make_scorer(
+    score_func, *, response_method="default", greater_is_better=True, **kwargs
+):
     """Make a scorer from a performance metric or loss function.
 
     A scorer is a wrapper around an arbitrary metric or loss function that is called
@@ -692,11 +695,12 @@ def make_scorer(score_func, *, response_method=None, greater_is_better=True, **k
 
     if response_method is None:
         warnings.warn(
-            "The default value of response_method will change from None to 'predict' "
-            "in version 1.8 and None wont be a valid option anymore. Set "
-            "response_method='predict' to avoid this warning.",
+            "response_method=None is deprecated in version 1.6 and will be removed "
+            "in version 1.8. Leave it to its default value to avoid this warning.",
             FutureWarning,
         )
+        response_method = "predict"
+    elif response_method == "default":
         response_method = "predict"
 
     return _Scorer(score_func, sign, kwargs, response_method)

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -28,7 +28,7 @@ import numpy as np
 
 from ..base import is_regressor
 from ..utils import Bunch
-from ..utils._param_validation import HasMethods, Hidden, StrOptions, validate_params
+from ..utils._param_validation import HasMethods, StrOptions, validate_params
 from ..utils._response import _get_response_values
 from ..utils.metadata_routing import (
     MetadataRequest,
@@ -605,55 +605,6 @@ def _check_multimetric_scoring(estimator, scoring):
     return scorers
 
 
-def _get_response_method(response_method, needs_threshold, needs_proba):
-    """Handles deprecation of `needs_threshold` and `needs_proba` parameters in
-    favor of `response_method`.
-    """
-    needs_threshold_provided = needs_threshold != "deprecated"
-    needs_proba_provided = needs_proba != "deprecated"
-    response_method_provided = response_method is not None
-
-    needs_threshold = False if needs_threshold == "deprecated" else needs_threshold
-    needs_proba = False if needs_proba == "deprecated" else needs_proba
-
-    if response_method_provided and (needs_proba_provided or needs_threshold_provided):
-        raise ValueError(
-            "You cannot set both `response_method` and `needs_proba` or "
-            "`needs_threshold` at the same time. Only use `response_method` since "
-            "the other two are deprecated in version 1.4 and will be removed in 1.6."
-        )
-
-    if needs_proba_provided or needs_threshold_provided:
-        warnings.warn(
-            (
-                "The `needs_threshold` and `needs_proba` parameter are deprecated in "
-                "version 1.4 and will be removed in 1.6. You can either let "
-                "`response_method` be `None` or set it to `predict` to preserve the "
-                "same behaviour."
-            ),
-            FutureWarning,
-        )
-
-    if response_method_provided:
-        return response_method
-
-    if needs_proba is True and needs_threshold is True:
-        raise ValueError(
-            "You cannot set both `needs_proba` and `needs_threshold` at the same "
-            "time. Use `response_method` instead since the other two are deprecated "
-            "in version 1.4 and will be removed in 1.6."
-        )
-
-    if needs_proba is True:
-        response_method = "predict_proba"
-    elif needs_threshold is True:
-        response_method = ("decision_function", "predict_proba")
-    else:
-        response_method = "predict"
-
-    return response_method
-
-
 def _get_response_method_name(response_method):
     try:
         return response_method.__name__
@@ -671,20 +622,10 @@ def _get_response_method_name(response_method):
             StrOptions({"predict", "predict_proba", "decision_function"}),
         ],
         "greater_is_better": ["boolean"],
-        "needs_proba": ["boolean", Hidden(StrOptions({"deprecated"}))],
-        "needs_threshold": ["boolean", Hidden(StrOptions({"deprecated"}))],
     },
     prefer_skip_nested_validation=True,
 )
-def make_scorer(
-    score_func,
-    *,
-    response_method=None,
-    greater_is_better=True,
-    needs_proba="deprecated",
-    needs_threshold="deprecated",
-    **kwargs,
-):
+def make_scorer(score_func, *, response_method=None, greater_is_better=True, **kwargs):
     """Make a scorer from a performance metric or loss function.
 
     A scorer is a wrapper around an arbitrary metric or loss function that is called
@@ -719,39 +660,14 @@ def make_scorer(
 
         .. versionadded:: 1.4
 
+        .. deprecated:: 1.6
+            None is equivalent to 'predict' and is deprecated. It will be removed in
+            version 1.8.
+
     greater_is_better : bool, default=True
         Whether `score_func` is a score function (default), meaning high is
         good, or a loss function, meaning low is good. In the latter case, the
         scorer object will sign-flip the outcome of the `score_func`.
-
-    needs_proba : bool, default=False
-        Whether `score_func` requires `predict_proba` to get probability
-        estimates out of a classifier.
-
-        If True, for binary `y_true`, the score function is supposed to accept
-        a 1D `y_pred` (i.e., probability of the positive class, shape
-        `(n_samples,)`).
-
-        .. deprecated:: 1.4
-           `needs_proba` is deprecated in version 1.4 and will be removed in
-           1.6. Use `response_method="predict_proba"` instead.
-
-    needs_threshold : bool, default=False
-        Whether `score_func` takes a continuous decision certainty.
-        This only works for binary classification using estimators that
-        have either a `decision_function` or `predict_proba` method.
-
-        If True, for binary `y_true`, the score function is supposed to accept
-        a 1D `y_pred` (i.e., probability of the positive class or the decision
-        function, shape `(n_samples,)`).
-
-        For example `average_precision` or the area under the roc curve
-        can not be computed using discrete predictions alone.
-
-        .. deprecated:: 1.4
-           `needs_threshold` is deprecated in version 1.4 and will be removed
-           in 1.6. Use `response_method=("decision_function", "predict_proba")`
-           instead to preserve the same behaviour.
 
     **kwargs : additional arguments
         Additional parameters to be passed to `score_func`.
@@ -772,10 +688,17 @@ def make_scorer(
     >>> grid = GridSearchCV(LinearSVC(), param_grid={'C': [1, 10]},
     ...                     scoring=ftwo_scorer)
     """
-    response_method = _get_response_method(
-        response_method, needs_threshold, needs_proba
-    )
     sign = 1 if greater_is_better else -1
+
+    if response_method is None:
+        warnings.warn(
+            "The default value of response_method will change from None to 'predict' "
+            "in version 1.8 and None wont be a valid option anymore. Set "
+            "response_method='predict' to avoid this warning.",
+            FutureWarning,
+        )
+        response_method = "predict"
+
     return _Scorer(score_func, sign, kwargs, response_method)
 
 

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1428,84 +1428,6 @@ def test_make_scorer_repr(scorer, expected_repr):
     assert repr(scorer) == expected_repr
 
 
-# TODO(1.6): rework this test after the deprecation of `needs_proba` and
-# `needs_threshold`
-@pytest.mark.filterwarnings("ignore:.*needs_proba.*:FutureWarning")
-@pytest.mark.parametrize(
-    "params, err_type, err_msg",
-    [
-        # response_method should not be set if needs_* are set
-        (
-            {"response_method": "predict_proba", "needs_proba": True},
-            ValueError,
-            "You cannot set both `response_method`",
-        ),
-        (
-            {"response_method": "predict_proba", "needs_threshold": True},
-            ValueError,
-            "You cannot set both `response_method`",
-        ),
-        # cannot set both needs_proba and needs_threshold
-        (
-            {"needs_proba": True, "needs_threshold": True},
-            ValueError,
-            "You cannot set both `needs_proba` and `needs_threshold`",
-        ),
-    ],
-)
-def test_make_scorer_error(params, err_type, err_msg):
-    """Check that `make_scorer` raises errors if the parameter used."""
-    with pytest.raises(err_type, match=err_msg):
-        make_scorer(lambda y_true, y_pred: 1, **params)
-
-
-# TODO(1.6): remove the following test
-@pytest.mark.parametrize(
-    "deprecated_params, new_params, warn_msg",
-    [
-        (
-            {"needs_proba": True},
-            {"response_method": "predict_proba"},
-            "The `needs_threshold` and `needs_proba` parameter are deprecated",
-        ),
-        (
-            {"needs_proba": True, "needs_threshold": False},
-            {"response_method": "predict_proba"},
-            "The `needs_threshold` and `needs_proba` parameter are deprecated",
-        ),
-        (
-            {"needs_threshold": True},
-            {"response_method": ("decision_function", "predict_proba")},
-            "The `needs_threshold` and `needs_proba` parameter are deprecated",
-        ),
-        (
-            {"needs_threshold": True, "needs_proba": False},
-            {"response_method": ("decision_function", "predict_proba")},
-            "The `needs_threshold` and `needs_proba` parameter are deprecated",
-        ),
-        (
-            {"needs_threshold": False, "needs_proba": False},
-            {"response_method": "predict"},
-            "The `needs_threshold` and `needs_proba` parameter are deprecated",
-        ),
-    ],
-)
-def test_make_scorer_deprecation(deprecated_params, new_params, warn_msg):
-    """Check that we raise a deprecation warning when using `needs_proba` or
-    `needs_threshold`."""
-    X, y = make_classification(n_samples=150, n_features=10, random_state=0)
-    classifier = LogisticRegression().fit(X, y)
-
-    # check deprecation of needs_proba
-    with pytest.warns(FutureWarning, match=warn_msg):
-        deprecated_roc_auc_scorer = make_scorer(roc_auc_score, **deprecated_params)
-    roc_auc_scorer = make_scorer(roc_auc_score, **new_params)
-
-    assert deprecated_roc_auc_scorer(classifier, X, y) == pytest.approx(
-        roc_auc_scorer(classifier, X, y)
-    )
-
-
 @pytest.mark.parametrize("pass_estimator", [True, False])
 def test_get_scorer_multimetric(pass_estimator):
     """Check that check_scoring is compatible with multi-metric configurations."""
@@ -1698,3 +1620,12 @@ def test_curve_scorer_pos_label(global_random_seed):
     assert 0.0 < scores_pos_label_0.min() < scores_pos_label_1.min()
     assert scores_pos_label_0.max() == pytest.approx(1.0)
     assert scores_pos_label_1.max() == pytest.approx(1.0)
+
+
+# TODO(1.8): remove
+def test_make_scorer_reponse_method_default_warning():
+    with pytest.warns(
+        FutureWarning,
+        match="The default value of response_method will change from None to 'predict'",
+    ):
+        make_scorer(accuracy_score)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1,5 +1,6 @@
 import numbers
 import pickle
+import warnings
 from copy import deepcopy
 from functools import partial
 from unittest.mock import Mock
@@ -1624,8 +1625,11 @@ def test_curve_scorer_pos_label(global_random_seed):
 
 # TODO(1.8): remove
 def test_make_scorer_reponse_method_default_warning():
-    with pytest.warns(
-        FutureWarning,
-        match="The default value of response_method will change from None to 'predict'",
-    ):
+    with pytest.warns(FutureWarning, match="response_method=None is deprecated"):
+        make_scorer(accuracy_score, response_method=None)
+
+    # No warning is raised if response_method is left to its default value
+    # because the future default value has the same effect as the current one.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
         make_scorer(accuracy_score)


### PR DESCRIPTION
removed deprecated parameters `needs_proba` and `needs_thresholds` of `make_scorer`.
`response_method=None` was possible during the deprecation cycle to detect when both are set but is now useless since it's equivalent to predict. This PR therefore deprecates None and announce the change of default to "predict" in 1.8.