### PR TITLE
DOC: Fix assume_centered parameter documentation in EmpiricalCovariance

### DIFF
--- a/doc/modules/covariance.rst
+++ b/doc/modules/covariance.rst
@@ -35,9 +35,9 @@ The empirical covariance matrix of a sample can be computed using the
 :class:`EmpiricalCovariance` object to the data sample with the
 :meth:`EmpiricalCovariance.fit` method. Be careful that results depend
 on whether the data are centered, so one may want to use the
-``assume_centered`` parameter accurately. More precisely, if 
-``assume_centered=True``, then all features in `X` should have a mean of zero. 
-If not, the data should be centered by the user, or `assume_centered=False` should be used.
+`assume_centered` parameter accurately. More precisely, if `assume_centered=True`, then
+all features in the train and test sets should have a mean of zero. If not, both should
+be centered by the user, or `assume_centered=False` should be used.
 
 .. rubric:: Examples
 

--- a/doc/modules/covariance.rst
+++ b/doc/modules/covariance.rst
@@ -35,10 +35,9 @@ The empirical covariance matrix of a sample can be computed using the
 :class:`EmpiricalCovariance` object to the data sample with the
 :meth:`EmpiricalCovariance.fit` method. Be careful that results depend
 on whether the data are centered, so one may want to use the
-``assume_centered`` parameter accurately. More precisely, if
-``assume_centered=False``, then the test set is supposed to have the
-same mean vector as the training set. If not, both should be centered
-by the user, and ``assume_centered=True`` should be used.
+``assume_centered`` parameter accurately. More precisely, if 
+``assume_centered=True``, then all features in `X` should have a mean of zero. 
+If not, the data should be centered by the user, or `assume_centered=False` should be used.
 
 .. rubric:: Examples
 


### PR DESCRIPTION
DOC: Fix assume_centered parameter documentation in EmpiricalCovariance

Corrected backwards logic in user guide documentation.
- assume_centered=True requires pre-centered data  
- assume_centered=False handles centering automatically

Fixes #31705

#### Reference Issues/PRs
Fixes #31705

#### What does this implement/fix? Explain your changes.
The user guide documentation for EmpiricalCovariance had backwards logic for the `assume_centered` parameter. The original text incorrectly stated that `assume_centered=False` required pre-centered data, when it actually handles centering automatically. This fix corrects the documentation to accurately describe the parameter behavior.

#### Any other comments?
This is a straightforward documentation fix that aligns the user guide with the actual parameter behavior, addressing the confusion identified in issue #31705.