### PR TITLE
CI Make common test xfails strict

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -112,7 +112,9 @@ def test_get_check_estimator_ids(val, expected):
 
 
 @parametrize_with_checks(
-    list(_tested_estimators()), expected_failed_checks=_get_expected_failed_checks
+    list(_tested_estimators()),
+    expected_failed_checks=_get_expected_failed_checks,
+    xfail_strict=True,
 )
 def test_estimators(estimator, check, request):
     # Common tests for estimator instances

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -145,12 +145,9 @@ from sklearn.multioutput import (
     RegressorChain,
 )
 from sklearn.neighbors import (
-    KernelDensity,
     KNeighborsClassifier,
     KNeighborsRegressor,
-    KNeighborsTransformer,
     NeighborhoodComponentsAnalysis,
-    RadiusNeighborsTransformer,
 )
 from sklearn.neural_network import BernoulliRBM, MLPClassifier, MLPRegressor
 from sklearn.pipeline import FeatureUnion, Pipeline
@@ -845,24 +842,6 @@ def _yield_instances_for_check(check, estimator_orig):
 
 
 PER_ESTIMATOR_XFAIL_CHECKS = {
-    AdaBoostClassifier: {
-        # TODO: replace by a statistical test, see meta-issue #16298
-        "check_sample_weight_equivalence_on_dense_data": (
-            "sample_weight is not equivalent to removing/repeating samples."
-        ),
-        "check_sample_weight_equivalence_on_sparse_data": (
-            "sample_weight is not equivalent to removing/repeating samples."
-        ),
-    },
-    AdaBoostRegressor: {
-        # TODO: replace by a statistical test, see meta-issue #16298
-        "check_sample_weight_equivalence_on_dense_data": (
-            "sample_weight is not equivalent to removing/repeating samples."
-        ),
-        "check_sample_weight_equivalence_on_sparse_data": (
-            "sample_weight is not equivalent to removing/repeating samples."
-        ),
-    },
     BaggingClassifier: {
         # TODO: replace by a statistical test, see meta-issue #16298
         "check_sample_weight_equivalence_on_dense_data": (
@@ -914,7 +893,6 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
         "check_dont_overwrite_parameters": "FIXME",
     },
     FixedThresholdClassifier: {
-        "check_classifiers_train": "Threshold at probability 0.5 does not hold",
         "check_sample_weight_equivalence_on_dense_data": (
             "Due to the cross-validation and sample ordering, removing a sample"
             " is not strictly equal to putting is weight to zero. Specific unit"
@@ -950,21 +928,15 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
         "check_fit2d_1sample": (
             "Fail during parameter check since min/max resources requires more samples"
         ),
-        "check_estimators_nan_inf": "FIXME",
-        "check_classifiers_one_label_sample_weights": "FIXME",
-        "check_fit2d_1feature": "FIXME",
-        "check_supervised_y_2d": "DataConversionWarning not caught",
         "check_requires_y_none": "Doesn't fail gracefully",
+        "check_supervised_y_2d": "DataConversionWarning not caught",
     },
     HalvingRandomSearchCV: {
         "check_fit2d_1sample": (
             "Fail during parameter check since min/max resources requires more samples"
         ),
-        "check_estimators_nan_inf": "FIXME",
-        "check_classifiers_one_label_sample_weights": "FIXME",
-        "check_fit2d_1feature": "FIXME",
-        "check_supervised_y_2d": "DataConversionWarning not caught",
         "check_requires_y_none": "Doesn't fail gracefully",
+        "check_supervised_y_2d": "DataConversionWarning not caught",
     },
     HistGradientBoostingClassifier: {
         # TODO: replace by a statistical test, see meta-issue #16298
@@ -993,11 +965,6 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
             "sample_weight is not equivalent to removing/repeating samples."
         ),
     },
-    KernelDensity: {
-        "check_sample_weight_equivalence_on_dense_data": (
-            "sample_weight must have positive values"
-        ),
-    },
     KMeans: {
         # TODO: replace by a statistical test, see meta-issue #16298
         "check_sample_weight_equivalence_on_dense_data": (
@@ -1007,9 +974,6 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
             "sample_weight is not equivalent to removing/repeating samples."
         ),
     },
-    KNeighborsTransformer: {
-        "check_methods_sample_order_invariance": "check is not applicable."
-    },
     LinearSVC: {
         # TODO: replace by a statistical test when _dual=True, see meta-issue #16298
         "check_sample_weight_equivalence_on_dense_data": (
@@ -1018,21 +982,9 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
         "check_sample_weight_equivalence_on_sparse_data": (
             "sample_weight is not equivalent to removing/repeating samples."
         ),
-        "check_non_transformer_estimators_n_iter": (
-            "n_iter_ cannot be easily accessed."
-        ),
     },
     LinearSVR: {
         # TODO: replace by a statistical test, see meta-issue #16298
-        "check_sample_weight_equivalence_on_dense_data": (
-            "sample_weight is not equivalent to removing/repeating samples."
-        ),
-        "check_sample_weight_equivalence_on_sparse_data": (
-            "sample_weight is not equivalent to removing/repeating samples."
-        ),
-    },
-    LogisticRegression: {
-        # TODO: fix sample_weight handling of this estimator, see meta-issue #16298
         "check_sample_weight_equivalence_on_dense_data": (
             "sample_weight is not equivalent to removing/repeating samples."
         ),
@@ -1106,9 +1058,6 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
             "Therefore this test is x-fail until we fix this."
         ),
     },
-    RadiusNeighborsTransformer: {
-        "check_methods_sample_order_invariance": "check is not applicable."
-    },
     RandomForestClassifier: {
         # TODO: replace by a statistical test, see meta-issue #16298
         "check_sample_weight_equivalence_on_dense_data": (
@@ -1128,8 +1077,8 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
         ),
     },
     RandomizedSearchCV: {
-        "check_supervised_y_2d": "DataConversionWarning not caught",
         "check_requires_y_none": "Doesn't fail gracefully",
+        "check_supervised_y_2d": "DataConversionWarning not caught",
     },
     RandomTreesEmbedding: {
         # TODO: replace by a statistical test, see meta-issue #16298
@@ -1206,11 +1155,6 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
         "check_estimators_dtypes": "raises nan error",
         "check_fit2d_1sample": "_scale_normalize fails",
         "check_fit2d_1feature": "raises apply_along_axis error",
-        "check_estimator_sparse_matrix": "does not fail gracefully",
-        "check_estimator_sparse_array": "does not fail gracefully",
-        "check_methods_subset_invariance": "empty array passed inside",
-        "check_dont_overwrite_parameters": "empty array passed inside",
-        "check_fit2d_predict1d": "empty array passed inside",
     },
     SVC: {
         # TODO: fix sample_weight handling of this estimator when probability=False
@@ -1254,7 +1198,9 @@ if sp_base_version < parse_version("1.11"):
 
 def _get_expected_failed_checks(estimator):
     """Get the expected failed checks for all estimators in scikit-learn."""
-    failed_checks = PER_ESTIMATOR_XFAIL_CHECKS.get(type(estimator), {})
+    # Make a copy so that our modifications are not permanent. Important for
+    # estimators that are tested with multiple hyper-parameters.
+    failed_checks = dict(PER_ESTIMATOR_XFAIL_CHECKS.get(type(estimator), {}))
 
     tags = get_tags(estimator)
 
@@ -1286,5 +1232,23 @@ def _get_expected_failed_checks(estimator):
                     ),
                 }
             )
+
+    if type(estimator) == DummyClassifier and estimator.strategy == "most_frequent":
+        failed_checks.pop("check_methods_sample_order_invariance")
+        failed_checks.pop("check_methods_subset_invariance")
+
+    if type(estimator) in (
+        GridSearchCV,
+        HalvingGridSearchCV,
+        HalvingRandomSearchCV,
+        RandomizedSearchCV,
+    ) and (
+        type(estimator.estimator) == LogisticRegression
+        or (
+            type(estimator.estimator) == Pipeline
+            and estimator.estimator.steps[1][0] == "logisticregression"
+        )
+    ):
+        failed_checks.pop("check_supervised_y_2d")
 
     return failed_checks


### PR DESCRIPTION
Follow up to https://github.com/scikit-learn/scikit-learn/pull/31951

This PR enables strict xfail mode for just the common estimator checks. This allows us to find common tests that were marked as xfail but have started passing. If a test outcome changes we either need to update our xfail list or it is a bug that needs adressing.

As part of this I found some checks that no longer fail, the xfail list is updated. There are also a few estimators that are tested in different configurations, and fail/pass depending on the configuration. I've implemented that by adding custom logic to `pop` the check from the xfail list for some configs.

For some of the checks related to sample weights I wonder if. they really pass now or if the check is not strict enough to detect that the estimator doesn't full fill the requirements implied by the check? Maybe @ogrisel knows more about this?

ping @adrinjalali who thought it could be interesting to enable this for the scikit-learn test suite. What do you think?