### PR TITLE
CI Bump macOS version to 13 on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -253,7 +253,7 @@ jobs:
 - template: build_tools/azure/posix.yml
   parameters:
     name: macOS
-    vmImage: macOS-12
+    vmImage: macOS-13
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
     # Runs when dependencies succeeded or skipped
     condition: |


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/10721. macOS-12 removal on Azure is scheduled for December 2024, brownout windows will start in November 2024.