### PR TITLE
Improve RidgeCV exception message 

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2531,9 +2531,7 @@ class _BaseRidgeCV(LinearModel):
     @property
     def cv_values_(self):
         if not hasattr(self, "cv_results_") and not self.store_cv_results:
-                raise AttributeError(
-                    "Call 'RidgeCV' with 'store_cv_results=True'"
-                )
+            raise AttributeError("Call 'RidgeCV' with 'store_cv_results=True'")
         return self.cv_results_
 
 

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2530,6 +2530,10 @@ class _BaseRidgeCV(LinearModel):
     )
     @property
     def cv_values_(self):
+        if not hasattr(self, "cv_results_") and not self.store_cv_results:
+                raise AttributeError(
+                    "Call 'RidgeCV' with 'store_cv_results=True'"
+                )
         return self.cv_results_
 
 


### PR DESCRIPTION
Improve RidgeCV exception message when called with store_cv_values=False

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Fixes #10525

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Adding a handler on cv_values (cv_results) to improve the error message when used without settings store_cv_results=True.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
