### PR TITLE
ENH check t-SNE input are all finite

### DIFF
--- a/sklearn/manifold/_t_sne.py
+++ b/sklearn/manifold/_t_sne.py
@@ -30,7 +30,12 @@ from sklearn.neighbors import NearestNeighbors
 from sklearn.utils import check_random_state
 from sklearn.utils._openmp_helpers import _openmp_effective_n_threads
 from sklearn.utils._param_validation import Interval, StrOptions, validate_params
-from sklearn.utils.validation import _num_samples, check_non_negative, validate_data
+from sklearn.utils.validation import (
+    _num_samples,
+    check_array,
+    check_non_negative,
+    validate_data,
+)
 
 MACHINE_EPSILON = np.finfo(np.double).eps
 
@@ -1024,6 +1029,9 @@ class TSNE(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
             X_embedded = 1e-4 * random_state.standard_normal(
                 size=(n_samples, self.n_components)
             ).astype(np.float32)
+
+        # Check for non-finite values (NaNs and Infs) in the initialization array
+        X_embedded = check_array(X_embedded, ensure_all_finite=True)
 
         # Degrees of freedom of the Student's t-distribution. The suggestion
         # degrees_of_freedom = n_components - 1 comes from


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#28368 reports crashes caused by t-SNE on Windows.

#29127 reports crashes on Mac.

#### What does this implement/fix? Explain your changes.

Before calling `_tsne()`, check the initialization array `X_embedded` to be all finite.

#### Any other comments?
In `sklearn.manifold._t_sne.TSNE._fit`:

```Python
        if isinstance(self.init, np.ndarray):
            X_embedded = self.init
        elif self.init == "pca":
            pca = PCA(
                n_components=self.n_components,
                svd_solver="randomized",
                random_state=random_state,
            )
            # Always output a numpy array, no matter what is configured globally
            pca.set_output(transform="default")
            X_embedded = pca.fit_transform(X).astype(np.float32, copy=False)
            # PCA is rescaled so that PC1 has standard deviation 1e-4 which is
            # the default value for random initialization. See issue #18018.
            X_embedded = X_embedded / np.std(X_embedded[:, 0]) * 1e-4
        elif self.init == "random":
            # The embedding is initialized with iid samples from Gaussians with
            # standard deviation 1e-4.
            X_embedded = 1e-4 * random_state.standard_normal(
                size=(n_samples, self.n_components)
            ).astype(np.float32)
```

The line `X_embedded = X_embedded / np.std(X_embedded[:, 0]) * 1e-4` would leads to all-**NaN** entries. This could happen if `np.std(X_embedded[:, 0])` evaluates to zero (The #29127 case) if the first principal component has zero standard deviation.

By user input, the line `X_embedded = self.init` would include **NaN** or **Inf** entries. The crash caused by `sklearn.manifold.TSNE` can be reproduced by inserting a **NaN** or **Inf** entry to the initial `X_embedded`:

```Python
x = np.random.random(size=(5, 7))

init_x_embeddings = np.random.random(size=(5, 2))  # user-defined initials

init_x_embeddings[1, 1] = np.nan  # <<<<<<<<<< insert a nan here

tsne = TSNE(n_components=2, perplexity=3, verbose=5, init=init_x_embeddings)
embeddings = tsne.fit_transform(x)
print(embeddings)
```

The code runs into Segmentation fault 

```
[t-SNE] Computing 4 nearest neighbors...
[t-SNE] Indexed 5 samples in 0.000s...
[t-SNE] Computed neighbors for 5 samples in 0.014s...
[t-SNE] Computed conditional probabilities for sample 5 / 5
[t-SNE] Mean sigma: 0.610483
[t-SNE] Computed conditional probabilities in 0.001s
Segmentation fault (core dumped)
```

Or run with gdb

```
Thread 1 "python" received signal SIGSEGV, Segmentation fault.
0x00007fff4bf46d59 in __pyx_f_7sklearn_9neighbors_10_quad_tree_9_QuadTree__insert_point_in_new_child ()
   from /home/tokai/dev/sklearn_tsne/scikit-learn/build/cp312/sklearn/neighbors/_quad_tree.cpython-312-x86_64-linux-gnu.so
```

Same outcome if **Inf** or **-Inf** is inserted to the embeddings, and same happens on Windows.

**go further...**

The `_QuadTree` is used by `_kl_divergence_bh` to calculate KL-divergence. The `_QuadTree.build_tree()` is recursive.

```Python
import numpy as np
from sklearn.neighbors._quad_tree import _QuadTree

Y = np.array([[np.nan, np.nan], [np.nan, np.nan]], dtype=np.float32)
print(Y)

tree = _QuadTree(n_dimensions=2, verbose=0)
tree.verbose = 500
tree.build_tree(Y)
```

Result of above snippet:

```
[QuadTree] inserted point 0 in new child 32713
[QuadTree] Inserting depth 32712
[QuadTree] selected child 32713
[QuadTree] Inserting depth 32713
[QuadTree] inserted point 0 in new child 32714
[QuadTree] Inserting depth 32713
[QuadTree] selected child 32714
[QuadTree] Inserting depth 32714
[QuadTree] inserted point 0 in new child 32715
[QuadTree] Inserting depth 32714
[QuadTree] selected child 32715
[QuadTree] Inserting depth 32715
[QuadTree] inserted point 0 in new child 32716
[QuadTree] Inserting depth 32715
[QuadTree] selected child 32716
[QuadTree] Inserting depth 32716
[QuadTree] inserted point 0 in new child 32717
[QuadTree] Inserting depth 32716
[QuadTree] selected child 32717
[QuadTree] Inserting depth 32717
Segmentation fault (core dumped)
```

The cause of the crash is highly suspected to be stack overflow caused by infinite recursion.
