### PR TITLE
MNT Replace tab by spaces in bash script

### DIFF
--- a/build_tools/github/upload_anaconda.sh
+++ b/build_tools/github/upload_anaconda.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 if [[ "$GITHUB_EVENT_NAME" == "schedule" \
-	|| "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+          || "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
     ANACONDA_ORG="scientific-python-nightly-wheels"
     ANACONDA_TOKEN="$SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN"
 else


### PR DESCRIPTION
Follow-up of #30890, I couldn't help notice that I introduced a tab instead of spaces :scream:.

Just to be explicit: this is only a cosmetic change, and has no impact on functionality.