### PR TITLE
DOC Fix return type for `d2_tweedie_score`

### DIFF
--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1622,7 +1622,7 @@ def d2_tweedie_score(y_true, y_pred, *, sample_weight=None, power=0):
 
     Returns
     -------
-    z : float or ndarray of floats
+    z : float
         The D^2 score.
 
     Notes


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs



#### What does this implement/fix? Explain your changes.
AFAICT `d2_tweedie_score` does not accept multi-output regression data, so I don't think it ever returns a "ndarray of floats" ?
Note this has been in docstring since initial PR that added this function (#17036)

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
