### PR TITLE
feat: support Intel GPUs in Array API testing

### DIFF
--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -86,7 +86,7 @@ def yield_namespace_device_dtype_combinations(include_numpy_namespaces=True):
     ):
         if array_namespace == "torch":
             for device, dtype in itertools.product(
-                ("cpu", "cuda"), ("float64", "float32")
+                ("cpu", "cuda", "xpu"), ("float64", "float32")
             ):
                 yield array_namespace, device, dtype
             yield array_namespace, "mps", "float32"

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1343,6 +1343,17 @@ def _array_api_for_tests(array_namespace, device):
                 "MPS is not available because the current PyTorch install was not "
                 "built with MPS enabled."
             )
+    elif array_namespace == "torch" and device == "xpu":
+        if not hasattr(xp, "xpu"):
+            # skip xpu testing for PyTorch <2.4
+            raise SkipTest(
+                "XPU is not available because the current PyTorch install was not "
+                "built with XPU support."
+            )
+        if not xp.xpu.is_available():
+            raise SkipTest(
+                "Skipping XPU device test because no XPU device is available"
+            )
     elif array_namespace == "cupy":  # pragma: nocover
         import cupy
 

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1343,7 +1343,7 @@ def _array_api_for_tests(array_namespace, device):
                 "MPS is not available because the current PyTorch install was not "
                 "built with MPS enabled."
             )
-    elif array_namespace == "torch" and device == "xpu":
+    elif array_namespace == "torch" and device == "xpu":  # pragma: nocover
         if not hasattr(xp, "xpu"):
             # skip xpu testing for PyTorch <2.4
             raise SkipTest(


### PR DESCRIPTION
Following on from #27098 which added support for Apple's Metal devices, this will add the ability to run scikit-learn's array_api testing using Intel GPUs via PyTorch (named XPU devices).  This enables scikit-learn to test on discrete and integrated GPUs using the Xe architecture, which was made possible with PyTorch since release 2.4.

It will first skip if the PyTorch version does not have xpu interfaces (indicating PyTorch < 2.4), and secondly will skip if a device is unavailable.
