### PR TITLE
FIX binary y in sample weight equivalence check

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.utils/30775.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/30775.fix.rst
@@ -1,7 +1,5 @@
--  :func:`utils.estimator_checks._enforce_estimator_tags_y` enforces a binary `y`
-   by taking the minimum as the negative class instead of the first element, which
-   makes it robust to `y` shuffling. It prevents
-   :func:`utils.estimator_checks.check_sample_weight_equivalence_on_dense_data` and
-   :func:`utils.estimator_checks.check_sample_weight_equivalence_on_sparse_data` to
-   wrongly fail on binary classifiers.
+-  In :mod:`utils.estimator_checks` we now enforce for binary classifiers a
+   binary `y` by taking the minimum as the negative class instead of the first
+   element, which makes it robust to `y` shuffling. It prevents two checks from
+   wrongly failing on binary classifiers.
    By :user:`Antoine Baker <antoinebaker>`.

--- a/doc/whats_new/upcoming_changes/sklearn.utils/30775.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/30775.fix.rst
@@ -1,0 +1,7 @@
+-  :func:`utils.estimator_checks._enforce_estimator_tags_y` enforces a binary `y`
+   by taking the minimum as the negative class instead of the first element, which
+   makes it robust to `y` shuffling. It prevents
+   :func:`utils.estimator_checks.check_sample_weight_equivalence_on_dense_data` and
+   :func:`utils.estimator_checks.check_sample_weight_equivalence_on_sparse_data` to
+   wrongly fail on binary classifiers.
+   By :user:`Antoine Baker <antoinebaker>`.

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1513,6 +1513,7 @@ def _check_sample_weight_equivalence(name, estimator_orig, sparse_container):
     n_samples = 15
     X = rng.rand(n_samples, n_samples * 2)
     y = rng.randint(0, 3, size=n_samples)
+    y = _enforce_estimator_tags_X(estimator_orig, y)
     # Use random integers (including zero) as weights.
     sw = rng.randint(0, 5, size=n_samples)
 
@@ -1547,9 +1548,6 @@ def _check_sample_weight_equivalence(name, estimator_orig, sparse_container):
             LeaveOneGroupOut().split(X_repeated, groups=groups_repeated)
         )
         estimator_repeated.set_params(cv=splits_repeated)
-
-    y_weighted = _enforce_estimator_tags_y(estimator_weighted, y_weighted)
-    y_repeated = _enforce_estimator_tags_y(estimator_repeated, y_repeated)
 
     # convert to sparse X if needed
     if sparse_container is not None:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -3931,7 +3931,7 @@ def _enforce_estimator_tags_y(estimator, y):
         and not tags.classifier_tags.multi_class
         and y.size > 0
     ):
-        y = np.where(y == y.flat[0], y, y.flat[0] + 1)
+        y = np.where(y == y.min(), y, y.min() + 1)
     # Estimators in mono_output_task_error raise ValueError if y is of 1-D
     # Convert into a 2-D y for those estimators.
     if tags.target_tags.multi_output and not tags.target_tags.single_output:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1513,7 +1513,6 @@ def _check_sample_weight_equivalence(name, estimator_orig, sparse_container):
     n_samples = 15
     X = rng.rand(n_samples, n_samples * 2)
     y = rng.randint(0, 3, size=n_samples)
-    y = _enforce_estimator_tags_X(estimator_orig, y)
     # Use random integers (including zero) as weights.
     sw = rng.randint(0, 5, size=n_samples)
 
@@ -1548,6 +1547,9 @@ def _check_sample_weight_equivalence(name, estimator_orig, sparse_container):
             LeaveOneGroupOut().split(X_repeated, groups=groups_repeated)
         )
         estimator_repeated.set_params(cv=splits_repeated)
+
+    y_weighted = _enforce_estimator_tags_y(estimator_weighted, y_weighted)
+    y_repeated = _enforce_estimator_tags_y(estimator_repeated, y_repeated)
 
     # convert to sparse X if needed
     if sparse_container is not None:


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #30770. Thanks a lot @pierrenodet for the bug report!

#### What does this implement/fix? Explain your changes.

The `_enforce_estimator_tags_y` allows to convert a generic `y` to a binary one for estimators that require it (binary classifiers). Unfortunately the current method (taking the first element as the negative class) is sensitive to shuffling and `_check_sample_weight_equivalence`  converts `y` after shuffling, which makes the `_check_sample_weight_equivalence` wrongly fail on binary classifiers.

This PR takes `y.min()` as the negative class to make `_enforce_estimator_tags_y` insensitive to shuffling. 