### PR TITLE
MNT Fix Binder on 1.6 doc

### DIFF
--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -6,9 +6,9 @@ set -e
 # inside a git checkout of the scikit-learn/scikit-learn repo. This script is
 # generating notebooks from the scikit-learn python examples.
 
-if [[ ! -f /.dockerenv ]]; then
-    echo "This script was written for repo2docker and is supposed to run inside a docker container."
-    echo "Exiting because this script can delete data if run outside of a docker container."
+if [[ -z "${REPO_DIR}" ]]; then
+    echo "This script was written for repo2docker and the REPO_DIR environment variable is supposed to be set."
+    echo "Exiting because this script can delete data if run outside of a repo2docker context."
     exit 1
 fi
 

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -23,7 +23,7 @@ find . -delete
 GENERATED_NOTEBOOKS_DIR=.generated-notebooks
 cp -r $TMP_CONTENT_DIR/examples $GENERATED_NOTEBOOKS_DIR
 
-find $GENERATED_NOTEBOOKS_DIR -name '*.py' -exec sphx_glr_python_to_jupyter.py '{}' +
+find $GENERATED_NOTEBOOKS_DIR -name '*.py' -exec sphinx_gallery_py2jupyter '{}' +
 NON_NOTEBOOKS=$(find $GENERATED_NOTEBOOKS_DIR -type f | grep -v '\.ipynb')
 rm -f $NON_NOTEBOOKS
 


### PR DESCRIPTION
Backport of #30835 and #30697 to fix Binder links for the stable doc.

Binder seems to work on my branch: https://mybinder.org/v2/gh/lesteve/scikit-learn/binder-doc-1.6.