### PR TITLE
Adapting step_size and sag updates for sample_weight

### DIFF
--- a/sklearn/linear_model/tests/test_sag.py
+++ b/sklearn/linear_model/tests/test_sag.py
@@ -177,7 +177,7 @@ def sag_sparse(
 
     counter = 0
     for epoch in range(max_iter):
-        previous_weights = weights.copy()
+        previous_weights = weights * wscale
         for k in range(n_samples):
             # idx = k
             idx = int(rng.rand() * n_samples)
@@ -246,11 +246,12 @@ def sag_sparse(
 
             counter += 1
         # callback on epoch end
+        scaled_weights = weights * wscale
         if callable(callback):
-            callback(dict(weights=weights, intercept=intercept, epoch=epoch))
+            callback(dict(weights=scaled_weights, intercept=intercept, epoch=epoch))
         # stopping criteria
-        max_weight = np.abs(weights).max()
-        max_change = np.abs(weights - previous_weights).max()
+        max_weight = np.abs(scaled_weights).max()
+        max_change = np.abs(scaled_weights - previous_weights).max()
         if (max_weight != 0 and max_change / max_weight <= tol) or (
             max_weight == 0 and max_change == 0
         ):

--- a/sklearn/linear_model/tests/test_sag.py
+++ b/sklearn/linear_model/tests/test_sag.py
@@ -794,6 +794,10 @@ def test_classifier_results(csr_container):
     assert_almost_equal(pred2, y, decimal=12)
 
 
+@pytest.mark.xfail(
+    reason="""Fix #31675 for sample weight handling in SAG(A) implemented
+    in the python solvers, not in the cython code yet"""
+)
 @pytest.mark.filterwarnings("ignore:The max_iter was reached")
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 def test_binary_classifier_class_weight(csr_container):
@@ -804,7 +808,6 @@ def test_binary_classifier_class_weight(csr_container):
     tol = 0.00001
     fit_intercept = True
     X, y = make_blobs(n_samples=n_samples, centers=2, random_state=10, cluster_std=0.1)
-    step_size = get_step_size(X, alpha, fit_intercept, classification=True)
     classes = np.unique(y)
     y_tmp = np.ones(n_samples)
     y_tmp[y != classes[1]] = -1
@@ -828,6 +831,9 @@ def test_binary_classifier_class_weight(csr_container):
     le = LabelEncoder()
     class_weight_ = compute_class_weight(class_weight, classes=np.unique(y), y=y)
     sample_weight = class_weight_[le.fit_transform(y)]
+    step_size = get_step_size(
+        X, alpha, fit_intercept, classification=True, sample_weight=sample_weight
+    )
     spweights, spintercept, sp_n_iter = sag_sparse(
         X,
         y,


### PR DESCRIPTION
#### Reference Issues/PRs

Helper for PR #31675 to fix sample_weight support in SAG(A) solvers #31536.

#### What does this implement/fix? Explain your changes.

In test_sag.py several fixes are made to properly handle sample_weight.

1. `get_step_size`: the formula Lipschitz smoothness constant are corrected to take into account sample_weight
2. `sag`: the updates for the weights and intercept are corrected
3. `sag`: the number of seen elements (which converges to `n_samples`) is replaced by the weighted sum of seen elements (which converges to `sample_weight.sum()`)

A `true_weights` argument was added to `sag` for visualisation purpose (plot the convergence towards the true minima). This is useful for the notebook below but can be removed in the final PR. A `tol` argument was also added to use the same stopping criterion as `_sag_fast.pyx`.

cc @snath-xoc 