### PR TITLE
CI: bump deprecated macos-12 to macos-13

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -102,22 +102,22 @@ jobs:
             free_threaded_support: True
 
           # MacOS x86_64
-          - os: macos-12
+          - os: macos-13
             python: 39
             platform_id: macosx_x86_64
-          - os: macos-12
+          - os: macos-13
             python: 310
             platform_id: macosx_x86_64
-          - os: macos-12
+          - os: macos-13
             python: 311
             platform_id: macosx_x86_64
-          - os: macos-12
+          - os: macos-13
             python: 312
             platform_id: macosx_x86_64
-          - os: macos-12
+          - os: macos-13
             python: 313
             platform_id: macosx_x86_64
-          - os: macos-12
+          - os: macos-13
             python: 313t
             platform_id: macosx_x86_64
             free_threaded_support: True


### PR DESCRIPTION
`macos-12` is now deprecated, but x86_64 should still be available with the `macos-13` image.