### PR TITLE
MAINT Clean up deprecations for 1.6: in ColumnTransformer

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -789,22 +789,17 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
                 if pd.NA not in Xs[col_name].values:
                     continue
                 class_name = self.__class__.__name__
-                # TODO(1.6): replace warning with ValueError
-                warnings.warn(
-                    (
-                        f"The output of the '{name}' transformer for column"
-                        f" '{col_name}' has dtype {dtype} and uses pandas.NA to"
-                        " represent null values. Storing this output in a numpy array"
-                        " can cause errors in downstream scikit-learn estimators, and"
-                        " inefficiencies. Starting with scikit-learn version 1.6, this"
-                        " will raise a ValueError. To avoid this problem you can (i)"
-                        " store the output in a pandas DataFrame by using"
-                        f" {class_name}.set_output(transform='pandas') or (ii) modify"
-                        f" the input data or the '{name}' transformer to avoid the"
-                        " presence of pandas.NA (for example by using"
-                        " pandas.DataFrame.astype)."
-                    ),
-                    FutureWarning,
+                raise ValueError(
+                    f"The output of the '{name}' transformer for column"
+                    f" '{col_name}' has dtype {dtype} and uses pandas.NA to"
+                    " represent null values. Storing this output in a numpy array"
+                    " can cause errors in downstream scikit-learn estimators, and"
+                    " inefficiencies. To avoid this problem you can (i)"
+                    " store the output in a pandas DataFrame by using"
+                    f" {class_name}.set_output(transform='pandas') or (ii) modify"
+                    f" the input data or the '{name}' transformer to avoid the"
+                    " presence of pandas.NA (for example by using"
+                    " pandas.DataFrame.astype)."
                 )
 
     def _record_output_indices(self, Xs):

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -2465,11 +2465,10 @@ def test_remainder_set_output():
     assert isinstance(out, np.ndarray)
 
 
-# TODO(1.6): replace the warning by a ValueError exception
 def test_transform_pd_na():
     """Check behavior when a tranformer's output contains pandas.NA
 
-    It should emit a warning unless the output config is set to 'pandas'.
+    It should emit an error unless the output config is set to 'pandas'.
     """
     pd = pytest.importorskip("pandas")
     if not hasattr(pd, "Float64Dtype"):
@@ -2484,19 +2483,18 @@ def test_transform_pd_na():
         warnings.simplefilter("error")
         ct.fit_transform(df)
     df = df.convert_dtypes()
+
     # Error with extension dtype and pd.NA
-    with pytest.warns(FutureWarning, match=r"set_output\(transform='pandas'\)"):
+    with pytest.raises(ValueError, match=r"set_output\(transform='pandas'\)"):
         ct.fit_transform(df)
-    # No warning when output is set to pandas
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        ct.set_output(transform="pandas")
-        ct.fit_transform(df)
+
+    # No error when output is set to pandas
+    ct.set_output(transform="pandas")
+    ct.fit_transform(df)
     ct.set_output(transform="default")
+
     # No warning when there are no pd.NA
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        ct.fit_transform(df.fillna(-1.0))
+    ct.fit_transform(df.fillna(-1.0))
 
 
 def test_dataframe_different_dataframe_libraries():

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -2468,7 +2468,7 @@ def test_remainder_set_output():
 def test_transform_pd_na():
     """Check behavior when a tranformer's output contains pandas.NA
 
-    It should emit an error unless the output config is set to 'pandas'.
+    It should raise an error unless the output config is set to 'pandas'.
     """
     pd = pytest.importorskip("pandas")
     if not hasattr(pd, "Float64Dtype"):
@@ -2493,7 +2493,7 @@ def test_transform_pd_na():
     ct.fit_transform(df)
     ct.set_output(transform="default")
 
-    # No warning when there are no pd.NA
+    # No error when there are no pd.NA
     ct.fit_transform(df.fillna(-1.0))
 
 


### PR DESCRIPTION
Switch from warning to error when there are `pandas.NA` but output is not set to pandas.