### PR TITLE
FIX test_csr_polynomial_expansion_index_overflow on [scipy-dev]

### DIFF
--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -1050,8 +1050,10 @@ def test_csr_polynomial_expansion_index_overflow(
     `scipy.sparse.hstack`.
     """
     data = [1.0]
-    row = [0]
-    col = [n_features - 1]
+    # Use int32 indices as much as we can
+    indices_dtype = np.int32 if n_features - 1 <= np.iinfo(np.int32).max else np.int64
+    row = np.array([0], dtype=indices_dtype)
+    col = np.array([n_features - 1], dtype=indices_dtype)
 
     # First degree index
     expected_indices = [

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -1123,13 +1123,14 @@ def test_csr_polynomial_expansion_index_overflow(
         return
     X_trans = pf.fit_transform(X)
 
-    expected_dtype = np.int64 if num_combinations > np.iinfo(np.int32).max else np.int32
+    expected_dtype_min_bits = 64 if num_combinations > np.iinfo(np.int32).max else 32
     # Terms higher than first degree
     non_bias_terms = 1 + (degree - 1) * int(not interaction_only)
     expected_nnz = int(include_bias) + non_bias_terms
     assert X_trans.dtype == X.dtype
     assert X_trans.shape == (1, pf.n_output_features_)
-    assert X_trans.indptr.dtype == X_trans.indices.dtype == expected_dtype
+    assert np.iinfo(X_trans.indptr.dtype).bits >= expected_dtype_min_bits
+    assert np.iinfo(X_trans.indices.dtype).bits >= expected_dtype_min_bits
     assert X_trans.nnz == expected_nnz
 
     if include_bias:

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -1125,14 +1125,13 @@ def test_csr_polynomial_expansion_index_overflow(
         return
     X_trans = pf.fit_transform(X)
 
-    expected_dtype_min_bits = 64 if num_combinations > np.iinfo(np.int32).max else 32
+    expected_dtype = np.int64 if num_combinations > np.iinfo(np.int32).max else np.int32
     # Terms higher than first degree
     non_bias_terms = 1 + (degree - 1) * int(not interaction_only)
     expected_nnz = int(include_bias) + non_bias_terms
     assert X_trans.dtype == X.dtype
     assert X_trans.shape == (1, pf.n_output_features_)
-    assert np.iinfo(X_trans.indptr.dtype).bits >= expected_dtype_min_bits
-    assert np.iinfo(X_trans.indices.dtype).bits >= expected_dtype_min_bits
+    assert X_trans.indptr.dtype == X_trans.indices.dtype == expected_dtype
     assert X_trans.nnz == expected_nnz
 
     if include_bias:


### PR DESCRIPTION
Fixes #30315, #30377 and partially #30378.

We probably want to backport this to 1.6.X.