### PR TITLE
CI Fix Azure install.sh bash regex match

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -47,7 +47,7 @@ pre_python_environment_install() {
 check_packages_dev_version() {
     for package in $@; do
         package_version=$(python -c "import $package; print($package.__version__)")
-        if [[ $package_version =~ "^[.0-9]+$" ]]; then
+        if [[ $package_version =~ ^[.0-9]+$ ]]; then
             echo "$package is not a development version: $package_version"
             exit 1
         fi


### PR DESCRIPTION
rhs needs to be without quotes for bash regex to actually work (quoted and unquoted works in zsh :shrug:).

```
bash-5.3$ package_version=3.4; if [[ $package_version =~ "^[.0-9]+$" ]]; then echo yes; fi
bash-5.3$ package_version=3.4; if [[ $package_version =~ ^[.0-9]+$ ]]; then echo yes; fi
yes
```

The impact was that the [check](https://github.com/scikit-learn/scikit-learn/blob/30eb7627247053b6f3b1019e37704bf3171b8bfe/build_tools/azure/install.sh#L76) to make sure that dev packages were used in scipy-dev was actually not checking anything.

The check seems to work in the CI [build log](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=78414&view=logs&j=dfe99b15-50db-5d7b-b1e9-4105c42527cf&t=eb5122d5-ab7e-5479-a8ce-245b4d64938b&l=377) [^1]

[^1]: scipy-dev is currently broken on `main` for a different reason