### PR TITLE
FIX: Remove blank figure that gets rendered in the load_digits API Example section

### DIFF
--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -991,8 +991,7 @@ def load_digits(*, n_class=10, return_X_y=False, as_frame=False):
         >>> print(digits.data.shape)
         (1797, 64)
         >>> import matplotlib.pyplot as plt
-        >>> plt.gray()
-        >>> plt.matshow(digits.images[0])
+        >>> plt.matshow(digits.images[0], cmap="gray")
         <...>
         >>> plt.show()
     """


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
N/A
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

This PR makes a very small tweak to the the code in the [load_digits](https://scikit-learn.org/dev/modules/generated/sklearn.datasets.load_digits.html) docstring Examples section, so that a blank figure is not displayed before the actual digits image:

| Branch | Rendered code |
|---------|---------|
| Main      | <img width="200" alt="Screenshot 2025-02-05 at 4 35 03 PM" src="https://github.com/user-attachments/assets/992426e1-9edf-4034-a235-0f0240034c67" /> | 
| This PR |  <img width="200" alt="Screenshot 2025-02-05 at 4 36 10 PM" src="https://github.com/user-attachments/assets/b6020377-a009-413d-a8d3-a509b2ca8afc" /> |


#### Any other comments?

EDIT: [Here is the relevant page from the rendered docs](https://output.circle-artifacts.com/output/job/b1f35c91-8092-4027-bf67-b89b55d032cb/artifacts/0/doc/modules/generated/sklearn.datasets.load_digits.html) from the CircleCI build
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
