### PR TITLE
MNT cleanup docstring of helper function

### DIFF
--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -459,8 +459,6 @@ _NUMPY_API_WRAPPER_INSTANCE = _NumPyAPIWrapper()
 def _remove_non_arrays(*arrays, remove_none=True, remove_types=(str,)):
     """Filter arrays to exclude None and/or specific types.
 
-    Raise ValueError if no arrays are left after filtering.
-
     Sparse arrays are always filtered out.
 
     Parameters


### PR DESCRIPTION
The ability of `_remove_non_arrays` to error was removed with #29476. This PR updates the docstring.