### PR TITLE
MAINT replace enable_slep006 fixture by @config_context(enable_metadata_routing=True)

### DIFF
--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -13,6 +13,7 @@ import pytest
 from numpy.testing import assert_allclose
 from scipy import sparse
 
+from sklearn import config_context
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.compose import (
     ColumnTransformer,
@@ -2685,8 +2686,8 @@ def test_routing_passed_metadata_not_supported(method):
         getattr(trs, method)([[1]], sample_weight=[1], prop="a")
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize("method", ["transform", "fit_transform", "fit"])
+@config_context(enable_metadata_routing=True)
 def test_metadata_routing_for_column_transformer(method):
     """Test that metadata is routed correctly for column transformer."""
     X = np.array([[0, 1, 2], [2, 4, 6]]).T
@@ -2722,7 +2723,7 @@ def test_metadata_routing_for_column_transformer(method):
         )
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_metadata_routing_no_fit_transform():
     """Test metadata routing when the sub-estimator doesn't implement
     ``fit_transform``."""
@@ -2757,8 +2758,8 @@ def test_metadata_routing_no_fit_transform():
     trs.fit_transform(X, y, sample_weight=sample_weight, metadata=metadata)
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize("method", ["transform", "fit_transform", "fit"])
+@config_context(enable_metadata_routing=True)
 def test_metadata_routing_error_for_column_transformer(method):
     """Test that the right error is raised when metadata is not requested."""
     X = np.array([[0, 1, 2], [2, 4, 6]]).T
@@ -2778,7 +2779,7 @@ def test_metadata_routing_error_for_column_transformer(method):
             getattr(trs, method)(X, y, sample_weight=sample_weight, metadata=metadata)
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_get_metadata_routing_works_without_fit():
     # Regression test for https://github.com/scikit-learn/scikit-learn/issues/28186
     # Make sure ct.get_metadata_routing() works w/o having called fit.
@@ -2786,7 +2787,7 @@ def test_get_metadata_routing_works_without_fit():
     ct.get_metadata_routing()
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_remainder_request_always_present():
     # Test that remainder request is always present.
     ct = ColumnTransformer(
@@ -2799,7 +2800,7 @@ def test_remainder_request_always_present():
     assert router.consumes("fit", ["metadata"]) == set(["metadata"])
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_unused_transformer_request_present():
     # Test that the request of a transformer is always present even when not
     # used due to no selected columns.

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -15,7 +15,7 @@ import pytest
 from _pytest.doctest import DoctestItem
 from threadpoolctl import threadpool_limits
 
-from sklearn import config_context, set_config
+from sklearn import set_config
 from sklearn._min_dependencies import PYTEST_MIN_VERSION
 from sklearn.datasets import (
     fetch_20newsgroups,
@@ -44,13 +44,6 @@ if parse_version(pytest.__version__) < parse_version(PYTEST_MIN_VERSION):
     )
 
 scipy_datasets_require_network = sp_version >= parse_version("1.10")
-
-
-@pytest.fixture
-def enable_slep006():
-    """Enable SLEP006 for all tests."""
-    with config_context(enable_metadata_routing=True):
-        yield
 
 
 def raccoon_face_or_skip():

--- a/sklearn/covariance/tests/test_graphical_lasso.py
+++ b/sklearn/covariance/tests/test_graphical_lasso.py
@@ -8,7 +8,7 @@ import pytest
 from numpy.testing import assert_allclose
 from scipy import linalg
 
-from sklearn import datasets
+from sklearn import config_context, datasets
 from sklearn.covariance import (
     GraphicalLasso,
     GraphicalLassoCV,
@@ -263,7 +263,7 @@ def test_graphical_lasso_cv_scores():
     )
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_graphical_lasso_cv_scores_with_routing(global_random_seed):
     """Check that `GraphicalLassoCV` internally dispatches metadata to
     the splitter.

--- a/sklearn/ensemble/tests/test_stacking.py
+++ b/sklearn/ensemble/tests/test_stacking.py
@@ -11,6 +11,7 @@ import pytest
 from numpy.testing import assert_array_equal
 from scipy import sparse
 
+from sklearn import config_context
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin, clone
 from sklearn.datasets import (
     load_breast_cancer,
@@ -920,7 +921,6 @@ def test_routing_passed_metadata_not_supported(Estimator, Child):
         )
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize(
     "Estimator, Child",
     [
@@ -928,13 +928,13 @@ def test_routing_passed_metadata_not_supported(Estimator, Child):
         (StackingRegressor, ConsumingRegressor),
     ],
 )
+@config_context(enable_metadata_routing=True)
 def test_get_metadata_routing_without_fit(Estimator, Child):
     # Test that metadata_routing() doesn't raise when called before fit.
     est = Estimator([("sub_est", Child())])
     est.get_metadata_routing()
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize(
     "Estimator, Child",
     [
@@ -945,6 +945,7 @@ def test_get_metadata_routing_without_fit(Estimator, Child):
 @pytest.mark.parametrize(
     "prop, prop_value", [("sample_weight", np.ones(X_iris.shape[0])), ("metadata", "a")]
 )
+@config_context(enable_metadata_routing=True)
 def test_metadata_routing_for_stacking_estimators(Estimator, Child, prop, prop_value):
     """Test that metadata is routed correctly for Stacking*."""
 
@@ -991,7 +992,6 @@ def test_metadata_routing_for_stacking_estimators(Estimator, Child, prop, prop_v
     )
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize(
     "Estimator, Child",
     [
@@ -999,6 +999,7 @@ def test_metadata_routing_for_stacking_estimators(Estimator, Child, prop, prop_v
         (StackingRegressor, ConsumingRegressor),
     ],
 )
+@config_context(enable_metadata_routing=True)
 def test_metadata_routing_error_for_stacking_estimators(Estimator, Child):
     """Test that the right error is raised when metadata is not requested."""
     sample_weight, metadata = np.ones(X_iris.shape[0]), "a"

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -5,7 +5,7 @@ import re
 import numpy as np
 import pytest
 
-from sklearn import datasets
+from sklearn import config_context, datasets
 from sklearn.base import BaseEstimator, ClassifierMixin, clone
 from sklearn.datasets import make_multilabel_classification
 from sklearn.dummy import DummyRegressor
@@ -606,8 +606,7 @@ def test_voting_verbose(estimator, capsys):
         r"\[Voting\].*\(1 of 2\) Processing lr, total=.*\n"
         r"\[Voting\].*\(2 of 2\) Processing rf, total=.*\n$"
     )
-
-    estimator.fit(X, y)
+    clone(estimator).fit(X, y)
     assert re.match(pattern, capsys.readouterr()[0])
 
 
@@ -712,23 +711,23 @@ def test_routing_passed_metadata_not_supported(Estimator, Child):
         Estimator(["clf", Child()]).fit(X, y, sample_weight=[1, 1, 1], metadata="a")
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize(
     "Estimator, Child",
     [(VotingClassifier, ConsumingClassifier), (VotingRegressor, ConsumingRegressor)],
 )
+@config_context(enable_metadata_routing=True)
 def test_get_metadata_routing_without_fit(Estimator, Child):
     # Test that metadata_routing() doesn't raise when called before fit.
     est = Estimator([("sub_est", Child())])
     est.get_metadata_routing()
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize(
     "Estimator, Child",
     [(VotingClassifier, ConsumingClassifier), (VotingRegressor, ConsumingRegressor)],
 )
 @pytest.mark.parametrize("prop", ["sample_weight", "metadata"])
+@config_context(enable_metadata_routing=True)
 def test_metadata_routing_for_voting_estimators(Estimator, Child, prop):
     """Test that metadata is routed correctly for Voting*."""
     X = np.array([[0, 1], [2, 2], [4, 6]])
@@ -762,11 +761,11 @@ def test_metadata_routing_for_voting_estimators(Estimator, Child, prop):
             check_recorded_metadata(obj=sub_est, method="fit", parent="fit", **kwargs)
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize(
     "Estimator, Child",
     [(VotingClassifier, ConsumingClassifier), (VotingRegressor, ConsumingRegressor)],
 )
+@config_context(enable_metadata_routing=True)
 def test_metadata_routing_error_for_voting_estimators(Estimator, Child):
     """Test that the right error is raised when metadata is not requested."""
     X = np.array([[0, 1], [2, 2], [4, 6]])

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 from scipy import interpolate, sparse
 
-from sklearn.base import clone, is_classifier
+from sklearn.base import clone, config_context, is_classifier
 from sklearn.datasets import load_diabetes, make_regression
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import (
@@ -1638,11 +1638,11 @@ def test_cv_estimators_reject_params_with_no_routing_enabled(EstimatorCV):
         estimator.fit(X, y, groups=groups)
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize(
     "MultiTaskEstimatorCV",
     [MultiTaskElasticNetCV, MultiTaskLassoCV],
 )
+@config_context(enable_metadata_routing=True)
 def test_multitask_cv_estimators_with_sample_weight(MultiTaskEstimatorCV):
     """Check that for :class:`MultiTaskElasticNetCV` and
     class:`MultiTaskLassoCV` if `sample_weight` is passed and the

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -2163,7 +2163,7 @@ def test_liblinear_not_stuck():
         clf.fit(X_prep, y)
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_lr_cv_scores_differ_when_sample_weight_is_requested():
     """Test that `sample_weight` is correctly passed to the scorer in
     `LogisticRegressionCV.fit` and `LogisticRegressionCV.score` by

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -2360,8 +2360,8 @@ def test_ridge_cv_custom_multioutput_scorer():
 # ======================
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize("metaestimator", [RidgeCV, RidgeClassifierCV])
+@config_context(enable_metadata_routing=True)
 def test_metadata_routing_with_default_scoring(metaestimator):
     """Test that `RidgeCV` or `RidgeClassifierCV` with default `scoring`
     argument (`None`), don't enter into `RecursionError` when metadata is routed.
@@ -2369,7 +2369,6 @@ def test_metadata_routing_with_default_scoring(metaestimator):
     metaestimator().get_metadata_routing()
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize(
     "metaestimator, make_dataset",
     [
@@ -2377,6 +2376,7 @@ def test_metadata_routing_with_default_scoring(metaestimator):
         (RidgeClassifierCV(), make_classification),
     ],
 )
+@config_context(enable_metadata_routing=True)
 def test_set_score_request_with_default_scoring(metaestimator, make_dataset):
     """Test that `set_score_request` is set within `RidgeCV.fit()` and
     `RidgeClassifierCV.fit()` when using the default scoring and no

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1211,8 +1211,8 @@ def test_scorer_set_score_request_raises(name):
         scorer.set_score_request()
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize("name", get_scorer_names(), ids=get_scorer_names())
+@config_context(enable_metadata_routing=True)
 def test_scorer_metadata_request(name):
     """Testing metadata requests for scorers.
 
@@ -1262,7 +1262,7 @@ def test_scorer_metadata_request(name):
     assert list(routed_params.scorer.score.keys()) == ["sample_weight"]
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_metadata_kwarg_conflict():
     """This test makes sure the right warning is raised if the user passes
     some metadata both as a constructor to make_scorer, and during __call__.
@@ -1285,7 +1285,7 @@ def test_metadata_kwarg_conflict():
         scorer(lr, X, y, labels=lr.classes_)
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_PassthroughScorer_set_score_request():
     """Test that _PassthroughScorer.set_score_request adds the correct metadata request
     on itself and doesn't change its estimator's routing."""
@@ -1320,7 +1320,7 @@ def test_PassthroughScorer_set_score_request_raises_without_routing_enabled():
         scorer.set_score_request(sample_weight="my_weights")
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_multimetric_scoring_metadata_routing():
     # Test that _MultimetricScorer properly routes metadata.
     def score1(y_true, y_pred):

--- a/sklearn/model_selection/tests/test_classification_threshold.py
+++ b/sklearn/model_selection/tests/test_classification_threshold.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from sklearn import config_context
 from sklearn.base import BaseEstimator, ClassifierMixin, clone
 from sklearn.datasets import (
     load_breast_cancer,
@@ -101,7 +102,7 @@ def test_fit_and_score_over_thresholds_prefit():
     assert_allclose(scores, [0.5, 1.0])
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_fit_and_score_over_thresholds_sample_weight():
     """Check that we dispatch the sample-weight to fit and score the classifier."""
     X, y = load_iris(return_X_y=True)
@@ -150,8 +151,8 @@ def test_fit_and_score_over_thresholds_sample_weight():
     assert_allclose(scores_repeated, scores)
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize("fit_params_type", ["list", "array"])
+@config_context(enable_metadata_routing=True)
 def test_fit_and_score_over_thresholds_fit_params(fit_params_type):
     """Check that we pass `fit_params` to the classifier when calling `fit`."""
     X, y = make_classification(n_samples=100, random_state=0)
@@ -344,8 +345,8 @@ def test_tuned_threshold_classifier_with_string_targets(response_method, metric)
     assert_array_equal(np.unique(y_pred), np.sort(classes))
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize("with_sample_weight", [True, False])
+@config_context(enable_metadata_routing=True)
 def test_tuned_threshold_classifier_refit(with_sample_weight, global_random_seed):
     """Check the behaviour of the `refit` parameter."""
     rng = np.random.RandomState(global_random_seed)
@@ -396,8 +397,8 @@ def test_tuned_threshold_classifier_refit(with_sample_weight, global_random_seed
     assert_allclose(model.estimator_.coef_, estimator.coef_)
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize("fit_params_type", ["list", "array"])
+@config_context(enable_metadata_routing=True)
 def test_tuned_threshold_classifier_fit_params(fit_params_type):
     """Check that we pass `fit_params` to the classifier when calling `fit`."""
     X, y = make_classification(n_samples=100, random_state=0)
@@ -412,7 +413,7 @@ def test_tuned_threshold_classifier_fit_params(fit_params_type):
     model.fit(X, y, **fit_params)
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_tuned_threshold_classifier_cv_zeros_sample_weights_equivalence():
     """Check that passing removing some sample from the dataset `X` is
     equivalent to passing a `sample_weight` with a factor 0."""
@@ -579,7 +580,7 @@ def test_fixed_threshold_classifier(response_method, threshold, pos_label):
         )
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_fixed_threshold_classifier_metadata_routing():
     """Check that everything works with metadata routing."""
     X, y = make_classification(random_state=0)

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -2593,7 +2593,6 @@ def test_inverse_transform_Xt_deprecation(SearchCV):
 # ======================
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize(
     "SearchCV, param_search",
     [
@@ -2601,6 +2600,7 @@ def test_inverse_transform_Xt_deprecation(SearchCV):
         (RandomizedSearchCV, "param_distributions"),
     ],
 )
+@config_context(enable_metadata_routing=True)
 def test_multi_metric_search_forwards_metadata(SearchCV, param_search):
     """Test that *SearchCV forwards metadata correctly when passed multiple metrics."""
     X, y = make_classification(random_state=42)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -13,6 +13,7 @@ import numpy as np
 import pytest
 from scipy.sparse import issparse
 
+from sklearn import config_context
 from sklearn.base import BaseEstimator, clone
 from sklearn.cluster import KMeans
 from sklearn.datasets import (
@@ -2511,7 +2512,6 @@ def test_fit_param_deprecation(func, extra_args):
         )
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize(
     "func, extra_args",
     [
@@ -2523,6 +2523,7 @@ def test_fit_param_deprecation(func, extra_args):
         (validation_curve, {"param_name": "alpha", "param_range": np.array([1])}),
     ],
 )
+@config_context(enable_metadata_routing=True)
 def test_groups_with_routing_validation(func, extra_args):
     """Check that we raise an error if `groups` are passed to the cv method instead
     of `params` when metadata routing is enabled.
@@ -2537,7 +2538,6 @@ def test_groups_with_routing_validation(func, extra_args):
         )
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize(
     "func, extra_args",
     [
@@ -2549,6 +2549,7 @@ def test_groups_with_routing_validation(func, extra_args):
         (validation_curve, {"param_name": "alpha", "param_range": np.array([1])}),
     ],
 )
+@config_context(enable_metadata_routing=True)
 def test_passed_unrequested_metadata(func, extra_args):
     """Check that we raise an error when passing metadata that is not
     requested."""
@@ -2563,7 +2564,6 @@ def test_passed_unrequested_metadata(func, extra_args):
         )
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize(
     "func, extra_args",
     [
@@ -2575,6 +2575,7 @@ def test_passed_unrequested_metadata(func, extra_args):
         (validation_curve, {"param_name": "alpha", "param_range": np.array([1])}),
     ],
 )
+@config_context(enable_metadata_routing=True)
 def test_validation_functions_routing(func, extra_args):
     """Check that the respective cv method is properly dispatching the metadata
     to the consumer."""
@@ -2667,7 +2668,7 @@ def test_validation_functions_routing(func, extra_args):
         )
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_learning_curve_exploit_incremental_learning_routing():
     """Test that learning_curve routes metadata to the estimator correctly while
     partial_fitting it with `exploit_incremental_learning=True`."""

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -925,7 +925,7 @@ def test_dataframe_protocol(constructor_name, minversion):
         no_op.transform(df_bad)
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_transformer_fit_transform_with_metadata_in_transform():
     """Test that having a transformer with metadata for transform raises a
     warning when calling fit_transform."""
@@ -951,7 +951,7 @@ def test_transformer_fit_transform_with_metadata_in_transform():
         assert len(record) == 0
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_outlier_mixin_fit_predict_with_metadata_in_predict():
     """Test that having an OutlierMixin with metadata for predict raises a
     warning when calling fit_predict."""

--- a/sklearn/tests/test_metadata_routing.py
+++ b/sklearn/tests/test_metadata_routing.py
@@ -62,13 +62,6 @@ my_weights = rng.rand(N)
 my_other_weights = rng.rand(N)
 
 
-@pytest.fixture(autouse=True)
-def enable_slep006():
-    """Enable SLEP006 for all tests."""
-    with config_context(enable_metadata_routing=True):
-        yield
-
-
 class SimplePipeline(BaseEstimator):
     """A very simple pipeline, assuming the last step is always a predictor.
 
@@ -127,6 +120,7 @@ class SimplePipeline(BaseEstimator):
         return router
 
 
+@config_context(enable_metadata_routing=True)
 def test_assert_request_is_empty():
     requests = MetadataRequest(owner="test")
     assert_request_is_empty(requests)
@@ -172,6 +166,7 @@ def test_assert_request_is_empty():
         WeightedMetaRegressor(estimator=ConsumingRegressor(), registry=_Registry()),
     ],
 )
+@config_context(enable_metadata_routing=True)
 def test_estimator_puts_self_in_registry(estimator):
     """Check that an estimator puts itself in the registry upon fit."""
     estimator.fit(X, y)
@@ -190,6 +185,7 @@ def test_estimator_puts_self_in_registry(estimator):
         ("valid_arg", True),
     ],
 )
+@config_context(enable_metadata_routing=True)
 def test_request_type_is_alias(val, res):
     # Test request_is_alias
     assert request_is_alias(val) == res
@@ -207,11 +203,13 @@ def test_request_type_is_alias(val, res):
         ("alias_arg", False),
     ],
 )
+@config_context(enable_metadata_routing=True)
 def test_request_type_is_valid(val, res):
     # Test request_is_valid
     assert request_is_valid(val) == res
 
 
+@config_context(enable_metadata_routing=True)
 def test_default_requests():
     class OddEstimator(BaseEstimator):
         __metadata_request__fit = {
@@ -242,6 +240,7 @@ def test_default_requests():
     assert_request_is_empty(est_request)
 
 
+@config_context(enable_metadata_routing=True)
 def test_default_request_override():
     """Test that default requests are correctly overridden regardless of the ASCII order
     of the class names, hence testing small and capital letter class name starts.
@@ -265,11 +264,13 @@ def test_default_request_override():
     )
 
 
+@config_context(enable_metadata_routing=True)
 def test_process_routing_invalid_method():
     with pytest.raises(TypeError, match="Can only route and process input"):
         process_routing(ConsumingClassifier(), "invalid_method", groups=my_groups)
 
 
+@config_context(enable_metadata_routing=True)
 def test_process_routing_invalid_object():
     class InvalidObject:
         pass
@@ -280,6 +281,7 @@ def test_process_routing_invalid_object():
 
 @pytest.mark.parametrize("method", METHODS)
 @pytest.mark.parametrize("default", [None, "default", []])
+@config_context(enable_metadata_routing=True)
 def test_process_routing_empty_params_get_with_default(method, default):
     empty_params = {}
     routed_params = process_routing(ConsumingClassifier(), "fit", **empty_params)
@@ -294,6 +296,7 @@ def test_process_routing_empty_params_get_with_default(method, default):
     assert default_params_for_method == params_for_method
 
 
+@config_context(enable_metadata_routing=True)
 def test_simple_metadata_routing():
     # Tests that metadata is properly routed
 
@@ -350,6 +353,7 @@ def test_simple_metadata_routing():
     )
 
 
+@config_context(enable_metadata_routing=True)
 def test_nested_routing():
     # check if metadata is routed in a nested routing situation.
     pipeline = SimplePipeline(
@@ -398,6 +402,7 @@ def test_nested_routing():
     )
 
 
+@config_context(enable_metadata_routing=True)
 def test_nested_routing_conflict():
     # check if an error is raised if there's a conflict between keys
     pipeline = SimplePipeline(
@@ -427,6 +432,7 @@ def test_nested_routing_conflict():
         pipeline.fit(X, y, metadata=my_groups, sample_weight=w1, outer_weights=w2)
 
 
+@config_context(enable_metadata_routing=True)
 def test_invalid_metadata():
     # check that passing wrong metadata raises an error
     trs = MetaTransformer(
@@ -449,6 +455,7 @@ def test_invalid_metadata():
         trs.fit(X, y).transform(X, sample_weight=my_weights)
 
 
+@config_context(enable_metadata_routing=True)
 def test_get_metadata_routing():
     class TestDefaultsBadMethodName(_MetadataRequester):
         __metadata_request__fit = {
@@ -525,6 +532,7 @@ def test_get_metadata_routing():
     assert_request_equal(est.get_metadata_routing(), expected)
 
 
+@config_context(enable_metadata_routing=True)
 def test_setting_default_requests():
     # Test _get_default_requests method
     test_cases = dict()
@@ -571,6 +579,7 @@ def test_setting_default_requests():
         Klass().fit(None, None)  # for coverage
 
 
+@config_context(enable_metadata_routing=True)
 def test_removing_non_existing_param_raises():
     """Test that removing a metadata using UNUSED which doesn't exist raises."""
 
@@ -586,6 +595,7 @@ def test_removing_non_existing_param_raises():
         InvalidRequestRemoval().get_metadata_routing()
 
 
+@config_context(enable_metadata_routing=True)
 def test_method_metadata_request():
     mmr = MethodMetadataRequest(owner="test", method="fit")
 
@@ -606,6 +616,7 @@ def test_method_metadata_request():
     assert mmr._get_param_names(return_alias=True) == {"bar"}
 
 
+@config_context(enable_metadata_routing=True)
 def test_get_routing_for_object():
     class Consumer(BaseEstimator):
         __metadata_request__fit = {"prop": None}
@@ -624,6 +635,7 @@ def test_get_routing_for_object():
     assert mr.fit.requests == {"prop": None}
 
 
+@config_context(enable_metadata_routing=True)
 def test_metadata_request_consumes_method():
     """Test that MetadataRequest().consumes() method works as expected."""
     request = MetadataRouter(owner="test")
@@ -638,6 +650,7 @@ def test_metadata_request_consumes_method():
     assert request.consumes(method="fit", params={"bar", "foo"}) == {"bar"}
 
 
+@config_context(enable_metadata_routing=True)
 def test_metadata_router_consumes_method():
     """Test that MetadataRouter().consumes method works as expected."""
     # having it here instead of parametrizing the test since `set_fit_request`
@@ -665,6 +678,7 @@ def test_metadata_router_consumes_method():
         assert obj.get_metadata_routing().consumes(method="fit", params=input) == output
 
 
+@config_context(enable_metadata_routing=True)
 def test_metaestimator_warnings():
     class WeightedMetaRegressorWarn(WeightedMetaRegressor):
         __metadata_request__fit = {"sample_weight": metadata_routing.WARN}
@@ -677,6 +691,7 @@ def test_metaestimator_warnings():
         ).fit(X, y, sample_weight=my_weights)
 
 
+@config_context(enable_metadata_routing=True)
 def test_estimator_warnings():
     class ConsumingRegressorWarn(ConsumingRegressor):
         __metadata_request__fit = {"sample_weight": metadata_routing.WARN}
@@ -689,6 +704,7 @@ def test_estimator_warnings():
         )
 
 
+@config_context(enable_metadata_routing=True)
 @pytest.mark.parametrize(
     "obj, string",
     [
@@ -717,6 +733,7 @@ def test_estimator_warnings():
         ),
     ],
 )
+@config_context(enable_metadata_routing=True)
 def test_string_representations(obj, string):
     assert str(obj) == string
 
@@ -754,11 +771,13 @@ def test_string_representations(obj, string):
         ),
     ],
 )
+@config_context(enable_metadata_routing=True)
 def test_validations(obj, method, inputs, err_cls, err_msg):
     with pytest.raises(err_cls, match=err_msg):
         getattr(obj, method)(**inputs)
 
 
+@config_context(enable_metadata_routing=True)
 def test_methodmapping():
     mm = (
         MethodMapping()
@@ -780,6 +799,7 @@ def test_methodmapping():
     assert repr(mm) == "[{'caller': 'score', 'callee': 'score'}]"
 
 
+@config_context(enable_metadata_routing=True)
 def test_metadatarouter_add_self_request():
     # adding a MetadataRequest as `self` adds a copy
     request = MetadataRequest(owner="nested")
@@ -809,6 +829,7 @@ def test_metadatarouter_add_self_request():
     assert router._self_request is not est._get_metadata_request()
 
 
+@config_context(enable_metadata_routing=True)
 def test_metadata_routing_add():
     # adding one with a string `method_mapping`
     router = MetadataRouter(owner="test").add(
@@ -839,6 +860,7 @@ def test_metadata_routing_add():
     )
 
 
+@config_context(enable_metadata_routing=True)
 def test_metadata_routing_get_param_names():
     router = (
         MetadataRouter(owner="test")
@@ -883,6 +905,7 @@ def test_metadata_routing_get_param_names():
     )
 
 
+@config_context(enable_metadata_routing=True)
 def test_method_generation():
     # Test if all required request methods are generated.
 
@@ -976,6 +999,7 @@ def test_method_generation():
         assert hasattr(SimpleEstimator(), f"set_{method}_request")
 
 
+@config_context(enable_metadata_routing=True)
 def test_composite_methods():
     # Test the behavior and the values of methods (composite methods) whose
     # request values are a union of requests by other methods (simple methods).
@@ -1028,6 +1052,7 @@ def test_composite_methods():
     }
 
 
+@config_context(enable_metadata_routing=True)
 def test_no_feature_flag_raises_error():
     """Test that when feature flag disabled, set_{method}_requests raises."""
     with config_context(enable_metadata_routing=False):
@@ -1035,11 +1060,13 @@ def test_no_feature_flag_raises_error():
             ConsumingClassifier().set_fit_request(sample_weight=True)
 
 
+@config_context(enable_metadata_routing=True)
 def test_none_metadata_passed():
     """Test that passing None as metadata when not requested doesn't raise"""
     MetaRegressor(estimator=ConsumingRegressor()).fit(X, y, sample_weight=None)
 
 
+@config_context(enable_metadata_routing=True)
 def test_no_metadata_always_works():
     """Test that when no metadata is passed, having a meta-estimator which does
     not yet support metadata routing works.
@@ -1060,6 +1087,7 @@ def test_no_metadata_always_works():
         MetaRegressor(estimator=Estimator()).fit(X, y, metadata=my_groups)
 
 
+@config_context(enable_metadata_routing=True)
 def test_unsetmetadatapassederror_correct():
     """Test that UnsetMetadataPassedError raises the correct error message when
     set_{method}_request is not set in nested cases."""
@@ -1076,6 +1104,7 @@ def test_unsetmetadatapassederror_correct():
         pipe.fit(X, y, metadata="blah")
 
 
+@config_context(enable_metadata_routing=True)
 def test_unsetmetadatapassederror_correct_for_composite_methods():
     """Test that UnsetMetadataPassedError raises the correct error message when
     composite metadata request methods are not set in nested cases."""
@@ -1094,6 +1123,7 @@ def test_unsetmetadatapassederror_correct_for_composite_methods():
         pipe.fit_transform(X, y, metadata="blah")
 
 
+@config_context(enable_metadata_routing=True)
 def test_unbound_set_methods_work():
     """Tests that if the set_{method}_request is unbound, it still works.
 

--- a/sklearn/tests/test_metaestimators_metadata_routing.py
+++ b/sklearn/tests/test_metaestimators_metadata_routing.py
@@ -90,13 +90,6 @@ sample_weight = rng.rand(N)
 groups = rng.randint(0, 10, size=len(y))
 
 
-@pytest.fixture(autouse=True)
-def enable_slep006():
-    """Enable SLEP006 for all tests."""
-    with config_context(enable_metadata_routing=True):
-        yield
-
-
 METAESTIMATORS: list = [
     {
         "metaestimator": MultiOutputRegressor,
@@ -591,6 +584,7 @@ def set_requests(estimator, *, method_mapping, methods, metadata_name, value=Tru
 
 
 @pytest.mark.parametrize("estimator", UNSUPPORTED_ESTIMATORS)
+@config_context(enable_metadata_routing=True)
 def test_unsupported_estimators_get_metadata_routing(estimator):
     """Test that get_metadata_routing is not implemented on meta-estimators for
     which we haven't implemented routing yet."""
@@ -599,6 +593,7 @@ def test_unsupported_estimators_get_metadata_routing(estimator):
 
 
 @pytest.mark.parametrize("estimator", UNSUPPORTED_ESTIMATORS)
+@config_context(enable_metadata_routing=True)
 def test_unsupported_estimators_fit_with_metadata(estimator):
     """Test that fit raises NotImplementedError when metadata routing is
     enabled and a metadata is passed on meta-estimators for which we haven't
@@ -612,6 +607,7 @@ def test_unsupported_estimators_fit_with_metadata(estimator):
             raise NotImplementedError
 
 
+@config_context(enable_metadata_routing=True)
 def test_registry_copy():
     # test that _Registry is not copied into a new instance.
     a = _Registry()
@@ -622,6 +618,7 @@ def test_registry_copy():
 
 
 @pytest.mark.parametrize("metaestimator", METAESTIMATORS, ids=METAESTIMATOR_IDS)
+@config_context(enable_metadata_routing=True)
 def test_default_request(metaestimator):
     # Check that by default request is empty and the right type
     metaestimator_class = metaestimator["metaestimator"]
@@ -638,6 +635,7 @@ def test_default_request(metaestimator):
 
 
 @pytest.mark.parametrize("metaestimator", METAESTIMATORS, ids=METAESTIMATOR_IDS)
+@config_context(enable_metadata_routing=True)
 def test_error_on_missing_requests_for_sub_estimator(metaestimator):
     # Test that a UnsetMetadataPassedError is raised when the sub-estimator's
     # requests are not set
@@ -696,6 +694,7 @@ def test_error_on_missing_requests_for_sub_estimator(metaestimator):
 
 
 @pytest.mark.parametrize("metaestimator", METAESTIMATORS, ids=METAESTIMATOR_IDS)
+@config_context(enable_metadata_routing=True)
 def test_setting_request_on_sub_estimator_removes_error(metaestimator):
     # When the metadata is explicitly requested on the sub-estimator, there
     # should be no errors.
@@ -765,6 +764,7 @@ def test_setting_request_on_sub_estimator_removes_error(metaestimator):
 
 
 @pytest.mark.parametrize("metaestimator", METAESTIMATORS, ids=METAESTIMATOR_IDS)
+@config_context(enable_metadata_routing=True)
 def test_non_consuming_estimator_works(metaestimator):
     # Test that when a non-consuming estimator is given, the meta-estimator
     # works w/o setting any requests.
@@ -803,6 +803,7 @@ def test_non_consuming_estimator_works(metaestimator):
 
 
 @pytest.mark.parametrize("metaestimator", METAESTIMATORS, ids=METAESTIMATOR_IDS)
+@config_context(enable_metadata_routing=True)
 def test_metadata_is_routed_correctly_to_scorer(metaestimator):
     """Test that any requested metadata is correctly routed to the underlying
     scorers in CV estimators.
@@ -848,6 +849,7 @@ def test_metadata_is_routed_correctly_to_scorer(metaestimator):
 
 
 @pytest.mark.parametrize("metaestimator", METAESTIMATORS, ids=METAESTIMATOR_IDS)
+@config_context(enable_metadata_routing=True)
 def test_metadata_is_routed_correctly_to_splitter(metaestimator):
     """Test that any requested metadata is correctly routed to the underlying
     splitters in CV estimators.
@@ -882,6 +884,7 @@ def test_metadata_is_routed_correctly_to_splitter(metaestimator):
 
 
 @pytest.mark.parametrize("metaestimator", METAESTIMATORS, ids=METAESTIMATOR_IDS)
+@config_context(enable_metadata_routing=True)
 def test_metadata_routed_to_group_splitter(metaestimator):
     """Test that groups are routed correctly if group splitter of CV estimator is used
     within cross_validate. Regression test for issue described in PR #29634 to test that

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -13,6 +13,7 @@ import joblib
 import numpy as np
 import pytest
 
+from sklearn import config_context
 from sklearn.base import BaseEstimator, TransformerMixin, clone, is_classifier
 from sklearn.cluster import KMeans
 from sklearn.datasets import load_iris
@@ -1872,9 +1873,9 @@ class SimpleEstimator(BaseEstimator):
         return X - 1
 
 
-@pytest.mark.usefixtures("enable_slep006")
 # split and partial_fit not relevant for pipelines
 @pytest.mark.parametrize("method", sorted(set(METHODS) - {"split", "partial_fit"}))
+@config_context(enable_metadata_routing=True)
 def test_metadata_routing_for_pipeline(method):
     """Test that metadata is routed correctly for pipelines."""
 
@@ -1939,11 +1940,11 @@ def test_metadata_routing_for_pipeline(method):
     )
 
 
-@pytest.mark.usefixtures("enable_slep006")
 # split and partial_fit not relevant for pipelines
 # sorted is here needed to make `pytest -nX` work. W/o it, tests are collected
 # in different orders between workers and that makes it fail.
 @pytest.mark.parametrize("method", sorted(set(METHODS) - {"split", "partial_fit"}))
+@config_context(enable_metadata_routing=True)
 def test_metadata_routing_error_for_pipeline(method):
     """Test that metadata is not routed for pipelines when not requested."""
     X, y = [[1]], [1]
@@ -1980,7 +1981,7 @@ def test_routing_passed_metadata_not_supported(method):
         getattr(pipe, method)([[1]], sample_weight=[1], prop="a")
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_pipeline_with_estimator_with_len():
     """Test that pipeline works with estimators that have a `__len__` method."""
     pipe = Pipeline(
@@ -1990,8 +1991,8 @@ def test_pipeline_with_estimator_with_len():
     pipe.predict([[1]])
 
 
-@pytest.mark.usefixtures("enable_slep006")
 @pytest.mark.parametrize("last_step", [None, "passthrough"])
+@config_context(enable_metadata_routing=True)
 def test_pipeline_with_no_last_step(last_step):
     """Test that the pipeline works when there is not last step.
 
@@ -2001,7 +2002,7 @@ def test_pipeline_with_no_last_step(last_step):
     assert pipe.fit([[1]], [1]).transform([[1], [2], [3]]) == [[1], [2], [3]]
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_feature_union_metadata_routing_error():
     """Test that the right error is raised when metadata is not requested."""
     X = np.array([[0, 1], [2, 2], [4, 6]])
@@ -2042,7 +2043,7 @@ def test_feature_union_metadata_routing_error():
         ).transform(X, sample_weight=sample_weight, metadata=metadata)
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 def test_feature_union_get_metadata_routing_without_fit():
     """Test that get_metadata_routing() works regardless of the Child's
     consumption of any metadata."""
@@ -2050,7 +2051,7 @@ def test_feature_union_get_metadata_routing_without_fit():
     feature_union.get_metadata_routing()
 
 
-@pytest.mark.usefixtures("enable_slep006")
+@config_context(enable_metadata_routing=True)
 @pytest.mark.parametrize(
     "transformer", [ConsumingTransformer, ConsumingNoFitTransformTransformer]
 )


### PR DESCRIPTION
This is a first step towards making it possible to use thread-based parallelism to run the tests to be able to test with the new free-threading mode of Python 3.13.

Discussed in https://github.com/scikit-learn/scikit-learn/issues/30007#issuecomment-2402384366.

In short: `sklearn.config_context` stores the active config in thread local variables. However, all the pytest fixtures are typically run in the main thread while the tests itself are run in a different thread when using one of the recent pytest plugins dedicated to running the tests in parallel using a thread pool (to detect GIL related compatibility issues).

One could argue that this is a design bug of those plugins, but more pragmatically, we can simplify our test suite by directly using `sklearn.config_context` as a function decorator instead of relying on a dedicated fixture. The function decorator is executed on the same thread as where the test function itself is run.