### PR TITLE
FIX - changed broken endpoint for reuters dataset

### DIFF
--- a/examples/applications/plot_out_of_core_classification.py
+++ b/examples/applications/plot_out_of_core_classification.py
@@ -142,9 +142,7 @@ def stream_reuters_documents(data_path=None):
 
     """
 
-    DOWNLOAD_URL = (
-        "https://kdd.ics.uci.edu/databases/reuters21578/" "reuters21578.tar.gz"
-    )
+    DOWNLOAD_URL = "https://kdd.ics.uci.edu/databases/reuters21578/reuters21578.tar.gz"
     ARCHIVE_SHA256 = "3bae43c9b14e387f76a61b6d82bf98a4fb5d3ef99ef7e7075ff2ccbcf59f9d30"
     ARCHIVE_FILENAME = "reuters21578.tar.gz"
 

--- a/examples/applications/plot_out_of_core_classification.py
+++ b/examples/applications/plot_out_of_core_classification.py
@@ -143,8 +143,8 @@ def stream_reuters_documents(data_path=None):
     """
 
     DOWNLOAD_URL = (
-        "http://archive.ics.uci.edu/ml/machine-learning-databases/"
-        "reuters21578-mld/reuters21578.tar.gz"
+        "https://kdd.ics.uci.edu/databases/reuters21578/"
+        "reuters21578.tar.gz"
     )
     ARCHIVE_SHA256 = "3bae43c9b14e387f76a61b6d82bf98a4fb5d3ef99ef7e7075ff2ccbcf59f9d30"
     ARCHIVE_FILENAME = "reuters21578.tar.gz"

--- a/examples/applications/plot_out_of_core_classification.py
+++ b/examples/applications/plot_out_of_core_classification.py
@@ -143,8 +143,7 @@ def stream_reuters_documents(data_path=None):
     """
 
     DOWNLOAD_URL = (
-        "https://kdd.ics.uci.edu/databases/reuters21578/"
-        "reuters21578.tar.gz"
+        "https://kdd.ics.uci.edu/databases/reuters21578/" "reuters21578.tar.gz"
     )
     ARCHIVE_SHA256 = "3bae43c9b14e387f76a61b6d82bf98a4fb5d3ef99ef7e7075ff2ccbcf59f9d30"
     ARCHIVE_FILENAME = "reuters21578.tar.gz"


### PR DESCRIPTION
This PR fixes bug #31185.

## Problem
The` plot_out_of_core_classification.py `example was failing with a StopIteration error when calling `vectorizer.transform(X_test_text)`. This problem occurred both by running the script directly and during the documentation build (`make html`).

As reported in bug #31185, the traceback indicated that the raw_X iterator within HashingVectorizer was empty, causing the `StopIteration` error at the `next(raw_X) `call.

##  Root Cause
The error was caused by the fact that the URL used to download the dataset Reuters-21578, needed for the example, was broken or no longer valid. As a result, the dataset was not being downloaded properly, leading to empty test data (`X_test_text`).

## Solution
This PR updates the constant DOWNLOAD_URL in the code related to fetching the Reuters dataset to point to the working URL hosted on the UCI Machine Learning repository.