### PR TITLE
PERF: Decision trees: improve prefs by ~20% with very simple changes

### DIFF
--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -490,10 +490,6 @@ cdef class ClassificationCriterion(Criterion):
         # self.sample_indices[-self.n_missing:] that is
         # self.sample_indices[end_non_missing:self.end].
         cdef intp_t end_non_missing = self.end - self.n_missing
-
-        cdef const intp_t[:] sample_indices = self.sample_indices
-        cdef const float64_t[:] sample_weight = self.sample_weight
-
         cdef intp_t i
         cdef intp_t p
         cdef intp_t k
@@ -509,10 +505,10 @@ cdef class ClassificationCriterion(Criterion):
         # of computations, i.e. from pos to new_pos or from end to new_po.
         if (new_pos - pos) <= (end_non_missing - new_pos):
             for p in range(pos, new_pos):
-                i = sample_indices[p]
+                i = self.sample_indices[p]
 
-                if sample_weight is not None:
-                    w = sample_weight[i]
+                if self.sample_weight is not None:
+                    w = self.sample_weight[i]
 
                 for k in range(self.n_outputs):
                     self.sum_left[k, <intp_t> self.y[i, k]] += w
@@ -523,10 +519,10 @@ cdef class ClassificationCriterion(Criterion):
             self.reverse_reset()
 
             for p in range(end_non_missing - 1, new_pos - 1, -1):
-                i = sample_indices[p]
+                i = self.sample_indices[p]
 
-                if sample_weight is not None:
-                    w = sample_weight[i]
+                if self.sample_weight is not None:
+                    w = self.sample_weight[i]
 
                 for k in range(self.n_outputs):
                     self.sum_left[k, <intp_t> self.y[i, k]] -= w
@@ -964,9 +960,6 @@ cdef class RegressionCriterion(Criterion):
 
     cdef int update(self, intp_t new_pos) except -1 nogil:
         """Updated statistics by moving sample_indices[pos:new_pos] to the left."""
-        cdef const float64_t[:] sample_weight = self.sample_weight
-        cdef const intp_t[:] sample_indices = self.sample_indices
-
         cdef intp_t pos = self.pos
 
         # The missing samples are assumed to be in
@@ -987,10 +980,10 @@ cdef class RegressionCriterion(Criterion):
         # of computations, i.e. from pos to new_pos or from end to new_pos.
         if (new_pos - pos) <= (end_non_missing - new_pos):
             for p in range(pos, new_pos):
-                i = sample_indices[p]
+                i = self.sample_indices[p]
 
-                if sample_weight is not None:
-                    w = sample_weight[i]
+                if self.sample_weight is not None:
+                    w = self.sample_weight[i]
 
                 for k in range(self.n_outputs):
                     self.sum_left[k] += w * self.y[i, k]
@@ -1000,10 +993,10 @@ cdef class RegressionCriterion(Criterion):
             self.reverse_reset()
 
             for p in range(end_non_missing - 1, new_pos - 1, -1):
-                i = sample_indices[p]
+                i = self.sample_indices[p]
 
-                if sample_weight is not None:
-                    w = sample_weight[i]
+                if self.sample_weight is not None:
+                    w = self.sample_weight[i]
 
                 for k in range(self.n_outputs):
                     self.sum_left[k] -= w * self.y[i, k]

--- a/sklearn/tree/_partitioner.pyx
+++ b/sklearn/tree/_partitioner.pyx
@@ -396,9 +396,7 @@ cdef class SparsePartitioner:
 
     cdef inline void next_p(self, intp_t* p_prev, intp_t* p) noexcept nogil:
         """Compute the next p_prev and p for iterating over feature values."""
-        cdef:
-            intp_t p_next
-            float32_t[::1] feature_values = self.feature_values
+        cdef intp_t p_next
 
         if p[0] + 1 != self.end_negative:
             p_next = p[0] + 1
@@ -406,7 +404,7 @@ cdef class SparsePartitioner:
             p_next = self.start_positive
 
         while (p_next < self.end and
-                feature_values[p_next] <= feature_values[p[0]] + FEATURE_THRESHOLD):
+                self.feature_values[p_next] <= self.feature_values[p[0]] + FEATURE_THRESHOLD):
             p[0] = p_next
             if p[0] + 1 != self.end_negative:
                 p_next = p[0] + 1
@@ -487,7 +485,7 @@ cdef class SparsePartitioner:
         """
         cdef intp_t[::1] samples = self.samples
         cdef float32_t[::1] feature_values = self.feature_values
-        cdef intp_t indptr_start = self.X_indptr[feature],
+        cdef intp_t indptr_start = self.X_indptr[feature]
         cdef intp_t indptr_end = self.X_indptr[feature + 1]
         cdef intp_t n_indices = <intp_t>(indptr_end - indptr_start)
         cdef intp_t n_samples = self.end - self.start

--- a/sklearn/tree/_partitioner.pyx
+++ b/sklearn/tree/_partitioner.pyx
@@ -171,13 +171,11 @@ cdef class DensePartitioner:
 
         The missing values are not included when iterating through the feature values.
         """
-        cdef:
-            float32_t[::1] feature_values = self.feature_values
-            intp_t end_non_missing = self.end - self.n_missing
+        cdef intp_t end_non_missing = self.end - self.n_missing
 
         while (
             p[0] + 1 < end_non_missing and
-            feature_values[p[0] + 1] <= feature_values[p[0]] + FEATURE_THRESHOLD
+            self.feature_values[p[0] + 1] <= self.feature_values[p[0]] + FEATURE_THRESHOLD
         ):
             p[0] += 1
 


### PR DESCRIPTION
I was doing some profiling with py-spy (amazing tool btw!), and I noticed something weird. When I dived in, I quickly found a **very-low hanging fruit for optimization**.

#### Reference Issues/PRs

None

#### Motivation (what is the weird thing I noticed)

In the flame graph produced by py-spy on the script below.

I noticed something weird: `partitioner.next_p` was taking ~8% of the runtime out of 80% taken by the tree building. It was very unexpected because `partitioner.next_p` does almost nothing and does sequential memory access:

<img width="1826" height="146" alt="vlcsnap-2025-09-14-16h09m02s847" src="https://github.com/user-attachments/assets/222acf5c-9175-4184-8178-b77a3e020bc7" />

After investigation, I determined this comes from this line:
`float32_t[::1] feature_values = self.feature_values`

According to ChatGPT (I'm by no mean a Cython expert so :sweat_smile: ), it's because float32_t[::1] is a not so light C-struct under-the-hood, so making a copy of it in a function that's otherwise super light can make the said function almost 10x slower...

#### Changes:

So I removed all patterns `type[::1] x = self.x` for all light methods I'm aware of in the tree module (and replaced `x` by `self.x`). This leads to this new flame graph:

<img width="1826" height="146" alt="after_changes" src="https://github.com/user-attachments/assets/7e52d737-13cc-44d0-ac82-736e7885f9b0" />

Where indeed `next_p` is much faster! And `criterion.update` to!

#### Benchmarks:

Using the script below (with d=20), on my machine:

Prior to changes: regression: 1.23s | classif: 1.37s
After the changes: regression: 1.00s | classif: 1.16s

It's a ~20% speed-up

The speed increase might be less in different configurations (smaller d for instance) and sometimes more (with nans for instance). 

#### The script:

```python
import argparse
from time import perf_counter
import numpy
from sklearn.tree import DecisionTreeRegressor, DecisionTreeClassifier

if __name__ == "__main__":
    parser = argparse.ArgumentParser()
    parser.add_argument("--clf", action="store_true", help="Use classifier instead of regressor")
    parser.add_argument("--d", type=int, default=20, help="Number of features")
    args = parser.parse_args()
    clf = args.clf
    d = args.d
    n = 3_000_000 // d
    n_fit = 10
    dt = 0
    for _ in range(n_fit):
        X = numpy.random.rand(n, d)
        y = numpy.random.rand(n) + X.sum(axis=1)
        if clf:
            # 3 classes:
            y = (y < numpy.quantile(y, 0.3)) + (y < numpy.quantile(y, 0.6))
        Tree = DecisionTreeClassifier if clf else DecisionTreeRegressor
        t = perf_counter()
        tree = Tree(max_depth=4, max_features=d).fit(X, y)
        dt += perf_counter() - t
    print(dt / n_fit)
```

You can run py-spy with `py-spy record -o profile.svg -n -- python script.py`. Note the `-n` for profiling "native code" (i.e. Cython code in this case).

#### Additional note

It might be a pattern present in other parts of sklearn. So it's worth communicating to other Cython mainteners.

Note that in "big" functions (i.e. not O(1)), this pattern is likely worth-it to avoid the indirection cost of doing `self.x`.