### PR TITLE
Preemptively fix incompatibilities with an upcoming array-api-strict release

### DIFF
--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1893,10 +1893,11 @@ def check_array_api_metric(
         np.asarray(a_xp)
         np.asarray(b_xp)
         numpy_as_array_works = True
-    except (TypeError, RuntimeError):
+    except (TypeError, RuntimeError, ValueError):
         # PyTorch with CUDA device and CuPy raise TypeError consistently.
-        # array-api-strict chose to raise RuntimeError instead. Exception type
-        # may need to be updated in the future for other libraries.
+        # array-api-strict chose to raise RuntimeError instead. NumPy raises
+        # a ValueError if the `__array__` dunder does not return an array.
+        # Exception type may need to be updated in the future for other libraries.
         numpy_as_array_works = False
 
     if numpy_as_array_works:

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -638,7 +638,7 @@ def _average(a, axis=None, weights=None, normalize=True, xp=None):
         # If weights are 1D, add singleton dimensions for broadcasting
         shape = [1] * a.ndim
         shape[axis] = a.shape[axis]
-        weights = xp.reshape(weights, shape)
+        weights = xp.reshape(weights, tuple(shape))
 
     if xp.isdtype(a.dtype, "complex floating"):
         raise NotImplementedError(

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1123,10 +1123,11 @@ def check_array_api_input(
         # now since array-api-strict seems a bit too strict ...
         numpy_asarray_works = xp.__name__ != "array_api_strict"
 
-    except (TypeError, RuntimeError):
+    except (TypeError, RuntimeError, ValueError):
         # PyTorch with CUDA device and CuPy raise TypeError consistently.
-        # array-api-strict chose to raise RuntimeError instead. Exception type
-        # may need to be updated in the future for other libraries.
+        # array-api-strict chose to raise RuntimeError instead. NumPy emits
+        # a ValueError if `__array__` dunder does not return an array.
+        # Exception type may need to be updated in the future for other libraries.
         numpy_asarray_works = False
 
     if numpy_asarray_works:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

`array-api-strict` plans a release "soon" (tm). Testing it locally smokes out two small failures, which this PR aims to fix:

- `xp.reshape(array, shape)` requires `shape` to be a tuple and rejects `shape` being a list. https://data-apis.org/array-api/latest/API_specification/generated/array_api.reshape.html#reshape

- a failed conversion to NumPy may emit a ValueError. This comes from https://github.com/data-apis/array-api-strict/pull/115 which --- finally! --- replaces `__array__`   with `__buffer__` (This was discussed at length in https://github.com/data-apis/array-api-strict/pull/69 and https://github.com/data-apis/array-api-strict/issues/67).  

#### Any other comments?

One other effect of using the buffer protocol for `np.asarray` is that testing with `array_api_strict` needs to use python 3.12 or above. The array api discussion is https://hackmd.io/zn5bvdZTQIeJmb3RW1B-8g#Meeting-minutes-14-November-2024

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
