### PR TITLE
MNT Update `asv.conf.json` to get rid of last references to Python 2.7

### DIFF
--- a/asv_benchmarks/asv.conf.json
+++ b/asv_benchmarks/asv.conf.json
@@ -4,14 +4,20 @@
     "version": 1,
 
     // The name of the project being benchmarked
-    "project": "asv",
+    "project": "scikit-learn",
 
     // The project's homepage
-    "project_url": "https://github.com/airspeed-velocity/asv/",
+    "project_url": "https://scikit-learn.org/",
 
     // The URL or local path of the source code repository for the
     // project being benchmarked
-    "repo": ".",
+    "repo": "..",
+
+    // Customizable commands for building, installing, and
+    // uninstalling the project. See asv.conf.json documentation.
+    "install_command": ["python -mpip install {wheel_file}"],
+    "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
+    "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
 
     // List of branches to benchmark. If not provided, defaults to "main"
     // (for git) or "default" (for mercurial).
@@ -21,14 +27,14 @@
     // determined from "repo" by looking at the protocol in the URL
     // (if remote), or by looking for special directories, such as
     // ".git" (if local).
-    "dvcs": "git",
+    // "dvcs": "git",
 
     // The tool to use to create environments.  May be "conda",
     // "virtualenv" or other value depending on the plugins in use.
     // If missing or the empty string, the tool will be automatically
     // determined by looking for tools on the PATH environment
     // variable.
-    "environment_type": "virtualenv",
+    "environment_type": "conda",
 
     // timeout in seconds for installing any dependencies in environment
     // defaults to 10 min
@@ -39,11 +45,11 @@
     //"default_benchmark_timeout": 60,
 
     // the base URL to show a commit for the project.
-    "show_commit_url": "http://github.com/airspeed-velocity/asv/commit/",
+    "show_commit_url": "https://github.com/scikit-learn/scikit-learn/commit/",
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.12"],
+    // "pythons": ["3.12"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty
@@ -55,8 +61,17 @@
     // pip (with all the conda available packages installed first,
     // followed by the pip installed packages).
     //
+    // The versions of the dependencies should be bumped in a dedicated commit
+    // to easily identify regressions/improvements due to code changes from
+    // those due to dependency changes.
+    //
     "matrix": {
-    	"six": []
+        "numpy": ["2.0.0"],
+        "scipy": ["1.14.0"],
+        "cython": ["3.0.10"],
+        "joblib": ["1.3.2"],
+        "threadpoolctl": ["3.2.0"],
+        "pandas": ["2.2.2"]
     },
 
     // Combinations of libraries/python versions can be excluded/included
@@ -98,15 +113,15 @@
 
     // The directory (relative to the current directory) to cache the Python
     // environments in.  If not provided, defaults to "env"
-    "env_dir": ".asv/env",
+    // "env_dir": "env",
 
     // The directory (relative to the current directory) that raw benchmark
     // results are stored in.  If not provided, defaults to "results".
-    "results_dir": ".asv/results",
+    // "results_dir": "results",
 
     // The directory (relative to the current directory) that the html tree
     // should be written to.  If not provided, defaults to "html".
-    "html_dir": ".asv/html",
+    // "html_dir": "html",
 
     // The number of characters to retain in the commit hashes.
     // "hash_length": 8,

--- a/asv_benchmarks/asv.conf.json
+++ b/asv_benchmarks/asv.conf.json
@@ -4,61 +4,49 @@
     "version": 1,
 
     // The name of the project being benchmarked
-    "project": "scikit-learn",
+    "project": "asv",
 
     // The project's homepage
-    "project_url": "scikit-learn.org/",
+    "project_url": "https://github.com/airspeed-velocity/asv/",
 
     // The URL or local path of the source code repository for the
     // project being benchmarked
-    "repo": "..",
+    "repo": ".",
 
-    // The Python project's subdirectory in your repo.  If missing or
-    // the empty string, the project is assumed to be located at the root
-    // of the repository.
-    // "repo_subdir": "",
-
-    // Customizable commands for building, installing, and
-    // uninstalling the project. See asv.conf.json documentation.
-    "install_command": ["python -mpip install {wheel_file}"],
-    "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
-    "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
-
-    // List of branches to benchmark. If not provided, defaults to "master
+    // List of branches to benchmark. If not provided, defaults to "main"
     // (for git) or "default" (for mercurial).
     "branches": ["main"],
-    // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL
     // (if remote), or by looking for special directories, such as
     // ".git" (if local).
-    // "dvcs": "git",
+    "dvcs": "git",
 
     // The tool to use to create environments.  May be "conda",
     // "virtualenv" or other value depending on the plugins in use.
     // If missing or the empty string, the tool will be automatically
     // determined by looking for tools on the PATH environment
     // variable.
-    "environment_type": "conda",
+    "environment_type": "virtualenv",
 
     // timeout in seconds for installing any dependencies in environment
     // defaults to 10 min
     //"install_timeout": 600,
 
+    // timeout in seconds all benchmarks, can be overridden per benchmark
+    // defaults to 1 min
+    //"default_benchmark_timeout": 60,
+
     // the base URL to show a commit for the project.
-    "show_commit_url": "https://github.com/scikit-learn/scikit-learn/commit/",
+    "show_commit_url": "http://github.com/airspeed-velocity/asv/commit/",
 
-    // The Pythons you'd like to test against. If not provided, defaults
+    // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    // "pythons": ["3.6"],
+    "pythons": ["3.12"],
 
-    // The list of conda channel names to be searched for benchmark
-    // dependency packages in the specified order
-    // "conda_channels": ["conda-forge", "defaults"]
-
-    // The matrix of dependencies to test. Each key is the name of a
-    // package (in PyPI) and the values are version numbers. An empty
+    // The matrix of dependencies to test.  Each key is the name of a
+    // package (in PyPI) and the values are version numbers.  An empty
     // list or empty string indicates to just test against the default
     // (latest) version. null indicates that the package is to not be
     // installed. If the package to be tested is only available from
@@ -67,17 +55,8 @@
     // pip (with all the conda available packages installed first,
     // followed by the pip installed packages).
     //
-    // The versions of the dependencies should be bumped in a dedicated commit
-    // to easily identify regressions/improvements due to code changes from
-    // those due to dependency changes.
-    //
     "matrix": {
-        "numpy": ["2.0.0"],
-        "scipy": ["1.14.0"],
-        "cython": ["3.0.10"],
-        "joblib": ["1.3.2"],
-        "threadpoolctl": ["3.2.0"],
-        "pandas": ["2.2.2"]
+    	"six": []
     },
 
     // Combinations of libraries/python versions can be excluded/included
@@ -102,12 +81,15 @@
     //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
     //
     // "exclude": [
-    //     {"python": "3.8", "sys_platform": "win32"}, // skip py38 on windows
+    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+    //     {"environment_type": "conda", "six": null}, // don't run without six on conda
     // ],
     //
     // "include": [
+    //     // additional env for python3.12
+    //     {"python": "3.12", "numpy": "1.26"},
     //     // additional env if run on windows+conda
-    //     {"sys_platform": "win32", "environment_type": "conda", "python": "3.8", "libpython": ""},
+    //     {"platform": "win32", "environment_type": "conda", "python": "3.12", "libpython": ""},
     // ],
 
     // The directory (relative to the current directory) that benchmarks are
@@ -116,23 +98,23 @@
 
     // The directory (relative to the current directory) to cache the Python
     // environments in.  If not provided, defaults to "env"
-    // "env_dir": "env",
+    "env_dir": ".asv/env",
 
     // The directory (relative to the current directory) that raw benchmark
     // results are stored in.  If not provided, defaults to "results".
-    // "results_dir": "results",
+    "results_dir": ".asv/results",
 
     // The directory (relative to the current directory) that the html tree
     // should be written to.  If not provided, defaults to "html".
-    // "html_dir": "html",
+    "html_dir": ".asv/html",
 
     // The number of characters to retain in the commit hashes.
     // "hash_length": 8,
 
-    // `asv` will cache results of the recent builds in each
+    // `asv` will cache wheels of the recent builds in each
     // environment, making them faster to install next time.  This is
-    // the number of builds to keep, per environment.
-    // "build_cache_size": 2,
+    // number of builds to keep, per environment.
+    // "build_cache_size": 0
 
     // The commits after which the regression search in `asv publish`
     // should start looking for regressions. Dictionary whose keys are
@@ -145,16 +127,5 @@
     // "regressions_first_commits": {
     //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
     //    "another_benchmark": null,   // Skip regression detection altogether
-    // },
-
-    // The thresholds for relative change in results, after which `asv
-    // publish` starts reporting regressions. Dictionary of the same
-    // form as in ``regressions_first_commits``, with values
-    // indicating the thresholds.  If multiple entries match, the
-    // maximum is taken. If no entry matches, the default is 5%.
-    //
-    // "regressions_thresholds": {
-    //    "some_benchmark": 0.01,     // Threshold of 1%
-    //    "another_benchmark": 0.5,   // Threshold of 50%
-    // },
+    // }
 }

--- a/asv_benchmarks/asv.conf.json
+++ b/asv_benchmarks/asv.conf.json
@@ -104,7 +104,7 @@
     //     // additional env for python3.12
     //     {"python": "3.12", "numpy": "1.26"},
     //     // additional env if run on windows+conda
-    //     {"platform": "win32", "environment_type": "conda", "python": "3.12", "libpython": ""},
+    //     {"sys_platform": "win32", "environment_type": "conda", "python": "3.12", "libpython": ""},
     // ],
 
     // The directory (relative to the current directory) that benchmarks are

--- a/asv_benchmarks/asv.conf.json
+++ b/asv_benchmarks/asv.conf.json
@@ -102,15 +102,12 @@
     //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
     //
     // "exclude": [
-    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
-    //     {"environment_type": "conda", "six": null}, // don't run without six on conda
+    //     {"python": "3.8", "sys_platform": "win32"}, // skip py38 on windows
     // ],
     //
     // "include": [
-    //     // additional env for python2.7
-    //     {"python": "2.7", "numpy": "1.8"},
     //     // additional env if run on windows+conda
-    //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "libpython": ""},
+    //     {"sys_platform": "win32", "environment_type": "conda", "python": "3.8", "libpython": ""},
     // ],
 
     // The directory (relative to the current directory) that benchmarks are


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

* `six` is not used anymore
* Use newer version of Python in examples.

Also fix typo:
`platform` → `sys_platform`


#### Any other comments?

Not sure about this one, I have yet to understand the comment:
https://github.com/scikit-learn/scikit-learn/blob/85fb4dab9f76af8a06706da48dc7dd56916b105e/sklearn/utils/deprecation.py#L98-L100