### PR TITLE
DOC Fix example comment being rendered as text

### DIFF
--- a/examples/inspection/plot_partial_dependence.py
+++ b/examples/inspection/plot_partial_dependence.py
@@ -539,6 +539,7 @@ _ = display.figure_.suptitle(
 #
 # Let's make the same partial dependence plot for the 2 features interaction,
 # this time in 3 dimensions.
+
 # unused but required import for doing 3d projections with matplotlib < 3.2
 import mpl_toolkits.mplot3d  # noqa: F401
 import numpy as np


### PR DESCRIPTION
Without the vertical line, the comment is rendered as text with the previous text block, see [dev doc](https://scikit-learn.org/dev/auto_examples/inspection/plot_partial_dependence.html#d-representation)

![image](https://github.com/user-attachments/assets/b250ebbd-6a61-4d06-9a29-b24848329fc9)
