### PR TITLE
CI Work around loky windows 3.13.7 for free threaded wheel

### DIFF
--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -24,7 +24,8 @@ if [[ $FREE_THREADED_BUILD == "False" ]]; then
         PYTHON_DOCKER_IMAGE_PART="${PYTHON_DOCKER_IMAGE_PART}-rc"
     fi
 
-    # Temporary work-around to avoid a loky issue on Windows >= 3.13.7
+    # Temporary work-around to avoid a loky issue on Windows >= 3.13.7, see
+    # https://github.com/joblib/loky/issues/459
     if [[ "$PYTHON_DOCKER_IMAGE_PART" == "3.13" ]]; then
         PYTHON_DOCKER_IMAGE_PART="3.13.6"
     fi

--- a/build_tools/wheels/build_wheels.sh
+++ b/build_tools/wheels/build_wheels.sh
@@ -53,5 +53,7 @@ fi
 # in the pyproject.toml file, while the tests are run
 # against the most recent version of the dependencies
 
-python -m pip install cibuildwheel
+# We install cibuildwheel 3.1.3 as a temporary work-around to avoid a loky
+# issue on Windows >= 3.13.7, see https://github.com/joblib/loky/issues/459.
+python -m pip install cibuildwheel==3.1.3
 python -m cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
Fix https://github.com/scikit-learn/scikit-learn/issues/31974.

Follow-up of https://github.com/scikit-learn/scikit-learn/pull/31964.

It seems like the only way to avoid Python 3.13.7 with `cibuildwheel` is to pin `cibuildwheel` version to `3.1.3`. I could not find way to specify the Python bugfix version (Python 3.13.6 vs Python 3.13.7).