### PR TITLE
DOC Add Python 3.14 support in pyproject.toml classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers=[
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 


### PR DESCRIPTION
Added Python 3.14 support classifier in pyproject.toml to reflect compatibility announced in release 1.7.2.

Reason
The release notes mention Python 3.14 support, but it was missing in the metadata. This PR ensures consistency across release notes and package metadata.

Closes: #32213 