### PR TITLE
DOC: Add example link to plot_poisson_regression_non_normal_loss.py in linear_model docs (#30621)

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -150,6 +150,7 @@ the corresponding solver is chosen.
 * :ref:`sphx_glr_auto_examples_linear_model_plot_ols_ridge.py`
 * :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_path.py`
 * :ref:`sphx_glr_auto_examples_inspection_plot_linear_model_coefficient_interpretation.py`
+* :ref:`sphx_glr_auto_examples_linear_model_plot_poisson_regression_non_normal_loss.py`
 
 Classification
 --------------


### PR DESCRIPTION
Towards #30621

This PR adds a reference to the example `plot_poisson_regression_non_normal_loss.py` under the Generalized Linear Models section in `linear_model.rst`.

This allows users to easily find the example illustrating Poisson regression with non-normal loss within the linear model documentation.

