### PR TITLE
DOC Enhance DBSCAN docstrings with clearer parameter guidance and descriptions

### DIFF
--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -41,6 +41,11 @@ def dbscan(
 ):
     """Perform DBSCAN clustering from vector array or distance matrix.
 
+    This function is a wrapper around :class:`~cluster.DBSCAN`, suitable for
+    quick, standalone clustering tasks. For estimator-based workflows, where
+    estimator attributes or pipeline integration is required, prefer
+    :class:`~cluster.DBSCAN`.
+
     DBSCAN (Density-Based Spatial Clustering of Applications with Noise) is a
     density-based clustering algorithm that groups together points that are
     closely packed while marking points in low-density regions as outliers.
@@ -49,7 +54,7 @@ def dbscan(
 
     Parameters
     ----------
-    X : {array-like, sparse (CSR) matrix} of shape (n_samples, n_features) or \
+    X : {array-like, scipy sparse matrix} of shape (n_samples, n_features) or \
             (n_samples, n_samples)
         A feature array, or array of distances between samples if
         ``metric='precomputed'``. When using precomputed distances, X must
@@ -60,14 +65,14 @@ def dbscan(
         as in the neighborhood of the other. This is not a maximum bound
         on the distances of points within a cluster. This is the most
         important DBSCAN parameter to choose appropriately for your data set
-        and distance function. Smaller values will result in more clusters,
-        while larger values will merge clusters together.
+        and distance function. Smaller values result in more clusters,
+        while larger values result in fewer, larger clusters.
 
     min_samples : int, default=5
         The number of samples (or total weight) in a neighborhood for a point
         to be considered as a core point. This includes the point itself.
-        Higher values will result in more conservative clustering (fewer,
-        denser clusters), while lower values will create more clusters.
+        Higher values yield fewer, denser clusters, while lower values yield
+        more, sparser clusters.
 
     metric : str or callable, default='minkowski'
         The metric to use when calculating distance between instances in a
@@ -89,7 +94,7 @@ def dbscan(
         to compute pointwise distances and find nearest neighbors.
         'auto' will attempt to decide the most appropriate algorithm
         based on the values passed to :meth:`fit` method.
-        See NearestNeighbors module documentation for details.
+        See :class:`~neighbors.NearestNeighbors` documentation for details.
 
     leaf_size : int, default=30
         Leaf size passed to BallTree or cKDTree. This can affect the speed
@@ -99,9 +104,10 @@ def dbscan(
         lead to faster queries but slower construction.
 
     p : float, default=2
-        The power of the Minkowski metric to be used to calculate distance
-        between points. When p=1, this is equivalent to Manhattan distance,
-        and when p=2, this is equivalent to Euclidean distance.
+        Power parameter for the Minkowski metric. When p = 1, this is equivalent
+        to using manhattan_distance (l1), and euclidean_distance (l2) for p = 2.
+        For arbitrary p, minkowski_distance (l_p) is used. This parameter is expected
+        to be positive.
 
     sample_weight : array-like of shape (n_samples,), default=None
         Weight of each sample, such that a sample with a weight of at least
@@ -247,7 +253,7 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         to compute pointwise distances and find nearest neighbors.
         'auto' will attempt to decide the most appropriate algorithm
         based on the values passed to :meth:`fit` method.
-        See NearestNeighbors module documentation for details.
+        See :class:`~neighbors.NearestNeighbors` documentation for details.
 
     leaf_size : int, default=30
         Leaf size passed to BallTree or cKDTree. This can affect the speed
@@ -469,7 +475,7 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         """Compute clusters from a data or distance matrix and predict labels.
 
         This method fits the model and returns the cluster labels in a single step.
-        It is equivalent to calling fit(X).labels_ but more efficient.
+        It is equivalent to calling fit(X).labels_.
 
         Parameters
         ----------

--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -94,7 +94,8 @@ def dbscan(
         to compute pointwise distances and find nearest neighbors.
         'auto' will attempt to decide the most appropriate algorithm
         based on the values passed to :meth:`fit` method.
-        See :class:`~neighbors.NearestNeighbors` documentation for details.
+        See :class:`~sklearn.neighbors.NearestNeighbors` documentation for
+        details.
 
     leaf_size : int, default=30
         Leaf size passed to BallTree or cKDTree. This can affect the speed
@@ -253,7 +254,8 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         to compute pointwise distances and find nearest neighbors.
         'auto' will attempt to decide the most appropriate algorithm
         based on the values passed to :meth:`fit` method.
-        See :class:`~neighbors.NearestNeighbors` documentation for details.
+        See :class:`~sklearn.neighbors.NearestNeighbors` documentation for
+        details.
 
     leaf_size : int, default=30
         Leaf size passed to BallTree or cKDTree. This can affect the speed

--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -41,6 +41,10 @@ def dbscan(
 ):
     """Perform DBSCAN clustering from vector array or distance matrix.
 
+    DBSCAN (Density-Based Spatial Clustering of Applications with Noise) is a
+    density-based clustering algorithm that groups together points that are
+    closely packed while marking points in low-density regions as outliers.
+
     Read more in the :ref:`User Guide <dbscan>`.
 
     Parameters
@@ -48,18 +52,22 @@ def dbscan(
     X : {array-like, sparse (CSR) matrix} of shape (n_samples, n_features) or \
             (n_samples, n_samples)
         A feature array, or array of distances between samples if
-        ``metric='precomputed'``.
+        ``metric='precomputed'``. When using precomputed distances, X must
+        be a square symmetric matrix.
 
     eps : float, default=0.5
         The maximum distance between two samples for one to be considered
         as in the neighborhood of the other. This is not a maximum bound
         on the distances of points within a cluster. This is the most
         important DBSCAN parameter to choose appropriately for your data set
-        and distance function.
+        and distance function. Smaller values will result in more clusters,
+        while larger values will merge clusters together.
 
     min_samples : int, default=5
         The number of samples (or total weight) in a neighborhood for a point
         to be considered as a core point. This includes the point itself.
+        Higher values will result in more conservative clustering (fewer,
+        denser clusters), while lower values will create more clusters.
 
     metric : str or callable, default='minkowski'
         The metric to use when calculating distance between instances in a
@@ -79,17 +87,21 @@ def dbscan(
     algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, default='auto'
         The algorithm to be used by the NearestNeighbors module
         to compute pointwise distances and find nearest neighbors.
+        'auto' will attempt to decide the most appropriate algorithm
+        based on the values passed to :meth:`fit` method.
         See NearestNeighbors module documentation for details.
 
     leaf_size : int, default=30
         Leaf size passed to BallTree or cKDTree. This can affect the speed
         of the construction and query, as well as the memory required
         to store the tree. The optimal value depends
-        on the nature of the problem.
+        on the nature of the problem. Generally, smaller leaf sizes
+        lead to faster queries but slower construction.
 
     p : float, default=2
         The power of the Minkowski metric to be used to calculate distance
-        between points.
+        between points. When p=1, this is equivalent to Manhattan distance,
+        and when p=2, this is equivalent to Euclidean distance.
 
     sample_weight : array-like of shape (n_samples,), default=None
         Weight of each sample, such that a sample with a weight of at least
@@ -101,7 +113,7 @@ def dbscan(
         The number of parallel jobs to run for neighbors search. ``None`` means
         1 unless in a :obj:`joblib.parallel_backend` context. ``-1`` means
         using all processors. See :term:`Glossary <n_jobs>` for more details.
-        If precomputed distance are used, parallel execution is not available
+        If precomputed distances are used, parallel execution is not available
         and thus n_jobs will have no effect.
 
     Returns
@@ -110,7 +122,8 @@ def dbscan(
         Indices of core samples.
 
     labels : ndarray of shape (n_samples,)
-        Cluster labels for each point.  Noisy samples are given the label -1.
+        Cluster labels for each point. Noisy samples are given the label -1.
+        Non-negative integers indicate cluster membership.
 
     See Also
     --------
@@ -183,7 +196,11 @@ class DBSCAN(ClusterMixin, BaseEstimator):
 
     DBSCAN - Density-Based Spatial Clustering of Applications with Noise.
     Finds core samples of high density and expands clusters from them.
-    Good for data which contains clusters of similar density.
+    This algorithm is particularly good for data which contains clusters of
+    similar density and can find clusters of arbitrary shape.
+
+    Unlike K-means, DBSCAN does not require specifying the number of clusters
+    in advance and can identify outliers as noise points.
 
     This implementation has a worst case memory complexity of :math:`O({n}^2)`,
     which can occur when the `eps` param is large and `min_samples` is low,
@@ -199,7 +216,7 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         as in the neighborhood of the other. This is not a maximum bound
         on the distances of points within a cluster. This is the most
         important DBSCAN parameter to choose appropriately for your data set
-        and distance function.
+        and distance function. Smaller values generally lead to more clusters.
 
     min_samples : int, default=5
         The number of samples (or total weight) in a neighborhood for a point to
@@ -228,6 +245,8 @@ class DBSCAN(ClusterMixin, BaseEstimator):
     algorithm : {'auto', 'ball_tree', 'kd_tree', 'brute'}, default='auto'
         The algorithm to be used by the NearestNeighbors module
         to compute pointwise distances and find nearest neighbors.
+        'auto' will attempt to decide the most appropriate algorithm
+        based on the values passed to :meth:`fit` method.
         See NearestNeighbors module documentation for details.
 
     leaf_size : int, default=30
@@ -239,7 +258,7 @@ class DBSCAN(ClusterMixin, BaseEstimator):
     p : float, default=None
         The power of the Minkowski metric to be used to calculate distance
         between points. If None, then ``p=2`` (equivalent to the Euclidean
-        distance).
+        distance). When p=1, this is equivalent to Manhattan distance.
 
     n_jobs : int, default=None
         The number of parallel jobs to run.
@@ -255,9 +274,10 @@ class DBSCAN(ClusterMixin, BaseEstimator):
     components_ : ndarray of shape (n_core_samples, n_features)
         Copy of each core sample found by training.
 
-    labels_ : ndarray of shape (n_samples)
+    labels_ : ndarray of shape (n_samples,)
         Cluster labels for each point in the dataset given to fit().
-        Noisy samples are given the label -1.
+        Noisy samples are given the label -1. Non-negative integers
+        indicate cluster membership.
 
     n_features_in_ : int
         Number of features seen during :term:`fit`.
@@ -448,6 +468,9 @@ class DBSCAN(ClusterMixin, BaseEstimator):
     def fit_predict(self, X, y=None, sample_weight=None):
         """Compute clusters from a data or distance matrix and predict labels.
 
+        This method fits the model and returns the cluster labels in a single step.
+        It is equivalent to calling fit(X).labels_ but more efficient.
+
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features), or \
@@ -469,6 +492,7 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         -------
         labels : ndarray of shape (n_samples,)
             Cluster labels. Noisy samples are given the label -1.
+            Non-negative integers indicate cluster membership.
         """
         self.fit(X, sample_weight=sample_weight)
         return self.labels_


### PR DESCRIPTION
#### Reference Issues/PRs
N/A - Documentation improvement


#### What does this implement/fix? Explain your changes.
This PR improves the documentation quality of the DBSCAN clustering algorithm by enhancing docstrings with clearer explanations and practical guidance for users.

Key improvements:

Enhanced algorithm description: Added comprehensive explanation of what DBSCAN does, its advantages over K-means (no need to specify cluster count, finds arbitrary shapes, identifies outliers), and when to use it.
Improved parameter descriptions with practical guidance:

eps: Added guidance on how parameter values affect clustering results (smaller values → more clusters)
min_samples: Clarified relationship between values and cluster density
algorithm: Explained what 'auto' does (attempts to decide most appropriate algorithm)
leaf_size: Added explanation of speed vs construction time trade-offs
p: Added concrete examples (p=1 for Manhattan, p=2 for Euclidean distance)
X: Added clarification that precomputed distance matrices must be square and symmetric
n_jobs: Fixed minor typo ("precomputed distance" → "precomputed distances")


Better return value descriptions:

labels: Clarified that non-negative integers indicate cluster membership
Enhanced fit_predict method description to explain efficiency benefits over calling fit(X).labels_


Consistency improvements: Made parameter descriptions more consistent between the dbscan function and DBSCAN class.

These changes make the API more accessible to users, especially those new to density-based clustering, by providing clearer guidance on parameter selection and expected behavior.

#### Any other comments?
The changes are purely documentation improvements with no functional changes to the algorithm implementation. All existing functionality and API behavior remain unchanged. The improvements should help users better understand how to tune DBSCAN parameters for their specific use cases.
