### PR TITLE
MNT Add robots.txt to avoid indexing of old version doc

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -340,7 +340,7 @@ html_sidebars = {
 html_additional_pages = {"index": "index.html"}
 
 # Additional files to copy
-# html_extra_path = []
+html_extra_path = ["robots.txt"]
 
 # Additional JS files
 html_js_files = [

--- a/doc/robots.txt
+++ b/doc/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /
+Allow: /stable
+Allow: /dev/developers


### PR DESCRIPTION
Fixes #8958.

After rereading the issue, adding a `robots.txt` seems like the simplest thing to do. I think this is worth trying for a few weeks and see whether this helps. ReadTheDocs mentions [robots.txt](https://docs.readthedocs.io/en/stable/reference/robots.html) for example.

For now I made the choice of excluding everything for indexing but:
- `/stable`
- `/dev/developers` to allow indexing of the developer doc

This can definitely be tweaked if you have better suggestions. 

I kind of tested manually the robots.txt with https://robotstxt.com/tester and it seems to do what we want.