### PR TITLE
FIX use objective instead of loss for convergence in SGD

### DIFF
--- a/sklearn/linear_model/_sgd_fast.pyx.tp
+++ b/sklearn/linear_model/_sgd_fast.pyx.tp
@@ -546,16 +546,6 @@ def _plain_sgd{{name_suffix}}(
                 t += 1
                 count += 1
 
-            # report epoch information
-            if verbose > 0:
-                with gil:
-                    print("Norm: %.2f, NNZs: %d, Bias: %.6f, T: %d, "
-                          "Avg. loss: %f"
-                          % (w.norm(), np.nonzero(weights)[0].shape[0],
-                             intercept, count, sumloss / train_count))
-                    print("Total training time: %.2f seconds."
-                          % (time() - t_start))
-
             # floating-point under-/overflow check.
             if (not isfinite(intercept) or any_nonfinite(weights)):
                 infinity = True
@@ -565,6 +555,13 @@ def _plain_sgd{{name_suffix}}(
             if early_stopping:
                 with gil:
                     score = validation_score_cb(weights.base, intercept)
+                    if verbose > 0:  # report epoch information
+                        print("Norm: %.2f, NNZs: %d, Bias: %.6f, T: %d, "
+                            "Avg. loss: %f, Validation score: %f"
+                            % (w.norm(), np.nonzero(weights)[0].shape[0],
+                                intercept, count, sumloss / train_count, score))
+                        print("Total training time: %.2f seconds."
+                            % (time() - t_start))
                 if tol > -INFINITY and score < best_score + tol:
                     no_improvement_count += 1
                 else:
@@ -577,6 +574,14 @@ def _plain_sgd{{name_suffix}}(
                     (1 - l1_ratio) * 0.5 * w.norm() ** 2 +
                     l1_ratio * w.l1norm()
                 )
+                if verbose > 0:  # report epoch information
+                    with gil:
+                        print("Norm: %.2f, NNZs: %d, Bias: %.6f, T: %d, "
+                            "Avg. loss: %f, Objective: %f"
+                            % (w.norm(), np.nonzero(weights)[0].shape[0],
+                                intercept, count, sumloss / train_count, objective))
+                        print("Total training time: %.2f seconds."
+                            % (time() - t_start))
                 if tol > -INFINITY and objective > best_objective - tol:
                     no_improvement_count += 1
                 else:

--- a/sklearn/linear_model/_sgd_fast.pyx.tp
+++ b/sklearn/linear_model/_sgd_fast.pyx.tp
@@ -577,12 +577,6 @@ def _plain_sgd{{name_suffix}}(
                     (1 - l1_ratio) * 0.5 * w.norm() ** 2 +
                     l1_ratio * w.l1norm()
                 )
-                if verbose > 0:
-                    with gil:
-                        print("Norm: %.2f, NNZs: %d, Bias: %.6f, T: %d, "
-                            "Avg. loss: %f, Objective: %f"
-                            % (w.norm(), np.nonzero(weights)[0].shape[0],
-                                intercept, count, sumloss / train_count, objective))
                 if tol > -INFINITY and objective > best_objective - tol:
                     no_improvement_count += 1
                 else:

--- a/sklearn/linear_model/_sgd_fast.pyx.tp
+++ b/sklearn/linear_model/_sgd_fast.pyx.tp
@@ -416,7 +416,8 @@ def _plain_sgd{{name_suffix}}(
     cdef double intercept_update = 0.0
     cdef double sumloss = 0.0
     cdef double score = 0.0
-    cdef double best_loss = INFINITY
+    cdef double objective = 0.0
+    cdef double best_objective = INFINITY
     cdef double best_score = -INFINITY
     cdef {{c_type}} y = 0.0
     cdef {{c_type}} sample_weight
@@ -572,12 +573,22 @@ def _plain_sgd{{name_suffix}}(
                     best_score = score
             # or evaluate the loss on the training set
             else:
-                if tol > -INFINITY and sumloss > best_loss - tol * train_count:
+                objective = sumloss / train_count + alpha * (
+                    (1 - l1_ratio) * 0.5 * w.norm() ** 2 +
+                    l1_ratio * w.l1norm()
+                )
+                if verbose > 0:
+                    with gil:
+                        print("Norm: %.2f, NNZs: %d, Bias: %.6f, T: %d, "
+                            "Avg. loss: %f, Objective: %f"
+                            % (w.norm(), np.nonzero(weights)[0].shape[0],
+                                intercept, count, sumloss / train_count, objective))
+                if tol > -INFINITY and objective > best_objective - tol:
                     no_improvement_count += 1
                 else:
                     no_improvement_count = 0
-                if sumloss < best_loss:
-                    best_loss = sumloss
+                if sumloss < best_objective:
+                    best_objective = objective
 
             # if there is no improvement several times in a row
             if no_improvement_count >= n_iter_no_change:

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -396,7 +396,7 @@ def test_early_stopping(klass):
         clf = klass(early_stopping=early_stopping, tol=1e-3, max_iter=max_iter).fit(
             X, Y
         )
-        assert clf.n_iter_ < max_iter
+        assert clf.n_iter_ < max_iter, f"{clf.n_iter_} >= {max_iter}"
 
 
 @pytest.mark.parametrize(

--- a/sklearn/utils/_weight_vector.pxd.tp
+++ b/sklearn/utils/_weight_vector.pxd.tp
@@ -31,6 +31,7 @@ cdef class WeightVector{{name_suffix}}(object):
     cdef double average_b
     cdef int n_features
     cdef double sq_norm
+    cdef double l1_norm
 
     cdef void add(self, {{c_type}} *x_data_ptr, int *x_ind_ptr,
                   int xnnz, {{c_type}} c) noexcept nogil
@@ -41,5 +42,6 @@ cdef class WeightVector{{name_suffix}}(object):
     cdef void scale(self, {{c_type}} c) noexcept nogil
     cdef void reset_wscale(self) noexcept nogil
     cdef {{c_type}} norm(self) noexcept nogil
+    cdef {{c_type}} l1norm(self) noexcept nogil
 
 {{endfor}}

--- a/sklearn/utils/_weight_vector.pyx.tp
+++ b/sklearn/utils/_weight_vector.pyx.tp
@@ -25,9 +25,9 @@ dtypes = [('64', 'double', 1e-9),
 
 cimport cython
 from libc.limits cimport INT_MAX
-from libc.math cimport sqrt
+from libc.math cimport sqrt, fabs
 
-from ._cython_blas cimport _dot, _scal, _axpy
+from ._cython_blas cimport _dot, _scal, _axpy, _asum
 
 {{for name_suffix, c_type, reset_wscale_threshold in dtypes}}
 
@@ -53,6 +53,8 @@ cdef class WeightVector{{name_suffix}}(object):
         The number of features (= dimensionality of ``w``).
     sq_norm : {{c_type}}
         The squared norm of ``w``.
+    l1_norm : {{c_type}}
+        The L1 norm of ``w``.
     """
 
     def __cinit__(self,
@@ -67,6 +69,7 @@ cdef class WeightVector{{name_suffix}}(object):
         self.wscale = 1.0
         self.n_features = w.shape[0]
         self.sq_norm = _dot(self.n_features, self.w_data_ptr, 1, self.w_data_ptr, 1)
+        self.l1_norm = _asum(self.n_features, self.w_data_ptr, 1)
 
         self.aw = aw
         if self.aw is not None:
@@ -78,7 +81,7 @@ cdef class WeightVector{{name_suffix}}(object):
                   {{c_type}} c) noexcept nogil:
         """Scales sample x by constant c and adds it to the weight vector.
 
-        This operation updates ``sq_norm``.
+        This operation updates ``sq_norm`` and ``l1_norm``.
 
         Parameters
         ----------
@@ -96,6 +99,7 @@ cdef class WeightVector{{name_suffix}}(object):
         cdef double val
         cdef double innerprod = 0.0
         cdef double xsqnorm = 0.0
+        cdef double xl1norm = 0.0
 
         # the next two lines save a factor of 2!
         cdef {{c_type}} wscale = self.wscale
@@ -106,9 +110,11 @@ cdef class WeightVector{{name_suffix}}(object):
             val = x_data_ptr[j]
             innerprod += (w_data_ptr[idx] * val)
             xsqnorm += (val * val)
+            xl1norm += fabs(val)
             w_data_ptr[idx] += val * (c / wscale)
 
         self.sq_norm += (xsqnorm * c * c) + (2.0 * innerprod * wscale * c)
+        self.l1_norm += (xl1norm * fabs(c)) + (innerprod * wscale * c)
 
     # Update the average weights according to the sparse trick defined
     # here: https://research.microsoft.com/pubs/192769/tricks-2012.pdf
@@ -180,10 +186,11 @@ cdef class WeightVector{{name_suffix}}(object):
     cdef void scale(self, {{c_type}} c) noexcept nogil:
         """Scales the weight vector by a constant ``c``.
 
-        It updates ``wscale`` and ``sq_norm``. If ``wscale`` gets too
+        It updates ``wscale``, ``sq_norm``, and ``l1_norm``. If ``wscale`` gets too
         small we call ``reset_swcale``."""
         self.wscale *= c
         self.sq_norm *= (c * c)
+        self.l1_norm *= fabs(c)
 
         if self.wscale < {{reset_wscale_threshold}}:
             self.reset_wscale()
@@ -203,5 +210,9 @@ cdef class WeightVector{{name_suffix}}(object):
     cdef {{c_type}} norm(self) noexcept nogil:
         """The L2 norm of the weight vector. """
         return sqrt(self.sq_norm)
+
+    cdef {{c_type}} l1norm(self) noexcept nogil:
+        """The L1 norm of the weight vector. """
+        return self.l1_norm
 
 {{endfor}}


### PR DESCRIPTION
closes #30027 

When no early-stopping is used in SGD estimator, the stopping criterion should be based on the value of the objective function (loss function + regularization terms). However, currently only the loss function is used to decide whether or not the estimator converged.

So as a solution here, I proposed to modify the `WeightVector` Cython class such that it also compute the L1-norm on the fly and then in the case that early-stopping is not activated, then we compute the objective function instead of solely the loss function and use it as a stopping criterion.

Things that I'm not sure at this stage:

- I did not check if I properly handle the intercept
- I am not sure to know what is the interaction with the tolerance: is the parameter super sensitive and should always be tweak depending of the problem at hand (i.e. regression or classifiation)?