### PR TITLE
DOC Use nightly WASM wheels for JupyterLite in the dev documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -688,7 +688,9 @@ def notebook_modification_function(notebook_content, notebook_filename):
     if "dev" in release:
         dev_docs_specific_code = [
             "import piplite",
-            "await piplite.install(['joblib', 'threadpoolctl', 'scipy'])",
+            "import joblib",
+            "import threadpoolctl",
+            "import scipy",
             "await piplite.install(\n"
             f"  'scikit-learn=={release}',\n"
             "   index_urls='https://pypi.anaconda.org/scientific-python-nightly-wheels/simple',\n"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -687,9 +687,9 @@ def notebook_modification_function(notebook_content, notebook_filename):
     # dependencies first, and then scikit-learn from Anaconda.org.
     if "dev" in release:
         dev_docs_specific_code = [
-            "import micropip",
-            "await micropip.install(['joblib', 'threadpoolctl', 'scipy'])",
-            "await micropip.install(\n"
+            "import piplite",
+            "await piplite.install(['joblib', 'threadpoolctl', 'scipy'])",
+            "await piplite.install(\n"
             "   'scikit-learn',\n"
             "   index_urls='https://pypi.anaconda.org/scientific-python-nightly-wheels/simple',\n"
             "   pre=True,\n"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -690,9 +690,8 @@ def notebook_modification_function(notebook_content, notebook_filename):
             "import piplite",
             "await piplite.install(['joblib', 'threadpoolctl', 'scipy'])",
             "await piplite.install(\n"
-            "   'scikit-learn',\n"
+            f"  'scikit-learn=={release}',\n"
             "   index_urls='https://pypi.anaconda.org/scientific-python-nightly-wheels/simple',\n"
-            "   pre=True,\n"
             ")",
         ]
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -682,6 +682,22 @@ def notebook_modification_function(notebook_content, notebook_filename):
     # imports inside functions
     code_lines.extend(["import matplotlib", "import pandas"])
 
+    # Work around https://github.com/jupyterlite/pyodide-kernel/issues/166
+    # and https://github.com/pyodide/micropip/issues/223 by installing the
+    # dependencies first, and then scikit-learn from Anaconda.org.
+    if "dev" in release:
+        dev_docs_specific_code = [
+            "import micropip",
+            "await micropip.install(['joblib', 'threadpoolctl', 'scipy'])",
+            "await micropip.install(\n"
+            "   'scikit-learn',\n"
+            "   index_urls='https://pypi.anaconda.org/scientific-python-nightly-wheels/simple',\n"
+            "   pre=True,\n"
+            ")",
+        ]
+
+        code_lines.extend(dev_docs_specific_code)
+
     if code_lines:
         code_lines = ["# JupyterLite-specific code"] + code_lines
         code = "\n".join(code_lines)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This PR builds on top of #29791 and #31078

#### What does this implement/fix? Explain your changes.

This PR updates the Sphinx-Gallery notebook modification function to install the Pyodide/WASM wheels for scikit-learn which are now available on https://anaconda.org/scientific-python-nightly-wheels/scikit-learn. This allows the JupyterLite-based interactive notebooks in the "Examples" section of the development version of the `scikit-learn` documentation to use as close to a tip-of-tree version of `scikit-learn` as it can be.

cc: @lesteve

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
N/A
