### PR TITLE
FIX `randomized_svd` for complex valued input

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.utils/30737.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/30737.fix.rst
@@ -1,0 +1,2 @@
+- :func:`utils.extmath.randomized_svd` now handles complex valued inputs. By
+    :user:`Connor Lane <clane9>`.

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -1108,3 +1108,21 @@ def _tolist(array, xp=None):
         return array.tolist()
     array_np = _convert_to_numpy(array, xp=xp)
     return [element.item() for element in array_np]
+
+
+def _conj_transpose(array, xp=None):
+    """Return the matrix transpose, or conjugate transpose for complex input.
+
+    Array API compliant version of `array.conj().T`.
+    """
+    xp, _ = get_namespace(array, xp=xp)
+    return xp.conj(array).T if _iscomplexobj(array, xp=xp) else array.T
+
+
+def _iscomplexobj(array, xp=None):
+    """Check if an array is complex valued.
+
+    Array API compliant version of `np.iscomplexobj()`.
+    """
+    xp, _ = get_namespace(array, xp=xp)
+    return hasattr(array, "dtype") and xp.isdtype(array.dtype, kind="complex floating")

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -11,7 +11,15 @@ import numpy as np
 from scipy import linalg, sparse
 
 from ..utils._param_validation import Interval, StrOptions, validate_params
-from ._array_api import _average, _is_numpy_namespace, _nanmean, device, get_namespace
+from ._array_api import (
+    _average,
+    _conj_transpose,
+    _is_numpy_namespace,
+    _iscomplexobj,
+    _nanmean,
+    device,
+    get_namespace,
+)
 from .sparsefuncs_fast import csr_row_norms
 from .validation import check_array, check_random_state
 
@@ -1358,17 +1366,3 @@ def _approximate_mode(class_counts, n_draws, rng):
             if need_to_add == 0:
                 break
     return floored.astype(int)
-
-
-def _conj_transpose(A, xp=None):
-    """Return the transpose of A, or conjugate transpose for complex input."""
-    xp, _ = get_namespace(A, xp=xp)
-
-    return xp.conj(A).T if _iscomplexobj(A, xp=xp) else A.T
-
-
-def _iscomplexobj(A, xp=None):
-    """Check if an array is complex valued."""
-    xp, _ = get_namespace(A, xp=xp)
-
-    return hasattr(A, "dtype") and xp.isdtype(A.dtype, kind="complex floating")

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -616,6 +616,61 @@ def test_randomized_svd_lapack_driver(n, m, k, seed):
     assert_allclose(vt1, vt2, atol=0, rtol=1e-3)
 
 
+def test_randomized_svd_complex():
+    # Check that randomized svd works for complex matrices by comparing with linalg.svd
+    n_samples = 100
+    n_features = 500
+    rank = 5
+    k = 10
+    decimal = 7
+
+    # Create low rank complex valued matrix consisting of low rank real and imaginary
+    # parts, with the same column space.
+    rng = np.random.RandomState(42)
+    X = make_low_rank_matrix(
+        n_samples=n_samples,
+        n_features=n_features,
+        effective_rank=rank,
+        tail_strength=0.0,
+        random_state=rng,
+    )
+    A = rng.randn(n_features, n_features)
+    X = X + 1.0j * (X @ A)
+
+    # compute the singular values of X using the slow exact method
+    U, s, Vt = linalg.svd(X, full_matrices=False)
+
+    for normalizer in ["auto", "LU", "QR"]:  # 'none' would not be stable
+        # compute the singular values of X using the fast approximate method
+        Ua, sa, Va = randomized_svd(
+            X, k, power_iteration_normalizer=normalizer, random_state=0
+        )
+
+        assert Ua.shape == (n_samples, k)
+        assert sa.shape == (k,)
+        assert Va.shape == (k, n_features)
+
+        # ensure that the singular values of both methods are equal up to the
+        # real rank of the matrix
+        assert_almost_equal(s[:k], sa, decimal=decimal)
+
+        # check the singular vectors too (while not checking the sign)
+        assert_almost_equal(
+            np.dot(U[:, :k], Vt[:k, :]), np.dot(Ua, Va), decimal=decimal
+        )
+
+        # check the sparse matrix representation
+        for csr_container in CSR_CONTAINERS:
+            X = csr_container(X)
+
+            # compute the singular values of X using the fast approximate method
+            Ua, sa, Va = randomized_svd(
+                X, k, power_iteration_normalizer=normalizer, random_state=0
+            )
+
+            assert_almost_equal(s[:rank], sa[:rank], decimal=decimal)
+
+
 def test_cartesian():
     # Check if cartesian product delivers the right results
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #30736 


#### What does this implement/fix? Explain your changes.

The current implementation of `randomized_svd` accepts complex valued inputs, but the results are incorrect. Replacing transpose with conjugate transpose in the power iteration makes the results now consistent with `scipy.linalg.svd`. I also added a test to check consistency with `scipy.linalg.svd` on complex inputs.

#### Any other comments?

I feel that a `randomized_svd` function that supports complex inputs is a nice feature. Personally, I would like it so that I can implement [complex PCA](https://www.nature.com/articles/s41593-022-01118-1).


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
