### PR TITLE
MAINT Remove scalar manipulation in `consine_distances` now `clip` fixed in array-api-compat

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -24,7 +24,6 @@ from ..utils._array_api import (
     _is_numpy_namespace,
     _max_precision_float_dtype,
     _modify_in_place_if_numpy,
-    device,
     get_namespace,
     get_namespace_and_device,
 )
@@ -1168,14 +1167,7 @@ def cosine_distances(X, Y=None):
     S = cosine_similarity(X, Y)
     S *= -1
     S += 1
-    # TODO: remove the xp.asarray calls once the following is fixed:
-    # https://github.com/data-apis/array-api-compat/issues/177
-    device_ = device(S)
-    S = xp.clip(
-        S,
-        xp.asarray(0.0, device=device_, dtype=S.dtype),
-        xp.asarray(2.0, device=device_, dtype=S.dtype),
-    )
+    S = xp.clip(S, 0.0, 2.0)
     if X is Y or Y is None:
         # Ensure that distances between vectors and themselves are set to 0.0.
         # This may not be the case due to floating point rounding errors.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
https://github.com/data-apis/array-api-compat/issues/177 has been fixed for a while and there has been a more recent release so I think this todo can be removed now.

cc @ogrisel 

#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
