### PR TITLE
Doc add link plot robust vs empirical covariance examples

### DIFF
--- a/sklearn/covariance/_robust_covariance.py
+++ b/sklearn/covariance/_robust_covariance.py
@@ -635,7 +635,7 @@ class MinCovDet(EmpiricalCovariance):
 
         For an example of comparing raw robust estimates with
         the true location and covariance, refer to
-        :ref:`sphx_glr_auto_examples_covariance_plot_robust_vs_empirical_covariance.py`
+        :ref:`sphx_glr_auto_examples_covariance_plot_robust_vs_empirical_covariance.py`.
 
     covariance_ : ndarray of shape (n_features, n_features)
         Estimated robust covariance matrix.

--- a/sklearn/covariance/_robust_covariance.py
+++ b/sklearn/covariance/_robust_covariance.py
@@ -633,9 +633,9 @@ class MinCovDet(EmpiricalCovariance):
     location_ : ndarray of shape (n_features,)
         Estimated robust location.
 
-    For an example of comparing raw robust estimates with
-    the true location and covariance, refer to
-    :ref:`sphx_glr_auto_examples_covariance_plot_robust_vs_empirical_covariance.py`
+        For an example of comparing raw robust estimates with
+        the true location and covariance, refer to
+        :ref:`sphx_glr_auto_examples_covariance_plot_robust_vs_empirical_covariance.py`
 
     covariance_ : ndarray of shape (n_features, n_features)
         Estimated robust covariance matrix.

--- a/sklearn/covariance/_robust_covariance.py
+++ b/sklearn/covariance/_robust_covariance.py
@@ -633,6 +633,10 @@ class MinCovDet(EmpiricalCovariance):
     location_ : ndarray of shape (n_features,)
         Estimated robust location.
 
+    For an example of comparing raw robust estimates with
+    the true location and covariance, refer to
+    :ref:`sphx_glr_auto_examples_covariance_plot_robust_vs_empirical_covariance.py`
+
     covariance_ : ndarray of shape (n_features, n_features)
         Estimated robust covariance matrix.
 


### PR DESCRIPTION
Towards #30621

This PR adds a reference to the `plot_robust_vs_empirical_covariance.py.`

The `plot_robust_vs_empirical_covariance` example is already referenced in the User Guide. I added a link to make the example visible from the class `MinCovDet` documentation.