### PR TITLE
DOC: Add link to OOB example in RandomForestClassifier docstring

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1450,6 +1450,11 @@ class RandomForestClassifier(ForestClassifier):
 
         .. versionadded:: 1.4
 
+    Examples
+    --------
+    See an example of using `RandomForestClassifier` with out-of-bag estimates:
+    :ref:`sphx_glr_auto_examples_ensemble_plot_ensemble_oob.py`
+
     See Also
     --------
     sklearn.tree.DecisionTreeClassifier : A decision tree classifier.
@@ -1490,6 +1495,9 @@ class RandomForestClassifier(ForestClassifier):
     RandomForestClassifier(...)
     >>> print(clf.predict([[0, 0, 0, 0]]))
     [1]
+
+  
+
     """
 
     _parameter_constraints: dict = {
@@ -2812,6 +2820,8 @@ class RandomTreesEmbedding(TransformerMixin, BaseForest):
         estimator. Each subset is defined by an array of the indices selected.
 
         .. versionadded:: 1.4
+
+   
 
     See Also
     --------

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1496,7 +1496,6 @@ class RandomForestClassifier(ForestClassifier):
     >>> print(clf.predict([[0, 0, 0, 0]]))
     [1]
 
-  
 
     """
 
@@ -2821,7 +2820,6 @@ class RandomTreesEmbedding(TransformerMixin, BaseForest):
 
         .. versionadded:: 1.4
 
-   
 
     See Also
     --------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Closes #30621

#### What does this implement/fix? Explain your changes.

This PR adds a link to the example script `plot_ensemble_oob.py` in the `RandomForestClassifier` docstring, as part of issue #30621.

The link is added using the Sphinx-gallery reference format, enabling users to navigate directly from the API documentation to the out-of-bag evaluation example.

#### Any other comments?

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
