### PR TITLE
ENH default routing policy for sample weight

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -10,6 +10,7 @@ import platform
 import re
 import warnings
 from collections import defaultdict
+from typing import Union
 
 import numpy as np
 
@@ -153,7 +154,20 @@ def _clone_parametrized(estimator, *, safe=True):
     return new_object
 
 
-class BaseEstimator(_HTMLDocumentationLinkMixin, _MetadataRequester):
+class _SampleWeightEstimatorMixin(_MetadataRequester):
+    """A Mixin to request ``sample_weight`` by default.
+
+    This Mixin makes the object to request ``sample_weight`` by default as ``True``
+    for both ``fit`` and ``score`` methods.
+
+    .. versionadded:: 1.7
+    """
+
+    __metadata_request__fit: dict[str, Union[bool, str]] = {"sample_weight": True}
+    __metadata_request__score: dict[str, Union[bool, str]] = {"sample_weight": True}
+
+
+class BaseEstimator(_HTMLDocumentationLinkMixin, _SampleWeightEstimatorMixin):
     """Base class for all estimators in scikit-learn.
 
     Inheriting from this class provides default implementations of:

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -184,7 +184,10 @@ class EmpiricalCovariance(BaseEstimator):
     """
 
     # X_test should have been called X
-    __metadata_request__score = {"X_test": metadata_routing.UNUSED}
+    __metadata_request__score = {
+        "X_test": metadata_routing.UNUSED,
+        "sample_weight": True,
+    }
 
     _parameter_constraints: dict = {
         "store_precision": ["boolean"],

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -879,7 +879,10 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
     # "check_input" is used for optimisation and isn't something to be passed
     # around in a pipeline.
-    __metadata_request__fit = {"check_input": metadata_routing.UNUSED}
+    __metadata_request__fit = {
+        "check_input": metadata_routing.UNUSED,
+        "sample_weight": True,
+    }
 
     _parameter_constraints: dict = {
         "alpha": [Interval(Real, 0, None, closed="left")],

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -195,7 +195,19 @@ class _MultimetricScorer:
         )
 
 
-class _BaseScorer(_MetadataRequester):
+class _SampleWeightScorerMixin(_MetadataRequester):
+    """A Mixin to request ``sample_weight`` by default.
+
+    This Mixin makes the object to request ``sample_weight`` by default as ``True``
+    for the ``score`` method.
+
+    .. versionadded:: 1.7
+    """
+
+    __metadata_request__score = {"sample_weight": True}
+
+
+class _BaseScorer(_SampleWeightScorerMixin):
     """Base scorer that is used as `scorer(estimator, X, y_true)`.
 
     Parameters

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2431,7 +2431,7 @@ class KernelCenterer(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEsti
 
     # X is called K in these methods.
     __metadata_request__transform = {"K": metadata_routing.UNUSED}
-    __metadata_request__fit = {"K": metadata_routing.UNUSED}
+    __metadata_request__fit = {"K": metadata_routing.UNUSED, "sample_weight": True}
 
     def fit(self, K, y=None):
         """Fit KernelCenterer.


### PR DESCRIPTION


#### Reference Issues/PRs

Towards #26179 (default policy for `sample_weight`) and meta-issue #16298 (making metaestimators satisfy the `sample_weight` equivalence check #29818 out of the box when metadata routing is enabled).


#### What does this implement/fix? Explain your changes.

In this draft PR, the `sample_weight` metadata is requested by default in all estimators (for fit and score methods) and scorers (for the score method).  

It's a similar strategy to the `groups` metadata which is requested by default in `groups`-consuming splitters like `GroupKFold`.

#### Motivation

The motivation behind is to make metaestimators handle `sample_weight` correctly by default, without the user needing to specify all requests. For example consider this metaestimator:
```python
scaler = StandardScaler()
spline = SplineTransformer(knots="quantile")
union = FeatureUnion([("scaler", scaler), ("spline", spline)])
logistic =  LogisticRegression()
pipe = Pipeline(steps=[("union", union), ("logistic", logistic)])
param_grid = {
    "union__spline__n_knots": [5, 6, 7],
    "logistic__C": np.logspace(-4, 4, 4),
}
search = GridSearchCV(pipe, param_grid, n_jobs=2)
```
We would like the `search` metaestimator to handle `sample_weight` correctly, for instance to respect the repeated/reweighted equivalence check #29818. In scikit-learn, this is only possible with metadata routing enabled.
With the current routing policy one needs to explicitly requests `sample_weight` for all objects/methods:
```python
scaler.set_fit_request(sample_weight=True)
spline.set_fit_request(sample_weight=True)
logistic.set_fit_request(sample_weight=True)
logistic.set_score_request(sample_weight=True)
pipe.set_score_request(sample_weight=True)
```
This works, the metaestimator satisfies the repeated/reweighted equivalence check. On the downside it is very verbose, and the user might easily forget a request or add an unnecessary one. It requires the user to know each subestimator and router inner mechanics precisely, which kind of defeats the purpose of  the metaestimator. Ideally we would like the metaestimator to "just work" when using `sample_weight`.

In this draft PR, `sample_weight` is requested by default, and `search.fit` handles `sample_weight` correctly out of the box and satisfy the repeated/reweighted equivalence check.

#### Any other comments?

This is a very crude draft and it breaks many tests! The current "solution" is wrong, but I hope it can serve as a basis for criticism, feedback on desired goals, and implementation ideas going forward.

For instance:
- [ ] what about estimator that don't support `sample_weight` ?
- [ ] what about metaestimator like `BaggingRegressor` which should consume `sample_weight` for sampling but not forward them to subestimator https://github.com/scikit-learn/scikit-learn/issues/26179#issuecomment-2582917080 ?
- [ ] should we rather implement a default `sample_weight="auto"` in the routing API ?
- [ ] what would be the intended behavior of the "auto" option ? 

cc @adrinjalali @ogrisel 



