### PR TITLE
MNT Remove redundant mkdir calls

### DIFF
--- a/sklearn/datasets/_california_housing.py
+++ b/sklearn/datasets/_california_housing.py
@@ -25,7 +25,7 @@ Statistics and Probability Letters, 33:291-297, 1997.
 import logging
 import tarfile
 from numbers import Integral, Real
-from os import PathLike, makedirs, remove
+from os import PathLike, remove
 from os.path import exists
 
 import joblib
@@ -162,8 +162,6 @@ def fetch_california_housing(
     ['MedInc', 'HouseAge', 'AveRooms', 'AveBedrms', 'Population', 'AveOccup']
     """
     data_home = get_data_home(data_home=data_home)
-    if not exists(data_home):
-        makedirs(data_home)
 
     filepath = _pkl_filepath(data_home, "cal_housing.pkz")
     if not exists(filepath):

--- a/sklearn/datasets/_olivetti_faces.py
+++ b/sklearn/datasets/_olivetti_faces.py
@@ -14,7 +14,7 @@ web page of Sam Roweis:
 # SPDX-License-Identifier: BSD-3-Clause
 
 from numbers import Integral, Real
-from os import PathLike, makedirs, remove
+from os import PathLike, remove
 from os.path import exists
 
 import joblib
@@ -140,8 +140,6 @@ def fetch_olivetti_faces(
     (400, 64, 64)
     """
     data_home = get_data_home(data_home=data_home)
-    if not exists(data_home):
-        makedirs(data_home)
     filepath = _pkl_filepath(data_home, "olivetti.pkz")
     if not exists(filepath):
         if not download_if_missing:

--- a/sklearn/datasets/_species_distributions.py
+++ b/sklearn/datasets/_species_distributions.py
@@ -31,7 +31,7 @@ R. P. Anderson, R. E. Schapire - Ecological Modelling, 190:231-259, 2006.
 import logging
 from io import BytesIO
 from numbers import Integral, Real
-from os import PathLike, makedirs, remove
+from os import PathLike, remove
 from os.path import exists
 
 import joblib
@@ -233,8 +233,6 @@ def fetch_species_distributions(
     see :ref:`sphx_glr_auto_examples_applications_plot_species_distribution_modeling.py`
     """
     data_home = get_data_home(data_home)
-    if not exists(data_home):
-        makedirs(data_home)
 
     # Define parameters for the data files.  These should not be changed
     # unless the data model changes.  They will be saved in the npz file


### PR DESCRIPTION
`get_data_home` always create the dir https://github.com/scikit-learn/scikit-learn/blob/aa680bc461a52301ff718cab81ce2be01dac2d04/sklearn/datasets/_base.py#L82-L86
