### PR TITLE
TST Improve `sklearn.linear_model.test_quantile.test_sparse_input`

### DIFF
--- a/sklearn/linear_model/tests/test_quantile.py
+++ b/sklearn/linear_model/tests/test_quantile.py
@@ -246,7 +246,7 @@ def test_sparse_input(sparse_container, solver, fit_intercept, global_random_see
         n_samples=300,
         n_features=20,
         n_informative=10,
-        random_state=1,
+        random_state=global_random_seed,
         noise=1.0,
     )
     X_sparse = sparse_container(X)
@@ -260,13 +260,13 @@ def test_sparse_input(sparse_container, solver, fit_intercept, global_random_see
     assert_allclose(quant_sparse.coef_, quant_dense.coef_, rtol=1e-2)
     sparse_support = quant_sparse.coef_ != 0
     dense_support = quant_dense.coef_ != 0
-    assert sparse_support.sum() == dense_support.sum() == n_informative
-    assert_allclose(sparse_support, dense_support)
+    assert dense_support.sum() == pytest.approx(n_informative, abs=1)
+    assert sparse_support.sum() == pytest.approx(n_informative, abs=1)
     if fit_intercept:
         assert quant_sparse.intercept_ == approx(quant_dense.intercept_)
         # check that we still predict fraction
         empirical_coverage = np.mean(y < quant_sparse.predict(X_sparse))
-        assert empirical_coverage == approx(quantile_level, abs=1e-2)
+        assert empirical_coverage == approx(quantile_level, abs=3e-2)
 
 
 def test_error_interior_point_future(X_y_data, monkeypatch):

--- a/sklearn/linear_model/tests/test_quantile.py
+++ b/sklearn/linear_model/tests/test_quantile.py
@@ -10,7 +10,7 @@ from sklearn.datasets import make_regression
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import HuberRegressor, QuantileRegressor
 from sklearn.metrics import mean_pinball_loss
-from sklearn.utils._testing import assert_allclose, skip_if_32bit
+from sklearn.utils._testing import assert_allclose
 from sklearn.utils.fixes import (
     COO_CONTAINERS,
     CSC_CONTAINERS,
@@ -233,26 +233,40 @@ def test_linprog_failure():
         reg.fit(X, y)
 
 
-@skip_if_32bit
 @pytest.mark.parametrize(
     "sparse_container", CSC_CONTAINERS + CSR_CONTAINERS + COO_CONTAINERS
 )
 @pytest.mark.parametrize("solver", ["highs", "highs-ds", "highs-ipm"])
 @pytest.mark.parametrize("fit_intercept", [True, False])
-def test_sparse_input(sparse_container, solver, fit_intercept):
+def test_sparse_input(sparse_container, solver, fit_intercept, global_random_seed):
     """Test that sparse and dense X give same results."""
-    X, y = make_regression(n_samples=100, n_features=20, random_state=1, noise=1.0)
+    n_informative = 10
+    quantile_level = 0.6
+    X, y = make_regression(
+        n_samples=300,
+        n_features=20,
+        n_informative=10,
+        random_state=1,
+        noise=1.0,
+    )
     X_sparse = sparse_container(X)
-    alpha = 1e-4
-    quant_dense = QuantileRegressor(alpha=alpha, fit_intercept=fit_intercept).fit(X, y)
+    alpha = 0.1
+    quant_dense = QuantileRegressor(
+        quantile=quantile_level, alpha=alpha, fit_intercept=fit_intercept
+    ).fit(X, y)
     quant_sparse = QuantileRegressor(
-        alpha=alpha, fit_intercept=fit_intercept, solver=solver
+        quantile=quantile_level, alpha=alpha, fit_intercept=fit_intercept, solver=solver
     ).fit(X_sparse, y)
     assert_allclose(quant_sparse.coef_, quant_dense.coef_, rtol=1e-2)
+    sparse_support = quant_sparse.coef_ != 0
+    dense_support = quant_dense.coef_ != 0
+    assert sparse_support.sum() == dense_support.sum() == n_informative
+    assert_allclose(sparse_support, dense_support)
     if fit_intercept:
         assert quant_sparse.intercept_ == approx(quant_dense.intercept_)
         # check that we still predict fraction
-        assert 0.45 <= np.mean(y < quant_sparse.predict(X_sparse)) <= 0.57
+        empirical_coverage = np.mean(y < quant_sparse.predict(X_sparse))
+        assert empirical_coverage == approx(quantile_level, abs=1e-2)
 
 
 def test_error_interior_point_future(X_y_data, monkeypatch):


### PR DESCRIPTION
As discovered in #30162, this test seems not to be robust to changes in OpenBLAS versions (and probably rounding errors more generally).

This is a refactoring of this test to make it:

- more stable by increasing sample size and regularization;
- more interesting by testing for a non-median quantile level;
- more model specific by checking that we can approximately recover the expected support size with the selected regularization level;
- not seed-sensitive by using `global_random_seed`.
