### PR TITLE
Use OS-specific cache directories for get_data_home and add tests

### DIFF
--- a/benchmarks/bench_tsne_mnist.py
+++ b/benchmarks/bench_tsne_mnist.py
@@ -15,6 +15,7 @@ from time import time
 
 import numpy as np
 from joblib import Memory
+from sklearn.utils._openmp_helpers import _openmp_effective_n_threads
 
 from sklearn.datasets import fetch_openml
 from sklearn.decomposition import PCA
@@ -22,7 +23,6 @@ from sklearn.manifold import TSNE
 from sklearn.neighbors import NearestNeighbors
 from sklearn.utils import check_array
 from sklearn.utils import shuffle as _shuffle
-from sklearn.utils._openmp_helpers import _openmp_effective_n_threads
 
 LOG_DIR = "mnist_tsne_output"
 if not os.path.exists(LOG_DIR):

--- a/doc/whats_new/upcoming_changes/sklearn.datasets/30196.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.datasets/30196.enhancement.rst
@@ -2,6 +2,3 @@
   default value of the parameter does not change how the function behaves.
   By :user:`Success Moses <SuccessMoses>` and :user:`Adam Cooper <arc12>`
 
-- Updated 'get_data_home' to use OS-specific cache directories instead of home dir by
-PR: 31267
-By :user:Namit24

--- a/doc/whats_new/upcoming_changes/sklearn.datasets/30196.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.datasets/30196.enhancement.rst
@@ -1,3 +1,7 @@
 - New parameter ``return_X_y`` added to :func:`datasets.make_classification`. The
   default value of the parameter does not change how the function behaves.
   By :user:`Success Moses <SuccessMoses>` and :user:`Adam Cooper <arc12>`
+
+- Updated 'get_data_home' to use OS-specific cache directories instead of home dir by
+PR: 31267
+By :user:Namit24

--- a/doc/whats_new/upcoming_changes/sklearn.datasets/31267.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.datasets/31267.rst
@@ -1,0 +1,3 @@
+- Updated 'get_data_home' to use OS-specific cache directories instead of home dir by
+PR: 31267
+By :user:Namit24

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -9,6 +9,7 @@ import csv
 import gzip
 import hashlib
 import os
+import platform
 import re
 import shutil
 import time
@@ -17,16 +18,16 @@ import warnings
 from collections import namedtuple
 from importlib import resources
 from numbers import Integral
-from os import environ, listdir, makedirs
-from os.path import expanduser, isdir, join, splitext
+from os import listdir, makedirs
+from os.path import isdir, join, splitext
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from urllib.error import URLError
 from urllib.parse import urlparse
 from urllib.request import urlretrieve
+
 import numpy as np
-import os
-import platform
+
 from ..preprocessing import scale
 from ..utils import Bunch, check_random_state
 from ..utils._optional_dependencies import check_pandas_support
@@ -45,37 +46,6 @@ RemoteFileMetadata = namedtuple("RemoteFileMetadata", ["filename", "url", "check
     },
     prefer_skip_nested_validation=True,
 )
-def get_data_home(data_home=None) -> str:
-    """Return the path of the scikit-learn data directory.
-
-    This folder is used by some large dataset loaders to avoid downloading the
-    data several times.
-
-    By default, the data directory is set to a folder named 'scikit_learn_data'
-    in the platform-specific cache directory:
-    - Linux: `$XDG_CACHE_HOME/scikit_learn_data` (if `XDG_CACHE_HOME` is set, else `~/.cache/scikit_learn_data`)
-    - macOS: `~/Library/Caches/scikit_learn_data`
-    - Windows: `%LOCALAPPDATA%\\scikit_learn_data`
-
-    Alternatively, it can be set by the 'SCIKIT_LEARN_DATA' environment variable
-    or programmatically by giving an explicit folder path. The '~' symbol is
-    expanded to the user home folder.
-
-    If the folder does not already exist, it is automatically created.
-
-    Parameters
-    ----------
-    data_home : str or path-like, default=None
-        The path to scikit-learn data directory. If None, the default path
-        is used based on the platform-specific cache directory.
-
-    Returns
-    -------
-    data_home : str
-        The path to scikit-learn data directory.
-    """
-
-
 def get_data_home(data_home=None):
     """Return the path to scikit-learn data home cache folder.
 

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -58,13 +58,13 @@ def get_data_home(data_home=None):
         # Determine the base cache directory based on the operating system
         system = platform.system()
         if system == "Linux":
-            base_dir = os.environ.get("XDG_CACHE_HOME",
-                                      os.path.expanduser("~/.cache"))
+            base_dir = os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
         elif system == "Darwin":  # macOS
             base_dir = os.path.expanduser("~/Library/Caches")
         elif system == "Windows":
-            base_dir = os.environ.get("LOCALAPPDATA",
-                                      os.path.expanduser("~/AppData/Local"))
+            base_dir = os.environ.get(
+                "LOCALAPPDATA", os.path.expanduser("~/AppData/Local")
+            )
         else:
             # Fallback for other operating systems
             base_dir = os.path.expanduser("~/.cache")
@@ -80,6 +80,7 @@ def get_data_home(data_home=None):
     # Create the directory if it doesn't exist
     os.makedirs(data_home, exist_ok=True)
     return data_home
+
 
 @validate_params(
     {

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -1004,6 +1004,7 @@ def test_get_params_html():
     assert est._get_params_html() == {"l1": 0, "empty": "test"}
     assert est._get_params_html().non_default == ("empty",)
 
+
 def test_get_data_home_platforms(monkeypatch, tmp_path):
     """Test platform-specific cache directories."""
 


### PR DESCRIPTION
Fixes #31267
This PR updates the get_data_home function to use platform-specific cache directories for storing scikit-learn datasets:

On Linux, it uses $XDG_CACHE_HOME/scikit_learn_data if set, otherwise falls back to ~/.cache/scikit_learn_data.
On macOS, it uses ~/Library/Caches/scikit_learn_data.
On Windows, it uses %LOCALAPPDATA%\scikit_learn_data.
Maintains support for the SCIKIT_LEARN_DATA environment variable override.
Adds new tests to verify this platform-specific behavior.
Fixes some linting and import organization in the related files.
This improves compliance with OS standards for cache storage and prevents cluttering the user’s home directory.

Ready for review. Happy to address feedback or make adjustments as needed.