### PR TITLE
MNT reduce test duration

### DIFF
--- a/sklearn/tests/test_metaestimators_metadata_routing.py
+++ b/sklearn/tests/test_metaestimators_metadata_routing.py
@@ -306,7 +306,7 @@ METAESTIMATORS: list = [
         "metaestimator": RANSACRegressor,
         "estimator_name": "estimator",
         "estimator": "regressor",
-        "init_args": {"min_samples": 0.5},
+        "init_args": {"min_samples": 0.5, "max_trials": 10},
         "X": X,
         "y": y,
         "preserves_metadata": "subset",


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.


#### Any other comments?
Often `RANSACRegressor` causes the slowest test, see e.g. https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=79084&view=logs&jobId=78a0bf4f-79e5-5387-94ec-13e67d216d6e&j=f71949a9-f9d9-549e-cf45-2e99c7b412d1&t=d5baef2b-8bda-5a4c-e848-157b5caff279

```
============================= slowest 20 durations =============================
25.49s call     tests/test_metaestimators_metadata_routing.py::test_setting_request_on_sub_estimator_removes_error[RANSACRegressor]
16.53s call     tests/test_metaestimators_metadata_routing.py::test_error_on_missing_requests_for_sub_estimator[RANSACRegressor]
11.64s call     model_selection/tests/test_validation.py::test_cross_validate_params_none[permutation_test_score-extra_args4]
8.37s call     model_selection/tests/test_validation.py::test_validation_functions_routing[permutation_test_score-extra_args4]
```

This PR reduces this time.