### PR TITLE
Added info and links to mixture examples for the GaussianMixture and BayesianGaussianMixture classes

### DIFF
--- a/sklearn/mixture/_bayesian_mixture.py
+++ b/sklearn/mixture/_bayesian_mixture.py
@@ -89,6 +89,9 @@ class BayesianGaussianMixture(BaseMixture):
 
     Read more in the :ref:`User Guide <bgmm>`.
 
+    For examples on how to implement the class model, please refer to:
+    :ref:`sphx_glr_auto_examples_mixture_plot_concentration_prior.py`
+
     Parameters
     ----------
     n_components : int, default=1

--- a/sklearn/mixture/_bayesian_mixture.py
+++ b/sklearn/mixture/_bayesian_mixture.py
@@ -89,7 +89,8 @@ class BayesianGaussianMixture(BaseMixture):
 
     Read more in the :ref:`User Guide <bgmm>`.
 
-    For examples on how to implement the class model, please refer to:
+    For a detailed example of how the weight_concentration_prior_type parameter 
+    influences the model's behaviour, please refer to:
     :ref:`sphx_glr_auto_examples_mixture_plot_concentration_prior.py`
 
     Parameters

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -517,6 +517,9 @@ class GaussianMixture(BaseMixture):
     For examples on different methods of initialization, refer to:
     :ref:`sphx_glr_auto_examples_mixture_plot_gmm_init.py`
 
+    For examples on model selection with Gassian Mixture, refer to:
+    :ref:`sphx_glr_auto_examples_mixture_plot_gmm_selection.py`
+
     .. versionadded:: 0.18
 
     Parameters

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -514,6 +514,9 @@ class GaussianMixture(BaseMixture):
 
     Read more in the :ref:`User Guide <gmm>`.
 
+    For examples on different methods of initialization, refer to:
+    :ref:`sphx_glr_auto_examples_mixture_plot_gmm_init.py`
+
     .. versionadded:: 0.18
 
     Parameters

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -514,13 +514,16 @@ class GaussianMixture(BaseMixture):
 
     Read more in the :ref:`User Guide <gmm>`.
 
-    For examples on different methods of initialization, refer to:
+    For a detailed example of how the init_params parameter impacts 
+    the model's convergence behaviour, refer to:
     :ref:`sphx_glr_auto_examples_mixture_plot_gmm_init.py`
 
-    For examples on model selection with Gassian Mixture, refer to:
+    For a detailed example of how the n_components and covariance_type
+    parameters influence the model's performance, refer to:
     :ref:`sphx_glr_auto_examples_mixture_plot_gmm_selection.py`
 
-    For example covariances types for Gaussian mixture models, see:
+    For a detailed example of how the covariance_type parameter 
+    impacts the model's performance, refer to:
     :ref:`sphx_glr_auto_examples_mixture_plot_gmm_covariances.py`
 
     .. versionadded:: 0.18

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -520,6 +520,9 @@ class GaussianMixture(BaseMixture):
     For examples on model selection with Gassian Mixture, refer to:
     :ref:`sphx_glr_auto_examples_mixture_plot_gmm_selection.py`
 
+    For example covariances types for Gaussian mixture models, see:
+    :ref:`sphx_glr_auto_examples_mixture_plot_gmm_covariances.py`
+
     .. versionadded:: 0.18
 
     Parameters


### PR DESCRIPTION
#### Reference Issues/PRs
This PR contributes towards issue #26927: Add links to examples from the docstrings and user guides. [https://github.com/scikit-learn/scikit-learn/issues/26927](url)

#### What does this implement/fix? Explain your changes.
This PR adds information and example links to the class GaussianMixture in sklearn/mixture/_gaussian_mixture.py from:
- examples/mixture/plot_gmm_init.py
- examples/mixture/plot_gmm_selection.py
- examples/mixture/plot_gmm_covariances.py

This PR also adds information and example links to the class BayesianGaussianMixture in sklearn/mixture/_bayesian_mixture.py from examples/mixture/plot_concentration_prior.py.

#### Any other comments?
Files modified: 
- sklearn/mixture/_gaussian_mixture.py
- sklearn/mixture/_bayesian_mixture.py