### PR TITLE
TST add test for DecisionBoundaryDisplay.plot with sample_weight (gh-27462)

### DIFF
--- a/benchmarks/bench_tsne_mnist.py
+++ b/benchmarks/bench_tsne_mnist.py
@@ -15,6 +15,7 @@ from time import time
 
 import numpy as np
 from joblib import Memory
+from sklearn.utils._openmp_helpers import _openmp_effective_n_threads
 
 from sklearn.datasets import fetch_openml
 from sklearn.decomposition import PCA
@@ -22,7 +23,6 @@ from sklearn.manifold import TSNE
 from sklearn.neighbors import NearestNeighbors
 from sklearn.utils import check_array
 from sklearn.utils import shuffle as _shuffle
-from sklearn.utils._openmp_helpers import _openmp_effective_n_threads
 
 LOG_DIR = "mnist_tsne_output"
 if not os.path.exists(LOG_DIR):

--- a/sklearn/inspection/tests/test_decision_boundary_display.py
+++ b/sklearn/inspection/tests/test_decision_boundary_display.py
@@ -1,19 +1,30 @@
-import pytest
 import numpy as np
+import pytest
+
 from sklearn.datasets import make_classification
-from sklearn.linear_model import LogisticRegression
 from sklearn.inspection import DecisionBoundaryDisplay
+from sklearn.linear_model import LogisticRegression
 
 
-@pytest.mark.parametrize("response_method", ["predict", "predict_proba", "decision_function"])
+@pytest.mark.parametrize(
+    "response_method",
+    ["predict", "predict_proba", "decision_function"],
+)
 def test_decision_boundary_display_plotting_with_sample_weight(response_method):
     """Check that DecisionBoundaryDisplay.plot works with sample_weight (gh-27462)."""
-    X, y = make_classification(n_samples=50, n_features=2, n_classes=2, random_state=42)
+    X, y = make_classification(
+        n_samples=50,
+        n_features=2,
+        n_classes=2,
+        random_state=42,
+    )
     sample_weight = np.random.RandomState(0).rand(y.shape[0])
 
     clf = LogisticRegression().fit(X, y, sample_weight=sample_weight)
 
     disp = DecisionBoundaryDisplay.from_estimator(
-        clf, X, response_method=response_method
+        clf,
+        X,
+        response_method=response_method,
     )
-    disp.plot(X, y, sample_weight=sample_weight) 
+    disp.plot(X, y, sample_weight=sample_weight)

--- a/sklearn/inspection/tests/test_decision_boundary_display.py
+++ b/sklearn/inspection/tests/test_decision_boundary_display.py
@@ -13,10 +13,7 @@ from sklearn.linear_model import LogisticRegression
 def test_decision_boundary_display_plotting_with_sample_weight(response_method):
     """Check that DecisionBoundaryDisplay.plot works with sample_weight (gh-27462)."""
     X, y = make_classification(
-        n_samples=50,
-        n_features=2,
-        n_classes=2,
-        random_state=42,
+        n_samples=50, n_features=2, n_classes=2, random_state=42
     )
     sample_weight = np.random.RandomState(0).rand(y.shape[0])
 

--- a/sklearn/inspection/tests/test_decision_boundary_display.py
+++ b/sklearn/inspection/tests/test_decision_boundary_display.py
@@ -1,0 +1,19 @@
+import pytest
+import numpy as np
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+from sklearn.inspection import DecisionBoundaryDisplay
+
+
+@pytest.mark.parametrize("response_method", ["predict", "predict_proba", "decision_function"])
+def test_decision_boundary_display_plotting_with_sample_weight(response_method):
+    """Check that DecisionBoundaryDisplay.plot works with sample_weight (gh-27462)."""
+    X, y = make_classification(n_samples=50, n_features=2, n_classes=2, random_state=42)
+    sample_weight = np.random.RandomState(0).rand(y.shape[0])
+
+    clf = LogisticRegression().fit(X, y, sample_weight=sample_weight)
+
+    disp = DecisionBoundaryDisplay.from_estimator(
+        clf, X, response_method=response_method
+    )
+    disp.plot(X, y, sample_weight=sample_weight) 

--- a/sklearn/inspection/tests/test_decision_boundary_display.py
+++ b/sklearn/inspection/tests/test_decision_boundary_display.py
@@ -12,9 +12,7 @@ from sklearn.linear_model import LogisticRegression
 )
 def test_decision_boundary_display_plotting_with_sample_weight(response_method):
     """Check that DecisionBoundaryDisplay.plot works with sample_weight (gh-27462)."""
-    X, y = make_classification(
-        n_samples=50, n_features=2, n_classes=2, random_state=42
-    )
+    X, y = make_classification(n_samples=50, n_features=2, n_classes=2, random_state=42)
     sample_weight = np.random.RandomState(0).rand(y.shape[0])
 
     clf = LogisticRegression().fit(X, y, sample_weight=sample_weight)


### PR DESCRIPTION
This PR adds a test for DecisionBoundaryDisplay.plot to ensure that it works
when sample_weight is passed, addressing issue #27462.

- Parametrized test over response_method = {"predict", "predict_proba", "decision_function"}
- Uses LogisticRegression with weighted samples
- Confirms plot runs without error