### PR TITLE
MNT Clean-up deprecations for 1.7: byte labels

### DIFF
--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -873,7 +873,6 @@ def test_binary_clf_curve_implicit_pos_label(curve_func):
         np.testing.assert_allclose(int_curve_part, float_curve_part)
 
 
-# TODO(1.7): Update test to check for error when bytes support is removed.
 @pytest.mark.filterwarnings("ignore:Support for labels represented as bytes")
 @pytest.mark.parametrize("curve_func", [precision_recall_curve, roc_curve])
 @pytest.mark.parametrize("labels_type", ["list", "array"])
@@ -881,12 +880,8 @@ def test_binary_clf_curve_implicit_bytes_pos_label(curve_func, labels_type):
     # Check that using bytes class labels raises an informative
     # error for any supported string dtype:
     labels = _convert_container([b"a", b"b"], labels_type)
-    msg = (
-        "y_true takes value in {b'a', b'b'} and pos_label is not "
-        "specified: either make y_true take value in {0, 1} or "
-        "{-1, 1} or pass pos_label explicitly."
-    )
-    with pytest.raises(ValueError, match=msg):
+    msg = "Support for labels represented as bytes is not supported"
+    with pytest.raises(TypeError, match=msg):
         curve_func(labels, [0.0, 1.0])
 
 

--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -358,17 +358,12 @@ def type_of_target(y, input_name="", raise_unknown=False):
                 y = check_array(y, dtype=object, **check_y_kwargs)
 
     try:
-        # TODO(1.7): Change to ValueError when byte labels is deprecated.
-        # labels in bytes format
         first_row_or_val = y[[0], :] if issparse(y) else y[0]
+        # labels in bytes format
         if isinstance(first_row_or_val, bytes):
-            warnings.warn(
-                (
-                    "Support for labels represented as bytes is deprecated in v1.5 and"
-                    " will error in v1.7. Convert the labels to a string or integer"
-                    " format."
-                ),
-                FutureWarning,
+            raise TypeError(
+                "Support for labels represented as bytes is not supported. Convert "
+                "the labels to a string or integer format."
             )
         # The old sequence of sequences format
         if (

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -602,16 +602,12 @@ def test_ovr_decision_function():
     assert_allclose(dec_values, dec_values_one, atol=1e-6)
 
 
-# TODO(1.7): Change to ValueError when byte labels is deprecated.
 @pytest.mark.parametrize("input_type", ["list", "array"])
-def test_labels_in_bytes_format(input_type):
+def test_labels_in_bytes_format_error(input_type):
     # check that we raise an error with bytes encoded labels
     # non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/16980
     target = _convert_container([b"a", b"b"], input_type)
-    err_msg = (
-        "Support for labels represented as bytes is deprecated in v1.5 and will"
-        " error in v1.7. Convert the labels to a string or integer format."
-    )
-    with pytest.warns(FutureWarning, match=err_msg):
+    err_msg = "Support for labels represented as bytes is not supported"
+    with pytest.raises(TypeError, match=err_msg):
         type_of_target(target)


### PR DESCRIPTION
`type_of_target` now errors when labels are in byte format.