### PR TITLE
Fixed a typo in linear_model.rst

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -298,7 +298,7 @@ computes the coefficients along the full path of possible values.
 Coordinate Descent with Gap Safe Screening Rules
 ------------------------------------------------
 
-Coordinate descent (CD) is a strategy so solve a minimization problem that considers a
+Coordinate descent (CD) is a strategy to solve a minimization problem that considers a
 single feature :math:`j` at a time. This way, the optimization problem is reduced to a
 1-dimensional problem which is easier to solve:
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

I found a small typo in [linear_model.rst](https://github.com/scikit-learn/scikit-learn/blob/main/doc/modules/linear_model.rst) that I fixed.

**Before**

```text
Coordinate descent (CD) is a strategy `so` solve a minimization problem ...
```

**After**

```text
Coordinate descent (CD) is a strategy `to` solve a minimization problem ...
```

#### Any other comments?

I love scikit-learn ❤️ 