### PR TITLE
Set requires_fit=False for FeatureHasher and HashingVectorizer (fixes…

### DIFF
--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -196,7 +196,10 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
         X.sum_duplicates()  # also sorts the indices
 
         return X
-
+    
+    def _get_tags(self):
+        return {**super()._get_tags(), "requires_fit": False}
+    
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.input_tags.two_d_array = False

--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -196,10 +196,10 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
         X.sum_duplicates()  # also sorts the indices
 
         return X
-    
+
     def _get_tags(self):
         return {**super()._get_tags(), "requires_fit": False}
-    
+
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.input_tags.two_d_array = False

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -2136,6 +2136,9 @@ class TfidfVectorizer(CountVectorizer):
 
         X = super().transform(raw_documents)
         return self._tfidf.transform(X, copy=False)
+    
+    def _get_tags(self):
+        return {**super()._get_tags(), "requires_fit": False}
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -2136,7 +2136,7 @@ class TfidfVectorizer(CountVectorizer):
 
         X = super().transform(raw_documents)
         return self._tfidf.transform(X, copy=False)
-    
+
     def _get_tags(self):
         return {**super()._get_tags(), "requires_fit": False}
 


### PR DESCRIPTION
Set requires_fit=False for FeatureHasher and HashingVectorizer

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Fixes #30689

#### What does this implement/fix? Explain your changes.

Both `FeatureHasher` and `HashingVectorizer` are stateless and do not require fitting.  
This PR sets their `"requires_fit"` tag to `False` via the `_get_tags` method.  
I also verified this with the existing tests.

#### Any other comments?

No further comments.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. We ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
