### PR TITLE
MNT Change LinearRegression default tol to not break behavior

### DIFF
--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -473,7 +473,7 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
     copy_X : bool, default=True
         If True, X will be copied; else, it may be overwritten.
 
-    tol : float, default=1e-4
+    tol : float, default=1e-6
         The precision of the solution (`coef_`) is determined by `tol` which
         specifies a different convergence criterion for the `lsqr` solver.
         `tol` is set as `atol` and `btol` of `scipy.sparse.linalg.lsqr` when
@@ -573,7 +573,7 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
         *,
         fit_intercept=True,
         copy_X=True,
-        tol=1e-4,
+        tol=1e-6,
         n_jobs=None,
         positive=False,
     ):

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -72,7 +72,7 @@ def test_linear_regression_sample_weights(
     sample_weight = 1.0 + rng.uniform(size=n_samples)
 
     # LinearRegression with explicit sample_weight
-    reg = LinearRegression(fit_intercept=fit_intercept)
+    reg = LinearRegression(fit_intercept=fit_intercept, tol=1e-16)
     reg.fit(X, y, sample_weight=sample_weight)
     coefs1 = reg.coef_
     inter1 = reg.intercept_


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/30684

Now that LinearRegression has a tol parameter we need to set it to a low value if we want to compare with the exact solution.