### PR TITLE
DOC fix typo in cyclical feature engineering example

### DIFF
--- a/examples/applications/plot_cyclical_feature_engineering.py
+++ b/examples/applications/plot_cyclical_feature_engineering.py
@@ -198,7 +198,7 @@ print("Categorical features:", categorical_columns.tolist())
 
 # %%
 #
-# Lets evaluate our gradient boosting model with the mean absolute error of the
+# Let's evaluate our gradient boosting model with the mean absolute error of the
 # relative demand averaged across our 5 time-based cross-validation splits:
 import numpy as np
 


### PR DESCRIPTION
This quick fix PR corrects a minor typo in an example