### PR TITLE
DOC Fix typo: "outiers" → "outliers" in K-Means comments

### DIFF
--- a/sklearn/cluster/_k_means_elkan.pyx
+++ b/sklearn/cluster/_k_means_elkan.pyx
@@ -262,7 +262,7 @@ def elkan_iter_chunked_dense(
         # An empty array was passed, do nothing and return early (before
         # attempting to compute n_chunks). This can typically happen when
         # calling the prediction function of a bisecting k-means model with a
-        # large fraction of outiers.
+        # large fraction of outliers.
         return
 
     cdef:
@@ -505,7 +505,7 @@ def elkan_iter_chunked_sparse(
         # An empty array was passed, do nothing and return early (before
         # attempting to compute n_chunks). This can typically happen when
         # calling the prediction function of a bisecting k-means model with a
-        # large fraction of outiers.
+        # large fraction of outliers.
         return
 
     cdef:

--- a/sklearn/cluster/_k_means_lloyd.pyx
+++ b/sklearn/cluster/_k_means_lloyd.pyx
@@ -82,7 +82,7 @@ def lloyd_iter_chunked_dense(
         # An empty array was passed, do nothing and return early (before
         # attempting to compute n_chunks). This can typically happen when
         # calling the prediction function of a bisecting k-means model with a
-        # large fraction of outiers.
+        # large fraction of outliers.
         return
 
     cdef:
@@ -280,7 +280,7 @@ def lloyd_iter_chunked_sparse(
         # An empty array was passed, do nothing and return early (before
         # attempting to compute n_chunks). This can typically happen when
         # calling the prediction function of a bisecting k-means model with a
-        # large fraction of outiers.
+        # large fraction of outliers.
         return
 
     cdef:


### PR DESCRIPTION
This PR fixes a small typo in the comments of K-Means functions:

- `lloyd_iter_chunked_dense` and `lloyd_iter_chunked_sparse` in `sklearn/cluster/_k_means_lloyd.pyx`
- `elkan_iter_chunked_dense` and `elkan_iter_chunked_sparse` in `sklearn/cluster/_k_means_elkan.pyx`

The word "outiers" was corrected to "outliers."

Fixes #30913.