### PR TITLE
ENH avoid np.square(X) in enet_coordinate_descent to save memory

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/31665.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/31665.enhancement.rst
@@ -1,0 +1,3 @@
+- class:`linear_model:ElasticNet` and class:`linear_model:Lasso` with
+  `precompute=False` uses less memory for dense `X` and is a bit faster.
+  By :user:`Christian Lorentzen <lorentzenchr>`

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -139,7 +139,10 @@ def enet_coordinate_descent(
     cdef unsigned int n_features = X.shape[1]
 
     # compute norms of the columns of X
-    cdef floating[::1] norm_cols_X = zeros(n_features, dtype=dtype)
+    # same as norm_cols_X = np.square(X).sum(axis=0)
+    cdef floating[::1] norm_cols_X = np.einsum(
+        "ij,ij->j", X.T, X.T, dtype=dtype, order="C"
+    )
 
     # initial value of the residuals
     cdef floating[::1] R = np.empty(n_samples, dtype=dtype)
@@ -169,16 +172,6 @@ def enet_coordinate_descent(
                       "unexpected results and is discouraged.")
 
     with nogil:
-        # norm_cols_X = np.square(X).sum(axis=0)
-        if no_sample_weights:
-            if not center:
-                for ii in range(n_features):
-                    norm_cols_X[ii] = _dot(n_samples, &X[0, ii], 1, &X[0, ii], 1)
-            else:
-                for ii in range(n_features):
-                    for jj in range(n_samples):
-                        norm_cols_X[ii] += (X[jj, ii] - X_mean[ii]) ** 2
-
         # R = y - np.dot(X, w)
         _copy(n_samples, &y[0], 1, &R[0], 1)
         _gemv(ColMajor, NoTrans, n_samples, n_features, -1.0, &X[0, 0],

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -141,7 +141,7 @@ def enet_coordinate_descent(
     # compute norms of the columns of X
     # same as norm_cols_X = np.square(X).sum(axis=0)
     cdef floating[::1] norm_cols_X = np.einsum(
-        "ij,ij->j", X.T, X.T, dtype=dtype, order="C"
+        "ij,ij->j", X, X, dtype=dtype, order="C"
     )
 
     # initial value of the residuals


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
This PR replaces `np.square(X).sum(axis=0)` by `np.einsum("ij,ij->j", X, X)` to avoid memory allocation of the size of `X`(usually the largest object).

#### Any other comments?
This also improves timing a bit.

We might even consider to write the loop explicitly like in (https://github.com/scikit-learn/scikit-learn/blob/20b8d0b4e2e7086f853a8e8d07c7496a882b8b91/sklearn/metrics/_pairwise_distances_reduction/_base.pyx.tp#L20-L26).