### PR TITLE
CI Add code scanning for Github Actions workflow files

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript-typescript', 'python' ]
+        language: [ 'javascript-typescript', 'python', 'actions' ]
         # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
         # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
         # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both


### PR DESCRIPTION
Code scanning for Github Actions files is in Public Preview since December 2024, see [announcement](https://github.blog/changelog/2024-12-17-find-and-fix-actions-workflows-vulnerabilities-with-codeql-public-preview/).

I think this needs to be merged first before being able to see the results. We can enable it, look at the results, leave it running for a bit and always turn it off later, if this turns out to be too noisy.

The advantage with having it on would be to avoid creating rookie security mistakes in Github actions.

Having read a bit about Github actions security issues recently, it's amazing how much I had very little understanding of these aspects before. And to be frank, what I understood only skims the surface of these aspects.

The kind of things I learned:
- [known caveats with `pull_request_target`](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/). Basically don't use `pull_request_target` on PR user code, which we kind of do in linting bot comment, but we use `curl` to fetch files from `main` so it's probably OK. This one I was aware of before, but rereading it makes it clearer.
- [blog post about Github cache poisoning](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/). Even if a `pull_request_target` has no token permission, you can poison the cache that gets reused in other branches like `main`, and you can steal tokens with higher permissions :exploding_head:.
- a token is valid for 6 hours (cache poisoning blog post). I naively assumed that the token was valid only for the job duration.

cc @adrinjalali since we talked about it.