### PR TITLE
REL Add 1.6.1 to news

### DIFF
--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -207,6 +207,7 @@
         <h4 class="sk-landing-call-header">News</h4>
         <ul class="sk-landing-call-list list-unstyled">
           <li><strong>On-going development:</strong> <a href="https://scikit-learn.org/dev/whats_new/v1.7.html#version-1-7-0">scikit-learn 1.7 (Changelog)</a>.</li>
+          <li><strong>January 2025.</strong> scikit-learn 1.6.1 is available for download (<a href="whats_new/v1.6.html#version-1-6-1">Changelog</a>).</li>
           <li><strong>December 2024.</strong> scikit-learn 1.6.0 is available for download (<a href="whats_new/v1.6.html#version-1-6-0">Changelog</a>).</li>
           <li><strong>September 2024.</strong> scikit-learn 1.5.2 is available for download (<a href="whats_new/v1.5.html#version-1-5-2">Changelog</a>).</li>
           <li><strong>July 2024.</strong> scikit-learn 1.5.1 is available for download (<a href="whats_new/v1.5.html#version-1-5-1">Changelog</a>).</li>


### PR DESCRIPTION
Part of the 1.6.1 release process. It will be backported in 1.6.X when merged.