### PR TITLE
MAINT Remove unnecessary check in tree.pyx

### DIFF
--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -107,19 +107,7 @@ cdef class TreeBuilder:
             # since we have to copy we will make it fortran for efficiency
             X = np.asfortranarray(X, dtype=DTYPE)
 
-        # TODO: This check for y seems to be redundant, as it is also
-        #  present in the BaseDecisionTree's fit method, and therefore
-        #  can be removed.
-        if y.base.dtype != DOUBLE or not y.base.flags.contiguous:
-            y = np.ascontiguousarray(y, dtype=DOUBLE)
-
-        if (
-            sample_weight is not None and
-            (
-                sample_weight.base.dtype != DOUBLE or
-                not sample_weight.base.flags.contiguous
-            )
-        ):
+        if sample_weight is not None and not sample_weight.base.flags.contiguous:
             sample_weight = np.asarray(sample_weight, dtype=DOUBLE, order="C")
 
         return X, y, sample_weight


### PR DESCRIPTION
The signature of the function contains
```
const float64_t[:, ::1] y,
const float64_t[:] sample_weight,
```
so if the provided y is not C-contiguous or float64, we get an error right away at run time like
```
ValueError: ndarray is not C-contiguous
```
or
```
ValueError: Buffer dtype mismatch, expected 'const float64_t' but got 'float'
```
So this is unreachable code and can be removed safely.