### PR TITLE
MAINT add deprecation for transition to new developer API tools

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -442,6 +442,7 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
             output["text/html"] = estimator_html_repr(self)
         return output
 
+    # TODO(1.8): Remove this method
     def _validate_data(self, *args, **kwargs):
         warnings.warn(
             "`BaseEstimator._validate_data` is deprecated in 1.6 and will be removed "
@@ -451,6 +452,7 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
         )
         validate_data(self, *args, **kwargs)
 
+    # TODO(1.8): Remove this method
     def _check_n_features(self, *args, **kwargs):
         warnings.warn(
             "`BaseEstimator._check_n_features` is deprecated in 1.6 and will be "
@@ -459,6 +461,7 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
         )
         _check_n_features(self, *args, **kwargs)
 
+    # TODO(1.8): Remove this method
     def _check_feature_names(self, *args, **kwargs):
         warnings.warn(
             "`BaseEstimator._check_feature_names` is deprecated in 1.6 and will be "

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -30,11 +30,14 @@ from .utils._tags import (
 )
 from .utils.fixes import _IS_32BIT
 from .utils.validation import (
+    _check_feature_names,
     _check_feature_names_in,
+    _check_n_features,
     _generate_get_feature_names_out,
     _is_fitted,
     check_array,
     check_is_fitted,
+    validate_data,
 )
 
 
@@ -438,6 +441,32 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
         if get_config()["display"] == "diagram":
             output["text/html"] = estimator_html_repr(self)
         return output
+
+    def _validate_data(self, *args, **kwargs):
+        warnings.warn(
+            "`BaseEstimator._validate_data` is deprecated in 1.6 and will be removed "
+            "in 1.8. Use `sklearn.utils.validation.validate_data` instead. This "
+            "function becomes public and is part of the scikit-learn developer API.",
+            FutureWarning,
+        )
+        validate_data(self, *args, **kwargs)
+
+    def _check_n_features(self, *args, **kwargs):
+        warnings.warn(
+            "`BaseEstimator._check_n_features` is deprecated in 1.6 and will be "
+            "removed in 1.8. Use `sklearn.utils.validation._check_n_features` instead.",
+            FutureWarning,
+        )
+        _check_n_features(self, *args, **kwargs)
+
+    def _check_feature_names(self, *args, **kwargs):
+        warnings.warn(
+            "`BaseEstimator._check_feature_names` is deprecated in 1.6 and will be "
+            "removed in 1.8. Use `sklearn.utils.validation._check_feature_names` "
+            "instead.",
+            FutureWarning,
+        )
+        _check_feature_names(self, *args, **kwargs)
 
 
 class ClassifierMixin:

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -442,30 +442,30 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
             output["text/html"] = estimator_html_repr(self)
         return output
 
-    # TODO(1.8): Remove this method
+    # TODO(1.7): Remove this method
     def _validate_data(self, *args, **kwargs):
         warnings.warn(
             "`BaseEstimator._validate_data` is deprecated in 1.6 and will be removed "
-            "in 1.8. Use `sklearn.utils.validation.validate_data` instead. This "
+            "in 1.7. Use `sklearn.utils.validation.validate_data` instead. This "
             "function becomes public and is part of the scikit-learn developer API.",
             FutureWarning,
         )
         validate_data(self, *args, **kwargs)
 
-    # TODO(1.8): Remove this method
+    # TODO(1.7): Remove this method
     def _check_n_features(self, *args, **kwargs):
         warnings.warn(
             "`BaseEstimator._check_n_features` is deprecated in 1.6 and will be "
-            "removed in 1.8. Use `sklearn.utils.validation._check_n_features` instead.",
+            "removed in 1.7. Use `sklearn.utils.validation._check_n_features` instead.",
             FutureWarning,
         )
         _check_n_features(self, *args, **kwargs)
 
-    # TODO(1.8): Remove this method
+    # TODO(1.7): Remove this method
     def _check_feature_names(self, *args, **kwargs):
         warnings.warn(
             "`BaseEstimator._check_feature_names` is deprecated in 1.6 and will be "
-            "removed in 1.8. Use `sklearn.utils.validation._check_feature_names` "
+            "removed in 1.7. Use `sklearn.utils.validation._check_feature_names` "
             "instead.",
             FutureWarning,
         )

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -450,7 +450,7 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
             "function becomes public and is part of the scikit-learn developer API.",
             FutureWarning,
         )
-        validate_data(self, *args, **kwargs)
+        return validate_data(self, *args, **kwargs)
 
     # TODO(1.7): Remove this method
     def _check_n_features(self, *args, **kwargs):

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -406,6 +406,7 @@ def test_check_inplace_ensure_writeable(estimator):
     check_inplace_ensure_writeable(name, estimator)
 
 
+# TODO(1.8): Remove this test when the deprecation cycle is over
 def test_transition_public_api_deprecations():
     """This test checks that we raised deprecation warning explaining how to transition
     to the new developer public API from 1.5 to 1.6.

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -414,7 +414,7 @@ def test_transition_public_api_deprecations():
 
     class OldEstimator(BaseEstimator):
         def fit(self, X, y=None):
-            self._validate_data(X, y)
+            X, y = self._validate_data(X, y)
             self._check_n_features(X, reset=True)
             self._check_feature_names(X, reset=True)
             return self

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -19,6 +19,7 @@ from scipy.linalg import LinAlgWarning
 import sklearn
 from sklearn.base import BaseEstimator
 from sklearn.compose import ColumnTransformer
+from sklearn.datasets import make_classification
 from sklearn.exceptions import ConvergenceWarning
 
 # make it possible to discover experimental estimators when calling `all_estimators`
@@ -403,3 +404,35 @@ def test_check_inplace_ensure_writeable(estimator):
         estimator.set_params(kernel="precomputed")
 
     check_inplace_ensure_writeable(name, estimator)
+
+
+def test_transition_public_api_deprecations():
+    """This test checks that we raised deprecation warning explaining how to transition
+    to the new developer public API from 1.5 to 1.6.
+    """
+    class OldEstimator(BaseEstimator):
+        def fit(self, X, y=None):
+            self._validate_data(X, y)
+            self._check_n_features(X, reset=True)
+            self._check_feature_names(X, reset=True)
+            return self
+
+        def transform(self, X):
+            return X
+
+    X, y = make_classification(n_samples=10, n_features=5, random_state=0)
+
+    old_estimator = OldEstimator()
+    with pytest.warns(FutureWarning) as warning_list:
+        old_estimator.fit(X)
+
+    assert len(warning_list) == 3
+    assert str(warning_list[0].message).startswith(
+        "`BaseEstimator._validate_data` is deprecated"
+    )
+    assert str(warning_list[1].message).startswith(
+        "`BaseEstimator._check_n_features` is deprecated"
+    )
+    assert str(warning_list[2].message).startswith(
+        "`BaseEstimator._check_feature_names` is deprecated"
+    )

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -410,6 +410,7 @@ def test_transition_public_api_deprecations():
     """This test checks that we raised deprecation warning explaining how to transition
     to the new developer public API from 1.5 to 1.6.
     """
+
     class OldEstimator(BaseEstimator):
         def fit(self, X, y=None):
             self._validate_data(X, y)

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -406,7 +406,7 @@ def test_check_inplace_ensure_writeable(estimator):
     check_inplace_ensure_writeable(name, estimator)
 
 
-# TODO(1.8): Remove this test when the deprecation cycle is over
+# TODO(1.7): Remove this test when the deprecation cycle is over
 def test_transition_public_api_deprecations():
     """This test checks that we raised deprecation warning explaining how to transition
     to the new developer public API from 1.5 to 1.6.

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -414,7 +414,7 @@ def test_transition_public_api_deprecations():
 
     class OldEstimator(BaseEstimator):
         def fit(self, X, y=None):
-            X, y = self._validate_data(X, y)
+            X = self._validate_data(X)
             self._check_n_features(X, reset=True)
             self._check_feature_names(X, reset=True)
             return self

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -420,7 +420,7 @@ def test_transition_public_api_deprecations():
             return self
 
         def transform(self, X):
-            return X
+            return X  # pragma: no cover
 
     X, y = make_classification(n_samples=10, n_features=5, random_state=0)
 


### PR DESCRIPTION
Partially address #30298 

This PR avoid the breaking changes that we introduced by moving tools and changing the name.
Instead, it raises a deprecation warning to give a bit more time for user to adapt their code.

#### TODO

- [x] warn for `_validate_data`
- [x] warn for `_check_feature_name`
- [x] warn for `_check_n_features`