### PR TITLE
CI Revert Python 3.13.7 work arounds in wheels

### DIFF
--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -25,12 +25,6 @@ if [[ $FREE_THREADED_BUILD == "False" ]]; then
         PYTHON_DOCKER_IMAGE_PART="3.14-rc"
     fi
 
-    # Temporary work-around to avoid a loky issue on Windows >= 3.13.7, see
-    # https://github.com/joblib/loky/issues/459
-    if [[ "$PYTHON_DOCKER_IMAGE_PART" == "3.13" ]]; then
-        PYTHON_DOCKER_IMAGE_PART="3.13.6"
-    fi
-
     # We could have all of the following logic in a Dockerfile but it's a lot
     # easier to do it in bash rather than figure out how to do it in Powershell
     # inside the Dockerfile ...

--- a/build_tools/wheels/build_wheels.sh
+++ b/build_tools/wheels/build_wheels.sh
@@ -53,7 +53,5 @@ fi
 # in the pyproject.toml file, while the tests are run
 # against the most recent version of the dependencies
 
-# We install cibuildwheel 3.1.3 as a temporary work-around to avoid a loky
-# issue on Windows >= 3.13.7, see https://github.com/joblib/loky/issues/459.
-python -m pip install cibuildwheel==3.1.3
+python -m pip install cibuildwheel
 python -m cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
The issue has been fixed in loky 3.5.6 and joblib 1.5.2.

Revert https://github.com/scikit-learn/scikit-learn/pull/31982 and https://github.com/scikit-learn/scikit-learn/pull/31964.