### PR TITLE
ENH Add parameter to return_X_y to `make_classification`

### DIFF
--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -292,12 +292,13 @@ def make_classification(
     for k, centroid in enumerate(centroids):
         start, stop = stop, stop + n_samples_per_cluster[k]
         y[start:stop] = k % n_classes  # assign labels
-        X_k = X[start:stop, feat_desc == 1]  # slice a view of the cluster
 
         A = 2 * generator.uniform(size=(n_informative, n_informative)) - 1
-        X_k[...] = np.dot(X_k, A)  # introduce random covariance
 
-        X_k += centroid  # shift the cluster to a vertex
+        # introduce random covariance
+        X[start:stop, feat_desc == 1] = np.dot(X[start:stop, feat_desc == 1], A)
+
+        X[start:stop, feat_desc == 1] += centroid  # shift the cluster to a vertex
 
     # Create redundant features
     B = 2 * generator.uniform(size=(n_informative, n_redundant)) - 1

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -267,10 +267,13 @@ def make_classification(
     # useless features have int flag 4
     feat_desc = np.zeros(n_features, dtype=int)
     feat_desc[:n_informative] = 1
-    feat_desc[n_informative : n_informative + n_redundant] = 2
+    if n_redundant > 0:
+        feat_desc[n_informative : n_informative + n_redundant] = 2
     n = n_informative + n_redundant
-    feat_desc[n : n + n_repeated] = 3
-    feat_desc[-n_useless:] = 4
+    if n_repeated > 0:
+        feat_desc[n : n + n_repeated] = 3
+    if n_useless > 0:
+        feat_desc[-n_useless:] = 4
 
     if shuffle:
         # Randomly permute samples
@@ -297,18 +300,15 @@ def make_classification(
         X_k += centroid  # shift the cluster to a vertex
 
     # Create redundant features
-    if n_redundant > 0:
-        B = 2 * generator.uniform(size=(n_informative, n_redundant)) - 1
-        X[:, feat_desc == 2] = np.dot(X[:, feat_desc == 1], B)
+    B = 2 * generator.uniform(size=(n_informative, n_redundant)) - 1
+    X[:, feat_desc == 2] = np.dot(X[:, feat_desc == 1], B)
 
     # Repeat some features
-    if n_repeated > 0:
-        indices = ((n - 1) * generator.uniform(size=n_repeated) + 0.5).astype(np.intp)
-        X[:, feat_desc == 3] = X[:, indices]
+    indices = ((n - 1) * generator.uniform(size=n_repeated) + 0.5).astype(np.intp)
+    X[:, feat_desc == 3] = X[:, indices]
 
     # Fill useless features
-    if n_useless > 0:
-        X[:, feat_desc == 4] = generator.standard_normal(size=(n_samples, n_useless))
+    X[:, feat_desc == 4] = generator.standard_normal(size=(n_samples, n_useless))
 
     # Randomly replace labels
     if flip_y >= 0.0:

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -281,12 +281,8 @@ def make_classification(
         generator.shuffle(feat_desc)
         X[:, :] = X[:, feat_desc]
 
-
     # Initially draw informative features from the standard normal
-    X[:, feat_desc == 1] = generator.standard_normal(
-        
-        size=(n_samples, n_informative)
-    )
+    X[:, feat_desc == 1] = generator.standard_normal(size=(n_samples, n_informative))
 
     # Create each cluster; a variant of make_blobs
     stop = 0
@@ -303,9 +299,7 @@ def make_classification(
     # Create redundant features
     if n_redundant > 0:
         B = 2 * generator.uniform(size=(n_informative, n_redundant)) - 1
-        X[:, feat_desc == 2] = np.dot(
-            X[:, feat_desc == 1], B
-        )
+        X[:, feat_desc == 2] = np.dot(X[:, feat_desc == 1], B)
 
     # Repeat some features
     if n_repeated > 0:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #16532

#### What does this implement/fix? Explain your changes.

- add parameter **return_X_y** to `make_classification`

#### Any other comments?
The dataset returned by `load_iris` is a Bunch, which is more descriptive. #16532 proposes same.
``` 
from sklearn.datasets import load_iris

data = load_iris()
print(data.DESCR)  # Prints a description of the Iris dataset
```
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
