### PR TITLE
CI Fix CUDA CI setting in automated lock-file update

### DIFF
--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -63,8 +63,15 @@ jobs:
         if: steps.cpr.outputs.pull-request-number != '' && matrix.name == 'array-api'
         env:
           GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          PR_NUMBER: ${{steps.cpr.outputs.pull-request-number}}
         run: |
-          gh pr edit ${{steps.cpr.outputs.pull-request-number}} --add-label "CUDA CI"
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/scikit-learn/scikit-learn/issues/$PR_NUMBER/labels \
+            -d '{"labels":["CUDA CI"]}'
 
       - name: Check Pull Request
         if: steps.cpr.outputs.pull-request-number != ''


### PR DESCRIPTION
Somehow `gh` needs additional permissions to be able to set the PR label. Using the REST API directly does not have this issue.

See https://github.com/scikit-learn/scikit-learn/pull/30065#issuecomment-2410115385 and https://github.com/scikit-learn/scikit-learn/issues/29781 for more context.

I did some quick testing that the `curl` command was working fine with one of my token with similar permission as the scikit-learn-bot one whereas using `gh` created the same error.

As an additional test, I created a scikit-learn-bot token with repo and workflow permissions (same permissions as in the CI) and ran the following to set the enhancement label as scikit-learn-bot which worked:
```bash
export GH_TOKEN=<created token>
# 30067 is the PR you are currently looking at
export PR_NUMBER=30067
curl -L \                                              
 -X POST \
 -H "Accept: application/vnd.github+json" \
 -H "Authorization: Bearer $GH_TOKEN" \
 -H "X-GitHub-Api-Version: 2022-11-28" \
 https://api.github.com/repos/scikit-learn/scikit-learn/issues/$PR_NUMBER/labels \
 -d '{"labels":["enhancement"]}'
```

I guess the real test would be to merge this and see if the CI works as expected. Trying to come up with a better test prior to merging this PR seems like a bit too much work ...

