### PR TITLE
TST raise explicit error when tags are missing

### DIFF
--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -808,7 +808,8 @@ def test_check_outlier_corruption():
 
 def test_check_estimator_transformer_no_mixin():
     # check that TransformerMixin is not required for transformer tests to run
-    with raises(AttributeError, ".*fit_transform.*"):
+    # but it fails since the tag is not set
+    with raises(RuntimeError, "the `transformer_tags` tag is not set"):
         check_estimator(BadTransformerWithoutMixin())
 
 


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/30237

This adds an explicit error when tags are missing which would result in failure of collecting tests. This gives an explicit error on why the collection fails.

