### PR TITLE
CI Add Windows free-threaded wheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -73,6 +73,10 @@ jobs:
           - os: windows-latest
             python: 313
             platform_id: win_amd64
+          - os: windows-latest
+            python: 313t
+            platform_id: win_amd64
+            free_threaded_support: True
 
           # Linux 64 bit manylinux2014
           - os: ubuntu-latest

--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -5,34 +5,41 @@ set -x
 
 PYTHON_VERSION=$1
 
-TEMP_FOLDER="$HOME/AppData/Local/Temp"
-WHEEL_PATH=$(ls -d $TEMP_FOLDER/**/*/repaired_wheel/*)
-WHEEL_NAME=$(basename $WHEEL_PATH)
+FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
 
-cp $WHEEL_PATH $WHEEL_NAME
+if [[ $FREE_THREADED_BUILD == "False" ]]; then
+    TEMP_FOLDER="$HOME/AppData/Local/Temp"
+    WHEEL_PATH=$(ls -d $TEMP_FOLDER/**/*/repaired_wheel/*)
+    WHEEL_NAME=$(basename $WHEEL_PATH)
 
-# Dot the Python version for identifying the base Docker image
-PYTHON_DOCKER_IMAGE_PART=$(echo ${PYTHON_VERSION:0:1}.${PYTHON_VERSION:1:2})
+    cp $WHEEL_PATH $WHEEL_NAME
 
-if [[ "$CIBW_PRERELEASE_PYTHONS" =~ [tT]rue ]]; then
-    PYTHON_DOCKER_IMAGE_PART="${PYTHON_DOCKER_IMAGE_PART}-rc"
+    # Dot the Python version for identifying the base Docker image
+    PYTHON_DOCKER_IMAGE_PART=$(echo ${PYTHON_VERSION:0:1}.${PYTHON_VERSION:1:2})
+
+    if [[ "$CIBW_PRERELEASE_PYTHONS" =~ [tT]rue ]]; then
+        PYTHON_DOCKER_IMAGE_PART="${PYTHON_DOCKER_IMAGE_PART}-rc"
+    fi
+
+    # We could have all of the following logic in a Dockerfile but it's a lot
+    # easier to do it in bash rather than figure out how to do it in Powershell
+    # inside the Dockerfile ...
+    DOCKER_IMAGE="winamd64/python:${PYTHON_DOCKER_IMAGE_PART}-windowsservercore"
+    MNT_FOLDER="C:/mnt"
+    CONTAINER_ID=$(docker run -it -v "$(cygpath -w $PWD):$MNT_FOLDER" -d $DOCKER_IMAGE)
+
+    function exec_inside_container() {
+        docker exec $CONTAINER_ID powershell -Command $1
+    }
+
+    exec_inside_container "python -m pip install $MNT_FOLDER/$WHEEL_NAME"
+    exec_inside_container "python -m pip install $CIBW_TEST_REQUIRES"
+
+    # Save container state to scikit-learn/minimal-windows image. On Windows the
+    # container needs to be stopped first.
+    docker stop $CONTAINER_ID
+    docker commit $CONTAINER_ID scikit-learn/minimal-windows
+else
+    # This is too cumbersome to use a Docker image in the free-threaded case
+    python -m pip install $CIBW_TEST_REQUIRES
 fi
-
-# We could have all of the following logic in a Dockerfile but it's a lot
-# easier to do it in bash rather than figure out how to do it in Powershell
-# inside the Dockerfile ...
-DOCKER_IMAGE="winamd64/python:${PYTHON_DOCKER_IMAGE_PART}-windowsservercore"
-MNT_FOLDER="C:/mnt"
-CONTAINER_ID=$(docker run -it -v "$(cygpath -w $PWD):$MNT_FOLDER" -d $DOCKER_IMAGE)
-
-function exec_inside_container() {
-    docker exec $CONTAINER_ID powershell -Command $1
-}
-
-exec_inside_container "python -m pip install $MNT_FOLDER/$WHEEL_NAME"
-exec_inside_container "python -m pip install $CIBW_TEST_REQUIRES"
-
-# Save container state to scikit-learn/minimal-windows image. On Windows the
-# container needs to be stopped first.
-docker stop $CONTAINER_ID
-docker commit $CONTAINER_ID scikit-learn/minimal-windows

--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -41,8 +41,9 @@ if [[ $FREE_THREADED_BUILD == "False" ]]; then
     docker commit $CONTAINER_ID scikit-learn/minimal-windows
 else
     # This is too cumbersome to use a Docker image in the free-threaded case
-    # TODO Remove next two lines when pandas has a release with a Windows free-threaded wheel
+    # TODO Remove next three lines when scipy and pandas has a release with a Windows free-threaded wheel
+    python -m pip install numpy
     dev_anaconda_url=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-    pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url pandas --only-binary :all:
+    python -m pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url scipy pandas --only-binary :all:
     python -m pip install $CIBW_TEST_REQUIRES
 fi

--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -8,6 +8,9 @@ PYTHON_VERSION=$1
 FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
 
 if [[ $FREE_THREADED_BUILD == "False" ]]; then
+    # Prepare a minimal Windows environement without any developer runtime libraries
+    # installed to check that the scikit-learn wheel does not implicitly rely on
+    # external DLLs when running the tests.
     TEMP_FOLDER="$HOME/AppData/Local/Temp"
     WHEEL_PATH=$(ls -d $TEMP_FOLDER/**/*/repaired_wheel/*)
     WHEEL_NAME=$(basename $WHEEL_PATH)
@@ -41,7 +44,8 @@ if [[ $FREE_THREADED_BUILD == "False" ]]; then
     docker commit $CONTAINER_ID scikit-learn/minimal-windows
 else
     # This is too cumbersome to use a Docker image in the free-threaded case
-    # TODO Remove next three lines when scipy and pandas has a release with a Windows free-threaded wheel
+    # TODO Remove the next three lines when scipy and pandas each have a release
+    # with a Windows free-threaded wheel.
     python -m pip install numpy
     dev_anaconda_url=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     python -m pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url scipy pandas --only-binary :all:

--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -41,5 +41,8 @@ if [[ $FREE_THREADED_BUILD == "False" ]]; then
     docker commit $CONTAINER_ID scikit-learn/minimal-windows
 else
     # This is too cumbersome to use a Docker image in the free-threaded case
+    # TODO Remove next two lines when pandas has a release with a Windows free-threaded wheel
+    dev_anaconda_url=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url pandas --only-binary :all:
     python -m pip install $CIBW_TEST_REQUIRES
 fi

--- a/build_tools/github/test_windows_wheels.sh
+++ b/build_tools/github/test_windows_wheels.sh
@@ -8,11 +8,20 @@ PROJECT_DIR=$2
 
 python $PROJECT_DIR/build_tools/wheels/check_license.py
 
-docker container run \
-    --rm scikit-learn/minimal-windows \
-    powershell -Command "python -c 'import sklearn; sklearn.show_versions()'"
+FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
 
-docker container run \
-    -e SKLEARN_SKIP_NETWORK_TESTS=1 \
-    --rm scikit-learn/minimal-windows \
-    powershell -Command "pytest --pyargs sklearn"
+if [[ $FREE_THREADED_BUILD == "False" ]]; then
+    docker container run \
+        --rm scikit-learn/minimal-windows \
+        powershell -Command "python -c 'import sklearn; sklearn.show_versions()'"
+
+    docker container run \
+        -e SKLEARN_SKIP_NETWORK_TESTS=1 \
+        --rm scikit-learn/minimal-windows \
+        powershell -Command "pytest --pyargs sklearn"
+else
+    # This is too cumbersome to use a Docker image in the free-threaded case
+    export PYTHON_GIL=0
+    python -c "import sklearn; sklearn.show_versions()"
+    pytest --pyargs sklearn
+fi

--- a/build_tools/github/test_windows_wheels.sh
+++ b/build_tools/github/test_windows_wheels.sh
@@ -11,6 +11,9 @@ python $PROJECT_DIR/build_tools/wheels/check_license.py
 FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
 
 if [[ $FREE_THREADED_BUILD == "False" ]]; then
+    # Run the tests for the scikit-learn wheel in a minimal Windows environment
+    # without any developer runtime libraries installed to ensure that it does not
+    # implicitly rely on the presence of the DLLs of such runtime libraries.
     docker container run \
         --rm scikit-learn/minimal-windows \
         powershell -Command "python -c 'import sklearn; sklearn.show_versions()'"


### PR DESCRIPTION
Seems like scipy has a free-threaded wheel in [scientific-python-nightly-wheel](https://anaconda.org/scientific-python-nightly-wheels/scipy/files).

As noted in https://github.com/scikit-learn/scikit-learn/issues/28978#issuecomment-2449309027 the fact that we use a Windows docker image in our setup is a bit cumbersome but I am trying the easiest thing for now which is to not use a Docker image for the free-threaded build.

The alternative would be to write some powershell to install free-threaded CPython in the minimal Docker image but it seems a bit too much work for what it is worth. I would guess this is not that likely that a missing DLL would happen for free-threaded and not vanilla CPython.

Context: the reason we have this custom Docker image on Windows is to avoid missing DLLs, see https://github.com/scikit-learn/scikit-learn/issues/15899, https://github.com/scikit-learn/scikit-learn/pull/18802 and https://github.com/scikit-learn/scikit-learn/issues/24612#issuecomment-1274952320.