### PR TITLE
Improve error message in `check_requires_y_none`

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -4397,7 +4397,14 @@ def check_requires_y_none(name, estimator_orig):
         estimator.fit(X, None)
     except ValueError as ve:
         if not any(msg in str(ve) for msg in expected_err_msgs):
-            raise ve
+            raise ValueError(
+                "Your estimator raised a ValueError, but with the incorrect or "
+                "incomplete error message to be considered a graceful fail. "
+                f"This is the error message in your exception: {ve}. "
+                "But the expected message in the ValueError should contain one of "
+                f"these literal strings:\n{expected_err_msgs}. "
+                f"For example, you could have `ValueError('{expected_err_msgs[0]}')`"
+            )
 
 
 @ignore_warnings(category=FutureWarning)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -4400,10 +4400,10 @@ def check_requires_y_none(name, estimator_orig):
             raise ValueError(
                 "Your estimator raised a ValueError, but with the incorrect or "
                 "incomplete error message to be considered a graceful fail. "
-                f"This is the error message in your exception: {ve}. "
-                "But the expected message in the ValueError should contain one of "
+                "The expected message in the ValueError should contain one of "
                 f"these literal strings:\n{expected_err_msgs}. "
-                f"For example, you could have `ValueError('{expected_err_msgs[0]}')`"
+                f"For example, you could have `ValueError('{expected_err_msgs[0]}')`.\n"
+                f"This is the error message in your exception:\n{ve}"
             )
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This PR improves the error message in the function `check_requires_y_none` adding explicit instructions on how to fix the error when developing a custom estimator. Otherwise the user needs to jump into the source code to understand where the error comes from.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
