### PR TITLE
CI Use released versions of dependencies in Python 3.13 wheels as much as possible

### DIFF
--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -30,15 +30,6 @@ function exec_inside_container() {
 }
 
 exec_inside_container "python -m pip install $MNT_FOLDER/$WHEEL_NAME"
-
-if [[ "$PYTHON_VERSION" == "313" ]]; then
-    # TODO: remove when pandas has a release with python 3.13 wheels
-    # First install numpy release
-    exec_inside_container "python -m pip install numpy"
-    # Then install pandas-dev
-    exec_inside_container "python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas --only-binary :all:"
-fi
-
 exec_inside_container "python -m pip install $CIBW_TEST_REQUIRES"
 
 # Save container state to scikit-learn/minimal-windows image. On Windows the

--- a/build_tools/wheels/cibw_before_test.sh
+++ b/build_tools/wheels/cibw_before_test.sh
@@ -6,14 +6,8 @@ set -x
 FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
 PY_VERSION=$(python -c 'import sys; print(f"{sys.version_info.major}{sys.version_info.minor}")')
 
+# TODO: remove when scipy has a release with free-threaded wheels
 if [[ $FREE_THREADED_BUILD == "True" ]]; then
-    # TODO: remove when numpy, scipy and pandas have releases with free-threaded wheels
-    python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy scipy pandas --only-binary :all:
-
-elif [[ "$PY_VERSION" == "313" ]]; then
-    # TODO: remove when pandas has a release with python 3.13 wheels
-    # First install numpy release
-    python -m pip install numpy --only-binary :all:
-    # Then install pandas-dev
-    python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas --only-binary :all:
+    python -m pip install numpy pandas
+    python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple scipy --only-binary :all:
 fi


### PR DESCRIPTION
This should fix https://github.com/scikit-learn/scikit-learn/issues/30265.

This cleans up a few temporary work-arounds that were using dev dependencies because Python 3.13 wheels were not available yet.