### PR TITLE
DOC Add early stopping case to `scoring` glossary entry

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1700,9 +1700,10 @@ functions or non-estimator constructors.
 ``
         * the score function to be maximized (usually by :ref:`cross
         validation <cross_validation>`),
-        * -- in some cases -- the multiple score functions to be reported, or
+        * -- in some cases --, the multiple score functions to be reported,
         * in a few specific cases, the score function to be used to check early
-          stopping
+          stopping, or
+        * for visualization related objects, the score to output or plot
 
         The score function can be a string accepted
         by :func:`metrics.get_scorer` or a callable :term:`scorer`, not to be

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1700,9 +1700,8 @@ functions or non-estimator constructors.
 
         * the score function to be maximized (usually by
           :ref:`cross validation <cross_validation>`),
-        * in some cases, the multiple score functions to be reported,
-        * in a few specific cases, the score function to be used to check early
-          stopping, or
+        * the multiple score functions to be reported,
+        * the score function to be used to check early stopping, or
         * for visualization related objects, the score function to output or plot
 
         The score function can be a string accepted

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1696,14 +1696,14 @@ functions or non-estimator constructors.
         objects and avoid common pitfalls, you may refer to :ref:`randomness`.
 
     ``scoring``
-        Specifies:
-``
-        * the score function to be maximized (usually by :ref:`cross
-        validation <cross_validation>`),
-        * -- in some cases --, the multiple score functions to be reported,
+        Depending on the object, can specify:
+
+        * the score function to be maximized (usually by
+          :ref:`cross validation <cross_validation>`),
+        * in some cases, the multiple score functions to be reported,
         * in a few specific cases, the score function to be used to check early
           stopping, or
-        * for visualization related objects, the score to output or plot
+        * for visualization related objects, the score function to output or plot
 
         The score function can be a string accepted
         by :func:`metrics.get_scorer` or a callable :term:`scorer`, not to be
@@ -1717,7 +1717,6 @@ functions or non-estimator constructors.
         callables as values or a callable that returns a dictionary. Note that
         this does *not* specify which score function is to be maximized, and
         another parameter such as ``refit`` maybe used for this purpose.
-
 
         The ``scoring`` parameter is validated and interpreted using
         :func:`metrics.check_scoring`.

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1696,9 +1696,15 @@ functions or non-estimator constructors.
         objects and avoid common pitfalls, you may refer to :ref:`randomness`.
 
     ``scoring``
-        Specifies the score function to be maximized (usually by :ref:`cross
-        validation <cross_validation>`), or -- in some cases -- multiple score
-        functions to be reported. The score function can be a string accepted
+        Specifies:
+``
+        * the score function to be maximized (usually by :ref:`cross
+        validation <cross_validation>`),
+        * -- in some cases -- the multiple score functions to be reported, or
+        * in a few specific cases, the score function to be used for early
+          stopping
+
+        The score function can be a string accepted
         by :func:`metrics.get_scorer` or a callable :term:`scorer`, not to be
         confused with an :term:`evaluation metric`, as the latter have a more
         diverse API.  ``scoring`` may also be set to None, in which case the

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1701,7 +1701,7 @@ functions or non-estimator constructors.
         * the score function to be maximized (usually by :ref:`cross
         validation <cross_validation>`),
         * -- in some cases -- the multiple score functions to be reported, or
-        * in a few specific cases, the score function to be used for early
+        * in a few specific cases, the score function to be used to check early
           stopping
 
         The score function can be a string accepted


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Relates to https://github.com/scikit-learn/scikit-learn/pull/30319#discussion_r1891065705

Adds to `scoring` glossary entry that this parameter may also be used to specify which scoring method to use to check early stopping


#### What does this implement/fix? Explain your changes.


#### Any other comments?
cc @StefanieSenger 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
