### PR TITLE
MNT Consistently use relative imports

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -12,8 +12,6 @@ import numpy as np
 from scipy.optimize import minimize
 from scipy.special import expit
 
-from sklearn.utils import Bunch
-
 from ._loss import HalfBinomialLoss
 from .base import (
     BaseEstimator,
@@ -28,7 +26,7 @@ from .isotonic import IsotonicRegression
 from .model_selection import LeaveOneOut, check_cv, cross_val_predict
 from .preprocessing import LabelEncoder, label_binarize
 from .svm import LinearSVC
-from .utils import _safe_indexing, column_or_1d, get_tags, indexable
+from .utils import _safe_indexing, column_or_1d, get_tags, indexable, Bunch
 from .utils._param_validation import (
     HasMethods,
     Hidden,

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -26,7 +26,7 @@ from .isotonic import IsotonicRegression
 from .model_selection import LeaveOneOut, check_cv, cross_val_predict
 from .preprocessing import LabelEncoder, label_binarize
 from .svm import LinearSVC
-from .utils import _safe_indexing, column_or_1d, get_tags, indexable, Bunch
+from .utils import Bunch, _safe_indexing, column_or_1d, get_tags, indexable
 from .utils._param_validation import (
     HasMethods,
     Hidden,

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -12,12 +12,10 @@ import warnings
 import numpy as np
 from scipy import linalg
 
-from sklearn.utils import metadata_routing
-
 from .. import config_context
 from ..base import BaseEstimator, _fit_context
 from ..metrics.pairwise import pairwise_distances
-from ..utils import check_array
+from ..utils import check_array, metadata_routing
 from ..utils._param_validation import validate_params
 from ..utils.extmath import fast_logdet
 from ..utils.validation import validate_data

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -15,7 +15,7 @@ import scipy.sparse as sp
 from scipy import linalg
 
 from ..preprocessing import MultiLabelBinarizer
-from ..utils import check_array, check_random_state, Bunch
+from ..utils import Bunch, check_array, check_random_state
 from ..utils import shuffle as util_shuffle
 from ..utils._param_validation import Interval, StrOptions, validate_params
 from ..utils.random import sample_without_replacement

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -14,10 +14,8 @@ import numpy as np
 import scipy.sparse as sp
 from scipy import linalg
 
-from sklearn.utils import Bunch
-
 from ..preprocessing import MultiLabelBinarizer
-from ..utils import check_array, check_random_state
+from ..utils import check_array, check_random_state, Bunch
 from ..utils import shuffle as util_shuffle
 from ..utils._param_validation import Interval, StrOptions, validate_params
 from ..utils.random import sample_without_replacement

--- a/sklearn/decomposition/_incremental_pca.py
+++ b/sklearn/decomposition/_incremental_pca.py
@@ -8,10 +8,8 @@ from numbers import Integral
 import numpy as np
 from scipy import linalg, sparse
 
-from sklearn.utils import metadata_routing
-
 from ..base import _fit_context
-from ..utils import gen_batches
+from ..utils import gen_batches, metadata_routing
 from ..utils._param_validation import Interval
 from ..utils.extmath import _incremental_mean_and_var, svd_flip
 from ..utils.validation import validate_data

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -14,8 +14,7 @@ from timeit import default_timer as time
 
 import numpy as np
 
-from sklearn.utils._openmp_helpers import _openmp_effective_n_threads
-
+from ...utils._openmp_helpers import _openmp_effective_n_threads
 from ._bitset import set_raw_bitset_from_binned_bitset
 from .common import (
     PREDICTOR_RECORD_DTYPE,

--- a/sklearn/feature_extraction/_dict_vectorizer.py
+++ b/sklearn/feature_extraction/_dict_vectorizer.py
@@ -9,10 +9,8 @@ from operator import itemgetter
 import numpy as np
 import scipy.sparse as sp
 
-from sklearn.utils import metadata_routing
-
 from ..base import BaseEstimator, TransformerMixin, _fit_context
-from ..utils import check_array
+from ..utils import check_array, metadata_routing
 from ..utils.validation import check_is_fitted
 
 

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -7,9 +7,8 @@ from numbers import Integral
 import numpy as np
 import scipy.sparse as sp
 
-from sklearn.utils import metadata_routing
-
 from ..base import BaseEstimator, TransformerMixin, _fit_context
+from ..utils import metadata_routing
 from ..utils._param_validation import Interval, StrOptions
 from ._hashing_fast import transform as _hashing_transform
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -16,11 +16,10 @@ from operator import itemgetter
 import numpy as np
 import scipy.sparse as sp
 
-from sklearn.utils import metadata_routing
-
 from ..base import BaseEstimator, OneToOneFeatureMixin, TransformerMixin, _fit_context
 from ..exceptions import NotFittedError
 from ..preprocessing import normalize
+from ..utils import metadata_routing
 from ..utils._param_validation import HasMethods, Interval, RealNotInt, StrOptions
 from ..utils.fixes import _IS_32BIT
 from ..utils.validation import FLOAT_DTYPES, check_array, check_is_fitted, validate_data

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -11,11 +11,9 @@ import numpy as np
 from scipy import interpolate, optimize
 from scipy.stats import spearmanr
 
-from sklearn.utils import metadata_routing
-
 from ._isotonic import _inplace_contiguous_isotonic_regression, _make_unique
 from .base import BaseEstimator, RegressorMixin, TransformerMixin, _fit_context
-from .utils import check_array, check_consistent_length
+from .utils import check_array, check_consistent_length, metadata_routing
 from .utils._param_validation import Interval, StrOptions, validate_params
 from .utils.fixes import parse_version, sp_base_version
 from .utils.validation import _check_sample_weight, check_is_fitted

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -12,11 +12,9 @@ import numpy as np
 from joblib import effective_n_jobs
 from scipy import sparse
 
-from sklearn.utils import metadata_routing
-
 from ..base import MultiOutputMixin, RegressorMixin, _fit_context
 from ..model_selection import check_cv
-from ..utils import Bunch, check_array, check_scalar
+from ..utils import Bunch, check_array, check_scalar, metadata_routing
 from ..utils._metadata_requests import (
     MetadataRouter,
     MethodMapping,

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -13,11 +13,9 @@ import numpy as np
 from joblib import effective_n_jobs
 from scipy import optimize
 
-from sklearn.metrics import get_scorer_names
-
 from .._loss.loss import HalfBinomialLoss, HalfMultinomialLoss
 from ..base import _fit_context
-from ..metrics import get_scorer
+from ..metrics import get_scorer, get_scorer_names
 from ..model_selection import check_cv
 from ..preprocessing import LabelBinarizer, LabelEncoder
 from ..svm._base import _fit_liblinear

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -15,7 +15,13 @@ import numpy as np
 from scipy import linalg, optimize, sparse
 from scipy.sparse import linalg as sp_linalg
 
-from ..base import MultiOutputMixin, RegressorMixin, _fit_context, is_classifier, BaseEstimator
+from ..base import (
+    BaseEstimator,
+    MultiOutputMixin,
+    RegressorMixin,
+    _fit_context,
+    is_classifier,
+)
 from ..exceptions import ConvergenceWarning
 from ..metrics import check_scoring, get_scorer_names
 from ..model_selection import GridSearchCV

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -15,9 +15,7 @@ import numpy as np
 from scipy import linalg, optimize, sparse
 from scipy.sparse import linalg as sp_linalg
 
-from sklearn.base import BaseEstimator
-
-from ..base import MultiOutputMixin, RegressorMixin, _fit_context, is_classifier
+from ..base import MultiOutputMixin, RegressorMixin, _fit_context, is_classifier, BaseEstimator
 from ..exceptions import ConvergenceWarning
 from ..metrics import check_scoring, get_scorer_names
 from ..model_selection import GridSearchCV

--- a/sklearn/metrics/_pairwise_distances_reduction/_base.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_base.pyx.tp
@@ -3,16 +3,17 @@ from cython.operator cimport dereference as deref
 from cython.parallel cimport parallel, prange
 from libcpp.vector cimport vector
 
+from numbers import Integral
+
+import numpy as np
+from scipy.sparse import issparse
+
 from ...utils._cython_blas cimport _dot
 from ...utils._openmp_helpers cimport omp_get_thread_num
 from ...utils._typedefs cimport intp_t, float32_t, float64_t, int32_t
 
-import numpy as np
-
-from scipy.sparse import issparse
-from numbers import Integral
-from sklearn import get_config
-from sklearn.utils import check_scalar
+from ... import get_config
+from ...utils import check_scalar
 from ...utils._openmp_helpers import _openmp_effective_n_threads
 
 #####################

--- a/sklearn/neighbors/_binary_tree.pxi.tp
+++ b/sklearn/neighbors/_binary_tree.pxi.tp
@@ -166,7 +166,6 @@ from libc.string cimport memcpy
 
 import numpy as np
 import warnings
-
 from ..metrics._dist_metrics cimport (
     DistanceMetric,
     DistanceMetric64,
@@ -181,6 +180,7 @@ from ..metrics._dist_metrics cimport (
 
 from ._partition_nodes cimport partition_node_indices
 
+from ..metrics._dist_metrics import get_valid_metric_ids
 from ..utils import check_array
 from ..utils._typedefs cimport float32_t, float64_t, intp_t
 from ..utils._heap cimport heap_push
@@ -788,7 +788,6 @@ def newObj(obj):
 
 ######################################################################
 # define the reverse mapping of VALID_METRICS{{name_suffix}}
-from sklearn.metrics._dist_metrics import get_valid_metric_ids
 VALID_METRIC_IDS{{name_suffix}} = get_valid_metric_ids(VALID_METRICS{{name_suffix}})
 
 

--- a/sklearn/neighbors/_classification.py
+++ b/sklearn/neighbors/_classification.py
@@ -8,8 +8,6 @@ from numbers import Integral
 
 import numpy as np
 
-from sklearn.neighbors._base import _check_precomputed
-
 from ..base import ClassifierMixin, _fit_context
 from ..metrics._pairwise_distances_reduction import (
     ArgKminClassMode,
@@ -25,7 +23,7 @@ from ..utils.validation import (
     check_is_fitted,
     validate_data,
 )
-from ._base import KNeighborsMixin, NeighborsBase, RadiusNeighborsMixin, _get_weights
+from ._base import KNeighborsMixin, NeighborsBase, RadiusNeighborsMixin, _get_weights, _check_precomputed
 
 
 def _adjusted_metric(metric, metric_kwargs, p=None):

--- a/sklearn/neighbors/_classification.py
+++ b/sklearn/neighbors/_classification.py
@@ -23,7 +23,13 @@ from ..utils.validation import (
     check_is_fitted,
     validate_data,
 )
-from ._base import KNeighborsMixin, NeighborsBase, RadiusNeighborsMixin, _get_weights, _check_precomputed
+from ._base import (
+    KNeighborsMixin,
+    NeighborsBase,
+    RadiusNeighborsMixin,
+    _check_precomputed,
+    _get_weights,
+)
 
 
 def _adjusted_metric(metric, metric_kwargs, p=None):

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -16,7 +16,7 @@ from ..base import (
     TransformerMixin,
     _fit_context,
 )
-from ..utils import _array_api, check_array, resample, metadata_routing
+from ..utils import _array_api, check_array, metadata_routing, resample
 from ..utils._array_api import (
     _find_matching_floating_dtype,
     _modify_in_place_if_numpy,

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -9,8 +9,6 @@ import numpy as np
 from scipy import sparse, stats
 from scipy.special import boxcox, inv_boxcox
 
-from sklearn.utils import metadata_routing
-
 from ..base import (
     BaseEstimator,
     ClassNamePrefixFeaturesOutMixin,
@@ -18,7 +16,7 @@ from ..base import (
     TransformerMixin,
     _fit_context,
 )
-from ..utils import _array_api, check_array, resample
+from ..utils import _array_api, check_array, resample, metadata_routing
 from ..utils._array_api import (
     _find_matching_floating_dtype,
     _modify_in_place_if_numpy,

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -15,14 +15,13 @@ from scipy import sparse
 from scipy.interpolate import BSpline
 from scipy.special import comb
 
-from sklearn.utils._array_api import (
+from ..base import BaseEstimator, TransformerMixin, _fit_context
+from ..utils import check_array
+from ..utils._array_api import (
     _is_numpy_namespace,
     get_namespace_and_device,
     supported_float_dtypes,
 )
-
-from ..base import BaseEstimator, TransformerMixin, _fit_context
-from ..utils import check_array
 from ..utils._mask import _get_mask
 from ..utils._param_validation import Interval, StrOptions
 from ..utils.fixes import parse_version, sp_version

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -15,8 +15,6 @@ from numbers import Integral, Real
 import numpy as np
 from scipy.sparse import issparse
 
-from sklearn.utils import metadata_routing
-
 from ..base import (
     BaseEstimator,
     ClassifierMixin,
@@ -26,7 +24,7 @@ from ..base import (
     clone,
     is_classifier,
 )
-from ..utils import Bunch, check_random_state, compute_sample_weight
+from ..utils import Bunch, check_random_state, compute_sample_weight, metadata_routing
 from ..utils._param_validation import Hidden, Interval, RealNotInt, StrOptions
 from ..utils.multiclass import check_classification_targets
 from ..utils.validation import (

--- a/sklearn/utils/_indexing.py
+++ b/sklearn/utils/_indexing.py
@@ -10,11 +10,10 @@ from itertools import compress, islice
 import numpy as np
 from scipy.sparse import issparse
 
-from sklearn.utils.fixes import PYARROW_VERSION_BELOW_17
-
 from ._array_api import _is_numpy_namespace, get_namespace
 from ._param_validation import Interval, validate_params
 from .extmath import _approximate_mode
+from .fixes import PYARROW_VERSION_BELOW_17
 from .validation import (
     _check_sample_weight,
     _is_arraylike_not_scalar,

--- a/sklearn/utils/_repr_html/params.py
+++ b/sklearn/utils/_repr_html/params.py
@@ -5,7 +5,7 @@ import html
 import reprlib
 from collections import UserDict
 
-from sklearn.utils._repr_html.base import ReprHTMLMixin
+from .base import ReprHTMLMixin
 
 
 def _read_params(name, value, non_default_params):

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -8,9 +8,9 @@ from contextlib import suppress
 from functools import partial
 from inspect import isfunction
 
-from sklearn import clone, config_context
-from sklearn.calibration import CalibratedClassifierCV
-from sklearn.cluster import (
+from ... import clone, config_context
+from ...calibration import CalibratedClassifierCV
+from ...cluster import (
     HDBSCAN,
     AffinityPropagation,
     AgglomerativeClustering,
@@ -24,10 +24,10 @@ from sklearn.cluster import (
     SpectralClustering,
     SpectralCoclustering,
 )
-from sklearn.compose import ColumnTransformer
-from sklearn.covariance import GraphicalLasso, GraphicalLassoCV
-from sklearn.cross_decomposition import CCA, PLSSVD, PLSCanonical, PLSRegression
-from sklearn.decomposition import (
+from ...compose import ColumnTransformer
+from ...covariance import GraphicalLasso, GraphicalLassoCV
+from ...cross_decomposition import CCA, PLSSVD, PLSCanonical, PLSRegression
+from ...decomposition import (
     NMF,
     PCA,
     DictionaryLearning,
@@ -43,9 +43,9 @@ from sklearn.decomposition import (
     SparsePCA,
     TruncatedSVD,
 )
-from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
-from sklearn.dummy import DummyClassifier
-from sklearn.ensemble import (
+from ...discriminant_analysis import LinearDiscriminantAnalysis
+from ...dummy import DummyClassifier
+from ...ensemble import (
     AdaBoostClassifier,
     AdaBoostRegressor,
     BaggingClassifier,
@@ -65,9 +65,9 @@ from sklearn.ensemble import (
     VotingClassifier,
     VotingRegressor,
 )
-from sklearn.exceptions import SkipTestWarning
-from sklearn.experimental import enable_halving_search_cv  # noqa: F401
-from sklearn.feature_selection import (
+from ...exceptions import SkipTestWarning
+from ...experimental import enable_halving_search_cv  # noqa: F401
+from ...feature_selection import (
     RFE,
     RFECV,
     SelectFdr,
@@ -75,14 +75,14 @@ from sklearn.feature_selection import (
     SelectKBest,
     SequentialFeatureSelector,
 )
-from sklearn.frozen import FrozenEstimator
-from sklearn.kernel_approximation import (
+from ...frozen import FrozenEstimator
+from ...kernel_approximation import (
     Nystroem,
     PolynomialCountSketch,
     RBFSampler,
     SkewedChi2Sampler,
 )
-from sklearn.linear_model import (
+from ...linear_model import (
     ARDRegression,
     BayesianRidge,
     ElasticNet,
@@ -117,15 +117,15 @@ from sklearn.linear_model import (
     TheilSenRegressor,
     TweedieRegressor,
 )
-from sklearn.manifold import (
+from ...manifold import (
     MDS,
     TSNE,
     Isomap,
     LocallyLinearEmbedding,
     SpectralEmbedding,
 )
-from sklearn.mixture import BayesianGaussianMixture, GaussianMixture
-from sklearn.model_selection import (
+from ...mixture import BayesianGaussianMixture, GaussianMixture
+from ...model_selection import (
     FixedThresholdClassifier,
     GridSearchCV,
     HalvingGridSearchCV,
@@ -133,18 +133,18 @@ from sklearn.model_selection import (
     RandomizedSearchCV,
     TunedThresholdClassifierCV,
 )
-from sklearn.multiclass import (
+from ...multiclass import (
     OneVsOneClassifier,
     OneVsRestClassifier,
     OutputCodeClassifier,
 )
-from sklearn.multioutput import (
+from ...multioutput import (
     ClassifierChain,
     MultiOutputClassifier,
     MultiOutputRegressor,
     RegressorChain,
 )
-from sklearn.neighbors import (
+from ...neighbors import (
     KernelDensity,
     KNeighborsClassifier,
     KNeighborsRegressor,
@@ -152,30 +152,30 @@ from sklearn.neighbors import (
     NeighborhoodComponentsAnalysis,
     RadiusNeighborsTransformer,
 )
-from sklearn.neural_network import BernoulliRBM, MLPClassifier, MLPRegressor
-from sklearn.pipeline import FeatureUnion, Pipeline
-from sklearn.preprocessing import (
+from ...neural_network import BernoulliRBM, MLPClassifier, MLPRegressor
+from ...pipeline import FeatureUnion, Pipeline
+from ...preprocessing import (
     KBinsDiscretizer,
     OneHotEncoder,
     SplineTransformer,
     StandardScaler,
     TargetEncoder,
 )
-from sklearn.random_projection import (
+from ...random_projection import (
     GaussianRandomProjection,
     SparseRandomProjection,
 )
-from sklearn.semi_supervised import (
+from ...semi_supervised import (
     LabelPropagation,
     LabelSpreading,
     SelfTrainingClassifier,
 )
-from sklearn.svm import SVC, SVR, LinearSVC, LinearSVR, NuSVC, NuSVR, OneClassSVM
-from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
-from sklearn.utils import all_estimators
-from sklearn.utils._tags import get_tags
-from sklearn.utils._testing import SkipTest
-from sklearn.utils.fixes import _IS_32BIT, parse_version, sp_base_version
+from ...svm import SVC, SVR, LinearSVC, LinearSVR, NuSVC, NuSVR, OneClassSVM
+from ...tree import DecisionTreeClassifier, DecisionTreeRegressor
+from .. import all_estimators
+from .._tags import get_tags
+from .._testing import SkipTest
+from ..fixes import _IS_32BIT, parse_version, sp_base_version
 
 CROSS_DECOMPOSITION = ["PLSCanonical", "PLSRegression", "CCA", "PLSSVD"]
 

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -37,22 +37,22 @@ from numpy.testing import (
     assert_array_less,
 )
 
-import sklearn
-from sklearn.utils import (
+from .. import __file__ as sklearn_path
+from . import (
     ClassifierTags,
     RegressorTags,
     Tags,
     TargetTags,
     TransformerTags,
 )
-from sklearn.utils._array_api import _check_array_api_dispatch
-from sklearn.utils.fixes import (
+from ._array_api import _check_array_api_dispatch
+from .fixes import (
     _IS_32BIT,
     VisibleDeprecationWarning,
     _in_unstable_openblas_configuration,
 )
-from sklearn.utils.multiclass import check_classification_targets
-from sklearn.utils.validation import (
+from .multiclass import check_classification_targets
+from .validation import (
     check_array,
     check_is_fitted,
     check_X_y,
@@ -927,7 +927,7 @@ def assert_run_python_script_without_output(source_code, pattern=".+", timeout=6
         with open(source_file, "wb") as f:
             f.write(source_code.encode("utf-8"))
         cmd = [sys.executable, source_file]
-        cwd = op.normpath(op.join(op.dirname(sklearn.__file__), ".."))
+        cwd = op.normpath(op.join(op.dirname(sklearn_path), ".."))
         env = os.environ.copy()
         try:
             env["PYTHONPATH"] = os.pathsep.join([cwd, env["PYTHONPATH"]])

--- a/sklearn/utils/_unique.py
+++ b/sklearn/utils/_unique.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 
-from sklearn.utils._array_api import get_namespace
+from ._array_api import get_namespace
 
 
 def _attach_unique(y):

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -20,7 +20,9 @@ import numpy as np
 from scipy import sparse
 from scipy.stats import rankdata
 
-from sklearn.base import (
+from .. import config_context
+from ..base import (
+    ClusterMixin,
     BaseEstimator,
     BiclusterMixin,
     ClassifierMixin,
@@ -32,11 +34,6 @@ from sklearn.base import (
     OutlierMixin,
     RegressorMixin,
     TransformerMixin,
-)
-
-from .. import config_context
-from ..base import (
-    ClusterMixin,
     clone,
     is_classifier,
     is_outlier_detector,

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -22,11 +22,11 @@ from scipy.stats import rankdata
 
 from .. import config_context
 from ..base import (
-    ClusterMixin,
     BaseEstimator,
     BiclusterMixin,
     ClassifierMixin,
     ClassNamePrefixFeaturesOutMixin,
+    ClusterMixin,
     DensityMixin,
     MetaEstimatorMixin,
     MultiOutputMixin,


### PR DESCRIPTION
Our convention is usually to use relative imports. During a review I noticed an absolute import within sklearn so I looked around and found a bunch of these throughout the code base.

I left absolute imports in `sklearn/conftest.py` for now because I'm not sure what the impact of using relative imports there would be. Will check later.

`utils._testing.py` and `utils.estimator_checks` were using only absolute imports. I believe it was so because we use absolute imports for the tests. But they are not test files, just tools in utils that we use in the tests. So I turned them into relative imports. I didn't notice any issue with that, but I might have missed something. Curious to know if there was a reason to use absolute imports there.