### PR TITLE
Fix: HTML display rendering poorly in vscode "Dark High Contrast" color theme

### DIFF
--- a/sklearn/utils/_estimator_html_repr.css
+++ b/sklearn/utils/_estimator_html_repr.css
@@ -242,7 +242,8 @@ clickable and can be expanded/collapsed.
 #$id div.sk-label label.sk-toggleable__label,
 #$id div.sk-label label {
   /* The background is the default theme color */
-  color: var(--sklearn-color-text-on-default-background);
+  color: var(--sklearn-color-text);
+  background-color: var(--sklearn-color-unfitted-level-2);
 }
 
 /* On hover, darken the color of the background */


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #30357

#### What does this implement/fix? Explain your changes.
Adds a background colour to the main title. 
The added colour may need to be corrected (maybe I should try to select just that top container, or find a more standard colour?). But I would like to  know if this is a good approach. 

#### Any other comments?

1. On the issue, Gaël linked a PR: https://github.com/skrub-data/skrub/pull/1201 .. I believe that [they used a new background-color (their own)](https://github.com/skrub-data/skrub/pull/1201/commits/df9ced4d7cabd9e4366a14dc463bff76c328ac89). I also checked another similar issue detected in skrub, and it was fixed by using an older sphinx theme at the time. 
2. It seems that the style set with file `sklearn.utils._estimator_html_repr.css`, is always defaulting to "light mode". The issue reported can be "debugged" setting a color on line 18. 
3. I tried using the latest `pydata-sphinx-theme` which is 0.16.1, and the issue persists. 
4. The `@media` in the same file `sklearn.utils._estimator_html_repr.css` is not doing anything and I think it's set incorrectly. The used themes should still detect that it's "dark". 
5. Since the colours may come from either sphinx-theme (this is also supposed to detect ligth/dark mode), vscode css and settings, Jupyter extensions for vscode, and scikit-learn css file.. I believe that the most safe way is just set the background ourselves.
6. Now that I'm at it , "clip" is deprecated in css. One can use https://jigsaw.w3.org/css-validator/ to check that the css file doesn't contain errors. (Not related to the issue I think, but could be fixed at the same time).

WDYT @glemaitre ?



<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
