### PR TITLE
MNT git ignore recent black/ruff updates

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -32,5 +32,14 @@ d4aad64b1eb2e42e76f49db2ccfbe4b4660d092b
 # PR 26649: Add isort and ruff rules
 42173fdb34b5aded79664e045cada719dfbe39dc
 
-# PR #28802: Update black to 24.3.0
+# PR 28802: Update black to 24.3.0
 c4c546355667b070edd5c892b206aa4a97af9a0b
+
+# PR 30694: Enforce ruff rules (RUF)
+fe7c4176828af5231f526e76683fb9bdb9ea0367
+
+# PR 30695: Apply ruff/flake8-implicit-str-concat rules (ISC)
+5cdbbf15e3fade7cc2462ef66dc4ea0f37f390e3
+
+# PR 31015: black -> ruff format
+ff78e258ccf11068e2b3a433c51517ae56234f88


### PR DESCRIPTION
#### Reference Issues/PRs

* #30694
* #30695
* ~~#30693~~
* #31015

#### What does this implement/fix? Explain your changes.

Ignore these commits:
* fe7c4176828af5231f526e76683fb9bdb9ea0367 Enforce ruff rules (RUF)
* 5cdbbf15e3fade7cc2462ef66dc4ea0f37f390e3 Apply ruff/flake8-implicit-str-concat rules (ISC)
* ff78e258ccf11068e2b3a433c51517ae56234f88 black → ruff format

#### Any other comments?
