### PR TITLE
MNT helper _nan_to_num function for array API

### DIFF
--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -1108,3 +1108,20 @@ def _tolist(array, xp=None):
         return array.tolist()
     array_np = _convert_to_numpy(array, xp=xp)
     return [element.item() for element in array_np]
+
+
+def _nan_to_num(array, xp=None):
+    """Substitutes NaN values of an array with 0 and inf values with the maximum or
+    minimum numbers available for the dtype respectively; like np.nan_to_num."""
+    xp, _ = get_namespace(array, xp=xp)
+    try:
+        array = xp.nan_to_num(array)
+    except AttributeError:  # currently catching exceptions from array_api_strict
+        array[xp.isnan(array)] = 0
+        if xp.isdtype(array.dtype, "real floating"):
+            array[xp.isinf(array) & (array > 0)] = xp.finfo(array.dtype).max
+            array[xp.isinf(array) & (array < 0)] = xp.finfo(array.dtype).min
+        else:  # xp.isdtype(array.dtype, "integral")
+            array[xp.isinf(array) & (array > 0)] = xp.iinfo(array.dtype).max
+            array[xp.isinf(array) & (array < 0)] = xp.iinfo(array.dtype).min
+    return array


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #26024

#### What does this implement/fix? Explain your changes.
Adding a function that might be useful for implementing Array API in `silhouette_samples` (and in `BaseSearchCV._format_results._store()` if we want that), where `np.nan_to_num` is used. I did not further check on these two.

(It was a by-product of #30440 and #30562, but due to selecting a different approach, not needed there anymore.)

#### Any other comments?
It is unclear if this function will be needed in the future (depending on how this will be decided in the corresponding [array api issue](https://github.com/data-apis/array-api/issues/878) and also depending on if we want to make `silhouette_samples` fully using all kinds of array or only make it compatible by only accepting all kind of array inputs). I don't mind if we don't do anything with this PR until it becomes clearer from the array api side how to handle this in the future.