### PR TITLE
FIX Stability of LinearRegression(positive=True) on 32-bit platform

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/31157.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/31157.fix.rst
@@ -1,0 +1,3 @@
+-  Rows with zero `sample_weight` are removed from the call to scipy `nnls` used
+   when fitting :class:`linear_model.LinearRegression` with `positive=True`.
+   By :user:`Antoine Baker <antoinebaker>`.

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -176,7 +176,7 @@ from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.utils import all_estimators
 from sklearn.utils._tags import get_tags
 from sklearn.utils._testing import SkipTest
-from sklearn.utils.fixes import _IS_32BIT, parse_version, sp_base_version
+from sklearn.utils.fixes import parse_version, sp_base_version
 
 CROSS_DECOMPOSITION = ["PLSCanonical", "PLSRegression", "CCA", "PLSSVD"]
 
@@ -1281,18 +1281,6 @@ def _get_expected_failed_checks(estimator):
                 {
                     "check_n_features_in_after_fitting": "FIXME",
                     "check_dataframe_column_names_consistency": "FIXME",
-                }
-            )
-    if type(estimator) == LinearRegression:
-        if _IS_32BIT:
-            failed_checks.update(
-                {
-                    "check_sample_weight_equivalence_on_dense_data": (
-                        "Issue #31098. Fails on 32-bit platforms with recent scipy."
-                    ),
-                    "check_sample_weight_equivalence_on_sparse_data": (
-                        "Issue #31098. Fails on 32-bit platforms with recent scipy."
-                    ),
                 }
             )
 


### PR DESCRIPTION
Fixes #31098.

#### What does this implement/fix? Explain your changes.

With `sample_weight`, the preprocessed `X` being scaled by `sqrt(sample_weight)` will contain allzeros rows.
This causes instabilities in `scipy.optimize.nnls` (scipy 1.5)  on 32-bit platform [#22791](https://github.com/scipy/scipy/issues/22791).
Here we remove rows corresponding to zero `sample_weight`.

#### Any other comments?

The nnls instability is fixed by https://github.com/scipy/scipy/pull/22802.

