### PR TITLE
MNT Avoid pre-commit failure

### DIFF
--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -36,7 +36,7 @@ from ..utils.graph import _fix_connected_components
 from ..utils.validation import check_memory, validate_data
 
 # mypy error: Module 'sklearn.cluster' has no attribute '_hierarchical_fast'
-from . import _hierarchical_fast as _hierarchical
+from . import _hierarchical_fast as _hierarchical  # type: ignore[attr-defined]
 from ._feature_agglomeration import AgglomerationTransform
 
 ###############################################################################


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
`mypy` in Pre-commit was failing locally:
```
sklearn/cluster/_agglomerative.py:39: error: Module "sklearn.cluster" has no attribute "_hierarchical_fast"
```
 The skip was removed here: https://github.com/scikit-learn/scikit-learn/pull/31226/files#diff-4cd0e4b7b1063f3f70c05f3d299765b1533d922cdc7d209ae86a331e7d668447L39:~:text=import%20_hierarchical_fast%20as-,_hierarchical,-%23%20type%3A%20ignore

#### Any other comments?
cc @glemaitre 


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
