### PR TITLE
DOC: Clarify the sign in log marginal likelihood plot.

### DIFF
--- a/examples/gaussian_process/plot_gpr_noisy.py
+++ b/examples/gaussian_process/plot_gpr_noisy.py
@@ -151,7 +151,7 @@ _ = plt.title(
 # Looking at the kernel hyperparameters, we see that the best combination found
 # has a smaller noise level and shorter length scale than the first model.
 #
-# We can inspect the Log-Marginal-Likelihood (LML) of
+# We can inspect the negative Log-Marginal-Likelihood (LML) of
 # :class:`~sklearn.gaussian_process.GaussianProcessRegressor`
 # for different hyperparameters to get a sense of the local minima.
 from matplotlib.colors import LogNorm
@@ -181,7 +181,7 @@ plt.xscale("log")
 plt.yscale("log")
 plt.xlabel("Length-scale")
 plt.ylabel("Noise-level")
-plt.title("Log-marginal-likelihood")
+plt.title("Negative log-marginal-likelihood")
 plt.show()
 
 # %%


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.

This clarifies that the plot of the log-marginal-likelihood is done with a minus sign. The title of the plot now reflects that together with one place in the text, which previously indicated the wrong sign.

#### Any other comments?

