### PR TITLE
DOC update scikit-learn contributors table

### DIFF
--- a/doc/communication_team.rst
+++ b/doc/communication_team.rst
@@ -7,7 +7,7 @@
     </style>
     <div>
     <a href='https://github.com/laurburke'><img src='https://avatars.githubusercontent.com/u/35973528?v=4' class='avatar' /></a> <br />
-    <p>Lauren Burke</p>
+    <p>Lauren Burke-McCarthy</p>
     </div>
     <div>
     <a href='https://github.com/francoisgoupil'><img src='https://avatars.githubusercontent.com/u/98105626?v=4' class='avatar' /></a> <br />

--- a/doc/maintainers.rst
+++ b/doc/maintainers.rst
@@ -54,6 +54,10 @@
     <p>Guillaume Lemaitre</p>
     </div>
     <div>
+    <a href='https://github.com/adam2392'><img src='https://avatars.githubusercontent.com/u/3460267?v=4' class='avatar' /></a> <br />
+    <p>Adam Li</p>
+    </div>
+    <div>
     <a href='https://github.com/lorentzenchr'><img src='https://avatars.githubusercontent.com/u/15324633?v=4' class='avatar' /></a> <br />
     <p>Christian Lorentzen</p>
     </div>


### PR DESCRIPTION
I just realised that @adam2392 was not appearing on our "About us" page so it seems that the site is out of date in this regard.

I ran the script `make authors` from the `build_tools` folder.

We should backport this PR in `1.5.X` branch.