### PR TITLE
DOC Make whole parameter cell clickable in HTML repr

### DIFF
--- a/sklearn/utils/_repr_html/params.css
+++ b/sklearn/utils/_repr_html/params.css
@@ -37,6 +37,7 @@
 */
 .estimator-table table td.param {
     text-align: left;
+    position: relative;
     padding: 0;
 }
 
@@ -69,11 +70,16 @@ a.param-doc-link:link,
 a.param-doc-link:visited {
     text-decoration: underline dashed;
     text-underline-offset: .3em;
-    position: relative;
     color: inherit;
     display: block;
     padding: .5em;
-    box-sizing: border-box;
+}
+
+/* "hack" to make the entire area of the cell containing the link clickable */
+a.param-doc-link::before {
+    position: absolute;
+    content: "";
+    inset: 0;
 }
 
 .param-doc-description {


### PR DESCRIPTION
Follow-up of #31564

Tweaked the css a bit to make the whole cell of the parameter name clickable, with the help of @rouk1.

<img width="521" height="325" alt="image" src="https://github.com/user-attachments/assets/628f55d2-0686-4477-b011-c709fe1567e9" />

try it out in the doc build.

cc/ @DeaMariaLeon @glemaitre 