### PR TITLE
MNT fix error message in `_num_samples`

### DIFF
--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1141,7 +1141,7 @@ def test_sample_weight_invalid():
 
     expected_err = re.escape(
         (
-            "Input 'x' should have at least 1 dimension i.e. satisfy "
+            "Input should have at least 1 dimension i.e. satisfy "
             "`len(x.shape) > 0`, got scalar `array(0.)` instead."
         )
     )

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -6,6 +6,7 @@ import copy
 import copyreg
 import io
 import pickle
+import re
 import struct
 from itertools import chain, product
 
@@ -1137,7 +1138,13 @@ def test_sample_weight_invalid():
         clf.fit(X, y, sample_weight=sample_weight)
 
     sample_weight = np.array(0)
-    expected_err = r"Singleton.* cannot be considered a valid collection"
+
+    expected_err = re.escape(
+        (
+            "Input 'x' should have at least 1 dimension i.e. satisfy "
+            "`len(x.shape) > 0`, got scalar `array(0.)` instead."
+        )
+    )
     with pytest.raises(TypeError, match=expected_err):
         clf.fit(X, y, sample_weight=sample_weight)
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -743,7 +743,10 @@ def test_check_array_min_samples_and_features_messages():
         check_array([], ensure_2d=False)
 
     # Invalid edge case when checking the default minimum sample of a scalar
-    msg = r"Expected collection, got `42` of type `<class 'numpy.ndarray'>` instead."
+    msg = (
+        "Expected array-like of collection type, got type `<class 'numpy.ndarray'>` "
+        "instead."
+    )
     with pytest.raises(TypeError, match=msg):
         check_array(42, ensure_2d=False)
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -744,7 +744,7 @@ def test_check_array_min_samples_and_features_messages():
 
     # Invalid edge case when checking the default minimum sample of a scalar
     msg = (
-        "Expected array-like of collection type, got type `<class 'numpy.ndarray'>` "
+        "Expected array-like or collection type, got type `<class 'numpy.ndarray'>` "
         "instead."
     )
     with pytest.raises(TypeError, match=msg):

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -743,7 +743,7 @@ def test_check_array_min_samples_and_features_messages():
         check_array([], ensure_2d=False)
 
     # Invalid edge case when checking the default minimum sample of a scalar
-    msg = r"Singleton array array\(42\) cannot be considered a valid" " collection."
+    msg = r"Expected collection, got `42` of type `<class 'numpy.ndarray'>` instead."
     with pytest.raises(TypeError, match=msg):
         check_array(42, ensure_2d=False)
 

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -745,7 +745,7 @@ def test_check_array_min_samples_and_features_messages():
     # Invalid edge case when checking the default minimum sample of a scalar
     msg = re.escape(
         (
-            "Input 'x' should have at least 1 dimension i.e. satisfy "
+            "Input should have at least 1 dimension i.e. satisfy "
             "`len(x.shape) > 0`, got scalar `array(42)` instead."
         )
     )

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -743,9 +743,11 @@ def test_check_array_min_samples_and_features_messages():
         check_array([], ensure_2d=False)
 
     # Invalid edge case when checking the default minimum sample of a scalar
-    msg = (
-        "Expected array-like or collection type, got type `<class 'numpy.ndarray'>` "
-        "instead."
+    msg = re.escape(
+        (
+            "Input 'x' should have at least 1 dimension i.e. satisfy "
+            "`len(x.shape) > 0`, got scalar `array(42)` instead."
+        )
     )
     with pytest.raises(TypeError, match=msg):
         check_array(42, ensure_2d=False)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -397,7 +397,7 @@ def _num_samples(x):
     if hasattr(x, "shape") and x.shape is not None:
         if len(x.shape) == 0:
             raise TypeError(
-                f"Expected collection, got `{x}` of type `{type(x)}` instead."
+                f"Expected array-like of collection type, got type `{type(x)}` instead."
             )
         # Check that shape is returning an integer or default to len
         # Dask dataframes may not return numeric shape[0] value

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -397,7 +397,7 @@ def _num_samples(x):
     if hasattr(x, "shape") and x.shape is not None:
         if len(x.shape) == 0:
             raise TypeError(
-                f"Expected array-like of collection type, got type `{type(x)}` instead."
+                f"Expected array-like or collection type, got type `{type(x)}` instead."
             )
         # Check that shape is returning an integer or default to len
         # Dask dataframes may not return numeric shape[0] value

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -397,7 +397,7 @@ def _num_samples(x):
     if hasattr(x, "shape") and x.shape is not None:
         if len(x.shape) == 0:
             raise TypeError(
-                f"Expected array-like or collection type, got type `{type(x)}` instead."
+                f"Input 'x' should have at least 1 dimension i.e. satisfy len(x.shape) > 0, got array scalar {!r} instead."
             )
         # Check that shape is returning an integer or default to len
         # Dask dataframes may not return numeric shape[0] value

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -397,7 +397,7 @@ def _num_samples(x):
     if hasattr(x, "shape") and x.shape is not None:
         if len(x.shape) == 0:
             raise TypeError(
-                "Input 'x' should have at least 1 dimension i.e. satisfy "
+                "Input should have at least 1 dimension i.e. satisfy "
                 f"`len(x.shape) > 0`, got scalar `{x!r}` instead."
             )
         # Check that shape is returning an integer or default to len

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -397,7 +397,7 @@ def _num_samples(x):
     if hasattr(x, "shape") and x.shape is not None:
         if len(x.shape) == 0:
             raise TypeError(
-                "Singleton array %r cannot be considered a valid collection." % x
+                f"Expected collection, got `{x}` of type `{type(x)}` instead."
             )
         # Check that shape is returning an integer or default to len
         # Dask dataframes may not return numeric shape[0] value

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -397,7 +397,8 @@ def _num_samples(x):
     if hasattr(x, "shape") and x.shape is not None:
         if len(x.shape) == 0:
             raise TypeError(
-                f"Input 'x' should have at least 1 dimension i.e. satisfy len(x.shape) > 0, got array scalar {!r} instead."
+                "Input 'x' should have at least 1 dimension i.e. satisfy "
+                f"`len(x.shape) > 0`, got scalar `{x!r}` instead."
             )
         # Check that shape is returning an integer or default to len
         # Dask dataframes may not return numeric shape[0] value


### PR DESCRIPTION
This PR suggests to specify an error message from within `_num_samples` to something more helpful, since this `TypeError` doesn't only raise on singleton arrays. Also, the term "singleton array" is not very widely used.

Reproducibles:

- `indexable(100)` or `indexable(np.array(100))` or `indexable(np.squeeze(np.array([[100]])))`
- `check_array(100, ensure_2d=False)` or `check_array(np.array(100), ensure_2d=False)`

```
import numpy as np
from sklearn.model_selection import train_test_split

X = np.array([[100], [4] ] )
y = np.array(100)

X_train, X_test, y_train, y_test = train_test_split(X, y)
```


@lesteve, since we found this together: do you want to have a look?