### PR TITLE
DOC Improve LARS Lasso mathematical formulation explanation

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -712,11 +712,12 @@ or :func:`lars_path_gram`.
   increased in a direction equiangular to each one's correlations with
   the residual.
 
-  Instead of giving a vector result, the LARS solution consists of a
-  curve denoting the solution for each value of the :math:`\ell_1` norm of the
-  parameter vector. The full coefficients path is stored in the array
-  ``coef_path_`` of shape `(n_features, max_features + 1)`. The first
-  column is always zero.
+  Instead of returning one vector of parameters, the LARS solution returns
+  a 2D array ``coef_path_`` of shape `(n_features, max_features + 1)`
+  containing the coefficients of the model at each step of the algorithm.
+  Each column represents the model parameters at different levels of
+  regularization as the :math:`\ell_1` norm constraint is progressively
+  relaxed. The first column is always zero, corresponding to the null model.
 
   .. rubric:: References
 


### PR DESCRIPTION
### What does this PR do?

This PR improves the documentation for the LARS Lasso mathematical formulation section by replacing confusing language with clearer explanations.

### Problem
The current documentation states:
> "Instead of giving a vector result, the LARS solution consists of a curve denoting the solution for each value of the ℓ₁ norm of the parameter vector."

This description is problematic because:
- It's not actually a "curve" - it's a discrete set of solutions
- The term "curve" is misleading and confusing
- It doesn't clearly explain what the  array contains

### Solution
The new documentation explains:
> "Instead of returning one vector of parameters, the LARS solution returns a 2D array  of shape  containing the coefficients of the model at each step of the algorithm. Each column represents the model parameters at different levels of regularization as the ℓ₁ norm constraint is progressively relaxed."

This provides:
- Clear explanation of what LARS actually returns
- Explicit description of the array structure
- Better understanding of what each column represents
- Clearer connection to the regularization process

Closes #32083