### PR TITLE
DOC Update link to latest PDF documentation

### DIFF
--- a/doc/support.rst
+++ b/doc/support.rst
@@ -111,14 +111,12 @@ mentioned in this document.
 Documentation Resources
 =======================
 
-This documentation is for |release|. Find documentation for other versions
-`here <https://scikit-learn.org/dev/versions.html>`__.
+This documentation is for |release|. Documentation for other versions can be found `here
+<https://scikit-learn.org/dev/versions.html>`__, including zip archives which can be
+downloaded for offline access.
 
-In case offline access is important, you can download a zipped bundle of the
-documentation.
-
-If you want a PDF, we don't provide one anymore, but you can still generate it
-locally by following the :ref:`building documentation instructions
-<building_documentation>`. The most recent version with a PDF documentation is
-0.23.2 (released in August 2020) and its PDF documentation is available `here
+We no longer provide a PDF version of the documentation, but you can still generate it
+locally by following the :ref:`building documentation instructions <building_documentation>`.
+The most recent version with a PDF documentation is quite old, 0.23.2 (released
+in August 2020), but the PDF is available `here
 <https://scikit-learn.org/0.23/_downloads/scikit-learn-docs.pdf>`__.

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -119,6 +119,6 @@ documentation.
 
 If you want a PDF, we don't provide one anymore, but you can still generate it
 locally by following the :ref:`building documentation instructions
-<building_documentation>`. The latest version with a `PDF documentation
-<https://scikit-learn.org/0.23/_downloads/scikit-learn-docs.pdf>`_ is 0.23.2,
-which was released in August 2020.
+<building_documentation>`. The most recent version with a PDF documentation is
+0.23.2 (released in August 2020) and its PDF documentation is available `here
+<https://scikit-learn.org/0.23/_downloads/scikit-learn-docs.pdf>`__.

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -12,12 +12,12 @@ There are several channels to connect with scikit-learn developers for assistanc
 Mailing Lists
 =============
 
-- **Main Mailing List**: Join the primary discussion 
-  platform for scikit-learn at `scikit-learn Mailing List       
+- **Main Mailing List**: Join the primary discussion
+  platform for scikit-learn at `scikit-learn Mailing List
   <https://mail.python.org/mailman/listinfo/scikitlearn>`_.
 
-- **Commit Updates**: Stay informed about repository 
-  updates and test failures on the `scikit-learn-commits list 
+- **Commit Updates**: Stay informed about repository
+  updates and test failures on the `scikit-learn-commits list
   <https://lists.sourceforge.net/lists/listinfo/scikit-learn-commits>`_.
 
 .. _user_questions:
@@ -27,28 +27,28 @@ User Questions
 
 If you have questions, this is our general workflow.
 
-- **Stack Overflow**: Some scikit-learn developers support users using the 
-  `[scikit-learn] <https://stackoverflow.com/questions/tagged/scikit-learn>`_ 
+- **Stack Overflow**: Some scikit-learn developers support users using the
+  `[scikit-learn] <https://stackoverflow.com/questions/tagged/scikit-learn>`_
   tag.
 
-- **General Machine Learning Queries**: For broader machine learning 
+- **General Machine Learning Queries**: For broader machine learning
   discussions, visit `Stack Exchange <https://stats.stackexchange.com/>`_.
 
 When posting questions:
 
-- Please use a descriptive question in the title field (e.g. no "Please 
-  help with scikit-learn!" as this is not a question) 
+- Please use a descriptive question in the title field (e.g. no "Please
+  help with scikit-learn!" as this is not a question)
 
 - Provide detailed context, expected results, and actual observations.
 
-- Include code and data snippets (preferably minimalistic scripts, 
+- Include code and data snippets (preferably minimalistic scripts,
   up to ~20 lines).
 
-- Describe your data and preprocessing steps, including sample size, 
-  feature types (categorical or numerical), and the target for supervised 
+- Describe your data and preprocessing steps, including sample size,
+  feature types (categorical or numerical), and the target for supervised
   learning tasks (classification type or regression).
 
-**Note**: Avoid asking user questions on the bug tracker to keep 
+**Note**: Avoid asking user questions on the bug tracker to keep
 the focus on development.
 
 - `GitHub Discussions <https://github.com/scikit-learn/scikit-learn/discussions>`_
@@ -61,7 +61,7 @@ the focus on development.
   Bug reports - Please do not ask usage questions on the issue tracker.
 
 - `Discord Server <https://discord.gg/h9qyrK8Jc8>`_
-  Current pull requests - Post any specific PR-related questions on your PR, 
+  Current pull requests - Post any specific PR-related questions on your PR,
   and you can share a link to your PR on this server.
 
 .. _bug_tracker:
@@ -83,7 +83,7 @@ Include in your report:
 - The ideal bug report contains a :ref:`short reproducible code snippet
   <minimal_reproducer>`, this way anyone can try to reproduce the bug easily.
 
-- If your snippet is longer than around 50 lines, please link to a 
+- If your snippet is longer than around 50 lines, please link to a
   `gist <https://gist.github.com>`_ or a github repo.
 
 **Tip**: Gists are Git repositories; you can push data files to them using Git.
@@ -102,8 +102,8 @@ questions.
 Gitter
 ======
 
-**Note**: The scikit-learn Gitter room is no longer an active community. 
-For live discussions and support, please refer to the other channels 
+**Note**: The scikit-learn Gitter room is no longer an active community.
+For live discussions and support, please refer to the other channels
 mentioned in this document.
 
 .. _documentation_resources:
@@ -111,11 +111,10 @@ mentioned in this document.
 Documentation Resources
 =======================
 
-This documentation is for |release|. Find documentation for other versions 
+This documentation is for |release|. Find documentation for other versions
 `here <https://scikit-learn.org/dev/versions.html>`__.
 
-Older versions' printable PDF documentation is available `here
-<https://sourceforge.net/projects/scikit-learn/files/documentation/>`_.
-Building the PDF documentation is no longer supported in the website,
-but you can still generate it locally by following the
-:ref:`building documentation instructions <building_documentation>`.
+The printable PDF documentation is available for 0.23.2 (released in August 2020) `here
+<https://scikit-learn.org/0.23/_downloads/scikit-learn-docs.pdf>`__.
+We don't build PDF documentation any more, but you can still generate it
+locally by following the :ref:`building documentation instructions <building_documentation>`.

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -114,7 +114,11 @@ Documentation Resources
 This documentation is for |release|. Find documentation for other versions
 `here <https://scikit-learn.org/dev/versions.html>`__.
 
-The printable PDF documentation is available for 0.23.2 (released in August 2020) `here
-<https://scikit-learn.org/0.23/_downloads/scikit-learn-docs.pdf>`__.
-We don't build PDF documentation any more, but you can still generate it
-locally by following the :ref:`building documentation instructions <building_documentation>`.
+In case offline access is important, you can download a zipped bundle of the
+documentation.
+
+If you want a PDF, we don't provide one anymore, but you can still generate it
+locally by following the :ref:`building documentation instructions
+<building_documentation>`. The latest version with a `PDF documentation
+<https://scikit-learn.org/0.23/_downloads/scikit-learn-docs.pdf>`_ is 0.23.2,
+which was released in August 2020.


### PR DESCRIPTION
Current link points to Sourceforge, https://sourceforge.net/projects/scikit-learn/files/documentation/, which has the 0.17 PDF documentation.

`pre-commit` forces me to remove trailing whitespaces, I can revert them if you are annoyed by this :wink:.

If you are really curious, the 0.23.2 PDF doc is 2,754 pages long and 49M ...