### PR TITLE
DOC Add example link to plot_confusion_matrix.py in ConfusionMatrixDisplay docstring

### DIFF
--- a/sklearn/metrics/_plot/confusion_matrix.py
+++ b/sklearn/metrics/_plot/confusion_matrix.py
@@ -79,6 +79,15 @@ class ConfusionMatrixDisplay:
     >>> disp.plot()
     <...>
     >>> plt.show()
+
+    Examples
+    --------
+    You can find a usage example in:
+    :ref:`sphx_glr_auto_examples_classification_plot_confusion_matrix.py`
+
+    .. minigallery:: sklearn.metrics.ConfusionMatrixDisplay
+        :add-heading: Examples using `ConfusionMatrixDisplay`:
+
     """
 
     def __init__(self, confusion_matrix, *, display_labels=None):


### PR DESCRIPTION
This PR adds a reference to the plot_confusion_matrix.py example and the minigallery directive in the ConfusionMatrixDisplay docstring as part of issue #30621.