### PR TITLE
CI add ccache for GitHub Actions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-${{ matrix.name }}-${{ hashFiles('**/*.pyx*', '**/*.pxd*', '**/*.pxi*', '**/*.h', '**/*.c', '**/*.cpp') }}
+          key: ccache-${{ matrix.name }}-${{ hashFiles('**/*.pyx*', '**/*.pxd*', '**/*.pxi*', '**/*.h', '**/*.c', '**/*.cpp', format('{0}', matrix.LOCK_FILE)) }}
           restore-keys: ccache-${{ matrix.name }}
 
       - name: Build scikit-learn

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -60,19 +60,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Create cache for ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-v1-${{ matrix.name }}-${{ hashFiles('**/*.pyx*', '**/*.pxd*', '**/*.pxi*', '**/*.h', '**/*.c', '**/*.cpp', format('{0}', matrix.LOCK_FILE)) }}
+          restore-keys: ccache-${{ matrix.name }}
+
       - name: Set up conda
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
           auto-activate-base: true
           activate-environment: ""
-
-      - name: Create cache for ccache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.CCACHE_DIR }}
-          key: ccache-${{ matrix.name }}-${{ hashFiles('**/*.pyx*', '**/*.pxd*', '**/*.pxi*', '**/*.h', '**/*.c', '**/*.cpp', format('{0}', matrix.LOCK_FILE)) }}
-          restore-keys: ccache-${{ matrix.name }}
 
       - name: Build scikit-learn
         run: bash -l build_tools/azure/install.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-${{ matrix.name }}-${{ hashFiles('**/*.c', '**/*.cpp') }}
+          key: ccache-${{ matrix.name }}-${{ hashFiles('**/*.pyx*', '**/*.pxd*', '**/*.pxi*', '**/*.h', '**/*.c', '**/*.cpp') }}
           restore-keys: ccache-${{ matrix.name }}
 
       - name: Build scikit-learn

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -71,8 +71,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-${{ matrix.name }}-${{ hashFiles('**/*.pyx*', '**/*.pxd*', '**/*.pxi*', '**/*.h', '**/*.c', '**/*.cpp', '${{ matrix.LOCK_FILE }}') }}
+          #key: ccache-${{ matrix.name }}-${{ hashFiles('**/*.pyx*', '**/*.pxd*', '**/*.pxi*', '**/*.h', '**/*.c', '**/*.cpp') }}
+          key: ccache-${{ matrix.name }}-${{ hashFiles(format("'**/*.pyx*', '**/*.pxd*', '**/*.pxi*', '**/*.h', '**/*.c', '**/*.cpp', '{0}'", matrix.LOCK_FILE)) }}
           restore-keys: ccache-${{ matrix.name }}
+
+          # hashFiles(format('{0}/**', matrix.bla)) }}
 
       - name: Build scikit-learn
         run: bash -l build_tools/azure/install.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -67,18 +67,12 @@ jobs:
           auto-activate-base: true
           activate-environment: ""
 
-      - name: Set compiler ID
-        id: get-compiler
-        run: echo "compiler=$(cc --version | head -n 1 | tr ' ' '_' | tr -d '()')" >> $GITHUB_OUTPUT
-
       - name: Create cache for ccache
         uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-${{ runner.os }}-${{ steps.get-compiler.outputs.compiler }}
-          restore-keys: |
-            ccache-${{ runner.os }}-
-            ccache-
+          key: ccache-${{ matrix.name }}-${{ hashFiles('**/*.c', '**/*.cpp') }}
+          restore-keys: ccache-${{ matrix.name }}
 
       - name: Build scikit-learn
         run: bash -l build_tools/azure/install.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-${{ matrix.name }}-${{ hashFiles('**/*.pyx*', '**/*.pxd*', '**/*.pxi*', '**/*.h', '**/*.c', '**/*.cpp') }}
+          key: ccache-${{ matrix.name }}-${{ hashFiles('**/*.pyx*', '**/*.pxd*', '**/*.pxi*', '**/*.h', '**/*.c', '**/*.cpp', '${{ matrix.LOCK_FILE }}') }}
           restore-keys: ccache-${{ matrix.name }}
 
       - name: Build scikit-learn

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Create cache for ccache
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/ccache
+          path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ runner.os }}-${{ steps.get-compiler.outputs.compiler }}
           restore-keys: |
             ccache-${{ runner.os }}-

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,6 +13,7 @@ concurrency:
 env:
   VIRTUALENV: testvenv
   TEST_DIR: ${{ github.workspace }}/tmp_folder
+  CCACHE_DIR: ${{ github.workspace }}/ccache
 
 jobs:
   lint:
@@ -59,11 +60,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v3
+      - name: Set up conda
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
           auto-activate-base: true
           activate-environment: ""
+
+      - name: Set compiler ID
+        id: get-compiler
+        run: echo "compiler=$(cc --version | head -n 1 | tr ' ' '_' | tr -d '()')" >> $GITHUB_OUTPUT
+
+      - name: Create cache for ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ccache-${{ runner.os }}-${{ steps.get-compiler.outputs.compiler }}
+          restore-keys: |
+            ccache-${{ runner.os }}-
+            ccache-
 
       - name: Build scikit-learn
         run: bash -l build_tools/azure/install.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -71,11 +71,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}
-          #key: ccache-${{ matrix.name }}-${{ hashFiles('**/*.pyx*', '**/*.pxd*', '**/*.pxi*', '**/*.h', '**/*.c', '**/*.cpp') }}
-          key: ccache-${{ matrix.name }}-${{ hashFiles(format("'**/*.pyx*', '**/*.pxd*', '**/*.pxi*', '**/*.h', '**/*.c', '**/*.cpp', '{0}'", matrix.LOCK_FILE)) }}
+          key: ccache-${{ matrix.name }}-${{ hashFiles('**/*.pyx*', '**/*.pxd*', '**/*.pxi*', '**/*.h', '**/*.c', '**/*.cpp') }}
           restore-keys: ccache-${{ matrix.name }}
-
-          # hashFiles(format('{0}/**', matrix.bla)) }}
 
       - name: Build scikit-learn
         run: bash -l build_tools/azure/install.sh

--- a/sklearn/svm/src/libsvm/libsvm_sparse_helper.c
+++ b/sklearn/svm/src/libsvm/libsvm_sparse_helper.c
@@ -8,7 +8,6 @@
 #ifndef MAX
     #define MAX(x, y) (((x) > (y)) ? (x) : (y))
 #endif
-// test comment
 
 /*
  * Convert scipy.sparse.csr to libsvm's sparse data structure

--- a/sklearn/svm/src/libsvm/libsvm_sparse_helper.c
+++ b/sklearn/svm/src/libsvm/libsvm_sparse_helper.c
@@ -9,6 +9,7 @@
     #define MAX(x, y) (((x) > (y)) ? (x) : (y))
 #endif
 
+
 /*
  * Convert scipy.sparse.csr to libsvm's sparse data structure
  */

--- a/sklearn/svm/src/libsvm/libsvm_sparse_helper.c
+++ b/sklearn/svm/src/libsvm/libsvm_sparse_helper.c
@@ -8,7 +8,7 @@
 #ifndef MAX
     #define MAX(x, y) (((x) > (y)) ? (x) : (y))
 #endif
-
+// test comment
 
 /*
  * Convert scipy.sparse.csr to libsvm's sparse data structure


### PR DESCRIPTION
#### Reference Issues/PRs
Follow up on #31832

#### What does this implement/fix? Explain your changes.
This PR adds a step to use a cache for ccache on the GitHub Actions job(s) in the `unit-tests.yml`.

Thanks for your support @lesteve and @adrinjalali! :heart_hands: 

#### Comments
From my experiments on another branch it seems that this speeds up the build of scikit-learn by 1 min (1 min instead of 2 mins) on ARM.

This won't work on windows.