### PR TITLE
CI Fix tests when matplotlib is not installed

### DIFF
--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -656,7 +656,7 @@ def test_multiclass_colors_cmap(pyplot, plot_method, multiclass_colors):
         assert quad.cmap == cmaps[idx]
 
 
-def test_multiclass_plot_max_class_cmap_kwarg():
+def test_multiclass_plot_max_class_cmap_kwarg(pyplot):
     """Check `cmap` kwarg ignored when using plotting max multiclass class."""
     X, y = load_iris_2d_scaled()
     clf = LogisticRegression().fit(X, y)


### PR DESCRIPTION
Fix #30953, fix #30961, fix #30960

I am surprised this was not caught by the CI, but apparently all CI builds that run in a PR have matplotlib ...

In other words, the only builds without matplotlib are wheel build (needs `[cd build]` message), scipy-dev (needs `[scipy-dev]` message), free-threaded build (needs `[free-threaded]` message).