### PR TITLE
FIX Make RFECV thread-safe when used with joblib threading backend

### DIFF
--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -882,7 +882,7 @@ class RFECV(RFE):
             func = delayed(_rfe_single_fit)
 
         scores_features = parallel(
-            func(rfe, self.estimator, X, y, train, test, scorer, routed_params)
+            func(clone(rfe), self.estimator, X, y, train, test, scorer, routed_params)
             for train, test in cv.split(X, y, **routed_params.splitter.split)
         )
         scores, step_n_features = zip(*scores_features)

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -6,6 +6,7 @@ from operator import attrgetter
 
 import numpy as np
 import pytest
+from joblib import parallel_config
 from numpy.testing import assert_allclose, assert_array_almost_equal, assert_array_equal
 
 from sklearn.base import BaseEstimator, ClassifierMixin
@@ -703,3 +704,21 @@ def test_rfe_with_sample_weight():
     rfe_sw_2.fit(X, y, sample_weight=sample_weight_2)
 
     assert not np.array_equal(rfe_sw_2.ranking_, rfe.ranking_)
+
+
+def test_rfe_with_joblib_threading_backend(global_random_seed):
+    X, y = make_classification(random_state=global_random_seed)
+
+    clf = LogisticRegression()
+    rfe = RFECV(
+        estimator=clf,
+        n_jobs=2,
+    )
+
+    rfe.fit(X, y)
+    ranking_ref = rfe.ranking_
+
+    with parallel_config(backend="threading"):
+        rfe.fit(X, y)
+
+    assert_array_equal(ranking_ref, rfe.ranking_)

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -6,7 +6,7 @@ from operator import attrgetter
 
 import numpy as np
 import pytest
-from joblib import parallel_config
+from joblib import parallel_backend
 from numpy.testing import assert_allclose, assert_array_almost_equal, assert_array_equal
 
 from sklearn.base import BaseEstimator, ClassifierMixin
@@ -718,7 +718,7 @@ def test_rfe_with_joblib_threading_backend(global_random_seed):
     rfe.fit(X, y)
     ranking_ref = rfe.ranking_
 
-    with parallel_config(backend="threading"):
+    with parallel_backend("threading"):
         rfe.fit(X, y)
 
     assert_array_equal(ranking_ref, rfe.ranking_)


### PR DESCRIPTION
Fix https://github.com/scikit-learn/scikit-learn/issues/29783.

This was noticed in when running the tests with default joblib backend switched to threading (to stress-test free-threaded CPython 3.13) and also in #29614.

This is a bit niche so I don't think a changelog entry is necessary but I can add one if someone insists.