### PR TITLE
ENH Show a more informative error when accessing an attribute

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -5,7 +5,6 @@ Ridge regression
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
-
 import numbers
 import warnings
 from abc import ABCMeta, abstractmethod
@@ -39,6 +38,7 @@ from ..utils._array_api import (
     get_namespace,
     get_namespace_and_device,
 )
+from ..utils._attribute import FittedAttribute
 from ..utils._param_validation import Hidden, Interval, StrOptions, validate_params
 from ..utils.extmath import row_norms, safe_sparse_dot
 from ..utils.fixes import _sparse_linalg_cg
@@ -2298,6 +2298,14 @@ class _RidgeGCV(LinearModel):
 
 
 class _BaseRidgeCV(LinearModel):
+    cv_results_ = FittedAttribute("store_cv_results=True and cv=None")
+    coef_ = FittedAttribute()
+    intercept_ = FittedAttribute()
+    alpha_ = FittedAttribute()
+    best_score_ = FittedAttribute()
+    n_features_in_ = FittedAttribute()
+    feature_names_in_ = FittedAttribute()
+
     _parameter_constraints: dict = {
         "alphas": ["array-like", Interval(Real, 0, None, closed="neither")],
         "fit_intercept": ["boolean"],

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -38,7 +38,7 @@ from ..utils._array_api import (
     get_namespace,
     get_namespace_and_device,
 )
-from ..utils._attribute import FittedAttribute
+from ..utils._attribute_validation import FittedAttribute
 from ..utils._param_validation import Hidden, Interval, StrOptions, validate_params
 from ..utils.extmath import row_norms, safe_sparse_dot
 from ..utils.fixes import _sparse_linalg_cg

--- a/sklearn/utils/_attribute.py
+++ b/sklearn/utils/_attribute.py
@@ -1,0 +1,22 @@
+# Authors: The scikit-learn developers
+# SPDX-License-Identifier: BSD-3-Clause
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class FittedAttribute:
+    """Descriptor to raise a better error when attribute is not defined."""
+
+    condition: str = ""
+    name: str = field(init=False)
+
+    def __get__(self, instance, owner):
+        if self.condition:
+            msg = f"Call `fit` with {self.condition} to define '{self.name}'"
+        else:
+            msg = f"Call `fit` {self.name} to define '{self.name}'"
+        raise AttributeError(msg)
+
+    def __set_name__(self, owner, name):
+        self.name = name

--- a/sklearn/utils/_attribute_validation.py
+++ b/sklearn/utils/_attribute_validation.py
@@ -15,7 +15,7 @@ class FittedAttribute:
         if self.condition:
             msg = f"Call `fit` with {self.condition} to define '{self.name}'"
         else:
-            msg = f"Call `fit` {self.name} to define '{self.name}'"
+            msg = f"Call `fit` to define '{self.name}'"
         raise AttributeError(msg)
 
     def __set_name__(self, owner, name):

--- a/sklearn/utils/tests/test_attribute.py
+++ b/sklearn/utils/tests/test_attribute.py
@@ -1,0 +1,28 @@
+import pytest
+
+from sklearn.utils._attribute_validation import FittedAttribute
+
+
+class MyObj:
+    coef_ = FittedAttribute()
+    cv_results_ = FittedAttribute("cv=None")
+
+    def fit(self):
+        self.coef_ = 123
+        self.cv_results_ = [1, 2, 3]
+
+
+def test_attribute_error():
+    my_obj = MyObj()
+
+    msg = "Call `fit` to define 'coef_'"
+    with pytest.raises(AttributeError, match=msg):
+        my_obj.coef_
+
+    msg = "Call `fit` with cv=None to define 'cv_results_'"
+    with pytest.raises(AttributeError, match=msg):
+        my_obj.cv_results_
+
+    my_obj.fit()
+    assert my_obj.coef_ == 123
+    assert my_obj.cv_results_ == [1, 2, 3]


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes https://github.com/scikit-learn/scikit-learn/issues/31010


#### What does this implement/fix? Explain your changes.
This PR implements a descriptor to raise a nicer error. 

#### Any other comments?
I'm not sure if I like it, but it's the "least magical".

I want the pattern to be "the class that sets the attributes should define `FittedAttribute`". In this case, `_BaseRidgeCV` defines them all, so it'll set them.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
