### PR TITLE
CI Switch to using newer ubuntu images for CI workflows

### DIFF
--- a/.github/workflows/cuda-label-remover.yml
+++ b/.github/workflows/cuda-label-remover.yml
@@ -16,7 +16,7 @@ jobs:
   label-remover:
     if: contains(github.event.pull_request.labels.*.name, 'CUDA CI')
     name: Remove "CUDA CI" Label
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions-ecosystem/action-remove-labels@v1
         with:

--- a/.github/workflows/cuda-label-remover.yml
+++ b/.github/workflows/cuda-label-remover.yml
@@ -16,7 +16,7 @@ jobs:
   label-remover:
     if: contains(github.event.pull_request.labels.*.name, 'CUDA CI')
     name: Remove "CUDA CI" Label
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-remove-labels@v1
         with:

--- a/.github/workflows/labeler-title-regex.yml
+++ b/.github/workflows/labeler-title-regex.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
 
   labeler:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/.github/workflows/labeler-title-regex.yml
+++ b/.github/workflows/labeler-title-regex.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
 
   labeler:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
 - job: git_commit
   displayName: Get Git Commit
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-24.04
   steps:
     - bash: python build_tools/azure/get_commit_message.py
       name: commit
@@ -27,7 +27,7 @@ jobs:
     )
   displayName: Linting
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-24.04
   steps:
     - task: UsePythonVersion@0
       inputs:
@@ -49,7 +49,7 @@ jobs:
 - template: build_tools/azure/posix.yml
   parameters:
     name: Linux_Nightly
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-22.04
     dependsOn: [git_commit, linting]
     condition: |
       and(
@@ -126,7 +126,7 @@ jobs:
 - template: build_tools/azure/posix.yml
   parameters:
     name: Linux_Runs
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-22.04
     dependsOn: [git_commit]
     condition: |
       and(
@@ -232,7 +232,7 @@ jobs:
 - template: build_tools/azure/posix-docker.yml
   parameters:
     name: Linux_Docker
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-24.04
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
     # Runs when dependencies succeeded or skipped
     condition: |


### PR DESCRIPTION
For these workflows it doesn't seem important to pin to a particular version and this way we don't have to periodically update the version.

I got an email from GitHub telling me that `ubuntu-20.04` will be turned off in April and that there will be brown outs before then.

There are also azure pipeline jobs that use 20.04, I've not touched those, but maybe we should do that (in this PR) as well?

---

 The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:

    March 4 14:00 UTC – 22:00 UTC
    March 11 13:00 UTC – 21:00 UTC
    March 18 13:00 UTC – 21:00 UTC
    March 25 13:00 UTC – 21:00 UTC

What you need to do

Jobs using the ubuntu-20.04 YAML workflow label should be updated to ubuntu-22.04, ubuntu-24.04 or ubuntu-latest. You can always get up-to-date information on our tools by reading about the software in the runner images repository. Please contact GitHub Support if you run into any problems or need help. 