### PR TITLE
DOC Enable the canonical link for docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -207,6 +207,9 @@ add_function_parentheses = False
 # Sphinx are currently 'default' and 'sphinxdoc'.
 html_theme = "pydata_sphinx_theme"
 
+# This config option is used to generate the canonical links in the header
+# of every page. The canonical link is needed to prevent search engines from
+# showing the same page from several versions as results.
 html_baseurl = "https://scikit-learn.org/stable/"
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -207,6 +207,8 @@ add_function_parentheses = False
 # Sphinx are currently 'default' and 'sphinxdoc'.
 html_theme = "pydata_sphinx_theme"
 
+html_baseurl = "https://scikit-learn.org/stable/"
+
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -209,7 +209,7 @@ html_theme = "pydata_sphinx_theme"
 
 # This config option is used to generate the canonical links in the header
 # of every page. The canonical link is needed to prevent search engines from
-# showing the same page from several versions as results.
+# returning results pointing to old scikit-learn versions.
 html_baseurl = "https://scikit-learn.org/stable/"
 
 # Theme options are theme-specific and customize the look and feel of a theme


### PR DESCRIPTION
Fixes #8958

This is an attempt to get the `<link rel=canonical />` tag back in our docs pages. In a local build this seems to fix the issue and generate a correct URL.

Waiting to see what the rendered docs do. I am not sure I know what (un)expected consequences this could have/which pages we'd need to look at to make sure the generated link is correct for all of them.

cc @lesteve 