### PR TITLE
FIX: fix wrongly used `plt.show()` in examples

### DIFF
--- a/examples/bicluster/plot_spectral_biclustering.py
+++ b/examples/bicluster/plot_spectral_biclustering.py
@@ -43,7 +43,7 @@ data, rows, columns = make_checkerboard(
 
 plt.matshow(data, cmap=plt.cm.Blues)
 plt.title("Original dataset")
-_ = plt.show()
+plt.show()
 
 # %%
 # We shuffle the data and the goal is to reconstruct it afterwards using
@@ -62,7 +62,7 @@ data = data[row_idx_shuffled][:, col_idx_shuffled]
 
 plt.matshow(data, cmap=plt.cm.Blues)
 plt.title("Shuffled dataset")
-_ = plt.show()
+plt.show()
 
 # %%
 # Fitting `SpectralBiclustering`
@@ -102,7 +102,7 @@ reordered_data = reordered_rows[:, np.argsort(model.column_labels_)]
 
 plt.matshow(reordered_data, cmap=plt.cm.Blues)
 plt.title("After biclustering; rearranged to show biclusters")
-_ = plt.show()
+plt.show()
 
 # %%
 # As a last step, we want to demonstrate the relationships between the row

--- a/examples/svm/plot_svm_kernels.py
+++ b/examples/svm/plot_svm_kernels.py
@@ -79,7 +79,7 @@ ax.set(xlim=(x_min, x_max), ylim=(y_min, y_max))
 scatter = ax.scatter(X[:, 0], X[:, 1], s=150, c=y, label=y, edgecolors="k")
 ax.legend(*scatter.legend_elements(), loc="upper right", title="Classes")
 ax.set_title("Samples in two-dimensional feature space")
-_ = plt.show()
+plt.show()
 
 # %%
 # We can see that the samples are not clearly separable by a straight line.


### PR DESCRIPTION
#### Reference Issues/PRs
No issue involved.

#### What does this implement/fix? Explain your changes.
Function `matplotlib.pyplot.show()` doesn't return a value (see: <https://github.com/matplotlib/matplotlib/blob/v3.10.3/lib/matplotlib/pyplot.py#L569-L614>), but at several examples it is used like `_ = plt.show()`.
This PR fixes this for all found occurrences:

```bash
$ git grep -E "= plt.show()"
examples/bicluster/plot_spectral_biclustering.py:_ = plt.show()
examples/bicluster/plot_spectral_biclustering.py:_ = plt.show()
examples/bicluster/plot_spectral_biclustering.py:_ = plt.show()
examples/svm/plot_svm_kernels.py:_ = plt.show()
```

#### Any other comments?
