### PR TITLE
DOC Add link to StandardScaler example in docstring

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -853,6 +853,10 @@ class StandardScaler(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
      [ 1.  1.]]
     >>> print(scaler.transform([[2, 2]]))
     [[3. 3.]]
+    You can find a visual comparison of different scalers, including `StandardScaler`, in the following example:
+
+    `Compare different scalers on synthetic data <https://scikit-learn.org/stable/auto_examples/preprocessing/plot_all_scaling.html>`_
+    
     """
 
     _parameter_constraints: dict = {


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #30621

#### What does this implement/fix? Explain your changes.

This PR adds a link to the visual example `plot_all_scaling.py` in the docstring of `StandardScaler`, to help users discover how `StandardScaler` compares to other scalers in practice.

#### Any other comments?

This is a small documentation enhancement as part of issue #30621. Let me know if any formatting or style changes are needed!

