### PR TITLE
MAINT Clean up deprecations for 1.6: in make_sparse_spd_matrix

### DIFF
--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -552,26 +552,6 @@ def test_make_sparse_spd_matrix(norm_diag, sparse_format, global_random_seed):
         assert_array_almost_equal(Xarr.diagonal(), np.ones(n_dim))
 
 
-# TODO(1.6): remove
-def test_make_sparse_spd_matrix_deprecation_warning():
-    """Check the message for future deprecation."""
-    warn_msg = "dim was deprecated in version 1.4"
-    with pytest.warns(FutureWarning, match=warn_msg):
-        make_sparse_spd_matrix(
-            dim=1,
-        )
-
-    error_msg = "`dim` and `n_dim` cannot be both specified"
-    with pytest.raises(ValueError, match=error_msg):
-        make_sparse_spd_matrix(
-            dim=1,
-            n_dim=1,
-        )
-
-    X = make_sparse_spd_matrix()
-    assert X.shape[1] == 1
-
-
 @pytest.mark.parametrize("hole", [False, True])
 def test_make_swiss_roll(hole):
     X, t = make_swiss_roll(n_samples=5, noise=0.0, random_state=0, hole=hole)


### PR DESCRIPTION
removed deprecated `dim` parameter of `make_sparse_spd_matrix`.

I directly removed None as a valid option that was only added (and marked as hidden) for the renaming transition. I don't think we need to start a new deprecation cycle for that.