### PR TITLE
CI Limit ninja number of parallel jobs in CircleCI

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -183,7 +183,7 @@ conda activate $CONDA_ENV_NAME
 
 show_installed_libraries
 
-pip install -e . --no-build-isolation
+pip install -e . --no-build-isolation --config-settings=compile-args="-j4"
 
 echo "ccache build summary:"
 ccache -s


### PR DESCRIPTION
Check this fixes the CircleCI issue see in many PRs for example in https://github.com/scikit-learn/scikit-learn/pull/30327#issuecomment-2493838844.

Not sure why this started being an issue, my guess is that something changed in CircleCI and ninja thinks he has too many cores instead of the 2 that it should see. ninja ends up creating too many processes and there is some kind of CircleCI job manager that kills the processes. This corroborates what was seen using CircleCI SSH debug with `htop`.

Apparently the default number of jobs is number of cores + 2 so I set it to 4 since we have two cores in our CircleCI job. Not sure the rule is so simple after reading a bit more but `-j4` makes the doc build pass so probably good enough.

There was this old ninja+CircleCI issue https://github.com/ninja-build/ninja/issues/1530 although I am guessing this is not fully relevant https://github.com/ninja-build/ninja/issues/1530. At least this points to https://github.com/ninja-build/ninja/blob/a3fda2b06c027f19c7ec68c08e21859e44c15cde/src/ninja.cc#L248-L258 that seems to point at the default parallelism rule. TL;DR in general parallelism is number of cores + 2, 3 for 2 cores and 2 for 1 core. 