### PR TITLE
MNT Output clearer pytest IDs for `yield_namespace_device_dtype_combinations`

### DIFF
--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -15,7 +15,6 @@ from sklearn.decomposition._pca import _assess_dimension, _infer_dimension
 from sklearn.utils._array_api import (
     _atol_for_type,
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._array_api import device as array_device
@@ -1007,9 +1006,7 @@ def check_array_api_get_precision(name, estimator, array_namespace, device, dtyp
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "array_namespace, device, dtype_name", yield_namespace_device_dtype_combinations()
 )
 @pytest.mark.parametrize(
     "check",
@@ -1041,9 +1038,7 @@ def test_pca_array_api_compliance(
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "array_namespace, device, dtype_name", yield_namespace_device_dtype_combinations()
 )
 @pytest.mark.parametrize(
     "check",

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -45,7 +45,6 @@ from sklearn.utils._array_api import (
     _NUMPY_NAMESPACE_NAMES,
     _atol_for_type,
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
     yield_namespace_device_dtype_combinations,
     yield_namespaces,
 )
@@ -1257,9 +1256,7 @@ def check_array_api_attributes(name, estimator, array_namespace, device, dtype_n
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "array_namespace, device, dtype_name", yield_namespace_device_dtype_combinations()
 )
 @pytest.mark.parametrize(
     "check",

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -23,10 +23,7 @@ from sklearn.metrics.cluster import (
 )
 from sklearn.metrics.cluster._supervised import _generalized_average, check_clusterings
 from sklearn.utils import assert_all_finite
-from sklearn.utils._array_api import (
-    _get_namespace_device_dtype_ids,
-    yield_namespace_device_dtype_combinations,
-)
+from sklearn.utils._array_api import yield_namespace_device_dtype_combinations
 from sklearn.utils._testing import _array_api_for_tests, assert_almost_equal
 
 score_funcs = [
@@ -274,9 +271,7 @@ def test_entropy():
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "array_namespace, device, dtype_name", yield_namespace_device_dtype_combinations()
 )
 def test_entropy_array_api(array_namespace, device, dtype_name):
     xp = _array_api_for_tests(array_namespace, device)

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -74,7 +74,6 @@ from sklearn.utils import shuffle
 from sklearn.utils._array_api import (
     _atol_for_type,
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._testing import (
@@ -2239,9 +2238,7 @@ def yield_metric_checker_combinations(metric_checkers=array_api_metric_checkers)
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "array_namespace, device, dtype_name", yield_namespace_device_dtype_combinations()
 )
 @pytest.mark.parametrize("metric, check_func", yield_metric_checker_combinations())
 def test_array_api_compliance(metric, array_namespace, device, dtype_name, check_func):

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -82,10 +82,7 @@ from sklearn.tests.metadata_routing_common import (
     check_recorded_metadata,
 )
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
-from sklearn.utils._array_api import (
-    _get_namespace_device_dtype_ids,
-    yield_namespace_device_dtype_combinations,
-)
+from sklearn.utils._array_api import yield_namespace_device_dtype_combinations
 from sklearn.utils._mocking import CheckingClassifier, MockDataFrame
 from sklearn.utils._testing import (
     MinimalClassifier,
@@ -2857,9 +2854,7 @@ def test_cv_results_multi_size_array():
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "array_namespace, device, dtype", yield_namespace_device_dtype_combinations()
 )
 @pytest.mark.parametrize("SearchCV", [GridSearchCV, RandomizedSearchCV])
 def test_array_api_search_cv_classifier(SearchCV, array_namespace, device, dtype):

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -43,7 +43,6 @@ from sklearn.svm import SVC
 from sklearn.tests.metadata_routing_common import assert_request_is_empty
 from sklearn.utils._array_api import (
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
     get_namespace,
     yield_namespace_device_dtype_combinations,
 )
@@ -1311,9 +1310,7 @@ def test_train_test_split_default_test_size(train_size, exp_train, exp_test):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "array_namespace, device, dtype_name", yield_namespace_device_dtype_combinations()
 )
 @pytest.mark.parametrize(
     "shuffle,stratify",

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -38,7 +38,6 @@ from sklearn.preprocessing._data import BOUNDS_THRESHOLD, _handle_zeros_in_scale
 from sklearn.svm import SVR
 from sklearn.utils import gen_batches, shuffle
 from sklearn.utils._array_api import (
-    _get_namespace_device_dtype_ids,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._test_common.instance_generator import _get_check_estimator_ids
@@ -690,9 +689,7 @@ def test_standard_check_array_of_inverse_transform():
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "array_namespace, device, dtype_name", yield_namespace_device_dtype_combinations()
 )
 @pytest.mark.parametrize(
     "check",

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -13,7 +13,6 @@ from sklearn.preprocessing._label import (
 )
 from sklearn.utils._array_api import (
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
     get_namespace,
     yield_namespace_device_dtype_combinations,
 )
@@ -708,9 +707,7 @@ def test_label_encoders_do_not_have_set_output(encoder):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "array_namespace, device, dtype", yield_namespace_device_dtype_combinations()
 )
 @pytest.mark.parametrize(
     "y",

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -116,23 +116,6 @@ def yield_namespace_device_dtype_combinations(include_numpy_namespaces=True):
             yield array_namespace, None, None
 
 
-def _get_namespace_device_dtype_ids(param):
-    """Get pytest parametrization IDs for `yield_namespace_device_dtype_combinations`"""
-    # Gives clearer IDs for array-api-strict devices, see #31042 for details
-    try:
-        import array_api_strict
-    except ImportError:
-        # `None` results in the default pytest representation
-        return None
-    else:
-        if param == array_api_strict.Device("CPU_DEVICE"):
-            return "CPU_DEVICE"
-        if param == array_api_strict.Device("device1"):
-            return "device1"
-        if param == array_api_strict.Device("device2"):
-            return "device2"
-
-
 def _check_array_api_dispatch(array_api_dispatch):
     """Check that array_api_compat is installed and NumPy version is compatible.
 

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -94,6 +94,7 @@ def yield_namespace_device_dtype_combinations(include_numpy_namespaces=True):
             try:
                 import array_api_strict
 
+                # Specify `id` to provide clearer device labels
                 yield pytest.param(
                     array_namespace,
                     array_api_strict.Device("CPU_DEVICE"),

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -9,6 +9,7 @@ import os
 from functools import wraps
 
 import numpy
+import pytest
 import scipy
 import scipy.sparse as sp
 import scipy.special as special
@@ -93,8 +94,18 @@ def yield_namespace_device_dtype_combinations(include_numpy_namespaces=True):
             try:
                 import array_api_strict
 
-                yield array_namespace, array_api_strict.Device("CPU_DEVICE"), "float64"
-                yield array_namespace, array_api_strict.Device("device1"), "float32"
+                yield pytest.param(
+                    array_namespace,
+                    array_api_strict.Device("CPU_DEVICE"),
+                    "float64",
+                    id=f"{array_namespace}-CPU_DEVICE-float64",
+                )
+                yield pytest.param(
+                    array_namespace,
+                    array_api_strict.Device("device1"),
+                    "float32",
+                    id=f"{array_namespace}-device1-float32",
+                )
             except ImportError:
                 # Those combinations will typically be skipped by pytest if
                 # array_api_strict is not installed but we still need to see them in

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -15,7 +15,6 @@ from sklearn.utils._array_api import (
     _count_nonzero,
     _estimator_with_converted_arrays,
     _fill_or_add_to_diagonal,
-    _get_namespace_device_dtype_ids,
     _is_numpy_namespace,
     _isin,
     _max_precision_float_dtype,
@@ -114,9 +113,7 @@ def test_asarray_with_order(array_api):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "array_namespace, device_, dtype_name", yield_namespace_device_dtype_combinations()
 )
 @pytest.mark.parametrize(
     "weights, axis, normalize, expected",
@@ -172,7 +169,6 @@ def test_average(
 @pytest.mark.parametrize(
     "array_namespace, device, dtype_name",
     yield_namespace_device_dtype_combinations(include_numpy_namespaces=False),
-    ids=_get_namespace_device_dtype_ids,
 )
 def test_average_raises_with_wrong_dtype(array_namespace, device, dtype_name):
     xp = _array_api_for_tests(array_namespace, device)
@@ -198,7 +194,6 @@ def test_average_raises_with_wrong_dtype(array_namespace, device, dtype_name):
 @pytest.mark.parametrize(
     "array_namespace, device, dtype_name",
     yield_namespace_device_dtype_combinations(include_numpy_namespaces=True),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize(
     "axis, weights, error, error_msg",
@@ -355,9 +350,7 @@ def test_nan_reductions(library, X, reduction, expected):
 
 
 @pytest.mark.parametrize(
-    "namespace, _device, _dtype",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "namespace, _device, _dtype", yield_namespace_device_dtype_combinations()
 )
 def test_ravel(namespace, _device, _dtype):
     xp = _array_api_for_tests(namespace, _device)
@@ -444,9 +437,7 @@ def test_convert_estimator_to_array_api():
 
 
 @pytest.mark.parametrize(
-    "namespace, _device, _dtype",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "namespace, _device, _dtype", yield_namespace_device_dtype_combinations()
 )
 def test_indexing_dtype(namespace, _device, _dtype):
     xp = _array_api_for_tests(namespace, _device)
@@ -458,9 +449,7 @@ def test_indexing_dtype(namespace, _device, _dtype):
 
 
 @pytest.mark.parametrize(
-    "namespace, _device, _dtype",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "namespace, _device, _dtype", yield_namespace_device_dtype_combinations()
 )
 def test_max_precision_float_dtype(namespace, _device, _dtype):
     xp = _array_api_for_tests(namespace, _device)
@@ -469,9 +458,7 @@ def test_max_precision_float_dtype(namespace, _device, _dtype):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, _",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "array_namespace, device, _", yield_namespace_device_dtype_combinations()
 )
 @pytest.mark.parametrize("invert", [True, False])
 @pytest.mark.parametrize("assume_unique", [True, False])
@@ -535,9 +522,7 @@ def test_get_namespace_and_device():
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "array_namespace, device_, dtype_name", yield_namespace_device_dtype_combinations()
 )
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 @pytest.mark.parametrize("axis", [0, 1, None, -1, -2])
@@ -574,9 +559,7 @@ def test_count_nonzero(
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "array_namespace, device_, dtype_name", yield_namespace_device_dtype_combinations()
 )
 @pytest.mark.parametrize("wrap", [True, False])
 def test_fill_or_add_to_diagonal(array_namespace, device_, dtype_name, wrap):

--- a/sklearn/utils/tests/test_indexing.py
+++ b/sklearn/utils/tests/test_indexing.py
@@ -9,10 +9,7 @@ from scipy.stats import kstest
 import sklearn
 from sklearn.externals._packaging.version import parse as parse_version
 from sklearn.utils import _safe_indexing, resample, shuffle
-from sklearn.utils._array_api import (
-    _get_namespace_device_dtype_ids,
-    yield_namespace_device_dtype_combinations,
-)
+from sklearn.utils._array_api import yield_namespace_device_dtype_combinations
 from sklearn.utils._indexing import (
     _determine_key_type,
     _get_column_indices,
@@ -108,9 +105,7 @@ def test_determine_key_type_slice_error():
 
 @skip_if_array_api_compat_not_configured
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "array_namespace, device, dtype_name", yield_namespace_device_dtype_combinations()
 )
 def test_determine_key_type_array_api(array_namespace, device, dtype_name):
     xp = _array_api_for_tests(array_namespace, device)

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -7,10 +7,7 @@ from scipy.sparse import issparse
 from sklearn import config_context, datasets
 from sklearn.model_selection import ShuffleSplit
 from sklearn.svm import SVC
-from sklearn.utils._array_api import (
-    _get_namespace_device_dtype_ids,
-    yield_namespace_device_dtype_combinations,
-)
+from sklearn.utils._array_api import yield_namespace_device_dtype_combinations
 from sklearn.utils._testing import (
     _array_api_for_tests,
     _convert_container,
@@ -385,7 +382,6 @@ def test_is_multilabel():
 @pytest.mark.parametrize(
     "array_namespace, device, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 def test_is_multilabel_array_api_compliance(array_namespace, device, dtype_name):
     xp = _array_api_for_tests(array_namespace, device)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -34,10 +34,7 @@ from sklearn.utils import (
     check_X_y,
     deprecated,
 )
-from sklearn.utils._array_api import (
-    _get_namespace_device_dtype_ids,
-    yield_namespace_device_dtype_combinations,
-)
+from sklearn.utils._array_api import yield_namespace_device_dtype_combinations
 from sklearn.utils._mocking import (
     MockDataFrame,
     _MockEstimatorOnOffPrediction,
@@ -1033,9 +1030,7 @@ def test_check_consistent_length():
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, _",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
+    "array_namespace, device, _", yield_namespace_device_dtype_combinations()
 )
 def test_check_consistent_length_array_api(array_namespace, device, _):
     """Test that check_consistent_length works with different array types."""


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

* Reverts #31074
* Uses `yield pytest.param` to set IDs as suggested by @thomasjpfan in #31180

Checked ID looks okay:
```
sklearn/preprocessing/tests/test_label.py::test_label_encoder_array_api_compliance[y0-numpy-None-None] PASSED                                                         [  3%]
sklearn/preprocessing/tests/test_label.py::test_label_encoder_array_api_compliance[y0-array_api_strict-CPU_DEVICE-float64] PASSED                                     [  7%]
sklearn/preprocessing/tests/test_label.py::test_label_encoder_array_api_compliance[y0-array_api_strict-device1-float32] PASSED 
```
#### What does this implement/fix? Explain your changes.


#### Any other comments?

cc @lesteve @ogrisel 
