### PR TITLE
[Mathijs] Task 17: DOC Fix html-noplot target to properly use SPHINXOPTS

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -78,8 +78,9 @@ html:
 # Default to SPHINX_NUMJOBS=auto (except on MacOS and CI) since this makes
 # html-noplot build faster
 html-noplot: SPHINX_NUMJOBS ?= $(SPHINX_NUMJOBS_NOPLOT_DEFAULT)
+html-noplot: SPHINXOPTS += -D plot_gallery=0
 html-noplot:
-	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) -j$(SPHINX_NUMJOBS) \
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) -j$(SPHINX_NUMJOBS) \
     $(BUILDDIR)/html/stable
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html/stable."


### PR DESCRIPTION
The html-noplot target was not properly using SPHINXOPTS from the environment because it was passing -D plot_gallery=0 directly to sphinx-build. This caused issues when users set additional options in SPHINXOPTS (e.g., -W for treating warnings as errors).

This change:
- Appends -D plot_gallery=0 to SPHINXOPTS instead of passing it directly
- Removes redundant option from sphinx-build command line
- Maintains the same functionality while respecting user's SPHINXOPTS

The workflow for building docs with `-W` and `--no-plot` is now:
1. First run `make html` to execute examples and generate all plots
2. Then run `make html-noplot` for faster incremental builds

This is because `--no-plot` skips example execution but still needs the image files to exist to avoid warnings about missing images.

Fixes #29742
