### PR TITLE
DOC Point users to pretty conda-forge install page

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -59,7 +59,7 @@ feature, code or documentation improvement).
    instead.
 
 #. Install a recent version of Python (3.9 or later at the time of writing) for
-   instance using Miniforge3_. Miniforge provides a conda-based distribution of
+   instance using Condaforge_. Conda-forge provides a conda-based distribution of
    Python and the most popular scientific libraries.
 
    If you installed Python with conda, we recommend to create a dedicated
@@ -258,8 +258,8 @@ to enable OpenMP support:
 
 For Apple Silicon M1 hardware, only the conda-forge method below is known to
 work at the time of writing (January 2021). You can install the `macos/arm64`
-distribution of conda using the `miniforge installer
-<https://github.com/conda-forge/miniforge#miniforge>`_
+distribution of conda using the `conda-forge installer
+<https://conda-forge.org/download/>`_
 
 macOS compilers from conda-forge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -482,4 +482,4 @@ the base system and these steps will not be necessary.
 .. _Homebrew: https://brew.sh
 .. _virtualenv: https://docs.python.org/3/tutorial/venv.html
 .. _conda environment: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html
-.. _Miniforge3: https://github.com/conda-forge/miniforge#miniforge3
+.. _Condaforge: https://conda-forge.org/download/

--- a/doc/install_instructions_conda.rst
+++ b/doc/install_instructions_conda.rst
@@ -1,5 +1,5 @@
 Install conda using the
-`miniforge installers <https://github.com/conda-forge/miniforge#miniforge>`__ (no
+`conda-forge installers <https://conda-forge.org/download/>`__ (no
 administrator permission required). Then run:
 
 .. prompt:: bash


### PR DESCRIPTION
TIL from @jakirkham that conda-forge/miniforge has a pretty and good looking page with install instructions: https://conda-forge.org/download/

I updated the docs to point people there instead of the IMHO somewhat scary/unexpected GitHub page we were currently using. I think that page is a bit unusual for people who aren't familiar with GitHub already, where as the new page looks official and nice. In addition people have been mentioning that the GitHub install page gets flagged by browsers as "this site contains harmful content" (probably because of `curl foo | bash` style instructions) and the new page doesn't get flagged.

I tried to replace the occurrences of the miniforge GitHub link.

I also tried to update the "branding"/wording so that we talk about installing conda-forge instead of miniforge. I think it is helpful to use the same words/brand that appears on the top of the page we link to. At least I find it jarring when I get told "To install foo go to X" and then X talks about "installing bar". @jakirkham is "conda-forge installer" the word you use/we should use? I've lost track of the various combos of mini x conda x mamba x forge so please point out what the right one is if I got it wrong.