### PR TITLE
MAINT conversion old->new/new->old tags

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -26,9 +26,9 @@ from .utils._tags import (
     Tags,
     TargetTags,
     TransformerTags,
+    _to_old_tags,
     default_tags,
     get_tags,
-    _to_old_tags,
 )
 from .utils.fixes import _IS_32BIT
 from .utils.validation import (

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -419,6 +419,12 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
                 # (i.e. calling more tags on BaseEstimator multiple times)
                 more_tags = base_class._more_tags(self)
                 collected_tags.update(more_tags)
+            elif hasattr(base_class, "__sklearn_tags__"):
+                # Since that some people will inherit from scikit-learn that implements
+                # the new infrastructure, we need to collect it and merge it with
+                # the old tags.
+                more_tags = base_class.__sklearn_tags__(self)
+                collected_tags.update(_to_old_tags(more_tags))
         return collected_tags
 
     def _validate_params(self):

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -413,6 +413,7 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
             classifier_tags=None,
         )
 
+    # TODO(1.7): Remove this method
     def _more_tags(self):
         warnings.warn(
             "The `_more_tags` method is deprecated in 1.6 and will be removed in "
@@ -421,6 +422,7 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
         )
         return _to_old_tags(default_tags(self))
 
+    # TODO(1.7): Remove this method
     def _get_tags(self):
         warnings.warn(
             "The `_get_tags` tag provider is deprecated in 1.6 and will be removed in "

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -503,7 +503,7 @@ class ClassifierMixin:
     # TODO(1.8): Remove this attribute
     _estimator_type = "classifier"
 
-    # TODO(1.8): Remove this method
+    # TODO(1.7): Remove this method
     def _more_tags(self):
         return {"requires_y": True}
 
@@ -580,7 +580,7 @@ class RegressorMixin:
     # TODO(1.8): Remove this attribute
     _estimator_type = "regressor"
 
-    # TODO(1.8): Remove this method
+    # TODO(1.7): Remove this method
     def _more_tags(self):
         return {"requires_y": True}
 
@@ -660,7 +660,7 @@ class ClusterMixin:
     # TODO(1.8): Remove this attribute
     _estimator_type = "clusterer"
 
-    # TODO(1.8): Remove this method
+    # TODO(1.7): Remove this method
     def _more_tags(self):
         return {"preserves_dtype": []}
 
@@ -1159,7 +1159,7 @@ class MetaEstimatorMixin:
 class MultiOutputMixin:
     """Mixin to mark estimators that support multioutput."""
 
-    # TODO(1.8): Remove this method
+    # TODO(1.7): Remove this method
     def _more_tags(self):
         return {"multioutput": True}
 
@@ -1172,7 +1172,7 @@ class MultiOutputMixin:
 class _UnstableArchMixin:
     """Mark estimators that are non-determinstic on 32bit or PowerPC"""
 
-    # TODO(1.8): Remove this method
+    # TODO(1.7): Remove this method
     def _more_tags(self):
         return {
             "non_deterministic": _IS_32BIT

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -411,6 +411,13 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
             "1.7. Please implement the `__sklearn_tags__` method.",
             category=FutureWarning,
         )
+        # In case a user called `_get_tags` but that the estimator already did the job
+        # implementing `__sklearn_tags__` completely, let's default back to the future
+        # behaviour.
+        from sklearn.utils._tags import get_tags, _find_tags_provider, _to_old_tags
+        if _find_tags_provider(self) == "__sklearn_tags__":
+            return _to_old_tags(get_tags(self))
+
         collected_tags = {}
         for base_class in reversed(inspect.getmro(self.__class__)):
             if hasattr(base_class, "_more_tags"):

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -412,9 +412,10 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
             category=FutureWarning,
         )
         # In case a user called `_get_tags` but that the estimator already did the job
-        # implementing `__sklearn_tags__` completely, let's default back to the future
-        # behaviour.
-        from sklearn.utils._tags import get_tags, _find_tags_provider, _to_old_tags
+        # implementing `__sklearn_tags__` completely and removed `_more_tags`, let's
+        # default back to the future behaviour. Otherwise, we will get the default tags.
+        from sklearn.utils._tags import _find_tags_provider, _to_old_tags, get_tags
+
         if _find_tags_provider(self) == "__sklearn_tags__":
             return _to_old_tags(get_tags(self))
 

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -399,16 +399,16 @@ class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
 
     def _more_tags(self):
         warnings.warn(
-            "The `_more_tags` method is deprecated in 1.8 and will be removed in "
-            "1.9. Please implement the `__sklearn_tags__` method.",
+            "The `_more_tags` method is deprecated in 1.6 and will be removed in "
+            "1.7. Please implement the `__sklearn_tags__` method.",
             category=FutureWarning,
         )
         return _to_old_tags(default_tags(self))
 
     def _get_tags(self):
         warnings.warn(
-            "The `_get_tags` tag provider is deprecated in 1.8 and will be removed in "
-            "1.9. Please implement the `__sklearn_tags__` method.",
+            "The `_get_tags` tag provider is deprecated in 1.6 and will be removed in "
+            "1.7. Please implement the `__sklearn_tags__` method.",
             category=FutureWarning,
         )
         collected_tags = {}

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -16,7 +16,7 @@ from operator import itemgetter
 import numpy as np
 import scipy.sparse as sp
 
-from sklearn.utils import metadata_routing
+from sklearn.utils import TransformerTags, metadata_routing
 
 from ..base import BaseEstimator, OneToOneFeatureMixin, TransformerMixin, _fit_context
 from ..exceptions import NotFittedError
@@ -553,6 +553,11 @@ class _VectorizerMixin:
                     "The parameter 'tokenizer' will not be used"
                     " since 'analyzer' != 'word'"
                 )
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.transformer_tags = TransformerTags(preserves_dtype=[])
+        return tags
 
 
 class HashingVectorizer(

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -9,7 +9,7 @@ import pytest
 from joblib import parallel_backend
 from numpy.testing import assert_allclose, assert_array_almost_equal, assert_array_equal
 
-from sklearn.base import BaseEstimator, ClassifierMixin, is_classifier
+from sklearn.base import BaseEstimator, ClassifierMixin, TransformerMixin, is_classifier
 from sklearn.compose import TransformedTargetRegressor
 from sklearn.cross_decomposition import CCA, PLSCanonical, PLSRegression
 from sklearn.datasets import load_iris, make_classification, make_friedman1
@@ -27,7 +27,7 @@ from sklearn.utils._testing import ignore_warnings
 from sklearn.utils.fixes import CSR_CONTAINERS
 
 
-class MockClassifier(ClassifierMixin, BaseEstimator):
+class MockClassifier(TransformerMixin, ClassifierMixin, BaseEstimator):
     """
     Dummy classifier to test recursive feature elimination
     """

--- a/sklearn/manifold/_mds.py
+++ b/sklearn/manifold/_mds.py
@@ -16,6 +16,7 @@ from ..isotonic import IsotonicRegression
 from ..metrics import euclidean_distances
 from ..utils import check_array, check_random_state, check_symmetric
 from ..utils._param_validation import Interval, StrOptions, validate_params
+from ..utils._tags import TransformerTags
 from ..utils.parallel import Parallel, delayed
 from ..utils.validation import validate_data
 
@@ -572,6 +573,7 @@ class MDS(BaseEstimator):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
+        tags.transformer_tags = TransformerTags(preserves_dtype=["float64"])
         tags.input_tags.pairwise = self.dissimilarity == "precomputed"
         return tags
 

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -23,6 +23,7 @@ from ..utils import (
 )
 from ..utils._arpack import _init_arpack_v0
 from ..utils._param_validation import Interval, StrOptions, validate_params
+from ..utils._tags import TransformerTags
 from ..utils.extmath import _deterministic_vector_sign_flip
 from ..utils.fixes import laplacian as csgraph_laplacian
 from ..utils.fixes import parse_version, sp_version
@@ -654,6 +655,7 @@ class SpectralEmbedding(BaseEstimator):
             "precomputed",
             "precomputed_nearest_neighbors",
         ]
+        tags.transformer_tags = TransformerTags(preserves_dtype=["float64"])
         return tags
 
     def _get_affinity_matrix(self, X, Y=None):

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -487,6 +487,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         tags.estimator_type = sub_estimator_tags.estimator_type
         tags.classifier_tags = deepcopy(sub_estimator_tags.classifier_tags)
         tags.regressor_tags = deepcopy(sub_estimator_tags.regressor_tags)
+        tags.transformer_tags = deepcopy(sub_estimator_tags.transformer_tags)
         # allows cross-validation to see 'precomputed' metrics
         tags.input_tags.pairwise = get_tags(self.estimator).input_tags.pairwise
         tags.array_api_support = get_tags(self.estimator).array_api_support

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -15,7 +15,7 @@ import pytest
 from scipy.stats import bernoulli, expon, uniform
 
 from sklearn import config_context
-from sklearn.base import BaseEstimator, ClassifierMixin, is_classifier
+from sklearn.base import BaseEstimator, ClassifierMixin, TransformerMixin, is_classifier
 from sklearn.cluster import KMeans
 from sklearn.compose import ColumnTransformer
 from sklearn.datasets import (
@@ -100,7 +100,7 @@ from sklearn.utils.validation import _num_samples
 
 # Neither of the following two estimators inherit from BaseEstimator,
 # to test hyperparameter search on user-defined classifiers.
-class MockClassifier(ClassifierMixin, BaseEstimator):
+class MockClassifier(TransformerMixin, ClassifierMixin, BaseEstimator):
     """Dummy classifier to test the parameter search algorithms"""
 
     def __init__(self, foo_param=0):

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -1253,7 +1253,7 @@ class Pipeline(_BaseComposition):
                 if tags.transformer_tags is not None:
                     tags.transformer_tags.preserves_dtype = preserves_dtype
             elif self.steps[-1][1] is None or self.steps[-1][1] == "passthrough":
-                # "passthrough" behaves like a transformer
+                # None and "passthrough" behave like a transformer
                 tags.transformer_tags = TransformerTags(preserves_dtype=[])
         except (ValueError, AttributeError, TypeError):
             # This happens when the `steps` is not a list of (name, estimator)

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -1230,35 +1230,35 @@ class Pipeline(_BaseComposition):
             # tuples and `fit` is not called yet to validate the steps.
             pass
 
-        # try:
-        # dtype preservation will depend on the intersection of all steps
-        preserves_dtype = []
-        for step in self.steps:
-            if step[1] is not None and step[1] != "passthrough":
-                step_tags = get_tags(step[1])
-                if step_tags.transformer_tags is not None:
-                    preserves_dtype.append(
-                        set(step_tags.transformer_tags.preserves_dtype)
-                    )
-        if preserves_dtype:
-            preserves_dtype = list(reduce(set.intersection, preserves_dtype))
+        try:
+            # dtype preservation will depend on the intersection of all steps
+            preserves_dtype = []
+            for step in self.steps:
+                if step[1] is not None and step[1] != "passthrough":
+                    step_tags = get_tags(step[1])
+                    if step_tags.transformer_tags is not None:
+                        preserves_dtype.append(
+                            set(step_tags.transformer_tags.preserves_dtype)
+                        )
+            if preserves_dtype:
+                preserves_dtype = list(reduce(set.intersection, preserves_dtype))
 
-        if self.steps[-1][1] is not None and self.steps[-1][1] != "passthrough":
-            last_step_tags = get_tags(self.steps[-1][1])
-            tags.estimator_type = last_step_tags.estimator_type
-            tags.target_tags.multi_output = last_step_tags.target_tags.multi_output
-            tags.classifier_tags = deepcopy(last_step_tags.classifier_tags)
-            tags.regressor_tags = deepcopy(last_step_tags.regressor_tags)
-            tags.transformer_tags = deepcopy(last_step_tags.transformer_tags)
-            if tags.transformer_tags is not None:
-                tags.transformer_tags.preserves_dtype = preserves_dtype
-        elif self.steps[-1][1] is None or self.steps[-1][1] == "passthrough":
-            # "passthrough" behaves like a transformer
-            tags.transformer_tags = TransformerTags(preserves_dtype=[])
-        # except (ValueError, AttributeError, TypeError):
-        #     # This happens when the `steps` is not a list of (name, estimator)
-        #     # tuples and `fit` is not called yet to validate the steps.
-        #     pass
+            if self.steps[-1][1] is not None and self.steps[-1][1] != "passthrough":
+                last_step_tags = get_tags(self.steps[-1][1])
+                tags.estimator_type = last_step_tags.estimator_type
+                tags.target_tags.multi_output = last_step_tags.target_tags.multi_output
+                tags.classifier_tags = deepcopy(last_step_tags.classifier_tags)
+                tags.regressor_tags = deepcopy(last_step_tags.regressor_tags)
+                tags.transformer_tags = deepcopy(last_step_tags.transformer_tags)
+                if tags.transformer_tags is not None:
+                    tags.transformer_tags.preserves_dtype = preserves_dtype
+            elif self.steps[-1][1] is None or self.steps[-1][1] == "passthrough":
+                # "passthrough" behaves like a transformer
+                tags.transformer_tags = TransformerTags(preserves_dtype=[])
+        except (ValueError, AttributeError, TypeError):
+            # This happens when the `steps` is not a list of (name, estimator)
+            # tuples and `fit` is not called yet to validate the steps.
+            pass
 
         return tags
 

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -35,7 +35,7 @@ from sklearn.preprocessing import (
     OneHotEncoder,
     StandardScaler,
 )
-from sklearn.utils import all_estimators
+from sklearn.utils import TransformerMixin, all_estimators
 from sklearn.utils._test_common.instance_generator import (
     _get_check_estimator_ids,
     _get_expected_failed_checks,
@@ -412,7 +412,7 @@ def test_transition_public_api_deprecations():
     to the new developer public API from 1.5 to 1.6.
     """
 
-    class OldEstimator(BaseEstimator):
+    class OldEstimator(TransformerMixin, BaseEstimator):
         def fit(self, X, y=None):
             X = self._validate_data(X)
             self._check_n_features(X, reset=True)

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -17,7 +17,7 @@ import pytest
 from scipy.linalg import LinAlgWarning
 
 import sklearn
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.compose import ColumnTransformer
 from sklearn.datasets import make_classification
 from sklearn.exceptions import ConvergenceWarning
@@ -35,7 +35,7 @@ from sklearn.preprocessing import (
     OneHotEncoder,
     StandardScaler,
 )
-from sklearn.utils import TransformerMixin, all_estimators
+from sklearn.utils import all_estimators
 from sklearn.utils._test_common.instance_generator import (
     _get_check_estimator_ids,
     _get_expected_failed_checks,

--- a/sklearn/tests/test_metaestimators.py
+++ b/sklearn/tests/test_metaestimators.py
@@ -19,6 +19,7 @@ from sklearn.pipeline import Pipeline, make_pipeline
 from sklearn.preprocessing import MaxAbsScaler, StandardScaler
 from sklearn.semi_supervised import SelfTrainingClassifier
 from sklearn.utils import all_estimators
+from sklearn.utils._tags import TransformerTags
 from sklearn.utils._test_common.instance_generator import _construct_instances
 from sklearn.utils._testing import SkipTest, set_random_state
 from sklearn.utils.estimator_checks import (
@@ -142,6 +143,12 @@ def test_metaestimator_delegation():
         def score(self, X, y, *args, **kwargs):
             self._check_fit()
             return 1.0
+
+        def __sklearn_tags__(self):
+            tags = super().__sklearn_tags__()
+            if hasattr(self, "transform"):
+                tags.transformer_tags = TransformerTags(preserves_dtype=[])
+            return tags
 
     methods = [
         k

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -2058,7 +2058,7 @@ def test_transform_tuple_input():
     ],
 )
 def test_pipeline_warns_not_fitted(method):
-    class StatelessEstimator(BaseEstimator):
+    class StatelessEstimator(TransformerMixin, ClassifierMixin, BaseEstimator):
         """Stateless estimator that doesn't check if it's fitted.
 
         Stateless estimators that don't require fit, should properly set the
@@ -2102,7 +2102,7 @@ def test_pipeline_warns_not_fitted(method):
 # =====================================================================
 
 
-class SimpleEstimator(BaseEstimator):
+class SimpleEstimator(TransformerMixin, ClassifierMixin, BaseEstimator):
     # This class is used in this section for testing routing in the pipeline.
     # This class should have every set_{method}_request
     def __sklearn_is_fitted__(self):

--- a/sklearn/utils/_tags.py
+++ b/sklearn/utils/_tags.py
@@ -394,8 +394,6 @@ def get_tags(estimator) -> Tags:
 
     tag_provider = _find_tags_provider(estimator)
     if tag_provider == "__sklearn_tags__":
-        from sklearn.base import TransformerMixin  # avoid circular dependency
-
         tags = estimator.__sklearn_tags__()
 
         # TODO (1.7): Remove this block

--- a/sklearn/utils/_tags.py
+++ b/sklearn/utils/_tags.py
@@ -395,6 +395,7 @@ def get_tags(estimator) -> Tags:
     tag_provider = _find_tags_provider(estimator)
     if tag_provider == "__sklearn_tags__":
         from sklearn.base import TransformerMixin  # avoid circular dependency
+
         tags = estimator.__sklearn_tags__()
 
         # TODO (1.7): Remove this block

--- a/sklearn/utils/_tags.py
+++ b/sklearn/utils/_tags.py
@@ -404,6 +404,20 @@ def get_tags(estimator) -> Tags:
     tag_provider = _find_tags_provider(estimator)
     if tag_provider == "__sklearn_tags__":
         tags = estimator.__sklearn_tags__()
+
+        # TODO (1.7): Remove this block
+        # Catch the corner case where a transformer inheriting from BaseEstimator but
+        # that does not inherit from TransformerMixin ends up without the
+        # transformer_tags set properly.
+        if hasattr(estimator, "transform") or hasattr(estimator, "fit_transform"):
+            warnings.warn(
+                "The transformer tags are not set properly for the estimator "
+                f"{estimator.__class__.__name__}. This will raise an error in "
+                "scikit-learn 1.7. Inherit from `TransformerMixin` or properly set "
+                "the `transformer_tags` attribute in `__sklearn_tags__`.",
+                category=FutureWarning,
+            )
+            tags.transformer_tags = TransformerTags()
     # TODO(1.7): Remove this block
     elif tag_provider == "_get_tags":
         if hasattr(estimator, "_get_tags"):

--- a/sklearn/utils/_tags.py
+++ b/sklearn/utils/_tags.py
@@ -404,7 +404,7 @@ def get_tags(estimator) -> Tags:
         # transformer_tags set properly.
         if (
             hasattr(estimator, "transform") or hasattr(estimator, "fit_transform")
-        ) and not isinstance(estimator, TransformerMixin):
+        ) and tags.transformer_tags is None:
             warnings.warn(
                 "The transformer tags are not set properly for the estimator "
                 f"{estimator.__class__.__name__}. This will raise an error in "

--- a/sklearn/utils/_tags.py
+++ b/sklearn/utils/_tags.py
@@ -245,7 +245,7 @@ class Tags:
     input_tags: InputTags = field(default_factory=InputTags)
 
 
-# TODO(1.8): Remove this function
+# TODO(1.7): Remove this function
 def default_tags(estimator) -> Tags:
     """Get the default tags for an estimator.
 

--- a/sklearn/utils/_tags.py
+++ b/sklearn/utils/_tags.py
@@ -438,6 +438,8 @@ def get_tags(estimator) -> Tags:
                 # is not a direct user call but an internal one.
                 tags = {**tags, **estimator._more_tags()}
             tags = _to_new_tags(tags)
+        else:
+            tags = default_tags(estimator)
     else:
         tags = default_tags(estimator)
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -115,13 +115,12 @@ def _raise_for_missing_tags(estimator, tag_name, Mixin):
     tags = get_tags(estimator)
     estimator_type = Mixin.__name__.replace("Mixin", "")
     if getattr(tags, tag_name) is None:
-        # raise RuntimeError(
-        #     f"Estimator {estimator.__class__.__name__} seems to be a {estimator_type},"
-        #     f" but the `{tag_name}` tag is not set. Either set the tag manually"
-        #     f" or inherit from the {Mixin.__name__}. Note that the order of inheritance"
-        #     f" matters, the {Mixin.__name__} should come before BaseEstimator."
-        # )
-        # warnings.warn("BROKEN SOON, IT WILL BE", FutureWarning)
+        raise RuntimeError(
+            f"Estimator {estimator.__class__.__name__} seems to be a {estimator_type},"
+            f" but the `{tag_name}` tag is not set. Either set the tag manually"
+            f" or inherit from the {Mixin.__name__}. Note that the order of inheritance"
+            f" matters, the {Mixin.__name__} should come before BaseEstimator."
+        )
         pass
 
 
@@ -279,8 +278,6 @@ def _yield_regressor_checks(regressor):
 def _yield_transformer_checks(transformer):
     _raise_for_missing_tags(transformer, "transformer_tags", TransformerMixin)
     tags = get_tags(transformer)
-    print(transformer)
-    print(tags)
     # All transformers should either deal with sparse data or raise an
     # exception with type TypeError and an intelligible error message
     if not tags.no_validation:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -121,8 +121,6 @@ def _raise_for_missing_tags(estimator, tag_name, Mixin):
             f" or inherit from the {Mixin.__name__}. Note that the order of inheritance"
             f" matters, the {Mixin.__name__} should come before BaseEstimator."
         )
-        pass
-
 
 
 def _yield_api_checks(estimator):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -121,7 +121,8 @@ def _raise_for_missing_tags(estimator, tag_name, Mixin):
         #     f" or inherit from the {Mixin.__name__}. Note that the order of inheritance"
         #     f" matters, the {Mixin.__name__} should come before BaseEstimator."
         # )
-        warnings.warn("BROKEN SOON, IT WILL BE", FutureWarning)
+        # warnings.warn("BROKEN SOON, IT WILL BE", FutureWarning)
+        pass
 
 
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -115,12 +115,14 @@ def _raise_for_missing_tags(estimator, tag_name, Mixin):
     tags = get_tags(estimator)
     estimator_type = Mixin.__name__.replace("Mixin", "")
     if getattr(tags, tag_name) is None:
-        raise RuntimeError(
-            f"Estimator {estimator.__class__.__name__} seems to be a {estimator_type},"
-            f" but the `{tag_name}` tag is not set. Either set the tag manually"
-            f" or inherit from the {Mixin.__name__}. Note that the order of inheritance"
-            f" matters, the {Mixin.__name__} should come before BaseEstimator."
-        )
+        # raise RuntimeError(
+        #     f"Estimator {estimator.__class__.__name__} seems to be a {estimator_type},"
+        #     f" but the `{tag_name}` tag is not set. Either set the tag manually"
+        #     f" or inherit from the {Mixin.__name__}. Note that the order of inheritance"
+        #     f" matters, the {Mixin.__name__} should come before BaseEstimator."
+        # )
+        warnings.warn("BROKEN SOON, IT WILL BE", FutureWarning)
+
 
 
 def _yield_api_checks(estimator):
@@ -276,6 +278,8 @@ def _yield_regressor_checks(regressor):
 def _yield_transformer_checks(transformer):
     _raise_for_missing_tags(transformer, "transformer_tags", TransformerMixin)
     tags = get_tags(transformer)
+    print(transformer)
+    print(tags)
     # All transformers should either deal with sparse data or raise an
     # exception with type TypeError and an intelligible error message
     if not tags.no_validation:

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -339,6 +339,7 @@ class BadTransformerWithoutMixinWithoutTags(BaseEstimator):
     mention that the `transformer_tags` tag is not set.
     As for 1.7, it will raise a RuntimeError because the tag is not set.
     """
+
     def fit(self, X, y=None):
         X = validate_data(self, X)
         return self
@@ -347,7 +348,6 @@ class BadTransformerWithoutMixinWithoutTags(BaseEstimator):
         check_is_fitted(self)
         X = validate_data(self, X, reset=False)
         return X
-
 
 
 class NotInvariantPredict(BaseEstimator):

--- a/sklearn/utils/tests/test_estimator_checks.py
+++ b/sklearn/utils/tests/test_estimator_checks.py
@@ -878,6 +878,7 @@ def test_check_estimator_transformer_no_mixin_without_tags():
     # TODO(1.7): replace the type of exception raised and remove the warning
     with raises(AttributeError, ".*fit_transform.*"):
         with warnings.catch_warnings(record=True) as record:
+            warnings.filterwarnings("ignore", category=FutureWarning)
             check_estimator(BadTransformerWithoutMixinWithoutTags())
     for rec in record:
         assert issubclass(rec.category, FutureWarning)

--- a/sklearn/utils/tests/test_tags.py
+++ b/sklearn/utils/tests/test_tags.py
@@ -8,7 +8,7 @@ from sklearn.base import (
     TransformerMixin,
 )
 from sklearn.utils import Tags, get_tags
-from sklearn.utils._tags import _to_new_tags, _to_old_tags, _safe_tags
+from sklearn.utils._tags import _safe_tags, _to_new_tags
 from sklearn.utils.estimator_checks import (
     check_estimator_tags_renamed,
     check_valid_tag_types,
@@ -85,6 +85,7 @@ def test_tag_test_passes_with_inheritance():
 # Test for the deprecation
 # TODO(1.7): Remove this
 ########################################################################################
+
 
 def test_tags_deprecation():
     class ChildClass(RegressorMixin, BaseEstimator):

--- a/sklearn/utils/tests/test_tags.py
+++ b/sklearn/utils/tests/test_tags.py
@@ -8,6 +8,7 @@ from sklearn.base import (
     TransformerMixin,
 )
 from sklearn.utils import Tags, get_tags
+from sklearn.utils._tags import _to_new_tags, _to_old_tags, _safe_tags
 from sklearn.utils.estimator_checks import (
     check_estimator_tags_renamed,
     check_valid_tag_types,
@@ -78,3 +79,130 @@ def test_tag_test_passes_with_inheritance():
             return tags
 
     check_valid_tag_types("MyEstimator", MyEstimator())
+
+
+########################################################################################
+# Test for the deprecation
+# TODO(1.7): Remove this
+########################################################################################
+
+def test_tags_deprecation():
+    class ChildClass(RegressorMixin, BaseEstimator):
+        """Child implementing the old tags API together with our new API."""
+
+        def _more_tags(self):
+            return {"allow_nan": True}
+
+    main_warn_msg = "only use `_get_tags` and `_more_tags`"
+    with pytest.warns(FutureWarning, match=main_warn_msg):
+        tags = ChildClass().__sklearn_tags__()
+    assert tags.input_tags.allow_nan
+
+    with pytest.warns(FutureWarning) as warning_list:
+        tags = _safe_tags(ChildClass())
+    assert len(warning_list) == 2, len(warning_list)
+    assert str(warning_list[0].message).startswith(
+        "The `_safe_tags` utility function is deprecated"
+    )
+    assert main_warn_msg in str(warning_list[1].message)
+
+    assert isinstance(tags, dict)
+    assert _to_new_tags(tags).input_tags.allow_nan
+
+    with pytest.warns(FutureWarning, match=main_warn_msg):
+        tags = get_tags(ChildClass())
+    assert tags.input_tags.allow_nan
+
+    class ChildClass(RegressorMixin, BaseEstimator):
+        """Child implementing the old and new tags API during the transition period."""
+
+        def _more_tags(self):
+            return {"allow_nan": True}
+
+        def __sklearn_tags__(self):
+            tags = super().__sklearn_tags__()
+            tags.input_tags.allow_nan = True
+            return tags
+
+    tags = get_tags(ChildClass())
+    assert tags.input_tags.allow_nan
+
+    warn_msg = "`_get_tags` tag provider is deprecated"
+    with pytest.warns(FutureWarning, match=warn_msg):
+        tags = ChildClass()._get_tags()
+    assert isinstance(tags, dict)
+    assert _to_new_tags(tags).input_tags.allow_nan
+
+    warn_msg = "`_safe_tags` utility function is deprecated"
+    with pytest.warns(FutureWarning, match=warn_msg):
+        tags = _safe_tags(ChildClass())
+    assert isinstance(tags, dict)
+    assert _to_new_tags(tags).input_tags.allow_nan
+
+    class ChildClass(RegressorMixin, BaseEstimator):
+        """Child not setting any tags."""
+
+    tags = get_tags(ChildClass())
+    assert tags.target_tags.required
+
+    warn_msg = "`_get_tags` tag provider is deprecated"
+    with pytest.warns(FutureWarning, match=warn_msg):
+        tags = ChildClass()._get_tags()
+    assert isinstance(tags, dict)
+    assert _to_new_tags(tags).target_tags.required
+
+    warn_msg = "`_safe_tags` utility function is deprecated"
+    with pytest.warns(FutureWarning, match=warn_msg):
+        tags = _safe_tags(ChildClass())
+    assert isinstance(tags, dict)
+    assert _to_new_tags(tags).target_tags.required
+
+    class Mixin:
+        def _more_tags(self):
+            return {"allow_nan": True}
+
+    class ChildClass(Mixin, BaseEstimator):
+        """Child following the new API with mixin following the old API."""
+
+        def __sklearn_tags__(self):
+            tags = super().__sklearn_tags__()
+            tags.target_tags.required = True
+            return tags
+
+    err_msg = (
+        "Some classes from which ChildClass inherits only use `_get_tags` and "
+        "`_more_tags`"
+    )
+    with pytest.raises(ValueError, match=err_msg):
+        tags = get_tags(ChildClass())
+    with pytest.raises(ValueError, match=err_msg):
+        with pytest.warns(FutureWarning):
+            tags = ChildClass()._get_tags()
+    with pytest.raises(ValueError, match=err_msg):
+        with pytest.warns(FutureWarning):
+            tags = _safe_tags(ChildClass())
+
+    class Mixin:
+        def _more_tags(self):
+            return {"allow_nan": True}
+
+    class ChildClass(Mixin, BaseEstimator):
+        """Child following the old API with mixin following the old API."""
+
+        def _more_tags(self):
+            return {"requires_y": True}
+
+    with pytest.warns(FutureWarning, match=main_warn_msg):
+        tags = ChildClass().__sklearn_tags__()
+    assert tags.input_tags.allow_nan
+
+    with pytest.warns(FutureWarning) as warning_list:
+        tags = _safe_tags(ChildClass())
+    assert len(warning_list) == 2, len(warning_list)
+    assert str(warning_list[0].message).startswith(
+        "The `_safe_tags` utility function is deprecated"
+    )
+    assert main_warn_msg in str(warning_list[1].message)
+
+    assert isinstance(tags, dict)
+    assert _to_new_tags(tags).input_tags.allow_nan

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -15,7 +15,7 @@ from pytest import importorskip
 import sklearn
 from sklearn._config import config_context
 from sklearn._min_dependencies import dependent_packages
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.datasets import make_blobs
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.exceptions import NotFittedError, PositiveSpectrumWarning
@@ -1990,7 +1990,7 @@ def test_get_feature_names_invalid_dtypes(names, dtypes):
         names = _get_feature_names(X)
 
 
-class PassthroughTransformer(BaseEstimator):
+class PassthroughTransformer(TransformerMixin, BaseEstimator):
     def fit(self, X, y=None):
         validate_data(self, X, reset=True)
         return self


### PR DESCRIPTION
Towards #30298 

This PR provides a way to convert old tags into new tags and new tags into old tags.
We should make sure that:

- An estimator implementing `_get_tags` or `_more_tags` get a warning but that the check_estimator should be working reasonably
- `_safe_tags` should raise a deprecation warning
- we should make sure that `get_tags` can get old tags and convert it to new tags. The tricky part is to detect whether `__sklearn_tags__` if present is implemented by the `BaseEstimator` from scikit-learn or the child class. If this is only the `BaseEstimator`, we should raise a warning to move to the new API and we should temporary use the `_get_tags`/`_safe_tags`, otherwise we are fine.
