### PR TITLE
DOC Add link to plot_lasso_coordinate_descent_path in lasso_path docstring(#30621)

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -322,10 +322,6 @@ def lasso_path(
     :ref:`examples/linear_model/plot_lasso_lasso_lars_elasticnet_path.py
     <sphx_glr_auto_examples_linear_model_plot_lasso_lasso_lars_elasticnet_path.py>`.
 
-    For a visual example of computing and plotting the Lasso coordinate
-    descent path, see the example:
-    :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_coordinate_descent_path`.
-
     To avoid unnecessary memory duplication the X argument of the fit method
     should be directly passed as a Fortran-contiguous numpy array.
 
@@ -348,6 +344,9 @@ def lasso_path(
     >>> print(coef_path)
     [[0.         0.         0.46874778]
      [0.2159048  0.4425765  0.23689075]]
+
+    For a full visual example using this function, see:
+    :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_coordinate_descent_path`.
 
     >>> # Now use lars_path and 1D linear interpolation to compute the
     >>> # same path

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -318,9 +318,9 @@ def lasso_path(
 
     Notes
     -----
-    For an example, see
+    For an example, see:
     :ref:`examples/linear_model/plot_lasso_lasso_lars_elasticnet_path.py
-    <sphx_glr_auto_examples_linear_model_plot_lasso_lasso_lars_elasticnet_path.py>`.\
+    <sphx_glr_auto_examples_linear_model_plot_lasso_lasso_lars_elasticnet_path.py>`.
 
     For a visual example of computing and plotting the Lasso coordinate
     descent path, see:

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -322,6 +322,10 @@ def lasso_path(
     :ref:`examples/linear_model/plot_lasso_lasso_lars_elasticnet_path.py
     <sphx_glr_auto_examples_linear_model_plot_lasso_lasso_lars_elasticnet_path.py>`.
 
+    For a visual example of computing and plotting the Lasso coordinate
+    descent path, see the example:
+    :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_coordinate_descent_path`.
+
     To avoid unnecessary memory duplication the X argument of the fit method
     should be directly passed as a Fortran-contiguous numpy array.
 
@@ -356,9 +360,6 @@ def lasso_path(
     [[0.         0.         0.46915237]
      [0.2159048  0.4425765  0.23668876]]
 
-    For a visual example of computing and plotting the Lasso coordinate
-    descent path, see the example:
-    :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_coordinate_descent_path`
     """
     return enet_path(
         X,

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -355,6 +355,11 @@ def lasso_path(
     >>> print(coef_path_continuous([5., 1., .5]))
     [[0.         0.         0.46915237]
      [0.2159048  0.4425765  0.23668876]]
+
+    For a visual example of computing and plotting the Lasso coordinate
+    descent path, see
+    :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_coordinate_descent_path.py`.
+
     """
     return enet_path(
         X,

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -358,7 +358,7 @@ def lasso_path(
 
     For a visual example of computing and plotting the Lasso coordinate
     descent path, see the example:
-    :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_coordinate_descent_path.py`.
+    :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_coordinate_descent_path`
     """
     return enet_path(
         X,

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -345,7 +345,8 @@ def lasso_path(
     [[0.         0.         0.46874778]
      [0.2159048  0.4425765  0.23689075]]
 
-    For a full visual example using this function, see:
+    For a visual example using this function, see:
+
     :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_coordinate_descent_path`.
 
     >>> # Now use lars_path and 1D linear interpolation to compute the

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -357,9 +357,8 @@ def lasso_path(
      [0.2159048  0.4425765  0.23668876]]
 
     For a visual example of computing and plotting the Lasso coordinate
-    descent path, see
+    descent path, see the example:
     :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_coordinate_descent_path.py`.
-
     """
     return enet_path(
         X,

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -320,7 +320,11 @@ def lasso_path(
     -----
     For an example, see
     :ref:`examples/linear_model/plot_lasso_lasso_lars_elasticnet_path.py
-    <sphx_glr_auto_examples_linear_model_plot_lasso_lasso_lars_elasticnet_path.py>`.
+    <sphx_glr_auto_examples_linear_model_plot_lasso_lasso_lars_elasticnet_path.py>`.\
+
+    For a visual example of computing and plotting the Lasso coordinate
+    descent path, see:
+    :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_coordinate_descent_path`.
 
     To avoid unnecessary memory duplication the X argument of the fit method
     should be directly passed as a Fortran-contiguous numpy array.
@@ -344,10 +348,6 @@ def lasso_path(
     >>> print(coef_path)
     [[0.         0.         0.46874778]
      [0.2159048  0.4425765  0.23689075]]
-
-    For a visual example using this function, see:
-
-    :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_coordinate_descent_path`.
 
     >>> # Now use lars_path and 1D linear interpolation to compute the
     >>> # same path


### PR DESCRIPTION
This PR adds a reference link to the example script 
`plot_lasso_coordinate_descent_path.py` in the `lasso_path` docstring.

This is part of the documentation improvement initiative in 
issue #30621 to better link example scripts to relevant API documentation.

Rendered documentation preview should now include:
"see :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_coordinate_descent_path.py`"

Thanks!