### PR TITLE
Improve whats_new doc

### DIFF
--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -770,8 +770,8 @@ Changelog
   :func:`model_selection.validation_curve`.
   :pr:`25120` by :user:`Guillaume Lemaitre <glemaitre>`.
 
-- |API| The parameter `log_scale` in the class
-  :class:`model_selection.LearningCurveDisplay` has been deprecated in 1.3 and
+- |API| The parameter `log_scale` in the method `plot` of the class 
+  :class:`model_selection.LearningCurveDisplay` has been deprecated in 1.3 and 
   will be removed in 1.5. The default scale can be overridden by setting it
   directly on the `ax` object and will be set automatically from the spacing
   of the data points otherwise.

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -770,8 +770,8 @@ Changelog
   :func:`model_selection.validation_curve`.
   :pr:`25120` by :user:`Guillaume Lemaitre <glemaitre>`.
 
-- |API| The parameter `log_scale` in the method `plot` of the class 
-  :class:`model_selection.LearningCurveDisplay` has been deprecated in 1.3 and 
+- |API| The parameter `log_scale` in the method `plot` of the class
+  :class:`model_selection.LearningCurveDisplay` has been deprecated in 1.3 and
   will be removed in 1.5. The default scale can be overridden by setting it
   directly on the `ax` object and will be set automatically from the spacing
   of the data points otherwise.

--- a/doc/whats_new/v1.4.rst
+++ b/doc/whats_new/v1.4.rst
@@ -989,7 +989,7 @@ Changelog
   when the input is a Series instead of a DataFrame.
   :pr:`28090` by :user:`Stan Furrer <stanFurrer>` and :user:`Yao Xiao <Charlie-XIAO>`.
 
-- |API| :func:`sklearn.extmath.log_logistic` is deprecated and will be removed in 1.6.
+- |API| :func:`sklearn.utils.extmath.log_logistic` is deprecated and will be removed in 1.6.
   Use `-np.logaddexp(0, -x)` instead.
   :pr:`27544` by :user:`Christian Lorentzen <lorentzenchr>`.
 

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -347,12 +347,11 @@ Changelog
   the previous predicted values were not affected by this bug.
   :pr:`28612` by :user:`Guillaume Lemaitre <glemaitre>`.
 
-- |API| Deprecates `Y` in favor of `y` in the methods fit, transform and
-  inverse_transform of:
-  :class:`cross_decomposition.PLSRegression`.
-  :class:`cross_decomposition.PLSCanonical`,
-  :class:`cross_decomposition.CCA`,
-  and :class:`cross_decomposition.PLSSVD`.
+- |API| Deprecates `Y` in favor of `y` in the methods `fit`, `transform` and `inverse_transform` of:
+  :class:`cross_decomposition.PLSRegression`, 
+  :class:`cross_decomposition.PLSCanonical`, 
+  and :class:`cross_decomposition.CCA`, 
+  and methods `fit` and `transform` of :class:`cross_decomposition.PLSSVD`.
   `Y` will be removed in version 1.7.
   :pr:`28604` by :user:`David Leon <davidleon123>`.
 
@@ -508,8 +507,8 @@ Changelog
   `OneVsRestClassifier(LogisticRegression(..))`.
   :pr:`28703` by :user:`Christian Lorentzen <lorentzenchr>`.
 
-- |API| `store_cv_values` and `cv_values_` are deprecated in favor of
-  `store_cv_results` and `cv_results_` in `~linear_model.RidgeCV` and
+- |API| Parameters `store_cv_values` and `cv_values_` are deprecated in favor of 
+  `store_cv_results` and `cv_results_` in `~linear_model.RidgeCV` and 
   `~linear_model.RidgeClassifierCV`.
   :pr:`28915` by :user:`Lucy Liu <lucyleeow>`.
 

--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -347,11 +347,13 @@ Changelog
   the previous predicted values were not affected by this bug.
   :pr:`28612` by :user:`Guillaume Lemaitre <glemaitre>`.
 
-- |API| Deprecates `Y` in favor of `y` in the methods `fit`, `transform` and `inverse_transform` of:
+- |API| Deprecates `Y` in favor of `y` in the methods `fit`, `transform` and
+  `inverse_transform` of:
   :class:`cross_decomposition.PLSRegression`, 
   :class:`cross_decomposition.PLSCanonical`, 
   and :class:`cross_decomposition.CCA`, 
-  and methods `fit` and `transform` of :class:`cross_decomposition.PLSSVD`.
+  and methods `fit` and `transform` of:
+  :class:`cross_decomposition.PLSSVD`.
   `Y` will be removed in version 1.7.
   :pr:`28604` by :user:`David Leon <davidleon123>`.
 
@@ -507,8 +509,8 @@ Changelog
   `OneVsRestClassifier(LogisticRegression(..))`.
   :pr:`28703` by :user:`Christian Lorentzen <lorentzenchr>`.
 
-- |API| Parameters `store_cv_values` and `cv_values_` are deprecated in favor of 
-  `store_cv_results` and `cv_results_` in `~linear_model.RidgeCV` and 
+- |API| Parameters `store_cv_values` and `cv_values_` are deprecated in favor of
+  `store_cv_results` and `cv_results_` in `~linear_model.RidgeCV` and
   `~linear_model.RidgeClassifierCV`.
   :pr:`28915` by :user:`Lucy Liu <lucyleeow>`.
 


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Issue #31571 

#### What does this implement/fix? Explain your changes.

I found some bugs or unclear areas that need further improvement in several versions of whats_new documentation.

##### [v1.5.0](https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/v1.5.rst#version-150)

- "Deprecates `Y` in favor of `y` in the methods fit, transform and inverse_transform of: :class:`cross_decomposition.PLSRegression`, :class:`cross_decomposition.PLSCanonical`, :class:`cross_decomposition.CCA`, and :class:`cross_decomposition.PLSSVD`."[(link)](https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/v1.5.rst#modsklearncross_decomposition) However, class`cross_decomposition.PLSSVD` doesn‘t seem to have the `inverse_transform` method (refer to [class PLSSVD](https://scikit-learn.org/stable/modules/generated/sklearn.cross_decomposition.PLSSVD.html#sklearn.cross_decomposition.PLSSVD))
- "store_cv_values and cv_values_ are deprecated in favor of store_cv_results and cv_results_ in ~linear_model.RidgeCV and ~linear_model.RidgeClassifierCV."[(link)](https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/v1.5.rst#modsklearnlinear_model) I recommend to make it clear that the `store_cv_values` and `cv_values_` are Parameters (like the previous item), otherwise it will be misleading to know whether they are parameters or methods.

##### [v1.4.0](https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/v1.4.rst)

- ":func:`sklearn.extmath.log_logistic` is deprecated and will be removed in 1.6. Use `-np.logaddexp(0, -x)` instead."[(link)](https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/v1.4.rst#modsklearnutils-1) The full qualified name of function `log_logistic` should be `sklearn.utils.extmath.log_logistic`.

##### [v1.3.0](https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/v1.3.rst)

- "The parameter log_scale in the class :class:`model_selection.LearningCurveDisplay` has been deprecated in 1.3 and will be removed in 1.5."[(link)](https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/v1.3.rst) The deprecated parameter `log_scale` is actually a parameter of the `plot` method of the class `model_selection.LearningCurveDisplay`, not the class constructor. Refer to [this](https://github.com/scikit-learn/scikit-learn/pull/25120/commits/90a2bf46fd700d7e5c8279cddef95da2f519574d).

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

@adrinjalali 