### PR TITLE
DOC: Add reference to digits classification example in LogisticRegression docstring

### DIFF
--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1103,6 +1103,10 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
     >>> clf.score(X, y)
     0.97...
 
+    See also
+    --------
+    :ref:`sphx_glr_auto_examples_classification_plot_digits_classification.py`
+
     For a comparison of the LogisticRegression with other classifiers see:
     :ref:`sphx_glr_auto_examples_classification_plot_classification_probability.py`.
     """


### PR DESCRIPTION
Adds a reference to the digits classification example (plot_digits_classification.py) in the LogisticRegression class docstring, following issue #30621.