### PR TITLE
DOC Add link to plot_sparse_cov example

### DIFF
--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -857,9 +857,10 @@ class GraphicalLassoCV(BaseGraphicalLasso):
     graphical_lasso : L1-penalized covariance estimator.
     GraphicalLasso : Sparse inverse covariance estimation
         with an l1-penalized estimator.
-    :ref:`sphx_glr_auto_examples_covariance_plot_sparse_cov.py` :
-        Synthetic example comparing **GraphicalLassoCV**, Ledoit-Wolf
-        shrinkage and the empirical covariance estimator on generated data.
+        For an example comparing :class:`sklearn.covariance.GraphicalLassoCV`, 
+        :func:`sklearn.covariance.ledoit_wolf` shrinkage and the empirical covariance 
+        on high-dimensional gaussian data, see 
+        :ref:`sphx_glr_auto_examples_covariance_plot_sparse_cov.py`.
 
     Notes
     -----

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -857,9 +857,9 @@ class GraphicalLassoCV(BaseGraphicalLasso):
     graphical_lasso : L1-penalized covariance estimator.
     GraphicalLasso : Sparse inverse covariance estimation
         with an l1-penalized estimator.
-        For an example comparing :class:`sklearn.covariance.GraphicalLassoCV`, 
-        :func:`sklearn.covariance.ledoit_wolf` shrinkage and the empirical covariance 
-        on high-dimensional gaussian data, see 
+        For an example comparing :class:`sklearn.covariance.GraphicalLassoCV`,
+        :func:`sklearn.covariance.ledoit_wolf` shrinkage and the empirical covariance
+        on high-dimensional gaussian data, see
         :ref:`sphx_glr_auto_examples_covariance_plot_sparse_cov.py`.
 
     Notes

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -857,6 +857,9 @@ class GraphicalLassoCV(BaseGraphicalLasso):
     graphical_lasso : L1-penalized covariance estimator.
     GraphicalLasso : Sparse inverse covariance estimation
         with an l1-penalized estimator.
+    :ref:`sphx_glr_auto_examples_covariance_plot_sparse_cov.py` :
+        Synthetic example comparing **GraphicalLassoCV**, Ledoit-Wolf
+        shrinkage and the empirical covariance estimator on generated data.
 
     Notes
     -----

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -857,10 +857,6 @@ class GraphicalLassoCV(BaseGraphicalLasso):
     graphical_lasso : L1-penalized covariance estimator.
     GraphicalLasso : Sparse inverse covariance estimation
         with an l1-penalized estimator.
-        For an example comparing :class:`sklearn.covariance.GraphicalLassoCV`,
-        :func:`sklearn.covariance.ledoit_wolf` shrinkage and the empirical covariance
-        on high-dimensional gaussian data, see
-        :ref:`sphx_glr_auto_examples_covariance_plot_sparse_cov.py`.
 
     Notes
     -----
@@ -897,6 +893,11 @@ class GraphicalLassoCV(BaseGraphicalLasso):
            [0.017, 0.036, 0.094, 0.69 ]])
     >>> np.around(cov.location_, decimals=3)
     array([0.073, 0.04 , 0.038, 0.143])
+
+    For an example comparing :class:`sklearn.covariance.GraphicalLassoCV`,
+    :func:`sklearn.covariance.ledoit_wolf` shrinkage and the empirical covariance
+    on high-dimensional gaussian data, see
+    :ref:`sphx_glr_auto_examples_covariance_plot_sparse_cov.py`.
     """
 
     _parameter_constraints: dict = {


### PR DESCRIPTION
#### Reference Issues
Towards #30621

#### What does this implement / change?
Adds a sphinx-gallery reference to `plot_sparse_cov.py` in the
`GraphicalLassoCV` docstring (and GraphicalLasso for symmetry).  
No runtime code touched.