### PR TITLE
DOC Update Pyodide version to 0.27.2 in JupyterLite deployment for 1.6 doc

### DIFF
--- a/doc/jupyter-lite.json
+++ b/doc/jupyter-lite.json
@@ -3,7 +3,7 @@
   "jupyter-config-data": {
     "litePluginSettings": {
       "@jupyterlite/pyodide-kernel-extension:kernel": {
-        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.26.0/full/pyodide.js"
+        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.27.2/full/pyodide.js"
       }
     }
   }


### PR DESCRIPTION
Backport of https://github.com/scikit-learn/scikit-learn/pull/30764

Seems to be working: double-check by clicking the JupyterLite link in this rendered doc [example](https://output.circle-artifacts.com/output/job/11a85d59-6cfb-4cf7-b713-2b438df8d6d5/artifacts/0/doc/auto_examples/release_highlights/plot_release_highlights_1_6_0.html#sphx-glr-auto-examples-release-highlights-plot-release-highlights-1-6-0-py)