### PR TITLE
DOC better internal docstring for Cython enet_coordinate_descent

### DIFF
--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -128,7 +128,8 @@ def enet_coordinate_descent(
         X -> (           X)    y -> (y)
              (sqrt(beta) I)         (0)
 
-    Note that y - X w also enters as current estimation of a dual feasible point v.
+    Note that the residual y - X w is an important ingredient for the estimation of a
+    dual feasible point v.
     At optimum of primal w* and dual v*, one has
 
         v = y* - X w*


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
Improve docstring of coordinate descent such that the actual implementation becomes easier to read.

#### Any other comments?
Does not touch anything public.