### PR TITLE
DOC: Clarify chance level label in RocCurveDisplay

### DIFF
--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -254,7 +254,7 @@ class RocCurveDisplay(_BinaryClassifierCurveDisplayMixin):
         )
 
         default_chance_level_line_kw = {
-            "label": "Chance level (AUC = 0.5)",
+            "label": "Non-informative baseline (AUC = 0.5)",
             "color": "k",
             "linestyle": "--",
         }


### PR DESCRIPTION
Fixes #30352

#### Description

This PR updates the default label for the chance level line in the `RocCurveDisplay` to be more descriptive and less ambiguous, as suggested in the issue. The label is changed from "Chance level" to "Non-informative baseline".