### PR TITLE
MNT Avoid nested sequence in `weighted_percentile`

### DIFF
--- a/sklearn/utils/stats.py
+++ b/sklearn/utils/stats.py
@@ -93,14 +93,13 @@ def _weighted_percentile(array, sample_weight, percentile_rank=50, xp=None):
     # For each feature with index j, find sample index i of the scalar value
     # `adjusted_percentile_rank[j]` in 1D array `weight_cdf[j]`, such that:
     # weight_cdf[j, i-1] < adjusted_percentile_rank[j] <= weight_cdf[j, i].
-    percentile_indices = xp.asarray(
+    percentile_indices = xp.stack(
         [
             xp.searchsorted(
                 weight_cdf[feature_idx, ...], adjusted_percentile_rank[feature_idx]
             )
             for feature_idx in range(weight_cdf.shape[0])
         ],
-        device=device,
     )
     # In rare cases, `percentile_indices` equals to `sorted_idx.shape[0]`
     max_idx = sorted_idx.shape[0] - 1


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Use `xp.stack` instead of `xp.asarray` with a nested sequence of arrays - see https://github.com/data-apis/array-api-strict/pull/147 - in `weighted_percentile`

I think this still gives the correct dtype and device of the output.


#### What does this implement/fix? Explain your changes.



#### Any other comments?


cc @ev-br and @ogrisel @betatim who reviewed the original PR
