### PR TITLE
MAINT only trigger towncrier when targeting main branch

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -39,8 +39,7 @@ fi
 if [ -n "$CI_PULL_REQUEST" ] && [ -z "$CI_TARGET_BRANCH" ]
 then
     # Get the target branch name when using CircleCI
-    PR_RESPONSE=$(curl -s "https://api.github.com/repos/scikit-learn/scikit-learn/pulls/$CIRCLE_PR_NUMBER")
-    CI_TARGET_BRANCH=$(echo "$PR_RESPONSE" | jq -r .base.ref)
+    CI_TARGET_BRANCH=$(curl -s "https://api.github.com/repos/scikit-learn/scikit-learn/pulls/$CIRCLE_PR_NUMBER" | jq -r .base.ref)
 fi
 
 get_build_type() {

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -36,7 +36,7 @@ then
     fi
 fi
 
-if [ -n "$CI_PULL_REQUEST" ] && [ -z "$CI_TARGET_BRANCH" ]
+if [[ -n "$CI_PULL_REQUEST"  && -z "$CI_TARGET_BRANCH" ]]
 then
     # Get the target branch name when using CircleCI
     CI_TARGET_BRANCH=$(curl -s "https://api.github.com/repos/scikit-learn/scikit-learn/pulls/$CIRCLE_PR_NUMBER" | jq -r .base.ref)
@@ -190,7 +190,7 @@ ccache -s
 
 export OMP_NUM_THREADS=1
 
-if [[ "$CIRCLE_BRANCH" =~ ^main$ || "$CI_TARGET_BRANCH" =~ ^main$ ) ]]
+if [[ "$CIRCLE_BRANCH" == "main" || "$CI_TARGET_BRANCH" == "main" ]]
 then
     towncrier build --yes
 fi

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -30,6 +30,7 @@ then
     then
         CIRCLE_BRANCH=$GITHUB_HEAD_REF
         CI_PULL_REQUEST=true
+        CI_TARGET_BRANCH=$GITHUB_BASE_REF
     else
         CIRCLE_BRANCH=$GITHUB_REF_NAME
     fi
@@ -183,7 +184,7 @@ ccache -s
 
 export OMP_NUM_THREADS=1
 
-if [[ "$CIRCLE_BRANCH" =~ ^main$ || -n "$CI_PULL_REQUEST" ]]
+if [[ "$CIRCLE_BRANCH" =~ ^main$ || ( -n "$CI_PULL_REQUEST" && "$CIRCLE_TARGET_BRANCH" =~ ^main$ ) ]]
 then
     towncrier build --yes
 fi

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -190,7 +190,7 @@ ccache -s
 
 export OMP_NUM_THREADS=1
 
-if [[ "$CIRCLE_BRANCH" =~ ^main$ || ( -n "$CI_PULL_REQUEST" && "$CI_TARGET_BRANCH" =~ ^main$ ) ]]
+if [[ "$CIRCLE_BRANCH" =~ ^main$ || "$CI_TARGET_BRANCH" =~ ^main$ ) ]]
 then
     towncrier build --yes
 fi

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -36,6 +36,13 @@ then
     fi
 fi
 
+if [ -n "$CI_PULL_REQUEST" ] && [ -z "$CI_TARGET_BRANCH" ]
+then
+    # Get the target branch name when using CircleCI
+    PR_RESPONSE=$(curl -s "https://api.github.com/repos/scikit-learn/scikit-learn/pulls/$CIRCLE_PR_NUMBER")
+    CI_TARGET_BRANCH=$(echo "$PR_RESPONSE" | jq -r .base.ref)
+fi
+
 get_build_type() {
     if [ -z "$CIRCLE_SHA1" ]
     then
@@ -184,7 +191,7 @@ ccache -s
 
 export OMP_NUM_THREADS=1
 
-if [[ "$CIRCLE_BRANCH" =~ ^main$ || ( -n "$CI_PULL_REQUEST" && "$CIRCLE_TARGET_BRANCH" =~ ^main$ ) ]]
+if [[ "$CIRCLE_BRANCH" =~ ^main$ || ( -n "$CI_PULL_REQUEST" && "$CI_TARGET_BRANCH" =~ ^main$ ) ]]
 then
     towncrier build --yes
 fi


### PR DESCRIPTION
When working on release branch, we should not automatically generate `towncrier` because this job is done by hand.

We witnessed that the current rule is wrong:
https://github.com/scikit-learn/scikit-learn/pull/30244

This PR check that we target `main` and we are in a PR to build the documentation or that we are in `main` to build the changelog in dev.