### PR TITLE
FEA Add DummyClassifier strategy that produces randomized probabilities

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.dummy/31462.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.dummy/31462.feature.rst
@@ -1,0 +1,5 @@
+- :class:`dummy.DummyClassifier` now supports a new strategy "uniform-proba" that
+  generates random probability distributions for each sample using a Dirichlet
+  distribution with all concentration parameters set to 1. This results in uniformly
+  distributed probability vectors that sum to 1 for each sample.
+  By :user:`Chris Boseakc <cboseak>`

--- a/doc/whats_new/upcoming_changes/sklearn.dummy/31462.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.dummy/31462.feature.rst
@@ -1,5 +1,0 @@
-- :class:`dummy.DummyClassifier` now supports a new strategy "uniform-proba" that
-  generates random probability distributions for each sample using a Dirichlet
-  distribution with all concentration parameters set to 1. This results in uniformly
-  distributed probability vectors that sum to 1 for each sample.
-  By :user:`Chris Boseakc <cboseak>`

--- a/doc/whats_new/upcoming_changes/sklearn.dummy/31488.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.dummy/31488.feature.rst
@@ -1,0 +1,5 @@
+- :class:`dummy.DummyClassifier` now supports a new strategy "uniform-proba" that
+  generates random probability distributions for each sample using a Dirichlet
+  distribution with all concentration parameters set to 1. This results in uniformly
+  distributed probability vectors that sum to 1 for each sample.
+  By :user:`Chris Boseakc <cboseak>`

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -713,3 +713,58 @@ def test_dtype_of_classifier_probas(strategy):
     probas = model.fit(X, y).predict_proba(X)
 
     assert probas.dtype == np.float64
+
+
+def test_uniform_proba_strategy(global_random_seed):
+    X = [[0]] * 5  # ignored
+    y = [1, 2, 1, 1, 2]
+    clf = DummyClassifier(strategy="uniform-proba", random_state=global_random_seed)
+    clf.fit(X, y)
+
+    X_test = [[0]] * 100
+    y_pred_proba = clf.predict_proba(X_test)
+
+    # Check that probabilities sum to 1 for each sample
+    assert_array_almost_equal(np.sum(y_pred_proba, axis=1), np.ones(len(X_test)))
+
+    # Check that all probabilities are >= 0
+    assert np.all(y_pred_proba >= 0)
+
+    # Check shape
+    assert y_pred_proba.shape == (len(X_test), len(np.unique(y)))
+
+    # Check that predict returns the class with highest probability
+    y_pred = clf.predict(X_test)
+    for i in range(len(X_test)):
+        assert y_pred[i] == clf.classes_[np.argmax(y_pred_proba[i])]
+
+    _check_predict_proba(clf, X_test, y)
+
+
+def test_uniform_proba_strategy_multioutput(global_random_seed):
+    X = [[0]] * 5  # ignored
+    y = np.array([[2, 1], [2, 2], [1, 1], [1, 2], [1, 1]])
+
+    clf = DummyClassifier(strategy="uniform-proba", random_state=global_random_seed)
+    clf.fit(X, y)
+
+    X_test = [[0]] * 100
+    y_pred = clf.predict(X_test)
+    y_pred_proba = clf.predict_proba(X_test)
+
+    # For multioutput, predict_proba returns a list of arrays
+    assert isinstance(y_pred_proba, list)
+    assert len(y_pred_proba) == y.shape[1]
+
+    for k in range(y.shape[1]):
+        # Check that probabilities sum to 1 for each sample
+        assert_array_almost_equal(np.sum(y_pred_proba[k], axis=1), np.ones(len(X_test)))
+
+        # Check that all probabilities are >= 0
+        assert np.all(y_pred_proba[k] >= 0)
+
+        # Check shape
+        assert y_pred_proba[k].shape == (len(X_test), len(np.unique(y[:, k])))
+
+    _check_predict_proba(clf, X_test, y)
+    _check_behavior_2d(clf)

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -715,7 +715,8 @@ def test_dtype_of_classifier_probas(strategy):
     assert probas.dtype == np.float64
 
 
-def test_uniform_proba_strategy(global_random_seed):
+def test_uniform_proba_strategy(global_random_seed) -> None:
+    """Basic checks on uniform probability distributions in the dummy classifier."""
     X = [[0]] * 5  # ignored
     y = [1, 2, 1, 1, 2]
     clf = DummyClassifier(strategy="uniform-proba", random_state=global_random_seed)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Fixes #31462



#### What does this implement/fix? Explain your changes.
This PR adds a new strategy to DummyClassifier called "random_proba" that generates randomized probability distributions for classification tasks. This strategy can be used for benchmarking and testing purposes where completely random probabilistic outputs are desirable.
