### PR TITLE
Backports in 1.6.X

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -340,7 +340,7 @@ html_sidebars = {
 html_additional_pages = {"index": "index.html"}
 
 # Additional files to copy
-# html_extra_path = []
+html_extra_path = ["robots.txt"]
 
 # Additional JS files
 html_js_files = [

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -59,7 +59,7 @@ feature, code or documentation improvement).
    instead.
 
 #. Install a recent version of Python (3.9 or later at the time of writing) for
-   instance using Miniforge3_. Miniforge provides a conda-based distribution of
+   instance using Condaforge_. Conda-forge provides a conda-based distribution of
    Python and the most popular scientific libraries.
 
    If you installed Python with conda, we recommend to create a dedicated
@@ -258,8 +258,8 @@ to enable OpenMP support:
 
 For Apple Silicon M1 hardware, only the conda-forge method below is known to
 work at the time of writing (January 2021). You can install the `macos/arm64`
-distribution of conda using the `miniforge installer
-<https://github.com/conda-forge/miniforge#miniforge>`_
+distribution of conda using the `conda-forge installer
+<https://conda-forge.org/download/>`_
 
 macOS compilers from conda-forge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -482,4 +482,4 @@ the base system and these steps will not be necessary.
 .. _Homebrew: https://brew.sh
 .. _virtualenv: https://docs.python.org/3/tutorial/venv.html
 .. _conda environment: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html
-.. _Miniforge3: https://github.com/conda-forge/miniforge#miniforge3
+.. _Condaforge: https://conda-forge.org/download/

--- a/doc/install_instructions_conda.rst
+++ b/doc/install_instructions_conda.rst
@@ -1,5 +1,5 @@
 Install conda using the
-`miniforge installers <https://github.com/conda-forge/miniforge#miniforge>`__ (no
+`conda-forge installers <https://conda-forge.org/download/>`__ (no
 administrator permission required). Then run:
 
 .. prompt:: bash

--- a/doc/robots.txt
+++ b/doc/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /
+Allow: /stable
+Allow: /dev/developers


### PR DESCRIPTION
backports these 2 commits in 1.6.X:

- 5691f2672a4d5bc0ce36629aec58d8a4076e5e99 from https://github.com/scikit-learn/scikit-learn/pull/30617
- 61077dc08fd9cd6538fa8cece2f1dc1cee49e57d from https://github.com/scikit-learn/scikit-learn/pull/30685*

cc/ @lesteve @betatim 