### PR TITLE
[FIX] Free memory in DBSCAN.fit() after clustering (fixes #31407)

### DIFF
--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -10,7 +10,7 @@ from numbers import Integral, Real
 
 import numpy as np
 from scipy import sparse
-
+import gc
 from ..base import BaseEstimator, ClusterMixin, _fit_context
 from ..metrics.pairwise import _VALID_METRICS
 from ..neighbors import NearestNeighbors
@@ -443,6 +443,11 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         else:
             # no core samples
             self.components_ = np.empty((0, X.shape[1]))
+        # Clean up large temporary objects to free memory after fit
+        # These are not needed after clustering and may consume significant memory
+        del neighborhoods
+        del neighbors_model
+        gc.collect()
         return self
 
     def fit_predict(self, X, y=None, sample_weight=None):

--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -5,12 +5,13 @@ DBSCAN: Density-Based Spatial Clustering of Applications with Noise
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import gc
 import warnings
 from numbers import Integral, Real
 
 import numpy as np
 from scipy import sparse
-import gc
+
 from ..base import BaseEstimator, ClusterMixin, _fit_context
 from ..metrics.pairwise import _VALID_METRICS
 from ..neighbors import NearestNeighbors


### PR DESCRIPTION
### What does this PR do?

Fixes a memory overuse issue in `DBSCAN.fit()` by explicitly deleting large temporary variables (`neighborhoods`, `neighbors_model`) and invoking `gc.collect()` after clustering is done.

These variables are not used after fitting, but they consume significant memory in large datasets. Releasing them manually helps prevent memory buildup in long-running environments (e.g., notebooks, servers).

--
### Related Issue

Closes: #31407

---

### Why is this important?

- DBSCAN can retain large temporary arrays in memory, especially on datasets with millions of rows.
- This fix reclaims 10–15+ MiB of memory immediately after `.fit()` is called.
- No change to clustering logic or public API.
- Helps in memory-critical environments, or when clustering is repeated in a loop.

---


### Memory Profile Insights

I've run a memory profile on the `DBSCAN` implementation to analyze its memory footprint.

<details>
<summary>Memory Profiler Output (100,000 samples)</summary>

```text
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
   366    132.4 MiB    132.4 MiB           1       @_fit_context(
   367                                                 # DBSCAN.metric is not validated yet
   368                                                 prefer_skip_nested_validation=False
   369                                             )
   370                                             @profile()
   371                                             def fit(self, X, y=None, sample_weight=None):
   372                                                 """Perform DBSCAN clustering from features, or distance matrix.
   373
   374                                                 Parameters
   375                                                 ----------
   376                                                 X : {array-like, sparse matrix} of shape (n_samples, n_features), or \
   377                                                     (n_samples, n_samples)
   378                                                     Training instances to cluster, or distances between instances if
   379                                                     `metric='precomputed'. If a sparse matrix is provided, it will
   380                                                     be converted into a sparse `csr_matrix.
   381
   382                                                 y : Ignored
   383                                                     Not used, present here for API consistency by convention.
   384
   385                                                 sample_weight : array-like of shape (n_samples,), default=None
   386                                                     Weight of each sample, such that a sample with a weight of at least
   387                                                     `min_samples is by itself a core sample; a sample with a
   388                                                     negative weight may inhibit its eps-neighbor from being core.
   389                                                     Note that weights are absolute, and default to 1.
   390
   391                                                 Returns
   392                                                 -------
   393                                                 self : object
   394                                                     Returns a fitted instance of self.
   395                                                 """
   396    132.4 MiB      0.0 MiB           1           X = validate_data(self, X, accept_sparse="csr")
   397
   398    132.4 MiB      0.0 MiB           1           if sample_weight is not None:
   399                                                     sample_weight = _check_sample_weight(sample_weight, X)
   400
   401                                                 # Calculate neighborhood for all samples. This leaves the original
   402                                                 # point in, which needs to be considered later (i.e. point i is in the
   403                                                 # neighborhood of point i. While True, its useless information)
   404    132.4 MiB      0.0 MiB           1           if self.metric == "precomputed" and sparse.issparse(X):
   405                                                     # set the diagonal to explicit values, as a point is its own
   406                                                     # neighbor
   407                                                     X = X.copy()  # copy to avoid in-place modification
   408                                                     with warnings.catch_warnings():
   409                                                         warnings.simplefilter("ignore", sparse.SparseEfficiencyWarning)
   410                                                         X.setdiag(X.diagonal())
   411
   412    132.4 MiB      0.0 MiB           2           neighbors_model = NearestNeighbors(
   413    132.4 MiB      0.0 MiB           1               radius=self.eps,
   414    132.4 MiB      0.0 MiB           1               algorithm=self.algorithm,
   415    132.4 MiB      0.0 MiB           1               leaf_size=self.leaf_size,
   416    132.4 MiB      0.0 MiB           1               metric=self.metric,
   417    132.4 MiB      0.0 MiB           1               metric_params=self.metric_params,
   418    132.4 MiB      0.0 MiB           1               p=self.p,
   419    132.4 MiB      0.0 MiB           1               n_jobs=self.n_jobs,
   420                                                 )
   421    132.6 MiB      0.2 MiB           1           neighbors_model.fit(X)
   422                                                 # This has worst case O(n^2) memory complexity
   423    148.8 MiB     16.2 MiB           1           neighborhoods = neighbors_model.radius_neighbors(X, return_distance=False)
   424    148.8 MiB      0.0 MiB           1           if sample_weight is None:
   425    150.6 MiB      1.8 MiB      100001               n_neighbors = np.array([len(neighbors) for neighbors in neighborhoods])
   426                                                 else:
   427                                                     n_neighbors = np.array(
   428                                                         [np.sum(sample_weight[neighbors]) for neighbors in neighborhoods]
   429                                                     )
   430
   431                                                 # Initially, all samples are noise.
   432    150.6 MiB      0.0 MiB           1           labels = np.full(X.shape[0], -1, dtype=np.intp)
   433
   434                                                 # A list of all core samples found.
   435    150.6 MiB      0.0 MiB           1           core_samples = np.asarray(n_neighbors >= self.min_samples, dtype=np.uint8)
   436    150.6 MiB      0.0 MiB           1           dbscan_inner(core_samples, neighborhoods, labels)
   437
   438    150.6 MiB      0.0 MiB           1           self.core_sample_indices_ = np.where(core_samples)[0]
   439    150.6 MiB      0.0 MiB           1           self.labels_ = labels
   440
   441    150.6 MiB      0.0 MiB           1           if len(self.core_sample_indices_):
   442                                                     # fix for scipy sparse indexing issue
   443                                                     self.components_ = X[self.core_sample_indices_].copy()
   444                                                 else:
   445                                                     # no core samples
   446    150.6 MiB      0.0 MiB           1               self.components_ = np.empty((0, X.shape[1]))
   447    141.8 MiB     -8.8 MiB           1           del neighborhoods
   448    138.6 MiB     -3.2 MiB           1           del neighbors_model
   449    138.6 MiB      0.0 MiB           1           gc.collect()
   450    138.6 MiB      0.0 MiB           1           return self
