### PR TITLE
doc/comment-nan-sort-behaviour-weighted-percentile

### DIFF
--- a/sklearn/utils/stats.py
+++ b/sklearn/utils/stats.py
@@ -71,6 +71,11 @@ def _weighted_percentile(array, sample_weight, percentile_rank=50, xp=None):
         sorted_idx[-1, ...], xp.arange(n_features, device=device)
     ]
     # NaN values get sorted to end (largest value)
+    # IMPORTANT: This assumes that all supported array libraries (e.g., NumPy, PyTorch, CuPy)
+    # sort NaN values to the end — like NumPy. This behaviour is currently true but not guaranteed
+    # by the Array API specification, which explicitly states sort order of NaNs is
+    # implementation-defined: https://data-apis.org/array-api/latest/API_specification/sorting_functions.html
+    # Revisit this assumption if adding support for new array libraries (e.g. JAX, Ivy, etc.)
     if xp.any(xp.isnan(largest_value_per_column)):
         sorted_nan_mask = xp.take_along_axis(xp.isnan(array), sorted_idx, axis=0)
         sorted_weights[sorted_nan_mask] = 0


### PR DESCRIPTION
Adds a developer-facing comment to clarify that _weighted_percentile assumes array backends sort NaNs to the end, consistent with NumPy’s behaviour. According to the Array API specification, the sort order of NaNs is implementation-defined and not guaranteed. This clarification helps future maintainers preserve compatibility when integrating new array backends.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
