### PR TITLE
DOC: Add link to plot_sparse_coding.py in DictionaryLearning and Mini…

### DIFF
--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1596,6 +1596,10 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
     >>> X_hat = X_transformed @ dict_learner.components_
     >>> np.mean(np.sum((X_hat - X) ** 2, axis=1) / np.sum(X ** 2, axis=1))
     np.float64(0.056)
+
+    See the example:
+    :ref:`sphx_glr_auto_examples_decomposition_plot_sparse_coding.py`
+
     """
 
     _parameter_constraints: dict = {
@@ -1955,6 +1959,10 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
     >>> X_hat = X_transformed @ dict_learner.components_
     >>> np.mean(np.sum((X_hat - X) ** 2, axis=1) / np.sum(X ** 2, axis=1))
     np.float64(0.052)
+
+    See the example:
+    :ref:`sphx_glr_auto_examples_decomposition_plot_sparse_coding.py`
+    
     """
 
     _parameter_constraints: dict = {

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1597,9 +1597,11 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
     >>> np.mean(np.sum((X_hat - X) ** 2, axis=1) / np.sum(X ** 2, axis=1))
     np.float64(0.056)
 
-    See the example:
-    :ref:`sphx_glr_auto_examples_decomposition_plot_sparse_coding.py`
+    .. note::
 
+    The example :ref:`sphx_glr_auto_examples_decomposition_plot_sparse_coding.py`
+    demonstrates sparse coding with a precomputed dictionary using `SparseCoder`.
+    This complements `DictionaryLearning`, which learns the dictionary from data.
     """
 
     _parameter_constraints: dict = {
@@ -1963,6 +1965,12 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
     See the example:
     :ref:`sphx_glr_auto_examples_decomposition_plot_sparse_coding.py`
     
+    .. note::
+
+    The example :ref:`sphx_glr_auto_examples_decomposition_plot_sparse_coding.py`
+    demonstrates sparse coding with a precomputed dictionary using `SparseCoder`.
+    While this class learns the dictionary incrementally, the example is useful for
+    understanding how sparse codes relate to fixed dictionaries.
     """
 
     _parameter_constraints: dict = {


### PR DESCRIPTION
…BatchDictionaryLearning docstrings

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses part of issue [#30621](https://github.com/scikit-learn/scikit-learn/issues/30621)


#### What does this implement/fix? Explain your changes.
This PR adds a reference to the example [plot_sparse_coding.py](https://github.com/scikit-learn/scikit-learn/blob/main/examples/decomposition/plot_sparse_coding.py) in the `Examples` sections of the `DictionaryLearning` and `MiniBatchDictionaryLearning` class docstrings.

This improves documentation discoverability by linking relevant usage examples to their associated estimators.

#### Any other comments?
N/A

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
