### PR TITLE
FIX: Change limits of power_t param to [0, inf)

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/31474.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/31474.api.rst
@@ -1,0 +1,6 @@
+- :class:`linear_model.SGDClassifier`, :class:`linear_model.SGDRegressor`, and
+  :class:`linear_model.SGDOneClassSVM` now deprecate negative values for the
+  `power_t` parameter. Using a negative value will raise a warning in version 1.8
+  and will raise an error in version 1.10. A value in the range [0, inf) must be used
+  instead.
+  By :user:`Ritvi Alagusankar <ritvi-alagusankar>`

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/31474.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/31474.api.rst
@@ -1,6 +1,6 @@
 - :class:`linear_model.SGDClassifier`, :class:`linear_model.SGDRegressor`, and
   :class:`linear_model.SGDOneClassSVM` now deprecate negative values for the
   `power_t` parameter. Using a negative value will raise a warning in version 1.8
-  and will raise an error in version 1.10. A value in the range [0, inf) must be used
+  and will raise an error in version 1.10. A value in the range [0.0, inf) must be used
   instead.
   By :user:`Ritvi Alagusankar <ritvi-alagusankar>`

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -731,6 +731,14 @@ class BaseSGDClassifier(LinearClassifierMixin, BaseSGD, metaclass=ABCMeta):
                 ),
                 ConvergenceWarning,
             )
+
+        if self.power_t < 0:
+            warnings.warn(
+                "Negative values for `power_t` are deprecated in version 1.8 and will raise an error in 1.10."
+                "Use values in the range [0.0, inf) instead.",
+                FutureWarning,
+            )
+
         return self
 
     def _fit_binary(self, X, y, alpha, C, sample_weight, learning_rate, max_iter):
@@ -1082,7 +1090,10 @@ class SGDClassifier(BaseSGDClassifier):
 
     power_t : float, default=0.5
         The exponent for inverse scaling learning rate.
-        Values must be in the range `[0.0, inf)`.
+
+        .. deprecated:: 1.8
+            Negative values for `power_t` are deprecated in version 1.8 and will raise an error in 1.10. 
+            Values must be in the range [0.0, inf).
 
     early_stopping : bool, default=False
         Whether to use early stopping to terminate training when validation
@@ -1208,7 +1219,7 @@ class SGDClassifier(BaseSGDClassifier):
         "penalty": [StrOptions({"l2", "l1", "elasticnet"}), None],
         "alpha": [Interval(Real, 0, None, closed="left")],
         "l1_ratio": [Interval(Real, 0, 1, closed="both"), None],
-        "power_t": [Interval(Real, 0, None, closed="left")],
+        "power_t": [Interval(Real, None, None, closed="neither")],
         "epsilon": [Interval(Real, 0, None, closed="left")],
         "learning_rate": [
             StrOptions({"constant", "optimal", "invscaling", "adaptive"}),
@@ -1585,6 +1596,13 @@ class BaseSGDRegressor(RegressorMixin, BaseSGD):
                 ConvergenceWarning,
             )
 
+        if self.power_t < 0:
+            warnings.warn(
+                "Negative values for `power_t` are deprecated in version 1.8 and will raise an error in 1.10."
+                "Use values in the range [0.0, inf) instead.",
+                FutureWarning,
+            )
+
         return self
 
     @_fit_context(prefer_skip_nested_validation=True)
@@ -1880,7 +1898,10 @@ class SGDRegressor(BaseSGDRegressor):
 
     power_t : float, default=0.25
         The exponent for inverse scaling learning rate.
-        Values must be in the range `[0.0, inf)`.
+
+        .. deprecated:: 1.8
+            Negative values for `power_t` are deprecated in version 1.8 and will raise an error in 1.10.
+            Values must be in the range [0.0, inf).
 
     early_stopping : bool, default=False
         Whether to use early stopping to terminate training when validation
@@ -1994,7 +2015,7 @@ class SGDRegressor(BaseSGDRegressor):
         "penalty": [StrOptions({"l2", "l1", "elasticnet"}), None],
         "alpha": [Interval(Real, 0, None, closed="left")],
         "l1_ratio": [Interval(Real, 0, 1, closed="both"), None],
-        "power_t": [Interval(Real, 0, None, closed="left")],
+        "power_t": [Interval(Real, None, None, closed="neither")],
         "learning_rate": [
             StrOptions({"constant", "optimal", "invscaling", "adaptive"}),
             Hidden(StrOptions({"pa1", "pa2"})),
@@ -2118,7 +2139,10 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
 
     power_t : float, default=0.5
         The exponent for inverse scaling learning rate.
-        Values must be in the range `[0.0, inf)`.
+
+        .. deprecated:: 1.8
+            Negative values for `power_t` are deprecated in version 1.8 and will raise an error in 1.10.
+            Values must be in the range [0.0, inf).
 
     warm_start : bool, default=False
         When set to True, reuse the solution of the previous call to fit as
@@ -2201,7 +2225,7 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
             Hidden(StrOptions({"pa1", "pa2"})),
         ],
         "eta0": [Interval(Real, 0, None, closed="left")],
-        "power_t": [Interval(Real, 0, None, closed="left")],
+        "power_t": [Interval(Real, None, None, closed="neither")],
     }
 
     def __init__(
@@ -2488,6 +2512,13 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
                     "improve the fit."
                 ),
                 ConvergenceWarning,
+            )
+
+        if self.power_t < 0:
+            warnings.warn(
+                "Negative values for `power_t` are deprecated in version 1.8 and will raise an error in 1.10."
+                "Use values in the range [0.0, inf) instead.",
+                FutureWarning,
             )
 
         return self

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -1880,7 +1880,7 @@ class SGDRegressor(BaseSGDRegressor):
 
     power_t : float, default=0.25
         The exponent for inverse scaling learning rate.
-        Values must be in the range `[0, inf)`.
+        Values must be in the range `[0.0, inf)`.
 
     early_stopping : bool, default=False
         Whether to use early stopping to terminate training when validation
@@ -2118,7 +2118,7 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
 
     power_t : float, default=0.5
         The exponent for inverse scaling learning rate.
-        Values must be in the range `[0, inf)`.
+        Values must be in the range `[0.0, inf)`.
 
     warm_start : bool, default=False
         When set to True, reuse the solution of the previous call to fit as

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -1082,7 +1082,7 @@ class SGDClassifier(BaseSGDClassifier):
 
     power_t : float, default=0.5
         The exponent for inverse scaling learning rate.
-        Values must be in the range `(-inf, inf)`.
+        Values must be in the range `[0.0, inf)`.
 
     early_stopping : bool, default=False
         Whether to use early stopping to terminate training when validation
@@ -1208,7 +1208,7 @@ class SGDClassifier(BaseSGDClassifier):
         "penalty": [StrOptions({"l2", "l1", "elasticnet"}), None],
         "alpha": [Interval(Real, 0, None, closed="left")],
         "l1_ratio": [Interval(Real, 0, 1, closed="both"), None],
-        "power_t": [Interval(Real, None, None, closed="neither")],
+        "power_t": [Interval(Real, 0, None, closed="left")],
         "epsilon": [Interval(Real, 0, None, closed="left")],
         "learning_rate": [
             StrOptions({"constant", "optimal", "invscaling", "adaptive"}),
@@ -1880,7 +1880,7 @@ class SGDRegressor(BaseSGDRegressor):
 
     power_t : float, default=0.25
         The exponent for inverse scaling learning rate.
-        Values must be in the range `(-inf, inf)`.
+        Values must be in the range `[0, inf)`.
 
     early_stopping : bool, default=False
         Whether to use early stopping to terminate training when validation
@@ -1994,7 +1994,7 @@ class SGDRegressor(BaseSGDRegressor):
         "penalty": [StrOptions({"l2", "l1", "elasticnet"}), None],
         "alpha": [Interval(Real, 0, None, closed="left")],
         "l1_ratio": [Interval(Real, 0, 1, closed="both"), None],
-        "power_t": [Interval(Real, None, None, closed="neither")],
+        "power_t": [Interval(Real, 0, None, closed="left")],
         "learning_rate": [
             StrOptions({"constant", "optimal", "invscaling", "adaptive"}),
             Hidden(StrOptions({"pa1", "pa2"})),
@@ -2118,7 +2118,7 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
 
     power_t : float, default=0.5
         The exponent for inverse scaling learning rate.
-        Values must be in the range `(-inf, inf)`.
+        Values must be in the range `[0, inf)`.
 
     warm_start : bool, default=False
         When set to True, reuse the solution of the previous call to fit as
@@ -2201,7 +2201,7 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
             Hidden(StrOptions({"pa1", "pa2"})),
         ],
         "eta0": [Interval(Real, 0, None, closed="left")],
-        "power_t": [Interval(Real, None, None, closed="neither")],
+        "power_t": [Interval(Real, 0, None, closed="left")],
     }
 
     def __init__(

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -1091,6 +1091,7 @@ class SGDClassifier(BaseSGDClassifier):
 
     power_t : float, default=0.5
         The exponent for inverse scaling learning rate.
+        Values must be in the range `[0.0, inf)`.
 
         .. deprecated:: 1.8
             Negative values for `power_t` are deprecated in version 1.8 and will raise
@@ -1900,6 +1901,7 @@ class SGDRegressor(BaseSGDRegressor):
 
     power_t : float, default=0.25
         The exponent for inverse scaling learning rate.
+        Values must be in the range `[0.0, inf)`.
 
         .. deprecated:: 1.8
             Negative values for `power_t` are deprecated in version 1.8 and will raise
@@ -2141,6 +2143,7 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
 
     power_t : float, default=0.5
         The exponent for inverse scaling learning rate.
+        Values must be in the range `[0.0, inf)`.
 
         .. deprecated:: 1.8
             Negative values for `power_t` are deprecated in version 1.8 and will raise

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -734,7 +734,8 @@ class BaseSGDClassifier(LinearClassifierMixin, BaseSGD, metaclass=ABCMeta):
 
         if self.power_t < 0:
             warnings.warn(
-                "Negative values for `power_t` are deprecated in version 1.8 and will raise an error in 1.10."
+                "Negative values for `power_t` are deprecated in version 1.8 "
+                "and will raise an error in 1.10. "
                 "Use values in the range [0.0, inf) instead.",
                 FutureWarning,
             )
@@ -1092,8 +1093,8 @@ class SGDClassifier(BaseSGDClassifier):
         The exponent for inverse scaling learning rate.
 
         .. deprecated:: 1.8
-            Negative values for `power_t` are deprecated in version 1.8 and will raise an error in 1.10. 
-            Values must be in the range [0.0, inf).
+            Negative values for `power_t` are deprecated in version 1.8 and will raise
+            an error in 1.10. Use values in the range [0.0, inf) instead.
 
     early_stopping : bool, default=False
         Whether to use early stopping to terminate training when validation
@@ -1598,7 +1599,8 @@ class BaseSGDRegressor(RegressorMixin, BaseSGD):
 
         if self.power_t < 0:
             warnings.warn(
-                "Negative values for `power_t` are deprecated in version 1.8 and will raise an error in 1.10."
+                "Negative values for `power_t` are deprecated in version 1.8 "
+                "and will raise an error in 1.10. "
                 "Use values in the range [0.0, inf) instead.",
                 FutureWarning,
             )
@@ -1900,8 +1902,8 @@ class SGDRegressor(BaseSGDRegressor):
         The exponent for inverse scaling learning rate.
 
         .. deprecated:: 1.8
-            Negative values for `power_t` are deprecated in version 1.8 and will raise an error in 1.10.
-            Values must be in the range [0.0, inf).
+            Negative values for `power_t` are deprecated in version 1.8 and will raise
+            an error in 1.10. Use values in the range [0.0, inf) instead.
 
     early_stopping : bool, default=False
         Whether to use early stopping to terminate training when validation
@@ -2141,8 +2143,8 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
         The exponent for inverse scaling learning rate.
 
         .. deprecated:: 1.8
-            Negative values for `power_t` are deprecated in version 1.8 and will raise an error in 1.10.
-            Values must be in the range [0.0, inf).
+            Negative values for `power_t` are deprecated in version 1.8 and will raise
+            an error in 1.10. Use values in the range [0.0, inf) instead.
 
     warm_start : bool, default=False
         When set to True, reuse the solution of the previous call to fit as
@@ -2516,7 +2518,8 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
 
         if self.power_t < 0:
             warnings.warn(
-                "Negative values for `power_t` are deprecated in version 1.8 and will raise an error in 1.10."
+                "Negative values for `power_t` are deprecated in version 1.8 "
+                "and will raise an error in 1.10. "
                 "Use values in the range [0.0, inf) instead.",
                 FutureWarning,
             )

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -507,6 +507,7 @@ def test_sgd_failing_penalty_validation(Estimator):
         clf.fit(X, Y)
 
 
+# TODO(1.10): remove this test
 @pytest.mark.parametrize(
     "klass",
     [
@@ -520,16 +521,10 @@ def test_sgd_failing_penalty_validation(Estimator):
 )
 def test_power_t_limits(klass):
     """Check that power_t is limited to [0, inf)"""
-    clf = klass(power_t=0.0)
-    clf.fit(X, Y)
-    assert clf.power_t == 0.0
-
-    clf = klass(power_t=0.5)
-    clf.fit(X, Y)
-    assert clf.power_t == 0.5
-
     clf = klass(power_t=-1.0)
-    with pytest.raises(ValueError, match=r"must be a float in the range \[0\.0, inf\)"):
+    with pytest.warns(
+        FutureWarning, match="Negative values for `power_t` are deprecated"
+    ):
         clf.fit(X, Y)
 
 

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -1,4 +1,5 @@
 import pickle
+import warnings
 from unittest.mock import Mock
 
 import joblib
@@ -520,12 +521,20 @@ def test_sgd_failing_penalty_validation(Estimator):
     ],
 )
 def test_power_t_limits(klass):
-    """Check that power_t is limited to [0, inf)"""
+    """Check that a warning is raised when `power_t` is negative."""
+
+    # Check that negative values of `power_t` raise a warning
     clf = klass(power_t=-1.0)
     with pytest.warns(
         FutureWarning, match="Negative values for `power_t` are deprecated"
     ):
         clf.fit(X, Y)
+
+    # Check that values of 'power_t in range [0, inf) do not raise a warning
+    with warnings.catch_warnings(record=True) as w:
+        clf = klass(power_t=0.5)
+        clf.fit(X, Y)
+    assert len(w) == 0
 
 
 ###############################################################################

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -506,6 +506,30 @@ def test_sgd_failing_penalty_validation(Estimator):
     ):
         clf.fit(X, Y)
 
+@pytest.mark.parametrize(
+    "klass",
+    [
+        SGDClassifier,
+        SparseSGDClassifier,
+        SGDRegressor,
+        SparseSGDRegressor,
+        SGDOneClassSVM,
+        SparseSGDOneClassSVM,
+    ],
+)
+def test_power_t_limits(klass):
+    """Check that power_t is limited to [0, inf)"""
+    clf = klass(power_t=0.0)
+    clf.fit(X, Y)
+    assert clf.power_t == 0.0
+
+    clf = klass(power_t=0.5)
+    clf.fit(X, Y)
+    assert clf.power_t == 0.5
+    
+    clf = klass(power_t=-1.0)
+    with pytest.raises(ValueError, match=r"must be a float in the range \[0\.0, inf\)"):
+        clf.fit(X, Y)
 
 ###############################################################################
 # Classification Test Case

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -506,6 +506,7 @@ def test_sgd_failing_penalty_validation(Estimator):
     ):
         clf.fit(X, Y)
 
+
 @pytest.mark.parametrize(
     "klass",
     [
@@ -526,10 +527,11 @@ def test_power_t_limits(klass):
     clf = klass(power_t=0.5)
     clf.fit(X, Y)
     assert clf.power_t == 0.5
-    
+
     clf = klass(power_t=-1.0)
     with pytest.raises(ValueError, match=r"must be a float in the range \[0\.0, inf\)"):
         clf.fit(X, Y)
+
 
 ###############################################################################
 # Classification Test Case


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #22178. Also see [#22215 comment](https://github.com/scikit-learn/scikit-learn/pull/22115#r780109928) for reference. 


#### What does this implement/fix? Explain your changes.
- Throw a warning when the power_t parameter is negative and warn the user that negative values will be invalid in two releases time. 
- Update the docstrings based on the changes to the constraints.
