### PR TITLE
CI Temporary work-around for Windows wheels on Python 3.13

### DIFF
--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -24,6 +24,11 @@ if [[ $FREE_THREADED_BUILD == "False" ]]; then
         PYTHON_DOCKER_IMAGE_PART="${PYTHON_DOCKER_IMAGE_PART}-rc"
     fi
 
+    # Temporary work-around to avoid a loky issue on Windows >= 3.13.7
+    if [[ "$PYTHON_DOCKER_IMAGE_PART" == "3.13" ]]; then
+        PYTHON_DOCKER_IMAGE_PART="3.13.6"
+    fi
+
     # We could have all of the following logic in a Dockerfile but it's a lot
     # easier to do it in bash rather than figure out how to do it in Powershell
     # inside the Dockerfile ...


### PR DESCRIPTION
Fix https://github.com/scikit-learn/scikit-learn/issues/31955 by making sure we are using Python 3.13.6 when testing the Python 3.13 wheel.