### PR TITLE
Corrected broken link in documentation

### DIFF
--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -78,7 +78,7 @@ Classification
 ==============
 
 Class :class:`MLPClassifier` implements a multi-layer perceptron (MLP) algorithm
-that trains using `Backpropagation <http://ufldl.stanford.edu/tutorial/supervised/MultiLayerNeuralNetworks/>`_.
+that trains using `Backpropagation <http://ufldl.stanford.edu/tutorial/supervised/MultiLayerNeuralNetworks/#backpropagation_algorithm>`_.
 
 MLP trains on two arrays: array X of size (n_samples, n_features), which holds
 the training samples represented as floating point feature vectors; and array

--- a/doc/modules/neural_networks_supervised.rst
+++ b/doc/modules/neural_networks_supervised.rst
@@ -78,7 +78,7 @@ Classification
 ==============
 
 Class :class:`MLPClassifier` implements a multi-layer perceptron (MLP) algorithm
-that trains using `Backpropagation <http://ufldl.stanford.edu/wiki/index.php/Backpropagation_Algorithm>`_.
+that trains using `Backpropagation <http://ufldl.stanford.edu/tutorial/supervised/MultiLayerNeuralNetworks/>`_.
 
 MLP trains on two arrays: array X of size (n_samples, n_features), which holds
 the training samples represented as floating point feature vectors; and array


### PR DESCRIPTION
[Documentation on "Backpropagation"](https://scikit-learn.org/stable/modules/neural_networks_supervised.html#classification) links to [http://ufldl.stanford.edu/wiki/index.php/Backpropagation_Algorithm](http://ufldl.stanford.edu/wiki/index.php/Backpropagation_Algorithm) which is broken (403 Forbidden - You don't have permission to access /wiki/index.php/Backpropagation_Algorithm on this server). Replacing with working link [http://ufldl.stanford.edu/tutorial/supervised/MultiLayerNeuralNetworks/ ](http://ufldl.stanford.edu/tutorial/supervised/MultiLayerNeuralNetworks/)

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
Existing link in documentation is broken - replacing with functioning link for the same resource.

#### Any other comments?
