### PR TITLE
MNT Fix docstring of _BaseComposition

### DIFF
--- a/sklearn/utils/metaestimators.py
+++ b/sklearn/utils/metaestimators.py
@@ -18,7 +18,8 @@ __all__ = ["available_if"]
 
 
 class _BaseComposition(BaseEstimator, metaclass=ABCMeta):
-    """Handles parameter management for classifiers composed of named estimators."""
+    """Handles parameter management for estimators that are composed of named
+    sub-estimators."""
 
     steps: List[Any]
 


### PR DESCRIPTION
This PR fixes the docstring of `_BaseComposition`.

`Pipeline`, `FeatureUnion`, `ColumnTransformer`, `Stacking*` and `Voting*` all inherit from it, so it's not specifically used in classifiers.