### PR TITLE
DOC: Add example link to LogisticRegression docstring

### DIFF
--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1123,7 +1123,8 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
     For a comparison of the LogisticRegression with other classifiers see:
     :ref:`sphx_glr_auto_examples_classification_plot_classification_probability.py`.
 
-    You can find a visual example here: :ref:`example_linear_model_plot_logistic_path`
+    You can find a visual example here: 
+    :ref:`example_linear_model_plot_logistic_path`
 
 
     """

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1122,6 +1122,10 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
 
     For a comparison of the LogisticRegression with other classifiers see:
     :ref:`sphx_glr_auto_examples_classification_plot_classification_probability.py`.
+
+    You can find a visual example here: :ref:`example_linear_model_plot_logistic_path`
+
+
     """
 
     _parameter_constraints: dict = {

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1510,8 +1510,8 @@ class RidgeClassifier(_RidgeClassifierMixin, _BaseRidge):
     >>> clf.score(X, y)
     0.9595...
 
-    You can also find a visual example here:
-    :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_classifier.py`
+    You can find a visual example here: :ref:`example_linear_model_plot_ridge_classifier`
+
 
     """
 

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1510,7 +1510,9 @@ class RidgeClassifier(_RidgeClassifierMixin, _BaseRidge):
     >>> clf.score(X, y)
     0.9595...
 
-    You can also find a visual example here: :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_classifier.py`
+    You can also find a visual example here:
+    :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_classifier.py`
+
     """
 
     _parameter_constraints: dict = {

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1509,6 +1509,8 @@ class RidgeClassifier(_RidgeClassifierMixin, _BaseRidge):
     >>> clf = RidgeClassifier().fit(X, y)
     >>> clf.score(X, y)
     0.9595...
+
+    You can also find a visual example here: :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_classifier.py`
     """
 
     _parameter_constraints: dict = {


### PR DESCRIPTION
This PR adds a Sphinx reference link to the `LogisticRegression` docstring.

It now points to the example:
:ref:`example_linear_model_plot_logistic_path`

This helps users find a working example more easily.

Let me know if anything needs fixing. Thanks!
