### PR TITLE
MNT Fix rst issues found by sphinx-lint

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -292,10 +292,10 @@ how to set up your git repository:
 
    .. code-block:: text
 
-        origin	git@github.com:YourLogin/scikit-learn.git (fetch)
-        origin	git@github.com:YourLogin/scikit-learn.git (push)
-        upstream	git@github.com:scikit-learn/scikit-learn.git (fetch)
-        upstream	git@github.com:scikit-learn/scikit-learn.git (push)
+        origin    git@github.com:YourLogin/scikit-learn.git (fetch)
+        origin    git@github.com:YourLogin/scikit-learn.git (push)
+        upstream  git@github.com:scikit-learn/scikit-learn.git (fetch)
+        upstream  git@github.com:scikit-learn/scikit-learn.git (push)
 
 You should now have a working installation of scikit-learn, and your git repository
 properly configured. It could be useful to run some test to verify your installation.

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -499,7 +499,7 @@ Estimator Tags
 The estimator tags are annotations of estimators that allow programmatic inspection of
 their capabilities, such as sparse matrix support, supported output types and supported
 methods. The estimator tags are an instance of :class:`~sklearn.utils.Tags` returned by
-the method :meth:`~sklearn.base.BaseEstimator.__sklearn_tags__()`. These tags are used
+the method :meth:`~sklearn.base.BaseEstimator.__sklearn_tags__`. These tags are used
 in different places, such as :func:`~base.is_regressor` or the common checks run by
 :func:`~sklearn.utils.estimator_checks.check_estimator` and
 :func:`~sklearn.utils.estimator_checks.parametrize_with_checks`, where tags determine

--- a/doc/modules/cross_validation.rst
+++ b/doc/modules/cross_validation.rst
@@ -931,8 +931,8 @@ A note on shuffling
 ===================
 
 If the data ordering is not arbitrary (e.g. samples with the same class label
-are contiguous), shuffling it first may be essential to get a meaningful cross-
-validation result. However, the opposite may be true if the samples are not
+are contiguous), shuffling it first may be essential to get a meaningful
+cross-validation result. However, the opposite may be true if the samples are not
 independently and identically distributed. For example, if samples correspond
 to news articles, and are ordered by their time of publication, then shuffling
 the data will likely lead to a model that is overfit and an inflated validation
@@ -943,8 +943,8 @@ Some cross validation iterators, such as :class:`KFold`, have an inbuilt option
 to shuffle the data indices before splitting them. Note that:
 
 * This consumes less memory than shuffling the data directly.
-* By default no shuffling occurs, including for the (stratified) K fold cross-
-  validation performed by specifying ``cv=some_integer`` to
+* By default no shuffling occurs, including for the (stratified) K fold
+  cross-validation performed by specifying ``cv=some_integer`` to
   :func:`cross_val_score`, grid search, etc. Keep in mind that
   :func:`train_test_split` still returns a random split.
 * The ``random_state`` parameter defaults to ``None``, meaning that the

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -1404,10 +1404,10 @@ calculated as follows:
 ================  ==========    ==========      ==========
 classifier        class 1       class 2         class 3
 ================  ==========    ==========      ==========
-classifier 1	  w1 * 0.2      w1 * 0.5        w1 * 0.3
-classifier 2	  w2 * 0.6      w2 * 0.3        w2 * 0.1
+classifier 1      w1 * 0.2      w1 * 0.5        w1 * 0.3
+classifier 2      w2 * 0.6      w2 * 0.3        w2 * 0.1
 classifier 3      w3 * 0.3      w3 * 0.4        w3 * 0.3
-weighted average  0.37	        0.4             0.23
+weighted average  0.37          0.4             0.23
 ================  ==========    ==========      ==========
 
 Here, the predicted class label is 2, since it has the highest average probability. See

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -792,9 +792,9 @@ problems which are currently outside of the scope of scikit-learn.
 Vectorizing a large text corpus with the hashing trick
 ------------------------------------------------------
 
-The above vectorization scheme is simple but the fact that it holds an **in-
-memory mapping from the string tokens to the integer feature indices** (the
-``vocabulary_`` attribute) causes several **problems when dealing with large
+The above vectorization scheme is simple but the fact that it holds an
+**in-memory mapping from the string tokens to the integer feature indices**
+(the ``vocabulary_`` attribute) causes several **problems when dealing with large
 datasets**:
 
 - the larger the corpus, the larger the vocabulary will grow and hence the

--- a/doc/modules/lda_qda.rst
+++ b/doc/modules/lda_qda.rst
@@ -93,10 +93,10 @@ predicted class is the one that maximises this log-posterior.
 
 .. note:: **Relation with Gaussian Naive Bayes**
 
-	  If in the QDA model one assumes that the covariance matrices are diagonal,
-	  then the inputs are assumed to be conditionally independent in each class,
-	  and the resulting classifier is equivalent to the Gaussian Naive Bayes
-	  classifier :class:`naive_bayes.GaussianNB`.
+    If in the QDA model one assumes that the covariance matrices are diagonal,
+    then the inputs are assumed to be conditionally independent in each class,
+    and the resulting classifier is equivalent to the Gaussian Naive Bayes
+    classifier :class:`naive_bayes.GaussianNB`.
 
 LDA
 ---

--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -258,7 +258,7 @@ Scoring string name                    Function                                 
 'neg_mean_poisson_deviance'            :func:`metrics.mean_poisson_deviance`
 'neg_mean_gamma_deviance'              :func:`metrics.mean_gamma_deviance`
 'neg_mean_absolute_percentage_error'   :func:`metrics.mean_absolute_percentage_error`
-'d2_absolute_error_score' 	           :func:`metrics.d2_absolute_error_score`
+'d2_absolute_error_score'              :func:`metrics.d2_absolute_error_score`
 ====================================   ==============================================     ==================================
 
 Usage examples:

--- a/doc/modules/multiclass.rst
+++ b/doc/modules/multiclass.rst
@@ -173,12 +173,12 @@ Valid :term:`multiclass` representations for
     >>> y_sparse = sparse.csr_matrix(y_dense)
     >>> print(y_sparse)
     <Compressed Sparse Row sparse matrix of dtype 'int64'
-    	with 4 stored elements and shape (4, 3)>
-      Coords	Values
-      (0, 0)	1
-      (1, 2)	1
-      (2, 0)	1
-      (3, 1)	1
+      with 4 stored elements and shape (4, 3)>
+      Coords Values
+      (0, 0) 1
+      (1, 2) 1
+      (2, 0) 1
+      (3, 1) 1
 
 For more information about :class:`~sklearn.preprocessing.LabelBinarizer`,
 refer to :ref:`preprocessing_targets`.
@@ -384,11 +384,11 @@ An example of the same ``y`` in sparse matrix form:
   >>> print(y_sparse)
   <Compressed Sparse Row sparse matrix of dtype 'int64'
     with 4 stored elements and shape (3, 4)>
-    Coords	Values
-    (0, 0)	1
-    (0, 3)	1
-    (1, 2)	1
-    (1, 3)	1
+    Coords Values
+    (0, 0) 1
+    (0, 3) 1
+    (1, 2) 1
+    (1, 3) 1
 
 .. _multioutputclassfier:
 

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -74,7 +74,7 @@ enhance the functionality of scikit-learn's estimators.
 - `dtreeviz <https://github.com/parrt/dtreeviz/>`_ A Python library for
   decision tree visualization and model interpretation.
 
-- `model-diagnostics <https://lorentzenchr.github.io/model-diagnostics/>` Tools for
+- `model-diagnostics <https://lorentzenchr.github.io/model-diagnostics/>`_ Tools for
   diagnostics and assessment of (machine learning) models (in Python).
 
 - `sklearn-evaluation <https://github.com/ploomber/sklearn-evaluation>`_

--- a/doc/whats_new/v0.15.rst
+++ b/doc/whats_new/v0.15.rst
@@ -184,8 +184,8 @@ Enhancements
 
 - Decision trees can now be fitted on fortran- and c-style arrays, and
   non-continuous arrays without the need to make a copy.
-  If the input array has a different dtype than ``np.float32``, a fortran-
-  style copy will be made since fortran-style memory layout has speed
+  If the input array has a different dtype than ``np.float32``, a
+  fortran-style copy will be made since fortran-style memory layout has speed
   advantages. By `Peter Prettenhofer`_ and `Gilles Louppe`_.
 
 - Speed improvement of regression trees by optimizing the
@@ -461,165 +461,165 @@ People
 
 List of contributors for release 0.15 by number of commits.
 
-* 312	Olivier Grisel
-* 275	Lars Buitinck
-* 221	Gael Varoquaux
-* 148	Arnaud Joly
-* 134	Johannes Schönberger
-* 119	Gilles Louppe
-* 113	Joel Nothman
-* 111	Alexandre Gramfort
-*  95	Jaques Grobler
-*  89	Denis Engemann
-*  83	Peter Prettenhofer
-*  83	Alexander Fabisch
-*  62	Mathieu Blondel
-*  60	Eustache Diemert
-*  60	Nelle Varoquaux
-*  49	Michael Bommarito
-*  45	Manoj-Kumar-S
-*  28	Kyle Kastner
-*  26	Andreas Mueller
-*  22	Noel Dawe
-*  21	Maheshakya Wijewardena
-*  21	Brooke Osborn
-*  21	Hamzeh Alsalhi
-*  21	Jake VanderPlas
-*  21	Philippe Gervais
-*  19	Bala Subrahmanyam Varanasi
-*  12	Ronald Phlypo
-*  10	Mikhail Korobov
-*   8	Thomas Unterthiner
-*   8	Jeffrey Blackburne
-*   8	eltermann
-*   8	bwignall
-*   7	Ankit Agrawal
-*   7	CJ Carey
-*   6	Daniel Nouri
-*   6	Chen Liu
-*   6	Michael Eickenberg
-*   6	ugurthemaster
-*   5	Aaron Schumacher
-*   5	Baptiste Lagarde
-*   5	Rajat Khanduja
-*   5	Robert McGibbon
-*   5	Sergio Pascual
-*   4	Alexis Metaireau
-*   4	Ignacio Rossi
-*   4	Virgile Fritsch
-*   4	Sebastian Säger
-*   4	Ilambharathi Kanniah
-*   4	sdenton4
-*   4	Robert Layton
-*   4	Alyssa
-*   4	Amos Waterland
-*   3	Andrew Tulloch
-*   3	murad
-*   3	Steven Maude
-*   3	Karol Pysniak
-*   3	Jacques Kvam
-*   3	cgohlke
-*   3	cjlin
-*   3	Michael Becker
-*   3	hamzeh
-*   3	Eric Jacobsen
-*   3	john collins
-*   3	kaushik94
-*   3	Erwin Marsi
-*   2	csytracy
-*   2	LK
-*   2	Vlad Niculae
-*   2	Laurent Direr
-*   2	Erik Shilts
-*   2	Raul Garreta
-*   2	Yoshiki Vázquez Baeza
-*   2	Yung Siang Liau
-*   2	abhishek thakur
-*   2	James Yu
-*   2	Rohit Sivaprasad
-*   2	Roland Szabo
-*   2	amormachine
-*   2	Alexis Mignon
-*   2	Oscar Carlsson
-*   2	Nantas Nardelli
-*   2	jess010
-*   2	kowalski87
-*   2	Andrew Clegg
-*   2	Federico Vaggi
-*   2	Simon Frid
-*   2	Félix-Antoine Fortin
-*   1	Ralf Gommers
-*   1	t-aft
-*   1	Ronan Amicel
-*   1	Rupesh Kumar Srivastava
-*   1	Ryan Wang
-*   1	Samuel Charron
-*   1	Samuel St-Jean
-*   1	Fabian Pedregosa
-*   1	Skipper Seabold
-*   1	Stefan Walk
-*   1	Stefan van der Walt
-*   1	Stephan Hoyer
-*   1	Allen Riddell
-*   1	Valentin Haenel
-*   1	Vijay Ramesh
-*   1	Will Myers
-*   1	Yaroslav Halchenko
-*   1	Yoni Ben-Meshulam
-*   1	Yury V. Zaytsev
-*   1	adrinjalali
-*   1	ai8rahim
-*   1	alemagnani
-*   1	alex
-*   1	benjamin wilson
-*   1	chalmerlowe
-*   1	dzikie drożdże
-*   1	jamestwebber
-*   1	matrixorz
-*   1	popo
-*   1	samuela
-*   1	François Boulogne
-*   1	Alexander Measure
-*   1	Ethan White
-*   1	Guilherme Trein
-*   1	Hendrik Heuer
-*   1	IvicaJovic
-*   1	Jan Hendrik Metzen
-*   1	Jean Michel Rouly
-*   1	Eduardo Ariño de la Rubia
-*   1	Jelle Zijlstra
-*   1	Eddy L O Jansson
-*   1	Denis
-*   1	John
-*   1	John Schmidt
-*   1	Jorge Cañardo Alastuey
-*   1	Joseph Perla
-*   1	Joshua Vredevoogd
-*   1	José Ricardo
-*   1	Julien Miotte
-*   1	Kemal Eren
-*   1	Kenta Sato
-*   1	David Cournapeau
-*   1	Kyle Kelley
-*   1	Daniele Medri
-*   1	Laurent Luce
-*   1	Laurent Pierron
-*   1	Luis Pedro Coelho
-*   1	DanielWeitzenfeld
-*   1	Craig Thompson
-*   1	Chyi-Kwei Yau
-*   1	Matthew Brett
-*   1	Matthias Feurer
-*   1	Max Linke
-*   1	Chris Filo Gorgolewski
-*   1	Charles Earl
-*   1	Michael Hanke
-*   1	Michele Orrù
-*   1	Bryan Lunt
-*   1	Brian Kearns
-*   1	Paul Butler
-*   1	Paweł Mandera
-*   1	Peter
-*   1	Andrew Ash
-*   1	Pietro Zambelli
-*   1	staubda
+* 312 Olivier Grisel
+* 275 Lars Buitinck
+* 221 Gael Varoquaux
+* 148 Arnaud Joly
+* 134 Johannes Schönberger
+* 119 Gilles Louppe
+* 113 Joel Nothman
+* 111 Alexandre Gramfort
+*  95 Jaques Grobler
+*  89 Denis Engemann
+*  83 Peter Prettenhofer
+*  83 Alexander Fabisch
+*  62 Mathieu Blondel
+*  60 Eustache Diemert
+*  60 Nelle Varoquaux
+*  49 Michael Bommarito
+*  45 Manoj-Kumar-S
+*  28 Kyle Kastner
+*  26 Andreas Mueller
+*  22 Noel Dawe
+*  21 Maheshakya Wijewardena
+*  21 Brooke Osborn
+*  21 Hamzeh Alsalhi
+*  21 Jake VanderPlas
+*  21 Philippe Gervais
+*  19 Bala Subrahmanyam Varanasi
+*  12 Ronald Phlypo
+*  10 Mikhail Korobov
+*   8 Thomas Unterthiner
+*   8 Jeffrey Blackburne
+*   8 eltermann
+*   8 bwignall
+*   7 Ankit Agrawal
+*   7 CJ Carey
+*   6 Daniel Nouri
+*   6 Chen Liu
+*   6 Michael Eickenberg
+*   6 ugurthemaster
+*   5 Aaron Schumacher
+*   5 Baptiste Lagarde
+*   5 Rajat Khanduja
+*   5 Robert McGibbon
+*   5 Sergio Pascual
+*   4 Alexis Metaireau
+*   4 Ignacio Rossi
+*   4 Virgile Fritsch
+*   4 Sebastian Säger
+*   4 Ilambharathi Kanniah
+*   4 sdenton4
+*   4 Robert Layton
+*   4 Alyssa
+*   4 Amos Waterland
+*   3 Andrew Tulloch
+*   3 murad
+*   3 Steven Maude
+*   3 Karol Pysniak
+*   3 Jacques Kvam
+*   3 cgohlke
+*   3 cjlin
+*   3 Michael Becker
+*   3 hamzeh
+*   3 Eric Jacobsen
+*   3 john collins
+*   3 kaushik94
+*   3 Erwin Marsi
+*   2 csytracy
+*   2 LK
+*   2 Vlad Niculae
+*   2 Laurent Direr
+*   2 Erik Shilts
+*   2 Raul Garreta
+*   2 Yoshiki Vázquez Baeza
+*   2 Yung Siang Liau
+*   2 abhishek thakur
+*   2 James Yu
+*   2 Rohit Sivaprasad
+*   2 Roland Szabo
+*   2 amormachine
+*   2 Alexis Mignon
+*   2 Oscar Carlsson
+*   2 Nantas Nardelli
+*   2 jess010
+*   2 kowalski87
+*   2 Andrew Clegg
+*   2 Federico Vaggi
+*   2 Simon Frid
+*   2 Félix-Antoine Fortin
+*   1 Ralf Gommers
+*   1 t-aft
+*   1 Ronan Amicel
+*   1 Rupesh Kumar Srivastava
+*   1 Ryan Wang
+*   1 Samuel Charron
+*   1 Samuel St-Jean
+*   1 Fabian Pedregosa
+*   1 Skipper Seabold
+*   1 Stefan Walk
+*   1 Stefan van der Walt
+*   1 Stephan Hoyer
+*   1 Allen Riddell
+*   1 Valentin Haenel
+*   1 Vijay Ramesh
+*   1 Will Myers
+*   1 Yaroslav Halchenko
+*   1 Yoni Ben-Meshulam
+*   1 Yury V. Zaytsev
+*   1 adrinjalali
+*   1 ai8rahim
+*   1 alemagnani
+*   1 alex
+*   1 benjamin wilson
+*   1 chalmerlowe
+*   1 dzikie drożdże
+*   1 jamestwebber
+*   1 matrixorz
+*   1 popo
+*   1 samuela
+*   1 François Boulogne
+*   1 Alexander Measure
+*   1 Ethan White
+*   1 Guilherme Trein
+*   1 Hendrik Heuer
+*   1 IvicaJovic
+*   1 Jan Hendrik Metzen
+*   1 Jean Michel Rouly
+*   1 Eduardo Ariño de la Rubia
+*   1 Jelle Zijlstra
+*   1 Eddy L O Jansson
+*   1 Denis
+*   1 John
+*   1 John Schmidt
+*   1 Jorge Cañardo Alastuey
+*   1 Joseph Perla
+*   1 Joshua Vredevoogd
+*   1 José Ricardo
+*   1 Julien Miotte
+*   1 Kemal Eren
+*   1 Kenta Sato
+*   1 David Cournapeau
+*   1 Kyle Kelley
+*   1 Daniele Medri
+*   1 Laurent Luce
+*   1 Laurent Pierron
+*   1 Luis Pedro Coelho
+*   1 DanielWeitzenfeld
+*   1 Craig Thompson
+*   1 Chyi-Kwei Yau
+*   1 Matthew Brett
+*   1 Matthias Feurer
+*   1 Max Linke
+*   1 Chris Filo Gorgolewski
+*   1 Charles Earl
+*   1 Michael Hanke
+*   1 Michele Orrù
+*   1 Bryan Lunt
+*   1 Brian Kearns
+*   1 Paul Butler
+*   1 Paweł Mandera
+*   1 Peter
+*   1 Andrew Ash
+*   1 Pietro Zambelli
+*   1 staubda

--- a/doc/whats_new/v0.16.rst
+++ b/doc/whats_new/v0.16.rst
@@ -26,7 +26,7 @@ Bug fixes
   caused unstable result in :class:`calibration.CalibratedClassifierCV` by
   `Jan Hendrik Metzen`_.
 
-- Fix sorting of labels in func:`preprocessing.label_binarize` by Michael Heilman.
+- Fix sorting of labels in :func:`preprocessing.label_binarize` by Michael Heilman.
 
 - Fix several stability and convergence issues in
   :class:`cross_decomposition.CCA` and

--- a/doc/whats_new/v0.19.rst
+++ b/doc/whats_new/v0.19.rst
@@ -129,7 +129,7 @@ Enhancements
 - To improve usability of version 0.19's :class:`pipeline.Pipeline`
   caching, ``memory`` now allows ``joblib.Memory`` instances.
   This make use of the new :func:`utils.validation.check_memory` helper.
-  issue:`9584` by :user:`Kumar Ashutosh <thechargedneutron>`
+  :issue:`9584` by :user:`Kumar Ashutosh <thechargedneutron>`
 
 - Some fixes to examples: :issue:`9750`, :issue:`9788`, :issue:`9815`
 

--- a/doc/whats_new/v0.20.rst
+++ b/doc/whats_new/v0.20.rst
@@ -37,8 +37,8 @@ The bundled version of joblib was upgraded from 0.13.0 to 0.13.2.
 .......................
 
 - |Fix| Fixed an issue in :class:`compose.ColumnTransformer` where using
-  DataFrames whose column order differs between :func:``fit`` and
-  :func:``transform`` could lead to silently passing incorrect columns to the
+  DataFrames whose column order differs between :func:`fit` and
+  :func:`transform` could lead to silently passing incorrect columns to the
   ``remainder`` transformer.
   :pr:`14237` by `Andreas Schuderer <schuderer>`.
 
@@ -1602,7 +1602,7 @@ Miscellaneous
   PyPy3-v5.10+, Numpy 1.14.0+, and scipy 1.1.0+ are required.
   :issue:`11010` by :user:`Ronan Lamy <rlamy>` and `Roman Yurchak`_.
 
-- |Feature| A utility method :func:`sklearn.show_versions()` was added to
+- |Feature| A utility method :func:`sklearn.show_versions` was added to
   print out information relevant for debugging. It includes the user system,
   the Python executable, the version of the main libraries and BLAS binding
   information. :issue:`11596` by :user:`Alexandre Boucaud <aboucaud>`

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -51,8 +51,8 @@ Changelog
 ......................
 
 - |Fix| Fixed an issue in :class:`compose.ColumnTransformer` where using
-  DataFrames whose column order differs between :func:``fit`` and
-  :func:``transform`` could lead to silently passing incorrect columns to the
+  DataFrames whose column order differs between :func:`fit` and
+  :func:`transform` could lead to silently passing incorrect columns to the
   ``remainder`` transformer.
   :pr:`14237` by `Andreas Schuderer <schuderer>`.
 

--- a/doc/whats_new/v0.22.rst
+++ b/doc/whats_new/v0.22.rst
@@ -408,15 +408,15 @@ Changelog
   :class:`decomposition.DictionaryLearning`, and
   :class:`decomposition.MiniBatchDictionaryLearning` now take a
   `transform_max_iter` parameter and pass it to either
-  :func:`decomposition.dict_learning()` or
-  :func:`decomposition.sparse_encode()`. :issue:`12650` by `Adrin Jalali`_.
+  :func:`decomposition.dict_learning` or
+  :func:`decomposition.sparse_encode`. :issue:`12650` by `Adrin Jalali`_.
 
 - |Enhancement| :class:`decomposition.IncrementalPCA` now accepts sparse
   matrices as input, converting them to dense in batches thereby avoiding the
   need to store the entire dense matrix at once.
   :pr:`13960` by :user:`Scott Gigante <scottgigante>`.
 
-- |Fix| :func:`decomposition.sparse_encode()` now passes the `max_iter` to the
+- |Fix| :func:`decomposition.sparse_encode` now passes the `max_iter` to the
   underlying :class:`linear_model.LassoLars` when `algorithm='lasso_lars'`.
   :issue:`12650` by `Adrin Jalali`_.
 
@@ -1004,7 +1004,7 @@ Changelog
   For example, the outcomes ``1``, ``10`` and ``100`` are all equally likely
   for ``loguniform(1, 100)``. See :issue:`11232` by
   :user:`Scott Sievert <stsievert>` and :user:`Nathaniel Saul <sauln>`,
-  and `SciPy PR 10815 <https://github.com/scipy/scipy/pull/10815>`.
+  and `SciPy PR 10815 <https://github.com/scipy/scipy/pull/10815>`_.
 
 - |Enhancement| `utils.safe_indexing` (now deprecated) accepts an
   ``axis`` parameter to index array-like across rows and columns. The column

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -554,8 +554,8 @@ Changelog
 :mod:`sklearn.datasets`
 .......................
 
-- |Enhancement| :func:`datasets.make_sparse_spd_matrix` now uses a more memory-
-  efficient sparse layout. It also accepts a new keyword `sparse_format` that allows
+- |Enhancement| :func:`datasets.make_sparse_spd_matrix` now uses a more memory-efficient
+  sparse layout. It also accepts a new keyword `sparse_format` that allows
   specifying the output format of the sparse matrix. By default `sparse_format=None`,
   which returns a dense numpy ndarray as before.
   :pr:`27438` by :user:`Yao Xiao <Charlie-XIAO>`.

--- a/examples/cluster/plot_dbscan.py
+++ b/examples/cluster/plot_dbscan.py
@@ -44,7 +44,7 @@ plt.show()
 # --------------
 #
 # One can access the labels assigned by :class:`~sklearn.cluster.DBSCAN` using
-# the `labels_` attribute. Noisy samples are given the label math:`-1`.
+# the `labels_` attribute. Noisy samples are given the label :math:`-1`.
 
 import numpy as np
 

--- a/examples/ensemble/plot_bias_variance.py
+++ b/examples/ensemble/plot_bias_variance.py
@@ -43,8 +43,8 @@ between the average prediction (in cyan) and the best possible model is larger
 curve is also slightly higher than in the lower left figure. In terms of
 variance however, the beam of predictions is narrower, which suggests that the
 variance is lower. Indeed, as the lower right figure confirms, the variance
-term (in green) is lower than for single decision trees. Overall, the bias-
-variance decomposition is therefore no longer the same. The tradeoff is better
+term (in green) is lower than for single decision trees. Overall, the bias-variance
+decomposition is therefore no longer the same. The tradeoff is better
 for bagging: averaging several decision trees fit on bootstrap copies of the
 dataset slightly increases the bias term but allows for a larger reduction of
 the variance, which results in a lower overall mean squared error (compare the

--- a/examples/ensemble/plot_forest_iris.py
+++ b/examples/ensemble/plot_forest_iris.py
@@ -7,8 +7,8 @@ Plot the decision surfaces of forests of randomized trees trained on pairs of
 features of the iris dataset.
 
 This plot compares the decision surfaces learned by a decision tree classifier
-(first column), by a random forest classifier (second column), by an extra-
-trees classifier (third column) and by an AdaBoost classifier (fourth column).
+(first column), by a random forest classifier (second column), by an extra-trees
+classifier (third column) and by an AdaBoost classifier (fourth column).
 
 In the first row, the classifiers are built using the sepal width and
 the sepal length features only, on the second row using the petal length and

--- a/examples/ensemble/plot_gradient_boosting_quantile.py
+++ b/examples/ensemble/plot_gradient_boosting_quantile.py
@@ -297,8 +297,8 @@ pprint(search_95p.best_params_)
 
 # %%
 # The result shows that the hyper-parameters for the 95th percentile regressor
-# identified by the search procedure are roughly in the same range as the hand-
-# tuned hyper-parameters for the median regressor and the hyper-parameters
+# identified by the search procedure are roughly in the same range as the hand-tuned
+# hyper-parameters for the median regressor and the hyper-parameters
 # identified by the search procedure for the 5th percentile regressor. However,
 # the hyper-parameter searches did lead to an improved 90% confidence interval
 # that is comprised by the predictions of those two tuned quantile regressors.

--- a/examples/model_selection/plot_grid_search_stats.py
+++ b/examples/model_selection/plot_grid_search_stats.py
@@ -422,7 +422,7 @@ cred_int_df
 # As shown in the table, there is a 50% probability that the true mean
 # difference between models will be between 0.000977 and 0.019023, 70%
 # probability that it will be between -0.005422 and 0.025422, and 95%
-# probability that it will be between -0.016445	and 0.036445.
+# probability that it will be between -0.016445 and 0.036445.
 
 # %%
 # Pairwise comparison of all models: frequentist approach

--- a/examples/multiclass/plot_multiclass_overview.py
+++ b/examples/multiclass/plot_multiclass_overview.py
@@ -53,7 +53,7 @@ y.value_counts().sort_index()
 #
 # We compare the following strategies:
 #
-# * :class:~sklearn.tree.DecisionTreeClassifier can handle multiclass
+# * :class:`~sklearn.tree.DecisionTreeClassifier` can handle multiclass
 #   classification without needing any special adjustments. It works by breaking
 #   down the training data into smaller subsets and focusing on the most common
 #   class in each subset. By repeating this process, the model can accurately

--- a/examples/release_highlights/plot_release_highlights_1_5_0.py
+++ b/examples/release_highlights/plot_release_highlights_1_5_0.py
@@ -147,7 +147,7 @@ print(f"Explained variance: {pca.explained_variance_ratio_.sum():.2f}")
 
 # %%
 # The `"full"` solver has also been improved to use less memory and allows
-# faster transformation. The default `svd_solver="auto"`` option takes
+# faster transformation. The default `svd_solver="auto"` option takes
 # advantage of the new solver and is now able to select an appropriate solver
 # for sparse datasets.
 #

--- a/examples/svm/plot_svm_kernels.py
+++ b/examples/svm/plot_svm_kernels.py
@@ -203,7 +203,7 @@ plot_training_data_with_decision_boundary("linear")
 plot_training_data_with_decision_boundary("poly")
 
 # %%
-# The polynomial kernel with `gamma=2`` adapts well to the training data,
+# The polynomial kernel with `gamma=2` adapts well to the training data,
 # causing the margins on both sides of the hyperplane to bend accordingly.
 #
 # RBF kernel


### PR DESCRIPTION
Run [sphinx-lint](https://github.com/sphinx-contrib/sphinx-lint) and fix issues it found. 

- hard to spot rst quirks, for example missing `:` (`func:` instead of `:func:`), missing `_` at the end of link, double back-quote instead of single, etc ...
- hyphens at end of line see https://github.com/sphinx-contrib/sphinx-lint/issues/54
- unnecessary parentheses in directives https://github.com/sphinx-contrib/sphinx-lint/issues/114
- replaced tabs by spaces

sphinx-lint is used by pandas and sympy. Maybe we could use sphinx-lint as well, but for a later PR?

Note that some content is generated (like with `.rst.template` or from `.py` with sphinx-gallery) so sphinx-gallery would not find everything but still probably an improvement?