### PR TITLE
handling nan values in AdaBoostClassifier

### DIFF
--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -22,6 +22,8 @@ The module structure is the following:
 import warnings
 from abc import ABCMeta, abstractmethod
 from numbers import Integral, Real
+from sklearn.impute import SimpleImputer
+from sklearn.exceptions import NotFittedError
 
 import numpy as np
 
@@ -54,9 +56,7 @@ __all__ = [
     "AdaBoostClassifier",
     "AdaBoostRegressor",
 ]
-from sklearn.impute import SimpleImputer
-from sklearn.preprocessing import LabelEncoder
-from sklearn.exceptions import NotFittedError
+
 
 class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
     """Base class for AdaBoost estimators.
@@ -536,7 +536,6 @@ class AdaBoostClassifier(
         self : object
             Fitted estimator.
         """
-        # Impute missing values in X
         X_imputed = self.imputer_.fit_transform(X)
         return super().fit(X_imputed, y)
 
@@ -877,9 +876,9 @@ class AdaBoostClassifier(
             The class probabilities of the input samples. The order of
             outputs is the same of that of the :term:`classes_` attribute.
         """
-
-        n_classes = self.n_classes_
         X = self._check_X_impute(X)
+        n_classes = self.n_classes_
+    
         for decision in self.staged_decision_function(X):
             yield self._compute_proba_from_decision(decision, n_classes)
 

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -22,8 +22,6 @@ The module structure is the following:
 import warnings
 from abc import ABCMeta, abstractmethod
 from numbers import Integral, Real
-from sklearn.impute import SimpleImputer
-from sklearn.exceptions import NotFittedError
 
 import numpy as np
 
@@ -34,6 +32,8 @@ from ..base import (
     is_classifier,
     is_regressor,
 )
+from ..exceptions import NotFittedError
+from ..impute import SimpleImputer
 from ..metrics import accuracy_score, r2_score
 from ..tree import DecisionTreeClassifier, DecisionTreeRegressor
 from ..utils import _safe_indexing, check_random_state

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -544,7 +544,6 @@ class AdaBoostClassifier(
         if not hasattr(self, 'imputer_'):
             raise NotFittedError("Imputer has not been fitted yet.")
         return self.imputer_.transform(X)
-    
     def _validate_estimator(self):
         """Check the estimator and set the estimator_ attribute."""
         super()._validate_estimator(default=DecisionTreeClassifier(max_depth=1))
@@ -878,7 +877,6 @@ class AdaBoostClassifier(
         """
         X = self._check_X_impute(X)
         n_classes = self.n_classes_
-    
         for decision in self.staged_decision_function(X):
             yield self._compute_proba_from_decision(decision, n_classes)
 

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -503,7 +503,7 @@ class AdaBoostClassifier(
         learning_rate=1.0,
         algorithm="deprecated",
         random_state=None,
-        imputation_strategy='mean',
+        imputation_strategy="mean",
         imputation_fill_value=None,
     ):
         super().__init__(
@@ -517,8 +517,7 @@ class AdaBoostClassifier(
         self.imputation_strategy = imputation_strategy
         self.imputation_fill_value = imputation_fill_value
         self.imputer_ = SimpleImputer(
-            strategy=self.imputation_strategy,
-            fill_value=self.imputation_fill_value
+            strategy=self.imputation_strategy, fill_value=self.imputation_fill_value
         )
 
     def fit(self, X, y):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
AdaBoostClassifier for nan values https://github.com/scikit-learn/scikit-learn/pull/30597

#### What does this implement/fix? Explain your changes.
The AdaBoostClassifier was modified to handle missing np.nan values by incorporating a SimpleImputer. This ensures that during both training and prediction, any missing data is automatically imputed using a specified strategy (e.g., mean). Key methods like fit and predict were overridden to include imputation steps, and imputation parameters were added to the constructor for flexibility. These changes enable the classifier to robustly process datasets with missing values without errors.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
