### PR TITLE
TST use global_random_seed in sklearn/linear_model/tests/test_linear_loss.py

### DIFF
--- a/sklearn/linear_model/tests/test_linear_loss.py
+++ b/sklearn/linear_model/tests/test_linear_loss.py
@@ -251,7 +251,7 @@ def test_loss_gradients_hessp_intercept(
     g_inter_corrected.T[-1] += l2_reg_strength * coef.T[-1]
     assert_allclose(g, g_inter_corrected)
 
-    s = np.random.RandomState(42).randn(*coef.shape)
+    s = np.random.RandomState(global_random_seed).randn(*coef.shape)
     h = hessp(s)
     h_inter = hessp_inter(s)
     h_inter_corrected = h_inter
@@ -358,7 +358,7 @@ def test_multinomial_coef_shape(fit_intercept, global_random_seed):
         n_features=n_features,
         seed=global_random_seed,
     )
-    s = np.random.RandomState(42).randn(*coef.shape)
+    s = np.random.RandomState(global_random_seed).randn(*coef.shape)
 
     l, g = loss.loss_gradient(coef, X, y)
     g1 = loss.gradient(coef, X, y)

--- a/sklearn/linear_model/tests/test_linear_loss.py
+++ b/sklearn/linear_model/tests/test_linear_loss.py
@@ -81,10 +81,12 @@ def random_X_y_coef(
 @pytest.mark.parametrize("fit_intercept", [False, True])
 @pytest.mark.parametrize("n_features", [0, 1, 10])
 @pytest.mark.parametrize("dtype", [None, np.float32, np.float64, np.int64])
-def test_init_zero_coef(base_loss, fit_intercept, n_features, dtype):
+def test_init_zero_coef(
+    base_loss, fit_intercept, n_features, dtype, global_random_seed
+):
     """Test that init_zero_coef initializes coef correctly."""
     loss = LinearModelLoss(base_loss=base_loss(), fit_intercept=fit_intercept)
-    rng = np.random.RandomState(42)
+    rng = np.random.RandomState(global_random_seed)
     X = rng.normal(size=(5, n_features))
     coef = loss.init_zero_coef(X, dtype=dtype)
     if loss.base_loss.is_multiclass:
@@ -108,12 +110,17 @@ def test_init_zero_coef(base_loss, fit_intercept, n_features, dtype):
 @pytest.mark.parametrize("l2_reg_strength", [0, 1])
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 def test_loss_grad_hess_are_the_same(
-    base_loss, fit_intercept, sample_weight, l2_reg_strength, csr_container
+    base_loss,
+    fit_intercept,
+    sample_weight,
+    l2_reg_strength,
+    csr_container,
+    global_random_seed,
 ):
     """Test that loss and gradient are the same across different functions."""
     loss = LinearModelLoss(base_loss=base_loss(), fit_intercept=fit_intercept)
     X, y, coef = random_X_y_coef(
-        linear_model_loss=loss, n_samples=10, n_features=5, seed=42
+        linear_model_loss=loss, n_samples=10, n_features=5, seed=global_random_seed
     )
     X_old, y_old, coef_old = X.copy(), y.copy(), coef.copy()
 
@@ -198,14 +205,17 @@ def test_loss_grad_hess_are_the_same(
 @pytest.mark.parametrize("l2_reg_strength", [0, 1])
 @pytest.mark.parametrize("X_container", CSR_CONTAINERS + [None])
 def test_loss_gradients_hessp_intercept(
-    base_loss, sample_weight, l2_reg_strength, X_container
+    base_loss, sample_weight, l2_reg_strength, X_container, global_random_seed
 ):
     """Test that loss and gradient handle intercept correctly."""
     loss = LinearModelLoss(base_loss=base_loss(), fit_intercept=False)
     loss_inter = LinearModelLoss(base_loss=base_loss(), fit_intercept=True)
     n_samples, n_features = 10, 5
     X, y, coef = random_X_y_coef(
-        linear_model_loss=loss, n_samples=n_samples, n_features=n_features, seed=42
+        linear_model_loss=loss,
+        n_samples=n_samples,
+        n_features=n_features,
+        seed=global_random_seed,
     )
 
     X[:, -1] = 1  # make last column of 1 to mimic intercept term
@@ -254,7 +264,7 @@ def test_loss_gradients_hessp_intercept(
 @pytest.mark.parametrize("sample_weight", [None, "range"])
 @pytest.mark.parametrize("l2_reg_strength", [0, 1])
 def test_gradients_hessians_numerically(
-    base_loss, fit_intercept, sample_weight, l2_reg_strength
+    base_loss, fit_intercept, sample_weight, l2_reg_strength, global_random_seed
 ):
     """Test gradients and hessians with numerical derivatives.
 
@@ -264,7 +274,10 @@ def test_gradients_hessians_numerically(
     loss = LinearModelLoss(base_loss=base_loss(), fit_intercept=fit_intercept)
     n_samples, n_features = 10, 5
     X, y, coef = random_X_y_coef(
-        linear_model_loss=loss, n_samples=n_samples, n_features=n_features, seed=42
+        linear_model_loss=loss,
+        n_samples=n_samples,
+        n_features=n_features,
+        seed=global_random_seed,
     )
     coef = coef.ravel(order="F")  # this is important only for multinomial loss
 
@@ -335,12 +348,15 @@ def test_gradients_hessians_numerically(
 
 
 @pytest.mark.parametrize("fit_intercept", [False, True])
-def test_multinomial_coef_shape(fit_intercept):
+def test_multinomial_coef_shape(fit_intercept, global_random_seed):
     """Test that multinomial LinearModelLoss respects shape of coef."""
     loss = LinearModelLoss(base_loss=HalfMultinomialLoss(), fit_intercept=fit_intercept)
     n_samples, n_features = 10, 5
     X, y, coef = random_X_y_coef(
-        linear_model_loss=loss, n_samples=n_samples, n_features=n_features, seed=42
+        linear_model_loss=loss,
+        n_samples=n_samples,
+        n_features=n_features,
+        seed=global_random_seed,
     )
     s = np.random.RandomState(42).randn(*coef.shape)
 
@@ -373,7 +389,7 @@ def test_multinomial_coef_shape(fit_intercept):
 
 
 @pytest.mark.parametrize("sample_weight", [None, "range"])
-def test_multinomial_hessian_3_classes(sample_weight):
+def test_multinomial_hessian_3_classes(sample_weight, global_random_seed):
     """Test multinomial hessian for 3 classes and 2 points.
 
     For n_classes = 3 and n_samples = 2, we have
@@ -391,7 +407,10 @@ def test_multinomial_hessian_3_classes(sample_weight):
         base_loss=HalfMultinomialLoss(n_classes=n_classes), fit_intercept=False
     )
     X, y, coef = random_X_y_coef(
-        linear_model_loss=loss, n_samples=n_samples, n_features=n_features, seed=42
+        linear_model_loss=loss,
+        n_samples=n_samples,
+        n_features=n_features,
+        seed=global_random_seed,
     )
     coef = coef.ravel(order="F")  # this is important only for multinomial loss
 

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -494,11 +494,11 @@ def test_regression_single_sample(metric):
         assert np.isnan(score)
 
 
-def test_tweedie_deviance_continuity(global_random_seed):
+def test_tweedie_deviance_continuity():
     n_samples = 100
 
-    y_true = np.random.RandomState(global_random_seed).rand(n_samples) + 0.1
-    y_pred = np.random.RandomState(global_random_seed + 1).rand(n_samples) + 0.1
+    y_true = np.random.RandomState(0).rand(n_samples) + 0.1
+    y_pred = np.random.RandomState(1).rand(n_samples) + 0.1
 
     assert_allclose(
         mean_tweedie_deviance(y_true, y_pred, power=0 - 1e-10),
@@ -518,18 +518,18 @@ def test_tweedie_deviance_continuity(global_random_seed):
     assert_allclose(
         mean_tweedie_deviance(y_true, y_pred, power=2 - 1e-10),
         mean_tweedie_deviance(y_true, y_pred, power=2),
-        atol=1e-5,
+        atol=1e-6,
     )
 
     assert_allclose(
         mean_tweedie_deviance(y_true, y_pred, power=2 + 1e-10),
         mean_tweedie_deviance(y_true, y_pred, power=2),
-        atol=1e-5,
+        atol=1e-6,
     )
 
 
-def test_mean_absolute_percentage_error(global_random_seed):
-    random_number_generator = np.random.RandomState(global_random_seed)
+def test_mean_absolute_percentage_error():
+    random_number_generator = np.random.RandomState(42)
     y_true = random_number_generator.exponential(size=100)
     y_pred = 1.2 * y_true
     assert mean_absolute_percentage_error(y_true, y_pred) == pytest.approx(0.2)
@@ -539,9 +539,7 @@ def test_mean_absolute_percentage_error(global_random_seed):
     "distribution", ["normal", "lognormal", "exponential", "uniform"]
 )
 @pytest.mark.parametrize("target_quantile", [0.05, 0.5, 0.75])
-def test_mean_pinball_loss_on_constant_predictions(
-    distribution, target_quantile, global_random_seed
-):
+def test_mean_pinball_loss_on_constant_predictions(distribution, target_quantile):
     if not hasattr(np, "quantile"):
         pytest.skip(
             "This test requires a more recent version of numpy "
@@ -549,8 +547,8 @@ def test_mean_pinball_loss_on_constant_predictions(
         )
 
     # Check that the pinball loss is minimized by the empirical quantile.
-    n_samples = 30000
-    rng = np.random.RandomState(global_random_seed)
+    n_samples = 3000
+    rng = np.random.RandomState(42)
     data = getattr(rng, distribution)(size=n_samples)
 
     # Compute the best possible pinball loss for any constant predictor:
@@ -585,20 +583,19 @@ def test_mean_pinball_loss_on_constant_predictions(
         return mean_pinball_loss(data, constant_pred, alpha=target_quantile)
 
     result = optimize.minimize(objective_func, data.mean(), method="Nelder-Mead")
-    result_x = result.x
     assert result.success
     # The minimum is not unique with limited data, hence the large tolerance.
-    assert result_x == pytest.approx(best_pred, rel=1e-2)
+    assert result.x == pytest.approx(best_pred, rel=1e-2)
     assert result.fun == pytest.approx(best_pbl)
 
 
-def test_dummy_quantile_parameter_tuning(global_random_seed):
+def test_dummy_quantile_parameter_tuning():
     # Integration test to check that it is possible to use the pinball loss to
     # tune the hyperparameter of a quantile regressor. This is conceptually
     # similar to the previous test but using the scikit-learn estimator and
     # scoring API instead.
     n_samples = 1000
-    rng = np.random.RandomState(global_random_seed)
+    rng = np.random.RandomState(0)
     X = rng.normal(size=(n_samples, 5))  # Ignored
     y = rng.exponential(size=n_samples)
 
@@ -619,9 +616,9 @@ def test_dummy_quantile_parameter_tuning(global_random_seed):
         assert grid_search.best_params_["quantile"] == pytest.approx(alpha)
 
 
-def test_pinball_loss_relation_with_mae(global_random_seed):
+def test_pinball_loss_relation_with_mae():
     # Test that mean_pinball loss with alpha=0.5 if half of mean absolute error
-    rng = np.random.RandomState(global_random_seed)
+    rng = np.random.RandomState(714)
     n = 100
     y_true = rng.normal(size=n)
     y_pred = y_true.copy() + rng.uniform(n)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #22827. All tests passed. @adrinjalali 

#### What does this implement/fix? Explain your changes.

Added `global_random_seed` parameter to: 
* `test_init_zero_coef`
* `test_loss_grad_hess_are_the_same` (passed to `random_X_y_coef`)
* `test_loss_gradients_hessp_intercept` (passed to `random_X_y_coef`)
* `test_gradients_hessians_numerically` (passed to `random_X_y_coef`)
* `test_multinomial_coef_shape` (passed to `random_X_y_coef`)
* `test_multinomial_hessian_3_classes` (passed to `random_X_y_coef`)

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
