### PR TITLE
MAINT use vmImage: macOS-13 on Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -253,7 +253,7 @@ jobs:
 - template: build_tools/azure/posix.yml
   parameters:
     name: macOS
-    vmImage: macOS-12
+    vmImage: macOS-13
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
     # Runs when dependencies succeeded or skipped
     condition: |


### PR DESCRIPTION
There is a brown out warning for `macOS-12` starting on Nov. the 4th.