### PR TITLE
DOC Add link to Quantile example in Gradient Boosting

### DIFF
--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1749,6 +1749,10 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         regression and is a robust loss function. 'huber' is a
         combination of the two. 'quantile' allows quantile regression (use
         `alpha` to specify the quantile).
+        See
+        :ref:`sphx_glr_auto_examples_ensemble_plot_gradient_boosting_quantile.py`
+        for an example that demonstrates quantile regression for
+        prediction intervals with `loss='quantile'`.
 
     learning_rate : float, default=0.1
         Learning rate shrinks the contribution of each tree by `learning_rate`.
@@ -1874,6 +1878,10 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         The alpha-quantile of the huber loss function and the quantile
         loss function. Only if ``loss='huber'`` or ``loss='quantile'``.
         Values must be in the range `(0.0, 1.0)`.
+        See
+        :ref:`sphx_glr_auto_examples_ensemble_plot_gradient_boosting_quantile.py`
+        for an example of using quantile regression with
+        different alpha values.
 
     verbose : int, default=0
         Enable verbose output. If 1 then it prints progress and performance

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1878,10 +1878,6 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         The alpha-quantile of the huber loss function and the quantile
         loss function. Only if ``loss='huber'`` or ``loss='quantile'``.
         Values must be in the range `(0.0, 1.0)`.
-        See
-        :ref:`sphx_glr_auto_examples_ensemble_plot_gradient_boosting_quantile.py`
-        for an example of using quantile regression with
-        different alpha values.
 
     verbose : int, default=0
         Enable verbose output. If 1 then it prints progress and performance

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1751,7 +1751,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         `alpha` to specify the quantile).
         See
         :ref:`sphx_glr_auto_examples_ensemble_plot_gradient_boosting_quantile.py`
-        for an example that demonstrates quantile regression for
+        for an example that demonstrates quantile regression for creating
         prediction intervals with `loss='quantile'`.
 
     learning_rate : float, default=0.1


### PR DESCRIPTION
#### Reference Issues/PRs
References #26927 


#### What does this fix?
Added links to gradient boosting quantile example in docs

