### PR TITLE
Fix empty column check in ColumnTransformer to be compatible with pandas>=3

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -1346,6 +1346,7 @@ def _is_empty_column_selection(column):
     """
     if (
         hasattr(column, "dtype")
+        # Not necessarily a numpy dtype, can be a pandas dtype as well
         and isinstance(column.dtype, np.dtype)
         and np.issubdtype(column.dtype, np.bool_)
     ):

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -1344,7 +1344,11 @@ def _is_empty_column_selection(column):
     boolean array).
 
     """
-    if hasattr(column, "dtype") and np.issubdtype(column.dtype, np.bool_):
+    if (
+        hasattr(column, "dtype")
+        and isinstance(column.dtype, np.dtype)
+        and np.issubdtype(column.dtype, np.bool_)
+    ):
         return not column.any()
     elif hasattr(column, "__len__"):
         return len(column) == 0 or (

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1402,7 +1402,7 @@ def test_make_column_selector_with_select_dtypes(cols, pattern, include, exclude
         {
             "col_int": np.array([0, 1, 2], dtype=int),
             "col_float": np.array([0.0, 1.0, 2.0], dtype=float),
-            "col_str": pd.Series(["one", "two", "three"], dtype=object),
+            "col_str": ["one", "two", "three"],
         },
         columns=["col_int", "col_float", "col_str"],
     )

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1397,7 +1397,7 @@ def test_make_column_selector_with_select_dtypes(cols, pattern, include, exclude
         {
             "col_int": np.array([0, 1, 2], dtype=int),
             "col_float": np.array([0.0, 1.0, 2.0], dtype=float),
-            "col_str": ["one", "two", "three"],
+            "col_str": pd.Series(["one", "two", "three"], dtype=object),
         },
         columns=["col_int", "col_float", "col_str"],
     )
@@ -1423,7 +1423,7 @@ def test_column_transformer_with_make_column_selector():
     )
     X_df["col_str"] = X_df["col_str"].astype("category")
 
-    cat_selector = make_column_selector(dtype_include=["category", object])
+    cat_selector = make_column_selector(dtype_include=["category", object, "str"])
     num_selector = make_column_selector(dtype_include=np.number)
 
     ohe = OneHotEncoder()

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1376,10 +1376,10 @@ def test_n_features_in():
     "cols, pattern, include, exclude",
     [
         (["col_int", "col_float"], None, np.number, None),
-        (["col_int", "col_float"], None, None, object),
+        (["col_int", "col_float"], None, None, [object, "string"]),
         (["col_int", "col_float"], None, [int, float], None),
-        (["col_str"], None, [object], None),
-        (["col_str"], None, object, None),
+        (["col_str"], None, [object, "string"], None),
+        (["col_float"], None, [float], None),
         (["col_float"], None, float, None),
         (["col_float"], "at$", [np.number], None),
         (["col_int"], None, [int], None),
@@ -1387,7 +1387,12 @@ def test_n_features_in():
         (["col_float", "col_str"], "float|str", None, None),
         (["col_str"], "^col_s", None, [int]),
         ([], "str$", float, None),
-        (["col_int", "col_float", "col_str"], None, [np.number, object], None),
+        (
+            ["col_int", "col_float", "col_str"],
+            None,
+            [np.number, object, "string"],
+            None,
+        ),
     ],
 )
 def test_make_column_selector_with_select_dtypes(cols, pattern, include, exclude):

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1423,7 +1423,7 @@ def test_column_transformer_with_make_column_selector():
     )
     X_df["col_str"] = X_df["col_str"].astype("category")
 
-    cat_selector = make_column_selector(dtype_include=["category", object, "str"])
+    cat_selector = make_column_selector(dtype_include=["category", object, "string"])
     num_selector = make_column_selector(dtype_include=np.number)
 
     ohe = OneHotEncoder()

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -200,7 +200,9 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
             # Dataframes can have multiple dtypes
             dtypes = X.dtypes
 
-        if not all(np.issubdtype(d, np.number) for d in dtypes):
+        if not all(
+            isinstance(d, np.dtype) and np.issubdtype(d, np.number) for d in dtypes
+        ):
             raise ValueError(
                 "'check_inverse' is only supported when all the elements in `X` is"
                 " numerical."

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -200,6 +200,7 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
             # Dataframes can have multiple dtypes
             dtypes = X.dtypes
 
+        # Not all dtypes are numpy dtypes, they can be pandas dtypes as well
         if not all(
             isinstance(d, np.dtype) and np.issubdtype(d, np.number) for d in dtypes
         ):

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -788,7 +788,7 @@ def test_encoder_dtypes_pandas():
     assert_array_equal(enc.transform(X).toarray(), exp)
 
     X = pd.DataFrame({"A": [1, 2], "B": ["a", "b"], "C": [3.0, 4.0]})
-    X_type = [X["A"].dtype, X["B"].dtype, X["C"].dtype]
+    X_type = ["int64", "object", "float64"]
     enc.fit(X)
     assert all([enc.categories_[i].dtype == X_type[i] for i in range(3)])
     assert_array_equal(enc.transform(X).toarray(), exp)

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -788,7 +788,7 @@ def test_encoder_dtypes_pandas():
     assert_array_equal(enc.transform(X).toarray(), exp)
 
     X = pd.DataFrame({"A": [1, 2], "B": ["a", "b"], "C": [3.0, 4.0]})
-    X_type = ["int64", "object", "float64"]
+    expected_cat_type = ["int64", "object", "float64"]
     enc.fit(X)
     assert all([enc.categories_[i].dtype == X_type[i] for i in range(3)])
     assert_array_equal(enc.transform(X).toarray(), exp)

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -790,7 +790,7 @@ def test_encoder_dtypes_pandas():
     X = pd.DataFrame({"A": [1, 2], "B": ["a", "b"], "C": [3.0, 4.0]})
     expected_cat_type = ["int64", "object", "float64"]
     enc.fit(X)
-    assert all([enc.categories_[i].dtype == X_type[i] for i in range(3)])
+    assert all([enc.categories_[i].dtype == expected_cat_type[i] for i in range(3)])
     assert_array_equal(enc.transform(X).toarray(), exp)
 
 


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses failures with nightly pandas as noticed in https://github.com/scikit-learn/scikit-learn/pull/31800. See also for more context https://github.com/pandas-dev/pandas/issues/61915

#### What does this implement/fix? Explain your changes.

The upcoming pandas 3.0 release will feature a default string dtype (see https://pandas.pydata.org/docs/dev/whatsnew/v2.3.0.html#upcoming-changes-in-pandas-3-0 for more context), which will be used instead of the current use of `object` numpy dtype for string data. 
This string dtype will be a pandas extension dtype and not longer a numpy dtype (and no longer numpy's `object` dtype, specifically), and this has some potential for behaviour changes when handling the dtype objects.

In general scikit-learn is already equipped to handle pandas extension dtypes (eg to handle categorical data, or to handle the nullable numeric data types in the validation code), but this uncovers some remaining cases (and quite likely there might be some more not covered by tests).

