### PR TITLE
Add requires_fit=False tag to FeatureHasher and HashingVectorizer

### DIFF
--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -206,3 +206,6 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
         elif self.input_type == "dict":
             tags.input_tags.dict = True
         return tags
+   
+    def _more_tags(self):
+        return {"requires_fit": False}

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -206,6 +206,6 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
         elif self.input_type == "dict":
             tags.input_tags.dict = True
         return tags
-   
+
     def _more_tags(self):
         return {"requires_fit": False}

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -2134,3 +2134,6 @@ class TfidfVectorizer(CountVectorizer):
         tags.input_tags.two_d_array = False
         tags._skip_test = True
         return tags
+
+    def _more_tags(self):
+        return {"requires_fit": False}

--- a/sklearn/tests/test_hash_requires_fit.py
+++ b/sklearn/tests/test_hash_requires_fit.py
@@ -1,4 +1,5 @@
-from sklearn.feature_extraction import FeatureHasher, HashingVectorizer
+from sklearn.feature_extraction import FeatureHasher
+from sklearn.feature_extraction.text import HashingVectorizer
 
 
 def test_feature_hasher_requires_fit():

--- a/sklearn/tests/test_hash_requires_fit.py
+++ b/sklearn/tests/test_hash_requires_fit.py
@@ -1,0 +1,8 @@
+from sklearn.feature_extraction import FeatureHasher, HashingVectorizer
+
+def test_feature_hasher_requires_fit():
+    assert not FeatureHasher()._get_tags()["requires_fit"]
+
+def test_hashing_vectorizer_requires_fit():
+    assert not HashingVectorizer()._get_tags()["requires_fit"]
+

--- a/sklearn/tests/test_hash_requires_fit.py
+++ b/sklearn/tests/test_hash_requires_fit.py
@@ -1,10 +1,13 @@
+import pytest
 from sklearn.feature_extraction import FeatureHasher
 from sklearn.feature_extraction.text import HashingVectorizer
 
+def test_feature_hasher_requires_fit_tag():
+    """Test that FeatureHasher has requires_fit=False tag."""
+    hasher = FeatureHasher()
+    assert hasher._more_tags()['requires_fit'] is False
 
-def test_feature_hasher_requires_fit():
-    assert not FeatureHasher()._get_tags()["requires_fit"]
-
-
-def test_hashing_vectorizer_requires_fit():
-    assert not HashingVectorizer()._get_tags()["requires_fit"]
+def test_hashing_vectorizer_requires_fit_tag():
+    """Test that HashingVectorizer has requires_fit=False tag."""
+    vectorizer = HashingVectorizer()
+    assert vectorizer._more_tags()['requires_fit'] is False

--- a/sklearn/tests/test_hash_requires_fit.py
+++ b/sklearn/tests/test_hash_requires_fit.py
@@ -1,8 +1,9 @@
 from sklearn.feature_extraction import FeatureHasher, HashingVectorizer
 
+
 def test_feature_hasher_requires_fit():
     assert not FeatureHasher()._get_tags()["requires_fit"]
 
+
 def test_hashing_vectorizer_requires_fit():
     assert not HashingVectorizer()._get_tags()["requires_fit"]
-


### PR DESCRIPTION
…x #30689)

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Adds "requires_fit = False tag" to  "FeatureHasher" and "HashingVectorizer" by overriding "_more_tags()" in each class. This aligns the behavior with the tag-based API in common estimator checks.

#### Any other comments?

- Added `sklearn/tests/test_hash_requires_fit.py` to verify that both estimators correctly expose the `requires_fit` tag.
- Verified successful compilation and tag evaluation in a clean environment.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
