### PR TITLE
DOC Add bash cell to Developer Guide to make it more intuitive

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -282,7 +282,13 @@ how to set up your git repository:
         git remote add upstream git@github.com:scikit-learn/scikit-learn.git
 
 7. Check that the `upstream` and `origin` remote aliases are configured correctly
-   by running `git remote -v` which should display:
+   by running:
+
+  .. prompt:: bash
+
+        git remote -v`
+
+  This should display:
 
    .. code-block:: text
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -284,11 +284,11 @@ how to set up your git repository:
 7. Check that the `upstream` and `origin` remote aliases are configured correctly
    by running:
 
-  .. prompt:: bash
+   .. prompt:: bash
 
-        git remote -v`
+        git remote -v
 
-  This should display:
+   This should display:
 
    .. code-block:: text
 


### PR DESCRIPTION
I have witnessed in a new contributor sprint that swapping back and forth between displaying the bash command and then the output of a bash command in a code block in the developer guide is confusing to people. 

It is more convenient to keep displaying all the bash commands in bash prompts for easy copy paste.