### PR TITLE
DOC Clarify LabelEncoder does not support set_output

### DIFF
--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -48,6 +48,11 @@ class LabelEncoder(TransformerMixin, BaseEstimator, auto_wrap_output_keys=None):
         scheme.
     OneHotEncoder : Encode categorical features as a one-hot numeric array.
 
+    Notes
+    -----
+    This transformer is designed for encoding the target `y` (a 1-dimensional array)
+    and does not support the `set_output` API.
+
     Examples
     --------
     `LabelEncoder` can be used to normalize labels.


### PR DESCRIPTION
Fixes #26711

#### What does this implement/fix? Explain your changes.

This PR addresses the `AttributeError` by adding a `Notes` section to the `LabelEncoder` docstring. The note clarifies that `LabelEncoder` is intended for target encoding (`y`) and does not support the `set_output` API. This helps manage user expectations and explains the intended use of the class.

#### Any other comments?

(No other comments)