### PR TITLE
DOC Fix example Recursive feature elimination with cross-validation

### DIFF
--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -105,7 +105,7 @@ import numpy as np
 
 for i in range(cv.n_splits):
     mask = rfecv.cv_results_[f"split{i}_support"][
-        rfecv.n_features_
+        rfecv.n_features_ - 1
     ]  # mask of features selected by the RFE
     features_selected = np.ma.compressed(np.ma.masked_array(feat_names, mask=1 - mask))
     print(f"Features selected in fold {i}: {features_selected}")


### PR DESCRIPTION
[Recursive feature elimination with cross-validation](https://scikit-learn.org/stable/auto_examples/feature_selection/plot_rfe_with_cross_validation.html#plot-number-of-features-vs-cross-validation-scores): The row number for `n_features_` in the `cv_results_` array is `n_features_ - 1`, not `n_features_`.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->




<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
