### PR TITLE
DOC Add additional donation options to About page

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -594,16 +594,29 @@ Donating to the project
 =======================
 
 If you are interested in donating to the project or to one of our code-sprints,
-please donate via the `NumFOCUS Donations Page
-<https://numfocus.org/donate-to-scikit-learn>`_.
+you have several options:
 
 .. raw:: html
 
   <p class="text-center">
     <a class="btn sk-btn-orange mb-1" href="https://numfocus.org/donate-to-scikit-learn">
-      Help us, <strong>donate!</strong>
+      Donate via NumFOCUS
+    </a>
+    <a class="btn sk-btn-orange mb-1" href="https://github.com/sponsors/scikit-learn">
+      Donate via GitHub Sponsors
     </a>
   </p>
+
+**Donation Options:**
+
+* **NumFOCUS**: Donate via the `NumFOCUS Donations Page
+  <https://numfocus.org/donate-to-scikit-learn>`_, scikit-learn's fiscal sponsor.
+
+* **GitHub Sponsors**: Support the project directly through `GitHub Sponsors
+  <https://github.com/sponsors/scikit-learn>`_.
+
+* **Corporate Giving Programs**: Many companies match employee donations through platforms like 
+  `Benevity <https://benevity.com/>`_ and `Open Collective <https://opencollective.com/scikit-learn>`_.
 
 All donations will be handled by `NumFOCUS <https://numfocus.org/>`_, a non-profit
 organization which is managed by a board of `Scipy community members

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -615,8 +615,6 @@ you have several options:
 * **GitHub Sponsors**: Support the project directly through `GitHub Sponsors
   <https://github.com/sponsors/scikit-learn>`_.
 
-* **Corporate Giving Programs**: Many companies match employee donations through platforms like 
-  `Benevity <https://benevity.com/>`_ and `Open Collective <https://opencollective.com/scikit-learn>`_.
 
 All donations will be handled by `NumFOCUS <https://numfocus.org/>`_, a non-profit
 organization which is managed by a board of `Scipy community members


### PR DESCRIPTION
#### Reference Issues/PRs
References #30826

#### What does this implement/fix? Explain your changes.
Updates the "Donating to the project" section on the About page to include additional donation options:
- Added GitHub Sponsors information
- Included corporate giving programs (Benevity and Open Collective)
- Maintained existing NumFOCUS donation information
- Formatted as bullet points for readability

#### Any other comments?
Open to feedback on wording or formatting if needed.