### PR TITLE
TST fix test_dtype_preprocess_data

### DIFF
--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -649,8 +649,8 @@ def test_dtype_preprocess_data(rescale_with_sw, fit_intercept, global_random_see
     assert X_64.dtype == np.float64
     assert y_64.dtype == np.float64
 
-    assert_allclose(Xt_32, Xt_64, rtol=1e-3, atol=1e-7)
-    assert_allclose(yt_32, yt_64, rtol=1e-3, atol=1e-7)
+    assert_allclose(Xt_32, Xt_64, rtol=1e-3, atol=1e-6)
+    assert_allclose(yt_32, yt_64, rtol=1e-3, atol=1e-6)
     assert_allclose(X_mean_32, X_mean_64, rtol=1e-6)
     assert_allclose(y_mean_32, y_mean_64, rtol=1e-6)
     assert_allclose(X_scale_32, X_scale_64)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes https://github.com/scikit-learn/scikit-learn/pull/31418#issuecomment-3178038134.

Close #31913

#### What does this implement/fix? Explain your changes.
`test_dtype_preprocess_data` fails for a few values of `SKLEARN_TESTS_GLOBAL_RANDOM_SEED`.

#### Any other comments?
