### PR TITLE
MAINT modify jinja template to keep title / date consistency

### DIFF
--- a/doc/whats_new/upcoming_changes/towncrier_template.rst.jinja2
+++ b/doc/whats_new/upcoming_changes/towncrier_template.rst.jinja2
@@ -1,12 +1,23 @@
 {% if render_title %}
 {% if versiondata.name %}
-{{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
-{{ top_underline * ((versiondata.name + versiondata.version + versiondata.date)|length + 4)}}
+{{ versiondata.name }} {{ versiondata.version }})
+{{ top_underline * ((versiondata.name + versiondata.version)|length + 3)}}
 {% else %}
-{{ versiondata.version }} ({{ versiondata.date }})
-{{ top_underline * ((versiondata.version + versiondata.date)|length + 3)}}
+{{ versiondata.version }}
+{{ top_underline * ((versiondata.version)|length + 2)}}
 {% endif %}
 {% endif %}
+
+{% set months = {
+    '01': 'January', '02': 'February', '03': 'March', '04': 'April',
+    '05': 'May', '06': 'June', '07': 'July', '08': 'August',
+    '09': 'September', '10': 'October', '11': 'November', '12': 'December'
+} %}
+{% set date_parts = versiondata.date.split('-') %}
+{% set year = date_parts[0] %}
+{% set month = date_parts[1] %}
+{% set date_release_lexical = months[month] + ' ' + year %}
+**{{ date_release_lexical }}**
 
 {% set underline = underlines[0] %}
 {% for section, content_per_category in sections.items() if content_per_category %}

--- a/doc/whats_new/upcoming_changes/towncrier_template.rst.jinja2
+++ b/doc/whats_new/upcoming_changes/towncrier_template.rst.jinja2
@@ -1,12 +1,6 @@
-{% if render_title %}
-{% if versiondata.name %}
-{{ versiondata.name }} {{ versiondata.version }})
-{{ top_underline * ((versiondata.name + versiondata.version)|length + 3)}}
-{% else %}
-{{ versiondata.version }}
-{{ top_underline * ((versiondata.version)|length + 2)}}
-{% endif %}
-{% endif %}
+{% set title = "Version " + versiondata.version %}
+{{ title }}
+{{ top_underline * title|length }}
 
 {% set month_names = {
     '01': 'January', '02': 'February', '03': 'March', '04': 'April',

--- a/doc/whats_new/upcoming_changes/towncrier_template.rst.jinja2
+++ b/doc/whats_new/upcoming_changes/towncrier_template.rst.jinja2
@@ -8,16 +8,14 @@
 {% endif %}
 {% endif %}
 
-{% set months = {
+{% set month_names = {
     '01': 'January', '02': 'February', '03': 'March', '04': 'April',
     '05': 'May', '06': 'June', '07': 'July', '08': 'August',
     '09': 'September', '10': 'October', '11': 'November', '12': 'December'
 } %}
-{% set date_parts = versiondata.date.split('-') %}
-{% set year = date_parts[0] %}
-{% set month = date_parts[1] %}
-{% set date_release_lexical = months[month] + ' ' + year %}
-**{{ date_release_lexical }}**
+{% set year, month, _ = versiondata.date.split('-') %}
+{% set release_date = month_names[month] + ' ' + year %}
+**{{ release_date }}**
 
 {% set underline = underlines[0] %}
 {% for section, content_per_category in sections.items() if content_per_category %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,7 +259,6 @@ package = "sklearn"  # name of your package
     directory = "doc/whats_new/upcoming_changes"
     issue_format = ":pr:`{issue}`"
     template = "doc/whats_new/upcoming_changes/towncrier_template.rst.jinja2"
-    title_format = "Version {version}"
     all_bullets = false
 
     [[tool.towncrier.type]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,7 +259,7 @@ package = "sklearn"  # name of your package
     directory = "doc/whats_new/upcoming_changes"
     issue_format = ":pr:`{issue}`"
     template = "doc/whats_new/upcoming_changes/towncrier_template.rst.jinja2"
-    title_format = "Version {version} ({project_date})"
+    title_format = "Version {version}"
     all_bullets = false
 
     [[tool.towncrier.type]]


### PR DESCRIPTION
This is a bit hackish but this the way to keep the title with the version number and show the date on a second line in bold as in the previous changelog.

The code does not seem so terrible thought.

For reference, it will generate something like:

```
Version 1.6.0
=============

**October 2024**
```

@lesteve WDYT?