### PR TITLE
Update multi_class deprecation to removal in 1.8

### DIFF
--- a/doc/whats_new/v1.5.rst
+++ b/doc/whats_new/v1.5.rst
@@ -503,7 +503,7 @@ Changelog
 
 - |API| Parameter `multi_class` was deprecated in
   :class:`linear_model.LogisticRegression` and
-  :class:`linear_model.LogisticRegressionCV`. `multi_class` will be removed in 1.7,
+  :class:`linear_model.LogisticRegressionCV`. `multi_class` will be removed in 1.8,
   and internally, for 3 and more classes, it will always use multinomial.
   If you still want to use the one-vs-rest scheme, you can use
   `OneVsRestClassifier(LogisticRegression(..))`.

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -990,7 +990,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
         .. versionchanged:: 0.22
             Default changed from 'ovr' to 'auto' in 0.22.
         .. deprecated:: 1.5
-           ``multi_class`` was deprecated in version 1.5 and will be removed in 1.7.
+           ``multi_class`` was deprecated in version 1.5 and will be removed in 1.8.
            From then on, the recommended 'multinomial' will always be used for
            `n_classes >= 3`.
            Solvers that do not support 'multinomial' will raise an error.
@@ -1262,7 +1262,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
             warnings.warn(
                 (
                     "'multi_class' was deprecated in version 1.5 and will be removed in"
-                    " 1.7. From then on, binary problems will be fit as proper binary "
+                    " 1.8. From then on, binary problems will be fit as proper binary "
                     " logistic regression models (as if multi_class='ovr' were set)."
                     " Leave it to its default value to avoid this warning."
                 ),
@@ -1272,7 +1272,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
             warnings.warn(
                 (
                     "'multi_class' was deprecated in version 1.5 and will be removed in"
-                    " 1.7. From then on, it will always use 'multinomial'."
+                    " 1.8. From then on, it will always use 'multinomial'."
                     " Leave it to its default value to avoid this warning."
                 ),
                 FutureWarning,
@@ -1281,7 +1281,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
             warnings.warn(
                 (
                     "'multi_class' was deprecated in version 1.5 and will be removed in"
-                    " 1.7. Use OneVsRestClassifier(LogisticRegression(..)) instead."
+                    " 1.8. Use OneVsRestClassifier(LogisticRegression(..)) instead."
                     " Leave it to its default value to avoid this warning."
                 ),
                 FutureWarning,
@@ -1678,7 +1678,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
         .. versionchanged:: 0.22
             Default changed from 'ovr' to 'auto' in 0.22.
         .. deprecated:: 1.5
-           ``multi_class`` was deprecated in version 1.5 and will be removed in 1.7.
+           ``multi_class`` was deprecated in version 1.5 and will be removed in 1.8.
            From then on, the recommended 'multinomial' will always be used for
            `n_classes >= 3`.
            Solvers that do not support 'multinomial' will raise an error.
@@ -1936,7 +1936,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
             warnings.warn(
                 (
                     "'multi_class' was deprecated in version 1.5 and will be removed in"
-                    " 1.7. From then on, binary problems will be fit as proper binary "
+                    " 1.8. From then on, binary problems will be fit as proper binary "
                     " logistic regression models (as if multi_class='ovr' were set)."
                     " Leave it to its default value to avoid this warning."
                 ),
@@ -1946,7 +1946,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
             warnings.warn(
                 (
                     "'multi_class' was deprecated in version 1.5 and will be removed in"
-                    " 1.7. From then on, it will always use 'multinomial'."
+                    " 1.8. From then on, it will always use 'multinomial'."
                     " Leave it to its default value to avoid this warning."
                 ),
                 FutureWarning,
@@ -1955,7 +1955,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
             warnings.warn(
                 (
                     "'multi_class' was deprecated in version 1.5 and will be removed in"
-                    " 1.7. Use OneVsRestClassifier(LogisticRegressionCV(..)) instead."
+                    " 1.8. Use OneVsRestClassifier(LogisticRegressionCV(..)) instead."
                     " Leave it to its default value to avoid this warning."
                 ),
                 FutureWarning,


### PR DESCRIPTION
## Update multi_class deprecation note in LogisticRegression to removal in 1.8

### Summary

This PR updates the deprecation note for the `multi_class` parameter in `LogisticRegression` to state that it will be removed in version 1.8, not 1.7. This aligns the documentation with the actual removal schedule as reflected in [PR #31241](https://github.com/scikit-learn/scikit-learn/pull/31241) and ongoing development discussions.

### Changes

- Updated the deprecation note in `sklearn/linear_model/_logistic.py` to indicate removal in 1.8.
- Updated the changelog in `doc/whats_new/v1.5.rst` to reflect the correct removal version.

### Motivation

The documentation previously mentioned that `multi_class` would be removed in version 1.7. However, per [PR #31241](https://github.com/scikit-learn/scikit-learn/pull/31241), the removal is scheduled for version 1.8. This PR corrects the documentation to avoid confusion.

### Related Issues and PRs

- Fixes #31781
- See also: [PR #31241](https://github.com/scikit-learn/scikit-learn/pull/31241)
