### PR TITLE
DOC fix formatting in maintainer information - releasing

### DIFF
--- a/doc/developers/maintainer.rst.template
+++ b/doc/developers/maintainer.rst.template
@@ -144,23 +144,22 @@ Reference Steps
     {% if key == "rc" %}
     - Create a PR from `main` and targeting `main` to prepare for the next version. In
       this PR you need to:
-      
+
       - Increment the dev0 `__version__` variable in `sklearn/__init__.py`. This means
         that while we are in the release candidate period, the latest stable is two
         versions behind the `main` branch, instead of one.
-      
+
       - Include a new what's new file under the `doc/whats_new/` directory. Don't forget
         to add an entry for this new file in `doc/whats_new.rst`.
 
       - Change the what's new file to the newly created one in the `filename` field of
-        the `tool.towncrier` section in `pyproject.toml`. 
-
+        the `tool.towncrier` section in `pyproject.toml`.
     {% endif %}
 
     - In the release branch, change the version number `__version__` in
       `sklearn/__init__.py` to `{{ version_full }}`.
 
-    - In the release branch, generate the changelog for the incoming version, i.e
+    - In the release branch, generate the changelog for the incoming version, i.e.,
       `doc/whats_new/{{ version_short }}.rst`.
       {%- if key == "rc" %}
       During the RC period we want to keep the fragments when we generate the changelog
@@ -169,31 +168,33 @@ Reference Steps
 
       .. prompt:: bash
 
-        towncrier build --keep --version {{ version_short}}.0
-      {%- else -%}
+        towncrier build --keep --version {{ version_short }}.0
+
+      {%- else %}
       For a non RC release, push a commit where you:
-      
-      - generate the changelog, not keeping the fragments.
 
-      .. prompt:: bash
+      - Generate the changelog, not keeping the fragments.
 
-        towncrier build --version {{ version_full}}
+        .. prompt:: bash
 
-      {%- if key == "final" %}
-      - link the release highlights example
-      {%- endif %}
-      - add the list of contributor names. Suppose that the tag of the last release in
-      the previous major/minor version is `{{ previous_tag }}`, then you can use the
-      following command to retrieve the list of contributor names:
+          towncrier build --version {{ version_full }}
 
-      .. prompt:: bash
+      {% if key == "final" -%}
+      - Link the release highlights example.
+      {% endif -%}
 
-        git shortlog -s {{ previous_tag }}.. |
-          cut -f2- |
-          sort --ignore-case |
-          tr "\n" ";" |
-          sed "s/;/, /g;s/, $//" |
-          fold -s
+      - Add the list of contributor names. Suppose that the tag of the last release in
+        the previous major/minor version is `{{ previous_tag }}`, then you can use the
+        following command to retrieve the list of contributor names:
+
+        .. prompt:: bash
+
+          git shortlog -s {{ previous_tag }}.. |
+            cut -f2- |
+            sort --ignore-case |
+            tr "\n" ";" |
+            sed "s/;/, /g;s/, $//" |
+            fold -s
 
       Then create a PR targeting the `main` branch and cherry-pick this commit there.
       {%- endif %}


### PR DESCRIPTION
See the following screenshots.

| From | To |
|:----:|:----:|
| ![image](https://github.com/user-attachments/assets/0fb3a577-7197-4e4e-8a1c-f91ed19d0853) | ![image](https://github.com/user-attachments/assets/68d64037-642d-4726-9c2e-f9e28efc35bc) |

This should also solve these warnings (which I see locally):

```
D:\Projects\scikit-learn-yxiao\doc\developers\maintainer.rst:296: WARNING: Explicit markup ends without a blank line; unexpected unindent. [docutils]
D:\Projects\scikit-learn-yxiao\doc\developers\maintainer.rst:298: WARNING: Bullet list ends without a blank line; unexpected unindent. [docutils]
D:\Projects\scikit-learn-yxiao\doc\developers\maintainer.rst:512: WARNING: Explicit markup ends without a blank line; unexpected unindent. [docutils]
D:\Projects\scikit-learn-yxiao\doc\developers\maintainer.rst:513: WARNING: Bullet list ends without a blank line; unexpected unindent. [docutils]
```

Check the rendered docs here: https://output.circle-artifacts.com/output/job/63e77d64-91e7-4a25-b00f-2c061683ea71/artifacts/0/doc/developers/maintainer.html#reference-steps, versus the dev docs: https://scikit-learn.org/dev/developers/maintainer.html#reference-steps