### PR TITLE
MNT Clean-up deprecation for 1.8: _raise_or_warn_if_not_fitted in Pipeline

### DIFF
--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -3,9 +3,7 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
-import warnings
 from collections import Counter, defaultdict
-from contextlib import contextmanager
 from copy import deepcopy
 from itertools import chain, islice
 
@@ -35,33 +33,6 @@ from sklearn.utils.parallel import Parallel, delayed
 from sklearn.utils.validation import check_is_fitted, check_memory
 
 __all__ = ["FeatureUnion", "Pipeline", "make_pipeline", "make_union"]
-
-
-@contextmanager
-def _raise_or_warn_if_not_fitted(estimator):
-    """A context manager to make sure a NotFittedError is raised, if a sub-estimator
-    raises the error.
-
-    Otherwise, we raise a warning if the pipeline is not fitted, with the deprecation.
-
-    TODO(1.8): remove this context manager and replace with check_is_fitted.
-    """
-    try:
-        yield
-    except NotFittedError as exc:
-        raise NotFittedError("Pipeline is not fitted yet.") from exc
-
-    # we only get here if the above didn't raise
-    try:
-        check_is_fitted(estimator)
-    except NotFittedError:
-        warnings.warn(
-            "This Pipeline instance is not fitted yet. Call 'fit' with "
-            "appropriate arguments before using other methods such as transform, "
-            "predict, etc. This will raise an error in 1.8 instead of the current "
-            "warning.",
-            FutureWarning,
-        )
 
 
 def _final_estimator_has(attr):
@@ -776,22 +747,19 @@ class Pipeline(_BaseComposition):
         y_pred : ndarray
             Result of calling `predict` on the final estimator.
         """
-        # TODO(1.8): Remove the context manager and use check_is_fitted(self)
-        with _raise_or_warn_if_not_fitted(self):
-            Xt = X
+        check_is_fitted(self)
+        Xt = X
 
-            if not _routing_enabled():
-                for _, name, transform in self._iter(with_final=False):
-                    Xt = transform.transform(Xt)
-                return self.steps[-1][1].predict(Xt, **params)
-
-            # metadata routing enabled
-            routed_params = process_routing(self, "predict", **params)
+        if not _routing_enabled():
             for _, name, transform in self._iter(with_final=False):
-                Xt = transform.transform(Xt, **routed_params[name].transform)
-            return self.steps[-1][1].predict(
-                Xt, **routed_params[self.steps[-1][0]].predict
-            )
+                Xt = transform.transform(Xt)
+            return self.steps[-1][1].predict(Xt, **params)
+
+        # metadata routing enabled
+        routed_params = process_routing(self, "predict", **params)
+        for _, name, transform in self._iter(with_final=False):
+            Xt = transform.transform(Xt, **routed_params[name].transform)
+        return self.steps[-1][1].predict(Xt, **routed_params[self.steps[-1][0]].predict)
 
     @available_if(_final_estimator_has("fit_predict"))
     @_fit_context(
@@ -892,22 +860,21 @@ class Pipeline(_BaseComposition):
         y_proba : ndarray of shape (n_samples, n_classes)
             Result of calling `predict_proba` on the final estimator.
         """
-        # TODO(1.8): Remove the context manager and use check_is_fitted(self)
-        with _raise_or_warn_if_not_fitted(self):
-            Xt = X
+        check_is_fitted(self)
+        Xt = X
 
-            if not _routing_enabled():
-                for _, name, transform in self._iter(with_final=False):
-                    Xt = transform.transform(Xt)
-                return self.steps[-1][1].predict_proba(Xt, **params)
-
-            # metadata routing enabled
-            routed_params = process_routing(self, "predict_proba", **params)
+        if not _routing_enabled():
             for _, name, transform in self._iter(with_final=False):
-                Xt = transform.transform(Xt, **routed_params[name].transform)
-            return self.steps[-1][1].predict_proba(
-                Xt, **routed_params[self.steps[-1][0]].predict_proba
-            )
+                Xt = transform.transform(Xt)
+            return self.steps[-1][1].predict_proba(Xt, **params)
+
+        # metadata routing enabled
+        routed_params = process_routing(self, "predict_proba", **params)
+        for _, name, transform in self._iter(with_final=False):
+            Xt = transform.transform(Xt, **routed_params[name].transform)
+        return self.steps[-1][1].predict_proba(
+            Xt, **routed_params[self.steps[-1][0]].predict_proba
+        )
 
     @available_if(_final_estimator_has("decision_function"))
     def decision_function(self, X, **params):
@@ -939,23 +906,22 @@ class Pipeline(_BaseComposition):
         y_score : ndarray of shape (n_samples, n_classes)
             Result of calling `decision_function` on the final estimator.
         """
-        # TODO(1.8): Remove the context manager and use check_is_fitted(self)
-        with _raise_or_warn_if_not_fitted(self):
-            _raise_for_params(params, self, "decision_function")
+        check_is_fitted(self)
+        _raise_for_params(params, self, "decision_function")
 
-            # not branching here since params is only available if
-            # enable_metadata_routing=True
-            routed_params = process_routing(self, "decision_function", **params)
+        # not branching here since params is only available if
+        # enable_metadata_routing=True
+        routed_params = process_routing(self, "decision_function", **params)
 
-            Xt = X
-            for _, name, transform in self._iter(with_final=False):
-                Xt = transform.transform(
-                    Xt, **routed_params.get(name, {}).get("transform", {})
-                )
-            return self.steps[-1][1].decision_function(
-                Xt,
-                **routed_params.get(self.steps[-1][0], {}).get("decision_function", {}),
+        Xt = X
+        for _, name, transform in self._iter(with_final=False):
+            Xt = transform.transform(
+                Xt, **routed_params.get(name, {}).get("transform", {})
             )
+        return self.steps[-1][1].decision_function(
+            Xt,
+            **routed_params.get(self.steps[-1][0], {}).get("decision_function", {}),
+        )
 
     @available_if(_final_estimator_has("score_samples"))
     def score_samples(self, X):
@@ -977,12 +943,11 @@ class Pipeline(_BaseComposition):
         y_score : ndarray of shape (n_samples,)
             Result of calling `score_samples` on the final estimator.
         """
-        # TODO(1.8): Remove the context manager and use check_is_fitted(self)
-        with _raise_or_warn_if_not_fitted(self):
-            Xt = X
-            for _, _, transformer in self._iter(with_final=False):
-                Xt = transformer.transform(Xt)
-            return self.steps[-1][1].score_samples(Xt)
+        check_is_fitted(self)
+        Xt = X
+        for _, _, transformer in self._iter(with_final=False):
+            Xt = transformer.transform(Xt)
+        return self.steps[-1][1].score_samples(Xt)
 
     @available_if(_final_estimator_has("predict_log_proba"))
     def predict_log_proba(self, X, **params):
@@ -1023,22 +988,21 @@ class Pipeline(_BaseComposition):
         y_log_proba : ndarray of shape (n_samples, n_classes)
             Result of calling `predict_log_proba` on the final estimator.
         """
-        # TODO(1.8): Remove the context manager and use check_is_fitted(self)
-        with _raise_or_warn_if_not_fitted(self):
-            Xt = X
+        check_is_fitted(self)
+        Xt = X
 
-            if not _routing_enabled():
-                for _, name, transform in self._iter(with_final=False):
-                    Xt = transform.transform(Xt)
-                return self.steps[-1][1].predict_log_proba(Xt, **params)
-
-            # metadata routing enabled
-            routed_params = process_routing(self, "predict_log_proba", **params)
+        if not _routing_enabled():
             for _, name, transform in self._iter(with_final=False):
-                Xt = transform.transform(Xt, **routed_params[name].transform)
-            return self.steps[-1][1].predict_log_proba(
-                Xt, **routed_params[self.steps[-1][0]].predict_log_proba
-            )
+                Xt = transform.transform(Xt)
+            return self.steps[-1][1].predict_log_proba(Xt, **params)
+
+        # metadata routing enabled
+        routed_params = process_routing(self, "predict_log_proba", **params)
+        for _, name, transform in self._iter(with_final=False):
+            Xt = transform.transform(Xt, **routed_params[name].transform)
+        return self.steps[-1][1].predict_log_proba(
+            Xt, **routed_params[self.steps[-1][0]].predict_log_proba
+        )
 
     def _can_transform(self):
         return self._final_estimator == "passthrough" or hasattr(
@@ -1078,17 +1042,16 @@ class Pipeline(_BaseComposition):
         Xt : ndarray of shape (n_samples, n_transformed_features)
             Transformed data.
         """
-        # TODO(1.8): Remove the context manager and use check_is_fitted(self)
-        with _raise_or_warn_if_not_fitted(self):
-            _raise_for_params(params, self, "transform")
+        check_is_fitted(self)
+        _raise_for_params(params, self, "transform")
 
-            # not branching here since params is only available if
-            # enable_metadata_routing=True
-            routed_params = process_routing(self, "transform", **params)
-            Xt = X
-            for _, name, transform in self._iter():
-                Xt = transform.transform(Xt, **routed_params[name].transform)
-            return Xt
+        # not branching here since params is only available if
+        # enable_metadata_routing=True
+        routed_params = process_routing(self, "transform", **params)
+        Xt = X
+        for _, name, transform in self._iter():
+            Xt = transform.transform(Xt, **routed_params[name].transform)
+        return Xt
 
     def _can_inverse_transform(self):
         return all(hasattr(t, "inverse_transform") for _, _, t in self._iter())
@@ -1123,19 +1086,16 @@ class Pipeline(_BaseComposition):
             Inverse transformed data, that is, data in the original feature
             space.
         """
-        # TODO(1.8): Remove the context manager and use check_is_fitted(self)
-        with _raise_or_warn_if_not_fitted(self):
-            _raise_for_params(params, self, "inverse_transform")
+        check_is_fitted(self)
+        _raise_for_params(params, self, "inverse_transform")
 
-            # we don't have to branch here, since params is only non-empty if
-            # enable_metadata_routing=True.
-            routed_params = process_routing(self, "inverse_transform", **params)
-            reverse_iter = reversed(list(self._iter()))
-            for _, name, transform in reverse_iter:
-                X = transform.inverse_transform(
-                    X, **routed_params[name].inverse_transform
-                )
-            return X
+        # we don't have to branch here, since params is only non-empty if
+        # enable_metadata_routing=True.
+        routed_params = process_routing(self, "inverse_transform", **params)
+        reverse_iter = reversed(list(self._iter()))
+        for _, name, transform in reverse_iter:
+            X = transform.inverse_transform(X, **routed_params[name].inverse_transform)
+        return X
 
     @available_if(_final_estimator_has("score"))
     def score(self, X, y=None, sample_weight=None, **params):
@@ -1174,28 +1134,25 @@ class Pipeline(_BaseComposition):
         score : float
             Result of calling `score` on the final estimator.
         """
-        # TODO(1.8): Remove the context manager and use check_is_fitted(self)
-        with _raise_or_warn_if_not_fitted(self):
-            Xt = X
-            if not _routing_enabled():
-                for _, name, transform in self._iter(with_final=False):
-                    Xt = transform.transform(Xt)
-                score_params = {}
-                if sample_weight is not None:
-                    score_params["sample_weight"] = sample_weight
-                return self.steps[-1][1].score(Xt, y, **score_params)
-
-            # metadata routing is enabled.
-            routed_params = process_routing(
-                self, "score", sample_weight=sample_weight, **params
-            )
-
-            Xt = X
+        check_is_fitted(self)
+        Xt = X
+        if not _routing_enabled():
             for _, name, transform in self._iter(with_final=False):
-                Xt = transform.transform(Xt, **routed_params[name].transform)
-            return self.steps[-1][1].score(
-                Xt, y, **routed_params[self.steps[-1][0]].score
-            )
+                Xt = transform.transform(Xt)
+            score_params = {}
+            if sample_weight is not None:
+                score_params["sample_weight"] = sample_weight
+            return self.steps[-1][1].score(Xt, y, **score_params)
+
+        # metadata routing is enabled.
+        routed_params = process_routing(
+            self, "score", sample_weight=sample_weight, **params
+        )
+
+        Xt = X
+        for _, name, transform in self._iter(with_final=False):
+            Xt = transform.transform(Xt, **routed_params[name].transform)
+        return self.steps[-1][1].score(Xt, y, **routed_params[self.steps[-1][0]].score)
 
     @property
     def classes_(self):

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -2089,7 +2089,6 @@ def test_transform_tuple_input():
 # =============================
 
 
-# TODO(1.8): change warning to checking for NotFittedError
 @pytest.mark.parametrize(
     "method",
     [
@@ -2140,7 +2139,7 @@ def test_pipeline_warns_not_fitted(method):
             return X
 
     pipe = Pipeline([("estimator", StatelessEstimator())])
-    with pytest.warns(FutureWarning, match="This Pipeline instance is not fitted yet."):
+    with pytest.raises(NotFittedError):
         getattr(pipe, method)([[1]])
 
 


### PR DESCRIPTION
Replace the uses of `_raise_or_warn_if_not_fitted` with `check_is_fitted` in `Pipeline`, see #29868.