### PR TITLE
MNT Consolidate Re-Calculated Multiplication in `matthews_corrcoef`

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1055,7 +1055,7 @@ def matthews_corrcoef(y_true, y_pred, *, sample_weight=None):
     if cov_ypyp_ytyt == 0:
         return 0.0
     else:
-        return cov_ytyp / np.sqrt(cov_ypyp_ytyt)
+        return float(cov_ytyp / np.sqrt(cov_ypyp_ytyt))
 
 
 @validate_params(

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1051,10 +1051,11 @@ def matthews_corrcoef(y_true, y_pred, *, sample_weight=None):
     cov_ypyp = n_samples**2 - np.dot(p_sum, p_sum)
     cov_ytyt = n_samples**2 - np.dot(t_sum, t_sum)
 
-    if cov_ypyp * cov_ytyt == 0:
+    cov_ypyp_ytyt = cov_ypyp * cov_ytyt
+    if cov_ypyp_ytyt == 0:
         return 0.0
     else:
-        return float(cov_ytyp / np.sqrt(cov_ytyt * cov_ypyp))
+        return cov_ytyp / np.sqrt(cov_ypyp_ytyt)
 
 
 @validate_params(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->
I have watched [this YouTube video](https://www.youtube.com/watch?v=5OL8XoMMOfA) and have read through the [Contributing guide here](https://scikit-learn.org/stable/developers/contributing.html).

### Update
This pull request replaces #30881 which was submitted against the wrong branch.

#### Reference Issues/PRs
There are no reference issues or performance regressions to do with this change. I was perusing the code base and came across a small, one-variable change that should speed up calculation of `matthews_corrcoef` in a miniscule way.

#### What does this implement/fix? Explain your changes.
This change is _very_ minor: in the `return` statement of the `matthews_corrcoef()` function, a multiplication is duplicated when the result of the multiplication is not identically zero. This particular multiplication will _not_ be equivalent to 0 the majority of the time, so the exact same calculation is duplicated in the `else` branch.

#### Any other comments?
The entirety of the PR is: assigning `cov_ypyp_ytyt` to the result of the multiplication of `cov_ypyp` and `cov_ytyt` so that it need not be re-calculated in the `else` branch.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->