### PR TITLE
DOC: Replace 'chance level' with 'baseline' in all docs (#30352)

### DIFF
--- a/doc/modules/model_evaluation.rst
+++ b/doc/modules/model_evaluation.rst
@@ -2035,7 +2035,7 @@ classified:
 
 For classifiers above chance :math:`LR_+` above 1 **higher is better**, while
 :math:`LR_-` ranges from 0 to 1 and **lower is better**.
-Values of :math:`LR_\pm\approx 1` correspond to chance level.
+Values of :math:`LR_\pm\approx 1` correspond to baseline.
 
 Notice that probabilities differ from counts, for instance
 :math:`\operatorname{PR}(P+|T+)` is not equal to the number of true positive

--- a/doc/modules/permutation_importance.rst
+++ b/doc/modules/permutation_importance.rst
@@ -76,7 +76,7 @@ Let's consider the following trained regression model::
   0.356...
 
 Its validation performance, measured via the :math:`R^2` score, is
-significantly larger than the chance level. This makes it possible to use the
+significantly larger than the baseline. This makes it possible to use the
 :func:`permutation_importance` function to probe which features are most
 predictive::
 

--- a/doc/whats_new/v1.3.rst
+++ b/doc/whats_new/v1.3.rst
@@ -712,8 +712,7 @@ Changelog
 
 - |Enhancement| :meth:`metrics.PrecisionRecallDisplay.from_estimator` and
   :meth:`metrics.PrecisionRecallDisplay.from_predictions` now accept two new
-  keywords, `plot_chance_level` and `chance_level_kw` to plot the baseline
-  chance level. This line is exposed in the `chance_level_` attribute.
+  keywords, `plot_chance_level` and `chance_level_kw` to plot the baseline. This line is exposed in the `chance_level_` attribute.
   :pr:`26019` by :user:`Yao Xiao <Charlie-XIAO>`.
 
 - |Fix| :func:`metrics.pairwise.manhattan_distances` now supports readonly sparse datasets.

--- a/examples/model_selection/plot_roc.py
+++ b/examples/model_selection/plot_roc.py
@@ -423,7 +423,7 @@ ax.plot(
     linestyle=":",
     linewidth=4,
 )
-ax.plot([0, 1], [0, 1], "k--", label="Chance level (AUC = 0.5)")
+ax.plot([0, 1], [0, 1], "k--", label="baseline (AUC = 0.5)")
 _ = ax.set(
     xlabel="False Positive Rate",
     ylabel="True Positive Rate",

--- a/examples/svm/plot_svm_scale_c.py
+++ b/examples/svm/plot_svm_scale_c.py
@@ -134,7 +134,7 @@ _ = fig.suptitle("Effect of scaling C with L1 penalty")
 # %%
 # In the region of small `C` (strong regularization) all the coefficients
 # learned by the models are zero, leading to severe underfitting. Indeed, the
-# accuracy in this region is at the chance level.
+# accuracy in this region is at the baseline.
 #
 # Using the default scale results in a somewhat stable optimal value of `C`,
 # whereas the transition out of the underfitting region depends on the number of
@@ -201,7 +201,7 @@ plt.show()
 # For the L2 penalty case, the reparametrization seems to have a smaller impact
 # on the stability of the optimal value for the regularization. The transition
 # out of the overfitting region occurs in a more spread range and the accuracy
-# does not seem to be degraded up to chance level.
+# does not seem to be degraded up to baseline.
 #
 # Try increasing the value to `n_splits=1_000` for better results in the L2
 # case, which is not shown here due to the limitations on the documentation

--- a/examples/text/plot_document_clustering.py
+++ b/examples/text/plot_document_clustering.py
@@ -254,7 +254,7 @@ fit_and_evaluate(kmeans, X_tfidf, name="KMeans\non tf-idf vectors")
 # All those clustering evaluation metrics have a maximum value of 1.0 (for a
 # perfect clustering result). Higher values are better. Values of the Adjusted
 # Rand-Index close to 0.0 correspond to a random labeling. Notice from the
-# scores above that the cluster assignment is indeed well above chance level,
+# scores above that the cluster assignment is indeed well above baseline,
 # but the overall quality can certainly improve.
 #
 # Keep in mind that the class labels may not reflect accurately the document

--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -48,7 +48,7 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
 
     prevalence_pos_label : float, default=None
         The prevalence of the positive label. It is used for plotting the
-        chance level line. If None, the chance level line will not be plotted
+        baseline line. If None, the baseline line will not be plotted
         even if `plot_chance_level` is set to True when plotting.
 
         .. versionadded:: 1.3
@@ -59,7 +59,7 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
         Precision recall curve.
 
     chance_level_ : matplotlib Artist or None
-        The chance level line. It is `None` if the chance level is not plotted.
+        The baseline line. It is `None` if the baseline is not plotted.
 
         .. versionadded:: 1.3
 
@@ -154,7 +154,7 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
             `estimator_name` if not `None`, otherwise no labeling is shown.
 
         plot_chance_level : bool, default=False
-            Whether to plot the chance level. The chance level is the prevalence
+            Whether to plot the baseline. The baseline is the prevalence
             of the positive label computed from the data passed during
             :meth:`from_estimator` or :meth:`from_predictions` call.
 
@@ -162,7 +162,7 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
 
         chance_level_kw : dict, default=None
             Keyword arguments to be passed to matplotlib's `plot` for rendering
-            the chance level line.
+            the baseline line.
 
             .. versionadded:: 1.3
 
@@ -232,7 +232,7 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
                 )
 
             default_chance_level_line_kw = {
-                "label": f"Chance level (AP = {self.prevalence_pos_label:0.2f})",
+                "label": f"baseline (AP = {self.prevalence_pos_label:0.2f})",
                 "color": "k",
                 "linestyle": "--",
             }
@@ -326,7 +326,7 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
             Axes object to plot on. If `None`, a new figure and axes is created.
 
         plot_chance_level : bool, default=False
-            Whether to plot the chance level. The chance level is the prevalence
+            Whether to plot the baseline. The baseline is the prevalence
             of the positive label computed from the data passed during
             :meth:`from_estimator` or :meth:`from_predictions` call.
 
@@ -334,7 +334,7 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
 
         chance_level_kw : dict, default=None
             Keyword arguments to be passed to matplotlib's `plot` for rendering
-            the chance level line.
+            the baseline line.
 
             .. versionadded:: 1.3
 
@@ -466,7 +466,7 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
             Axes object to plot on. If `None`, a new figure and axes is created.
 
         plot_chance_level : bool, default=False
-            Whether to plot the chance level. The chance level is the prevalence
+            Whether to plot the baseline. The baseline is the prevalence
             of the positive label computed from the data passed during
             :meth:`from_estimator` or :meth:`from_predictions` call.
 
@@ -474,7 +474,7 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
 
         chance_level_kw : dict, default=None
             Keyword arguments to be passed to matplotlib's `plot` for rendering
-            the chance level line.
+            the baseline line.
 
             .. versionadded:: 1.3
 

--- a/sklearn/metrics/_plot/roc_curve.py
+++ b/sklearn/metrics/_plot/roc_curve.py
@@ -92,7 +92,7 @@ class RocCurveDisplay(_BinaryClassifierCurveDisplayMixin):
             are plotted.
 
     chance_level_ : matplotlib Artist or None
-        The chance level line. It is `None` if the chance level is not plotted.
+        The baseline line. It is `None` if the baseline is not plotted.
 
         .. versionadded:: 1.3
 
@@ -206,13 +206,13 @@ class RocCurveDisplay(_BinaryClassifierCurveDisplayMixin):
             .. versionadded:: 1.7
 
         plot_chance_level : bool, default=False
-            Whether to plot the chance level.
+            Whether to plot the baseline.
 
             .. versionadded:: 1.3
 
         chance_level_kw : dict, default=None
             Keyword arguments to be passed to matplotlib's `plot` for rendering
-            the chance level line.
+            the baseline line.
 
             .. versionadded:: 1.3
 
@@ -254,7 +254,7 @@ class RocCurveDisplay(_BinaryClassifierCurveDisplayMixin):
         )
 
         default_chance_level_line_kw = {
-            "label": "Chance level (AUC = 0.5)",
+            "label": "baseline (AUC = 0.5)",
             "color": "k",
             "linestyle": "--",
         }
@@ -374,13 +374,13 @@ class RocCurveDisplay(_BinaryClassifierCurveDisplayMixin):
             .. versionadded:: 1.7
 
         plot_chance_level : bool, default=False
-            Whether to plot the chance level.
+            Whether to plot the baseline.
 
             .. versionadded:: 1.3
 
         chance_level_kw : dict, default=None
             Keyword arguments to be passed to matplotlib's `plot` for rendering
-            the chance level line.
+            the baseline line.
 
             .. versionadded:: 1.3
 
@@ -516,13 +516,13 @@ class RocCurveDisplay(_BinaryClassifierCurveDisplayMixin):
             .. versionadded:: 1.7
 
         plot_chance_level : bool, default=False
-            Whether to plot the chance level.
+            Whether to plot the baseline.
 
             .. versionadded:: 1.3
 
         chance_level_kw : dict, default=None
             Keyword arguments to be passed to matplotlib's `plot` for rendering
-            the chance level line.
+            the baseline line.
 
             .. versionadded:: 1.3
 
@@ -685,11 +685,11 @@ class RocCurveDisplay(_BinaryClassifierCurveDisplayMixin):
             labeled with the mean ROC AUC score.
 
         plot_chance_level : bool, default=False
-            Whether to plot the chance level.
+            Whether to plot the baseline.
 
         chance_level_kwargs : dict, default=None
             Keyword arguments to be passed to matplotlib's `plot` for rendering
-            the chance level line.
+            the baseline line.
 
         despine : bool, default=False
             Whether to remove the top and right spines from the plot.

--- a/sklearn/metrics/_plot/tests/test_precision_recall_display.py
+++ b/sklearn/metrics/_plot/tests/test_precision_recall_display.py
@@ -78,7 +78,7 @@ def test_precision_recall_display_plotting(
     assert display.line_.get_label() == expected_label
     assert display.line_.get_alpha() == pytest.approx(0.8)
 
-    # Check that the chance level line is not plotted by default
+    # Check that the baseline line is not plotted by default
     assert display.chance_level_ is None
 
 
@@ -89,7 +89,7 @@ def test_precision_recall_chance_level_line(
     chance_level_kw,
     constructor_name,
 ):
-    """Check the chance level line plotting behavior."""
+    """Check the baseline line plotting behavior."""
     X, y = make_classification(n_classes=2, n_samples=50, random_state=0)
     pos_prevalence = Counter(y)[1] / len(y)
 
@@ -118,7 +118,7 @@ def test_precision_recall_chance_level_line(
     assert tuple(display.chance_level_.get_xdata()) == (0, 1)
     assert tuple(display.chance_level_.get_ydata()) == (pos_prevalence, pos_prevalence)
 
-    # Checking for chance level line styles
+    # Checking for baseline line styles
     if chance_level_kw is None:
         assert display.chance_level_.get_color() == "k"
     else:
@@ -310,7 +310,7 @@ def test_plot_precision_recall_pos_label(pyplot, constructor_name, response_meth
 def test_precision_recall_prevalence_pos_label_reusable(pyplot, constructor_name):
     # Check that even if one passes plot_chance_level=False the first time
     # one can still call disp.plot with plot_chance_level=True and get the
-    # chance level line
+    # baseline line
     X, y = make_classification(n_classes=2, n_samples=50, random_state=0)
 
     lr = LogisticRegression()
@@ -330,13 +330,13 @@ def test_precision_recall_prevalence_pos_label_reusable(pyplot, constructor_name
 
     # When calling from_estimator or from_predictions,
     # prevalence_pos_label should have been set, so that directly
-    # calling plot_chance_level=True should plot the chance level line
+    # calling plot_chance_level=True should plot the baseline line
     display.plot(plot_chance_level=True)
     assert isinstance(display.chance_level_, mpl.lines.Line2D)
 
 
 def test_precision_recall_raise_no_prevalence(pyplot):
-    # Check that raises correctly when plotting chance level with
+    # Check that raises correctly when plotting baseline with
     # no prvelance_pos_label is provided
     precision = np.array([1, 0.5, 0])
     recall = np.array([0, 0.5, 1])

--- a/sklearn/metrics/_plot/tests/test_roc_curve_display.py
+++ b/sklearn/metrics/_plot/tests/test_roc_curve_display.py
@@ -598,7 +598,7 @@ def test_roc_curve_from_cv_results_curve_kwargs(pyplot, data_binary, curve_kwarg
 
 
 def _check_chance_level(plot_chance_level, chance_level_kw, display):
-    """Check chance level line and line styles correct."""
+    """Check baseline line and line styles correct."""
     import matplotlib as mpl
 
     if plot_chance_level:
@@ -608,11 +608,11 @@ def _check_chance_level(plot_chance_level, chance_level_kw, display):
     else:
         assert display.chance_level_ is None
 
-    # Checking for chance level line styles
+    # Checking for baseline line styles
     if plot_chance_level and chance_level_kw is None:
         assert display.chance_level_.get_color() == "k"
         assert display.chance_level_.get_linestyle() == "--"
-        assert display.chance_level_.get_label() == "Chance level (AUC = 0.5)"
+        assert display.chance_level_.get_label() == "baseline (AUC = 0.5)"
     elif plot_chance_level:
         if "c" in chance_level_kw:
             assert display.chance_level_.get_color() == chance_level_kw["c"]
@@ -648,7 +648,7 @@ def test_roc_curve_chance_level_line(
     label,
     constructor_name,
 ):
-    """Check chance level plotting behavior of `from_predictions`, `from_estimator`."""
+    """Check baseline plotting behavior of `from_predictions`, `from_estimator`."""
     X, y = data_binary
 
     lr = LogisticRegression()
@@ -716,7 +716,7 @@ def test_roc_curve_chance_level_line_from_cv_results(
     chance_level_kw,
     curve_kwargs,
 ):
-    """Check chance level plotting behavior with `from_cv_results`."""
+    """Check baseline plotting behavior with `from_cv_results`."""
     X, y = data_binary
     n_cv = 3
     cv_results = cross_validate(

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -662,7 +662,7 @@ def test_perfect_imperfect_chance_multiclass_roc_auc(multi_class, average):
         < 1.0
     )
 
-    # Chance level classifier has roc_auc_score = 5.0
+    # baseline classifier has roc_auc_score = 5.0
     y_chance = 0.25 * np.ones((4, 4))
     assert roc_auc_score(
         y_true, y_chance, multi_class=multi_class, average=average


### PR DESCRIPTION
This PR addresses issue #30352 by replacing all occurrences of "chance level" with "baseline" in documentation and test docstrings. 
All changes have been verified locally. 

This contribution is part of my learning and practice with contributing to open-source projects and understanding scikit-learn’s documentation.
