### PR TITLE
DOC/MNT remove sklearn-evaluation and py-earth

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -47,7 +47,7 @@ enhance the functionality of scikit-learn's estimators.
   the objects that EvalML creates use an sklearn-compatible API.
 
 - `MLJAR AutoML <https://github.com/mljar/mljar-supervised>`_
-  Python package for AutoML on Tabular Data with Feature Engineering, 
+  Python package for AutoML on Tabular Data with Feature Engineering,
   Hyper-Parameters Tuning, Explanations and Automatic Documentation.
 
 **Experimentation and model registry frameworks**
@@ -73,11 +73,6 @@ enhance the functionality of scikit-learn's estimators.
 
 - `dtreeviz <https://github.com/parrt/dtreeviz/>`_ A python library for
   decision tree visualization and model interpretation.
-
-- `sklearn-evaluation <https://github.com/ploomber/sklearn-evaluation>`_
-  Machine learning model evaluation made easy: plots, tables, HTML reports,
-  experiment tracking and Jupyter notebook analysis. Visual analysis, model
-  selection, evaluation and diagnostics.
 
 - `yellowbrick <https://github.com/DistrictDataLabs/yellowbrick>`_ A suite of
   custom matplotlib visualizers for scikit-learn estimators to support visual feature
@@ -121,7 +116,7 @@ enhance the functionality of scikit-learn's estimators.
 
 - `BiocSklearn <https://bioconductor.org/packages/BiocSklearn>`_
   Exposes a small number of dimension reduction facilities as an illustration
-  of the basilisk protocol for interfacing python with R. Intended as a 
+  of the basilisk protocol for interfacing python with R. Intended as a
   springboard for more complete interop.
 
 

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -201,9 +201,6 @@ Note scikit-learn own modern gradient boosting estimators
 
 **Other regression and classification**
 
-- `py-earth <https://github.com/scikit-learn-contrib/py-earth>`_ Multivariate
-  adaptive regression splines
-
 - `gplearn <https://github.com/trevorstephens/gplearn>`_ Genetic Programming
   for symbolic regression tasks.
 


### PR DESCRIPTION
https://github.com/ploomber/sklearn-evaluation was archieved 28 February 2025, so we should remove it from recommended/related projects.

https://github.com/scikit-learn-contrib/py-earth was archieved  6 Dec 2023.