### PR TITLE
MNT Fix the formatting of the what's new entries for 1.7

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.feature_selection/30179.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.feature_selection/30179.enhancement.rst
@@ -1,3 +1,3 @@
 - :class:`feature_selection.RFECV` now gives access to the ranking and support in each
- iteration and cv step of feature selection.
+  iteration and cv step of feature selection.
   By :user:`Marie S. <MarieSacksick>`

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/30521.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/30521.fix.rst
@@ -1,4 +1,4 @@
--  |Enhancement| Added a new parameter `tol` to
-   :class:`linear_model.LinearRegression` that determines the precision of the
-   solution `coef_` when fitting on sparse data.
-   By :user:`Success Moses <SuccessMoses>`
+- |Enhancement| Added a new parameter `tol` to
+  :class:`linear_model.LinearRegression` that determines the precision of the
+  solution `coef_` when fitting on sparse data.
+  By :user:`Success Moses <SuccessMoses>`

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/30616.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/30616.api.rst
@@ -1,9 +1,9 @@
-The parameter `n_alphas` has been deprecated in the following classes:
-:class:`linear_model.ElasticNetCV` and :class:`linear_model.LassoCV`
-and :class:`linear_model.MultiTaskElasticNetCV` 
-and :class:`linear_model.MultiTaskLassoCV`, and will be removed in 1.9. The parameter
-`alphas` now supports both integers and array-likes, removing the need for `n_alphas`.
-From now on, only `alphas` should be set to either indicate the number of alphas to
-automatically generate (int) or to provide a list of alphas (array-like) to test along
-the regularization path.
-By :user:`Siddharth Bansal <KANNAHWORLD >`.
+- The parameter `n_alphas` has been deprecated in the following classes:
+  :class:`linear_model.ElasticNetCV` and :class:`linear_model.LassoCV`
+  and :class:`linear_model.MultiTaskElasticNetCV`
+  and :class:`linear_model.MultiTaskLassoCV`, and will be removed in 1.9. The parameter
+  `alphas` now supports both integers and array-likes, removing the need for `n_alphas`.
+  From now on, only `alphas` should be set to either indicate the number of alphas to
+  automatically generate (int) or to provide a list of alphas (array-like) to test along
+  the regularization path.
+  By :user:`Siddharth Bansal <KANNAHWORLD >`.

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/30644.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/30644.fix.rst
@@ -1,3 +1,3 @@
--  The update and initialization of the hyperparameters now properly handle
-   sample weights in :class:`linear_model.BayesianRidge`.
-   By :user:`Antoine Baker <antoinebaker>`.
+- The update and initialization of the hyperparameters now properly handle
+  sample weights in :class:`linear_model.BayesianRidge`.
+  By :user:`Antoine Baker <antoinebaker>`.

--- a/doc/whats_new/upcoming_changes/sklearn.manifold/31117.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.manifold/31117.enhancement.rst
@@ -1,3 +1,3 @@
-:class:`manifold.MDS` will switch to use `n_init=1` by default,
-starting from version 1.9.
-By :user:`Dmitry Kobak <dkobak>`
+- :class:`manifold.MDS` will switch to use `n_init=1` by default,
+  starting from version 1.9.
+  By :user:`Dmitry Kobak <dkobak>`

--- a/doc/whats_new/upcoming_changes/sklearn.manifold/31117.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.manifold/31117.fix.rst
@@ -1,5 +1,5 @@
-:class:`manifold.MDS` now uses `eps=1e-6` by default and the convergence
-criterion was adjusted to make sense for both metric and non-metric MDS
-and to follow the reference R implementation. The formula for normalized
-stress was adjusted to follow the original definition by Kruskal.
-By :user:`Dmitry Kobak <dkobak>`
+- :class:`manifold.MDS` now uses `eps=1e-6` by default and the convergence
+  criterion was adjusted to make sense for both metric and non-metric MDS
+  and to follow the reference R implementation. The formula for normalized
+  stress was adjusted to follow the original definition by Kruskal.
+  By :user:`Dmitry Kobak <dkobak>`

--- a/doc/whats_new/upcoming_changes/sklearn.neural_network/24788.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.neural_network/24788.fix.rst
@@ -1,3 +1,3 @@
-:class:`neural_network.MLPRegressor` now raises an informative error when
-`early_stopping` is set and the computed validation set is too small.
-By :user:`David Shumway <davidshumway>`.
+- :class:`neural_network.MLPRegressor` now raises an informative error when
+  `early_stopping` is set and the computed validation set is too small.
+  By :user:`David Shumway <davidshumway>`.

--- a/doc/whats_new/upcoming_changes/sklearn.utils/29907.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/29907.enhancement.rst
@@ -1,5 +1,4 @@
-
 - :func: `resample` now handles sample weights which allows
   weighted resampling.
-  :pr:`29907` by :user:`Shruti Nath <snath-xoc>` and :user:`Olivier Grisel
+  By :user:`Shruti Nath <snath-xoc>` and :user:`Olivier Grisel
   <ogrisel>`

--- a/doc/whats_new/upcoming_changes/sklearn.utils/30775.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/30775.fix.rst
@@ -1,5 +1,5 @@
--  In :mod:`utils.estimator_checks` we now enforce for binary classifiers a
-   binary `y` by taking the minimum as the negative class instead of the first
-   element, which makes it robust to `y` shuffling. It prevents two checks from
-   wrongly failing on binary classifiers.
-   By :user:`Antoine Baker <antoinebaker>`.
+- In :mod:`utils.estimator_checks` we now enforce for binary classifiers a
+  binary `y` by taking the minimum as the negative class instead of the first
+  element, which makes it robust to `y` shuffling. It prevents two checks from
+  wrongly failing on binary classifiers.
+  By :user:`Antoine Baker <antoinebaker>`.


### PR DESCRIPTION
Multiple what's new entries for 1.7 have wrong formatting and render incorrectly. This PR fixes all of them.