### PR TITLE
MNT Improve exception handling for invalid labels in cohen_kappa_score

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -832,7 +832,9 @@ def cohen_kappa_score(y1, y2, *, labels=None, weights=None, sample_weight=None):
     labels : array-like of shape (n_classes,), default=None
         List of labels to index the matrix. This may be used to select a
         subset of labels. If `None`, all labels that appear at least once in
-        ``y1`` or ``y2`` are used.
+        ``y1`` or ``y2`` are used. Note: at least one label in labels must be present in
+         `y1`, even though the function is otherwise agnostic to the order of `y1` and
+         `y2`.
 
     weights : {'linear', 'quadratic'}, default=None
         Weighting type to calculate the score. `None` means not weighted;
@@ -866,7 +868,14 @@ def cohen_kappa_score(y1, y2, *, labels=None, weights=None, sample_weight=None):
     >>> cohen_kappa_score(y1, y2)
     0.6875
     """
-    confusion = confusion_matrix(y1, y2, labels=labels, sample_weight=sample_weight)
+    try:
+        confusion = confusion_matrix(y1, y2, labels=labels, sample_weight=sample_weight)
+    except ValueError as e:
+        if "At least one label specified must be in y_true" in str(e):
+            msg = str(e).replace("y_true", "y1")
+            raise ValueError(msg) from e
+        raise
+
     n_classes = confusion.shape[0]
     sum0 = np.sum(confusion, axis=0)
     sum1 = np.sum(confusion, axis=1)

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -872,7 +872,10 @@ def cohen_kappa_score(y1, y2, *, labels=None, weights=None, sample_weight=None):
         confusion = confusion_matrix(y1, y2, labels=labels, sample_weight=sample_weight)
     except ValueError as e:
         if "At least one label specified must be in y_true" in str(e):
-            msg = str(e).replace("y_true", "y1")
+            msg = (
+                "At least one label in `labels` must be present in `y1` (even though "
+                "the function is otherwise agnostic to the order of `y1` and `y2`)."
+            )
             raise ValueError(msg) from e
         raise
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -832,9 +832,9 @@ def cohen_kappa_score(y1, y2, *, labels=None, weights=None, sample_weight=None):
     labels : array-like of shape (n_classes,), default=None
         List of labels to index the matrix. This may be used to select a
         subset of labels. If `None`, all labels that appear at least once in
-        ``y1`` or ``y2`` are used. Note that at least one label in `labels` must be present in
-         `y1`, even though this function is otherwise agnostic to the order of `y1` and
-         `y2`.
+        ``y1`` or ``y2`` are used. Note that at least one label in `labels` must be
+         present in `y1`, even though this function is otherwise agnostic to the order
+         of `y1` and `y2`.
 
     weights : {'linear', 'quadratic'}, default=None
         Weighting type to calculate the score. `None` means not weighted;

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -832,8 +832,8 @@ def cohen_kappa_score(y1, y2, *, labels=None, weights=None, sample_weight=None):
     labels : array-like of shape (n_classes,), default=None
         List of labels to index the matrix. This may be used to select a
         subset of labels. If `None`, all labels that appear at least once in
-        ``y1`` or ``y2`` are used. Note: at least one label in labels must be present in
-         `y1`, even though the function is otherwise agnostic to the order of `y1` and
+        ``y1`` or ``y2`` are used. Note that at least one label in `labels` must be present in
+         `y1`, even though this function is otherwise agnostic to the order of `y1` and
          `y2`.
 
     weights : {'linear', 'quadratic'}, default=None

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -874,7 +874,8 @@ def cohen_kappa_score(y1, y2, *, labels=None, weights=None, sample_weight=None):
         if "At least one label specified must be in y_true" in str(e):
             msg = (
                 "At least one label in `labels` must be present in `y1` (even though "
-                "the function is otherwise agnostic to the order of `y1` and `y2`)."
+                "`cohen_kappa_score` is otherwise agnostic to the order of `y1` and "
+                "`y2`)."
             )
             raise ValueError(msg) from e
         raise

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -926,6 +926,19 @@ def test_cohen_kappa():
     )
 
 
+def test_cohen_kappa_score_wrong_label():
+    """Test that correct error is raised when users pass labels that are not in y1."""
+    labels = [1, 2]
+    y1 = np.array(["a"] * 5 + ["b"] * 5)
+    y2 = np.array(["b"] * 10)
+    with pytest.raises(ValueError, match="At least one label specified must be in y1"):
+        cohen_kappa_score(y1, y2, labels=labels)
+
+    y1 = np.array([1] * 5 + [2] * 5)
+    y2 = np.array(["b"] * 10)
+    cohen_kappa_score(y1, y2, labels=labels)
+
+
 @pytest.mark.parametrize("zero_division", [0, 1, np.nan])
 @pytest.mark.parametrize("y_true, y_pred", [([0], [0])])
 @pytest.mark.parametrize(

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -926,17 +926,15 @@ def test_cohen_kappa():
     )
 
 
-def test_cohen_kappa_score_wrong_label():
+def test_cohen_kappa_score_error_wrong_label():
     """Test that correct error is raised when users pass labels that are not in y1."""
     labels = [1, 2]
     y1 = np.array(["a"] * 5 + ["b"] * 5)
     y2 = np.array(["b"] * 10)
-    with pytest.raises(ValueError, match="At least one label specified must be in y1"):
+    with pytest.raises(
+        ValueError, match="At least one label in `labels` must be present in `y1`"
+    ):
         cohen_kappa_score(y1, y2, labels=labels)
-
-    y1 = np.array([1] * 5 + [2] * 5)
-    y2 = np.array(["b"] * 10)
-    cohen_kappa_score(y1, y2, labels=labels)
 
 
 @pytest.mark.parametrize("zero_division", [0, 1, np.nan])


### PR DESCRIPTION
This PR fixes a possibly confusing error message coming from confusion matrix by re-raising it with a corrected message.

It also adds a section to the documentation explaining that when passing `labels`, the order of `y1` and `y2` does matter, which otherwise could be surprising to the users.