### PR TITLE
TST Fix the error message in test_min_dependencies_readme

### DIFF
--- a/sklearn/tests/test_min_dependencies_readme.py
+++ b/sklearn/tests/test_min_dependencies_readme.py
@@ -61,7 +61,7 @@ def test_min_dependencies_readme():
                 min_version = parse_version(dependent_packages[package][0])
 
                 message = (
-                    f"{package} has inconsistent minimum versions in pyproject.toml and"
+                    f"{package} has inconsistent minimum versions in README.rst and"
                     f" _min_depencies.py: {version} != {min_version}"
                 )
                 assert version == min_version, message


### PR DESCRIPTION
The current msg mentions `pyproject.toml` vs `_min_dependencies.py`, but the test is about `README.rst` vs `_min_dependencies.py`.