### PR TITLE
FEA/API expose BaseScorer as public API

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/31985.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/31985.api.rst
@@ -1,0 +1,3 @@
+- :class:`sklearn.metrics.BaseScorer` is now a part of the public API. Custom scorers
+  can be implemented by inheriting from this class.
+  By `Adrin Jalali`_

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -576,7 +576,9 @@ def test_raises_on_score_list():
         grid_search.fit(X, y)
 
 
-@pytest.mark.parametrize("name", set(get_scorer_names()) - set(REGRESSION_SCORERS))
+@pytest.mark.parametrize(
+    "name", sorted(set(get_scorer_names()) - set(REGRESSION_SCORERS))
+)
 def test_classification_scorer_sample_weight(name):
     # Test that classification scorers support sample_weight or raise sensible
     # errors

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -251,7 +251,7 @@ def check_scoring_validator_for_single_metric_usecases(scoring_validator):
     estimator = EstimatorWithFit()
     scorer = scoring_validator(estimator, scoring="accuracy")
     assert isinstance(scorer, _Scorer)
-    assert scorer._response_method == "predict"
+    assert scorer.response_method == "predict"
 
     # Test the allow_none parameter for check_scoring alone
     if scoring_validator is check_scoring:
@@ -294,7 +294,7 @@ def test_check_scoring_and_check_multimetric_scoring(scoring):
     assert isinstance(scorers, dict)
     assert sorted(scorers.keys()) == sorted(list(scoring))
     assert all([isinstance(scorer, _Scorer) for scorer in list(scorers.values())])
-    assert all(scorer._response_method == "predict" for scorer in scorers.values())
+    assert all(scorer.response_method == "predict" for scorer in scorers.values())
 
     if "acc" in scoring:
         assert_almost_equal(
@@ -351,12 +351,12 @@ def test_check_scoring_gridsearchcv():
     grid = GridSearchCV(LinearSVC(), param_grid={"C": [0.1, 1]}, cv=3)
     scorer = check_scoring(grid, scoring="f1")
     assert isinstance(scorer, _Scorer)
-    assert scorer._response_method == "predict"
+    assert scorer.response_method == "predict"
 
     pipe = make_pipeline(LinearSVC())
     scorer = check_scoring(pipe, scoring="f1")
     assert isinstance(scorer, _Scorer)
-    assert scorer._response_method == "predict"
+    assert scorer.response_method == "predict"
 
     # check that cross_val_score definitely calls the scorer
     # and doesn't make any assumptions about the estimator apart from having a
@@ -1182,7 +1182,7 @@ def test_scorer_select_proba_error(scorer):
         n_classes=2, n_informative=3, n_samples=20, random_state=0
     )
     lr = LogisticRegression().fit(X, y)
-    assert scorer._kwargs["pos_label"] not in np.unique(y).tolist()
+    assert scorer.kwargs["pos_label"] not in np.unique(y).tolist()
 
     err_msg = "is not a valid label"
     with pytest.raises(ValueError, match=err_msg):

--- a/sklearn/tests/metadata_routing_common.py
+++ b/sklearn/tests/metadata_routing_common.py
@@ -443,14 +443,14 @@ class ConsumingScorer(_Scorer):
         )
         self.registry = registry
 
-    def _score(self, method_caller, clf, X, y, **kwargs):
+    def score(self, clf, X, y, y_pred, **kwargs):
         if self.registry is not None:
             self.registry.append(self)
 
         record_metadata_not_default(self, **kwargs)
 
         sample_weight = kwargs.get("sample_weight", None)
-        return super()._score(method_caller, clf, X, y, sample_weight=sample_weight)
+        return super().score(clf, X, y, y_pred, sample_weight=sample_weight)
 
 
 class ConsumingSplitter(GroupsConsumerMixin, BaseCrossValidator):

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -1429,9 +1429,17 @@ class _MetadataRequester:
             super().__init_subclass__(**kwargs)
             return
 
+        if "ConsumingRegressor" in cls.__name__:
+            print("ConsumingRegressor")
+
         for method in SIMPLE_METHODS:
-            if hasattr(cls, f"set_{method}_request"):
-                # we don't want to override existing methods (e.g. in scorers)
+            # We only override descriptors set by parent classes, and not actual
+            # methods implemented by the classes. "set_{method}_request" is explicitly
+            # implemented in scorers and some splitters for instance.
+            existing_method = getattr(cls, f"set_{method}_request", None)
+            if existing_method is not None and "RequestMethod" not in getattr(
+                existing_method, "__qualname__", ""
+            ):
                 continue
             mmr = getattr(requests, method)
             # set ``set_{method}_request`` methods

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -1429,9 +1429,6 @@ class _MetadataRequester:
             super().__init_subclass__(**kwargs)
             return
 
-        if "ConsumingRegressor" in cls.__name__:
-            print("ConsumingRegressor")
-
         for method in SIMPLE_METHODS:
             # We only override descriptors set by parent classes, and not actual
             # methods implemented by the classes. "set_{method}_request" is explicitly

--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -1430,6 +1430,9 @@ class _MetadataRequester:
             return
 
         for method in SIMPLE_METHODS:
+            if hasattr(cls, f"set_{method}_request"):
+                # we don't want to override existing methods (e.g. in scorers)
+                continue
             mmr = getattr(requests, method)
             # set ``set_{method}_request`` methods
             if not len(mmr.requests):


### PR DESCRIPTION
Exposing `BaseScorer` as a part of the public API.

This PR renames `_BaseScorer` to `BaseScorer`, and leaves `_BaseScorer` as a deprecated thing for one version to give people time to adapt. It also makes the attributes public (`score_func` instead of `_score_func`, ...).

The rest is what comes as a consequence of the change.

I'm thinking of moving things to `_Scorer` and make `_MultimetricScorer` also inherit from `_BaseScorer`.

