### PR TITLE
ENH Adds groups parameter to TargetEncoder with validation for non-overlapping CV splits

### DIFF
--- a/sklearn/preprocessing/_target_encoder.py
+++ b/sklearn/preprocessing/_target_encoder.py
@@ -13,6 +13,7 @@ from sklearn.preprocessing._target_encoder_fast import (
     _fit_encoding_fast_auto_smooth,
 )
 from sklearn.utils._param_validation import Interval, StrOptions
+from sklearn.utils.metadata_routing import MetadataRouter, MethodMapping
 from sklearn.utils.multiclass import type_of_target
 from sklearn.utils.validation import (
     _check_feature_names_in,
@@ -266,6 +267,24 @@ class TargetEncoder(OneToOneFeatureMixin, _BaseEncoder):
         self.cv = cv
         self.shuffle = shuffle
         self.random_state = random_state
+
+    def get_metadata_routing(self):
+        """Define how metadata such as `groups` is routed to CV splitters.
+
+        Returns
+        -------
+        router : MetadataRouter
+            The router defining how metadata like `groups` is passed from
+            the encoder to its internal CV splitter.
+        """
+        router = MetadataRouter(owner=self.__class__.__name__)
+        router.add(
+            self.cv,
+            method_mapping=MethodMapping()
+            .add(caller="fit", callee="split")
+            .add(caller="fit_transform", callee="split"),
+        )
+        return router
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X, y, groups=None):

--- a/sklearn/preprocessing/tests/test_target_encoder.py
+++ b/sklearn/preprocessing/tests/test_target_encoder.py
@@ -716,17 +716,24 @@ def test_pandas_copy_on_write():
 
 def test_target_encoder_with_groups():
     """Test TargetEncoder with groups parameter using GroupKFold."""
-    X = np.array([
-        ['NYC'], ['NYC'], ['LA'], ['LA'],          # Group 1
-        ['NYC'], ['LA'], ['Chicago'], ['Chicago'], # Group 2
-        ['NYC'], ['LA'], ['Chicago'], ['Miami']    # Group 3
-    ])
-    y = np.array([1, 1, 0, 0,
-                  1, 0, 1, 1,
-                  0, 1, 1, 1])
-    groups = np.array([1, 1, 1, 1,
-                       2, 2, 2, 2,
-                       3, 3, 3, 3])
+    X = np.array(
+        [
+            ["NYC"],
+            ["NYC"],
+            ["LA"],
+            ["LA"],  # Group 1
+            ["NYC"],
+            ["LA"],
+            ["Chicago"],
+            ["Chicago"],  # Group 2
+            ["NYC"],
+            ["LA"],
+            ["Chicago"],
+            ["Miami"],  # Group 3
+        ]
+    )
+    y = np.array([1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 1, 1])
+    groups = np.array([1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3])
 
     # WITH groups → should use GroupKFold
     enc_with_groups = TargetEncoder(cv=3, random_state=42)
@@ -752,7 +759,7 @@ def test_target_encoder_with_groups():
 
 def test_target_encoder_groups_continuous_target():
     """TargetEncoder with groups for continuous targets."""
-    X = np.array([['A'], ['B'], ['A'], ['B']])
+    X = np.array([["A"], ["B"], ["A"], ["B"]])
     y = np.array([1.5, 2.3, 1.8, 2.1])
     groups = np.array([1, 1, 2, 2])
 
@@ -766,8 +773,8 @@ def test_target_encoder_groups_continuous_target():
 
 def test_target_encoder_groups_multiclass():
     """TargetEncoder with groups for multiclass targets."""
-    X = np.array([['A'], ['B'], ['A'], ['B'], ['C'], ['C']])
-    y = np.array(['class1', 'class2', 'class1', 'class3', 'class2', 'class3'])
+    X = np.array([["A"], ["B"], ["A"], ["B"], ["C"], ["C"]])
+    y = np.array(["class1", "class2", "class1", "class3", "class2", "class3"])
     groups = np.array([1, 1, 2, 2, 3, 3])
 
     enc = TargetEncoder(cv=3, random_state=42)
@@ -784,7 +791,7 @@ def test_target_encoder_cv_validation():
     """Test validation of custom CV splitters with overlaps."""
     from sklearn.preprocessing._target_encoder import _validate_cv_no_overlap
 
-    X = np.array([['A'], ['B'], ['A'], ['B']])
+    X = np.array([["A"], ["B"], ["A"], ["B"]])
     y = np.array([1, 0, 1, 0])
 
     class BadCV:
@@ -796,4 +803,3 @@ def test_target_encoder_cv_validation():
 
     with pytest.raises(ValueError, match="overlapping validation sets"):
         _validate_cv_no_overlap(bad_cv, X, y)
-


### PR DESCRIPTION
**Summary**

Enhancement: Add groups parameter to TargetEncoder
This PR extends TargetEncoder with an optional groups argument:
If groups is provided → use GroupKFold.
Otherwise → fall back to existing behavior (KFold for continuous targets, StratifiedKFold for classification).
Also adds _validate_cv_no_overlap utility to raise if custom CV splitters produce overlapping validation sets.

**Added tests for:**

Using groups with binary, continuous, and multiclass targets.
Behavior difference with/without groups.
Error when using a custom CV splitter that overlaps.

**Motivation**

Currently, TargetEncoder always uses KFold or StratifiedKFold for internal cross-fitting.
This can cause data leakage when samples are not independent (e.g., repeated measures, clustered patients, or time-series grouped by entity).
By adding a groups parameter, users can ensure that samples from the same group always appear in the same fold, preventing leakage and producing more reliable encodings.

**Remaining work**

Update the documentation (user guide + TargetEncoder docstring).

**Related Issue**
Closes: #32076

Thanks to @MatthiasLoefflerQC for opening the issue and @adrinjalali & @thomasjpfan for guiding the implementation.