### PR TITLE
DOC Fix conda-forge typo

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -59,7 +59,7 @@ feature, code or documentation improvement).
    instead.
 
 #. Install a recent version of Python (3.9 or later at the time of writing) for
-   instance using Condaforge_. Conda-forge provides a conda-based distribution of
+   instance using conda-forge_. Conda-forge provides a conda-based distribution of
    Python and the most popular scientific libraries.
 
    If you installed Python with conda, we recommend to create a dedicated
@@ -482,4 +482,4 @@ the base system and these steps will not be necessary.
 .. _Homebrew: https://brew.sh
 .. _virtualenv: https://docs.python.org/3/tutorial/venv.html
 .. _conda environment: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html
-.. _Condaforge: https://conda-forge.org/download/
+.. _conda-forge: https://conda-forge.org/download/


### PR DESCRIPTION
https://github.com/scikit-learn/scikit-learn/pull/30727#issuecomment-2618566101 Condaforge appears as a single word.

I use conda-forge without capital in the middle of the sentence because this is what I would use naturally and this is what is used in the linked page https://conda-forge.org/download/