### PR TITLE
Adds disable_convergence_warnings option to global config for issue #29294

### DIFF
--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -20,6 +20,7 @@ _global_config = {
     "transform_output": "default",
     "enable_metadata_routing": False,
     "skip_parameter_validation": False,
+    "disable_convergence_warnings": False,
 }
 _threadlocal = threading.local()
 
@@ -68,6 +69,7 @@ def set_config(
     transform_output=None,
     enable_metadata_routing=None,
     skip_parameter_validation=None,
+    disable_convergence_warnings=None,
 ):
     """Set global scikit-learn configuration.
 
@@ -174,6 +176,11 @@ def set_config(
 
         .. versionadded:: 1.3
 
+    disable_convergence_warnings : bool, default=None
+        If `True` disables convergence warnings including subprocesses.
+
+        .. versionadded:: 1.5
+
     See Also
     --------
     config_context : Context manager for global scikit-learn configuration.
@@ -209,6 +216,8 @@ def set_config(
         local_config["enable_metadata_routing"] = enable_metadata_routing
     if skip_parameter_validation is not None:
         local_config["skip_parameter_validation"] = skip_parameter_validation
+    if disable_convergence_warnings is not None:
+        local_config["disable_convergence_warnings"] = disable_convergence_warnings
 
 
 @contextmanager
@@ -224,6 +233,7 @@ def config_context(
     transform_output=None,
     enable_metadata_routing=None,
     skip_parameter_validation=None,
+    disable_convergence_warnings=None,
 ):
     """Context manager for global scikit-learn configuration.
 
@@ -329,6 +339,11 @@ def config_context(
 
         .. versionadded:: 1.3
 
+    disable_convergence_warnings : bool, default=None
+        If `True` disables convergence warnings including subprocesses.
+
+        .. versionadded:: 1.5
+
     Yields
     ------
     None.
@@ -368,6 +383,7 @@ def config_context(
         transform_output=transform_output,
         enable_metadata_routing=enable_metadata_routing,
         skip_parameter_validation=skip_parameter_validation,
+        disable_convergence_warnings=disable_convergence_warnings,
     )
 
     try:

--- a/sklearn/linear_model/_sag.py
+++ b/sklearn/linear_model/_sag.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 
 from ..exceptions import ConvergenceWarning
+from .._config import get_config
 from ..utils import check_array
 from ..utils.extmath import row_norms
 from ..utils.validation import _check_sample_weight
@@ -344,7 +345,8 @@ def sag_solver(
         verbose,
     )
 
-    if n_iter_ == max_iter:
+    is_convergence_warnings_disabled = get_config()["disable_convergence_warnings"]
+    if (n_iter_ == max_iter) & (not is_convergence_warnings_disabled):
         warnings.warn(
             "The max_iter was reached which means the coef_ did not converge",
             ConvergenceWarning,


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes issue #29294 regarding convergence warning issues by adding to global config


#### What does this implement/fix? Explain your changes.
Adds `disable_convergence_warnings` to global_config

#### Any other comments?
Draft PR

- [ ] Update documentation
- [ ] Create test to determine if the fix works for subprocesses
- [X] run `pytest sklearn/linear_model/_sag.py`
- [X] run `pytest sklearn/linear_model/tests/test_sag.py`
- [ ] run `pytest sklearn/linear_model`
- [ ] run `pytest doc/modules/linear_model.rst`

