### PR TITLE
DOC Fix broken formatting of `cohen_kappa_score` docstring

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -831,8 +831,8 @@ def cohen_kappa_score(y1, y2, *, labels=None, weights=None, sample_weight=None):
         List of labels to index the matrix. This may be used to select a
         subset of labels. If `None`, all labels that appear at least once in
         ``y1`` or ``y2`` are used. Note that at least one label in `labels` must be
-         present in `y1`, even though this function is otherwise agnostic to the order
-         of `y1` and `y2`.
+        present in `y1`, even though this function is otherwise agnostic to the order
+        of `y1` and `y2`.
 
     weights : {'linear', 'quadratic'}, default=None
         Weighting type to calculate the score. `None` means not weighted;


### PR DESCRIPTION
This fixes an `Unexpected indentation Error` in the docstring of `cohen_cappa_score`.
Found while building the docs.