### PR TITLE
FIX LinearRegression sample weight bug (numpy solver)

### DIFF
--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -261,6 +261,10 @@ Changelog
 :mod:`sklearn.linear_model`
 ...........................
 
+- |Fix| :class:`linear_model.LinearRegression` replaces the `scipy.linalg.lstsq`
+  solver by `numpy.linalg.lstsq` and sets the `rcond` parameter.
+  :pr:`30040` by :user:`Antoine Baker <antoinebaker>`.
+
 - |Fix| :class:`linear_model.LogisticRegressionCV` corrects sample weight handling
   for the calculation of test scores.
   :pr:`29419` by :user:`Shruti Nath <snath-xoc>`.

--- a/doc/whats_new/v1.6.rst
+++ b/doc/whats_new/v1.6.rst
@@ -263,7 +263,7 @@ Changelog
 
 - |Fix| :class:`linear_model.LinearRegression` replaces the `scipy.linalg.lstsq`
   solver by `numpy.linalg.lstsq` and sets the `rcond` parameter.
-  :pr:`30040` by :user:`Antoine Baker <antoinebaker>`.
+  :pr:`30030` by :user:`Antoine Baker <antoinebaker>`.
 
 - |Fix| :class:`linear_model.LogisticRegressionCV` corrects sample weight handling
   for the calculation of test scores.

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -673,7 +673,11 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
                 )
                 self.coef_ = np.vstack([out[0] for out in outs])
         else:
-            self.coef_, _, self.rank_, self.singular_ = np.linalg.lstsq(X, y)
+            # cut-off ratio for small singular values (numpy 2.0 default value)
+            rcond = max(X.shape) * np.finfo(X.dtype).eps
+            self.coef_, _, self.rank_, self.singular_ = np.linalg.lstsq(
+                X, y, rcond=rcond
+            )
             self.coef_ = self.coef_.T
 
         if y.ndim == 1:

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -12,7 +12,7 @@ from numbers import Integral
 
 import numpy as np
 import scipy.sparse as sp
-from scipy import linalg, optimize, sparse
+from scipy import optimize, sparse
 from scipy.sparse.linalg import lsqr
 from scipy.special import expit
 
@@ -525,7 +525,7 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
     Notes
     -----
     From the implementation point of view, this is just plain Ordinary
-    Least Squares (scipy.linalg.lstsq) or Non Negative Least Squares
+    Least Squares (numpy.linalg.lstsq) or Non Negative Least Squares
     (scipy.optimize.nnls) wrapped as a predictor object.
 
     Examples
@@ -673,7 +673,7 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
                 )
                 self.coef_ = np.vstack([out[0] for out in outs])
         else:
-            self.coef_, _, self.rank_, self.singular_ = linalg.lstsq(X, y)
+            self.coef_, _, self.rank_, self.singular_ = np.linalg.lstsq(X, y)
             self.coef_ = self.coef_.T
 
         if y.ndim == 1:

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -741,7 +741,7 @@ def test_linear_regression_sample_weight_consistency(
         intercept = reg.intercept_
 
     reg.fit(X, y, sample_weight=np.pi * sample_weight)
-    assert_allclose(reg.coef_, coef, rtol=1e-6 if sparse_container is None else 1e-5)
+    assert_allclose(reg.coef_, coef, rtol=1e-6)
     if fit_intercept:
         assert_allclose(reg.intercept_, intercept)
 
@@ -756,7 +756,7 @@ def test_linear_regression_sample_weight_consistency(
     reg.fit(X[:-5], y[:-5], sample_weight=sample_weight[:-5])
     # TODO: see if it fixes
     # https://github.com/scikit-learn/scikit-learn/issues/26164
-    assert_allclose(reg.coef_, coef_0, rtol=1e-5)
+    assert_allclose(reg.coef_, coef_0, rtol=1e-6)
     if fit_intercept:
         assert_allclose(reg.intercept_, intercept_0)
 
@@ -775,6 +775,6 @@ def test_linear_regression_sample_weight_consistency(
 
     reg1 = LinearRegression(**params).fit(X, y, sample_weight=sample_weight_1)
     reg2 = LinearRegression(**params).fit(X2, y2, sample_weight=sample_weight_2)
-    assert_allclose(reg1.coef_, reg2.coef_, rtol=1e-6)
+    assert_allclose(reg1.coef_, reg2.coef_, rtol=1e-5)
     if fit_intercept:
         assert_allclose(reg1.intercept_, reg2.intercept_)

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -704,7 +704,7 @@ def test_linear_regression_sample_weight_consistency(
     It is very similar to test_enet_sample_weight_consistency.
     """
     rng = np.random.RandomState(global_random_seed)
-    n_samples, n_features = 10, 5
+    n_samples, n_features = 10, 15
 
     X = rng.rand(n_samples, n_features)
     y = rng.rand(n_samples)
@@ -754,17 +754,11 @@ def test_linear_regression_sample_weight_consistency(
     if fit_intercept:
         intercept_0 = reg.intercept_
     reg.fit(X[:-5], y[:-5], sample_weight=sample_weight[:-5])
-    if fit_intercept and sparse_container is None:
-        # FIXME: https://github.com/scikit-learn/scikit-learn/issues/26164
-        # This often fails, e.g. when calling
-        # SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest \
-        # sklearn/linear_model/tests/test_base.py\
-        # ::test_linear_regression_sample_weight_consistency
-        pass
-    else:
-        assert_allclose(reg.coef_, coef_0, rtol=1e-5)
-        if fit_intercept:
-            assert_allclose(reg.intercept_, intercept_0)
+    # TODO: see if it fixes
+    # https://github.com/scikit-learn/scikit-learn/issues/26164
+    assert_allclose(reg.coef_, coef_0, rtol=1e-5)
+    if fit_intercept:
+        assert_allclose(reg.intercept_, intercept_0)
 
     # 5) check that multiplying sample_weight by 2 is equivalent to repeating
     # corresponding samples twice

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -704,7 +704,7 @@ def test_linear_regression_sample_weight_consistency(
     It is very similar to test_enet_sample_weight_consistency.
     """
     rng = np.random.RandomState(global_random_seed)
-    n_samples, n_features = 10, 15
+    n_samples, n_features = 10, 5
 
     X = rng.rand(n_samples, n_features)
     y = rng.rand(n_samples)
@@ -741,7 +741,7 @@ def test_linear_regression_sample_weight_consistency(
         intercept = reg.intercept_
 
     reg.fit(X, y, sample_weight=np.pi * sample_weight)
-    assert_allclose(reg.coef_, coef, rtol=1e-6)
+    assert_allclose(reg.coef_, coef, rtol=1e-6 if sparse_container is None else 1e-5)
     if fit_intercept:
         assert_allclose(reg.intercept_, intercept)
 
@@ -754,9 +754,7 @@ def test_linear_regression_sample_weight_consistency(
     if fit_intercept:
         intercept_0 = reg.intercept_
     reg.fit(X[:-5], y[:-5], sample_weight=sample_weight[:-5])
-    # TODO: see if it fixes
-    # https://github.com/scikit-learn/scikit-learn/issues/26164
-    assert_allclose(reg.coef_, coef_0, rtol=1e-6)
+    assert_allclose(reg.coef_, coef_0, rtol=1e-5)
     if fit_intercept:
         assert_allclose(reg.intercept_, intercept_0)
 
@@ -775,6 +773,6 @@ def test_linear_regression_sample_weight_consistency(
 
     reg1 = LinearRegression(**params).fit(X, y, sample_weight=sample_weight_1)
     reg2 = LinearRegression(**params).fit(X2, y2, sample_weight=sample_weight_2)
-    assert_allclose(reg1.coef_, reg2.coef_, rtol=1e-5)
+    assert_allclose(reg1.coef_, reg2.coef_, rtol=1e-6)
     if fit_intercept:
         assert_allclose(reg1.intercept_, reg2.intercept_)


### PR DESCRIPTION
#### Reference Issues/PRs

#29818  and #26164 revealed that LinearRegression was failing the sample weight consistency check (using weights should be equivalent to removing/repeating samples). 

Related to #22947  #25948

#### What does this implement/fix? Explain your changes.

The `scipy.linalg.lstsq` solver fails the sample weight consistency test for wide dataset (`n_features > n_samples`) after centering `X,y` (as done when `fit_intercept=True`).

Using the `numpy.linalg.lstsq` solver seems to solve the bug.

`test_linear_regression_sample_weight_consistency` now uses `n_features > n_samples` to fail more consistently.
