### PR TITLE
FIX ensure proper point dropping in roc_curve with drop_interm…

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/31647.bugfix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/31647.bugfix.rst
@@ -1,0 +1,2 @@
+- :func:metrics.roc_curve now correctly drops intermediate points after prepending the (0, 0) threshold and uses geometric collinearity detection via cross‑products when drop_intermediate=True.
+  By :user:Shaik Imran <imran4444shaik>

--- a/doc/whats_new/upcoming_changes/sklearn.metrics/31647.bugfix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/31647.bugfix.rst
@@ -1,2 +1,0 @@
-- :func:metrics.roc_curve now correctly drops intermediate points after prepending the (0, 0) threshold and uses geometric collinearity detection via cross‑products when drop_intermediate=True.
-  By :user:Shaik Imran <imran4444shaik>

--- a/doc/whats_new/upcoming_changes/sklearn.metrics/31647.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/31647.fix.rst
@@ -1,0 +1,2 @@
+- :func:metrics.roc_curve now correctly drops intermediate points after prepending the (0, 0) threshold and uses geometric collinearity detection via cross‑products when drop_intermediate=True.
+  By :user:Shaik Imran <imran4444shaik>

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1076,7 +1076,7 @@ def _roc_collinear_free_mask_xp(fps, tps, xp, device, tolerance=1e-12):
     """Return indices of non-collinear points preserving endpoints using array API."""
     n = fps.shape[0]
     if n <= 2:
-        return xp.arange(n)
+        return xp.arange(n, device=device)
 
     # Compute segment vectors
     dx0 = fps[1:-1] - fps[:-2]

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1094,7 +1094,7 @@ def collinear_free_mask(fps_np, tps_np, tolerance=1e-12):
     {
         "y_true": ["array-like"],
         "y_score": ["array-like"],
-        "pos_label": [Real, str, "boolean", None],
+        "pos_label": [Real, bool, str, None],
         "sample_weight": ["array-like", None],
         "drop_intermediate": ["boolean"],
     },

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1074,9 +1074,6 @@ def precision_recall_curve(
 
 def _roc_collinear_free_mask_xp(fps, tps, xp, device, tolerance=1e-12):
     """Return indices of non-collinear points preserving endpoints using array API."""
-    n = fps.shape[0]
-    if n <= 2:
-        return xp.arange(n, device=device)
 
     # Compute segment vectors
     dx0 = fps[1:-1] - fps[:-2]

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1212,7 +1212,7 @@ def roc_curve(
     # Prepend start of curve
     fps = xp.concat([xp.asarray([0.0], device=device), fps])
     tps = xp.concat([xp.asarray([0.0], device=device), tps])
-    thresholds = xp.concatenate(
+    thresholds = xp.concat(
         [
             xp.asarray([xp.inf], device=device),
             xp.astype(thresholds, _max_precision_float_dtype(xp, device)),

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -363,9 +363,9 @@ def test_roc_curve_toydata():
         "No positive samples in y_true, true positive value should be meaningless"
     )
     with pytest.warns(UndefinedMetricWarning, match=expected_message):
-        tpr, fpr, _ = roc_curve(y_true, y_score)
-    assert_array_almost_equal(tpr, [0.0, 0.5, 1.0])
+        fpr, tpr, _ = roc_curve(y_true, y_score)
     assert_array_almost_equal(fpr, [np.nan, np.nan, np.nan])
+    assert_array_almost_equal(tpr, [0.0, 0.5, 1.0])
     expected_message = (
         "Only one class is present in y_true. "
         "ROC AUC score is not defined in that case."
@@ -382,9 +382,9 @@ def test_roc_curve_toydata():
         "No negative samples in y_true, false positive value should be meaningless"
     )
     with pytest.warns(UndefinedMetricWarning, match=expected_message):
-        tpr, fpr, _ = roc_curve(y_true, y_score)
-    assert_array_almost_equal(tpr, [np.nan, np.nan, np.nan])
+        fpr, tpr, _ = roc_curve(y_true, y_score)
     assert_array_almost_equal(fpr, [0.0, 0.5, 1.0])
+    assert_array_almost_equal(tpr, [np.nan, np.nan, np.nan])
     expected_message = (
         "Only one class is present in y_true. "
         "ROC AUC score is not defined in that case."

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -317,15 +317,15 @@ def test_roc_curve_toydata():
     # Binary classification
     y_true = [0, 1]
     y_score = [0, 1]
-    tpr, fpr, _ = roc_curve(y_true, y_score)
+    fpr, tpr, _ = roc_curve(y_true, y_score)
     roc_auc = roc_auc_score(y_true, y_score)
-    assert_array_almost_equal(tpr, [0, 0, 1])
+    assert_array_almost_equal(tpr, [0, 1, 1])
     assert_array_almost_equal(fpr, [0, 0, 1])
     assert_almost_equal(roc_auc, 1.0)
 
     y_true = [0, 1]
     y_score = [1, 0]
-    tpr, fpr, _ = roc_curve(y_true, y_score)
+    fpr, tpr, _ = roc_curve(y_true, y_score)
     roc_auc = roc_auc_score(y_true, y_score)
     assert_array_almost_equal(tpr, [0, 1, 1])
     assert_array_almost_equal(fpr, [0, 0, 1])
@@ -333,7 +333,7 @@ def test_roc_curve_toydata():
 
     y_true = [1, 0]
     y_score = [1, 1]
-    tpr, fpr, _ = roc_curve(y_true, y_score)
+    fpr, tpr, _ = roc_curve(y_true, y_score)
     roc_auc = roc_auc_score(y_true, y_score)
     assert_array_almost_equal(tpr, [0, 1])
     assert_array_almost_equal(fpr, [0, 1])
@@ -341,7 +341,7 @@ def test_roc_curve_toydata():
 
     y_true = [1, 0]
     y_score = [1, 0]
-    tpr, fpr, _ = roc_curve(y_true, y_score)
+    fpr, tpr, _ = roc_curve(y_true, y_score)
     roc_auc = roc_auc_score(y_true, y_score)
     assert_array_almost_equal(tpr, [0, 0, 1])
     assert_array_almost_equal(fpr, [0, 0, 1])
@@ -349,7 +349,7 @@ def test_roc_curve_toydata():
 
     y_true = [1, 0]
     y_score = [0.5, 0.5]
-    tpr, fpr, _ = roc_curve(y_true, y_score)
+    fpr, tpr, _ = roc_curve(y_true, y_score)
     roc_auc = roc_auc_score(y_true, y_score)
     assert_array_almost_equal(tpr, [0, 1])
     assert_array_almost_equal(fpr, [0, 1])
@@ -431,13 +431,13 @@ def test_roc_curve_drop_intermediate():
     # Test that drop_intermediate drops the correct thresholds
     y_true = [0, 0, 0, 0, 1, 1]
     y_score = [0.0, 0.2, 0.5, 0.6, 0.7, 1.0]
-    tpr, fpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=True)
+    fpr, tpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=True)
     assert_array_almost_equal(thresholds, [np.inf, 1.0, 0.7, 0.0])
 
     # Test dropping thresholds with repeating scores
     y_true = [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1]
     y_score = [0.0, 0.1, 0.6, 0.6, 0.7, 0.8, 0.9, 0.6, 0.7, 0.8, 0.9, 0.9, 1.0]
-    tpr, fpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=True)
+    fpr, tpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=True)
     assert_array_almost_equal(thresholds, [np.inf, 1.0, 0.9, 0.7, 0.6, 0.0])
 
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -317,15 +317,15 @@ def test_roc_curve_toydata():
     # Binary classification
     y_true = [0, 1]
     y_score = [0, 1]
-    fpr, tpr, _ = roc_curve(y_true, y_score)
+    tpr, fpr, _ = roc_curve(y_true, y_score)
     roc_auc = roc_auc_score(y_true, y_score)
-    assert_array_almost_equal(tpr, [0, 1, 1])
-    assert_array_almost_equal(fpr, [0, 0, 1])
+    assert_array_almost_equal(tpr, [0, 0, 1])
+    assert_array_almost_equal(fpr, [0, 1, 1])
     assert_almost_equal(roc_auc, 1.0)
 
     y_true = [0, 1]
     y_score = [1, 0]
-    fpr, tpr, _ = roc_curve(y_true, y_score)
+    tpr, fpr, _ = roc_curve(y_true, y_score)
     roc_auc = roc_auc_score(y_true, y_score)
     assert_array_almost_equal(tpr, [0, 1, 1])
     assert_array_almost_equal(fpr, [0, 0, 1])
@@ -333,7 +333,7 @@ def test_roc_curve_toydata():
 
     y_true = [1, 0]
     y_score = [1, 1]
-    fpr, tpr, _ = roc_curve(y_true, y_score)
+    tpr, fpr, _ = roc_curve(y_true, y_score)
     roc_auc = roc_auc_score(y_true, y_score)
     assert_array_almost_equal(tpr, [0, 1])
     assert_array_almost_equal(fpr, [0, 1])
@@ -341,15 +341,15 @@ def test_roc_curve_toydata():
 
     y_true = [1, 0]
     y_score = [1, 0]
-    fpr, tpr, _ = roc_curve(y_true, y_score)
+    tpr, fpr, _ = roc_curve(y_true, y_score)
     roc_auc = roc_auc_score(y_true, y_score)
     assert_array_almost_equal(tpr, [0, 0, 1])
-    assert_array_almost_equal(fpr, [0, 0, 1])
+    assert_array_almost_equal(fpr, [0, 1, 1])
     assert_almost_equal(roc_auc, 1.0)
 
     y_true = [1, 0]
     y_score = [0.5, 0.5]
-    fpr, tpr, _ = roc_curve(y_true, y_score)
+    tpr, fpr, _ = roc_curve(y_true, y_score)
     roc_auc = roc_auc_score(y_true, y_score)
     assert_array_almost_equal(tpr, [0, 1])
     assert_array_almost_equal(fpr, [0, 1])
@@ -363,9 +363,9 @@ def test_roc_curve_toydata():
         "No positive samples in y_true, true positive value should be meaningless"
     )
     with pytest.warns(UndefinedMetricWarning, match=expected_message):
-        fpr, tpr, _ = roc_curve(y_true, y_score)
-    assert_array_almost_equal(fpr, [np.nan, np.nan, np.nan])
-    assert_array_almost_equal(tpr, [0.0, 0.5, 1.0])
+        tpr, fpr, _ = roc_curve(y_true, y_score)
+    assert_array_almost_equal(tpr, [0.0, 1.0])
+    assert_array_almost_equal(fpr, [np.nan, np.nan])
     expected_message = (
         "Only one class is present in y_true. "
         "ROC AUC score is not defined in that case."
@@ -382,9 +382,9 @@ def test_roc_curve_toydata():
         "No negative samples in y_true, false positive value should be meaningless"
     )
     with pytest.warns(UndefinedMetricWarning, match=expected_message):
-        fpr, tpr, _ = roc_curve(y_true, y_score)
-    assert_array_almost_equal(fpr, [0.0, 0.5, 1.0])
-    assert_array_almost_equal(tpr, [np.nan, np.nan, np.nan])
+        tpr, fpr, _ = roc_curve(y_true, y_score)
+    assert_array_almost_equal(tpr, [np.nan, np.nan])
+    assert_array_almost_equal(fpr, [0.0, 1.0])
     expected_message = (
         "Only one class is present in y_true. "
         "ROC AUC score is not defined in that case."
@@ -431,13 +431,13 @@ def test_roc_curve_drop_intermediate():
     # Test that drop_intermediate drops the correct thresholds
     y_true = [0, 0, 0, 0, 1, 1]
     y_score = [0.0, 0.2, 0.5, 0.6, 0.7, 1.0]
-    fpr, tpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=True)
-    assert_array_almost_equal(thresholds, [np.inf, 1.0, 0.7, 0.0])
+    tpr, fpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=True)
+    assert_array_almost_equal(thresholds, [np.inf, 0.7, 0.0])
 
     # Test dropping thresholds with repeating scores
     y_true = [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1]
     y_score = [0.0, 0.1, 0.6, 0.6, 0.7, 0.8, 0.9, 0.6, 0.7, 0.8, 0.9, 0.9, 1.0]
-    fpr, tpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=True)
+    tpr, fpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=True)
     assert_array_almost_equal(thresholds, [np.inf, 1.0, 0.9, 0.7, 0.6, 0.0])
 
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -320,7 +320,7 @@ def test_roc_curve_toydata():
     tpr, fpr, _ = roc_curve(y_true, y_score)
     roc_auc = roc_auc_score(y_true, y_score)
     assert_array_almost_equal(tpr, [0, 0, 1])
-    assert_array_almost_equal(fpr, [0, 1, 1])
+    assert_array_almost_equal(fpr, [0, 0, 1])
     assert_almost_equal(roc_auc, 1.0)
 
     y_true = [0, 1]
@@ -344,7 +344,7 @@ def test_roc_curve_toydata():
     tpr, fpr, _ = roc_curve(y_true, y_score)
     roc_auc = roc_auc_score(y_true, y_score)
     assert_array_almost_equal(tpr, [0, 0, 1])
-    assert_array_almost_equal(fpr, [0, 1, 1])
+    assert_array_almost_equal(fpr, [0, 0, 1])
     assert_almost_equal(roc_auc, 1.0)
 
     y_true = [1, 0]


### PR DESCRIPTION
Fixes #31635

BUG Fix two issues in roc_curve with drop_intermediate=True

1. Fix incorrect ordering of point dropping vs prepending (0,0):
   - Now prepends (0,0) and inf threshold BEFORE dropping intermediates

2. Replace faulty collinearity heuristic with geometric check:
   - Uses vector cross-products to properly detect collinear points
   - Fixes cases where redundant points weren't being dropped

Examples fixed:
- y_true = [0,0,0,0,1,1,1,1], y_score = [0,1,2,3,4,5,6,7]
  Now correctly returns 3 points instead of 4
