### PR TITLE
DOC Add example link to plot_rfe_digits.py in RFE docstring

### DIFF
--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -190,6 +190,9 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
            False])
     >>> selector.ranking_
     array([1, 1, 1, 1, 1, 6, 4, 3, 2, 5])
+
+    See :ref:`sphx_glr_auto_examples_feature_selection_plot_rfe_digits.py`.
+
     """
 
     _parameter_constraints: dict = {


### PR DESCRIPTION
This PR adds a reference link to the example `plot_rfe_digits.py` in the docstring of the `RFE` class, as part of issue #30621.

