### PR TITLE
DOC Fixed minor typo: "multiclasss" -> "multiclass"

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -3539,7 +3539,7 @@ def brier_score_loss(
         When True, scale the Brier score by 1/2 to lie in the [0, 1] range instead
         of the [0, 2] range. The default "auto" option implements the rescaling to
         [0, 1] only for binary classification (as customary) but keeps the
-        original [0, 2] range for multiclasss classification.
+        original [0, 2] range for multiclass classification.
 
         .. versionadded:: 1.7
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->


#### What does this implement/fix? Explain your changes.
This fixes a misspelling of "multiclass" in the [documentation](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.brier_score_loss.html) for the Brier score metric.
