### PR TITLE
ENH Add multi-threshold classification to FixedThresholdClassifier

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.model_selection/31544.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.model_selection/31544.feature.rst
@@ -1,0 +1,5 @@
+- :class:`model_selection.FixedThresholdClassifier`
+  now supports multi-threshold classification to FixedThresholdClassifier, 
+  enabling discretization of continuous decision scores into multiple classes
+  by accepting a list of thresholds and optional labels.
+  By :user:`Nuno Martins <nunofbiomartins>` and :user:`Pedro Lopes <pedroL0pes>`

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -1049,16 +1049,83 @@ def check_scoring(estimator=None, scoring=None, *, allow_none=False, raise_exc=T
             )
 
 
-def _threshold_scores_to_class_labels(y_score, threshold, classes, pos_label):
-    """Threshold `y_score` and return the associated class labels."""
-    if pos_label is None:
-        map_thresholded_score_to_label = np.array([0, 1])
-    else:
-        pos_label_idx = np.flatnonzero(classes == pos_label)[0]
-        neg_label_idx = np.flatnonzero(classes != pos_label)[0]
-        map_thresholded_score_to_label = np.array([neg_label_idx, pos_label_idx])
+def _threshold_scores_to_class_labels(
+    y_score, threshold, classes, pos_label=None, labels=None
+):
+    """Convert continuous scores into discrete class predictions based on thresholds.
 
-    return classes[map_thresholded_score_to_label[(y_score >= threshold).astype(int)]]
+    Parameters
+    -------
+    y_score : array-like of shape (n_samples,)
+        Continuous prediction scores (e.g. probabilities) from a classifier.
+
+    threshold : float or array-like of floats
+        Threshold(s) used to convert scores into class labels.
+        A single float implies binary classification;
+        multiple values define bin edges for multi-class prediction.
+
+    classes : array-like of shape (n_classes,)
+        The original class labels from the classifier.
+
+    pos_label : int, float, bool or str, default=None
+        The class to treat as the positive class in binary thresholding.
+        Required if `classes` contains more than two labels or is non-standard.
+
+    labels : array-like of shape (n_bins,), optional
+        Class labels to assign to each bin for multi-threshold classification,
+        or to the binary decisions if a single threshold is used.
+        For binary classification, must have exactly two labels.
+
+    Returns
+    -------
+    y_pred : ndarray of shape (n_samples,)
+        Predicted class labels or bin indices, depending on `threshold` and `labels`.
+
+    Raises
+    -------
+    ValueError
+        If `threshold` contains multiple values that are not strictly increasing.
+        If `labels` is provided but:
+        - In multi-threshold classification, its length does not match the number
+        of bins (`len(threshold) + 1`).
+        - In binary classification, it does not contain exactly two elements.
+    """
+    y_score_arr = np.asarray(y_score)
+    th_arr = np.atleast_1d(threshold)
+
+    # multiple threshold classification
+    if th_arr.ndim == 1 and th_arr.size > 1:
+        if not np.all(np.diff(th_arr) > 0):
+            raise ValueError("Thresholds must be in strictly increasing order.")
+        bin_indices = np.digitize(y_score_arr, th_arr)
+        if labels is not None:
+            expected_bins = len(th_arr) + 1
+            if len(labels) != expected_bins:
+                raise ValueError(
+                    f"Number of labels must match number of bins ({expected_bins})"
+                    f", got {len(labels)} instead."
+                )
+            return np.array(labels)[bin_indices]
+        return bin_indices
+
+    # binary classification
+    decisions = (y_score_arr >= threshold).astype(int)
+
+    if labels is not None:
+        if len(labels) != 2:
+            raise ValueError(
+                "Labels must contain exactly two elements for binary classification."
+            )
+        return np.array(labels)[decisions]
+
+    if pos_label is None:
+        map_idx = np.array([0, 1])
+    else:
+        pos_idx = np.flatnonzero(classes == pos_label)[0]
+        neg_idx = np.flatnonzero(classes != pos_label)[0]
+        map_idx = np.array([neg_idx, pos_idx])
+
+    return classes[map_idx[decisions]]
 
 
 class _CurveScorer(_BaseScorer):

--- a/sklearn/model_selection/_classification_threshold.py
+++ b/sklearn/model_selection/_classification_threshold.py
@@ -211,11 +211,13 @@ class BaseThresholdClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator
 
 
 class FixedThresholdClassifier(BaseThresholdClassifier):
-    """Binary classifier that manually sets the decision threshold.
+    """Classifier that sets decision threshold(s) for binarized/binned classification.
 
     This classifier allows to change the default decision threshold used for
     converting posterior probability estimates (i.e. output of `predict_proba`) or
     decision scores (i.e. output of `decision_function`) into a class label.
+    It also supports applying multiple thresholds to discretize scores into bins
+    for multi-class or ordinal-style classification.
 
     Here, the threshold is not optimized and is set to a constant value.
 
@@ -235,6 +237,16 @@ class FixedThresholdClassifier(BaseThresholdClassifier):
         `decision_function`) into a class label. When `"auto"`, the threshold is set
         to 0.5 if `predict_proba` is used as `response_method`, otherwise it is set to
         0 (i.e. the default threshold for `decision_function`).
+
+    labels : list, default=None
+        Class labels corresponding to output bins. Used for both binary and
+        multi-threshold classification.
+
+        - For binary classification, must contain exactly 2 elements.
+        - For multi-thresholding, must contain exactly `len(threshold) + 1` labels.
+
+        If `labels` is None, binary outputs are inferred from `classes_`, and
+        multi-threshold outputs are bin indices.
 
     pos_label : int, float, bool or str, default=None
         The label of the positive class. Used to process the output of the
@@ -280,6 +292,8 @@ class FixedThresholdClassifier(BaseThresholdClassifier):
     >>> from sklearn.linear_model import LogisticRegression
     >>> from sklearn.metrics import confusion_matrix
     >>> from sklearn.model_selection import FixedThresholdClassifier, train_test_split
+
+    >>> # Binary classification with custom threshold
     >>> X, y = make_classification(
     ...     n_samples=1_000, weights=[0.9, 0.1], class_sep=0.8, random_state=42
     ... )
@@ -296,12 +310,25 @@ class FixedThresholdClassifier(BaseThresholdClassifier):
     >>> print(confusion_matrix(y_test, classifier_other_threshold.predict(X_test)))
     [[184  40]
      [  6  20]]
+
+    >>> # Multi-threshold classification using discretized scores
+    >>> import numpy as np
+    >>> base_clf = LogisticRegression(random_state=0)
+    >>> clf_multi = FixedThresholdClassifier(
+    ...     base_clf, threshold=[0.3, 0.6], labels=["Low", "Medium", "High"]
+    ... ).fit(X_train, y_train)
+    >>> y_pred = clf_multi.predict(X_test)
+    >>> labels, counts = np.unique(y_pred, return_counts=True)
+    >>> result = [(str(label), int(count)) for label, count in zip(labels, counts)]
+    >>> print(result)
+    [('High', 14), ('Low', 218), ('Medium', 18)]
     """
 
     _parameter_constraints: dict = {
         **BaseThresholdClassifier._parameter_constraints,
-        "threshold": [StrOptions({"auto"}), Real],
+        "threshold": [StrOptions({"auto"}), Real, list],
         "pos_label": [Real, str, "boolean", None],
+        "labels": [None, list],
     }
 
     def __init__(
@@ -309,12 +336,14 @@ class FixedThresholdClassifier(BaseThresholdClassifier):
         estimator,
         *,
         threshold="auto",
+        labels=None,
         pos_label=None,
         response_method="auto",
     ):
         super().__init__(estimator=estimator, response_method=response_method)
         self.pos_label = pos_label
         self.threshold = threshold
+        self.labels = labels
 
     @property
     def classes_(self):
@@ -383,7 +412,7 @@ class FixedThresholdClassifier(BaseThresholdClassifier):
             decision_threshold = self.threshold
 
         return _threshold_scores_to_class_labels(
-            y_score, decision_threshold, self.classes_, self.pos_label
+            y_score, decision_threshold, self.classes_, self.pos_label, self.labels
         )
 
     def get_metadata_routing(self):


### PR DESCRIPTION
This commit adds support for multi-threshold classification to FixedThresholdClassifier, enabling discretization of continuous decision scores into multiple classes.
The classifier now accepts a list of thresholds and optional labels for each bin.
Includes:
- Unit tests covering the new functionality
- Documentation and usage example

#### Reference Issues/PRs
#30452 
Multiple thresholds in FixedThresholdClassifier 

#### What does this implement/fix? Explain your changes.
This PR extends FixedThresholdClassifier to support discretization of continuous decision scores into multiple classes, by allowing the threshold parameter to be a list of values. This enables users to bin decision function outputs (such as probabilities or scores) into more than two risk classes or categories, a common requirement in real-world applications such as credit scoring, risk modeling, and regulatory compliance.

Key additions:
- Multi-threshold support: The classifier now accepts a list of threshold values to bin decision scores.
- Custom labels: Users can optionally provide a list of labels for the output classes corresponding to each bin.
- Backward compatibility: The original binary thresholding behavior is preserved when a single float is passed.
- Improved _threshold_scores_to_class_labels function to convert scores to class labels efficiently.
- Validation: Checks for consistency between number of thresholds and number of labels.
- Error handling: Raises informative errors for invalid parameter combinations.
