### PR TITLE
MNT add slots to tags

### DIFF
--- a/sklearn/utils/_tags.py
+++ b/sklearn/utils/_tags.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from .fixes import _dataclass_args
+
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
 
-@dataclass(slots=True)
+@dataclass(**_dataclass_args())
 class InputTags:
     """Tags for the input data.
 
@@ -67,7 +69,7 @@ class InputTags:
     pairwise: bool = False
 
 
-@dataclass(slots=True)
+@dataclass(**_dataclass_args())
 class TargetTags:
     """Tags for the target data.
 
@@ -106,7 +108,7 @@ class TargetTags:
     single_output: bool = True
 
 
-@dataclass(slots=True)
+@dataclass(**_dataclass_args())
 class TransformerTags:
     """Tags for the transformer.
 
@@ -126,7 +128,7 @@ class TransformerTags:
     preserves_dtype: list[str] = field(default_factory=lambda: ["float64"])
 
 
-@dataclass(slots=True)
+@dataclass(**_dataclass_args())
 class ClassifierTags:
     """Tags for the classifier.
 
@@ -154,7 +156,7 @@ class ClassifierTags:
     multi_label: bool = False
 
 
-@dataclass(slots=True)
+@dataclass(**_dataclass_args())
 class RegressorTags:
     """Tags for the regressor.
 
@@ -176,7 +178,7 @@ class RegressorTags:
     multi_label: bool = False
 
 
-@dataclass(slots=True)
+@dataclass(**_dataclass_args())
 class Tags:
     """Tags for the estimator.
 

--- a/sklearn/utils/_tags.py
+++ b/sklearn/utils/_tags.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 # SPDX-License-Identifier: BSD-3-Clause
 
 
-@dataclass
+@dataclass(slots=True)
 class InputTags:
     """Tags for the input data.
 
@@ -67,7 +67,7 @@ class InputTags:
     pairwise: bool = False
 
 
-@dataclass
+@dataclass(slots=True)
 class TargetTags:
     """Tags for the target data.
 
@@ -106,7 +106,7 @@ class TargetTags:
     single_output: bool = True
 
 
-@dataclass
+@dataclass(slots=True)
 class TransformerTags:
     """Tags for the transformer.
 
@@ -126,7 +126,7 @@ class TransformerTags:
     preserves_dtype: list[str] = field(default_factory=lambda: ["float64"])
 
 
-@dataclass
+@dataclass(slots=True)
 class ClassifierTags:
     """Tags for the classifier.
 
@@ -154,7 +154,7 @@ class ClassifierTags:
     multi_label: bool = False
 
 
-@dataclass
+@dataclass(slots=True)
 class RegressorTags:
     """Tags for the regressor.
 
@@ -176,7 +176,7 @@ class RegressorTags:
     multi_label: bool = False
 
 
-@dataclass
+@dataclass(slots=True)
 class Tags:
     """Tags for the estimator.
 

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -426,3 +426,10 @@ else:
 
     def _create_pandas_dataframe_from_non_pandas_container(X, *, index, copy):
         return pd.DataFrame(X, index=index, copy=copy)
+
+
+# TODO: Remove when python>=3.10 is the minimum supported version
+def _dataclass_args():
+    if sys.version_info < (3, 10):
+        return ()
+    return {"slots": True}

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -431,5 +431,5 @@ else:
 # TODO: Remove when python>=3.10 is the minimum supported version
 def _dataclass_args():
     if sys.version_info < (3, 10):
-        return ()
+        return {}
     return {"slots": True}


### PR DESCRIPTION
This adds `__slots__` to the tags dataclasses, which makes them error when the user has a typo in a field when setting it.

I encountered the issue for instance, when doing `tags.transformer_tags.preserve_dtype` instead of `tags.transformertags.preserve[s]_dtype` and being confused as why things don't work.

This also has the side effect of tags taking less memory and dealing with them being a lot faster.

cc @Charlie-XIAO @adam2392 