### PR TITLE
Backport docs updates (conda-forge link, canonical URL) to 1.5.x

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -179,7 +179,7 @@ show_installed_libraries
 # Set parallelism to 3 to overlap IO bound tasks with CPU bound tasks on CI
 # workers with 2 cores when building the compiled extensions of scikit-learn.
 export SKLEARN_BUILD_PARALLEL=3
-pip install -e . --no-build-isolation
+pip install -e . --no-build-isolation --config-settings=compile-args="-j4"
 
 echo "ccache build summary:"
 ccache -s

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -207,6 +207,11 @@ add_function_parentheses = False
 # Sphinx are currently 'default' and 'sphinxdoc'.
 html_theme = "pydata_sphinx_theme"
 
+# This config option is used to generate the canonical links in the header
+# of every page. The canonical link is needed to prevent search engines from
+# returning results pointing to old scikit-learn versions.
+html_baseurl = "https://scikit-learn.org/stable/"
+
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -59,7 +59,7 @@ feature, code or documentation improvement).
    instead.
 
 #. Install a recent version of Python (3.9 or later at the time of writing) for
-   instance using Miniforge3_. Miniforge provides a conda-based distribution of
+   instance using Condaforge_. Conda-forge provides a conda-based distribution of
    Python and the most popular scientific libraries.
 
    If you installed Python with conda, we recommend to create a dedicated
@@ -255,8 +255,8 @@ to enable OpenMP support:
 
 For Apple Silicon M1 hardware, only the conda-forge method below is known to
 work at the time of writing (January 2021). You can install the `macos/arm64`
-distribution of conda using the `miniforge installer
-<https://github.com/conda-forge/miniforge#miniforge>`_
+distribution of conda using the `conda-forge installer
+<https://conda-forge.org/download/>`_
 
 macOS compilers from conda-forge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -480,6 +480,7 @@ the base system and these steps will not be necessary.
 .. _virtualenv: https://docs.python.org/3/tutorial/venv.html
 .. _conda environment: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html
 .. _Miniforge3: https://github.com/conda-forge/miniforge#miniforge3
+.. _Condaforge: https://conda-forge.org/download/
 
 Alternative compilers
 =====================

--- a/doc/install_instructions_conda.rst
+++ b/doc/install_instructions_conda.rst
@@ -1,5 +1,5 @@
 Install conda using the
-`miniforge installers <https://github.com/conda-forge/miniforge#miniforge>`__ (no
+`conda-forge installers <https://conda-forge.org/download/>`__ (no
 administrator permission required). Then run:
 
 .. prompt:: bash


### PR DESCRIPTION
I followed the first step from https://scikit-learn.org/dev/developers/maintainer.html#reference-steps (create a new branch from main, then rebase from `upstream/1.5.x`).

I picked two commits. The first one updates the conda-forge install page we link to, the second one adds teh canonical URL to our docs pages. Need to check if we need the conda-forge change/if it makes sense.

* 5691f2672a DOC Point users to pretty conda-forge install page (#30617)
* ed3e4237be DOC Enable the canonical link for docs (#30725)

xref #30727