### PR TITLE
CI Use miniforge for wheel building [cd build]

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -170,6 +170,8 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v3
         if: ${{ startsWith(matrix.platform_id, 'macosx') }}
+        with:
+          miniforge-version: latest
 
       - name: Build and test wheels
         env:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/31789


#### What does this implement/fix? Explain your changes.
`miniconda` will [stop supporting MacOS x86 soon](https://www.anaconda.com/docs/getting-started/miniconda/release-notes#miniconda-25-5-1-1). Their [repo](https://repo.anaconda.com/miniconda/) does have `Miniconda3-latest-MacOSX-x86_64.sh`, so I suspect the CI error came from their repo not having the build yet.

Given our recent move to using `miniforge`, I think this is good to migrate in the wheel builder as well.


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
