### PR TITLE
DOC Add Ninja as a build dependency

### DIFF
--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -25,6 +25,7 @@ dependent_packages = {
     "threadpoolctl": (THREADPOOLCTL_MIN_VERSION, "install"),
     "cython": (CYTHON_MIN_VERSION, "build"),
     "meson-python": ("0.16.0", "build"),
+    "ninja": ("1.8.2", "build"),
     "matplotlib": ("3.5.0", "benchmark, docs, examples, tests"),
     "scikit-image": ("0.19.0", "docs, examples, tests"),
     "pandas": ("1.4.0", "benchmark, docs, examples, tests"),


### PR DESCRIPTION

#### Reference Issues/PRs

See https://github.com/scikit-learn/scikit-learn/pull/31142#discussion_r2027412520.

#### What does this implement/fix? Explain your changes.

While meson-python depends on Ninja, most package managers do not pull Ninja when installing Meson. They expect Ninja to be installed separately.

#### Any other comments?

Some Meson installation methods install Ninja as well, but most of them don't.

From the [Getting Meson](https://mesonbuild.com/Getting-meson.html) page:

> ### Installing Meson and Ninja with the MSI installer
> 
> We provide an MSI installer on the [GitHub release page](https://github.com/mesonbuild/meson/releases) that can be used to install both Meson and Ninja at once for Windows. It also contains an embedded copy of Python, so scripts that use the [Python module](https://mesonbuild.com/Python-module.html) and do not have any external dependencies will continue to work as expected.

> ### Dependencies
> 
> In the most common case, you will need the [Ninja executable](https://ninja-build.org/) for using the `ninja` backend, which is the default in Meson. This backend can be used on all platforms and with all toolchains, including GCC, Clang, Visual Studio, MinGW, ICC, ARMCC, etc.
> 
> You can use the version provided by your package manager if possible, otherwise download the binary executable from the [Ninja project's release page](https://github.com/ninja-build/ninja/releases).

From the [Using Meson](https://mesonbuild.com/Quick-guide.html) page:

> _Ninja is only needed if you use the Ninja backend. Meson can also generate native VS and Xcode project files._
> 
> ### Installation using package manager
> 
> Debian or Ubuntu:
> ```
> $ sudo apt-get install python3 ninja-build meson
> ```

> ### Installation using Python
> 
> Requirements: **pip3**
> 
> This is the best way to receive the most up-to-date version of Mesonbuild.
> 
> First, install dependencies using the package manager:
> ```
> $ sudo apt-get install python3 python3-pip python3-setuptools \
>                        python3-wheel ninja-build
> ```