### PR TITLE
MNT Skip test relying on `np.seterr` for Pyodide

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -74,7 +74,7 @@ jobs:
           SKLEARN_SKIP_NETWORK_TESTS: 1
           CIBW_TEST_REQUIRES: "pytest pandas"
           # -s pytest argument is needed to avoid an issue in pytest output capturing with Pyodide
-          CIBW_TEST_COMMAND: "python -m pytest -svra --pyargs sklearn --durations 20 --showlocals"
+          CIBW_TEST_COMMAND: "python -m pytest -sra --pyargs sklearn --durations 20 --showlocals"
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -72,9 +72,6 @@ jobs:
           CIBW_PLATFORM: pyodide
           SKLEARN_SKIP_OPENMP_TEST: "true"
           SKLEARN_SKIP_NETWORK_TESTS: 1
-          # Temporary work-around to avoid joblib 1.5.0 until there is a joblib
-          # release with https://github.com/joblib/joblib/pull/1721
-          CIBW_TEST_REQUIRES: "pytest pandas joblib!=1.5.0"
           # -s pytest argument is needed to avoid an issue in pytest output capturing with Pyodide
           CIBW_TEST_COMMAND: "python -m pytest -svra --pyargs sklearn --durations 20 --showlocals"
 

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -72,6 +72,7 @@ jobs:
           CIBW_PLATFORM: pyodide
           SKLEARN_SKIP_OPENMP_TEST: "true"
           SKLEARN_SKIP_NETWORK_TESTS: 1
+          CIBW_TEST_REQUIRES: "pytest pandas"
           # -s pytest argument is needed to avoid an issue in pytest output capturing with Pyodide
           CIBW_TEST_COMMAND: "python -m pytest -svra --pyargs sklearn --durations 20 --showlocals"
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -59,6 +59,7 @@ from sklearn.utils.estimator_checks import (
     check_array_api_input_and_values,
 )
 from sklearn.utils.fixes import (
+    _IS_WASM,
     COO_CONTAINERS,
     CSC_CONTAINERS,
     CSR_CONTAINERS,
@@ -2760,6 +2761,13 @@ def test_power_transformer_constant_feature(standardize):
             assert_allclose(Xt_, X)
 
 
+@pytest.mark.xfail(
+    _IS_WASM,
+    reason=(
+        "no floating point exceptions, see"
+        " https://github.com/numpy/numpy/pull/21895#issuecomment-1311525881"
+    ),
+)
 def test_yeo_johnson_inverse_transform_warning():
     """Check if a warning is triggered when the inverse transformations of the
     Box-Cox and Yeo-Johnson transformers return NaN values."""


### PR DESCRIPTION
From [build log](https://github.com/scikit-learn/scikit-learn/actions/runs/17422449131)

```
FAILED preprocessing/tests/test_data.py::test_yeo_johnson_inverse_transform_warning - Failed: DID NOT WARN. No warnings of type (<class 'UserWarning'>,) were emitted.
```

`np.seterr` does not do anything on Pyodide. My understanding is that this is related to floating point exception support see https://github.com/numpy/numpy/pull/21895#issuecomment-1311525881?

This is a new test recently introduced in https://github.com/scikit-learn/scikit-learn/pull/29307.
