### PR TITLE
CI Avoid joblib 1.5.0 in Pyodide

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -72,7 +72,9 @@ jobs:
           CIBW_PLATFORM: pyodide
           SKLEARN_SKIP_OPENMP_TEST: "true"
           SKLEARN_SKIP_NETWORK_TESTS: 1
-          CIBW_TEST_REQUIRES: "pytest pandas"
+          # Temporary work-around to avoid joblib 1.5.0 until there is a joblib
+          # release with https://github.com/joblib/joblib/pull/1721
+          CIBW_TEST_REQUIRES: "pytest pandas joblib!=1.5.0"
           # -s pytest argument is needed to avoid an issue in pytest output capturing with Pyodide
           CIBW_TEST_COMMAND: "python -m pytest -svra --pyargs sklearn --durations 20 --showlocals"
 


### PR DESCRIPTION
Pyodide CI is broken since joblib 1.5.0 release (see [build logs](https://github.com/scikit-learn/scikit-learn/actions/workflows/emscripten.yml?query=event%3Aschedule)). We haven't uploaded a scikit-learn Pyodide wheel to scientific-python-nightly-wheel and as a consequence
the JupyterLite dev is slightly broken, see https://github.com/scikit-learn/scikit-learn/pull/31400#issuecomment-2894461934 for more details.

Maybe worth a work-around until there is a joblib 1.5.1 release?

