### PR TITLE
MNT Add tags to GaussianMixture array API and precise them for PCA

### DIFF
--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -848,7 +848,10 @@ class PCA(_BasePCA):
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.transformer_tags.preserves_dtype = ["float64", "float32"]
-        tags.array_api_support = True
+        tags.array_api_support = (
+            self.svd_solver in ["full", "randomized"]
+            and self.power_iteration_normalizer == "QR"
+        )
         tags.input_tags.sparse = self.svd_solver in (
             "auto",
             "arpack",

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -992,3 +992,10 @@ class GaussianMixture(BaseMixture):
             The lower the better.
         """
         return -2 * self.score(X) * X.shape[0] + 2 * self._n_parameters()
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.array_api_support = (
+            self.init_params in ["random", "random_from_data"] and not self.warm_start
+        )
+        return tags


### PR DESCRIPTION
Follow-up of https://github.com/scikit-learn/scikit-learn/pull/30777#issuecomment-2991480918.

This is based on the info from the [doc](https://scikit-learn.org/dev/modules/array_api.html#estimators).