### PR TITLE
Add compatibility for tarfile filter in Python <3.12

### DIFF
--- a/sklearn/datasets/_twenty_newsgroups.py
+++ b/sklearn/datasets/_twenty_newsgroups.py
@@ -35,6 +35,7 @@ import tarfile
 from contextlib import suppress
 from numbers import Integral, Real
 
+import sys
 import joblib
 import numpy as np
 import scipy.sparse as sp
@@ -84,7 +85,11 @@ def _download_20newsgroups(target_dir, cache_path, n_retries, delay):
         # Use filter="data" to prevent the most dangerous security issues.
         # For more details, see
         # https://docs.python.org/3.9/library/tarfile.html#tarfile.TarFile.extractall
-        fp.extractall(path=target_dir, filter="data")
+        
+        if sys.version_info >= (3, 12):
+            fp.extractall(path=target_dir, filter="data")
+        else:
+            fp.extractall(path=target_dir)
 
     with suppress(FileNotFoundError):
         os.remove(archive_path)


### PR DESCRIPTION
Ensures compatibility across Python versions by conditionally applying `filter="data"` only when the Python version is >= 3.12. 

Prevents `TypeError` on older versions when using `sklearn.datasets.fetch_20newsgroups()`.


#### What does this implement/fix?
This update prevents a runtime error when using the dataset loader on Python versions before 3.12, by conditionally applying the `filter` argument based on `sys.version_info`. The `filter="data"` option improves security, and this change ensures that it's used only where supported.

Fixes #31521.
<!-- Thank you, reviewers!  -->