### PR TITLE
EXA Download parquet file from data.openml.org

### DIFF
--- a/examples/applications/plot_time_series_lagged_features.py
+++ b/examples/applications/plot_time_series_lagged_features.py
@@ -40,12 +40,7 @@ from sklearn.datasets import fetch_file
 pl.Config.set_fmt_str_lengths(20)
 
 bike_sharing_data_file = fetch_file(
-    # Original file was hosted at:
-    # https://openml1.win.tue.nl/datasets/0004/44063/dataset_44063.pq
-    # but is no longer reachable.
-    # TODO: switch to https://data.openml.org/datasets/0004/44063/dataset_44063.pq
-    # once possible.
-    "https://github.com/scikit-learn/examples-data/raw/refs/heads/master/bike-sharing-demand/dataset_44063.pq",
+    "https://data.openml.org/datasets/0004/44063/dataset_44063.pq",
     sha256="d120af76829af0d256338dc6dd4be5df4fd1f35bf3a283cab66a51c1c6abd06a",
 )
 bike_sharing_data_file


### PR DESCRIPTION
Upside: CORS headers are set on openml.org so the data download works in JupyterLite without any work-around see https://github.com/scikit-learn/scikit-learn/pull/30708#issuecomment-2654338036.

Downside seems to be that it may considered an OpenML implementation detail, see https://github.com/scikit-learn/scikit-learn/pull/30715#issuecomment-2621161183.

If we want to make this more robust, we can always add a bit of Python to do the equivalent of: 
```bash
curl -s https://api.openml.org/api/v1/json/data/44063 | jq .data_set_description.parquet_url
```

This will make the example robust at the cost of making it less realistic/more convoluted (people would load a parquet URL or parquet file directly)

cc @ogrisel.
