### PR TITLE
TST check inheritance order in common tests

### DIFF
--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -305,7 +305,7 @@ def _sparse_random_matrix(n_components, n_features, density="auto", random_state
 
 
 class BaseRandomProjection(
-    TransformerMixin, BaseEstimator, ClassNamePrefixFeaturesOutMixin, metaclass=ABCMeta
+    ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator, metaclass=ABCMeta
 ):
     """Base class for random projections.
 

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -3,6 +3,7 @@
 # tests to make sure estimator_checks works without pytest.
 
 import importlib
+import re
 import sys
 import unittest
 import warnings
@@ -69,6 +70,7 @@ from sklearn.utils.estimator_checks import (
     check_fit_score_takes_y,
     check_methods_sample_order_invariance,
     check_methods_subset_invariance,
+    check_mixin_order,
     check_no_attributes_set_in_init,
     check_outlier_contamination,
     check_outlier_corruption,
@@ -1456,3 +1458,15 @@ def test_estimator_with_set_output():
 
         estimator = StandardScaler().set_output(transform=lib)
         check_estimator(estimator)
+
+
+def test_check_mixin_order():
+    """Test that the check raises an error when the mixin order is incorrect."""
+
+    class BadEstimator(BaseEstimator, TransformerMixin):
+        def fit(self, X, y=None):
+            return self
+
+    msg = "TransformerMixin comes before/left side of BaseEstimator"
+    with raises(AssertionError, match=re.escape(msg)):
+        check_mixin_order("BadEstimator", BadEstimator())


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/30228

This adds a test to our API checks, to test whether the inheritance order is correct.

We can add / change the defined DAG in the future / in this PR.

cc @adam2392 @thomasjpfan @glemaitre 