### PR TITLE
DOC Add bumping dependencies guidelines to maintainer doc

### DIFF
--- a/doc/developers/maintainer.rst.template
+++ b/doc/developers/maintainer.rst.template
@@ -362,8 +362,8 @@ Guideline for bumping minimum versions of our dependencies
 ----------------------------------------------------------
 
 - **minimum Python version**: at the time of a minor scikit-learn release (`X.Y.0`),
-  we drop the Python version with an initial release date of more than 4 years ago. In other words,
-  our minimum Python version is between 3 and 4 years old.
+  we drop the Python version with an initial release date of more than 4 years
+  ago. In other words, our minimum Python version is between 3 and 4 years old.
 - **compiled dependencies** (numpy, scipy, as well as compiled optional
   dependencies (pandas, matplotlib, pyamg, pillow, ...): we take the oldest minor
   release (`X.Y.0`) that has wheels for our minimum Python version. In practice

--- a/doc/developers/maintainer.rst.template
+++ b/doc/developers/maintainer.rst.template
@@ -377,24 +377,13 @@ Guideline for bumping minimum versions of our dependencies
   critical bugfix in one of our dependencies makes it too costly to support it in
   terms of maintenance.
 
+`maint_tools/bump-dependencies-versions.py` implements these rules and can be
+used to give the new minimum dependency versions. It takes as input the
+expected scikit-learn release date, for example:
 
-Example for the upcoming scikit-learn 1.8 release
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: bash
 
-The upcoming 1.8 release is scheduled around November/December, let's pretend
-it will happen on 2025-12-01, Python 3.10 (released in October 2021) will be
-more than 4 years old and will be dropped so our minimum supported Python will
-be Python 3.11 (a bit more than 3 years old).
-
-The dependencies minimum versions will be bumped as follow:
-
-- python: 3.10 -> 3.11
-- numpy: 1.22.0 -> 1.24.0 (oldest version with Python 3.11 wheels)
-- scipy: 1.8.0 -> 1.10.0 (oldest scipy version with Python 3.11 wheels)
-- pandas: 1.4.0 -> 1.5.0 (oldest pandas version with Python 3.11 wheels)
-- matplotlib: 3.5.0 -> 3.6.0 (oldest matplotlib version with Python 3.11 wheels)
-- joblib: 1.2.0 -> 1.3.0 (1.3.0 will be ~2 years 5 month old, 1.4.0 will be less than 2 years old)
-- threadpoolctl: 3.1.0 -> 3.2.0 (3.2.0 will be ~2 years 5 months old, 3.3.0 will be less than 2 years old)
+    python maint_tools/bump-dependencies-versions.py 2025-12-01
 
 Merging Pull Requests
 ---------------------

--- a/doc/developers/maintainer.rst.template
+++ b/doc/developers/maintainer.rst.template
@@ -369,7 +369,7 @@ Guideline for bumping minimum versions of our dependencies
   release (`X.Y.0`) that has wheels for our minimum Python version. In practice
   this means that our minimum supported version is around 3 years old, maybe a
   bit less.
-- pure Python dependencies (joblib, threadpoolctl): at the time of the
+- **pure Python dependencies** (joblib, threadpoolctl): at the time of the
   scikit-learn release our minimum supported version is the most recent minor
   release (`X.Y.0`) that is at least 2 years old.
 - we may decide to be less conservative than this guideline in some edge cases.

--- a/doc/developers/maintainer.rst.template
+++ b/doc/developers/maintainer.rst.template
@@ -25,6 +25,9 @@ We adopted the following release schedule:
 - Make sure the deprecations, FIXMEs, and TODOs tagged for the release have been taken
   care of.
 
+- Make sure that the minimum supported versions of our dependencies have been bumped, see
+  :ref:`bumping_dependencies_guideline` for details.
+
 - For major/minor final releases, make sure that a *Release Highlights* page has been
   done as a runnable example and check that its HTML rendering looks correct. It should
   be linked from the what's new file for the new version of scikit-learn.
@@ -352,6 +355,46 @@ following script and enter the token when prompted:
 
   cd build_tools
   make authors  # Enter the token when prompted
+
+.. _bumping_dependencies_guideline:
+
+Guideline for bumping minimum versions of our dependencies
+----------------------------------------------------------
+
+- **minimum Python version**: at the time of a minor scikit-learn release (`X.Y.0`),
+  we drop Python whose initial release was more than 4 years old. In other words,
+  our minimum Python version is between 3 and 4 years old.
+- **compiled dependencies** (numpy, scipy, as well as compiled optional
+  dependencies (pandas, matplotlib, pyamg, pillow, ...): we take the oldest minor
+  release (`X.Y.0`) that has wheels for our minimum Python version. In practice
+  this means that our minimum supported version is around 3 years old, maybe a
+  bit less.
+- pure Python dependencies (joblib, threadpoolctl): at the time of the
+  scikit-learn release our minimum supported version is the most recent minor
+  release (`X.Y.0`) that is at least 2 years old.
+- we may decide to be less conservative than this guideline in some edge cases.
+  These edge cases include: a security bugfix in one of our dependencies or a
+  critical bugfix in one of our dependencies makes it too costly to support it in
+  terms of maintenance.
+
+
+Example for the upcoming scikit-learn 1.8 release
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The upcoming 1.8 release is scheduled around November/December, let's pretend
+it will happen on 2025-12-01, Python 3.10 (released in October 2021) will be
+more than 4 years old and will be dropped so our minimum supported Python will
+be Python 3.11 (a bit more than 3 years old).
+
+The dependencies minimum versions will be bumped as follow:
+
+- python: 3.10 -> 3.11
+- numpy: 1.22.0 -> 1.24.0 (oldest version with Python 3.11 wheels)
+- scipy: 1.8.0 -> 1.10.0 (oldest scipy version with Python 3.11 wheels)
+- pandas: 1.4.0 -> 1.5.0 (oldest pandas version with Python 3.11 wheels)
+- matplotlib: 3.5.0 -> 3.6.0 (oldest matplotlib version with Python 3.11 wheels)
+- joblib: 1.2.0 -> 1.3.0 (1.3.0 will be ~2 years 5 month old, 1.4.0 will be less than 2 years old)
+- threadpoolctl: 3.1.0 -> 3.2.0 (3.2.0 will be ~2 years 5 months old, 3.3.0 will be less than 2 years old)
 
 Merging Pull Requests
 ---------------------

--- a/doc/developers/maintainer.rst.template
+++ b/doc/developers/maintainer.rst.template
@@ -362,7 +362,7 @@ Guideline for bumping minimum versions of our dependencies
 ----------------------------------------------------------
 
 - **minimum Python version**: at the time of a minor scikit-learn release (`X.Y.0`),
-  we drop Python whose initial release was more than 4 years old. In other words,
+  we drop the Python version with an initial release date of more than 4 years ago. In other words,
   our minimum Python version is between 3 and 4 years old.
 - **compiled dependencies** (numpy, scipy, as well as compiled optional
   dependencies (pandas, matplotlib, pyamg, pillow, ...): we take the oldest minor

--- a/maint_tools/bump-dependencies-versions.py
+++ b/maint_tools/bump-dependencies-versions.py
@@ -1,0 +1,173 @@
+import re
+from datetime import datetime
+from pathlib import Path
+import subprocess
+import sys
+
+import requests
+from packaging import version
+
+import pandas as pd
+
+
+df_list = pd.read_html("https://devguide.python.org/versions/")
+df = pd.concat(df_list).astype({"Branch": str})
+release_dates = {}
+python_version_info = {
+    version: release_date
+    for version, release_date in zip(df["Branch"], df["First release"])
+}
+python_version_info = {
+    version: pd.to_datetime(release_date)
+    for version, release_date in python_version_info.items()
+}
+
+
+def get_min_version_with_wheel(package_name, python_version):
+    # For compiled dependencies we want the oldest minor version that has wheels for 'python_version'
+    url = f"https://pypi.org/pypi/{package_name}/json"
+    response = requests.get(url)
+    if response.status_code != 200:
+        return None
+
+    data = response.json()
+    releases = data["releases"]
+
+    compatible_versions = []
+    # We want only minor X.Y.0 and not bugfix X.Y.Z
+    minor_releases = [
+        (ver, release_info)
+        for ver, release_info in releases.items()
+        if re.match(r"^\d+\.\d+\.0$", ver)
+    ]
+    for ver, release_info in minor_releases:
+        for file_info in release_info:
+            if (
+                file_info["packagetype"] == "bdist_wheel"
+                and f'cp{python_version.replace(".", "")}' in file_info["filename"]
+                and not file_info["yanked"]
+            ):
+                compatible_versions.append(ver)
+                break
+
+    if not compatible_versions:
+        return None
+
+    return min(compatible_versions, key=version.parse)
+
+
+def get_min_python_version(scikit_learn_release_date_str="today"):
+    # min Python version is the most recent Python release at least 3 years old
+    # at the time of the scikit-learn release
+    if scikit_learn_release_date_str == "today":
+        scikit_learn_release_date = pd.to_datetime(datetime.now().date())
+    else:
+        scikit_learn_release_date = datetime.strptime(
+            scikit_learn_release_date_str, "%Y-%m-%d"
+        )
+    version_and_releases = [
+        {"python_version": python_version, "python_release_date": python_release_date}
+        for python_version, python_release_date in python_version_info.items()
+        if (scikit_learn_release_date - python_release_date).days > 365 * 3
+    ]
+    return max(version_and_releases, key=lambda each: each["python_release_date"])[
+        "python_version"
+    ]
+
+
+def get_min_version_pure_python(package_name, scikit_learn_release_date_str="today"):
+    # for pure Python dependencies we want the most recent minor release that is at least 2 years old
+    if scikit_learn_release_date_str == "today":
+        scikit_learn_release_date = pd.to_datetime(datetime.now().date())
+    else:
+        scikit_learn_release_date = datetime.strptime(
+            scikit_learn_release_date_str, "%Y-%m-%d"
+        )
+
+    url = f"https://pypi.org/pypi/{package_name}/json"
+    response = requests.get(url)
+    if response.status_code != 200:
+        return None
+
+    data = response.json()
+    releases = data["releases"]
+
+    compatible_versions = []
+    # We want only minor X.Y.0 and not bugfix X.Y.Z
+    releases = [
+        (ver, release_info)
+        for ver, release_info in releases.items()
+        if re.match(r"^\d+\.\d+\.0$", ver)
+    ]
+    for ver, release_info in releases:
+        for file_info in release_info:
+            if (
+                file_info["packagetype"] == "bdist_wheel"
+                and not file_info["yanked"]
+                and (
+                    scikit_learn_release_date - pd.to_datetime(file_info["upload_time"])
+                ).days
+                > 365 * 2
+            ):
+                compatible_versions.append(ver)
+                break
+
+    if not compatible_versions:
+        return None
+
+    return max(compatible_versions, key=version.parse)
+
+
+def get_current_dependencies_version(dep):
+    return (
+        subprocess.check_output([sys.executable, "sklearn/_min_dependencies.py", dep])
+        .decode()
+        .strip()
+    )
+
+
+def get_current_min_python_version():
+    content = Path("pyproject.toml").read_text()
+    min_python = re.findall(r'requires-python\s*=\s*">=(\d+\.\d+)"', content)[0]
+
+    return min_python
+
+
+def show_versions_update(scikit_learn_release_date="today"):
+    future_versions = {"python": get_min_python_version(scikit_learn_release_date)}
+
+    compiled_dependencies = ["numpy", "scipy", "pandas", "matplotlib", "pyamg"]
+    future_versions.update(
+        {
+            dep: get_min_version_with_wheel(dep, future_versions["python"])
+            for dep in compiled_dependencies
+        }
+    )
+
+    pure_python_dependencies = ["joblib", "threadpoolctl"]
+    future_versions.update(
+        {
+            dep: get_min_version_pure_python(dep, scikit_learn_release_date)
+            for dep in pure_python_dependencies
+        }
+    )
+
+
+    current_versions = {"python": get_current_min_python_version()}
+    current_versions.update(
+        {
+            dep: get_current_dependencies_version(dep)
+            for dep in compiled_dependencies + pure_python_dependencies
+        }
+    )
+
+    print(f"For future release at date {scikit_learn_release_date}")
+    for k in future_versions:
+        if future_versions[k] != current_versions[k]:
+            print(f"- {k}: {current_versions[k]} -> {future_versions[k]}")
+
+
+
+if __name__ == "__main__":
+    scikit_learn_release_date = sys.argv[1] if len(sys.argv) > 1 else "today"
+    show_versions_update(scikit_learn_release_date)

--- a/maint_tools/bump-dependencies-versions.py
+++ b/maint_tools/bump-dependencies-versions.py
@@ -1,14 +1,12 @@
 import re
-from datetime import datetime
-from pathlib import Path
 import subprocess
 import sys
-
-import requests
-from packaging import version
+from datetime import datetime
+from pathlib import Path
 
 import pandas as pd
-
+import requests
+from packaging import version
 
 df_list = pd.read_html("https://devguide.python.org/versions/")
 df = pd.concat(df_list).astype({"Branch": str})
@@ -24,7 +22,8 @@ python_version_info = {
 
 
 def get_min_version_with_wheel(package_name, python_version):
-    # For compiled dependencies we want the oldest minor version that has wheels for 'python_version'
+    # For compiled dependencies we want the oldest minor version that has
+    # wheels for 'python_version'
     url = f"https://pypi.org/pypi/{package_name}/json"
     response = requests.get(url)
     if response.status_code != 200:
@@ -76,7 +75,8 @@ def get_min_python_version(scikit_learn_release_date_str="today"):
 
 
 def get_min_version_pure_python(package_name, scikit_learn_release_date_str="today"):
-    # for pure Python dependencies we want the most recent minor release that is at least 2 years old
+    # for pure Python dependencies we want the most recent minor release that
+    # is at least 2 years old
     if scikit_learn_release_date_str == "today":
         scikit_learn_release_date = pd.to_datetime(datetime.now().date())
     else:
@@ -152,7 +152,6 @@ def show_versions_update(scikit_learn_release_date="today"):
         }
     )
 
-
     current_versions = {"python": get_current_min_python_version()}
     current_versions.update(
         {
@@ -165,7 +164,6 @@ def show_versions_update(scikit_learn_release_date="today"):
     for k in future_versions:
         if future_versions[k] != current_versions[k]:
             print(f"- {k}: {current_versions[k]} -> {future_versions[k]}")
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As discussed during the monthly scikit-learn developer meeting.

Close #30888.

I reused the content of https://github.com/scikit-learn/scikit-learn/issues/30888#issuecomment-2766112386.

I propose to add a script in `maint_tools` based on https://gist.github.com/lesteve/4a7d42bfaab461ab90fcdcc613d01081 in a separate PR.