### PR TITLE
CI Fix nightly wheel upload script

### DIFF
--- a/build_tools/github/upload_anaconda.sh
+++ b/build_tools/github/upload_anaconda.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 if [[ "$GITHUB_EVENT_NAME" == "schedule" \
-        || "$GITHUB_EVENT_NAME" == "workflow_dispatch"]]; then
+	|| "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
     ANACONDA_ORG="scientific-python-nightly-wheels"
     ANACONDA_TOKEN="$SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN"
 else


### PR DESCRIPTION
Wheel uploads have been failing for roughly 13 days according to [this](https://anaconda.org/scientific-python-nightly-wheels/scikit-learn/files), see [build logs](https://github.com/scikit-learn/scikit-learn/actions/workflows/wheels.yml?query=branch%3Amain+event%3Aschedule)

This is because of a failing space in bash :sweat: 