### PR TITLE
DOC add link to plot_multi_metric_evaluation in make scorer #30841

### DIFF
--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -714,6 +714,9 @@ def make_scorer(
     >>> from sklearn.svm import LinearSVC
     >>> grid = GridSearchCV(LinearSVC(), param_grid={'C': [1, 10]},
     ...                     scoring=ftwo_scorer)
+
+    For an example on how to use multiple scorers at the same time see
+    :ref:`sphx_glr_auto_examples_model_selection_plot_multi_metric_evaluation.py`.
     """
     sign = 1 if greater_is_better else -1
 


### PR DESCRIPTION
Towards https://github.com/scikit-learn/scikit-learn/issues/30621.Towards https://github.com/scikit-learn/scikit-learn/issues/30621.

This PR adds a reference to the 'plot_multi_metric_evaluation.py' example.

The 'plot_multi_metric_evaluation' example is already referenced in the [User Guide](https://scikit-learn.org/stable/modules/grid_search.html#specifying-multiple-metrics-for-evaluation). I added a link to the API docs of the related make_scorer function, because users might start from there. 

However, [this example ](https://scikit-learn.org/stable/auto_examples/ensemble/plot_gradient_boosting_quantile.html#tuning-the-hyper-parameters-of-the-quantile-regressors), namely :ref:`sphx_glr_auto_examples_linear_model_plot_quantile_regression.py`, from the API documentation would also be a valid example as more parameters are used.