### PR TITLE
CI Update changelog check after move to towncrier

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   changelog_checker:
-    name: Check if towncrier changelog entry is correct
+    name: A reviewer will let you know if it is required or can be bypassed
     runs-on: ubuntu-latest
     steps:
     - uses: scientific-python/action-towncrier-changelog@v1

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -20,13 +20,13 @@ jobs:
           set -xe
           changed_files=$(git diff --name-only origin/main)
           # Changelog should be updated only if tests have been modified
-          if [[ ! "$changed_files" =~ tests ]]
+          if [[ "$changed_files" =~ tests ]]
           then
-            echo "needs_changelog_check=true" >> $GITHUB_OUTPUT
+            echo check_changelog=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Check changelog entry
-        if: steps.tests_changed.needs_changelog == 'true'
+        if: steps.tests_changed.check_changelog == 'true'
         uses: scientific-python/action-towncrier-changelog@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -22,7 +22,7 @@ jobs:
           # Changelog should be updated only if tests have been modified
           if [[ "$changed_files" =~ tests ]]
           then
-            echo check_changelog=true" >> $GITHUB_OUTPUT
+            echo "check_changelog=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Check changelog entry

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -26,7 +26,7 @@ jobs:
           fi
 
       - name: Check changelog entry
-        if: steps.tests_changed.check_changelog == 'true'
+        if: steps.tests_changed.outputs.check_changelog == 'true'
         uses: scientific-python/action-towncrier-changelog@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -11,7 +11,23 @@ jobs:
     name: A reviewer will let you know if it is required or can be bypassed
     runs-on: ubuntu-latest
     steps:
-    - uses: scientific-python/action-towncrier-changelog@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BOT_USERNAME: changelog-bot
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+      - name: Check if tests have changed
+        id: tests_changed
+        run: |
+          set -xe
+          changed_files=$(git diff --name-only origin/main)
+          # Changelog should be updated only if tests have been modified
+          if [[ ! "$changed_files" =~ tests ]]
+          then
+            echo "needs_changelog_check=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check changelog entry
+        if: steps.tests_changed.needs_changelog == 'true'
+        uses: scientific-python/action-towncrier-changelog@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BOT_USERNAME: changelog-bot

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -1,68 +1,15 @@
-name: Check Changelog
-# This check makes sure that the changelog is properly updated
-# when a PR introduces a change in a test file.
-# To bypass this check, label the PR with "No Changelog Needed".
+name: Check PR changelog
+
 on:
   pull_request:
-    types: [opened, edited, labeled, unlabeled, synchronize]
+    types: [opened, synchronize, labeled, unlabeled]
 
 jobs:
-  check:
-    name: A reviewer will let you know if it is required or can be bypassed
+  changelog_checker:
+    name: Check if towncrier changelog entry is correct
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'No Changelog Needed') == 0 }}
     steps:
-      - name: Get PR number and milestone
-        run: |
-          echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-          echo "TAGGED_MILESTONE=${{ github.event.pull_request.milestone.title }}" >> $GITHUB_ENV
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: '0'
-      - name: Check the changelog entry
-        run: |
-          set -xe
-          changed_files=$(git diff --name-only origin/main)
-          # Changelog should be updated only if tests have been modified
-          if [[ ! "$changed_files" =~ tests ]]
-          then
-            exit 0
-          fi
-          all_changelogs=$(cat ./doc/whats_new/v*.rst)
-          if [[ "$all_changelogs" =~ :pr:\`$PR_NUMBER\` ]]
-          then
-            echo "Changelog has been updated."
-            # If the pull request is milestoned check the correspondent changelog
-            if exist -f ./doc/whats_new/v${TAGGED_MILESTONE:0:4}.rst
-            then
-              expected_changelog=$(cat ./doc/whats_new/v${TAGGED_MILESTONE:0:4}.rst)
-              if [[ "$expected_changelog" =~ :pr:\`$PR_NUMBER\` ]]
-              then
-                echo "Changelog and milestone correspond."
-              else
-                echo "Changelog and milestone do not correspond."
-                echo "If you see this error make sure that the tagged milestone for the PR"
-                echo "and the edited changelog filename properly match."
-                exit 1
-              fi
-            fi
-          else
-            echo "A Changelog entry is missing."
-            echo ""
-            echo "Please add an entry to the changelog at 'doc/whats_new/v*.rst'"
-            echo "to document your change assuming that the PR will be merged"
-            echo "in time for the next release of scikit-learn."
-            echo ""
-            echo "Look at other entries in that file for inspiration and please"
-            echo "reference this pull request using the ':pr:' directive and"
-            echo "credit yourself (and other contributors if applicable) with"
-            echo "the ':user:' directive."
-            echo ""
-            echo "If you see this error and there is already a changelog entry,"
-            echo "check that the PR number is correct."
-            echo ""
-            echo "If you believe that this PR does not warrant a changelog"
-            echo "entry, say so in a comment so that a maintainer will label"
-            echo "the PR with 'No Changelog Needed' to bypass this check."
-            exit 1
-          fi
+    - uses: scientific-python/action-towncrier-changelog@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BOT_USERNAME: changelog-bot

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -1,11 +1,13 @@
-name: Check PR changelog
-
+name: Check Changelog
+# This check makes sure that the changelog is properly updated
+# when a PR introduces a change in a test file.
+# To bypass this check, label the PR with "No Changelog Needed".
 on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]
 
 jobs:
-  changelog_checker:
+  check:
     name: A reviewer will let you know if it is required or can be bypassed
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,11 +255,9 @@ package = "sklearn"  # name of your package
 
 [tool.changelog-bot]
     [tool.changelog-bot.towncrier_changelog]
-        enabled = true  # default is false
-        verify_pr_number = true  # default is false
-        changelog_skip_label = "Do Not Add Changelog"  # this one will error if set and there is a changelog
-        changelog_noop_label = "No Changelog Needed" # this one always skips
-        whatsnew_label = "Needs Changelog"
+        enabled = true
+        verify_pr_number = true
+        changelog_noop_label = "No Changelog Needed"
         whatsnew_pattern = 'doc/whatsnew/upcoming_changes/[^/]+/\d+\.[^.]+\.rst'
 
 [tool.towncrier]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,6 +253,15 @@ package = "sklearn"  # name of your package
   "spin.cmds.meson.docs"
 ]
 
+[tool.changelog-bot]
+    [tool.changelog-bot.towncrier_changelog]
+        enabled = true  # default is false
+        verify_pr_number = true  # default is false
+        changelog_skip_label = "Do Not Add Changelog"  # this one will error if set and there is a changelog
+        changelog_noop_label = "No Changelog Needed" # this one always skips
+        whatsnew_label = "Needs Changelog"
+        whatsnew_pattern = 'doc/whatsnew/upcoming_changes/[^/]+/\d+\.[^.]+\.rst'
+
 [tool.towncrier]
     package = "sklearn"
     filename = "doc/whats_new/notes-towncrier.rst"


### PR DESCRIPTION
This uses https://github.com/scientific-python/action-towncrier-changelog/ which I tested a bit in https://github.com/lesteve/scikit-learn/pull/37.

~I think right now the major difference compared to our previous setup is that we don't have the logic "no tests changed" => "dont' bother checking for a changelog".~ this was implemented later.

The previous milestone check does not make sense anymore, so "edited" event is not needed. 
