### PR TITLE
CI Use venv rather than virtualenv

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -34,13 +34,13 @@ pre_python_environment_install() {
     if [[ "$DISTRIB" == "ubuntu" ]]; then
         sudo apt-get update
         sudo apt-get install python3-scipy python3-matplotlib \
-             libatlas3-base libatlas-base-dev python3-virtualenv ccache
+             libatlas3-base libatlas-base-dev python3-venv ccache
 
     elif [[ "$DISTRIB" == "debian-32" ]]; then
         apt-get update
         apt-get install -y python3-dev python3-numpy python3-scipy \
                 python3-matplotlib libopenblas-dev \
-                python3-virtualenv python3-pandas ccache git
+                python3-venv python3-pandas ccache git
     fi
 }
 
@@ -60,7 +60,7 @@ python_environment_install_and_activate() {
         activate_environment
 
     elif [[ "$DISTRIB" == "ubuntu" || "$DISTRIB" == "debian-32" ]]; then
-        python3 -m virtualenv --system-site-packages --python=python3 $VIRTUALENV
+        python3 -m venv --system-site-packages $VIRTUALENV
         activate_environment
         pip install -r "${LOCK_FILE}"
 


### PR DESCRIPTION
I guess this was historically used because of Python 2 support (`venv` is Python 3.3+)? A more detailed comparison [here](https://virtualenv.pypa.io/en/latest/#virtualenv-vs-venv).