### PR TITLE
DOC fix a grammar issue in the about-us page

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -8,7 +8,7 @@ History
 =======
 
 This project was started in 2007 as a Google Summer of Code project by
-David Cournapeau. Later that year,Matthieu Brucher started working on this project 
+David Cournapeau. Later that year, Matthieu Brucher started working on this project 
 as part of his thesis.
 
 In 2010 Fabian Pedregosa, Gael Varoquaux, Alexandre Gramfort and Vincent

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -8,8 +8,8 @@ History
 =======
 
 This project was started in 2007 as a Google Summer of Code project by
-David Cournapeau. Later that year, Matthieu Brucher started work on
-this project as part of his thesis.
+David Cournapeau. Later that year,Matthieu Brucher started working on this project 
+as part of his thesis.
 
 In 2010 Fabian Pedregosa, Gael Varoquaux, Alexandre Gramfort and Vincent
 Michel of INRIA took leadership of the project and made the first public


### PR DESCRIPTION
closes #30136

Solve a typo in the "about us" page.