### PR TITLE
DOC Add link to plot_lasso_dense_vs_sparse_data in Lasso docstring (#30621)

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1314,10 +1314,10 @@ class Lasso(ElasticNet):
         Regression) for sparse signal recovery in the presence of noise and
         feature correlation.
 
-    For a visual comparison of Lasso on dense vs sparse data, see
-    :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_dense_vs_sparse_data.py`.
+        For a visual comparison of Lasso on dense vs sparse data, see
+        :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_dense_vs_sparse_data.py`.
 
-    """
+        """
 
     _parameter_constraints: dict = {
         **ElasticNet._parameter_constraints,

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -318,9 +318,8 @@ def lasso_path(
 
     Notes
     -----
-    For an example, see
-    :ref:`examples/linear_model/plot_lasso_lasso_lars_elasticnet_path.py
-    <sphx_glr_auto_examples_linear_model_plot_lasso_lasso_lars_elasticnet_path.py>`.
+    :ref:`this example
+    <sphx_glr_auto_examples_linear_model_plot_lasso_lasso_lars_elasticnet_path>`.
 
     To avoid unnecessary memory duplication the X argument of the fit method
     should be directly passed as a Fortran-contiguous numpy array.
@@ -523,9 +522,9 @@ def enet_path(
 
     Notes
     -----
-    For an example, see
-    :ref:`examples/linear_model/plot_lasso_lasso_lars_elasticnet_path.py
-    <sphx_glr_auto_examples_linear_model_plot_lasso_lasso_lars_elasticnet_path.py>`.
+    :ref:`this example
+    <sphx_glr_auto_examples_linear_model_plot_lasso_lasso_lars_elasticnet_path>`.
+
 
     Examples
     --------
@@ -2088,8 +2087,8 @@ class LassoCV(RegressorMixin, LinearModelCV):
     To avoid unnecessary memory duplication the `X` argument of the `fit`
     method should be directly passed as a Fortran-contiguous numpy array.
 
-    For an example, see :ref:`examples/linear_model/plot_lasso_model_selection.py
-    <sphx_glr_auto_examples_linear_model_plot_lasso_model_selection.py>`.
+    :ref:`Lasso model selection
+    <sphx_glr_auto_examples_linear_model_plot_lasso_model_selection>`.
 
     :class:`LassoCV` leads to different results than a hyperparameter
     search using :class:`~sklearn.model_selection.GridSearchCV` with a
@@ -2374,9 +2373,8 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
 
         alpha = a + b and l1_ratio = a / (a + b).
 
-    For an example, see
-    :ref:`examples/linear_model/plot_lasso_model_selection.py
-    <sphx_glr_auto_examples_linear_model_plot_lasso_model_selection.py>`.
+    :ref:`Lasso model selection example
+    <sphx_glr_auto_examples_linear_model_plot_lasso_model_selection>`.
 
     Examples
     --------

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1175,6 +1175,9 @@ class Lasso(ElasticNet):
 
     Read more in the :ref:`User Guide <lasso>`.
 
+    For a visual comparison of Lasso on dense vs sparse data, see the example:
+    :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_dense_vs_sparse_data.py`
+
     Parameters
     ----------
     alpha : float, default=1.0
@@ -1313,9 +1316,6 @@ class Lasso(ElasticNet):
         compares Lasso with other L1-based regression models (ElasticNet and ARD
         Regression) for sparse signal recovery in the presence of noise and
         feature correlation.
-
-    -   For a visual comparison of Lasso on dense vs sparse data, see:
-        :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_dense_vs_sparse_data.py`
 
     """
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1176,7 +1176,7 @@ class Lasso(ElasticNet):
     Read more in the :ref:`User Guide <lasso>`.
 
     For a visual comparison of Lasso on dense vs sparse data, see the example:
-    :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_dense_vs_sparse_data.py`
+    :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_dense_vs_sparse_data`
 
     Parameters
     ----------

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1314,10 +1314,10 @@ class Lasso(ElasticNet):
         Regression) for sparse signal recovery in the presence of noise and
         feature correlation.
 
-        For a visual comparison of Lasso on dense vs sparse data, see
-        :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_dense_vs_sparse_data.py`.
+    -   For a visual comparison of Lasso on dense vs sparse data, see:
+        :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_dense_vs_sparse_data.py`
 
-        """
+    """
 
     _parameter_constraints: dict = {
         **ElasticNet._parameter_constraints,

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1173,10 +1173,10 @@ class Lasso(ElasticNet):
     Technically the Lasso model is optimizing the same objective function as
     the Elastic Net with ``l1_ratio=1.0`` (no L2 penalty).
 
-    Read more in the :ref:`User Guide <lasso>`.
+    A comparison of Lasso on dense versus sparse data is available in the example:
+    :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_dense_vs_sparse_data`.
 
-    For a visual comparison of Lasso on dense vs sparse data, see the example:
-    :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_dense_vs_sparse_data`
+    Read more in the :ref:`User Guide <lasso>`.
 
     Parameters
     ----------

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1313,6 +1313,10 @@ class Lasso(ElasticNet):
         compares Lasso with other L1-based regression models (ElasticNet and ARD
         Regression) for sparse signal recovery in the presence of noise and
         feature correlation.
+
+    For a visual comparison of Lasso on dense vs sparse data, see
+    :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_dense_vs_sparse_data.py`.
+
     """
 
     _parameter_constraints: dict = {


### PR DESCRIPTION
Reference added to the Lasso class docstring for the example:
`plot_lasso_dense_vs_sparse_data.py`.

This is part of the ongoing effort in issue #30621 to improve discoverability
of example scripts via direct docstring links.
