### PR TITLE
TST Added global_random_seed to test functions

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_binning.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_binning.py
@@ -143,8 +143,8 @@ def test_bin_mapper_random_data(max_bins):
 
 
 @pytest.mark.parametrize("n_samples, max_bins", [(5, 5), (5, 10), (5, 11), (42, 255)])
-def test_bin_mapper_small_random_data(n_samples, max_bins):
-    data = np.random.RandomState(42).normal(size=n_samples).reshape(-1, 1)
+def test_bin_mapper_small_random_data(n_samples, max_bins,global_random_seed):
+    data = np.random.RandomState(global_random_seed).normal(size=n_samples).reshape(-1, 1)
     assert len(np.unique(data)) == n_samples
 
     # max_bins is the number of bins for non-missing values
@@ -174,8 +174,8 @@ def test_bin_mapper_identity_repeated_values(max_bins, n_distinct, multiplier):
 
 
 @pytest.mark.parametrize("n_distinct", [2, 7, 42])
-def test_bin_mapper_repeated_values_invariance(n_distinct):
-    rng = np.random.RandomState(42)
+def test_bin_mapper_repeated_values_invariance(n_distinct, global_random_seed):
+    rng = np.random.RandomState(global_random_seed)
     distinct_values = rng.normal(size=n_distinct)
     assert len(np.unique(distinct_values)) == n_distinct
 
@@ -226,9 +226,9 @@ def test_bin_mapper_identity_small(max_bins, scale, offset):
         (42, 255),
     ],
 )
-def test_bin_mapper_idempotence(max_bins_small, max_bins_large):
+def test_bin_mapper_idempotence(max_bins_small, max_bins_large, global_random_seed):
     assert max_bins_large >= max_bins_small
-    data = np.random.RandomState(42).normal(size=30000).reshape(-1, 1)
+    data = np.random.RandomState(global_random_seed).normal(size=30000).reshape(-1, 1)
     mapper_small = _BinMapper(n_bins=max_bins_small + 1)
     mapper_large = _BinMapper(n_bins=max_bins_small + 1)
     binned_small = mapper_small.fit_transform(data)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_binning.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_binning.py
@@ -143,8 +143,10 @@ def test_bin_mapper_random_data(max_bins):
 
 
 @pytest.mark.parametrize("n_samples, max_bins", [(5, 5), (5, 10), (5, 11), (42, 255)])
-def test_bin_mapper_small_random_data(n_samples, max_bins,global_random_seed):
-    data = np.random.RandomState(global_random_seed).normal(size=n_samples).reshape(-1, 1)
+def test_bin_mapper_small_random_data(n_samples, max_bins, global_random_seed):
+    data = (
+        np.random.RandomState(global_random_seed).normal(size=n_samples).reshape(-1, 1)
+    )
     assert len(np.unique(data)) == n_samples
 
     # max_bins is the number of bins for non-missing values

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -1604,7 +1604,9 @@ def test_dataframe_categorical_results_same_as_ndarray(
     "HistGradientBoosting",
     [HistGradientBoostingClassifier, HistGradientBoostingRegressor],
 )
-def test_dataframe_categorical_errors(dataframe_lib, HistGradientBoosting, global_random_seed):
+def test_dataframe_categorical_errors(
+    dataframe_lib, HistGradientBoosting, global_random_seed
+):
     """Check error cases for pandas categorical feature."""
     pytest.importorskip(dataframe_lib)
     msg = "Categorical feature 'f_cat' is expected to have a cardinality <= 16"

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_grower.py
@@ -222,7 +222,9 @@ def test_predictor_from_grower():
         (300, 301, 255, True, 0.1),
     ],
 )
-def test_min_samples_leaf(n_samples, min_samples_leaf, n_bins, constant_hessian, noise, global_random_seed):
+def test_min_samples_leaf(
+    n_samples, min_samples_leaf, n_bins, constant_hessian, noise, global_random_seed
+):
     rng = np.random.RandomState(global_random_seed)
     # data = linear target, 3 features, 1 irrelevant.
     X = rng.normal(size=(n_samples, 3))
@@ -512,7 +514,9 @@ def test_grow_tree_categories():
 @pytest.mark.parametrize("min_samples_leaf", (1, 20))
 @pytest.mark.parametrize("n_unique_categories", (2, 10, 100))
 @pytest.mark.parametrize("target", ("binary", "random", "equal"))
-def test_ohe_equivalence(min_samples_leaf, n_unique_categories, target, global_random_seed):
+def test_ohe_equivalence(
+    min_samples_leaf, n_unique_categories, target, global_random_seed
+):
     # Make sure that native categorical splits are equivalent to using a OHE,
     # when given enough depth
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_grower.py
@@ -222,8 +222,8 @@ def test_predictor_from_grower():
         (300, 301, 255, True, 0.1),
     ],
 )
-def test_min_samples_leaf(n_samples, min_samples_leaf, n_bins, constant_hessian, noise):
-    rng = np.random.RandomState(seed=0)
+def test_min_samples_leaf(n_samples, min_samples_leaf, n_bins, constant_hessian, noise, global_random_seed):
+    rng = np.random.RandomState(global_random_seed)
     # data = linear target, 3 features, 1 irrelevant.
     X = rng.normal(size=(n_samples, 3))
     y = X[:, 0] - X[:, 1]
@@ -259,10 +259,10 @@ def test_min_samples_leaf(n_samples, min_samples_leaf, n_bins, constant_hessian,
 
 
 @pytest.mark.parametrize("n_samples, min_samples_leaf", [(99, 50), (100, 50)])
-def test_min_samples_leaf_root(n_samples, min_samples_leaf):
+def test_min_samples_leaf_root(n_samples, min_samples_leaf, global_random_seed):
     # Make sure root node isn't split if n_samples is not at least twice
     # min_samples_leaf
-    rng = np.random.RandomState(seed=0)
+    rng = np.random.RandomState(global_random_seed)
 
     n_bins = 256
 
@@ -298,9 +298,9 @@ def assert_is_stump(grower):
 
 
 @pytest.mark.parametrize("max_depth", [1, 2, 3])
-def test_max_depth(max_depth):
+def test_max_depth(max_depth, global_random_seed):
     # Make sure max_depth parameter works as expected
-    rng = np.random.RandomState(seed=0)
+    rng = np.random.RandomState(global_random_seed)
 
     n_bins = 256
     n_samples = 1000
@@ -512,11 +512,11 @@ def test_grow_tree_categories():
 @pytest.mark.parametrize("min_samples_leaf", (1, 20))
 @pytest.mark.parametrize("n_unique_categories", (2, 10, 100))
 @pytest.mark.parametrize("target", ("binary", "random", "equal"))
-def test_ohe_equivalence(min_samples_leaf, n_unique_categories, target):
+def test_ohe_equivalence(min_samples_leaf, n_unique_categories, target, global_random_seed):
     # Make sure that native categorical splits are equivalent to using a OHE,
     # when given enough depth
 
-    rng = np.random.RandomState(0)
+    rng = np.random.RandomState(global_random_seed)
     n_samples = 10_000
     X_binned = rng.randint(0, n_unique_categories, size=(n_samples, 1), dtype=np.uint8)
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_histogram.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_histogram.py
@@ -50,10 +50,10 @@ def test_build_histogram(build_func):
     assert_allclose(hist["sum_hessians"], [2, 2, 1])
 
 
-def test_histogram_sample_order_independence():
+def test_histogram_sample_order_independence(global_random_seed):
     # Make sure the order of the samples has no impact on the histogram
     # computations
-    rng = np.random.RandomState(42)
+    rng = np.random.RandomState(global_random_seed)
     n_sub_samples = 100
     n_samples = 1000
     n_bins = 256
@@ -108,10 +108,10 @@ def test_histogram_sample_order_independence():
 
 
 @pytest.mark.parametrize("constant_hessian", [True, False])
-def test_unrolled_equivalent_to_naive(constant_hessian):
+def test_unrolled_equivalent_to_naive(constant_hessian, global_random_seed):
     # Make sure the different unrolled histogram computations give the same
     # results as the naive one.
-    rng = np.random.RandomState(42)
+    rng = np.random.RandomState(global_random_seed)
     n_samples = 10
     n_bins = 5
     sample_indices = np.arange(n_samples).astype(np.uint32)
@@ -162,10 +162,10 @@ def test_unrolled_equivalent_to_naive(constant_hessian):
 
 
 @pytest.mark.parametrize("constant_hessian", [True, False])
-def test_hist_subtraction(constant_hessian):
+def test_hist_subtraction(constant_hessian, global_random_seed):
     # Make sure the histogram subtraction trick gives the same result as the
     # classical method.
-    rng = np.random.RandomState(42)
+    rng = np.random.RandomState(global_random_seed)
     n_samples = 10
     n_bins = 5
     sample_indices = np.arange(n_samples).astype(np.uint32)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
@@ -20,8 +20,8 @@ n_threads = _openmp_effective_n_threads()
 
 
 @pytest.mark.parametrize("n_bins", [3, 32, 256])
-def test_histogram_split(n_bins):
-    rng = np.random.RandomState(42)
+def test_histogram_split(n_bins, global_random_seed):
+    rng = np.random.RandomState(global_random_seed)
     feature_idx = 0
     l2_regularization = 0
     min_hessian_to_split = 1e-3
@@ -325,12 +325,12 @@ def test_split_indices():
     assert samples_right.shape[0] == si_root.n_samples_right
 
 
-def test_min_gain_to_split():
+def test_min_gain_to_split(global_random_seed):
     # Try to split a pure node (all gradients are equal, same for hessians)
     # with min_gain_to_split = 0 and make sure that the node is not split (best
     # possible gain = -1). Note: before the strict inequality comparison, this
     # test would fail because the node would be split with a gain of 0.
-    rng = np.random.RandomState(42)
+    rng = np.random.RandomState(global_random_seed)
     l2_regularization = 0
     min_hessian_to_split = 0
     min_samples_leaf = 1

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
@@ -864,7 +864,7 @@ def test_splitting_categorical_sanity(
     assert_array_equal(sample_indices[~left_mask], samples_right)
 
 
-def test_split_interaction_constraints():
+def test_split_interaction_constraints(global_random_seed):
     """Check that allowed_features are respected."""
     n_features = 4
     # features 1 and 2 are not allowed to be split on
@@ -886,7 +886,7 @@ def test_split_interaction_constraints():
     # The loop is to ensure that we split at least once on each allowed feature (0, 3).
     # This is tracked by split_features and checked at the end.
     for i in range(10):
-        rng = np.random.RandomState(919 + i)
+        rng = np.random.RandomState(global_random_seed + i)
         X_binned = np.asfortranarray(
             rng.randint(0, n_bins - 1, size=(n_samples, n_features)),
             dtype=X_BINNED_DTYPE,

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_warm_start.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_warm_start.py
@@ -184,7 +184,7 @@ def test_warm_start_clear(GradientBoosting, X, y):
     ],
 )
 @pytest.mark.parametrize("rng_type", ("none", "int", "instance"))
-def test_random_seeds_warm_start(GradientBoosting, X, y, rng_type):
+def test_random_seeds_warm_start(GradientBoosting, X, y, rng_type, global_random_seed):
     # Make sure the seeds for train/val split and small trainset subsampling
     # are correctly set in a warm start context.
     def _get_rng(rng_type):
@@ -194,7 +194,7 @@ def test_random_seeds_warm_start(GradientBoosting, X, y, rng_type):
         elif rng_type == "int":
             return 42
         else:
-            return np.random.RandomState(0)
+            return np.random.RandomState(global_random_seed)
 
     random_state = _get_rng(rng_type)
     gb_1 = GradientBoosting(early_stopping=True, max_iter=2, random_state=random_state)


### PR DESCRIPTION
I picked up on the Issue #22827 and added global_random_seed to functions that use RandomState.

All my changes were in the sklearn/ensemble/_hist_gradient_boosting/tests/ directory/
Most of the functions were changed to add the global_random_seed, but some produced errors when changing so I kept them as they were.
All the tests passed after the changes and now the following python files are cleared from the issue :
- sklearn/ensemble/_hist_gradient_boosting/tests/test_binning.py
- sklearn/ensemble/_hist_gradient_boosting/tests/test_bitset.py
- sklearn/ensemble/_hist_gradient_boosting/tests/test_compare_lightgbm.py
- sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
- sklearn/ensemble/_hist_gradient_boosting/tests/test_grower.py
- sklearn/ensemble/_hist_gradient_boosting/tests/test_histogram.py
- sklearn/ensemble/_hist_gradient_boosting/tests/test_monotonic_contraints.py
- sklearn/ensemble/_hist_gradient_boosting/tests/test_predictor.py
- sklearn/ensemble/_hist_gradient_boosting/tests/test_splitting.py
- sklearn/ensemble/_hist_gradient_boosting/tests/test_warm_start.py