### PR TITLE
FIX Restore support for n_samples == n_features in MinCovDet.

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.covariance/30483.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.covariance/30483.fix.rst
@@ -1,0 +1,2 @@
+- Support for ``n_samples == n_features`` in `sklearn.covariance.MinCovDet` has
+  been restored.  By :user:`Antony Lee <anntzer>`.

--- a/sklearn/covariance/_robust_covariance.py
+++ b/sklearn/covariance/_robust_covariance.py
@@ -433,7 +433,7 @@ def fast_mcd(
 
     # minimum breakdown value
     if support_fraction is None:
-        n_support = int(np.ceil(0.5 * (n_samples + n_features + 1)))
+        n_support = min(int(np.ceil(0.5 * (n_samples + n_features + 1))), n_samples)
     else:
         n_support = int(support_fraction * n_samples)
 

--- a/sklearn/covariance/tests/test_robust_covariance.py
+++ b/sklearn/covariance/tests/test_robust_covariance.py
@@ -34,6 +34,9 @@ def test_mcd(global_random_seed):
     # 1D data set
     launch_mcd_on_dataset(500, 1, 100, 0.02, 0.02, 350, global_random_seed)
 
+    # n_samples == n_features
+    launch_mcd_on_dataset(20, 20, 0, 0.1, 0.1, 15, global_random_seed)
+
 
 def test_fast_mcd_on_invalid_input():
     X = np.arange(100)


### PR DESCRIPTION
Fixes #30625

https://github.com/scikit-learn/scikit-learn/pull/29835 broke support for the (degenerate) `n_samples == n_features` (and support_fraction unset) case in MinCovDet because this led to `n_support = n_samples + 1`, which was implicitly clipped to `n_support = n_samples` previously (at `np.argsort(dist)[:n_support]`) but not anymore now (and crashes `np.argpartition(dist, n_support - 1)`.

To fix this, explicitly clip `n_support`.

Noticed at https://github.com/pyRiemann/pyRiemann/pull/335.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
