### PR TITLE
CI Use pytest-xdist in debian 32 build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -213,8 +213,6 @@ jobs:
         DISTRIB: 'debian-32'
         COVERAGE: "true"
         LOCK_FILE: './build_tools/azure/debian_32bit_lock.txt'
-        # disable pytest xdist due to unknown bug with 32-bit container
-        PYTEST_XDIST_VERSION: 'none'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '4'  # non-default seed
 
 - template: build_tools/azure/posix.yml

--- a/build_tools/azure/debian_32bit_lock.txt
+++ b/build_tools/azure/debian_32bit_lock.txt
@@ -8,9 +8,11 @@ coverage[toml]==7.10.5
     # via pytest-cov
 cython==3.1.3
     # via -r build_tools/azure/debian_32bit_requirements.txt
+execnet==2.1.1
+    # via pytest-xdist
 iniconfig==2.1.0
     # via pytest
-joblib==1.5.1
+joblib==1.5.2
     # via -r build_tools/azure/debian_32bit_requirements.txt
 meson==1.9.0
     # via meson-python
@@ -35,7 +37,10 @@ pytest==8.4.1
     # via
     #   -r build_tools/azure/debian_32bit_requirements.txt
     #   pytest-cov
+    #   pytest-xdist
 pytest-cov==6.2.1
+    # via -r build_tools/azure/debian_32bit_requirements.txt
+pytest-xdist==3.8.0
     # via -r build_tools/azure/debian_32bit_requirements.txt
 threadpoolctl==3.6.0
     # via -r build_tools/azure/debian_32bit_requirements.txt

--- a/build_tools/azure/debian_32bit_requirements.txt
+++ b/build_tools/azure/debian_32bit_requirements.txt
@@ -5,6 +5,7 @@ cython
 joblib
 threadpoolctl
 pytest
+pytest-xdist
 pytest-cov
 ninja
 meson-python

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -58,7 +58,7 @@ if [[ "$COVERAGE" == "true" ]]; then
 fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
-    XDIST_WORKERS=$(python -c "import joblib; print(joblib.cpu_count(only_physical_cores=True))")
+    XDIST_WORKERS=$(python -c "import joblib; print(joblib.cpu_count())")
     TEST_CMD="$TEST_CMD -n$XDIST_WORKERS"
 fi
 

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -59,7 +59,9 @@ fi
 
 if [[ "$PYTEST_XDIST_VERSION" != "none" ]]; then
     XDIST_WORKERS=$(python -c "import joblib; print(joblib.cpu_count())")
-    TEST_CMD="$TEST_CMD -n$XDIST_WORKERS"
+    if [[ "$XDIST_WORKERS" != 1 ]]; then
+        TEST_CMD="$TEST_CMD -n$XDIST_WORKERS"
+    fi
 fi
 
 if [[ -n "$SELECTED_TESTS" ]]; then

--- a/build_tools/update_environments_and_lock_files.py
+++ b/build_tools/update_environments_and_lock_files.py
@@ -411,6 +411,7 @@ build_metadata_list = [
             "joblib",
             "threadpoolctl",
             "pytest",
+            "pytest-xdist",
             "pytest-cov",
             "ninja",
             "meson-python",


### PR DESCRIPTION
Debian 32 build tends to be one of the slow build I think, something like ~25 minutes where others are more 10-20 minutes. Let's see if using `pytest-xdist` still has issues and whether it speeds things up a bit.