### PR TITLE
DOC: Clarify how candidate split thresholds are chosen in DecisionTre…

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -1013,6 +1013,17 @@ on your specific problem to determine which model is the best fit.
 .. rubric:: Examples
 
 * :ref:`sphx_glr_auto_examples_ensemble_plot_forest_hist_grad_boosting_comparison.py`
+.. note::
+
+   Candidate split thresholds are determined exhaustively. For each feature
+   considered at a split, the training samples are sorted by their feature
+   values, and thresholds are chosen as the midpoints between successive
+   distinct feature values. This results in up to ``O(N × F)`` candidate
+   thresholds, where ``N`` is the number of samples at the node and ``F`` is
+   the number of features considered. In ensembles such as RandomForest,
+   ``F`` is restricted to a random subset of features controlled by the
+   ``max_features`` parameter.
+
 
 Extremely Randomized Trees
 --------------------------

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -1015,19 +1015,19 @@ on your specific problem to determine which model is the best fit.
 * :ref:`sphx_glr_auto_examples_ensemble_plot_forest_hist_grad_boosting_comparison.py`
 .. note::
 
-   Candidate split thresholds are determined exhaustively. For each feature
-   considered at a split, the training samples are sorted by their feature
-   values, and thresholds are chosen as the midpoints between successive
-   distinct feature values.
+  Candidate split thresholds are determined exhaustively. For each feature
+  considered at a split, the training samples are sorted by their feature
+  values, and thresholds are chosen as the midpoints between successive
+  distinct feature values.
 
-   The number of candidate thresholds for a feature is:
+  The number of candidate thresholds for a feature is:
+  
+  - ``n_unique - 1``, if there are no missing values
+  - ``2 × n_unique - 1``, if missing values are present (NaN is not counted in ``n_unique``)
 
-   - ``n_unique - 1``, if there are no missing values
-   - ``2 × n_unique - 1``, if missing values are present (NaN is not counted in ``n_unique``)
-
-   In the worst case, this leads to up to ``O(N × F)`` candidate thresholds,
-   where ``N`` is the number of samples at the node and ``F`` is the number
-   of features.
+  In the worst case, this leads to up to ``O(N × F)`` candidate thresholds,
+  where ``N`` is the number of samples at the node and ``F`` is the number
+  of features.
 
    
 

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -1020,12 +1020,15 @@ on your specific problem to determine which model is the best fit.
    values, and thresholds are chosen as the midpoints between successive
    distinct feature values.
 
-   The number of candidate thresholds for a feature is equal to the number
-   of unique feature values minus one (``n_unique - 1``) if there are no
-   missing values, or ``2 × n_unique - 1`` if missing values are present
-   (NaN is not counted in ``n_unique``). In the worst case, this leads to
-   up to ``O(N × F)`` candidate thresholds, where ``N`` is the number of
-   samples at the node and ``F`` is the number of features.
+   The number of candidate thresholds for a feature is:
+
+   - ``n_unique - 1``, if there are no missing values
+   - ``2 × n_unique - 1``, if missing values are present (NaN is not counted in ``n_unique``)
+
+   In the worst case, this leads to up to ``O(N × F)`` candidate thresholds,
+   where ``N`` is the number of samples at the node and ``F`` is the number
+   of features.
+
    
 
 

--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -1018,11 +1018,15 @@ on your specific problem to determine which model is the best fit.
    Candidate split thresholds are determined exhaustively. For each feature
    considered at a split, the training samples are sorted by their feature
    values, and thresholds are chosen as the midpoints between successive
-   distinct feature values. This results in up to ``O(N × F)`` candidate
-   thresholds, where ``N`` is the number of samples at the node and ``F`` is
-   the number of features considered. In ensembles such as RandomForest,
-   ``F`` is restricted to a random subset of features controlled by the
-   ``max_features`` parameter.
+   distinct feature values.
+
+   The number of candidate thresholds for a feature is equal to the number
+   of unique feature values minus one (``n_unique - 1``) if there are no
+   missing values, or ``2 × n_unique - 1`` if missing values are present
+   (NaN is not counted in ``n_unique``). In the worst case, this leads to
+   up to ``O(N × F)`` candidate thresholds, where ``N`` is the number of
+   samples at the node and ``F`` is the number of features.
+   
 
 
 Extremely Randomized Trees

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -250,6 +250,16 @@ instead of integer values::
 
 
 .. _tree_multioutput:
+.. note::
+
+   Candidate split thresholds are determined exhaustively. For each feature
+   considered at a split, the training samples are sorted by their feature
+   values, and thresholds are chosen as the midpoints between successive
+   distinct feature values. This results in up to ``O(N × F)`` candidate
+   thresholds, where ``N`` is the number of samples at the node and ``F`` is
+   the number of features considered. In ensembles such as RandomForest,
+   ``F`` is restricted to a random subset of features controlled by the
+   ``max_features`` parameter.
 
 Multi-output problems
 =====================

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -255,11 +255,15 @@ instead of integer values::
    Candidate split thresholds are determined exhaustively. For each feature
    considered at a split, the training samples are sorted by their feature
    values, and thresholds are chosen as the midpoints between successive
-   distinct feature values. This results in up to ``O(N × F)`` candidate
-   thresholds, where ``N`` is the number of samples at the node and ``F`` is
-   the number of features considered. In ensembles such as RandomForest,
-   ``F`` is restricted to a random subset of features controlled by the
-   ``max_features`` parameter.
+   distinct feature values.
+
+   The number of candidate thresholds for a feature is equal to the number
+   of unique feature values minus one (``n_unique - 1``) if there are no
+   missing values, or ``2 × n_unique - 1`` if missing values are present
+   (NaN is not counted in ``n_unique``). In the worst case, this leads to
+   up to ``O(N × F)`` candidate thresholds, where ``N`` is the number of
+   samples at the node and ``F`` is the number of features.
+
 
 Multi-output problems
 =====================

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -252,19 +252,19 @@ instead of integer values::
 .. _tree_multioutput:
 .. note::
 
-   Candidate split thresholds are determined exhaustively. For each feature
-   considered at a split, the training samples are sorted by their feature
-   values, and thresholds are chosen as the midpoints between successive
-   distinct feature values.
+  Candidate split thresholds are determined exhaustively. For each feature
+  considered at a split, the training samples are sorted by their feature
+  values, and thresholds are chosen as the midpoints between successive
+  distinct feature values.
 
-   The number of candidate thresholds for a feature is:
+  The number of candidate thresholds for a feature is:
 
-   - ``n_unique - 1``, if there are no missing values
-   - ``2 × n_unique - 1``, if missing values are present (NaN is not counted in ``n_unique``)
+  - ``n_unique - 1``, if there are no missing values
+  - ``2 × n_unique - 1``, if missing values are present (NaN is not counted in ``n_unique``)
 
-   In the worst case, this leads to up to ``O(N × F)`` candidate thresholds,
-   where ``N`` is the number of samples at the node and ``F`` is the number
-   of features.
+  In the worst case, this leads to up to ``O(N × F)`` candidate thresholds,
+  where ``N`` is the number of samples at the node and ``F`` is the number
+  of features.
 
 
 Multi-output problems

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -257,12 +257,14 @@ instead of integer values::
    values, and thresholds are chosen as the midpoints between successive
    distinct feature values.
 
-   The number of candidate thresholds for a feature is equal to the number
-   of unique feature values minus one (``n_unique - 1``) if there are no
-   missing values, or ``2 × n_unique - 1`` if missing values are present
-   (NaN is not counted in ``n_unique``). In the worst case, this leads to
-   up to ``O(N × F)`` candidate thresholds, where ``N`` is the number of
-   samples at the node and ``F`` is the number of features.
+   The number of candidate thresholds for a feature is:
+
+   - ``n_unique - 1``, if there are no missing values
+   - ``2 × n_unique - 1``, if missing values are present (NaN is not counted in ``n_unique``)
+
+   In the worst case, this leads to up to ``O(N × F)`` candidate thresholds,
+   where ``N`` is the number of samples at the node and ``F`` is the number
+   of features.
 
 
 Multi-output problems


### PR DESCRIPTION
Closes #27159

Added clarification in documentation explaining how candidate split thresholds
are chosen in DecisionTree and RandomForest. Thresholds are the midpoints between
successive distinct feature values, leading to O(N × F) candidate splits.
