### PR TITLE
CD add windows ARM64 in wheels builder

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -78,6 +78,23 @@ jobs:
             platform_id: win_amd64
             free_threaded_support: True
 
+          # Window ARM64
+          - os: windows-latest
+            python: 39
+            platform_id: win_arm64
+          - os: windows-latest
+            python: 310
+            platform_id: win_arm64
+          - os: windows-latest
+            python: 311
+            platform_id: win_arm64
+          - os: windows-latest
+            python: 312
+            platform_id: win_arm64
+          - os: windows-latest
+            python: 313
+            platform_id: win_arm64
+
           # Linux 64 bit manylinux2014
           - os: ubuntu-latest
             python: 39
@@ -188,7 +205,9 @@ jobs:
           CIBW_TEST_COMMAND: bash {project}/build_tools/wheels/test_wheels.sh {project}
           CIBW_TEST_COMMAND_WINDOWS: bash {project}/build_tools/github/test_windows_wheels.sh ${{ matrix.python }} {project}
           CIBW_BUILD_VERBOSITY: 1
-
+          # It is not possible to test the wheels on because it uses cross-compilation
+          # c.f. https://cibuildwheel.pypa.io/en/stable/faq/#windows-arm64
+          CIBW_TEST_SKIP: "*-win_arm64"
         run: bash build_tools/wheels/build_wheels.sh
 
       - name: Store artifacts


### PR DESCRIPTION
Partially address #30567 

Check that:

- we can build the wheels for windows ARM 64 bits
- assess how slow is the cross-compilation going