### PR TITLE
DOC: Update install instructions to recommend conda-forge over Anaconda

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -27,6 +27,8 @@ There are different ways to install scikit-learn:
 
 Installing the latest release
 =============================
+For most users, we recommend installing scikit-learn using the `conda-forge` channel on Conda. `conda-forge` provides up-to-date packages that are optimized for scientific computing and ensure better compatibility across platforms. If you prefer using pip, scikit-learn is also available on PyPI.
+
 
 .. raw:: html
 


### PR DESCRIPTION
#### Reference Issues/PRs

Follow-up of #30193 with the goal of having a smaller scope.

#### What does this implement/fix? Explain your changes.

This Pull Request updates the **Installing the latest release** section of the documentation to recommend `conda-forge` as the preferred installation method for scikit-learn. Changes include:

- Highlighting the advantages of using `conda-forge` for dependency management and cross-platform compatibility.
- Making minimal changes to ensure the scope of this PR is focused and easy to review.

#### Any other comments?

I have tested the updated documentation locally using `make doc` and confirmed that it builds without warnings or errors. Please let me know if there are additional adjustments or improvements required. Thank you for your guidance and feedback throughout this process!