### PR TITLE
DOC: Poisson criterion is not slower than MSE in decision trees

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -560,9 +560,9 @@ Mean Poisson deviance:
 
 Setting `criterion="poisson"` might be a good choice if your target is a count
 or a frequency (count per some unit). In any case, :math:`y >= 0` is a
-necessary condition to use this criterion. Note that it fits much slower than
-the MSE criterion. For performance reasons the actual implementation minimizes
-the half mean poisson deviance, i.e. the mean poisson deviance divided by 2.
+necessary condition to use this criterion. For performance reasons the actual
+implementation minimizes the half mean poisson deviance, i.e. the mean poisson
+deviance divided by 2.
 
 Mean Absolute Error:
 


### PR DESCRIPTION
In the user guide, remove the sentence:

> Note that it fits much slower than the MSE criterion. 

From:

> Setting criterion="poisson" might be a good choice if your target is a count or a frequency (count per some unit). In any case, 
>  is a necessary condition to use this criterion. Note that it fits much slower than the MSE criterion. For performance reasons the actual implementation minimizes the half mean poisson deviance, i.e. the mean poisson deviance divided by 2.

As it's not true: poisson criterion is only ~10% slower than MSE criterion. Did the experiment with the same script than for this PR https://github.com/scikit-learn/scikit-learn/pull/32181 for both criteria, the execution time is vastly dominated by the sort (`sort_samples_and_feature_values`).



