### PR TITLE
FIX Add validation for FeatureUnion transformer outputs (#31318)

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.pipeline/31559.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.pipeline/31559.fix.rst
@@ -1,4 +1,4 @@
-- :class:`pipeline.FeatureUnion` now validates that all transformers return 2D arrays
-  and raises an informative error when transformers return 1D arrays, preventing
+- :class:`pipeline.FeatureUnion` now validates that all transformers return 2D outputs
+  and raises an informative error when transformers return 1D outputs, preventing
   silent failures that previously produced meaningless concatenated results.
-  By :user:`gguiomar <gguiomar>`
+  By :user:`gguiomar <gguiomar>`.

--- a/doc/whats_new/upcoming_changes/sklearn.pipeline/31559.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.pipeline/31559.fix.rst
@@ -1,0 +1,4 @@
+- :class:`pipeline.FeatureUnion` now validates that all transformers return 2D arrays
+  and raises an informative error when transformers return 1D arrays, preventing
+  silent failures that previously produced meaningless concatenated results.
+  By :user:`gguiomar <gguiomar>`

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -10,7 +10,6 @@ from tempfile import mkdtemp
 
 import joblib
 import numpy as np
-import pandas as pd
 import pytest
 
 from sklearn import config_context
@@ -1891,6 +1890,22 @@ def test_feature_union_feature_names_in_():
     assert not hasattr(union, "feature_names_in_")
 
 
+def test_feature_union_1d_output():
+    """Test that FeatureUnion raises error for 1D transformer outputs."""
+    X = np.arange(6).reshape(3, 2)
+
+    with pytest.raises(
+        ValueError,
+        match="Transformer 'b' returned an array or dataframe with 1 dimensions",
+    ):
+        FeatureUnion(
+            [
+                ("a", FunctionTransformer(lambda X: X)),
+                ("b", FunctionTransformer(lambda X: X[:, 1])),
+            ]
+        ).fit_transform(X)
+
+
 # transform_input tests
 # =====================
 
@@ -2398,20 +2413,6 @@ def test_feature_union_metadata_routing(transformer):
                 parent="fit",
                 **kwargs,
             )
-
-
-@config_context(enable_metadata_routing=True)
-def test_feature_union_xs_dims():
-    """Test that FeatureUnion raises error for 1D transformer outputs."""
-    data = pd.DataFrame(dict(a=range(3), b=range(3)))
-
-    with pytest.raises(ValueError, match="returned an array with 1 dimensions"):
-        FeatureUnion(
-            [
-                ("a", FunctionTransformer(lambda df: df["a"])),
-                ("b", FunctionTransformer(lambda df: df["b"])),
-            ]
-        ).fit_transform(data)
 
 
 # End of routing tests

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -10,6 +10,7 @@ from tempfile import mkdtemp
 
 import joblib
 import numpy as np
+import pandas as pd
 import pytest
 
 from sklearn import config_context
@@ -2397,6 +2398,20 @@ def test_feature_union_metadata_routing(transformer):
                 parent="fit",
                 **kwargs,
             )
+
+
+@config_context(enable_metadata_routing=True)
+def test_feature_union_xs_dims():
+    """Test that FeatureUnion raises error for 1D transformer outputs."""
+    data = pd.DataFrame(dict(a=range(3), b=range(3)))
+
+    with pytest.raises(ValueError, match="returned an array with 1 dimensions"):
+        FeatureUnion(
+            [
+                ("a", FunctionTransformer(lambda df: df["a"])),
+                ("b", FunctionTransformer(lambda df: df["b"])),
+            ]
+        ).fit_transform(data)
 
 
 # End of routing tests


### PR DESCRIPTION
## Description
Fixes #31318 

This PR adds validation to `FeatureUnion._hstack()` to prevent silent failures when transformers return 1D arrays instead of the expected 2D arrays.

## Changes Made
- Modified `FeatureUnion._hstack()` to validate transformer outputs are 2D
- Added checks for consistent sample counts across transformers  
- Updated `transform()` method to pass transformer names for better error messages
- Added informative error messages including transformer name and expected shapes
- Added test case to verify the validation works correctly

## Before
```python
# This would silently produce meaningless results
FeatureUnion([
    ("a", FunctionTransformer(lambda df: df["a"])),  # Returns 1D
    ("b", FunctionTransformer(lambda df: df["b"])),  # Returns 1D
]).fit_transform(data)
# Output: array([0, 1, 2, 0, 1, 2])  # Meaningless concatenation

# This now raises an informative error (please check the test_feature_union_xs_dims() in tests/test_pipeline.py
FeatureUnion([
    ("a", FunctionTransformer(lambda df: df["a"])),
    ("b", FunctionTransformer(lambda df: df["b"])),
]).fit_transform(data)
# Raises: ValueError: Transformer 'a' returned an array with 1 dimensions, 
#         but expected 2 dimensions (n_samples, n_features).
