### PR TITLE
Implement MultiHorizonTimeSeriesSplit for multi-horizon CV

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -3053,3 +3053,176 @@ def _yields_constant_splits(cv):
     shuffle = getattr(cv, "shuffle", True)
     random_state = getattr(cv, "random_state", 0)
     return isinstance(random_state, numbers.Integral) or not shuffle
+
+
+class MultiHorizonTimeSeriesSplit(TimeSeriesSplit):
+    """Time Series cross-validator with multiple prediction horizons.
+
+    Provides train/test indices to split time series data samples that are
+    observed at fixed time intervals, into multiple training and test sets.
+    Unlike `TimeSeriesSplit`, which creates contiguous test sets, this class
+    generates test sets consisting of specific points determined by the
+    `horizons` parameter, allowing evaluation at multiple forecast horizons.
+
+    This cross-validation object inherits from `TimeSeriesSplit` and maintains
+    the temporal order of the data, ensuring that training sets only include
+    past data relative to the test sets.
+
+    Parameters
+    ----------
+    n_splits : int, default=5
+        Number of splits. Must be at least 1.
+
+    horizons : list of int, default=[1]
+        List of positive integers representing the forecast horizons
+        (steps ahead to predict). Must be a non-empty list containing only
+        positive integers.
+
+    max_train_size : int or None, optional
+        Maximum size for a single training set. If `None`, no upper limit is
+        imposed. Inherited from `TimeSeriesSplit`.
+
+    test_size : int or None, optional
+        Size of the test set. If provided, it must be at least as large as the
+        maximum value in `horizons`. If `None`, the test set positions are
+        determined based on the number of horizons and splits. Inherited from
+        `TimeSeriesSplit`.
+
+    gap : int, default=0
+        Number of samples to exclude between the end of the training set and
+        the start of the test set. Inherited from `TimeSeriesSplit`.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.model_selection import MultiHorizonTimeSeriesSplit
+    >>> X = np.array(range(10))
+    >>> cv = MultiHorizonTimeSeriesSplit(n_splits=2, horizons=[1, 2], gap=0)
+    >>> for train_index, test_index in cv.split(X):
+    ...     print("TRAIN:", train_index, "TEST:", test_index)
+    TRAIN: [0 1 2 3 4] TEST: [5 6]
+    TRAIN: [0 1 2 3 4 5 6] TEST: [7 8]
+
+    >>> # Example with horizons=[1, 3]
+    >>> cv = MultiHorizonTimeSeriesSplit(n_splits=2, horizons=[1, 3], gap=0)
+    >>> for train_index, test_index in cv.split(X):
+    ...     print("TRAIN:", train_index, "TEST:", test_index)
+    TRAIN: [0 1 2 3] TEST: [4 6]
+    TRAIN: [0 1 2 3 4 5] TEST: [6 8]
+
+    Notes
+    -----
+    - Test indices are computed as `test_start + h - 1` for each horizon `h` in
+      `horizons`, where `test_start` is the starting index of the test set,
+      determined by the number of splits and the maximum horizon.
+    - When `test_size` is specified, it defines the step size between
+      consecutive `test_start` positions and must accommodate the maximum
+      horizon.
+    - If `test_size` is `None`, the step between test sets is equal to the
+      number of horizons, and the initial offset is calculated to fit the
+      specified number of splits.
+    - The class ensures that test indices do not exceed the number of samples,
+      potentially skipping splits if insufficient data remains.
+
+    """
+
+    def __init__(
+        self, n_splits=5, *, horizons=[1], max_train_size=None, test_size=None, gap=0
+    ):
+        if not isinstance(horizons, (list, tuple)) or len(horizons) == 0:
+            raise ValueError(
+                "`horizons` must be a non-empty list of positive integers."
+            )
+        if not all(isinstance(h, int) and h > 0 for h in horizons):
+            raise ValueError("All horizon values must be positive integers.")
+        self.horizons = sorted(set(horizons))
+        super().__init__(
+            n_splits=n_splits,
+            gap=gap,
+            max_train_size=max_train_size,
+            test_size=test_size,
+        )
+
+    def split(self, X, y=None, groups=None):
+        """Generate indices to split data into training and test sets.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training data, where `n_samples` is the number of samples and
+            `n_features` is the number of features.
+
+        y : array-like of shape (n_samples,), default=None
+            The target variable for supervised learning problems. Always
+            ignored, exists for compatibility.
+
+        groups : array-like of shape (n_samples,), default=None
+            Group labels for the samples used while splitting the dataset.
+            Always ignored, exists for compatibility.
+
+        Yields
+        ------
+        train : ndarray
+            The training set indices for that split.
+
+        test : ndarray
+            The testing set indices for that split, corresponding to the
+            specified horizons.
+        """
+        (X,) = indexable(X)
+        n_samples = _num_samples(X)
+        n_splits = self.n_splits
+        gap = self.gap
+        max_horizon = max(self.horizons)
+
+        if n_splits < 1:
+            raise ValueError(f"n_splits must be at least 1, got {n_splits}.")
+        if n_samples <= max_horizon:
+            raise ValueError(
+                f"Not enough samples ({n_samples}) for the maximum horizon \
+                    ({max_horizon})."
+            )
+
+        if self.test_size is not None:
+            test_size = self.test_size
+            if test_size < max_horizon:
+                raise ValueError(
+                    f"test_size={test_size} must be at least as large as \
+                        max(horizons)={max_horizon}."
+                )
+            test_starts = range(n_samples - n_splits * test_size, n_samples, test_size)
+        else:
+            step = len(self.horizons)
+            initial_offset = n_samples - 1 - max_horizon - (n_splits - 1) * step
+            if initial_offset < 0:
+                raise ValueError(
+                    f"Not enough samples={n_samples} for n_splits={n_splits} \
+                        with horizons={self.horizons}."
+                )
+            test_starts = [initial_offset + i * step for i in range(n_splits)]
+
+        indices = np.arange(n_samples)
+
+        for test_start in test_starts:
+            train_end = test_start - gap
+            if train_end <= 0:
+                raise ValueError(
+                    "Not enough data to create training set before test_start."
+                )
+
+            if self.max_train_size is not None and self.max_train_size < train_end:
+                train_indices = indices[train_end - self.max_train_size : train_end]
+            else:
+                train_indices = indices[:train_end]
+
+            test_indices = [
+                test_start + h - 1
+                for h in self.horizons
+                if test_start + h - 1 < n_samples
+            ]
+
+            if len(test_indices) < len(self.horizons):
+                # Skip this split if not all horizons can be included
+                break
+
+            yield train_indices, np.array(test_indices)

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -35,6 +35,7 @@ from sklearn.model_selection import (
     train_test_split,
 )
 from sklearn.model_selection._split import (
+    MultiHorizonTimeSeriesSplit,
     _build_repr,
     _validate_shuffle_split,
     _yields_constant_splits,
@@ -2100,3 +2101,138 @@ def test_stratified_splitter_without_y(cv):
     msg = "missing 1 required positional argument: 'y'"
     with pytest.raises(TypeError, match=msg):
         cv.split(X)
+
+
+def test_multi_horizon_timeseries_split_proposal_horizons_1_2():
+    """Splitting with horizons=[1, 2] and gap=0 produces the expected
+    train/test indices."""
+    X = np.arange(10)
+    cv = MultiHorizonTimeSeriesSplit(n_splits=2, horizons=[1, 2], gap=0)
+    splits = list(cv.split(X))
+    assert len(splits) == 2
+    assert_array_equal(splits[0][0], [0, 1, 2, 3, 4])
+    assert_array_equal(splits[0][1], [5, 6])
+    assert_array_equal(splits[1][0], [0, 1, 2, 3, 4, 5, 6])
+    assert_array_equal(splits[1][1], [7, 8])
+
+
+def test_horizons_1_2_3_default_gap():
+    """Splitting with horizons=[1, 2, 3] and default gap=0 yields the
+    correct train/test indices."""
+    X = np.arange(10)
+    cv = MultiHorizonTimeSeriesSplit(n_splits=2, horizons=[1, 2, 3], gap=0)
+    splits = list(cv.split(X))
+    assert len(splits) == 2
+
+    # First fold: test_start=3 → train=[0,1,2], test=[3,4,5]
+    train0, test0 = splits[0]
+    assert_array_equal(train0, np.array([0, 1, 2]))
+    assert_array_equal(test0, np.array([3, 4, 5]))
+
+    # Second fold: test_start=6 → train=[0,1,2,3,4,5], test=[6,7,8]
+    train1, test1 = splits[1]
+    assert_array_equal(train1, np.array([0, 1, 2, 3, 4, 5]))
+    assert_array_equal(test1, np.array([6, 7, 8]))
+
+
+def test_horizons_1_2_gap_1():
+    """Splitting with horizons=[1, 2] and gap=1 leaves a one-step separation
+    between train and test."""
+    X = np.arange(10)
+    cv = MultiHorizonTimeSeriesSplit(n_splits=2, horizons=[1, 2], gap=1)
+    splits = list(cv.split(X))
+    assert len(splits) == 2
+
+    # First fold: test_start=5, train_end=5-1=4 → train=[0,1,2,3], test=[5,6]
+    train0, test0 = splits[0]
+    assert_array_equal(train0, np.array([0, 1, 2, 3]))
+    assert_array_equal(test0, np.array([5, 6]))
+
+    # Second fold: test_start=7, train_end=7-1=6 → train=[0,1,2,3,4,5], test=[7,8]
+    train1, test1 = splits[1]
+    assert_array_equal(train1, np.array([0, 1, 2, 3, 4, 5]))
+    assert_array_equal(test1, np.array([7, 8]))
+
+
+def test_horizons_1_2_with_test_size_3():
+    """Splitting with horizons=[1, 2], test_size=3, gap=0 selects correct
+    indices within each block."""
+    X = np.arange(10)
+    cv = MultiHorizonTimeSeriesSplit(n_splits=2, horizons=[1, 2], gap=0, test_size=3)
+    splits = list(cv.split(X))
+    assert len(splits) == 2
+
+    # test_starts = [4, 7]
+    # First fold: train=[0,1,2,3], test=[4,5]
+    train0, test0 = splits[0]
+    assert_array_equal(train0, np.array([0, 1, 2, 3]))
+    assert_array_equal(test0, np.array([4, 5]))
+
+    # Second fold: train=[0,1,2,3,4,5,6], test=[7,8]
+    train1, test1 = splits[1]
+    assert_array_equal(train1, np.array([0, 1, 2, 3, 4, 5, 6]))
+    assert_array_equal(test1, np.array([7, 8]))
+
+
+def test_horizons_1_2_with_max_train_size_3():
+    """Splitting with horizons=[1, 2] and max_train_size=3 uses only the
+    last 3 samples for each train."""
+    X = np.arange(10)
+    cv = MultiHorizonTimeSeriesSplit(
+        n_splits=2, horizons=[1, 2], gap=0, max_train_size=3
+    )
+    splits = list(cv.split(X))
+    assert len(splits) == 2
+
+    # test_starts = [5, 7]
+    # First fold: train_end=5 → train full=[0..4],
+    # but max_train_size=3 → train=[2,3,4], test=[5,6]
+    train0, test0 = splits[0]
+    assert_array_equal(train0, np.array([2, 3, 4]))
+    assert_array_equal(test0, np.array([5, 6]))
+
+    # Second fold: train_end=7 → full=[0..6],
+    # but max_train_size=3 → train=[4,5,6], test=[7,8]
+    train1, test1 = splits[1]
+    assert_array_equal(train1, np.array([4, 5, 6]))
+    assert_array_equal(test1, np.array([7, 8]))
+
+
+def test_init_invalid_horizons():
+    """Constructor must raise ValueError if horizons list is empty or
+    contains non-positive ints."""
+    with pytest.raises(ValueError):
+        MultiHorizonTimeSeriesSplit(n_splits=2, horizons=[])
+    with pytest.raises(ValueError):
+        MultiHorizonTimeSeriesSplit(n_splits=2, horizons=[0, 1])
+    with pytest.raises(ValueError):
+        MultiHorizonTimeSeriesSplit(n_splits=2, horizons=[-1, 2])
+    with pytest.raises(ValueError):
+        MultiHorizonTimeSeriesSplit(n_splits=2, horizons=[1, "a"])
+
+
+def test_split_test_size_too_small_for_horizons():
+    """split should raise ValueError if test_size < max(horizons)."""
+    X = np.arange(10)
+    cv = MultiHorizonTimeSeriesSplit(n_splits=2, horizons=[1, 2, 3], gap=0, test_size=2)
+    with pytest.raises(ValueError):
+        list(cv.split(X))
+
+
+def test_split_initial_offset_negative():
+    """split should raise ValueError when there are not enough samples
+    to position n_splits folds given horizons (initial_offset < 0)."""
+    X = np.arange(4)
+    # Here, n_splits=2, horizons=[1,3] → max_horizon=3, step=2
+    # initial_offset = 4-1-3-(2-1)*2 = 3-3-2 = -2
+    cv = MultiHorizonTimeSeriesSplit(n_splits=2, horizons=[1, 3], gap=0)
+    with pytest.raises(ValueError):
+        list(cv.split(X))
+
+
+def test_split_train_end_zero_or_negative():
+    """split should raise ValueError when train_end <= 0."""
+    X = np.arange(3)
+    cv = MultiHorizonTimeSeriesSplit(n_splits=2, horizons=[1], gap=0)
+    with pytest.raises(ValueError):
+        list(cv.split(X))


### PR DESCRIPTION
Co-authored-by: Joao Barros <joao.f.barros@tecnico.ulisboa.pt>

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Implements #31344.
<!--
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This implements a new class, MultiHorizonTimeSeriesSplit, to enhance time series cross-validation by supporting multiple prediction horizons per split. 
The existing TimeSeriesSplit class is limited to generating a single, contiguous test set per split, which is insufficient for scenarios requiring forecasts over multiple future steps (e.g., predicting 1, 3, and 5 days ahead). 
This new class addresses that limitation by enabling users to evaluate time series models across various forecast horizons in a single, streamlined workflow.

Here’s a breakdown of the modifications:
- Added MultiHorizonTimeSeriesSplit as a subclass of TimeSeriesSplit.
- Introduced a horizons parameter (a list of positive integers) to specify the prediction steps for the test sets.
- Modified the split method to generate test indices based on the provided horizons.
- Added checks to ensure horizons is a non-empty list of positive integers and that the input data length supports the specified horizons and number of splits.
- Created tests to verify the correctness of splits across different configurations (e.g., varying horizons, gaps, and test sizes).

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
