### PR TITLE
Doc: Use `.. rubric:: References` for consistency in documentation

### DIFF
--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -175,8 +175,7 @@ Note that a call to the ``transform`` method of :class:`IterativeImputer` is
 not allowed to change the number of samples. Therefore multiple imputations
 cannot be achieved by a single call to ``transform``.
 
-References
-----------
+.. rubric:: References
 
 .. [1] `Stef van Buuren, Karin Groothuis-Oudshoorn (2011). "mice: Multivariate
    Imputation by Chained Equations in R". Journal of Statistical Software 45:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR updates the references section in the documentation to use `.. rubric::` References instead of a plain heading. This change ensures consistency with other sections and improves readability.

#### Changes include:

- Replacing the References section header with `.. rubric::` References.