### PR TITLE
ENH add `store_cv_models` option to `ElasticNetCV` #28726

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -518,6 +518,23 @@ The objective function to minimize is in this case
 The class :class:`ElasticNetCV` can be used to set the parameters
 ``alpha`` (:math:`\alpha`) and ``l1_ratio`` (:math:`\rho`) by cross-validation.
 
+A new option ``store_cv_models`` allows you to store and access the full set of models
+trained during cross-validation, not just the best one. This is useful for
+inspecting coefficient paths, intercept evolution, or validation scores across
+all folds and parameter combinations.
+
+This feature can be used for detailed analysis or advanced visualizations.
+
+.. code-block:: python
+
+    model = ElasticNetCV(store_cv_models=True)
+    model.fit(X, y)
+
+    # Access coefficients and intercepts for each fold and parameter
+    coefs = model.cv_coefs_  # shape: (n_folds, n_l1_ratio, n_alphas, n_targets, n_features)
+    intercepts = model.cv_intercepts_
+    mse = model.cv_mse_
+
 .. rubric:: Examples
 
 * :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_and_elasticnet.py`

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/28726.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/28726.enhancement.rst
@@ -1,0 +1,5 @@
+- :class:`linear_model.ElasticNetCV` now accepts a `store_cv_models` parameter to
+  store all coefficients, intercepts, alphas, and MSEs computed during cross-validation
+  for each fold and each parameter setting. This enables detailed inspection and analysis
+  of the full regularization path.
+  By :user:`Guilherme Henriques <henriquessss>` and :user:`Guilherme Peixoto <guilhermecsnpeixoto>`


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Fixes #28726 
-->


#### What does this implement/fix? Explain your changes.
This PR introduces a new optional parameter store_cv_models to ElasticNetCV.
When store_cv_models=True, the object retains all models trained during cross-validation — not just the best one. This enables users to access:

- Coefficients (cv_coefs_)
- Intercepts (cv_intercepts_)
- Mean squared errors (cv_mse_)
...for every combination of fold and hyperparameters.

This is useful for:
- Analyzing how model weights evolve across folds
- Creating advanced visualizations (e.g., regularization paths)
- Performing custom diagnostics and validation studies

Default behavior remains unchanged (store_cv_models=False), preserving backward compatibility and avoiding unnecessary memory usage for most users.

#### Any other comments?

This addition offers deeper access to the training process for power users without affecting default performance.
