### PR TITLE
FIX: Fixed AttributeError in str_escape when handling numpy.int64 in sklearn/tree/_export.py

### DIFF
--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -578,7 +578,7 @@ class _DOTTreeExporter(_BaseTreeExporter):
 
     def str_escape(self, string):
         # override default escaping for graphviz
-        return string.replace('"', r"\"")
+        return str(string).replace('"', r"\"")
 
 
 class _MPLTreeExporter(_BaseTreeExporter):


### PR DESCRIPTION
This PR fixes [Issue #30834](https://github.com/scikit-learn/scikit-learn/issues/30834), where an AttributeError occurs in sklearn.tree._export.py when export_text() or related functions receive a numpy.int64 feature name. The issue arises because str_escape() expects a string but receives a numpy.int64, which lacks the .replace() method.

#### Reference Issues/PRs
Fix issue #30834


#### What does this implement/fix? Explain your changes.
* Converted the feature variable to a string before calling `.replace() `in `str_escape`

#### Any other comments?
Nope.
