### PR TITLE
CI Use explicit permissions update-lock-file workflow

### DIFF
--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -1,5 +1,7 @@
 # Workflow to update lock files
 name: Update lock files
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
#30702

I think `contents: read` is enough since most steps that needs permissions use the scikit-learn-bot token.

The PR CI is not going to test anything unfortunately, so the only way to know would be to merge this and wait until next Monday to see if the lock-file automated PRs were opened ...