### PR TITLE
MNT Remove pr directives from towncrier fragments

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/30521.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/30521.fix.rst
@@ -1,4 +1,4 @@
-- |Enhancement| Added a new parameter `tol` to
+- Added a new parameter `tol` to
   :class:`linear_model.LinearRegression` that determines the precision of the
   solution `coef_` when fitting on sparse data.
   By :user:`Success Moses <SuccessMoses>`

--- a/doc/whats_new/upcoming_changes/sklearn.metrics/29151.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/29151.enhancement.rst
@@ -3,4 +3,4 @@
   `drop_intermediate` option to drop thresholds where true positives (tp) do not
   change from the previous or subsequent thresholds. All points with the same tp
   value have the same `fnr` and thus same y coordinate in a DET curve.
-  :pr:`29151` by :user:`Arturo Amor <ArturoAmorQ>`.
+  By :user:`Arturo Amor <ArturoAmorQ>`

--- a/doc/whats_new/upcoming_changes/sklearn.metrics/29151.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/29151.fix.rst
@@ -1,4 +1,4 @@
 - :func:`metrics.det_curve` and :class:`metrics.DetCurveDisplay` now return an
   extra threshold at infinity where the classifier always predicts the negative
   class i.e. tps = fps = 0.
-  :pr:`29151` by :user:`Arturo Amor <ArturoAmorQ>`.
+  By :user:`Arturo Amor <ArturoAmorQ>`

--- a/doc/whats_new/upcoming_changes/sklearn.preprocessing/29907.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.preprocessing/29907.enhancement.rst
@@ -1,6 +1,6 @@
 - :class:`preprocessing.KBinsDiscretizer` with `strategy="uniform"` now
   accepts `sample_weight`. Additionally with `strategy="quantile"` the
   `quantile_method` can now be specified (in the future
-  `quantile_method="averaged_inverted_cdf"` will become the default)
-  :pr:`29907` by :user:`Shruti Nath <snath-xoc>` and :user:`Olivier Grisel
+  `quantile_method="averaged_inverted_cdf"` will become the default).
+  By :user:`Shruti Nath <snath-xoc>` and :user:`Olivier Grisel
   <ogrisel>`

--- a/doc/whats_new/upcoming_changes/sklearn.preprocessing/29907.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.preprocessing/29907.fix.rst
@@ -2,5 +2,5 @@
   sample weights are given and subsampling is used. This may change results
   even when not using sample weights, although in absolute and not in terms
   of statistical properties.
-  :pr:`29907` by :user:`Shruti Nath <snath-xoc>` and :user:`Jérémie du Boisberranger
+  By :user:`Shruti Nath <snath-xoc>` and :user:`Jérémie du Boisberranger
   <jeremiedbb>`

--- a/doc/whats_new/upcoming_changes/sklearn.utils/26335.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/26335.enhancement.rst
@@ -1,4 +1,4 @@
-- |Enhancement| :func:`utils.multiclass.type_of_target` raises a warning when the number
+- :func:`utils.multiclass.type_of_target` raises a warning when the number
   of unique classes is greater than 50% of the number of samples. This warning is raised
   only if `y` has more than 20 samples.
   By :user:`Rahil Parikh <rprkh>`.


### PR DESCRIPTION
PR number is automatically added by towncrier, no need to add `:pr:` directive.

See for example https://scikit-learn.org/dev/whats_new/v1.7.html#sklearn-metrics

![image](https://github.com/user-attachments/assets/5a22bd0c-b1e9-4615-860d-66995eedc4e9)

In case this is useful, the fragment instructions are in [`doc/whats_new/upcoming_changes/README.md`](https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md)