### PR TITLE
DEBUG: Buffer dtype mismatch, expected 'const float' but got 'double'

### DIFF
--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -539,7 +539,11 @@ PER_ESTIMATOR_CHECK_PARAMS: dict = {
             dict(solver="liblinear"),
             dict(solver="newton-cg"),
             dict(solver="newton-cholesky"),
-        ]
+        ],
+        "check_classifiers_train": [
+            dict(),
+            dict(solver="newton-cholesky", max_iter=1000, tol=1e-12),
+        ],
     },
     MDS: {"check_dict_unchanged": dict(max_iter=5, n_components=1, n_init=2)},
     MiniBatchDictionaryLearning: {


### PR DESCRIPTION
Trying to isolate a low level Cython error when calling in `loss_gradient` from the `check_classifiers_train` estimator check with memory mapped inputs.

Originally discovered in https://github.com/scikit-learn/scikit-learn/pull/30143#issuecomment-2436114765.