### PR TITLE
CI Xfail test for Pyodide

### DIFF
--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -139,7 +139,7 @@ def test_check_warnings_threading():
         assert all(w == filters for w in all_warnings)
 
 
-@pytest.mark.xfail(_IS_WASM, "Pyodide always use the sequential backend")
+@pytest.mark.xfail(_IS_WASM, reason="Pyodide always use the sequential backend")
 def test_filter_warning_propagates_no_side_effect_with_loky_backend():
     with warnings.catch_warnings():
         warnings.simplefilter("error", category=ConvergenceWarning)

--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -14,6 +14,7 @@ from sklearn.exceptions import ConvergenceWarning
 from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
+from sklearn.utils._fixes import _IS_WASM
 from sklearn.utils.parallel import Parallel, delayed
 
 
@@ -138,6 +139,7 @@ def test_check_warnings_threading():
         assert all(w == filters for w in all_warnings)
 
 
+@pytest.mark.xfail(_IS_WASM, "Pyodide always use the sequential backend")
 def test_filter_warning_propagates_no_side_effect_with_loky_backend():
     with warnings.catch_warnings():
         warnings.simplefilter("error", category=ConvergenceWarning)

--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -14,7 +14,7 @@ from sklearn.exceptions import ConvergenceWarning
 from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
-from sklearn.utils._fixes import _IS_WASM
+from sklearn.utils.fixes import _IS_WASM
 from sklearn.utils.parallel import Parallel, delayed
 
 


### PR DESCRIPTION
Pyodide is always using the sequential backend so there is actually some side effect and the test needs to be xfailed.

Failure seen in [build log](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=73633&view=logs&jobId=6fac3219-cc32-5595-eb73-7f086a643b12&j=6fac3219-cc32-5595-eb73-7f086a643b12&t=dfb0637f-eb02-5202-9884-61d82a155bad).