### PR TITLE
Revert "Make FrozenEstimator explicitly accept and ignore sample_weight"

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.frozen/30874.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.frozen/30874.enhancement.rst
@@ -1,3 +1,0 @@
-- :class:`~frozen.FrozenEstimator` now explicitly accepts a `sample_weight`
-  argument in `fit` (and ignores it explicitly) to make it inspectable by
-  meta-estimators and testing frameworks. By :user:`Olivier Grisel <ogrisel>`

--- a/sklearn/frozen/_frozen.py
+++ b/sklearn/frozen/_frozen.py
@@ -86,7 +86,7 @@ class FrozenEstimator(BaseEstimator):
         except NotFittedError:
             return False
 
-    def fit(self, X, y, sample_weight=None, *args, **kwargs):
+    def fit(self, X, y, *args, **kwargs):
         """No-op.
 
         As a frozen estimator, calling `fit` has no effect.
@@ -97,9 +97,6 @@ class FrozenEstimator(BaseEstimator):
             Ignored.
 
         y : object
-            Ignored.
-
-        sample_weight : object
             Ignored.
 
         *args : tuple

--- a/sklearn/frozen/tests/test_frozen.py
+++ b/sklearn/frozen/tests/test_frozen.py
@@ -26,7 +26,7 @@ from sklearn.neighbors import LocalOutlierFactor
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import RobustScaler, StandardScaler
 from sklearn.utils._testing import set_random_state
-from sklearn.utils.validation import check_is_fitted, has_fit_parameter
+from sklearn.utils.validation import check_is_fitted
 
 
 @pytest.fixture
@@ -221,16 +221,3 @@ def test_frozen_params():
     other_est = LocalOutlierFactor()
     frozen.set_params(estimator=other_est)
     assert frozen.get_params() == {"estimator": other_est}
-
-
-def test_frozen_ignores_sample_weight(regression_dataset):
-    X, y = regression_dataset
-    estimator = LinearRegression().fit(X, y)
-    frozen = FrozenEstimator(estimator)
-
-    # Should not raise: sample_weight is just ignored as it is not used.
-    frozen.fit(X, y, sample_weight=np.ones(len(y)))
-
-    # FrozenEstimator should have sample_weight in its signature to make it
-    # explicit that sample_weight is accepted and ignored intentionally.
-    assert has_fit_parameter(frozen, "sample_weight")


### PR DESCRIPTION
Reverts scikit-learn/scikit-learn#30874

Based on the points mentioned in https://github.com/scikit-learn/scikit-learn/pull/30874#issuecomment-2681370389

CC: @adrinjalali @ogrisel 