### PR TITLE
Fixing bug in `get_namespace_and_device`.

### DIFF
--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -619,11 +619,10 @@ def get_namespace_and_device(*array_list, remove_none=True, remove_types=(str,))
     skip_remove_kwargs = dict(remove_none=False, remove_types=[])
 
     xp, is_array_api = get_namespace(*array_list, **skip_remove_kwargs)
-    arrays_device = device(*array_list, **skip_remove_kwargs)
     if is_array_api:
-        return xp, is_array_api, arrays_device
+        return xp, is_array_api, device(*array_list, **skip_remove_kwargs)
     else:
-        return xp, False, arrays_device
+        return xp, False, None
 
 
 def _expit(X, xp=None):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
When we upgraded to  `scikit-learn` version `1.6.0` we encountered a bug:
```
Traceback (most recent call last):
  File "/workspace/examples/graph_sage_unsup.py", line 80, in <module>
    val_acc, test_acc = test()
                        ^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/examples/graph_sage_unsup.py", line 70, in test
    val_acc = clf.score(out[data.val_mask], data.y[data.val_mask])
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sklearn/base.py", line 572, in score
    return accuracy_score(y, self.predict(X), sample_weight=sample_weight)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sklearn/utils/_param_validation.py", line 216, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sklearn/metrics/_classification.py", line 224, in accuracy_score
    xp, _, device = get_namespace_and_device(y_true, y_pred, sample_weight)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sklearn/utils/_array_api.py", line 614, in get_namespace_and_device
    arrays_device = device(*array_list, **skip_remove_kwargs)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/sklearn/utils/_array_api.py", line 178, in device
    raise ValueError(
ValueError: Input arrays use different devices: cpu, cpu
```

It appears that `device(*array_list, **skip_remove_kwargs)`  should only be called when `is_array_api` is `True`, as it was correctly handled in version `1.5.2`:
```
    xp, is_array_api = get_namespace(*array_list, **skip_remove_kwargs)
    if is_array_api:
        return (
            xp,
            is_array_api,
            device(*array_list, **skip_remove_kwargs),
        )
    else:
        return xp, False, None
```

The proposed changes corrected this error.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
