### PR TITLE
MNT Clean-up deprecations for 1.8: _estimator_type in sklearn.base mixins

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -526,9 +526,6 @@ class ClassifierMixin:
     0.66...
     """
 
-    # TODO(1.8): Remove this attribute
-    _estimator_type = "classifier"
-
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.estimator_type = "classifier"
@@ -598,9 +595,6 @@ class RegressorMixin:
     >>> estimator.score(X, y)
     0.0
     """
-
-    # TODO(1.8): Remove this attribute
-    _estimator_type = "regressor"
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
@@ -674,9 +668,6 @@ class ClusterMixin:
     >>> MyClusterer().fit_predict(X)
     array([1, 1, 1])
     """
-
-    # TODO(1.8): Remove this attribute
-    _estimator_type = "clusterer"
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
@@ -1029,9 +1020,6 @@ class DensityMixin:
     True
     """
 
-    # TODO(1.8): Remove this attribute
-    _estimator_type = "DensityEstimator"
-
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.estimator_type = "density_estimator"
@@ -1078,9 +1066,6 @@ class OutlierMixin:
     >>> estimator.fit_predict(X)
     array([1., 1., 1.])
     """
-
-    # TODO(1.8): Remove this attribute
-    _estimator_type = "outlier_detector"
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
@@ -1219,15 +1204,6 @@ def is_classifier(estimator):
     >>> is_classifier(kmeans)
     False
     """
-    # TODO(1.8): Remove this check
-    if isinstance(estimator, type):
-        warnings.warn(
-            f"passing a class to {print(inspect.stack()[0][3])} is deprecated and "
-            "will be removed in 1.8. Use an instance of the class instead.",
-            FutureWarning,
-        )
-        return getattr(estimator, "_estimator_type", None) == "classifier"
-
     return get_tags(estimator).estimator_type == "classifier"
 
 
@@ -1259,15 +1235,6 @@ def is_regressor(estimator):
     >>> is_regressor(kmeans)
     False
     """
-    # TODO(1.8): Remove this check
-    if isinstance(estimator, type):
-        warnings.warn(
-            f"passing a class to {print(inspect.stack()[0][3])} is deprecated and "
-            "will be removed in 1.8. Use an instance of the class instead.",
-            FutureWarning,
-        )
-        return getattr(estimator, "_estimator_type", None) == "regressor"
-
     return get_tags(estimator).estimator_type == "regressor"
 
 
@@ -1301,15 +1268,6 @@ def is_clusterer(estimator):
     >>> is_clusterer(kmeans)
     True
     """
-    # TODO(1.8): Remove this check
-    if isinstance(estimator, type):
-        warnings.warn(
-            f"passing a class to {print(inspect.stack()[0][3])} is deprecated and "
-            "will be removed in 1.8. Use an instance of the class instead.",
-            FutureWarning,
-        )
-        return getattr(estimator, "_estimator_type", None) == "clusterer"
-
     return get_tags(estimator).estimator_type == "clusterer"
 
 
@@ -1326,15 +1284,6 @@ def is_outlier_detector(estimator):
     out : bool
         True if estimator is an outlier detector and False otherwise.
     """
-    # TODO(1.8): Remove this check
-    if isinstance(estimator, type):
-        warnings.warn(
-            f"passing a class to {print(inspect.stack()[0][3])} is deprecated and "
-            "will be removed in 1.8. Use an instance of the class instead.",
-            FutureWarning,
-        )
-        return getattr(estimator, "_estimator_type", None) == "outlier_detector"
-
     return get_tags(estimator).estimator_type == "outlier_detector"
 
 

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -228,11 +228,6 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         self.importance_getter = importance_getter
         self.verbose = verbose
 
-    # TODO(1.8) remove this property
-    @property
-    def _estimator_type(self):
-        return self.estimator._estimator_type
-
     @property
     def classes_(self):
         """Classes labels available when `estimator` is a classifier.

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -483,11 +483,6 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
         self.error_score = error_score
         self.return_train_score = return_train_score
 
-    @property
-    # TODO(1.8) remove this property
-    def _estimator_type(self):
-        return self.estimator._estimator_type
-
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         sub_estimator_tags = get_tags(self.estimator)

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -402,16 +402,6 @@ class Pipeline(_BaseComposition):
             return self.named_steps[ind]
         return est
 
-    # TODO(1.8): Remove this property
-    @property
-    def _estimator_type(self):
-        """Return the estimator type of the last step in the pipeline."""
-
-        if not self.steps:
-            return None
-
-        return self.steps[-1][1]._estimator_type
-
     @property
     def named_steps(self):
         """Access the steps by name.

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -19,12 +19,10 @@ from sklearn.base import (
     clone,
     is_classifier,
     is_clusterer,
-    is_outlier_detector,
     is_regressor,
 )
 from sklearn.cluster import KMeans
 from sklearn.decomposition import PCA
-from sklearn.ensemble import IsolationForest
 from sklearn.exceptions import InconsistentVersionWarning
 from sklearn.metrics import get_scorer
 from sklearn.model_selection import GridSearchCV, KFold
@@ -267,21 +265,6 @@ def test_get_params():
 
     with pytest.raises(ValueError):
         test.set_params(a__a=2)
-
-
-# TODO(1.8): Remove this test when the deprecation is removed
-def test_is_estimator_type_class():
-    with pytest.warns(FutureWarning, match="passing a class to.*is deprecated"):
-        assert is_classifier(SVC)
-
-    with pytest.warns(FutureWarning, match="passing a class to.*is deprecated"):
-        assert is_regressor(SVR)
-
-    with pytest.warns(FutureWarning, match="passing a class to.*is deprecated"):
-        assert is_clusterer(KMeans)
-
-    with pytest.warns(FutureWarning, match="passing a class to.*is deprecated"):
-        assert is_outlier_detector(IsolationForest)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -932,7 +932,7 @@ def test_make_pipeline():
             make_pipeline(StandardScaler()),
             lambda est: get_tags(est).estimator_type is None,
         ),
-        (Pipeline([]), lambda est: est._estimator_type is None),
+        (Pipeline([]), lambda est: get_tags(est).estimator_type is None),
     ],
 )
 def test_pipeline_estimator_type(pipeline, check_estimator_type):

--- a/sklearn/utils/tests/test_tags.py
+++ b/sklearn/utils/tests/test_tags.py
@@ -20,13 +20,8 @@ from sklearn.utils.estimator_checks import (
 )
 
 
-class NoTagsEstimator:
+class EmptyClassifier(ClassifierMixin, BaseEstimator):
     pass
-
-
-class ClassifierEstimator:
-    # This is to test whether not inheriting from mixins works.
-    _estimator_type = "classifier"
 
 
 class EmptyTransformer(TransformerMixin, BaseEstimator):
@@ -37,15 +32,10 @@ class EmptyRegressor(RegressorMixin, BaseEstimator):
     pass
 
 
-# TODO(1.8): Update when implementing __sklearn_tags__ is required
-@pytest.mark.filterwarnings(
-    "ignore:.*no attribute '__sklearn_tags__'.*:DeprecationWarning"
-)
 @pytest.mark.parametrize(
     "estimator, value",
     [
-        [NoTagsEstimator(), False],
-        [ClassifierEstimator(), True],
+        [EmptyClassifier(), True],
         [EmptyTransformer(), False],
         [EmptyRegressor(), True],
         [BaseEstimator(), False],
@@ -89,14 +79,13 @@ def test_tag_test_passes_with_inheritance():
     check_valid_tag_types("MyEstimator", MyEstimator())
 
 
-# TODO(1.8): Update this test to check for errors
 def test_tags_no_sklearn_tags_concrete_implementation():
     """Non-regression test for:
     https://github.com/scikit-learn/scikit-learn/issues/30479
 
     Either the estimator doesn't implement `__sklearn_tags` or there is no class
     implementing `__sklearn_tags__` without calling `super().__sklearn_tags__()` in
-    its mro. Thus, we raise a warning and request to inherit from
+    its mro. Thus, we raise an error and request to inherit from
     `BaseEstimator` that implements `__sklearn_tags__`.
     """
 
@@ -117,7 +106,7 @@ def test_tags_no_sklearn_tags_concrete_implementation():
             return np.full(shape=X.shape[0], fill_value=self.param)
 
     my_pipeline = Pipeline([("estimator", MyEstimator(param=1))])
-    with pytest.warns(DeprecationWarning, match="The following error was raised"):
+    with pytest.raises(AttributeError, match="The following error was raised"):
         my_pipeline.fit(X, y).predict(X)
 
     # 2nd case, the estimator doesn't implement `__sklearn_tags__` at all.
@@ -133,7 +122,7 @@ def test_tags_no_sklearn_tags_concrete_implementation():
             return np.full(shape=X.shape[0], fill_value=self.param)
 
     my_pipeline = Pipeline([("estimator", MyEstimator2(param=1))])
-    with pytest.warns(DeprecationWarning, match="The following error was raised"):
+    with pytest.raises(AttributeError, match="The following error was raised"):
         my_pipeline.fit(X, y).predict(X)
 
     # check that we still raise an error if it is not a AttributeError or related to


### PR DESCRIPTION
Remove deprecated `_estimator_type` class attribute in the mixin classes of `sklearn.base`.