### PR TITLE
CI Actually use ccache in CircleCI

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -174,7 +174,11 @@ bash ./miniconda.sh -b -p $MINIFORGE_PATH
 source $MINIFORGE_PATH/etc/profile.d/conda.sh
 conda activate
 
+# Sets up ccache when using system compiler
 export PATH="/usr/lib/ccache:$PATH"
+# Sets up ccache when using conda-forge compilers
+export CC="ccache $CC"
+export CXX="ccache $CXX"
 ccache -M 512M
 export CCACHE_COMPRESS=1
 

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -192,7 +192,10 @@ ccache -z
 
 show_installed_libraries
 
-time pip install -e . --no-build-isolation --config-settings=compile-args="-j2" -v
+# Specify explictly ninja -j argument because ninja does not handle cgroups v2 and
+# use the same default rule as ninja (-j3 since we have 2 cores on CircleCI), see
+# https://github.com/scikit-learn/scikit-learn/pull/30333
+pip install -e . --no-build-isolation --config-settings=compile-args="-j 3"
 
 echo "ccache build summary:"
 ccache -s

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -192,7 +192,7 @@ ccache -z
 
 show_installed_libraries
 
-time pip install -e . --no-build-isolation --config-settings=compile-args="-j3" -v
+time pip install -e . --no-build-isolation --config-settings=compile-args="-j2" -v
 
 echo "ccache build summary:"
 ccache -s

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -181,7 +181,8 @@ conda activate $CONDA_ENV_NAME
 
 # Sets up ccache when using system compiler
 export PATH="/usr/lib/ccache:$PATH"
-# Sets up ccache when using conda-forge compilers
+# Sets up ccache when using conda-forge compilers (needs to be after conda
+# activate which sets CC and CXX)
 export CC="ccache $CC"
 export CXX="ccache $CXX"
 ccache -M 512M

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -192,7 +192,7 @@ ccache -z
 
 show_installed_libraries
 
-pip install -e . --no-build-isolation --config-settings=compile-args="-j4" -v
+time pip install -e . --no-build-isolation --config-settings=compile-args="-j3" -v
 
 echo "ccache build summary:"
 ccache -s

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+set -x
 
 # Decide what kind of documentation build to run, and run it.
 #
@@ -174,6 +175,10 @@ bash ./miniconda.sh -b -p $MINIFORGE_PATH
 source $MINIFORGE_PATH/etc/profile.d/conda.sh
 conda activate
 
+
+create_conda_environment_from_lock_file $CONDA_ENV_NAME $LOCK_FILE
+conda activate $CONDA_ENV_NAME
+
 # Sets up ccache when using system compiler
 export PATH="/usr/lib/ccache:$PATH"
 # Sets up ccache when using conda-forge compilers
@@ -181,9 +186,6 @@ export CC="ccache $CC"
 export CXX="ccache $CXX"
 ccache -M 512M
 export CCACHE_COMPRESS=1
-
-create_conda_environment_from_lock_file $CONDA_ENV_NAME $LOCK_FILE
-conda activate $CONDA_ENV_NAME
 
 show_installed_libraries
 

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -187,7 +187,7 @@ conda activate $CONDA_ENV_NAME
 
 show_installed_libraries
 
-pip install -e . --no-build-isolation --config-settings=compile-args="-j4"
+pip install -e . --no-build-isolation --config-settings=compile-args="-j4" -v
 
 echo "ccache build summary:"
 ccache -s

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -187,6 +187,8 @@ export CC="ccache $CC"
 export CXX="ccache $CXX"
 ccache -M 512M
 export CCACHE_COMPRESS=1
+# Zeroing statistics so that ccache statistics are shown only for this build
+ccache -z
 
 show_installed_libraries
 


### PR DESCRIPTION
Search for ccache build summary in CircleCI log and you find ccache is not used. This is likely because we are using conda-forge compilers and our current set-up works with system compilers ...

```
ccache build summary:
Summary:
  Hits:               0 /    0
    Direct:           0 /    0
    Preprocessed:     0 /    0
  Misses:             0
    Direct:           0
    Preprocessed:     0
Primary storage:
  Hits:               0 /    0
  Misses:             0
  Cache size (GB): 0.00 / 0.51 (0.00 %)
```