### PR TITLE
DOC Skip @property on classes in the auto generated API reference

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -799,6 +799,13 @@ def disable_plot_gallery_for_linkcheck(app):
         sphinx_gallery_conf["plot_gallery"] = "False"
 
 
+def skip_properties(app, what, name, obj, skip, options):
+    """Do not list @property in the auto generated API documentation."""
+    if isinstance(obj, property):
+        return True
+    return skip
+
+
 def setup(app):
     # do not run the examples when using linkcheck by using a small priority
     # (default priority is 500 and sphinx-gallery using builder-inited event too)
@@ -810,6 +817,8 @@ def setup(app):
     # to hide/show the prompt in code examples
     app.connect("build-finished", make_carousel_thumbs)
     app.connect("build-finished", filter_search_index)
+
+    app.connect("autodoc-skip-member", skip_properties)
 
 
 # The following is used by sphinx.ext.linkcode to provide links to github

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -800,9 +800,11 @@ def disable_plot_gallery_for_linkcheck(app):
 
 
 def skip_properties(app, what, name, obj, skip, options):
-    """Do not list @property in the auto generated API documentation."""
+    """Skip properties that are fitted attributes"""
     if isinstance(obj, property):
-        return True
+        if name.endswith("_") and not name.startswith("_"):
+            return True
+
     return skip
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Closes #30957


#### What does this implement/fix? Explain your changes.

This sets up a function to determine what should be automatically documented and what not. We skip over `@property` as these get documented manually in the Attributes section already.

#### Any other comments?

I asked perplexity how to do this and this is the suggestion. Let's see if this works 🤞 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
