### PR TITLE
Avoid numpy array resize refcheck in svmlight format

### DIFF
--- a/sklearn/datasets/_svmlight_format_fast.pyx
+++ b/sklearn/datasets/_svmlight_format_fast.pyx
@@ -78,10 +78,7 @@ def _load_svmlight_file(f, dtype, bint multilabel, bint zero_based,
         if n_features and features[0].startswith(qid_prefix):
             _, value = features[0].split(COLON, 1)
             if query_id:
-                # Disable refcheck because it doesn't work on all Python
-                # implementations. We know we are the sole owner at this point
-                query.resize(len(query) + 1, refcheck=False)
-                query[len(query) - 1] = np.int64(value)
+                query = np.append(query, np.int64(value))
             features.pop(0)
             n_features -= 1
 

--- a/sklearn/datasets/_svmlight_format_fast.pyx
+++ b/sklearn/datasets/_svmlight_format_fast.pyx
@@ -78,7 +78,9 @@ def _load_svmlight_file(f, dtype, bint multilabel, bint zero_based,
         if n_features and features[0].startswith(qid_prefix):
             _, value = features[0].split(COLON, 1)
             if query_id:
-                query.resize(len(query) + 1)
+                # Disable refcheck because it doesn't work on all Python
+                # implementations. We know we are the sole owner at this point
+                query.resize(len(query) + 1, refcheck=False)
                 query[len(query) - 1] = np.int64(value)
             features.pop(0)
             n_features -= 1


### PR DESCRIPTION
[`numpy.ndarray.resize`](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.resize.html#numpy.ndarray.resize) does a reference check that there is only one reference to the array and so the resizing is safe. In this specific piece of code, the array has just been created and there is obviously only one reference. But this reference check doesn't work on PyPy and GraalPy, because they don't do reference counting the same way as CPython. I know that neither are officially supported, but they tend to mostly work and turning the check off could help those that want to try them.