### PR TITLE
FIX signature of deprecated classes

### DIFF
--- a/sklearn/utils/deprecation.py
+++ b/sklearn/utils/deprecation.py
@@ -3,6 +3,7 @@
 
 import functools
 import warnings
+from inspect import signature
 
 __all__ = ["deprecated"]
 
@@ -64,17 +65,21 @@ class deprecated:
             msg += "; %s" % self.extra
 
         new = cls.__new__
+        sig = signature(cls)
 
         def wrapped(cls, *args, **kwargs):
             warnings.warn(msg, category=FutureWarning)
             if new is object.__new__:
                 return object.__new__(cls)
+
             return new(cls, *args, **kwargs)
 
         cls.__new__ = wrapped
 
         wrapped.__name__ = "__new__"
         wrapped.deprecated_original = new
+        # Restore the original signature, see PEP 362.
+        cls.__signature__ = sig
 
         return cls
 

--- a/sklearn/utils/tests/test_deprecation.py
+++ b/sklearn/utils/tests/test_deprecation.py
@@ -3,6 +3,7 @@
 
 
 import pickle
+from inspect import signature
 
 import pytest
 
@@ -86,3 +87,12 @@ def test_is_deprecated():
 
 def test_pickle():
     pickle.loads(pickle.dumps(mock_function))
+
+
+def test_deprecated_class_signature():
+    @deprecated()
+    class MockClass:
+        def __init__(self, a, b=1, c=2):
+            pass
+
+    assert list(signature(MockClass).parameters.keys()) == ["a", "b", "c"]


### PR DESCRIPTION
#### Reference Issues/PRs
None. Popped up in #29097.


#### What does this implement/fix? Explain your changes.
Our common tests fail if a whole class is decorated by `deprecated` because the signature of `__new__` changes to the generic `(*args, **kwargs)`.


#### Any other comments?
