### PR TITLE
FIX metadata routing for scorer

### DIFF
--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -134,11 +134,9 @@ class _MultimetricScorer:
                     method_name = _get_response_method_name(scorer, estimator)
                     score_kwargs = {
                         **routed_params.estimator[method_name],
-                        **routed_params.get(name).score
+                        **routed_params.get(name).score,
                     }
-                    score = scorer._score(
-                        cached_call, estimator, *args, **score_kwargs
-                    )
+                    score = scorer._score(cached_call, estimator, *args, **score_kwargs)
                 else:
                     score = scorer(estimator, *args, **routed_params.get(name).score)
                 scores[name] = score
@@ -204,10 +202,13 @@ class _MultimetricScorer:
         computed for each estimator separately, as the metadata routing depends
         on the estimator.
         """
-        all_methods = list(set(
-            _get_response_method_name(scorer, estimator)
-            for scorer in self._scorers.values() if isinstance(scorer, _BaseScorer)
-        ))
+        all_methods = list(
+            set(
+                _get_response_method_name(scorer, estimator)
+                for scorer in self._scorers.values()
+                if isinstance(scorer, _BaseScorer)
+            )
+        )
         if _routing_enabled():
             request_routing = self.get_metadata_routing()
             method_mapping = MethodMapping()
@@ -233,9 +234,7 @@ class _MultimetricScorer:
             any_accept = False
             for name, scorer in self._scorers.items():
                 if scorer._accept_sample_weight():
-                    routed_params[name].score["sample_weight"] = kwargs[
-                        "sample_weight"
-                    ]
+                    routed_params[name].score["sample_weight"] = kwargs["sample_weight"]
                     any_accept = True
             if not any_accept:
                 raise TypeError(
@@ -474,9 +473,7 @@ class _Scorer(_BaseScorer):
         # is passed but unsupported. This does not work for metadata other than
         # sample_weight, which would require the user to enable metadata routing.
         if "sample_weight" in kwargs and not self._accept_sample_weight():
-            raise TypeError(
-                "sample_weight parameter is not accepted by this scorer."
-            )
+            raise TypeError("sample_weight parameter is not accepted by this scorer.")
         return Bunch(
             estimator=Bunch(**{method_name: {}}),
             score=Bunch(score=kwargs.copy()),

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -38,7 +38,6 @@ from ..utils.metadata_routing import (
     _raise_for_params,
     _routing_enabled,
     get_routing_for_object,
-    process_routing,
 )
 from ..utils.validation import _check_response_method
 from . import (

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -254,21 +254,23 @@ class _BaseScorer(_MetadataRequester):
         computed for each estimator separately, as the metadata routing depends
         on the estimator.
         """
-        request_routing = MetadataRouter(owner=self.__class__.__name__).add(
-            estimator=estimator,
-            method_mapping=MethodMapping().add(
-                caller='score',
-                callee=self._response_method,
-            ),
-        ).add(
-            score=self,
-            method_mapping=MethodMapping().add(
-                caller="score", callee="score"
-            ),
+        request_routing = (
+            MetadataRouter(owner=self.__class__.__name__)
+            .add(
+                estimator=estimator,
+                method_mapping=MethodMapping().add(
+                    caller="score",
+                    callee=self._response_method,
+                ),
+            )
+            .add(
+                score=self,
+                method_mapping=MethodMapping().add(caller="score", callee="score"),
+            )
         )
 
-        request_routing.validate_metadata(params=kwargs, method='score')
-        return request_routing.route_params(params=kwargs, caller='score')
+        request_routing.validate_metadata(params=kwargs, method="score")
+        return request_routing.route_params(params=kwargs, caller="score")
 
     def _accept_sample_weight(self):
         # TODO(slep006): remove when metadata routing is the only way
@@ -431,9 +433,6 @@ class _Scorer(_BaseScorer):
             **routed_params.estimator[self._response_method],
         )
 
-        scoring_kwargs = {
-
-        }
         return self._sign * self._score_func(
             y_true, y_pred, **self._kwargs, **routed_params.score.score
         )

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1395,7 +1395,6 @@ def test_multimetric_scoring_kwargs():
 
 @config_context(enable_metadata_routing=True)
 def test_scorer_metadata_routing():
-
     class MyClf(DummyClassifier):
         def fit(self, X, y, metadata=None):
             return super().fit(X, y)
@@ -1417,7 +1416,6 @@ def test_scorer_metadata_routing():
 
     score = make_scorer(accuracy_score)
     score(clf, X, y, metadata=metadata)
-
 
 
 def test_kwargs_without_metadata_routing_error():

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -19,6 +19,7 @@ from sklearn.datasets import (
     make_multilabel_classification,
     make_regression,
 )
+from sklearn.dummy import DummyClassifier
 from sklearn.linear_model import LogisticRegression, Perceptron, Ridge
 from sklearn.metrics import (
     accuracy_score,
@@ -1390,6 +1391,33 @@ def test_multimetric_scoring_kwargs():
     scorer_dict = _check_multimetric_scoring(clf, scorers)
     multi_scorer = _MultimetricScorer(scorers=scorer_dict)
     multi_scorer(clf, X, y, common_arg=1, sample_weight=1)
+
+
+@config_context(enable_metadata_routing=True)
+def test_scorer_metadata_routing():
+
+    class MyClf(DummyClassifier):
+        def fit(self, X, y, metadata=None):
+            return super().fit(X, y)
+
+        def predict(self, X, metadata=None):
+            return super().predict(X)
+
+    X, y = make_classification(
+        n_samples=50, n_features=2, n_redundant=0, random_state=0
+    )
+    metadata = np.ones(X.shape[0])
+
+    clf = (
+        MyClf()
+        .set_fit_request(metadata=True)
+        .set_predict_request(metadata=True)
+        .fit(X, y, metadata=metadata)
+    )
+
+    score = make_scorer(accuracy_score)
+    score(clf, X, y, metadata=metadata)
+
 
 
 def test_kwargs_without_metadata_routing_error():

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -363,15 +363,16 @@ def cross_validate(
                 estimator=estimator,
                 # TODO(SLEP6): also pass metadata to the predict method for
                 # scoring?
-                method_mapping=MethodMapping().add(caller="fit", callee="fit"),
-            )
-            .add(
-                scorer=scorers,
-                method_mapping=MethodMapping().add(caller="fit", callee="score"),
+                method_mapping=MethodMapping().add(caller="fit", callee="fit")
             )
         )
         try:
             routed_params = process_routing(router, "fit", **params)
+            scorer_router = scorers._route_scorer_metadata(estimator, params)
+            routed_params.scorer = Bunch(score={
+                k: v for step in scorer_router.values()
+                for params in step.values() for k, v in params.items()
+            })
         except UnsetMetadataPassedError as e:
             # The default exception would mention `fit` since in the above
             # `process_routing` code, we pass `fit` as the caller. However,

--- a/sklearn/utils/_response.py
+++ b/sklearn/utils/_response.py
@@ -119,6 +119,7 @@ def _get_response_values(
     response_method,
     pos_label=None,
     return_response_method_used=False,
+    **metadata
 ):
     """Compute the response values of a classifier, an outlier detector, or a regressor.
 
@@ -169,6 +170,10 @@ def _get_response_values(
 
         .. versionadded:: 1.4
 
+    **metadata : dict, default=None
+        Metadata dictionary that can be used to pass additional information
+        to the estimator.
+
     Returns
     -------
     y_pred : ndarray of shape (n_samples,), (n_samples, n_classes) or \
@@ -211,7 +216,7 @@ def _get_response_values(
             elif pos_label is None and target_type == "binary":
                 pos_label = classes[-1]
 
-        y_pred = prediction_method(X)
+        y_pred = prediction_method(X, **metadata)
 
         if prediction_method.__name__ in ("predict_proba", "predict_log_proba"):
             y_pred = _process_predict_proba(
@@ -229,7 +234,7 @@ def _get_response_values(
             )
     elif is_outlier_detector(estimator):
         prediction_method = _check_response_method(estimator, response_method)
-        y_pred, pos_label = prediction_method(X), None
+        y_pred, pos_label = prediction_method(X, **metadata), None
     else:  # estimator is a regressor
         if response_method != "predict":
             raise ValueError(
@@ -239,7 +244,7 @@ def _get_response_values(
                 f"{response_method} instead."
             )
         prediction_method = estimator.predict
-        y_pred, pos_label = prediction_method(X), None
+        y_pred, pos_label = prediction_method(X, **metadata), None
 
     if return_response_method_used:
         return y_pred, pos_label, prediction_method.__name__

--- a/sklearn/utils/_response.py
+++ b/sklearn/utils/_response.py
@@ -119,7 +119,7 @@ def _get_response_values(
     response_method,
     pos_label=None,
     return_response_method_used=False,
-    **metadata
+    **metadata,
 ):
     """Compute the response values of a classifier, an outlier detector, or a regressor.
 


### PR DESCRIPTION
Fixes #27977

This PR add metadata routing to the estimator to score when calling a scorer.
One thing that is not easy to understand is that here, the routing needs to be dynamic, as it depends on the estimator that is being scored.
For now it is implemented for unique scorer, I have to see how to do this for multiple scorer...

**TODO**
- [x] Add a test
- [ ] Check that this works for multiple scorer