### PR TITLE
Add reference to biclustering example in biclustering.rst documentation

### DIFF
--- a/doc/modules/biclustering.rst
+++ b/doc/modules/biclustering.rst
@@ -304,3 +304,6 @@ are identical.
 * Hochreiter, Bodenhofer, et. al., 2010. `FABIA: factor analysis
   for bicluster acquisition
   <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2881408/>`__.
+
+
+See the example: :ref:`sphx_glr_auto_examples_bicluster_plot_biclustering_newsgroups`


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
#30621 
This PR improves the documentation for the biclustering module by adding a reference to the corresponding example script located in the examples/ directory.

Specifically:

Added a link to the plot_bicluster_newsgroups.py example in biclustering.rst

This helps users quickly access a runnable example, improving the learnability and usability of the module

This change follows the standard documentation guidelines for cross-linking examples and enhances the overall developer experience.