### PR TITLE
MAINT: mutual information using upstream KDTree

### DIFF
--- a/sklearn/feature_selection/_mutual_info.py
+++ b/sklearn/feature_selection/_mutual_info.py
@@ -5,10 +5,11 @@ from numbers import Integral
 
 import numpy as np
 from scipy.sparse import issparse
+from scipy.spatial import KDTree
 from scipy.special import digamma
 
 from ..metrics.cluster import mutual_info_score
-from ..neighbors import KDTree, NearestNeighbors
+from ..neighbors import NearestNeighbors
 from ..preprocessing import scale
 from ..utils import check_random_state
 from ..utils._param_validation import Interval, StrOptions, validate_params
@@ -62,12 +63,12 @@ def _compute_mi_cc(x, y, n_neighbors):
 
     # KDTree is explicitly fit to allow for the querying of number of
     # neighbors within a specified radius
-    kd = KDTree(x, metric="chebyshev")
-    nx = kd.query_radius(x, radius, count_only=True, return_distance=False)
+    kd = KDTree(x)
+    nx = kd.query_ball_point(x, radius, p=np.inf, return_length=True)
     nx = np.array(nx) - 1.0
 
-    kd = KDTree(y, metric="chebyshev")
-    ny = kd.query_radius(y, radius, count_only=True, return_distance=False)
+    kd = KDTree(y)
+    ny = kd.query_ball_point(y, radius, p=np.inf, return_length=True)
     ny = np.array(ny) - 1.0
 
     mi = (
@@ -140,7 +141,7 @@ def _compute_mi_cd(c, d, n_neighbors):
     radius = radius[mask]
 
     kd = KDTree(c)
-    m_all = kd.query_radius(c, radius, count_only=True, return_distance=False)
+    m_all = kd.query_ball_point(c, radius, return_length=True)
     m_all = np.array(m_all)
 
     mi = (


### PR DESCRIPTION
* This patch aims to test the waters for reducing community duplication of effort/maintenance with `KDTree`. In particular, a few select use cases of the `sklearn` in-house `KDTree` by the mutual information infrastructure are replaced with upstream `KDTree` from SciPy. The full test suite appears to pass locally.

If there is an appetite for this, we could spend some time on it (https://github.com/scientific-python/summit-2025/issues/31). I've placed some more detailed discussion points below. This may also interest @sturlamolden.

---------------

More detailed Analysis of the Situation

**Potential Advantages of Doing This**:

1. The SciPy version of `KDTree` has been heavily optimized and supports concurrency in many places that the `sklearn` version does not, as far as I can tell.
2. Reduced duplication of effort--community folks who are experts on `KDTree` could focus their efforts on a single (or at least, less) implementation(s). This is the main one I had in mind.

**Considerations, Drawbacks, Points that are not clear**:
1. An obvious question is what "replacing" would even mean and how far it would go--we could just replace a few obvious cases to start, like here, but leave the in-house `KDTree` sources and offerings alone for quite some time to see how that goes first, progressively performing replacements in cases where there's an obvious benefit, or at least no loss of performance or functionality.
2. The switchover would require reviewer bandwidth, and `KDTree` code is quite complex. The features offered by both libraries are not identical, and if you have a code base using two types of `KDTree` it may temporarily make things even more complex.
3. (minor) you don't have `asv` benchmarks for your `KDTree` implementation I don't think? We'd want to add that to avoid performance regressions I suspect, and/or to demonstrate improvements where SciPy adds the `workers`/concurrency option.
4. A design challenge is that `sklearn` uses a "base" `BinaryTree` that is "specialized" to `KDTree` and `BallTree` in an object-oriented style. SciPy doesn't have `BallTree` (should it?)--how would this be coordinated if there was an appetite for upstreaming?
5. There appears to be some `sklearn` activity surrounding 32- and 64-bit "variations" or type preservation with the binary tree infrastructure? I'm not so sure how this would fly/work for SciPy.
6. Compatibility with pipelines may require quite a bit more thought when upstreaming.