### PR TITLE
MNT Use regex capturing in `assert_docstring_consistency`

### DIFF
--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -701,7 +701,6 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
         a whole new ensemble. See :term:`the Glossary <warm_start>`.
 
         .. versionadded:: 0.17
-           *warm_start* constructor parameter.
 
     n_jobs : int, default=None
         The number of jobs to run in parallel for both :meth:`fit` and
@@ -1130,6 +1129,8 @@ class BaggingRegressor(RegressorMixin, BaseBagging):
         When set to True, reuse the solution of the previous call to fit
         and add more estimators to the ensemble, otherwise, just fit
         a whole new ensemble. See :term:`the Glossary <warm_start>`.
+
+        .. versionadded:: 0.17
 
     n_jobs : int, default=None
         The number of jobs to run in parallel for both :meth:`fit` and

--- a/sklearn/mixture/_bayesian_mixture.py
+++ b/sklearn/mixture/_bayesian_mixture.py
@@ -102,10 +102,10 @@ class BayesianGaussianMixture(BaseMixture):
         String describing the type of covariance parameters to use.
         Must be one of:
 
-        - 'full' (each component has its own general covariance matrix),
-        - 'tied' (all components share the same general covariance matrix),
-        - 'diag' (each component has its own diagonal covariance matrix),
-        - 'spherical' (each component has its own single variance).
+        - 'full': each component has its own general covariance matrix,
+        - 'tied': all components share the same general covariance matrix,
+        - 'diag': each component has its own diagonal covariance matrix,
+        - 'spherical': each component has its own single variance.
 
     tol : float, default=1e-3
         The convergence threshold. EM iterations will stop when the
@@ -128,9 +128,9 @@ class BayesianGaussianMixture(BaseMixture):
         The method used to initialize the weights, the means and the
         covariances. String must be one of:
 
-        - 'kmeans': responsibilities are initialized using kmeans.
-        - 'k-means++': use the k-means++ method to initialize.
-        - 'random': responsibilities are initialized randomly.
+        - 'kmeans': responsibilities are initialized using kmeans,
+        - 'k-means++': use the k-means++ method to initialize,
+        - 'random': responsibilities are initialized randomly,
         - 'random_from_data': initial means are randomly selected data points.
 
         .. versionchanged:: v1.1
@@ -187,6 +187,8 @@ class BayesianGaussianMixture(BaseMixture):
         If 'warm_start' is True, the solution of the last fitting is used as
         initialization for the next call of fit(). This can speed up
         convergence when fit is called several times on similar problems.
+        In that case, 'n_init' is ignored and only a single initialization
+        occurs upon the first call.
         See :term:`the Glossary <warm_start>`.
 
     verbose : int, default=0
@@ -196,7 +198,7 @@ class BayesianGaussianMixture(BaseMixture):
         for each step.
 
     verbose_interval : int, default=10
-        Number of iteration done before the next print.
+        Number of iterations done before the next print.
 
     Attributes
     ----------
@@ -222,7 +224,7 @@ class BayesianGaussianMixture(BaseMixture):
         equivalently parameterized by the precision matrices. Storing the
         precision matrices instead of the covariance matrices makes it more
         efficient to compute the log-likelihood of new samples at test time.
-        The shape depends on ``covariance_type``::
+        The shape depends on `covariance_type`::
 
             (n_components,)                        if 'spherical',
             (n_features, n_features)               if 'tied',
@@ -236,7 +238,7 @@ class BayesianGaussianMixture(BaseMixture):
         Gaussian can be equivalently parameterized by the precision matrices.
         Storing the precision matrices instead of the covariance matrices makes
         it more efficient to compute the log-likelihood of new samples at test
-        time. The shape depends on ``covariance_type``::
+        time. The shape depends on `covariance_type`::
 
             (n_components,)                        if 'spherical',
             (n_features, n_features)               if 'tied',
@@ -247,7 +249,7 @@ class BayesianGaussianMixture(BaseMixture):
         True when convergence of the best fit of inference was reached, False otherwise.
 
     n_iter_ : int
-        Number of step used by the best fit of inference to reach the
+        Number of steps used by the best fit of inference to reach the
         convergence.
 
     lower_bound_ : float

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -532,17 +532,15 @@ class GaussianMixture(BaseMixture):
         String describing the type of covariance parameters to use.
         Must be one of:
 
-        - 'full': each component has its own general covariance matrix.
-        - 'tied': all components share the same general covariance matrix.
-        - 'diag': each component has its own diagonal covariance matrix.
+        - 'full': each component has its own general covariance matrix,
+        - 'tied': all components share the same general covariance matrix,
+        - 'diag': each component has its own diagonal covariance matrix,
         - 'spherical': each component has its own single variance.
-
-        For an example of using `covariance_type`, refer to
-        :ref:`sphx_glr_auto_examples_mixture_plot_gmm_selection.py`.
 
     tol : float, default=1e-3
         The convergence threshold. EM iterations will stop when the
-        lower bound average gain is below this threshold.
+        lower bound average gain on the likelihood (of the training data with
+        respect to the model) is below this threshold.
 
     reg_covar : float, default=1e-6
         Non-negative regularization added to the diagonal of covariance.
@@ -552,7 +550,8 @@ class GaussianMixture(BaseMixture):
         The number of EM iterations to perform.
 
     n_init : int, default=1
-        The number of initializations to perform. The best results are kept.
+        The number of initializations to perform. The result with the highest
+        lower bound value on the likelihood is kept.
 
     init_params : {'kmeans', 'k-means++', 'random', 'random_from_data'}, \
     default='kmeans'
@@ -560,10 +559,10 @@ class GaussianMixture(BaseMixture):
         precisions.
         String must be one of:
 
-        - 'kmeans' : responsibilities are initialized using kmeans.
-        - 'k-means++' : use the k-means++ method to initialize.
-        - 'random' : responsibilities are initialized randomly.
-        - 'random_from_data' : initial means are randomly selected data points.
+        - 'kmeans': responsibilities are initialized using kmeans,
+        - 'k-means++': use the k-means++ method to initialize,
+        - 'random': responsibilities are initialized randomly,
+        - 'random_from_data': initial means are randomly selected data points.
 
         .. versionchanged:: v1.1
             `init_params` now accepts 'random_from_data' and 'k-means++' as
@@ -612,7 +611,7 @@ class GaussianMixture(BaseMixture):
         for each step.
 
     verbose_interval : int, default=10
-        Number of iteration done before the next print.
+        Number of iterations done before the next print.
 
     Attributes
     ----------
@@ -663,7 +662,7 @@ class GaussianMixture(BaseMixture):
         True when convergence of the best fit of EM was reached, False otherwise.
 
     n_iter_ : int
-        Number of step used by the best fit of EM to reach the convergence.
+        Number of steps used by the best fit of EM to reach the convergence.
 
     lower_bound_ : float
         Lower bound value on the log-likelihood (of the training data with

--- a/sklearn/tests/test_docstring_parameters_consistency.py
+++ b/sklearn/tests/test_docstring_parameters_consistency.py
@@ -16,7 +16,7 @@ CLASS_DOCSTRING_CONSISTENCY_CASES = [
         "exclude_attrs": ["final_estimator_"],
         "include_returns": False,
         "exclude_returns": None,
-        "descr_regex_pattern": None,
+        "descr_regex_patterns": {},
     },
 ]
 
@@ -30,54 +30,20 @@ FUNCTION_DOCSTRING_CONSISTENCY_CASES = [
             metrics.recall_score,
         ],
         "include_params": True,
-        "exclude_params": ["average", "zero_division"],
-        "include_attrs": False,
-        "exclude_attrs": None,
-        "include_returns": False,
-        "exclude_returns": None,
-        "descr_regex_pattern": None,
-    },
-    {
-        "objects": [
-            metrics.precision_recall_fscore_support,
-            metrics.f1_score,
-            metrics.fbeta_score,
-            metrics.precision_score,
-            metrics.recall_score,
+        "exclude_params": [
+            "zero_division",
         ],
-        "include_params": ["average"],
-        "exclude_params": None,
         "include_attrs": False,
         "exclude_attrs": None,
         "include_returns": False,
         "exclude_returns": None,
-        "descr_regex_pattern": " ".join(
-            (
-                r"""This parameter is required for multiclass/multilabel targets\.
-            If ``None``, the metrics for each class are returned\. Otherwise, this
-            determines the type of averaging performed on the data:
-            ``'binary'``:
-                Only report results for the class specified by ``pos_label``\.
-                This is applicable only if targets \(``y_\{true,pred\}``\) are binary\.
-            ``'micro'``:
-                Calculate metrics globally by counting the total true positives,
-                false negatives and false positives\.
-            ``'macro'``:
-                Calculate metrics for each label, and find their unweighted
-                mean\.  This does not take label imbalance into account\.
-            ``'weighted'``:
-                Calculate metrics for each label, and find their average weighted
-                by support \(the number of true instances for each label\)\. This
-                alters 'macro' to account for label imbalance; it can result in an
-                F-score that is not between precision and recall\."""
-                + r"[\s\w]*\.*"  # optionally match additional sentence
-                + r"""
-            ``'samples'``:
-                Calculate metrics for each instance, and find their average \(only
-                meaningful for multilabel classification where this differs from
-                :func:`accuracy_score`\)\."""
-            ).split()
-        ),
+        "descr_regex_patterns": {
+            # Non-greedily matches anything until non-capturing group
+            # "Weighted recall is equal to accuracy. " is found, then
+            # matches anything until end of line. If not found first group
+            # matches everything.
+            "average": r"^(.+?)(?:Weighted recall is equal to accuracy\.\s(.*))?$",
+        },
     },
 ]
 

--- a/sklearn/tests/test_docstring_parameters_consistency.py
+++ b/sklearn/tests/test_docstring_parameters_consistency.py
@@ -1,6 +1,8 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+from typing import Any
+
 import pytest
 
 from sklearn import metrics
@@ -13,7 +15,7 @@ from sklearn.ensemble import (
 from sklearn.mixture import BayesianGaussianMixture, GaussianMixture
 from sklearn.utils._testing import assert_docstring_consistency, skip_if_no_numpydoc
 
-CLASS_DOCSTRING_CONSISTENCY_CASES = [
+CLASS_DOCSTRING_CONSISTENCY_CASES: list[dict[str, Any]] = [
     {
         "objects": [AdaBoostClassifier, AdaBoostRegressor],
         "include_params": True,

--- a/sklearn/tests/test_docstring_parameters_consistency.py
+++ b/sklearn/tests/test_docstring_parameters_consistency.py
@@ -4,10 +4,59 @@
 import pytest
 
 from sklearn import metrics
-from sklearn.ensemble import StackingClassifier, StackingRegressor
+from sklearn.ensemble import (
+    AdaBoostClassifier,
+    AdaBoostRegressor,
+    StackingClassifier,
+    StackingRegressor,
+)
+from sklearn.mixture import BayesianGaussianMixture, GaussianMixture
 from sklearn.utils._testing import assert_docstring_consistency, skip_if_no_numpydoc
 
 CLASS_DOCSTRING_CONSISTENCY_CASES = [
+    {
+        "objects": [AdaBoostClassifier, AdaBoostRegressor],
+        "include_params": True,
+        "exclude_params": None,
+        "include_attrs": True,
+        "exclude_attrs": [
+            # type differs
+            "estimators_",
+            "",
+        ],
+        "include_returns": False,
+        "exclude_returns": None,
+        "descr_regex_patterns": {
+            # Excludes 2nd sentence if present, matches last sentence until "."
+            "estimator": r"^([^.]+\.)(?:\s+[^.]+\.)?\s+([^.]+\.)",
+            "learning_rate": (
+                r"^(.*?)(?:regressor |classifier )(.*?)(?:regressor|classifier)(.*)$"
+            ),
+            # Excludes 3rd sentence if present.
+            "random_state": r"([^.]+\.[^.]+\.)(?:\s+[^.]+\.)?(\s[^.]+\.[^.]+\.)",
+            # Excludes words "Classification "/"Regression "
+            "estimator_errors_": r"^(?:Classification |Regression )(.*)$",
+        },
+    },
+    {
+        "objects": [GaussianMixture, BayesianGaussianMixture],
+        "include_params": True,
+        "exclude_params": None,
+        "include_attrs": True,
+        "exclude_attrs": ["lower_bound_"],
+        "include_returns": False,
+        "exclude_returns": None,
+        "descr_regex_patterns": {
+            # Match first sentence only
+            "n_components": r"^[^.?!]*[.]",
+            # Excludes words "precisions" or "covariances"
+            "init_params": r"^(.*?)(?:precisions.|covariances.)(.*)$",
+            # Excludes words "inference " or "EM "
+            "converged_": r"^(.*?)(?:inference |EM )(.*)$",
+            # Excludes words "inference " or "EM "
+            "n_iter_": r"^(.*?)(?:inference |EM )(.*)$",
+        },
+    },
     {
         "objects": [StackingClassifier, StackingRegressor],
         "include_params": ["cv", "n_jobs", "passthrough", "verbose"],
@@ -38,10 +87,7 @@ FUNCTION_DOCSTRING_CONSISTENCY_CASES = [
         "include_returns": False,
         "exclude_returns": None,
         "descr_regex_patterns": {
-            # Non-greedily matches anything until non-capturing group
-            # "Weighted recall is equal to accuracy. " is found, then
-            # matches anything until end of line. If not found first group
-            # matches everything.
+            # Matches everything, excluding "Weighted recall is equal to accuracy. "
             "average": r"^(.+?)(?:Weighted recall is equal to accuracy\.\s(.*))?$",
         },
     },

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -796,7 +796,7 @@ def assert_docstring_consistency(
 
     descr_regex_patterns : dict, default={}
         Dictionary of parameter/attribute/return name to the regular expression to
-        capture the part of the description to match between objects.
+        capture the portion of the description to match between objects.
         If match contains subgroups, matching subgroups are joined together, this
         enables us to discard non-capturing groups.
         If match does not contain subgroups, whole match is used.


### PR DESCRIPTION
#### Reference Issues/PRs
Follows on from https://github.com/scikit-learn/scikit-learn/pull/28678#issuecomment-2683585241

#### What does this implement/fix? Explain your changes.

Amend the regex parameter `descr_regex_pattern` to `descr_regex_patterns` with the following changes:

* `descr_regex_patterns` takes a dict, key is the parameter/attr/return name, and value is the regex
* The regex is now used to capture the portion of the description to be matched
   * pro: this avoids us having to re-write the description
   * con: there is a bit of mucking around with regex to get it to work correctly, but as we have example regexes in the tests that perform common manipulations, it should be reasonably easy to adapt a pattern to match other situations
   * con: if there is a situation where the description should be one of 2 sentences/words (e.g., either "classifier" or "regressor") we can't ensure one of these 2 options is written, we can only exclude that specific word from being matched

I am not 100% on this solution, so happy to amend or abandon altogether.

If we do go ahead, I wonder if I should do more param checking for `descr_regex_patterns` (ensure it is a dict)

#### Any other comments?

cc @StefanieSenger @adrinjalali @glemaitre 
