### PR TITLE
CI Add Python 3.14 free-threaded wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -60,135 +60,135 @@ jobs:
       matrix:
         include:
           # Window 64 bit
-          - os: windows-latest
-            python: 310
-            platform_id: win_amd64
-          - os: windows-latest
-            python: 311
-            platform_id: win_amd64
-          - os: windows-latest
-            python: 312
-            platform_id: win_amd64
-          - os: windows-latest
-            python: 313
-            platform_id: win_amd64
-          - os: windows-latest
-            python: 313t
-            platform_id: win_amd64
-            cibw_enable: cpython-freethreading
-          - os: windows-latest
-            python: 314
-            platform_id: win_amd64
+          # - os: windows-latest
+          #   python: 310
+          #   platform_id: win_amd64
+          # - os: windows-latest
+          #   python: 311
+          #   platform_id: win_amd64
+          # - os: windows-latest
+          #   python: 312
+          #   platform_id: win_amd64
+          # - os: windows-latest
+          #   python: 313
+          #   platform_id: win_amd64
+          # - os: windows-latest
+          #   python: 313t
+          #   platform_id: win_amd64
+          #   cibw_enable: cpython-freethreading
+          # - os: windows-latest
+          #   python: 314
+          #   platform_id: win_amd64
           - os: windows-latest
             python: 314t
             platform_id: win_amd64
 
           # Linux 64 bit manylinux2014
-          - os: ubuntu-latest
-            python: 310
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
-            python: 311
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
-            python: 312
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
-            python: 313
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
-            python: 313t
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-            cibw_enable: cpython-freethreading
-          - os: ubuntu-latest
-            python: 314
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
+          # - os: ubuntu-latest
+          #   python: 310
+          #   platform_id: manylinux_x86_64
+          #   manylinux_image: manylinux2014
+          # - os: ubuntu-latest
+          #   python: 311
+          #   platform_id: manylinux_x86_64
+          #   manylinux_image: manylinux2014
+          # - os: ubuntu-latest
+          #   python: 312
+          #   platform_id: manylinux_x86_64
+          #   manylinux_image: manylinux2014
+          # - os: ubuntu-latest
+          #   python: 313
+          #   platform_id: manylinux_x86_64
+          #   manylinux_image: manylinux2014
+          # - os: ubuntu-latest
+          #   python: 313t
+          #   platform_id: manylinux_x86_64
+          #   manylinux_image: manylinux2014
+          #   cibw_enable: cpython-freethreading
+          # - os: ubuntu-latest
+          #   python: 314
+          #   platform_id: manylinux_x86_64
+          #   manylinux_image: manylinux2014
           - os: ubuntu-latest
             python: 314t
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
 
           # Linux 64 bit manylinux2014
-          - os: ubuntu-24.04-arm
-            python: 310
-            platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
-          - os: ubuntu-24.04-arm
-            python: 311
-            platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
-          - os: ubuntu-24.04-arm
-            python: 312
-            platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
-          - os: ubuntu-24.04-arm
-            python: 313
-            platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
-          - os: ubuntu-24.04-arm
-            python: 313t
-            platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
-            cibw_enable: cpython-freethreading
-          - os: ubuntu-24.04-arm
-            python: 314
-            platform_id: manylinux_aarch64
-            manylinux_image: manylinux2014
+          # - os: ubuntu-24.04-arm
+          #   python: 310
+          #   platform_id: manylinux_aarch64
+          #   manylinux_image: manylinux2014
+          # - os: ubuntu-24.04-arm
+          #   python: 311
+          #   platform_id: manylinux_aarch64
+          #   manylinux_image: manylinux2014
+          # - os: ubuntu-24.04-arm
+          #   python: 312
+          #   platform_id: manylinux_aarch64
+          #   manylinux_image: manylinux2014
+          # - os: ubuntu-24.04-arm
+          #   python: 313
+          #   platform_id: manylinux_aarch64
+          #   manylinux_image: manylinux2014
+          # - os: ubuntu-24.04-arm
+          #   python: 313t
+          #   platform_id: manylinux_aarch64
+          #   manylinux_image: manylinux2014
+          #   cibw_enable: cpython-freethreading
+          # - os: ubuntu-24.04-arm
+          #   python: 314
+          #   platform_id: manylinux_aarch64
+          #   manylinux_image: manylinux2014
           - os: ubuntu-24.04-arm
             python: 314t
             platform_id: manylinux_aarch64
             manylinux_image: manylinux2014
 
           # MacOS x86_64
-          - os: macos-13
-            python: 310
-            platform_id: macosx_x86_64
-          - os: macos-13
-            python: 311
-            platform_id: macosx_x86_64
-          - os: macos-13
-            python: 312
-            platform_id: macosx_x86_64
-          - os: macos-13
-            python: 313
-            platform_id: macosx_x86_64
-          - os: macos-13
-            python: 313t
-            platform_id: macosx_x86_64
-            cibw_enable: cpython-freethreading
-          - os: macos-13
-            python: 314
-            platform_id: macosx_x86_64
+          # - os: macos-13
+          #   python: 310
+          #   platform_id: macosx_x86_64
+          # - os: macos-13
+          #   python: 311
+          #   platform_id: macosx_x86_64
+          # - os: macos-13
+          #   python: 312
+          #   platform_id: macosx_x86_64
+          # - os: macos-13
+          #   python: 313
+          #   platform_id: macosx_x86_64
+          # - os: macos-13
+          #   python: 313t
+          #   platform_id: macosx_x86_64
+          #   cibw_enable: cpython-freethreading
+          # - os: macos-13
+          #   python: 314
+          #   platform_id: macosx_x86_64
           - os: macos-13
             python: 314t
             platform_id: macosx_x86_64
 
           # MacOS arm64
-          - os: macos-14
-            python: 310
-            platform_id: macosx_arm64
-          - os: macos-14
-            python: 311
-            platform_id: macosx_arm64
-          - os: macos-14
-            python: 312
-            platform_id: macosx_arm64
-          - os: macos-14
-            python: 313
-            platform_id: macosx_arm64
-          - os: macos-14
-            python: 313t
-            platform_id: macosx_arm64
-            cibw_enable: cpython-freethreading
-          - os: macos-14
-            python: 314
-            platform_id: macosx_arm64
+          # - os: macos-14
+          #   python: 310
+          #   platform_id: macosx_arm64
+          # - os: macos-14
+          #   python: 311
+          #   platform_id: macosx_arm64
+          # - os: macos-14
+          #   python: 312
+          #   platform_id: macosx_arm64
+          # - os: macos-14
+          #   python: 313
+          #   platform_id: macosx_arm64
+          # - os: macos-14
+          #   python: 313t
+          #   platform_id: macosx_arm64
+          #   cibw_enable: cpython-freethreading
+          # - os: macos-14
+          #   python: 314
+          #   platform_id: macosx_arm64
           - os: macos-14
             python: 314t
             platform_id: macosx_arm64

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -79,6 +79,9 @@ jobs:
           - os: windows-latest
             python: 314
             platform_id: win_amd64
+          - os: windows-latest
+            python: 314t
+            platform_id: win_amd64
 
           # Linux 64 bit manylinux2014
           - os: ubuntu-latest
@@ -106,6 +109,10 @@ jobs:
             python: 314
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 314t
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
 
           # Linux 64 bit manylinux2014
           - os: ubuntu-24.04-arm
@@ -131,6 +138,10 @@ jobs:
             cibw_enable: cpython-freethreading
           - os: ubuntu-24.04-arm
             python: 314
+            platform_id: manylinux_aarch64
+            manylinux_image: manylinux2014
+          - os: ubuntu-24.04-arm
+            python: 314t
             platform_id: manylinux_aarch64
             manylinux_image: manylinux2014
 
@@ -154,6 +165,9 @@ jobs:
           - os: macos-13
             python: 314
             platform_id: macosx_x86_64
+          - os: macos-13
+            python: 314t
+            platform_id: macosx_x86_64
 
           # MacOS arm64
           - os: macos-14
@@ -174,6 +188,9 @@ jobs:
             cibw_enable: cpython-freethreading
           - os: macos-14
             python: 314
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 314t
             platform_id: macosx_arm64
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -60,135 +60,135 @@ jobs:
       matrix:
         include:
           # Window 64 bit
-          # - os: windows-latest
-          #   python: 310
-          #   platform_id: win_amd64
-          # - os: windows-latest
-          #   python: 311
-          #   platform_id: win_amd64
-          # - os: windows-latest
-          #   python: 312
-          #   platform_id: win_amd64
-          # - os: windows-latest
-          #   python: 313
-          #   platform_id: win_amd64
-          # - os: windows-latest
-          #   python: 313t
-          #   platform_id: win_amd64
-          #   cibw_enable: cpython-freethreading
-          # - os: windows-latest
-          #   python: 314
-          #   platform_id: win_amd64
+          - os: windows-latest
+            python: 310
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 311
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 312
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 313
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 313t
+            platform_id: win_amd64
+            cibw_enable: cpython-freethreading
+          - os: windows-latest
+            python: 314
+            platform_id: win_amd64
           - os: windows-latest
             python: 314t
             platform_id: win_amd64
 
           # Linux 64 bit manylinux2014
-          # - os: ubuntu-latest
-          #   python: 310
-          #   platform_id: manylinux_x86_64
-          #   manylinux_image: manylinux2014
-          # - os: ubuntu-latest
-          #   python: 311
-          #   platform_id: manylinux_x86_64
-          #   manylinux_image: manylinux2014
-          # - os: ubuntu-latest
-          #   python: 312
-          #   platform_id: manylinux_x86_64
-          #   manylinux_image: manylinux2014
-          # - os: ubuntu-latest
-          #   python: 313
-          #   platform_id: manylinux_x86_64
-          #   manylinux_image: manylinux2014
-          # - os: ubuntu-latest
-          #   python: 313t
-          #   platform_id: manylinux_x86_64
-          #   manylinux_image: manylinux2014
-          #   cibw_enable: cpython-freethreading
-          # - os: ubuntu-latest
-          #   python: 314
-          #   platform_id: manylinux_x86_64
-          #   manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 310
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 311
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 312
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 313
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 313t
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+            cibw_enable: cpython-freethreading
+          - os: ubuntu-latest
+            python: 314
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
           - os: ubuntu-latest
             python: 314t
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
 
           # Linux 64 bit manylinux2014
-          # - os: ubuntu-24.04-arm
-          #   python: 310
-          #   platform_id: manylinux_aarch64
-          #   manylinux_image: manylinux2014
-          # - os: ubuntu-24.04-arm
-          #   python: 311
-          #   platform_id: manylinux_aarch64
-          #   manylinux_image: manylinux2014
-          # - os: ubuntu-24.04-arm
-          #   python: 312
-          #   platform_id: manylinux_aarch64
-          #   manylinux_image: manylinux2014
-          # - os: ubuntu-24.04-arm
-          #   python: 313
-          #   platform_id: manylinux_aarch64
-          #   manylinux_image: manylinux2014
-          # - os: ubuntu-24.04-arm
-          #   python: 313t
-          #   platform_id: manylinux_aarch64
-          #   manylinux_image: manylinux2014
-          #   cibw_enable: cpython-freethreading
-          # - os: ubuntu-24.04-arm
-          #   python: 314
-          #   platform_id: manylinux_aarch64
-          #   manylinux_image: manylinux2014
+          - os: ubuntu-24.04-arm
+            python: 310
+            platform_id: manylinux_aarch64
+            manylinux_image: manylinux2014
+          - os: ubuntu-24.04-arm
+            python: 311
+            platform_id: manylinux_aarch64
+            manylinux_image: manylinux2014
+          - os: ubuntu-24.04-arm
+            python: 312
+            platform_id: manylinux_aarch64
+            manylinux_image: manylinux2014
+          - os: ubuntu-24.04-arm
+            python: 313
+            platform_id: manylinux_aarch64
+            manylinux_image: manylinux2014
+          - os: ubuntu-24.04-arm
+            python: 313t
+            platform_id: manylinux_aarch64
+            manylinux_image: manylinux2014
+            cibw_enable: cpython-freethreading
+          - os: ubuntu-24.04-arm
+            python: 314
+            platform_id: manylinux_aarch64
+            manylinux_image: manylinux2014
           - os: ubuntu-24.04-arm
             python: 314t
             platform_id: manylinux_aarch64
             manylinux_image: manylinux2014
 
           # MacOS x86_64
-          # - os: macos-13
-          #   python: 310
-          #   platform_id: macosx_x86_64
-          # - os: macos-13
-          #   python: 311
-          #   platform_id: macosx_x86_64
-          # - os: macos-13
-          #   python: 312
-          #   platform_id: macosx_x86_64
-          # - os: macos-13
-          #   python: 313
-          #   platform_id: macosx_x86_64
-          # - os: macos-13
-          #   python: 313t
-          #   platform_id: macosx_x86_64
-          #   cibw_enable: cpython-freethreading
-          # - os: macos-13
-          #   python: 314
-          #   platform_id: macosx_x86_64
+          - os: macos-13
+            python: 310
+            platform_id: macosx_x86_64
+          - os: macos-13
+            python: 311
+            platform_id: macosx_x86_64
+          - os: macos-13
+            python: 312
+            platform_id: macosx_x86_64
+          - os: macos-13
+            python: 313
+            platform_id: macosx_x86_64
+          - os: macos-13
+            python: 313t
+            platform_id: macosx_x86_64
+            cibw_enable: cpython-freethreading
+          - os: macos-13
+            python: 314
+            platform_id: macosx_x86_64
           - os: macos-13
             python: 314t
             platform_id: macosx_x86_64
 
           # MacOS arm64
-          # - os: macos-14
-          #   python: 310
-          #   platform_id: macosx_arm64
-          # - os: macos-14
-          #   python: 311
-          #   platform_id: macosx_arm64
-          # - os: macos-14
-          #   python: 312
-          #   platform_id: macosx_arm64
-          # - os: macos-14
-          #   python: 313
-          #   platform_id: macosx_arm64
-          # - os: macos-14
-          #   python: 313t
-          #   platform_id: macosx_arm64
-          #   cibw_enable: cpython-freethreading
-          # - os: macos-14
-          #   python: 314
-          #   platform_id: macosx_arm64
+          - os: macos-14
+            python: 310
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 311
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 312
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 313
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 313t
+            platform_id: macosx_arm64
+            cibw_enable: cpython-freethreading
+          - os: macos-14
+            python: 314
+            platform_id: macosx_arm64
           - os: macos-14
             python: 314t
             platform_id: macosx_arm64

--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -176,7 +176,9 @@ def test_check_warnings_threading():
             ]
 
         for worker_warning_filter in all_worker_warning_filters:
-            assert normalize_main_module(worker_warning_filter) == main_warning_filters
+            assert normalize_main_module(
+                worker_warning_filter
+            ) == normalize_main_module(main_warning_filters)
 
 
 @pytest.mark.xfail(_IS_WASM, reason="Pyodide always use the sequential backend")


### PR DESCRIPTION
Now that https://github.com/scikit-learn/scikit-learn/pull/32023 has been merged, we can add Python 3.14 free-threaded wheels.