### PR TITLE
Final Fix/average precision single sample validation Fixes #30615 

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -220,7 +220,6 @@ def average_precision_score(
 
     def _binary_uninterpolated_average_precision(
         y_true, y_score, pos_label=1, sample_weight=None
-
     ):
         if len(y_true) < 2:
             raise ValueError(

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -221,10 +221,10 @@ def average_precision_score(
     def _binary_uninterpolated_average_precision(
         y_true, y_score, pos_label=1, sample_weight=None
     ):
-        if len(y_true) < 2:
+        if y_true.shape[0] < 2:
             raise ValueError(
-                f"Average precision requires at least 2 samples. Got {len(y_true)}."
-                " A single sample cannot form a precision-recall curve."
+                "Average precision requires at least 2 samples to compute a meaningful "
+                f"score, but got array with shape = {y_true.shape}"
             )
         precision, recall, _ = precision_recall_curve(
             y_true, y_score, pos_label=pos_label, sample_weight=sample_weight

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -227,7 +227,6 @@ def average_precision_score(
                 f"Average precision requires at least 2 samples. Got {len(y_true)}."
                 " A single sample cannot form a precision-recall curve."
             )
-
         precision, recall, _ = precision_recall_curve(
             y_true, y_score, pos_label=pos_label, sample_weight=sample_weight
         )

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -219,6 +219,14 @@ def average_precision_score(
     def _binary_uninterpolated_average_precision(
         y_true, y_score, pos_label=1, sample_weight=None
     ):
+        
+        if len(y_true) < 2:
+            raise ValueError(
+                "Average precision requires at least 2 samples to compute a meaningful "
+                "score. A single sample cannot form a precision-recall curve. "
+                f"Got array with shape ({len(y_true)},)"
+            )
+   
         precision, recall, _ = precision_recall_curve(
             y_true, y_score, pos_label=pos_label, sample_weight=sample_weight
         )

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -220,25 +220,14 @@ def average_precision_score(
 
     def _binary_uninterpolated_average_precision(
         y_true, y_score, pos_label=1, sample_weight=None
-<<<<<<< HEAD
-    ):  
+
+    ):
         if len(y_true) < 2:
             raise ValueError(
                 f"Average precision requires at least 2 samples. Got {len(y_true)}."
                 " A single sample cannot form a precision-recall curve."
             )
 
-=======
-    ):
-        
-        if len(y_true) < 2:
-            raise ValueError(
-                "Average precision requires at least 2 samples to compute a meaningful "
-                "score. A single sample cannot form a precision-recall curve. "
-                f"Got array with shape ({len(y_true)},)"
-            )
-   
->>>>>>> 2f224d2fb39498443d7d56a73d0261284425880f
         precision, recall, _ = precision_recall_curve(
             y_true, y_score, pos_label=pos_label, sample_weight=sample_weight
         )

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -220,7 +220,13 @@ def average_precision_score(
 
     def _binary_uninterpolated_average_precision(
         y_true, y_score, pos_label=1, sample_weight=None
-    ):
+    ):  
+        if len(y_true) < 2:
+            raise ValueError(
+                f"Average precision requires at least 2 samples. Got {len(y_true)}."
+                " A single sample cannot form a precision-recall curve."
+            )
+
         precision, recall, _ = precision_recall_curve(
             y_true, y_score, pos_label=pos_label, sample_weight=sample_weight
         )


### PR DESCRIPTION
### Fixes #30615  

### **Solution**  
The issue was resolved by introducing an additional validation check in the `_binary_uninterpolated_average_precision` function. This ensures that the function receives at least two samples (`y_true`) before attempting to compute the average precision score.  

### **Implementation Details**  

#### Key Changes:
1. **Input Validation**:  
   A validation check was added to verify that the input `y_true` contains at least two samples. If the condition is not met, a `ValueError` is raised with a descriptive error message.  

2. **Error Messaging**:  
   The error message is detailed and aligns with scikit-learn's conventions, explaining why computation with fewer than two samples is not meaningful.  

#### Updated Code:  

```python
def _binary_uninterpolated_average_precision(
    y_true, y_score, pos_label=1, sample_weight=None
):
    # Validation: Ensure at least 2 samples
    if y_true.shape[0] < 2:
        raise ValueError(
            "Average precision requires at least 2 samples to compute a meaningful "
            f"score, but got an array with shape = {y_true.shape}."
        )
    
    # Compute precision and recall
    precision, recall, _ = precision_recall_curve(
        y_true, y_score, pos_label=pos_label, sample_weight=sample_weight
    )
    
    # Return the step function integral
    return max(0.0, -np.sum(np.diff(recall) * np.array(precision)[:-1]))
```

---

### **Key Improvements Over Original Code**  

#### Before:  
- **Original Code**:  
  No validation was performed on the number of samples, which could lead to runtime errors or misleading results when processing very small datasets.  

```python
def _binary_uninterpolated_average_precision(
    y_true, y_score, pos_label=1, sample_weight=None
):
    precision, recall, _ = precision_recall_curve(
        y_true, y_score, pos_label=pos_label, sample_weight=sample_weight
    )
    return max(0.0, -np.sum(np.diff(recall) * np.array(precision)[:-1]))
```

#### After:  
- **Enhanced Code**:  
  Added a validation step to prevent potential errors and provided a clear, actionable error message for users.

---

### **Additional Notes**  
- The validation complements existing input checks by the `@validate_params` decorator and related functions, enhancing robustness.
- The function is compatible with both NumPy arrays and array-like inputs.
