### PR TITLE
Enhance ROC Curve Display Tests for Improved Clarity and Maintainability

### DIFF
--- a/sklearn/metrics/_plot/tests/test_roc_curve_display.py
+++ b/sklearn/metrics/_plot/tests/test_roc_curve_display.py
@@ -5,15 +5,14 @@ from scipy.integrate import trapezoid
 
 from sklearn import clone
 from sklearn.compose import make_column_transformer
-from sklearn.datasets import load_breast_cancer, load_iris
+from sklearn.datasets import load_breast_cancer, load_iris, make_classification
 from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import RocCurveDisplay, auc, roc_curve
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
-from sklearn.utils import shuffle
-from sklearn.datasets import make_classification
+from sklearn.utils import shuffle 
 
 
 @pytest.fixture(scope="module")

--- a/sklearn/metrics/_plot/tests/test_roc_curve_display.py
+++ b/sklearn/metrics/_plot/tests/test_roc_curve_display.py
@@ -13,6 +13,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils import shuffle
+from sklearn.datasets import make_classification
 
 
 @pytest.fixture(scope="module")
@@ -26,8 +27,16 @@ def data():
 
 @pytest.fixture(scope="module")
 def data_binary(data):
-    X, y = data
-    return X[y < 2], y[y < 2]
+    X, y = make_classification(
+        n_samples=200,
+        n_features=20,
+        n_informative=5,
+        n_redundant=2,
+        flip_y=0.1,        # Add some label noise
+        class_sep=0.8,     # Reduce separation for more overlap
+        random_state=42,
+    )
+    return X, y
 
 
 @pytest.mark.parametrize("response_method", ["predict_proba", "decision_function"])


### PR DESCRIPTION
### PR Description:

#### Summary of Changes:
This PR refactors the `data_binary` fixture in the `test_roc_curve_display.py` file. The previous fixture filtered a multiclass dataset (Iris) to create a binary classification task. However, this approach resulted in AUC values consistently reaching 1.0, which does not reflect real-world challenges. 

The new fixture utilizes `make_classification` from `sklearn.datasets` to generate a synthetic binary classification dataset with the following characteristics:
- 200 samples and 20 features.
- 5 informative features and 2 redundant features.
- 10% label noise (`flip_y=0.1`) to simulate real-world imperfections in the data.
- Class separation (`class_sep=0.8`) set to avoid perfect separation.

These changes provide a more complex and representative dataset for testing the `roc_curve_display` function and other related metrics, thereby improving the robustness of tests.

#### Reference Issues/PRs:
- Fixes #31243
- See also #30399 (comment)

---

#### For Reviewers:
- This change ensures that the dataset used for testing is more reflective of real-world data, particularly in classification tasks that may involve noise and less clear separation between classes.
