### PR TITLE
Added documentation reference to plot_segmentation_toy.py to spectral.py

### DIFF
--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -388,6 +388,11 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
     If the affinity matrix is the adjacency matrix of a graph, this method
     can be used to find normalized graph cuts [1]_, [2]_.
 
+    For an example of spectral clustering applied to image segmentation
+    using normalized cuts, see
+    :ref:`sphx_glr_auto_examples_cluster_plot_segmentation_toy.py`
+
+
     When calling ``fit``, an affinity matrix is constructed using either
     a kernel function such the Gaussian (aka RBF) kernel with Euclidean
     distance ``d(X, X)``::


### PR DESCRIPTION
**Reference Issues/PRs**

Adds links to examples/cluster mentioned in #30621


**What does this implement/fix? Explain your changes.**

This PR improves the SpectralClustering documentation by adding a reference to plot_segmentation_toy.py, which demonstrates the application of Spectral Clustering in image segmentation using normalized cuts.

**Any other comments?**

Examples linked:

examples/cluster
plot_segmentation_toy.p