### PR TITLE
Updated _base.py

### DIFF
--- a/sklearn/neural_network/_base.py
+++ b/sklearn/neural_network/_base.py
@@ -39,6 +39,7 @@ def inplace_logistic(X):
     X : {array-like, sparse matrix}, shape (n_samples, n_features)
         The input data.
     """
+    np.clip(X, -30, 30, out=X)  # Preventing saturation beyond sigmoid's steep region
     logistic_sigmoid(X, out=X)
 
 


### PR DESCRIPTION
  Issue #31235 
![Screenshot 2025-04-22 205821](https://github.com/user-attachments/assets/f3c15063-a088-4152-a8e1-8fb8a827fb6d)
Clipping function becomes zero when x>30 or x< -30 . So Clipping helps keeping it in a range where gradient flow is non-zero and training can proceed.



**This change improves the numerical stability and learning performance of the logistic (sigmoid) activation function used in MLPClassifier and MLPRegressor by clipping the input range to the sigmoid.**



#