### PR TITLE
CI Fix pyodide wheel testing

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -73,8 +73,10 @@ jobs:
           SKLEARN_SKIP_OPENMP_TEST: "true"
           SKLEARN_SKIP_NETWORK_TESTS: 1
           CIBW_TEST_REQUIRES: "pytest pandas"
-          # need cd otherwise some confusion between installed sklearn package and sklearn folder
-          # -s is needed in pytest to avoid issue in pytest output capturing 
+          # need cd before pytest, otherwise there is an error at pytest
+          # collection time, likely a confusion between installed sklearn
+          # package and sklearn folder.
+          # -s pytest argument is needed to avoid issue in pytest output capturing
           CIBW_TEST_COMMAND: "cd && python -m pytest -svra --pyargs sklearn --durations 20 --showlocals"
 
       - name: Upload wheel artifact

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -73,7 +73,9 @@ jobs:
           SKLEARN_SKIP_OPENMP_TEST: "true"
           SKLEARN_SKIP_NETWORK_TESTS: 1
           CIBW_TEST_REQUIRES: "pytest pandas"
-          CIBW_TEST_COMMAND: "python -m pytest -svra --pyargs sklearn --durations 20 --showlocals"
+          # need cd otherwise some confusion between installed sklearn package and sklearn folder
+          # -s is needed in pytest to avoid issue in pytest output capturing 
+          CIBW_TEST_COMMAND: "cd && python -m pytest -svra --pyargs sklearn --durations 20 --showlocals"
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -67,17 +67,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pypa/cibuildwheel@6c426a3a17cfcadf4b6048de53653eba55d7ae4f # v2.23.2
+      - uses: pypa/cibuildwheel@d04cacbc9866d432033b1d09142936e6a0e2121a # v2.23.2
         env:
           CIBW_PLATFORM: pyodide
           SKLEARN_SKIP_OPENMP_TEST: "true"
           SKLEARN_SKIP_NETWORK_TESTS: 1
           CIBW_TEST_REQUIRES: "pytest pandas"
-          # need cd before pytest, otherwise there is an error at pytest
-          # collection time, likely a confusion between installed sklearn
-          # package and sklearn folder.
           # -s pytest argument is needed to avoid an issue in pytest output capturing with Pyodide
-          CIBW_TEST_COMMAND: "cd && python -m pytest -svra --pyargs sklearn --durations 20 --showlocals"
+          CIBW_TEST_COMMAND: "python -m pytest -svra --pyargs sklearn --durations 20 --showlocals"
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -76,7 +76,7 @@ jobs:
           # need cd before pytest, otherwise there is an error at pytest
           # collection time, likely a confusion between installed sklearn
           # package and sklearn folder.
-          # -s pytest argument is needed to avoid issue in pytest output capturing
+          # -s pytest argument is needed to avoid an issue in pytest output capturing with Pyodide
           CIBW_TEST_COMMAND: "cd && python -m pytest -svra --pyargs sklearn --durations 20 --showlocals"
 
       - name: Upload wheel artifact


### PR DESCRIPTION
Not sure why this started happening recently, see [build log](https://github.com/scikit-learn/scikit-learn/actions/runs/14234547028/job/39924542138).

I get a similar error locally when trying to run from the scikit-learn root folder and cding out of it seems to fix it ...
```
+ python -m pytest -svra --pyargs sklearn --durations 20 --showlocals
  ImportError while loading conftest '/home/runner/work/scikit-learn/scikit-learn/sklearn/conftest.py'.
  sklearn/__init__.py:69: in <module>
      from . import (  # noqa: F401 E402
  sklearn/__check_build/__init__.py:54: in <module>
      raise_build_error(e)
  sklearn/__check_build/__init__.py:35: in raise_build_error
      raise ImportError(
  E   ImportError: No module named 'sklearn.__check_build._check_build'
  E   ___________________________________________________________________________
  E   Contents of /home/runner/work/scikit-learn/scikit-learn/sklearn/__check_build:
  E   __init__.py               _check_build.pyx          meson.build
  E   ___________________________________________________________________________
  E   It seems that scikit-learn has not been built correctly.
  E   
  E   If you have installed scikit-learn from source, please do not forget
  E   to build the package before using it. For detailed instructions, see:
  E   https://scikit-learn.org/dev/developers/advanced_installation.html#building-from-source
  E   
  E   If you have used an installer, please check that it is suited for your
  E   Python version, your operating system and your platform.
  Traceback (most recent call last):
    File "/home/runner/work/_temp/cibw/bin/cibuildwheel", line 8, in <module>
      sys.exit(main())
               ^^^^^^
    File "/home/runner/work/_temp/cibw/lib/python3.12/site-packages/cibuildwheel/__main__.py", line 62, in main
      main_inner(global_options)
    File "/home/runner/work/_temp/cibw/lib/python3.12/site-packages/cibuildwheel/__main__.py", line 203, in main_inner
      build_in_directory(args)
    File "/home/runner/work/_temp/cibw/lib/python3.12/site-packages/cibuildwheel/__main__.py", line 382, in build_in_directory
      platform_module.build(options, tmp_path)
    File "/home/runner/work/_temp/cibw/lib/python3.12/site-packages/cibuildwheel/platforms/pyodide.py", line 431, in build
      shell(test_command_prepared, cwd=test_cwd, env=virtualenv_env)
    File "/home/runner/work/_temp/cibw/lib/python3.12/site-packages/cibuildwheel/util/cmd.py", line 83, in shell
      subprocess.run(command, env=env, cwd=cwd, shell=True, check=True)
    File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/subprocess.py", line 573, in run
      raise CalledProcessError(retcode, process.args,
  subprocess.CalledProcessError: Command 'python -m pytest -svra --pyargs sklearn --durations 20 --showlocals' returned non-zero exit status 4.
```