### PR TITLE
DOC fix typo in `plot_stock_market.py` example 

### DIFF
--- a/examples/applications/plot_stock_market.py
+++ b/examples/applications/plot_stock_market.py
@@ -187,7 +187,7 @@ embedding = node_position_model.fit_transform(X.T).T
 # - the 2D embedding is used to position the nodes in the plan
 #
 # This example has a fair amount of visualization-related code, as
-# visualization is crucial here to display the graph. One of the challenge
+# visualization is crucial here to display the graph. One of the challenges
 # is to position the labels minimizing overlap. For this, we use an
 # heuristic based on the direction of the nearest neighbor along each
 # axis.

--- a/examples/applications/plot_stock_market.py
+++ b/examples/applications/plot_stock_market.py
@@ -17,8 +17,8 @@ that are linked tend to fluctuate in relation to each other during a day.
 # Retrieve the data from Internet
 # -------------------------------
 #
-# The data is from 2003 - 2008. This is reasonably calm: (not too long ago so
-# that we get high-tech firms, and before the 2008 crash). This kind of
+# The data is from 2003 - 2008. This is reasonably calm: not too long ago so
+# that we get high-tech firms, and before the 2008 crash. This kind of
 # historical data can be obtained from APIs like the
 # `data.nasdaq.com <https://data.nasdaq.com/>`_ and
 # `alphavantage.co <https://www.alphavantage.co/>`_.
@@ -158,10 +158,10 @@ for i in range(n_labels + 1):
 # ---------------------
 #
 # For visualization purposes, we need to lay out the different symbols on a
-# 2D canvas. For this we use :ref:`manifold` techniques to retrieve 2D
+# 2D canvas. For this, we use :ref:`manifold` techniques to retrieve 2D
 # embedding.
-# We use a dense eigen_solver to achieve reproducibility (arpack is initiated
-# with the random vectors that we don't control). In addition, we use a large
+# We use a dense ``eigen_solver`` to achieve reproducibility (arpack is initiated
+# with the random vectors that we do not control). In addition, we use a large
 # number of neighbors to capture the large-scale structure.
 
 # Finding a low-dimension embedding for visualization: find the best position of
@@ -180,7 +180,7 @@ embedding = node_position_model.fit_transform(X.T).T
 # -------------
 #
 # The output of the 3 models are combined in a 2D graph where nodes
-# represents the stocks and edges the:
+# represent the stocks and edges the connections (partial correlations):
 #
 # - cluster labels are used to define the color of the nodes
 # - the sparse covariance model is used to display the strength of the edges
@@ -188,7 +188,7 @@ embedding = node_position_model.fit_transform(X.T).T
 #
 # This example has a fair amount of visualization-related code, as
 # visualization is crucial here to display the graph. One of the challenge
-# is to position the labels minimizing overlap. For this we use an
+# is to position the labels minimizing overlap. For this, we use an
 # heuristic based on the direction of the nearest neighbor along each
 # axis.
 


### PR DESCRIPTION
This small PR corrects some minor typos and provides some clarification in the `applications/plot_stock_market.py` example