### PR TITLE
TST: force dtype of arange to int64 to not be platform dependent

### DIFF
--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2826,7 +2826,7 @@ def test_sort_log2_build():
     rng = np.random.default_rng(75)
     some = rng.normal(loc=0.0, scale=10.0, size=10).astype(np.float32)
     feature_values = np.concatenate([some] * 5)
-    samples = np.arange(50)
+    samples = np.arange(50, dtype=np.intp)
     _py_sort(feature_values, samples, 50)
     # fmt: off
     # no black reformatting for this specific array


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes https://github.com/scikit-learn/scikit-learn/issues/30782, specifically applying the suggestion that @glemaitre had made here: https://github.com/scikit-learn/scikit-learn/issues/30782#issuecomment-2694422320