### PR TITLE
TST Fix array API `test_fill_or_add_to_diagonal`

### DIFF
--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -582,7 +582,7 @@ def test_count_nonzero(
 def test_fill_or_add_to_diagonal(array_namespace, device_, dtype_name, wrap):
     xp = _array_api_for_tests(array_namespace, device_)
     array_np = numpy.zeros((5, 4), dtype=dtype_name)
-    array_xp = xp.asarray(array_np)
+    array_xp = xp.asarray(array_np, device=device_)
     _fill_or_add_to_diagonal(array_xp, value=1, xp=xp, add_value=False, wrap=wrap)
     numpy.fill_diagonal(array_np, val=1, wrap=wrap)
     assert_array_equal(_convert_to_numpy(array_xp, xp=xp), array_np)

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -583,7 +583,7 @@ def test_fill_or_add_to_diagonal(array_namespace, device_, dtype_name, wrap):
     xp = _array_api_for_tests(array_namespace, device_)
 
     array_np = numpy.zeros((5, 4), dtype=dtype_name)
-    array_xp = xp.asarray(array_np, device=device_)
+    array_xp = xp.asarray(array_np.copy(), device=device_)
 
     numpy.fill_diagonal(array_np, val=1, wrap=wrap)
     with config_context(array_api_dispatch=True):

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -581,10 +581,14 @@ def test_count_nonzero(
 @pytest.mark.parametrize("wrap", [True, False])
 def test_fill_or_add_to_diagonal(array_namespace, device_, dtype_name, wrap):
     xp = _array_api_for_tests(array_namespace, device_)
+
     array_np = numpy.zeros((5, 4), dtype=dtype_name)
-    array_xp = xp.asarray(array_np, device=device_)
-    _fill_or_add_to_diagonal(array_xp, value=1, xp=xp, add_value=False, wrap=wrap)
     numpy.fill_diagonal(array_np, val=1, wrap=wrap)
+
+    array_xp = xp.asarray(array_np, device=device_)
+    with config_context(array_api_dispatch=True):
+        _fill_or_add_to_diagonal(array_xp, value=1, xp=xp, add_value=False, wrap=wrap)
+
     assert_array_equal(_convert_to_numpy(array_xp, xp=xp), array_np)
 
 

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -583,9 +583,9 @@ def test_fill_or_add_to_diagonal(array_namespace, device_, dtype_name, wrap):
     xp = _array_api_for_tests(array_namespace, device_)
 
     array_np = numpy.zeros((5, 4), dtype=dtype_name)
-    numpy.fill_diagonal(array_np, val=1, wrap=wrap)
-
     array_xp = xp.asarray(array_np, device=device_)
+
+    numpy.fill_diagonal(array_np, val=1, wrap=wrap)
     with config_context(array_api_dispatch=True):
         _fill_or_add_to_diagonal(array_xp, value=1, xp=xp, add_value=False, wrap=wrap)
 

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -581,7 +581,7 @@ def test_count_nonzero(
 @pytest.mark.parametrize("wrap", [True, False])
 def test_fill_or_add_to_diagonal(array_namespace, device_, dtype_name, wrap):
     xp = _array_api_for_tests(array_namespace, device_)
-    array_np = numpy.zeros((5, 4), dtype=numpy.int64)
+    array_np = numpy.zeros((5, 4), dtype=dtype_name)
     array_xp = xp.asarray(array_np)
     _fill_or_add_to_diagonal(array_xp, value=1, xp=xp, add_value=False, wrap=wrap)
     numpy.fill_diagonal(array_np, val=1, wrap=wrap)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
* Use `dtype_name` from parametrization in `test_fill_or_add_to_diagonal`.
* add `array_api_dispatch` config
* Specify device when creating the array

#### What does this implement/fix? Explain your changes.


#### Any other comments?

@OmarManzoor I *think* this test should use the `dtype_name` parametrizations, and not just test int64? 

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
