### PR TITLE
MNT add __reduce__ to loss objects

### DIFF
--- a/sklearn/_loss/_loss.pyx.tp
+++ b/sklearn/_loss/_loss.pyx.tp
@@ -818,6 +818,9 @@ cdef inline double_pair cgrad_hess_exponential(
 cdef class CyLossFunction:
     """Base class for convex loss functions."""
 
+    def __reduce__(self):
+        return (self.__class__, ())
+
     cdef double cy_loss(self, double y_true, double raw_prediction) noexcept nogil:
         """Compute the loss for a single sample.
 
@@ -1011,6 +1014,11 @@ cdef class {{name}}(CyLossFunction):
     {{if param is not None}}
     def __init__(self, {{param}}):
         self.{{param}} = {{param}}
+    {{endif}}
+
+    {{if param is not None}}
+    def __reduce__(self):
+        return (self.__class__, (self.{{param}},))
     {{endif}}
 
     cdef inline double cy_loss(self, double y_true, double raw_prediction) noexcept nogil:


### PR DESCRIPTION
This adds `__reduce__` with the same format as it was already included in `sgd_fast` loss objects.

```py
loss.__reduce__()
(<cyfunction __pyx_unpickle_CyHalfTweedieLossIdentity at 0x793fed21c520>,
 (_loss.CyHalfTweedieLossIdentity, 8221022, (5.0,)))
```

to the other simpler format:

```py
Hinge().__reduce__()
(sklearn.linear_model._sgd_fast.Hinge, (1.0,))
```

This doesn't change anything wrt `pickle`, but it makes `skops.io` be able to save/load these objects.

cc @lesteve @glemaitre 

Since some objects are removed from `sgd_fast` in this release, and the errors are triggered in `skops` for this `1.6` release, it'd be nice to backport this to the release.