### PR TITLE
DOC moved legend in LOF Novelty Detection

### DIFF
--- a/examples/neighbors/plot_lof_novelty_detection.py
+++ b/examples/neighbors/plot_lof_novelty_detection.py
@@ -89,4 +89,5 @@ plt.xlabel(
     "errors novel regular: %d/40 ; errors novel abnormal: %d/40"
     % (n_error_test, n_error_outliers)
 )
+plt.tight_layout()
 plt.show()

--- a/examples/neighbors/plot_lof_novelty_detection.py
+++ b/examples/neighbors/plot_lof_novelty_detection.py
@@ -82,7 +82,7 @@ plt.legend(
         "new regular observations",
         "new abnormal observations",
     ],
-    loc="upper left",
+    loc=(1.05, 0.4),
     prop=matplotlib.font_manager.FontProperties(size=11),
 )
 plt.xlabel(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

In LOF Novelty Detection, I moved the legend to the right of the plot.   
In this way, the legend won't block the graph at all.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
