### PR TITLE
MAINT bump version from 1.6.dev0 to 1.7.dev0

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,6 +15,7 @@ Changelogs and release notes for all scikit-learn releases are linked in this pa
 .. toctree::
    :maxdepth: 2
 
+   whats_new/v1.7.rst
    whats_new/v1.6.rst
    whats_new/v1.5.rst
    whats_new/v1.4.rst

--- a/doc/whats_new/v1.7.rst
+++ b/doc/whats_new/v1.7.rst
@@ -1,0 +1,34 @@
+.. include:: _contributors.rst
+
+.. currentmodule:: sklearn
+
+.. _release_notes_1_7:
+
+===========
+Version 1.7
+===========
+
+..
+  -- UNCOMMENT WHEN 1.7.0 IS RELEASED --
+  For a short description of the main highlights of the release, please refer to
+  :ref:`sphx_glr_auto_examples_release_highlights_plot_release_highlights_1_6_0.py`.
+
+
+..
+  DELETE WHEN 1.7.0 IS RELEASED
+  Since October 2024, DO NOT add your changelog entry in this file.
+..
+  Instead, create a file named `<PR_NUMBER>.<TYPE>.rst` in the relevant sub-folder in
+  `doc/whats_new/upcoming_changes/`. For full details, see:
+  https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
+
+.. include:: changelog_legend.inc
+
+.. towncrier release notes start
+
+.. rubric:: Code and documentation contributors
+
+Thanks to everyone who has contributed to the maintenance and improvement of
+the project since version 1.7, including:
+
+TODO: update at the time of the release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,7 +263,7 @@ package = "sklearn"  # name of your package
 
 [tool.towncrier]
     package = "sklearn"
-    filename = "doc/whats_new/v1.6.rst"
+    filename = "doc/whats_new/v1.7.rst"
     single_file = true
     directory = "doc/whats_new/upcoming_changes"
     issue_format = ":pr:`{issue}`"

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = "1.6.dev0"
+__version__ = "1.7.dev0"
 
 
 # On OSX, we can get a runtime error due to multiple OpenMP libraries loaded


### PR DESCRIPTION
Bumping the version in `main` from 1.6.dev0 to 1.7.dev0 and target the new rst file with towncrier.