### PR TITLE
DOC Fix link to dev changelog

### DIFF
--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -206,7 +206,7 @@
       <div class="col-md-4">
         <h4 class="sk-landing-call-header">News</h4>
         <ul class="sk-landing-call-list list-unstyled">
-          <li><strong>On-going development:</strong> <a href="whats_new/v1.6.html#version-1-6-0">scikit-learn 1.6 (Changelog)</a>.</li>
+          <li><strong>On-going development:</strong> <a href="https://scikit-learn.org/dev/whats_new/v1.6.html#version-1-6-0">scikit-learn 1.6 (Changelog)</a>.</li>
           <li><strong>September 2024.</strong> scikit-learn 1.5.2 is available for download (<a href="whats_new/v1.5.html#version-1-5-2">Changelog</a>).</li>
           <li><strong>July 2024.</strong> scikit-learn 1.5.1 is available for download (<a href="whats_new/v1.5.html#version-1-5-1">Changelog</a>).</li>
           <li><strong>May 2024.</strong> scikit-learn 1.5.0 is available for download (<a href="whats_new/v1.5.html#version-1-5-0">Changelog</a>).</li>


### PR DESCRIPTION
The link to the ongoing dev changelog should point to the dev version of the website because it doesn't exist on the stable version. It was working until 1.4 but I mistakenly changed it then :/

cc/ @glemaitre 