### PR TITLE
MNT Use pytest --import-mode=importlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ testpaths = "sklearn"
 addopts = [
     "--disable-pytest-warnings",
     "--color=yes",
+    "--import-mode=importlib",
 ]
 
 [tool.ruff]

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -706,3 +706,7 @@ def test_isotonic_regression_output_predict():
 
     assert isinstance(X_trans, pd.DataFrame)
     assert isinstance(y_pred, np.ndarray)
+
+
+def test_broken():
+    assert 2 + 1 == 10

--- a/sklearn/tests/test_isotonic.py
+++ b/sklearn/tests/test_isotonic.py
@@ -706,7 +706,3 @@ def test_isotonic_regression_output_predict():
 
     assert isinstance(X_trans, pd.DataFrame)
     assert isinstance(y_pred, np.ndarray)
-
-
-def test_broken():
-    assert 2 + 1 == 10


### PR DESCRIPTION
This would get pytest assertion rewriting back with meson editable install after @fcharras's investigation of https://github.com/mesonbuild/meson-python/issues/646.

`--import-mode=importlib` is what pytest recommends see their [doc](https://docs.pytest.org/en/stable/explanation/goodpractices.html#choosing-an-import-mode). The default `prepend` is an historical thing that they don't recommend and they probably don't want to change the default to not break backward-compatibility.

The recommendation was already the case for our minimum pytest version see [7.1.x doc](https://docs.pytest.org/en/7.1.x/explanation/goodpractices.html#choosing-an-import-mode).

This seems to be working fine locally, let's see what the CI has to say about it.

