### PR TITLE
FIX: Repair PCA array API support tag for svd_solver "full", "covariance_eigh", or "auto"

### DIFF
--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -112,7 +112,7 @@ Estimators and other tools in scikit-learn that support Array API compatible inp
 Estimators
 ----------
 
-- :class:`decomposition.PCA` (with `svd_solver="full"`,
+- :class:`decomposition.PCA` (with `svd_solver="full"`, `svd_solver="covariance_eigh"`,
   `svd_solver="randomized"` and `power_iteration_normalizer="QR"`)
 - :class:`linear_model.Ridge` (with `solver="svd"`)
 - :class:`discriminant_analysis.LinearDiscriminantAnalysis` (with `solver="svd"`)

--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -112,8 +112,8 @@ Estimators and other tools in scikit-learn that support Array API compatible inp
 Estimators
 ----------
 
-- :class:`decomposition.PCA` (with `svd_solver="full"`, `svd_solver="covariance_eigh"`,
-  `svd_solver="randomized"` and `power_iteration_normalizer="QR"`)
+- :class:`decomposition.PCA` (with `svd_solver="full"`, `svd_solver="covariance_eigh"`, or
+  `svd_solver="randomized"` (`svd_solver="randomized"` only if `power_iteration_normalizer="QR"`))
 - :class:`linear_model.Ridge` (with `solver="svd"`)
 - :class:`discriminant_analysis.LinearDiscriminantAnalysis` (with `solver="svd"`)
 - :class:`preprocessing.Binarizer`

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -844,7 +844,7 @@ class PCA(_BasePCA):
         tags.array_api_support = (
             solver not in ["arpack", "randomized"]
             or (solver == "randomized"
-            and self.power_iteration_normalizer == "QR"))
+            and self.power_iteration_normalizer == "QR")
         )
         tags.input_tags.sparse = self.svd_solver in (
             "auto",

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -840,7 +840,7 @@ class PCA(_BasePCA):
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.transformer_tags.preserves_dtype = ["float64", "float32"]
-        solver = getattr(self, "_fit_svd_solver", self.fit_solver)
+        solver = getattr(self, "_fit_svd_solver", self.svd_solver)
         tags.array_api_support = solver not in ["arpack", "randomized"] or (
             solver == "randomized" and self.power_iteration_normalizer == "QR"
         )

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -842,9 +842,9 @@ class PCA(_BasePCA):
         tags.transformer_tags.preserves_dtype = ["float64", "float32"]
         solver = getattr(self, "_fit_svd_solver", self.fit_solver)
         tags.array_api_support = (
-            solver == "full"
-            or solver == "randomized"
-            and self.power_iteration_normalizer == "QR"
+            solver not in ["arpack", "randomized"]
+            or (solver == "randomized"
+            and self.power_iteration_normalizer == "QR"))
         )
         tags.input_tags.sparse = self.svd_solver in (
             "auto",

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -840,8 +840,10 @@ class PCA(_BasePCA):
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.transformer_tags.preserves_dtype = ["float64", "float32"]
+        solver = getattr(self, "_fit_svd_solver", self.fit_solver)
         tags.array_api_support = (
-            not hasattr(self, "_fit_svd_solver") or self._fit_svd_solver == "full" or self._fit_svd_solver == "randomized"
+            solver == "full"
+            or solver == "randomized"
             and self.power_iteration_normalizer == "QR"
         )
         tags.input_tags.sparse = self.svd_solver in (

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -841,7 +841,7 @@ class PCA(_BasePCA):
         tags = super().__sklearn_tags__()
         tags.transformer_tags.preserves_dtype = ["float64", "float32"]
         tags.array_api_support = (
-            self.svd_solver == "full" or self.svd_solver == "randomized"
+            not hasattr(self, "_fit_svd_solver") or self._fit_svd_solver == "full" or self._fit_svd_solver == "randomized"
             and self.power_iteration_normalizer == "QR"
         )
         tags.input_tags.sparse = self.svd_solver in (

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -841,7 +841,7 @@ class PCA(_BasePCA):
         tags = super().__sklearn_tags__()
         tags.transformer_tags.preserves_dtype = ["float64", "float32"]
         tags.array_api_support = (
-            self.svd_solver in ["full", "randomized"]
+            self.svd_solver == "full" or self.svd_solver == "randomized"
             and self.power_iteration_normalizer == "QR"
         )
         tags.input_tags.sparse = self.svd_solver in (

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -841,10 +841,8 @@ class PCA(_BasePCA):
         tags = super().__sklearn_tags__()
         tags.transformer_tags.preserves_dtype = ["float64", "float32"]
         solver = getattr(self, "_fit_svd_solver", self.fit_solver)
-        tags.array_api_support = (
-            solver not in ["arpack", "randomized"]
-            or (solver == "randomized"
-            and self.power_iteration_normalizer == "QR")
+        tags.array_api_support = solver not in ["arpack", "randomized"] or (
+            solver == "randomized" and self.power_iteration_normalizer == "QR"
         )
         tags.input_tags.sparse = self.svd_solver in (
             "auto",


### PR DESCRIPTION
Follow on to #31784 (which is a follow-up to #30777), the conditions laid out in documentation for PCA: https://scikit-learn.org/dev/modules/array_api.html#estimators states:

> PCA with svd_solver="full", svd_solver="randomized" and power_iteration_normalizer="QR")

The documentation for PCA states for ```power_iteration_normalizer``` ("https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html) that:

> Power iteration normalizer for randomized SVD solver. Not used by ARPACK. See randomized_svd for more details.

This is leading to array API support failures in our repository (uxlfoundation/scikit-learn-intelex#2578) as we prep for your 1.8 release.

The logic should swap from a whitelist to a blacklist to speed and simplify logic, thereby only checking the power_iteration_normalizer if svd_solver is either 1) "randomized" or _fit_svd_solver is set to "randomized". This corrects the logic to probe for the ```_fit_svd_solver``` if available (to handle the ```svd_sovler=auto``` condition) or fall back to checking ```svd_solver``` if the PCA estimator has not been fit.

I'm not sure how to update the documentation to reflect this as the 'covariance_eigh' solver also supports array API but is not reflected in the documentation.
@OmarManzoor @lesteve 

