### PR TITLE
randomized_svd: More efficient SVD computation

### DIFF
--- a/benchmarks/bench_plot_randomized_svd.py
+++ b/benchmarks/bench_plot_randomized_svd.py
@@ -73,6 +73,7 @@ from time import time
 
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 import scipy as sp
 
 from sklearn.datasets import (
@@ -118,7 +119,9 @@ SVHN_FOLDER = "./SVHN/"
 
 datasets = [
     "low rank matrix",
-    "lfw_people",
+    # "lfw_people",  # temporarily skipped
+    # (raises ValueError with `n_iter = 5 on sklearn - none` due to overflow)
+    # TODO: fix benchmark to not crash here
     "olivetti_faces",
     "20newsgroups",
     "mnist_784",
@@ -193,6 +196,8 @@ def get_data(dataset_name):
         del col
     else:
         X = fetch_openml(dataset_name).data
+        if isinstance(X, pd.DataFrame):
+            X = X.to_numpy()
     return X
 
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -531,7 +531,7 @@ def randomized_svd(
 
     # project M to the (k + p) dimensional space using the basis vectors
     B = Q.T @ M  # shape (k + p, M.shape[1])
-    
+
     # Typically M.shape[1] > k + p, therefore we
     # compute the SVD of the tall and thin matrix B.T with shape (M.shape[1], k + p)
     # instead of less efficient SVD of (wide) matrix B.

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -530,26 +530,35 @@ def randomized_svd(
     )
 
     # project M to the (k + p) dimensional space using the basis vectors
-    B = Q.T @ M  # shape (k + p, M.shape[1])
+    B = Q.T @ M  # shape (k + p, M.shape[1]), often M.shape[1] > k + p
 
-    # Typically M.shape[1] > k + p, therefore we
-    # compute the SVD of the tall and thin matrix B.T with shape (M.shape[1], k + p)
-    # instead of less efficient SVD of (wide) matrix B.
+    # It is more efficient to compute the SVD of a tall and thin matrix.
+    # Therefore, if B is wide, we compute the SVD of its transpose.
+    thin = B.shape[0] > B.shape[1]
+    # When array_api_dispatch is disabled, rely on scipy.linalg
+    # instead of numpy.linalg to avoid introducing a behavior change w.r.t.
+    # previous versions of scikit-learn.
     xp, is_array_api_compliant = get_namespace(B)
-    if is_array_api_compliant:
-        V, s, Uhat_t = xp.linalg.svd(B.T, full_matrices=False)
-    else:
-        # When array_api_dispatch is disabled, rely on scipy.linalg
-        # instead of numpy.linalg to avoid introducing a behavior change w.r.t.
-        # previous versions of scikit-learn.
-        V, s, Uhat_t = linalg.svd(
-            B.T, full_matrices=False, lapack_driver=svd_lapack_driver
+    if thin:
+        Uhat, s, Vt = (
+            xp.linalg.svd(B, full_matrices=False)
+            if is_array_api_compliant
+            else linalg.svd(B, full_matrices=False, lapack_driver=svd_lapack_driver)
         )
+    else:
+        V, s, Uhat_t = (
+            xp.linalg.svd(B.T, full_matrices=False)
+            if is_array_api_compliant
+            else linalg.svd(B.T, full_matrices=False, lapack_driver=svd_lapack_driver)
+        )
+        Uhat = Uhat_t.T
+        del Uhat_t
+        Vt = V.T
+        del V
     del B
-    U = Q @ Uhat_t.T
-    del Uhat_t
-    Vt = V.T
-    del V
+
+    U = Q @ Uhat
+    del Uhat
 
     if flip_sign:
         if not transpose:


### PR DESCRIPTION
Efficiency improvement in randomized_svd: compute SVD of a tall and thin matrix instead of a wide matrix

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Despite the code stating 
> compute the SVD on the **_thin_** matrix: (k + p) wide

the matrix B has (k + p) _rows_, not columns; it is wide. For a wide matrix (`shape[1] > shape[0]`) it is more efficient to compute the SVD of its transpose and then transpose the factors.

Complexity of SVD (assuming $m \times n$ matrix) is $O(mn^2)$, so if $m < n$ it is cheaper to perform the operation on the matrix transpose.

#### Any other comments?
See e.g. https://mathoverflow.net/a/221216 for a brief complexity analysis.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
