### PR TITLE
FIX HDBSCAN: prevent in-place mutation for dense precomputed matrices

### DIFF
--- a/sklearn/cluster/_hdbscan/hdbscan.py
+++ b/sklearn/cluster/_hdbscan/hdbscan.py
@@ -658,7 +658,7 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
         "cluster_selection_method": [StrOptions({"eom", "leaf"})],
         "allow_single_cluster": ["boolean"],
         "store_centers": [None, StrOptions({"centroid", "medoid", "both"})],
-        "copy": ["boolean",None],
+        "copy": ["boolean", None],
     }
 
     def __init__(
@@ -719,14 +719,14 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
             raise ValueError(
                 "Cannot store centers when using a precomputed distance matrix."
             )
-        
-        #a copy of the copy parameter is made to avoid modifying the original
-        copy_val=self.copy
+
+        copy_val = self.copy
         # If copy_val is not specified, we default it to True for 'precomputed'
-        # metrics to avoid inplace modifications and False for all other metrics.
+        # and not sparseto avoid inplace modifications and
+        # False for all other metrics.
         if copy_val is None:
             copy_val = self.metric == "precomputed" and not issparse(X)
-            
+
         self._metric_params = self.metric_params or {}
         if self.metric != "precomputed":
             # Non-precomputed matrices may contain non-finite values.
@@ -780,9 +780,9 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
             # Perform data validation after removing infinite values (numpy.inf)
             # from the given distance matrix.
             X = validate_data(
-                self, 
-                X, 
-                ensure_all_finite=False, 
+                self,
+                X,
+                ensure_all_finite=False,
                 dtype=np.float64,
                 force_writeable=True,
             )

--- a/sklearn/cluster/_hdbscan/hdbscan.py
+++ b/sklearn/cluster/_hdbscan/hdbscan.py
@@ -718,8 +718,9 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
             raise ValueError(
                 "Cannot store centers when using a precomputed distance matrix."
             )
-        # If copy is not specified, we default to True for precomputed and
-        # False for all other metrics.
+        
+        # If copy is not specified, we default to True for precomputed
+        # to avoid inplace modifications and False for all other metrics.
         if self.copy is None:
             self.copy = self.metric == "precomputed"
             

--- a/sklearn/cluster/_hdbscan/hdbscan.py
+++ b/sklearn/cluster/_hdbscan/hdbscan.py
@@ -527,12 +527,14 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
           depend on a euclidean metric.
         - `"both"` which computes and stores both forms of centers.
 
-    copy : bool, default=False
+    copy : bool, default=None
         If `copy=True` then any time an in-place modifications would be made
         that would overwrite data passed to :term:`fit`, a copy will first be
         made, guaranteeing that the original data will be unchanged.
         Currently, it only applies when `metric="precomputed"`, when passing
         a dense array or a CSR sparse matrix and when `algorithm="brute"`.
+        If None (default), the behavior is chosen automatically:
+        copy=True if metric='precomputed'; otherwise copy=False.
 
     Attributes
     ----------
@@ -716,7 +718,8 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
             raise ValueError(
                 "Cannot store centers when using a precomputed distance matrix."
             )
-
+        # If copy is not specified, we default to True for precomputed and
+        # False for all other metrics.
         if self.copy is None:
             self.copy = self.metric == "precomputed"
             

--- a/sklearn/cluster/_hdbscan/hdbscan.py
+++ b/sklearn/cluster/_hdbscan/hdbscan.py
@@ -655,7 +655,7 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
         "cluster_selection_method": [StrOptions({"eom", "leaf"})],
         "allow_single_cluster": ["boolean"],
         "store_centers": [None, StrOptions({"centroid", "medoid", "both"})],
-        "copy": ["boolean"],
+        "copy": ["boolean",None],
     }
 
     def __init__(
@@ -673,7 +673,7 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
         cluster_selection_method="eom",
         allow_single_cluster=False,
         store_centers=None,
-        copy=False,
+        copy=None,
     ):
         self.min_cluster_size = min_cluster_size
         self.min_samples = min_samples
@@ -717,6 +717,9 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
                 "Cannot store centers when using a precomputed distance matrix."
             )
 
+        if self.copy is None:
+            self.copy = self.metric == "precomputed"
+            
         self._metric_params = self.metric_params or {}
         if self.metric != "precomputed":
             # Non-precomputed matrices may contain non-finite values.
@@ -770,7 +773,11 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
             # Perform data validation after removing infinite values (numpy.inf)
             # from the given distance matrix.
             X = validate_data(
-                self, X, ensure_all_finite=False, dtype=np.float64, force_writeable=True
+                self, 
+                X, 
+                ensure_all_finite=False, 
+                dtype=np.float64,
+                force_writeable=True,
             )
             if np.isnan(X).any():
                 # TODO: Support np.nan in Cython implementation for precomputed


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #31907 


#### What does this implement/fix? Explain your changes.
What’s the bug:
When using `metric='precomputed'`, scikit-learn’s HDBSCAN modified the input matrix in place. 
This breaks the expected contract that input data passed to `fit` remain unchanged.

What this PR does:
- Changes the default `copy` parameter from False to None.
- Allows `None` in `_parameter_constraints` for `copy` to enable the new default.
- In `fit()`, handles `copy` automatically if not explicitly set by the user.
- In `fit()`, the code automatically sets `copy=True` if `metric='precomputed'` and was not set by the user; otherwise sets to `copy=False` maintaining the earlier default behavior.
- Updates `copy` parameter documentation to describe this improved behavior.

Why:
This ensures the user’s dense precomputed distance matrix is preserved during clustering, 
avoiding unintended side effects, while preventing unnecessary copies when not needed.

#### Any other comments?

I have some other ideas as well to fix this bug if `None` should be strictly avoided for the `copy` parameter.
