### PR TITLE
[DRAFT] Engine plugin API for whole class dispatching

### DIFF
--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -20,6 +20,7 @@ from ..base import (
 from ..exceptions import ConvergenceWarning
 from ..metrics.pairwise import _euclidean_distances, euclidean_distances
 from ..utils import check_array, check_random_state
+from ..utils._backend import find_backend
 from ..utils._openmp_helpers import _openmp_effective_n_threads
 from ..utils._param_validation import Interval, StrOptions, validate_params
 from ..utils.extmath import row_norms, stable_cumsum
@@ -1061,6 +1062,10 @@ class _BaseKMeans(
         labels : ndarray of shape (n_samples,)
             Index of the cluster each sample belongs to.
         """
+        self._backend = find_backend(self, X, y=y, sample_weight=sample_weight)
+        if self._backend is not None:
+            self._backend.fit_predict(X, y=y, sample_weight=sample_weight)
+
         return self.fit(X, sample_weight=sample_weight).labels_
 
     def predict(self, X):
@@ -1081,6 +1086,8 @@ class _BaseKMeans(
             Index of the cluster each sample belongs to.
         """
         check_is_fitted(self)
+        if self._backend is not None:
+            return self._backend.predict(X)
 
         X = self._check_test_data(X)
 
@@ -1119,6 +1126,9 @@ class _BaseKMeans(
         X_new : ndarray of shape (n_samples, n_clusters)
             X transformed in the new space.
         """
+        self._backend = find_backend(self, X, y=y, sample_weight=sample_weight)
+        if self._backend is not None:
+            return self._backend.fit_transform(X, y=y, sample_weight=sample_weight)
         return self.fit(X, sample_weight=sample_weight)._transform(X)
 
     def transform(self, X):
@@ -1139,6 +1149,10 @@ class _BaseKMeans(
             X transformed in the new space.
         """
         check_is_fitted(self)
+        if self._backend is not None:
+            return self._backend.transform(
+                X,
+            )
 
         X = self._check_test_data(X)
         return self._transform(X)
@@ -1453,6 +1467,11 @@ class KMeans(_BaseKMeans):
         self : object
             Fitted estimator.
         """
+        self._backend = find_backend(self, X, y=y, sample_weight=sample_weight)
+        if self._backend is not None:
+            self._backend.fit(X, y=y, sample_weight=sample_weight)
+            return self
+
         X = validate_data(
             self,
             X,

--- a/sklearn/utils/_backend.py
+++ b/sklearn/utils/_backend.py
@@ -1,0 +1,104 @@
+"""Utilities for backend dispatching."""
+
+# Authors: The scikit-learn developers
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+import functools
+import os
+import warnings
+from importlib.metadata import entry_points
+
+
+def _entry_points(group="sklearn_backends"):
+    # Support Python versions before 3.10, which do not let you
+    # filter groups directly.
+    all_entry_points = entry_points()
+    if hasattr(all_entry_points, "select"):
+        selected_entry_points = all_entry_points.select(group=group)
+    else:
+        selected_entry_points = all_entry_points.get(group, ())
+    return selected_entry_points
+
+
+@functools.cache
+def all_backends():
+    """Find all backends that provide an implementation for an estimator"""
+    backends = {}
+
+    for backend in _entry_points():
+        backends[backend.name] = backend.load()
+
+    return backends
+
+
+def dispatching_disabled():
+    """Determine if dispatching has been disabled by the user"""
+    no_dispatching = os.environ.get("SKLEARN_NO_DISPATCHING", False)
+    if no_dispatching == "1":
+        return True
+    else:
+        return False
+
+
+def public_api_name(estimator):
+    """Get the name of the public module for a scikit-learn estimator.
+
+    This computes the name of the public submodule in which the estimator
+    can be found.
+    """
+    full_name = estimator.__module__
+    # This relies on the fact that scikit-learn does not use
+    # sub-submodules in its public API.
+    # This means that public name can be atmost `sklearn.foobar`.
+    # XXX Without this assumption it is very hard (impossible?)
+    # XXX to compute the public name without a lot of acrobatics
+    # XXX of walking up/down namespaces.
+    public_name = ".".join(full_name.split(".")[:2])
+    return public_name
+
+
+def find_backend(estimator, *fit_args, **fit_kwargs):
+    """Find a suitable backend for the combination of estimator and arguments."""
+    if dispatching_disabled():
+        return
+
+    # XXX Keeping it simple for now, we can re-use most of the infrastructure
+    # XXX from the existing plugins PR to help find backends via entrypoints
+    # XXX as well as deal with enabling this via a config option.
+    # XXX For now using a hardcoded list of backends
+    module_path = public_api_name(estimator)
+    name = estimator.__class__.__name__
+    estimator_name = f"{module_path}:{name}"
+
+    # Backends are tried in alphabetical order, this makes things
+    # predictable and stable across runs. Might need a better solution
+    # when it becomes common that users have more than one backend
+    # that would accept a particular call.
+    for name in sorted(all_backends()):
+        backend = all_backends()[name]
+
+        wants_it = backend.can_has(estimator_name, estimator, *fit_args, **fit_kwargs)
+        if not wants_it:
+            continue
+
+        Implementation = backend.get_implementation(estimator_name)
+
+        impl = Implementation(estimator)
+        warnings.warn(
+            f"The '{estimator_name}' implementation was dispatched to"
+            f" the '{name}' backend. Set SKLEARN_NO_DISPATCHING=1 to"
+            " disable this behaviour.",
+            DispatchNotification,
+            # XXX from where should this warning originate?
+            # XXX what is the right stacklevel here? 4 seems right for KMeans
+            # XXX but in general?
+            stacklevel=4,
+        )
+        return impl
+
+
+class DispatchNotification(RuntimeWarning):
+    """Notification issued when a estimator is dispatched to a backend."""
+
+    pass


### PR DESCRIPTION
Putting this PR up so we can look at it, not because it is anywhere near to being done or what we should be doing.

The idea here is to explore how "whole class dispatching" could look like. This is a bit different from what we explored in #25535 which took the approach of fine grained and well defined functions being dispatched to a backend.

I've made a simple "backend" to get a feel for things: https://github.com/betatim/scikit-learn-phony-backend

---

The big idea, compared to the previous PR, is that a backend gets to handle "everything" an estimator does. This might make the dispatching mechanism simpler and easier to use for backend implementors. It also means there is more work needed to make a compliant backend because it has to do everything (algorithm implementation, input validation, etc).

When `fit` (or a `fit_*`) is called we use `find_backend(estimator_instance, fit_args)` to loop through the installed backends to find out if one of them wants to handle this case. A backend has to provide a function that we can call with these arguments that returns a `True`/`False` decision. If the backend wants to handle the case we instantiate its implementation and call its `.fit()` method. The backend is responsible for setting all the fitted attributes on the original estimator instance. It also has to perform all the input and parameter validation that currently happens in `fit` itself.

If no suitable backend is found, we execute the normal `fit` code.

In all methods that are not `fit*` we inspect the `_backend` attribute to see if a backend was using during fitting or not. If one was used, it will be called again to do the work for `predict`, `score`, etc. If for whatever reason the backend can't do it (say the input is in a format it doesn't support) it has to raise an exception telling the user. In the past we settled on backends having to provide a method for converting an estimator from/to Numpy arrays that users can call. I think this is an idea to keep (and add here). Explicit failure with conversion instructions seems better than trying to make it work via some magic (maybe in a later version?).

I've not hooked into the config system of scikit-learn, mostly because I think we should just do what #25535 did. Actually, for most things that are missing here I think "let's do what #25535 did".

WDYT @ogrisel @thomasjpfan ? Interested to hear thoughts