### PR TITLE
DOC Improve explanation of candidate split thresholds in decision trees

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -1010,9 +1010,28 @@ characteristics of the dataset and the modeling task. It's a good idea
 to try both models and compare their performance and computational efficiency
 on your specific problem to determine which model is the best fit.
 
+
+
 .. rubric:: Examples
 
 * :ref:`sphx_glr_auto_examples_ensemble_plot_forest_hist_grad_boosting_comparison.py`
+
+.. note::
+
+   Candidate split thresholds are determined exhaustively. For each feature
+   considered at a split, the training samples are sorted by their feature
+   values, and thresholds are chosen as the midpoints between successive
+   distinct feature values.
+
+   The number of candidate thresholds for a feature is:
+
+   - ``n_unique - 1``, if there are no missing values
+   - ``2 × n_unique - 1``, if missing values are present (NaN is not counted in ``n_unique``)
+
+   In the worst case, this leads to up to ``O(N × F)`` candidate thresholds,
+   where ``N`` is the number of samples at the node and ``F`` is the number
+   of features.
+
 
 Extremely Randomized Trees
 --------------------------

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -251,6 +251,23 @@ instead of integer values::
 
 .. _tree_multioutput:
 
+.. note::
+
+   Candidate split thresholds are determined exhaustively. For each feature
+   considered at a split, the training samples are sorted by their feature
+   values, and thresholds are chosen as the midpoints between successive
+   distinct feature values.
+
+   The number of candidate thresholds for a feature is:
+
+   - ``n_unique - 1``, if there are no missing values
+   - ``2 × n_unique - 1``, if missing values are present (NaN is not counted in ``n_unique``)
+
+   In the worst case, this leads to up to ``O(N × F)`` candidate thresholds,
+   where ``N`` is the number of samples at the node and ``F`` is the number
+   of features.
+
+
 Multi-output problems
 =====================
 


### PR DESCRIPTION
The number of candidate thresholds per feature depends on the number of unique values:

.) n_unique - 1 if no missing values

.) 2 × n_unique - 1 if there are missing values

I’ll update the note to reflect this so it’s more accurate than just saying O(N × F).