### PR TITLE
CI Fix lock-file update workflow

### DIFF
--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           source build_tools/shared.sh
           source $CONDA/bin/activate
+          conda update -n base --all
           conda install -n base conda conda-libmamba-solver -y
           conda config --set solver libmamba
           conda install -c conda-forge "$(get_dep conda-lock min)" -y

--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update_lock_files:
-    if: github.repository == 'scikit-learn/scikit-learn'
+    # if: github.repository == 'scikit-learn/scikit-learn'
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update_lock_files:
-    # if: github.repository == 'scikit-learn/scikit-learn'
+    if: github.repository == 'scikit-learn/scikit-learn'
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Lock-files hasn't been updated two weeks in a row, see [build logs](https://github.com/scikit-learn/scikit-learn/actions/workflows/update-lock-files.yml).

The work-around from https://github.com/conda/conda/issues/14569#issuecomment-2654211257 seems to do the trick.

cc @ogrisel who discovered this and mentioned in this [Discord thread](https://discord.com/channels/731163543038197871/1343526459939229716/1343526475336257537).

Tested on my fork, see [build log](https://github.com/lesteve/scikit-learn/actions/runs/13522282744/job/37784086752). The workflow is still red but the lock-file generation works, the failure comes from the create-pull-request part which is not supposed to work on my fork, since I don't have the necessary token.

