### PR TITLE
DOC add description of missing values in tree-based models

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1185,11 +1185,11 @@ class RandomForestClassifier(ForestClassifier):
     `bootstrap=True` (default), otherwise the whole dataset is used to build
     each tree.
 
-    This estimator has native support for missing values (NaNs). During training, 
-    the tree grower learns at each split point whether samples with missing values 
-    should go to the left or right child, based on the potential gain. When predicting, 
-    samples with missing values are assigned to the left or right child consequently. 
-    If no missing values were encountered for a given feature during training, then 
+    This estimator has native support for missing values (NaNs). During training,
+    the tree grower learns at each split point whether samples with missing values
+    should go to the left or right child, based on the potential gain. When predicting,
+    samples with missing values are assigned to the left or right child consequently.
+    If no missing values were encountered for a given feature during training, then
     samples with missing values are mapped to whichever child has the most samples.
 
     For a comparison between tree-based ensemble models see the example
@@ -1579,11 +1579,11 @@ class RandomForestRegressor(ForestRegressor):
     `bootstrap=True` (default), otherwise the whole dataset is used to build
     each tree.
 
-    This estimator has native support for missing values (NaNs). During training, 
-    the tree grower learns at each split point whether samples with missing values 
-    should go to the left or right child, based on the potential gain. When predicting, 
-    samples with missing values are assigned to the left or right child consequently. 
-    If no missing values were encountered for a given feature during training, then 
+    This estimator has native support for missing values (NaNs). During training,
+    the tree grower learns at each split point whether samples with missing values
+    should go to the left or right child, based on the potential gain. When predicting,
+    samples with missing values are assigned to the left or right child consequently.
+    If no missing values were encountered for a given feature during training, then
     samples with missing values are mapped to whichever child has the most samples.
 
     For a comparison between tree-based ensemble models see the example
@@ -2316,11 +2316,11 @@ class ExtraTreesRegressor(ForestRegressor):
     of the dataset and uses averaging to improve the predictive accuracy
     and control over-fitting.
 
-    This estimator has native support for missing values (NaNs). During training, 
-    the tree grower learns at each split point whether samples with missing values 
-    should go to the left or right child, based on the potential gain. When predicting, 
-    samples with missing values are assigned to the left or right child consequently. 
-    If no missing values were encountered for a given feature during training, then 
+    This estimator has native support for missing values (NaNs). During training,
+    the tree grower learns at each split point whether samples with missing values
+    should go to the left or right child, based on the potential gain. When predicting,
+    samples with missing values are assigned to the left or right child consequently.
+    If no missing values were encountered for a given feature during training, then
     samples with missing values are mapped to whichever child has the most samples.
 
     Read more in the :ref:`User Guide <forest>`.

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1185,6 +1185,13 @@ class RandomForestClassifier(ForestClassifier):
     `bootstrap=True` (default), otherwise the whole dataset is used to build
     each tree.
 
+    This estimator has native support for missing values (NaNs). During training, 
+    the tree grower learns at each split point whether samples with missing values 
+    should go to the left or right child, based on the potential gain. When predicting, 
+    samples with missing values are assigned to the left or right child consequently. 
+    If no missing values were encountered for a given feature during training, then 
+    samples with missing values are mapped to whichever child has the most samples.
+
     For a comparison between tree-based ensemble models see the example
     :ref:`sphx_glr_auto_examples_ensemble_plot_forest_hist_grad_boosting_comparison.py`.
 
@@ -1571,6 +1578,13 @@ class RandomForestRegressor(ForestRegressor):
     The sub-sample size is controlled with the `max_samples` parameter if
     `bootstrap=True` (default), otherwise the whole dataset is used to build
     each tree.
+
+    This estimator has native support for missing values (NaNs). During training, 
+    the tree grower learns at each split point whether samples with missing values 
+    should go to the left or right child, based on the potential gain. When predicting, 
+    samples with missing values are assigned to the left or right child consequently. 
+    If no missing values were encountered for a given feature during training, then 
+    samples with missing values are mapped to whichever child has the most samples.
 
     For a comparison between tree-based ensemble models see the example
     :ref:`sphx_glr_auto_examples_ensemble_plot_forest_hist_grad_boosting_comparison.py`.
@@ -2301,6 +2315,13 @@ class ExtraTreesRegressor(ForestRegressor):
     randomized decision trees (a.k.a. extra-trees) on various sub-samples
     of the dataset and uses averaging to improve the predictive accuracy
     and control over-fitting.
+
+    This estimator has native support for missing values (NaNs). During training, 
+    the tree grower learns at each split point whether samples with missing values 
+    should go to the left or right child, based on the potential gain. When predicting, 
+    samples with missing values are assigned to the left or right child consequently. 
+    If no missing values were encountered for a given feature during training, then 
+    samples with missing values are mapped to whichever child has the most samples.
 
     Read more in the :ref:`User Guide <forest>`.
 


### PR DESCRIPTION
**References Issues/PRs**

Fixes #30821

**What does this implement/fix? Explain your changes.**

This PR updates the documentation in `RandomForestClassifier`, `RandomForestRegressor` & `ExtraTreesRegressor` about how these algorithm handle missing values

- This change improves clarity for users encountering the issue..

**Any other comments?**

- This change was discussed in the related issue and aligns with the suggested fix.
- Let me know if any refinements are needed!
