### PR TITLE
modifying the error message for _check_sample_weight functions - Fix #31712

### DIFF
--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1608,7 +1608,7 @@ def _check_sample_weight_common(xp):
     assert_allclose(_convert_to_numpy(sample_weight, xp), 2 * np.ones(5))
 
     # check wrong number of dimensions
-    with pytest.raises(ValueError, match="Sample weights must be 1D array or scalar"):
+    with pytest.raises(ValueError, match="Sample weights must be 1D array or scalar (only applicable to ridge regression)"):
         _check_sample_weight(xp.ones((2, 4)), X=xp.ones((2, 2)))
 
     # check incorrect n_samples

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -2215,7 +2215,7 @@ def _check_sample_weight(
             input_name="sample_weight",
         )
         if sample_weight.ndim != 1:
-            raise ValueError("Sample weights must be 1D array or scalar")
+            raise ValueError("Sample weights must be 1D array or scalar (only applicable to ridge regression)")
 
         if sample_weight.shape != (n_samples,):
             raise ValueError(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
#31712 
Fixes / addresses #31712 with the misleading error message. Modified the error message to clarify that sample weights can only be a scalar if Ridge regression is used. See the thread https://github.com/scikit-learn/scikit-learn/issues/31712 for more details. 
-->


#### What does this implement/fix? Explain your changes.
This improves the error messaging when sample_weights are called by user and ValueError("Sample weights must be 1D array or scalar") is raised. In most situations, we wouldn't expect sample_weights to be a scalar. Only for Ridge Regression can sample_weights be a scalar.

#### Any other comments?
N/A

-->
