### PR TITLE
ENH add sparse_matmul_to_dense

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.utils/31952.efficiency.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/31952.efficiency.rst
@@ -1,0 +1,5 @@
+- The function :func:`linear_model.utils.safe_sparse_dot` was improved by a dedicated
+  Cython routine for the case of `a @ b` with sparse 2-dimensional `a` and `b` and when
+  a dense output is required, i.e., `dense_output=True`. This improves many algorithms
+  in scikit-learn when dealing with sparse arrays (or matrices).
+  By :user:`Christian Lorentzen <lorentzenchr>`.

--- a/doc/whats_new/upcoming_changes/sklearn.utils/31952.efficiency.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/31952.efficiency.rst
@@ -1,5 +1,5 @@
 - The function :func:`linear_model.utils.safe_sparse_dot` was improved by a dedicated
   Cython routine for the case of `a @ b` with sparse 2-dimensional `a` and `b` and when
-  a dense output is required, i.e., `dense_output=True`. This improves many algorithms
-  in scikit-learn when dealing with sparse arrays (or matrices).
+  a dense output is required, i.e., `dense_output=True`. This improves several
+  algorithms in scikit-learn when dealing with sparse arrays (or matrices).
   By :user:`Christian Lorentzen <lorentzenchr>`.

--- a/sklearn/linear_model/_linear_loss.py
+++ b/sklearn/linear_model/_linear_loss.py
@@ -8,7 +8,7 @@ Loss functions for linear models with raw_prediction = X @ coef
 import numpy as np
 from scipy import sparse
 
-from sklearn.utils.extmath import squared_norm
+from sklearn.utils.extmath import safe_sparse_dot, squared_norm
 
 
 def sandwich_dot(X, W):
@@ -24,9 +24,11 @@ def sandwich_dot(X, W):
     # which (might) detect the symmetry and use BLAS SYRK under the hood.
     n_samples = X.shape[0]
     if sparse.issparse(X):
-        return (
-            X.T @ sparse.dia_matrix((W, 0), shape=(n_samples, n_samples)) @ X
-        ).toarray()
+        return safe_sparse_dot(
+            X.T,
+            sparse.dia_matrix((W, 0), shape=(n_samples, n_samples)) @ X,
+            dense_output=True,
+        )
     else:
         # np.einsum may use less memory but the following, using BLAS matrix
         # multiplication (gemm), is by far faster.

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -14,6 +14,9 @@ from sklearn.utils.sparsefuncs_fast import (
     csc_mean_variance_axis0 as _csc_mean_var_axis0,
 )
 from sklearn.utils.sparsefuncs_fast import (
+    csr_matmul_csr_to_dense,
+)
+from sklearn.utils.sparsefuncs_fast import (
     csr_mean_variance_axis0 as _csr_mean_var_axis0,
 )
 from sklearn.utils.sparsefuncs_fast import (
@@ -740,3 +743,65 @@ def _implicit_column_offset(X, offset):
         dtype=X.dtype,
         shape=X.shape,
     )
+
+
+def sparse_matmul_to_dense(A, B, out=None):
+    """Compute A @ B for sparse and 2-dim A and B, return ndarray.
+
+    Parameters
+    ----------
+    A : sparse matrix of shape (n1, n2) and format CSC or CSR
+
+    B : sparse matrix of shape (n2, n3) and format CSC or CSR
+
+    out : ndarray of shape (n1, n3) or None
+
+    Returns
+    -------
+    out
+        ndarray, new created if out=None
+    """
+    if not (sp.issparse(A) and A.format in ("csc", "csr") and A.ndim == 2):
+        raise ValueError("Input 'A' must be a sparse 2-dim CSC or CSR array.")
+    if not (sp.issparse(B) and B.format in ("csc", "csr") and B.ndim == 2):
+        raise ValueError("Input 'B' must be a sparse 2-dim CSC or CSR array.")
+    if A.shape[1] != B.shape[0]:
+        msg = (
+            "Shapes must fulfil A.shape[1] == B.shape[1], "
+            f"got {A.shape[1]} == {B.shape[0]}."
+        )
+        raise ValueError(msg)
+    n1, n2 = A.shape
+    n3 = B.shape[1]
+    if A.dtype != B.dtype or A.dtype not in (np.float32, np.float64):
+        msg = "Dtype of A and B must be the same, either both float32 or float64."
+        raise ValueError(msg)
+    if out is None:
+        out = np.empty((n1, n3), dtype=A.data.dtype)
+    else:
+        if out.shape[0] != n1 or out.shape[1] != n3:
+            raise ValueError("Shape of out must be ({n1}, {n3}), got {out.shape}.")
+        if out.dtype != A.data.dtype:
+            raise ValueError("Dtype of out must match the one of input A..")
+
+    transpose_out = False
+    if A.format == "csc":
+        if B.format == "csc":
+            # out.T = (A @ B).T = B.T @ B.T, note that A.T and B.T are csr
+            transpose_out = True
+            A, B, out = B.T, A.T, out.T
+            n1, n3 = n3, n1
+        else:
+            # It seems best to just convert to csr.
+            A = A.tocsr()
+    elif B.format == "csc":
+        # It seems best to just convert to csr.
+        B = B.tocsr()
+
+    csr_matmul_csr_to_dense(
+        A.data, A.indices, A.indptr, B.data, B.indices, B.indptr, out, n1, n2, n3
+    )
+    if transpose_out:
+        out = out.T
+
+    return out

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -751,15 +751,16 @@ def sparse_matmul_to_dense(A, B, out=None):
     Parameters
     ----------
     A : sparse matrix of shape (n1, n2) and format CSC or CSR
-
+        Left-side input matrix.
     B : sparse matrix of shape (n2, n3) and format CSC or CSR
-
+        Right-side input matrix.
     out : ndarray of shape (n1, n3) or None
+        Optional ndarray into which the result is written.
 
     Returns
     -------
     out
-        ndarray, new created if out=None
+        An ndarray, new created if out=None.
     """
     if not (sp.issparse(A) and A.format in ("csc", "csr") and A.ndim == 2):
         raise ValueError("Input 'A' must be a sparse 2-dim CSC or CSR array.")

--- a/sklearn/utils/sparsefuncs.py
+++ b/sklearn/utils/sparsefuncs.py
@@ -746,7 +746,7 @@ def _implicit_column_offset(X, offset):
 
 
 def sparse_matmul_to_dense(A, B, out=None):
-    """Compute A @ B for sparse and 2-dim A and B, return ndarray.
+    """Compute A @ B for sparse and 2-dim A and B while returning an ndarray.
 
     Parameters
     ----------
@@ -768,7 +768,7 @@ def sparse_matmul_to_dense(A, B, out=None):
         raise ValueError("Input 'B' must be a sparse 2-dim CSC or CSR array.")
     if A.shape[1] != B.shape[0]:
         msg = (
-            "Shapes must fulfil A.shape[1] == B.shape[1], "
+            "Shapes must fulfil A.shape[1] == B.shape[0], "
             f"got {A.shape[1]} == {B.shape[0]}."
         )
         raise ValueError(msg)
@@ -783,12 +783,12 @@ def sparse_matmul_to_dense(A, B, out=None):
         if out.shape[0] != n1 or out.shape[1] != n3:
             raise ValueError("Shape of out must be ({n1}, {n3}), got {out.shape}.")
         if out.dtype != A.data.dtype:
-            raise ValueError("Dtype of out must match the one of input A..")
+            raise ValueError("Dtype of out must match that of input A..")
 
     transpose_out = False
     if A.format == "csc":
         if B.format == "csc":
-            # out.T = (A @ B).T = B.T @ B.T, note that A.T and B.T are csr
+            # out.T = (A @ B).T = B.T @ A.T, note that A.T and B.T are csr
             transpose_out = True
             A, B, out = B.T, A.T, out.T
             n1, n3 = n3, n1

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -658,6 +658,8 @@ def csr_matmul_csr_to_dense(
 ):
     """Computes a @ b for sparse csr a and b, returns dense array.
 
+    The shape of `a` is `(n1, n2)` and the shape of `b` is `(n2, n3)`.
+
     See also
     Gamma: Leveraging Gustavson's Algorithm to Accelerate Sparse Matrix Multiplication
     https://dl.acm.org/doi/pdf/10.1145/3445814.3446702

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -15,6 +15,10 @@ ctypedef fused integral:
     int32_t
     int64_t
 
+ctypedef fused integral2:
+    int32_t
+    int64_t
+
 
 def csr_row_norms(X):
     """Squared L2 norm of each row in CSR matrix X."""
@@ -645,8 +649,8 @@ def csr_matmul_csr_to_dense(
     const integral[:] a_indices,
     const integral[:] a_indptr,
     const floating[:] b_data,
-    const integral[:] b_indices,
-    const integral[:] b_indptr,
+    const integral2[:] b_indices,
+    const integral2[:] b_indptr,
     floating[:, :] out,
     uint64_t n1,
     uint64_t n2,
@@ -660,7 +664,7 @@ def csr_matmul_csr_to_dense(
     """
     cdef uint64_t i
     cdef uint64_t j
-    cdef integral j_ind
+    cdef integral2 j_ind
     cdef uint64_t k
     cdef integral k_ind
     cdef floating a_value

--- a/sklearn/utils/sparsefuncs_fast.pyx
+++ b/sklearn/utils/sparsefuncs_fast.pyx
@@ -652,7 +652,12 @@ def csr_matmul_csr_to_dense(
     uint64_t n2,
     uint64_t n3,
 ):
-    """Computes a @ b for sparse csr a and b, returns dense array."""
+    """Computes a @ b for sparse csr a and b, returns dense array.
+
+    See also
+    Gamma: Leveraging Gustavson's Algorithm to Accelerate Sparse Matrix Multiplication
+    https://dl.acm.org/doi/pdf/10.1145/3445814.3446702
+    """
     cdef uint64_t i
     cdef uint64_t j
     cdef integral j_ind
@@ -670,64 +675,3 @@ def csr_matmul_csr_to_dense(
                 j = b_indices[j_ind]
                 # out[i, j] += a[i, k] * b[k, j]
                 out[i, j] += a_value * b_data[j_ind]
-
-
-def csr_matmul_csc_to_dense(
-    const floating[:] a_data,
-    const integral[:] a_indices,
-    const integral[:] a_indptr,
-    const floating[:] b_data,
-    const integral[:] b_indices,
-    const integral[:] b_indptr,
-    floating[:, :] out,
-    uint64_t n1,
-    uint64_t n2,
-    uint64_t n3,
-):
-    """Computes a @ b for sparse csr a and csc b, returns dense array.
-
-    See also
-    Gamma: Leveraging Gustavson’s Algorithm to Accelerate Sparse Matrix Multiplication
-    https://dl.acm.org/doi/pdf/10.1145/3445814.3446702
-    """
-    cdef uint64_t i
-    cdef uint64_t j
-    cdef uint64_t k
-    cdef uint64_t k_a
-    cdef uint64_t k_b
-    cdef integral a_indp
-    cdef integral a_indp_end
-    cdef integral b_indp
-    cdef integral b_indp_end
-
-    with nogil:
-        for i in range(n1):  # n1
-            for j in range(n3):  # n3
-                out[i, j] = 0
-                a_indp = a_indptr[i]
-                a_indp_end = a_indptr[i + 1]
-                k_a = a_indices[a_indp]
-                b_indp = b_indptr[j]
-                b_indp_end = b_indptr[j + 1]
-                k_b = b_indices[b_indp]
-                for k in range(n2):  # n2 maximum number of iterations
-                    if k_a < k_b:
-                        a_indp += 1
-                        if a_indp >= a_indp_end:
-                            break  # end of for k
-                        k_a = a_indices[a_indp]
-                    elif k_b < k_a:
-                        b_indp += 1
-                        if b_indp >= b_indp_end:
-                            break  # end of for k
-                        k_b = b_indices[b_indp]
-                    else:
-                        out[i, j] += a_data[a_indp] * b_data[b_indp]
-                        a_indp += 1
-                        if a_indp >= a_indp_end:
-                            break  # end of for k
-                        k_a = a_indices[a_indp]
-                        b_indp += 1
-                        if b_indp >= b_indp_end:
-                            break  # end of for k
-                        k_b = b_indices[b_indp]

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -19,6 +19,7 @@ from sklearn.utils.sparsefuncs import (
     inplace_swap_row,
     mean_variance_axis,
     min_max_axis,
+    sparse_matmul_to_dense,
 )
 from sklearn.utils.sparsefuncs_fast import (
     assign_rows_csr,
@@ -996,3 +997,57 @@ def test_implit_center_rmatvec(global_random_seed, centered_matrices):
     y = rng.standard_normal(X_dense_centered.shape[0])
     assert_allclose(X_dense_centered.T @ y, X_sparse_centered.rmatvec(y))
     assert_allclose(X_dense_centered.T @ y, X_sparse_centered.T @ y)
+
+
+@pytest.mark.parametrize(
+    ["A", "B", "out", "msg"],
+    [
+        (sp.eye(3, format="csr"), sp.eye(2, format="csr"), None, "Shapes must fulfil"),
+        (sp.eye(2, format="csr"), sp.eye(2, format="csr"), np.eye(3), "Shape of out"),
+        (sp.eye(2, format="coo"), sp.eye(2, format="csr"), None, "Input 'A' must"),
+        (sp.eye(2, format="csr"), sp.eye(2, format="coo"), None, "Input 'B' must"),
+        (
+            sp.eye(2, format="csr", dtype=np.int32),
+            sp.eye(2, format="csr"),
+            None,
+            "Dtype of A and B",
+        ),
+        (
+            sp.eye(2, format="csr", dtype=np.float32),
+            sp.eye(2, format="csr", dtype=np.float64),
+            None,
+            "Dtype of A and B",
+        ),
+    ],
+)
+def test_csr_matmul_csr_to_dense_raises(A, B, out, msg):
+    """Test that sparse_matmul_to_dense raises when it should."""
+    with pytest.raises(ValueError, match=msg):
+        sparse_matmul_to_dense(A, B, out=out)
+
+
+@pytest.mark.parametrize("out_is_None", [False, True])
+@pytest.mark.parametrize("a_container", CSC_CONTAINERS + CSR_CONTAINERS)
+@pytest.mark.parametrize("b_container", CSC_CONTAINERS + CSR_CONTAINERS)
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_csr_matmul_csr_to_dense(
+    global_random_seed, out_is_None, a_container, b_container, dtype
+):
+    """Test that sparse_matmul_to_dense computes correctly."""
+    rng = np.random.default_rng(global_random_seed)
+    n1, n2, n3 = 10, 19, 13
+    a_dense = rng.standard_normal((n1, n2)).astype(dtype)
+    b_dense = rng.standard_normal((n2, n3)).astype(dtype)
+    a_dense.flat[rng.choice([False, True], size=n1 * n2, p=[0.5, 0.5])] = 0
+    b_dense.flat[rng.choice([False, True], size=n2 * n3, p=[0.5, 0.5])] = 0
+    a = a_container(a_dense)
+    b = b_container(b_dense)
+    if out_is_None:
+        out = None
+    else:
+        out = np.empty((n1, n3), dtype=dtype)
+
+    result = sparse_matmul_to_dense(a, b, out=out)
+    assert_allclose(result, a_dense @ b_dense)
+    if not out_is_None:
+        assert_allclose(out, result)

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -1020,7 +1020,7 @@ def test_implit_center_rmatvec(global_random_seed, centered_matrices):
         ),
     ],
 )
-def test_csr_matmul_csr_to_dense_raises(A, B, out, msg):
+def test_sparse_matmul_to_dense_raises(A, B, out, msg):
     """Test that sparse_matmul_to_dense raises when it should."""
     with pytest.raises(ValueError, match=msg):
         sparse_matmul_to_dense(A, B, out=out)
@@ -1030,7 +1030,7 @@ def test_csr_matmul_csr_to_dense_raises(A, B, out, msg):
 @pytest.mark.parametrize("a_container", CSC_CONTAINERS + CSR_CONTAINERS)
 @pytest.mark.parametrize("b_container", CSC_CONTAINERS + CSR_CONTAINERS)
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_csr_matmul_csr_to_dense(
+def test_sparse_matmul_to_dense(
     global_random_seed, out_is_None, a_container, b_container, dtype
 ):
     """Test that sparse_matmul_to_dense computes correctly."""


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #516.

#### What does this implement/fix? Explain your changes.
This adds a dedicated Cython routine to compute `dense_C = sparse_A @ sparse_B`.

#### Any other comments?
