### PR TITLE
MNT/DOC Raise for `**fit_params` in `fit_transform` if not expected by `fit`

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -889,6 +889,7 @@ class TransformerMixin(_SetOutputMixin):
                     ),
                     UserWarning,
                 )
+
         if y is None:
             # fit method of arity 1 (unsupervised transformation)
             return self.fit(X, **fit_params).transform(X)

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -889,30 +889,29 @@ class TransformerMixin(_SetOutputMixin):
                     ),
                     UserWarning,
                 )
-
-        if y is None:
-            # fit method of arity 1 (unsupervised transformation)
-            try:
+        try:
+            if y is None:
+                # fit method of arity 1 (unsupervised transformation)
                 return self.fit(X, **fit_params).transform(X)
-            except TypeError as e:
-                # re-raise if the transformer doesn't accept the passed **fit_params
-                for key, _ in fit_params.items():
-                    if (
-                        key not in inspect.signature(self.fit).parameters
-                        and "fit_params" not in inspect.signature(self.fit).parameters
-                    ):
-                        message = (
-                            f"`{self.__class__.__name__}.fit` got an unexpected "
-                            f"keyword argument `{key}`. Only pass `{key}` into "
-                            "`fit_transform` if `fit` expects it or can handle "
-                            "`**fit_params`."
-                        )
-                        raise TypeError(message) from e
-                raise
+            else:
+                # fit method of arity 2 (supervised transformation)
+                return self.fit(X, y, **fit_params).transform(X)
 
-        else:
-            # fit method of arity 2 (supervised transformation)
-            return self.fit(X, y, **fit_params).transform(X)
+        except TypeError as e:
+            # re-raise if the transformer doesn't accept the passed **fit_params
+            for key, _ in fit_params.items():
+                if (
+                    key not in inspect.signature(self.fit).parameters
+                    and "fit_params" not in inspect.signature(self.fit).parameters
+                ):
+                    message = (
+                        f"`{self.__class__.__name__}.fit` got an unexpected "
+                        f"keyword argument `{key}`. Only pass `{key}` into "
+                        "`fit_transform` if `fit` expects it or can handle "
+                        "`**fit_params`."
+                    )
+                    raise TypeError(message) from e
+            raise
 
 
 class OneToOneFeatureMixin:

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -854,6 +854,7 @@ class TransformerMixin(_SetOutputMixin):
 
         **fit_params : dict
             Additional fit parameters.
+            Pass only if the estimator accepts additional params in its `fit` method.
 
         Returns
         -------
@@ -888,6 +889,18 @@ class TransformerMixin(_SetOutputMixin):
                     ),
                     UserWarning,
                 )
+
+        for key, _ in fit_params.items():
+            if (
+                key not in inspect.signature(self.fit).parameters
+                and "fit_params" not in inspect.signature(self.fit).parameters
+            ):
+                message = (
+                    f"`{self.__class__.__name__}.fit` got an unexpected keyword "
+                    f"argument `{key}`. Only pass {key} into `fit_transform` if `fit` "
+                    "expects them or can handle `**fit_params`."
+                )
+                raise TypeError(message)
 
         if y is None:
             # fit method of arity 1 (unsupervised transformation)

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -889,29 +889,12 @@ class TransformerMixin(_SetOutputMixin):
                     ),
                     UserWarning,
                 )
-        try:
-            if y is None:
-                # fit method of arity 1 (unsupervised transformation)
-                return self.fit(X, **fit_params).transform(X)
-            else:
-                # fit method of arity 2 (supervised transformation)
-                return self.fit(X, y, **fit_params).transform(X)
-
-        except TypeError as e:
-            # re-raise if the transformer doesn't accept the passed **fit_params
-            for key, _ in fit_params.items():
-                if (
-                    key not in inspect.signature(self.fit).parameters
-                    and "fit_params" not in inspect.signature(self.fit).parameters
-                ):
-                    message = (
-                        f"`{self.__class__.__name__}.fit` got an unexpected "
-                        f"keyword argument `{key}`. Only pass `{key}` into "
-                        "`fit_transform` if `fit` expects it or can handle "
-                        "`**fit_params`."
-                    )
-                    raise TypeError(message) from e
-            raise
+        if y is None:
+            # fit method of arity 1 (unsupervised transformation)
+            return self.fit(X, **fit_params).transform(X)
+        else:
+            # fit method of arity 2 (supervised transformation)
+            return self.fit(X, y, **fit_params).transform(X)
 
 
 class OneToOneFeatureMixin:

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -969,27 +969,6 @@ def test_transformer_fit_transform_with_metadata_in_transform():
         assert len(record) == 0
 
 
-def test_transformer_fit_transform_without_metadata_in_fit():
-    """Test that a transformer that does not accept an additional param its `fit` method
-    raises if that param gets passed into `fit_transform`."""
-
-    class NonConsumingTransformer(TransformerMixin):
-        def fit(self, X, y=None):
-            return self  # pragma: no cover
-
-        def transform(X):
-            return X  # pragma: no cover
-
-    message = (
-        "`NonConsumingTransformer.fit` got an unexpected keyword argument "
-        "`sample_weight`."
-    )
-    with pytest.raises(TypeError, match=message):
-        NonConsumingTransformer().fit_transform(
-            X=[[1]], sample_weight=np.array([[1, 1, 1]])
-        )
-
-
 @config_context(enable_metadata_routing=True)
 def test_outlier_mixin_fit_predict_with_metadata_in_predict():
     """Test that having an OutlierMixin with metadata for predict raises a

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -980,13 +980,11 @@ def test_transformer_fit_transform_without_metadata_in_fit():
         def transform(X):
             return X
 
-    with pytest.raises(
-        TypeError,
-        match=(
-            "`NonConsumingTransformer.fit` got an unexpected keyword argument "
-            "`sample_weight`."
-        ),
-    ):
+    message = (
+        "`NonConsumingTransformer.fit` got an unexpected keyword argument "
+        "`sample_weight`."
+    )
+    with pytest.raises(TypeError, match=message):
         NonConsumingTransformer().fit_transform(
             X=[[1]], sample_weight=np.array([[1, 1, 1]])
         )

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -969,6 +969,29 @@ def test_transformer_fit_transform_with_metadata_in_transform():
         assert len(record) == 0
 
 
+def test_transformer_fit_transform_without_metadata_in_fit():
+    """Test that a transformer that does not accept an additional param its `fit` method
+    raises if that param gets passed into `fit_transform`."""
+
+    class NonConsumingTransformer(TransformerMixin):
+        def fit(self, X, y=None):
+            return self
+
+        def transform(X):
+            return X
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            "`NonConsumingTransformer.fit` got an unexpected keyword argument "
+            "`sample_weight`."
+        ),
+    ):
+        NonConsumingTransformer().fit_transform(
+            X=[[1]], sample_weight=np.array([[1, 1, 1]])
+        )
+
+
 @config_context(enable_metadata_routing=True)
 def test_outlier_mixin_fit_predict_with_metadata_in_predict():
     """Test that having an OutlierMixin with metadata for predict raises a

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -975,10 +975,10 @@ def test_transformer_fit_transform_without_metadata_in_fit():
 
     class NonConsumingTransformer(TransformerMixin):
         def fit(self, X, y=None):
-            return self
+            return self  # pragma: no cover
 
         def transform(X):
-            return X
+            return X  # pragma: no cover
 
     message = (
         "`NonConsumingTransformer.fit` got an unexpected keyword argument "


### PR DESCRIPTION
For transformers that inherit from `TransformerMixin`, the docs always display `fit_params` as passable into `fit_transform` even if their `fit` method doesn't accept anything other than `X` (and `y=None`).

That is for instance the case in `Normalizer`, `LinearDiscriminantAnalysis` and `FeatureHasher`:
> fit_transform(X, y=None, **fit_params)

A python `TypeError` is raised in this case:
```py
from sklearn.preprocessing import Normalizer

X = [[4, 1, 2, 2],
[1, 3, 9, 3],
[5, 7, 5, 1]]

Normalizer().fit_transform(X, sample_weight=np.array([[1,1,1]]))
```

`TypeError: Normalizer.fit() got an unexpected keyword argument 'sample_weight'`

This PR documents this on the method and adds a more intuitive error message that scikit-learn can raise directly.

This doesn't prevent `fit_params` to be displayed in wrong places in the docs, but deals with the problems that users can encounter in such a case.

Another solution to this problem that would remove `fit_params` from the docs in wrong places would be to over-write more of the `fit_transform` methods in the classes of routers (as it is already the case in many places), as for instance in `Stacking*` and `RFE` that still use fit_transform from TransformerMixin, and thus totally de-coubple the metadata routing-logic from `TransformerMixin`'s `fit_transform`. Or, alternatively, add an additional `RoutingTransformerMixin` for the routing logic.
But both breakages of inheritance structure seem a bit too much for handling this little thing.

CC: @adrinjalali 