### PR TITLE
DOC Add reference to plot_lasso_model_selection example in linear_model.rst(#30621)

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -271,6 +271,7 @@ computes the coefficients along the full path of possible values.
 * :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_and_elasticnet.py`
 * :ref:`sphx_glr_auto_examples_applications_plot_tomography_l1_reconstruction.py`
 * :ref:`sphx_glr_auto_examples_inspection_plot_linear_model_coefficient_interpretation.py`
+* :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_model_selection.py`
 
 
 .. note:: **Feature selection with Lasso**


### PR DESCRIPTION
Reference Issue
 #30621

What does this implement/fix?
Adds a documentation reference link for the example:
`plot_lasso_model_selection.py` under `examples/linear_model/` to the `linear_model.rst` user guide.

Any additional context?
Verified that this example was not previously referenced and has now been properly linked.
