### PR TITLE
MNT Clean-up deprecations for 1.7: sample_weight as positional arg when not consumed

### DIFF
--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -370,8 +370,7 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
         self : object
             Fitted estimator.
         """
-        sample_weight = fit_params.pop("sample_weight", None)
-        _raise_for_params(fit_params, self, "fit")
+        _raise_for_params(fit_params, self, "fit", allow=["sample_weight"])
 
         # Convert data (X is required to be 2d and indexable)
         X, y = validate_data(
@@ -383,10 +382,6 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
             ensure_all_finite=False,
             multi_output=True,
         )
-
-        if sample_weight is not None:
-            sample_weight = _check_sample_weight(sample_weight, X, dtype=None)
-            fit_params["sample_weight"] = sample_weight
 
         return self._fit(X, y, max_samples=self.max_samples, **fit_params)
 

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -388,8 +388,6 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
             sample_weight = _check_sample_weight(sample_weight, X, dtype=None)
             fit_params["sample_weight"] = sample_weight
 
-        if sample_weight is not None:
-            fit_params["sample_weight"] = sample_weight
         return self._fit(X, y, max_samples=self.max_samples, **fit_params)
 
     def _parallel_args(self):

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -39,7 +39,6 @@ from ..utils.parallel import Parallel, delayed
 from ..utils.validation import (
     _check_feature_names_in,
     _check_response_method,
-    _deprecate_positional_args,
     _estimator_has,
     check_is_fitted,
     column_or_1d,
@@ -657,11 +656,7 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
 
         return names, estimators
 
-    # TODO(1.7): remove `sample_weight` from the signature after deprecation
-    # cycle; pop it from `fit_params` before the `_raise_for_params` check and
-    # reinsert afterwards, for backwards compatibility
-    @_deprecate_positional_args(version="1.7")
-    def fit(self, X, y, *, sample_weight=None, **fit_params):
+    def fit(self, X, y, **fit_params):
         """Fit the estimators.
 
         Parameters
@@ -675,11 +670,6 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
             numerically increasing order or lexicographic order. If the order
             matter (e.g. for ordinal regression), one should numerically encode
             the target `y` before calling :term:`fit`.
-
-        sample_weight : array-like of shape (n_samples,), default=None
-            Sample weights. If None, then samples are equally weighted.
-            Note that this is supported only if all underlying estimators
-            support sample weights.
 
         **fit_params : dict
             Parameters to pass to the underlying estimators.
@@ -696,7 +686,9 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
         self : object
             Returns a fitted instance of estimator.
         """
+        sample_weight = fit_params.pop("sample_weight", None)
         _raise_for_params(fit_params, self, "fit")
+
         check_classification_targets(y)
         if type_of_target(y) == "multilabel-indicator":
             self._label_encoder = [LabelEncoder().fit(yk) for yk in y.T]
@@ -1020,11 +1012,7 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
                 )
             )
 
-    # TODO(1.7): remove `sample_weight` from the signature after deprecation
-    # cycle; pop it from `fit_params` before the `_raise_for_params` check and
-    # reinsert afterwards, for backwards compatibility
-    @_deprecate_positional_args(version="1.7")
-    def fit(self, X, y, *, sample_weight=None, **fit_params):
+    def fit(self, X, y, **fit_params):
         """Fit the estimators.
 
         Parameters
@@ -1035,11 +1023,6 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
 
         y : array-like of shape (n_samples,)
             Target values.
-
-        sample_weight : array-like of shape (n_samples,), default=None
-            Sample weights. If None, then samples are equally weighted.
-            Note that this is supported only if all underlying estimators
-            support sample weights.
 
         **fit_params : dict
             Parameters to pass to the underlying estimators.
@@ -1056,8 +1039,11 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
         self : object
             Returns a fitted instance.
         """
+        sample_weight = fit_params.pop("sample_weight", None)
         _raise_for_params(fit_params, self, "fit")
+
         y = column_or_1d(y, warn=True)
+
         if sample_weight is not None:
             fit_params["sample_weight"] = sample_weight
         return super().fit(X, y, **fit_params)
@@ -1078,11 +1064,7 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
         """
         return self._transform(X)
 
-    # TODO(1.7): remove `sample_weight` from the signature after deprecation
-    # cycle; pop it from `fit_params` before the `_raise_for_params` check and
-    # reinsert afterwards, for backwards compatibility
-    @_deprecate_positional_args(version="1.7")
-    def fit_transform(self, X, y, *, sample_weight=None, **fit_params):
+    def fit_transform(self, X, y, **fit_params):
         """Fit the estimators and return the predictions for X for each estimator.
 
         Parameters
@@ -1093,11 +1075,6 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
 
         y : array-like of shape (n_samples,)
             Target values.
-
-        sample_weight : array-like of shape (n_samples,), default=None
-            Sample weights. If None, then samples are equally weighted.
-            Note that this is supported only if all underlying estimators
-            support sample weights.
 
         **fit_params : dict
             Parameters to pass to the underlying estimators.
@@ -1114,7 +1091,9 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
         y_preds : ndarray of shape (n_samples, n_estimators)
             Prediction outputs for each estimator.
         """
+        sample_weight = fit_params.pop("sample_weight", None)
         _raise_for_params(fit_params, self, "fit")
+
         if sample_weight is not None:
             fit_params["sample_weight"] = sample_weight
         return super().fit_transform(X, y, **fit_params)

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -686,8 +686,7 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
         self : object
             Returns a fitted instance of estimator.
         """
-        sample_weight = fit_params.pop("sample_weight", None)
-        _raise_for_params(fit_params, self, "fit")
+        _raise_for_params(fit_params, self, "fit", allow=["sample_weight"])
 
         check_classification_targets(y)
         if type_of_target(y) == "multilabel-indicator":
@@ -704,8 +703,6 @@ class StackingClassifier(ClassifierMixin, _BaseStacking):
             self.classes_ = self._label_encoder.classes_
             y_encoded = self._label_encoder.transform(y)
 
-        if sample_weight is not None:
-            fit_params["sample_weight"] = sample_weight
         return super().fit(X, y_encoded, **fit_params)
 
     @available_if(
@@ -1039,13 +1036,10 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
         self : object
             Returns a fitted instance.
         """
-        sample_weight = fit_params.pop("sample_weight", None)
-        _raise_for_params(fit_params, self, "fit")
+        _raise_for_params(fit_params, self, "fit", allow=["sample_weight"])
 
         y = column_or_1d(y, warn=True)
 
-        if sample_weight is not None:
-            fit_params["sample_weight"] = sample_weight
         return super().fit(X, y, **fit_params)
 
     def transform(self, X):
@@ -1091,11 +1085,8 @@ class StackingRegressor(RegressorMixin, _BaseStacking):
         y_preds : ndarray of shape (n_samples, n_estimators)
             Prediction outputs for each estimator.
         """
-        sample_weight = fit_params.pop("sample_weight", None)
-        _raise_for_params(fit_params, self, "fit")
+        _raise_for_params(fit_params, self, "fit", allow=["sample_weight"])
 
-        if sample_weight is not None:
-            fit_params["sample_weight"] = sample_weight
         return super().fit_transform(X, y, **fit_params)
 
     @available_if(

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -379,8 +379,7 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
         self : object
             Returns the instance itself.
         """
-        sample_weight = fit_params.pop("sample_weight", None)
-        _raise_for_params(fit_params, self, "fit")
+        _raise_for_params(fit_params, self, "fit", allow=["sample_weight"])
 
         y_type = type_of_target(y, input_name="y")
         if y_type in ("unknown", "continuous"):
@@ -402,9 +401,6 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
         self.le_ = LabelEncoder().fit(y)
         self.classes_ = self.le_.classes_
         transformed_y = self.le_.transform(y)
-
-        if sample_weight is not None:
-            fit_params["sample_weight"] = sample_weight
 
         return super().fit(X, transformed_y, **fit_params)
 
@@ -675,13 +671,10 @@ class VotingRegressor(RegressorMixin, _BaseVoting):
         self : object
             Fitted estimator.
         """
-        sample_weight = fit_params.pop("sample_weight", None)
-        _raise_for_params(fit_params, self, "fit")
+        _raise_for_params(fit_params, self, "fit", allow=["sample_weight"])
 
         y = column_or_1d(y, warn=True)
 
-        if sample_weight is not None:
-            fit_params["sample_weight"] = sample_weight
         return super().fit(X, y, **fit_params)
 
     def predict(self, X):

--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -38,7 +38,6 @@ from ..utils.multiclass import type_of_target
 from ..utils.parallel import Parallel, delayed
 from ..utils.validation import (
     _check_feature_names_in,
-    _deprecate_positional_args,
     check_is_fitted,
     column_or_1d,
 )
@@ -352,11 +351,7 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
         # estimators in VotingClassifier.estimators are not validated yet
         prefer_skip_nested_validation=False
     )
-    # TODO(1.7): remove `sample_weight` from the signature after deprecation
-    # cycle; pop it from `fit_params` before the `_raise_for_params` check and
-    # reinsert later, for backwards compatibility
-    @_deprecate_positional_args(version="1.7")
-    def fit(self, X, y, *, sample_weight=None, **fit_params):
+    def fit(self, X, y, **fit_params):
         """Fit the estimators.
 
         Parameters
@@ -367,13 +362,6 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
 
         y : array-like of shape (n_samples,)
             Target values.
-
-        sample_weight : array-like of shape (n_samples,), default=None
-            Sample weights. If None, then samples are equally weighted.
-            Note that this is supported only if all underlying estimators
-            support sample weights.
-
-            .. versionadded:: 0.18
 
         **fit_params : dict
             Parameters to pass to the underlying estimators.
@@ -391,7 +379,9 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
         self : object
             Returns the instance itself.
         """
+        sample_weight = fit_params.pop("sample_weight", None)
         _raise_for_params(fit_params, self, "fit")
+
         y_type = type_of_target(y, input_name="y")
         if y_type in ("unknown", "continuous"):
             # raise a specific ValueError for non-classification tasks
@@ -657,11 +647,7 @@ class VotingRegressor(RegressorMixin, _BaseVoting):
         # estimators in VotingRegressor.estimators are not validated yet
         prefer_skip_nested_validation=False
     )
-    # TODO(1.7): remove `sample_weight` from the signature after deprecation cycle;
-    # pop it from `fit_params` before the `_raise_for_params` check and reinsert later,
-    # for backwards compatibility
-    @_deprecate_positional_args(version="1.7")
-    def fit(self, X, y, *, sample_weight=None, **fit_params):
+    def fit(self, X, y, **fit_params):
         """Fit the estimators.
 
         Parameters
@@ -672,11 +658,6 @@ class VotingRegressor(RegressorMixin, _BaseVoting):
 
         y : array-like of shape (n_samples,)
             Target values.
-
-        sample_weight : array-like of shape (n_samples,), default=None
-            Sample weights. If None, then samples are equally weighted.
-            Note that this is supported only if all underlying estimators
-            support sample weights.
 
         **fit_params : dict
             Parameters to pass to the underlying estimators.
@@ -694,8 +675,11 @@ class VotingRegressor(RegressorMixin, _BaseVoting):
         self : object
             Fitted estimator.
         """
+        sample_weight = fit_params.pop("sample_weight", None)
         _raise_for_params(fit_params, self, "fit")
+
         y = column_or_1d(y, warn=True)
+
         if sample_weight is not None:
             fit_params["sample_weight"] = sample_weight
         return super().fit(X, y, **fit_params)

--- a/sklearn/ensemble/tests/test_voting.py
+++ b/sklearn/ensemble/tests/test_voting.py
@@ -340,7 +340,7 @@ def test_sample_weight(global_random_seed):
     )
     sample_weight = np.random.RandomState(global_random_seed).uniform(size=(len(y),))
     eclf3 = VotingClassifier(estimators=[("lr", clf1)], voting="soft")
-    eclf3.fit(X_scaled, y, sample_weight)
+    eclf3.fit(X_scaled, y, sample_weight=sample_weight)
     clf1.fit(X_scaled, y, sample_weight)
     assert_array_equal(eclf3.predict(X_scaled), clf1.predict(X_scaled))
     assert_array_almost_equal(
@@ -355,7 +355,7 @@ def test_sample_weight(global_random_seed):
     )
     msg = "Underlying estimator KNeighborsClassifier does not support sample weights."
     with pytest.raises(TypeError, match=msg):
-        eclf3.fit(X_scaled, y, sample_weight)
+        eclf3.fit(X_scaled, y, sample_weight=sample_weight)
 
     # check that _fit_single_estimator will raise the right error
     # it should raise the original error if this is not linked to sample_weight

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -35,7 +35,6 @@ from ..utils.random import sample_without_replacement
 from ..utils.validation import (
     _check_method_params,
     _check_sample_weight,
-    _deprecate_positional_args,
     check_is_fitted,
     has_fit_parameter,
     validate_data,
@@ -319,11 +318,7 @@ class RANSACRegressor(
         # RansacRegressor.estimator is not validated yet
         prefer_skip_nested_validation=False
     )
-    # TODO(1.7): remove `sample_weight` from the signature after deprecation
-    # cycle; for backwards compatibility: pop it from `fit_params` before the
-    # `_raise_for_params` check and reinsert it after the check
-    @_deprecate_positional_args(version="1.7")
-    def fit(self, X, y, *, sample_weight=None, **fit_params):
+    def fit(self, X, y, sample_weight=None, **fit_params):
         """Fit estimator using RANSAC algorithm.
 
         Parameters

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -130,7 +130,7 @@ def _routing_enabled():
     return get_config().get("enable_metadata_routing", False)
 
 
-def _raise_for_params(params, owner, method):
+def _raise_for_params(params, owner, method, allow=None):
     """Raise an error if metadata routing is not enabled and params are passed.
 
     .. versionadded:: 1.4
@@ -146,6 +146,10 @@ def _raise_for_params(params, owner, method):
     method : str
         The name of the method, e.g. "fit".
 
+    allow : list of str, default=None
+        A list of parameters which are allowed to be passed even if metadata
+        routing is not enabled.
+
     Raises
     ------
     ValueError
@@ -154,7 +158,10 @@ def _raise_for_params(params, owner, method):
     caller = (
         f"{owner.__class__.__name__}.{method}" if method else owner.__class__.__name__
     )
-    if not _routing_enabled() and params:
+
+    allow = allow if allow is not None else {}
+
+    if not _routing_enabled() and (params.keys() - allow):
         raise ValueError(
             f"Passing extra keyword arguments to {caller} is only supported if"
             " enable_metadata_routing=True, which you can set using"


### PR DESCRIPTION
Removed deprecated `sample_weight` as positional arg in estimators when it's only routed.

I haven't removed it from `RANSAC` yet because the fact that it's only routing sample weight is probably a bug and it should also be a consumer, see https://github.com/scikit-learn/scikit-learn/issues/15836. ping @ogrisel for confirmation. In which case, `sample_weight` should remain an explicit parameter, right ? ping @adrinjalali