### PR TITLE
MNT Avoid DeprecationWarning in numpy-dev

### DIFF
--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -100,7 +100,7 @@ def _affinity_propagation(
         R += tmp
 
         # tmp = Rp; compute availabilities
-        np.maximum(R, 0, tmp)
+        np.maximum(R, 0, out=tmp)
         tmp.flat[:: n_samples + 1] = R.flat[:: n_samples + 1]
 
         # tmp = -Anew


### PR DESCRIPTION
Fix #32005.

This is the warning:
```
DeprecationWarning: Passing more than 2 positional arguments to np.maximum and np.minimum is deprecated. If you meant to use the third argument as an output, use the `out` keyword argument instead. If you hoped to work with more than 2 inputs, combine them into a single array and get the extrema for the relevant axis.
```
