### PR TITLE
DOC: Add example refs for Ridge/Lasso in user guide

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -62,6 +62,7 @@ example, when data are collected without an experimental design.
 .. rubric:: Examples
 
 * :ref:`sphx_glr_auto_examples_linear_model_plot_ols_ridge.py`
+* :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_path.py`
 
 Non-Negative Least Squares
 --------------------------
@@ -270,6 +271,7 @@ computes the coefficients along the full path of possible values.
 * :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_and_elasticnet.py`
 * :ref:`sphx_glr_auto_examples_applications_plot_tomography_l1_reconstruction.py`
 * :ref:`sphx_glr_auto_examples_inspection_plot_linear_model_coefficient_interpretation.py`
+* :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_model_selection.py`
 
 
 .. note:: **Feature selection with Lasso**

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -150,7 +150,7 @@ the corresponding solver is chosen.
 * :ref:`sphx_glr_auto_examples_linear_model_plot_ols_ridge.py`
 * :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_path.py`
 * :ref:`sphx_glr_auto_examples_inspection_plot_linear_model_coefficient_interpretation.py`
-* :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_coeffs.p`
+* :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_coeffs.py`
 
 Classification
 --------------

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -62,7 +62,6 @@ example, when data are collected without an experimental design.
 .. rubric:: Examples
 
 * :ref:`sphx_glr_auto_examples_linear_model_plot_ols_ridge.py`
-* :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_path.py`
 
 Non-Negative Least Squares
 --------------------------
@@ -151,6 +150,7 @@ the corresponding solver is chosen.
 * :ref:`sphx_glr_auto_examples_linear_model_plot_ols_ridge.py`
 * :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_path.py`
 * :ref:`sphx_glr_auto_examples_inspection_plot_linear_model_coefficient_interpretation.py`
+* :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_coeffs.p`
 
 Classification
 --------------


### PR DESCRIPTION
### What
Add :ref: links to relevant Sphinx-Gallery examples from the Ridge and Lasso
sections in the linear_model user guide.

### Why
Improves navigation by letting readers jump from docs to runnable examples.

### How
- Edited doc/modules/linear_model.rst to include refs for Ridge coefficients and
  Lasso model selection.

### Notes
Docs-only change.
