### PR TITLE
DOC Clarify usage of d2_pinball_score with model selection tools

### DIFF
--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1752,9 +1752,8 @@ def d2_pinball_score(
 
     This metric is not a built-in scoring string for use in model selection
     tools such as `GridSearchCV` or `RandomizedSearchCV`.
-
     To use it as a custom scoring function, wrap it using
-    :func:`~sklearn.metrics.make_scorer`:
+    :func:`~sklearn.metrics.make_scorer`. See Examples for details.
 
     References
     ----------
@@ -1767,23 +1766,29 @@ def d2_pinball_score(
 
     Examples
     --------
+    >>> import numpy as np
     >>> from sklearn.metrics import d2_pinball_score
-    >>> y_true = [1, 2, 3]
-    >>> y_pred = [1, 3, 3]
-    >>> d2_pinball_score(y_true, y_pred)
-    0.5
-    >>> d2_pinball_score(y_true, y_pred, alpha=0.9)
-    0.772...
-    >>> d2_pinball_score(y_true, y_pred, alpha=0.1)
-    -1.045...
-    >>> d2_pinball_score(y_true, y_true, alpha=0.1)
-    1.0
+    >>> y_true = [3, -0.5, 2, 7]
+    >>> y_pred = [2.5, 0.0, 2, 8]
+    >>> d2_pinball_score(y_true, y_pred, alpha=0.95)
+    0.968...
 
-    >>> # Using d2_pinball_score with model selection tools
+    Using with :func:`~sklearn.metrics.make_scorer`:
+
     >>> from sklearn.metrics import make_scorer, d2_pinball_score
-    >>> scorer = make_scorer(d2_pinball_score, alpha=0.95)
-    >>> # Use `scoring=scorer` in RandomizedSearchCV or GridSearchCV
-"""
+    >>> pinball_95_scorer = make_scorer(d2_pinball_score, alpha=0.95)
+    >>> from sklearn.model_selection import GridSearchCV
+    >>> from sklearn.linear_model import LinearRegression
+    >>> X = np.array([[1], [2], [3], [4]])
+    >>> y = np.array([2.5, 0.0, 2, 8])
+    >>> grid = GridSearchCV(
+    ...     LinearRegression(),
+    ...     param_grid={"fit_intercept": [True, False]},
+    ...     scoring=pinball_95_scorer,
+    ...     cv=2,
+    ... )
+    >>> _ = grid.fit(X, y)
+    """
 
     y_type, y_true, y_pred, multioutput = _check_reg_targets(
         y_true, y_pred, multioutput

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1756,10 +1756,6 @@ def d2_pinball_score(
     To use it as a custom scoring function, wrap it using
     :func:`~sklearn.metrics.make_scorer`:
 
-    >>> from sklearn.metrics import make_scorer, d2_pinball_score
-    >>> scorer = make_scorer(d2_pinball_score, alpha=0.95)
-    >>> # Then use it as `scoring=scorer` in RandomizedSearchCV or GridSearchCV
-
     References
     ----------
     .. [1] Eq. (7) of `Koenker, Roger; Machado, José A. F. (1999).
@@ -1783,10 +1779,11 @@ def d2_pinball_score(
     >>> d2_pinball_score(y_true, y_true, alpha=0.1)
     1.0
 
-    >>> # Using with make_scorer
-    >>> from sklearn.metrics import make_scorer
+    >>> # Using d2_pinball_score with model selection tools
+    >>> from sklearn.metrics import make_scorer, d2_pinball_score
     >>> scorer = make_scorer(d2_pinball_score, alpha=0.95)
-    """
+    >>> # Use `scoring=scorer` in RandomizedSearchCV or GridSearchCV
+"""
 
     y_type, y_true, y_pred, multioutput = _check_reg_targets(
         y_true, y_pred, multioutput

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1750,7 +1750,17 @@ def d2_pinball_score(
     This metric is not well-defined for a single point and will return a NaN
     value if n_samples is less than two.
 
-     References
+    This metric is not a built-in scoring string for use in model selection
+    tools such as `GridSearchCV` or `RandomizedSearchCV`.
+
+    To use it as a custom scoring function, wrap it using
+    :func:`~sklearn.metrics.make_scorer`:
+
+    >>> from sklearn.metrics import make_scorer, d2_pinball_score
+    >>> scorer = make_scorer(d2_pinball_score, alpha=0.95)
+    >>> # Then use it as `scoring=scorer` in RandomizedSearchCV or GridSearchCV
+
+    References
     ----------
     .. [1] Eq. (7) of `Koenker, Roger; Machado, José A. F. (1999).
            "Goodness of Fit and Related Inference Processes for Quantile Regression"
@@ -1772,7 +1782,12 @@ def d2_pinball_score(
     -1.045...
     >>> d2_pinball_score(y_true, y_true, alpha=0.1)
     1.0
+
+    >>> # Using with make_scorer
+    >>> from sklearn.metrics import make_scorer
+    >>> scorer = make_scorer(d2_pinball_score, alpha=0.95)
     """
+
     y_type, y_true, y_pred, multioutput = _check_reg_targets(
         y_true, y_pred, multioutput
     )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Towards #28671 
This PR addresses confusion discussed by users trying to use d2_pinball_score directly as a string value for the scoring parameter in model selection APIs such as GridSearchCV and RandomizedSearchCV.

Although d2_pinball_score is a valid scoring function, it is not registered as a string scorer and must be wrapped using make_scorer. This was not clearly explained in the docstring.




#### What does this implement/fix? Explain your changes.
This improves the documentation of sklearn.metrics.d2_pinball_score by:

Adding a note to clarify that this metric is not a valid string identifier for the scoring parameter in model selection tools.

Providing a code example showing how to use make_scorer to wrap the function correctly for use with GridSearchCV or RandomizedSearchCV.

Adding a usage snippet under the Examples section for easy discoverability.

This change is intended to make usage of d2_pinball_score more transparent and reduce common user errors and confusion.

#### Any other comments?
This PR does not affect the behavior of the function or its API — it is documentation-only.

The motivation arose from real-world usage in probabilistic forecasting, where d2_pinball_score is useful but hard to integrate into model selection workflows due to missing documentation around make_scorer.
