### PR TITLE
MNT DNPY_NO_DEPRECATED_API=NPY_1_22_API_VERSION and security fixes

### DIFF
--- a/sklearn/meson.build
+++ b/sklearn/meson.build
@@ -100,7 +100,7 @@ inc_np = include_directories(incdir_numpy)
 # Don't use the deprecated NumPy C API. Define this to a fixed version instead of
 # NPY_API_VERSION in order not to break compilation for released SciPy versions
 # when NumPy introduces a new deprecation.
-numpy_no_deprecated_api = ['-DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION']
+numpy_no_deprecated_api = ['-DNPY_NO_DEPRECATED_API=NPY_1_22_API_VERSION']
 np_dep = declare_dependency(include_directories: inc_np, compile_args: numpy_no_deprecated_api)
 
 openmp_dep = dependency('OpenMP', language: 'c', required: false)

--- a/sklearn/metrics/_dist_metrics.pyx.tp
+++ b/sklearn/metrics/_dist_metrics.pyx.tp
@@ -846,7 +846,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
 
             intp_t i1, i2
             intp_t x1_start, x1_end
-            {{INPUT_DTYPE_t}} * x2_data
+            const {{INPUT_DTYPE_t}} * x2_data
 
         with nogil:
             # Use the exact same adaptation for CSR than in SparseDenseDatasetsPair
@@ -910,7 +910,7 @@ cdef class DistanceMetric{{name_suffix}}(DistanceMetric):
             {{INPUT_DTYPE_t}}[:, ::1] Darr = np.empty((n_X, n_Y), dtype={{INPUT_DTYPE}}, order='C')
 
             intp_t i1, i2
-            {{INPUT_DTYPE_t}} * x1_data
+            const {{INPUT_DTYPE_t}} * x1_data
 
             intp_t x2_start, x2_end
 

--- a/sklearn/neighbors/_ball_tree.pyx.tp
+++ b/sklearn/neighbors/_ball_tree.pyx.tp
@@ -98,7 +98,7 @@ cdef int init_node{{name_suffix}}(
     cdef float64_t radius
     cdef const {{INPUT_DTYPE_t}} *this_pt
 
-    cdef intp_t* idx_array = &tree.idx_array[0]
+    cdef const intp_t* idx_array = &tree.idx_array[0]
     cdef const {{INPUT_DTYPE_t}}* data = &tree.data[0, 0]
     cdef {{INPUT_DTYPE_t}}* centroid = &tree.node_bounds[0, i_node, 0]
 

--- a/sklearn/svm/src/liblinear/linear.cpp
+++ b/sklearn/svm/src/liblinear/linear.cpp
@@ -73,7 +73,7 @@ static void info(const char *fmt,...)
 	char buf[BUFSIZ];
 	va_list ap;
 	va_start(ap,fmt);
-	vsprintf(buf,fmt,ap);
+	vsnprintf(buf,sizeof buf,fmt,ap);
 	va_end(ap);
 	(*liblinear_print_string)(buf);
 }

--- a/sklearn/svm/src/liblinear/tron.cpp
+++ b/sklearn/svm/src/liblinear/tron.cpp
@@ -23,7 +23,7 @@ void TRON::info(const char *fmt,...)
 	char buf[BUFSIZ];
 	va_list ap;
 	va_start(ap,fmt);
-	vsprintf(buf,fmt,ap);
+	vsnprintf(buf,sizeof buf,fmt,ap);
 	va_end(ap);
 	(*tron_print_string)(buf);
 }

--- a/sklearn/svm/src/libsvm/svm.cpp
+++ b/sklearn/svm/src/libsvm/svm.cpp
@@ -117,7 +117,7 @@ static void info(const char *fmt,...)
 	char buf[BUFSIZ];
 	va_list ap;
 	va_start(ap,fmt);
-	vsprintf(buf,fmt,ap);
+	vsnprintf(buf,sizeof buf,fmt,ap);
 	va_end(ap);
 	(*svm_print_string)(buf);
 }


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
With minimum numpy version 1.22 (as of now), it makes sense to enforce the numpy C API version 1.22.
This PR also fixes some minor (security) issues.

#### Any other comments?
My compiler says:
```
warning: 'vsprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use vsnprintf(3) instead. [-Wdeprecated-declarations]
     76 |         vsprintf(buf,fmt,ap);
        |         ^
```