### PR TITLE
Defines missing base.is_transformer API

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.base/30368.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.base/30368.api.rst
@@ -1,0 +1,3 @@
+- Defines :func:`~sklearn.base.is_transformer` to check if an estimator is a
+  transformer.
+  By `Thomas Fan`_

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -857,6 +857,7 @@ class TransformerMixin(_SetOutputMixin):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
+        tags.estimator_type = "transformer"
         tags.transformer_tags = TransformerTags()
         return tags
 
@@ -1275,6 +1276,34 @@ def is_regressor(estimator):
         return getattr(estimator, "_estimator_type", None) == "regressor"
 
     return get_tags(estimator).estimator_type == "regressor"
+
+
+def is_transformer(estimator):
+    """Return True if the given estimator is (probably) a transformer.
+
+    Parameters
+    ----------
+    estimator : estimator instance
+        Estimator object to test.
+
+    Returns
+    -------
+    out : bool
+        True if estimator is a regressor and False otherwise.
+
+    Examples
+    --------
+    >>> from sklearn.base import is_transformer
+    >>> from sklearn.svm import SVC
+    >>> from sklearn.preprocessing import StandardScaler
+    >>> svc = SVC()
+    >>> scalar = StandardScaler()
+    >>> is_transformer(svc)
+    False
+    >>> is_transformer(scalar)
+    True
+    """
+    return get_tags(estimator).estimator_type == "transformer"
 
 
 def is_clusterer(estimator):

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1289,7 +1289,7 @@ def is_transformer(estimator):
     Returns
     -------
     out : bool
-        True if estimator is a regressor and False otherwise.
+        True if estimator is a transformer and False otherwise.
 
     Examples
     --------

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -21,6 +21,7 @@ from sklearn.base import (
     is_clusterer,
     is_outlier_detector,
     is_regressor,
+    is_transformer,
 )
 from sklearn.cluster import KMeans
 from sklearn.decomposition import PCA
@@ -332,6 +333,23 @@ def test_is_regressor(estimator, expected_result):
 )
 def test_is_clusterer(estimator, expected_result):
     assert is_clusterer(estimator) == expected_result
+
+
+@pytest.mark.parametrize(
+    "estimator, expected_result",
+    [
+        (KMeans(), True),
+        (GridSearchCV(KMeans(), {"n_clusters": [3, 8]}), True),
+        (Pipeline([("km", KMeans())]), True),
+        (Pipeline([("km_cv", GridSearchCV(KMeans(), {"n_clusters": [3, 8]}))]), True),
+        (SVC(), False),
+        (GridSearchCV(SVC(), {"C": [0.1, 1]}), False),
+        (Pipeline([("svc", SVC())]), False),
+        (Pipeline([("svc_cv", GridSearchCV(SVC(), {"C": [0.1, 1]}))]), False),
+    ],
+)
+def test_is_transformer(estimator, expected_result):
+    assert is_transformer(estimator) == expected_result
 
 
 def test_set_params():


### PR DESCRIPTION
#### Reference Issues/PRs
Related to https://github.com/scikit-learn/scikit-learn/pull/29677

#### What does this implement/fix? Explain your changes.
This `is_transformer` is referenced in the `api_reference` but never defined:

https://github.com/scikit-learn/scikit-learn/blob/1f593bfa435ced7cb141b96cb67cfd8c8ffced5c/doc/api_reference.py#L126

This PR defines it.

#### Any other comments?
I do not think we had a `_estimator_type="transformer"`, so there is no need to check for it.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
