### PR TITLE
Update _encoders.py

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -551,9 +551,8 @@ class OneHotEncoder(_BaseEncoder):
 
         - 'error' : Raise an error if an unknown category is present during transform.
         - 'ignore' : When an unknown category is encountered during
-          transform, the resulting one-hot encoded columns for this feature
-          will be all zeros. In the inverse transform, an unknown category
-          will be denoted as None.
+          transform, it will be encoded as an additional category. In the 
+          inverse transform, an unknown category will be denoted as None.
         - 'infrequent_if_exist' : When an unknown category is encountered
           during transform, the resulting one-hot encoded columns for this
           feature will map to the infrequent category if it exists. The


### PR DESCRIPTION
I updated the documentation to match the code behaviour

Minimal working example:
```python
from sklearn.preprocessing import OneHotEncoder
ohe = OneHotEncoder(handle_unknown="ignore", sparse_output=False)
inputs = [["A"], [None], ["B"], ["B"], ["A"]]
encoded = ohe.fit_transform(inputs)
print(ohe.categories_)
# [array(['A', 'B', None], dtype=object)]
decoded = ohe.inverse_transform(encoded)
assert decoded[1] is None
```

Note: it would actually be useful to add an option to make unknown all zeros instead of adding a category. I can implement it if necessary