### PR TITLE
TST remove `xfail` marker for `check_sample_weight_equivalence_on_dense_data` and `LinearRegression`

### DIFF
--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -556,6 +556,12 @@ PER_ESTIMATOR_CHECK_PARAMS: dict = {
         "check_dict_unchanged": dict(batch_size=10, max_iter=5, n_components=1)
     },
     LinearDiscriminantAnalysis: {"check_dict_unchanged": dict(n_components=1)},
+    LinearRegression: {
+        "check_sample_weight_equivalence_on_dense_data": [
+            dict(positive=False),
+            dict(positive=True),
+        ]
+    },
     LocallyLinearEmbedding: {"check_dict_unchanged": dict(max_iter=5, n_components=1)},
     LogisticRegression: {
         "check_sample_weight_equivalence_on_dense_data": [
@@ -964,16 +970,13 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
         "check_methods_sample_order_invariance": "check is not applicable."
     },
     LinearRegression: {
-        # TODO: investigate failure see meta-issue #16298
-        #
-        # Note: this model should converge to the minimum norm solution of the
+        # TODO: this model should converge to the minimum norm solution of the
         # least squares problem and as result be numerically stable enough when
         # running the equivalence check even if n_features > n_samples. Maybe
         # this is is not the case and a different choice of solver could fix
-        # this problem.
-        "check_sample_weight_equivalence_on_dense_data": (
-            "sample_weight is not equivalent to removing/repeating samples."
-        ),
+        # this problem. This might require setting a low enough value for the
+        # tolerance of the lsqr solver:
+        # https://github.com/scikit-learn/scikit-learn/issues/30131
         "check_sample_weight_equivalence_on_sparse_data": (
             "sample_weight is not equivalent to removing/repeating samples."
         ),


### PR DESCRIPTION
This was fixed in #30040 for `positive=False` and passes for `positive=True`.

The sparse case is being concurrently handled in #30131 and the linked PR #30521.