### PR TITLE
DOC updated math font in SGD formulation

### DIFF
--- a/doc/modules/sgd.rst
+++ b/doc/modules/sgd.rst
@@ -402,7 +402,7 @@ We describe here the mathematical details of the SGD procedure. A good
 overview with convergence rates can be found in [#6]_.
 
 Given a set of training examples :math:`(x_1, y_1), \ldots, (x_n, y_n)` where
-:math:`x_i \in \mathbf{R}^m` and :math:`y_i \in \mathcal{R}` (:math:`y_i \in
+:math:`x_i \in \mathbf{R}^m` and :math:`y_i \in \mathbf{R}` (:math:`y_i \in
 {-1, 1}` for classification), our goal is to learn a linear scoring function
 :math:`f(x) = w^T x + b` with model parameters :math:`w \in \mathbf{R}^m` and
 intercept :math:`b \in \mathbf{R}`. In order to make predictions for binary


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Updating DOC ad hoc


#### What does this implement/fix? Explain your changes.
Updated an instance of `mathcal{R}` to `mathbf{R}`  (line 405) to maintain consistency throughout the Stochastic Gradient Descent mathematical formulation reference/documentation.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
