### PR TITLE
MNT Clean-up deprecations for 1.7: Y in PLS*

### DIFF
--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -48,11 +48,11 @@ def _pinv2_old(a):
 
 
 def _get_first_singular_vectors_power_method(
-    X, Y, mode="A", max_iter=500, tol=1e-06, norm_y_weights=False
+    X, y, mode="A", max_iter=500, tol=1e-06, norm_y_weights=False
 ):
-    """Return the first left and right singular vectors of X'Y.
+    """Return the first left and right singular vectors of X'y.
 
-    Provides an alternative to the svd(X'Y) and uses the power method instead.
+    Provides an alternative to the svd(X'y) and uses the power method instead.
     With norm_y_weights to True and in mode A, this corresponds to the
     algorithm section 11.3 of the Wegelin's review, except this starts at the
     "update saliences" part.
@@ -60,7 +60,7 @@ def _get_first_singular_vectors_power_method(
 
     eps = np.finfo(X.dtype).eps
     try:
-        y_score = next(col for col in Y.T if np.any(np.abs(col) > eps))
+        y_score = next(col for col in y.T if np.any(np.abs(col) > eps))
     except StopIteration as e:
         raise StopIteration("y residual is constant") from e
 
@@ -73,7 +73,7 @@ def _get_first_singular_vectors_power_method(
         # As a result, and as detailed in the Wegelin's review, CCA (i.e. mode
         # B) will be unstable if n_features > n_samples or n_targets >
         # n_samples
-        X_pinv, Y_pinv = _pinv2_old(X), _pinv2_old(Y)
+        X_pinv, y_pinv = _pinv2_old(X), _pinv2_old(y)
 
     for i in range(max_iter):
         if mode == "B":
@@ -85,17 +85,17 @@ def _get_first_singular_vectors_power_method(
         x_score = np.dot(X, x_weights)
 
         if mode == "B":
-            y_weights = np.dot(Y_pinv, x_score)
+            y_weights = np.dot(y_pinv, x_score)
         else:
-            y_weights = np.dot(Y.T, x_score) / np.dot(x_score.T, x_score)
+            y_weights = np.dot(y.T, x_score) / np.dot(x_score.T, x_score)
 
         if norm_y_weights:
             y_weights /= np.sqrt(np.dot(y_weights, y_weights)) + eps
 
-        y_score = np.dot(Y, y_weights) / (np.dot(y_weights, y_weights) + eps)
+        y_score = np.dot(y, y_weights) / (np.dot(y_weights, y_weights) + eps)
 
         x_weights_diff = x_weights - x_weights_old
-        if np.dot(x_weights_diff, x_weights_diff) < tol or Y.shape[1] == 1:
+        if np.dot(x_weights_diff, x_weights_diff) < tol or y.shape[1] == 1:
             break
         x_weights_old = x_weights
 
@@ -106,40 +106,40 @@ def _get_first_singular_vectors_power_method(
     return x_weights, y_weights, n_iter
 
 
-def _get_first_singular_vectors_svd(X, Y):
-    """Return the first left and right singular vectors of X'Y.
+def _get_first_singular_vectors_svd(X, y):
+    """Return the first left and right singular vectors of X'y.
 
     Here the whole SVD is computed.
     """
-    C = np.dot(X.T, Y)
+    C = np.dot(X.T, y)
     U, _, Vt = svd(C, full_matrices=False)
     return U[:, 0], Vt[0, :]
 
 
-def _center_scale_xy(X, Y, scale=True):
-    """Center X, Y and scale if the scale parameter==True
+def _center_scale_xy(X, y, scale=True):
+    """Center X, y and scale if the scale parameter==True
 
     Returns
     -------
-        X, Y, x_mean, y_mean, x_std, y_std
+        X, y, x_mean, y_mean, x_std, y_std
     """
     # center
     x_mean = X.mean(axis=0)
     X -= x_mean
-    y_mean = Y.mean(axis=0)
-    Y -= y_mean
+    y_mean = y.mean(axis=0)
+    y -= y_mean
     # scale
     if scale:
         x_std = X.std(axis=0, ddof=1)
         x_std[x_std == 0.0] = 1.0
         X /= x_std
-        y_std = Y.std(axis=0, ddof=1)
+        y_std = y.std(axis=0, ddof=1)
         y_std[y_std == 0.0] = 1.0
-        Y /= y_std
+        y /= y_std
     else:
         x_std = np.ones(X.shape[1])
-        y_std = np.ones(Y.shape[1])
-    return X, Y, x_mean, y_mean, x_std, y_std
+        y_std = np.ones(y.shape[1])
+    return X, y, x_mean, y_mean, x_std, y_std
 
 
 def _svd_flip_1d(u, v):
@@ -150,28 +150,6 @@ def _svd_flip_1d(u, v):
     sign = np.sign(u[biggest_abs_val_idx])
     u *= sign
     v *= sign
-
-
-# TODO(1.7): Remove
-def _deprecate_Y_when_optional(y, Y):
-    if Y is not None:
-        warnings.warn(
-            "`Y` is deprecated in 1.5 and will be removed in 1.7. Use `y` instead.",
-            FutureWarning,
-        )
-        if y is not None:
-            raise ValueError(
-                "Cannot use both `y` and `Y`. Use only `y` as `Y` is deprecated."
-            )
-        return Y
-    return y
-
-
-# TODO(1.7): Remove
-def _deprecate_Y_when_required(y, Y):
-    if y is None and Y is None:
-        raise ValueError("y is required.")
-    return _deprecate_Y_when_optional(y, Y)
 
 
 class _PLS(
@@ -225,7 +203,7 @@ class _PLS(
         self.copy = copy
 
     @_fit_context(prefer_skip_nested_validation=True)
-    def fit(self, X, y=None, Y=None):
+    def fit(self, X, y):
         """Fit model to data.
 
         Parameters
@@ -238,20 +216,11 @@ class _PLS(
             Target vectors, where `n_samples` is the number of samples and
             `n_targets` is the number of response variables.
 
-        Y : array-like of shape (n_samples,) or (n_samples, n_targets)
-            Target vectors, where `n_samples` is the number of samples and
-            `n_targets` is the number of response variables.
-
-            .. deprecated:: 1.5
-               `Y` is deprecated in 1.5 and will be removed in 1.7. Use `y` instead.
-
         Returns
         -------
         self : object
             Fitted model.
         """
-        y = _deprecate_Y_when_required(y, Y)
-
         check_consistent_length(X, y)
         X = validate_data(
             self,
@@ -282,7 +251,7 @@ class _PLS(
         n_components = self.n_components
         # With PLSRegression n_components is bounded by the rank of (X.T X) see
         # Wegelin page 25. With CCA and PLSCanonical, n_components is bounded
-        # by the rank of X and the rank of Y: see Wegelin page 12
+        # by the rank of X and the rank of y: see Wegelin page 12
         rank_upper_bound = (
             min(n, p) if self.deflation_mode == "regression" else min(n, p, q)
         )
@@ -313,7 +282,7 @@ class _PLS(
         # paper.
         y_eps = np.finfo(yk.dtype).eps
         for k in range(n_components):
-            # Find first left and right singular vectors of the X.T.dot(Y)
+            # Find first left and right singular vectors of the X.T.dot(y)
             # cross-covariance matrix.
             if self.algorithm == "nipals":
                 # Replace columns that are all close to zero with zeros
@@ -347,7 +316,7 @@ class _PLS(
             # inplace sign flip for consistency across solvers and archs
             _svd_flip_1d(x_weights, y_weights)
 
-            # compute scores, i.e. the projections of X and Y
+            # compute scores, i.e. the projections of X and y
             x_scores = np.dot(Xk, x_weights)
             if norm_y_weights:
                 y_ss = 1
@@ -355,16 +324,16 @@ class _PLS(
                 y_ss = np.dot(y_weights, y_weights)
             y_scores = np.dot(yk, y_weights) / y_ss
 
-            # Deflation: subtract rank-one approx to obtain Xk+1 and Yk+1
+            # Deflation: subtract rank-one approx to obtain Xk+1 and yk+1
             x_loadings = np.dot(x_scores, Xk) / np.dot(x_scores, x_scores)
             Xk -= np.outer(x_scores, x_loadings)
 
             if self.deflation_mode == "canonical":
-                # regress Yk on y_score
+                # regress yk on y_score
                 y_loadings = np.dot(y_scores, yk) / np.dot(y_scores, y_scores)
                 yk -= np.outer(y_scores, y_loadings)
             if self.deflation_mode == "regression":
-                # regress Yk on x_score
+                # regress yk on x_score
                 y_loadings = np.dot(x_scores, yk) / np.dot(x_scores, x_scores)
                 yk -= np.outer(x_scores, y_loadings)
 
@@ -396,7 +365,7 @@ class _PLS(
         self._n_features_out = self.x_rotations_.shape[1]
         return self
 
-    def transform(self, X, y=None, Y=None, copy=True):
+    def transform(self, X, y=None, copy=True):
         """Apply the dimension reduction.
 
         Parameters
@@ -407,22 +376,14 @@ class _PLS(
         y : array-like of shape (n_samples, n_targets), default=None
             Target vectors.
 
-        Y : array-like of shape (n_samples, n_targets), default=None
-            Target vectors.
-
-            .. deprecated:: 1.5
-               `Y` is deprecated in 1.5 and will be removed in 1.7. Use `y` instead.
-
         copy : bool, default=True
-            Whether to copy `X` and `Y`, or perform in-place normalization.
+            Whether to copy `X` and `y`, or perform in-place normalization.
 
         Returns
         -------
         x_scores, y_scores : array-like or tuple of array-like
-            Return `x_scores` if `Y` is not given, `(x_scores, y_scores)` otherwise.
+            Return `x_scores` if `y` is not given, `(x_scores, y_scores)` otherwise.
         """
-        y = _deprecate_Y_when_optional(y, Y)
-
         check_is_fitted(self)
         X = validate_data(self, X, copy=copy, dtype=FLOAT_DTYPES, reset=False)
         # Normalize
@@ -443,7 +404,7 @@ class _PLS(
 
         return x_scores
 
-    def inverse_transform(self, X, y=None, Y=None):
+    def inverse_transform(self, X, y=None):
         """Transform data back to its original space.
 
         Parameters
@@ -455,13 +416,6 @@ class _PLS(
         y : array-like of shape (n_samples,) or (n_samples, n_components)
             New target, where `n_samples` is the number of samples
             and `n_components` is the number of pls components.
-
-        Y : array-like of shape (n_samples, n_components)
-            New target, where `n_samples` is the number of samples
-            and `n_components` is the number of pls components.
-
-            .. deprecated:: 1.5
-               `Y` is deprecated in 1.5 and will be removed in 1.7. Use `y` instead.
 
         Returns
         -------
@@ -475,8 +429,6 @@ class _PLS(
         -----
         This transformation will only be exact if `n_components=n_features`.
         """
-        y = _deprecate_Y_when_optional(y, Y)
-
         check_is_fitted(self)
         X = check_array(X, input_name="X", dtype=FLOAT_DTYPES)
         # From pls space to original space
@@ -505,7 +457,7 @@ class _PLS(
             Samples.
 
         copy : bool, default=True
-            Whether to copy `X` and `Y`, or perform in-place normalization.
+            Whether to copy `X` or perform in-place normalization.
 
         Returns
         -------
@@ -522,8 +474,8 @@ class _PLS(
         X = validate_data(self, X, copy=copy, dtype=FLOAT_DTYPES, reset=False)
         # Only center X but do not scale it since the coefficients are already scaled
         X -= self._x_mean
-        Ypred = X @ self.coef_.T + self.intercept_
-        return Ypred.ravel() if self._predict_1d else Ypred
+        y_pred = X @ self.coef_.T + self.intercept_
+        return y_pred.ravel() if self._predict_1d else y_pred
 
     def fit_transform(self, X, y=None):
         """Learn and apply the dimension reduction on the train data.
@@ -541,7 +493,7 @@ class _PLS(
         Returns
         -------
         self : ndarray of shape (n_samples, n_components)
-            Return `x_scores` if `Y` is not given, `(x_scores, y_scores)` otherwise.
+            Return `x_scores` if `y` is not given, `(x_scores, y_scores)` otherwise.
         """
         return self.fit(X, y).transform(X, y)
 
@@ -571,7 +523,7 @@ class PLSRegression(_PLS):
         Number of components to keep. Should be in `[1, n_features]`.
 
     scale : bool, default=True
-        Whether to scale `X` and `Y`.
+        Whether to scale `X` and `y`.
 
     max_iter : int, default=500
         The maximum number of iterations of the power method when
@@ -583,7 +535,7 @@ class PLSRegression(_PLS):
         than `tol`, where `u` corresponds to the left singular vector.
 
     copy : bool, default=True
-        Whether to copy `X` and `Y` in :term:`fit` before applying centering,
+        Whether to copy `X` and `y` in :term:`fit` before applying centering,
         and potentially scaling. If `False`, these operations will be done
         inplace, modifying both arrays.
 
@@ -601,7 +553,7 @@ class PLSRegression(_PLS):
         The loadings of `X`.
 
     y_loadings_ : ndarray of shape (n_targets, n_components)
-        The loadings of `Y`.
+        The loadings of `y`.
 
     x_scores_ : ndarray of shape (n_samples, n_components)
         The transformed training samples.
@@ -613,15 +565,15 @@ class PLSRegression(_PLS):
         The projection matrix used to transform `X`.
 
     y_rotations_ : ndarray of shape (n_targets, n_components)
-        The projection matrix used to transform `Y`.
+        The projection matrix used to transform `y`.
 
     coef_ : ndarray of shape (n_target, n_features)
-        The coefficients of the linear model such that `Y` is approximated as
-        `Y = X @ coef_.T + intercept_`.
+        The coefficients of the linear model such that `y` is approximated as
+        `y = X @ coef_.T + intercept_`.
 
     intercept_ : ndarray of shape (n_targets,)
-        The intercepts of the linear model such that `Y` is approximated as
-        `Y = X @ coef_.T + intercept_`.
+        The intercepts of the linear model such that `y` is approximated as
+        `y = X @ coef_.T + intercept_`.
 
         .. versionadded:: 1.1
 
@@ -650,7 +602,7 @@ class PLSRegression(_PLS):
     >>> pls2 = PLSRegression(n_components=2)
     >>> pls2.fit(X, y)
     PLSRegression()
-    >>> Y_pred = pls2.predict(X)
+    >>> y_pred = pls2.predict(X)
 
     For a comparison between PLS Regression and :class:`~sklearn.decomposition.PCA`, see
     :ref:`sphx_glr_auto_examples_cross_decomposition_plot_pcr_vs_pls.py`.
@@ -662,9 +614,9 @@ class PLSRegression(_PLS):
 
     # This implementation provides the same results that 3 PLS packages
     # provided in the R language (R-project):
-    #     - "mixOmics" with function pls(X, Y, mode = "regression")
-    #     - "plspm " with function plsreg2(X, Y)
-    #     - "pls" with function oscorespls.fit(X, Y)
+    #     - "mixOmics" with function pls(X, y, mode = "regression")
+    #     - "plspm " with function plsreg2(X, y)
+    #     - "pls" with function oscorespls.fit(X, y)
 
     def __init__(
         self, n_components=2, *, scale=True, max_iter=500, tol=1e-06, copy=True
@@ -680,7 +632,7 @@ class PLSRegression(_PLS):
             copy=copy,
         )
 
-    def fit(self, X, y=None, Y=None):
+    def fit(self, X, y):
         """Fit model to data.
 
         Parameters
@@ -693,20 +645,11 @@ class PLSRegression(_PLS):
             Target vectors, where `n_samples` is the number of samples and
             `n_targets` is the number of response variables.
 
-        Y : array-like of shape (n_samples,) or (n_samples, n_targets)
-            Target vectors, where `n_samples` is the number of samples and
-            `n_targets` is the number of response variables.
-
-            .. deprecated:: 1.5
-               `Y` is deprecated in 1.5 and will be removed in 1.7. Use `y` instead.
-
         Returns
         -------
         self : object
             Fitted model.
         """
-        y = _deprecate_Y_when_required(y, Y)
-
         super().fit(X, y)
         # expose the fitted attributes `x_scores_` and `y_scores_`
         self.x_scores_ = self._x_scores
@@ -731,7 +674,7 @@ class PLSCanonical(_PLS):
         n_features, n_targets)]`.
 
     scale : bool, default=True
-        Whether to scale `X` and `Y`.
+        Whether to scale `X` and `y`.
 
     algorithm : {'nipals', 'svd'}, default='nipals'
         The algorithm used to estimate the first singular vectors of the
@@ -748,7 +691,7 @@ class PLSCanonical(_PLS):
         than `tol`, where `u` corresponds to the left singular vector.
 
     copy : bool, default=True
-        Whether to copy `X` and `Y` in fit before applying centering, and
+        Whether to copy `X` and `y` in fit before applying centering, and
         potentially scaling. If False, these operations will be done inplace,
         modifying both arrays.
 
@@ -766,21 +709,21 @@ class PLSCanonical(_PLS):
         The loadings of `X`.
 
     y_loadings_ : ndarray of shape (n_targets, n_components)
-        The loadings of `Y`.
+        The loadings of `y`.
 
     x_rotations_ : ndarray of shape (n_features, n_components)
         The projection matrix used to transform `X`.
 
     y_rotations_ : ndarray of shape (n_targets, n_components)
-        The projection matrix used to transform `Y`.
+        The projection matrix used to transform `y`.
 
     coef_ : ndarray of shape (n_targets, n_features)
-        The coefficients of the linear model such that `Y` is approximated as
-        `Y = X @ coef_.T + intercept_`.
+        The coefficients of the linear model such that `y` is approximated as
+        `y = X @ coef_.T + intercept_`.
 
     intercept_ : ndarray of shape (n_targets,)
-        The intercepts of the linear model such that `Y` is approximated as
-        `Y = X @ coef_.T + intercept_`.
+        The intercepts of the linear model such that `y` is approximated as
+        `y = X @ coef_.T + intercept_`.
 
         .. versionadded:: 1.1
 
@@ -818,7 +761,7 @@ class PLSCanonical(_PLS):
         _parameter_constraints.pop(param)
 
     # This implementation provides the same results that the "plspm" package
-    # provided in the R language (R-project), using the function plsca(X, Y).
+    # provided in the R language (R-project), using the function plsca(X, y).
     # Results are equal or collinear with the function
     # ``pls(..., mode = "canonical")`` of the "mixOmics" package. The
     # difference relies in the fact that mixOmics implementation does not
@@ -862,7 +805,7 @@ class CCA(_PLS):
         n_features, n_targets)]`.
 
     scale : bool, default=True
-        Whether to scale `X` and `Y`.
+        Whether to scale `X` and `y`.
 
     max_iter : int, default=500
         The maximum number of iterations of the power method.
@@ -873,7 +816,7 @@ class CCA(_PLS):
         than `tol`, where `u` corresponds to the left singular vector.
 
     copy : bool, default=True
-        Whether to copy `X` and `Y` in fit before applying centering, and
+        Whether to copy `X` and `y` in fit before applying centering, and
         potentially scaling. If False, these operations will be done inplace,
         modifying both arrays.
 
@@ -891,21 +834,21 @@ class CCA(_PLS):
         The loadings of `X`.
 
     y_loadings_ : ndarray of shape (n_targets, n_components)
-        The loadings of `Y`.
+        The loadings of `y`.
 
     x_rotations_ : ndarray of shape (n_features, n_components)
         The projection matrix used to transform `X`.
 
     y_rotations_ : ndarray of shape (n_targets, n_components)
-        The projection matrix used to transform `Y`.
+        The projection matrix used to transform `y`.
 
     coef_ : ndarray of shape (n_targets, n_features)
-        The coefficients of the linear model such that `Y` is approximated as
-        `Y = X @ coef_.T + intercept_`.
+        The coefficients of the linear model such that `y` is approximated as
+        `y = X @ coef_.T + intercept_`.
 
     intercept_ : ndarray of shape (n_targets,)
-        The intercepts of the linear model such that `Y` is approximated as
-        `Y = X @ coef_.T + intercept_`.
+        The intercepts of the linear model such that `y` is approximated as
+        `y = X @ coef_.T + intercept_`.
 
         .. versionadded:: 1.1
 
@@ -935,7 +878,7 @@ class CCA(_PLS):
     >>> cca = CCA(n_components=1)
     >>> cca.fit(X, y)
     CCA(n_components=1)
-    >>> X_c, Y_c = cca.transform(X, y)
+    >>> X_c, y_c = cca.transform(X, y)
     """
 
     _parameter_constraints: dict = {**_PLS._parameter_constraints}
@@ -961,8 +904,8 @@ class PLSSVD(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
     """Partial Least Square SVD.
 
     This transformer simply performs a SVD on the cross-covariance matrix
-    `X'Y`. It is able to project both the training data `X` and the targets
-    `Y`. The training data `X` is projected on the left singular vectors, while
+    `X'y`. It is able to project both the training data `X` and the targets
+    `y`. The training data `X` is projected on the left singular vectors, while
     the targets are projected on the right singular vectors.
 
     Read more in the :ref:`User Guide <cross_decomposition>`.
@@ -976,10 +919,10 @@ class PLSSVD(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         min(n_samples, n_features, n_targets)]`.
 
     scale : bool, default=True
-        Whether to scale `X` and `Y`.
+        Whether to scale `X` and `y`.
 
     copy : bool, default=True
-        Whether to copy `X` and `Y` in fit before applying centering, and
+        Whether to copy `X` and `y` in fit before applying centering, and
         potentially scaling. If `False`, these operations will be done inplace,
         modifying both arrays.
 
@@ -1037,7 +980,7 @@ class PLSSVD(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         self.copy = copy
 
     @_fit_context(prefer_skip_nested_validation=True)
-    def fit(self, X, y=None, Y=None):
+    def fit(self, X, y):
         """Fit model to data.
 
         Parameters
@@ -1048,18 +991,11 @@ class PLSSVD(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         y : array-like of shape (n_samples,) or (n_samples, n_targets)
             Targets.
 
-        Y : array-like of shape (n_samples,) or (n_samples, n_targets)
-            Targets.
-
-            .. deprecated:: 1.5
-               `Y` is deprecated in 1.5 and will be removed in 1.7. Use `y` instead.
-
         Returns
         -------
         self : object
             Fitted estimator.
         """
-        y = _deprecate_Y_when_required(y, Y)
         check_consistent_length(X, y)
         X = validate_data(
             self,
@@ -1108,7 +1044,7 @@ class PLSSVD(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         self._n_features_out = self.x_weights_.shape[1]
         return self
 
-    def transform(self, X, y=None, Y=None):
+    def transform(self, X, y=None):
         """
         Apply the dimensionality reduction.
 
@@ -1121,20 +1057,12 @@ class PLSSVD(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
                 default=None
             Targets.
 
-        Y : array-like of shape (n_samples,) or (n_samples, n_targets), \
-                default=None
-            Targets.
-
-            .. deprecated:: 1.5
-               `Y` is deprecated in 1.5 and will be removed in 1.7. Use `y` instead.
-
         Returns
         -------
         x_scores : array-like or tuple of array-like
-            The transformed data `X_transformed` if `Y is not None`,
-            `(X_transformed, Y_transformed)` otherwise.
+            The transformed data `X_transformed` if `y is not None`,
+            `(X_transformed, y_transformed)` otherwise.
         """
-        y = _deprecate_Y_when_optional(y, Y)
         check_is_fitted(self)
         X = validate_data(self, X, dtype=np.float64, reset=False)
         Xr = (X - self._x_mean) / self._x_std
@@ -1163,7 +1091,7 @@ class PLSSVD(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         Returns
         -------
         out : array-like or tuple of array-like
-            The transformed data `X_transformed` if `Y is not None`,
-            `(X_transformed, Y_transformed)` otherwise.
+            The transformed data `X_transformed` if `y is not None`,
+            `(X_transformed, y_transformed)` otherwise.
         """
         return self.fit(X, y).transform(X, y)

--- a/sklearn/cross_decomposition/tests/test_pls.py
+++ b/sklearn/cross_decomposition/tests/test_pls.py
@@ -28,40 +28,40 @@ def test_pls_canonical_basics():
     # Basic checks for PLSCanonical
     d = load_linnerud()
     X = d.data
-    Y = d.target
+    y = d.target
 
     pls = PLSCanonical(n_components=X.shape[1])
-    pls.fit(X, Y)
+    pls.fit(X, y)
 
     assert_matrix_orthogonal(pls.x_weights_)
     assert_matrix_orthogonal(pls.y_weights_)
     assert_matrix_orthogonal(pls._x_scores)
     assert_matrix_orthogonal(pls._y_scores)
 
-    # Check X = TP' and Y = UQ'
+    # Check X = TP' and y = UQ'
     T = pls._x_scores
     P = pls.x_loadings_
     U = pls._y_scores
     Q = pls.y_loadings_
     # Need to scale first
-    Xc, Yc, x_mean, y_mean, x_std, y_std = _center_scale_xy(
-        X.copy(), Y.copy(), scale=True
+    Xc, yc, x_mean, y_mean, x_std, y_std = _center_scale_xy(
+        X.copy(), y.copy(), scale=True
     )
     assert_array_almost_equal(Xc, np.dot(T, P.T))
-    assert_array_almost_equal(Yc, np.dot(U, Q.T))
+    assert_array_almost_equal(yc, np.dot(U, Q.T))
 
     # Check that rotations on training data lead to scores
     Xt = pls.transform(X)
     assert_array_almost_equal(Xt, pls._x_scores)
-    Xt, Yt = pls.transform(X, Y)
+    Xt, yt = pls.transform(X, y)
     assert_array_almost_equal(Xt, pls._x_scores)
-    assert_array_almost_equal(Yt, pls._y_scores)
+    assert_array_almost_equal(yt, pls._y_scores)
 
     # Check that inverse_transform works
     X_back = pls.inverse_transform(Xt)
     assert_array_almost_equal(X_back, X)
-    _, Y_back = pls.inverse_transform(Xt, Yt)
-    assert_array_almost_equal(Y_back, Y)
+    _, y_back = pls.inverse_transform(Xt, yt)
+    assert_array_almost_equal(y_back, y)
 
 
 def test_sanity_check_pls_regression():
@@ -70,10 +70,10 @@ def test_sanity_check_pls_regression():
 
     d = load_linnerud()
     X = d.data
-    Y = d.target
+    y = d.target
 
     pls = PLSRegression(n_components=X.shape[1])
-    X_trans, _ = pls.fit_transform(X, Y)
+    X_trans, _ = pls.fit_transform(X, y)
 
     # FIXME: one would expect y_trans == pls.y_scores_ but this is not
     # the case.
@@ -127,16 +127,16 @@ def test_sanity_check_pls_regression():
     assert_array_almost_equal(y_loadings_sign_flip, y_weights_sign_flip)
 
 
-def test_sanity_check_pls_regression_constant_column_Y():
-    # Check behavior when the first column of Y is constant
+def test_sanity_check_pls_regression_constant_column_y():
+    # Check behavior when the first column of y is constant
     # The results are checked against a modified version of plsreg2
     # from the R-package plsdepot
     d = load_linnerud()
     X = d.data
-    Y = d.target
-    Y[:, 0] = 1
+    y = d.target
+    y[:, 0] = 1
     pls = PLSRegression(n_components=X.shape[1])
-    pls.fit(X, Y)
+    pls.fit(X, y)
 
     expected_x_weights = np.array(
         [
@@ -183,10 +183,10 @@ def test_sanity_check_pls_canonical():
 
     d = load_linnerud()
     X = d.data
-    Y = d.target
+    y = d.target
 
     pls = PLSCanonical(n_components=X.shape[1])
-    pls.fit(X, Y)
+    pls.fit(X, y)
 
     expected_x_weights = np.array(
         [
@@ -251,12 +251,12 @@ def test_sanity_check_pls_canonical_random():
     l2 = rng.normal(size=n)
     latents = np.array([l1, l1, l2, l2]).T
     X = latents + rng.normal(size=4 * n).reshape((n, 4))
-    Y = latents + rng.normal(size=4 * n).reshape((n, 4))
+    y = latents + rng.normal(size=4 * n).reshape((n, 4))
     X = np.concatenate((X, rng.normal(size=p_noise * n).reshape(n, p_noise)), axis=1)
-    Y = np.concatenate((Y, rng.normal(size=q_noise * n).reshape(n, q_noise)), axis=1)
+    y = np.concatenate((y, rng.normal(size=q_noise * n).reshape(n, q_noise)), axis=1)
 
     pls = PLSCanonical(n_components=3)
-    pls.fit(X, Y)
+    pls.fit(X, y)
 
     expected_x_weights = np.array(
         [
@@ -347,10 +347,10 @@ def test_convergence_fail():
     # Make sure ConvergenceWarning is raised if max_iter is too small
     d = load_linnerud()
     X = d.data
-    Y = d.target
+    y = d.target
     pls_nipals = PLSCanonical(n_components=X.shape[1], max_iter=2)
     with pytest.warns(ConvergenceWarning):
-        pls_nipals.fit(X, Y)
+        pls_nipals.fit(X, y)
 
 
 @pytest.mark.parametrize("Est", (PLSSVD, PLSRegression, PLSCanonical))
@@ -358,10 +358,10 @@ def test_attibutes_shapes(Est):
     # Make sure attributes are of the correct shape depending on n_components
     d = load_linnerud()
     X = d.data
-    Y = d.target
+    y = d.target
     n_components = 2
     pls = Est(n_components=n_components)
-    pls.fit(X, Y)
+    pls.fit(X, y)
     assert all(
         attr.shape[1] == n_components for attr in (pls.x_weights_, pls.y_weights_)
     )
@@ -369,14 +369,14 @@ def test_attibutes_shapes(Est):
 
 @pytest.mark.parametrize("Est", (PLSRegression, PLSCanonical, CCA))
 def test_univariate_equivalence(Est):
-    # Ensure 2D Y with 1 column is equivalent to 1D Y
+    # Ensure 2D y with 1 column is equivalent to 1D y
     d = load_linnerud()
     X = d.data
-    Y = d.target
+    y = d.target
 
     est = Est(n_components=1)
-    one_d_coeff = est.fit(X, Y[:, 0]).coef_
-    two_d_coeff = est.fit(X, Y[:, :1]).coef_
+    one_d_coeff = est.fit(X, y[:, 0]).coef_
+    two_d_coeff = est.fit(X, y[:, :1]).coef_
 
     assert one_d_coeff.shape == two_d_coeff.shape
     assert_array_almost_equal(one_d_coeff, two_d_coeff)
@@ -387,16 +387,16 @@ def test_copy(Est):
     # check that the "copy" keyword works
     d = load_linnerud()
     X = d.data
-    Y = d.target
+    y = d.target
     X_orig = X.copy()
 
     # copy=True won't modify inplace
-    pls = Est(copy=True).fit(X, Y)
+    pls = Est(copy=True).fit(X, y)
     assert_array_equal(X, X_orig)
 
     # copy=False will modify inplace
     with pytest.raises(AssertionError):
-        Est(copy=False).fit(X, Y)
+        Est(copy=False).fit(X, y)
         assert_array_almost_equal(X, X_orig)
 
     if Est is PLSSVD:
@@ -404,7 +404,7 @@ def test_copy(Est):
 
     X_orig = X.copy()
     with pytest.raises(AssertionError):
-        pls.transform(X, Y, copy=False),
+        pls.transform(X, y, copy=False),
         assert_array_almost_equal(X, X_orig)
 
     X_orig = X.copy()
@@ -414,7 +414,7 @@ def test_copy(Est):
 
     # Make sure copy=True gives same transform and predictions as predict=False
     assert_array_almost_equal(
-        pls.transform(X, Y, copy=True), pls.transform(X.copy(), Y.copy(), copy=False)
+        pls.transform(X, y, copy=True), pls.transform(X.copy(), y.copy(), copy=False)
     )
     assert_array_almost_equal(
         pls.predict(X, copy=True), pls.predict(X.copy(), copy=False)
@@ -429,43 +429,43 @@ def _generate_test_scale_and_stability_datasets():
     n_targets = 5
     n_features = 10
     Q = rng.randn(n_targets, n_features)
-    Y = rng.randn(n_samples, n_targets)
-    X = np.dot(Y, Q) + 2 * rng.randn(n_samples, n_features) + 1
+    y = rng.randn(n_samples, n_targets)
+    X = np.dot(y, Q) + 2 * rng.randn(n_samples, n_features) + 1
     X *= 1000
-    yield X, Y
+    yield X, y
 
     # Data set where one of the features is constraint
-    X, Y = load_linnerud(return_X_y=True)
+    X, y = load_linnerud(return_X_y=True)
     # causes X[:, -1].std() to be zero
     X[:, -1] = 1.0
-    yield X, Y
+    yield X, y
 
     X = np.array([[0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [2.0, 2.0, 2.0], [3.0, 5.0, 4.0]])
-    Y = np.array([[0.1, -0.2], [0.9, 1.1], [6.2, 5.9], [11.9, 12.3]])
-    yield X, Y
+    y = np.array([[0.1, -0.2], [0.9, 1.1], [6.2, 5.9], [11.9, 12.3]])
+    yield X, y
 
     # Seeds that provide a non-regression test for #18746, where CCA fails
     seeds = [530, 741]
     for seed in seeds:
         rng = np.random.RandomState(seed)
         X = rng.randn(4, 3)
-        Y = rng.randn(4, 2)
-        yield X, Y
+        y = rng.randn(4, 2)
+        yield X, y
 
 
 @pytest.mark.parametrize("Est", (CCA, PLSCanonical, PLSRegression, PLSSVD))
-@pytest.mark.parametrize("X, Y", _generate_test_scale_and_stability_datasets())
-def test_scale_and_stability(Est, X, Y):
+@pytest.mark.parametrize("X, y", _generate_test_scale_and_stability_datasets())
+def test_scale_and_stability(Est, X, y):
     """scale=True is equivalent to scale=False on centered/scaled data
     This allows to check numerical stability over platforms as well"""
 
-    X_s, Y_s, *_ = _center_scale_xy(X, Y)
+    X_s, y_s, *_ = _center_scale_xy(X, y)
 
-    X_score, Y_score = Est(scale=True).fit_transform(X, Y)
-    X_s_score, Y_s_score = Est(scale=False).fit_transform(X_s, Y_s)
+    X_score, y_score = Est(scale=True).fit_transform(X, y)
+    X_s_score, y_s_score = Est(scale=False).fit_transform(X_s, y_s)
 
     assert_allclose(X_s_score, X_score, atol=1e-4)
-    assert_allclose(Y_s_score, Y_score, atol=1e-4)
+    assert_allclose(y_s_score, y_score, atol=1e-4)
 
 
 @pytest.mark.parametrize("Estimator", (PLSSVD, PLSRegression, PLSCanonical, CCA))
@@ -473,32 +473,32 @@ def test_n_components_upper_bounds(Estimator):
     """Check the validation of `n_components` upper bounds for `PLS` regressors."""
     rng = np.random.RandomState(0)
     X = rng.randn(10, 5)
-    Y = rng.randn(10, 3)
+    y = rng.randn(10, 3)
     est = Estimator(n_components=10)
     err_msg = "`n_components` upper bound is .*. Got 10 instead. Reduce `n_components`."
     with pytest.raises(ValueError, match=err_msg):
-        est.fit(X, Y)
+        est.fit(X, y)
 
 
 def test_n_components_upper_PLSRegression():
     """Check the validation of `n_components` upper bounds for PLSRegression."""
     rng = np.random.RandomState(0)
     X = rng.randn(20, 64)
-    Y = rng.randn(20, 3)
+    y = rng.randn(20, 3)
     est = PLSRegression(n_components=30)
     err_msg = "`n_components` upper bound is 20. Got 30 instead. Reduce `n_components`."
     with pytest.raises(ValueError, match=err_msg):
-        est.fit(X, Y)
+        est.fit(X, y)
 
 
 @pytest.mark.parametrize("n_samples, n_features", [(100, 10), (100, 200)])
 def test_singular_value_helpers(n_samples, n_features, global_random_seed):
     # Make sure SVD and power method give approximately the same results
-    X, Y = make_regression(
+    X, y = make_regression(
         n_samples, n_features, n_targets=5, random_state=global_random_seed
     )
-    u1, v1, _ = _get_first_singular_vectors_power_method(X, Y, norm_y_weights=True)
-    u2, v2 = _get_first_singular_vectors_svd(X, Y)
+    u1, v1, _ = _get_first_singular_vectors_power_method(X, y, norm_y_weights=True)
+    u2, v2 = _get_first_singular_vectors_svd(X, y)
 
     _svd_flip_1d(u1, v1)
     _svd_flip_1d(u2, v2)
@@ -512,10 +512,10 @@ def test_singular_value_helpers(n_samples, n_features, global_random_seed):
 def test_one_component_equivalence(global_random_seed):
     # PLSSVD, PLSRegression and PLSCanonical should all be equivalent when
     # n_components is 1
-    X, Y = make_regression(100, 10, n_targets=5, random_state=global_random_seed)
-    svd = PLSSVD(n_components=1).fit(X, Y).transform(X)
-    reg = PLSRegression(n_components=1).fit(X, Y).transform(X)
-    canonical = PLSCanonical(n_components=1).fit(X, Y).transform(X)
+    X, y = make_regression(100, 10, n_targets=5, random_state=global_random_seed)
+    svd = PLSSVD(n_components=1).fit(X, y).transform(X)
+    reg = PLSRegression(n_components=1).fit(X, y).transform(X)
+    canonical = PLSCanonical(n_components=1).fit(X, y).transform(X)
 
     rtol = 1e-3
     # Setting atol because some entries are very close to zero
@@ -579,11 +579,11 @@ def test_pls_coef_shape(PLSEstimator):
     """
     d = load_linnerud()
     X = d.data
-    Y = d.target
+    y = d.target
 
-    pls = PLSEstimator(copy=True).fit(X, Y)
+    pls = PLSEstimator(copy=True).fit(X, y)
 
-    n_targets, n_features = Y.shape[1], X.shape[1]
+    n_targets, n_features = y.shape[1], X.shape[1]
     assert pls.coef_.shape == (n_targets, n_features)
 
 
@@ -593,24 +593,24 @@ def test_pls_prediction(PLSEstimator, scale):
     """Check the behaviour of the prediction function."""
     d = load_linnerud()
     X = d.data
-    Y = d.target
+    y = d.target
 
-    pls = PLSEstimator(copy=True, scale=scale).fit(X, Y)
-    Y_pred = pls.predict(X, copy=True)
+    pls = PLSEstimator(copy=True, scale=scale).fit(X, y)
+    y_pred = pls.predict(X, copy=True)
 
-    y_mean = Y.mean(axis=0)
+    y_mean = y.mean(axis=0)
     X_trans = X - X.mean(axis=0)
 
     assert_allclose(pls.intercept_, y_mean)
-    assert_allclose(Y_pred, X_trans @ pls.coef_.T + pls.intercept_)
+    assert_allclose(y_pred, X_trans @ pls.coef_.T + pls.intercept_)
 
 
 @pytest.mark.parametrize("Klass", [CCA, PLSSVD, PLSRegression, PLSCanonical])
 def test_pls_feature_names_out(Klass):
     """Check `get_feature_names_out` cross_decomposition module."""
-    X, Y = load_linnerud(return_X_y=True)
+    X, y = load_linnerud(return_X_y=True)
 
-    est = Klass().fit(X, Y)
+    est = Klass().fit(X, y)
     names_out = est.get_feature_names_out()
 
     class_name_lower = Klass.__name__.lower()
@@ -625,10 +625,10 @@ def test_pls_feature_names_out(Klass):
 def test_pls_set_output(Klass):
     """Check `set_output` in cross_decomposition module."""
     pd = pytest.importorskip("pandas")
-    X, Y = load_linnerud(return_X_y=True, as_frame=True)
+    X, y = load_linnerud(return_X_y=True, as_frame=True)
 
-    est = Klass().set_output(transform="pandas").fit(X, Y)
-    X_trans, y_trans = est.transform(X, Y)
+    est = Klass().set_output(transform="pandas").fit(X, y)
+    X_trans, y_trans = est.transform(X, y)
     assert isinstance(y_trans, np.ndarray)
     assert isinstance(X_trans, pd.DataFrame)
     assert_array_equal(X_trans.columns, est.get_feature_names_out())
@@ -657,94 +657,21 @@ def test_pls_regression_fit_1d_y():
 
 def test_pls_regression_scaling_coef():
     """Check that when using `scale=True`, the coefficients are using the std. dev. from
-    both `X` and `Y`.
+    both `X` and `y`.
 
     Non-regression test for:
     https://github.com/scikit-learn/scikit-learn/issues/27964
     """
-    # handcrafted data where we can predict Y from X with an additional scaling factor
+    # handcrafted data where we can predict y from X with an additional scaling factor
     rng = np.random.RandomState(0)
     coef = rng.uniform(size=(3, 5))
     X = rng.normal(scale=10, size=(30, 5))  # add a std of 10
-    Y = X @ coef.T
+    y = X @ coef.T
 
     # we need to make sure that the dimension of the latent space is large enough to
-    # perfectly predict `Y` from `X` (no information loss)
-    pls = PLSRegression(n_components=5, scale=True).fit(X, Y)
+    # perfectly predict `y` from `X` (no information loss)
+    pls = PLSRegression(n_components=5, scale=True).fit(X, y)
     assert_allclose(pls.coef_, coef)
 
-    # we therefore should be able to predict `Y` from `X`
-    assert_allclose(pls.predict(X), Y)
-
-
-# TODO(1.7): Remove
-@pytest.mark.parametrize("Klass", [PLSRegression, CCA, PLSSVD, PLSCanonical])
-def test_pls_fit_warning_on_deprecated_Y_argument(Klass):
-    # Test warning message is shown when using Y instead of y
-
-    d = load_linnerud()
-    X = d.data
-    Y = d.target
-    y = d.target
-
-    msg = "`Y` is deprecated in 1.5 and will be removed in 1.7. Use `y` instead."
-    with pytest.warns(FutureWarning, match=msg):
-        Klass().fit(X=X, Y=Y)
-
-    err_msg1 = "Cannot use both `y` and `Y`. Use only `y` as `Y` is deprecated."
-    with (
-        pytest.warns(FutureWarning, match=msg),
-        pytest.raises(ValueError, match=err_msg1),
-    ):
-        Klass().fit(X, y, Y)
-
-    err_msg2 = "y is required."
-    with pytest.raises(ValueError, match=err_msg2):
-        Klass().fit(X)
-
-
-# TODO(1.7): Remove
-@pytest.mark.parametrize("Klass", [PLSRegression, CCA, PLSSVD, PLSCanonical])
-def test_pls_transform_warning_on_deprecated_Y_argument(Klass):
-    # Test warning message is shown when using Y instead of y
-
-    d = load_linnerud()
-    X = d.data
-    Y = d.target
-    y = d.target
-
-    plsr = Klass().fit(X, y)
-    msg = "`Y` is deprecated in 1.5 and will be removed in 1.7. Use `y` instead."
-    with pytest.warns(FutureWarning, match=msg):
-        plsr.transform(X=X, Y=Y)
-
-    err_msg1 = "Cannot use both `y` and `Y`. Use only `y` as `Y` is deprecated."
-    with (
-        pytest.warns(FutureWarning, match=msg),
-        pytest.raises(ValueError, match=err_msg1),
-    ):
-        plsr.transform(X, y, Y)
-
-
-# TODO(1.7): Remove
-@pytest.mark.parametrize("Klass", [PLSRegression, CCA, PLSCanonical])
-def test_pls_inverse_transform_warning_on_deprecated_Y_argument(Klass):
-    # Test warning message is shown when using Y instead of y
-
-    d = load_linnerud()
-    X = d.data
-    y = d.target
-
-    plsr = Klass().fit(X, y)
-    X_transformed, y_transformed = plsr.transform(X, y)
-
-    msg = "`Y` is deprecated in 1.5 and will be removed in 1.7. Use `y` instead."
-    with pytest.warns(FutureWarning, match=msg):
-        plsr.inverse_transform(X=X_transformed, Y=y_transformed)
-
-    err_msg1 = "Cannot use both `y` and `Y`. Use only `y` as `Y` is deprecated."
-    with (
-        pytest.warns(FutureWarning, match=msg),
-        pytest.raises(ValueError, match=err_msg1),
-    ):
-        plsr.inverse_transform(X=X_transformed, y=y_transformed, Y=y_transformed)
+    # we therefore should be able to predict `y` from `X`
+    assert_allclose(pls.predict(X), y)


### PR DESCRIPTION
Removed deprecated `Y` in `PLS*` estimators.

I also replaced all remaining occurrences of `Y` by `y` in the code and docstrings, even in private functions, for consistency and to prevent confusion.
Should we replace in the user guide as well ? It can be done in a subsequent PR though.