### PR TITLE
DOC Add link to random tree embedding example in docs

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -2641,6 +2641,9 @@ class RandomTreesEmbedding(TransformerMixin, BaseForest):
     ``n_out <= n_estimators * max_leaf_nodes``. If ``max_leaf_nodes == None``,
     the number of leaf nodes is at most ``n_estimators * 2 ** max_depth``.
 
+    For a usage example of random trees embedding, see
+    :ref:`sphx_glr_auto_examples_ensemble_plot_random_forest_embedding.py`.
+
     Read more in the :ref:`User Guide <random_trees_embedding>`.
 
     Parameters

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -2641,7 +2641,8 @@ class RandomTreesEmbedding(TransformerMixin, BaseForest):
     ``n_out <= n_estimators * max_leaf_nodes``. If ``max_leaf_nodes == None``,
     the number of leaf nodes is at most ``n_estimators * 2 ** max_depth``.
 
-    For a usage example of random trees embedding, see
+    For an example of applying Random Trees Embedding to non-linear
+    classification, see
     :ref:`sphx_glr_auto_examples_ensemble_plot_random_forest_embedding.py`.
 
     Read more in the :ref:`User Guide <random_trees_embedding>`.


### PR DESCRIPTION
**Reference Issues/PRs**
[#26927](https://github.com/scikit-learn/scikit-learn/issues/26927)

**What does this implement/fix? Explain your changes.**
Added [random forest embedding example](https://scikit-learn.org/1.6/auto_examples/ensemble/plot_random_forest_embedding.html) reference to the docstring of  [RandomTreesEmbedding class in _forest.py](https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/ensemble/_forest.py#L2630).