### PR TITLE
TST use global_random_seed in sklearn/utils/tests/test_stats.py

### DIFF
--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1019,8 +1019,8 @@ def test_matthews_corrcoef_against_jurman(global_random_seed):
     assert_almost_equal(mcc_ours, mcc_jurman, 10)
 
 
-def test_matthews_corrcoef():
-    rng = np.random.RandomState(0)
+def test_matthews_corrcoef(global_random_seed):
+    rng = np.random.RandomState(global_random_seed)
     y_true = ["a" if i == 0 else "b" for i in rng.randint(0, 2, size=20)]
 
     # corrcoef of same vectors must be 1

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1111,9 +1111,9 @@ def test_matthews_corrcoef_multiclass(global_random_seed):
 
 
 @pytest.mark.parametrize("n_points", [100, 10000])
-def test_matthews_corrcoef_overflow(n_points):
+def test_matthews_corrcoef_overflow(n_points, global_random_seed):
     # https://github.com/scikit-learn/scikit-learn/issues/9622
-    rng = np.random.RandomState(20170906)
+    rng = np.random.RandomState(global_random_seed)
 
     def mcc_safe(y_true, y_pred):
         conf_matrix = confusion_matrix(y_true, y_pred)

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -55,7 +55,7 @@ from sklearn.utils.validation import check_random_state
 # Utilities for testing
 
 
-def make_prediction(dataset=None, binary=False):
+def make_prediction(global_random_seed, dataset=None, binary=False):
     """Make some classification predictions on a toy dataset using a SVC
 
     If binary is True restrict to a binary classification problem instead of a
@@ -82,7 +82,7 @@ def make_prediction(dataset=None, binary=False):
     half = int(n_samples / 2)
 
     # add noisy features to make the problem harder and avoid perfect results
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(global_random_seed)
     X = np.c_[X, rng.randn(n_samples, 200 * n_features)]
 
     # run classifier, get class probabilities and label predictions

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -980,11 +980,11 @@ def test_matthews_corrcoef_against_numpy_corrcoef(global_random_seed):
     )
 
 
-def test_matthews_corrcoef_against_jurman():
+def test_matthews_corrcoef_against_jurman(global_random_seed):
     # Check that the multiclass matthews_corrcoef agrees with the definition
     # presented in Jurman, Riccadonna, Furlanello, (2012). A Comparison of MCC
     # and CEN Error Measures in MultiClass Prediction
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(global_random_seed)
     y_true = rng.randint(0, 2, size=20)
     y_pred = rng.randint(0, 2, size=20)
     sample_weight = rng.rand(20)

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -2946,13 +2946,13 @@ def test_balanced_accuracy_score(y_true, y_pred):
 @pytest.mark.parametrize(
     "classes", [(False, True), (0, 1), (0.0, 1.0), ("zero", "one")]
 )
-def test_classification_metric_pos_label_types(metric, classes):
+def test_classification_metric_pos_label_types(metric, classes, global_random_seed):
     """Check that the metric works with different types of `pos_label`.
 
     We can expect `pos_label` to be a bool, an integer, a float, a string.
     No error should be raised for those types.
     """
-    rng = np.random.RandomState(42)
+    rng = np.random.RandomState(global_random_seed)
     n_samples, pos_label = 10, classes[-1]
     y_true = rng.choice(classes, size=n_samples, replace=True)
     if metric is brier_score_loss:

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -55,7 +55,7 @@ from sklearn.utils.validation import check_random_state
 # Utilities for testing
 
 
-def make_prediction(global_random_seed, dataset=None, binary=False):
+def make_prediction(dataset=None, binary=False):
     """Make some classification predictions on a toy dataset using a SVC
 
     If binary is True restrict to a binary classification problem instead of a
@@ -82,7 +82,7 @@ def make_prediction(global_random_seed, dataset=None, binary=False):
     half = int(n_samples / 2)
 
     # add noisy features to make the problem harder and avoid perfect results
-    rng = np.random.RandomState(global_random_seed)
+    rng = np.random.RandomState(0)
     X = np.c_[X, rng.randn(n_samples, 200 * n_features)]
 
     # run classifier, get class probabilities and label predictions

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1054,8 +1054,8 @@ def test_matthews_corrcoef(global_random_seed):
         assert_almost_equal(matthews_corrcoef(y_1, y_2, sample_weight=mask), 0.0)
 
 
-def test_matthews_corrcoef_multiclass():
-    rng = np.random.RandomState(0)
+def test_matthews_corrcoef_multiclass(global_random_seed):
+    rng = np.random.RandomState(global_random_seed)
     ord_a = ord("a")
     n_classes = 4
     y_true = [chr(ord_a + i) for i in rng.randint(0, n_classes, size=20)]

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -970,8 +970,8 @@ def test_zero_division_nan_warning(metric, y_true, y_pred):
     assert result == 0.0
 
 
-def test_matthews_corrcoef_against_numpy_corrcoef():
-    rng = np.random.RandomState(0)
+def test_matthews_corrcoef_against_numpy_corrcoef(global_random_seed):
+    rng = np.random.RandomState(global_random_seed)
     y_true = rng.randint(0, 2, size=20)
     y_pred = rng.randint(0, 2, size=20)
 

--- a/sklearn/utils/tests/test_stats.py
+++ b/sklearn/utils/tests/test_stats.py
@@ -21,8 +21,8 @@ def test_averaged_weighted_median():
     condition=np_version < parse_version("1.22"),
     reason="older numpy do not support the 'method' parameter",
 )
-def test_averaged_weighted_percentile():
-    rng = np.random.RandomState(0)
+def test_averaged_weighted_percentile(global_random_seed):
+    rng = np.random.RandomState(global_random_seed)
     y = rng.randint(20, size=10)
 
     sw = np.ones(10)

--- a/sklearn/utils/tests/test_stats.py
+++ b/sklearn/utils/tests/test_stats.py
@@ -86,9 +86,9 @@ def test_weighted_percentile_zero_weight_zero_percentile():
     assert approx(score) == 4
 
 
-def test_weighted_median_equal_weights():
+def test_weighted_median_equal_weights(global_random_seed):
     # Checks weighted percentile=0.5 is same as median when weights equal
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(global_random_seed)
     # Odd size as _weighted_percentile takes lower weighted percentile
     x = rng.randint(10, size=11)
     weights = np.ones(x.shape)

--- a/sklearn/utils/tests/test_stats.py
+++ b/sklearn/utils/tests/test_stats.py
@@ -112,9 +112,9 @@ def test_weighted_median_integer_weights():
     assert median == approx(w_median)
 
 
-def test_weighted_percentile_2d():
+def test_weighted_percentile_2d(global_random_seed):
     # Check for when array 2D and sample_weight 1D
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(global_random_seed)
     x1 = rng.randint(10, size=10)
     w1 = rng.choice(5, size=10)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
towards https://github.com/scikit-learn/scikit-learn/issues/22827

#### What does this implement/fix? Explain your changes.
I added the global_random_seed fixture to the tests:-
- test_weighted_percentile_2d
- test_weighted_median_equal_weights
- test_averaged_weighted_percentile

#### Any other comments?
Feedback and guidance is highly appreciated. Looking forward to contributing to this project more and more in the coming days. Thanks in advance!

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
