### PR TITLE
MAINT add Python 3.13 to metadata of pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers=[
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 


### PR DESCRIPTION
Small changes to add to the `classifier` metadata the support for Python 3.13.