### PR TITLE
DOC add link plot_tomography_l1_reconstruction 

### DIFF
--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -224,7 +224,9 @@ alpha parameter, the fewer features selected.
   noise, the smallest absolute value of non-zero coefficients, and the
   structure of the design matrix X. In addition, the design matrix must
   display certain specific properties, such as not being too correlated
-  (See :ref:`sphx_glr_auto_examples_applications_plot_tomography_l1_reconstruction.py`).
+  On the use of Lasso for sparse signal recovery, see this example on 
+  compressive sensing: 
+  :ref:`sphx_glr_auto_examples_applications_plot_tomography_l1_reconstruction.py`.
 
   There is no general rule to select an alpha parameter for recovery of
   non-zero coefficients. It can by set by cross-validation

--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -223,7 +223,8 @@ alpha parameter, the fewer features selected.
   coefficients, the logarithm of the number of features, the amount of
   noise, the smallest absolute value of non-zero coefficients, and the
   structure of the design matrix X. In addition, the design matrix must
-  display certain specific properties, such as not being too correlated.
+  display certain specific properties, such as not being too correlated
+  (See :ref:`sphx_glr_auto_examples_applications_plot_tomography_l1_reconstruction.py`).
 
   There is no general rule to select an alpha parameter for recovery of
   non-zero coefficients. It can by set by cross-validation

--- a/doc/modules/feature_selection.rst
+++ b/doc/modules/feature_selection.rst
@@ -223,7 +223,7 @@ alpha parameter, the fewer features selected.
   coefficients, the logarithm of the number of features, the amount of
   noise, the smallest absolute value of non-zero coefficients, and the
   structure of the design matrix X. In addition, the design matrix must
-  display certain specific properties, such as not being too correlated
+  display certain specific properties, such as not being too correlated.
   On the use of Lasso for sparse signal recovery, see this example on 
   compressive sensing: 
   :ref:`sphx_glr_auto_examples_applications_plot_tomography_l1_reconstruction.py`.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

add link plot_tomography_l1_reconstruction in compressive sensing paragraph towards -#26927
