### PR TITLE
Fix KernelDensity for non-whitened data (issue #25623)

### DIFF
--- a/sklearn/neighbors/_kde.py
+++ b/sklearn/neighbors/_kde.py
@@ -233,13 +233,15 @@ class KernelDensity(BaseEstimator):
         cov = np.cov(X, rowvar=False)
         if n_features == 1:
             std = np.sqrt(cov)
-            self.whitening_matrix_ = 1.0 / std   # scalar
+            self.whitening_matrix_ = 1.0 / std  # scalar
             # self.whitening_matrix_ = np.array([[1.0 / std]])
             self.log_jacobian_det_ = -np.log(std)
             X_white = X * self.whitening_matrix_
         else:
             eigvals, eigvecs = np.linalg.eigh(cov)
-            self.whitening_matrix_ = eigvecs @ np.diag(1.0 / np.sqrt(eigvals)) @ eigvecs.T
+            self.whitening_matrix_ = (
+                eigvecs @ np.diag(1.0 / np.sqrt(eigvals)) @ eigvecs.T
+            )
             self.log_jacobian_det_ = np.log(np.linalg.det(self.whitening_matrix_))
             # Whiten training data
             X_white = X @ self.whitening_matrix_.T


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #25623: https://github.com/scikit-learn/scikit-learn/issues/25623

#### Summary

This PR updates `KernelDensity` to correctly handle datasets whose covariance matrix is not the identity matrix.

#### Problem

Currently, `KernelDensity` assumes that the input data is already whitened (i.e., has identity covariance) when applying scalar bandwidths. As issue #25623 describes, density estimates are incorrect with non-whitened data.

#### Solution

This PR fixes the issue by:

1. Computing the empirical covariance matrix of the training data.
2. Computing a whitening transformation $W = \sigma^{-1/2}$ using eigen-decomposition.
3. Applying this transformation to both training and query data internally.
4. Correcting the final log-density estimates by adding the log-determinant of the whitening transform, restoring the correct units in the original feature space.

Special care is taken to:

- Support both 1D and nD data correctly.
- Preserve expected behavior when a fixed scalar bandwidth is manually specified.

I have tested this in 1D and 2D and the results match those of `scipy.stats.gaussian_kde()`. I haven't added any additional unit tests yet though.

#### Any other comments?

It seems there's also a separate pull request for this issue by @Charlie-XIAO, which I didn't notice before working on this patch. That PR is here: https://github.com/scikit-learn/scikit-learn/pull/27971.

It would be nice to get this fixed! `KernelDensity()` gives wildly incorrect results right now ...