### PR TITLE
FEAT Ridge: specify individual coefficients for positive constraint

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/31031.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/31031.feature.rst
@@ -1,0 +1,5 @@
+- :class:`linear_model.Ridge` now supports both single bool and list of bools for the `positive` parameter
+  to enforce non-negativity constraints on the coefficients.
+  Single bool is equivalent to passing a list of bools with all elements set to the same value.
+  List of bools allows to specify non-negativity constraints for each target variable independently.
+  By :user:`Daniel Smith <thedanindanger>`

--- a/examples/linear_model/plot_ridge_path_specify_non_negative.py
+++ b/examples/linear_model/plot_ridge_path_specify_non_negative.py
@@ -26,12 +26,20 @@ change in the target variable can cause huge variances in the
 calculated weights. In such cases, it is useful to set a certain
 regularization (alpha) to reduce this variation (noise).
 
-When alpha is very large, the regularization effect dominates the
-squared loss function and the coefficients tend to zero.
-At the end of the path, as alpha tends toward zero
-and the solution tends towards the ordinary least squares, coefficients
-exhibit big oscillations. In practise it is necessary to tune alpha
-in such a way that a balance is maintained between both.
+This example expands on the alpha sensitivity exploration. We show the
+effect of different levels of allowed minimum alpha values on the
+coefficients.
+
+We show at relatively high alpha values, the coefficients are similar
+between the two Ridge solvers, and the coefficients are relatively
+stable in relation to the alpha value. This is true for both positive
+and non-positive coefficient constraints.
+
+However, at very low alpha values, the magnitude of the coefficients
+is very different between the two Ridge solvers. Additionally, in the
+case of positive coefficient constraints, the coefficient weights
+have a period of instability as alpha decreases - but eventually
+converge to more stable values.
 
 """
 
@@ -40,11 +48,24 @@ in such a way that a balance is maintained between both.
 
 import matplotlib.pyplot as plt
 import numpy as np
+from scipy import optimize
 
 from sklearn import linear_model
 
+# Set random seed for reproducibility
+np.random.seed(123)
+
 # X is the 10x10 Hilbert matrix
 X = 1.0 / (np.arange(1, 11) + np.arange(0, 10)[:, np.newaxis])
+y = np.ones(10)
+
+# %%
+# Positive coefficient constraints
+# Assign a True boolean value to any feature index to enforce a positive
+# coefficient. In this case, the first, third, fifth, seventh, and ninth
+# features will be forced to have positive coefficients.
+# Coefficient array must have same number of values and X.shape[1]
+# -------------------------------
 X_positive_coefficient = [
     True,
     False,
@@ -57,79 +78,209 @@ X_positive_coefficient = [
     True,
     False,
 ]
-y = np.ones(10)
-#
+
+
 # %%
-# Compute paths
+# Construct function using lbfgs solver without positive coefficient constraints
+# Ridge implementation of lbfgs solver requires positive=True or positive=[bool,...]
+# This is because other solvers are far more efficient for this problem.
+# Here we have an example, both to show how positive constraints are implemented
+# and to show the effect of regularization on the coefficients.
+# -------------------------------
+
+
+def _solve_lbfgs_unconstrained(
+    X,
+    y,
+    alpha,
+    tol=1e-4,
+):
+    # replicate transformations in _BaseRidge
+    alpha = np.array([alpha] * y.shape[0])
+    y = np.reshape(y, (-1, 1))
+
+    # get n_features for coefs shape
+    n_samples, n_features = X.shape
+
+    coefs = np.empty((y.shape[1], n_features), dtype=X.dtype)
+
+    # scipy.optimize config options
+    config = {
+        "method": "L-BFGS-B",
+        "tol": tol,
+        "jac": True,
+    }
+
+    # Optimize objective function
+    for i in range(y.shape[1]):
+        x0 = np.zeros((n_features,))
+        y_column = y[:, i]
+
+        def func(w):
+            residual = X.dot(w) - y_column
+            f = 0.5 * residual.dot(residual) + 0.5 * alpha[i] * w.dot(w)
+            grad = X.T @ residual + alpha[i] * w
+            return f, grad
+
+        result = optimize.minimize(func, x0, **config)
+        coefs[i] = result["x"]
+
+    return coefs
+
+
+# %%
+# Generate coefficients for Ridge regression with different alphas
+# for different scenarios
+# 1. Default Ridge regression, no positive constraint
+# 2. Ridge regression with lbfgs solver, no positive constraint
+# 3. Ridge regression with all positive constraints
+# 4. Ridge regression with some positive constraints
 # -------------
 
+
+def generate_path(X, y, alphas, positive=False, scenario="default"):
+    coefs = []
+    for a in alphas:
+        if scenario == "default":
+            ridge = linear_model.Ridge(alpha=a, fit_intercept=False, positive=positive)
+            ridge.fit(X, y)
+            coefs.append(ridge.coef_)
+        elif scenario == "lbfgs_unconstrained":
+            ridge = _solve_lbfgs_unconstrained(X, y, alpha=a)
+            coefs.append(ridge.flatten())
+    return coefs
+
+
+def plot_results(coefs, alphas, title):
+    """Plot the coefficients as a function of alpha"""
+    ax = plt.gca()
+    ax.plot(alphas, coefs)
+    ax.set_xscale("log")
+    ax.set_xlim(ax.get_xlim()[::-1])  # reverse axis
+    plt.xlabel("alpha")
+    plt.ylabel("weights")
+    plt.title(title)
+    plt.axis("tight")
+    plt.show()
+
+
+# %%
+# Generate coefficients for Ridge regression with different alphas
+# for different levels of allowed minimum alpha
+# Default Ridge regression, with no positive constraint and lbfgs solver
+# Generalize to similar coefficeint weights at high alpha values
+# However, at very low alpha values, the coefficients are very different
+# both between the two Ridge solvers and between positive and non-positive
+# coefficient constraints.
+# -------------
+
+# Min alpha 1e-3, max alpha 1
 n_alphas = 200
-alphas = np.logspace(-10, -2, n_alphas)
+alphas = np.logspace(-3, 0, n_alphas)
 
-
-# %%
-
-coefs = []
-coefs_all_positive = []
-coefs_some_positive = []
-for a in alphas:
-    ridge = linear_model.Ridge(alpha=a, fit_intercept=False, positive=False)
-    ridge_all_positive = linear_model.Ridge(alpha=a, fit_intercept=False, positive=True)
-    ridge_some_positive = linear_model.Ridge(
-        alpha=a, fit_intercept=False, positive=X_positive_coefficient
-    )
-
-    ridge.fit(X, y)
-    ridge_all_positive.fit(X, y)
-    ridge_some_positive.fit(X, y)
-
-    coefs.append(ridge.coef_)
-    coefs_all_positive.append(ridge_all_positive.coef_)
-    coefs_some_positive.append(ridge_some_positive.coef_)
-
-# %%
-# Display results
-# ---------------
-
-ax = plt.gca()
-
-ax.plot(alphas, coefs)
-ax.set_xscale("log")
-ax.set_xlim(ax.get_xlim()[::-1])  # reverse axis
-plt.xlabel("alpha")
-plt.ylabel("weights")
-plt.title(
-    "Ridge coef. as a func. of regularization without positive coefficient constraints"
+coefs = generate_path(X, y, alphas, positive=False, scenario="default")
+coefs_lbfgs_unconstrained = generate_path(
+    X, y, alphas, positive=False, scenario="lbfgs_unconstrained"
 )
-plt.axis("tight")
-plt.show()
+coefs_all_positive = generate_path(X, y, alphas, positive=True, scenario="default")
+coefs_some_positive = generate_path(
+    X, y, alphas, positive=X_positive_coefficient, scenario="default"
+)
+
+
+min_alpha = alphas.min()
+plot_results(
+    coefs,
+    alphas,
+    f"Ridge coefs without positive coefficient constraints - alpha_min={min_alpha}",
+)
+plot_results(
+    coefs_lbfgs_unconstrained,
+    alphas,
+    f"Approx. of lbfgs Ridge without positive constraints - alpha_min={min_alpha}",
+)
+plot_results(
+    coefs_some_positive,
+    alphas,
+    f"Ridge coefs with conditional positive constraints - alpha_min={min_alpha}",
+)
+plot_results(
+    coefs_all_positive,
+    alphas,
+    f"Ridge coefs with all positive constraints - alpha_min={min_alpha}",
+)
+
 
 # %%
-# Display conditional positive results
-# ----------------------------
+# Min alpha 1e-5, max alpha 1
+n_alphas = 200
+alphas = np.logspace(-5, 0, n_alphas)
 
-ax = plt.gca()
-ax.plot(alphas, coefs_some_positive)
-ax.set_xscale("log")
-ax.set_xlim(ax.get_xlim()[::-1])  # reverse axis
-plt.xlabel("alpha")
-plt.ylabel("weights")
-plt.title("Ridge coefficients with conditional positive constraints")
-plt.axis("tight")
-plt.show()
+coefs = generate_path(X, y, alphas, positive=False, scenario="default")
+coefs_lbfgs_unconstrained = generate_path(
+    X, y, alphas, positive=False, scenario="lbfgs_unconstrained"
+)
+coefs_all_positive = generate_path(X, y, alphas, positive=True, scenario="default")
+coefs_some_positive = generate_path(
+    X, y, alphas, positive=X_positive_coefficient, scenario="default"
+)
+
+min_alpha = alphas.min()
+plot_results(
+    coefs,
+    alphas,
+    f"Ridge coefs without positive coefficient constraints - alpha_min={min_alpha}",
+)
+plot_results(
+    coefs_lbfgs_unconstrained,
+    alphas,
+    f"Approx. of lbfgs Ridge without positive constraints - alpha_min={min_alpha}",
+)
+plot_results(
+    coefs_some_positive,
+    alphas,
+    f"Ridge coefs with conditional positive constraints - alpha_min={min_alpha}",
+)
+plot_results(
+    coefs_all_positive,
+    alphas,
+    f"Ridge coefs with all positive constraints - alpha_min={min_alpha}",
+)
+
 
 # %%
-# Display all positive results
-# ----------------------------
+# Min alpha 1e-10, max alpha 1
+n_alphas = 200
+alphas = np.logspace(-10, 0, n_alphas)
 
-ax = plt.gca()
-ax.plot(alphas, coefs_all_positive)
-ax.set_xscale("log")
-ax.set_xlim(ax.get_xlim()[::-1])  # reverse axis
-plt.xlabel("alpha")
-plt.ylabel("weights")
-plt.title("Ridge coefficients with all positive constraints")
-plt.axis("tight")
-plt.show()
+coefs = generate_path(X, y, alphas, positive=False, scenario="default")
+coefs_lbfgs_unconstrained = generate_path(
+    X, y, alphas, positive=False, scenario="lbfgs_unconstrained"
+)
+coefs_all_positive = generate_path(X, y, alphas, positive=True, scenario="default")
+coefs_some_positive = generate_path(
+    X, y, alphas, positive=X_positive_coefficient, scenario="default"
+)
 
+min_alpha = alphas.min()
+plot_results(
+    coefs,
+    alphas,
+    f"Ridge coefs without positive coefficient constraints - alpha_min={min_alpha}",
+)
+plot_results(
+    coefs_lbfgs_unconstrained,
+    alphas,
+    f"Approx. of lbfgs Ridge without positive constraints - alpha_min={min_alpha}",
+)
+plot_results(
+    coefs_some_positive,
+    alphas,
+    f"Ridge coefs with conditional positive constraints - alpha_min={min_alpha}",
+)
+plot_results(
+    coefs_all_positive,
+    alphas,
+    f"Ridge coefs with all positive constraints - alpha_min={min_alpha}",
+)
 # %%

--- a/examples/linear_model/plot_ridge_path_specify_non_negative.py
+++ b/examples/linear_model/plot_ridge_path_specify_non_negative.py
@@ -1,0 +1,135 @@
+"""
+================================================================================================
+Plot Ridge coefficients as a function of the regularization
+and positive coefficient constraints
+================================================================================================
+
+Shows the effect of collinearity in the coefficients of an estimator.
+As well as a comparison between options to force positive coefficients.
+
+.. currentmodule:: sklearn.linear_model
+
+:class:`Ridge` Regression is the estimator used in this example.
+Each color represents a different feature of the
+coefficient vector, and this is displayed as a function of the
+regularization parameter.
+
+This example is an extension of the `plot_ridge_path` example. We
+add the option to force some coefficients to be positive. This is
+implemented by either setting the `positive` parameter of the Ridge estimator
+to `True` or by setting the `positive` parameter to an array containing
+`True` for the features that should be positive and `False` for the others.
+
+The original example also shows the usefulness of applying Ridge regression
+to highly ill-conditioned matrices. For such matrices, a slight
+change in the target variable can cause huge variances in the
+calculated weights. In such cases, it is useful to set a certain
+regularization (alpha) to reduce this variation (noise).
+
+When alpha is very large, the regularization effect dominates the
+squared loss function and the coefficients tend to zero.
+At the end of the path, as alpha tends toward zero
+and the solution tends towards the ordinary least squares, coefficients
+exhibit big oscillations. In practise it is necessary to tune alpha
+in such a way that a balance is maintained between both.
+
+"""
+
+# Authors: The scikit-learn developers
+# SPDX-License-Identifier: BSD-3-Clause
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from sklearn import linear_model
+
+# X is the 10x10 Hilbert matrix
+X = 1.0 / (np.arange(1, 11) + np.arange(0, 10)[:, np.newaxis])
+X_positive_coefficient = [
+    True,
+    False,
+    True,
+    False,
+    True,
+    False,
+    True,
+    False,
+    True,
+    False,
+]
+y = np.ones(10)
+#
+# %%
+# Compute paths
+# -------------
+
+n_alphas = 200
+alphas = np.logspace(-10, -2, n_alphas)
+
+
+# %%
+
+coefs = []
+coefs_all_positive = []
+coefs_some_positive = []
+for a in alphas:
+    ridge = linear_model.Ridge(alpha=a, fit_intercept=False, positive=False)
+    ridge_all_positive = linear_model.Ridge(alpha=a, fit_intercept=False, positive=True)
+    ridge_some_positive = linear_model.Ridge(
+        alpha=a, fit_intercept=False, positive=X_positive_coefficient
+    )
+
+    ridge.fit(X, y)
+    ridge_all_positive.fit(X, y)
+    ridge_some_positive.fit(X, y)
+
+    coefs.append(ridge.coef_)
+    coefs_all_positive.append(ridge_all_positive.coef_)
+    coefs_some_positive.append(ridge_some_positive.coef_)
+
+# %%
+# Display results
+# ---------------
+
+ax = plt.gca()
+
+ax.plot(alphas, coefs)
+ax.set_xscale("log")
+ax.set_xlim(ax.get_xlim()[::-1])  # reverse axis
+plt.xlabel("alpha")
+plt.ylabel("weights")
+plt.title(
+    "Ridge coef. as a func. of regularization without positive coefficient constraints"
+)
+plt.axis("tight")
+plt.show()
+
+# %%
+# Display conditional positive results
+# ----------------------------
+
+ax = plt.gca()
+ax.plot(alphas, coefs_some_positive)
+ax.set_xscale("log")
+ax.set_xlim(ax.get_xlim()[::-1])  # reverse axis
+plt.xlabel("alpha")
+plt.ylabel("weights")
+plt.title("Ridge coefficients with conditional positive constraints")
+plt.axis("tight")
+plt.show()
+
+# %%
+# Display all positive results
+# ----------------------------
+
+ax = plt.gca()
+ax.plot(alphas, coefs_all_positive)
+ax.set_xscale("log")
+ax.set_xlim(ax.get_xlim()[::-1])  # reverse axis
+plt.xlabel("alpha")
+plt.ylabel("weights")
+plt.title("Ridge coefficients with all positive constraints")
+plt.axis("tight")
+plt.show()
+
+# %%

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1145,8 +1145,13 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
         .. versionadded:: 0.19
            SAGA solver.
 
-    positive : bool, default=False
+    positive : bool or list of bool, default=False
         When set to ``True``, forces the coefficients to be positive.
+        When set to ``[True, True, False]``, forces the first two
+        coefficients to be positive and the third one to be negative.
+        When set to ``False``, no specific constraint is enforced.
+        When positive is list, the list must have the same length as the number
+        of expected coefficients. (X.shape[1])
         Only 'lbfgs' solver is supported in this case.
 
     random_state : int, RandomState instance, default=None

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -525,11 +525,11 @@ def ridge_regression(
 
     positive : bool or list of bool, default=False
         When set to ``True``, forces the coefficients to be positive.
-        When set to ``[True, True, False]``, forces the first two
-        coefficients to be positive and the third one to be negative.
-        When set to ``False``, no specific constraint is enforced.
-        When positive is list, the list must have the same length as the number
-        of expected coefficients. (X.shape[1])
+        Positivity constraint on the coefficients. 
+        If True, forces all coefficients to be positive.
+        If False, no constraint is enforced.
+        If list of length `n_features`, the positivity constraint is specified 
+        for each feature, forcing the corresponding coefficient to be positive.
         Only 'lbfgs' solver is supported in this case.
 
     random_state : int, RandomState instance, default=None

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -636,7 +636,15 @@ def _ridge_regression(
     elif isinstance(positive, list):
         if len(positive) != X.shape[1]:
             raise ValueError(
-                "Length of 'positive' list must be equal to the number of features"
+                "Parameter positive should be a boolean or a list of booleans"
+            )
+        if not all(isinstance(p, bool) for p in positive):
+            raise ValueError(
+                """
+                If providing a list limiting specific coefficients to positive values,
+                'positive' parameter must be a list of booleans
+                the same length as the number of expected coefficients.
+                """
             )
         _positive = True
 

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -333,6 +333,10 @@ def _solve_lbfgs(
             raise ValueError(
                 "Length of 'positive' list must be equal to the number of features"
             )
+        elif not all(isinstance(p, bool) for p in positive):
+            raise ValueError(
+                "'positive' must be either a boolean or a list of booleans"
+            )
         config["bounds"] = [(0, np.inf) if p else (None, None) for p in positive]
     else:
         raise ValueError("'positive' must be either a boolean or a list of booleans")
@@ -519,8 +523,13 @@ def ridge_regression(
         Verbosity level. Setting verbose > 0 will display additional
         information depending on the solver used.
 
-    positive : bool, default=False
+    positive : bool or list of bool, default=False
         When set to ``True``, forces the coefficients to be positive.
+        When set to ``[True, True, False]``, forces the first two
+        coefficients to be positive and the third one to be negative.
+        When set to ``False``, no specific constraint is enforced.
+        When positive is list, the list must have the same length as the number
+        of expected coefficients. (X.shape[1])
         Only 'lbfgs' solver is supported in this case.
 
     random_state : int, RandomState instance, default=None

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -636,15 +636,11 @@ def _ridge_regression(
     elif isinstance(positive, list):
         if len(positive) != X.shape[1]:
             raise ValueError(
-                "Parameter positive should be a boolean or a list of booleans"
+                "Length of 'positive' list must be equal to the number of features"
             )
         if not all(isinstance(p, bool) for p in positive):
             raise ValueError(
-                """
-                If providing a list limiting specific coefficients to positive values,
-                'positive' parameter must be a list of booleans
-                the same length as the number of expected coefficients.
-                """
+                "'positive' must be either a boolean or a list of booleans"
             )
         _positive = True
 

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -2225,8 +2225,8 @@ def test_lbfgs_solver_error():
 @pytest.mark.parametrize("positive", [[True, True, True]])
 def test_lbfgs_positive_list(alpha, positive):
     """
-    Test that LBGFS gets almost the same coef when
-    positive=True and positive=List[*True].
+    Test that LBGFS gets the same coef when
+    positive=True and positive=[True]*n_features.
     """
     X, y = make_regression(n_samples=100, n_features=3, random_state=42)
     y = np.expand_dims(y, 1)
@@ -2250,7 +2250,7 @@ def test_lbfgs_positive_list(alpha, positive):
 
 @pytest.mark.parametrize("positive", [[True], [True, True, True]])
 def test_lbfgs_positive_list_error_length(positive):
-    """Test that LBGFS returns error when list length does not equal features."""
+    """Test that LBGFS raises an error when len(positive) != n_features."""
     X, y = make_regression(n_samples=100, n_features=2, random_state=42)
     y = np.expand_dims(y, 1)
     config_list_bool = {

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -2025,11 +2025,7 @@ def test_ridge_positive_list_type_error_test(positive):
 
     with pytest.raises(
         ValueError,
-        match="""
-                If providing a list limiting specific coefficients to positive values,
-                'positive' parameter must be a list of booleans
-                the same length as the number of expected coefficients.
-                """,
+        match="'positive' must be either a boolean or a list of booleans",
     ):
         model.fit(X, y)
 
@@ -2060,7 +2056,7 @@ def test_ridge_positive_list_length_error_test(positive):
 
     with pytest.raises(
         ValueError,
-        match="Parameter positive should be a boolean or a list of booleans",
+        match="Length of 'positive' list must be equal to the number of features",
     ):
         model.fit(X, y)
 


### PR DESCRIPTION
In linear_model.Ridge, enables specifying the coefficients to constrain as positive only.

#### Reference Issues/PRs
Enhancement of feature implemented in PR: https://github.com/scikit-learn/scikit-learn/issues/19772

This is a feature available in other implementations such as GLMNET in R and has been requested in some capacity on stackoverflow, although searching the issues did not surface a particular ticket.

#### What does this implement/fix? Explain your changes.
Updated 'positive' parameter in BaseRidge class to accept either single boolean or an list of boolean values. List corresponds to X feature input.

Param validation was updated to accept an array like object and exception added if 'positive' is list and is not the same length as as shape[1] of X input matrix.

#### Highlighted Feature Code Changes:

file: `sklearn/linear_model/_ridge.py`

function: `_solve_lbfgs` [current version](https://github.com/scikit-learn/scikit-learn/blob/89511842526b1f38cff35a2fc199bfd049cc2e1c/sklearn/linear_model/_ridge.py#L299)

original, constructs list of 'True' bools if param `positive` is True: 
``` python
    if positive:
        config["bounds"] = [(0, np.inf)] * n_features
```

updated, retains existing capability, plus allows user to submit list of bools to isolate certain variables for non-negative constraint:
``` python
    if isinstance(positive, bool):
        if positive:
            config["bounds"] = [(0, np.inf)] * n_features
    elif isinstance(positive, list):
        if len(positive) != n_features:
            raise ValueError(
                "Length of 'positive' list must be equal to the number of features"
            )
        elif not all(isinstance(p, bool) for p in positive):
            raise ValueError(
                "'positive' must be either a boolean or a list of booleans"
            )
        config["bounds"] = [(0, np.inf) if p else (None, None) for p in positive]
    else:
        raise ValueError("'positive' must be either a boolean or a list of booleans")
```

#### Additional Changes

1. ridge.py data validation `positive` parameter to accept 'array-like' values
2. Updated docstrings in Ridge class and _ridge_regression function 
3. test_ridge.py tests
-   `test_lbfgs_positive_list`
-   `test_lbfgs_positive_list_error_length`
-   `test_lbfgs_positive_list_error_type`
-   `test_lbfgs_positive_error_type`
-   `test_ridge_positive_list_type_error_test`
-   `test_ridge_positive_list_length_error_test`
-   `test_ridge_positive_list_length_test`
4. Added 31031.feature.rst to upcoming changes
5. Added examples/linear_model/plot_ridge_path_specify_non_negative.py


#### Future Enhancements
Feature could easily be extended to accept list of constraints as well as bools; however, test surface would expand greatly and other algorithms are likely more appropriate for more specific constrained calculations.  
