### PR TITLE
MNT Un-xfail SplitTransformer check_estimators_pickle common test

### DIFF
--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -1220,7 +1220,7 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
 }
 
 
-if sp_base_version < parse_version("1.13"):
+if sp_base_version < parse_version("1.11"):
     PER_ESTIMATOR_XFAIL_CHECKS[SplineTransformer] = {
         "check_estimators_pickle": (
             "Current Scipy implementation of _bsplines does not"

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -1219,9 +1219,7 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
     },
 }
 
-# TODO remove the >= 1.15 check when
-# https://github.com/scipy/scipy/issues/22143 is fixed
-if sp_base_version < parse_version("1.11") or sp_base_version >= parse_version("1.15"):
+if sp_base_version < parse_version("1.11"):
     PER_ESTIMATOR_XFAIL_CHECKS[SplineTransformer] = {
         "check_estimators_pickle": (
             "scipy < 1.11 implementation of _bsplines does not"

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -1219,6 +1219,7 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
     },
 }
 
+# TODO: remove when scipy min version >= 1.11
 if sp_base_version < parse_version("1.11"):
     PER_ESTIMATOR_XFAIL_CHECKS[SplineTransformer] = {
         "check_estimators_pickle": (

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -177,6 +177,7 @@ from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.utils import all_estimators
 from sklearn.utils._tags import get_tags
 from sklearn.utils._testing import SkipTest
+from sklearn.utils.fixes import parse_version, sp_base_version
 
 CROSS_DECOMPOSITION = ["PLSCanonical", "PLSRegression", "CCA", "PLSSVD"]
 
@@ -1188,12 +1189,6 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
         "check_dont_overwrite_parameters": "empty array passed inside",
         "check_fit2d_predict1d": "empty array passed inside",
     },
-    SplineTransformer: {
-        "check_estimators_pickle": (
-            "Current Scipy implementation of _bsplines does not"
-            "support const memory views."
-        ),
-    },
     SVC: {
         # TODO: fix sample_weight handling of this estimator when probability=False
         # TODO: replace by a statistical test when probability=True
@@ -1223,6 +1218,15 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
         ),
     },
 }
+
+
+if sp_base_version < parse_version("1.13"):
+    PER_ESTIMATOR_XFAIL_CHECKS[SplineTransformer] = {
+        "check_estimators_pickle": (
+            "Current Scipy implementation of _bsplines does not"
+            "support const memory views."
+        ),
+    }
 
 
 def _get_expected_failed_checks(estimator):

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -1219,7 +1219,8 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
     },
 }
 
-# TODO Remove the upper bound when https://github.com/scipy/scipy/issues/22143 is fixed
+# TODO remove the >= 1.15 check when
+# https://github.com/scipy/scipy/issues/22143 is fixed
 if sp_base_version < parse_version("1.11") or sp_base_version >= parse_version("1.15"):
     PER_ESTIMATOR_XFAIL_CHECKS[SplineTransformer] = {
         "check_estimators_pickle": (

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -1219,11 +1219,11 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
     },
 }
 
-
-if sp_base_version < parse_version("1.11"):
+# TODO Remove the upper bound when https://github.com/scipy/scipy/issues/22143 is fixed
+if sp_base_version < parse_version("1.11") or sp_base_version >= parse_version("1.15"):
     PER_ESTIMATOR_XFAIL_CHECKS[SplineTransformer] = {
         "check_estimators_pickle": (
-            "Current Scipy implementation of _bsplines does not"
+            "scipy < 1.11 implementation of _bsplines does not"
             "support const memory views."
         ),
     }


### PR DESCRIPTION
Seen in https://github.com/scikit-learn/scikit-learn/issues/30512#issuecomment-2557049469.

Scipy fixed it in 1.13 https://github.com/scipy/scipy/pull/18153. It is currently broken again in 1.15dev https://github.com/scipy/scipy/issues/22143. Edit: has been fixed in scipy-dev in https://github.com/scipy/scipy/pull/22158.