### PR TITLE
Sample_weight is silently ignored in LogisticRegressionCV.score when metadata routing is enabled

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/30843.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/30843.fix.rst
@@ -1,0 +1,4 @@
+- :class:`sklearn.linear_model.LogisticRegressionCV` now properly uses sample_weights in
+  :func:`sklearn.linear_model.LogisticRegressionCV.score` when called with
+  :func:`sklearn.set_config` with enable_metadata_routing=True
+  By :user:`David Leonardo Espinosa <Dalesrox>`

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -2240,6 +2240,10 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
                 sample_weight=sample_weight,
                 **score_params,
             )
+            if sample_weight is not None:
+                routed_params.scorer.score["sample_weight"] = (
+                    sample_weight  # Add sample_weight to scorer if passed
+                )
         else:
             routed_params = Bunch()
             routed_params.scorer = Bunch(score={})

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -2264,7 +2264,7 @@ def test_lr_cv_scores_differ_when_sample_weight_is_requested():
 
     scorer1 = get_scorer("accuracy")
     lr_cv1 = LogisticRegressionCV(scoring=scorer1)
-    lr_cv1.fit(X, y, **kwargs)
+    lr_cv1.fit(X, y)
 
     scorer2 = get_scorer("accuracy")
     scorer2.set_score_request(sample_weight=True)
@@ -2273,7 +2273,7 @@ def test_lr_cv_scores_differ_when_sample_weight_is_requested():
 
     assert not np.allclose(lr_cv1.scores_[1], lr_cv2.scores_[1])
 
-    score_1 = lr_cv1.score(X_t, y_t, **kwargs)
+    score_1 = lr_cv1.score(X_t, y_t)
     score_2 = lr_cv2.score(X_t, y_t, **kwargs)
 
     assert not np.allclose(score_1, score_2)


### PR DESCRIPTION
.
