### PR TITLE
MNT Clean-up deprecations for 1.7: proba_pred in precision_recall_curve

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -29,7 +29,7 @@ from ..utils import (
     column_or_1d,
 )
 from ..utils._encode import _encode, _unique
-from ..utils._param_validation import Hidden, Interval, StrOptions, validate_params
+from ..utils._param_validation import Interval, StrOptions, validate_params
 from ..utils.extmath import stable_cumsum
 from ..utils.multiclass import type_of_target
 from ..utils.sparsefuncs import count_nonzero
@@ -866,25 +866,20 @@ def _binary_clf_curve(y_true, y_score, pos_label=None, sample_weight=None):
 @validate_params(
     {
         "y_true": ["array-like"],
-        "y_score": ["array-like", Hidden(None)],
+        "y_score": ["array-like"],
         "pos_label": [Real, str, "boolean", None],
         "sample_weight": ["array-like", None],
         "drop_intermediate": ["boolean"],
-        "probas_pred": [
-            "array-like",
-            Hidden(StrOptions({"deprecated"})),
-        ],
     },
     prefer_skip_nested_validation=True,
 )
 def precision_recall_curve(
     y_true,
-    y_score=None,
+    y_score,
     *,
     pos_label=None,
     sample_weight=None,
     drop_intermediate=False,
-    probas_pred="deprecated",
 ):
     """Compute precision-recall pairs for different probability thresholds.
 
@@ -936,15 +931,6 @@ def precision_recall_curve(
 
         .. versionadded:: 1.3
 
-    probas_pred : array-like of shape (n_samples,)
-        Target scores, can either be probability estimates of the positive
-        class, or non-thresholded measure of decisions (as returned by
-        `decision_function` on some classifiers).
-
-        .. deprecated:: 1.5
-            `probas_pred` is deprecated and will be removed in 1.7. Use
-            `y_score` instead.
-
     Returns
     -------
     precision : ndarray of shape (n_thresholds + 1,)
@@ -957,7 +943,7 @@ def precision_recall_curve(
 
     thresholds : ndarray of shape (n_thresholds,)
         Increasing thresholds on the decision function used to compute
-        precision and recall where `n_thresholds = len(np.unique(probas_pred))`.
+        precision and recall where `n_thresholds = len(np.unique(y_score))`.
 
     See Also
     --------
@@ -984,24 +970,6 @@ def precision_recall_curve(
     >>> thresholds
     array([0.1 , 0.35, 0.4 , 0.8 ])
     """
-    # TODO(1.7): remove in 1.7 and reset y_score to be required
-    # Note: validate params will raise an error if probas_pred is not array-like,
-    # or "deprecated"
-    if y_score is not None and not isinstance(probas_pred, str):
-        raise ValueError(
-            "`probas_pred` and `y_score` cannot be both specified. Please use `y_score`"
-            " only as `probas_pred` is deprecated in v1.5 and will be removed in v1.7."
-        )
-    if y_score is None:
-        warnings.warn(
-            (
-                "probas_pred was deprecated in version 1.5 and will be removed in 1.7."
-                "Please use ``y_score`` instead."
-            ),
-            FutureWarning,
-        )
-        y_score = probas_pred
-
     fps, tps, thresholds = _binary_clf_curve(
         y_true, y_score, pos_label=pos_label, sample_weight=sample_weight
     )

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -2248,25 +2248,3 @@ def test_roc_curve_with_probablity_estimates(global_random_seed):
     y_score = rng.rand(10)
     _, _, thresholds = roc_curve(y_true, y_score)
     assert np.isinf(thresholds[0])
-
-
-# TODO(1.7): remove
-def test_precision_recall_curve_deprecation_warning():
-    """Check the message for future deprecation."""
-    # Check precision_recall_curve function
-    y_true, _, y_score = make_prediction(binary=True)
-
-    warn_msg = "probas_pred was deprecated in version 1.5"
-    with pytest.warns(FutureWarning, match=warn_msg):
-        precision_recall_curve(
-            y_true,
-            probas_pred=y_score,
-        )
-
-    error_msg = "`probas_pred` and `y_score` cannot be both specified"
-    with pytest.raises(ValueError, match=error_msg):
-        precision_recall_curve(
-            y_true,
-            probas_pred=y_score,
-            y_score=y_score,
-        )


### PR DESCRIPTION
Removed deprecated `proba_pred` parameter in `precision_recall_curve`.