### PR TITLE
DOC Clean up build dependencies

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -69,11 +69,11 @@ feature, code or documentation improvement).
 
    If you installed Python with conda, we recommend to create a dedicated
    `conda environment`_ with all the build dependencies of scikit-learn
-   (namely NumPy_, SciPy_, Cython_ and meson-python_):
+   (namely NumPy_, SciPy_, Cython_, meson-python_ and Ninja_):
 
    .. prompt:: bash $
 
-     conda create -n sklearn-env -c conda-forge python numpy scipy cython meson-python
+     conda create -n sklearn-env -c conda-forge python numpy scipy cython meson-python ninja
 
    It is not always necessary but it is safer to open a new prompt before
    activating the newly created conda environment.

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -69,11 +69,11 @@ feature, code or documentation improvement).
 
    If you installed Python with conda, we recommend to create a dedicated
    `conda environment`_ with all the build dependencies of scikit-learn
-   (namely NumPy_, SciPy_, Cython_, meson-python_ and Ninja_):
+   (namely NumPy_, SciPy_, Cython_ and meson-python_):
 
    .. prompt:: bash $
 
-     conda create -n sklearn-env -c conda-forge python numpy scipy cython meson-python ninja
+     conda create -n sklearn-env -c conda-forge python numpy scipy cython meson-python
 
    It is not always necessary but it is safer to open a new prompt before
    activating the newly created conda environment.

--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -98,6 +98,15 @@ feature, code or documentation improvement).
    for :ref:`compiler_windows`, :ref:`compiler_macos`, :ref:`compiler_linux`
    and :ref:`compiler_freebsd`.
 
+   .. note::
+
+      If OpenMP is not supported by the compiler, the build will be done with
+      OpenMP functionalities disabled. This is not recommended since it will force
+      some estimators to run in sequential mode instead of leveraging thread-based
+      parallelism. Setting the ``SKLEARN_FAIL_NO_OPENMP`` environment variable
+      (before cythonization) will force the build to fail if OpenMP is not
+      supported.
+
 #. Build the project with pip:
 
    .. prompt:: bash $
@@ -129,55 +138,6 @@ feature, code or documentation improvement).
 
     Note that `--config-settings` is only supported in `pip` version 23.1 or
     later. To upgrade `pip` to a compatible version, run `pip install -U pip`.
-
-Dependencies
-------------
-
-Runtime dependencies
-~~~~~~~~~~~~~~~~~~~~
-
-Scikit-learn requires the following dependencies both at build time and at
-runtime:
-
-- Python (>= |PythonMinVersion|),
-- NumPy (>= |NumpyMinVersion|),
-- SciPy (>= |ScipyMinVersion|),
-- Joblib (>= |JoblibMinVersion|),
-- threadpoolctl (>= |ThreadpoolctlMinVersion|).
-
-Build dependencies
-~~~~~~~~~~~~~~~~~~
-
-Building Scikit-learn also requires:
-
-- Cython >= |CythonMinVersion|
-- A C/C++ compiler and a matching OpenMP_ runtime library. See the
-  :ref:`platform system specific instructions
-  <platform_specific_instructions>` for more details.
-
-.. note::
-
-   If OpenMP is not supported by the compiler, the build will be done with
-   OpenMP functionalities disabled. This is not recommended since it will force
-   some estimators to run in sequential mode instead of leveraging thread-based
-   parallelism. Setting the ``SKLEARN_FAIL_NO_OPENMP`` environment variable
-   (before cythonization) will force the build to fail if OpenMP is not
-   supported.
-
-Since version 0.21, scikit-learn automatically detects and uses the linear
-algebra library used by SciPy **at runtime**. Scikit-learn has therefore no
-build dependency on BLAS/LAPACK implementations such as OpenBlas, Atlas, Blis
-or MKL.
-
-Test dependencies
-~~~~~~~~~~~~~~~~~
-
-Running tests requires:
-
-- pytest >= |PytestMinVersion|
-
-Some tests also require `pandas <https://pandas.pydata.org>`_.
-
 
 Building a specific version from a tag
 --------------------------------------


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #31131.

#### What does this implement/fix? Explain your changes.

We remove this [section listing dependencies](https://scikit-learn.org/1.6/developers/advanced_installation.html#dependencies) because:
* It appears after the builds instructions — too late.
* The build instructions already list dependencies — without minimum versions though.
* The minimum versions already appear in the [installation instructions](https://scikit-learn.org/1.6/install.html#installing-the-latest-release).

Also remove Ninja from the list of build dependencies, as it is not a direct build dependency. More precisely:
* scikit-learn depends on meson-python,
* meson-python depends on Meson,
* Meson depends on Ninja.

#### Any other comments?