### PR TITLE
DOC: Clarify team descriptions on About Us page

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -38,10 +38,9 @@ central roles, however a more complete list of contributors can be found `on
 GitHub
 <https://github.com/scikit-learn/scikit-learn/graphs/contributors>`__.
 
-Active Core Contributors
-------------------------
 
-Maintainers Team
+
+Core-devs
 ................
 
 The following people are currently maintainers, in charge of
@@ -630,7 +629,7 @@ list of events.
 Donating to the project
 =======================
 
-If you have found scikit-learn to be useful in your work, research, or company, 
+If you have found scikit-learn to be useful in your work, research, or company,
 please consider making a donation to the project commensurate with your resources.
 There are several options for making donations:
 
@@ -663,15 +662,15 @@ There are several options for making donations:
   able to make a donation with a company match as high as 100%. Our project
   ID is `433725 <https://causes.benevity.org/projects/433725>`_.
 
-All donations are managed by `NumFOCUS <https://numfocus.org/>`_, a 501(c)(3) 
+All donations are managed by `NumFOCUS <https://numfocus.org/>`_, a 501(c)(3)
 non-profit organization based in Austin, Texas, USA. The NumFOCUS board
-consists of `SciPy community members <https://numfocus.org/board.html>`_. 
+consists of `SciPy community members <https://numfocus.org/board.html>`_.
 Contributions are tax-deductible to the extent allowed by law.
 
 .. rubric:: Notes
 
-Contributions support the maintenance of the project, including development, 
-documentation, infrastructure and coding sprints. 
+Contributions support the maintenance of the project, including development,
+documentation, infrastructure and coding sprints.
 
 
 scikit-learn Swag


### PR DESCRIPTION
Closes #31653

I have updated the team names and structure on the "About Us" page (`about.rst`) to resolve the inconsistency noted in the issue.

It removes the "Active Core Contributors" heading and renames the "Maintainers Team" to "Core-devs" to align with the official GitHub teams list. 

