### PR TITLE
DOC Add paid support section

### DIFF
--- a/doc/support.rst
+++ b/doc/support.rst
@@ -124,8 +124,9 @@ in August 2020), but the PDF is available `here
 Paid support
 ============
 
-In addition to the previous options, paid support is available from the
-following organizations (listed in alphabetical order):
+Companies in the following list (listed in alphabetical order) offer support
+services related to scikit-learn and have a proven track record of employing
+long-term maintainers of scikit-learn and related open source projects:
 
 - `:probabl <https://support.probabl.ai>`__
 - `Quansight <https://quansight.com/open-source-services>`__

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -128,5 +128,5 @@ Companies in the following list (listed in alphabetical order) offer support
 services related to scikit-learn and have a proven track record of employing
 long-term maintainers of scikit-learn and related open source projects:
 
-- `:probabl <https://support.probabl.ai>`__
+- `:probabl. <https://support.probabl.ai>`__
 - `Quansight <https://quansight.com/open-source-services>`__

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -120,3 +120,12 @@ locally by following the :ref:`building documentation instructions <building_doc
 The most recent version with a PDF documentation is quite old, 0.23.2 (released
 in August 2020), but the PDF is available `here
 <https://scikit-learn.org/0.23/_downloads/scikit-learn-docs.pdf>`__.
+
+Paid support
+============
+
+In addition to the previous options, paid support is available from the
+following organizations (listed in alphabetical order):
+
+- `:probabl <https://support.probabl.ai>`__
+- `QuanSight <https://quansight.com/open-source-services>`__

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -95,7 +95,7 @@ The following companies (listed in alphabetical order) offer support services
 related to scikit-learn and have a proven track record of employing long-term
 maintainers of scikit-learn and related open source projects:
 
-- `:probabl. <https://support.probabl.ai>`__
+- `:probabl. <https://support.probabl.ai/?utm_source=scikit_learn_docs&utm_medium=documentation&utm_campaign=pro_support>`__
 - `Quansight <https://quansight.com/open-source-services>`__
 
 .. _social_media:

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -128,4 +128,4 @@ In addition to the previous options, paid support is available from the
 following organizations (listed in alphabetical order):
 
 - `:probabl <https://support.probabl.ai>`__
-- `QuanSight <https://quansight.com/open-source-services>`__
+- `Quansight <https://quansight.com/open-source-services>`__

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -88,6 +88,16 @@ Include in your report:
 
 **Tip**: Gists are Git repositories; you can push data files to them using Git.
 
+Paid support
+============
+
+The following companies (listed in alphabetical order) offer support services
+related to scikit-learn and have a proven track record of employing long-term
+maintainers of scikit-learn and related open source projects:
+
+- `:probabl. <https://support.probabl.ai>`__
+- `Quansight <https://quansight.com/open-source-services>`__
+
 .. _social_media:
 
 Social Media
@@ -120,13 +130,3 @@ locally by following the :ref:`building documentation instructions <building_doc
 The most recent version with a PDF documentation is quite old, 0.23.2 (released
 in August 2020), but the PDF is available `here
 <https://scikit-learn.org/0.23/_downloads/scikit-learn-docs.pdf>`__.
-
-Paid support
-============
-
-Companies in the following list (listed in alphabetical order) offer support
-services related to scikit-learn and have a proven track record of employing
-long-term maintainers of scikit-learn and related open source projects:
-
-- `:probabl. <https://support.probabl.ai>`__
-- `Quansight <https://quansight.com/open-source-services>`__


### PR DESCRIPTION
As discussed during the monthly developer meeting, there seems to be a consensus around adding a "Paid support" section similar to the [Dask paid support page](https://docs.dask.org/en/stable/support.html#paid-support) and listing Probabl and Quansight.

The general feeling during the meeting about "as a company, what is the rule to be added to this list?"
- this should be related to paying an active developer (including doing reviews)

I would say providing scikit-learn paid support is also a requirement. "paid support" may need to be made more precise what it actually entails?

I would rather discuss a "somewhat simple rule" in the issue and link to this issue in the doc, rather than adding the rule in the doc. I would agree that opinions may vary on this.