### PR TITLE
MNT Add `flexibe_types` to `assert_docstring_consistency`

### DIFF
--- a/sklearn/tests/test_docstring_parameters_consistency.py
+++ b/sklearn/tests/test_docstring_parameters_consistency.py
@@ -4,7 +4,13 @@
 import pytest
 
 from sklearn import metrics
-from sklearn.ensemble import StackingClassifier, StackingRegressor
+from sklearn.ensemble import (
+    BaggingClassifier,
+    BaggingRegressor,
+    IsolationForest,
+    StackingClassifier,
+    StackingRegressor,
+)
 from sklearn.utils._testing import assert_docstring_consistency, skip_if_no_numpydoc
 
 CLASS_DOCSTRING_CONSISTENCY_CASES = [
@@ -17,6 +23,17 @@ CLASS_DOCSTRING_CONSISTENCY_CASES = [
         "include_returns": False,
         "exclude_returns": None,
         "descr_regex_pattern": None,
+    },
+    {
+        "objects": [BaggingClassifier, BaggingRegressor, IsolationForest],
+        "include_params": ["max_samples"],
+        "exclude_params": None,
+        "include_attrs": False,
+        "exclude_attrs": None,
+        "include_returns": False,
+        "exclude_returns": None,
+        "descr_regex_pattern": r"The number of samples to draw from X to train each.*",
+        "flexible_types": {"max_samples": 2},
     },
 ]
 


### PR DESCRIPTION
#### Reference Issues/PRs

Follows from https://github.com/scikit-learn/scikit-learn/pull/28678#issuecomment-2677297422

#### What does this implement/fix? Explain your changes.

Adds `flexibe_types`:
* dictionary allowing you to specify flexible types for individual param/attr/return 
* allows you to specify the number of types that should be common between objects
* also remove default type checking, if you wish to only use this set int to `0`

Added a very simple test case just to demonstrate its use, but no unit tests.

#### Any other comments?

The addition is probably more complicated than I would like, both the parameter use and the code. I do think it does address most (all?) of the type cases we would encounter though.

Not 100% and open to suggestions. Potentially a simple `ignore_type` option may be easier?

Note this is a draft PR, as it is just to see if we like the addition.

cc @glemaitre @adrinjalali @StefanieSenger 
