### PR TITLE
DOC add link to plot_cv_predict example in cross_val_predict docstring(#30621)

### DIFF
--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -1047,6 +1047,11 @@ def cross_val_predict(
 
     Read more in the :ref:`User Guide <cross_validation>`.
 
+    .. seealso::
+
+        :ref:`sphx_glr_auto_examples_model_selection_plot_cv_predict.py`
+            Example of using cross_val_predict to visualize prediction results.
+
     Parameters
     ----------
     estimator : estimator

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -1040,17 +1040,16 @@ def cross_val_predict(
     to exactly one test set, and its prediction is computed with an
     estimator fitted on the corresponding training set.
 
+    This function can be useful to visualize prediction results,
+    as shown in the example:
+    :ref:`sphx_glr_auto_examples_model_selection_plot_cv_predict.py`.
+
     Passing these predictions into an evaluation metric may not be a valid
     way to measure generalization performance. Results can differ from
     :func:`cross_validate` and :func:`cross_val_score` unless all tests sets
     have equal size and the metric decomposes over samples.
 
     Read more in the :ref:`User Guide <cross_validation>`.
-
-    .. seealso::
-
-        :ref:`sphx_glr_auto_examples_model_selection_plot_cv_predict.py`
-            Example of using cross_val_predict to visualize prediction results.
 
     Parameters
     ----------


### PR DESCRIPTION
Reference Issues/PRs  
Fixes #30621.

What does this implement/fix? 
Added an inline reference link to the `plot_cv_predict.py` example from `examples/model_selection/` in the `cross_val_predict` docstring (located in `sklearn/model_selection/_validation.py`). This enhances discoverability by allowing users to directly access relevant usage examples from the API documentation.

These changes are documentation-only and do not affect code functionality.

When convenient, could you also look at my earlier PR for plot_rfe_with_cross_validation.py? Thank you for your continued guidance!