### PR TITLE
DOC impact of stratification on the target class in cross-validation splitters

### DIFF
--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -543,11 +543,11 @@ relative class frequencies are approximately preserved in each fold.
   aforementioned engineering problems rather than solve a statistical one.
 
   Stratification makes cross-validation folds more homogeneous, and as a result
-  hides some of the variability inherent to fitting models with a limitted
+  hides some of the variability inherent to fitting models with a limited
   number of observations.
 
   As a result, stratification can artificially shrink the spread of the metric
-  measured accross cross-validation iterations: the inter-fold variabiliy does
+  measured across cross-validation iterations: the inter-fold variability does
   no longer reflect the uncertainty in the performance of classifiers in the
   presence of rare classes.
 

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -523,28 +523,27 @@ the proportion of samples on each side of the train / test split.
 Cross-validation iterators with stratification based on class labels
 --------------------------------------------------------------------
 
-Some classification problems can exhibit a large imbalance in the distribution
-of the target classes: for instance there could be orders of magnitude more
+Some classification problems can exhibit very rare classes.
+of the target classes: for instance, there could be orders of magnitude more
 negative observations than positive observations. As a result, cross-validation
 splitting can generate train or validation folds without any occurence of
 observations of a particular class. This typically leads to undefined
 classification metrics (e.g. ROC AUC), exceptions raised when attempting to
-call fit on a single-class training fold or missing columns in the output of
+call :term:`fit` or missing columns in the output of
 the `predict_proba` or `decision_function` methods of multiclass classifiers
 trained on different folds.
 
 To mitigate such problems, splitters such as :class:`StratifiedKFold` and
 :class:`StratifiedShuffleSplit` implement stratified sampling to ensure that
-relative class frequencies are approximately preserved in each train and
-validation fold.
+relative class frequencies are approximately preserved in each fold.
 
 .. note::
 
   Stratified sampling was introduced in scikit-learn to workaround the
   afore mentionned engineering problems rather than solve a statistical one.
 
-  On highly imbalanced classification problems, the inter-fold variability of
-  the performance metric values measured via stratified cross-validation can
+  On classification problems with very rare classes, the inter-fold variability of
+  the performance metric measured via stratified cross-validation can
   arbitrarily **under-estimate the uncertainty** in the "true" metric value of
   the classifier retrained on all the available data and evaluated on an
   hypothetical infinite test set.

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -523,14 +523,14 @@ the proportion of samples on each side of the train / test split.
 Cross-validation iterators with stratification based on class labels
 --------------------------------------------------------------------
 
-Some classification problems can exhibit very rare classes. of the target
-classes: for instance, there could be orders of magnitude more negative
-observations than positive observations. As a result, cross-validation
-splitting can generate train or validation folds without any occurence of a
-particular class. This typically leads to undefined classification metrics
-(e.g. ROC AUC), exceptions raised when attempting to call :term:`fit` or
-missing columns in the output of the `predict_proba` or `decision_function`
-methods of multiclass classifiers trained on different folds.
+Some classification tasks can exhibit very rare classes. of the target classes:
+for instance, there could be orders of magnitude more negative observations
+than positive observations. As a result, cross-validation splitting can
+generate train or validation folds without any occurence of a particular class.
+This typically leads to undefined classification metrics (e.g. ROC AUC),
+exceptions raised when attempting to call :term:`fit` or missing columns in the
+output of the `predict_proba` or `decision_function` methods of multiclass
+classifiers trained on different folds.
 
 To mitigate such problems, splitters such as :class:`StratifiedKFold` and
 :class:`StratifiedShuffleSplit` implement stratified sampling to ensure that

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -523,15 +523,14 @@ the proportion of samples on each side of the train / test split.
 Cross-validation iterators with stratification based on class labels
 --------------------------------------------------------------------
 
-Some classification problems can exhibit very rare classes.
-of the target classes: for instance, there could be orders of magnitude more
-negative observations than positive observations. As a result, cross-validation
-splitting can generate train or validation folds without any occurence of
-a particular class. This typically leads to undefined
-classification metrics (e.g. ROC AUC), exceptions raised when attempting to
-call :term:`fit` or missing columns in the output of
-the `predict_proba` or `decision_function` methods of multiclass classifiers
-trained on different folds.
+Some classification problems can exhibit very rare classes. of the target
+classes: for instance, there could be orders of magnitude more negative
+observations than positive observations. As a result, cross-validation
+splitting can generate train or validation folds without any occurence of a
+particular class. This typically leads to undefined classification metrics
+(e.g. ROC AUC), exceptions raised when attempting to call :term:`fit` or
+missing columns in the output of the `predict_proba` or `decision_function`
+methods of multiclass classifiers trained on different folds.
 
 To mitigate such problems, splitters such as :class:`StratifiedKFold` and
 :class:`StratifiedShuffleSplit` implement stratified sampling to ensure that
@@ -540,13 +539,16 @@ relative class frequencies are approximately preserved in each fold.
 .. note::
 
   Stratified sampling was introduced in scikit-learn to workaround the
-  afore mentionned engineering problems rather than solve a statistical one.
+  aforementioned engineering problems rather than solve a statistical one.
 
-  On classification problems with very rare classes, the inter-fold variability of
-  the performance metric measured via stratified cross-validation can
-  arbitrarily **under-estimate the uncertainty** in the "true" metric value of
-  the classifier retrained on all the available data and evaluated on an
-  hypothetical infinite test set.
+  Stratification makes cross-validation folds more homogeneous, and as a result
+  hides some of the variability inherent to fitting models with a limitted
+  number of observations.
+
+  As a result, stratification can artificially shrink the spread of the metric
+  measured accross cross-validation iterations: the inter-fold variabiliy does
+  no longer reflect the uncertainty in the performance of classifiers in the
+  presence of rare classes.
 
 .. _stratified_k_fold:
 

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -523,14 +523,15 @@ the proportion of samples on each side of the train / test split.
 Cross-validation iterators with stratification based on class labels
 --------------------------------------------------------------------
 
-Some classification tasks can exhibit very rare classes. of the target classes:
-for instance, there could be orders of magnitude more negative observations
-than positive observations. As a result, cross-validation splitting can
-generate train or validation folds without any occurence of a particular class.
-This typically leads to undefined classification metrics (e.g. ROC AUC),
-exceptions raised when attempting to call :term:`fit` or missing columns in the
-output of the `predict_proba` or `decision_function` methods of multiclass
-classifiers trained on different folds.
+Some classification tasks can naturally exhibit rare classes: for instance,
+there could be orders of magnitude more negative observations than positive
+observations (e.g. medical screening, fraud detection, etc). As a result,
+cross-validation splitting can generate train or validation folds without any
+occurence of a particular class. This typically leads to undefined
+classification metrics (e.g. ROC AUC), exceptions raised when attempting to
+call :term:`fit` or missing columns in the output of the `predict_proba` or
+`decision_function` methods of multiclass classifiers trained on different
+folds.
 
 To mitigate such problems, splitters such as :class:`StratifiedKFold` and
 :class:`StratifiedShuffleSplit` implement stratified sampling to ensure that

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -524,11 +524,30 @@ Cross-validation iterators with stratification based on class labels
 --------------------------------------------------------------------
 
 Some classification problems can exhibit a large imbalance in the distribution
-of the target classes: for instance there could be several times more negative
-samples than positive samples. In such cases it is recommended to use
-stratified sampling as implemented in :class:`StratifiedKFold` and
-:class:`StratifiedShuffleSplit` to ensure that relative class frequencies is
-approximately preserved in each train and validation fold.
+of the target classes: for instance there could be orders of magnitude more
+negative observations than positive observations. As a result, cross-validation
+splitting can generate train or validation folds without any occurence of
+observations of a particular class. This typically leads to undefined
+classification metrics (e.g. ROC AUC), exceptions raised when attempting to
+call fit on a single-class training fold or missing columns in the output of
+the `predict_proba` or `decision_function` methods of multiclass classifiers
+trained on different folds.
+
+To mitigate such problems, splitters such as :class:`StratifiedKFold` and
+:class:`StratifiedShuffleSplit` implement stratified sampling to ensure that
+relative class frequencies are approximately preserved in each train and
+validation fold.
+
+.. note::
+
+  Stratified sampling was introduced in scikit-learn to workaround the
+  afore mentionned engineering problems rather than solve a statistical one.
+
+  On highly imbalanced classification problems, the inter-fold variability of
+  the performance metric values measured via stratified cross-validation can
+  arbitrarily **under-estimate the uncertainty** in the "true" metric value of
+  the classifier retrained on all the available data and evaluated on an
+  hypothetical infinite test set.
 
 .. _stratified_k_fold:
 

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -527,7 +527,7 @@ Some classification problems can exhibit very rare classes.
 of the target classes: for instance, there could be orders of magnitude more
 negative observations than positive observations. As a result, cross-validation
 splitting can generate train or validation folds without any occurence of
-observations of a particular class. This typically leads to undefined
+a particular class. This typically leads to undefined
 classification metrics (e.g. ROC AUC), exceptions raised when attempting to
 call :term:`fit` or missing columns in the output of
 the `predict_proba` or `decision_function` methods of multiclass classifiers

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -684,19 +684,25 @@ class GroupKFold(GroupsConsumerMixin, _BaseKFold):
 
 
 class StratifiedKFold(_BaseKFold):
-    """Stratified K-Fold cross-validator.
+    """Class-wise stratified K-Fold cross-validator.
 
     Provides train/test indices to split data in train/test sets.
 
     This cross-validation object is a variation of KFold that returns
     stratified folds. The folds are made by preserving the percentage of
-    samples for each class.
+    samples for each class in `y` in a binary or multiclass classification
+    setting.
 
     Read more in the :ref:`User Guide <stratified_k_fold>`.
 
     For visualisation of cross-validation behaviour and
     comparison between common scikit-learn split methods
     refer to :ref:`sphx_glr_auto_examples_model_selection_plot_cv_indices.py`
+
+    .. note::
+
+        Stratification on the class label solves an engineering problem rather
+        than a statistical one. See :ref:`stratification` for more details.
 
     Parameters
     ----------
@@ -883,11 +889,12 @@ class StratifiedKFold(_BaseKFold):
 
 
 class StratifiedGroupKFold(GroupsConsumerMixin, _BaseKFold):
-    """Stratified K-Fold iterator variant with non-overlapping groups.
+    """Class-wise stratified K-Fold iterator variant with non-overlapping groups.
 
     This cross-validation object is a variation of StratifiedKFold attempts to
     return stratified folds with non-overlapping groups. The folds are made by
-    preserving the percentage of samples for each class.
+    preserving the percentage of samples for each class in `y` in a binary or
+    multiclass classification setting.
 
     Each group will appear exactly once in the test set across all folds (the
     number of distinct groups has to be at least equal to the number of folds).
@@ -905,6 +912,11 @@ class StratifiedGroupKFold(GroupsConsumerMixin, _BaseKFold):
     For visualisation of cross-validation behaviour and
     comparison between common scikit-learn split methods
     refer to :ref:`sphx_glr_auto_examples_model_selection_plot_cv_indices.py`
+
+    .. note::
+
+        Stratification on the class label solves an engineering problem rather
+        than a statistical one. See :ref:`stratification` for more details.
 
     Parameters
     ----------
@@ -1726,12 +1738,17 @@ class RepeatedKFold(_UnsupportedGroupCVMixin, _RepeatedSplits):
 
 
 class RepeatedStratifiedKFold(_UnsupportedGroupCVMixin, _RepeatedSplits):
-    """Repeated Stratified K-Fold cross validator.
+    """Repeated class-wise stratified K-Fold cross validator.
 
     Repeats Stratified K-Fold n times with different randomization in each
     repetition.
 
     Read more in the :ref:`User Guide <repeated_k_fold>`.
+
+    .. note::
+
+        Stratification on the class label solves an engineering problem rather
+        than a statistical one. See :ref:`stratification` for more details.
 
     Parameters
     ----------
@@ -2204,13 +2221,14 @@ class GroupShuffleSplit(GroupsConsumerMixin, BaseShuffleSplit):
 
 
 class StratifiedShuffleSplit(BaseShuffleSplit):
-    """Stratified ShuffleSplit cross-validator.
+    """Class-wise stratified ShuffleSplit cross-validator.
 
     Provides train/test indices to split data in train/test sets.
 
     This cross-validation object is a merge of :class:`StratifiedKFold` and
     :class:`ShuffleSplit`, which returns stratified randomized folds. The folds
-    are made by preserving the percentage of samples for each class.
+    are made by preserving the percentage of samples for each class in `y` in a
+    binary or multiclass classification setting.
 
     Note: like the :class:`ShuffleSplit` strategy, stratified random splits
     do not guarantee that test sets across all folds will be mutually exclusive,
@@ -2222,6 +2240,11 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     For visualisation of cross-validation behaviour and
     comparison between common scikit-learn split methods
     refer to :ref:`sphx_glr_auto_examples_model_selection_plot_cv_indices.py`
+
+    .. note::
+
+        Stratification on the class label solves an engineering problem rather
+        than a statistical one. See :ref:`stratification` for more details.
 
     Parameters
     ----------


### PR DESCRIPTION
Better document the motivation and warn about the statistical impact of stratification on the target class.

I also changed the splitter docstrings to make it a bit more explicit that (as of now) stratification happens on the target class labels, hence can only be used for classification problems.

As discussed in #4757.