### PR TITLE
DOC small note and crossref on the equivalency of recall (macro average) and balanced_accuracy_score

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -575,15 +575,15 @@ or *informedness*.
 
     * Our definition: [Mosley2013]_, [Kelleher2015]_ and [Guyon2015]_, where
       [Guyon2015]_ adopt the adjusted version to ensure that random predictions
-      have a score of :math:`0` and perfect predictions have a score of :math:`1`..
+      have a score of :math:`0` and perfect predictions have a score of :math:`1`.
     * Class balanced accuracy as described in [Mosley2013]_: the minimum between the precision
       and the recall for each class is computed. Those values are then averaged over the total
       number of classes to get the balanced accuracy.
     * Balanced Accuracy as described in [Urbanowicz2015]_: the average of sensitivity and specificity
       is computed for each class and then averaged over total number of classes.
 
-    The noted equivalency of macro average Recall, our version of balanced accuracy,
-    and raw accuracy with inverse prevalence weighting is detailed in [Opitz2024]_ (Eq. 8).
+    The noted equivalency of our version of balanced accuracy, macro averaged Recall,
+    and raw accuracy with inverse prevalence weighting is detailed in [Opitz2024]_.
 
 .. rubric:: References
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -567,6 +567,16 @@ With ``adjusted=True``, balanced accuracy reports the relative increase from
 `*Youden's J statistic* <https://en.wikipedia.org/wiki/Youden%27s_J_statistic>`_,
 or *informedness*.
 
+The equivalency to macro Recall (say N classes) becomes clear with the default
+``sample_weight=None``, i.e.,
+
+.. math::
+
+   \texttt{balanced-accuracy}(y, \hat{y}) = \frac{1}{N} \sum_{k=1}^N \frac{\sum_i 1(\hat{y}_i = y_i = k)}{\sum_j 1(y_j = k)} = \texttt{macro-recall}(y, \hat{y})
+
+Here we took the arithmetic mean of all class-wise recall scores, just as
+in macro recall (``average=macro``).
+
 .. note::
 
     The multiclass definition here seems the most reasonable extension of the
@@ -582,8 +592,10 @@ or *informedness*.
     * Balanced Accuracy as described in [Urbanowicz2015]_: the average of sensitivity and specificity
       is computed for each class and then averaged over total number of classes.
 
-    The noted equivalency of our version of balanced accuracy, macro averaged Recall,
-    and raw accuracy with inverse prevalence weighting is detailed in [Opitz2024]_.
+    There are some cases, where balanced accuracy does not avoid inflated performance
+    scores in imbalanced datasets (for example, when minority classes are detected well, but
+    majority classes aren't). In these cases, accuracy can be low, but balanced accuracy can
+    be high. Therefore [Opitz2024]_ recommend inspecting balanced accuracy together with accuracy.
 
 .. rubric:: References
 

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -582,6 +582,9 @@ or *informedness*.
     * Balanced Accuracy as described in [Urbanowicz2015]_: the average of sensitivity and specificity
       is computed for each class and then averaged over total number of classes.
 
+    The noted equivalency of macro average Recall, our version of balanced accuracy,
+    and raw accuracy with inverse prevalence weighting is detailed in [Opitz2024]_ (Eq. 8).
+
 .. rubric:: References
 
 .. [Guyon2015] I. Guyon, K. Bennett, G. Cawley, H.J. Escalante, S. Escalera, T.K. Ho, N. Macià,
@@ -596,7 +599,10 @@ or *informedness*.
 .. [Urbanowicz2015] Urbanowicz R.J.,  Moore, J.H. :doi:`ExSTraCS 2.0: description
     and evaluation of a scalable learning classifier
     system <10.1007/s12065-015-0128-8>`, Evol. Intel. (2015) 8: 89.
-
+.. [Opitz2024] J. Opitz (2024). `A Closer Look at Classification Evaluation Metrics
+   and a Critical Reflection of Common Evaluation Practice
+   <https://doi.org/10.1162/tacl_a_00675>`_, TACL 2024.
+  
 .. _cohen_kappa:
 
 Cohen's kappa

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2363,13 +2363,12 @@ def recall_score(
     When used with ``average=macro``, the result equals that of
     :func:`balanced_accuracy_score`. That is,
     ``recall_score(y_true, y_pred, average=macro)`` is equivalent to
-    ``balanced_accuracy_score(y_true, y_pred)``.
+    ``balanced_accuracy_score(y_true, y_pred)``. See also [1], Eq. 8.
 
     References
     ----------
     .. [1] J. Opitz (2024). `"A Closer Look at Classification Evaluation Metrics
-           and a Critical Reflection of Common Evaluation Practice". Transactions
-           of the Association for Computational Linguistics 12 (2024): 820-836
+           and a Critical Reflection of Common Evaluation Practice". TACL
            <https://doi.org/10.1162/tacl_a_00675>`_.
 
     Examples
@@ -2490,8 +2489,7 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
            <https://mitpress.mit.edu/books/fundamentals-machine-learning-predictive-data-analytics>`_.
 
     .. [3] J. Opitz (2024). `"A Closer Look at Classification Evaluation Metrics
-           and a Critical Reflection of Common Evaluation Practice". Transactions
-           of the Association for Computational Linguistics 12 (2024): 820-836
+           and a Critical Reflection of Common Evaluation Practice". TACL
            <https://doi.org/10.1162/tacl_a_00675>`_.
 
     Examples

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2359,12 +2359,12 @@ def recall_score(
     When ``true positive + false negative == 0``, recall returns 0 and raises
     ``UndefinedMetricWarning``. This behavior can be modified with
     ``zero_division``.
-    
+
     When used with ``average=macro``, the result equals that of
     :func:`balanced_accuracy_score`. That is,
     ``recall_score(y_true, y_pred, average=macro)`` is equivalent to
     ``balanced_accuracy_score(y_true, y_pred)``.
-    
+
     References
     ----------
     .. [1] J. Opitz (2024). `"A Closer Look at Classification Evaluation Metrics
@@ -2471,24 +2471,24 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
     definition is equivalent to :func:`accuracy_score` with class-balanced
     sample weights, and shares desirable properties with the binary case.
     See the :ref:`User Guide <balanced_accuracy_score>`.
-    
+
     Also note the equivalency of our defintion of balanced accuracy and
     macro-averaged :func:`recall_score`.
     That is, ``balanced_accuracy_score(y_true, y_pred)`` equals
     ``recall_score(y_true, y_pred, average=macro)``.
-    
+
     References
     ----------
     .. [1] Brodersen, K.H.; Ong, C.S.; Stephan, K.E.; Buhmann, J.M. (2010).
            The balanced accuracy and its posterior distribution.
            Proceedings of the 20th International Conference on Pattern
            Recognition, 3121-24.
-           
+
     .. [2] John. D. Kelleher, Brian Mac Namee, Aoife D'Arcy, (2015).
            `Fundamentals of Machine Learning for Predictive Data Analytics:
            Algorithms, Worked Examples, and Case Studies
            <https://mitpress.mit.edu/books/fundamentals-machine-learning-predictive-data-analytics>`_.
-           
+
     .. [3] J. Opitz (2024). `"A Closer Look at Classification Evaluation Metrics
            and a Critical Reflection of Common Evaluation Practice". Transactions
            of the Association for Computational Linguistics 12 (2024): 820-836

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2369,8 +2369,8 @@ def recall_score(
     ----------
     .. [1] J. Opitz (2024). `"A Closer Look at Classification Evaluation Metrics
            and a Critical Reflection of Common Evaluation Practice". Transactions
-           of the Association for Computational Linguistics 12 (2024): 820-836.
-           <https://doi.org/10.1162/tacl_a_00675>`_
+           of the Association for Computational Linguistics 12 (2024): 820-836
+           <https://doi.org/10.1162/tacl_a_00675>`_.
 
     Examples
     --------
@@ -2473,7 +2473,7 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
     See the :ref:`User Guide <balanced_accuracy_score>`.
     
     Also note the equivalency of our defintion of balanced accuracy and
-    macro-averaged :func:`recall`.
+    macro-averaged :func:`recall_score`.
     That is, ``balanced_accuracy_score(y_true, y_pred)`` equals
     ``recall_score(y_true, y_pred, average=macro)``.
     
@@ -2491,8 +2491,8 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
            
     .. [3] J. Opitz (2024). `"A Closer Look at Classification Evaluation Metrics
            and a Critical Reflection of Common Evaluation Practice". Transactions
-           of the Association for Computational Linguistics 12 (2024): 820-836.
-           <https://doi.org/10.1162/tacl_a_00675>`_
+           of the Association for Computational Linguistics 12 (2024): 820-836
+           <https://doi.org/10.1162/tacl_a_00675>`_.
 
     Examples
     --------

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2360,7 +2360,7 @@ def recall_score(
     ``UndefinedMetricWarning``. This behavior can be modified with
     ``zero_division``.
     
-    When used with ``average=macro``, the result equals balanced_accuracy_score .
+    When used with ``average=macro``, the result equals the balanced accuracy.
     That is, ``recall_score(y_true, y_pred, average=macro)`` is the same as
     ``balanced_accuracy_score(y_true, y_pred)``.
     
@@ -2369,7 +2369,7 @@ def recall_score(
     .. [1] J. Opitz (2024). `"A Closer Look at Classification Evaluation Metrics
            and a Critical Reflection of Common Evaluation Practice". Transactions
            of the Association for Computational Linguistics 12 (2024): 820-836.
-           <https://doi.org/10.1162/tacl_a_00675>`_.
+           <https://doi.org/10.1162/tacl_a_00675>`_
 
     Examples
     --------
@@ -2471,9 +2471,9 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
     sample weights, and shares desirable properties with the binary case.
     See the :ref:`User Guide <balanced_accuracy_score>`.
     
-    Further note the equivalency of balanced accuracy and macro-averaged recall.
+    Also note the equivalency of balanced accuracy and macro-averaged recall.
     That is, ``balanced_accuracy_score(y_true, y_pred)`` is equal to
-    ``recall_score(y_true, y_pred, average=macro)`` using recall_score .
+    ``recall_score(y_true, y_pred, average=macro)``.
     
     References
     ----------
@@ -2481,15 +2481,16 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
            The balanced accuracy and its posterior distribution.
            Proceedings of the 20th International Conference on Pattern
            Recognition, 3121-24.
+           
     .. [2] John. D. Kelleher, Brian Mac Namee, Aoife D'Arcy, (2015).
            `Fundamentals of Machine Learning for Predictive Data Analytics:
            Algorithms, Worked Examples, and Case Studies
-           <https://mitpress.mit.edu/books/fundamentals-machine-learning-predictive-data-analytics>`_.
+           <https://mitpress.mit.edu/books/fundamentals-machine-learning-predictive-data-analytics>`_
            
     .. [3] J. Opitz (2024). `"A Closer Look at Classification Evaluation Metrics
            and a Critical Reflection of Common Evaluation Practice". Transactions
            of the Association for Computational Linguistics 12 (2024): 820-836.
-           <https://doi.org/10.1162/tacl_a_00675>`_.
+           <https://doi.org/10.1162/tacl_a_00675>`_
 
     Examples
     --------

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2360,8 +2360,9 @@ def recall_score(
     ``UndefinedMetricWarning``. This behavior can be modified with
     ``zero_division``.
     
-    When used with ``average=macro``, the result equals the balanced accuracy.
-    That is, ``recall_score(y_true, y_pred, average=macro)`` is the same as
+    When used with ``average=macro``, the result equals that of
+    :func:`balanced_accuracy_score`. That is, 
+    ``recall_score(y_true, y_pred, average=macro)`` is the same as
     ``balanced_accuracy_score(y_true, y_pred)``.
     
     References
@@ -2471,8 +2472,8 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
     sample weights, and shares desirable properties with the binary case.
     See the :ref:`User Guide <balanced_accuracy_score>`.
     
-    Also note the equivalency of balanced accuracy and macro-averaged recall.
-    That is, ``balanced_accuracy_score(y_true, y_pred)`` is equal to
+    Also note the equivalency of balanced accuracy and macro-averaged 
+    :func:`recall`. That is, ``balanced_accuracy_score(y_true, y_pred)`` equals
     ``recall_score(y_true, y_pred, average=macro)``.
     
     References
@@ -2485,7 +2486,7 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
     .. [2] John. D. Kelleher, Brian Mac Namee, Aoife D'Arcy, (2015).
            `Fundamentals of Machine Learning for Predictive Data Analytics:
            Algorithms, Worked Examples, and Case Studies
-           <https://mitpress.mit.edu/books/fundamentals-machine-learning-predictive-data-analytics>`_
+           <https://mitpress.mit.edu/books/fundamentals-machine-learning-predictive-data-analytics>`_.
            
     .. [3] J. Opitz (2024). `"A Closer Look at Classification Evaluation Metrics
            and a Critical Reflection of Common Evaluation Practice". Transactions

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2359,6 +2359,17 @@ def recall_score(
     When ``true positive + false negative == 0``, recall returns 0 and raises
     ``UndefinedMetricWarning``. This behavior can be modified with
     ``zero_division``.
+    
+    When used with ``average=macro``, the result equals balanced_accuracy_score .
+    That is, ``recall_score(y_true, y_pred, average=macro)`` is the same as
+    ``balanced_accuracy_score(y_true, y_pred)``.
+    
+    References
+    ----------
+    .. [1] J. Opitz, (2024). `"A Closer Look at Classification Evaluation Metrics
+           and a Critical Reflection of Common Evaluation Practice". Transactions
+           of the Association for Computational Linguistics 12 (2024): 820-836.
+           <https://doi.org/10.1162/tacl_a_00675>`_.
 
     Examples
     --------
@@ -2459,7 +2470,11 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
     definition is equivalent to :func:`accuracy_score` with class-balanced
     sample weights, and shares desirable properties with the binary case.
     See the :ref:`User Guide <balanced_accuracy_score>`.
-
+    
+    Further note the equivalency of balanced accuracy and macro-averaged recall.
+    That is, ``balanced_accuracy_score(y_true, y_pred)`` is equal to
+    ``recall_score(y_true, y_pred, average=macro)`` using recall_score .
+    
     References
     ----------
     .. [1] Brodersen, K.H.; Ong, C.S.; Stephan, K.E.; Buhmann, J.M. (2010).
@@ -2470,6 +2485,11 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
            `Fundamentals of Machine Learning for Predictive Data Analytics:
            Algorithms, Worked Examples, and Case Studies
            <https://mitpress.mit.edu/books/fundamentals-machine-learning-predictive-data-analytics>`_.
+           
+    .. [3] J. Opitz (2024). `"A Closer Look at Classification Evaluation Metrics
+           and a Critical Reflection of Common Evaluation Practice". Transactions
+           of the Association for Computational Linguistics 12 (2024): 820-836.
+           <https://doi.org/10.1162/tacl_a_00675>`_.
 
     Examples
     --------

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2361,8 +2361,8 @@ def recall_score(
     ``zero_division``.
     
     When used with ``average=macro``, the result equals that of
-    :func:`balanced_accuracy_score`. That is, 
-    ``recall_score(y_true, y_pred, average=macro)`` is the same as
+    :func:`balanced_accuracy_score`. That is,
+    ``recall_score(y_true, y_pred, average=macro)`` is equivalent to
     ``balanced_accuracy_score(y_true, y_pred)``.
     
     References
@@ -2472,8 +2472,9 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
     sample weights, and shares desirable properties with the binary case.
     See the :ref:`User Guide <balanced_accuracy_score>`.
     
-    Also note the equivalency of balanced accuracy and macro-averaged 
-    :func:`recall`. That is, ``balanced_accuracy_score(y_true, y_pred)`` equals
+    Also note the equivalency of our defintion of balanced accuracy and
+    macro-averaged :func:`recall`.
+    That is, ``balanced_accuracy_score(y_true, y_pred)`` equals
     ``recall_score(y_true, y_pred, average=macro)``.
     
     References

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2366,7 +2366,7 @@ def recall_score(
     
     References
     ----------
-    .. [1] J. Opitz, (2024). `"A Closer Look at Classification Evaluation Metrics
+    .. [1] J. Opitz (2024). `"A Closer Look at Classification Evaluation Metrics
            and a Critical Reflection of Common Evaluation Practice". Transactions
            of the Association for Computational Linguistics 12 (2024): 820-836.
            <https://doi.org/10.1162/tacl_a_00675>`_.

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2363,13 +2363,8 @@ def recall_score(
     When used with ``average=macro``, the result equals that of
     :func:`balanced_accuracy_score`. That is,
     ``recall_score(y_true, y_pred, average=macro)`` is equivalent to
-    ``balanced_accuracy_score(y_true, y_pred)``. See also [1], Eq. 8.
-
-    References
-    ----------
-    .. [1] J. Opitz (2024). `"A Closer Look at Classification Evaluation Metrics
-           and a Critical Reflection of Common Evaluation Practice". TACL
-           <https://doi.org/10.1162/tacl_a_00675>`_.
+    ``balanced_accuracy_score(y_true, y_pred)``. See also the
+    :ref:`User Guide <balanced_accuracy_score>`. 
 
     Examples
     --------
@@ -2474,7 +2469,8 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
     Also note the equivalency of our defintion of balanced accuracy and
     macro-averaged :func:`recall_score`.
     That is, ``balanced_accuracy_score(y_true, y_pred)`` equals
-    ``recall_score(y_true, y_pred, average=macro)``.
+    ``recall_score(y_true, y_pred, average=macro)``. See also the
+    :ref:`User Guide <balanced_accuracy_score>`.
 
     References
     ----------
@@ -2487,10 +2483,6 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
            `Fundamentals of Machine Learning for Predictive Data Analytics:
            Algorithms, Worked Examples, and Case Studies
            <https://mitpress.mit.edu/books/fundamentals-machine-learning-predictive-data-analytics>`_.
-
-    .. [3] J. Opitz (2024). `"A Closer Look at Classification Evaluation Metrics
-           and a Critical Reflection of Common Evaluation Practice". TACL
-           <https://doi.org/10.1162/tacl_a_00675>`_.
 
     Examples
     --------


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

It adds a note and cross-reference in the documentation about the equivalency of Balanced Accuracy and Recall (when the latter is used with macro average).

#### Any other comments?

It's conceptually the same. I additionally verified it within sklearn -- This runs without fault:

```python
import numpy as np
from sklearn.metrics import balanced_accuracy_score, recall_score

def generate_yx(num_labels):
    y = np.random.randint(0, num_labels, 500)
    x = np.random.randint(0, num_labels, 500)
    return y, x

for _ in range(1000):
    for n in [2, 3, 4, 5]:
        y, x = generate_yx(n)
        r = recall_score(y, x, average="macro")
        b = balanced_accuracy_score(y, x)
        assert r == b
```

Just think it's something useful to highlight in the Docs.
