### PR TITLE
DOC: Add link to plot_nnls example

### DIFF
--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -558,6 +558,9 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
     np.float64(3.0...)
     >>> reg.predict(np.array([[3, 5]]))
     array([16.])
+
+    For an example of using Non-negative least squares in linear regression see
+    :ref:`sphx_glr_auto_examples_linear_model_plot_nnls.py`.
     """
 
     _parameter_constraints: dict = {

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -494,6 +494,10 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
         When set to ``True``, forces the coefficients to be positive. This
         option is only supported for dense arrays.
 
+        For a comparison between a linear regression model with positive constraints
+        on the regression coefficients and a linear regression without such constraints,
+        see :ref:`sphx_glr_auto_examples_linear_model_plot_nnls.py`.
+
         .. versionadded:: 0.24
 
     Attributes
@@ -558,9 +562,6 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
     np.float64(3.0...)
     >>> reg.predict(np.array([[3, 5]]))
     array([16.])
-
-    For an example of using Non-negative least squares in linear regression see
-    :ref:`sphx_glr_auto_examples_linear_model_plot_nnls.py`.
     """
 
     _parameter_constraints: dict = {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #30621.

#### What does this implement/fix? Explain your changes.
This is intended to add a link to the Non-negative least squares example in the LimearRegression API page.
The following example is used: `plot_nnls.py`
This example is linked in the User Guide for Linear Regression, but not anywhere on the API page.
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
