### PR TITLE
FIX Clip negative diagonal covariance estimate to 0 in GaussianMixture

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.mixture/30401.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.mixture/30401.fix.rst
@@ -1,0 +1,4 @@
+- :class:`mixture.GaussianMixture` with `covariance_type="diag"` or
+  `covariance_type="spherical"` now clips the negative entries caused by
+  rounding errors to zero.
+  By :user:`Olivier Grisel <ogrisel>`

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -229,7 +229,11 @@ def _estimate_gaussian_covariances_diag(resp, X, nk, means, reg_covar):
     avg_X2 = np.dot(resp.T, X * X) / nk[:, np.newaxis]
     avg_means2 = means**2
     avg_X_means = means * np.dot(resp.T, X) / nk[:, np.newaxis]
-    return avg_X2 - 2 * avg_X_means + avg_means2 + reg_covar
+    # We clip negative values to 0 in the empirical estimate of the diagonal
+    # covariance values caused by numerical errors (catastrophic cancellation),
+    # before adding the regularization term.
+    # XXX: not sure this is a valid (or optimal) way to handle this.
+    return np.clip(avg_X2 - 2 * avg_X_means + avg_means2, 0, None) + reg_covar
 
 
 def _estimate_gaussian_covariances_spherical(resp, X, nk, means, reg_covar):

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -228,12 +228,11 @@ def _estimate_gaussian_covariances_diag(resp, X, nk, means, reg_covar):
     """
     avg_X2 = np.dot(resp.T, X * X) / nk[:, np.newaxis]
     avg_means2 = means**2
-    avg_X_means = means * np.dot(resp.T, X) / nk[:, np.newaxis]
     # We clip negative values to 0 in the empirical estimate of the diagonal
     # covariance values caused by numerical errors (catastrophic cancellation),
     # before adding the regularization term.
     # XXX: not sure this is a valid (or optimal) way to handle this.
-    return np.clip(avg_X2 - 2 * avg_X_means + avg_means2, 0, None) + reg_covar
+    return np.clip(avg_X2 - avg_means2, 0, None) + reg_covar
 
 
 def _estimate_gaussian_covariances_spherical(resp, X, nk, means, reg_covar):

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -1394,6 +1394,13 @@ def test_gaussian_mixture_single_component_stable():
 def test_gaussian_mixture_stability_on_unscaled_1d_data(
     covariance_type, global_random_seed
 ):
+    if covariance_type == "tied":
+        # XXX: TODO: investigate if we can improve the stability the estimation
+        # of the tied covariance in this case: depending on the random seed
+        # this can either lead to a bad estimate of the covariance or a
+        # ValueErorr caused by a LinalgError in the Cholesky decomposition.
+        pytest.xfail("The 'tied' covariance type fails to estimates the covariance.")
+
     # Non-regression test for #30382.
     reg_covar = 0.1
     rng = np.random.default_rng(global_random_seed)
@@ -1416,10 +1423,6 @@ def test_gaussian_mixture_stability_on_unscaled_1d_data(
     assert_allclose(sorted(gmm.means_.ravel()), locations.ravel(), **tols)
 
     # The estimated covariance(s) should be close to the regularization:
-    if covariance_type == "tied":
-        # XXX: TODO: investigate if we can improve the stability the estimation
-        # of the tied covariance in this case.
-        pytest.xfail("The 'tied' covariance type fails to estimates the covariance.")
     assert_allclose(gmm.covariances_, 0.1, **tols)
 
 

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -1396,9 +1396,10 @@ def test_gaussian_mixture_stability_on_unscaled_1d_data(
 ):
     if covariance_type == "tied":
         # XXX: TODO: investigate if we can improve the stability the estimation
-        # of the tied covariance in this case: depending on the random seed
-        # this can either lead to a bad estimate of the covariance or a
-        # ValueErorr caused by a LinalgError in the Cholesky decomposition.
+        # of the tied covariance in this case: depending on the BLAS/LAPACK
+        # implementation or the random seed this can either lead to a bad
+        # estimate of the covariance or a ValueErorr caused by a LinalgError in
+        # the Cholesky decomposition.
         pytest.xfail("The 'tied' covariance type fails to estimates the covariance.")
 
     # Non-regression test for #30382.


### PR DESCRIPTION
Hackish tentative fix for #30382.

I am not sure if this is the correct way to handle this but would like to discuss it (if the tests pass).