### PR TITLE
DOC Add Links to plot_lof_novelty_detection example

### DIFF
--- a/doc/modules/outlier_detection.rst
+++ b/doc/modules/outlier_detection.rst
@@ -418,5 +418,3 @@ Novelty detection with :class:`neighbors.LocalOutlierFactor` is illustrated belo
     :target: ../auto_examples/neighbors/plot_lof_novelty_detection.html
     :align: center
     :scale: 75%
-
-

--- a/doc/modules/outlier_detection.rst
+++ b/doc/modules/outlier_detection.rst
@@ -411,10 +411,8 @@ Note that ``fit_predict`` is not available in this case to avoid inconsistencies
   The scores of abnormality of the training samples are always accessible
   through the ``negative_outlier_factor_`` attribute.
 
-Novelty detection with Local Outlier Factor is illustrated below.
-
-* See :ref:`sphx_glr_auto_examples_neighbors_plot_lof_novelty_detection.py`
-  for an illustration of the use of :class:`neighbors.LocalOutlierFactor` for novelty detection.
+Novelty detection with :class:`neighbors.LocalOutlierFactor` is illustrated below
+(see :ref:`sphx_glr_auto_examples_neighbors_plot_lof_novelty_detection.py`).
 
 .. figure:: ../auto_examples/neighbors/images/sphx_glr_plot_lof_novelty_detection_001.png
     :target: ../auto_examples/neighbors/plot_lof_novelty_detection.html

--- a/doc/modules/outlier_detection.rst
+++ b/doc/modules/outlier_detection.rst
@@ -413,7 +413,12 @@ Note that ``fit_predict`` is not available in this case to avoid inconsistencies
 
 Novelty detection with Local Outlier Factor is illustrated below.
 
+* See :ref:`sphx_glr_auto_examples_neighbors_plot_lof_novelty_detection.py`
+  for an illustration of the use of :class:`neighbors.LocalOutlierFactor` for novelty detection.
+
 .. figure:: ../auto_examples/neighbors/images/sphx_glr_plot_lof_novelty_detection_001.png
     :target: ../auto_examples/neighbors/plot_lof_novelty_detection.html
     :align: center
     :scale: 75%
+
+


### PR DESCRIPTION
Reference Issues/PRs

Towards #30621.

What does this implement/fix? Explain your changes.

Added a link to the plot_lof_novelty_detection example to outlier_detection.rst. The example was already referenced via a figure target, but adding a link makes it more discoverable.
