### PR TITLE
Revert "API make murmurhash3_32 private (#32103)"

### DIFF
--- a/doc/api_reference.py
+++ b/doc/api_reference.py
@@ -1351,4 +1351,4 @@ DEPRECATED_API_REFERENCE = {
 }
 """
 
-DEPRECATED_API_REFERENCE = {"1.8.0": ["utils.murmurhash3_32"]}  # type: ignore[var-annotated]
+DEPRECATED_API_REFERENCE = {}  # type: ignore[var-annotated]

--- a/doc/whats_new/upcoming_changes/sklearn.utils/32103.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/32103.api.rst
@@ -1,3 +1,0 @@
-- The function :function:`utils.murmurhash.murmurhash3_32` is now deprecated and will be
-  removed in version 1.10.
-  By :user:`François Paugam <FrancoisPgm>`.

--- a/sklearn/utils/murmurhash.pyx
+++ b/sklearn/utils/murmurhash.pyx
@@ -17,8 +17,6 @@ from ..utils._typedefs cimport int32_t, uint32_t
 
 import numpy as np
 
-from sklearn.utils.deprecation import deprecated
-
 cdef extern from "src/MurmurHash3.h":
     void MurmurHash3_x86_32(void *key, int len, uint32_t seed, void *out)
     void MurmurHash3_x86_128(void *key, int len, uint32_t seed, void *out)
@@ -81,17 +79,8 @@ def _murmurhash3_bytes_array_s32(
     return np.asarray(out)
 
 
-# TODO(1.10): remove
-@deprecated(
-    "Function `murmurhash3_32` was deprecated in 1.8 and will be "
-    "removed in 1.10."
-)
 def murmurhash3_32(key, seed=0, positive=False):
     """Compute the 32bit murmurhash3 of key at seed.
-
-    .. deprecated:: 1.8
-        Function `murmurhash3_32` was deprecated in 1.8.0 and will be
-        removed in 1.10.0.
 
     The underlying implementation is MurmurHash3_x86_32 generating low
     latency 32bits hash suitable for implementing lookup tables, Bloom
@@ -115,36 +104,6 @@ def murmurhash3_32(key, seed=0, positive=False):
     --------
     >>> from sklearn.utils import murmurhash3_32
     >>> murmurhash3_32(b"Hello World!", seed=42)
-    3565178
-    """
-    return _murmurhash3_32(key, seed, positive)
-
-
-def _murmurhash3_32(key, seed=0, positive=False):
-    """Compute the 32bit murmurhash3 of key at seed.
-
-    The underlying implementation is MurmurHash3_x86_32 generating low
-    latency 32bits hash suitable for implementing lookup tables, Bloom
-    filters, count min sketch or feature hashing.
-
-    Parameters
-    ----------
-    key : np.int32, bytes, unicode or ndarray of dtype=np.int32
-        The physical object to hash.
-
-    seed : int, default=0
-        Integer seed for the hashing algorithm.
-
-    positive : bool, default=False
-        True: the results is casted to an unsigned int
-          from 0 to 2 ** 32 - 1
-        False: the results is casted to a signed int
-          from -(2 ** 31) to 2 ** 31 - 1
-
-    Examples
-    --------
-    >>> from sklearn.utils.murmurhash import _murmurhash3_32
-    >>> _murmurhash3_32(b"Hello World!", seed=42)
     3565178
     """
     if isinstance(key, bytes):

--- a/sklearn/utils/tests/test_murmurhash.py
+++ b/sklearn/utils/tests/test_murmurhash.py
@@ -2,24 +2,23 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np
-import pytest
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
-from sklearn.utils.murmurhash import _murmurhash3_32, murmurhash3_32
+from sklearn.utils.murmurhash import murmurhash3_32
 
 
 def test_mmhash3_int():
-    assert _murmurhash3_32(3) == 847579505
-    assert _murmurhash3_32(3, seed=0) == 847579505
-    assert _murmurhash3_32(3, seed=42) == -1823081949
+    assert murmurhash3_32(3) == 847579505
+    assert murmurhash3_32(3, seed=0) == 847579505
+    assert murmurhash3_32(3, seed=42) == -1823081949
 
-    assert _murmurhash3_32(3, positive=False) == 847579505
-    assert _murmurhash3_32(3, seed=0, positive=False) == 847579505
-    assert _murmurhash3_32(3, seed=42, positive=False) == -1823081949
+    assert murmurhash3_32(3, positive=False) == 847579505
+    assert murmurhash3_32(3, seed=0, positive=False) == 847579505
+    assert murmurhash3_32(3, seed=42, positive=False) == -1823081949
 
-    assert _murmurhash3_32(3, positive=True) == 847579505
-    assert _murmurhash3_32(3, seed=0, positive=True) == 847579505
-    assert _murmurhash3_32(3, seed=42, positive=True) == 2471885347
+    assert murmurhash3_32(3, positive=True) == 847579505
+    assert murmurhash3_32(3, seed=0, positive=True) == 847579505
+    assert murmurhash3_32(3, seed=42, positive=True) == 2471885347
 
 
 def test_mmhash3_int_array():
@@ -28,38 +27,36 @@ def test_mmhash3_int_array():
     keys = keys.reshape((3, 2, 1))
 
     for seed in [0, 42]:
-        expected = np.array([_murmurhash3_32(int(k), seed) for k in keys.flat])
+        expected = np.array([murmurhash3_32(int(k), seed) for k in keys.flat])
         expected = expected.reshape(keys.shape)
-        assert_array_equal(_murmurhash3_32(keys, seed), expected)
+        assert_array_equal(murmurhash3_32(keys, seed), expected)
 
     for seed in [0, 42]:
-        expected = np.array(
-            [_murmurhash3_32(k, seed, positive=True) for k in keys.flat]
-        )
+        expected = np.array([murmurhash3_32(k, seed, positive=True) for k in keys.flat])
         expected = expected.reshape(keys.shape)
-        assert_array_equal(_murmurhash3_32(keys, seed, positive=True), expected)
+        assert_array_equal(murmurhash3_32(keys, seed, positive=True), expected)
 
 
 def test_mmhash3_bytes():
-    assert _murmurhash3_32(b"foo", 0) == -156908512
-    assert _murmurhash3_32(b"foo", 42) == -1322301282
+    assert murmurhash3_32(b"foo", 0) == -156908512
+    assert murmurhash3_32(b"foo", 42) == -1322301282
 
-    assert _murmurhash3_32(b"foo", 0, positive=True) == 4138058784
-    assert _murmurhash3_32(b"foo", 42, positive=True) == 2972666014
+    assert murmurhash3_32(b"foo", 0, positive=True) == 4138058784
+    assert murmurhash3_32(b"foo", 42, positive=True) == 2972666014
 
 
 def test_mmhash3_unicode():
-    assert _murmurhash3_32("foo", 0) == -156908512
-    assert _murmurhash3_32("foo", 42) == -1322301282
+    assert murmurhash3_32("foo", 0) == -156908512
+    assert murmurhash3_32("foo", 42) == -1322301282
 
-    assert _murmurhash3_32("foo", 0, positive=True) == 4138058784
-    assert _murmurhash3_32("foo", 42, positive=True) == 2972666014
+    assert murmurhash3_32("foo", 0, positive=True) == 4138058784
+    assert murmurhash3_32("foo", 42, positive=True) == 2972666014
 
 
 def test_no_collision_on_byte_range():
     previous_hashes = set()
     for i in range(100):
-        h = _murmurhash3_32(" " * i, 0)
+        h = murmurhash3_32(" " * i, 0)
         assert h not in previous_hashes, "Found collision on growing empty string"
 
 
@@ -68,14 +65,9 @@ def test_uniform_distribution():
     bins = np.zeros(n_bins, dtype=np.float64)
 
     for i in range(n_samples):
-        bins[_murmurhash3_32(i, positive=True) % n_bins] += 1
+        bins[murmurhash3_32(i, positive=True) % n_bins] += 1
 
     means = bins / n_samples
     expected = np.full(n_bins, 1.0 / n_bins)
 
     assert_array_almost_equal(means / expected, np.ones(n_bins), 2)
-
-
-def test_deprecation_warning():
-    with pytest.warns(FutureWarning, match="`murmurhash3_32` was deprecated"):
-        murmurhash3_32(3)


### PR DESCRIPTION
This reverts commit 7f2692036a38fc1b95824a43326ed4206302a87a.

`murmurhash3` is used by other projects like skrub, and deprecating it has a huge cost for them:
- either add a new dependency (like mmh3)
- or implement it and have to compile c++ code making it not pure python anymore

Given that we're keeping the cython implementation and that #32103 was just about removing the public name, the tradeoff benefit for sklearn downside for other projects doesn't seem worth.

On a longer term perspective, we could discuss using a c++ implementation from the the stdlib as explained here https://github.com/scikit-learn/scikit-learn/issues/27593#issuecomment-3253467758. Then the benefit for sklearn would be significant enough to reconsider deprecating murmuhash3.