### PR TITLE
CI Use right environment in Pyodide wheel upload

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -88,6 +88,7 @@ jobs:
     name: Upload scikit-learn WASM wheels to Anaconda.org
     runs-on: ubuntu-latest
     permissions: {}
+    environment: upload_anaconda
     needs: [build_wasm_wheel]
     if: github.repository == 'scikit-learn/scikit-learn' && github.event_name != 'pull_request'
     steps:


### PR DESCRIPTION
Follow-up of #29791 after the upload fails https://github.com/scikit-learn/scikit-learn/pull/29791#issuecomment-2753650747 because the token is empty.

Not sure if we should use the same environment or if we should have a separate environment for the main wheels upload and the Pyodide wheel upload. In particular the Pyodide wheel upload only needs `SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN` and not `SCIKIT_LEARN_STAGING_UPLOAD_TOKEN`. cc @ogrisel.