### PR TITLE
MNT Use PYTHON_GIL=0 only at test time to avoid interference with conda

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,6 @@ jobs:
       )
     matrix:
       pylatest_free_threaded:
-        PYTHON_GIL: '0'
         DISTRIB: 'conda-free-threaded'
         LOCK_FILE: './build_tools/azure/pylatest_free_threaded_linux-64_conda.lock'
         COVERAGE: 'false'

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -75,6 +75,14 @@ else
     echo "Could not inspect CPU architecture."
 fi
 
+if [[ "$DISTRIB" == "conda-free-threaded" ]]; then
+    # Make sure that GIL is disabled even when importing extensions that have
+    # not declared free-threaded compatibility. This can be removed when numpy,
+    # scipy and scikit-learn extensions all have declared free-threaded
+    # compatibility.
+    export PYTHON_GIL=0
+fi
+
 TEST_CMD="$TEST_CMD --pyargs sklearn"
 
 set -x


### PR DESCRIPTION
This does not seem an issue anymore (probably runners image update?) but this avoids the interference between `PYTHON_GIL=0` and conda as noted in https://github.com/scikit-learn/scikit-learn/pull/31335#issuecomment-2865331291.