### PR TITLE
DOC add link to plot_iris_dtc example in DecisionTreeClassifier documentation

### DIFF
--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -944,6 +944,10 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
     ...
     array([ 1.     ,  0.93...,  0.86...,  0.93...,  0.93...,
             0.93...,  0.93...,  1.     ,  0.93...,  1.      ])
+
+    See :ref:`sphx_glr_auto_examples_tree_plot_iris_dtc.py` for an
+    example of training and visualizing a decision tree classifer on
+    the Iris dataset.
     """
 
     # "check_input" is used for optimisation and isn't something to be passed


### PR DESCRIPTION
This pull request adds a reference link to the `plot_iris_dtc.py` example in the documentation for `DecisionTreeClassifier`. 

### Changes:
- Added a link to `plot_iris_dtc.py` in the `DecisionTreeClassifier` API docstring to give an example.

### Purpose:
- To make it easier for users to discover examples relevant to `DecisionTreeClassifier`.

### Related Issue:
Towards #30621.

