### PR TITLE
 DOC improve doc for `_check_n_features` and `_check_feature_names` and fix their usages

### DIFF
--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -249,13 +249,9 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
         X_out : array-like, shape (n_samples, n_features)
             Transformed input.
         """
-        X = validate_data(
-            self,
-            X,
-            reset=False,
-            accept_sparse=self.accept_sparse,
-            skip_check_array=not self.validate,
-        )
+        if self.validate:
+            X = validate_data(self, X, reset=False, accept_sparse=self.accept_sparse)
+
         out = self._transform(X, func=self.func, kw_args=self.kw_args)
         output_config = _get_output_config("transform", self)["dense"]
 

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -229,9 +229,6 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
             X,
             reset=True,
             accept_sparse=self.accept_sparse,
-            dtype="numeric",
-            ensure_all_finite="allow-nan",
-            ensure_2d=True,
             skip_check_array=not self.validate,
         )
         if self.check_inverse and not (self.func is None or self.inverse_func is None):
@@ -257,9 +254,6 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
             X,
             reset=False,
             accept_sparse=self.accept_sparse,
-            dtype="numeric",
-            ensure_all_finite="allow-nan",
-            ensure_2d=True,
             skip_check_array=not self.validate,
         )
         out = self._transform(X, func=self.func, kw_args=self.kw_args)

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -230,7 +230,7 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
             reset=True,
             accept_sparse=self.accept_sparse,
             dtype="numeric",
-            force_all_finite="allow-nan",
+            ensure_all_finite="allow-nan",
             ensure_2d=True,
             skip_check_array=not self.validate,
         )
@@ -258,7 +258,7 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
             reset=False,
             accept_sparse=self.accept_sparse,
             dtype="numeric",
-            force_all_finite="allow-nan",
+            ensure_all_finite="allow-nan",
             ensure_2d=True,
             skip_check_array=not self.validate,
         )

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -176,14 +176,6 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
         self.kw_args = kw_args
         self.inv_kw_args = inv_kw_args
 
-    def _check_input(self, X, *, reset):
-        if self.validate:
-            return validate_data(self, X, accept_sparse=self.accept_sparse, reset=reset)
-        elif reset:
-            # Use validate_data to perform shape and feature name checks
-            return validate_data(self, X, reset=reset, skip_check_array=True)
-        return X
-
     def _check_inverse_transform(self, X):
         """Check that func and inverse_func are the inverse."""
         idx_selected = slice(None, None, max(1, X.shape[0] // 100))
@@ -232,7 +224,16 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
         self : object
             FunctionTransformer class instance.
         """
-        X = self._check_input(X, reset=True)
+        X = validate_data(
+            self,
+            X,
+            reset=True,
+            accept_sparse=self.accept_sparse,
+            dtype="numeric",
+            force_all_finite="allow-nan",
+            ensure_2d=True,
+            skip_check_array=not self.validate,
+        )
         if self.check_inverse and not (self.func is None or self.inverse_func is None):
             self._check_inverse_transform(X)
         return self
@@ -251,7 +252,16 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
         X_out : array-like, shape (n_samples, n_features)
             Transformed input.
         """
-        X = self._check_input(X, reset=False)
+        X = validate_data(
+            self,
+            X,
+            reset=False,
+            accept_sparse=self.accept_sparse,
+            dtype="numeric",
+            force_all_finite="allow-nan",
+            ensure_2d=True,
+            skip_check_array=not self.validate,
+        )
         out = self._transform(X, func=self.func, kw_args=self.kw_args)
         output_config = _get_output_config("transform", self)["dense"]
 

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -182,9 +182,8 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
         if self.validate:
             return validate_data(self, X, accept_sparse=self.accept_sparse, reset=reset)
         elif reset:
-            # Set feature_names_in_ and n_features_in_ even if validate=False
-            # We run this only when reset==True to store the attributes but not
-            # validate them, because validate=False
+            #  Usage of _check_n_features and _check_feature_names here aligns with
+            # validate_data(..., skip_check_array=True), which avoids full validation.
             _check_n_features(self, X, reset=reset)
             _check_feature_names(self, X, reset=reset)
         return X

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -16,9 +16,7 @@ from ..utils._set_output import (
 from ..utils.metaestimators import available_if
 from ..utils.validation import (
     _allclose_dense_sparse,
-    _check_feature_names,
     _check_feature_names_in,
-    _check_n_features,
     _get_feature_names,
     _is_pandas_df,
     _is_polars_df,
@@ -182,10 +180,8 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
         if self.validate:
             return validate_data(self, X, accept_sparse=self.accept_sparse, reset=reset)
         elif reset:
-            #  Usage of _check_n_features and _check_feature_names here aligns with
-            # validate_data(..., skip_check_array=True), which avoids full validation.
-            _check_n_features(self, X, reset=reset)
-            _check_feature_names(self, X, reset=reset)
+            # Use validate_data to perform shape and feature name checks
+            return validate_data(self, X, reset=reset, skip_check_array=True)
         return X
 
     def _check_inverse_transform(self, X):

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -2706,27 +2706,36 @@ def _to_object_array(sequence):
 
 
 def _check_feature_names(estimator, X, *, reset):
-    """Check or set the `feature_names_in_` attribute for an estimator.
+    """Set or check the `feature_names_in_` attribute of an estimator.
 
-       This is typically used when `validate=False` during fitting, to still
-       record the feature names.
+    .. versionadded:: 1.0
 
-       📌 Note: Prefer using `validate_data(..., skip_check_array=True)` when
-       possible, as it handles these checks more comprehensively.
+    .. versionchanged:: 1.6
+        Moved from :class:`~sklearn.base.BaseEstimator` to
+        :mod:`sklearn.utils.validation`.
+
+    .. note::
+        To only check feature names without conducting a full data validation, prefer
+        using `validate_data(..., skip_check_array=True)` if possible.
 
     Parameters
     ----------
     estimator : estimator instance
-        The estimator to check or set features name for.
+        The estimator to validate the input for.
 
-    X : DataFrame, ndarray, or similar
-        Input data used to extract feature names.
-
+    X : {ndarray, dataframe} of shape (n_samples, n_features)
+        The input samples.
 
     reset : bool
-        If True, sets the `feature_names_in_` attribute from `X`.
-        If False, checks for consistency with `feature_names_in_`.
+        Whether to reset the `feature_names_in_` attribute.
+        If True, resets the `feature_names_in_` attribute as inferred from `X`.
+        If False, the input will be checked for consistency with
+        feature names of data provided when reset was last True.
 
+        .. note::
+           It is recommended to call `reset=True` in `fit` and in the first
+           call to `partial_fit`. All other methods that validate `X`
+           should set `reset=False`.
     """
 
     if reset:
@@ -2798,12 +2807,9 @@ def _check_feature_names(estimator, X, *, reset):
 def _check_n_features(estimator, X, reset):
     """Set the `n_features_in_` attribute, or check against it on an estimator.
 
-    This is used internally by `sklearn` to track the number of features seen
-    during `fit`, and ensure consistency at `transform` or `predict`.
-
-    📌 Note: In most cases, users should prefer using
-    `validate_data(..., skip_check_array=True)` instead of calling this function
-    directly.
+    .. note::
+        To only check n_features without conducting a full data validation, prefer
+        using `validate_data(..., skip_check_array=True)` if possible.
 
     .. versionchanged:: 1.6
         Moved from :class:`~sklearn.base.BaseEstimator` to
@@ -2818,9 +2824,16 @@ def _check_n_features(estimator, X, reset):
         The input samples.
 
     reset : bool
+        Whether to reset the `n_features_in_` attribute.
         If True, the `n_features_in_` attribute is set to `X.shape[1]`.
-        If False, the input will be checked for consistency with
-        `n_features_in_`.
+        If False and the attribute exists, then check that it is equal to
+        `X.shape[1]`. If False and the attribute does *not* exist, then
+        the check is skipped.
+
+        .. note::
+           It is recommended to call `reset=True` in `fit` and in the first
+           call to `partial_fit`. All other methods that validate `X`
+           should set `reset=False`.
     """
     try:
         n_features = _num_features(X)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -2706,30 +2706,27 @@ def _to_object_array(sequence):
 
 
 def _check_feature_names(estimator, X, *, reset):
-    """Set or check the `feature_names_in_` attribute of an estimator.
+    """Check or set the `feature_names_in_` attribute for an estimator.
 
-    .. versionadded:: 1.0
+       This is typically used when `validate=False` during fitting, to still
+       record the feature names.
 
-    .. versionchanged:: 1.6
-        Moved from :class:`~sklearn.base.BaseEstimator` to
-        :mod:`sklearn.utils.validation`.
+       📌 Note: Prefer using `validate_data(..., skip_check_array=True)` when
+       possible, as it handles these checks more comprehensively.
 
     Parameters
     ----------
     estimator : estimator instance
-        The estimator to validate the input for.
+        The estimator to check or set features name for.
 
-    X : {ndarray, dataframe} of shape (n_samples, n_features)
-        The input samples.
+    X : DataFrame, ndarray, or similar
+        Input data used to extract feature names.
+
 
     reset : bool
-        Whether to reset the `feature_names_in_` attribute.
-        If False, the input will be checked for consistency with
-        feature names of data provided when reset was last True.
-        .. note::
-           It is recommended to call `reset=True` in `fit` and in the first
-           call to `partial_fit`. All other methods that validate `X`
-           should set `reset=False`.
+        If True, sets the `feature_names_in_` attribute from `X`.
+        If False, checks for consistency with `feature_names_in_`.
+
     """
 
     if reset:
@@ -2801,6 +2798,13 @@ def _check_feature_names(estimator, X, *, reset):
 def _check_n_features(estimator, X, reset):
     """Set the `n_features_in_` attribute, or check against it on an estimator.
 
+    This is used internally by `sklearn` to track the number of features seen
+    during `fit`, and ensure consistency at `transform` or `predict`.
+
+    📌 Note: In most cases, users should prefer using
+    `validate_data(..., skip_check_array=True)` instead of calling this function
+    directly.
+
     .. versionchanged:: 1.6
         Moved from :class:`~sklearn.base.BaseEstimator` to
         :mod:`~sklearn.utils.validation`.
@@ -2815,13 +2819,8 @@ def _check_n_features(estimator, X, reset):
 
     reset : bool
         If True, the `n_features_in_` attribute is set to `X.shape[1]`.
-        If False and the attribute exists, then check that it is equal to
-        `X.shape[1]`. If False and the attribute does *not* exist, then
-        the check is skipped.
-        .. note::
-           It is recommended to call reset=True in `fit` and in the first
-           call to `partial_fit`. All other methods that validate `X`
-           should set `reset=False`.
+        If False, the input will be checked for consistency with
+        `n_features_in_`.
     """
     try:
         n_features = _num_features(X)


### PR DESCRIPTION
Towards #30389

This PR improves the documentation for _check_n_features and _check_feature_names by:

Adding clear docstrings to guide users toward using validate_data(skip_check_array=True) as the preferred public interface.

Including a clarifying comment in FunctionTransformer._check_input explaining that the use of these internal functions aligns with validate_data(..., skip_check_array=True) and is appropriate in this context.
