### PR TITLE
meson-python 0.17.1+ required to build sklearn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ maintenance = ["conda-lock==3.0.1"]
 build-backend = "mesonpy"
 # Minimum requirements for the build system to execute.
 requires = [
-    "meson-python>=0.16.0",
+    "meson-python>=0.17.1",
     "Cython>=3.1.2",
     "numpy>=2",
     "scipy>=1.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ requires = [
     "meson-python>=0.17.1",
     "Cython>=3.1.2",
     "numpy>=2",
-    "scipy>=1.8.0",
+    "scipy>=1.10.0",
 ]
 
 [tool.pytest.ini_options]

--- a/sklearn/tests/test_min_dependencies_readme.py
+++ b/sklearn/tests/test_min_dependencies_readme.py
@@ -16,14 +16,13 @@ for package, (min_version, extras) in dependent_packages.items():
     for extra in extras.split(", "):
         min_depencies_tag_to_packages_without_version[extra].append(package)
 
-min_dependencies_tag_to_pyproject_section = {
-    "build": "build-system.requires",
-    "install": "project.dependencies",
+pyproject_section_to_min_dependencies_tag = {
+    "build-system.requires": "build",
+    "project.dependencies": "install",
 }
 for tag in min_depencies_tag_to_packages_without_version:
-    min_dependencies_tag_to_pyproject_section[tag] = (
-        f"project.optional-dependencies.{tag}"
-    )
+    section = f"project.optional-dependencies.{tag}"
+    pyproject_section_to_min_dependencies_tag[section] = tag
 
 
 def test_min_dependencies_readme():
@@ -108,6 +107,10 @@ def check_pyproject_section(
                 "Only >= and == are supported for version requirements"
             )
 
+        # It's Cython in pyproject.toml but cython in _min_dependencies.py
+        if package == "Cython":
+            package = "cython"
+
         pyproject_build_min_versions[package] = version
 
     assert sorted(pyproject_build_min_versions) == sorted(expected_packages)
@@ -126,8 +129,8 @@ def check_pyproject_section(
 
 
 @pytest.mark.parametrize(
-    "min_dependencies_tag, pyproject_section",
-    min_dependencies_tag_to_pyproject_section.items(),
+    "pyproject_section, min_dependencies_tag",
+    pyproject_section_to_min_dependencies_tag.items(),
 )
 def test_min_dependencies_pyproject_toml(pyproject_section, min_dependencies_tag):
     """Check versions in pyproject.toml is consistent with _min_dependencies."""


### PR DESCRIPTION
#### Reference Issues/PRs

#31560 updated pyproject.toml to use a newer license metadata format only supported in meson-python 0.17.1+.

#### What does this implement/fix? Explain your changes.

#31560 updated the `[build]` extra, but didn't actually updated the build dependencies used by pip.

#### Any other comments?

@rrricharrrd @betatim @adrinjalali