### PR TITLE
DOC Add link for prediction latency plot example in SGD Regression

### DIFF
--- a/doc/modules/sgd.rst
+++ b/doc/modules/sgd.rst
@@ -231,6 +231,10 @@ For regression with a squared loss and a :math:`L_2` penalty, another variant of
 SGD with an averaging strategy is available with Stochastic Average
 Gradient (SAG) algorithm, available as a solver in :class:`Ridge`.
 
+.. rubric:: Examples
+
+- :ref:`sphx_glr_auto_examples_applications_plot_prediction_latency.py`
+
 .. _sgd_online_one_class_svm:
 
 Online One-Class SVM

--- a/doc/modules/sgd.rst
+++ b/doc/modules/sgd.rst
@@ -289,6 +289,7 @@ supports averaged SGD. Averaging can be enabled by setting ``average=True``.
 .. rubric:: Examples
 
 - :ref:`sphx_glr_auto_examples_linear_model_plot_sgdocsvm_vs_ocsvm.py`
+- :ref:`sphx_glr_auto_examples_applications_plot_prediction_latency.py`
 
 Stochastic Gradient Descent for sparse data
 ===========================================

--- a/doc/modules/sgd.rst
+++ b/doc/modules/sgd.rst
@@ -293,7 +293,6 @@ supports averaged SGD. Averaging can be enabled by setting ``average=True``.
 .. rubric:: Examples
 
 - :ref:`sphx_glr_auto_examples_linear_model_plot_sgdocsvm_vs_ocsvm.py`
-- :ref:`sphx_glr_auto_examples_applications_plot_prediction_latency.py`
 
 Stochastic Gradient Descent for sparse data
 ===========================================


### PR DESCRIPTION
References [Add links to examples from the docstrings and user guide](https://github.com/scikit-learn/scikit-learn/issues/30621)

Adds example link to plot_prediction_latency at Stochastic Gradient
Descent Regression.
