### PR TITLE
Add Frisch-Newton Solver for Quantile Regression without Penalization

### DIFF
--- a/sklearn/linear_model/_quantile.py
+++ b/sklearn/linear_model/_quantile.py
@@ -118,6 +118,7 @@ class QuantileRegressor(LinearModel, RegressorMixin, BaseEstimator):
                     "highs",
                     "interior-point",
                     "revised simplex",
+                    "frisch-newton"
                 }
             ),
         ],
@@ -186,6 +187,11 @@ class QuantileRegressor(LinearModel, RegressorMixin, BaseEstimator):
                 f"Solver {self.solver} is not anymore available in SciPy >= 1.11.0."
             )
 
+        if self.solver == "frisch-newton" and alpha != 0:
+            raise ValueError(
+                "Frisch-Newton solver does not support alpha != 0."
+            )
+
         if sparse.issparse(X) and self.solver not in ["highs", "highs-ds", "highs-ipm"]:
             raise ValueError(
                 f"Solver {self.solver} does not support sparse X. "
@@ -246,6 +252,11 @@ class QuantileRegressor(LinearModel, RegressorMixin, BaseEstimator):
                 A_eq = sparse.hstack([ones, X, -ones, -X, eye, -eye], format="csc")
             else:
                 A_eq = sparse.hstack([X, -X, eye, -eye], format="csc")
+
+        elif self.solver == "frisch-newton":
+            # not necessary to do all the work below
+            pass
+
         else:
             eye = np.eye(n_indices)
             if self.fit_intercept:
@@ -254,38 +265,56 @@ class QuantileRegressor(LinearModel, RegressorMixin, BaseEstimator):
             else:
                 A_eq = np.concatenate([X, -X, eye, -eye], axis=1)
 
-        b_eq = y
+        if self.solver == "frisch-newton":
 
-        result = linprog(
-            c=c,
-            A_eq=A_eq,
-            b_eq=b_eq,
-            method=self.solver,
-            options=solver_options,
-        )
-        solution = result.x
-        if not result.success:
-            failure = {
-                1: "Iteration limit reached.",
-                2: "Problem appears to be infeasible.",
-                3: "Problem appears to be unbounded.",
-                4: "Numerical difficulties encountered.",
-            }
-            warnings.warn(
-                "Linear programming for QuantileRegressor did not succeed.\n"
-                f"Status is {result.status}: "
-                + failure.setdefault(result.status, "unknown reason")
-                + "\n"
-                + "Result message of linprog:\n"
-                + result.message,
-                ConvergenceWarning,
+            if self.fit_intercept:
+                ones = np.ones((n_indices, 1))
+                X = np.concatenate([ones, X], axis = 1)
+
+            params, _it = frisch_newton_solver(
+                A=X.T,
+                b=(1 - self.quantile) * X.T @ np.ones(n_indices),
+                c=-y,
+                u=np.ones(n_indices),
+                q=self.quantile,
+                solver_options=solver_options
+
             )
 
-        # positive slack - negative slack
-        # solution is an array with (params_pos, params_neg, u, v)
-        params = solution[:n_params] - solution[n_params : 2 * n_params]
+        else:
 
-        self.n_iter_ = result.nit
+            b_eq = y
+            result = linprog(
+                c=c,
+                A_eq=A_eq,
+                b_eq=b_eq,
+                method=self.solver,
+                options=solver_options,
+            )
+
+            solution = result.x
+            if not result.success:
+                failure = {
+                    1: "Iteration limit reached.",
+                    2: "Problem appears to be infeasible.",
+                    3: "Problem appears to be unbounded.",
+                    4: "Numerical difficulties encountered.",
+                }
+                warnings.warn(
+                    "Linear programming for QuantileRegressor did not succeed.\n"
+                    f"Status is {result.status}: "
+                    + failure.setdefault(result.status, "unknown reason")
+                    + "\n"
+                    + "Result message of linprog:\n"
+                    + result.message,
+                    ConvergenceWarning,
+                )
+
+            # positive slack - negative slack
+            # solution is an array with (params_pos, params_neg, u, v)
+            params = solution[:n_params] - solution[n_params : 2 * n_params]
+
+        self.n_iter_ = _it if self.solver == "frisch-newton" else result.nit
 
         if self.fit_intercept:
             self.coef_ = params[1:]
@@ -299,3 +328,121 @@ class QuantileRegressor(LinearModel, RegressorMixin, BaseEstimator):
         tags = super().__sklearn_tags__()
         tags.input_tags.sparse = True
         return tags
+
+
+
+# -----------------------------------------------------------------------
+# FN Implementation from pyfixest starts here
+
+def _duality_gap(x, z, s, w):
+    return x @ z + s @ w
+
+
+def _bound(v: np.ndarray, dv: np.ndarray, backoff: float):
+    mask = dv < 0
+    if not mask.any():
+        return 1.0
+    alpha_max = (-v[mask] / dv[mask]).min()
+    return min(backoff * alpha_max, 1.0)
+
+
+def _step_length(a: tuple, b: tuple, backoff: float) -> float:
+    x, dx = a
+    s, ds = b
+    return min(_bound(x, dx, backoff), _bound(s, ds, backoff))
+
+
+def cold_start(A: np.ndarray, c: np.ndarray, q: float):
+    n = A.shape[1]
+    x = np.full(n, 1.0 - q)
+    s = np.full_like(x, q)
+    d_plus = np.maximum(c, 0.0)
+    d_minus = np.maximum(-c, 0.0)
+    U = x @ d_plus + s @ d_minus
+    mu0 = max(1, U / n)
+    alpha = (n * mu0 - U) / (np.sum(1 / x) + np.sum(1 / s))
+    eps = 1e-8
+    z = np.maximum(d_plus, eps) + alpha / x
+    w = np.maximum(d_minus, eps) + alpha / s
+    y = np.linalg.solve(A @ A.T, A @ (c - z + w))
+    return x, s, z, w, y
+
+
+def frisch_newton_solver(
+    A: np.ndarray,
+    b: np.ndarray,
+    c: np.ndarray,
+    u: np.ndarray,
+    q: float,
+    backoff: float = 0.9995,
+    solver_options: dict = None,
+):
+    if solver_options is None:
+        solver_options = {}
+    tol = solver_options.get("tol", 1e-7)
+    max_iter = solver_options.get("max_iter", 100)
+
+    m, n = A.shape
+    c, b, u = c.ravel(), b.ravel(), u.ravel()
+
+    x, s, z, w, y = cold_start(A=A, c=c, q=q)
+
+    mu_curr = _duality_gap(x=x, z=z, s=s, w=w)
+
+    for _it in range(max_iter):
+        if mu_curr < tol:
+            break
+
+        r1_tilde = c - A.T @ y
+        r2_tilde = b - A @ x
+
+        Qinv = 1.0 / (z / x + w / s)
+        M = A @ (Qinv[:, None] * A.T)
+        work_m = r2_tilde + A @ (Qinv * r1_tilde)
+        dy_aff = np.linalg.solve(M, work_m)
+
+        dx_aff = Qinv * (A.T @ dy_aff - r1_tilde)
+        ds_aff = -dx_aff
+        dz_aff = -z - (z / x) * dx_aff
+        dw_aff = -w - (w / s) * ds_aff
+
+        alpha_p_aff = _step_length(a=(x, dx_aff), b=(s, ds_aff), backoff=backoff)
+        alpha_d_aff = _step_length(a=(z, dz_aff), b=(w, dw_aff), backoff=backoff)
+
+        x_pred = x + alpha_p_aff * dx_aff
+        s_pred = s + alpha_p_aff * ds_aff
+        y_pred = y + alpha_d_aff * dy_aff
+        z_pred = z + alpha_d_aff * dz_aff
+        w_pred = w + alpha_d_aff * dw_aff
+
+        mu_aff = _duality_gap(x=x_pred, z=z_pred, s=s_pred, w=w_pred)
+
+        sigma = (mu_aff / mu_curr) ** 2
+        mu_targ = sigma * mu_curr / n
+
+        r1_hat = (
+            mu_targ * (1 / s - 1 / x) + (dx_aff * dz_aff) / x - (ds_aff * dw_aff) / s
+        )
+        work_m = A @ (Qinv * r1_hat)
+        dy_cor = np.linalg.solve(M, work_m)
+        dx_cor = Qinv * (A.T @ dy_cor - r1_hat)
+        ds_cor = -dx_cor
+        dz_cor = -(z / x) * dx_cor + (mu_targ - dx_aff * dz_aff) / x
+        dw_cor = -(w / s) * ds_cor + (mu_targ - ds_aff * dw_aff) / s
+
+        alpha_p_cor = _step_length(
+            a=(x_pred, dx_cor), b=(s_pred, ds_cor), backoff=backoff
+        )
+        alpha_d_cor = _step_length(
+            a=(z_pred, dz_cor), b=(w_pred, dw_cor), backoff=backoff
+        )
+
+        x = x_pred + alpha_p_cor * dx_cor
+        s = s_pred + alpha_p_cor * ds_cor
+        y = y_pred + alpha_d_cor * dy_cor
+        z = z_pred + alpha_d_cor * dz_cor
+        w = w_pred + alpha_d_cor * dw_cor
+
+        mu_curr = _duality_gap(x=x, z=z, s=s, w=w)
+
+    return -y, _it


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs

Implementation for Frisch Newton Solver: https://github.com/scikit-learn/scikit-learn/issues/31708


#### What does this implement/fix? Explain your changes.

Adds a faster solver for the Quantile Regression Problem without penalization (alpha = 0). 

#### Any other comments?

Very much in draft state; I will clean it up further tomorrow. 