### PR TITLE
MNT Add changelog README and PR checklist to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,14 @@
 <!--
-Thanks for contributing a pull request! Please ensure you have taken a look at
+🙌 Thanks for contributing a pull request! Please ensure you have taken a look at
 the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
+
+✅ In particular following the pull request checklist will increase the likelihood
+of having maintainers review your PR:
+https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist
+
+📋 If your PR is likely to affect users, you will need to add a changelog entry
+describing your PR changes, see:
+https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
 -->
 
 #### Reference Issues/PRs

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 <!--
-🙌 Thanks for contributing a pull request! Please ensure you have taken a look at
-the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
+🙌 Thanks for contributing a pull request!
+
+👀 Please ensure you have taken a look at the contribution guidelines:
+https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
 
 ✅ In particular following the pull request checklist will increase the likelihood
 of having maintainers review your PR:


### PR DESCRIPTION
Tackles @betatim's suggestion https://github.com/scikit-learn/scikit-learn/pull/31954#issuecomment-3197494088 to make it easier to have the link to the changelog README handy when you open a PR (even for maintainers).


Also:
1. add emoticons to make the content stand out a bit more (more than open to tweak the emoticons)
2. add a link to the PR checklist, on top of the link to `CONTRIBUTING.md` which is already there. `CONTRIBUTING.md` is short which is good but you can not expect people to click on the link and read the full contributing doc which any way is way too long (in my opinion).

If any of these 2 points proves too controversial I'll revert it :wink:
