### PR TITLE
CI Restore cache from main on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,9 @@ jobs:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh
       - restore_cache:
-          key: v1-doc-min-deps-datasets-{{ .Branch }}
+          keys:
+            - v1-doc-min-deps-datasets-{{ .Branch }}
+            - v1-doc-min-deps-datasets
       - restore_cache:
           keys:
             - doc-min-deps-ccache-{{ .Branch }}
@@ -69,7 +71,9 @@ jobs:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh
       - restore_cache:
-          key: v1-doc-datasets-{{ .Branch }}
+          keys:
+            - v1-doc-datasets-{{ .Branch }}
+            - v1-doc-datasets
       - restore_cache:
           keys:
             - doc-ccache-{{ .Branch }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - restore_cache:
           keys:
             - v1-doc-min-deps-datasets-{{ .Branch }}
-            - v1-doc-min-deps-datasets
+            - v1-doc-min-deps-datasets-main
       - restore_cache:
           keys:
             - doc-min-deps-ccache-{{ .Branch }}
@@ -73,7 +73,7 @@ jobs:
       - restore_cache:
           keys:
             - v1-doc-datasets-{{ .Branch }}
-            - v1-doc-datasets
+            - v1-doc-datasets-main
       - restore_cache:
           keys:
             - doc-ccache-{{ .Branch }}


### PR DESCRIPTION
An attempt to reuse the cache from main inside PRs. This could be useful until OpenML is getting back to normal.

This does something similar to the ccache cache a few lines below.

Note: there are some [caveats](https://circleci.com/docs/oss/#caching) (see [this](https://circleci.com/docs/oss/#pass-secrets-to-builds-from-forked-pull-requests) also) with the approach but it looks like we were already doing so maybe it's OK enough :thinking:.