### PR TITLE
FEAT allow RFE(CV) be used with `pemutation_importance`

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.feature_selection/32251.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.feature_selection/32251.feature.rst
@@ -5,5 +5,5 @@
   The attribute :attr:`feature_indices` stores the index of the features from the full dataset
   that have not been eliminated yet.
   This allows methods that need a test set, like :func:`permutation_importance`, to know which
-  features of to use in their predictions.
+  features to use in their predictions.
   By :user:`Gaétan de Castellane <GaetandeCast>`.

--- a/doc/whats_new/upcoming_changes/sklearn.feature_selection/32251.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.feature_selection/32251.feature.rst
@@ -1,9 +1,9 @@
 - :class:`feature_selection.RFE` and :class:`feature_selection.RFECV`
   now support the use of :func:`permutation_importance` as an :attr:`importance_getter`.
-  When a callable, and when it can accept it, the :attr:`importance_getter` will be passed
-  :attr:`feature_indices` along the fitted estimator.
+  When a callable, and when it can accept it, the :attr:`importance_getter` is passed
+  :attr:`feature_indices` along with the fitted estimator.
   The attribute :attr:`feature_indices` stores the index of the features from the full dataset
   that have not been eliminated yet.
-  This allows methods like :func:`permutation_importance` to extract the relevant features
-  from its test set.
+  This allows methods that need a test set, like :func:`permutation_importance`, to know which
+  features of to use in their predictions.
   By :user:`Gaétan de Castellane <GaetandeCast>`.

--- a/doc/whats_new/upcoming_changes/sklearn.feature_selection/32251.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.feature_selection/32251.feature.rst
@@ -1,6 +1,6 @@
 - :class:`feature_selection.RFE` and :class:`feature_selection.RFECV`
   now support the use of :func:`permutation_importance` as an :attr:`importance_getter`.
-  When a callable, and when it can accept it, the :attr:`importance_getter` is passed
+  When a callable, and when possible, the :attr:`importance_getter` is passed
   :attr:`feature_indices` along with the fitted estimator.
   The attribute :attr:`feature_indices` stores the index of the features from the full dataset
   that have not been eliminated yet.

--- a/doc/whats_new/upcoming_changes/sklearn.feature_selection/32251.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.feature_selection/32251.feature.rst
@@ -1,0 +1,9 @@
+- :class:`feature_selection.RFE` and :class:`feature_selection.RFECV`
+  now support the use of :func:`permutation_importance` as an :attr:`importance_getter`.
+  When a callable, and when it can accept it, the :attr:`importance_getter` will be passed
+  :attr:`feature_indices` along the fitted estimator.
+  The attribute :attr:`feature_indices` stores the index of the features from the full dataset
+  that have not been eliminated yet.
+  This allows methods like :func:`permutation_importance` to extract the relevant features
+  from its test set.
+  By :user:`Gaétan de Castellane <GaetandeCast>`.

--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -137,7 +137,7 @@ X_test, y_test = make_classification(
     n_classes=8,
     n_clusters_per_class=1,
     class_sep=0.8,
-    random_state=0,
+    random_state=1,
 )
 
 
@@ -148,6 +148,8 @@ def permutation_importance_getter(model, feature_indices, X_test, y_test, random
         model,
         X_test[:, feature_indices],
         y_test,
+        n_repeats=10,
+        n_jobs=2,
         random_state=random_state,
     ).importances_mean
 

--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -118,16 +118,16 @@ for i in range(cv.n_splits):
 # Using `permutation_importance` to select features
 # -------------------------------------------------
 # Under the hood, `RFECV` uses importance scores derived from the coefficients of the
-# linear model we used to choose which feature to eliminate. We show here how to use
+# linear model we used, to choose which feature to eliminate. We show here how to use
 # `permutation_importance` as an alternative way to measure the importance of features.
-# For that, we need to feed the `importance_getter` parameter of RFECV a callable
-# that accepts a fitted model and an array containing the indices of the features that
-# have not been eliminated yet.
+# For that, we use a callable in the `importance_getter` parameter of RFECV.
+# This callable accepts a fitted model and an array containing the indices of the
+# features that have not been eliminated yet.
 
 # %%
 from sklearn.inspection import permutation_importance
 
-# Permutation importance need test data to produce reliable importance measures.
+# Permutation importance needs test data to produce reliable importance measures.
 X_test, y_test = make_classification(
     n_samples=500,
     n_features=n_features,
@@ -141,8 +141,8 @@ X_test, y_test = make_classification(
 )
 
 
-# Use `feature_indices` to extract the features that have not been eliminated yet from
-# test set.
+# Use `feature_indices` to extract from the test set the features that have not been
+# eliminated yet.
 def permutation_importance_getter(model, feature_indices, X_test, y_test, random_state):
     return permutation_importance(
         model,

--- a/sklearn/feature_selection/_base.py
+++ b/sklearn/feature_selection/_base.py
@@ -254,11 +254,14 @@ def _get_feature_importances(
     elif not callable(getter):
         raise ValueError("`importance_getter` has to be a string or `callable`")
 
-    param_names = list(inspect.signature(getter).parameters.keys())
-    if "feature_indices" in param_names:
-        importances = getter(estimator, feature_indices)
-    else:
+    if isinstance(getter, attrgetter):
         importances = getter(estimator)
+    else:
+        param_names = list(inspect.signature(getter).parameters.keys())
+        if "feature_indices" in param_names:
+            importances = getter(estimator, feature_indices)
+        else:
+            importances = getter(estimator)
 
     if transform_func is None:
         return importances

--- a/sklearn/feature_selection/_base.py
+++ b/sklearn/feature_selection/_base.py
@@ -220,11 +220,7 @@ def _get_feature_importances(
 
     feature_indices : ndarray of shape (n_features,), default=None
         The indices of features from the full dataset whose importance are currently
-        evaluated. These are passed to `getter` when it can accept them which allows
-        using RFE with permutation importance, as shown in this documentation example:
-
-        #TODO: create and link here a documentation example showing how to use
-        # `permutation_importance` with RFE(CV).
+        evaluated. These are passed to `getter` when it can accept them.
 
     norm_order : int, default=1
         The norm order to apply when `transform_func="norm"`. Only applied

--- a/sklearn/feature_selection/_base.py
+++ b/sklearn/feature_selection/_base.py
@@ -252,7 +252,7 @@ def _get_feature_importances(
 
     if isinstance(getter, attrgetter):
         importances = getter(estimator)
-    else:
+    else:  # callable
         param_names = list(inspect.signature(getter).parameters.keys())
         if "feature_indices" in param_names:
             importances = getter(estimator, feature_indices)

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -124,7 +124,13 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
 
         If `callable`, overrides the default feature importance getter.
         The callable is passed with the fitted estimator and it should
-        return importance for each feature.
+        return importance for each feature. When  it accepts it, the callable is passed
+        `feature_indices` which stores the index of the features in the full dataset
+        that have not been eliminated yet.
+
+        `feature_indices` allows RFE to be used with permutation importance, as
+        shown on RFECV at the end of
+        :ref:`sphx_glr_auto_examples_feature_selection_plot_rfe_with_cross_validation.py`.
 
         .. versionadded:: 0.24
 
@@ -647,7 +653,13 @@ class RFECV(RFE):
 
         If `callable`, overrides the default feature importance getter.
         The callable is passed with the fitted estimator and it should
-        return importance for each feature.
+        return importance for each feature. When it accepts it, the callable is passed
+        `feature_indices` which stores the index of the features in the full dataset
+        that have not been eliminated yet.
+
+        `feature_indices` allows RFECV to be used with permutation importance, as
+        shown at the end of
+        :ref:`sphx_glr_auto_examples_feature_selection_plot_rfe_with_cross_validation.py`.
 
         .. versionadded:: 0.24
 

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -124,9 +124,9 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
 
         If `callable`, overrides the default feature importance getter.
         The callable is passed with the fitted estimator and it should
-        return importance for each feature. When it accepts it, the callable is passed
-        `feature_indices` which stores the index of the features in the full dataset
-        that have not yet been eliminated in previous iterations.
+        return importance for each feature. When the callable also accepts
+        `feature_indices` in its signature, it will be passed the index of the features
+        of the full dataset that remain after elimination in previous iterations.
 
         `feature_indices` allows `RFE` to be used with permutation importance, as
         shown on `RFECV` at the end of
@@ -657,9 +657,9 @@ class RFECV(RFE):
 
         If `callable`, overrides the default feature importance getter.
         The callable is passed with the fitted estimator and it should
-        return importance for each feature. When it accepts it, the callable is passed
-        `feature_indices` which stores the index of the features in the full dataset
-        that have not yet been eliminated in previous iterations.
+        return importance for each feature. When the callable also accepts
+        `feature_indices` in its signature, it will be passed the index of the features
+        of the full dataset that remain after elimination in previous iterations.
 
         `feature_indices` allows `RFE` to be used with permutation importance, as
         shown on `RFECV` at the end of

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -124,15 +124,19 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
 
         If `callable`, overrides the default feature importance getter.
         The callable is passed with the fitted estimator and it should
-        return importance for each feature. When  it accepts it, the callable is passed
+        return importance for each feature. When it accepts it, the callable is passed
         `feature_indices` which stores the index of the features in the full dataset
-        that have not been eliminated yet.
+        that have not yet been eliminated in previous iterations.
 
         `feature_indices` allows `RFE` to be used with permutation importance, as
         shown on `RFECV` at the end of
         :ref:`sphx_glr_auto_examples_feature_selection_plot_rfe_with_cross_validation.py`.
 
         .. versionadded:: 0.24
+
+        .. versionchanged:: 1.8
+            Add support for passing `feature_indices` to the callable when part of its
+            signature.
 
     Attributes
     ----------
@@ -655,13 +659,17 @@ class RFECV(RFE):
         The callable is passed with the fitted estimator and it should
         return importance for each feature. When it accepts it, the callable is passed
         `feature_indices` which stores the index of the features in the full dataset
-        that have not been eliminated yet.
+        that have not yet been eliminated in previous iterations.
 
-        `feature_indices` allows `RFECV` to be used with permutation importance, as
-        shown at the end of
+        `feature_indices` allows `RFE` to be used with permutation importance, as
+        shown on `RFECV` at the end of
         :ref:`sphx_glr_auto_examples_feature_selection_plot_rfe_with_cross_validation.py`.
 
         .. versionadded:: 0.24
+
+        .. versionchanged:: 1.8
+            Add support for passing `feature_indices` to the callable when part of its
+            signature.
 
     Attributes
     ----------

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -346,6 +346,7 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
             importances = _get_feature_importances(
                 estimator,
                 self.importance_getter,
+                features,
                 transform_func="square",
             )
             ranks = np.argsort(importances)

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -120,7 +120,7 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         For example, give `regressor_.coef_` in case of
         :class:`~sklearn.compose.TransformedTargetRegressor`  or
         `named_steps.clf.feature_importances_` in case of
-        class:`~sklearn.pipeline.Pipeline` with its last step named `clf`.
+        :class:`~sklearn.pipeline.Pipeline` with its last step named `clf`.
 
         If `callable`, overrides the default feature importance getter.
         The callable is passed with the fitted estimator and it should
@@ -128,8 +128,8 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         `feature_indices` which stores the index of the features in the full dataset
         that have not been eliminated yet.
 
-        `feature_indices` allows RFE to be used with permutation importance, as
-        shown on RFECV at the end of
+        `feature_indices` allows `RFE` to be used with permutation importance, as
+        shown on `RFECV` at the end of
         :ref:`sphx_glr_auto_examples_feature_selection_plot_rfe_with_cross_validation.py`.
 
         .. versionadded:: 0.24
@@ -657,7 +657,7 @@ class RFECV(RFE):
         `feature_indices` which stores the index of the features in the full dataset
         that have not been eliminated yet.
 
-        `feature_indices` allows RFECV to be used with permutation importance, as
+        `feature_indices` allows `RFECV` to be used with permutation importance, as
         shown at the end of
         :ref:`sphx_glr_auto_examples_feature_selection_plot_rfe_with_cross_validation.py`.
 

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -14,12 +14,13 @@ from sklearn.base import BaseEstimator, ClassifierMixin, is_classifier
 from sklearn.compose import TransformedTargetRegressor
 from sklearn.cross_decomposition import CCA, PLSCanonical, PLSRegression
 from sklearn.datasets import load_iris, make_classification, make_friedman1
-from sklearn.ensemble import RandomForestClassifier
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.feature_selection import RFE, RFECV
 from sklearn.impute import SimpleImputer
+from sklearn.inspection import permutation_importance
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.metrics import get_scorer, make_scorer, zero_one_loss
-from sklearn.model_selection import GroupKFold, cross_val_score
+from sklearn.model_selection import GroupKFold, cross_val_score, train_test_split
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC, SVR, LinearSVR
@@ -753,3 +754,38 @@ def test_results_per_cv_in_rfecv(global_random_seed):
     assert len(rfecv.cv_results_["split1_ranking"]) == len(
         rfecv.cv_results_["split2_ranking"]
     )
+
+
+def test_rfe_with_permutation_importance(global_random_seed):
+    """
+    Ensure that using permutation_importance as a importance_getter returns the right
+    amount of features.
+    """
+    X, y = make_friedman1(n_samples=100, n_features=7, random_state=global_random_seed)
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.5, random_state=global_random_seed
+    )
+
+    reg = RandomForestRegressor(random_state=global_random_seed, n_estimators=2)
+
+    def permutation_importance_getter(
+        model, feature_indices, X_test, y_test, global_random_seed
+    ):
+        return permutation_importance(
+            model,
+            X_test[:, feature_indices],
+            y_test,
+            n_repeats=2,
+            random_state=global_random_seed,
+        ).importances_mean
+
+    rfe = RFE(
+        estimator=reg,
+        importance_getter=lambda model, feature_indices: permutation_importance_getter(
+            model, feature_indices, X_test, y_test, global_random_seed
+        ),
+        n_features_to_select=5,
+    ).fit(X_train, y_train)
+
+    assert rfe.n_features_ == 5

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -770,14 +770,14 @@ def test_rfe_with_permutation_importance(global_random_seed):
     reg = RandomForestRegressor(random_state=global_random_seed, n_estimators=2)
 
     def permutation_importance_getter(
-        model, feature_indices, X_test, y_test, global_random_seed
+        model, feature_indices, X_test, y_test, random_state
     ):
         return permutation_importance(
             model,
             X_test[:, feature_indices],
             y_test,
             n_repeats=2,
-            random_state=global_random_seed,
+            random_state=random_state,
         ).importances_mean
 
     rfe = RFE(
@@ -807,22 +807,22 @@ def test_rfecv_with_permutation_importance(global_random_seed):
     reg = RandomForestRegressor(random_state=global_random_seed, n_estimators=15)
 
     def permutation_importance_getter(
-        model, feature_indices, X_test, y_test, global_random_seed
+        model, feature_indices, X_test, y_test, random_state
     ):
         return permutation_importance(
             model,
             X_test[:, feature_indices],
             y_test,
             n_repeats=2,
-            random_state=global_random_seed,
+            random_state=random_state,
         ).importances_mean
 
-    rfe = RFECV(
+    rfecv = RFECV(
         estimator=reg,
         importance_getter=lambda model, feature_indices: permutation_importance_getter(
             model, feature_indices, X_test, y_test, global_random_seed
         ),
     ).fit(X_train, y_train)
 
-    assert rfe.n_features_ == 5
-    assert_array_equal(rfe.support_, np.array(([True] * 5) + ([False] * 2)))
+    assert rfecv.n_features_ == 5
+    assert_array_equal(rfecv.support_, np.array(([True] * 5) + ([False] * 2)))


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #32201 

#### What does this implement/fix? Explain your changes.
To be used in RFE and RFECV, `permutation_importance` needs to be aware of which features were already eliminated by the procedure to reduce its test dataset. 
This PR adds a `feature_indices` parameter to `sklearn.feature_selection._base._get_feature_importances` that is given to the `importance_getter` so that it is aware of which features to compute the importance of.

#### Any other comments?
The new feature is added to the test suite and illustrated in the `RFECV` doc example.

@glemaitre @ogrisel