### PR TITLE
TST move test for parameters consistency checks

### DIFF
--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -12,9 +12,7 @@ import numpy as np
 import pytest
 
 import sklearn
-from sklearn import metrics
 from sklearn.datasets import make_classification
-from sklearn.ensemble import StackingClassifier, StackingRegressor
 
 # make it possible to discover experimental estimators when calling `all_estimators`
 from sklearn.experimental import (
@@ -27,10 +25,8 @@ from sklearn.utils import all_estimators
 from sklearn.utils._test_common.instance_generator import _construct_instances
 from sklearn.utils._testing import (
     _get_func_name,
-    assert_docstring_consistency,
     check_docstring_parameters,
     ignore_warnings,
-    skip_if_no_numpydoc,
 )
 from sklearn.utils.deprecation import _is_deprecated
 from sklearn.utils.estimator_checks import (
@@ -326,63 +322,3 @@ def _get_all_fitted_attributes(estimator):
             fit_attr.append(name)
 
     return [k for k in fit_attr if k.endswith("_") and not k.startswith("_")]
-
-
-@skip_if_no_numpydoc
-def test_precision_recall_f_score_docstring_consistency():
-    """Check docstrings parameters of related metrics are consistent."""
-    metrics_to_check = [
-        metrics.precision_recall_fscore_support,
-        metrics.f1_score,
-        metrics.fbeta_score,
-        metrics.precision_score,
-        metrics.recall_score,
-    ]
-    assert_docstring_consistency(
-        metrics_to_check,
-        include_params=True,
-        # "zero_division" - the reason for zero division differs between f scores,
-        # precision and recall.
-        exclude_params=["average", "zero_division"],
-    )
-    description_regex = (
-        r"""This parameter is required for multiclass/multilabel targets\.
-        If ``None``, the metrics for each class are returned\. Otherwise, this
-        determines the type of averaging performed on the data:
-        ``'binary'``:
-            Only report results for the class specified by ``pos_label``\.
-            This is applicable only if targets \(``y_\{true,pred\}``\) are binary\.
-        ``'micro'``:
-            Calculate metrics globally by counting the total true positives,
-            false negatives and false positives\.
-        ``'macro'``:
-            Calculate metrics for each label, and find their unweighted
-            mean\.  This does not take label imbalance into account\.
-        ``'weighted'``:
-            Calculate metrics for each label, and find their average weighted
-            by support \(the number of true instances for each label\)\. This
-            alters 'macro' to account for label imbalance; it can result in an
-            F-score that is not between precision and recall\."""
-        + r"[\s\w]*\.*"  # optionally match additional sentence
-        + r"""
-        ``'samples'``:
-            Calculate metrics for each instance, and find their average \(only
-            meaningful for multilabel classification where this differs from
-            :func:`accuracy_score`\)\."""
-    )
-    assert_docstring_consistency(
-        metrics_to_check,
-        include_params=["average"],
-        descr_regex_pattern=" ".join(description_regex.split()),
-    )
-
-
-@skip_if_no_numpydoc
-def test_stacking_classifier_regressor_docstring_consistency():
-    """Check docstrings parameters stacking estimators are consistent."""
-    assert_docstring_consistency(
-        [StackingClassifier, StackingRegressor],
-        include_params=["cv", "n_jobs", "passthrough", "verbose"],
-        include_attrs=True,
-        exclude_attrs=["final_estimator_"],
-    )

--- a/sklearn/tests/test_docstring_parameters_consistency.py
+++ b/sklearn/tests/test_docstring_parameters_consistency.py
@@ -1,0 +1,96 @@
+# Authors: The scikit-learn developers
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+from sklearn import metrics
+from sklearn.ensemble import StackingClassifier, StackingRegressor
+from sklearn.utils._testing import assert_docstring_consistency, skip_if_no_numpydoc
+
+CLASS_DOCSTRING_CONSISTENCY_CASES = [
+    {
+        "objects": [StackingClassifier, StackingRegressor],
+        "include_params": ["cv", "n_jobs", "passthrough", "verbose"],
+        "exclude_params": None,
+        "include_attrs": True,
+        "exclude_attrs": ["final_estimator_"],
+        "include_returns": False,
+        "exclude_returns": None,
+        "descr_regex_pattern": None,
+    },
+]
+
+FUNCTION_DOCSTRING_CONSISTENCY_CASES = [
+    {
+        "objects": [
+            metrics.precision_recall_fscore_support,
+            metrics.f1_score,
+            metrics.fbeta_score,
+            metrics.precision_score,
+            metrics.recall_score,
+        ],
+        "include_params": True,
+        "exclude_params": ["average", "zero_division"],
+        "include_attrs": False,
+        "exclude_attrs": None,
+        "include_returns": False,
+        "exclude_returns": None,
+        "descr_regex_pattern": None,
+    },
+    {
+        "objects": [
+            metrics.precision_recall_fscore_support,
+            metrics.f1_score,
+            metrics.fbeta_score,
+            metrics.precision_score,
+            metrics.recall_score,
+        ],
+        "include_params": ["average"],
+        "exclude_params": None,
+        "include_attrs": False,
+        "exclude_attrs": None,
+        "include_returns": False,
+        "exclude_returns": None,
+        "descr_regex_pattern": " ".join(
+            (
+                r"""This parameter is required for multiclass/multilabel targets\.
+            If ``None``, the metrics for each class are returned\. Otherwise, this
+            determines the type of averaging performed on the data:
+            ``'binary'``:
+                Only report results for the class specified by ``pos_label``\.
+                This is applicable only if targets \(``y_\{true,pred\}``\) are binary\.
+            ``'micro'``:
+                Calculate metrics globally by counting the total true positives,
+                false negatives and false positives\.
+            ``'macro'``:
+                Calculate metrics for each label, and find their unweighted
+                mean\.  This does not take label imbalance into account\.
+            ``'weighted'``:
+                Calculate metrics for each label, and find their average weighted
+                by support \(the number of true instances for each label\)\. This
+                alters 'macro' to account for label imbalance; it can result in an
+                F-score that is not between precision and recall\."""
+                + r"[\s\w]*\.*"  # optionally match additional sentence
+                + r"""
+            ``'samples'``:
+                Calculate metrics for each instance, and find their average \(only
+                meaningful for multilabel classification where this differs from
+                :func:`accuracy_score`\)\."""
+            ).split()
+        ),
+    },
+]
+
+
+@pytest.mark.parametrize("case", CLASS_DOCSTRING_CONSISTENCY_CASES)
+@skip_if_no_numpydoc
+def test_class_docstring_consistency(case):
+    """Check docstrings parameters consistency between related classes."""
+    assert_docstring_consistency(**case)
+
+
+@pytest.mark.parametrize("case", FUNCTION_DOCSTRING_CONSISTENCY_CASES)
+@skip_if_no_numpydoc
+def test_function_docstring_consistency(case):
+    """Check docstrings parameters consistency between related functions."""
+    assert_docstring_consistency(**case)


### PR DESCRIPTION
Moving the test for docstring parameters consistency into its own file.
It will make it easier to track progress.