### PR TITLE
FIX: Ignore pos_label for non-binary f1_score in scorer

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/31709.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/31709.fix.rst
@@ -1,0 +1,4 @@
+- :func:`metrics.make_scorer` now correctly ignores `pos_label` parameter for multiclass 
+ metrics (`f1_score`, `precision_score`, `recall_score`) when using averages 'micro', 
+ 'macro', 'weighted', or 'samples'. Previously raised ValueError with invalid pos_label.
+ By :user:`ShauryaDusht <ShauryaDusht>` :pr:`#31709`.

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -719,8 +719,8 @@ def make_scorer(
 
     # Ignore pos_label for multiclass averages
     if hasattr(score_func, "__name__") and score_func.__name__ in [
-        "f1_score", 
-        "precision_score", 
+        "f1_score",
+        "precision_score",
         "recall_score"
     ]:
         if "average" in kwargs and "pos_label" in kwargs:

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -718,13 +718,15 @@ def make_scorer(
     sign = 1 if greater_is_better else -1
 
     # Ignore pos_label for multiclass averages
-    if hasattr(score_func, '__name__') and score_func.__name__ in [
-        'f1_score', 'precision_score', 'recall_score'
+    if hasattr(score_func, "__name__") and score_func.__name__ in [
+        "f1_score", 
+        "precision_score", 
+        "recall_score"
     ]:
-        if 'average' in kwargs and 'pos_label' in kwargs:
-            avg = kwargs['average']
-            if avg in ['micro', 'macro', 'weighted', 'samples']:
-                kwargs['pos_label'] = None
+        if "average" in kwargs and "pos_label" in kwargs:
+            avg = kwargs["average"]
+            if avg in ["micro", "macro", "weighted", "samples"]:
+                kwargs["pos_label"] = None
 
     if response_method is None:
         warnings.warn(

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -718,7 +718,9 @@ def make_scorer(
     sign = 1 if greater_is_better else -1
 
     # Ignore pos_label for multiclass averages
-    if hasattr(score_func, '__name__') and score_func.__name__ in ['f1_score', 'precision_score', 'recall_score']:
+    if hasattr(score_func, '__name__') and score_func.__name__ in [
+        'f1_score', 'precision_score', 'recall_score'
+    ]:
         if 'average' in kwargs and 'pos_label' in kwargs:
             avg = kwargs['average']
             if avg in ['micro', 'macro', 'weighted', 'samples']:

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -721,7 +721,7 @@ def make_scorer(
     if hasattr(score_func, "__name__") and score_func.__name__ in [
         "f1_score",
         "precision_score",
-        "recall_score"
+        "recall_score",
     ]:
         if "average" in kwargs and "pos_label" in kwargs:
             avg = kwargs["average"]

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -717,6 +717,13 @@ def make_scorer(
     """
     sign = 1 if greater_is_better else -1
 
+    # Ignore pos_label for multiclass averages
+    if hasattr(score_func, '__name__') and score_func.__name__ in ['f1_score', 'precision_score', 'recall_score']:
+        if 'average' in kwargs and 'pos_label' in kwargs:
+            avg = kwargs['average']
+            if avg in ['micro', 'macro', 'weighted', 'samples']:
+                kwargs['pos_label'] = None
+
     if response_method is None:
         warnings.warn(
             "response_method=None is deprecated in version 1.6 and will be removed "

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1665,7 +1665,6 @@ def test_make_scorer_reponse_method_default_warning():
         warnings.simplefilter("error", FutureWarning)
         make_scorer(accuracy_score)
 
-
 def test_f1_score_multiclass_pos_label_ignored():
     """Check that pos_label is ignored for multiclass f1_score with micro average."""
     data = load_iris()
@@ -1673,7 +1672,7 @@ def test_f1_score_multiclass_pos_label_ignored():
     y = np.array([data.target_names[label] for label in data.target])
 
     # This should not raise an error
-    f1_scorer = make_scorer(f1_score, average='micro', pos_label=1)
+    f1_scorer = make_scorer(f1_score, average="micro", pos_label=1)
     classifier = LogisticRegression(random_state=0, max_iter=1000)
 
     scores = cross_val_score(classifier, X, y, cv=3, scoring=f1_scorer)
@@ -1690,7 +1689,7 @@ def test_multiclass_scorers_ignore_pos_label():
 
     # This should not raise an error
     for metric in [f1_score, precision_score, recall_score]:
-        for avg in ['micro', 'macro', 'weighted']:
+        for avg in ["micro", "macro", "weighted"]:
             scorer = make_scorer(metric, average=avg, pos_label=1)
             scores = cross_val_score(classifier, X, y, cv=3, scoring=scorer)
             assert len(scores) == 3
@@ -1700,12 +1699,12 @@ def test_multiclass_scorers_ignore_pos_label():
 def test_binary_classification_pos_label_still_works():
     """Check that pos_label still works for binary classification."""
     X, y = make_classification(n_samples=100, n_classes=2, random_state=0)
-    y = np.array(['class_a', 'class_b'])[y]
+    y = np.array(["class_a", "class_b"])[y]
 
     classifier = LogisticRegression(random_state=0)
 
     # This should work with valid pos_label
-    scorer = make_scorer(f1_score, pos_label='class_a')
+    scorer = make_scorer(f1_score, pos_label="class_a")
     scores = cross_val_score(classifier, X, y, cv=3, scoring=scorer)
     assert len(scores) == 3
     assert all(~np.isnan(scores))

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -13,8 +13,8 @@ from sklearn import config_context
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.cluster import KMeans
 from sklearn.datasets import (
-    load_iris,
     load_diabetes,
+    load_iris,
     make_blobs,
     make_classification,
     make_multilabel_classification,
@@ -1671,23 +1671,23 @@ def test_f1_score_multiclass_pos_label_ignored():
     data = load_iris()
     X = data.data
     y = np.array([data.target_names[label] for label in data.target])
-    
+
     # This should not raise an error
     f1_scorer = make_scorer(f1_score, average='micro', pos_label=1)
     classifier = LogisticRegression(random_state=0, max_iter=1000)
-    
+
     scores = cross_val_score(classifier, X, y, cv=3, scoring=f1_scorer)
     assert len(scores) == 3
     assert all(~np.isnan(scores))
 
 
 def test_multiclass_scorers_ignore_pos_label():
-    """Check that multiclass averages ignore pos_label for f1, precision, recall."""    
+    """Check that multiclass averages ignore pos_label for f1, precision, recall."""
     data = load_iris()
     X = data.data
     y = np.array([data.target_names[label] for label in data.target])
     classifier = LogisticRegression(random_state=0, max_iter=1000)
-    
+
     # This should not raise an error
     for metric in [f1_score, precision_score, recall_score]:
         for avg in ['micro', 'macro', 'weighted']:
@@ -1701,9 +1701,9 @@ def test_binary_classification_pos_label_still_works():
     """Check that pos_label still works for binary classification."""
     X, y = make_classification(n_samples=100, n_classes=2, random_state=0)
     y = np.array(['class_a', 'class_b'])[y]
-    
+
     classifier = LogisticRegression(random_state=0)
-    
+
     # This should work with valid pos_label
     scorer = make_scorer(f1_score, pos_label='class_a')
     scores = cross_val_score(classifier, X, y, cv=3, scoring=scorer)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1022,7 +1022,7 @@ def string_labeled_classification_problem():
     idx_negative = np.flatnonzero(y == 0)
     idx_selected = np.hstack([idx_negative, idx_positive[:25]])
     X, y = X[idx_selected], y[idx_selected]
-    X, y = shuffle(X, y, random_state=0)
+    X, y = shuffle(X, y, random_state=42)
     # only use 2 features to make the problem even harder
     X = X[:, :2]
     y = np.array(["cancer" if c == 1 else "not cancer" for c in y], dtype=object)

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1665,6 +1665,7 @@ def test_make_scorer_reponse_method_default_warning():
         warnings.simplefilter("error", FutureWarning)
         make_scorer(accuracy_score)
 
+
 def test_f1_score_multiclass_pos_label_ignored():
     """Check that pos_label is ignored for multiclass f1_score with micro average."""
     data = load_iris()


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #29734

#### What does this implement/fix?

Ignores `pos_label` in `make_scorer` when using `f1_score`, `precision_score`, or `recall_score` with non-binary averages (`micro`, `macro`, `weighted`, `samples`).

#### Any other comments?
- Added check in `scorer.py`
- Tests added (passed locally)
