### PR TITLE
DOC: Add prediction latency plot links to out-of-core classification docs

### DIFF
--- a/doc/computing/scaling_strategies.rst
+++ b/doc/computing/scaling_strategies.rst
@@ -103,6 +103,8 @@ Finally, we have a full-fledged example of
 :ref:`sphx_glr_auto_examples_applications_plot_out_of_core_classification.py`. It is aimed at
 providing a starting point for people wanting to build out-of-core learning
 systems and demonstrates most of the notions discussed above.
+For a benchmark comparing the prediction latency of various estimators, see
+:ref:`sphx_glr_auto_examples_benchmarks_plot_prediction_latency.py`.
 
 Furthermore, it also shows the evolution of the performance of different
 algorithms with the number of processed examples.
@@ -118,6 +120,9 @@ vectorization is much more expensive than learning itself. From the different
 algorithms, ``MultinomialNB`` is the most expensive, but its overhead can be
 mitigated by increasing the size of the mini-batches (exercise: change
 ``minibatch_size`` to 100 and 10000 in the program and compare).
+
+For a comparison of the prediction latency for various estimators,
+see :ref:`sphx_glr_auto_examples_benchmarks_plot_prediction_latency.py`.
 
 .. |computation_time| image::  ../auto_examples/applications/images/sphx_glr_plot_out_of_core_classification_003.png
     :target: ../auto_examples/applications/plot_out_of_core_classification.html

--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -891,6 +891,9 @@ The :class:`HashingVectorizer` also comes with the following limitations:
   For a full-fledged example of out-of-core scaling in a text classification
   task see :ref:`sphx_glr_auto_examples_applications_plot_out_of_core_classification.py`.
 
+  For prediction latency comparisons of different text classification approaches, see
+  :ref:`sphx_glr_auto_examples_applications_plot_prediction_latency.py`.
+
 
 Customizing the vectorizer classes
 ----------------------------------

--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -65,6 +65,9 @@ distribution can be independently estimated as a one dimensional distribution.
 This in turn helps to alleviate problems stemming from the curse of
 dimensionality.
 
+For detailed prediction latency comparisons, see
+:ref:`sphx_glr_auto_examples_applications_plot_prediction_latency.py`.
+
 On the flip side, although naive Bayes is known as a decent classifier,
 it is known to be a bad estimator, so the probability outputs from
 ``predict_proba`` are not to be taken too seriously.


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #30462

This PR adds prediction latency plot references to documentation files that mention out-of-core classification, as requested in issue #30462.

**Changes made:**
- Added prediction latency benchmark references in `doc/computing/scaling_strategies.rst`
- Added prediction latency benchmark references in `doc/modules/naive_bayes.rst`  
- Added prediction latency benchmark references in `doc/modules/feature_extraction.rst`

This helps users find prediction latency benchmarks when reading about out-of-core classification methods, improving the discoverability of performance comparison information.

This addresses the documentation enhancement request to link prediction latency plots wherever out-of-core classification examples are mentioned. The links are added in the same sections where `plot_out_of_core_classification.py` is referenced to maintain contextual relevance.