### PR TITLE
Add Adjusted R² (R2_adj) Regression Score Function

### DIFF
--- a/doc/api_reference.py
+++ b/doc/api_reference.py
@@ -773,6 +773,7 @@ API_REFERENCE = {
                     "mean_tweedie_deviance",
                     "median_absolute_error",
                     "r2_score",
+                    "adjusted_r2_score",
                     "root_mean_squared_error",
                     "root_mean_squared_log_error",
                 ],

--- a/doc/whats_new/upcoming_changes/sklearn.metrics/30336.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/30336.enhancement.rst
@@ -1,0 +1,6 @@
+- :func:`sklearn.metrics.adjusted_r2_score`, a new function to calculate the 
+  adjusted R² score for regression models. This metric accounts for the number of 
+  predictors, making it a more reliable performance measure, especially when comparing 
+  models with different numbers of features. It supports sample weights and handles 
+  edge cases with constant data. 
+  By :user:`Kashif Ali Khan <kashifalikhan36>`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ requires = [
 ]
 
 [tool.black]
-line-length = 88
+line-length = 114
 target-version = ['py39', 'py310', 'py311']
 preview = true
 exclude = '''
@@ -126,7 +126,7 @@ exclude = '''
 
 [tool.ruff]
 # max line length for black
-line-length = 88
+line-length = 114
 target-version = "py38"
 exclude=[
     ".git",
@@ -191,7 +191,7 @@ notice-rgx = "\\#\\ Authors:\\ The\\ scikit\\-learn\\ developers\\\r?\\\n\\#\\ S
 
 [tool.cython-lint]
 # Ignore the same error codes as ruff
-# + E501 (line too long) because keeping it < 88 in cython
+# + E501 (line too long) because keeping it < 114 in cython
 # often makes code less readable.
 ignore = [
     # multiple spaces/tab after comma

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -62,6 +62,7 @@ from ._regression import (
     mean_tweedie_deviance,
     median_absolute_error,
     r2_score,
+    adjusted_r2_score,
     root_mean_squared_error,
     root_mean_squared_log_error,
 )
@@ -164,6 +165,7 @@ __all__ = [
     "precision_score",
     "PredictionErrorDisplay",
     "r2_score",
+    "adjusted_r2_score",
     "rand_score",
     "recall_score",
     "RocCurveDisplay",

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1274,17 +1274,13 @@ def adjusted_r2_score(
     # Check input shapes and lengths
     if len(y_true) != len(y_pred):
         raise ValueError("Length of y_true and y_pred must be the same.")
-    
     n = len(y_true)  # Number of samples
     p = y_pred.shape[1] if len(y_pred.shape) > 1 else 1  # Number of predictors (features)
-    
     # Calculate R²
     r2 = r2_score(y_true, y_pred, sample_weight=sample_weight, multioutput=multioutput, force_finite=force_finite)
-
     # Calculate Adjusted R²
     if n - p - 1 == 0:  # To avoid division by zero
         return float("nan")
-    
     adjusted_r2 = 1 - ((1 - r2) * (n - 1)) / (n - p - 1)
     return adjusted_r2
 def max_error(y_true, y_pred):

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -43,6 +43,7 @@ __ALL__ = [
     "mean_absolute_percentage_error",
     "mean_pinball_loss",
     "r2_score",
+    "adjusted_r2_score",
     "root_mean_squared_log_error",
     "root_mean_squared_error",
     "explained_variance_score",
@@ -1230,6 +1231,62 @@ def r2_score(
     },
     prefer_skip_nested_validation=True,
 )
+def adjusted_r2_score(
+    y_true,
+    y_pred,
+    *,
+    sample_weight=None,
+    multioutput="uniform_average",
+    force_finite=True,
+):
+    """
+    Adjusted R² (coefficient of determination) regression score function.
+
+    This is an adjusted version of the R² score that accounts for the number
+    of features (predictors) in the model. The adjusted R² is useful when
+    comparing models with a different number of predictors.
+
+    Best possible score is 1.0, but it can be negative if the model is worse than a constant model.
+
+    Parameters
+    ----------
+    y_true : array-like of shape (n_samples,) or (n_samples, n_outputs)
+        Ground truth (correct) target values.
+
+    y_pred : array-like of shape (n_samples,) or (n_samples, n_outputs)
+        Estimated target values.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    multioutput : {'raw_values', 'uniform_average', 'variance_weighted'}, \
+            array-like of shape (n_outputs,) or None, default='uniform_average'
+        Defines aggregating of multiple output scores.
+
+    force_finite : bool, default=True
+        Flag indicating if NaN and -Inf scores resulting from constant data should be replaced with real numbers.
+
+    Returns
+    -------
+    float or ndarray of floats
+        The adjusted R² score or ndarray of scores if 'multioutput' is 'raw_values'.
+    """
+    # Check input shapes and lengths
+    if len(y_true) != len(y_pred):
+        raise ValueError("Length of y_true and y_pred must be the same.")
+    
+    n = len(y_true)  # Number of samples
+    p = y_pred.shape[1] if len(y_pred.shape) > 1 else 1  # Number of predictors (features)
+    
+    # Calculate R²
+    r2 = r2_score(y_true, y_pred, sample_weight=sample_weight, multioutput=multioutput, force_finite=force_finite)
+
+    # Calculate Adjusted R²
+    if n - p - 1 == 0:  # To avoid division by zero
+        return float("nan")
+    
+    adjusted_r2 = 1 - ((1 - r2) * (n - 1)) / (n - p - 1)
+    return adjusted_r2
 def max_error(y_true, y_pred):
     """
     The max_error metric calculates the maximum residual error.

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -23,6 +23,7 @@ from sklearn.metrics import (
     mean_tweedie_deviance,
     median_absolute_error,
     r2_score,
+    adjusted_r2_score,
     root_mean_squared_error,
     root_mean_squared_log_error,
 )

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -23,7 +23,6 @@ from sklearn.metrics import (
     mean_tweedie_deviance,
     median_absolute_error,
     r2_score,
-    adjusted_r2_score,
     root_mean_squared_error,
     root_mean_squared_log_error,
 )

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -294,6 +294,7 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.precision_recall_fscore_support",
     "sklearn.metrics.precision_score",
     "sklearn.metrics.r2_score",
+    "sklearn.metrics.adjusted_r2_score",
     "sklearn.metrics.rand_score",
     "sklearn.metrics.recall_score",
     "sklearn.metrics.roc_auc_score",


### PR DESCRIPTION
Reference Issues/PRs
No related issues or pull requests.

What does this implement/fix? Explain your changes.
This pull request adds adjusted_r2_score, a regression metric that accounts for the number of predictors, offering better model comparison. It supports sample weights and handles edge cases with constant data.

Any other comments?
No additional comments at this time.
