### PR TITLE
DOC: Add example link to RidgeClassifier docstring (#30621)

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1510,8 +1510,8 @@ class RidgeClassifier(_RidgeClassifierMixin, _BaseRidge):
     >>> clf.score(X, y)
     0.9595...
 
-    You can also find a visual example here:
-    :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_classifier.py`
+    You can find a visual example here: :ref:`example_linear_model_plot_ridge_classifier`
+
 
     """
 

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1510,7 +1510,9 @@ class RidgeClassifier(_RidgeClassifierMixin, _BaseRidge):
     >>> clf.score(X, y)
     0.9595...
 
-    You can also find a visual example here: :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_classifier.py`
+    You can also find a visual example here:
+    :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_classifier.py`
+
     """
 
     _parameter_constraints: dict = {

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1509,6 +1509,8 @@ class RidgeClassifier(_RidgeClassifierMixin, _BaseRidge):
     >>> clf = RidgeClassifier().fit(X, y)
     >>> clf.score(X, y)
     0.9595...
+
+    You can also find a visual example here: :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_classifier.py`
     """
 
     _parameter_constraints: dict = {


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #30621

#### What does this implement/fix? Explain your changes.

This PR adds a visual example reference link to the `RidgeClassifier` docstring in `sklearn.linear_model._ridge`.

#### Any other comments?

N/A
