### PR TITLE
BLD Add missing cython generator for a few extensions

### DIFF
--- a/sklearn/cluster/_hdbscan/meson.build
+++ b/sklearn/cluster/_hdbscan/meson.build
@@ -1,7 +1,7 @@
 cluster_hdbscan_extension_metadata = {
   '_linkage': {'sources': [cython_gen.process('_linkage.pyx'), metrics_cython_tree]},
   '_reachability': {'sources': [cython_gen.process('_reachability.pyx')]},
-  '_tree': {'sources': ['_tree.pyx']}
+  '_tree': {'sources': [cython_gen.process('_tree.pyx')]}
 }
 
 foreach ext_name, ext_dict : cluster_hdbscan_extension_metadata

--- a/sklearn/meson.build
+++ b/sklearn/meson.build
@@ -219,7 +219,7 @@ extensions = ['_isotonic']
 
 py.extension_module(
   '_isotonic',
-  '_isotonic.pyx',
+  cython_gen.process('_isotonic.pyx'),
   cython_args: cython_args,
   install: true,
   subdir: 'sklearn',

--- a/sklearn/neighbors/meson.build
+++ b/sklearn/neighbors/meson.build
@@ -39,7 +39,7 @@ neighbors_extension_metadata = {
   '_partition_nodes':
       {'sources': [cython_gen_cpp.process('_partition_nodes.pyx')],
        'dependencies': [np_dep]},
-  '_quad_tree': {'sources': ['_quad_tree.pyx'], 'dependencies': [np_dep]},
+  '_quad_tree': {'sources': [cython_gen.process('_quad_tree.pyx')], 'dependencies': [np_dep]},
 }
 
 foreach ext_name, ext_dict : neighbors_extension_metadata

--- a/sklearn/utils/meson.build
+++ b/sklearn/utils/meson.build
@@ -20,7 +20,7 @@ utils_extension_metadata = {
   '_cython_blas': {'sources': [cython_gen.process('_cython_blas.pyx')]},
   'arrayfuncs': {'sources': [cython_gen.process('arrayfuncs.pyx')]},
   'murmurhash': {
-      'sources': ['murmurhash.pyx', 'src' / 'MurmurHash3.cpp'],
+      'sources': [cython_gen.process('murmurhash.pyx'), 'src' / 'MurmurHash3.cpp'],
   },
   '_fast_dict':
     {'sources': [cython_gen_cpp.process('_fast_dict.pyx')]},


### PR DESCRIPTION
Follow-up of #31212 noticed in #31342.

I found all of them through the following `git grep`. The remaining matches are `custom_target`:
```
❯ git grep '\.pyx' -- **/meson.build | grep -v process | grep -P '\w+\.pyx'
sklearn/_loss/meson.build:  output: '_loss.pyx',
sklearn/_loss/meson.build:  input: '_loss.pyx.tp',
sklearn/metrics/_pairwise_distances_reduction/meson.build:  output: '_datasets_pair.pyx',
sklearn/metrics/_pairwise_distances_reduction/meson.build:  input: '_datasets_pair.pyx.tp',
sklearn/metrics/_pairwise_distances_reduction/meson.build:  output: '_base.pyx',
sklearn/metrics/_pairwise_distances_reduction/meson.build:  input: '_base.pyx.tp',
sklearn/metrics/_pairwise_distances_reduction/meson.build:  output: '_middle_term_computer.pyx',
sklearn/metrics/_pairwise_distances_reduction/meson.build:  input: '_middle_term_computer.pyx.tp',
sklearn/metrics/_pairwise_distances_reduction/meson.build:    output: '_argkmin.pyx',
sklearn/metrics/_pairwise_distances_reduction/meson.build:    input: '_argkmin.pyx.tp',
sklearn/metrics/_pairwise_distances_reduction/meson.build:    output: '_radius_neighbors.pyx',
sklearn/metrics/_pairwise_distances_reduction/meson.build:    input: '_radius_neighbors.pyx.tp',
sklearn/metrics/_pairwise_distances_reduction/meson.build:  output: '_argkmin_classmode.pyx',
sklearn/metrics/_pairwise_distances_reduction/meson.build:  input: '_argkmin_classmode.pyx.tp',
sklearn/metrics/_pairwise_distances_reduction/meson.build:  output: '_radius_neighbors_classmode.pyx',
sklearn/metrics/_pairwise_distances_reduction/meson.build:  input: '_radius_neighbors_classmode.pyx.tp',
sklearn/metrics/meson.build:  output: '_dist_metrics.pyx',
sklearn/metrics/meson.build:  input: '_dist_metrics.pyx.tp',
```

The impact of this is that `cython_args` are not used for these extensions. Probably worth back-porting for 1.7.