### PR TITLE
MNT: Check if running inside repo2docker more explicitly

### DIFF
--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -6,7 +6,7 @@ set -e
 # inside a git checkout of the scikit-learn/scikit-learn repo. This script is
 # generating notebooks from the scikit-learn python examples.
 
-if [[ ! -f /.dockerenv ]]; then
+if [[ -z "${REPO_DIR}" ]];; then
     echo "This script was written for repo2docker and is supposed to run inside a docker container."
     echo "Exiting because this script can delete data if run outside of a docker container."
     exit 1

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -7,7 +7,7 @@ set -e
 # generating notebooks from the scikit-learn python examples.
 
 if [[ -z "${REPO_DIR}" ]]; then
-    echo "This script was written for repo2docker and is supposed to run inside a docker container."
+    echo "This script was written for repo2docker and is supposed to have REPO_DIR environment variable set."
     echo "Exiting because this script can delete data if run outside of a docker container."
     exit 1
 fi

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -7,7 +7,7 @@ set -e
 # generating notebooks from the scikit-learn python examples.
 
 if [[ -z "${REPO_DIR}" ]]; then
-    echo "This script was written for repo2docker and is supposed to have REPO_DIR environment variable set."
+    echo "This script was written for repo2docker and the REPO_DIR environment variable is supposed to be set."
     echo "Exiting because this script can delete data if run outside of a docker container."
     exit 1
 fi

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -6,7 +6,7 @@ set -e
 # inside a git checkout of the scikit-learn/scikit-learn repo. This script is
 # generating notebooks from the scikit-learn python examples.
 
-if [[ -z "${REPO_DIR}" ]];; then
+if [[ -z "${REPO_DIR}" ]]; then
     echo "This script was written for repo2docker and is supposed to run inside a docker container."
     echo "Exiting because this script can delete data if run outside of a docker container."
     exit 1

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -8,7 +8,7 @@ set -e
 
 if [[ -z "${REPO_DIR}" ]]; then
     echo "This script was written for repo2docker and the REPO_DIR environment variable is supposed to be set."
-    echo "Exiting because this script can delete data if run outside of a docker container."
+    echo "Exiting because this script can delete data if run outside of a repo2docker context."
     exit 1
 fi
 


### PR DESCRIPTION
.dockerenv is only supported in the old docker based builder, which has been deprecated for a few years now. It isn't supported by buildkit / docker buildx, which repo2docker *just* moved to (https://github.com/jupyterhub/repo2docker/pull/1402). Using buikdkit gives us faster and more reliable builds.

This converts the test for checking if the script is being run by repo2docker to check for an env var that repo2docker sets instead.
