### PR TITLE
DOC Improve resizing of plotly parallel coord plots

### DIFF
--- a/doc/js/scripts/sg_plotly_resize.js
+++ b/doc/js/scripts/sg_plotly_resize.js
@@ -2,13 +2,9 @@
 // There an interaction between plotly and bootstrap/pydata-sphinx-theme
 // that causes plotly figures to not detect the right-hand sidebar width
 
-function resizePlotlyGraphs() {
-    const plotlyDivs = document.getElementsByClassName("plotly-graph-div");
+// Plotly figures are responsive, this triggers a resize event once the DOM has
+// finished loading so that they resize themselves.
 
-    for (const div of plotlyDivs) {
-        Plotly.Plots.resize(div);
-    }
-}
-
-window.addEventListener("resize", resizePlotlyGraphs);
-document.addEventListener("DOMContentLoaded", resizePlotlyGraphs);
+document.addEventListener("DOMContentLoaded", () => {
+  window.dispatchEvent(new Event("resize"));
+});

--- a/examples/model_selection/plot_grid_search_text_feature_extraction.py
+++ b/examples/model_selection/plot_grid_search_text_feature_extraction.py
@@ -261,5 +261,3 @@ fig
 #
 # The best accuracy scores are obtained when `alpha` is between :math:`10^{-6}`
 # and :math:`10^0`, regardless of the hyperparameter `norm`.
-#
-# added comment to trigger CircleCI run

--- a/examples/model_selection/plot_grid_search_text_feature_extraction.py
+++ b/examples/model_selection/plot_grid_search_text_feature_extraction.py
@@ -261,3 +261,5 @@ fig
 #
 # The best accuracy scores are obtained when `alpha` is between :math:`10^{-6}`
 # and :math:`10^0`, regardless of the hyperparameter `norm`.
+#
+# added comment to trigger CircleCI run


### PR DESCRIPTION
Improvement of https://github.com/scikit-learn/scikit-learn/pull/30297

As discussed with @glemaitre and @lesteve : 

I tried to use the strategy used to resize plotly figures in the example gallery for the skrub library, however it was failing when I had several parallel plots in the same example

in skrub I changed the script as shown in this PR:

the figures are already responsive by default, so we don't need to resize them manually using `Plotly.Plots.resize` (nor to listen to resize events). It seems to be enough to trigger a resize event once the DOM has loaded and the figures will adjust themselves.

_But_ I haven't tried to reproduce the issue I had in a scikit-learn example so actually I don't know if the problem would occur or if this change would help :shrug: 