### PR TITLE
ENH avoid copies of X in `_alpha_grid` for coordinate descent

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/31946.efficiency.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/31946.efficiency.rst
@@ -1,0 +1,4 @@
+- :class:`linear_model.ElasticNetCV`, :class:`linear_model.LassoCV`,
+  :class:`linear_model.MultiTaskElasticNetCV` and :class:`linear_model.MultiTaskLassoCV`
+  avoid an additional copy of `X` with default `copy_X=True`.
+  By :user:`Christian Lorentzen <lorentzenchr>`.


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
This PR avoids copies of `X` in any case in `_alpha_grid`. The main impact is in `ElasticNetCV(copy_X=True)`, `LassoCV(copy_X=True)`, `MultiTaskElasticNetCV(copy_X=True)` and `MultiTaskLassoCV(copy_X=True)`.

#### Any other comments?
It also decouples `_alpha_grid` and `_preprocess_data`.