### PR TITLE
FIX _safe_indexing for pyarrow

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.compose/31040.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.compose/31040.fix.rst
@@ -1,0 +1,3 @@
+- Passing a pyarrow `Table` as `X` in a :class:`compose.ColumnTransformer` is now
+  possible. A bug in the private function :func:`utils._safe_indexing` was fixed.
+  By :user:`Christian Lorentzen <lorentzenchr>`

--- a/doc/whats_new/upcoming_changes/sklearn.compose/31040.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.compose/31040.fix.rst
@@ -1,3 +1,0 @@
-- Passing a pyarrow `Table` as `X` in a :class:`compose.ColumnTransformer` is now
-  possible. A bug in the private function :func:`utils._safe_indexing` was fixed.
-  By :user:`Christian Lorentzen <lorentzenchr>`

--- a/doc/whats_new/upcoming_changes/sklearn.utils/31040.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/31040.enhancement.rst
@@ -1,0 +1,4 @@
+- The private helper function :func:`utils._safe_indexing` now officially supports
+  pyarrow data. For instance, passing a pyarrow `Table` as `X` in a
+  :class:`compose.ColumnTransformer` is now possible.
+  By :user:`Christian Lorentzen <lorentzenchr>`

--- a/sklearn/utils/_indexing.py
+++ b/sklearn/utils/_indexing.py
@@ -101,7 +101,7 @@ def _dataframe_interchange_protocol_indexing(X, key, key_dtype):
     # https://github.com/data-apis/dataframe-api/issues/85.
     # As a dirty workaround, we will check for a method "select" being available and
     # use that one.
-    if not hasattr(X, "select"):
+    if not hasattr(X, "select"):  # pragma: no cover
         msg = (
             f"While the passed object X, {type(X)=}, has the __dataframe__ interchange "
             "protocol implemented, scikit-learn currently does not know how to deal "
@@ -110,7 +110,7 @@ def _dataframe_interchange_protocol_indexing(X, key, key_dtype):
         raise NotImplementedError(msg)
 
     if key_dtype == "bool":
-        key = np.asarray(key).nonzero().tolist()
+        key = np.asarray(key).nonzero()[0].tolist()
         key_dtype == "int"
     elif key_dtype == "str":
         key = _get_column_indices_interchange(X.__dataframe__(), key, key_dtype)

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -979,6 +979,7 @@ def _convert_container(
     elif constructor_name == "pyarrow":
         pa = pytest.importorskip("pyarrow", minversion=minversion)
         array = np.asarray(container)
+        array = array[:, None] if array.ndim == 1 else array
         if columns_name is None:
             columns_name = [f"col{i}" for i in range(array.shape[1])]
         data = {name: array[:, i] for i, name in enumerate(columns_name)}
@@ -1000,6 +1001,9 @@ def _convert_container(
     elif constructor_name == "series":
         pd = pytest.importorskip("pandas", minversion=minversion)
         return pd.Series(container, dtype=dtype)
+    elif constructor_name == "pyarrow_array":
+        pa = pytest.importorskip("pyarrow", minversion=minversion)
+        return pa.array(container)
     elif constructor_name == "polars_series":
         pl = pytest.importorskip("polars", minversion=minversion)
         return pl.Series(values=container)

--- a/sklearn/utils/tests/test_indexing.py
+++ b/sklearn/utils/tests/test_indexing.py
@@ -201,8 +201,6 @@ def test_safe_indexing_2d_container_axis_1(array_type, indices_type, indices):
 def test_safe_indexing_2d_read_only_axis_1(
     array_read_only, indices_read_only, array_type, indices_type, axis, expected_array
 ):
-    if array_type == "pyarrow" and axis == 0:
-        pytest.skip()
     array = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     if array_read_only:
         array.setflags(write=False)

--- a/sklearn/utils/tests/test_indexing.py
+++ b/sklearn/utils/tests/test_indexing.py
@@ -174,11 +174,7 @@ def test_safe_indexing_2d_container_axis_1(array_type, indices_type, indices):
     )
     indices_converted = _convert_container(indices_converted, indices_type)
 
-    if isinstance(indices[0], str) and array_type not in (
-        "dataframe",
-        "pyarrow",
-        "polars",
-    ):
+    if isinstance(indices[0], str) and array_type in ("array", "sparse"):
         err_msg = (
             "Specifying the columns using strings is only supported for dataframes"
         )

--- a/sklearn/utils/tests/test_testing.py
+++ b/sklearn/utils/tests/test_testing.py
@@ -899,6 +899,10 @@ def test_create_memmap_backed_data(monkeypatch):
         ("dataframe", lambda: pytest.importorskip("pandas").DataFrame),
         ("series", lambda: pytest.importorskip("pandas").Series),
         ("index", lambda: pytest.importorskip("pandas").Index),
+        ("pyarrow", lambda: pytest.importorskip("pyarrow").Table),
+        ("pyarrow_array", lambda: pytest.importorskip("pyarrow").Array),
+        ("polars", lambda: pytest.importorskip("polars").DataFrame),
+        ("polars_series", lambda: pytest.importorskip("polars").Series),
         ("slice", slice),
     ],
 )
@@ -919,7 +923,15 @@ def test_convert_container(
 ):
     """Check that we convert the container to the right type of array with the
     right data type."""
-    if constructor_name in ("dataframe", "polars", "series", "polars_series", "index"):
+    if constructor_name in (
+        "dataframe",
+        "index",
+        "polars",
+        "polars_series",
+        "pyarrow",
+        "pyarrow_array",
+        "series",
+    ):
         # delay the import of pandas/polars within the function to only skip this test
         # instead of the whole file
         container_type = container_type()
@@ -936,6 +948,8 @@ def test_convert_container(
         # list and tuple will use Python class dtype: int, float
         # pandas index will always use high precision: np.int64 and np.float64
         assert np.issubdtype(type(container_converted[0]), superdtype)
+    elif constructor_name in ("polars", "polars_series", "pyarrow", "pyarrow_array"):
+        return
     elif hasattr(container_converted, "dtype"):
         assert container_converted.dtype == dtype
     elif hasattr(container_converted, "dtypes"):

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -2349,6 +2349,15 @@ def _is_pandas_df(X):
     return isinstance(X, pd.DataFrame)
 
 
+def _is_pyarrow_data(X):
+    """Return True if the X is a pyarrow Table, RecordBatch, Array or ChunkedArray."""
+    try:
+        pa = sys.modules["pyarrow"]
+    except KeyError:
+        return False
+    return isinstance(X, (pa.Table, pa.RecordBatch, pa.Array, pa.ChunkedArray))
+
+
 def _is_polars_df_or_series(X):
     """Return True if the X is a polars dataframe or series."""
     try:


### PR DESCRIPTION
#### Reference Issues/PRs
Partially addresses https://github.com/scikit-learn/scikit-learn/issues/25896#issuecomment-2740201980.

#### What does this implement/fix? Explain your changes.
`_safe_indexing(.., axis=1)` is used in the `ColumnTransformer` and raises an error if a `pyarrow.Table` is passed even though it implements the __dataframe__ interchange protocol:
```python
import pyarrow as pa
from sklearn.datasets import load_iris
from sklearn.preprocessing import StandardScaler, KBinsDiscretizer
from sklearn.compose import ColumnTransformer

X, y = load_iris(as_frame=True, return_X_y=True)
sepal_cols = ["sepal length (cm)", "sepal width (cm)"]
petal_cols = ["petal length (cm)", "petal width (cm)"]

preprocessor = ColumnTransformer(
    [
        ("scaler", StandardScaler(), sepal_cols),
        ("kbin", KBinsDiscretizer(encode="ordinal"), petal_cols),
    ],
    verbose_feature_names_out=False,
)

X_pa = pa.table(X)
preprocessor.fit_transform(X_pa)
```
results in 
```
python3.10/site-packages/sklearn/utils/_indexing.py:270, in _safe_indexing(X, indices, axis)
    268     return _polars_indexing(X, indices, indices_dtype, axis=axis)
    269 elif hasattr(X, "shape"):
--> 270     return _array_indexing(X, indices, indices_dtype, axis=axis)
    271 else:
    272     return _list_indexing(X, indices, indices_dtype)

File python3.10/site-packages/sklearn/utils/_indexing.py:36, in _array_indexing(array, key, key_dtype, axis)
     34 if isinstance(key, tuple):
     35     key = list(key)
---> 36 return array[key, ...] if axis == 0 else array[:, key]

...
python3.10/site-packages/pyarrow/table.pxi:1725, in pyarrow.lib._Tabular._ensure_integer_index()

TypeError: Index must either be string or integer
```
which shows that the wrong branch (`elif hasattr(X, "shape"):`) is taken.


#### Any other comments?
There is no general solution with `__dataframe__` because of https://github.com/data-apis/dataframe-api/issues/85.

~~Therefore a dirtier solution is taken.~~
Therefore, just pyarrow indexing is implemented.

[narwhals](https://github.com/narwhals-dev/narwhals) would be much cleaner, but needs its own dedicated issue for discussion. This PR just fixes a bug with pyarrow.Table passed around.