### PR TITLE
DOC added reference link to plot_monotonic_constraints.py

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1599,7 +1599,8 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         If an array, the features are mapped to constraints by position. See
         :ref:`monotonic_cst_features_names` for a usage example.
 
-        Read more in the :ref:`User Guide <monotonic_cst_gbdt>`.
+        Read more in the :ref:`User Guide <monotonic_cst_gbdt>` and
+        :ref:`sphx_glr_auto_examples_ensemble_plot_monotonic_constraints.py`.
 
         .. versionadded:: 0.23
 


### PR DESCRIPTION
Reference Issues/PRs

Towards #30621 -Linked example for plot_monotonic_constraints.py from examples/ensemble

What does this implement/fix? Explain your changes.

plot_monotonic_constraints.py
- Added description to the API documentation in sklearn.ensemble.HistGradientBoostingRegressor

Any other comments?