### PR TITLE
DOC improve docs in DecisionBoundaryDisplay and linear models

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -47,8 +47,8 @@ solves a problem of the form:
     LinearRegression()
     >>> reg.coef_
     array([0.5, 0.5])
-    >>> round(reg.intercept_)
-    0
+    >>> reg.intercept_
+    0.0
 
 The coefficient estimates for Ordinary Least Squares rely on the
 independence of the features. When features are correlated and some

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -48,7 +48,7 @@ solves a problem of the form:
     >>> reg.coef_
     array([0.5, 0.5])
     >>> reg.intercept_
-    np.float64(1.11022...)
+    np.float64(2.22044...)
 
 The coefficient estimates for Ordinary Least Squares rely on the
 independence of the features. When features are correlated and some

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -37,8 +37,8 @@ solves a problem of the form:
    :align: center
    :scale: 50%
 
-:class:`LinearRegression` will take in its ``fit`` method arguments ``X``, ``y``,
-``sample_weight`` and will store the coefficients :math:`w` of the linear model in its
+:class:`LinearRegression` takes in its ``fit`` method arguments ``X``, ``y``,
+``sample_weight`` and stores the coefficients :math:`w` of the linear model in its
 ``coef_`` and ``intercept_`` attributes::
 
     >>> from sklearn import linear_model

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -47,8 +47,8 @@ solves a problem of the form:
     LinearRegression()
     >>> reg.coef_
     array([0.5, 0.5])
-    >>> reg.intercept_
-    np.float64(2.22044...)
+    >>> round(reg.intercept_)
+    0
 
 The coefficient estimates for Ordinary Least Squares rely on the
 independence of the features. When features are correlated and some

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -37,9 +37,9 @@ solves a problem of the form:
    :align: center
    :scale: 50%
 
-:class:`LinearRegression` will take in its ``fit`` method arrays ``X``, ``y``
-and will store the coefficients :math:`w` of the linear model in its
-``coef_`` member::
+:class:`LinearRegression` will take in its ``fit`` method arguments ``X``, ``y``,
+``sample_weight`` and will store the coefficients :math:`w` of the linear model in its
+``coef_`` and ``intercept_`` attributes::
 
     >>> from sklearn import linear_model
     >>> reg = linear_model.LinearRegression()
@@ -47,9 +47,11 @@ and will store the coefficients :math:`w` of the linear model in its
     LinearRegression()
     >>> reg.coef_
     array([0.5, 0.5])
+    >>> reg.intercept_
+    np.float64(1.11022...)
 
 The coefficient estimates for Ordinary Least Squares rely on the
-independence of the features. When features are correlated and the
+independence of the features. When features are correlated and some
 columns of the design matrix :math:`X` have an approximately linear
 dependence, the design matrix becomes close to singular
 and as a result, the least-squares estimate becomes highly sensitive
@@ -79,7 +81,7 @@ Ordinary Least Squares Complexity
 ---------------------------------
 
 The least squares solution is computed using the singular value
-decomposition of X. If X is a matrix of shape `(n_samples, n_features)`
+decomposition of :math:`X`. If :math:`X` is a matrix of shape `(n_samples, n_features)`
 this method has a cost of
 :math:`O(n_{\text{samples}} n_{\text{features}}^2)`, assuming that
 :math:`n_{\text{samples}} \geq n_{\text{features}}`.

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -26,11 +26,10 @@ def _check_boundary_response_method(estimator, response_method, class_of_interes
     estimator : object
         Fitted estimator to check.
 
-    response_method : {'auto', 'predict_proba', 'decision_function', 'predict'}
-        Specifies whether to use :term:`predict_proba`,
-        :term:`decision_function`, :term:`predict` as the target response.
-        If set to 'auto', the response method is tried in the following order:
-        :term:`decision_function`, :term:`predict_proba`, :term:`predict`.
+    response_method : {'auto', 'decision_function', 'predict_proba', 'predict'}
+        Specifies whether to use :term:`decision_function`, :term:`predict_proba`,
+        :term:`predict` as the target response. If set to 'auto', the response method is
+        tried in the before mentioned order.
 
     class_of_interest : int, float, bool, str or None
         The class considered when plotting the decision. Cannot be None if

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -248,14 +248,12 @@ class DecisionBoundaryDisplay:
             :func:`contour <matplotlib.pyplot.contour>`,
             :func:`pcolormesh <matplotlib.pyplot.pcolormesh>`.
 
-        response_method : {'auto', 'predict_proba', 'decision_function', \
+        response_method : {'auto', 'decision_function', 'predict_proba', \
                 'predict'}, default='auto'
-            Specifies whether to use :term:`predict_proba`,
-            :term:`decision_function`, :term:`predict` as the target response.
-            If set to 'auto', the response method is tried in the following order:
-            :term:`decision_function`, :term:`predict_proba`, :term:`predict`.
-            For multiclass problems, :term:`predict` is selected when
-            `response_method="auto"`.
+            Specifies whether to use :term:`decision_function`, :term:`predict_proba`
+            or :term:`predict` as the target response. If set to 'auto', the response
+            method is tried in the before mentioned order. For multiclass problems,
+            :term:`predict` is selected when `response_method="auto"`.
 
         class_of_interest : int, float, bool or str, default=None
             The class considered when plotting the decision. If None,


### PR DESCRIPTION
This PR proposes doc improvements in the docstring of `DecisionBoundaryDisplay.from_estimator` and in and `linear_models.rst` to facilitate readability.
