### PR TITLE
CI Remove conda environment cache in CUDA CI

### DIFF
--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -52,14 +52,7 @@ jobs:
           python-version: '3.12.3'
       - name: Checkout main repository
         uses: actions/checkout@v4
-      - name: Cache conda environment
-        id: cache-conda
-        uses: actions/cache@v4
-        with:
-          path: ~/conda
-          key: ${{ runner.os }}-build-${{ hashFiles('build_tools/github/create_gpu_environment.sh') }}-${{ hashFiles('build_tools/github/pylatest_conda_forge_cuda_array-api_linux-64_conda.lock') }}
       - name: Install miniforge
-        if: ${{ steps.cache-conda.outputs.cache-hit != 'true' }}
         run: bash build_tools/github/create_gpu_environment.sh
       - name: Install scikit-learn
         run: |


### PR DESCRIPTION
Installing and creating the environment from scratch takes 1 min 30s:
[build log](https://github.com/scikit-learn/scikit-learn/actions/runs/16719279030/job/47319996827?pr=31879)
<img width="1441" height="387" alt="image" src="https://github.com/user-attachments/assets/13075842-efba-4d2e-9993-f03ceb92fb7e" />

Reusing the cache takes ~2 minutes so it's actually slower:
[build log](https://github.com/scikit-learn/scikit-learn/actions/runs/16719279030/job/47319996827?pr=31879)
<img width="1451" height="285" alt="image" src="https://github.com/user-attachments/assets/bc7d6387-90ad-4474-84d1-07ff8462bb4b" />

It seems like this pattern is consistent e.g. [build log without cache](https://github.com/scikit-learn/scikit-learn/actions/runs/16443569810/job/46470029792?pr=31814) and [build log with cache](https://github.com/scikit-learn/scikit-learn/actions/runs/16494123130/job/46635929847?pr=31814).

I noticed because the cache is quite big ~6.4GB (out of a 10GB quota in principle), see all our [caches](https://github.com/scikit-learn/scikit-learn/actions/caches).
<img width="1279" height="237" alt="image" src="https://github.com/user-attachments/assets/1eeb6070-31da-4442-825c-42de6aa62dab" />

So basically if you run the CUDA CI in 2 different PRs you will create 2 cache entries (different branches) and you are above the quota limit. I am not sure how strongly this quota is enforced to be honest but I noticed there was a warning the other day that we were above our limit.

cc @betatim in case you remember some details about using caching for the conda environment in https://github.com/scikit-learn/scikit-learn/pull/29130.
