### PR TITLE
CI Add explicit permissions to more GHA workflows

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -1,4 +1,7 @@
 name: Check Changelog
+permissions:
+  contents: read
+
 # This check makes sure that the changelog is properly updated
 # when a PR introduces a change in a test file.
 # To bypass this check, label the PR with "No Changelog Needed".

--- a/.github/workflows/check-sdist.yml
+++ b/.github/workflows/check-sdist.yml
@@ -1,4 +1,6 @@
 name: "Check sdist"
+permissions:
+  contents: read
 
 on:
   schedule:

--- a/.github/workflows/label-blank-issue.yml
+++ b/.github/workflows/label-blank-issue.yml
@@ -1,4 +1,6 @@
 name: Labels Blank issues
+permissions:
+  issues: write
 
 on:
   issues:

--- a/.github/workflows/update_tracking_issue.yml
+++ b/.github/workflows/update_tracking_issue.yml
@@ -11,6 +11,9 @@
 # Where JOB_NAME is contains the status of the job you are interested in
 
 name: "Update tracking issue"
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Part of #30702.

Those are the most straightforward ones where there is mostly an `actions/checkout` and you need `contents: read` for this.

Note that this PR is not testing anything since triggers are not `pull_request` + `push`