### PR TITLE
Fix cibuildwheel for macos

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,6 +44,11 @@ jobs:
   build_wheels:
     name: Build wheel for cp${{ matrix.python }}-${{ matrix.platform_id }}-${{ matrix.manylinux_image }}
     runs-on: ${{ matrix.os }}
+
+    # For conda-incubator/setup-miniconda to work
+    defaults:
+      run:
+        shell: bash -el {0}
     needs: check_build_trigger
     if: needs.check_build_trigger.outputs.build
 
@@ -152,33 +157,8 @@ jobs:
         with:
           python-version: "3.11" # update once build dependencies are available
 
-      - name: Install conda for macos arm64
-        if: ${{ matrix.platform_id == 'macosx_arm64' }}
-        run: |
-          set -ex
-          # macos arm64 runners do not have conda installed. Thus we much install conda manually
-          EXPECTED_SHA="dd832d8a65a861b5592b2cf1d55f26031f7c1491b30321754443931e7b1e6832"
-          MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/download/23.11.0-0/Mambaforge-23.11.0-0-MacOSX-arm64.sh"
-          curl -L --retry 10 $MINIFORGE_URL -o miniforge.sh
-
-          # Check SHA
-          file_sha=$(shasum -a 256 miniforge.sh | awk '{print $1}')
-          if [ "$EXPECTED_SHA" != "$file_sha" ]; then
-              echo "SHA values did not match!"
-              exit 1
-          fi
-
-          # Install miniforge
-          MINIFORGE_PATH=$HOME/miniforge
-          bash ./miniforge.sh -b -p $MINIFORGE_PATH
-          echo "$MINIFORGE_PATH/bin" >> $GITHUB_PATH
-          echo "CONDA_HOME=$MINIFORGE_PATH" >> $GITHUB_ENV
-
-      - name: Set conda environment for non-macos arm64 environments
-        if: ${{ matrix.platform_id != 'macosx_arm64' }}
-        run: |
-          # Non-macos arm64 envrionments already have conda installed
-          echo "CONDA_HOME=/usr/local/miniconda" >> $GITHUB_ENV
+      - uses: conda-incubator/setup-miniconda@v3
+        if: ${{ startsWith(matrix.platform_id, 'macosx') }}
 
       - name: Build and test wheels
         env:

--- a/build_tools/cirrus/arm_wheel.yml
+++ b/build_tools/cirrus/arm_wheel.yml
@@ -11,6 +11,7 @@ linux_arm64_wheel_task:
     CIBW_BEFORE_BUILD: bash {project}/build_tools/wheels/cibw_before_build.sh {project}
     CIBW_TEST_COMMAND: bash {project}/build_tools/wheels/test_wheels.sh {project}
     CIBW_TEST_REQUIRES: pytest pandas threadpoolctl pytest-xdist
+    CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
     CIBW_BUILD_VERBOSITY: 1
     RUNNER_OS: Linux
     # Upload tokens have been encrypted via the CirrusCI interface:

--- a/build_tools/wheels/build_wheels.sh
+++ b/build_tools/wheels/build_wheels.sh
@@ -38,7 +38,7 @@ if [[ $(uname) == "Darwin" ]]; then
         OPENMP_URL="https://anaconda.org/conda-forge/llvm-openmp/11.1.0/download/osx-64/llvm-openmp-11.1.0-hda6cdc1_1.tar.bz2"
     fi
 
-    sudo conda create -n build $OPENMP_URL
+    conda create -n build $OPENMP_URL
     PREFIX="$HOME/miniconda3/envs/build"
 
     export CC=/usr/bin/clang

--- a/build_tools/wheels/build_wheels.sh
+++ b/build_tools/wheels/build_wheels.sh
@@ -39,7 +39,7 @@ if [[ $(uname) == "Darwin" ]]; then
     fi
 
     sudo conda create -n build $OPENMP_URL
-    PREFIX="$CONDA_HOME/envs/build"
+    PREFIX="$HOME/miniconda3/envs/build"
 
     export CC=/usr/bin/clang
     export CXX=/usr/bin/clang++


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fix #30071, follow-up of https://github.com/scikit-learn/scikit-learn/pull/30060.

macOS 13 and 14 do not ship with conda anymore. We have to install it first to use it in the wheel builder.


#### What does this implement/fix? Explain your changes.
This PR uses `conda-incubator/setup-miniconda@v3` to install conda first before cibuildwheel runs for macos.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
