### PR TITLE
TST: Fix test_plot_sets_title in ROC plot tests

### DIFF
--- a/sklearn/metrics/tests/test_plot_roc.py
+++ b/sklearn/metrics/tests/test_plot_roc.py
@@ -1,0 +1,15 @@
+import pytest
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.metrics import RocCurveDisplay
+
+def test_plot_sets_title():
+    fpr = np.array([0.0, 0.1, 0.2, 1.0])
+    tpr = np.array([0.0, 0.4, 0.8, 1.0])
+    display = RocCurveDisplay(fpr=fpr, tpr=tpr, roc_auc=0.85, name="Test")
+
+    fig, ax = plt.subplots()
+    title_text = "Custom ROC Title"
+    display.plot(ax=ax, title=title_text)
+
+    assert ax.get_title() == title_text


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This PR adds a unit test (`test_plot_sets_title`) to verify that the title is correctly set in ROC curve plots using `plot_roc_curve`.

- Ensures correct title rendering via Matplotlib.
- Adds test coverage for a critical visualization path.
- No impact on existing functionality.


#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
