### PR TITLE
MNT Tweak towncrier fragments to follow guideline

### DIFF
--- a/doc/whats_new/upcoming_changes/array-api/29978.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/29978.feature.rst
@@ -1,3 +1,3 @@
 - :func:`sklearn.metrics.explained_variance_score` and
   :func:`sklearn.metrics.mean_pinball_loss` now support Array API compatible inputs.
-  by :user:`Virgil Chan <virchan>`
+  By :user:`Virgil Chan <virchan>`

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/30521.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/30521.fix.rst
@@ -1,4 +1,4 @@
 -  |Enhancement| Added a new paramenter `tol` to
    :class:`linear_model.LinearRegression` that determines the precision of the
-   solution `coef_` when fitting on sparse data. :pr:`30521` by :user:`Success Moses
-   <SuccessMoses>`.
+   solution `coef_` when fitting on sparse data.
+   By :user:`Success Moses <SuccessMoses>`

--- a/doc/whats_new/upcoming_changes/sklearn.pipeline/30406.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.pipeline/30406.enhancement.rst
@@ -1,4 +1,4 @@
 - Expose the ``verbose_feature_names_out`` argument in the
   :func:`pipeline.make_union` function, allowing users to control
   feature name uniqueness in the :class:`pipeline.FeatureUnion`.
-  By :user:`Abhijeetsingh Meena <Ethan0456>`.
+  By :user:`Abhijeetsingh Meena <Ethan0456>`


### PR DESCRIPTION
The main thing was that one fragment was using ``:pr:`<some-number>` `` which is not needed, since towncrier adds the PR automatically it would mention the PR twice.

See [dev changelog](https://scikit-learn.org/dev/whats_new/v1.7.html#sklearn-linear-model) 
![image](https://github.com/user-attachments/assets/41e1ce0e-c4dc-4cb5-8d02-974079dd8c03)

While I was at it, I tweaked a few other fragments to follow the [guideline](https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md)