### PR TITLE
DOC add a link to GitHub Discussions on home page

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -282,6 +282,33 @@ usually a major and lengthy undertaking, it is recommended to start with
 :ref:`known issues <new_contributors>`. Please do not contact the contributors
 of scikit-learn directly regarding contributing to scikit-learn.
 
+How can I be active within the community?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+You can be an active member of the Scikit-Learn community by `:ref:contributing` to 
+open issues, whether they're documentation improvements, code enhancements, or bug fixes. 
+Scikit-Learn often tags issues with “good first issue” or “help wanted,” 
+which are excellent starting points for new contributors.
+
+Engaging in the `Discussions <https://github.com/scikit-learn/scikit-learn/discussions>` 
+forum is another valuable way to participate, where you can ask questions, share insights, 
+answer others' questions, and contribute ideas to help solve challenges together. 
+If you're new to contributing, joining discussions is a great way to learn about community 
+practices and see which areas align with your interests. Don’t hesitate to suggest ideas 
+or give feedback on proposed features; fresh perspectives are always welcome.
+
+Additionally, reviewing and providing feedback on pull requests submitted by others is 
+a great way to support the maintainers and learn best practices. You don’t need to be an 
+expert—even small comments on code readability or documentation clarity can be valuable 
+and appreciated by other contributors.
+
+For beginners, small contributions like fixing typos, clarifying documentation, or adding 
+examples are impactful ways to get started. Scikit-Learn also hosts occasional sprints and 
+community meetings, which are great opportunities to collaborate in real-time with other 
+contributors.
+
+Don’t hesitate to contribute even small fixes or suggestions—every contribution helps 
+improve Scikit-Learn and strengthens the community!
+
 Why is my pull request not getting any attention?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -223,7 +223,7 @@
       <div class="col-md-4">
         <h4 class="sk-landing-call-header">Community</h4>
         <ul class="sk-landing-call-list list-unstyled">
-          <li><strong>About us:</strong> See <a href="about.html#the-people-behind-scikit-learn">people</a> and <a href="{{ contributing_link }}" {{ contributing_attrs }}>contributing</a></li>
+          <li><strong>About us:</strong> See <a href="about.html#the-people-behind-scikit-learn">people</a>, <a href="{{ contributing_link }}" {{ contributing_attrs }}>contributing</a>, and <a href="https://github.com/scikit-learn/scikit-learn/discussions">discussing</a></li>
           <li><strong>More Machine Learning:</strong> Find <a href="related_projects.html">related projects</a></li>
           <li><strong>Questions?</strong> See <a href="faq.html">FAQ</a>, <a href="support.html">support</a>, and <a href="https://stackoverflow.com/questions/tagged/scikit-learn">stackoverflow</a></li>
           <li><strong>Subscribe to the</strong> <a href="https://mail.python.org/mailman/listinfo/scikit-learn">mailing list</a></li>


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #29530 
See [Github Issue](https://github.com/scikit-learn/scikit-learn/issues/29530)

#### What does this implement/fix? Explain your changes.
This update enhances the community section by adding a direct link to the [GitHub Discussions forum](https://github.com/scikit-learn/scikit-learn/discussions), making it easier for users to engage in open discussions, ask questions, and share ideas within the Scikit-Learn community. Additionally, I’ve expanded the guidelines on how users, especially beginners, can actively participate, covering ways to contribute through open issues, discussions, and pull request reviews. This improvement aims to foster more community interaction and make it easier for newcomers to find opportunities to contribute.
