### PR TITLE
FIX: Use context managers to safely close dataset files

### DIFF
--- a/sklearn/datasets/_kddcup99.py
+++ b/sklearn/datasets/_kddcup99.py
@@ -388,7 +388,6 @@ def _fetch_brute_kddcup99(
         archive_path = join(kddcup_dir, archive.filename)
         Xy = []
 
-        # Opening file using context manager to ensure file is always closed
         with GzipFile(filename=archive_path, mode="r") as file_:
             for line in file_.readlines():
                 line = line.decode()

--- a/sklearn/datasets/_kddcup99.py
+++ b/sklearn/datasets/_kddcup99.py
@@ -386,12 +386,14 @@ def _fetch_brute_kddcup99(
         DT = np.dtype(dt)
         logger.debug("extracting archive")
         archive_path = join(kddcup_dir, archive.filename)
-        file_ = GzipFile(filename=archive_path, mode="r")
+        #file_ = GzipFile(filename=archive_path, mode="r")
         Xy = []
-        for line in file_.readlines():
-            line = line.decode()
-            Xy.append(line.replace("\n", "").split(","))
-        file_.close()
+        # Opening file using context manager to insure file is always closed
+        with GzipFile(filename=archive_path, mode="r") as file_:
+            for line in file_.readlines():
+                line = line.decode()
+                Xy.append(line.replace("\n", "").split(","))
+        #file_.close()
         logger.debug("extraction done")
         os.remove(archive_path)
 

--- a/sklearn/datasets/_kddcup99.py
+++ b/sklearn/datasets/_kddcup99.py
@@ -387,13 +387,13 @@ def _fetch_brute_kddcup99(
         logger.debug("extracting archive")
         archive_path = join(kddcup_dir, archive.filename)
         Xy = []
-        
-        # Opening file using context manager to insure file is always closed
+
+        # Opening file using context manager to ensure file is always closed
         with GzipFile(filename=archive_path, mode="r") as file_:
             for line in file_.readlines():
                 line = line.decode()
                 Xy.append(line.replace("\n", "").split(","))
-        
+
         logger.debug("extraction done")
         os.remove(archive_path)
 

--- a/sklearn/datasets/_kddcup99.py
+++ b/sklearn/datasets/_kddcup99.py
@@ -386,14 +386,14 @@ def _fetch_brute_kddcup99(
         DT = np.dtype(dt)
         logger.debug("extracting archive")
         archive_path = join(kddcup_dir, archive.filename)
-        #file_ = GzipFile(filename=archive_path, mode="r")
         Xy = []
+        
         # Opening file using context manager to insure file is always closed
         with GzipFile(filename=archive_path, mode="r") as file_:
             for line in file_.readlines():
                 line = line.decode()
                 Xy.append(line.replace("\n", "").split(","))
-        #file_.close()
+        
         logger.debug("extraction done")
         os.remove(archive_path)
 

--- a/sklearn/datasets/_lfw.py
+++ b/sklearn/datasets/_lfw.py
@@ -169,7 +169,7 @@ def _load_imgs(file_paths, slice_, color, resize):
 
         # Checks if jpeg reading worked. Refer to issue #3594 for more
         # details.
-        
+
         # Opening file using a context manager to insure file is always closed
         with Image.open(file_path) as pil_img:
             pil_img = pil_img.crop(

--- a/sklearn/datasets/_lfw.py
+++ b/sklearn/datasets/_lfw.py
@@ -170,7 +170,6 @@ def _load_imgs(file_paths, slice_, color, resize):
         # Checks if jpeg reading worked. Refer to issue #3594 for more
         # details.
 
-        # Opening file using a context manager to insure file is always closed
         with Image.open(file_path) as pil_img:
             pil_img = pil_img.crop(
                 (w_slice.start, h_slice.start, w_slice.stop, h_slice.stop)

--- a/sklearn/datasets/_lfw.py
+++ b/sklearn/datasets/_lfw.py
@@ -169,13 +169,15 @@ def _load_imgs(file_paths, slice_, color, resize):
 
         # Checks if jpeg reading worked. Refer to issue #3594 for more
         # details.
-        pil_img = Image.open(file_path)
-        pil_img = pil_img.crop(
-            (w_slice.start, h_slice.start, w_slice.stop, h_slice.stop)
-        )
-        if resize is not None:
-            pil_img = pil_img.resize((w, h))
-        face = np.asarray(pil_img, dtype=np.float32)
+        
+        # Opening file using a context manager to insure file is always closed
+        with Image.open(file_path) as pil_img:
+            pil_img = pil_img.crop(
+                (w_slice.start, h_slice.start, w_slice.stop, h_slice.stop)
+            )
+            if resize is not None:
+                pil_img = pil_img.resize((w, h))
+            face = np.asarray(pil_img, dtype=np.float32)
 
         if face.ndim == 0:
             raise RuntimeError(


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #31834

#### What does this implement/fix? Explain your changes.
This PR fixes resource cleanup issues in two dataset loader functions where files were opened but not robustly closed.

- In `sklearn/datasets/_lfw.py`, `Image.open()` was called in a loop without a context manager. This change wraps the call in a with statement to ensure the file handle is always closed, preventing potential resource leaks when loading many images.

- In `sklearn/datasets/_kddcup99.py`, a `GzipFile` was manually closed after a processing loop. This is not exception-safe. The fix uses a with statement to guarantee the file is closed even if an error occurs during processing.

#### Any other comments?
Co-authored with @i3hz