### PR TITLE
MAINT: remove unused local var in `sklearn.linear_model._ridge._ridge_regression`

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -665,10 +665,8 @@ def _ridge_regression(
     if y.ndim > 2:
         raise ValueError("Target y has the wrong shape %s" % str(y.shape))
 
-    ravel = False
     if y.ndim == 1:
         y = xp.reshape(y, (-1, 1))
-        ravel = True
 
     n_samples_, n_targets = y.shape
 


### PR DESCRIPTION
#### Reference Issues/PRs
No issue involved.

#### What does this implement/fix? Explain your changes.
This PR removes an unused local var in `.\sklearn\linear_model\_ridge.py` at line 671 in function `_ridge_regression`.

#### Any other comments?
