### PR TITLE
DOC attempt to fix lorenz_curve in plot tweedie regression example

### DIFF
--- a/examples/linear_model/plot_tweedie_regression_insurance_claims.py
+++ b/examples/linear_model/plot_tweedie_regression_insurance_claims.py
@@ -655,8 +655,9 @@ def lorenz_curve(y_true, y_pred, exposure):
     ranked_pure_premium = y_true[ranking]
     cumulated_claim_amount = np.cumsum(ranked_pure_premium * ranked_exposure)
     cumulated_claim_amount /= cumulated_claim_amount[-1]
-    cumulated_samples = np.linspace(0, 1, len(cumulated_claim_amount))
-    return cumulated_samples, cumulated_claim_amount
+    cumulated_exposure = np.cumsum(ranked_exposure)
+    cumulated_exposure /= cumulated_exposure[-1]
+    return cumulated_exposure, cumulated_claim_amount
 
 
 fig, ax = plt.subplots(figsize=(8, 8))


### PR DESCRIPTION
#### Reference Issues/PRs
Fix attempt of #28534 


#### What does this implement/fix? Explain your changes.
Take definition of Lorenz Curve from [Poisson regression and non-normal loss](https://scikit-learn.org/stable/auto_examples/linear_model/plot_poisson_regression_non_normal_loss.html) and use it in [Tweedie regression on insurance claims](https://scikit-learn.org/stable/auto_examples/linear_model/plot_tweedie_regression_insurance_claims.html)

#### Any other comments?
Following the discussion in #28534 it seems to me that the Lorenz curve should not use a linespace for the x values of the curve if the data is weighted.
Example snippet to test behaviour when linspace is used:

```python 3
import matplotlib.pyplot as plt
import numpy as np


rng = np.random.default_rng(0)
n = 30
y_true = rng.uniform(low=0, high=10, size=n)
y_pred = y_true * rng.uniform(low=0.9, high=1.1, size=n)
exposure = rng.integers(low=0, high=10, size=n)

def lorenz_curve_linspace(frequency, exposure):
    ranking = np.argsort(frequency)
    ranked_frequencies = frequency[ranking]
    ranked_exposure = exposure[ranking]
    cumulated_claims = np.cumsum(ranked_frequencies * ranked_exposure)
    cumulated_claims = cumulated_claims / cumulated_claims[-1]
    cumulated_exposure = np.linspace(0, 1, len(frequency))
    plt.scatter(
        cumulated_exposure,
        cumulated_claims,
        marker=".",
        alpha=0.5,
    )
    return cumulated_exposure, cumulated_claims

y_true_repeated = y_true.repeat(exposure)
y_pred_repeated = y_pred.repeat(exposure)
sample_weight = np.ones_like(y_pred_repeated)
res = lorenz_curve_linspace(y_pred_repeated, sample_weight)

y_true_weighted = y_true
y_pred_weighted = y_pred
sample_weight = exposure
res = lorenz_curve_linspace(y_pred_weighted, sample_weight)
```

Results in

![image](https://github.com/user-attachments/assets/ac2e0d11-5cb6-4c75-97e8-70f858705dd0)

Snippet for results using the version of [Poisson regression and non-normal loss](https://scikit-learn.org/stable/auto_examples/linear_model/plot_poisson_regression_non_normal_loss.html), also implemented in this PR:

<details>

```python 3

import matplotlib.pyplot as plt
import numpy as np


rng = np.random.default_rng(0)
n = 30
y_true = rng.uniform(low=0, high=10, size=n)
y_pred = y_true * rng.uniform(low=0.9, high=1.1, size=n)
exposure = rng.integers(low=0, high=10, size=n)

def lorenz_curve(frequency, exposure, weighted=True):
    ranking = np.argsort(frequency)
    ranked_frequencies = frequency[ranking]
    ranked_exposure = exposure[ranking]
    cumulated_claims = np.cumsum(ranked_frequencies * ranked_exposure)
    cumulated_claims = cumulated_claims / cumulated_claims[-1]
    if weighted:
        cumulated_exposure = np.cumsum(ranked_exposure)
        cumulated_exposure = cumulated_exposure / cumulated_exposure[-1]
        plt.scatter(
            cumulated_exposure,
            cumulated_claims,
            marker=".",
            alpha=0.5,
            label="weighted",
        )
    else:
        cumulated_exposure = np.linspace(0, 1, len(frequency))
        plt.scatter(
            cumulated_exposure,
            cumulated_claims,
            marker=".",
            alpha=0.5,
            label="unweighted",
        )
    return cumulated_exposure, cumulated_claims

y_true_repeated = y_true.repeat(exposure)
y_pred_repeated = y_pred.repeat(exposure)
sample_weight = np.ones_like(y_pred_repeated)
res = lorenz_curve(y_pred_repeated, sample_weight, False)

y_true_weighted = y_true
y_pred_weighted = y_pred
sample_weight = exposure
res = lorenz_curve(y_pred_weighted, sample_weight, True)
plt.legend();

```

![image](https://github.com/user-attachments/assets/fd79010a-a64c-485b-a9b4-d2256877826d)

</details>
