### PR TITLE
CI Add Python 3.14 nightly wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -207,7 +207,7 @@ jobs:
           CIBW_BEFORE_TEST_WINDOWS: bash build_tools/github/build_minimal_windows_image.sh ${{ matrix.python }}
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
           # TODO Put back pandas when they have released wheels on Python 3.14
-          CIBW_TEST_REQUIRES: ${{ contains(matrix.python, 'py314') && 'pytest' || 'pytest pandas' }}
+          CIBW_TEST_REQUIRES: ${{ contains(matrix.python, '314') && 'pytest' || 'pytest pandas' }}
           # On Windows, we use a custom Docker image and CIBW_TEST_REQUIRES_WINDOWS
           # does not make sense because it would install dependencies in the host
           # rather than inside the Docker image

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -206,7 +206,7 @@ jobs:
           CIBW_BEFORE_BUILD: bash {project}/build_tools/wheels/cibw_before_build.sh {project}
           CIBW_BEFORE_TEST_WINDOWS: bash build_tools/github/build_minimal_windows_image.sh ${{ matrix.python }}
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
-          CIBW_TEST_REQUIRES: pytest pandas
+          CIBW_TEST_REQUIRES: pytest # pandas
           # On Windows, we use a custom Docker image and CIBW_TEST_REQUIRES_WINDOWS
           # does not make sense because it would install dependencies in the host
           # rather than inside the Docker image

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -76,6 +76,9 @@ jobs:
             python: 313t
             platform_id: win_amd64
             cibw_enable: cpython-freethreading
+          - os: windows-latest
+            python: 314
+            platform_id: win_amd64
 
           # Linux 64 bit manylinux2014
           - os: ubuntu-latest
@@ -99,8 +102,12 @@ jobs:
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
             cibw_enable: cpython-freethreading
+          - os: ubuntu-latest
+            python: 314
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
 
-          # # Linux 64 bit manylinux2014
+          # Linux 64 bit manylinux2014
           - os: ubuntu-24.04-arm
             python: 310
             platform_id: manylinux_aarch64
@@ -122,6 +129,10 @@ jobs:
             platform_id: manylinux_aarch64
             manylinux_image: manylinux2014
             cibw_enable: cpython-freethreading
+          - os: ubuntu-24.04-arm
+            python: 314
+            platform_id: manylinux_aarch64
+            manylinux_image: manylinux2014
 
           # MacOS x86_64
           - os: macos-13
@@ -140,6 +151,9 @@ jobs:
             python: 313t
             platform_id: macosx_x86_64
             cibw_enable: cpython-freethreading
+          - os: macos-13
+            python: 314
+            platform_id: macosx_x86_64
 
           # MacOS arm64
           - os: macos-14
@@ -158,6 +172,9 @@ jobs:
             python: 313t
             platform_id: macosx_arm64
             cibw_enable: cpython-freethreading
+          - os: macos-14
+            python: 314
+            platform_id: macosx_arm64
 
     steps:
       - name: Checkout scikit-learn

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -60,118 +60,118 @@ jobs:
       matrix:
         include:
           # Window 64 bit
-          # - os: windows-latest
-          #   python: 310
-          #   platform_id: win_amd64
-          # - os: windows-latest
-          #   python: 311
-          #   platform_id: win_amd64
-          # - os: windows-latest
-          #   python: 312
-          #   platform_id: win_amd64
-          # - os: windows-latest
-          #   python: 313
-          #   platform_id: win_amd64
-          # - os: windows-latest
-          #   python: 313t
-          #   platform_id: win_amd64
-          #   cibw_enable: cpython-freethreading
+          - os: windows-latest
+            python: 310
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 311
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 312
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 313
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 313t
+            platform_id: win_amd64
+            cibw_enable: cpython-freethreading
           - os: windows-latest
             python: 314
             platform_id: win_amd64
 
           # Linux 64 bit manylinux2014
-          # - os: ubuntu-latest
-          #   python: 310
-          #   platform_id: manylinux_x86_64
-          #   manylinux_image: manylinux2014
-          # - os: ubuntu-latest
-          #   python: 311
-          #   platform_id: manylinux_x86_64
-          #   manylinux_image: manylinux2014
-          # - os: ubuntu-latest
-          #   python: 312
-          #   platform_id: manylinux_x86_64
-          #   manylinux_image: manylinux2014
-          # - os: ubuntu-latest
-          #   python: 313
-          #   platform_id: manylinux_x86_64
-          #   manylinux_image: manylinux2014
-          # - os: ubuntu-latest
-          #   python: 313t
-          #   platform_id: manylinux_x86_64
-          #   manylinux_image: manylinux2014
-          #   cibw_enable: cpython-freethreading
+          - os: ubuntu-latest
+            python: 310
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 311
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 312
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 313
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 313t
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+            cibw_enable: cpython-freethreading
           - os: ubuntu-latest
             python: 314
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
 
           # Linux 64 bit manylinux2014
-          # - os: ubuntu-24.04-arm
-          #   python: 310
-          #   platform_id: manylinux_aarch64
-          #   manylinux_image: manylinux2014
-          # - os: ubuntu-24.04-arm
-          #   python: 311
-          #   platform_id: manylinux_aarch64
-          #   manylinux_image: manylinux2014
-          # - os: ubuntu-24.04-arm
-          #   python: 312
-          #   platform_id: manylinux_aarch64
-          #   manylinux_image: manylinux2014
-          # - os: ubuntu-24.04-arm
-          #   python: 313
-          #   platform_id: manylinux_aarch64
-          #   manylinux_image: manylinux2014
-          # - os: ubuntu-24.04-arm
-          #   python: 313t
-          #   platform_id: manylinux_aarch64
-          #   manylinux_image: manylinux2014
-          #   cibw_enable: cpython-freethreading
+          - os: ubuntu-24.04-arm
+            python: 310
+            platform_id: manylinux_aarch64
+            manylinux_image: manylinux2014
+          - os: ubuntu-24.04-arm
+            python: 311
+            platform_id: manylinux_aarch64
+            manylinux_image: manylinux2014
+          - os: ubuntu-24.04-arm
+            python: 312
+            platform_id: manylinux_aarch64
+            manylinux_image: manylinux2014
+          - os: ubuntu-24.04-arm
+            python: 313
+            platform_id: manylinux_aarch64
+            manylinux_image: manylinux2014
+          - os: ubuntu-24.04-arm
+            python: 313t
+            platform_id: manylinux_aarch64
+            manylinux_image: manylinux2014
+            cibw_enable: cpython-freethreading
           - os: ubuntu-24.04-arm
             python: 314
             platform_id: manylinux_aarch64
             manylinux_image: manylinux2014
 
           # MacOS x86_64
-          # - os: macos-13
-          #   python: 310
-          #   platform_id: macosx_x86_64
-          # - os: macos-13
-          #   python: 311
-          #   platform_id: macosx_x86_64
-          # - os: macos-13
-          #   python: 312
-          #   platform_id: macosx_x86_64
-          # - os: macos-13
-          #   python: 313
-          #   platform_id: macosx_x86_64
-          # - os: macos-13
-          #   python: 313t
-          #   platform_id: macosx_x86_64
-          #   cibw_enable: cpython-freethreading
+          - os: macos-13
+            python: 310
+            platform_id: macosx_x86_64
+          - os: macos-13
+            python: 311
+            platform_id: macosx_x86_64
+          - os: macos-13
+            python: 312
+            platform_id: macosx_x86_64
+          - os: macos-13
+            python: 313
+            platform_id: macosx_x86_64
+          - os: macos-13
+            python: 313t
+            platform_id: macosx_x86_64
+            cibw_enable: cpython-freethreading
           - os: macos-13
             python: 314
             platform_id: macosx_x86_64
 
           # MacOS arm64
-          # - os: macos-14
-          #   python: 310
-          #   platform_id: macosx_arm64
-          # - os: macos-14
-          #   python: 311
-          #   platform_id: macosx_arm64
-          # - os: macos-14
-          #   python: 312
-          #   platform_id: macosx_arm64
-          # - os: macos-14
-          #   python: 313
-          #   platform_id: macosx_arm64
-          # - os: macos-14
-          #   python: 313t
-          #   platform_id: macosx_arm64
-          #   cibw_enable: cpython-freethreading
+          - os: macos-14
+            python: 310
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 311
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 312
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 313
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 313t
+            platform_id: macosx_arm64
+            cibw_enable: cpython-freethreading
           - os: macos-14
             python: 314
             platform_id: macosx_arm64
@@ -206,7 +206,7 @@ jobs:
           CIBW_BEFORE_BUILD: bash {project}/build_tools/wheels/cibw_before_build.sh {project}
           CIBW_BEFORE_TEST_WINDOWS: bash build_tools/github/build_minimal_windows_image.sh ${{ matrix.python }}
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
-          # TODO Put back pandas when they have released wheels on Python 3.14
+          # TODO Put back pandas when there is a pandas release with Python 3.14 wheels
           CIBW_TEST_REQUIRES: ${{ contains(matrix.python, '314') && 'pytest' || 'pytest pandas' }}
           # On Windows, we use a custom Docker image and CIBW_TEST_REQUIRES_WINDOWS
           # does not make sense because it would install dependencies in the host

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -60,118 +60,118 @@ jobs:
       matrix:
         include:
           # Window 64 bit
-          - os: windows-latest
-            python: 310
-            platform_id: win_amd64
-          - os: windows-latest
-            python: 311
-            platform_id: win_amd64
-          - os: windows-latest
-            python: 312
-            platform_id: win_amd64
-          - os: windows-latest
-            python: 313
-            platform_id: win_amd64
-          - os: windows-latest
-            python: 313t
-            platform_id: win_amd64
-            cibw_enable: cpython-freethreading
+          # - os: windows-latest
+          #   python: 310
+          #   platform_id: win_amd64
+          # - os: windows-latest
+          #   python: 311
+          #   platform_id: win_amd64
+          # - os: windows-latest
+          #   python: 312
+          #   platform_id: win_amd64
+          # - os: windows-latest
+          #   python: 313
+          #   platform_id: win_amd64
+          # - os: windows-latest
+          #   python: 313t
+          #   platform_id: win_amd64
+          #   cibw_enable: cpython-freethreading
           - os: windows-latest
             python: 314
             platform_id: win_amd64
 
           # Linux 64 bit manylinux2014
-          - os: ubuntu-latest
-            python: 310
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
-            python: 311
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
-            python: 312
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
-            python: 313
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
-            python: 313t
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-            cibw_enable: cpython-freethreading
+          # - os: ubuntu-latest
+          #   python: 310
+          #   platform_id: manylinux_x86_64
+          #   manylinux_image: manylinux2014
+          # - os: ubuntu-latest
+          #   python: 311
+          #   platform_id: manylinux_x86_64
+          #   manylinux_image: manylinux2014
+          # - os: ubuntu-latest
+          #   python: 312
+          #   platform_id: manylinux_x86_64
+          #   manylinux_image: manylinux2014
+          # - os: ubuntu-latest
+          #   python: 313
+          #   platform_id: manylinux_x86_64
+          #   manylinux_image: manylinux2014
+          # - os: ubuntu-latest
+          #   python: 313t
+          #   platform_id: manylinux_x86_64
+          #   manylinux_image: manylinux2014
+          #   cibw_enable: cpython-freethreading
           - os: ubuntu-latest
             python: 314
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
 
           # Linux 64 bit manylinux2014
-          - os: ubuntu-24.04-arm
-            python: 310
-            platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
-          - os: ubuntu-24.04-arm
-            python: 311
-            platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
-          - os: ubuntu-24.04-arm
-            python: 312
-            platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
-          - os: ubuntu-24.04-arm
-            python: 313
-            platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
-          - os: ubuntu-24.04-arm
-            python: 313t
-            platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
-            cibw_enable: cpython-freethreading
+          # - os: ubuntu-24.04-arm
+          #   python: 310
+          #   platform_id: manylinux_aarch64
+          #   manylinux_image: manylinux2014
+          # - os: ubuntu-24.04-arm
+          #   python: 311
+          #   platform_id: manylinux_aarch64
+          #   manylinux_image: manylinux2014
+          # - os: ubuntu-24.04-arm
+          #   python: 312
+          #   platform_id: manylinux_aarch64
+          #   manylinux_image: manylinux2014
+          # - os: ubuntu-24.04-arm
+          #   python: 313
+          #   platform_id: manylinux_aarch64
+          #   manylinux_image: manylinux2014
+          # - os: ubuntu-24.04-arm
+          #   python: 313t
+          #   platform_id: manylinux_aarch64
+          #   manylinux_image: manylinux2014
+          #   cibw_enable: cpython-freethreading
           - os: ubuntu-24.04-arm
             python: 314
             platform_id: manylinux_aarch64
             manylinux_image: manylinux2014
 
           # MacOS x86_64
-          - os: macos-13
-            python: 310
-            platform_id: macosx_x86_64
-          - os: macos-13
-            python: 311
-            platform_id: macosx_x86_64
-          - os: macos-13
-            python: 312
-            platform_id: macosx_x86_64
-          - os: macos-13
-            python: 313
-            platform_id: macosx_x86_64
-          - os: macos-13
-            python: 313t
-            platform_id: macosx_x86_64
-            cibw_enable: cpython-freethreading
+          # - os: macos-13
+          #   python: 310
+          #   platform_id: macosx_x86_64
+          # - os: macos-13
+          #   python: 311
+          #   platform_id: macosx_x86_64
+          # - os: macos-13
+          #   python: 312
+          #   platform_id: macosx_x86_64
+          # - os: macos-13
+          #   python: 313
+          #   platform_id: macosx_x86_64
+          # - os: macos-13
+          #   python: 313t
+          #   platform_id: macosx_x86_64
+          #   cibw_enable: cpython-freethreading
           - os: macos-13
             python: 314
             platform_id: macosx_x86_64
 
           # MacOS arm64
-          - os: macos-14
-            python: 310
-            platform_id: macosx_arm64
-          - os: macos-14
-            python: 311
-            platform_id: macosx_arm64
-          - os: macos-14
-            python: 312
-            platform_id: macosx_arm64
-          - os: macos-14
-            python: 313
-            platform_id: macosx_arm64
-          - os: macos-14
-            python: 313t
-            platform_id: macosx_arm64
-            cibw_enable: cpython-freethreading
+          # - os: macos-14
+          #   python: 310
+          #   platform_id: macosx_arm64
+          # - os: macos-14
+          #   python: 311
+          #   platform_id: macosx_arm64
+          # - os: macos-14
+          #   python: 312
+          #   platform_id: macosx_arm64
+          # - os: macos-14
+          #   python: 313
+          #   platform_id: macosx_arm64
+          # - os: macos-14
+          #   python: 313t
+          #   platform_id: macosx_arm64
+          #   cibw_enable: cpython-freethreading
           - os: macos-14
             python: 314
             platform_id: macosx_arm64

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -206,7 +206,8 @@ jobs:
           CIBW_BEFORE_BUILD: bash {project}/build_tools/wheels/cibw_before_build.sh {project}
           CIBW_BEFORE_TEST_WINDOWS: bash build_tools/github/build_minimal_windows_image.sh ${{ matrix.python }}
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
-          CIBW_TEST_REQUIRES: pytest # pandas
+          # TODO Put back pandas when they have released wheels on Python 3.14
+          CIBW_TEST_REQUIRES: ${{ contains(matrix.python, 'py314') && 'pytest' || 'pytest pandas' }}
           # On Windows, we use a custom Docker image and CIBW_TEST_REQUIRES_WINDOWS
           # does not make sense because it would install dependencies in the host
           # rather than inside the Docker image

--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -24,6 +24,11 @@ if [[ $FREE_THREADED_BUILD == "False" ]]; then
         PYTHON_DOCKER_IMAGE_PART="${PYTHON_DOCKER_IMAGE_PART}-rc"
     fi
 
+    # TODO Temporary work-around not sure CIBW_PRERELEASE_PYTHONS is still a thing
+    if [[ "$PYTHON_DOCKER_IMAGE_PART" == "3.14" ]]; then
+        PYTHON_DOCKER_IMAGE_PART="3.14-rc"
+    fi
+
     # Temporary work-around to avoid a loky issue on Windows >= 3.13.7, see
     # https://github.com/joblib/loky/issues/459
     if [[ "$PYTHON_DOCKER_IMAGE_PART" == "3.13" ]]; then

--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -20,11 +20,7 @@ if [[ $FREE_THREADED_BUILD == "False" ]]; then
     # Dot the Python version for identifying the base Docker image
     PYTHON_DOCKER_IMAGE_PART=$(echo ${PYTHON_VERSION:0:1}.${PYTHON_VERSION:1:2})
 
-    if [[ "$CIBW_PRERELEASE_PYTHONS" =~ [tT]rue ]]; then
-        PYTHON_DOCKER_IMAGE_PART="${PYTHON_DOCKER_IMAGE_PART}-rc"
-    fi
-
-    # TODO Temporary work-around not sure CIBW_PRERELEASE_PYTHONS is still a thing
+    # TODO Remove this when Python 3.14 is released and there is a Docker image
     if [[ "$PYTHON_DOCKER_IMAGE_PART" == "3.14" ]]; then
         PYTHON_DOCKER_IMAGE_PART="3.14-rc"
     fi

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -258,6 +258,12 @@ def test_warn_if_metric_bool_data_no_bool():
     msg = f"Data will be converted to boolean for metric {pairwise_metric}"
 
     with pytest.warns(DataConversionWarning, match=msg) as warn_record:
+        # Avoid a DeprecatedWarning from joblib <= 1.5.1 in Python 3.14
+        warnings.filterwarnings(
+            "ignore",
+            message="'asyncio.iscoroutinefunction' is deprecated",
+            category=DeprecationWarning,
+        )
         OPTICS(metric=pairwise_metric).fit(X)
         assert len(warn_record) == 1
 

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -258,7 +258,7 @@ def test_warn_if_metric_bool_data_no_bool():
     msg = f"Data will be converted to boolean for metric {pairwise_metric}"
 
     with pytest.warns(DataConversionWarning, match=msg) as warn_record:
-        # Avoid a DeprecatedWarning from joblib <= 1.5.1 in Python 3.14
+        # Avoid a DeprecationWarning from joblib <= 1.5.1 in Python 3.14
         warnings.filterwarnings(
             "ignore",
             message="'asyncio.iscoroutinefunction' is deprecated",

--- a/sklearn/cluster/tests/test_optics.py
+++ b/sklearn/cluster/tests/test_optics.py
@@ -258,7 +258,7 @@ def test_warn_if_metric_bool_data_no_bool():
     msg = f"Data will be converted to boolean for metric {pairwise_metric}"
 
     with pytest.warns(DataConversionWarning, match=msg) as warn_record:
-        # Avoid a DeprecationWarning from joblib <= 1.5.1 in Python 3.14
+        # Silence a DeprecationWarning from joblib <= 1.5.1 in Python 3.14+.
         warnings.filterwarnings(
             "ignore",
             message="'asyncio.iscoroutinefunction' is deprecated",

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -115,6 +115,7 @@ def _retry_on_network_error(
 
                     retry_counter -= 1
                     time.sleep(delay)
+
         return wrapper
 
     return decorator

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -112,6 +112,10 @@ def _retry_on_network_error(
                     retry_counter -= 1
                     time.sleep(delay)
 
+                    # This is needed to avoid a ResourceWarning on Python 3.14
+                    if isinstance(e, HTTPError):
+                        e.close()
+
         return wrapper
 
     return decorator

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -109,13 +109,12 @@ def _retry_on_network_error(
                     warn(
                         f"A network error occurred while downloading {url}. Retrying..."
                     )
-                    retry_counter -= 1
-                    time.sleep(delay)
-
-                    # Avoid a ResourceWarning on Python 3.14
+                    # Avoid a ResourceWarning on Python 3.14 and later.
                     if isinstance(e, HTTPError):
                         e.close()
 
+                    retry_counter -= 1
+                    time.sleep(delay)
         return wrapper
 
     return decorator

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -112,7 +112,7 @@ def _retry_on_network_error(
                     retry_counter -= 1
                     time.sleep(delay)
 
-                    # This is needed to avoid a ResourceWarning on Python 3.14
+                    # Avoid a ResourceWarning on Python 3.14
                     if isinstance(e, HTTPError):
                         e.close()
 

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -1540,9 +1540,11 @@ def test_open_openml_url_retry_on_network_error(monkeypatch):
             f" {invalid_openml_url}. Retrying..."
         ),
     ) as record:
-        with pytest.raises(HTTPError, match="Simulated network error"):
+        with pytest.raises(HTTPError, match="Simulated network error") as exc_info:
             _open_openml_url(invalid_openml_url, None, delay=0)
         assert len(record) == 3
+        # Avoids a ResourceWarning on Python 3.14
+        exc_info.value.close()
 
 
 ###############################################################################

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -1543,7 +1543,7 @@ def test_open_openml_url_retry_on_network_error(monkeypatch):
         with pytest.raises(HTTPError, match="Simulated network error") as exc_info:
             _open_openml_url(invalid_openml_url, None, delay=0)
         assert len(record) == 3
-        # Avoids a ResourceWarning on Python 3.14
+        # Avoid a ResourceWarning on Python 3.14
         exc_info.value.close()
 
 

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -1543,7 +1543,7 @@ def test_open_openml_url_retry_on_network_error(monkeypatch):
         with pytest.raises(HTTPError, match="Simulated network error") as exc_info:
             _open_openml_url(invalid_openml_url, None, delay=0)
         assert len(record) == 3
-        # Avoid a ResourceWarning on Python 3.14
+        # Avoid a ResourceWarning on Python 3.14 and later.
         exc_info.value.close()
 
 


### PR DESCRIPTION
Python 3.14 is rc2 right: now https://peps.python.org/pep-0745/.

Numpy has Python 3.14 wheels in their latest release (2.3.2 released end July 2025, see [this](pypi.org/project/numpy/2.3.2/#files)) and Scipy too (1.6.1 released end-July 2025 see [this](https://pypi.org/project/scipy/1.16.1/#files)).

pandas does not have Python 3.14 wheels yet, so I run the tests without pandas for Python 3.14.