### PR TITLE
MNT clean up python 2 super()

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1708,7 +1708,7 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         verbose=0,
         random_state=None,
     ):
-        super(HistGradientBoostingRegressor, self).__init__(
+        super().__init__(
             loss=loss,
             learning_rate=learning_rate,
             max_iter=max_iter,
@@ -2091,7 +2091,7 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
         random_state=None,
         class_weight=None,
     ):
-        super(HistGradientBoostingClassifier, self).__init__(
+        super().__init__(
             loss=loss,
             learning_rate=learning_rate,
             max_iter=max_iter,

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -134,9 +134,7 @@ class Hyperparameter(
 
         if fixed is None:
             fixed = isinstance(bounds, str) and bounds == "fixed"
-        return super(Hyperparameter, cls).__new__(
-            cls, name, value_type, bounds, n_elements, fixed
-        )
+        return super().__new__(cls, name, value_type, bounds, n_elements, fixed)
 
     # This is mainly a testing utility to check that two hyperparameters
     # are equal.

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -2235,7 +2235,7 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
         average=False,
     ):
         self.nu = nu
-        super(SGDOneClassSVM, self).__init__(
+        super().__init__(
             loss="hinge",
             penalty="l2",
             C=1.0,

--- a/sklearn/neighbors/_graph.py
+++ b/sklearn/neighbors/_graph.py
@@ -398,7 +398,7 @@ class KNeighborsTransformer(
         metric_params=None,
         n_jobs=None,
     ):
-        super(KNeighborsTransformer, self).__init__(
+        super().__init__(
             n_neighbors=n_neighbors,
             radius=None,
             algorithm=algorithm,
@@ -623,7 +623,7 @@ class RadiusNeighborsTransformer(
         metric_params=None,
         n_jobs=None,
     ):
-        super(RadiusNeighborsTransformer, self).__init__(
+        super().__init__(
             n_neighbors=None,
             radius=radius,
             algorithm=algorithm,


### PR DESCRIPTION
This PR updates Python 2 to Python 3 syntax in regards to using `super().__init__()`.

In all the classes modified in this PR, we use the MRO of the current class to resolve which class's method to call next, so in Python 3,  it doesn't make a difference if we specify the class in the `super()` call or if we don't. 

This way, we avoid suggesting to other developers that we're using the MRO of a different class than the one we're in, which reduces mental load when reading code.