### PR TITLE
DOC Duplicate information about supported Python versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,10 +72,6 @@ scikit-learn requires:
 
 =======
 
-**Scikit-learn 0.20 was the last version to support Python 2.7 and Python 3.4.**
-scikit-learn 1.0 and later require Python 3.7 or newer.
-scikit-learn 1.1 and later require Python 3.8 or newer.
-
 Scikit-learn plotting capabilities (i.e., functions start with ``plot_`` and
 classes end with ``Display``) require Matplotlib (>= |MatplotlibMinVersion|).
 For running the examples Matplotlib >= |MatplotlibMinVersion| is required.


### PR DESCRIPTION
#### Reference Issues/PRs

Fix issue reported in https://github.com/scikit-learn/scikit-learn/pull/31024#issuecomment-2754974586.

#### What does this implement/fix? Explain your changes.

Remove from README information about versions of Python supported by older versions of scikit-learn:
https://github.com/scikit-learn/scikit-learn/blob/0ae1c431bcd4800c7d7902d9d56c834f3982e97f/README.rst?plain=1#L75-L77

More up-to-date and complete information is available in section [Installing scikit-learn](https://github.com/scikit-learn/scikit-learn/blob/main/doc/install.rst):
https://github.com/scikit-learn/scikit-learn/blob/0ae1c431bcd4800c7d7902d9d56c834f3982e97f/doc/install.rst?plain=1#L204-L211

#### Any other comments?
