### PR TITLE
FIX Revert tarfile_extractall clean-up

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.datasets/31685.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.datasets/31685.fix.rst
@@ -1,0 +1,4 @@
+- Fixed a regression preventing to extract the downloaded dataset in
+  :func:`datasets.fetch_20newsgroups`, :func:`datasets.fetch_20newsgroups_vectorized`,
+  :func:`datasets.fetch_lfw_people` and :func:`datasets.fetch_lfw_pairs`.
+  By :user:`Jérémie du Boisberranger <jeremiedbb>`.

--- a/doc/whats_new/upcoming_changes/sklearn.datasets/31685.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.datasets/31685.fix.rst
@@ -1,4 +1,5 @@
 - Fixed a regression preventing to extract the downloaded dataset in
   :func:`datasets.fetch_20newsgroups`, :func:`datasets.fetch_20newsgroups_vectorized`,
-  :func:`datasets.fetch_lfw_people` and :func:`datasets.fetch_lfw_pairs`.
+  :func:`datasets.fetch_lfw_people` and :func:`datasets.fetch_lfw_pairs`. This
+  only affects Python versions `>=3.10.0,<=3.10.11` and `>=3.11.0,<=3.11.3`.
   By :user:`Jérémie du Boisberranger <jeremiedbb>`.

--- a/sklearn/datasets/_lfw.py
+++ b/sklearn/datasets/_lfw.py
@@ -19,6 +19,7 @@ from joblib import Memory
 
 from ..utils import Bunch
 from ..utils._param_validation import Hidden, Interval, StrOptions, validate_params
+from ..utils.fixes import tarfile_extractall
 from ._base import (
     RemoteFileMetadata,
     _fetch_remote,
@@ -117,10 +118,7 @@ def _check_fetch_lfw(
 
         logger.debug("Decompressing the data archive to %s", data_folder_path)
         with tarfile.open(archive_path, "r:gz") as fp:
-            # Use filter="data" to prevent the most dangerous security issues.
-            # For more details, see
-            # https://docs.python.org/3.9/library/tarfile.html#tarfile.TarFile.extractall
-            fp.extractall(path=lfw_home, filter="data")
+            tarfile_extractall(fp, path=lfw_home)
 
         remove(archive_path)
 

--- a/sklearn/datasets/_twenty_newsgroups.py
+++ b/sklearn/datasets/_twenty_newsgroups.py
@@ -43,6 +43,7 @@ from .. import preprocessing
 from ..feature_extraction.text import CountVectorizer
 from ..utils import Bunch, check_random_state
 from ..utils._param_validation import Interval, StrOptions, validate_params
+from ..utils.fixes import tarfile_extractall
 from . import get_data_home, load_files
 from ._base import (
     RemoteFileMetadata,
@@ -81,10 +82,7 @@ def _download_20newsgroups(target_dir, cache_path, n_retries, delay):
 
     logger.debug("Decompressing %s", archive_path)
     with tarfile.open(archive_path, "r:gz") as fp:
-        # Use filter="data" to prevent the most dangerous security issues.
-        # For more details, see
-        # https://docs.python.org/3.9/library/tarfile.html#tarfile.TarFile.extractall
-        fp.extractall(path=target_dir, filter="data")
+        tarfile_extractall(fp, path=target_dir)
 
     with suppress(FileNotFoundError):
         os.remove(archive_path)

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -361,6 +361,17 @@ else:
     )
 
 
+# TODO: Remove when Python min version >= 3.12.
+def tarfile_extractall(tarfile, path):
+    try:
+        # Use filter="data" to prevent the most dangerous security issues.
+        # For more details, see
+        # https://docs.python.org/3.9/library/tarfile.html#tarfile.TarFile.extractall
+        tarfile.extractall(path, filter="data")
+    except TypeError:
+        tarfile.extractall(path)
+
+
 def _in_unstable_openblas_configuration():
     """Return True if in an unstable configuration for OpenBLAS"""
 

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -366,7 +366,7 @@ def tarfile_extractall(tarfile, path):
     try:
         # Use filter="data" to prevent the most dangerous security issues.
         # For more details, see
-        # https://docs.python.org/3.9/library/tarfile.html#tarfile.TarFile.extractall
+        # https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractall
         tarfile.extractall(path, filter="data")
     except TypeError:
         tarfile.extractall(path)


### PR DESCRIPTION
Fixes #31521
Closes #31523

`tarfile_extractall` was removed in 1.7 because we thought that the `filter` arg was added in Python 3.10 but it turns out that only Python 3.12 has it from the start (3.12.0). Previous versions introduced it as part of a micro version.