### PR TITLE
DOC Fix doc build now that OpenML is back

### DIFF
--- a/examples/applications/plot_time_series_lagged_features.py
+++ b/examples/applications/plot_time_series_lagged_features.py
@@ -40,7 +40,7 @@ from sklearn.datasets import fetch_file
 pl.Config.set_fmt_str_lengths(20)
 
 bike_sharing_data_file = fetch_file(
-    "https://openml1.win.tue.nl/datasets/0004/44063/dataset_44063.pq",
+    "https://openml.org/datasets/0004/44063/dataset_44063.pq",
     sha256="d120af76829af0d256338dc6dd4be5df4fd1f35bf3a283cab66a51c1c6abd06a",
 )
 bike_sharing_data_file

--- a/examples/applications/plot_time_series_lagged_features.py
+++ b/examples/applications/plot_time_series_lagged_features.py
@@ -40,7 +40,7 @@ from sklearn.datasets import fetch_file
 pl.Config.set_fmt_str_lengths(20)
 
 bike_sharing_data_file = fetch_file(
-    "https://github.com/lesteve/scikit_learn_data/raw/refs/heads/main/openml1.win.tue.nl/datasets_0004_44063/dataset_44063.pq",
+    "https://github.com/scikit-learn/examples-data/raw/refs/heads/master/bike-sharing-demand/dataset_44063.pq",
     sha256="d120af76829af0d256338dc6dd4be5df4fd1f35bf3a283cab66a51c1c6abd06a",
 )
 bike_sharing_data_file

--- a/examples/applications/plot_time_series_lagged_features.py
+++ b/examples/applications/plot_time_series_lagged_features.py
@@ -40,6 +40,11 @@ from sklearn.datasets import fetch_file
 pl.Config.set_fmt_str_lengths(20)
 
 bike_sharing_data_file = fetch_file(
+    # Original file was hosted at:
+    # https://openml1.win.tue.nl/datasets/0004/44063/dataset_44063.pq
+    # but is no longer reachable.
+    # TODO: switch to https://data.openml.org/datasets/0004/44063/dataset_44063.pq
+    # once possible.
     "https://github.com/scikit-learn/examples-data/raw/refs/heads/master/bike-sharing-demand/dataset_44063.pq",
     sha256="d120af76829af0d256338dc6dd4be5df4fd1f35bf3a283cab66a51c1c6abd06a",
 )

--- a/examples/applications/plot_time_series_lagged_features.py
+++ b/examples/applications/plot_time_series_lagged_features.py
@@ -40,7 +40,7 @@ from sklearn.datasets import fetch_file
 pl.Config.set_fmt_str_lengths(20)
 
 bike_sharing_data_file = fetch_file(
-    "https://openml.org/datasets/0004/44063/dataset_44063.pq",
+    "https://github.com/lesteve/scikit_learn_data/raw/refs/heads/main/openml1.win.tue.nl/datasets_0004_44063/dataset_44063.pq",
     sha256="d120af76829af0d256338dc6dd4be5df4fd1f35bf3a283cab66a51c1c6abd06a",
 )
 bike_sharing_data_file


### PR DESCRIPTION
OpenML should be mostly back to normal according to https://github.com/scikit-learn/scikit-learn/pull/30708#issuecomment-2613855878.

Actually the example with the OpenML parquet file still fails. For now I am using https://github.com/scikit-learn/examples-data to host the file. In the medium term we will be able to use a similar URL in `https://data.openml.org`, see  see https://github.com/scikit-learn/scikit-learn/pull/30708#issuecomment-2613916304.