### PR TITLE
DOC: added link to cluster_plot_coin_ward_segmentation example in feature_extraction.grid_to_graph

### DIFF
--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -1041,6 +1041,8 @@ implemented as a scikit-learn transformer, so it can be used in pipelines. See::
     >>> patches.shape
     (45, 2, 2, 3)
 
+.. _connectivity_graph_image:
+
 Connectivity graph of an image
 -------------------------------
 

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -205,6 +205,8 @@ def grid_to_graph(
 
     Edges exist if 2 voxels are connected.
 
+    Read more in the :ref:`User Guide <connectivity_graph_image>`.
+
     Parameters
     ----------
     n_x : int
@@ -241,8 +243,6 @@ def grid_to_graph(
       Coords	Values
       (0, 0)    1
       (1, 1)    1
-
-    see also: :ref:`sphx_glr_auto_examples_cluster_plot_coin_ward_segmentation.py`.
     """
     return _to_graph(n_x, n_y, n_z, mask=mask, return_as=return_as, dtype=dtype)
 

--- a/sklearn/feature_extraction/image.py
+++ b/sklearn/feature_extraction/image.py
@@ -241,6 +241,8 @@ def grid_to_graph(
       Coords	Values
       (0, 0)    1
       (1, 1)    1
+
+    see also: :ref:`sphx_glr_auto_examples_cluster_plot_coin_ward_segmentation.py`.
     """
     return _to_graph(n_x, n_y, n_z, mask=mask, return_as=return_as, dtype=dtype)
 


### PR DESCRIPTION
#### Reference Issues/PRs

Towards https://github.com/scikit-learn/scikit-learn/issues/30621

#### What does this implement/fix? Explain your changes.

Added a link to an example of structured Ward hierarchical clustering on an image of coins in `feature_extraction.grid_to_graph` method.