### PR TITLE
DOC : correct comment in _locally_linear_embedding

### DIFF
--- a/sklearn/manifold/_locally_linear.py
+++ b/sklearn/manifold/_locally_linear.py
@@ -243,7 +243,7 @@ def _locally_linear_embedding(
             M = M.T * M
         else:
             M = (W.T * W - W.T - W).toarray()
-            M.flat[:: M.shape[0] + 1] += 1  # W = W - I = W - I
+            M.flat[:: M.shape[0] + 1] += 1  # M = W' W - W' - W + I
 
     elif method == "hessian":
         dp = n_components * (n_components + 1) // 2


### PR DESCRIPTION
#### Reference Issues/PRs

https://github.com/pyRiemann/pyRiemann/pull/159

#### What does this implement/fix? Explain your changes.

As noted in this discussion https://github.com/pyRiemann/pyRiemann/pull/159#discussion_r773896493,
there is a small mistake in the comment of the function `_locally_linear_embedding`:
`# W = W - I = W - I`
must be corrected into
`# M = W' W - W' - W + I`

#### Any other comments?
