### PR TITLE
DOC fix tooltip not showing up on the dropdown toggles

### DIFF
--- a/doc/js/scripts/dropdown.js
+++ b/doc/js/scripts/dropdown.js
@@ -35,6 +35,8 @@ document.addEventListener("DOMContentLoaded", () => {
     newStateMarker.setAttribute("data-bs-placement", "top");
     newStateMarker.setAttribute("data-bs-offset", "0,10");
     newStateMarker.setAttribute("data-bs-title", "Toggle all dropdowns");
+    // Enable the tooltip
+    new bootstrap.Tooltip(newStateMarker);
 
     // Assign the collapse/expand action to the state marker
     newStateMarker.addEventListener("click", () => {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a74e4e10-ea21-41c9-b995-861ef201c478)

This tooltip has not been showing up since our 1.6.x docs. Bootstrap tooltips are opt-in for performance reasons and has to be manually enabled [[ref](https://getbootstrap.com/docs/5.3/components/tooltips/#enable-tooltips)].

You may experiment with this dropdown in the built artifact: https://output.circle-artifacts.com/output/job/e77a5a0a-dd7b-4fa7-929c-0229446af67f/artifacts/0/doc/modules/linear_model.html#references, versus the dev docs: https://scikit-learn.org/dev/modules/linear_model.html#references