### PR TITLE
DOC Add link to plot_monotonic_constraints.py in ensemble examples

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -74,6 +74,9 @@ estimators is slightly different, and some of the features from
 :class:`GradientBoostingClassifier` and :class:`GradientBoostingRegressor`
 are not yet supported, for instance some loss functions.
 
+For a practical implementation of monotonic constraints with the histogram-based gradient boosting, including how they can improve generalization when "domain knowledge is available", see
+:ref:`this example <sphx_glr_auto_examples_ensemble_plot_monotonic_constraints.py>`.
+
 .. rubric:: Examples
 
 * :ref:`sphx_glr_auto_examples_inspection_plot_partial_dependence.py`

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -74,8 +74,6 @@ estimators is slightly different, and some of the features from
 :class:`GradientBoostingClassifier` and :class:`GradientBoostingRegressor`
 are not yet supported, for instance some loss functions.
 
-For a practical implementation of monotonic constraints with the histogram-based gradient boosting, including how they can improve generalization when "domain knowledge is available", see
-:ref:`this example <sphx_glr_auto_examples_ensemble_plot_monotonic_constraints.py>`.
 
 .. rubric:: Examples
 

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -74,7 +74,6 @@ estimators is slightly different, and some of the features from
 :class:`GradientBoostingClassifier` and :class:`GradientBoostingRegressor`
 are not yet supported, for instance some loss functions.
 
-
 .. rubric:: Examples
 
 * :ref:`sphx_glr_auto_examples_inspection_plot_partial_dependence.py`
@@ -371,8 +370,8 @@ following modelling constraint:
 Also, monotonic constraints are not supported for multiclass classification.
 
 For a practical implementation of monotonic constraints with the histogram-based
-gradient boosting, including how they can improve generalization when "domain knowledge
-is available", see
+gradient boosting, including how they can improve generalization when domain knowledge
+is available, see
 :ref:`sphx_glr_auto_examples_ensemble_plot_monotonic_constraints.py`.
 
 .. note::

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -372,13 +372,17 @@ following modelling constraint:
 
 Also, monotonic constraints are not supported for multiclass classification.
 
+For a practical implementation of monotonic constraints with the histogram-based
+gradient boosting, including how they can improve generalization when "domain knowledge
+is available", see
+:ref:`sphx_glr_auto_examples_ensemble_plot_monotonic_constraints.py`.
+
 .. note::
     Since categories are unordered quantities, it is not possible to enforce
     monotonic constraints on categorical features.
 
 .. rubric:: Examples
 
-* :ref:`sphx_glr_auto_examples_ensemble_plot_monotonic_constraints.py`
 * :ref:`sphx_glr_auto_examples_ensemble_plot_hgbt_regression.py`
 
 .. _interaction_cst_hgbt:


### PR DESCRIPTION
Reference Issues/PRs
Towards https://github.com/scikit-learn/scikit-learn/issues/30621

What does this implement/fix? Explain your changes.
-Added plot_monotonic_constraints.py example link to ensemble methods, under histogram based gradient boost

Screenshot of local check:

![Screenshot 2025-06-02 at 6 42 42 PM](https://github.com/user-attachments/assets/91258759-0c13-4ecc-9bf1-e56e9cf6acc0)

The example showed how to apply monotonic constraints in gradient boosting, which is useful when domain knowledge points that a feature should have a consistent directional effect on the target variable.

For example: in a marketing model, if we know that increasing the number of ad clicks should not decrease the likelihood of a user converting, we can enforce a monotonic constraint to ensure the model respects this expected behavior. 
(slightly bland example but I guess this would at least give an idea on why I picked this one up)