### PR TITLE
Fix do not recommend to increase `max_iter` in `ConvergenceWarning` when not appropriate

### DIFF
--- a/doc/whats_new/upcoming_changes/changed-models/31316.fix.rst
+++ b/doc/whats_new/upcoming_changes/changed-models/31316.fix.rst
@@ -1,0 +1,5 @@
+- Change the `ConvergenceWarning` message of estimators that rely on the
+  `"lbfgs"` optimizer internally to be more informative and to avoid
+  suggesting to increase the maximum number of iterations when it is not
+  user-settable or when the convergence problem happens before reaching it.
+  By :user:`Olivier Grisel <ogrisel>`.

--- a/sklearn/linear_model/_glm/_newton_solver.py
+++ b/sklearn/linear_model/_glm/_newton_solver.py
@@ -178,13 +178,14 @@ class NewtonSolver(ABC):
             - self.coef
             - self.converged
         """
+        max_iter = self.max_iter - self.iteration
         opt_res = scipy.optimize.minimize(
             self.linear_loss.loss_gradient,
             self.coef,
             method="L-BFGS-B",
             jac=True,
             options={
-                "maxiter": self.max_iter - self.iteration,
+                "maxiter": max_iter,
                 "maxls": 50,  # default is 20
                 "iprint": self.verbose - 1,
                 "gtol": self.tol,
@@ -192,7 +193,7 @@ class NewtonSolver(ABC):
             },
             args=(X, y, sample_weight, self.l2_reg_strength, self.n_threads),
         )
-        self.iteration += _check_optimize_result("lbfgs", opt_res)
+        self.iteration += _check_optimize_result("lbfgs", opt_res, max_iter=max_iter)
         self.coef = opt_res.x
         self.converged = opt_res.status == 0
 

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -282,7 +282,9 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
                 },
                 args=(X, y, sample_weight, l2_reg_strength, n_threads),
             )
-            self.n_iter_ = _check_optimize_result("lbfgs", opt_res)
+            self.n_iter_ = _check_optimize_result(
+                "lbfgs", opt_res, max_iter=self.max_iter
+            )
             coef = opt_res.x
         elif self.solver == "newton-cholesky":
             sol = NewtonCholeskySolver(

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -444,7 +444,7 @@ def test_logistic_regression_path_convergence_fail():
 
     assert len(record) == 1
     warn_msg = record[0].message.args[0]
-    assert "lbfgs failed to converge" in warn_msg
+    assert "lbfgs failed to converge after 1 iteration(s) toto" in warn_msg
     assert "Increase the number of iterations" in warn_msg
     assert "scale the data" in warn_msg
     assert "linear_model.html#logistic-regression" in warn_msg

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -444,7 +444,7 @@ def test_logistic_regression_path_convergence_fail():
 
     assert len(record) == 1
     warn_msg = record[0].message.args[0]
-    assert "lbfgs failed to converge after 1 iteration(s) toto" in warn_msg
+    assert "lbfgs failed to converge after 1 iteration(s)" in warn_msg
     assert "Increase the number of iterations" in warn_msg
     assert "scale the data" in warn_msg
     assert "linear_model.html#logistic-regression" in warn_msg

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -352,25 +352,33 @@ def _check_optimize_result(solver, result, max_iter=None, extra_warning_msg=None
     """
     # handle both scipy and scikit-learn solver names
     if solver == "lbfgs":
-        if result.status != 0:
-            result_message = result.message
-
-            warning_msg = (
-                "{} failed to converge (status={}):\n{}.\n\n"
-                "Increase the number of iterations (max_iter) "
-                "or scale the data as shown in:\n"
-                "    https://scikit-learn.org/stable/modules/"
-                "preprocessing.html"
-            ).format(solver, result.status, result_message)
-            if extra_warning_msg is not None:
-                warning_msg += "\n" + extra_warning_msg
-            warnings.warn(warning_msg, ConvergenceWarning, stacklevel=2)
         if max_iter is not None:
             # In scipy <= 1.0.0, nit may exceed maxiter for lbfgs.
             # See https://github.com/scipy/scipy/issues/7854
             n_iter_i = min(result.nit, max_iter)
         else:
             n_iter_i = result.nit
+
+        if result.status != 0:
+            warning_msg = (
+                f"{solver} failed to converge after {n_iter_i} iteration(s) "
+                f"(status={result.status}):\n"
+                f"{result.message}\n"
+            )
+            if max_iter is not None and n_iter_i == max_iter:
+                warning_msg += (
+                    f"\nIncrease the number of iterations to improve the "
+                    f"convergence (max_iter={max_iter})."
+                )
+            warning_msg += (
+                "\nYou might also want to scale the data as shown in:\n"
+                "    https://scikit-learn.org/stable/modules/"
+                "preprocessing.html"
+            )
+            if extra_warning_msg is not None:
+                warning_msg += "\n" + extra_warning_msg
+            warnings.warn(warning_msg, ConvergenceWarning, stacklevel=2)
+
     else:
         raise NotImplementedError
 

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -369,10 +369,6 @@ def _check_optimize_result(solver, result, max_iter=None, extra_warning_msg=None
             # number of iterations reaches the maximum allowed (max_iter),
             # as this suggests the optimization may have been prematurely
             # terminated due to the iteration limit.
-            #
-            # Furthermore, this recommandation should only be displayed
-            # when max_iter is provided hence assumed settable by the
-            # user-facing API.
             if max_iter is not None and n_iter_i == max_iter:
                 warning_msg += (
                     f"\nIncrease the number of iterations to improve the "

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -365,6 +365,14 @@ def _check_optimize_result(solver, result, max_iter=None, extra_warning_msg=None
                 f"(status={result.status}):\n"
                 f"{result.message}\n"
             )
+            # Append a recommendation to increase iterations only when the
+            # number of iterations reaches the maximum allowed (max_iter),
+            # as this suggests the optimization may have been prematurely
+            # terminated due to the iteration limit.
+            #
+            # Furthermore, this recommandation should only be displayed
+            # when max_iter is provided hence assumed settable by the
+            # user-facing API.
             if max_iter is not None and n_iter_i == max_iter:
                 warning_msg += (
                     f"\nIncrease the number of iterations to improve the "

--- a/sklearn/utils/tests/test_optimize.py
+++ b/sklearn/utils/tests/test_optimize.py
@@ -1,10 +1,13 @@
+import warnings
+
 import numpy as np
 import pytest
 from scipy.optimize import fmin_ncg
 
 from sklearn.exceptions import ConvergenceWarning
+from sklearn.utils._bunch import Bunch
 from sklearn.utils._testing import assert_allclose
-from sklearn.utils.optimize import _newton_cg
+from sklearn.utils.optimize import _check_optimize_result, _newton_cg
 
 
 def test_newton_cg(global_random_seed):
@@ -160,3 +163,58 @@ def test_newton_cg_verbosity(capsys, verbose):
         ]
         for m in msg:
             assert m in captured.out
+
+
+def test_check_optimize():
+    # Mock some lbfgs output using a Bunch instance:
+    result = Bunch()
+
+    # First case: no warnings
+    result.nit = 1
+    result.status = 0
+    result.message = "OK"
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _check_optimize_result("lbfgs", result)
+
+    # Second case: warning about implicit `max_iter`: do not recommend the user
+    # to increase `max_iter` this is not a user settable parameter.
+    result.status = 1
+    result.message = "STOP: TOTAL NO. OF ITERATIONS REACHED LIMIT"
+    with pytest.warns(ConvergenceWarning) as record:
+        _check_optimize_result("lbfgs", result)
+
+    assert len(record) == 1
+    warn_msg = record[0].message.args[0]
+    assert "lbfgs failed to converge after 1 iteration(s)" in warn_msg
+    assert result.message in warn_msg
+    assert "Increase the number of iterations" not in warn_msg
+    assert "scale the data" in warn_msg
+
+    # Third case: warning about explicit `max_iter`: recommend user to increase
+    # `max_iter`.
+    with pytest.warns(ConvergenceWarning) as record:
+        _check_optimize_result("lbfgs", result, max_iter=1)
+
+    assert len(record) == 1
+    warn_msg = record[0].message.args[0]
+    assert "lbfgs failed to converge after 1 iteration(s)" in warn_msg
+    assert result.message in warn_msg
+    assert "Increase the number of iterations" in warn_msg
+    assert "scale the data" in warn_msg
+
+    # Fourth case: other convergence problem before reaching `max_iter`: do not
+    # recommend increasing `max_iter`.
+    result.nit = 2
+    result.status = 2
+    result.message = "ABNORMAL"
+    with pytest.warns(ConvergenceWarning) as record:
+        _check_optimize_result("lbfgs", result, max_iter=10)
+
+    assert len(record) == 1
+    warn_msg = record[0].message.args[0]
+    assert "lbfgs failed to converge after 2 iteration(s)" in warn_msg
+    assert result.message in warn_msg
+    assert "Increase the number of iterations" not in warn_msg
+    assert "scale the data" in warn_msg


### PR DESCRIPTION
While investigating #31164 I found out that `_check_optimize_result` can sometimes lead to misleading error messages.

This fix should help avoid pointing people in a misleading direction when investigating such convergence problems.