### PR TITLE
DOC: Add section navigation to model_evaluation page (#30309)

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -6,6 +6,10 @@
 Metrics and scoring: quantifying the quality of predictions
 ===========================================================
 
+.. contents:: Section Navigation
+   :local:
+   :depth: 2
+
 .. _which_scoring_function:
 
 Which scoring function should I use?


### PR DESCRIPTION
This PR adds a ".. contents:: Section Navigation" directive to the model_evaluation.rst documentation page. This restores the sidebar navigation for improved readability and structure.

Fixes: #30309