### PR TITLE
DOC avoid version switcher dropdown being cut off by right boundary

### DIFF
--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -14,7 +14,7 @@ code.literal {
 
 /* Version switcher */
 
-.version-switcher__menu {
+.version-switcher__menu.dropdown-menu {
   // The version switcher is aligned right so we need to avoid the dropdown menu
   // to be cut off by the right boundary
   left: unset;

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -14,15 +14,22 @@ code.literal {
 
 /* Version switcher */
 
-.version-switcher__menu a.list-group-item.sk-avail-docs-link {
-  display: flex;
-  align-items: center;
+.version-switcher__menu {
+  // The version switcher is aligned right so we need to avoid the dropdown menu
+  // to be cut off by the right boundary
+  left: unset;
+  right: 0;
 
-  &:after {
-    content: var(--pst-icon-external-link);
-    font: var(--fa-font-solid);
-    font-size: 0.75rem;
-    margin-left: 0.5rem;
+  a.list-group-item.sk-avail-docs-link {
+    display: flex;
+    align-items: center;
+
+    &:after {
+      content: var(--pst-icon-external-link);
+      font: var(--fa-font-solid);
+      font-size: 0.75rem;
+      margin-left: 0.5rem;
+    }
   }
 }
 


### PR DESCRIPTION
See the screenshot:

<img src="https://github.com/user-attachments/assets/888a0ae3-2feb-4f60-a05b-53386c92851d" width="200px">

The dropdown menu is cut off because it is aligned to the left boundary with `left: 0`. With this PR it will be aligned to the right boundary with `right: 0`.
