### PR TITLE
DOC add link to plot_lw_vs_oas example in docstrings

### DIFF
--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -565,7 +565,8 @@ class LedoitWolf(EmpiricalCovariance):
     array([ 0.0595... , -0.0075...])
 
     See also :ref:`sphx_glr_auto_examples_covariance_plot_covariance_estimation.py`
-    for a more detailed example.
+    and :ref:`sphx_glr_auto_examples_covariance_plot_lw_vs_oas.py`
+    for more detailed examples.
     """
 
     _parameter_constraints: dict = {
@@ -785,7 +786,8 @@ class OAS(EmpiricalCovariance):
     np.float64(0.0195...)
 
     See also :ref:`sphx_glr_auto_examples_covariance_plot_covariance_estimation.py`
-    for a more detailed example.
+    and :ref:`sphx_glr_auto_examples_covariance_plot_lw_vs_oas.py`
+    for more detailed examples.
     """
 
     @_fit_context(prefer_skip_nested_validation=True)


### PR DESCRIPTION
#### Reference Issues/PRs
PR [#26927](https://github.com/scikit-learn/scikit-learn/issues/26927)


#### What does this implement/fix? Explain your changes.
Added links to plot_lw_vs_oas example in docstrings of classes `LedoitWolf` and `OAS` in _shrunk_covariance.py
