### PR TITLE
MNT Keep bumping min Python version to 3.10

### DIFF
--- a/.github/workflows/check-sdist.yml
+++ b/.github/workflows/check-sdist.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Install dependencies
         # scipy and cython are required to build sdist
         run: |


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Follow-up of https://github.com/scikit-learn/scikit-learn/pull/30895.

Fixes #31020.

See also  #31016.

#### What does this implement/fix? Explain your changes.

The Python version currently needs to be updated in multiple places.

#### Any other comments?
