### PR TITLE
WIP: Feature: Simple imputer many missing data kinds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ jupyterlite_contents
 
 # file recognised by vscode IDEs containing env variables
 .env
+.venv

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -652,6 +652,7 @@ class SimpleImputer(_BaseImputer):
         else:
             # same as np.isnan but also works for object dtypes
             invalid_mask = _get_mask(statistics, np.nan)
+
             valid_mask = np.logical_not(invalid_mask)
             valid_statistics = statistics[valid_mask]
             valid_statistics_indexes = np.flatnonzero(valid_mask)

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1404,6 +1404,57 @@ def test_simple_imputation_string_list(strategy, expected):
     assert_array_equal(X_trans, X_true)
 
 
+def test_simple_imputer_many_missing_values_each_columns():
+    pd = pytest.importorskip("pandas")
+
+    fill_value = 999
+
+    X = pd.DataFrame([[1, np.nan, 3], [None, 4, 5], [6, 7, pd.NA]])
+
+    X_true = np.array([[1, fill_value, 3], [fill_value, 4, 5], [6, 7, fill_value]])
+
+    imputer = SimpleImputer(
+        strategy="constant", fill_value=fill_value, missing_values=[np.nan, None, pd.NA]
+    )
+    X_trans = imputer.fit_transform(X)
+
+    assert_array_equal(X_trans, X_true)
+
+
+def test_simple_imputer_many_missing_values_each_same_column():
+    pd = pytest.importorskip("pandas")
+
+    fill_value = 999
+
+    X = pd.DataFrame([[1, 2, None], [3, 4, np.nan], [5, 6, pd.NA]])
+
+    X_true = np.array([[1, 2, fill_value], [3, 4, fill_value], [5, 6, fill_value]])
+
+    imputer = SimpleImputer(
+        strategy="constant", fill_value=fill_value, missing_values=[np.nan, None, pd.NA]
+    )
+    X_trans = imputer.fit_transform(X)
+
+    assert_array_equal(X_trans, X_true)
+
+
+def test_simple_imputer_many_missing_values_without_pandas_na():
+    pd = pytest.importorskip("pandas")
+
+    fill_value = 999
+
+    X = pd.DataFrame([[1, 2, None], [3, 4, np.nan], [5, 6, 7]])
+
+    X_true = np.array([[1, 2, fill_value], [3, 4, fill_value], [5, 6, 7]])
+
+    imputer = SimpleImputer(
+        strategy="constant", fill_value=fill_value, missing_values=[np.nan, None]
+    )
+    X_trans = imputer.fit_transform(X)
+
+    assert_array_equal(X_trans, X_true)
+
+
 @pytest.mark.parametrize(
     "order, idx_order",
     [("ascending", [3, 4, 2, 0, 1]), ("descending", [1, 0, 2, 4, 3])],

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -347,6 +347,7 @@ def test_imputation_most_frequent(csc_container):
 
 
 @pytest.mark.parametrize("marker", [None, np.nan, "NAN", "", 0])
+# @pytest.mark.parametrize("marker", [None])
 def test_imputation_most_frequent_objects(marker):
     # Test imputation using the most-frequent strategy.
     X = np.array(
@@ -1409,7 +1410,7 @@ def test_simple_imputer_many_missing_values_each_columns():
 
     fill_value = 999
 
-    X = pd.DataFrame([[1, np.nan, 3], [None, 4, 5], [6, 7, pd.NA]])
+    X = [[1, np.nan, 3], [None, 4, 5], [6, 7, pd.NA]]
 
     X_true = np.array([[1, fill_value, 3], [fill_value, 4, 5], [6, 7, fill_value]])
 
@@ -1426,7 +1427,7 @@ def test_simple_imputer_many_missing_values_each_same_column():
 
     fill_value = 999
 
-    X = pd.DataFrame([[1, 2, None], [3, 4, np.nan], [5, 6, pd.NA]])
+    X = [[1, 2, None], [3, 4, np.nan], [5, 6, pd.NA]]
 
     X_true = np.array([[1, 2, fill_value], [3, 4, fill_value], [5, 6, fill_value]])
 
@@ -1443,7 +1444,7 @@ def test_simple_imputer_many_missing_values_without_pandas_na():
 
     fill_value = 999
 
-    X = pd.DataFrame([[1, 2, None], [3, 4, np.nan], [5, 6, 7]])
+    X = [[1, 2, None], [3, 4, np.nan], [5, 6, 7]]
 
     X_true = np.array([[1, 2, fill_value], [3, 4, fill_value], [5, 6, 7]])
 

--- a/sklearn/utils/_mask.py
+++ b/sklearn/utils/_mask.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from contextlib import suppress
+from functools import reduce
 
 import numpy as np
 from scipy import sparse as sp
@@ -26,6 +27,9 @@ def _get_dense_mask(X, value_to_mask):
         elif X.dtype.kind in ("i", "u"):
             # can't have NaNs in integer array.
             Xt = np.zeros(X.shape, dtype=bool)
+        elif X.dtype.kind == "O":
+            Xt = _convert_pandas_na_to(X, False)
+            Xt = Xt == value_to_mask
         else:
             # np.isnan does not work on object dtypes.
             Xt = _object_dtype_isnan(X)
@@ -33,6 +37,15 @@ def _get_dense_mask(X, value_to_mask):
         Xt = X == value_to_mask
 
     return Xt
+
+
+def _convert_pandas_na_to(X, value_to_convert):
+    try:
+        import pandas
+
+        return np.where(pandas.isna(X), value_to_convert, X)
+    except ImportError:
+        return X
 
 
 def _get_mask(X, value_to_mask):
@@ -65,6 +78,29 @@ def _get_mask(X, value_to_mask):
     )
 
     return Xt_sparse
+
+
+def _get_mask_from_many_values(X, values_to_mask):
+    """Compute the boolean mask X == values_to_mask or X in values_to_mask.
+
+    Parameters
+    ----------
+    X : {ndarray, sparse matrix} of shape (n_samples, n_features)
+        Input data, where ``n_samples`` is the number of samples and
+        ``n_features`` is the number of features.
+
+    value_to_mask : {int, float, List|Set|Tuple[int|float]}
+        The values which is to be masked in X.
+
+    Returns
+    -------
+    X_mask : {ndarray, sparse matrix} of shape (n_samples, n_features)
+        Missing mask.
+    """
+
+    if isinstance(values_to_mask, (list, set, tuple)):
+        return reduce(lambda a, b: a | b, [_get_mask(X, v) for v in values_to_mask])
+    return _get_mask(X, values_to_mask)
 
 
 @validate_params(

--- a/sklearn/utils/_missing.py
+++ b/sklearn/utils/_missing.py
@@ -66,3 +66,36 @@ def is_pandas_na(x):
         return x is NA
 
     return False
+
+
+def array_like_has_any_na(x):
+    """Test if x is list, tuple or set and have pd.NA o NaN
+
+    Parameters
+    ----------
+    x : any type
+
+    Returns
+    -------
+    boolean
+    """
+    if isinstance(x, (list, set, tuple)):
+        return any(is_scalar_nan(v) or is_pandas_na(v) for v in x)
+    return False
+
+
+def has_only_number_or_none(x):
+    """Test if x is number or none, or if x is list, tuple or set
+    that has only numbers or None
+
+    Parameters
+    ----------
+    x : any type
+
+    Returns
+    -------
+    boolean
+    """
+    if isinstance(x, (list, set, tuple)):
+        return any(isinstance(v, numbers.Real) or v is None for v in x)
+    return isinstance(x, numbers.Real) or x is None

--- a/sklearn/utils/_missing.py
+++ b/sklearn/utils/_missing.py
@@ -5,6 +5,8 @@ import math
 import numbers
 from contextlib import suppress
 
+import numpy as np
+
 
 def is_scalar_nan(x):
     """Test if x is NaN.
@@ -99,3 +101,11 @@ def has_only_number_or_none(x):
     if isinstance(x, (list, set, tuple)):
         return any(isinstance(v, numbers.Real) or v is None for v in x)
     return isinstance(x, numbers.Real) or x is None
+
+
+try:
+    import pandas
+
+    is_pandas_na_only = np.frompyfunc(lambda a: a is pandas.NA or a is pandas.NaT, 1, 1)
+except ImportError:
+    is_pandas_na_only = lambda a: False


### PR DESCRIPTION
#### Reference Issues/PRs

https://github.com/scikit-learn/scikit-learn/issues/17625

#### What does this implement/fix? Explain your changes.

Enabling the possibility to specify multiple `missing_values` in SimpleImputer, as discussed in this issue: https://github.com/scikit-learn/scikit-learn/issues/17625

PR still in progress to be discussed in the issue.

```python
SimpleImputer(
        ...
       missing_values=[np.nan, None, pd.NA]
)
```

#### Any other comments?

The idea is to start by allowing multiple missing values and then, in a later PR, change the default `missing_values` to include all common missing values (`np.nan`, `None`, `pd.NA`, `pd.NaT`). There may be an intermediate PR after this one, before the later PR that changes the default, to add a *FutureWarning* explaining the upcoming change in the default `missing_values`.


