### PR TITLE
First steps toward sparray migration pass 2

### DIFF
--- a/sklearn/manifold/_locally_linear.py
+++ b/sklearn/manifold/_locally_linear.py
@@ -404,7 +404,7 @@ def _locally_linear_embedding(
             nbrs_x, nbrs_y = np.meshgrid(neighbors[i], neighbors[i])
             M[nbrs_x, nbrs_y] += np.dot(Wi, Wi.T)
             Wi_sum1 = Wi.sum(1)
-            M[i, neighbors[i]] -= Wi_sum1
+            M[[i], neighbors[i]] -= Wi_sum1
             M[neighbors[i], [i]] -= Wi_sum1
             M[i, i] += s_i
 

--- a/sklearn/manifold/_locally_linear.py
+++ b/sklearn/manifold/_locally_linear.py
@@ -7,7 +7,7 @@ from numbers import Integral, Real
 
 import numpy as np
 from scipy.linalg import eigh, qr, solve, svd
-from scipy.sparse import csr_array, csr_matrix, eye_array, lil_array
+from scipy.sparse import csr_array, csr_matrix, eye, lil_array
 from scipy.sparse.linalg import eigsh
 
 from ..base import (
@@ -246,7 +246,9 @@ def _locally_linear_embedding(
         # we'll compute M = (I-W)'(I-W)
         # depending on the solver, we'll do this differently
         if M_sparse:
-            M = eye_array(*W.shape, format=W.format) - W
+            # change when SciPy 1.12+ is guaranteed to
+            # M = eye_array(*W.shape, format=W.format) - W
+            M = csr_array(eye(*W.shape)).asformat(W.format) - W
             M = M.T @ M
         else:
             M = (W.T @ W - W.T - W).toarray()

--- a/sklearn/manifold/tests/test_locally_linear.py
+++ b/sklearn/manifold/tests/test_locally_linear.py
@@ -18,7 +18,8 @@ eigen_solvers = ["dense", "arpack"]
 
 # ----------------------------------------------------------------------
 # Test utility routines
-def test_barycenter_kneighbors_graph(global_dtype):
+@pytest.mark.parametrize("spmatrix", [True, False])
+def test_barycenter_kneighbors_graph(global_dtype, spmatrix):
     X = np.array([[0, 1], [1.01, 1.0], [2, 0]], dtype=global_dtype)
 
     graph = barycenter_kneighbors_graph(X, 1)
@@ -30,7 +31,7 @@ def test_barycenter_kneighbors_graph(global_dtype):
 
     assert_allclose(graph.toarray(), expected_graph)
 
-    graph = barycenter_kneighbors_graph(X, 2)
+    graph = barycenter_kneighbors_graph(X, 2, spmatrix=spmatrix)
     # check that columns sum to one
     assert_allclose(np.sum(graph.toarray(), axis=1), np.ones(3))
     pred = np.dot(graph.toarray(), X)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -203,6 +203,12 @@ def test_adjusted_mutual_info_score():
     C = contingency_matrix(labels_a, labels_b, sparse=True)
     mi = mutual_info_score(labels_a, labels_b, contingency=C)
     assert_almost_equal(mi, 0.41022, 5)
+    C = contingency_matrix(labels_a, labels_b, sparse="sparray")
+    mi = mutual_info_score(labels_a, labels_b, contingency=C)
+    assert_almost_equal(mi, 0.41022, 5)
+    C = contingency_matrix(labels_a, labels_b, sparse="spmatrix")
+    mi = mutual_info_score(labels_a, labels_b, contingency=C)
+    assert_almost_equal(mi, 0.41022, 5)
     # with provided dense contingency
     C = contingency_matrix(labels_a, labels_b)
     mi = mutual_info_score(labels_a, labels_b, contingency=C)
@@ -291,8 +297,16 @@ def test_contingency_matrix_sparse():
     C = contingency_matrix(labels_a, labels_b)
     C_sparse = contingency_matrix(labels_a, labels_b, sparse=True).toarray()
     assert_array_almost_equal(C, C_sparse)
-    with pytest.raises(ValueError, match="Cannot set 'eps' when sparse=True"):
+    C_sparse = contingency_matrix(labels_a, labels_b, sparse="spmatrix").toarray()
+    assert_array_almost_equal(C, C_sparse)
+    C_sparse = contingency_matrix(labels_a, labels_b, sparse="sparray").toarray()
+    assert_array_almost_equal(C, C_sparse)
+    with pytest.raises(ValueError, match="Cannot set 'eps' when sparse is not False"):
         contingency_matrix(labels_a, labels_b, eps=1e-10, sparse=True)
+    with pytest.raises(ValueError, match="Cannot set 'eps' when sparse is not False"):
+        contingency_matrix(labels_a, labels_b, eps=1e-10, sparse="sparray")
+    with pytest.raises(ValueError, match="Cannot set 'eps' when sparse is not False"):
+        contingency_matrix(labels_a, labels_b, eps=1e-10, sparse="spmatrix")
 
 
 def test_exactly_zero_info_score():


### PR DESCRIPTION
This PR converts `sklearn/metrics/cluster/_supervised.py` [Edit: and `sklearn/manifold/_locally_linear.py`] to use sparray. The reason for doing a small ~~one-file~~ two-file PR here is to get feedback on kwargs that direct spmatrix vs sparray. [Edit: the second module includes a function that has no current sparse keyword -- so maybe needs a new one. see the next comment in this PR.]

1) For the function `contingency_matrix` this PR extends the `sparse` keyword to allow "boolean or str" input with valid string inputs being `"sparray"` or `"spmatrix"`. The value `False` continues to signify an ndarray return value while `True` signifies `spmatrix` for now with a note that this will change behavior to `sparray` alongside the deprecation of `spmatrix`.  Note that in this module all calls to `contingency_matrix` lead to non-sparse output so have been switched from `sparse=True` to  `sparse="sparray"` in alignment with Pass 2 of migration to sparray making all internal (non-user facing) sparse usage be `sparray`.
    - All calls to `contingency_matrix` repo-wide that use sparse have been updated (all are in this module).
    - Tests are updated to check the new keyword args.
    - Is this the right approach? the right wording?   Thanks! 

2) There is a doc reference to `sklearn.sparse.csr_matrix` which I assume never existed. So I reworded that doc.

3) This file has a function `fowles_mallow_score` which has a `sparse` keyword but it is never used. There is a PR #28981 which points out this flaw and attempts to make the keyword work, but the function's code/algorithm uses sparse features of the contingency_matrix -- so the code would not work with dense arrays -- the keyword cannot be meaningful here without new and less efficient code. I believe that the keyword should simply be removed. It is broken and shouldn't be enabled. 
    - So, this PR removes the `sparse` keyword from `fowlkes_mallow_score`.  Let me know if this should be separated from the rest of this PR.

This PR relates to #26418 (`RFC supporting scipy.sparse.sparray`)