### PR TITLE
DOC Fix `pos_label` docstring in Display classes

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -1103,6 +1103,7 @@ class CalibrationDisplay(_BinaryClassifierCurveDisplayMixin):
 
     pos_label : int, float, bool or str, default=None
         The positive class when computing the calibration curve.
+        If not `None`, this value is displayed in the x- and y-axes labels.
         By default, `pos_label` is set to `estimators.classes_[1]` when using
         `from_estimator` and set to 1 when using `from_predictions`.
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -1102,7 +1102,7 @@ class CalibrationDisplay(_BinaryClassifierCurveDisplayMixin):
         Name of estimator. If None, the estimator name is not shown.
 
     pos_label : int, float, bool or str, default=None
-        The positive class when computing the calibration curve.
+        The positive class when calibration curve computed.
         If not `None`, this value is displayed in the x- and y-axes labels.
 
         .. versionadded:: 1.1
@@ -1384,7 +1384,8 @@ class CalibrationDisplay(_BinaryClassifierCurveDisplayMixin):
 
         pos_label : int, float, bool or str, default=None
             The positive class when computing the calibration curve.
-            By default `pos_label` is set to 1.
+            When `pos_label=None`, if `y_true` is in {-1, 1} or {0, 1},
+            `pos_label` is set to 1, otherwise an error will be raised.
 
             .. versionadded:: 1.1
 

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -1104,8 +1104,6 @@ class CalibrationDisplay(_BinaryClassifierCurveDisplayMixin):
     pos_label : int, float, bool or str, default=None
         The positive class when computing the calibration curve.
         If not `None`, this value is displayed in the x- and y-axes labels.
-        By default, `pos_label` is set to `estimators.classes_[1]` when using
-        `from_estimator` and set to 1 when using `from_predictions`.
 
         .. versionadded:: 1.1
 

--- a/sklearn/metrics/_plot/det_curve.py
+++ b/sklearn/metrics/_plot/det_curve.py
@@ -137,9 +137,8 @@ class DetCurveDisplay(_BinaryClassifierCurveDisplayMixin):
             exist :term:`decision_function` is tried next.
 
         pos_label : int, float, bool or str, default=None
-            The label of the positive class. When `pos_label=None`, if `y_true`
-            is in {-1, 1} or {0, 1}, `pos_label` is set to 1, otherwise an
-            error will be raised.
+            The label of the positive class. By default, `estimators.classes_[1]`
+            is considered as the positive class.
 
         name : str, default=None
             Name of DET curve for labeling. If `None`, use the name of the

--- a/sklearn/metrics/_plot/det_curve.py
+++ b/sklearn/metrics/_plot/det_curve.py
@@ -34,7 +34,8 @@ class DetCurveDisplay(_BinaryClassifierCurveDisplayMixin):
         Name of estimator. If None, the estimator name is not shown.
 
     pos_label : int, float, bool or str, default=None
-        The label of the positive class.
+        The label of the positive class. If not `None`, this value is displayed in
+        the x- and y-axes labels.
 
     Attributes
     ----------

--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -40,8 +40,8 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
         Name of estimator. If None, then the estimator name is not shown.
 
     pos_label : int, float, bool or str, default=None
-        The class considered as the positive class. If None, the class will not
-        be shown in the legend.
+        The class considered as the positive class. If not `None`, this value is
+        displayed in the x- and y-axes labels.
 
         .. versionadded:: 0.24
 

--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -40,8 +40,8 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
         Name of estimator. If None, then the estimator name is not shown.
 
     pos_label : int, float, bool or str, default=None
-        The class considered as the positive class. If not `None`, this value is
-        displayed in the x- and y-axes labels.
+        The class considered the positive class when precision and recall metrics
+        computed. If not `None`, this value is displayed in the x- and y-axes labels.
 
         .. versionadded:: 0.24
 
@@ -449,7 +449,9 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
 
         pos_label : int, float, bool or str, default=None
             The class considered as the positive class when computing the
-            precision and recall metrics.
+            precision and recall metrics. When `pos_label=None`, if `y_true` is
+            in {-1, 1} or {0, 1}, `pos_label` is set to 1, otherwise an error
+            will be raised.
 
         name : str, default=None
             Name for labeling curve. If `None`, name will be set to

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -72,8 +72,7 @@ class RocCurveDisplay(_BinaryClassifierCurveDisplayMixin):
 
     pos_label : int, float, bool or str, default=None
         The class considered as the positive class when computing the roc auc
-        metrics. By default, `estimators.classes_[1]` is considered
-        as the positive class.
+        metrics. Used for labelling the axes. If `None` not included in labels.
 
         .. versionadded:: 0.24
 

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -71,8 +71,8 @@ class RocCurveDisplay(_BinaryClassifierCurveDisplayMixin):
         .. versionadded:: 1.7
 
     pos_label : int, float, bool or str, default=None
-        The class considered as the positive class when computing the roc auc
-        metrics. If not `None`, this value is displayed in the x- and y-axes labels.
+        The class considered the positive class when ROC AUC metrics computed.
+        If not `None`, this value is displayed in the x- and y-axes labels.
 
         .. versionadded:: 0.24
 

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -72,7 +72,7 @@ class RocCurveDisplay(_BinaryClassifierCurveDisplayMixin):
 
     pos_label : int, float, bool or str, default=None
         The class considered as the positive class when computing the roc auc
-        metrics. Used for labelling the axes. If `None` not included in labels.
+        metrics. Used for labelling the axes. If `None`, not included in labels.
 
         .. versionadded:: 0.24
 

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -72,7 +72,7 @@ class RocCurveDisplay(_BinaryClassifierCurveDisplayMixin):
 
     pos_label : int, float, bool or str, default=None
         The class considered as the positive class when computing the roc auc
-        metrics. Used for labelling the axes. If `None`, not included in labels.
+        metrics. If not `None`, this value is displayed in the x- and y-axes labels.
 
         .. versionadded:: 0.24
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
Noticed when working on #28972

Specify that `pos_label` from init is used to label the x and y axes. Fixes some inaccuracies:

* `pos_label` parameter in display class init is not able to be infer `pos_label` (as it does not have access to estimator or predictions). 
* it is not used in legend labelling, only in the x and y axes

Fix docstrings accordingly.


#### What does this implement/fix? Explain your changes.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
