### PR TITLE
MAINT resize plotly figure to take right-hand sidebar into account

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -346,6 +346,7 @@ html_additional_pages = {"index": "index.html"}
 html_js_files = [
     "scripts/dropdown.js",
     "scripts/version-switcher.js",
+    "scripts/sg_plotly_resize.js",
 ]
 
 # Compile scss files into css files using sphinxcontrib-sass

--- a/doc/js/scripts/sg_plotly_resize.js
+++ b/doc/js/scripts/sg_plotly_resize.js
@@ -1,0 +1,14 @@
+// Related to https://github.com/scikit-learn/scikit-learn/issues/30279
+// There an interaction between plotly and bootstrap/pydata-sphinx-theme
+// that causes plotly figures to not detect the right-hand sidebar width
+
+function resizePlotlyGraphs() {
+    const plotlyDivs = document.getElementsByClassName("plotly-graph-div");
+
+    for (const div of plotlyDivs) {
+        Plotly.Plots.resize(div);
+    }
+}
+
+window.addEventListener("resize", resizePlotlyGraphs);
+document.addEventListener("DOMContentLoaded", resizePlotlyGraphs);


### PR DESCRIPTION
closes #30279 

There an interaction between bootstrap/pydata-sphinx/theme and plotly figure where the width of the figure when loading the page does not take into account the right-hand sidebar during the first page loading. The reason could be due that in the HTML code, the right-hand sidebar comes after the plotly figure.

Here, this is a hack to trigger a figure resizing after the page is loaded. It does the job.