### PR TITLE
Fix #30832 LogisticRegressionCV with underrepresented classes

### DIFF
--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1956,6 +1956,21 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
 
         # init cross-validation generator
         cv = check_cv(self.cv, y, classifier=True)
+
+        if isinstance(cv, int):
+            n_splits = cv
+        else:
+            n_splits = cv.get_n_splits()
+        min_samples_class = min(np.bincount(y))
+
+        if n_splits > min_samples_class:
+            raise ValueError(
+                "The least populated class in y has only %d"
+                " sample(s), which is less than number of splits"
+                " (n_splits=%d). Reduce the number of splits or"
+                " increase the dataset size." % (min_samples_class, n_splits)
+            )
+
         folds = list(cv.split(X, y, **routed_params.splitter.split))
 
         # Use the label encoded classes


### PR DESCRIPTION
Training a model with at least a class on the dataset with less samples than folds during Logistic Regression's Cross-Validation led to an incorrect model training as some folds wouldn't have at least a sample of that class.
With this fix, users now receive a much clearer and more meaningful exception, reducing the number of warnings and errors. Additionally, a test was added to ensure that the new exception is correctly triggered in such cases.


#### Reference Issues/PRs
Fixes #30832 
