### PR TITLE
DOC Fix misleading statement about model refitting in permutation importance docs

### DIFF
--- a/examples/ensemble/plot_forest_importances.py
+++ b/examples/ensemble/plot_forest_importances.py
@@ -102,10 +102,10 @@ print(f"Elapsed time to compute the importances: {elapsed_time:.3f} seconds")
 forest_importances = pd.Series(result.importances_mean, index=feature_names)
 
 # %%
-# The computation for full permutation importance is more costly. Features are
-# shuffled n times and the model refitted to estimate the importance of it.
-# Please see :ref:`permutation_importance` for more details. We can now plot
-# the importance ranking.
+# The computation for full permutation importance is more costly. Each feature is
+# shuffled n times and the model is used to make predictions on the permuted data to see
+# the drop in performance. Please see :ref:`permutation_importance` for more details.
+# We can now plot the importance ranking.
 
 fig, ax = plt.subplots()
 forest_importances.plot.bar(yerr=result.importances_std, ax=ax)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The current documentation incorrectly states that the model is refitted during permutation importance in the `plot_forest_importances.py` example. This PR corrects the description to clarify that the model is not refitted: predictions are made on permuted data to measure performance drop.

Cc: @ogrisel @antoinebaker 
