### PR TITLE
ENH add normalize to LDA.transform

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.decomposition/30097.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.decomposition/30097.enhancement.rst
@@ -1,0 +1,4 @@
+- :class:`~sklearn.decomposition.LatentDirichletAllocation` now has a
+  ``normalize`` parameter in ``transform`` and ``fit_transform`` methods
+  to control whether the document topic distribution is normalized.
+  By `Adrin Jalali`_.

--- a/sklearn/decomposition/_lda.py
+++ b/sklearn/decomposition/_lda.py
@@ -751,7 +751,7 @@ class LatentDirichletAllocation(
             doc_topic_distr /= doc_topic_distr.sum(axis=1)[:, np.newaxis]
         return doc_topic_distr
 
-    def fit_transform(self, X, y=None, normalize=True):
+    def fit_transform(self, X, y=None, *, normalize=True):
         """
         Fit to data, then transform it.
 

--- a/sklearn/decomposition/_lda.py
+++ b/sklearn/decomposition/_lda.py
@@ -723,7 +723,7 @@ class LatentDirichletAllocation(
 
         return doc_topic_distr
 
-    def transform(self, X):
+    def transform(self, X, *, normalize=True):
         """Transform data X according to the fitted model.
 
         .. versionchanged:: 0.18
@@ -733,6 +733,9 @@ class LatentDirichletAllocation(
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
             Document word matrix.
+
+        normalize : bool, default=True
+            Whether to normalize the document topic distribution.
 
         Returns
         -------
@@ -744,8 +747,34 @@ class LatentDirichletAllocation(
             X, reset_n_features=False, whom="LatentDirichletAllocation.transform"
         )
         doc_topic_distr = self._unnormalized_transform(X)
-        doc_topic_distr /= doc_topic_distr.sum(axis=1)[:, np.newaxis]
+        if normalize:
+            doc_topic_distr /= doc_topic_distr.sum(axis=1)[:, np.newaxis]
         return doc_topic_distr
+
+    def fit_transform(self, X, y=None, normalize=True):
+        """
+        Fit to data, then transform it.
+
+        Fits transformer to `X` and `y` and returns a transformed version of `X`.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Input samples.
+
+        y :  array-like of shape (n_samples,) or (n_samples, n_outputs), \
+                default=None
+            Target values (None for unsupervised transformations).
+
+        normalize : bool, default=True
+            Whether to normalize the document topic distribution in `transform`.
+
+        Returns
+        -------
+        X_new : ndarray array of shape (n_samples, n_features_new)
+            Transformed array.
+        """
+        return self.fit(X, y).transform(X, normalize=normalize)
 
     def _approx_bound(self, X, doc_topic_distr, sub_sampling):
         """Estimate the variational bound.

--- a/sklearn/decomposition/tests/test_online_lda.py
+++ b/sklearn/decomposition/tests/test_online_lda.py
@@ -132,7 +132,7 @@ def test_lda_dense_input(csr_container):
 
 def test_lda_transform():
     # Test LDA transform.
-    # Transform result cannot be negative and should be normalized
+    # Transform result cannot be negative and should be normalized by default
     rng = np.random.RandomState(0)
     X = rng.randint(5, size=(20, 10))
     n_components = 3
@@ -140,6 +140,11 @@ def test_lda_transform():
     X_trans = lda.fit_transform(X)
     assert (X_trans > 0.0).any()
     assert_array_almost_equal(np.sum(X_trans, axis=1), np.ones(X_trans.shape[0]))
+
+    X_trans_unnormalized = lda.transform(X, normalize=False)
+    assert_array_almost_equal(
+        X_trans, X_trans_unnormalized / X_trans_unnormalized.sum(axis=1)[:, np.newaxis]
+    )
 
 
 @pytest.mark.parametrize("method", ("online", "batch"))


### PR DESCRIPTION
Closes https://github.com/scikit-learn/scikit-learn/issues/29320, Closes https://github.com/scikit-learn/scikit-learn/issues/16643

This adds a `normalize` to `lda.transform`, allowing to return unnormalized transformed values.

cc @glemaitre @adam2392 @ogrisel 