### PR TITLE
DOC Add link to FeatureAgglomeration examples in docstrings

### DIFF
--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -1260,7 +1260,7 @@ class FeatureAgglomeration(
     >>> X_reduced.shape
     (1797, 32)
 
-    For a comparison between FeatureAgglomeration and univariate feature selection refer to example
+    For a comparison between FeatureAgglomeration and feature selection refer to example
     :ref:`sphx_glr_auto_examples_cluster_plot_feature_agglomeration_vs_univariate_selection.py`.
     """
 

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -1259,6 +1259,9 @@ class FeatureAgglomeration(
     >>> X_reduced = agglo.transform(X)
     >>> X_reduced.shape
     (1797, 32)
+
+    For a comparison between FeatureAgglomeration and univariate feature selection refer to example
+    :ref:`sphx_glr_auto_examples_cluster_plot_feature_agglomeration_vs_univariate_selection.py`.
     """
 
     _parameter_constraints: dict = {

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -1122,8 +1122,8 @@ class FeatureAgglomeration(
 
     Refer to
     :ref:`sphx_glr_auto_examples_cluster_plot_feature_agglomeration_vs_univariate_selection.py`
-    for an example comparison :class:`FeatureAgglomration` strategy with a univariate
-    feature selection strategy (based on ANOVA).
+    for an example comparison of :class:`FeatureAgglomeration` strategy with a
+    univariate feature selection strategy (based on ANOVA).
 
     Read more in the :ref:`User Guide <hierarchical_clustering>`.
 

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -1120,6 +1120,11 @@ class FeatureAgglomeration(
 
     Recursively merges pair of clusters of features.
 
+    Refer to
+    :ref:`sphx_glr_auto_examples_cluster_plot_feature_agglomeration_vs_univariate_selection.py`
+    for an example comparison :class:`FeatureAgglomration` strategy with a univariate
+    feature selection strategy (based on ANOVA).
+
     Read more in the :ref:`User Guide <hierarchical_clustering>`.
 
     Parameters
@@ -1259,9 +1264,6 @@ class FeatureAgglomeration(
     >>> X_reduced = agglo.transform(X)
     >>> X_reduced.shape
     (1797, 32)
-
-    For a comparison between FeatureAgglomeration and feature selection refer to example
-    :ref:`sphx_glr_auto_examples_cluster_plot_feature_agglomeration_vs_univariate_selection.py`.
     """
 
     _parameter_constraints: dict = {


### PR DESCRIPTION
#### Reference Issues/PRs
References https://github.com/scikit-learn/scikit-learn/issues/26927


#### What does this implement/fix? Explain your changes.
Adds link in `cluster/_agglomerative.py` to example file `examples/cluster/plot_feature_agglomeration_vs_univariate_selection.py`. This example clarifies the usage and comparison of two different dimensionality reduction techniques, univariate feature selection and feature agglomeration.

#### Any other comments?
Appreciate any feedback!

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
