### PR TITLE
MNT Make ruff check line-too-long (E501)

### DIFF
--- a/examples/covariance/plot_mahalanobis_distances.py
+++ b/examples/covariance/plot_mahalanobis_distances.py
@@ -60,7 +60,7 @@ observation ranking and clustering.
     Proceedings of the National Academy of Sciences of the United States
     of America, 17, 684-688.
 
-"""
+"""  # noqa: E501
 
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause

--- a/examples/feature_selection/plot_rfe_digits.py
+++ b/examples/feature_selection/plot_rfe_digits.py
@@ -16,7 +16,7 @@ at the center of the image tend to be more predictive than those near the edges.
 
     See also :ref:`sphx_glr_auto_examples_feature_selection_plot_rfe_with_cross_validation.py`
 
-"""
+"""  # noqa: E501
 
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause

--- a/examples/feature_selection/plot_select_from_model_diabetes.py
+++ b/examples/feature_selection/plot_select_from_model_diabetes.py
@@ -40,7 +40,7 @@ print(diabetes.DESCR)
 # were already standardized.
 # For a more complete example on the interpretations of the coefficients of
 # linear models, you may refer to
-# :ref:`sphx_glr_auto_examples_inspection_plot_linear_model_coefficient_interpretation.py`.
+# :ref:`sphx_glr_auto_examples_inspection_plot_linear_model_coefficient_interpretation.py`.  # noqa: E501
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/examples/miscellaneous/plot_partial_dependence_visualization_api.py
+++ b/examples/miscellaneous/plot_partial_dependence_visualization_api.py
@@ -11,7 +11,7 @@ customize the plot with the visualization API.
 
     See also :ref:`sphx_glr_auto_examples_miscellaneous_plot_roc_curve_visualization_api.py`
 
-"""
+"""  # noqa: E501
 
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause

--- a/examples/text/plot_document_classification_20newsgroups.py
+++ b/examples/text/plot_document_classification_20newsgroups.py
@@ -356,7 +356,7 @@ def benchmark(clf, custom_name=False):
 # Notice that the most important hyperparameters values were tuned using a grid
 # search procedure not shown in this notebook for the sake of simplicity. See
 # the example script
-# :ref:`sphx_glr_auto_examples_model_selection_plot_grid_search_text_feature_extraction.py`
+# :ref:`sphx_glr_auto_examples_model_selection_plot_grid_search_text_feature_extraction.py`  # noqa: E501
 # for a demo on how such tuning can be done.
 
 from sklearn.ensemble import RandomForestClassifier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ preview = true
 # This enables us to use the explicit preview rules that we want only
 explicit-preview-rules = true
 # all rules can be found here: https://docs.astral.sh/ruff/rules/
-extend-select = ["W", "I", "CPY001", "RUF"]
+extend-select = ["W", "I", "CPY001", "RUF", "E501"]
 ignore=[
     # do not assign a lambda expression, use a def
     "E731",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ preview = true
 # This enables us to use the explicit preview rules that we want only
 explicit-preview-rules = true
 # all rules can be found here: https://docs.astral.sh/ruff/rules/
-extend-select = ["W", "I", "CPY001", "RUF", "E501"]
+extend-select = ["E", "W", "I", "CPY001", "RUF"]
 ignore=[
     # do not assign a lambda expression, use a def
     "E731",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ preview = true
 # This enables us to use the explicit preview rules that we want only
 explicit-preview-rules = true
 # all rules can be found here: https://docs.astral.sh/ruff/rules/
-extend-select = ["E", "W", "I", "CPY001", "RUF"]
+extend-select = ["E501", "W", "I", "CPY001", "RUF"]
 ignore=[
     # do not assign a lambda expression, use a def
     "E731",

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -141,7 +141,7 @@ def _monkey_patch_webbased_functions(context, data_id, gzip_response):
         # For simplicity the mock filenames don't contain the filename, i.e.
         # the last part of the data description url after the last /.
         # For example for id_1, data description download url is:
-        # gunzip -c sklearn/datasets/tests/data/openml/id_1/api-v1-jd-1.json.gz | grep '"url"
+        # gunzip -c sklearn/datasets/tests/data/openml/id_1/api-v1-jd-1.json.gz | grep '"url"  # noqa: E501
         # "https:\/\/www.openml.org\/data\/v1\/download\/1\/anneal.arff"
         # but the mock filename does not contain anneal.arff and is:
         # sklearn/datasets/tests/data/openml/id_1/data-v1-dl-1.arff.gz.

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -444,7 +444,7 @@ GridSearchCV(cv=3, error_score='raise-deprecating',
                                                      score_func=<function chi2 at some_address>)],
                           'reduce_dim__k': [2, 4, 8]}],
              pre_dispatch='2*n_jobs', refit=True, return_train_score=False,
-             scoring=None, verbose=0)"""
+             scoring=None, verbose=0)"""  # noqa: E501
 
     expected = expected[1:]  # remove first \n
     repr_ = pp.pformat(gspipline)


### PR DESCRIPTION
It seems like checking too-long-lines was lost in https://github.com/scikit-learn/scikit-learn/pull/31015.

For now I added only `E501` for checking too-long-lines but maybe we want to add more.

@DimitriPapadopoulos can you explain the reasoning behind your changes in [`pyproject.toml`](https://github.com/scikit-learn/scikit-learn/pull/31015/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711). I was not able to find any discussion about this in your PR.

cc @jeremiedbb.