### PR TITLE
TST use `global_random_seed` in `sklearn/compose/tests/test_target.py`

### DIFF
--- a/sklearn/compose/tests/test_target.py
+++ b/sklearn/compose/tests/test_target.py
@@ -15,8 +15,8 @@ from sklearn.utils._testing import assert_allclose
 friedman = datasets.make_friedman1(random_state=0)
 
 
-def test_transform_target_regressor_error():
-    X, y = friedman
+def test_transform_target_regressor_error(global_random_seed):
+    X, y = datasets.make_friedman1(random_state=global_random_seed)
     # provide a transformer and functions at the same time
     regr = TransformedTargetRegressor(
         regressor=LinearRegression(),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#22827 

#### What does this implement/fix? Explain your changes.
I'm just changing the first test `test_transform_target_regressor_error`. This is because I would like to know if the way I did it is correct. If it is, I'll continue with the rest of the tests in the same file.

All the seeds passed locally. (As in `SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest ./sklearn/compose/tests/test_target.py -k test_transform_target_regressor_error`) 

#### Any other comments?
Friendly ping @glemaitre 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
