### PR TITLE
Fix bug with _transform_one() default argument

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -1506,7 +1506,7 @@ def make_pipeline(*steps, memory=None, transform_input=None, verbose=False):
     )
 
 
-def _transform_one(transformer, X, y, weight, params=None):
+def _transform_one(transformer, X, y, weight, params=Bunch(transform={})):
     """Call transform and apply weight to output.
 
     Parameters

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -1506,7 +1506,7 @@ def make_pipeline(*steps, memory=None, transform_input=None, verbose=False):
     )
 
 
-def _transform_one(transformer, X, y, weight, params=Bunch(transform={})):
+def _transform_one(transformer, X, y, weight, params):
     """Call transform and apply weight to output.
 
     Parameters


### PR DESCRIPTION
When "params=None", the call to "params.transform" below used to crash

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
N/A

#### What does this implement/fix? Explain your changes.
The default argument "params=None of _transform_one() is broken, the call of `**params.transform` raises an exception.
This change makes the default argument behave as intended.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
