### PR TITLE
MNT little refactor and doc improvement for metadata routing consumes() methods

### DIFF
--- a/sklearn/tests/test_metadata_routing.py
+++ b/sklearn/tests/test_metadata_routing.py
@@ -638,14 +638,14 @@ def test_get_routing_for_object():
 @config_context(enable_metadata_routing=True)
 def test_metadata_request_consumes_method():
     """Test that MetadataRequest().consumes() method works as expected."""
-    request = MetadataRouter(owner="test")
+    request = MetadataRequest(owner="test_method")
     assert request.consumes(method="fit", params={"foo"}) == set()
 
-    request = MetadataRequest(owner="test")
+    request = MetadataRequest(owner="test_method")
     request.fit.add_request(param="foo", alias=True)
     assert request.consumes(method="fit", params={"foo"}) == {"foo"}
 
-    request = MetadataRequest(owner="test")
+    request = MetadataRequest(owner="test_method")
     request.fit.add_request(param="foo", alias="bar")
     assert request.consumes(method="fit", params={"bar", "foo"}) == {"bar"}
 

--- a/sklearn/tests/test_metadata_routing.py
+++ b/sklearn/tests/test_metadata_routing.py
@@ -638,14 +638,14 @@ def test_get_routing_for_object():
 @config_context(enable_metadata_routing=True)
 def test_metadata_request_consumes_method():
     """Test that MetadataRequest().consumes() method works as expected."""
-    request = MetadataRequest(owner="test_method")
+    request = MetadataRequest(owner="test")
     assert request.consumes(method="fit", params={"foo"}) == set()
 
-    request = MetadataRequest(owner="test_method")
+    request = MetadataRequest(owner="test")
     request.fit.add_request(param="foo", alias=True)
     assert request.consumes(method="fit", params={"foo"}) == {"foo"}
 
-    request = MetadataRequest(owner="test_method")
+    request = MetadataRequest(owner="test")
     request.fit.add_request(param="foo", alias="bar")
     assert request.consumes(method="fit", params={"bar", "foo"}) == {"bar"}
 

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -501,8 +501,7 @@ class MethodMetadataRequest:
         return res
 
     def _consumes(self, params):
-        """Return the subset of `params` that are consumed by the method that owns this
-        instance.
+        """Return subset of `params` consumed by the method that owns this instance.
 
         Parameters
         ----------
@@ -592,7 +591,7 @@ class MetadataRequest:
         Returns
         -------
         method_consumes : set of str
-            A subset of parameters from `params` which are consumed by this method.
+            A subset of parameters from `params` which are consumed by the given method.
         """
         return getattr(self, method)._consumes(params=params)
 
@@ -908,8 +907,8 @@ class MetadataRouter:
     def consumes(self, method, params):
         """Return params consumed as metadata in a :term:`router` or its sub-estimators.
 
-        This method returns the subset of given `params` that are consumed by the
-        given `method`. A `param` is considered consumed if it is used in the specified
+        This method returns the subset of `params` that are consumed by the
+        `method`. A `param` is considered consumed if it is used in the specified
         method of the :term:`router` itself or any of its sub-estimators (or their
         sub-estimators).
 

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -501,7 +501,7 @@ class MethodMetadataRequest:
         return res
 
     def _consumes(self, params):
-        """Return the subset of given `params` consumed by the method that owns this
+        """Return the subset of `params` that are consumed by the method that owns this
         instance.
 
         Parameters

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -572,7 +572,12 @@ class MetadataRequest:
             )
 
     def consumes(self, method, params):
-        """Return the subset of given `params` consumed by the given `method`.
+        """Return params consumed as metadata in a :term:`consumer`.
+
+        This method returns the subset of given `params` that are consumed by the
+        given `method`. It can be used to check if parameters are used as metadata in
+        the specified method of the :term:`consumer` that owns this `MetadataRequest`
+        instance.
 
         .. versionadded:: 1.4
 
@@ -901,11 +906,12 @@ class MetadataRouter:
         return self
 
     def consumes(self, method, params):
-        """Return the subset of given `params` consumed by the given `method`.
+        """Return params consumed as metadata in a :term:`router` or its sub-estimators.
 
-        A `param` is considered consumed if it is used by the :term:`router` itself,
-        or by any sub-estimator (or their sub-estimators) that this router delegates
-        metadata to via the specified `method`.
+        This method returns the subset of given `params` that are consumed by the
+        given `method`. A `param` is considered consumed if it is used in the specified
+        method of the :term:`router` itself or any of its sub-estimators (or their
+        sub-estimators).
 
         .. versionadded:: 1.4
 

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -510,17 +510,17 @@ class MethodMetadataRequest:
 
         Returns
         -------
-        method_consumes : set of str
+        consumed_params : set of str
             A subset of parameters from `params` which are consumed by this method.
         """
         params = set(params)
-        method_consumes = set()
+        consumed_params = set()
         for metadata_name, alias in self._requests.items():
             if alias is True and metadata_name in params:
-                method_consumes.add(metadata_name)
+                consumed_params.add(metadata_name)
             elif isinstance(alias, str) and alias in params:
-                method_consumes.add(alias)
-        return method_consumes
+                consumed_params.add(alias)
+        return consumed_params
 
     def _serialize(self):
         """Serialize the object.
@@ -590,7 +590,7 @@ class MetadataRequest:
 
         Returns
         -------
-        method_consumes : set of str
+        consumed_params : set of str
             A subset of parameters from `params` which are consumed by the given method.
         """
         return getattr(self, method)._consumes(params=params)
@@ -924,23 +924,23 @@ class MetadataRouter:
 
         Returns
         -------
-        method_consumes : set of str
+        consumed_params : set of str
             A subset of parameters from `params` which are consumed by this method.
         """
-        method_consumes = set()
+        consumed_params = set()
         if self._self_request:
-            method_consumes.update(
+            consumed_params.update(
                 self._self_request.consumes(method=method, params=params)
             )
 
         for _, route_mapping in self._route_mappings.items():
             for caller, callee in route_mapping.mapping:
                 if caller == method:
-                    method_consumes.update(
+                    consumed_params.update(
                         route_mapping.router.consumes(method=callee, params=params)
                     )
 
-        return method_consumes
+        return consumed_params
 
     def _get_param_names(self, *, method, return_alias, ignore_self_request):
         """Get names of all metadata that can be consumed or routed by specified \


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR aims to make metadata routing more intuitive and maintainable by a little refactoring and doc improvements:
- simplifies the code in `MetadataRequest.consumes()` to use set notation (which I think is easier to read)
- improves the docstrings of all three `consumes` methods
- renames variables names to make them more specific
- corrects a mistake in `test_metadata_request_consumes_method`