### PR TITLE
DOC: add link to example plot_digits_agglomeration.py

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -655,6 +655,11 @@ considers at each step all the possible merges.
    number of features. It is a dimensionality reduction tool, see
    :ref:`data_reduction`.
 
+.. rubric:: Examples
+
+* :ref:`sphx_glr_auto_examples_cluster_plot_digits_agglomeration.py`: This
+  example shows how similar features are merged together using feature
+  agglomeration
 Different linkage type: Ward, complete, average, and single linkage
 -------------------------------------------------------------------
 

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -659,7 +659,7 @@ considers at each step all the possible merges.
 
 * :ref:`sphx_glr_auto_examples_cluster_plot_digits_agglomeration.py`: This
   example shows how similar features are merged together using feature
-  agglomeration
+  agglomeration.
 Different linkage type: Ward, complete, average, and single linkage
 -------------------------------------------------------------------
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
An example for plot_digits_agglomeration.py was missing in the clustering documentation, so I added it into clustering.rst under the feature agglomeration section.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
