### PR TITLE
MNT Mention security advisory in our security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,12 +9,15 @@
 
 ## Reporting a Vulnerability
 
-Please report security vulnerabilities by email to `security@scikit-learn.org`.
-This email is an alias to a subset of the scikit-learn maintainers' team.
+Please report security vulnerabilities by opening a new [GitHub security
+advisory](https://github.com/scikit-learn/scikit-learn/security/advisories/new).
+
+You can also send an email to `security@scikit-learn.org`, which is an alias to
+a subset of the scikit-learn maintainers' team.
 
 If the security vulnerability is accepted, a patch will be crafted privately
 in order to prepare a dedicated bugfix release as timely as possible (depending
 on the complexity of the fix).
 
-In addition to sending the report by email, you can also report security
-vulnerabilities to [tidelift](https://tidelift.com/security).
+In addition to the options above, you can also report security vulnerabilities
+to [tidelift](https://tidelift.com/security).


### PR DESCRIPTION
The advantage of GitHub security advisory are the following:
- private reporting with private PR can be crafted to address the issue in collaboration with the reporter
- better than email to discuss security issues, in particular share code snippets
- can help discussing issues reported on Huntr since Huntr as a plaform has a few quirks

We have enabled it for joblib and so far our experience is good.

