### PR TITLE
FIX normalization in semi_supervised label_propagation

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.semi_supervised/31924.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.semi_supervised/31924.fix.rst
@@ -1,4 +1,4 @@
-- |Fix| User written kernel results are now normalized in
+- User written kernel results are now normalized in
   :class:`semi-supervized._label_propagation.LabelPropagation`
   so all row sums equal 1 even if kernel gives asymmetric or non-uniform row sums.
-  By :user:`Dan Schult <dschult>`. :pr:`31924`
+  By :user:`Dan Schult <dschult>`.

--- a/doc/whats_new/upcoming_changes/sklearn.semi_supervised/31924.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.semi_supervised/31924.fix.rst
@@ -1,0 +1,4 @@
+- |Fix| User written kernel results are now normalized in
+  :class:`semi-supervized._label_propagation.LabelPropagation`
+  so all row sums equal 1 even if kernel gives asymmetric or non-uniform row sums.
+  By :user:`Dan Schult <dschult>`. :pr:`31924`

--- a/doc/whats_new/upcoming_changes/sklearn.semi_supervised/31924.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.semi_supervised/31924.fix.rst
@@ -1,4 +1,4 @@
 - User written kernel results are now normalized in
-  :class:`semi-supervized.LabelPropagation`
+  :class:`semi_supervized.LabelPropagation`
   so all row sums equal 1 even if kernel gives asymmetric or non-uniform row sums.
   By :user:`Dan Schult <dschult>`.

--- a/doc/whats_new/upcoming_changes/sklearn.semi_supervised/31924.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.semi_supervised/31924.fix.rst
@@ -1,4 +1,4 @@
 - User written kernel results are now normalized in
-  :class:`semi_supervized.LabelPropagation`
+  :class:`semi_supervised.LabelPropagation`
   so all row sums equal 1 even if kernel gives asymmetric or non-uniform row sums.
   By :user:`Dan Schult <dschult>`.

--- a/doc/whats_new/upcoming_changes/sklearn.semi_supervised/31924.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.semi_supervised/31924.fix.rst
@@ -1,4 +1,4 @@
 - User written kernel results are now normalized in
-  :class:`semi-supervized._label_propagation.LabelPropagation`
+  :class:`semi-supervized.LabelPropagation`
   so all row sums equal 1 even if kernel gives asymmetric or non-uniform row sums.
   By :user:`Dan Schult <dschult>`.

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -462,9 +462,11 @@ class LabelPropagation(BaseLabelPropagation):
             # handle spmatrix (make 1D)
             if sparse.isspmatrix(affinity_matrix):
                 normalizer = np.ravel(normalizer)
-            # common case: knn method gives row sum k for all rows
-            # but user-kernel row sums may not be the same so normalize that case
-            if not np.all(normalizer == normalizer[0]):
+            # common case: knn method gives row sum k for all rows but
+            # a user-kernel may have varied row sums so "else" handles that
+            if np.all(normalizer == normalizer[0]):
+                affinity_matrix.data /= normalizer[0]
+            else:
                 if affinity_matrix.format == "csr":
                     repeats = np.diff(affinity_matrix.indptr)
                     rows = np.repeat(np.arange(affinity_matrix.shape[0]), repeats)

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -461,7 +461,14 @@ class LabelPropagation(BaseLabelPropagation):
         # handle spmatrix (make normalizer 1D)
         if sparse.isspmatrix(affinity_matrix):
             normalizer = np.ravel(normalizer)
-        affinity_matrix /= normalizer[:, np.newaxis]
+        # Todo: when SciPy 1.12+ is min dependence, replace up to ---- with:
+        # affinity_matrix /= normalizer[:, np.newaxis]
+        if sparse.issparse(affinity_matrix):
+            inv_normalizer = sparse.diags(1.0 / normalizer)
+            affinity_matrix = inv_normalizer @ affinity_matrix
+        else:  # Dense affinity_matrix
+            affinity_matrix /= normalizer[:, np.newaxis]
+        # ----
         return affinity_matrix
 
     def fit(self, X, y):

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -463,9 +463,8 @@ class LabelPropagation(BaseLabelPropagation):
             if sparse.isspmatrix(affinity_matrix):
                 normalizer = np.ravel(normalizer)
             # common case: knn method gives row sum k for all rows
-            if np.all(normalizer == normalizer[0]):
-                affinity_matrix.data /= normalizer[0]
-            else:  # row sums not the same
+            # but user-kernel row sums may not be the same so normalize that case
+            if not np.all(normalizer == normalizer[0]):
                 if affinity_matrix.format == "csr":
                     repeats = np.diff(affinity_matrix.indptr)
                     rows = np.repeat(np.arange(affinity_matrix.shape[0]), repeats)

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -461,7 +461,7 @@ class LabelPropagation(BaseLabelPropagation):
         # handle spmatrix (make normalizer 1D)
         if sparse.isspmatrix(affinity_matrix):
             normalizer = np.ravel(normalizer)
-        # Todo: when SciPy 1.12+ is min dependence, replace up to ---- with:
+        # TODO: when SciPy 1.12+ is min dependence, replace up to ---- with:
         # affinity_matrix /= normalizer[:, np.newaxis]
         if sparse.issparse(affinity_matrix):
             inv_normalizer = sparse.diags(1.0 / normalizer)

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -458,23 +458,10 @@ class LabelPropagation(BaseLabelPropagation):
             self.nn_fit = None
         affinity_matrix = self._get_kernel(self.X_)
         normalizer = affinity_matrix.sum(axis=1)
-        if sparse.issparse(affinity_matrix):
-            # handle spmatrix (make 1D)
-            if sparse.isspmatrix(affinity_matrix):
-                normalizer = np.ravel(normalizer)
-            # common case: knn method gives row sum k for all rows but
-            # a user-kernel may have varied row sums so "else" handles that
-            if np.all(normalizer == normalizer[0]):
-                affinity_matrix.data /= normalizer[0]
-            else:
-                if affinity_matrix.format == "csr":
-                    repeats = np.diff(affinity_matrix.indptr)
-                    rows = np.repeat(np.arange(affinity_matrix.shape[0]), repeats)
-                else:  # CSC format
-                    rows = affinity_matrix.indices
-                affinity_matrix.data /= normalizer[rows]
-        else:  # Dense affinity_matrix
-            affinity_matrix /= normalizer[:, np.newaxis]
+        # handle spmatrix (make normalizer 1D)
+        if sparse.isspmatrix(affinity_matrix):
+            normalizer = np.ravel(normalizer)
+        affinity_matrix /= normalizer[:, np.newaxis]
         return affinity_matrix
 
     def fit(self, X, y):

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -160,7 +160,7 @@ def test_label_propagation_build_graph_normalized(constructor, Estimator, parame
 
     clf = Estimator(kernel=kernel_affinity_matrix).fit(X, labels)
     graph = clf._build_graph()
-    assert_allclose(graph.sum(axis=1), 1)  # normalized
+    assert_allclose(graph.sum(axis=1), 1)  # normalized rows
 
     if issparse(graph):
         graph = graph.toarray()

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -160,7 +160,9 @@ def test_label_propagation_build_graph_normalized(constructor, Estimator, parame
 
     clf = Estimator(kernel=kernel_affinity_matrix).fit(X, labels)
     graph = clf._build_graph()
-    if sparse.issparse(graph):
+    assert_allclose(graph.sum(axis=1), 1)  # normalized
+
+    if issparse(graph):
         graph = graph.toarray()
     assert_allclose(graph, expected)
 

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -145,8 +145,8 @@ def test_sparse_input_types(
 
 
 @pytest.mark.parametrize("constructor", CONSTRUCTOR_TYPES)
-@pytest.mark.parametrize("Estimator, parameters", ESTIMATORS[1:2])
-def test_build_graph_normalized(constructor, Estimator, parameters):
+@pytest.mark.parametrize("Estimator, parameters", ESTIMATORS[:2])
+def test_label_propagation_build_graph_normalized(constructor, Estimator, parameters):
     # required but unused X and labels values
     X = np.array([[1.0, 0.0], [1.0, 1.0], [1.0, 3.0]])
     labels = [0, 1, -1]

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -160,7 +160,9 @@ def test_label_propagation_build_graph_normalized(constructor, Estimator, parame
 
     clf = Estimator(kernel=kernel_affinity_matrix).fit(X, labels)
     graph = clf._build_graph()
-    assert_array_equal(getattr(graph, "toarray", lambda: graph)(), expected)
+    if sparse.issparse(graph):
+        graph = graph.toarray()
+    assert_allclose(graph, expected)
 
 
 @pytest.mark.parametrize("constructor_type", CONSTRUCTOR_TYPES)

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -36,6 +36,10 @@ ESTIMATORS = [
     ),
 ]
 
+LP_ESTIMATORS = [
+    est for est in ESTIMATORS if isinstance(est, label_propagation.LabelPropagation)
+]
+
 
 @pytest.mark.parametrize("Estimator, parameters", ESTIMATORS)
 def test_fit_transduction(global_dtype, Estimator, parameters):
@@ -145,7 +149,7 @@ def test_sparse_input_types(
 
 
 @pytest.mark.parametrize("constructor", CONSTRUCTOR_TYPES)
-@pytest.mark.parametrize("Estimator, parameters", ESTIMATORS[:2])
+@pytest.mark.parametrize("Estimator, parameters", LP_ESTIMATORS)
 def test_label_propagation_build_graph_normalized(constructor, Estimator, parameters):
     # required but unused X and labels values
     X = np.array([[1.0, 0.0], [1.0, 1.0], [1.0, 3.0]])

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -37,7 +37,9 @@ ESTIMATORS = [
 ]
 
 LP_ESTIMATORS = [
-    est for est in ESTIMATORS if isinstance(est, label_propagation.LabelPropagation)
+    (klass, params)
+    for (klass, params) in ESTIMATORS
+    if klass == label_propagation.LabelPropagation
 ]
 
 


### PR DESCRIPTION
Fixes #31872 : strange normalization in semi-supervised label propagation

**The trouble briefly:**
- In the dense affinity_matrix case, the current code sums axis=0 and then divides the rows by these sums. Other normalizations in `semi_supervised` use axis=1. This does not cause errors so long as we have symmetric affinity_matrix. The dense case arises for kernel `"rbf"` which provides symmetric matrices. But if someone provides their own kernel the normalization could be incorrect.
- In the sparse affinity_matrix case, the current code divides all rows by the sum of the first row. This does not cause errors so long as the row sums are all the same. The sparse case arises for kernel `"knn"` which has all rows sum to `k`. But if someone provides their own kernel the normalization could be incorrect.
- The normalization is different for the dense and sparse cases, which could be confusing to someone writing their own kernel.

This PR adds tests to of proper normalization that agrees between sparse and dense.
It also adjusts the code so it can work with sparse arrays or sparse matrices.

The tests check that normalization agrees between dense and sparse cases even if the affinity_matrix is not symmetric and does not have equal row sums.  The errors corrected here do not arise for users who use the sklearn kernel options.

I discovered this when working on making sure sparse arrays and sparse matrices result in the same values (#31177). This PR splits it out of the other PR because it corrects/changes the current code and adds a test. Separating it from the large number of changes in the other PR is prudent, and eases review. 