### PR TITLE
add reference to plot_face_compression.py in clustering.rst

### DIFF
--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -145,6 +145,11 @@ unseen data.
 * :ref:`sphx_glr_auto_examples_cluster_plot_inductive_clustering.py`: An example
   of an inductive clustering model for handling new data.
 
+
+* :ref:`sphx_glr_auto_examples_cluster_plot_face_compression.py`: This example
+  shows how one can use :class:`~sklearn.preprocessing.KBinsDiscretizer
+  to perform vector quantization on a set of toy image.
+
 .. _k_means:
 
 K-means


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

I added a reference to plot_face_compress.py in the clustering.rst file, after the reference to the plot_inductive_clustering.py reference, as an added supplementary example, coming before the sections on the main ML algorithms of the doc.

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
