### PR TITLE
CI Avoid using deprecated Ubuntu-20.04 image from Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -161,7 +161,7 @@ jobs:
 - template: build_tools/azure/posix.yml
   parameters:
     name: Linux
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-22.04
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
     # Runs when dependencies succeeded or skipped
     condition: |


### PR DESCRIPTION
Brownout error seen in https://github.com/scikit-learn/scikit-learn/pull/31118, see [build log](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=75296&view=results).

This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101