### PR TITLE
DOC add caching example link to Pipeline class

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -182,7 +182,9 @@ class Pipeline(_BaseComposition):
         before fitting. Therefore, the transformer instance given to the
         pipeline cannot be inspected directly. Use the attribute ``named_steps``
         or ``steps`` to inspect estimators within the pipeline. Caching the
-        transformers is advantageous when fitting is time consuming.
+        transformers is advantageous when fitting is time consuming. See
+        :ref:`sphx_glr_auto_examples_neighbors_plot_caching_nearest_neighbors.py`
+        for an example on how to enable caching.
 
     verbose : bool, default=False
         If True, the time elapsed while fitting each step will be printed as it


### PR DESCRIPTION
**Reference Issues/PRs**

This PR contributes towards issue [#26927 ]( https://github.com/scikit-learn/scikit-learn/issues/26927).

**What does this implement/fix? Explain your changes.**

This PR adds an example link in the `Pipeline` class  in `sklearn/pipeline.py` to `examples/neighbors/plot_caching_nearest_neighbors.py` to make it more discoverable.

**Any other comments?**

Files modified:
- sklearn/pipeline.py

@adrinjalali 
