### PR TITLE
MAINT raise a FutureWarning specifically when _estimator_type is defined

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -194,6 +194,22 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
     array([3, 3, 3])
     """
 
+    def __new__(cls, *args, **kwargs):
+        if hasattr(cls, "_estimator_type"):
+            attr = inspect.getattr_static(cls, "_estimator_type")
+            if not isinstance(attr, property):
+                # we use properties in scikit-learn to avoid false positive warning for
+                # people using our mixin classes.
+                warnings.warn(
+                    "`_estimator_type` is deprecated in 1.6 and will be removed "
+                    "in 1.8. Instead, use `estimator_type` defined in `Tags` "
+                    "through `__sklearn_tags__` method. See "
+                    "https://scikit-learn.org/dev/developers/develop.html#"
+                    "estimator-tags for more information.",
+                    FutureWarning,
+                )
+        return super().__new__(cls)
+
     @classmethod
     def _get_param_names(cls):
         """Get parameter names for the estimator"""
@@ -475,7 +491,9 @@ class ClassifierMixin:
     """
 
     # TODO(1.8): Remove this attribute
-    _estimator_type = "classifier"
+    @property
+    def _estimator_type(self):
+        return "classifier"
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
@@ -548,7 +566,9 @@ class RegressorMixin:
     """
 
     # TODO(1.8): Remove this attribute
-    _estimator_type = "regressor"
+    @property
+    def _estimator_type(self):
+        return "regressor"
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
@@ -624,7 +644,9 @@ class ClusterMixin:
     """
 
     # TODO(1.8): Remove this attribute
-    _estimator_type = "clusterer"
+    @property
+    def _estimator_type(self):
+        return "clusterer"
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
@@ -977,7 +999,9 @@ class DensityMixin:
     """
 
     # TODO(1.8): Remove this attribute
-    _estimator_type = "DensityEstimator"
+    @property
+    def _estimator_type(self):
+        return "DensityEstimator"
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
@@ -1027,7 +1051,9 @@ class OutlierMixin:
     """
 
     # TODO(1.8): Remove this attribute
-    _estimator_type = "outlier_detector"
+    @property
+    def _estimator_type(self):
+        return "outlier_detector"
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()

--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -781,6 +781,10 @@ class OAS(EmpiricalCovariance):
     >>> oas.shrinkage_
     np.float64(0.0195...)
     """
+    # TODO(1.8): Remove this method. Necessary for passing the docstring check
+    # during the deprecation of _estimator_type.
+    def __init__(self):
+        super().__init__()
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X, y=None):

--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -781,10 +781,13 @@ class OAS(EmpiricalCovariance):
     >>> oas.shrinkage_
     np.float64(0.0195...)
     """
+
     # TODO(1.8): Remove this method. Necessary for passing the docstring check
     # during the deprecation of _estimator_type.
-    def __init__(self):
-        super().__init__()
+    def __init__(self, store_precision=True, assume_centered=False):
+        super().__init__(
+            store_precision=store_precision, assume_centered=assume_centered
+        )
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X, y=None):

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2677,6 +2677,10 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
     >>> clf.score(X, y)
     0.5166...
     """
+    # TODO(1.8): Remove this method. Necessary for passing the docstring check
+    # during the deprecation of _estimator_type.
+    def __init__(self):
+        super().__init__()
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X, y, sample_weight=None, **params):

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2677,6 +2677,7 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
     >>> clf.score(X, y)
     0.5166...
     """
+
     # TODO(1.8): Remove this method. Necessary for passing the docstring check
     # during the deprecation of _estimator_type.
     def __init__(

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2679,8 +2679,28 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
     """
     # TODO(1.8): Remove this method. Necessary for passing the docstring check
     # during the deprecation of _estimator_type.
-    def __init__(self):
-        super().__init__()
+    def __init__(
+        self,
+        alphas=(0.1, 1.0, 10.0),
+        *,
+        fit_intercept=True,
+        scoring=None,
+        cv=None,
+        gcv_mode=None,
+        store_cv_results=None,
+        alpha_per_target=False,
+        store_cv_values="deprecated",
+    ):
+        super().__init__(
+            alphas=alphas,
+            fit_intercept=fit_intercept,
+            scoring=scoring,
+            cv=cv,
+            gcv_mode=gcv_mode,
+            store_cv_results=store_cv_results,
+            alpha_per_target=alpha_per_target,
+            store_cv_values=store_cv_values,
+        )
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X, y, sample_weight=None, **params):

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -1206,8 +1206,16 @@ class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
     """
     # TODO(1.8): Remove this method. Necessary for passing the docstring check
     # during the deprecation of _estimator_type.
-    def __init__(self):
-        super().__init__()
+    def __init__(
+        self, base_estimator, *, order=None, cv=None, random_state=None, verbose=False
+    ):
+        super().__init__(
+            base_estimator,
+            order=order,
+            cv=cv,
+            random_state=random_state,
+            verbose=verbose,
+        )
 
     @_fit_context(
         # RegressorChain.base_estimator is not validated yet

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -1204,6 +1204,10 @@ class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
            [1., 1.],
            [2., 0.]])
     """
+    # TODO(1.8): Remove this method. Necessary for passing the docstring check
+    # during the deprecation of _estimator_type.
+    def __init__(self):
+        super().__init__()
 
     @_fit_context(
         # RegressorChain.base_estimator is not validated yet

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -1204,6 +1204,7 @@ class RegressorChain(MetaEstimatorMixin, RegressorMixin, _BaseChain):
            [1., 1.],
            [2., 0.]])
     """
+
     # TODO(1.8): Remove this method. Necessary for passing the docstring check
     # during the deprecation of _estimator_type.
     def __init__(

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2428,6 +2428,11 @@ class KernelCenterer(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEsti
     __metadata_request__transform = {"K": metadata_routing.UNUSED}
     __metadata_request__fit = {"K": metadata_routing.UNUSED}
 
+    # TODO(1.8): Remove this method. Necessary for passing the docstring check
+    # during the deprecation of _estimator_type.
+    def __init__(self):
+        super().__init__()
+
     def fit(self, K, y=None):
         """Fit KernelCenterer.
 

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -77,6 +77,11 @@ class LabelEncoder(TransformerMixin, BaseEstimator, auto_wrap_output_keys=None):
     [np.str_('tokyo'), np.str_('tokyo'), np.str_('paris')]
     """
 
+    # TODO(1.8): Remove this method. Necessary for passing the docstring check
+    # during the deprecation of _estimator_type.
+    def __init__(self):
+        super().__init__()
+
     def fit(self, y):
         """Fit label encoder.
 

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -992,3 +992,34 @@ def test_outlier_mixin_fit_predict_with_metadata_in_predict():
     with warnings.catch_warnings(record=True) as record:
         CustomOutlierDetector().set_predict_request(prop=True).fit_predict([[1]], [1])
         assert len(record) == 0
+
+
+def test_deprecation_estimator_type():
+    """Test that the deprecation of _estimator_type works."""
+
+    class MyRegressor(BaseEstimator):
+        pass
+
+    class MyClassifier(BaseEstimator):
+        pass
+
+    class MyOutlierDetector(BaseEstimator, OutlierMixin):
+        pass
+
+    class MyTransformer(BaseEstimator, TransformerMixin):
+        pass
+
+    # Classes without _estimator_type should not raise warnings
+    with warnings.catch_warnings(record=True) as record:
+        MyRegressor()
+        MyClassifier()
+        MyOutlierDetector()
+        MyTransformer()
+        assert len(record) == 0
+
+    # Class with _estimator_type should raise FutureWarning
+    class EstimatorWithType(BaseEstimator):
+        _estimator_type = "classifier"
+
+    with pytest.warns(FutureWarning, match="`_estimator_type` is deprecated"):
+        EstimatorWithType()

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -496,8 +496,54 @@ class UntaggedBinaryClassifier(SGDClassifier):
 class TaggedBinaryClassifier(UntaggedBinaryClassifier):
     # TODO(1.8): Remove this method. Necessary for passing the docstring check
     # during the deprecation of _estimator_type.
-    def __init__(self):
-        super().__init__()
+    def __init__(
+        self,
+        loss="hinge",
+        *,
+        penalty="l2",
+        alpha=0.0001,
+        l1_ratio=0.15,
+        fit_intercept=True,
+        max_iter=1000,
+        tol=1e-3,
+        shuffle=True,
+        verbose=0,
+        epsilon=0.1,
+        n_jobs=None,
+        random_state=None,
+        learning_rate="optimal",
+        eta0=0.0,
+        power_t=0.5,
+        early_stopping=False,
+        validation_fraction=0.1,
+        n_iter_no_change=5,
+        class_weight=None,
+        warm_start=False,
+        average=False,
+    ):
+        super().__init__(
+            loss=loss,
+            penalty=penalty,
+            alpha=alpha,
+            l1_ratio=l1_ratio,
+            fit_intercept=fit_intercept,
+            max_iter=max_iter,
+            tol=tol,
+            shuffle=shuffle,
+            verbose=verbose,
+            epsilon=epsilon,
+            n_jobs=n_jobs,
+            random_state=random_state,
+            learning_rate=learning_rate,
+            eta0=eta0,
+            power_t=power_t,
+            early_stopping=early_stopping,
+            validation_fraction=validation_fraction,
+            n_iter_no_change=n_iter_no_change,
+            class_weight=class_weight,
+            warm_start=warm_start,
+            average=average,
+        )
 
     def fit(self, X, y):
         y_type = type_of_target(y, input_name="y", raise_unknown=True)

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -315,6 +315,11 @@ class BadBalancedWeightsClassifier(BaseBadClassifier):
 
 
 class BadTransformerWithoutMixin(BaseEstimator):
+    # TODO(1.8): Remove this method. Necessary for passing the docstring check
+    # during the deprecation of _estimator_type.
+    def __init__(self):
+        super().__init__()
+
     def fit(self, X, y=None):
         X = validate_data(self, X)
         return self

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -494,6 +494,11 @@ class UntaggedBinaryClassifier(SGDClassifier):
 
 
 class TaggedBinaryClassifier(UntaggedBinaryClassifier):
+    # TODO(1.8): Remove this method. Necessary for passing the docstring check
+    # during the deprecation of _estimator_type.
+    def __init__(self):
+        super().__init__()
+
     def fit(self, X, y):
         y_type = type_of_target(y, input_name="y", raise_unknown=True)
         if y_type != "binary":

--- a/sklearn/utils/tests/test_tags.py
+++ b/sklearn/utils/tests/test_tags.py
@@ -20,7 +20,9 @@ class NoTagsEstimator:
 
 class ClassifierEstimator:
     # This is to test whether not inheriting from mixins works.
-    _estimator_type = "classifier"
+    @property
+    def _estimator_type(self):
+        return "classifier"
 
 
 class EmptyTransformer(TransformerMixin, BaseEstimator):


### PR DESCRIPTION
Partially addressing #30298

This PR explicitly raise a FutureWarning when `_estimator_type` has been defined in classes.
It calls for removal and to use the `estimator_type` from the `Tags` API.