### PR TITLE
DOC: Add seealso link to Ridge regression example in user guide (#30621)

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -109,6 +109,13 @@ The complexity parameter :math:`\alpha \geq 0` controls the amount
 of shrinkage: the larger the value of :math:`\alpha`, the greater the amount
 of shrinkage and thus the coefficients become more robust to collinearity.
 
+.. seealso:: 
+
+    For a visual demonstration of how Ridge coefficients evolve with regularization, 
+    see *plot_ridge_path.py*:
+    :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_path.py`
+
+
 .. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_ridge_path_001.png
    :target: ../auto_examples/linear_model/plot_ridge_path.html
    :align: center

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -109,13 +109,6 @@ The complexity parameter :math:`\alpha \geq 0` controls the amount
 of shrinkage: the larger the value of :math:`\alpha`, the greater the amount
 of shrinkage and thus the coefficients become more robust to collinearity.
 
-.. seealso:: 
-
-    For a visual demonstration of how Ridge coefficients evolve with regularization, 
-    see *plot_ridge_path.py*:
-    :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_path.py`
-
-
 .. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_ridge_path_001.png
    :target: ../auto_examples/linear_model/plot_ridge_path.html
    :align: center

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -109,6 +109,9 @@ The complexity parameter :math:`\alpha \geq 0` controls the amount
 of shrinkage: the larger the value of :math:`\alpha`, the greater the amount
 of shrinkage and thus the coefficients become more robust to collinearity.
 
+See the example: :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_path.py`
+    for a visual illustration of how the coefficients evolve with varying alpha.
+
 .. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_ridge_path_001.png
    :target: ../auto_examples/linear_model/plot_ridge_path.html
    :align: center

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1038,6 +1038,9 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
         If an array is passed, penalties are assumed to be specific to the
         targets. Hence they must correspond in number.
 
+        See the example: :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_path.py`
+        for a visual illustration of how the coefficients evolve with varying alpha.
+
     fit_intercept : bool, default=True
         Whether to fit the intercept for this model. If set
         to false, no intercept will be used in calculations


### PR DESCRIPTION
This PR adds a contextual `seealso` reference in the Ridge regression section of the user guide to link the `plot_ridge_path.py` example.

Although the example was already listed at the bottom, this inline reference improves discoverability for readers following the theoretical explanation.

Towards #30621 for this example.
