### PR TITLE
MNT fix error message for UnsetMetadataPassedError in validation

### DIFF
--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -378,19 +378,8 @@ def cross_validate(
             # `process_routing` code, we pass `fit` as the caller. However,
             # the user is not calling `fit` directly, so we change the message
             # to make it more suitable for this case.
-            unrequested_params = sorted(e.unrequested_params)
             raise UnsetMetadataPassedError(
-                message=(
-                    f"{unrequested_params} are passed to cross validation but are not"
-                    " explicitly set as requested or not requested for cross_validate's"
-                    f" estimator: {estimator.__class__.__name__}. Call"
-                    " `.set_fit_request({{metadata}}=True)` on the estimator for"
-                    f" each metadata in {unrequested_params} that you"
-                    " want to use and `metadata=False` for not using it. See the"
-                    " Metadata Routing User guide"
-                    " <https://scikit-learn.org/stable/metadata_routing.html> for more"
-                    " information."
-                ),
+                message=str(e).replace("cross_validate.fit", "cross_validate"),
                 unrequested_params=e.unrequested_params,
                 routed_params=e.routed_params,
             )
@@ -1202,18 +1191,8 @@ def cross_val_predict(
             # `process_routing` code, we pass `fit` as the caller. However,
             # the user is not calling `fit` directly, so we change the message
             # to make it more suitable for this case.
-            unrequested_params = sorted(e.unrequested_params)
             raise UnsetMetadataPassedError(
-                message=(
-                    f"{unrequested_params} are passed to `cross_val_predict` but are"
-                    " not explicitly set as requested or not requested for"
-                    f" cross_validate's estimator: {estimator.__class__.__name__} Call"
-                    " `.set_fit_request({{metadata}}=True)` on the estimator for"
-                    f" each metadata in {unrequested_params} that you want to use and"
-                    " `metadata=False` for not using it. See the Metadata Routing User"
-                    " guide <https://scikit-learn.org/stable/metadata_routing.html>"
-                    " for more information."
-                ),
+                message=str(e).replace("cross_val_predict.fit", "cross_val_predict"),
                 unrequested_params=e.unrequested_params,
                 routed_params=e.routed_params,
             )
@@ -1677,19 +1656,9 @@ def permutation_test_score(
             # `process_routing` code, we pass `fit` as the caller. However,
             # the user is not calling `fit` directly, so we change the message
             # to make it more suitable for this case.
-            unrequested_params = sorted(e.unrequested_params)
             raise UnsetMetadataPassedError(
-                message=(
-                    f"{unrequested_params} are passed to `permutation_test_score`"
-                    " but are not explicitly set as requested or not requested"
-                    " for permutation_test_score's"
-                    f" estimator: {estimator.__class__.__name__}. Call"
-                    " `.set_fit_request({{metadata}}=True)` on the estimator for"
-                    f" each metadata in {unrequested_params} that you"
-                    " want to use and `metadata=False` for not using it. See the"
-                    " Metadata Routing User guide"
-                    " <https://scikit-learn.org/stable/metadata_routing.html> for more"
-                    " information."
+                message=str(e).replace(
+                    "permutation_test_score.fit", "permutation_test_score"
                 ),
                 unrequested_params=e.unrequested_params,
                 routed_params=e.routed_params,
@@ -2029,19 +1998,8 @@ def learning_curve(
             # `process_routing` code, we pass `fit` as the caller. However,
             # the user is not calling `fit` directly, so we change the message
             # to make it more suitable for this case.
-            unrequested_params = sorted(e.unrequested_params)
             raise UnsetMetadataPassedError(
-                message=(
-                    f"{unrequested_params} are passed to `learning_curve` but are not"
-                    " explicitly set as requested or not requested for learning_curve's"
-                    f" estimator: {estimator.__class__.__name__}. Call"
-                    " `.set_fit_request({{metadata}}=True)` on the estimator for"
-                    f" each metadata in {unrequested_params} that you"
-                    " want to use and `metadata=False` for not using it. See the"
-                    " Metadata Routing User guide"
-                    " <https://scikit-learn.org/stable/metadata_routing.html> for more"
-                    " information."
-                ),
+                message=str(e).replace("learning_curve.fit", "learning_curve"),
                 unrequested_params=e.unrequested_params,
                 routed_params=e.routed_params,
             )
@@ -2485,19 +2443,8 @@ def validation_curve(
             # `process_routing` code, we pass `fit` as the caller. However,
             # the user is not calling `fit` directly, so we change the message
             # to make it more suitable for this case.
-            unrequested_params = sorted(e.unrequested_params)
             raise UnsetMetadataPassedError(
-                message=(
-                    f"{unrequested_params} are passed to `validation_curve` but are not"
-                    " explicitly set as requested or not requested for"
-                    f" validation_curve's estimator: {estimator.__class__.__name__}."
-                    " Call `.set_fit_request({{metadata}}=True)` on the estimator for"
-                    f" each metadata in {unrequested_params} that you"
-                    " want to use and `metadata=False` for not using it. See the"
-                    " Metadata Routing User guide"
-                    " <https://scikit-learn.org/stable/metadata_routing.html> for more"
-                    " information."
-                ),
+                message=str(e).replace("validation_curve.fit", "validation_curve"),
                 unrequested_params=e.unrequested_params,
                 routed_params=e.routed_params,
             )

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -1173,7 +1173,7 @@ def cross_val_predict(
         # methods. For these router methods, we create the router to use
         # `process_routing` on it.
         router = (
-            MetadataRouter(owner="cross_validate")
+            MetadataRouter(owner="cross_val_predict")
             .add(
                 splitter=cv,
                 method_mapping=MethodMapping().add(caller="fit", callee="split"),

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -2575,7 +2575,11 @@ def test_cross_validate_params_none(func, extra_args):
 def test_passed_unrequested_metadata(func, extra_args):
     """Check that we raise an error when passing metadata that is not
     requested."""
-    err_msg = "but are not explicitly set as requested or not requested"
+
+    err_msg = re.escape(
+        "[metadata] are passed but are not explicitly set as requested or not "
+        "requested for ConsumingClassifier.fit, which is used within"
+    )
     with pytest.raises(UnsetMetadataPassedError, match=err_msg):
         func(
             estimator=ConsumingClassifier(),
@@ -2591,7 +2595,9 @@ def test_passed_unrequested_metadata(func, extra_args):
     )
     with pytest.raises(UnsetMetadataPassedError, match=err_msg):
         func(
-            estimator=ConsumingClassifier().set_fit_request(metadata=True),
+            estimator=ConsumingClassifier()
+            .set_fit_request(metadata=True)
+            .set_partial_fit_request(metadata=True),
             X=X,
             y=y2,
             params=dict(metadata=[]),

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -2589,6 +2589,10 @@ def test_passed_unrequested_metadata(func, extra_args):
             **extra_args,
         )
 
+    # cross_val_predict doesn't use scoring
+    if func == cross_val_predict:
+        return
+
     err_msg = re.escape(
         "[metadata] are passed but are not explicitly set as requested or not "
         "requested for ConsumingClassifier.score, which is used within"

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -25,7 +25,7 @@ from sklearn.datasets import (
     make_regression,
 )
 from sklearn.ensemble import RandomForestClassifier
-from sklearn.exceptions import FitFailedWarning
+from sklearn.exceptions import FitFailedWarning, UnsetMetadataPassedError
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import (
     LogisticRegression,
@@ -2575,12 +2575,25 @@ def test_cross_validate_params_none(func, extra_args):
 def test_passed_unrequested_metadata(func, extra_args):
     """Check that we raise an error when passing metadata that is not
     requested."""
-    err_msg = re.escape("but are not explicitly set as requested or not requested")
-    with pytest.raises(ValueError, match=err_msg):
+    err_msg = "but are not explicitly set as requested or not requested"
+    with pytest.raises(UnsetMetadataPassedError, match=err_msg):
         func(
             estimator=ConsumingClassifier(),
             X=X,
-            y=y,
+            y=y2,
+            params=dict(metadata=[]),
+            **extra_args,
+        )
+
+    err_msg = re.escape(
+        "[metadata] are passed but are not explicitly set as requested or not "
+        "requested for ConsumingClassifier.score, which is used within"
+    )
+    with pytest.raises(UnsetMetadataPassedError, match=err_msg):
+        func(
+            estimator=ConsumingClassifier().set_fit_request(metadata=True),
+            X=X,
+            y=y2,
             params=dict(metadata=[]),
             **extra_args,
         )


### PR DESCRIPTION
Fixes error message in the validation module.

closes #30818 

follow-up fix for #28517 and  #28056