### PR TITLE
FIX unintentional sample_weight upcast in CalibratedClassifierCV

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.calibration/30873.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.calibration/30873.fix.rst
@@ -1,0 +1,7 @@
+- :class:`~calibration.CalibratedClassifierCV` now raises `FutureWarning`
+  instead of instead of `UserWarning` when passing `cv="prefit`". By
+  :user:`Olivier Grisel <ogrisel>`
+- :class:`~calibration.CalibratedClassifierCV` with `method="sigmoid"` no
+  longer crashes when passing `float64`-dtyped `sample_weight` along with a
+  base estimator that outputs `float32`-dtyped predictions. By :user:`Olivier
+  Grisel <ogrisel>`

--- a/doc/whats_new/upcoming_changes/sklearn.calibration/30873.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.calibration/30873.fix.rst
@@ -1,5 +1,5 @@
 - :class:`~calibration.CalibratedClassifierCV` now raises `FutureWarning`
-  instead of instead of `UserWarning` when passing `cv="prefit`". By
+  instead of `UserWarning` when passing `cv="prefit`". By
   :user:`Olivier Grisel <ogrisel>`
 - :class:`~calibration.CalibratedClassifierCV` with `method="sigmoid"` no
   longer crashes when passing `float64`-dtyped `sample_weight` along with a

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -318,9 +318,6 @@ class CalibratedClassifierCV(ClassifierMixin, MetaEstimatorMixin, BaseEstimator)
         """
         check_classification_targets(y)
         X, y = indexable(X, y)
-        if sample_weight is not None:
-            sample_weight = _check_sample_weight(sample_weight, X)
-
         estimator = self._get_estimator()
 
         _ensemble = self.ensemble
@@ -638,10 +635,10 @@ def _fit_classifier_calibrator_pair(
         predictions = predictions.reshape(-1, 1)
 
     if sample_weight is not None:
-        sw_test = _safe_indexing(sample_weight, test)
         # Check that the sample_weight dtype is consistent with the predictions
         # to avoid unintentional upcasts.
-        sw_test = _check_sample_weight(sw_test, predictions, dtype=predictions.dtype)
+        sample_weight = _check_sample_weight(sample_weight, X, dtype=predictions.dtype)
+        sw_test = _safe_indexing(sample_weight, test)
     else:
         sw_test = None
     calibrated_classifier = _fit_calibrator(

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -1091,7 +1091,12 @@ def test_float32_predict_proba(data, use_sample_weight, method):
     if use_sample_weight:
         # Use dtype=np.float64 to check that this does not trigger an
         # unintentional upcasting: the dtype of the base estimator should
-        # control the dtype of the final model.
+        # control the dtype of the final model. In particular, the
+        # sigmoid calibrator relies on inputs (predictions and sample weights)
+        # with consistent dtypes because it is partially written in Cython. 
+        # As this test forces the predictions to be `float32`, we want to check
+        # that `CalibratedClassifierCV` internally converts `sample_weight` to
+        # the same dtype to avoid crashing the Cython call.
         sample_weight = np.ones_like(data[1], dtype=np.float64)
     else:
         sample_weight = None

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -579,8 +579,12 @@ def test_calibration_attributes(clf, cv):
     X, y = make_classification(n_samples=10, n_features=5, n_classes=2, random_state=7)
     if cv == "prefit":
         clf = clf.fit(X, y)
-    calib_clf = CalibratedClassifierCV(clf, cv=cv)
-    calib_clf.fit(X, y)
+        calib_clf = CalibratedClassifierCV(clf, cv=cv)
+        with pytest.warns(FutureWarning):
+            calib_clf.fit(X, y)
+    else:
+        calib_clf = CalibratedClassifierCV(clf, cv=cv)
+        calib_clf.fit(X, y)
 
     if cv == "prefit":
         assert_array_equal(calib_clf.classes_, clf.classes_)

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -1093,7 +1093,7 @@ def test_float32_predict_proba(data, use_sample_weight, method):
         # unintentional upcasting: the dtype of the base estimator should
         # control the dtype of the final model. In particular, the
         # sigmoid calibrator relies on inputs (predictions and sample weights)
-        # with consistent dtypes because it is partially written in Cython. 
+        # with consistent dtypes because it is partially written in Cython.
         # As this test forces the predictions to be `float32`, we want to check
         # that `CalibratedClassifierCV` internally converts `sample_weight` to
         # the same dtype to avoid crashing the Cython call.


### PR DESCRIPTION
Fixes #30868.

Note: I could have moved the call to `_check_sample_weight` inside `_SigmoidCalibration` only as `IsotonicRegression` does not really care. However, I have the feeling that it's better to do it upfront, as early as possible, in the meta-estimator itself. But I am not sure what's best. I can update the PR if people disagree.