### PR TITLE
DOC Add references to DetCurveDisplay docstring

### DIFF
--- a/sklearn/metrics/_plot/det_curve.py
+++ b/sklearn/metrics/_plot/det_curve.py
@@ -15,12 +15,10 @@ class DetCurveDisplay(_BinaryClassifierCurveDisplayMixin):
     or :func:`~sklearn.metrics.DetCurveDisplay.from_predictions` to create a
     visualizer. All parameters are stored as attributes.
 
-    Read more in the :ref:`User Guide <det_curve>`.
-
     For general information regarding `scikit-learn` visualization tools, see
     the :ref:`Visualization Guide <visualizations>`.
     For guidance on interpreting these plots, refer to the
-    :ref:`Model Evaluation Guide <model_evaluation>`.
+    :ref:`Model Evaluation Guide <det_curve>`.
 
 
     .. versionadded:: 0.24
@@ -102,13 +100,12 @@ class DetCurveDisplay(_BinaryClassifierCurveDisplayMixin):
     ):
         """Plot DET curve given an estimator and data.
 
-        Read more in the :ref:`User Guide <det_curve>`.
         Plot DET curve given an estimator and data.
 
         For general information regarding `scikit-learn` visualization tools, see
         the :ref:`Visualization Guide <visualizations>`.
         For guidance on interpreting these plots, refer to the
-        :ref:`Model Evaluation Guide <model_evaluation>`.
+        :ref:`Model Evaluation Guide <det_curve>`.
 
 
         .. versionadded:: 1.0
@@ -220,12 +217,10 @@ class DetCurveDisplay(_BinaryClassifierCurveDisplayMixin):
     ):
         """Plot the DET curve given the true and predicted labels.
 
-        Read more in the :ref:`User Guide <det_curve>`.
-        Plot the DET curve given the true and predicted labels.
         For general information regarding `scikit-learn` visualization tools, see
         the :ref:`Visualization Guide <visualizations>`.
         For guidance on interpreting these plots, refer to the
-        :ref:`Model Evaluation Guide <model_evaluation>`.
+        :ref:`Model Evaluation Guide <det_curve>`.
 
 
         .. versionadded:: 1.0

--- a/sklearn/metrics/_plot/det_curve.py
+++ b/sklearn/metrics/_plot/det_curve.py
@@ -20,7 +20,6 @@ class DetCurveDisplay(_BinaryClassifierCurveDisplayMixin):
     For guidance on interpreting these plots, refer to the
     :ref:`Model Evaluation Guide <det_curve>`.
 
-
     .. versionadded:: 0.24
 
     Parameters
@@ -106,7 +105,6 @@ class DetCurveDisplay(_BinaryClassifierCurveDisplayMixin):
         the :ref:`Visualization Guide <visualizations>`.
         For guidance on interpreting these plots, refer to the
         :ref:`Model Evaluation Guide <det_curve>`.
-
 
         .. versionadded:: 1.0
 
@@ -221,7 +219,6 @@ class DetCurveDisplay(_BinaryClassifierCurveDisplayMixin):
         the :ref:`Visualization Guide <visualizations>`.
         For guidance on interpreting these plots, refer to the
         :ref:`Model Evaluation Guide <det_curve>`.
-
 
         .. versionadded:: 1.0
 

--- a/sklearn/metrics/_plot/det_curve.py
+++ b/sklearn/metrics/_plot/det_curve.py
@@ -99,8 +99,6 @@ class DetCurveDisplay(_BinaryClassifierCurveDisplayMixin):
     ):
         """Plot DET curve given an estimator and data.
 
-        Plot DET curve given an estimator and data.
-
         For general information regarding `scikit-learn` visualization tools, see
         the :ref:`Visualization Guide <visualizations>`.
         For guidance on interpreting these plots, refer to the

--- a/sklearn/metrics/_plot/det_curve.py
+++ b/sklearn/metrics/_plot/det_curve.py
@@ -17,6 +17,12 @@ class DetCurveDisplay(_BinaryClassifierCurveDisplayMixin):
 
     Read more in the :ref:`User Guide <det_curve>`.
 
+    For general information regarding `scikit-learn` visualization tools, see
+    the :ref:`Visualization Guide <visualizations>`.
+    For guidance on interpreting these plots, refer to the
+    :ref:`Model Evaluation Guide <model_evaluation>`.
+
+
     .. versionadded:: 0.24
 
     Parameters
@@ -97,6 +103,13 @@ class DetCurveDisplay(_BinaryClassifierCurveDisplayMixin):
         """Plot DET curve given an estimator and data.
 
         Read more in the :ref:`User Guide <det_curve>`.
+        Plot DET curve given an estimator and data.
+
+        For general information regarding `scikit-learn` visualization tools, see
+        the :ref:`Visualization Guide <visualizations>`.
+        For guidance on interpreting these plots, refer to the
+        :ref:`Model Evaluation Guide <model_evaluation>`.
+
 
         .. versionadded:: 1.0
 
@@ -208,6 +221,12 @@ class DetCurveDisplay(_BinaryClassifierCurveDisplayMixin):
         """Plot the DET curve given the true and predicted labels.
 
         Read more in the :ref:`User Guide <det_curve>`.
+        Plot the DET curve given the true and predicted labels.
+        For general information regarding `scikit-learn` visualization tools, see
+        the :ref:`Visualization Guide <visualizations>`.
+        For guidance on interpreting these plots, refer to the
+        :ref:`Model Evaluation Guide <model_evaluation>`.
+
 
         .. versionadded:: 1.0
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Addresses #31304

#### What does this implement/fix? Explain your changes.

Adds cross-references in the DetCurveDisplay docstrings (class, from_estimator, and from_predictions) to the Visualization Guide and the Model Evaluation Guide for improved documentation discoverability.

#### Any other comments?

Done during the unaite x probabl sprint.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
