### PR TITLE
API drop Tags.regressor_tags.multi_label

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1165,11 +1165,6 @@ class ForestRegressor(RegressorMixin, BaseForest, metaclass=ABCMeta):
 
         return averaged_predictions
 
-    def __sklearn_tags__(self):
-        tags = super().__sklearn_tags__()
-        tags.regressor_tags.multi_label = True
-        return tags
-
 
 class RandomForestClassifier(ForestClassifier):
     """

--- a/sklearn/utils/_tags.py
+++ b/sklearn/utils/_tags.py
@@ -98,6 +98,8 @@ class TargetTags:
         Whether a regressor supports multi-target outputs or a classifier supports
         multi-class multi-output.
 
+        See :term:`multi-output` in the glossary.
+
     single_output : bool, default=True
         Whether the target can be single-output. This can be ``False`` if the
         estimator supports only multi-output cases.
@@ -150,8 +152,13 @@ class ClassifierTags:
         classification. Therefore this flag indicates whether the
         classifier is a binary-classifier-only or not.
 
+        See :term:`multi-class` in the glossary.
+
     multi_label : bool, default=False
-        Whether the classifier supports multi-label output.
+        Whether the classifier supports multi-label output: a data point can
+        be predicted to belong to a variable number of classes.
+
+        See :term:`multi-label` in the glossary.
     """
 
     poor_score: bool = False
@@ -172,13 +179,9 @@ class RegressorTags:
         n_informative=1, bias=5.0, noise=20, random_state=42)``. The
         dataset and values are based on current estimators in scikit-learn
         and might be replaced by something more systematic.
-
-    multi_label : bool, default=False
-        Whether the regressor supports multilabel output.
     """
 
     poor_score: bool = False
-    multi_label: bool = False
 
 
 @dataclass(**_dataclass_args())

--- a/sklearn/utils/_tags.py
+++ b/sklearn/utils/_tags.py
@@ -499,7 +499,6 @@ def _to_new_tags(old_tags, estimator=None):
     if estimator_type == "regressor":
         regressor_tags = RegressorTags(
             poor_score=old_tags["poor_score"],
-            multi_label=old_tags["multilabel"],
         )
     else:
         regressor_tags = None
@@ -523,18 +522,16 @@ def _to_old_tags(new_tags):
     """Utility function convert old tags (dictionary) to new tags (dataclass)."""
     if new_tags.classifier_tags:
         binary_only = not new_tags.classifier_tags.multi_class
-        multilabel_clf = new_tags.classifier_tags.multi_label
+        multilabel = new_tags.classifier_tags.multi_label
         poor_score_clf = new_tags.classifier_tags.poor_score
     else:
         binary_only = False
-        multilabel_clf = False
+        multilabel = False
         poor_score_clf = False
 
     if new_tags.regressor_tags:
-        multilabel_reg = new_tags.regressor_tags.multi_label
         poor_score_reg = new_tags.regressor_tags.poor_score
     else:
-        multilabel_reg = False
         poor_score_reg = False
 
     if new_tags.transformer_tags:
@@ -546,7 +543,7 @@ def _to_old_tags(new_tags):
         "allow_nan": new_tags.input_tags.allow_nan,
         "array_api_support": new_tags.array_api_support,
         "binary_only": binary_only,
-        "multilabel": multilabel_clf or multilabel_reg,
+        "multilabel": multilabel,
         "multioutput": new_tags.target_tags.multi_output,
         "multioutput_only": (
             not new_tags.target_tags.single_output and new_tags.target_tags.multi_output

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -4438,7 +4438,6 @@ def check_valid_tag_types(name, estimator):
 
     if tags.regressor_tags is not None:
         assert isinstance(tags.regressor_tags.poor_score, bool), err_msg
-        assert isinstance(tags.regressor_tags.multi_label, bool), err_msg
 
     if tags.transformer_tags is not None:
         assert isinstance(tags.transformer_tags.preserves_dtype, list), err_msg

--- a/sklearn/utils/tests/test_tags.py
+++ b/sklearn/utils/tests/test_tags.py
@@ -451,7 +451,7 @@ def test_old_tags():
         "allow_nan": True,
         "array_api_support": False,
         "binary_only": False,
-        "multilabel": True,
+        "multilabel": False,
         "multioutput": True,
         "multioutput_only": True,
         "no_validation": False,

--- a/sklearn/utils/tests/test_tags.py
+++ b/sklearn/utils/tests/test_tags.py
@@ -434,7 +434,6 @@ def test_old_tags():
             classifier_tags = None
             regressor_tags = RegressorTags(
                 poor_score=True,
-                multi_label=True,
             )
             return Tags(
                 estimator_type=self._estimator_type,


### PR DESCRIPTION
Follow-up on #29677 discovered while reviewing #30187.

Let's remove the field `tags.regressor_tags.multi_label` because:

- it's meaningless;
- it's redundant with `tags.target_tags.multi_output` automatically set by `MultioutputMixin` for regressors;
- it does not map to any concept document in our glossary.

Note that the bug was already present in `ForestRegressor._more_tags` before #29677, but since 1.6 is not released yet, let's fix this before making it officially part of our new Tag API.