### PR TITLE
MNT Skip sample_weight common test only for scipy 1.15

### DIFF
--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -1284,7 +1284,13 @@ def _get_expected_failed_checks(estimator):
                 }
             )
     if type(estimator) == LinearRegression:
-        if _IS_32BIT:
+        # TODO: remove when scipy min version >= 1.16
+        # Regression introduced in scipy 1.15 and fixed in 1.16, see
+        # https://github.com/scipy/scipy/issues/22791
+        if (
+            parse_version("1.15.0") <= sp_base_version < parse_version("1.16")
+            and _IS_32BIT
+        ):
             failed_checks.update(
                 {
                     "check_sample_weight_equivalence_on_dense_data": (


### PR DESCRIPTION
Closes #31098 

The skip was added as a consequence of a regression introduced in scipy 1.15, see #31101.
It's fixed in scipy main and so will be part of scipy 1.16, see https://github.com/scipy/scipy/issues/22791 So we only need to skip the check for scipy 1.15.

cc/ @ogrisel @antoinebaker 