### PR TITLE
DOC Increase prominence of starting from existing issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ The latest contributing guide is available in the repository at
 
 https://scikit-learn.org/dev/developers/contributing.html
 
-There are many ways to contribute to scikit-learn.  Improving the
+There are many ways to contribute to scikit-learn. Improving the
 documentation is no less important than improving the code of the library
 itself. If you find a typo in the documentation, or have made improvements, do
 not hesitate to create a GitHub issue or preferably submit a GitHub pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ The latest contributing guide is available in the repository at
 https://scikit-learn.org/dev/developers/contributing.html
 
 There are many ways to contribute to scikit-learn.  Improving the
-documentation is no less important than improving the library itself.  If you
-find a typo in the documentation, or have made improvements, do not hesitate to
-create a GitHub issue or preferably submit a GitHub pull request.
+documentation is no less important than improving the code of the library
+itself. If you find a typo in the documentation, or have made improvements, do
+not hesitate to create a GitHub issue or preferably submit a GitHub pull request.
 
 There are many other ways to help. In particular [improving, triaging, and
 investigating issues](https://github.com/scikit-learn/scikit-learn/issues),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ https://scikit-learn.org/dev/developers/contributing.html
 There are many ways to contribute to scikit-learn.  Improving the
 documentation is no less important than improving the library itself.  If you
 find a typo in the documentation, or have made improvements, do not hesitate to
-create a GitHub issue or preferably submit a GitHub pull request.
+create a GitHub issue or submit a GitHub pull request.
 
 There are many other ways to help. In particular [improving, triaging, and
 investigating issues](https://github.com/scikit-learn/scikit-learn/issues),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ The latest contributing guide is available in the repository at
 
 https://scikit-learn.org/dev/developers/contributing.html
 
-There are many ways to contribute to scikit-learn.  Improving the
-documentation is no less important than improving the library itself.  If you
+There are many ways to contribute to scikit-learn. Improving the
+documentation is no less important than improving the library itself. If you
 find a typo in the documentation, or have made improvements, do not hesitate to
 create a GitHub issue or submit a GitHub pull request.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,17 +7,14 @@ The latest contributing guide is available in the repository at
 
 https://scikit-learn.org/dev/developers/contributing.html
 
-There are many ways to contribute to scikit-learn, with the most common ones
-being contribution of code or documentation to the project. Improving the
-documentation is no less important than improving the library itself. If you
+There are many ways to contribute to scikit-learn.  Improving the
+documentation is no less important than improving the library itself.  If you
 find a typo in the documentation, or have made improvements, do not hesitate to
-send an email to the mailing list or preferably submit a GitHub pull request.
-Documentation can be found under the
-[doc/](https://github.com/scikit-learn/scikit-learn/tree/main/doc) directory.
+create a GitHub issue or preferably submit a GitHub pull request.
 
-But there are many other ways to help. In particular answering queries on the
-[issue tracker](https://github.com/scikit-learn/scikit-learn/issues),
-investigating bugs, and [reviewing other developers' pull
+There are many other ways to help. In particular [improving, triaging, and
+investigating issues](https://github.com/scikit-learn/scikit-learn/issues),
+and [reviewing other developers' pull
 requests](https://scikit-learn.org/dev/developers/contributing.html#code-review-guidelines)
 are very valuable contributions that decrease the burden on the project
 maintainers.

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -47,7 +47,7 @@ welcome to post feature requests or pull requests.
 Ways to contribute
 ==================
 
-There are many ways to contribute to scikit-learn.  Improving the
+There are many ways to contribute to scikit-learn. Improving the
 documentation is no less important than improving the code of the library
 itself. If you find a typo in the documentation, or have made improvements, do
 not hesitate to create a GitHub issue or preferably submit a GitHub pull request.

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -48,9 +48,9 @@ Ways to contribute
 ==================
 
 There are many ways to contribute to scikit-learn.  Improving the
-documentation is no less important than improving the library itself.  If you
-find a typo in the documentation, or have made improvements, do not hesitate to
-create a GitHub issue or preferably submit a GitHub pull request.
+documentation is no less important than improving the code of the library
+itself. If you find a typo in the documentation, or have made improvements, do
+not hesitate to create a GitHub issue or preferably submit a GitHub pull request.
 
 There are many ways to help. In particular helping to
 :ref:`improve, triage, and investigate issues <bug_triaging>` and

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -699,7 +699,8 @@ underestimate how easy an issue is to solve!
 Documentation
 =============
 
-We are glad to accept any sort of documentation:
+We welcome thoughtful contributions to the documentation and are happy to review
+additions in the following areas:
 
 * **Function/method/class docstrings:** Also known as "API documentation", these
   describe what the object does and detail any parameters, attributes and

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -47,10 +47,10 @@ welcome to post feature requests or pull requests.
 Ways to contribute
 ==================
 
-There are many ways to contribute to scikit-learn.  Improving the
-documentation is no less important than improving the library itself.  If you
+There are many ways to contribute to scikit-learn. Improving the
+documentation is no less important than improving the library itself. If you
 find a typo in the documentation, or have made improvements, do not hesitate to
-create a GitHub issue or preferably submit a GitHub pull request.
+create a GitHub issue or submit a GitHub pull request.
 
 There are many ways to help. In particular helping to
 :ref:`improve, triage, and investigate issues <bug_triaging>` and

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -11,9 +11,9 @@ contribute. It is hosted on https://github.com/scikit-learn/scikit-learn.
 The decision making process and governance structure of scikit-learn is laid
 out in :ref:`governance`.
 
-Scikit-learn is somewhat :ref:`selective <selectiveness>` when it comes to
-adding new algorithms, and the best way to contribute and to help the project
-is to start working on known issues.
+Scikit-learn is :ref:`selective <selectiveness>` when it comes to
+adding new algorithms and features. This means the best way to contribute
+and help the project is to start working on known issues.
 See :ref:`new_contributors` to get started.
 
 .. topic:: **Our community, our values**
@@ -47,20 +47,17 @@ welcome to post feature requests or pull requests.
 Ways to contribute
 ==================
 
-There are many ways to contribute to scikit-learn, with the most common ones
-being contribution of code or documentation to the project. Improving the
+There are many ways to contribute to scikit-learn.  Improving the
 documentation is no less important than improving the library itself.  If you
 find a typo in the documentation, or have made improvements, do not hesitate to
 create a GitHub issue or preferably submit a GitHub pull request.
-Full documentation can be found under the doc/ directory.
 
-But there are many other ways to help. In particular helping to
+There are many ways to help. In particular helping to
 :ref:`improve, triage, and investigate issues <bug_triaging>` and
 :ref:`reviewing other developers' pull requests <code_review>` are very
-valuable contributions that decrease the burden on the project
-maintainers.
+valuable contributions that move the project forward.
 
-Another way to contribute is to report issues you're facing, and give a "thumbs
+Another way to contribute is to report issues you are facing, and give a "thumbs
 up" on issues that others reported and that are relevant to you.  It also helps
 us if you spread the word: reference the project from your blog and articles,
 link to it from your website, or simply star to say "I use it":


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR makes a few changes to our contributing documentation. The goal is to increase the prominence of the advice to start from known issues and ways of helping out that do not involve writing (unsolicited) code.

I think we can safely state that we are selective (not just somewhat selective) when it comes to new estimators as well as new features. The linked FAQ entry applies to all kinds of code contributions.

#### Any other comments?

We could probably also work on the PR template to include questions similar to the ones for new features. Maybe in a new PR. We could also make bigger changes to the contrib docs, I was looking at the [Numpy guide](https://numpy.org/contribute/) which feels nice and organised. But again, maybe something for the future

What do people think?