### PR TITLE
MAINT Tweak a few changelog entries

### DIFF
--- a/doc/whats_new/upcoming_changes/README.md
+++ b/doc/whats_new/upcoming_changes/README.md
@@ -31,7 +31,7 @@ folder with the following content::
   now supports missing values in the data matrix `X`. Missing-values are
   handled by randomly moving all of the samples to the left, or right child
   node as the tree is traversed.
-  By :user:`Adam Li <adam2392>`.
+  By :user:`Adam Li <adam2392>`
 ```
 
 If you are unsure how to name the news fragment or which folder to use, don't

--- a/doc/whats_new/upcoming_changes/array-api/27736.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/27736.feature.rst
@@ -1,1 +1,3 @@
-- :func:`sklearn.metrics.mean_absolute_error` by :user:`Edoardo Abati <EdAbati>`
+- :func:`sklearn.metrics.mean_absolute_error` now supports Array API compatible
+  inputs.
+  By :user:`Edoardo Abati <EdAbati>`

--- a/doc/whats_new/upcoming_changes/array-api/28106.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/28106.feature.rst
@@ -1,1 +1,3 @@
-- :func:`sklearn.metrics.mean_tweedie_deviance` by :user:`Thomas Li <lithomas1>`
+- :func:`sklearn.metrics.mean_tweedie_deviance` now supports Array API
+  compatible inputs.
+  By :user:`Thomas Li <lithomas1>`

--- a/doc/whats_new/upcoming_changes/array-api/29014.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29014.feature.rst
@@ -1,1 +1,3 @@
-- :func:`sklearn.metrics.pairwise.cosine_similarity` by :user:`Edoardo Abati <EdAbati>`
+- :func:`sklearn.metrics.pairwise.cosine_similarity` now supports Array API
+  compatible inputs.
+  By :user:`Edoardo Abati <EdAbati>`

--- a/doc/whats_new/upcoming_changes/array-api/29112.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29112.feature.rst
@@ -1,1 +1,3 @@
-- :func:`sklearn.metrics.pairwise.paired_cosine_distances` by :user:`Edoardo Abati <EdAbati>`
+- :func:`sklearn.metrics.pairwise.paired_cosine_distances` now supports Array
+  API compatible inputs.
+  By :user:`Edoardo Abati <EdAbati>`

--- a/doc/whats_new/upcoming_changes/array-api/29141.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29141.feature.rst
@@ -1,1 +1,3 @@
-- :func:`sklearn.metrics.cluster.entropy` by :user:`Yaroslav Korobko <Tialo>`
+- :func:`sklearn.metrics.cluster.entropy` now supports Array API compatible
+  inputs.
+  By :user:`Yaroslav Korobko <Tialo>`

--- a/doc/whats_new/upcoming_changes/array-api/29142.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29142.feature.rst
@@ -1,1 +1,3 @@
-- :func:`sklearn.metrics.mean_squared_error` by :user:`Yaroslav Korobko <Tialo>`
+- :func:`sklearn.metrics.mean_squared_error` now supports Array API compatible
+  inputs.
+  By :user:`Yaroslav Korobko <Tialo>`

--- a/doc/whats_new/upcoming_changes/array-api/29143.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29143.feature.rst
@@ -1,2 +1,0 @@
-- :func:`sklearn.metrics.mean_absolute_error` by :user:`Tialo <Tialo>` and
-  :user:`Loïc Estève <lesteve>`

--- a/doc/whats_new/upcoming_changes/array-api/29144.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29144.feature.rst
@@ -1,2 +1,3 @@
-- :func:`sklearn.metrics.pairwise.additive_chi2_kernel` by
-  :user:`Yaroslav Korobko <Tialo>`
+- :func:`sklearn.metrics.pairwise.additive_chi2_kernel` now supports Array API
+  compatible inputs.
+  By :user:`Yaroslav Korobko <Tialo>`

--- a/doc/whats_new/upcoming_changes/array-api/29207.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29207.feature.rst
@@ -1,1 +1,3 @@
-- :func:`sklearn.metrics.d2_tweedie_score` by :user:`Emily Chen <EmilyXinyi>`
+- :func:`sklearn.metrics.d2_tweedie_score` now supports Array API compatible
+  inputs.
+  By :user:`Emily Chen <EmilyXinyi>`

--- a/doc/whats_new/upcoming_changes/array-api/29212.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29212.feature.rst
@@ -1,1 +1,2 @@
-- :func:`sklearn.metrics.max_error` by :user:`Edoardo Abati <EdAbati>`
+- :func:`sklearn.metrics.max_error` now supports Array API compatible inputs.
+  By :user:`Edoardo Abati <EdAbati>`

--- a/doc/whats_new/upcoming_changes/array-api/29227.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29227.feature.rst
@@ -1,1 +1,3 @@
-- :func:`sklearn.metrics.mean_poisson_deviance` by :user:`Emily Chen <EmilyXinyi>`
+- :func:`sklearn.metrics.mean_poisson_deviance` now supports Array API
+  compatible inputs.
+  By :user:`Emily Chen <EmilyXinyi>`

--- a/doc/whats_new/upcoming_changes/array-api/29239.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29239.feature.rst
@@ -1,1 +1,3 @@
-- :func:`sklearn.metrics.mean_gamma_deviance` by :user:`Emily Chen <EmilyXinyi>`
+- :func:`sklearn.metrics.mean_gamma_deviance` now supports Array API compatible
+  inputs.
+  By :user:`Emily Chen <EmilyXinyi>`

--- a/doc/whats_new/upcoming_changes/array-api/29265.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29265.feature.rst
@@ -1,1 +1,3 @@
-- :func:`sklearn.metrics.pairwise.cosine_distances` by :user:`Emily Chen <EmilyXinyi>`
+- :func:`sklearn.metrics.pairwise.cosine_distances` now supports Array API
+  compatible inputs.
+  By :user:`Emily Chen <EmilyXinyi>`

--- a/doc/whats_new/upcoming_changes/array-api/29267.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29267.feature.rst
@@ -1,1 +1,3 @@
-- :func:`sklearn.metrics.pairwise.chi2_kernel` by :user:`Yaroslav Korobko <Tialo>`
+- :func:`sklearn.metrics.pairwise.chi2_kernel` now supports Array API
+  compatible inputs.
+  By :user:`Yaroslav Korobko <Tialo>`

--- a/doc/whats_new/upcoming_changes/array-api/29300.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29300.feature.rst
@@ -1,2 +1,3 @@
-- :func:`sklearn.metrics.mean_absolute_percentage_error` by
-  :user:`Emily Chen <EmilyXinyi>`
+- :func:`sklearn.metrics.mean_absolute_percentage_error` now supports Array API
+  compatible inputs.
+  By :user:`Emily Chen <EmilyXinyi>`

--- a/doc/whats_new/upcoming_changes/array-api/29389.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29389.feature.rst
@@ -1,1 +1,3 @@
-- :func:`sklearn.metrics.pairwise.paired_euclidean_distances` by :user:`Emily Chen <EmilyXinyi>`
+- :func:`sklearn.metrics.pairwise.paired_euclidean_distances` now supports
+  Array API compatible inputs.
+  By :user:`Emily Chen <EmilyXinyi>`

--- a/doc/whats_new/upcoming_changes/array-api/29433.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29433.feature.rst
@@ -1,2 +1,4 @@
 - :func:`sklearn.metrics.pairwise.euclidean_distances` and
-  :func:`sklearn.metrics.pairwise.rbf_kernel` by :user:`Omar Salman <OmarManzoor>`
+  :func:`sklearn.metrics.pairwise.rbf_kernel` now supports Array API compatible
+  inputs.
+  By :user:`Omar Salman <OmarManzoor>`

--- a/doc/whats_new/upcoming_changes/array-api/29475.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29475.feature.rst
@@ -1,4 +1,5 @@
 - :func:`sklearn.metrics.pairwise.linear_kernel`,
   :func:`sklearn.metrics.pairwise.sigmoid_kernel`, and
-  :func:`sklearn.metrics.pairwise.polynomial_kernel` by
-  :user:`Omar Salman <OmarManzoor>`
+  :func:`sklearn.metrics.pairwise.polynomial_kernel` now supports Array API
+  compatible inputs.
+  By :user:`Omar Salman <OmarManzoor>`

--- a/doc/whats_new/upcoming_changes/array-api/29709.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29709.feature.rst
@@ -1,3 +1,4 @@
 - :func:`sklearn.metrics.mean_squared_log_error` and
   :func:`sklearn.metrics.root_mean_squared_log_error`
-  by :user:`Virgil Chan <virchan>`
+  now supports Array API compatible inputs.
+  By :user:`Virgil Chan <virchan>`

--- a/doc/whats_new/upcoming_changes/array-api/29751.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29751.feature.rst
@@ -1,2 +1,3 @@
-- :class:`preprocessing.MinMaxScaler` with `clip=True`.
+- :class:`preprocessing.MinMaxScaler` with `clip=True` now supports Array API
+  compatible inputs.
   By :user:`Shreekant Nandiyawar <Shree7676>`


### PR DESCRIPTION
Follow-up of #30081:
- remove changelog about #29143 which was a fix on the unreleased feature in #27736. I added the changelog myself at the time but I don't think it is needed. I would avoid using the advanced towncrier feature that we can list multiple PRs in the same entry unless really necessary.
- make each Array API fragment more explicit
- tweak README since no final `.` was used in #30081. This was done in https://github.com/scikit-learn/scikit-learn/pull/30083 as well but I feel that #30083 may take a bit more time to settle that this PR :crossed_fingers:

cc @glemaitre