### PR TITLE
DOC Recommend setting `array_api_dispatch` globally in array API docs

### DIFF
--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -30,7 +30,7 @@ data structures and automatically dispatch operations to the underlying namespac
 instead of relying on NumPy.
 
 At this stage, this support is **considered experimental** and must be enabled
-explicitly as explained in the following.
+explicitly by the `array_api_dispatch` configuration. See below for details.
 
 .. note::
     Currently, only `array-api-strict`, `cupy`, and `PyTorch` are known to work
@@ -45,7 +45,12 @@ and how it facilitates interoperability between array libraries:
 Example usage
 =============
 
-Here is an example code snippet to demonstrate how to use `CuPy
+The configuration `array_api_dispatch=True` needs to be set to `True` to enable array
+API support. Note that we set it with :func:`config_context` below to avoid
+inadvertent affects when building our documentation but we recommend setting
+this configuration globally to prevent accidentally forgetting to enable it
+in downstream code.
+The example code snippet below demonstrates how to use `CuPy
 <https://cupy.dev/>`_ to run
 :class:`~discriminant_analysis.LinearDiscriminantAnalysis` on a GPU::
 
@@ -82,8 +87,7 @@ transfers an estimator attributes from Array API to a ndarray::
 PyTorch Support
 ---------------
 
-PyTorch Tensors are supported by setting `array_api_dispatch=True` and passing in
-the tensors directly::
+PyTorch Tensors can also be passed directly::
 
     >>> import torch
     >>> X_torch = torch.asarray(X_np, device="cuda", dtype=torch.float32)

--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -46,10 +46,11 @@ Example usage
 =============
 
 The configuration `array_api_dispatch=True` needs to be set to `True` to enable array
-API support. Note that we set it with :func:`config_context` below to avoid
-inadvertent affects when building our documentation but we recommend setting
-this configuration globally to ensure consistent behaviour and prevent accidental
-mixing of array namespaces.
+API support. We recommend setting this configuration globally to ensure consistent
+behaviour and prevent accidental mixing of array namespaces.
+Note that we set it with :func:`config_context` below to avoid having to call
+:func:`set_config(array_api_dispatch=False)` at the end of every code snippet
+that uses the array API.
 The example code snippet below demonstrates how to use `CuPy
 <https://cupy.dev/>`_ to run
 :class:`~discriminant_analysis.LinearDiscriminantAnalysis` on a GPU::

--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -48,8 +48,8 @@ Example usage
 The configuration `array_api_dispatch=True` needs to be set to `True` to enable array
 API support. Note that we set it with :func:`config_context` below to avoid
 inadvertent affects when building our documentation but we recommend setting
-this configuration globally to prevent accidentally forgetting to enable it
-in downstream code.
+this configuration globally to ensure consistent behaviour and prevent accidental
+mixing of array namespaces.
 The example code snippet below demonstrates how to use `CuPy
 <https://cupy.dev/>`_ to run
 :class:`~discriminant_analysis.LinearDiscriminantAnalysis` on a GPU::


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Discussed in https://github.com/scikit-learn/scikit-learn/pull/31486#discussion_r2144420732 and https://github.com/scikit-learn/scikit-learn/issues/26083#issuecomment-1505442394

#### What does this implement/fix? Explain your changes.
Recommend setting the `array_api_dispatch` globally in our docs and explain why we set it in a with context in our example code.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
