### PR TITLE
BLD Fix another Meson dependency

### DIFF
--- a/sklearn/linear_model/meson.build
+++ b/sklearn/linear_model/meson.build
@@ -22,7 +22,7 @@ foreach name: name_list
     # TODO in principle this should go in py.exension_module below. This is
     # temporary work-around for dependency issue with .pyx.tp files. For more
     # details, see https://github.com/mesonbuild/meson/issues/13212
-    depends: [linear_model_cython_tree, utils_cython_tree],
+    depends: [linear_model_cython_tree, utils_cython_tree, _loss_cython_tree],
   )
   py.extension_module(
     name,


### PR DESCRIPTION
Found them through `ninja -t missingdeps`. I don't think this has caused any issue in practice but this doesn't hurt to fix it.

Here is how to run `ninja -t missingdeps`
```
rm -rf my-build
meson setup my-build --reconfigure
ninja -C my-build -t missingdeps
```

Output:
```
Missing dep: sklearn/linear_model/_sgd_fast.cpython-313-x86_64-linux-gnu.so.p/sklearn/linear_model/_sgd_fast.pyx.c uses sklearn/_loss/_loss.pxd (generated by CUSTOM_COMMAND)
Missing dep: sklearn/linear_model/_sag_fast.cpython-313-x86_64-linux-gnu.so.p/sklearn/linear_model/_sag_fast.pyx.c uses sklearn/_loss/_loss.pxd (generated by CUSTOM_COMMAND)
Processed 255 nodes.
Error: There are 2 missing dependency paths.
2 targets had depfile dependencies on 1 distinct generated inputs (from 1 rules)  without a non-depfile dep path to the generator.
There might be build flakiness if any of the targets listed above are built alone, or not late enough, in a clean output directory.
```

You can also get an error by explicitly building explicitly one of the two targets with missing dependencies e.g.:
```
rm -rf my-build
ninja -C my-build sklearn/linear_model/_sag_fast.cpython-313-x86_64-linux-gnu.so.p/sklearn/linear_model/_sag_fast.pyx.c
```

Output:
```
ninja: Entering directory `my-build'
[14/14] Compiling Cython source sklearn/linear_model/_sag_fast.pyx
FAILED: sklearn/linear_model/_sag_fast.cpython-313-x86_64-linux-gnu.so.p/sklearn/linear_model/_sag_fast.pyx.c 
cython -M --fast-fail -3 '-X language_level=3' '-X boundscheck=False' '-X wraparound=False' '-X initializedcheck=False' '-X nonecheck=False' '-X cdivision=True' '-X profile=False' --include-dir /home/lesteve/dev/scikit-learn/my-build sklearn/linear_model/_sag_fast.pyx -o sklearn/linear_model/_sag_fast.cpython-313-x86_64-linux-gnu.so.p/sklearn/linear_model/_sag_fast.pyx.c

Error compiling Cython file:
------------------------------------------------------------
...
import numpy as np
from libc.math cimport exp, fabs, isfinite, log
from libc.time cimport time, time_t
from libc.stdio cimport printf

from .._loss._loss cimport (
^
------------------------------------------------------------

sklearn/linear_model/_sag_fast.pyx:8:0: 'sklearn/_loss/_loss.pxd' not found
ninja: build stopped: subcommand failed.
```