### PR TITLE
DOC Update rst doctests to be compatible with numpy >= 2

### DIFF
--- a/doc/conftest.py
+++ b/doc/conftest.py
@@ -170,10 +170,10 @@ def pytest_collection_modifyitems(config, items):
     items : list of collected items
     """
     skip_doctests = False
-    if np_base_version >= parse_version("2"):
-        # Skip doctests when using numpy 2 for now. See the following discussion
-        # to decide what to do in the longer term:
-        # https://github.com/scikit-learn/scikit-learn/issues/27339
+    if np_base_version < parse_version("2"):
+        # TODO: configure numpy to output scalar arrays as regular Python scalars
+        # once possible to improve readability of the tests docstrings.
+        # https://numpy.org/neps/nep-0051-scalar-representation.html#implementation
         reason = "Due to NEP 51 numpy scalar repr has changed in numpy 2"
         skip_doctests = True
 

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -266,7 +266,8 @@ interactions with `pytest`)::
 
   >>> from sklearn.utils.estimator_checks import check_estimator
   >>> from sklearn.tree import DecisionTreeClassifier
-  >>> check_estimator(DecisionTreeClassifier())  # passes            # doctest: +SKIP
+  >>> check_estimator(DecisionTreeClassifier())  # passes
+  [{'estimator': DecisionTreeClassifier(), ...]
 
 The main motivation to make a class compatible to the scikit-learn estimator
 interface might be that you want to use it together with model evaluation and

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -267,7 +267,7 @@ interactions with `pytest`)::
   >>> from sklearn.utils.estimator_checks import check_estimator
   >>> from sklearn.tree import DecisionTreeClassifier
   >>> check_estimator(DecisionTreeClassifier())  # passes
-  [{'estimator': DecisionTreeClassifier(), ...]
+  ...
 
 The main motivation to make a class compatible to the scikit-learn estimator
 interface might be that you want to use it together with model evaluation and

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -266,7 +266,7 @@ interactions with `pytest`)::
 
   >>> from sklearn.utils.estimator_checks import check_estimator
   >>> from sklearn.tree import DecisionTreeClassifier
-  >>> check_estimator(DecisionTreeClassifier())  # passes
+  >>> check_estimator(DecisionTreeClassifier())  # passes            # doctest: +SKIP
 
 The main motivation to make a class compatible to the scikit-learn estimator
 interface might be that you want to use it together with model evaluation and
@@ -346,7 +346,8 @@ the correct interface more easily.
 And you can check that the above estimator passes all common checks::
 
     >>> from sklearn.utils.estimator_checks import check_estimator
-    >>> check_estimator(TemplateClassifier())  # passes
+    >>> check_estimator(TemplateClassifier())  # passes            # doctest: +SKIP
+
 
 get_params and set_params
 -------------------------

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -267,7 +267,7 @@ interactions with `pytest`)::
   >>> from sklearn.utils.estimator_checks import check_estimator
   >>> from sklearn.tree import DecisionTreeClassifier
   >>> check_estimator(DecisionTreeClassifier())  # passes
-  ...
+  [...]
 
 The main motivation to make a class compatible to the scikit-learn estimator
 interface might be that you want to use it together with model evaluation and

--- a/doc/modules/classification_threshold.rst
+++ b/doc/modules/classification_threshold.rst
@@ -115,7 +115,7 @@ a meaningful metric for their use case.
         0.88...
         >>> # compare it with the internal score found by cross-validation
         >>> model.best_score_
-        0.86...
+        np.float64(0.86...)
 
 Important notes regarding the internal cross-validation
 -------------------------------------------------------

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -1305,7 +1305,7 @@ ignoring permutations::
   >>> labels_true = [0, 0, 0, 1, 1, 1]
   >>> labels_pred = [0, 0, 1, 1, 2, 2]
   >>> metrics.rand_score(labels_true, labels_pred)
-  0.66...
+  np.float64(0.66...)
 
 The Rand index does not ensure to obtain a value close to 0.0 for a
 random labelling. The adjusted Rand index **corrects for chance** and
@@ -1319,7 +1319,7 @@ labels, rename 2 to 3, and get the same score::
 
   >>> labels_pred = [1, 1, 0, 0, 3, 3]
   >>> metrics.rand_score(labels_true, labels_pred)
-  0.66...
+  np.float64(0.66...)
   >>> metrics.adjusted_rand_score(labels_true, labels_pred)
   0.24...
 
@@ -1328,7 +1328,7 @@ Furthermore, both :func:`rand_score` :func:`adjusted_rand_score` are
 thus be used as **consensus measures**::
 
   >>> metrics.rand_score(labels_pred, labels_true)
-  0.66...
+  np.float64(0.66...)
   >>> metrics.adjusted_rand_score(labels_pred, labels_true)
   0.24...
 
@@ -1348,7 +1348,7 @@ will not necessarily be close to zero.::
   >>> labels_true = [0, 0, 0, 0, 0, 0, 1, 1]
   >>> labels_pred = [0, 1, 2, 3, 4, 5, 5, 6]
   >>> metrics.rand_score(labels_true, labels_pred)
-  0.39...
+  np.float64(0.39...)
   >>> metrics.adjusted_rand_score(labels_true, labels_pred)
   -0.07...
 
@@ -1644,16 +1644,16 @@ We can turn those concept as scores :func:`homogeneity_score` and
   >>> labels_pred = [0, 0, 1, 1, 2, 2]
 
   >>> metrics.homogeneity_score(labels_true, labels_pred)
-  0.66...
+  np.float64(0.66...)
 
   >>> metrics.completeness_score(labels_true, labels_pred)
-  0.42...
+  np.float64(0.42...)
 
 Their harmonic mean called **V-measure** is computed by
 :func:`v_measure_score`::
 
   >>> metrics.v_measure_score(labels_true, labels_pred)
-  0.51...
+  np.float64(0.51...)
 
 This function's formula is as follows:
 
@@ -1662,12 +1662,12 @@ This function's formula is as follows:
 `beta` defaults to a value of 1.0, but for using a value less than 1 for beta::
 
   >>> metrics.v_measure_score(labels_true, labels_pred, beta=0.6)
-  0.54...
+  np.float64(0.54...)
 
 more weight will be attributed to homogeneity, and using a value greater than 1::
 
   >>> metrics.v_measure_score(labels_true, labels_pred, beta=1.8)
-  0.48...
+  np.float64(0.48...)
 
 more weight will be attributed to completeness.
 
@@ -1678,14 +1678,14 @@ Homogeneity, completeness and V-measure can be computed at once using
 :func:`homogeneity_completeness_v_measure` as follows::
 
   >>> metrics.homogeneity_completeness_v_measure(labels_true, labels_pred)
-  (0.66..., 0.42..., 0.51...)
+  (np.float64(0.66...), np.float64(0.42...), np.float64(0.51...))
 
 The following clustering assignment is slightly better, since it is
 homogeneous but not complete::
 
   >>> labels_pred = [0, 0, 0, 1, 2, 2]
   >>> metrics.homogeneity_completeness_v_measure(labels_true, labels_pred)
-  (1.0, 0.68..., 0.81...)
+  (np.float64(1.0), np.float64(0.68...), np.float64(0.81...))
 
 .. note::
 
@@ -1815,7 +1815,7 @@ between two clusters.
   >>> labels_pred = [0, 0, 1, 1, 2, 2]
 
   >>> metrics.fowlkes_mallows_score(labels_true, labels_pred)
-  0.47140...
+  np.float64(0.47140...)
 
 One can permute 0 and 1 in the predicted labels, rename 2 to 3 and get
 the same score::
@@ -1823,13 +1823,13 @@ the same score::
   >>> labels_pred = [1, 1, 0, 0, 3, 3]
 
   >>> metrics.fowlkes_mallows_score(labels_true, labels_pred)
-  0.47140...
+  np.float64(0.47140...)
 
 Perfect labeling is scored 1.0::
 
   >>> labels_pred = labels_true[:]
   >>> metrics.fowlkes_mallows_score(labels_true, labels_pred)
-  1.0
+  np.float64(1.0)
 
 Bad (e.g. independent labelings) have zero scores::
 
@@ -1912,7 +1912,7 @@ cluster analysis.
   >>> kmeans_model = KMeans(n_clusters=3, random_state=1).fit(X)
   >>> labels = kmeans_model.labels_
   >>> metrics.silhouette_score(X, labels, metric='euclidean')
-  0.55...
+  np.float64(0.55...)
 
 .. topic:: Advantages:
 
@@ -1969,7 +1969,7 @@ cluster analysis:
   >>> kmeans_model = KMeans(n_clusters=3, random_state=1).fit(X)
   >>> labels = kmeans_model.labels_
   >>> metrics.calinski_harabasz_score(X, labels)
-  561.59...
+  np.float64(561.59...)
 
 
 .. topic:: Advantages:
@@ -2043,7 +2043,7 @@ cluster analysis as follows:
   >>> kmeans = KMeans(n_clusters=3, random_state=1).fit(X)
   >>> labels = kmeans.labels_
   >>> davies_bouldin_score(X, labels)
-  0.666...
+  np.float64(0.666...)
 
 
 .. topic:: Advantages:

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -241,7 +241,7 @@ The following toy example demonstrates that samples with a sample weight of zero
     >>> gb.predict([[1, 0]])
     array([1])
     >>> gb.predict_proba([[1, 0]])[0, 1]
-    0.99...
+    np.float64(0.999...)
 
 As you can see, the `[1, 0]` is comfortably classified as `1` since the first
 two samples are ignored due to their sample weights.
@@ -1035,19 +1035,19 @@ in bias::
     ...     random_state=0)
     >>> scores = cross_val_score(clf, X, y, cv=5)
     >>> scores.mean()
-    0.98...
+    np.float64(0.98...)
 
     >>> clf = RandomForestClassifier(n_estimators=10, max_depth=None,
     ...     min_samples_split=2, random_state=0)
     >>> scores = cross_val_score(clf, X, y, cv=5)
     >>> scores.mean()
-    0.999...
+    np.float64(0.999...)
 
     >>> clf = ExtraTreesClassifier(n_estimators=10, max_depth=None,
     ...     min_samples_split=2, random_state=0)
     >>> scores = cross_val_score(clf, X, y, cv=5)
     >>> scores.mean() > 0.999
-    True
+    np.True_
 
 .. figure:: ../auto_examples/ensemble/images/sphx_glr_plot_forest_iris_001.png
     :target: ../auto_examples/ensemble/plot_forest_iris.html
@@ -1701,7 +1701,7 @@ learners::
     >>> clf = AdaBoostClassifier(n_estimators=100)
     >>> scores = cross_val_score(clf, X, y, cv=5)
     >>> scores.mean()
-    0.9...
+    np.float64(0.9...)
 
 The number of weak learners is controlled by the parameter ``n_estimators``. The
 ``learning_rate`` parameter controls the contribution of the weak learners in

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -124,7 +124,7 @@ its ``coef_`` member::
     >>> reg.coef_
     array([0.34545455, 0.34545455])
     >>> reg.intercept_
-    0.13636...
+    np.float64(0.13636...)
 
 Note that the class :class:`Ridge` allows for the user to specify that the
 solver be automatically chosen by setting `solver="auto"`. When this option
@@ -209,7 +209,7 @@ Usage example::
     RidgeCV(alphas=array([1.e-06, 1.e-05, 1.e-04, 1.e-03, 1.e-02, 1.e-01, 1.e+00, 1.e+01,
           1.e+02, 1.e+03, 1.e+04, 1.e+05, 1.e+06]))
     >>> reg.alpha_
-    0.01
+    np.float64(0.01)
 
 Specifying the value of the :term:`cv` attribute will trigger the use of
 cross-validation with :class:`~sklearn.model_selection.GridSearchCV`, for
@@ -1278,7 +1278,7 @@ Usage example::
     >>> reg.coef_
     array([0.2463..., 0.4337...])
     >>> reg.intercept_
-    -0.7638...
+    np.float64(-0.7638...)
 
 
 .. rubric:: Examples

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -389,9 +389,9 @@ You can create your own custom scorer object using
       >>> clf = DummyClassifier(strategy='most_frequent', random_state=0)
       >>> clf = clf.fit(X, y)
       >>> my_custom_loss_func(y, clf.predict(X))
-      0.69...
+      np.float64(0.69...)
       >>> score(clf, X, y)
-      -0.69...
+      np.float64(-0.69...)
 
 .. dropdown:: Custom scorer objects from scratch
 
@@ -673,10 +673,10 @@ where :math:`k` is the number of guesses allowed and :math:`1(x)` is the
   ...                     [0.2, 0.4, 0.3],
   ...                     [0.7, 0.2, 0.1]])
   >>> top_k_accuracy_score(y_true, y_score, k=2)
-  0.75
+  np.float64(0.75)
   >>> # Not normalizing gives the number of "correctly" classified samples
   >>> top_k_accuracy_score(y_true, y_score, k=2, normalize=False)
-  3
+  np.int64(3)
 
 .. _balanced_accuracy_score:
 
@@ -786,7 +786,7 @@ and not for more than two annotators.
   >>> labeling1 = [2, 0, 2, 2, 0, 1]
   >>> labeling2 = [0, 0, 2, 2, 0, 2]
   >>> cohen_kappa_score(labeling1, labeling2)
-  0.4285714285714286
+  np.float64(0.4285714285714286)
 
 .. _confusion_matrix:
 
@@ -839,7 +839,7 @@ false negatives and true positives as follows::
   >>> y_pred = [0, 1, 0, 1, 0, 1, 0, 1]
   >>> tn, fp, fn, tp = confusion_matrix(y_true, y_pred).ravel()
   >>> tn, fp, fn, tp
-  (2, 1, 2, 3)
+  (np.int64(2), np.int64(1), np.int64(2), np.int64(3))
 
 .. rubric:: Examples
 
@@ -1115,7 +1115,7 @@ Here are some small examples in binary classification::
   >>> threshold
   array([0.1 , 0.35, 0.4 , 0.8 ])
   >>> average_precision_score(y_true, y_scores)
-  0.83...
+  np.float64(0.83...)
 
 
 
@@ -1234,19 +1234,19 @@ In the binary case::
   >>> y_pred = np.array([[1, 1, 1],
   ...                    [1, 0, 0]])
   >>> jaccard_score(y_true[0], y_pred[0])
-  0.6666...
+  np.float64(0.6666...)
 
 In the 2D comparison case (e.g. image similarity):
 
   >>> jaccard_score(y_true, y_pred, average="micro")
-  0.6
+  np.float64(0.6)
 
 In the multilabel case with binary label indicators::
 
   >>> jaccard_score(y_true, y_pred, average='samples')
-  0.5833...
+  np.float64(0.5833...)
   >>> jaccard_score(y_true, y_pred, average='macro')
-  0.6666...
+  np.float64(0.6666...)
   >>> jaccard_score(y_true, y_pred, average=None)
   array([0.5, 0.5, 1. ])
 
@@ -1258,9 +1258,9 @@ multilabel problem::
   >>> jaccard_score(y_true, y_pred, average=None)
   array([1. , 0. , 0.33...])
   >>> jaccard_score(y_true, y_pred, average='macro')
-  0.44...
+  np.float64(0.44...)
   >>> jaccard_score(y_true, y_pred, average='micro')
-  0.33...
+  np.float64(0.33...)
 
 .. _hinge_loss:
 
@@ -1315,7 +1315,7 @@ with a svm classifier in a binary class problem::
   >>> pred_decision
   array([-2.18...,  2.36...,  0.09...])
   >>> hinge_loss([-1, 1, 1], pred_decision)
-  0.3...
+  np.float64(0.3...)
 
 Here is an example demonstrating the use of the :func:`hinge_loss` function
 with a svm classifier in a multiclass problem::
@@ -1329,7 +1329,7 @@ with a svm classifier in a multiclass problem::
   >>> pred_decision = est.decision_function([[-1], [2], [3]])
   >>> y_true = [0, 2, 3]
   >>> hinge_loss(y_true, pred_decision, labels=labels)
-  0.56...
+  np.float64(0.56...)
 
 .. _log_loss:
 
@@ -1445,7 +1445,7 @@ function:
     >>> y_true = [+1, +1, +1, -1]
     >>> y_pred = [+1, -1, +1, +1]
     >>> matthews_corrcoef(y_true, y_pred)
-    -0.33...
+    np.float64(-0.33...)
 
 .. rubric:: References
 
@@ -1640,12 +1640,12 @@ We can use the probability estimates corresponding to `clf.classes_[1]`.
 
   >>> y_score = clf.predict_proba(X)[:, 1]
   >>> roc_auc_score(y, y_score)
-  0.99...
+  np.float64(0.99...)
 
 Otherwise, we can use the non-thresholded decision values
 
   >>> roc_auc_score(y, clf.decision_function(X))
-  0.99...
+  np.float64(0.99...)
 
 .. _roc_auc_multiclass:
 
@@ -1951,13 +1951,13 @@ Here is a small example of usage of this function::
     >>> y_prob = np.array([0.1, 0.9, 0.8, 0.4])
     >>> y_pred = np.array([0, 1, 1, 0])
     >>> brier_score_loss(y_true, y_prob)
-    0.055
+    np.float64(0.055)
     >>> brier_score_loss(y_true, 1 - y_prob, pos_label=0)
-    0.055
+    np.float64(0.055)
     >>> brier_score_loss(y_true_categorical, y_prob, pos_label="ham")
-    0.055
+    np.float64(0.055)
     >>> brier_score_loss(y_true, y_prob > 0.5)
-    0.0
+    np.float64(0.0)
 
 The Brier score can be used to assess how well a classifier is calibrated.
 However, a lower Brier score loss does not always mean a better calibration.
@@ -2232,7 +2232,7 @@ Here is a small example of usage of this function::
     >>> y_true = np.array([[1, 0, 0], [0, 0, 1]])
     >>> y_score = np.array([[0.75, 0.5, 1], [1, 0.2, 0.1]])
     >>> coverage_error(y_true, y_score)
-    2.5
+    np.float64(2.5)
 
 .. _label_ranking_average_precision:
 
@@ -2279,7 +2279,7 @@ Here is a small example of usage of this function::
     >>> y_true = np.array([[1, 0, 0], [0, 0, 1]])
     >>> y_score = np.array([[0.75, 0.5, 1], [1, 0.2, 0.1]])
     >>> label_ranking_average_precision_score(y_true, y_score)
-    0.416...
+    np.float64(0.416...)
 
 .. _label_ranking_loss:
 
@@ -2314,11 +2314,11 @@ Here is a small example of usage of this function::
     >>> y_true = np.array([[1, 0, 0], [0, 0, 1]])
     >>> y_score = np.array([[0.75, 0.5, 1], [1, 0.2, 0.1]])
     >>> label_ranking_loss(y_true, y_score)
-    0.75...
+    np.float64(0.75...)
     >>> # With the following prediction, we have perfect and minimal loss
     >>> y_score = np.array([[1.0, 0.1, 0.2], [0.1, 0.2, 0.9]])
     >>> label_ranking_loss(y_true, y_score)
-    0.0
+    np.float64(0.0)
 
 
 .. dropdown:: References
@@ -2696,7 +2696,7 @@ function::
   >>> y_true = [3, -0.5, 2, 7]
   >>> y_pred = [2.5, 0.0, 2, 8]
   >>> median_absolute_error(y_true, y_pred)
-  0.5
+  np.float64(0.5)
 
 
 
@@ -2728,7 +2728,7 @@ Here is a small example of usage of the :func:`max_error` function::
   >>> y_true = [3, 2, 7, 1]
   >>> y_pred = [9, 2, 7, 1]
   >>> max_error(y_true, y_pred)
-  6
+  np.int64(6)
 
 The :func:`max_error` does not support multioutput.
 
@@ -3007,15 +3007,15 @@ of 0.0.
     >>> y_true = [3, -0.5, 2, 7]
     >>> y_pred = [2.5, 0.0, 2, 8]
     >>> d2_absolute_error_score(y_true, y_pred)
-    0.764...
+    np.float64(0.764...)
     >>> y_true = [1, 2, 3]
     >>> y_pred = [1, 2, 3]
     >>> d2_absolute_error_score(y_true, y_pred)
-    1.0
+    np.float64(1.0)
     >>> y_true = [1, 2, 3]
     >>> y_pred = [2, 2, 2]
     >>> d2_absolute_error_score(y_true, y_pred)
-    0.0
+    np.float64(0.0)
 
 
 .. _visualization_regression_evaluation:

--- a/doc/modules/preprocessing_targets.rst
+++ b/doc/modules/preprocessing_targets.rst
@@ -95,8 +95,8 @@ hashable and comparable) to numerical labels::
     >>> le.fit(["paris", "paris", "tokyo", "amsterdam"])
     LabelEncoder()
     >>> list(le.classes_)
-    ['amsterdam', 'paris', 'tokyo']
+    [np.str_('amsterdam'), np.str_('paris'), np.str_('tokyo')]
     >>> le.transform(["tokyo", "tokyo", "paris"])
     array([2, 2, 1])
     >>> list(le.inverse_transform([2, 2, 1]))
-    ['tokyo', 'tokyo', 'paris']
+    [np.str_('tokyo'), np.str_('tokyo'), np.str_('paris')]

--- a/doc/modules/random_projection.rst
+++ b/doc/modules/random_projection.rst
@@ -58,7 +58,7 @@ bounded distortion introduced by the random projection::
 
   >>> from sklearn.random_projection import johnson_lindenstrauss_min_dim
   >>> johnson_lindenstrauss_min_dim(n_samples=1e6, eps=0.5)
-  663
+  np.int64(663)
   >>> johnson_lindenstrauss_min_dim(n_samples=1e6, eps=[0.5, 0.1, 0.01])
   array([    663,   11841, 1112658])
   >>> johnson_lindenstrauss_min_dim(n_samples=[1e4, 1e5, 1e6], eps=0.1)


### PR DESCRIPTION
Similar to https://github.com/scikit-learn/scikit-learn/pull/29613 but for doctests inside rst files.

Let's see what the CI has to say about it.

Edit: turns out we were not running the rst doctests in any of our CI build (because the combination numpy<2 and matplotlib and maybe other things to run doctests were not inside any CI build) ... oh well there was only one failure to fix.