### PR TITLE
MNT Add missing cython-lint install in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
           curl https://raw.githubusercontent.com/${{ github.repository }}/main/build_tools/shared.sh --retry 5 -o ./build_tools/shared.sh
           source build_tools/shared.sh
           # Include pytest compatibility with mypy
-          pip install pytest $(get_dep ruff min) $(get_dep mypy min)
+          pip install pytest $(get_dep ruff min) $(get_dep mypy min) cython-lint
           # we save the versions of the linters to be used in the error message later.
           python -c "from importlib.metadata import version; print(f\"ruff={version('ruff')}\")" >> /tmp/versions.txt
           python -c "from importlib.metadata import version; print(f\"mypy={version('mypy')}\")" >> /tmp/versions.txt

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -3,8 +3,6 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
-# asdf
-
 import os
 import threading
 from contextlib import contextmanager as contextmanager

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -3,6 +3,8 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+# asdf
+
 import os
 import threading
 from contextlib import contextmanager as contextmanager


### PR DESCRIPTION
#### Reference Issues/PRs

See #31015.

#### What does this implement/fix? Explain your changes.

Fix bug introduced by this commit in #31015:
620b0ded MNT black → ruff format

#### Any other comments?

See for example;
https://github.com/scikit-learn/scikit-learn/actions/runs/14468417323/job/40576084429?pr=31207

The linter issue cannot be entirely fixed within this PR, because the CI job is partly driven by `main`. See https://github.com/scikit-learn/scikit-learn/pull/31015#pullrequestreview-2713012970 and https://github.com/scikit-learn/scikit-learn/pull/31015#pullrequestreview-2713012970.