### PR TITLE
ENH Add parameters `V`, `VI`, `p`, `w` to AgglomerativeClustering

### DIFF
--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -787,173 +787,173 @@ def _hc_cut(n_clusters, children, n_leaves):
 
 class AgglomerativeClustering(ClusterMixin, BaseEstimator):
     """
-        Agglomerative Clustering.
+    Agglomerative Clustering.
 
-        Recursively merges pair of clusters of sample data; uses linkage distance.
+    Recursively merges pair of clusters of sample data; uses linkage distance.
 
-        Read more in the :ref:`User Guide <hierarchical_clustering>`.
+    Read more in the :ref:`User Guide <hierarchical_clustering>`.
 
-        Parameters
-        ----------
-        n_clusters : int or None, default=2
-            The number of clusters to find. It must be ``None`` if
-            ``distance_threshold`` is not ``None``.
+    Parameters
+    ----------
+    n_clusters : int or None, default=2
+        The number of clusters to find. It must be ``None`` if
+        ``distance_threshold`` is not ``None``.
 
-        metric : str or callable, default="euclidean"
-            Metric used to compute the linkage. Can be "euclidean", "l1", "l2",
-            "manhattan", "cosine", or "precomputed". If linkage is "ward", only
-            "euclidean" is accepted. If "precomputed", a distance matrix is needed
-            as input for the fit method. If connectivity is None, linkage is
-            "single" and affinity is not "precomputed" any valid pairwise distance
-            metric can be assigned.
+    metric : str or callable, default="euclidean"
+        Metric used to compute the linkage. Can be "euclidean", "l1", "l2",
+        "manhattan", "cosine", or "precomputed". If linkage is "ward", only
+        "euclidean" is accepted. If "precomputed", a distance matrix is needed
+        as input for the fit method. If connectivity is None, linkage is
+        "single" and affinity is not "precomputed" any valid pairwise distance
+        metric can be assigned.
 
-            .. versionadded:: 1.2
+        .. versionadded:: 1.2
 
-        memory : str or object with the joblib.Memory interface, default=None
-            Used to cache the output of the computation of the tree.
-            By default, no caching is done. If a string is given, it is the
-            path to the caching directory.
+    memory : str or object with the joblib.Memory interface, default=None
+        Used to cache the output of the computation of the tree.
+        By default, no caching is done. If a string is given, it is the
+        path to the caching directory.
 
-        connectivity : array-like, sparse matrix, or callable, default=None
-            Connectivity matrix. Defines for each sample the neighboring
-            samples following a given structure of the data.
-            This can be a connectivity matrix itself or a callable that transforms
-            the data into a connectivity matrix, such as derived from
-            `kneighbors_graph`. Default is ``None``, i.e, the
-            hierarchical clustering algorithm is unstructured.
+    connectivity : array-like, sparse matrix, or callable, default=None
+        Connectivity matrix. Defines for each sample the neighboring
+        samples following a given structure of the data.
+        This can be a connectivity matrix itself or a callable that transforms
+        the data into a connectivity matrix, such as derived from
+        `kneighbors_graph`. Default is ``None``, i.e, the
+        hierarchical clustering algorithm is unstructured.
 
-            For an example of connectivity matrix using
-            :class:`~sklearn.neighbors.kneighbors_graph`, see
-            :ref:`sphx_glr_auto_examples_cluster_plot_agglomerative_clustering.py`.
+        For an example of connectivity matrix using
+        :class:`~sklearn.neighbors.kneighbors_graph`, see
+        :ref:`sphx_glr_auto_examples_cluster_plot_agglomerative_clustering.py`.
 
-        compute_full_tree : 'auto' or bool, default='auto'
-            Stop early the construction of the tree at ``n_clusters``. This is
-            useful to decrease computation time if the number of clusters is not
-            small compared to the number of samples. This option is useful only
-            when specifying a connectivity matrix. Note also that when varying the
-            number of clusters and using caching, it may be advantageous to compute
-            the full tree. It must be ``True`` if ``distance_threshold`` is not
-            ``None``. By default `compute_full_tree` is "auto", which is equivalent
-            to `True` when `distance_threshold` is not `None` or that `n_clusters`
-            is inferior to the maximum between 100 or `0.02 * n_samples`.
-            Otherwise, "auto" is equivalent to `False`.
+    compute_full_tree : 'auto' or bool, default='auto'
+        Stop early the construction of the tree at ``n_clusters``. This is
+        useful to decrease computation time if the number of clusters is not
+        small compared to the number of samples. This option is useful only
+        when specifying a connectivity matrix. Note also that when varying the
+        number of clusters and using caching, it may be advantageous to compute
+        the full tree. It must be ``True`` if ``distance_threshold`` is not
+        ``None``. By default `compute_full_tree` is "auto", which is equivalent
+        to `True` when `distance_threshold` is not `None` or that `n_clusters`
+        is inferior to the maximum between 100 or `0.02 * n_samples`.
+        Otherwise, "auto" is equivalent to `False`.
 
-        linkage : {'ward', 'complete', 'average', 'single'}, default='ward'
-            Which linkage criterion to use. The linkage criterion determines which
-            distance to use between sets of observation. The algorithm will merge
-            the pairs of cluster that minimize this criterion.
+    linkage : {'ward', 'complete', 'average', 'single'}, default='ward'
+        Which linkage criterion to use. The linkage criterion determines which
+        distance to use between sets of observation. The algorithm will merge
+        the pairs of cluster that minimize this criterion.
 
-            - 'ward' minimizes the variance of the clusters being merged.
-            - 'average' uses the average of the distances of each observation of
-              the two sets.
-            - 'complete' or 'maximum' linkage uses the maximum distances between
-              all observations of the two sets.
-            - 'single' uses the minimum of the distances between all observations
-              of the two sets.
+        - 'ward' minimizes the variance of the clusters being merged.
+        - 'average' uses the average of the distances of each observation of
+            the two sets.
+        - 'complete' or 'maximum' linkage uses the maximum distances between
+            all observations of the two sets.
+        - 'single' uses the minimum of the distances between all observations
+            of the two sets.
 
-            .. versionadded:: 0.20
-                Added the 'single' option
+        .. versionadded:: 0.20
+            Added the 'single' option
 
-            For examples comparing different `linkage` criteria, see
-            :ref:`sphx_glr_auto_examples_cluster_plot_linkage_comparison.py`.
+        For examples comparing different `linkage` criteria, see
+        :ref:`sphx_glr_auto_examples_cluster_plot_linkage_comparison.py`.
 
-        distance_threshold : float, default=None
-            The linkage distance threshold at or above which clusters will not be
-            merged. If not ``None``, ``n_clusters`` must be ``None`` and
-            ``compute_full_tree`` must be ``True``.
+    distance_threshold : float, default=None
+        The linkage distance threshold at or above which clusters will not be
+        merged. If not ``None``, ``n_clusters`` must be ``None`` and
+        ``compute_full_tree`` must be ``True``.
 
-            .. versionadded:: 0.21
+        .. versionadded:: 0.21
 
-        compute_distances : bool, default=False
-            Computes distances between clusters even if `distance_threshold` is not
-            used. This can be used to make dendrogram visualization, but introduces
-            a computational and memory overhead.
+    compute_distances : bool, default=False
+        Computes distances between clusters even if `distance_threshold` is not
+        used. This can be used to make dendrogram visualization, but introduces
+        a computational and memory overhead.
 
-            .. versionadded:: 0.24
+        .. versionadded:: 0.24
 
-            For an example of dendrogram visualization, see
-            :ref:`sphx_glr_auto_examples_cluster_plot_agglomerative_dendrogram.py`.
+        For an example of dendrogram visualization, see
+        :ref:`sphx_glr_auto_examples_cluster_plot_agglomerative_dendrogram.py`.
 
-        V : ndarray, optional
-            The variance vector for standardized Euclidean.
+    V : ndarray, optional
+        The variance vector for standardized Euclidean.
 
-            .. versionadded:: 1.7
+        .. versionadded:: 1.7
 
-        VI : ndarray, optional
-            The inverse of the covariance matrix for Mahalanobis.
+    VI : ndarray, optional
+        The inverse of the covariance matrix for Mahalanobis.
 
-            .. versionadded:: 1.7
+        .. versionadded:: 1.7
 
-        p : float, optional
-            The p-norm to apply for Minkowski, weighted and unweighted.
+    p : float, optional
+        The p-norm to apply for Minkowski, weighted and unweighted.
 
-            .. versionadded:: 1.7
+        .. versionadded:: 1.7
 
-        w : ndarray, optional
-            The weight vector for metrics that support weights (e.g., Minkowski).
+    w : ndarray, optional
+        The weight vector for metrics that support weights (e.g., Minkowski).
 
-            .. versionadded:: 1.7
+        .. versionadded:: 1.7
 
-        Attributes
-        ----------
-        n_clusters_ : int
-            The number of clusters found by the algorithm. If
-            ``distance_threshold=None``, it will be equal to the given
-            ``n_clusters``.
+    Attributes
+    ----------
+    n_clusters_ : int
+        The number of clusters found by the algorithm. If
+        ``distance_threshold=None``, it will be equal to the given
+        ``n_clusters``.
 
-        labels_ : ndarray of shape (n_samples)
-            Cluster labels for each point.
+    labels_ : ndarray of shape (n_samples)
+        Cluster labels for each point.
 
-        n_leaves_ : int
-            Number of leaves in the hierarchical tree.
+    n_leaves_ : int
+        Number of leaves in the hierarchical tree.
 
-        n_connected_components_ : int
-            The estimated number of connected components in the graph.
+    n_connected_components_ : int
+        The estimated number of connected components in the graph.
 
-            .. versionadded:: 0.21
-                ``n_connected_components_`` was added to replace ``n_components_``.
+        .. versionadded:: 0.21
+            ``n_connected_components_`` was added to replace ``n_components_``.
 
-        n_features_in_ : int
-            Number of features seen during :term:`fit`.
+    n_features_in_ : int
+        Number of features seen during :term:`fit`.
 
-            .. versionadded:: 0.24
+        .. versionadded:: 0.24
 
-        feature_names_in_ : ndarray of shape (`n_features_in_`,)
-            Names of features seen during :term:`fit`. Defined only when `X`
-            has feature names that are all strings.
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of features seen during :term:`fit`. Defined only when `X`
+        has feature names that are all strings.
 
-            .. versionadded:: 1.0
+        .. versionadded:: 1.0
 
-        children_ : array-like of shape (n_samples-1, 2)
-            The children of each non-leaf node. Values less than `n_samples`
-            correspond to leaves of the tree which are the original samples.
-            A node `i` greater than or equal to `n_samples` is a non-leaf
+    children_ : array-like of shape (n_samples-1, 2)
+        The children of each non-leaf node. Values less than `n_samples`
+        correspond to leaves of the tree which are the original samples.
+        A node `i` greater than or equal to `n_samples` is a non-leaf
     c        node and has children `children_[i - n_samples]`. Alternatively
-            at the i-th iteration, children[i][0] and children[i][1]
-            are merged to form node `n_samples + i`.
+        at the i-th iteration, children[i][0] and children[i][1]
+        are merged to form node `n_samples + i`.
 
-        distances_ : array-like of shape (n_nodes-1,)
-            Distances between nodes in the corresponding place in `children_`.
-            Only computed if `distance_threshold` is used or `compute_distances`
-            is set to `True`.
+    distances_ : array-like of shape (n_nodes-1,)
+        Distances between nodes in the corresponding place in `children_`.
+        Only computed if `distance_threshold` is used or `compute_distances`
+        is set to `True`.
 
-        See Also
-        --------
-        FeatureAgglomeration : Agglomerative clustering but for features instead of
-            samples.
-        ward_tree : Hierarchical clustering with ward linkage.
+    See Also
+    --------
+    FeatureAgglomeration : Agglomerative clustering but for features instead of
+        samples.
+    ward_tree : Hierarchical clustering with ward linkage.
 
-        Examples
-        --------
-        >>> from sklearn.cluster import AgglomerativeClustering
-        >>> import numpy as np
-        >>> X = np.array([[1, 2], [1, 4], [1, 0],
-        ...               [4, 2], [4, 4], [4, 0]])
-        >>> clustering = AgglomerativeClustering().fit(X)
-        >>> clustering
-        AgglomerativeClustering()
-        >>> clustering.labels_
-        array([1, 1, 1, 0, 0, 0])
+    Examples
+    --------
+    >>> from sklearn.cluster import AgglomerativeClustering
+    >>> import numpy as np
+    >>> X = np.array([[1, 2], [1, 4], [1, 0],
+    ...               [4, 2], [4, 4], [4, 0]])
+    >>> clustering = AgglomerativeClustering().fit(X)
+    >>> clustering
+    AgglomerativeClustering()
+    >>> clustering.labels_
+    array([1, 1, 1, 0, 0, 0])
     """
 
     _parameter_constraints: dict = {

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -68,12 +68,12 @@ def test_linkage_misc():
     # test hierarchical clustering on a precomputed distances matrix
     dis = cosine_distances(X)
 
-    res = linkage_tree(dis, affinity="precomputed")
-    assert_array_equal(res[0], linkage_tree(X, affinity="cosine")[0])
+    res = linkage_tree(dis, metric="precomputed")
+    assert_array_equal(res[0], linkage_tree(X, metric="cosine")[0])
 
     # test hierarchical clustering on a precomputed distances matrix
-    res = linkage_tree(X, affinity=manhattan_distances)
-    assert_array_equal(res[0], linkage_tree(X, affinity="manhattan")[0])
+    res = linkage_tree(X, metric=manhattan_distances)
+    assert_array_equal(res[0], linkage_tree(X, metric="manhattan")[0])
 
 
 def test_structured_linkage_tree():
@@ -143,7 +143,7 @@ def test_zero_cosine_linkage_tree():
     X = np.array([[0, 1], [0, 0]])
     msg = "Cosine affinity cannot be used when X contains zero vectors"
     with pytest.raises(ValueError, match=msg):
-        linkage_tree(X, affinity="cosine")
+        linkage_tree(X, metric="cosine")
 
 
 @pytest.mark.parametrize("n_clusters, distance_threshold", [(None, 0.5), (10, None)])
@@ -719,7 +719,7 @@ def test_affinity_passed_to_fix_connectivity():
 
     fa = FakeAffinity()
 
-    linkage_tree(X, connectivity=connectivity, affinity=fa.increment)
+    linkage_tree(X, connectivity=connectivity, metric=fa.increment)
 
     assert fa.counter == 3
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This PR partially fixes #26961. These parameters are passed to the `DistanceMetric.get_metric` method so that "seuclidean" and "mahalanobis" metrics work with linkage = "single".

#### Any other comments?
When linkage != "single", `scipy.cluster.hierachy.linkage` is used. This method does not request for additional parameters like `V` for seuclidean.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
