### PR TITLE
DOC: Improve Ridge regression example — fix typo, clarify title, add legend

### DIFF
--- a/examples/linear_model/plot_ridge_path.py
+++ b/examples/linear_model/plot_ridge_path.py
@@ -22,7 +22,7 @@ When alpha is very large, the regularization effect dominates the
 squared loss function and the coefficients tend to zero.
 At the end of the path, as alpha tends toward zero
 and the solution tends towards the ordinary least squares, coefficients
-exhibit big oscillations. In practise it is necessary to tune alpha
+exhibit big oscillations. In practice it is necessary to tune alpha
 in such a way that a balance is maintained between both.
 
 """
@@ -63,6 +63,7 @@ ax.set_xscale("log")
 ax.set_xlim(ax.get_xlim()[::-1])  # reverse axis
 plt.xlabel("alpha")
 plt.ylabel("weights")
-plt.title("Ridge coefficients as a function of the regularization")
+plt.title("Ridge Coefficients vs Regularization Strength (alpha)")
 plt.axis("tight")
+plt.legend([f"Feature {i+1}" for i in range(X.shape[1])], loc="best", fontsize="small")
 plt.show()

--- a/examples/linear_model/plot_ridge_path.py
+++ b/examples/linear_model/plot_ridge_path.py
@@ -65,5 +65,7 @@ plt.xlabel("alpha")
 plt.ylabel("weights")
 plt.title("Ridge Coefficients vs Regularization Strength (alpha)")
 plt.axis("tight")
-plt.legend([f"Feature {i+1}" for i in range(X.shape[1])], loc="best", fontsize="small")
+plt.legend(
+    [f"Feature {i + 1}" for i in range(X.shape[1])], loc="best", fontsize="small"
+)
 plt.show()


### PR DESCRIPTION
This PR improves the `plot_ridge_path.py` example in the following ways:

- Fixed a small typo: "practise" → "practice"
- Updated the plot title for clarity
- Added a legend to distinguish coefficients by feature index

The goal is to make the example more beginner-friendly and easier to interpret.  
If the maintainers prefer the original minimal design without a legend, I’m happy to remove that part — just let me know.

Thanks for reviewing!
