### PR TITLE
CI Replace deprecated circle CI "deploy" key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
       - attach_workspace:
           at: doc/_build/html
       - run: ls -ltrh doc/_build/html/stable
-      - deploy:
+      - run:
           command: |
             if [[ "${CIRCLE_BRANCH}" =~ ^main$|^[0-9]+\.[0-9]+\.X$ ]]; then
               bash build_tools/circle/push_doc.sh doc/_build/html/stable


### PR DESCRIPTION
Following these instructions https://circleci.com/docs/migrate-from-deploy-to-run/