### PR TITLE
FEA Include CV groups to BaseChain constructor

### DIFF
--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -651,6 +651,7 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
         ],
         "order": ["array-like", StrOptions({"random"}), None],
         "cv": ["cv_object", StrOptions({"prefit"})],
+        "groups": ["array-like", None],
         "random_state": ["random_state"],
         "verbose": ["boolean"],
     }
@@ -662,6 +663,7 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
         *,
         order=None,
         cv=None,
+        groups=None,
         random_state=None,
         verbose=False,
         base_estimator="deprecated",
@@ -670,6 +672,7 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
         self.base_estimator = base_estimator
         self.order = order
         self.cv = cv
+        self.groups = groups
         self.random_state = random_state
         self.verbose = verbose
 
@@ -845,6 +848,7 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
                     X_aug[:, :col_idx],
                     y=y,
                     cv=self.cv,
+                    groups=self.groups,
                     method=chain_method,
                 )
                 # `predict_proba` output is 2D, we use only output for classes[-1]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
There are no issues or pull requests related with this feature.
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
RegressorChain does not support metadata routing when working with XGBoost. If you try to set a whatever fit_param that is not supported by XGBoost the code will bring an exception.

```python
X_train, y_train, g_train = join_matrix(series_train, exog_train, T, group=True)
cv = GroupKFold(n_splits=folds, shuffle=True, random_state=SEED)

estimator = xgb.XGBRegressor(...)

chain = RegressorChain(estimator, order=range(T), random_state=SEED, verbose=True, cv=cv)

# Training step and cross-validation
chain.fit(X_train, y_train)
```
```
  File "/.../sklearn_api/xgboost_regressor_raw.py", line 166, in objective_fn
    chain.fit(X_train, y_train, groups=g_train)
  File "/.../lib/python3.11/site-packages/sklearn/base.py", line 1389, in wrapper
    return fit_method(estimator, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../lib/python3.11/site-packages/sklearn/multioutput.py", line 1243, in fit
    super().fit(X, Y, **fit_params)
  File "/.../lib/python3.11/site-packages/sklearn/multioutput.py", line 795, in fit
    estimator.fit(
  File "/.../lib/python3.11/site-packages/xgboost/core.py", line 726, in inner_f
    return func(**kwargs)
           ^^^^^^^^^^^^^^
TypeError: XGBModel.fit() got an unexpected keyword argument 'groups'
```
What is more, the function ```cross_val_predict``` has defined an input argument for including groups 1-D array, ignored by fit method on the BaseChain class.
```python
class _BaseChain(BaseEstimator, metaclass=ABCMeta):
[...]
@abstractmethod
    def fit(self, X, Y, **fit_params):
        [...]
            if self.cv is not None and chain_idx < len(self.estimators_) - 1:
                col_idx = X.shape[1] + chain_idx
                cv_result = cross_val_predict(
                    self.base_estimator,
                    X_aug[:, :col_idx],
                    y=y,
                    cv=self.cv,
                    groups=... # missing code
                    method=chain_method,
                )
```
The key is not include a single new argument on the BaseChain class, so then you can specify the group 1-D array every time you create a CV strategy for the fitting method.
#### Any other comments?
After the changes the code will be in the following way:
```python
X_train, y_train, g_train = join_matrix(series_train, exog_train, T, group=True)
cv = GroupKFold(n_splits=folds, shuffle=True, random_state=SEED)

estimator = xgb.XGBRegressor(...)

chain = RegressorChain(estimator, order=range(T), random_state=SEED, verbose=True, cv=cv, groups=g_train)

# Training step and cross-validation
chain.fit(X_train, y_train)
```
*NOTE*: making a refit with different data would involve changing state of the RegressorChain definition.
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
