### PR TITLE
MAINT fix references to sample_weight meta-issue in comments

### DIFF
--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1179,7 +1179,7 @@ class _BaseKMeans(
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: replace by a statistical test, see meta-issue #162298
+        # TODO: replace by a statistical test, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -643,7 +643,7 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = get_tags(self._get_estimator()).input_tags.allow_nan
-        # TODO: replace by a statistical test, see meta-issue #162298
+        # TODO: replace by a statistical test, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1560,7 +1560,7 @@ class RandomForestClassifier(ForestClassifier):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: replace by a statistical test, see meta-issue #162298
+        # TODO: replace by a statistical test, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."
@@ -1931,7 +1931,7 @@ class RandomForestRegressor(ForestRegressor):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: replace by a statistical test, see meta-issue #162298
+        # TODO: replace by a statistical test, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."
@@ -3016,7 +3016,7 @@ class RandomTreesEmbedding(TransformerMixin, BaseForest):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: replace by a statistical test, see meta-issue #162298
+        # TODO: replace by a statistical test, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1727,7 +1727,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: investigate failure see meta-issue #162298
+        # TODO: investigate failure see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."
@@ -2194,7 +2194,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: investigate failure see meta-issue #162298
+        # TODO: investigate failure see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1389,7 +1389,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
-        # TODO: replace by a statistical test, see meta-issue #162298
+        # TODO: replace by a statistical test, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -633,7 +633,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: replace by a statistical test, see meta-issue #162298
+        # TODO: replace by a statistical test, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -860,7 +860,7 @@ class AdaBoostClassifier(
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: replace by a statistical test, see meta-issue #162298
+        # TODO: replace by a statistical test, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."
@@ -1179,7 +1179,7 @@ class AdaBoostRegressor(_RoutingNotSupportedMixin, RegressorMixin, BaseWeightBoo
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: replace by a statistical test, see meta-issue #162298
+        # TODO: replace by a statistical test, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -683,7 +683,7 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: investigate failure see meta-issue #162298
+        # TODO: investigate failure see meta-issue #16298
         #
         # Note: this model should converge to the minimum norm solution of the
         # least squares problem and as result be numerically stable enough when

--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -432,7 +432,7 @@ class BayesianRidge(RegressorMixin, LinearModel):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: fix sample_weight handling of this estimator, see meta-issue #162298
+        # TODO: fix sample_weight handling of this estimator, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."

--- a/sklearn/linear_model/_perceptron.py
+++ b/sklearn/linear_model/_perceptron.py
@@ -227,7 +227,7 @@ class Perceptron(BaseSGDClassifier):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: replace by a statistical test, see meta-issue #162298
+        # TODO: replace by a statistical test, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -723,7 +723,7 @@ class RANSACRegressor(
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: replace by a statistical test, see meta-issue #162298
+        # TODO: replace by a statistical test, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -1376,7 +1376,7 @@ class SGDClassifier(BaseSGDClassifier):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: replace by a statistical test, see meta-issue #162298
+        # TODO: replace by a statistical test, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."
@@ -2061,7 +2061,7 @@ class SGDRegressor(BaseSGDRegressor):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: replace by a statistical test, see meta-issue #162298
+        # TODO: replace by a statistical test, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."
@@ -2642,7 +2642,7 @@ class SGDOneClassSVM(BaseSGD, OutlierMixin):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: replace by a statistical test, see meta-issue #162298
+        # TODO: replace by a statistical test, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -1433,7 +1433,7 @@ class CategoricalNB(_BaseDiscreteNB):
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.input_tags.positive_only = True
-        # TODO: fix sample_weight handling of this estimator, see meta-issue #162298
+        # TODO: fix sample_weight handling of this estimator, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -465,7 +465,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: fix sample_weight handling of this estimator, see meta-issue #162298
+        # TODO: fix sample_weight handling of this estimator, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -351,7 +351,7 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: replace by a statistical test when _dual=True, see meta-issue #162298
+        # TODO: replace by a statistical test when _dual=True, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."
@@ -615,7 +615,7 @@ class LinearSVR(RegressorMixin, LinearModel):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: replace by a statistical test, see meta-issue #162298
+        # TODO: replace by a statistical test, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."
@@ -900,7 +900,7 @@ class SVC(BaseSVC):
         tags._xfail_checks = {
             # TODO: fix sample_weight handling of this estimator when probability=False
             # TODO: replace by a statistical test when probability=True
-            # see meta-issue #162298
+            # see meta-issue #16298
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."
             ),
@@ -1177,7 +1177,7 @@ class NuSVC(BaseSVC):
             "check_class_weight_classifiers": "class_weight is ignored.",
             # TODO: fix sample_weight handling of this estimator when probability=False
             # TODO: replace by a statistical test when probability=True
-            # see meta-issue #162298
+            # see meta-issue #16298
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."
             ),
@@ -1381,7 +1381,7 @@ class SVR(RegressorMixin, BaseLibSVM):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: fix sample_weight handling of this estimator, see meta-issue #162298
+        # TODO: fix sample_weight handling of this estimator, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."
@@ -1576,7 +1576,7 @@ class NuSVR(RegressorMixin, BaseLibSVM):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: fix sample_weight handling of this estimator, see meta-issue #162298
+        # TODO: fix sample_weight handling of this estimator, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."
@@ -1840,7 +1840,7 @@ class OneClassSVM(OutlierMixin, BaseLibSVM):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # TODO: fix sample_weight handling of this estimator, see meta-issue #162298
+        # TODO: fix sample_weight handling of this estimator, see meta-issue #16298
         tags._xfail_checks = {
             "check_sample_weight_equivalence": (
                 "sample_weight is not equivalent to removing/repeating samples."


### PR DESCRIPTION
#### Reference Issues/PRs

Follow up to #29818


#### What does this implement/fix? Explain your changes.

Looking at #29818, I noticed many instances of this comment:

```text
# TODO: replace by a statistical test, see meta-issue #162298
```

I went to look into that issue (I'm interested in this, as a maintainer of some scikit-learn compatible estimators), and found it doesn't exist. I believe that was meant to be #16298.

This fixes all such references, to save others a bit of time.

#### Any other comments?

Confirmed that I got all of these like this:

```shell
git grep 162298
```

Thanks for your time and consideration.
