### PR TITLE
Refactor code to remove sorting of argument names for __repr__

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -215,8 +215,8 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
                     " %s with constructor %s doesn't "
                     " follow this convention." % (cls, init_signature)
                 )
-        # Extract and sort argument names excluding 'self'
-        return sorted([p.name for p in parameters])
+        # Extract argument names excluding 'self'
+        return [p.name for p in parameters]
 
     def get_params(self, deep=True):
         """

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -215,8 +215,8 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
                     " %s with constructor %s doesn't "
                     " follow this convention." % (cls, init_signature)
                 )
-        # Extract argument names excluding 'self'
-        return [p.name for p in parameters]
+        # Extract and sort argument names excluding 'self'
+        return sorted([p.name for p in parameters])
 
     def get_params(self, deep=True):
         """

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2882,7 +2882,7 @@ def _pprint(params, offset=0, printer=repr):
     params_list = list()
     this_line_length = offset
     line_sep = ",\n" + (1 + offset // 2) * " "
-    for i, (k, v) in enumerate(sorted(params.items())):
+    for i, (k, v) in enumerate(params.items()):
         if isinstance(v, float):
             # use str for representing floating point numbers
             # this way we get consistent representation across
@@ -2944,7 +2944,6 @@ def _build_repr(self):
         finally:
             warnings.filters.pop(0)
         params[key] = value
-
     return "%s(%s)" % (class_name, _pprint(params, offset=len(class_name)))
 
 

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2920,13 +2920,11 @@ def _build_repr(self):
     if init is object.__init__:
         args = []
     else:
-        args = sorted(
-            [
-                p.name
-                for p in init_signature.parameters.values()
-                if p.name != "self" and p.kind != p.VAR_KEYWORD
-            ]
-        )
+        args = [
+            p.name
+            for p in init_signature.parameters.values()
+            if p.name != "self" and p.kind != p.VAR_KEYWORD
+        ]
     class_name = self.__class__.__name__
     params = dict()
     for key in args:

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -909,7 +909,7 @@ class StratifiedGroupKFold(GroupsConsumerMixin, _BaseKFold):
     >>> sgkf.get_n_splits(X, y)
     3
     >>> print(sgkf)
-    StratifiedGroupKFold(n_splits=2, shuffle=False, random_state=None)
+    StratifiedGroupKFold(n_splits=3, shuffle=False, random_state=None)
     >>> for i, (train_index, test_index) in enumerate(sgkf.split(X, y, groups)):
     ...     print(f"Fold {i}:")
     ...     print(f"  Train: index={train_index}")
@@ -1117,7 +1117,7 @@ class TimeSeriesSplit(_BaseKFold):
     >>> y = np.array([1, 2, 3, 4, 5, 6])
     >>> tscv = TimeSeriesSplit()
     >>> print(tscv)
-    TimeSeriesSplit(gap=0, max_train_size=None, n_splits=5, test_size=None)
+    TimeSeriesSplit(n_splits=5, max_train_size=None, test_size=None, gap=0)
     >>> for i, (train_index, test_index) in enumerate(tscv.split(X)):
     ...     print(f"Fold {i}:")
     ...     print(f"  Train: index={train_index}")

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -477,7 +477,7 @@ class KFold(_UnsupportedGroupCVMixin, _BaseKFold):
     >>> kf.get_n_splits(X)
     2
     >>> print(kf)
-    KFold(n_splits=2, random_state=None, shuffle=False)
+    KFold(n_splits=2, shuffle=False, random_state=None)
     >>> for i, (train_index, test_index) in enumerate(kf.split(X)):
     ...     print(f"Fold {i}:")
     ...     print(f"  Train: index={train_index}")
@@ -701,7 +701,7 @@ class StratifiedKFold(_BaseKFold):
     >>> skf.get_n_splits(X, y)
     2
     >>> print(skf)
-    StratifiedKFold(n_splits=2, random_state=None, shuffle=False)
+    StratifiedKFold(n_splits=2, shuffle=False, random_state=None)
     >>> for i, (train_index, test_index) in enumerate(skf.split(X, y)):
     ...     print(f"Fold {i}:")
     ...     print(f"  Train: index={train_index}")
@@ -909,7 +909,7 @@ class StratifiedGroupKFold(GroupsConsumerMixin, _BaseKFold):
     >>> sgkf.get_n_splits(X, y)
     3
     >>> print(sgkf)
-    StratifiedGroupKFold(n_splits=3, random_state=None, shuffle=False)
+    StratifiedGroupKFold(n_splits=2, shuffle=False, random_state=None)
     >>> for i, (train_index, test_index) in enumerate(sgkf.split(X, y, groups)):
     ...     print(f"Fold {i}:")
     ...     print(f"  Train: index={train_index}")
@@ -1663,7 +1663,7 @@ class RepeatedKFold(_UnsupportedGroupCVMixin, _RepeatedSplits):
     >>> rkf.get_n_splits(X, y)
     4
     >>> print(rkf)
-    RepeatedKFold(n_repeats=2, n_splits=2, random_state=2652124)
+    RepeatedKFold(n_splits=2, n_repeats=2, random_state=2652124)
     >>> for i, (train_index, test_index) in enumerate(rkf.split(X)):
     ...     print(f"Fold {i}:")
     ...     print(f"  Train: index={train_index}")
@@ -1731,7 +1731,7 @@ class RepeatedStratifiedKFold(_UnsupportedGroupCVMixin, _RepeatedSplits):
     >>> rskf.get_n_splits(X, y)
     4
     >>> print(rskf)
-    RepeatedStratifiedKFold(n_repeats=2, n_splits=2, random_state=36851234)
+    RepeatedStratifiedKFold(n_splits=2, n_repeats=2, random_state=36851234)
     >>> for i, (train_index, test_index) in enumerate(rskf.split(X, y)):
     ...     print(f"Fold {i}:")
     ...     print(f"  Train: index={train_index}")
@@ -1975,7 +1975,7 @@ class ShuffleSplit(_UnsupportedGroupCVMixin, BaseShuffleSplit):
     >>> rs.get_n_splits(X)
     5
     >>> print(rs)
-    ShuffleSplit(n_splits=5, random_state=0, test_size=0.25, train_size=None)
+    ShuffleSplit(n_splits=5, test_size=0.25, train_size=None, random_state=0)
     >>> for i, (train_index, test_index) in enumerate(rs.split(X)):
     ...     print(f"Fold {i}:")
     ...     print(f"  Train: index={train_index}")
@@ -2100,7 +2100,7 @@ class GroupShuffleSplit(GroupsConsumerMixin, BaseShuffleSplit):
     >>> gss.get_n_splits()
     2
     >>> print(gss)
-    GroupShuffleSplit(n_splits=2, random_state=42, test_size=None, train_size=0.7)
+    GroupShuffleSplit(n_splits=2, test_size=None, train_size=0.7, random_state=42)
     >>> for i, (train_index, test_index) in enumerate(gss.split(X, y, groups)):
     ...     print(f"Fold {i}:")
     ...     print(f"  Train: index={train_index}, group={groups[train_index]}")
@@ -2230,7 +2230,8 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     >>> sss.get_n_splits(X, y)
     5
     >>> print(sss)
-    StratifiedShuffleSplit(n_splits=5, random_state=0, ...)
+    StratifiedShuffleSplit(n_splits=5, test_size=0.5, train_size=None,
+            random_state=0)
     >>> for i, (train_index, test_index) in enumerate(sss.split(X, y)):
     ...     print(f"Fold {i}:")
     ...     print(f"  Train: index={train_index}")

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -139,15 +139,15 @@ def test_cross_validator_with_default_params():
 
     loo_repr = "LeaveOneOut()"
     lpo_repr = "LeavePOut(p=2)"
-    kf_repr = "KFold(n_splits=2, random_state=None, shuffle=False)"
-    skf_repr = "StratifiedKFold(n_splits=2, random_state=None, shuffle=False)"
+    kf_repr = "KFold(n_splits=2, shuffle=False, random_state=None)"
+    skf_repr = "StratifiedKFold(n_splits=2, shuffle=False, random_state=None)"
     lolo_repr = "LeaveOneGroupOut()"
     lopo_repr = "LeavePGroupsOut(n_groups=2)"
     ss_repr = (
-        "ShuffleSplit(n_splits=10, random_state=0, test_size=None, train_size=None)"
+        "ShuffleSplit(n_splits=5, test_size=0.25, train_size=None, random_state=0)"
     )
     ps_repr = "PredefinedSplit(test_fold=array([1, 1, 2, 2]))"
-    sgkf_repr = "StratifiedGroupKFold(n_splits=2, random_state=None, shuffle=False)"
+    sgkf_repr = "StratifiedGroupKFold(n_splits=2, shuffle=False, random_state=None)"
 
     n_splits_expected = [
         n_samples,

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1164,7 +1164,7 @@ def test_repeated_cv_value_errors():
 def test_repeated_cv_repr(RepeatedCV):
     n_splits, n_repeats = 2, 6
     repeated_cv = RepeatedCV(n_splits=n_splits, n_repeats=n_repeats)
-    repeated_cv_repr = "{}(n_repeats=6, n_splits=2, random_state=None)".format(
+    repeated_cv_repr = "{}(n_splits=2, n_repeats=6, random_state=None)".format(
         repeated_cv.__class__.__name__
     )
     assert repeated_cv_repr == repr(repeated_cv)

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -144,7 +144,7 @@ def test_cross_validator_with_default_params():
     lolo_repr = "LeaveOneGroupOut()"
     lopo_repr = "LeavePGroupsOut(n_groups=2)"
     ss_repr = (
-        "ShuffleSplit(n_splits=5, test_size=0.25, train_size=None, random_state=0)"
+        "ShuffleSplit(n_splits=10, test_size=None, train_size=None, random_state=0)"
     )
     ps_repr = "PredefinedSplit(test_fold=array([1, 1, 2, 2]))"
     sgkf_repr = "StratifiedGroupKFold(n_splits=2, shuffle=False, random_state=None)"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Correctly fixes #14970
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This refactor removes the unnecessary sorting of argument names for the `__repr__` method. Parameter sorting can confuse and misrepresent the actual order in which arguments are passed during object initialization. The updated code now maintains the parameter order defined in the `__init__` method, ensuring a more accurate and logical representation of the object.

By keeping the order consistent, the `__repr__` follows Python's convention that `__repr__` should ideally output a string that could be used to recreate the object, preserving the original argument order. This change improves readability and aligns with standard practices seen in the Python standard library.

#### Any other comments?
NIL

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
