### PR TITLE
DOC Added references to plot_ica_blind_source_separation & plot_ica_vs_pca.py

### DIFF
--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -55,9 +55,7 @@ data based on the amount of variance it explains. As such it implements a
 
 * :ref:`sphx_glr_auto_examples_decomposition_plot_pca_iris.py`
 * :ref:`sphx_glr_auto_examples_decomposition_plot_pca_vs_lda.py`
-* :ref:`sphx_glr_auto_examples_decomposition_plot_ica_vs_pca.py`
 * :ref:`sphx_glr_auto_examples_decomposition_plot_pca_vs_fa_model_selection.py`
-* :ref:`sphx_glr_auto_examples_decomposition_plot_ica_blind_source_separation.py`
 
 .. _IncrementalPCA:
 
@@ -770,7 +768,6 @@ components with some sparsity:
 * :ref:`sphx_glr_auto_examples_decomposition_plot_ica_blind_source_separation.py`
 * :ref:`sphx_glr_auto_examples_decomposition_plot_ica_vs_pca.py`
 * :ref:`sphx_glr_auto_examples_decomposition_plot_faces_decomposition.py`
-
 
 .. _NMF:
 

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -55,6 +55,7 @@ data based on the amount of variance it explains. As such it implements a
 
 * :ref:`sphx_glr_auto_examples_decomposition_plot_pca_iris.py`
 * :ref:`sphx_glr_auto_examples_decomposition_plot_pca_vs_lda.py`
+* :ref:`sphx_glr_auto_examples_decomposition_plot_ica_vs_pca.py`
 * :ref:`sphx_glr_auto_examples_decomposition_plot_pca_vs_fa_model_selection.py`
 
 

--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -57,7 +57,7 @@ data based on the amount of variance it explains. As such it implements a
 * :ref:`sphx_glr_auto_examples_decomposition_plot_pca_vs_lda.py`
 * :ref:`sphx_glr_auto_examples_decomposition_plot_ica_vs_pca.py`
 * :ref:`sphx_glr_auto_examples_decomposition_plot_pca_vs_fa_model_selection.py`
-
+* :ref:`sphx_glr_auto_examples_decomposition_plot_ica_blind_source_separation.py`
 
 .. _IncrementalPCA:
 

--- a/examples/decomposition/plot_ica_blind_source_separation.py
+++ b/examples/decomposition/plot_ica_blind_source_separation.py
@@ -11,10 +11,6 @@ recording the mixed signals. ICA is used to recover the sources
 ie. what is played by each instrument. Importantly, PCA fails
 at recovering our `instruments` since the related signals reflect
 non-Gaussian processes.
-
-See
-:ref:`sphx_glr_auto_examples_decomposition_plot_ica_vs_pca.py`
-for an example comparing the component analysis by ICA and PCA.
 """
 
 # Authors: The scikit-learn developers

--- a/examples/decomposition/plot_ica_blind_source_separation.py
+++ b/examples/decomposition/plot_ica_blind_source_separation.py
@@ -12,6 +12,9 @@ ie. what is played by each instrument. Importantly, PCA fails
 at recovering our `instruments` since the related signals reflect
 non-Gaussian processes.
 
+See
+:ref:`sphx_glr_auto_examples_decomposition_plot_ica_vs_pca.py`
+for an example comparing the component analysis by ICA and PCA.
 """
 
 # Authors: The scikit-learn developers

--- a/examples/decomposition/plot_ica_vs_pca.py
+++ b/examples/decomposition/plot_ica_vs_pca.py
@@ -26,11 +26,6 @@ represented by orange vectors. We represent the signal in the PCA space,
 after whitening by the variance corresponding to the PCA vectors (lower
 left). Running ICA corresponds to finding a rotation in this space to
 identify the directions of largest non-Gaussianity (lower right).
-
-See
-:ref:`sphx_glr_auto_examples_decomposition_plot_ica_blind_source_separation.py`
-for an example comparing the performance of ICA and PCA in estimating sources
-from noisy data.
 """
 
 # Authors: The scikit-learn developers

--- a/examples/decomposition/plot_ica_vs_pca.py
+++ b/examples/decomposition/plot_ica_vs_pca.py
@@ -27,6 +27,10 @@ after whitening by the variance corresponding to the PCA vectors (lower
 left). Running ICA corresponds to finding a rotation in this space to
 identify the directions of largest non-Gaussianity (lower right).
 
+See
+:ref:`sphx_glr_auto_examples_decomposition_plot_ica_blind_source_separation.py`
+for an example comparing the performance of ICA and PCA in estimating sources
+from noisy data.
 """
 
 # Authors: The scikit-learn developers


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #30621 


#### What does this implement/fix? Explain your changes.

1. Added references to files `plot_ica_blind_source_separation.py` & `plot_ica_vs_pca.py`  under description of PCA in "Decomposing signals in components"
2. Both `plot_ica_blind_source_separation.py` &  `plot_ica_vs_pca.py` compare PCA & ICA performance for different tasks -- signal source estimation and component analysis, so added references to the other example under each.


