### PR TITLE
MNT remove PA_C from SGD and (re-) use eta0

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -1363,13 +1363,14 @@ Passive Aggressive Algorithms
 The passive-aggressive (PA) algorithms are another family of 2 algorithms (PA-I and
 PA-II) for large-scale online learning that derive from SGD. They are similar to the
 Perceptron in that they do not require a learning rate. However, contrary to the
-Perceptron, they include a regularization parameter ``PA_C``.
+Perceptron, they include a regularization parameter ``eta0`` (:math:`C` in the
+reference paper).
 
 For classification,
-:class:`SGDClassifier(loss="hinge", penalty=None, learning_rate="pa1", PA_C=1.0)` can
+:class:`SGDClassifier(loss="hinge", penalty=None, learning_rate="pa1", eta0=1.0)` can
 be used for PA-I or with ``learning_rate="pa2"`` for PA-II. For regression,
 :class:`SGDRegressor(loss="epsilon_insensitive", penalty=None, learning_rate="pa1",
-PA_C=1.0)` can be used for PA-I or with ``learning_rate="pa2"`` for PA-II.
+eta0=1.0)` can be used for PA-I or with ``learning_rate="pa2"`` for PA-II.
 
 .. dropdown:: References
 

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/29097.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/29097.api.rst
@@ -3,4 +3,4 @@
   and `SGDRegressor`, both of which expose the options `learning_rate="pa1"` and
   `"pa2"`. The parameter `eta0` can be used to specify the aggressiveness parameter of
   the Passive-Aggressive-Algorithms, called C in the reference paper.
-  By :user:`Christian Lorentzen <lorentzenchr>`.
+  By :user:`Christian Lorentzen <lorentzenchr>` :pr:`31932` and

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/29097.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/29097.api.rst
@@ -1,6 +1,6 @@
 - `PassiveAggressiveClassifier` and `PassiveAggressiveRegressor` are deprecated
   and will be removed in 1.10. Equivalent estimators are available with `SGDClassifier`
   and `SGDRegressor`, both of which expose the options `learning_rate="pa1"` and
-  `"pa2"` as well as the new parameter `PA_C` for the aggressiveness parameter of the
-  Passive-Aggressive-Algorithms.
+  `"pa2"`. The parameter `eta0` can be used to specify the aggressiveness parameter of
+  the Passive-Aggressive-Algorithms, called C in the reference paper.
   By :user:`Christian Lorentzen <lorentzenchr>`.

--- a/examples/applications/plot_out_of_core_classification.py
+++ b/examples/applications/plot_out_of_core_classification.py
@@ -209,7 +209,7 @@ partial_fit_classifiers = {
     "Perceptron": Perceptron(),
     "NB Multinomial": MultinomialNB(alpha=0.01),
     "Passive-Aggressive": SGDClassifier(
-        loss="hinge", penalty=None, learning_rate="pa1", PA_C=1.0
+        loss="hinge", penalty=None, learning_rate="pa1", eta0=1.0
     ),
 }
 

--- a/sklearn/linear_model/_passive_aggressive.py
+++ b/sklearn/linear_model/_passive_aggressive.py
@@ -16,7 +16,7 @@ from sklearn.utils._param_validation import Interval, StrOptions
 # TODO(1.10): Remove
 @deprecated(
     "this is deprecated in version 1.8 and will be removed in 1.10. "
-    "Use `SGDClassifier(loss='hinge', penalty=None, learning_rate='pa1', PA_C=1.0)` "
+    "Use `SGDClassifier(loss='hinge', penalty=None, learning_rate='pa1', eta0=1.0)` "
     "instead."
 )
 class PassiveAggressiveClassifier(BaseSGDClassifier):
@@ -32,7 +32,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
                 loss="hinge",
                 penalty=None,
                 learning_rate="pa1",  # or "pa2"
-                PA_C=1.0,  # for parameter C
+                eta0=1.0,  # for parameter C
             )
 
     Read more in the :ref:`User Guide <passive_aggressive>`.
@@ -42,8 +42,8 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
     C : float, default=1.0
         Aggressiveness parameter for the passive-agressive algorithm, see [1].
         For PA-I it is the maximum step size. For PA-II it regularizes the
-        step size (the smaller `PA_C` the more it regularizes).
-        As a general rule-of-thumb, `PA_C` should be small when the data is noisy.
+        step size (the smaller `C` the more it regularizes).
+        As a general rule-of-thumb, `C` should be small when the data is noisy.
 
     fit_intercept : bool, default=True
         Whether the intercept should be estimated or not. If False, the
@@ -234,8 +234,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
             shuffle=shuffle,
             verbose=verbose,
             random_state=random_state,
-            eta0=1.0,
-            PA_C=C,
+            eta0=C,
             warm_start=warm_start,
             class_weight=class_weight,
             average=average,
@@ -343,7 +342,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
 @deprecated(
     "this is deprecated in version 1.8 and will be removed in 1.10. "
     "Use `SGDRegressor(loss='epsilon_insensitive', penalty=None, learning_rate='pa1', "
-    "PA_C = 1.0)` instead."
+    "eta0 = 1.0)` instead."
 )
 class PassiveAggressiveRegressor(BaseSGDRegressor):
     """Passive Aggressive Regressor.
@@ -358,7 +357,7 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
                 loss="epsilon_insensitive",
                 penalty=None,
                 learning_rate="pa1",  # or "pa2"
-                PA_C=1.0,  # for parameter C
+                eta0=1.0,  # for parameter C
             )
 
     Read more in the :ref:`User Guide <passive_aggressive>`.
@@ -369,8 +368,8 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
     C : float, default=1.0
         Aggressiveness parameter for the passive-agressive algorithm, see [1].
         For PA-I it is the maximum step size. For PA-II it regularizes the
-        step size (the smaller `PA_C` the more it regularizes).
-        As a general rule-of-thumb, `PA_C` should be small when the data is noisy.
+        step size (the smaller `C` the more it regularizes).
+        As a general rule-of-thumb, `C` should be small when the data is noisy.
 
     fit_intercept : bool, default=True
         Whether the intercept should be estimated or not. If False, the
@@ -536,8 +535,7 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
             penalty=None,
             l1_ratio=0,
             epsilon=epsilon,
-            eta0=1.0,
-            PA_C=C,
+            eta0=C,
             fit_intercept=fit_intercept,
             max_iter=max_iter,
             tol=tol,

--- a/sklearn/linear_model/_sgd_fast.pyx.tp
+++ b/sklearn/linear_model/_sgd_fast.pyx.tp
@@ -280,7 +280,6 @@ def _plain_sgd{{name_suffix}}(
     CyLossFunction loss,
     int penalty_type,
     double alpha,
-    double PA_C,
     double l1_ratio,
     SequentialDataset{{name_suffix}} dataset,
     const uint8_t[::1] validation_mask,
@@ -322,12 +321,6 @@ def _plain_sgd{{name_suffix}}(
         The penalty 2 for L2, 1 for L1, and 3 for Elastic-Net.
     alpha : float
         The regularization parameter.
-    PA_C : float
-        Aggressiveness parameter for the passive-agressive algorithm, see [1].
-        For PA-I (PA1) it is the maximum step size. For PA-II (PA2) it regularizes the
-        step size (the smaller `PA_C` the more it regularizes).
-        As a general rule-of-thumb, `PA_C` should be small when the data is noisy.
-        Only used if `learning_rate=PA1` or `PA2`.
     l1_ratio : float
         The Elastic Net mixing parameter, with 0 <= l1_ratio <= 1.
         l1_ratio=0 corresponds to L2 penalty, l1_ratio=1 to L1.
@@ -365,10 +358,19 @@ def _plain_sgd{{name_suffix}}(
         (2) optimal, eta = 1.0/(alpha * t).
         (3) inverse scaling, eta = eta0 / pow(t, power_t)
         (4) adaptive decrease
-        (5) Passive Aggressive-I, eta = min(PA_C, loss/norm(x)**2), see [1]
-        (6) Passive Aggressive-II, eta = 1.0 / (norm(x)**2 + 0.5/PA_C), see [1]
+        (5) Passive Aggressive-I, eta = min(eta0, loss/norm(x)**2), see [1]
+        (6) Passive Aggressive-II, eta = 1.0 / (norm(x)**2 + 0.5/eta0), see [1]
     eta0 : double
         The initial learning rate.
+        For PA-1 (`learning_rate=PA1`) and PA-II (`PA2`), it specifies the
+        aggressiveness parameter for the passive-agressive algorithm, see [1] where it
+        is called C:
+
+        - For PA-I it is the maximum step size.
+        - For PA-II it regularizes the step size (the smaller `eta0` the more it
+          regularizes).
+
+        As a general rule-of-thumb for PA, `eta0` should be small when the data is noisy.
     power_t : double
         The exponent for inverse scaling learning rate.
     one_class : boolean
@@ -380,7 +382,6 @@ def _plain_sgd{{name_suffix}}(
     average : int
         The number of iterations before averaging starts. average=1 is
         equivalent to averaging for all iterations.
-
 
     Returns
     -------
@@ -496,10 +497,10 @@ def _plain_sgd{{name_suffix}}(
                     update = sqnorm(x_data_ptr, x_ind_ptr, xnnz)
                     if update == 0:
                         continue
-                    update = min(PA_C, loss.cy_loss(y, p) / update)
+                    update = min(eta0, loss.cy_loss(y, p) / update)
                 elif learning_rate == PA2:
                     update = sqnorm(x_data_ptr, x_ind_ptr, xnnz)
-                    update = loss.cy_loss(y, p) / (update + 0.5 / PA_C)
+                    update = loss.cy_loss(y, p) / (update + 0.5 / eta0)
                 else:
                     dloss = loss.cy_gradient(y, p)
                     # clip dloss with large values to avoid numerical

--- a/sklearn/linear_model/tests/test_passive_aggressive.py
+++ b/sklearn/linear_model/tests/test_passive_aggressive.py
@@ -317,7 +317,7 @@ def test_passive_aggressive_classifier_vs_sgd(loss, lr):
     )
     pa = PassiveAggressiveClassifier(loss=loss, C=0.987, random_state=42).fit(X, y)
     sgd = SGDClassifier(
-        loss="hinge", penalty=None, learning_rate=lr, PA_C=0.987, random_state=42
+        loss="hinge", penalty=None, learning_rate=lr, eta0=0.987, random_state=42
     ).fit(X, y)
     assert_allclose(pa.decision_function(X), sgd.decision_function(X))
 
@@ -339,7 +339,7 @@ def test_passive_aggressive_regressor_vs_sgd(loss, lr):
         epsilon=0.123,
         penalty=None,
         learning_rate=lr,
-        PA_C=0.987,
+        eta0=0.987,
         random_state=42,
     ).fit(X, y)
     assert_allclose(pa.predict(X), sgd.predict(X))

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1469,7 +1469,9 @@ def test_learning_curve_with_shuffle():
     groups = np.array([1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 4, 4, 4, 4])
     # Splits on these groups fail without shuffle as the first iteration
     # of the learning curve doesn't contain label 4 in the training set.
-    estimator = SGDClassifier(max_iter=5, tol=None, shuffle=False, learning_rate="pa1")
+    estimator = SGDClassifier(
+        max_iter=5, tol=None, shuffle=False, learning_rate="pa1", eta0=1
+    )
 
     cv = GroupKFold(n_splits=2)
     train_sizes_batch, train_scores_batch, test_scores_batch = learning_curve(


### PR DESCRIPTION
#### Reference Issues/PRs
Follow-up of #29097.

#### What does this implement/fix? Explain your changes.
This PR removes the newly introduces (not yet released) `PA_C` parameter of SGD and reuses the already existing `eta0` to specify the aggressiveness parameter for the passive-aggressive algorithm.

#### Any other comments?
No deprecation cycle need if merged before 1.8 release.