### PR TITLE
DOC Update Pyodide version to 0.27.2 in JupyterLite deployment

### DIFF
--- a/doc/jupyter-lite.json
+++ b/doc/jupyter-lite.json
@@ -3,7 +3,7 @@
   "jupyter-config-data": {
     "litePluginSettings": {
       "@jupyterlite/pyodide-kernel-extension:kernel": {
-        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.26.0/full/pyodide.js"
+        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.27.2/full/pyodide.js"
       }
     }
   }


### PR DESCRIPTION
Fix https://github.com/scikit-learn/scikit-learn/issues/30762

This seems to fix the issue: double-check by clicking on the JupyterLite link in the rendered doc [example](https://output.circle-artifacts.com/output/job/30b761fe-255d-4610-b370-25362197d1d8/artifacts/0/doc/auto_examples/release_highlights/plot_release_highlights_1_6_0.html#sphx-glr-auto-examples-release-highlights-plot-release-highlights-1-6-0-py)