### PR TITLE
FIX Fix device detection when array API dispatch is disabled

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/30454.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/30454.fix.rst
@@ -1,0 +1,3 @@
+- Fix regression when scikit-learn metric called on PyTorch CPU tensors would
+  raise an error (with array API dispatch disabled which is the default).
+  By :user:`Loïc Estève <lesteve>`

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1817,6 +1817,38 @@ def check_array_api_metric(
     if isinstance(multioutput, np.ndarray):
         metric_kwargs["multioutput"] = xp.asarray(multioutput, device=device)
 
+    # When array API dispatch is disabled, and np.asarray works (for example PyTorch
+    # with CPU device), calling metric with array API inputs should work
+    try:
+        np.asarray(a_xp)
+        np.asarray(b_xp)
+        numpy_as_array_works = True
+    except TypeError:
+        # PyTorch with CUDA device and CuPy raise TypeError consistently.
+        # Exception type may need to be updated in the future for other
+        # libraries.
+        numpy_as_array_works = False
+
+    if numpy_as_array_works:
+        metric_xp = metric(a_xp, b_xp, **metric_kwargs)
+        assert_allclose(
+            metric_xp,
+            metric_np,
+            atol=_atol_for_type(dtype_name),
+        )
+        metric_xp_mixed_1 = metric(a_np, b_xp, **metric_kwargs)
+        assert_allclose(
+            metric_xp_mixed_1,
+            metric_np,
+            atol=_atol_for_type(dtype_name),
+        )
+        metric_xp_mixed_2 = metric(a_xp, b_np, **metric_kwargs)
+        assert_allclose(
+            metric_xp_mixed_2,
+            metric_np,
+            atol=_atol_for_type(dtype_name),
+        )
+
     with config_context(array_api_dispatch=True):
         metric_xp = metric(a_xp, b_xp, **metric_kwargs)
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1818,7 +1818,9 @@ def check_array_api_metric(
         metric_kwargs["multioutput"] = xp.asarray(multioutput, device=device)
 
     # When array API dispatch is disabled, and np.asarray works (for example PyTorch
-    # with CPU device), calling metric with array API inputs should work
+    # with CPU device), calling the metric function with such numpy compatible inputs
+    # should work (albeit by implicitly converting to numpy arrays instead of
+    # dispatching to the array library).
     try:
         np.asarray(a_xp)
         np.asarray(b_xp)

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -134,7 +134,10 @@ def _single_array_device(array):
         isinstance(array, (numpy.ndarray, numpy.generic))
         or not hasattr(array, "device")
         # When array API dispatch is disabled, we expect the scikit-learn code
-        # to do np.asarray so that the resulting array will be on the CPU.
+        # to do np.asarray so that the resulting NumPy array will implicitly use the
+        # CPU. In this case, scikit-learn should stay as device neutral as possible,
+        # hence the use of `device=None` which is accepted by all libraries before
+        # and after the expected conversion to NumPy via np.asarray.
         or not get_config()["array_api_dispatch"]
     ):
         return None

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -130,8 +130,12 @@ def _check_array_api_dispatch(array_api_dispatch):
 
 def _single_array_device(array):
     """Hardware device where the array data resides on."""
-    if isinstance(array, (numpy.ndarray, numpy.generic)) or not hasattr(
-        array, "device"
+    if (
+        isinstance(array, (numpy.ndarray, numpy.generic))
+        or not hasattr(array, "device")
+        # When array API dispatch is disabled, we expect the scikit-learn code
+        # to do np.asarray so that the resulting array will be on the CPU.
+        or not get_config()["array_api_dispatch"]
     ):
         return "cpu"
     else:

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -137,7 +137,7 @@ def _single_array_device(array):
         # to do np.asarray so that the resulting array will be on the CPU.
         or not get_config()["array_api_dispatch"]
     ):
-        return "cpu"
+        return None
     else:
         return array.device
 

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -134,9 +134,9 @@ def _single_array_device(array):
         isinstance(array, (numpy.ndarray, numpy.generic))
         or not hasattr(array, "device")
         # When array API dispatch is disabled, we expect the scikit-learn code
-        # to do np.asarray so that the resulting NumPy array will implicitly use the
+        # to use np.asarray so that the resulting NumPy array will implicitly use the
         # CPU. In this case, scikit-learn should stay as device neutral as possible,
-        # hence the use of `device=None` which is accepted by all libraries before
+        # hence the use of `device=None` which is accepted by all libraries, before
         # and after the expected conversion to NumPy via np.asarray.
         or not get_config()["array_api_dispatch"]
     ):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1118,9 +1118,11 @@ def check_array_api_input(
         np.asarray(y_xp)
         # TODO There are a few errors in SearchCV with array-api-strict because
         # we end up doing X[train_indices] where X is a array-api-strict array
-        # and indices a numpy array. Probably not worth investigating for now,
-        # since using array-api-strict with array API disabled does not seem a
-        # very relevant.
+        # and train_indices is a numpy array. array-api-strict insists
+        # train_indices should be an array-api-strict array. On the other hand,
+        # all the array API library (PyTorch, jax, CuPy) accept to index with a
+        # numpy array. This is probably not worth doing anything about it for
+        # now since array-api-strict seems a bit too strict ...
         numpy_asarray_works = xp.__name__ != "array_api_strict"
 
     except TypeError:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1116,10 +1116,11 @@ def check_array_api_input(
     try:
         np.asarray(X_xp)
         np.asarray(y_xp)
-        # TODO For some reason there are a few errors with array-api-strict.
-        # Probably not worth investigating for now, since using
-        # array-api-strict with array API disabled does not seem a very
-        # relevant use case.
+        # TODO There are a few errors in SearchCV with array-api-strict because
+        # we end up doing X[train_indices] where X is a array-api-strict array
+        # and indices a numpy array. Probably not worth investigating for now,
+        # since using array-api-strict with array API disabled does not seem a
+        # very relevant.
         numpy_asarray_works = xp.__name__ != "array_api_strict"
 
     except TypeError:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1117,11 +1117,11 @@ def check_array_api_input(
         np.asarray(X_xp)
         np.asarray(y_xp)
         # TODO There are a few errors in SearchCV with array-api-strict because
-        # we end up doing X[train_indices] where X is a array-api-strict array
+        # we end up doing X[train_indices] where X is an array-api-strict array
         # and train_indices is a numpy array. array-api-strict insists
         # train_indices should be an array-api-strict array. On the other hand,
-        # all the array API library (PyTorch, jax, CuPy) accept to index with a
-        # numpy array. This is probably not worth doing anything about it for
+        # all the array API libraries (PyTorch, jax, CuPy) accept indexing with a
+        # numpy array. This is probably not worth doing anything about for
         # now since array-api-strict seems a bit too strict ...
         numpy_asarray_works = xp.__name__ != "array_api_strict"
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1130,11 +1130,11 @@ def check_array_api_input(
         numpy_asarray_works = False
 
     if numpy_asarray_works:
-        # In this case, array_api_dispatch is disabled and we rely on the
-        # np.asarray being called on the array inputs
+        # In this case, array_api_dispatch is disabled and we rely on np.asarray 
+        # being called to convert the non-NumPy inputs to NumPy arrays when needed.
         est_fitted_with_as_array = clone(est).fit(X_xp, y_xp)
         # We only do a smoke test for now, in order to avoid complicating the
-        # test function even further
+        # test function even further.
         for method_name in methods:
             method = getattr(est_fitted_with_as_array, method_name, None)
             if method is None:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1130,7 +1130,7 @@ def check_array_api_input(
         numpy_asarray_works = False
 
     if numpy_asarray_works:
-        # In this case, array_api_dispatch is disabled and we rely on np.asarray 
+        # In this case, array_api_dispatch is disabled and we rely on np.asarray
         # being called to convert the non-NumPy inputs to NumPy arrays when needed.
         est_fitted_with_as_array = clone(est).fit(X_xp, y_xp)
         # We only do a smoke test for now, in order to avoid complicating the

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -274,7 +274,7 @@ def test_device_inspection():
     with pytest.raises(TypeError):
         hash(Array("device").device)
 
-    # If array API dispatch is disabled the device is always "cpu". Erroring
+    # If array API dispatch is disabled the device should be ignored. Erroring
     # early for different devices would prevent the np.asarray conversion to
     # happen. For example, `r2_score(np.ones(5), torch.ones(5))` should work
     # fine with array API disabled.

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -277,7 +277,7 @@ def test_device_inspection():
     # early for different devices would prevent the np.asarray conversion to
     # happen. For example, `r2_score(np.ones(5), torch.ones(5))` should work
     # fine with array API disabled.
-    assert device(Array("cpu"), Array("mygpu")) == "cpu"
+    assert device(Array("cpu"), Array("mygpu")) is None
 
     # Test raise if on different devices and array API dispatch is enabled
     err_msg = "Input arrays use different devices: cpu, mygpu"
@@ -285,13 +285,13 @@ def test_device_inspection():
         with pytest.raises(ValueError, match=err_msg):
             device(Array("cpu"), Array("mygpu"))
 
-    # Test expected value is returned otherwise
-    array1 = Array("device")
-    array2 = Array("device")
+        # Test expected value is returned otherwise
+        array1 = Array("device")
+        array2 = Array("device")
 
-    assert array1.device == device(array1)
-    assert array1.device == device(array1, array2)
-    assert array1.device == device(array1, array1, array2)
+        assert array1.device == device(array1)
+        assert array1.device == device(array1, array2)
+        assert array1.device == device(array1, array1, array2)
 
 
 # TODO: add cupy to the list of libraries once the the following upstream issue
@@ -560,7 +560,7 @@ def test_get_namespace_and_device():
     namespace, is_array_api, device = get_namespace_and_device(some_torch_tensor)
     assert namespace is get_namespace(some_numpy_array)[0]
     assert not is_array_api
-    assert device == "cpu"
+    assert device is None
 
     # Otherwise, expose the torch namespace and device via array API compat
     # wrapper.
@@ -628,8 +628,8 @@ def test_sparse_device(csr_container, dispatch):
     try:
         with config_context(array_api_dispatch=dispatch):
             assert device(a, b) is None
-            assert device(a, numpy.array([1])) == "cpu"
+            assert device(a, numpy.array([1])) is None
             assert get_namespace_and_device(a, b)[2] is None
-            assert get_namespace_and_device(a, numpy.array([1]))[2] == "cpu"
+            assert get_namespace_and_device(a, numpy.array([1]))[2] is None
     except ImportError:
         raise SkipTest("array_api_compat is not installed")

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -248,6 +248,7 @@ def test_device_none_if_no_input():
     assert device(None, "name") is None
 
 
+@skip_if_array_api_compat_not_configured
 def test_device_inspection():
     class Device:
         def __init__(self, name):

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -280,7 +280,8 @@ def test_device_inspection():
     # fine with array API disabled.
     assert device(Array("cpu"), Array("mygpu")) is None
 
-    # Test raise if on different devices and array API dispatch is enabled
+    # Test that ValueError is raised if on different devices and array API dispatch is
+    # enabled.
     err_msg = "Input arrays use different devices: cpu, mygpu"
     with config_context(array_api_dispatch=True):
         with pytest.raises(ValueError, match=err_msg):


### PR DESCRIPTION
Fix #29107, in particular https://github.com/scikit-learn/scikit-learn/issues/29107#issuecomment-2530676583 which is a regression in 1.6.

Main change: with `array_api_dispatch=False`, the device is always `None` (I tried `"cpu"` originally but this doesn't work with array-api-strict). In this case `np.asarray` will be called and the resulting array will always be CPU. We don't want to check devices too early and prevent the `np.asarray` conversion to happen (there may be an error like np.asarray with a PyTorch array on a CUDA device).

Tests added:
- calling metric with array API inputs and array API disabled, this is pretty much the new regression in 1.6 https://github.com/scikit-learn/scikit-learn/issues/29107#issuecomment-2530676583
- smoke-test in `estimator_checks` that makes sure that when array API is disabled you can fit and call other methods on numpy-convertible arrays (for example PyTorch array on CPU)