### PR TITLE
Fix doc formatting in ElasticNet and update _coordinate_descent

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -761,8 +761,8 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
     .. math::
 
         \\frac{1}{2 n_{\\rm samples}} \\|y - X w\\|_2^2
-        + \\alpha \\cdot l1_{ratio} \\|w\\|_1
-        + 0.5 \\cdot \\alpha \\cdot (1 - l1_{ratio}) \\|w\\|_2^2
+        + \\alpha \\cdot {\\rm l1_{ratio}} \\|w\\|_1
+        + 0.5 \\cdot \\alpha \\cdot (1 - {\\rm l1_{ratio}}) \\|w\\|_2^2
 
     If you are interested in controlling the L1 and L2 penalty
     separately, keep in mind that this is equivalent to:
@@ -775,11 +775,11 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
     .. math::
 
-        \\alpha = a + b, \\quad l1_{ratio} = \\frac{a}{a + b}
+        \\alpha = a + b, \\quad {\\rm l1_{ratio}} = \\frac{a}{a + b}
 
-    The parameter l1_{ratio} corresponds to alpha in the glmnet R package while
-    alpha corresponds to the lambda parameter in glmnet. Specifically, l1_{ratio}
-    = 1 is the lasso penalty. Currently, l1_{ratio} <= 0.01 is not reliable,
+    The parameter l1_ratio corresponds to alpha in the glmnet R package while
+    alpha corresponds to the lambda parameter in glmnet. Specifically, l1_ratio
+    = 1 is the lasso penalty. Currently, l1_ratio <= 0.01 is not reliable,
     unless you supply your own sequence of alpha.
 
     Read more in the :ref:`User Guide <elastic_net>`.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -769,7 +769,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
     .. math::
 
-        a \\|w\\|_1 + 0.5 b \\|w\\|_2^2
+        a \\cdot \\|w\\|_1 + 0.5 \\cdot b \\cdot \\|w\\|_2^2
 
     where:
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -760,9 +760,9 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
     .. math::
 
-        \\frac{1}{2 n_{\\rm samples}} \\|y - X w\\|_2^2
-        + \\alpha \\cdot {\\rm l1\\_{ratio}} \\|w\\|_1
-        + 0.5 \\cdot \\alpha \\cdot (1 - {\\rm l1\\_{ratio}}) \\|w\\|_2^2
+        \\frac{1}{2 n_{\\rm samples}} \\cdot \\|y - X w\\|_2^2
+        + \\alpha \\cdot {\\rm l1\\_{ratio}} \\cdot \\|w\\|_1
+        + 0.5 \\cdot \\alpha \\cdot (1 - {\\rm l1\\_{ratio}}) \\cdot \\|w\\|_2^2
 
     If you are interested in controlling the L1 and L2 penalty
     separately, keep in mind that this is equivalent to:

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -761,8 +761,8 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
     .. math::
 
         \\frac{1}{2 n_{\\rm samples}} \\|y - X w\\|_2^2
-        + \\alpha \\cdot {\\rm l1\_{ratio}} \\|w\\|_1
-        + 0.5 \\cdot \\alpha \\cdot (1 - {\\rm l1\_{ratio}}) \\|w\\|_2^2
+        + \\alpha \\cdot {\\rm l1\\_{ratio}} \\|w\\|_1
+        + 0.5 \\cdot \\alpha \\cdot (1 - {\\rm l1\\_{ratio}}) \\|w\\|_2^2
 
     If you are interested in controlling the L1 and L2 penalty
     separately, keep in mind that this is equivalent to:
@@ -775,7 +775,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
     .. math::
 
-        \\alpha = a + b, \\quad {\\rm l1\_{ratio}} = \\frac{a}{a + b}
+        \\alpha = a + b, \\quad {\\rm l1\\_{ratio}} = \\frac{a}{a + b}
 
     The parameter l1_ratio corresponds to alpha in the glmnet R package while
     alpha corresponds to the lambda parameter in glmnet. Specifically, l1_ratio

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -761,8 +761,8 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
     .. math::
 
         \\frac{1}{2 n_{\\rm samples}} \\|y - X w\\|_2^2
-        + \\alpha \\cdot {\\rm l1_{ratio}} \\|w\\|_1
-        + 0.5 \\cdot \\alpha \\cdot (1 - {\\rm l1_{ratio}}) \\|w\\|_2^2
+        + \\alpha \\cdot {\\rm l1\_{ratio}} \\|w\\|_1
+        + 0.5 \\cdot \\alpha \\cdot (1 - {\\rm l1\_{ratio}}) \\|w\\|_2^2
 
     If you are interested in controlling the L1 and L2 penalty
     separately, keep in mind that this is equivalent to:
@@ -775,7 +775,7 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
     .. math::
 
-        \\alpha = a + b, \\quad {\\rm l1_{ratio}} = \\frac{a}{a + b}
+        \\alpha = a + b, \\quad {\\rm l1\_{ratio}} = \\frac{a}{a + b}
 
     The parameter l1_ratio corresponds to alpha in the glmnet R package while
     alpha corresponds to the lambda parameter in glmnet. Specifically, l1_ratio

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -754,7 +754,7 @@ def enet_path(
 
 
 class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
-    """Linear regression with combined L1 and L2 priors as regularizer.
+    r"""Linear regression with combined L1 and L2 priors as regularizer.
 
     Minimizes the objective function:
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -758,22 +758,22 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
     Minimizes the objective function::
 
-    .. math::
+        .. math::
 
             \frac{1}{2 n_{\rm samples}} \|y - X w\|_2^2
             + \alpha \cdot {\rm l1\_ratio} \cdot \|w\|_1
             + 0.5 \cdot \alpha \cdot (1 - {\rm l1\_ratio}) \cdot \|w\|_2^2
 
     If you are interested in controlling the L1 and L2 penalty
-    separately, keep in mind that this is equivalent to:
+    separately, keep in mind that this is equivalent to::
 
-    .. math::
+        .. math::
 
             a \|w\|_1 + 0.5 b \|w\|_2^2
 
     where::
 
-    .. math::
+        .. math::
 
             \alpha = a + b, \quad {\rm l1\_ratio} = \frac{a}{a + b}
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -755,7 +755,7 @@ def enet_path(
 
 class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
     r"""Linear regression with combined L1 and L2 priors as regularizer.
-    
+
     Minimizes the objective function::
 
     .. math::

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -754,22 +754,28 @@ def enet_path(
 
 
 class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
-    """Linear regression with combined L1 and L2 priors as regularizer.
-
+    r"""Linear regression with combined L1 and L2 priors as regularizer.
+    
     Minimizes the objective function::
 
-            1 / (2 * n_samples) * ||y - Xw||^2_2
-            + alpha * l1_ratio * ||w||_1
-            + 0.5 * alpha * (1 - l1_ratio) * ||w||^2_2
+    .. math::
+
+            \frac{1}{2 n_{\rm samples}} \|y - X w\|_2^2
+            + \alpha \cdot {\rm l1\_ratio} \cdot \|w\|_1
+            + 0.5 \cdot \alpha \cdot (1 - {\rm l1\_ratio}) \cdot \|w\|_2^2
 
     If you are interested in controlling the L1 and L2 penalty
-    separately, keep in mind that this is equivalent to::
+    separately, keep in mind that this is equivalent to:
 
-            a * ||w||_1 + 0.5 * b * ||w||_2^2
+    .. math::
+
+            a \|w\|_1 + 0.5 b \|w\|_2^2
 
     where::
 
-            alpha = a + b and l1_ratio = a / (a + b)
+    .. math::
+
+            \alpha = a + b, \quad {\rm l1\_ratio} = \frac{a}{a + b}
 
     The parameter l1_ratio corresponds to alpha in the glmnet R package while
     alpha corresponds to the lambda parameter in glmnet. Specifically, l1_ratio

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -754,28 +754,28 @@ def enet_path(
 
 
 class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
-    r"""Linear regression with combined L1 and L2 priors as regularizer.
+    """Linear regression with combined L1 and L2 priors as regularizer.
 
-    Minimizes the objective function::
+    Minimizes the objective function:
 
-        .. math::
+    .. math::
 
-            \frac{1}{2 n_{\rm samples}} \|y - X w\|_2^2
-            + \alpha \cdot {\rm l1\_ratio} \cdot \|w\|_1
-            + 0.5 \cdot \alpha \cdot (1 - {\rm l1\_ratio}) \cdot \|w\|_2^2
+        \frac{1}{2 n_{\rm samples}} \|y - X w\|_2^2
+        + \alpha \cdot {\rm l1\_ratio} \cdot \|w\|_1
+        + 0.5 \cdot \alpha \cdot (1 - {\rm l1\_ratio}) \cdot \|w\|_2^2
 
     If you are interested in controlling the L1 and L2 penalty
-    separately, keep in mind that this is equivalent to::
+    separately, keep in mind that this is equivalent to:
 
-        .. math::
+    .. math::
 
-            a \|w\|_1 + 0.5 b \|w\|_2^2
+        a \|w\|_1 + 0.5 b \|w\|_2^2
 
-    where::
+    where:
 
-        .. math::
+    .. math::
 
-            \alpha = a + b, \quad {\rm l1\_ratio} = \frac{a}{a + b}
+        \alpha = a + b, \quad {\rm l1\_ratio} = \frac{a}{a + b}
 
     The parameter l1_ratio corresponds to alpha in the glmnet R package while
     alpha corresponds to the lambda parameter in glmnet. Specifically, l1_ratio

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -761,8 +761,8 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
     .. math::
 
         \\frac{1}{2 n_{\\rm samples}} \\|y - X w\\|_2^2
-        + \\alpha \\cdot {\\rm l1_ratio} \\|w\\|_1
-        + 0.5 \\cdot \\alpha \\cdot (1 - {\\rm l1_ratio}) \\|w\\|_2^2
+        + \\alpha \\cdot l1_{ratio} \\|w\\|_1
+        + 0.5 \\cdot \\alpha \\cdot (1 - l1_{ratio}) \\|w\\|_2^2
 
     If you are interested in controlling the L1 and L2 penalty
     separately, keep in mind that this is equivalent to:
@@ -775,11 +775,11 @@ class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
 
     .. math::
 
-        \\alpha = a + b, \\quad {\\rm l1_ratio} = \\frac{a}{a + b}
+        \\alpha = a + b, \\quad l1_{ratio} = \\frac{a}{a + b}
 
-    The parameter l1_ratio corresponds to alpha in the glmnet R package while
-    alpha corresponds to the lambda parameter in glmnet. Specifically, l1_ratio
-    = 1 is the lasso penalty. Currently, l1_ratio <= 0.01 is not reliable,
+    The parameter l1_{ratio} corresponds to alpha in the glmnet R package while
+    alpha corresponds to the lambda parameter in glmnet. Specifically, l1_{ratio}
+    = 1 is the lasso penalty. Currently, l1_{ratio} <= 0.01 is not reliable,
     unless you supply your own sequence of alpha.
 
     Read more in the :ref:`User Guide <elastic_net>`.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -754,28 +754,28 @@ def enet_path(
 
 
 class ElasticNet(MultiOutputMixin, RegressorMixin, LinearModel):
-    r"""Linear regression with combined L1 and L2 priors as regularizer.
+    """Linear regression with combined L1 and L2 priors as regularizer.
 
     Minimizes the objective function:
 
     .. math::
 
-        \frac{1}{2 n_{\rm samples}} \|y - X w\|_2^2
-        + \alpha \cdot {\rm l1\_ratio} \cdot \|w\|_1
-        + 0.5 \cdot \alpha \cdot (1 - {\rm l1\_ratio}) \cdot \|w\|_2^2
+        \\frac{1}{2 n_{\\rm samples}} \\|y - X w\\|_2^2
+        + \\alpha \\cdot {\\rm l1_ratio} \\|w\\|_1
+        + 0.5 \\cdot \\alpha \\cdot (1 - {\\rm l1_ratio}) \\|w\\|_2^2
 
     If you are interested in controlling the L1 and L2 penalty
     separately, keep in mind that this is equivalent to:
 
     .. math::
 
-        a \|w\|_1 + 0.5 b \|w\|_2^2
+        a \\|w\\|_1 + 0.5 b \\|w\\|_2^2
 
     where:
 
     .. math::
 
-        \alpha = a + b, \quad {\rm l1\_ratio} = \frac{a}{a + b}
+        \\alpha = a + b, \\quad {\\rm l1_ratio} = \\frac{a}{a + b}
 
     The parameter l1_ratio corresponds to alpha in the glmnet R package while
     alpha corresponds to the lambda parameter in glmnet. Specifically, l1_ratio


### PR DESCRIPTION
Reference Issues/PRs
Towards https://github.com/scikit-learn/scikit-learn/issues/31593

What does this implement/fix? Explain your changes.
Fixes the ElasticNet documentation so that the formulas render correctly using LaTeX in the API reference. Previously, formulas were shown as plain text (e.g., a * ||w||_1 + 0.5 * b * ||w||_2^2), and now they render properly in mathematical notation.

Any other comments?
No functional changes were made to the code — this is purely a documentation improvement.