### PR TITLE
MNT Apply ruff/flake8-implicit-str-concat rules (ISC)

### DIFF
--- a/build_tools/get_comment.py
+++ b/build_tools/get_comment.py
@@ -56,9 +56,8 @@ def get_step_message(log, start, end, title, message, details):
         return ""
     res = (
         "-----------------------------------------------\n"
-        + f"### {title}\n\n"
-        + message
-        + "\n\n"
+        f"### {title}\n\n"
+        f"{message}\n\n"
     )
     if details:
         res += (

--- a/examples/classification/plot_lda.py
+++ b/examples/classification/plot_lda.py
@@ -98,10 +98,10 @@ plt.ylabel("Classification accuracy")
 plt.legend(loc="lower left")
 plt.ylim((0.65, 1.0))
 plt.suptitle(
-    "LDA (Linear Discriminant Analysis) vs. "
-    + "\n"
-    + "LDA with Ledoit Wolf vs. "
-    + "\n"
-    + "LDA with OAS (1 discriminative feature)"
+    "LDA (Linear Discriminant Analysis) vs."
+    "\n"
+    "LDA with Ledoit Wolf vs."
+    "\n"
+    "LDA with OAS (1 discriminative feature)"
 )
 plt.show()

--- a/examples/cluster/plot_cluster_comparison.py
+++ b/examples/cluster/plot_cluster_comparison.py
@@ -224,14 +224,14 @@ for i_dataset, (dataset, algo_params) in enumerate(datasets):
             warnings.filterwarnings(
                 "ignore",
                 message="the number of connected components of the "
-                + "connectivity matrix is [0-9]{1,2}"
-                + " > 1. Completing it to avoid stopping the tree early.",
+                "connectivity matrix is [0-9]{1,2}"
+                " > 1. Completing it to avoid stopping the tree early.",
                 category=UserWarning,
             )
             warnings.filterwarnings(
                 "ignore",
                 message="Graph is not fully connected, spectral embedding"
-                + " may not work as expected.",
+                " may not work as expected.",
                 category=UserWarning,
             )
             algorithm.fit(X)

--- a/examples/cluster/plot_linkage_comparison.py
+++ b/examples/cluster/plot_linkage_comparison.py
@@ -123,8 +123,8 @@ for i_dataset, (dataset, algo_params) in enumerate(datasets):
             warnings.filterwarnings(
                 "ignore",
                 message="the number of connected components of the "
-                + "connectivity matrix is [0-9]{1,2}"
-                + " > 1. Completing it to avoid stopping the tree early.",
+                "connectivity matrix is [0-9]{1,2}"
+                " > 1. Completing it to avoid stopping the tree early.",
                 category=UserWarning,
             )
             algorithm.fit(X)

--- a/examples/kernel_approximation/plot_scalable_poly_kernels.py
+++ b/examples/kernel_approximation/plot_scalable_poly_kernels.py
@@ -143,7 +143,7 @@ for n_components in N_COMPONENTS:
     }
     print(
         f"Linear SVM score on {n_components} PolynomialCountSketch "
-        + f"features: {ps_lsvm_score:.2f}%"
+        f"features: {ps_lsvm_score:.2f}%"
     )
 
 # %%

--- a/examples/mixture/plot_concentration_prior.py
+++ b/examples/mixture/plot_concentration_prior.py
@@ -103,7 +103,7 @@ means = np.array([[0.0, -0.70], [0.0, 0.0], [0.0, 0.70]])
 # mean_precision_prior= 0.8 to minimize the influence of the prior
 estimators = [
     (
-        "Finite mixture with a Dirichlet distribution\nprior and " r"$\gamma_0=$",
+        "Finite mixture with a Dirichlet distribution\n" r"prior and $\gamma_0=$",
         BayesianGaussianMixture(
             weight_concentration_prior_type="dirichlet_distribution",
             n_components=2 * n_components,
@@ -116,7 +116,7 @@ estimators = [
         [0.001, 1, 1000],
     ),
     (
-        "Infinite mixture with a Dirichlet process\n prior and" r"$\gamma_0=$",
+        "Infinite mixture with a Dirichlet process\n" r"prior and $\gamma_0=$",
         BayesianGaussianMixture(
             weight_concentration_prior_type="dirichlet_process",
             n_components=2 * n_components,

--- a/maint_tools/sort_whats_new.py
+++ b/maint_tools/sort_whats_new.py
@@ -23,7 +23,7 @@ bucketed = defaultdict(list)
 
 for entry in re.split("\n(?=- )", text.strip()):
     modules = re.findall(
-        r":(?:func|meth|mod|class):" r"`(?:[^<`]*<|~)?(?:sklearn.)?([a-z]\w+)", entry
+        r":(?:func|meth|mod|class):`(?:[^<`]*<|~)?(?:sklearn.)?([a-z]\w+)", entry
     )
     modules = set(modules)
     if len(modules) > 1:

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -110,8 +110,8 @@ def _clone_parametrized(estimator, *, safe=True):
             if isinstance(estimator, type):
                 raise TypeError(
                     "Cannot clone object. "
-                    + "You should provide an instance of "
-                    + "scikit-learn estimator instead of a class."
+                    "You should provide an instance of "
+                    "scikit-learn estimator instead of a class."
                 )
             else:
                 raise TypeError(

--- a/sklearn/compose/tests/test_target.py
+++ b/sklearn/compose/tests/test_target.py
@@ -36,7 +36,7 @@ def test_transform_target_regressor_error():
     )
     with pytest.raises(
         TypeError,
-        match=r"fit\(\) got an unexpected " "keyword argument 'sample_weight'",
+        match=r"fit\(\) got an unexpected keyword argument 'sample_weight'",
     ):
         regr.fit(X, y, sample_weight=sample_weight)
 

--- a/sklearn/datasets/_twenty_newsgroups.py
+++ b/sklearn/datasets/_twenty_newsgroups.py
@@ -115,7 +115,7 @@ def strip_newsgroup_header(text):
 
 
 _QUOTE_RE = re.compile(
-    r"(writes in|writes:|wrote:|says:|said:" r"|^In article|^Quoted from|^\||^>)"
+    r"(writes in|writes:|wrote:|says:|said:|^In article|^Quoted from|^\||^>)"
 )
 
 

--- a/sklearn/datasets/tests/test_samples_generator.py
+++ b/sklearn/datasets/tests/test_samples_generator.py
@@ -689,7 +689,7 @@ def test_make_moons_unbalanced():
 
     with pytest.raises(
         ValueError,
-        match=r"`n_samples` can be either an int " r"or a two-element tuple.",
+        match=r"`n_samples` can be either an int or a two-element tuple.",
     ):
         make_moons(n_samples=(10,))
 

--- a/sklearn/decomposition/_factor_analysis.py
+++ b/sklearn/decomposition/_factor_analysis.py
@@ -295,8 +295,8 @@ class FactorAnalysis(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEsti
         else:
             warnings.warn(
                 "FactorAnalysis did not converge."
-                + " You might want"
-                + " to increase the number of iterations.",
+                " You might want"
+                " to increase the number of iterations.",
                 ConvergenceWarning,
             )
 

--- a/sklearn/decomposition/tests/test_fastica.py
+++ b/sklearn/decomposition/tests/test_fastica.py
@@ -367,7 +367,7 @@ def test_fastica_errors():
     with pytest.raises(ValueError, match=r"alpha must be in \[1,2\]"):
         fastica(X, fun_args={"alpha": 0})
     with pytest.raises(
-        ValueError, match="w_init has invalid shape.+" r"should be \(3L?, 3L?\)"
+        ValueError, match=r"w_init has invalid shape.+should be \(3L?, 3L?\)"
     ):
         fastica(X, w_init=w_init)
 

--- a/sklearn/feature_selection/_base.py
+++ b/sklearn/feature_selection/_base.py
@@ -260,8 +260,8 @@ def _get_feature_importances(estimator, getter, transform_func=None, norm_order=
     else:
         raise ValueError(
             "Valid values for `transform_func` are "
-            + "None, 'norm' and 'square'. Those two "
-            + "transformation are only supported now"
+            "None, 'norm' and 'square'. Those two "
+            "transformation are only supported now"
         )
 
     return importances

--- a/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
+++ b/sklearn/inspection/_plot/tests/test_plot_partial_dependence.py
@@ -1186,9 +1186,9 @@ def test_plot_partial_dependence_lines_kw(
     )
 
     line = disp.lines_[0, 0, -1]
-    assert line.get_color() == expected_colors[0], (
-        f"{line.get_color()}!={expected_colors[0]}\n" f"{line_kw} and {pd_line_kw}"
-    )
+    assert (
+        line.get_color() == expected_colors[0]
+    ), f"{line.get_color()}!={expected_colors[0]}\n{line_kw} and {pd_line_kw}"
     if pd_line_kw is not None:
         if "linestyle" in pd_line_kw:
             assert line.get_linestyle() == pd_line_kw["linestyle"]

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -524,7 +524,7 @@ def test_ridge_regression_convergence_fail():
     rng = np.random.RandomState(0)
     y = rng.randn(5)
     X = rng.randn(5, 10)
-    warning_message = r"sparse_cg did not converge after" r" [0-9]+ iterations."
+    warning_message = r"sparse_cg did not converge after [0-9]+ iterations."
     with pytest.warns(ConvergenceWarning, match=warning_message):
         ridge_regression(
             X, y, alpha=1.0, solver="sparse_cg", tol=0.0, max_iter=None, verbose=1

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -40,7 +40,7 @@ score_funcs = [
 def test_error_messages_on_wrong_input():
     for score_func in score_funcs:
         expected = (
-            r"Found input variables with inconsistent numbers " r"of samples: \[2, 3\]"
+            r"Found input variables with inconsistent numbers of samples: \[2, 3\]"
         )
         with pytest.raises(ValueError, match=expected):
             score_func([0, 1], [1, 1, 1])

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1801,7 +1801,7 @@ def test_metrics_pos_label_error_str(metric, y_pred_threshold, dtype_y_str):
         "pass pos_label explicit"
     )
     err_msg_pos_label_1 = (
-        r"pos_label=1 is not a valid label. It should be one of " r"\['eggs', 'spam'\]"
+        r"pos_label=1 is not a valid label. It should be one of \['eggs', 'spam'\]"
     )
 
     pos_label_default = signature(metric).parameters["pos_label"].default

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -1528,7 +1528,7 @@ def test_pairwise_distances_data_derived_params_error(metric):
 
     with pytest.raises(
         ValueError,
-        match=rf"The '(V|VI)' parameter is required for the " rf"{metric} metric",
+        match=rf"The '(V|VI)' parameter is required for the {metric} metric",
     ):
         pairwise_distances(X, Y, metric=metric)
 

--- a/sklearn/neighbors/tests/test_nca.py
+++ b/sklearn/neighbors/tests/test_nca.py
@@ -401,7 +401,7 @@ def test_verbose(init_name, capsys):
             line,
         )
     assert re.match(
-        r"\[NeighborhoodComponentsAnalysis\] Training took\ *" r"\d+\.\d{2}s\.",
+        r"\[NeighborhoodComponentsAnalysis\] Training took\ *\d+\.\d{2}s\.",
         lines[-2],
     )
     assert lines[-1] == ""

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2279,7 +2279,7 @@ def test_power_transformer_shape_exception(method):
     # Exceptions should be raised for arrays with different num_columns
     # than during fitting
     wrong_shape_message = (
-        r"X has \d+ features, but PowerTransformer is " r"expecting \d+ features"
+        r"X has \d+ features, but PowerTransformer is expecting \d+ features"
     )
 
     with pytest.raises(ValueError, match=wrong_shape_message):

--- a/sklearn/tests/test_docstring_parameters_consistency.py
+++ b/sklearn/tests/test_docstring_parameters_consistency.py
@@ -70,8 +70,8 @@ FUNCTION_DOCSTRING_CONSISTENCY_CASES = [
                 by support \(the number of true instances for each label\)\. This
                 alters 'macro' to account for label imbalance; it can result in an
                 F-score that is not between precision and recall\."""
-                + r"[\s\w]*\.*"  # optionally match additional sentence
-                + r"""
+                r"[\s\w]*\.*"  # optionally match additional sentence
+                r"""
             ``'samples'``:
                 Calculate metrics for each instance, and find their average \(only
                 meaningful for multilabel classification where this differs from

--- a/sklearn/tests/test_min_dependencies_readme.py
+++ b/sklearn/tests/test_min_dependencies_readme.py
@@ -33,9 +33,9 @@ def test_min_dependencies_readme():
 
     pattern = re.compile(
         r"(\.\. \|)"
-        + r"(([A-Za-z]+\-?)+)"
-        + r"(MinVersion\| replace::)"
-        + r"( [0-9]+\.[0-9]+(\.[0-9]+)?)"
+        r"(([A-Za-z]+\-?)+)"
+        r"(MinVersion\| replace::)"
+        r"( [0-9]+\.[0-9]+(\.[0-9]+)?)"
     )
 
     readme_path = Path(sklearn.__file__).parent.parent

--- a/sklearn/tests/test_min_dependencies_readme.py
+++ b/sklearn/tests/test_min_dependencies_readme.py
@@ -34,7 +34,6 @@ def test_min_dependencies_readme():
     pattern = re.compile(
         r"(\.\. \|)"
         r"(([A-Za-z]+\-?)+)"
-        r"(([A-Za-z]+(?:-[A-Za-z]+)*)?)"
         r"(MinVersion\| replace::)"
         r"( [0-9]+\.[0-9]+(\.[0-9]+)?)"
     )

--- a/sklearn/tests/test_min_dependencies_readme.py
+++ b/sklearn/tests/test_min_dependencies_readme.py
@@ -34,6 +34,7 @@ def test_min_dependencies_readme():
     pattern = re.compile(
         r"(\.\. \|)"
         r"(([A-Za-z]+\-?)+)"
+        r"(([A-Za-z]+(?:-[A-Za-z]+)*)?)"
         r"(MinVersion\| replace::)"
         r"( [0-9]+\.[0-9]+(\.[0-9]+)?)"
     )

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2317,7 +2317,7 @@ def check_estimators_empty_data_messages(name, estimator_orig):
     # the following y should be accepted by both classifiers and regressors
     # and ignored by unsupervised models
     y = _enforce_estimator_tags_y(e, np.array([1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]))
-    msg = r"0 feature\(s\) \(shape=\(\d*, 0\)\) while a minimum of \d* " "is required."
+    msg = r"0 feature\(s\) \(shape=\(\d*, 0\)\) while a minimum of \d* is required."
     with raises(ValueError, match=msg):
         e.fit(X_zero_features, y)
 

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -443,8 +443,7 @@ def test_check_docstring_parameters():
             "+ ['a', 'b']",
         ],
         [
-            "In function: "
-            + "sklearn.utils.tests.test_testing.f_too_many_param_docstring",
+            "In function: sklearn.utils.tests.test_testing.f_too_many_param_docstring",
             (
                 "Parameters in function docstring have more items w.r.t. function"
                 " signature, first extra item: c"
@@ -475,8 +474,7 @@ def test_check_docstring_parameters():
             "+ []",
         ],
         [
-            "In function: "
-            + f"sklearn.utils.tests.test_testing.{mock_meta_name}.predict",
+            f"In function: sklearn.utils.tests.test_testing.{mock_meta_name}.predict",
             (
                 "There's a parameter name mismatch in function docstring w.r.t."
                 " function signature, at index 0 diff: 'X' != 'y'"
@@ -489,21 +487,20 @@ def test_check_docstring_parameters():
         ],
         [
             "In function: "
-            + f"sklearn.utils.tests.test_testing.{mock_meta_name}."
-            + "predict_proba",
+            f"sklearn.utils.tests.test_testing.{mock_meta_name}."
+            "predict_proba",
             "potentially wrong underline length... ",
             "Parameters ",
             "--------- in ",
         ],
         [
-            "In function: "
-            + f"sklearn.utils.tests.test_testing.{mock_meta_name}.score",
+            f"In function: sklearn.utils.tests.test_testing.{mock_meta_name}.score",
             "potentially wrong underline length... ",
             "Parameters ",
             "--------- in ",
         ],
         [
-            "In function: " + f"sklearn.utils.tests.test_testing.{mock_meta_name}.fit",
+            f"In function: sklearn.utils.tests.test_testing.{mock_meta_name}.fit",
             (
                 "Parameters in function docstring have less items w.r.t. function"
                 " signature, first missing item: X"
@@ -788,13 +785,13 @@ def test_assert_docstring_consistency_descr_regex_pattern():
     # Check regex that matches full parameter descriptions
     regex_full = (
         r"The (set|group) "  # match 'set' or 'group'
-        + r"of labels to (include|add) "  # match 'include' or 'add'
-        + r"when `average \!\= 'binary'`, and (their|the) "  #  match 'their' or 'the'
-        + r"order if `average is None`\."
-        + r"[\s\w]*\.* "  # optionally match additional sentence
-        + r"Labels present (on|in) "  # match 'on' or 'in'
-        + r"(them|the) "  # match 'them' or 'the'
-        + r"datas? can be excluded\."  # match 'data' or 'datas'
+        r"of labels to (include|add) "  # match 'include' or 'add'
+        r"when `average \!\= 'binary'`, and (their|the) "  #  match 'their' or 'the'
+        r"order if `average is None`\."
+        r"[\s\w]*\.* "  # optionally match additional sentence
+        r"Labels present (on|in) "  # match 'on' or 'in'
+        r"(them|the) "  # match 'them' or 'the'
+        r"datas? can be excluded\."  # match 'data' or 'datas'
     )
 
     assert_docstring_consistency(

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -733,7 +733,7 @@ def test_check_array_accept_large_sparse_raise_exception(X_64bit):
 
 def test_check_array_min_samples_and_features_messages():
     # empty list is considered 2D by default:
-    msg = r"0 feature\(s\) \(shape=\(1, 0\)\) while a minimum of 1 is" " required."
+    msg = r"0 feature\(s\) \(shape=\(1, 0\)\) while a minimum of 1 is required."
     with pytest.raises(ValueError, match=msg):
         check_array([[]])
 
@@ -756,7 +756,7 @@ def test_check_array_min_samples_and_features_messages():
     # Simulate a model that would need at least 2 samples to be well defined
     X = np.ones((1, 10))
     y = np.ones(1)
-    msg = r"1 sample\(s\) \(shape=\(1, 10\)\) while a minimum of 2 is" " required."
+    msg = r"1 sample\(s\) \(shape=\(1, 10\)\) while a minimum of 2 is required."
     with pytest.raises(ValueError, match=msg):
         check_X_y(X, y, ensure_min_samples=2)
 
@@ -769,7 +769,7 @@ def test_check_array_min_samples_and_features_messages():
     # with k=3)
     X = np.ones((10, 2))
     y = np.ones(2)
-    msg = r"2 feature\(s\) \(shape=\(10, 2\)\) while a minimum of 3 is" " required."
+    msg = r"2 feature\(s\) \(shape=\(10, 2\)\) while a minimum of 3 is required."
     with pytest.raises(ValueError, match=msg):
         check_X_y(X, y, ensure_min_features=3)
 
@@ -782,7 +782,7 @@ def test_check_array_min_samples_and_features_messages():
     # 2D dataset.
     X = np.empty(0).reshape(10, 0)
     y = np.ones(10)
-    msg = r"0 feature\(s\) \(shape=\(10, 0\)\) while a minimum of 1 is" " required."
+    msg = r"0 feature\(s\) \(shape=\(10, 0\)\) while a minimum of 1 is required."
     with pytest.raises(ValueError, match=msg):
         check_X_y(X, y)
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Applying rule `ISC001` merges split string literals — usually as a result of black unfolding a line.

As for rule `ISC003`, it may appear it doesn't improve readability in some cases. However, I see such cases as black formatting issues.

#### Any other comments?

Not sure these rules should be enforced in CI, because I'm not certain they're always compatible with black.

[doc skip]
