### PR TITLE
FIX update deprecated param for example using class_likelihood_ratios

### DIFF
--- a/examples/model_selection/plot_likelihood_ratios.py
+++ b/examples/model_selection/plot_likelihood_ratios.py
@@ -61,7 +61,7 @@ from sklearn.metrics import class_likelihood_ratios
 
 estimator = LogisticRegression().fit(X_train, y_train)
 y_pred = estimator.predict(X_test)
-pos_LR, neg_LR = class_likelihood_ratios(y_test, y_pred)
+pos_LR, neg_LR = class_likelihood_ratios(y_test, y_pred, replace_undefined_by=1.0)
 print(f"LR+: {pos_LR:.3f}")
 
 # %%
@@ -81,7 +81,7 @@ import pandas as pd
 
 def scoring(estimator, X, y):
     y_pred = estimator.predict(X)
-    pos_lr, neg_lr = class_likelihood_ratios(y, y_pred, raise_warning=False)
+    pos_lr, neg_lr = class_likelihood_ratios(y, y_pred, replace_undefined_by=1.0)
     return {"positive_likelihood_ratio": pos_lr, "negative_likelihood_ratio": neg_lr}
 
 

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -753,11 +753,11 @@ matthews_corrcoef_scorer = make_scorer(matthews_corrcoef)
 
 
 def positive_likelihood_ratio(y_true, y_pred):
-    return class_likelihood_ratios(y_true, y_pred)[0]
+    return class_likelihood_ratios(y_true, y_pred, replace_undefined_by=1.0)[0]
 
 
 def negative_likelihood_ratio(y_true, y_pred):
-    return class_likelihood_ratios(y_true, y_pred)[1]
+    return class_likelihood_ratios(y_true, y_pred, replace_undefined_by=1.0)[1]
 
 
 positive_likelihood_ratio_scorer = make_scorer(positive_likelihood_ratio)


### PR DESCRIPTION
This fixes a failure with the doc build on main that was accidentally introduced with #29288 (see comment https://github.com/scikit-learn/scikit-learn/pull/29288#issuecomment-2598701450).

Also, the PR makes `class_likelihood_ratios` use the new param when it's indirectly used in the scoring, so that users don't get the `FutureWarning`, when they have no control about it.

@lesteve @adrinjalali 