### PR TITLE
DOC: clarify handling of huntr reports in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,23 +1,21 @@
 # Security Policy
 
-## Supported Versions
-
-| Version       | Supported          |
-| ------------- | ------------------ |
-| 1.7.1         | :white_check_mark: |
-| < 1.7.1       | :x:                |
-
 ## Reporting a Vulnerability
 
-Please report security vulnerabilities by opening a new [GitHub security
-advisory](https://github.com/scikit-learn/scikit-learn/security/advisories/new).
+The scikit-learn project is **not reviewing reports submitted to huntr**.  
+Please use this SECURITY.md file to submit reports.
 
-You can also send an email to `security@scikit-learn.org`, which is an alias to
-a subset of the scikit-learn maintainers' team.
+When reporting a security issue, please include:
 
-If the security vulnerability is accepted, a patch will be crafted privately
-in order to prepare a dedicated bugfix release as timely as possible (depending
-on the complexity of the fix).
+- A Proof of Concept (POC)
+- A Proof of Impact (POI)
 
-In addition to the options above, you can also report security vulnerabilities
-to [tidelift](https://tidelift.com/security).
+If your report is deemed impactful, you may then report it to huntr to collect a bounty.
+
+To submit a report privately, please use GitHub Security Advisories:  
+👉 https://github.com/scikit-learn/scikit-learn/security/advisories/new
+
+## Additional References
+- [Scientific Python SPEC](https://scientific-python.org/specs/)
+- [NumPy discussion on security](https://github.com/numpy/numpy/discussions)
+- [Dask: comment from huntr person](https://github.com/dask)


### PR DESCRIPTION
What does this implement/fix?

This PR updates SECURITY.md to clarify how the scikit-learn project handles security reports submitted via huntr and similar bug-bounty services.

Changes include:

Stating that scikit-learn does not review huntr reports directly.

Directing security reporters to use GitHub Security Advisories and provide Proof of Concept (PoC) and Proof of Impact (PoI).

Adding references for context.

This update clarifies handling of huntr reports. Contribution by Bhumika Sahu.

Reference Issues/PRs

No linked issues; documentation-only change.

Any other comments?

This is a documentation-only change and does not affect code or functionality.