### PR TITLE
MNT Clean-up deprecations for 1.7: Ridge cv_values

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -30,7 +30,6 @@ from ..utils import (
     check_scalar,
     column_or_1d,
     compute_sample_weight,
-    deprecated,
 )
 from ..utils._array_api import (
     _is_numpy_namespace,
@@ -39,7 +38,7 @@ from ..utils._array_api import (
     get_namespace,
     get_namespace_and_device,
 )
-from ..utils._param_validation import Hidden, Interval, StrOptions, validate_params
+from ..utils._param_validation import Interval, StrOptions, validate_params
 from ..utils.extmath import row_norms, safe_sparse_dot
 from ..utils.fixes import _sparse_linalg_cg
 from ..utils.metadata_routing import (
@@ -2304,9 +2303,8 @@ class _BaseRidgeCV(LinearModel):
         "scoring": [StrOptions(set(get_scorer_names())), callable, None],
         "cv": ["cv_object"],
         "gcv_mode": [StrOptions({"auto", "svd", "eigen"}), None],
-        "store_cv_results": ["boolean", Hidden(None)],
+        "store_cv_results": ["boolean"],
         "alpha_per_target": ["boolean"],
-        "store_cv_values": ["boolean", Hidden(StrOptions({"deprecated"}))],
     }
 
     def __init__(
@@ -2317,9 +2315,8 @@ class _BaseRidgeCV(LinearModel):
         scoring=None,
         cv=None,
         gcv_mode=None,
-        store_cv_results=None,
+        store_cv_results=False,
         alpha_per_target=False,
-        store_cv_values="deprecated",
     ):
         self.alphas = alphas
         self.fit_intercept = fit_intercept
@@ -2328,7 +2325,6 @@ class _BaseRidgeCV(LinearModel):
         self.gcv_mode = gcv_mode
         self.store_cv_results = store_cv_results
         self.alpha_per_target = alpha_per_target
-        self.store_cv_values = store_cv_values
 
     def fit(self, X, y, sample_weight=None, **params):
         """Fit Ridge regression model with cv.
@@ -2372,28 +2368,6 @@ class _BaseRidgeCV(LinearModel):
         _raise_for_params(params, self, "fit")
         cv = self.cv
         scorer = self._get_scorer()
-
-        # TODO(1.7): Remove in 1.7
-        # Also change `store_cv_results` default back to False
-        if self.store_cv_values != "deprecated":
-            if self.store_cv_results is not None:
-                raise ValueError(
-                    "Both 'store_cv_values' and 'store_cv_results' were set. "
-                    "'store_cv_values' is deprecated in version 1.5 and will be "
-                    "removed in 1.7. To avoid this error, only set 'store_cv_results'."
-                )
-            warnings.warn(
-                (
-                    "'store_cv_values' is deprecated in version 1.5 and will be "
-                    "removed in 1.7. Use 'store_cv_results' instead."
-                ),
-                FutureWarning,
-            )
-            self._store_cv_results = self.store_cv_values
-        elif self.store_cv_results is None:
-            self._store_cv_results = False
-        else:
-            self._store_cv_results = self.store_cv_results
 
         # `_RidgeGCV` does not work for alpha = 0
         if cv is None:
@@ -2444,7 +2418,7 @@ class _BaseRidgeCV(LinearModel):
                 fit_intercept=self.fit_intercept,
                 scoring=scorer,
                 gcv_mode=self.gcv_mode,
-                store_cv_results=self._store_cv_results,
+                store_cv_results=self.store_cv_results,
                 is_clf=is_classifier(self),
                 alpha_per_target=self.alpha_per_target,
             )
@@ -2456,10 +2430,10 @@ class _BaseRidgeCV(LinearModel):
             )
             self.alpha_ = estimator.alpha_
             self.best_score_ = estimator.best_score_
-            if self._store_cv_results:
+            if self.store_cv_results:
                 self.cv_results_ = estimator.cv_results_
         else:
-            if self._store_cv_results:
+            if self.store_cv_results:
                 raise ValueError("cv!=None and store_cv_results=True are incompatible")
             if self.alpha_per_target:
                 raise ValueError("cv!=None and alpha_per_target=True are incompatible")
@@ -2531,16 +2505,6 @@ class _BaseRidgeCV(LinearModel):
             # by the user.
             scorer.set_score_request(sample_weight=True)
         return scorer
-
-    # TODO(1.7): Remove
-    # mypy error: Decorated property not supported
-    @deprecated(  # type: ignore
-        "Attribute `cv_values_` is deprecated in version 1.5 and will be removed "
-        "in 1.7. Use `cv_results_` instead."
-    )
-    @property
-    def cv_values_(self):
-        return self.cv_results_
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
@@ -2629,16 +2593,6 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         When set to `False`, a single alpha is used for all targets.
 
         .. versionadded:: 0.24
-
-    store_cv_values : bool
-        Flag indicating if the cross-validation values corresponding to
-        each alpha should be stored in the ``cv_values_`` attribute (see
-        below). This flag is only compatible with ``cv=None`` (i.e. using
-        Leave-One-Out Cross-Validation).
-
-        .. deprecated:: 1.5
-            `store_cv_values` is deprecated in version 1.5 in favor of
-            `store_cv_results` and will be removed in version 1.7.
 
     Attributes
     ----------
@@ -2807,16 +2761,6 @@ class RidgeClassifierCV(_RidgeClassifierMixin, _BaseRidgeCV):
         .. versionchanged:: 1.5
             Parameter name changed from `store_cv_values` to `store_cv_results`.
 
-    store_cv_values : bool
-        Flag indicating if the cross-validation values corresponding to
-        each alpha should be stored in the ``cv_values_`` attribute (see
-        below). This flag is only compatible with ``cv=None`` (i.e. using
-        Leave-One-Out Cross-Validation).
-
-        .. deprecated:: 1.5
-            `store_cv_values` is deprecated in version 1.5 in favor of
-            `store_cv_results` and will be removed in version 1.7.
-
     Attributes
     ----------
     cv_results_ : ndarray of shape (n_samples, n_targets, n_alphas), optional
@@ -2896,8 +2840,7 @@ class RidgeClassifierCV(_RidgeClassifierMixin, _BaseRidgeCV):
         scoring=None,
         cv=None,
         class_weight=None,
-        store_cv_results=None,
-        store_cv_values="deprecated",
+        store_cv_results=False,
     ):
         super().__init__(
             alphas=alphas,
@@ -2905,7 +2848,6 @@ class RidgeClassifierCV(_RidgeClassifierMixin, _BaseRidgeCV):
             scoring=scoring,
             cv=cv,
             store_cv_results=store_cv_results,
-            store_cv_values=store_cv_values,
         )
         self.class_weight = class_weight
 

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -2233,32 +2233,6 @@ def test_ridge_sample_weight_consistency(
         assert_allclose(reg1.intercept_, reg2.intercept_)
 
 
-# TODO(1.7): Remove
-def test_ridge_store_cv_values_deprecated():
-    """Check `store_cv_values` parameter deprecated."""
-    X, y = make_regression(n_samples=6, random_state=42)
-    ridge = RidgeCV(store_cv_values=True)
-    msg = "'store_cv_values' is deprecated"
-    with pytest.warns(FutureWarning, match=msg):
-        ridge.fit(X, y)
-
-    # Error when both set
-    ridge = RidgeCV(store_cv_results=True, store_cv_values=True)
-    msg = "Both 'store_cv_values' and 'store_cv_results' were"
-    with pytest.raises(ValueError, match=msg):
-        ridge.fit(X, y)
-
-
-def test_ridge_cv_values_deprecated():
-    """Check `cv_values_` deprecated."""
-    X, y = make_regression(n_samples=6, random_state=42)
-    ridge = RidgeCV(store_cv_results=True)
-    msg = "Attribute `cv_values_` is deprecated"
-    with pytest.warns(FutureWarning, match=msg):
-        ridge.fit(X, y)
-        ridge.cv_values_
-
-
 @pytest.mark.parametrize("with_sample_weight", [False, True])
 @pytest.mark.parametrize("fit_intercept", [False, True])
 @pytest.mark.parametrize("n_targets", [1, 2])


### PR DESCRIPTION
Removed deprecated `store_cv_values` parameter and `cv_values_` attribute from `Ridge*` estimators.