### PR TITLE
MNT Clean-up deprecations for 1.7: y_prob in brier_score_loss

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -3464,24 +3464,22 @@ def _validate_binary_probabilistic_prediction(y_true, y_prob, sample_weight, pos
 @validate_params(
     {
         "y_true": ["array-like"],
-        "y_proba": ["array-like", Hidden(None)],
+        "y_proba": ["array-like"],
         "sample_weight": ["array-like", None],
         "pos_label": [Real, str, "boolean", None],
         "labels": ["array-like", None],
         "scale_by_half": ["boolean", StrOptions({"auto"})],
-        "y_prob": ["array-like", Hidden(StrOptions({"deprecated"}))],
     },
     prefer_skip_nested_validation=True,
 )
 def brier_score_loss(
     y_true,
-    y_proba=None,
+    y_proba,
     *,
     sample_weight=None,
     pos_label=None,
     labels=None,
     scale_by_half="auto",
-    y_prob="deprecated",
 ):
     r"""Compute the Brier score loss.
 
@@ -3532,13 +3530,6 @@ def brier_score_loss(
         original [0, 2] range for multiclasss classification.
 
         .. versionadded:: 1.7
-
-    y_prob : array-like of shape (n_samples,)
-        Probabilities of the positive class.
-
-        .. deprecated:: 1.5
-            `y_prob` is deprecated and will be removed in 1.7. Use
-            `y_proba` instead.
 
     Returns
     -------
@@ -3598,24 +3589,6 @@ def brier_score_loss(
     ... )
     0.146...
     """
-    # TODO(1.7): remove in 1.7 and reset y_proba to be required
-    # Note: validate params will raise an error if y_prob is not array-like,
-    # or "deprecated"
-    if y_proba is not None and not isinstance(y_prob, str):
-        raise ValueError(
-            "`y_prob` and `y_proba` cannot be both specified. Please use `y_proba` only"
-            " as `y_prob` is deprecated in v1.5 and will be removed in v1.7."
-        )
-    if y_proba is None:
-        warnings.warn(
-            (
-                "y_prob was deprecated in version 1.5 and will be removed in 1.7."
-                "Please use ``y_proba`` instead."
-            ),
-            FutureWarning,
-        )
-        y_proba = y_prob
-
     y_proba = check_array(
         y_proba, ensure_2d=False, dtype=[np.float64, np.float32, np.float16]
     )

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -3166,29 +3166,6 @@ def test_classification_metric_division_by_zero_nan_validaton(scoring):
     cross_val_score(classifier, X, y, scoring=scoring, n_jobs=2, error_score="raise")
 
 
-# TODO(1.7): remove
-def test_brier_score_loss_deprecation_warning():
-    """Check the message for future deprecation."""
-    # Check brier_score_loss function
-    y_true = np.array([0, 1, 1, 0, 1, 1])
-    y_pred = np.array([0.1, 0.8, 0.9, 0.3, 1.0, 0.95])
-
-    warn_msg = "y_prob was deprecated in version 1.5"
-    with pytest.warns(FutureWarning, match=warn_msg):
-        brier_score_loss(
-            y_true,
-            y_prob=y_pred,
-        )
-
-    error_msg = "`y_prob` and `y_proba` cannot be both specified"
-    with pytest.raises(ValueError, match=error_msg):
-        brier_score_loss(
-            y_true,
-            y_prob=y_pred,
-            y_proba=y_pred,
-        )
-
-
 def test_d2_log_loss_score():
     y_true = [0, 0, 0, 1, 1, 1]
     y_true_string = ["no", "no", "no", "yes", "yes", "yes"]


### PR DESCRIPTION
removed deprecated `y_prob` parameter of `brier_score_loss`.