### PR TITLE
FIX properly report `n_iter_` in case of fallback from Newton-Cholesky to LBFGS 

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/30100.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/30100.fix.rst
@@ -2,4 +2,4 @@
   accept `solver="newton-cholesky"` now report the correct number of iterations
   when they fall back to the `"lbfgs"` solver because of a rank deficient
   Hessian matrix.
-  By :user:`Olivier Grisel <ogrisel>`.
+  By :user:`Olivier Grisel <ogrisel>`

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/30100.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/30100.fix.rst
@@ -1,0 +1,5 @@
+- :class:`linear_model.LogisticRegression` and and other linear models that
+  accept `solver="newton-cholesky"` now report the correct number of iterations
+  when they fall back to the `"lbfgs"` solver because of a rank deficient
+  Hessian matrix.
+  By :user:`Olivier Grisel <ogrisel>`.

--- a/sklearn/linear_model/_glm/_newton_solver.py
+++ b/sklearn/linear_model/_glm/_newton_solver.py
@@ -184,7 +184,7 @@ class NewtonSolver(ABC):
             method="L-BFGS-B",
             jac=True,
             options={
-                "maxiter": self.max_iter,
+                "maxiter": self.max_iter - self.iteration,
                 "maxls": 50,  # default is 20
                 "iprint": self.verbose - 1,
                 "gtol": self.tol,
@@ -192,7 +192,7 @@ class NewtonSolver(ABC):
             },
             args=(X, y, sample_weight, self.l2_reg_strength, self.n_threads),
         )
-        self.n_iter_ = _check_optimize_result("lbfgs", opt_res)
+        self.iteration += _check_optimize_result("lbfgs", opt_res)
         self.coef = opt_res.x
         self.converged = opt_res.status == 0
 

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -2391,8 +2391,8 @@ def test_newton_cholesky_fallback_to_lbfgs(global_random_seed):
         warnings.simplefilter("error")
         lr_lbfgs.fit(X, y)
 
-    n_iter_lbgs = lr_lbfgs.n_iter_[0]
-    assert n_iter_lbgs >= 1
+    n_iter_lbfgs = lr_lbfgs.n_iter_[0]
+    assert n_iter_lbfgs >= 1
 
     # Check that the Newton-Cholesky solver raises a warning and falls back to
     # LBFGS. This should converge with the same number of iterations as the
@@ -2402,15 +2402,15 @@ def test_newton_cholesky_fallback_to_lbfgs(global_random_seed):
     with pytest.warns(LinAlgWarning, match="ill-conditioned Hessian matrix"):
         lr_nc.fit(X, y)
 
-    assert lr_nc.n_iter_[0] == n_iter_lbgs
+    assert lr_nc.n_iter_[0] == n_iter_lbfgs
 
     # Trying to fit the same model again with a small iteration budget should
     # therefore raise a ConvergenceWarning:
     lr_nc_limited = LogisticRegression(
-        solver="newton-cholesky", C=C, max_iter=n_iter_lbgs - 1
+        solver="newton-cholesky", C=C, max_iter=n_iter_lbfgs - 1
     )
     with pytest.warns(LinAlgWarning, match="ill-conditioned Hessian matrix"):
         with pytest.warns(ConvergenceWarning, match="lbfgs failed to converge"):
             lr_nc_limited.fit(X, y)
 
-    lr_nc_limited.n_iter_[0] == n_iter_lbgs - 1
+    lr_nc_limited.n_iter_[0] == n_iter_lbfgs - 1

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -12,7 +12,7 @@ from numpy.testing import (
     assert_array_equal,
 )
 from scipy import sparse
-from scipy.linalg import svd
+from scipy.linalg import LinAlgWarning, svd
 
 from sklearn import config_context
 from sklearn._loss import HalfMultinomialLoss
@@ -2374,3 +2374,43 @@ def test_multi_class_deprecated():
     lrCV = LogisticRegressionCV(multi_class="multinomial")
     with pytest.warns(FutureWarning, match=msg):
         lrCV.fit(X, y)
+
+
+def test_newton_cholesky_fallback_to_lbfgs(global_random_seed):
+    # Wide data matrix should lead to a rank-deficient Hessian matrix
+    # hence make the Newton-Cholesky solver raise a warning and fallback to
+    # lbfgs.
+    X, y = make_classification(
+        n_samples=10, n_features=11, random_state=global_random_seed
+    )
+    C = 1e20  # very high C to nearly disable regularization
+
+    # Check that LBFGS can converge without any warning on this problem.
+    lr_lbfgs = LogisticRegression(solver="lbfgs", C=C)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        lr_lbfgs.fit(X, y)
+
+    n_iter_lbgs = lr_lbfgs.n_iter_[0]
+    assert n_iter_lbgs >= 1
+
+    # Check that the Newton-Cholesky solver raises a warning and falls back to
+    # LBFGS. This should also converges in the same number of iterations as the
+    # previous call since the Newton-Cholesky solver should trigger the
+    # fallback before completing the first iteration.
+    lr_nc = LogisticRegression(solver="newton-cholesky", C=C)
+    with pytest.warns(LinAlgWarning, match="ill-conditioned Hessian matrix"):
+        lr_nc.fit(X, y)
+
+    assert lr_nc.n_iter_[0] == n_iter_lbgs
+
+    # Trying to fit the same model again with a small iteration budget should
+    # therefore raise a ConvergenceWarning:
+    lr_nc_limited = LogisticRegression(
+        solver="newton-cholesky", C=C, max_iter=n_iter_lbgs - 1
+    )
+    with pytest.warns(LinAlgWarning, match="ill-conditioned Hessian matrix"):
+        with pytest.warns(ConvergenceWarning, match="lbfgs failed to converge"):
+            lr_nc_limited.fit(X, y)
+
+    lr_nc_limited.n_iter_[0] == n_iter_lbgs - 1

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -2395,9 +2395,9 @@ def test_newton_cholesky_fallback_to_lbfgs(global_random_seed):
     assert n_iter_lbgs >= 1
 
     # Check that the Newton-Cholesky solver raises a warning and falls back to
-    # LBFGS. This should also converges in the same number of iterations as the
-    # previous call since the Newton-Cholesky solver should trigger the
-    # fallback before completing the first iteration.
+    # LBFGS. This should converge with the same number of iterations as the
+    # above call of lbfgs since the Newton-Cholesky triggers the fallback
+    # before completing the first iteration, for the problem setting at hand.
     lr_nc = LogisticRegression(solver="newton-cholesky", C=C)
     with pytest.warns(LinAlgWarning, match="ill-conditioned Hessian matrix"):
         lr_nc.fit(X, y)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -2415,6 +2415,4 @@ def test_newton_cholesky_fallback_to_lbfgs(global_random_seed):
             lr_nc_limited.fit(X, y)
             n_iter_nc_limited = lr_nc_limited.n_iter_[0]
 
-    # XXX: Is this a one-off error? Shouln't it be equal to
-    # lr_nc_limited.max_iter instead?
     assert n_iter_nc_limited == lr_nc_limited.max_iter - 1

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -2390,8 +2390,8 @@ def test_newton_cholesky_fallback_to_lbfgs(global_random_seed):
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         lr_lbfgs.fit(X, y)
+        n_iter_lbfgs = lr_lbfgs.n_iter_[0]
 
-    n_iter_lbfgs = lr_lbfgs.n_iter_[0]
     assert n_iter_lbfgs >= 1
 
     # Check that the Newton-Cholesky solver raises a warning and falls back to
@@ -2399,7 +2399,6 @@ def test_newton_cholesky_fallback_to_lbfgs(global_random_seed):
     # above call of lbfgs since the Newton-Cholesky triggers the fallback
     # before completing the first iteration, for the problem setting at hand.
     lr_nc = LogisticRegression(solver="newton-cholesky", C=C)
-    # with pytest.warns(LinAlgWarning, match="ill-conditioned Hessian matrix"):
     with ignore_warnings(category=LinAlgWarning):
         lr_nc.fit(X, y)
         n_iter_nc = lr_nc.n_iter_[0]
@@ -2411,7 +2410,6 @@ def test_newton_cholesky_fallback_to_lbfgs(global_random_seed):
     lr_nc_limited = LogisticRegression(
         solver="newton-cholesky", C=C, max_iter=n_iter_lbfgs - 1
     )
-    # with pytest.warns(LinAlgWarning, match="ill-conditioned Hessian matrix"):
     with ignore_warnings(category=LinAlgWarning):
         with pytest.warns(ConvergenceWarning, match="lbfgs failed to converge"):
             lr_nc_limited.fit(X, y)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -2381,9 +2381,9 @@ def test_newton_cholesky_fallback_to_lbfgs(global_random_seed):
     # hence make the Newton-Cholesky solver raise a warning and fallback to
     # lbfgs.
     X, y = make_classification(
-        n_samples=10, n_features=11, random_state=global_random_seed
+        n_samples=10, n_features=20, random_state=global_random_seed
     )
-    C = 1e20  # very high C to nearly disable regularization
+    C = 1e30  # very high C to nearly disable regularization
 
     # Check that LBFGS can converge without any warning on this problem.
     lr_lbfgs = LogisticRegression(solver="lbfgs", C=C)


### PR DESCRIPTION
Fix for a small bug discovered while reviewing #28840: whenever the Newton-Cholesky solver of LogisticRegression would fall back to LFGS, the reported `n_iter_` attribute would be left to zero.

I made it such that any completed iteration from the Newton-Cholesky solver would be subtracted from `max_iter` before calling LBFGS, and then report the sum of the numbers of iterations completed by the two solvers in the end. In practice, this does not seem to change anything because when Hessian conditioning problem always happens during the first iteration in my experiments with low regularized, rank deficient problems that typically trigger the LBFGS fallback mechanism.

Note that I find that the LBFGS fallback warning quite annoying whenever it is triggered while tuning the regularization level (e.g. using `LogisticRegressionCV` or `RandomizedSearchCV`). I have the feeling that this should be a regular verbose print instead, but we can tackle that in a separate PR.