### PR TITLE
DBSCAN++: Run DBSCAN on 100x larger datasets, up to 100x faster in subsampling

### DIFF
--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -24,6 +24,8 @@ from ._dbscan_inner import dbscan_inner
     {
         "X": ["array-like", "sparse matrix"],
         "sample_weight": ["array-like", None],
+        "subsample": [Interval(Real, 0, 1, closed="neither"), None],
+        "random_state": ["random_state"],
     },
     prefer_skip_nested_validation=False,
 )
@@ -389,21 +391,18 @@ class DBSCAN(ClusterMixin, BaseEstimator):
             Note that weights are absolute, and default to 1.
 
         subsample : float, default=None
-            Sampling probability. By default, no sampling is done. Between 0.0
-            and 1.0 and represents the proportion of the dataset that can be
-            labeled a core sample. All data points are still used in the
-            eps-neighborhood graph. The lower the subsample, the less memory
-            and computation is used. For large datasets, subsampled DBSCAN
-            is sub-quadratic and has comparable performance to full DBSCAN.
+            Should be between [0, 1]. By default, no sampling is done.
+            Sampling probability, representing the proportion of the dataset
+            that can be labeled a core sample. The lower the subsample, the
+            less memory and computation is used.
             See: Jang, J. and Jiang, H. "DBSCAN++: Towards fast and scalable
             density clustering". Proceedings of the 36th International Conference
             on Machine Learning, 2019.
 
         random_state : int, RandomState instance or None, default=None
-            Only relevant when ``subsample`` is set; has no effect otherwise.
-            Controls the randomness of the subsampling. Pass an int for
-            reproducible output across multiple function calls.
-            See :term:`Glossary <random_state>`.
+            Only relevant when ``subsample`` is set. Controls the randomness
+            of the subsampling. Pass an int for reproducible output across
+            multiple function calls. See :term:`Glossary <random_state>`.
 
         Returns
         -------
@@ -511,21 +510,18 @@ class DBSCAN(ClusterMixin, BaseEstimator):
             Note that weights are absolute, and default to 1.
 
         subsample : float, default=None
-            Sampling probability. By default, no sampling is done. Between 0.0
-            and 1.0 and represents the proportion of the dataset that can be
-            labeled a core sample. All data points are still used in the
-            eps-neighborhood graph. The lower the subsample, the less memory
-            and computation is used. For large datasets, subsampled DBSCAN
-            is sub-quadratic and has comparable performance to full DBSCAN.
+            Should be between [0, 1]. By default, no sampling is done.
+            Sampling probability, representing the proportion of the dataset
+            that can be labeled a core sample. The lower the subsample, the
+            less memory and computation is used.
             See: Jang, J. and Jiang, H. "DBSCAN++: Towards fast and scalable
             density clustering". Proceedings of the 36th International Conference
             on Machine Learning, 2019.
 
         random_state : int, RandomState instance or None, default=None
-            Only relevant when ``subsample`` is set; has no effect otherwise.
-            Controls the randomness of the subsampling. Pass an int for
-            reproducible output across multiple function calls.
-            See :term:`Glossary <random_state>`.
+            Only relevant when ``subsample`` is set. Controls the randomness
+            of the subsampling. Pass an int for reproducible output across
+            multiple function calls. See :term:`Glossary <random_state>`.
 
         Returns
         -------

--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -109,6 +109,20 @@ def dbscan(
         If precomputed distance are used, parallel execution is not available
         and thus n_jobs will have no effect.
 
+    subsample : float, default=None
+        Should be between [0, 1]. By default, no sampling is done.
+        Sampling probability, representing the proportion of the dataset
+        that can be labeled a core sample. The lower the subsample, the
+        less memory and computation is used.
+        See: Jang, J. and Jiang, H. "DBSCAN++: Towards fast and scalable
+        density clustering". Proceedings of the 36th International Conference
+        on Machine Learning, 2019.
+
+    random_state : int, RandomState instance or None, default=None
+        Only relevant when ``subsample`` is set. Controls the randomness
+        of the subsampling. Pass an int for reproducible output across
+        multiple function calls. See :term:`Glossary <random_state>`.
+
     Returns
     -------
     core_samples : ndarray of shape (n_core_samples,)
@@ -301,6 +315,9 @@ class DBSCAN(ClusterMixin, BaseEstimator):
 
     Another way to reduce memory and computation time is to remove
     (near-)duplicate points and use ``sample_weight`` instead.
+
+    Yet another way is to use ``subsample`` in order to reduce the core
+    samples search space.
 
     :class:`~sklearn.cluster.OPTICS` provides a similar clustering with lower memory
     usage.

--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -6,7 +6,7 @@ DBSCAN: Density-Based Spatial Clustering of Applications with Noise
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings
-from numbers import Integral, Real
+from numbers import Integral, Number, Real
 
 import numpy as np
 from scipy import sparse
@@ -14,6 +14,7 @@ from scipy import sparse
 from ..base import BaseEstimator, ClusterMixin, _fit_context
 from ..metrics.pairwise import _VALID_METRICS
 from ..neighbors import NearestNeighbors
+from ..utils import check_random_state
 from ..utils._param_validation import Interval, StrOptions, validate_params
 from ..utils.validation import _check_sample_weight, validate_data
 from ._dbscan_inner import dbscan_inner
@@ -38,6 +39,8 @@ def dbscan(
     p=2,
     sample_weight=None,
     n_jobs=None,
+    subsample=None,
+    random_state=None,
 ):
     """Perform DBSCAN clustering from vector array or distance matrix.
 
@@ -174,7 +177,9 @@ def dbscan(
         p=p,
         n_jobs=n_jobs,
     )
-    est.fit(X, sample_weight=sample_weight)
+    est.fit(
+        X, sample_weight=sample_weight, subsample=subsample, random_state=random_state
+    )
     return est.core_sample_indices_, est.labels_
 
 
@@ -363,7 +368,7 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         # DBSCAN.metric is not validated yet
         prefer_skip_nested_validation=False
     )
-    def fit(self, X, y=None, sample_weight=None):
+    def fit(self, X, y=None, sample_weight=None, subsample=None, random_state=None):
         """Perform DBSCAN clustering from features, or distance matrix.
 
         Parameters
@@ -383,6 +388,23 @@ class DBSCAN(ClusterMixin, BaseEstimator):
             negative weight may inhibit its eps-neighbor from being core.
             Note that weights are absolute, and default to 1.
 
+        subsample : float, default=None
+            Sampling probability. By default, no sampling is done. Between 0.0
+            and 1.0 and represents the proportion of the dataset that can be
+            labeled a core sample. All data points are still used in the
+            eps-neighborhood graph. The lower the subsample, the less memory
+            and computation is used. For large datasets, subsampled DBSCAN
+            is sub-quadratic and has comparable performance to full DBSCAN.
+            See: Jang, J. and Jiang, H. "DBSCAN++: Towards fast and scalable
+            density clustering". Proceedings of the 36th International Conference
+            on Machine Learning, 2019.
+
+        random_state : int, RandomState instance or None, default=None
+            Only relevant when ``subsample`` is set; has no effect otherwise.
+            Controls the randomness of the subsampling. Pass an int for
+            reproducible output across multiple function calls.
+            See :term:`Glossary <random_state>`.
+
         Returns
         -------
         self : object
@@ -392,6 +414,9 @@ class DBSCAN(ClusterMixin, BaseEstimator):
 
         if sample_weight is not None:
             sample_weight = _check_sample_weight(sample_weight, X)
+        if subsample is not None:
+            if not isinstance(subsample, Number) or not 0 < subsample < 1:
+                raise ValueError("Subsample needs to be float between 0 and 1.")
 
         # Calculate neighborhood for all samples. This leaves the original
         # point in, which needs to be considered later (i.e. point i is in the
@@ -413,19 +438,40 @@ class DBSCAN(ClusterMixin, BaseEstimator):
             p=self.p,
             n_jobs=self.n_jobs,
         )
+
+        n = X.shape[0]
         neighbors_model.fit(X)
-        # This has worst case O(n^2) memory complexity
-        neighborhoods = neighbors_model.radius_neighbors(X, return_distance=False)
+
+        if subsample:
+            rng = check_random_state(random_state)
+            mask = np.full(n, False)
+            mask[: int(n * subsample)] = True
+            rng.shuffle(mask)
+            neighborhoods = np.full(n, None)
+            neighborhoods[mask] = neighbors_model.radius_neighbors(
+                X[mask], return_distance=False
+            )
+        else:
+            # This has worst case O(n^2) memory complexity
+            neighborhoods = neighbors_model.radius_neighbors(X, return_distance=False)
 
         if sample_weight is None:
-            n_neighbors = np.array([len(neighbors) for neighbors in neighborhoods])
+            n_neighbors = np.array(
+                [
+                    0 if neighbors is None else len(neighbors)
+                    for neighbors in neighborhoods
+                ]
+            )
         else:
             n_neighbors = np.array(
-                [np.sum(sample_weight[neighbors]) for neighbors in neighborhoods]
+                [
+                    0 if neighbors is None else np.sum(sample_weight[neighbors])
+                    for neighbors in neighborhoods
+                ]
             )
 
         # Initially, all samples are noise.
-        labels = np.full(X.shape[0], -1, dtype=np.intp)
+        labels = np.full(n, -1, dtype=np.intp)
 
         # A list of all core samples found.
         core_samples = np.asarray(n_neighbors >= self.min_samples, dtype=np.uint8)
@@ -442,7 +488,9 @@ class DBSCAN(ClusterMixin, BaseEstimator):
             self.components_ = np.empty((0, X.shape[1]))
         return self
 
-    def fit_predict(self, X, y=None, sample_weight=None):
+    def fit_predict(
+        self, X, y=None, sample_weight=None, subsample=None, random_state=None
+    ):
         """Compute clusters from a data or distance matrix and predict labels.
 
         Parameters
@@ -462,12 +510,34 @@ class DBSCAN(ClusterMixin, BaseEstimator):
             negative weight may inhibit its eps-neighbor from being core.
             Note that weights are absolute, and default to 1.
 
+        subsample : float, default=None
+            Sampling probability. By default, no sampling is done. Between 0.0
+            and 1.0 and represents the proportion of the dataset that can be
+            labeled a core sample. All data points are still used in the
+            eps-neighborhood graph. The lower the subsample, the less memory
+            and computation is used. For large datasets, subsampled DBSCAN
+            is sub-quadratic and has comparable performance to full DBSCAN.
+            See: Jang, J. and Jiang, H. "DBSCAN++: Towards fast and scalable
+            density clustering". Proceedings of the 36th International Conference
+            on Machine Learning, 2019.
+
+        random_state : int, RandomState instance or None, default=None
+            Only relevant when ``subsample`` is set; has no effect otherwise.
+            Controls the randomness of the subsampling. Pass an int for
+            reproducible output across multiple function calls.
+            See :term:`Glossary <random_state>`.
+
         Returns
         -------
         labels : ndarray of shape (n_samples,)
             Cluster labels. Noisy samples are given the label -1.
         """
-        self.fit(X, sample_weight=sample_weight)
+        self.fit(
+            X,
+            sample_weight=sample_weight,
+            subsample=subsample,
+            random_state=random_state,
+        )
         return self.labels_
 
     def __sklearn_tags__(self):

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -384,10 +384,8 @@ def test_subsampled_dbscan(global_random_seed):
     with pytest.raises(ValueError):
         dbscan([[0], [1]], subsample="")
 
-    core1, label1 = dbscan(X, subsample=0.1, random_state=global_random_seed)
-    assert_array_equal(core1, [0, 13, 19, 43])
-
     # ensure subsample has an effect
+    core1, label1 = dbscan(X, subsample=0.1, random_state=global_random_seed)
     core2 = dbscan(X, subsample=None)[0]
     assert len(core1) != len(core2)
 

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -373,6 +373,43 @@ def test_weighted_dbscan(global_random_seed):
     assert_array_equal(label1, est.labels_)
 
 
+def test_subsampled_dbscan(global_random_seed):
+    # ensure subsample is validated
+    with pytest.raises(ValueError):
+        dbscan([[0], [1]], subsample=1.1)
+    with pytest.raises(ValueError):
+        dbscan([[0], [1]], subsample=0)
+    with pytest.raises(ValueError):
+        dbscan([[0], [1]], subsample=-0.1)
+    with pytest.raises(ValueError):
+        dbscan([[0], [1]], subsample="")
+
+    core1, label1 = dbscan(X, subsample=0.1, random_state=global_random_seed)
+    assert_array_equal(core1, [0, 13, 19, 43])
+
+    # ensure subsample has an effect
+    core2 = dbscan(X, subsample=None)[0]
+    assert len(core1) != len(core2)
+
+    # subsample should work with precomputed distance matrix
+    D = pairwise_distances(X)
+    core3 = dbscan(
+        D, subsample=0.1, random_state=global_random_seed, metric="precomputed"
+    )[0]
+    assert_array_equal(core1, core3)
+
+    # subsample should work with estimator
+    est = DBSCAN().fit(X, subsample=0.1, random_state=global_random_seed)
+    assert_array_equal(core1, est.core_sample_indices_)
+    assert_array_equal(label1, est.labels_)
+
+    est = DBSCAN()
+    label4 = est.fit_predict(X, subsample=0.1, random_state=global_random_seed)
+    assert_array_equal(core1, est.core_sample_indices_)
+    assert_array_equal(label1, label4)
+    assert_array_equal(label1, est.labels_)
+
+
 @pytest.mark.parametrize("algorithm", ["brute", "kd_tree", "ball_tree"])
 def test_dbscan_core_samples_toy(algorithm):
     X = [[0], [2], [3], [4], [6], [8], [10]]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
See https://github.com/scikit-learn/scikit-learn/issues/17650.


#### What does this implement/fix? Explain your changes.
Instead of calculating the pairwise distances for all pairs of points to obtain nearest-neighbor graphs for DBSCAN, the `subsampled` option only calculates nearest-neighbor graphs for a fraction of points uniformly selected at random. The nearest-neighbor graphs are calculated only for subsampled points, but every point in the dataset may be a neighbor. This means that we will have a subset of core samples, but our research shows that clustering performance is similar.

With this implementation, we saw over 10x speedup on datasets where DBSCAN actually finished running. For datasets where DBSCAN did not finish running, subsampled DBSCAN is able to run on 100x larger datasets.

Performance is on a c5d.24xlarge Amazon EC2 instance with 96 vCPUs and 196 GB RAM. For all runs, `eps = 1` and `min_samples = 10`. Dataset was an equal mixture of four multivariate normals. We compare the results using the clustering metrics [adjusted RAND score](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.adjusted_rand_score.html) and [adjusted mutual information score](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.adjusted_mutual_info_score.html).
<img width="684" alt="image" src="https://github.com/user-attachments/assets/d91d6572-ad1f-473f-b387-635e875c760f" />

See: [Jang, J. and Jiang, H. "DBSCAN++: Towards fast and scalable density clustering". Proceedings of the 36th International Conference on Machine Learning, 2019.](https://proceedings.mlr.press/v97/jang19a.html)


#### Any other comments?
Per the November scikit-learn monthly meeting notes: 
<img width="735" alt="image" src="https://github.com/user-attachments/assets/1a0352be-7dc4-482e-ad5a-2e41f99ac860" />


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
