### PR TITLE
DOC Add missing directives to det_curve-related docstrings

### DIFF
--- a/sklearn/metrics/_plot/det_curve.py
+++ b/sklearn/metrics/_plot/det_curve.py
@@ -120,6 +120,8 @@ class DetCurveDisplay(_BinaryClassifierCurveDisplayMixin):
             from the previous or subsequent threshold. All points with the same
             tp value have the same `fnr` and thus same y coordinate.
 
+            .. versionadded:: 1.7
+
         response_method : {'predict_proba', 'decision_function', 'auto'} \
                 default='auto'
             Specifies whether to use :term:`predict_proba` or
@@ -226,6 +228,8 @@ class DetCurveDisplay(_BinaryClassifierCurveDisplayMixin):
             Whether to drop thresholds where true positives (tp) do not change
             from the previous or subsequent threshold. All points with the same
             tp value have the same `fnr` and thus same y coordinate.
+
+            .. versionadded:: 1.7
 
         pos_label : int, float, bool or str, default=None
             The label of the positive class. When `pos_label=None`, if `y_true`

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -334,8 +334,11 @@ def det_curve(
 
     thresholds : ndarray of shape (n_thresholds,)
         Decreasing thresholds on the decision function (either `predict_proba`
-        or `decision_function`) used to compute FPR and FNR. An arbitrary
-        threshold at infinity is added for the case `fpr=0` and `fnr=1`.
+        or `decision_function`) used to compute FPR and FNR.
+
+        .. versionchanged:: 1.7
+           An arbitrary threshold at infinity is added for the case `fpr=0`
+           and `fnr=1`.
 
     See Also
     --------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Follow-up from #29151.

#### What does this implement/fix? Explain your changes.

This PR:
- adds the `versionadded` directives to the public parameters introduced in #29151, as mentioned in https://github.com/scikit-learn/scikit-learn/pull/29151#discussion_r2049134301 and;
- adds a `versionchanged` directive to `det_curve`'s attribute `thresholds` as mentioned in https://github.com/scikit-learn/scikit-learn/pull/29151#discussion_r2049136065 .

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
