### PR TITLE
DOC redirect to GitHub issues & PR instead of mailing list when it comes to contribution

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -347,7 +347,8 @@ The next steps now describe the process of modifying code and submitting a PR:
     instructions to create a pull request from your fork. This will send an
     notification to potential reviewers. You may want to consider sending an message to
     the `discord <https://discord.com/invite/h9qyrK8Jc8>`_ in the development
-    channel for more visibility (instant replies are not guaranteed).
+    channel for more visibility if your pull request does not receive attention after
+    a couple of days (instant replies are not guaranteed though).
 
 It is often helpful to keep your local feature branch synchronized with the
 latest changes of the main scikit-learn repository:

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -347,7 +347,7 @@ The next steps now describe the process of modifying code and submitting a PR:
     instructions to create a pull request from your fork. This will send an
     email to the committers. You may want to consider sending an message to
     the `discord <https://discord.com/invite/h9qyrK8Jc8>`_ in the development
-    chanel for more visibility (instant replies are not guaranteed).
+    channel for more visibility (instant replies are not guaranteed).
 
 It is often helpful to keep your local feature branch synchronized with the
 latest changes of the main scikit-learn repository:

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -345,7 +345,7 @@ The next steps now describe the process of modifying code and submitting a PR:
 12. Follow `these
     <https://help.github.com/articles/creating-a-pull-request-from-a-fork>`_
     instructions to create a pull request from your fork. This will send an
-    email to the committers. You may want to consider sending an message to
+    notification to potential reviewers. You may want to consider sending an message to
     the `discord <https://discord.com/invite/h9qyrK8Jc8>`_ in the development
     channel for more visibility (instant replies are not guaranteed).
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -51,7 +51,7 @@ There are many ways to contribute to scikit-learn, with the most common ones
 being contribution of code or documentation to the project. Improving the
 documentation is no less important than improving the library itself.  If you
 find a typo in the documentation, or have made improvements, do not hesitate to
-send an email to the mailing list or preferably submit a GitHub pull request.
+create a GitHub issue or preferably submit a GitHub pull request.
 Full documentation can be found under the doc/ directory.
 
 But there are many other ways to help. In particular helping to
@@ -345,8 +345,9 @@ The next steps now describe the process of modifying code and submitting a PR:
 12. Follow `these
     <https://help.github.com/articles/creating-a-pull-request-from-a-fork>`_
     instructions to create a pull request from your fork. This will send an
-    email to the committers. You may want to consider sending an email to the
-    mailing list for more visibility.
+    email to the committers. You may want to consider sending an message to
+    the `discord <https://discord.com/invite/h9qyrK8Jc8>`_ in the development
+    chanel for more visibility (instant replies are not guaranteed).
 
 It is often helpful to keep your local feature branch synchronized with the
 latest changes of the main scikit-learn repository:


### PR DESCRIPTION
... instead of mailing list


#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
Orient people towards the most used tools instead of mailing list, also to avoid spam. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
