### PR TITLE
MNT Avoid pytest warnings when pytest-run-parallel is not installed

### DIFF
--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -38,6 +38,14 @@ from sklearn.utils.fixes import (
 )
 
 try:
+    import pytest_run_parallel  # noqa:F401
+
+    PARALLEL_RUN_AVAILABLE = True
+except ImportError:
+    PARALLEL_RUN_AVAILABLE = False
+
+
+try:
     from scipy_doctest.conftest import dt_config
 except ModuleNotFoundError:
     dt_config = None
@@ -317,6 +325,11 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("global_random_seed", random_seeds)
 
 
+def pytest_addoption(parser, pluginmanager):
+    if not PARALLEL_RUN_AVAILABLE:
+        parser.addini("thread_unsafe_fixtures", "list of stuff")
+
+
 def pytest_configure(config):
     # Use matplotlib agg backend during the tests including doctests
     try:
@@ -345,6 +358,25 @@ def pytest_configure(config):
     if faulthandler_timeout > 0:
         faulthandler.enable()
         faulthandler.dump_traceback_later(faulthandler_timeout, exit=True)
+
+    if not PARALLEL_RUN_AVAILABLE:
+        config.addinivalue_line(
+            "markers",
+            "parallel_threads(n): run the given test function in parallel "
+            "using `n` threads.",
+        )
+        config.addinivalue_line(
+            "markers",
+            "thread_unsafe: mark the test function as single-threaded",
+        )
+        config.addinivalue_line(
+            "markers",
+            "iterations(n): run the given test function `n` times in each thread",
+        )
+        config.addinivalue_line(
+            "markers",
+            "iterations(n): run the given test function `n` times in each thread",
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
Fix @lorentzenchr's workflow regression from https://github.com/scikit-learn/scikit-learn/pull/31342#issuecomment-3245966736. Obligatory [xkcd](https://xkcd.com/1172/) :wink:. 

Inspired from scipy [conftest.py](https://github.com/scipy/scipy/blob/main/scipy/conftest.py) + tweak to add `thread_unsafe_fixtures` (I guess scipy does not use this option).

Tested locally with:
```
pytest -Werror sklearn/decomposition  
```

With the previous pytest command, on this PR the tests run [^1]. On `main` it fails at collection time with pytest `INTERNALERROR`. 

[^1]: eventually the tests fail because there are plenty of warnings in the scikit-learn suite