### PR TITLE
wip: experiment with alternative to `scipy.optimize.minimize_scalar`

### DIFF
--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -1154,7 +1154,7 @@ class _TemperatureScaling(RegressorMixin, BaseEstimator):
         if not log_beta_minimizer.success:  # pragma: no cover
             raise RuntimeError(
                 "Temperature scaling fails to optimize during calibration. "
-                "Reason from `scipy.optimize.minimize_scalar`: "
+                "Reason from `scipy.optimize.find_minimum`: "
                 f"{log_beta_minimizer.message}"
             )
 


### PR DESCRIPTION
```console
scikit-learn on 🎋 31869 via 🐍 
❯ pwd
/Users/lucascolley/ghq/github.com/glemaitre/python-stack/scikit-learn/scikit-learn

scikit-learn on 🎋 31869 via 🐍 
❯ pixi run tests -t sklearn.tests.test_calibration
✨ Pixi task (tests in dev): spin test -t sklearn.tests.test_calibration
{snip}
sklearn/tests/test_calibration.py ..................................................s................................................................                                                [100%]

=============================================================================== 114 passed, 1 skipped, 33 warnings in 9.70s ================================================================================
```

> gh-32107 show the existing test-suite passing while naïvely replacing `minimize_scalar` with `bracket_minimum` and `find_minimum` (benchmarks may be a different matter).
> 
> As documented at https://scipy.github.io/devdocs/dev/api-dev/array_api_modules_tables/optimize_elementwise.html, these functions have CuPy and PyTorch support, so this may be an interesting starting point for you @OmarManzoor @lucyleeow !
> 
> I haven't investigated performance for NumPy at all, but this may at least get you by as a fallback for non-NumPy arrays, while you wait for some more ticks to materialise in https://scipy.github.io/devdocs/dev/api-dev/array_api_modules_tables/optimize.html. 

 _Originally posted by @lucascolley in [#31869](https://github.com/scikit-learn/scikit-learn/issues/31869#issuecomment-3255933155)_