### PR TITLE
MAINT Tweak meson-python version check

### DIFF
--- a/sklearn/meson.build
+++ b/sklearn/meson.build
@@ -48,7 +48,7 @@ if not meson.is_cross_build()
   # meson-python is required only when going through pip. Using meson directly
   # should not check meson-python version.
   meson_python_version_command_result = run_command(py,
-    ['-c', 'import mesonpy; print(mesonpy.__version__)'], check: false)
+    ['-c', 'import importlib.metadata; print(importlib.metadata.version("meson-python"))'], check: false)
   meson_python_installed = meson_python_version_command_result.returncode() == 0
   if meson_python_installed
     meson_python_version = meson_python_version_command_result.stdout().strip()


### PR DESCRIPTION
`mesonpy.__version__` will be removed in meson-python 0.18 see https://github.com/mesonbuild/meson-python/pull/691, or maybe a bit later depending on the discussion. Using the recommendation from https://github.com/mesonbuild/meson-python/pull/691#issuecomment-2440139101.
