### PR TITLE
DOC add a point about org bans due to AI

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -19,7 +19,15 @@ the Python Software Foundation: https://www.python.org/psf/codeofconduct/
 Due to the burden put on maintainers, users submitting multiple low quality pull
 requests, or AI generated comments, reviews, issues, or pull requests, where the
 user does not show a good understanding of what they are posting, might be banned
-from the organisation.
+from the organisation. Some examples of poor etiquette are:
+
+- Opening a PR for issues where they are not triaged yet and the "triage" label is not
+  removed;
+- Claiming to work on many issues at the same time;
+- Claiming issues or opening pull requests where another person has already
+  claimed it or where there's already a PR fixing the issue;
+- Opening AI generated pull requests w/o understanding them;
+- Leaving AI generated comments on issues and pull requests.
 
 For more context, you can check out this blog post on [
 The Cost of AI in Open Source Maintenance

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -13,3 +13,17 @@ all priceless contributions.
 
 We abide by the principles of openness, respect, and consideration of others of
 the Python Software Foundation: https://www.python.org/psf/codeofconduct/
+
+# Low Quality and AI Generated Contributions Policy
+
+Due to the burden put on maintainers, users submitting multiple low quality pull
+requests, or AI generated comments, reviews, issues, or pull requests, where the
+user does not show a good understanding of what they are posting, might be banned
+from the organisation.
+
+For more context, you can check out this blog post on [
+The Cost of AI in Open Source Maintenance
+](https://adrin.info/the-cost-of-ai-in-open-source-maintenance.html).
+
+If this happens to you and you believe it's been a mistake, you can reach us on
+`coc@scikit-learn.org`.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -21,7 +21,7 @@ requests, or AI generated comments, reviews, issues, or pull requests, where the
 user does not show a good understanding of what they are posting, might be banned
 from the organisation. Some examples of poor etiquette are:
 
-- Opening a PR for issues where they are not triaged yet and the "triage" label is not
+- Opening a PR for issues which are not yet triaged and the "triage" label is not
   removed;
 - Claiming to work on many issues at the same time;
 - Claiming issues or opening pull requests where another person has already

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,9 @@ up" on issues that others reported and that are relevant to you. It also helps
 us if you spread the word: reference the project from your blog and articles,
 link to it from your website, or simply star it in GitHub to say "I use it".
 
+Note that communications on all channels should respect our `Code of Conduct
+<https://github.com/scikit-learn/scikit-learn/blob/main/CODE_OF_CONDUCT.md>`_.
+
 Quick links
 -----------
 
@@ -31,9 +34,3 @@ Quick links
 * [Contributing code](https://scikit-learn.org/dev/developers/contributing.html#contributing-code)
 * [Coding guidelines](https://scikit-learn.org/dev/developers/develop.html#coding-guidelines)
 * [Tips to read current code](https://scikit-learn.org/dev/developers/contributing.html#reading-the-existing-code-base)
-
-Code of Conduct
----------------
-
-We abide by the principles of openness, respect, and consideration of others
-of the Python Software Foundation: https://www.python.org/psf/codeofconduct/.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ up" on issues that others reported and that are relevant to you. It also helps
 us if you spread the word: reference the project from your blog and articles,
 link to it from your website, or simply star it in GitHub to say "I use it".
 
-Note that communications on all channels should respect our `Code of Conduct
-<https://github.com/scikit-learn/scikit-learn/blob/main/CODE_OF_CONDUCT.md>`_.
+Note that communications on all channels should respect our
+[Code of Conduct](./CODE_OF_CONDUCT.md).
 
 Quick links
 -----------

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -51,9 +51,9 @@ See :ref:`new_contributors` to get started.
     issues, organizing and teaching tutorials, working on the website,
     improving the documentation, are all priceless contributions.
 
-    We abide by the principles of openness, respect, and consideration of
-    others of the Python Software Foundation:
-    https://www.python.org/psf/codeofconduct/
+    Communications on all channels should respect our `Code of Conduct
+    <https://github.com/scikit-learn/scikit-learn/blob/main/CODE_OF_CONDUCT.md>`_.
+
 
 
 In case you experience issues using this package, do not hesitate to submit a

--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -237,7 +237,7 @@
           <li><strong>Instagram:</strong> <a href="https://www.instagram.com/scikitlearnofficial/">@scikitlearnofficial</a></li>
           <li><strong>TikTok:</strong> <a href="https://www.tiktok.com/@scikit.learn">@scikit.learn</a></li>
           <li><strong>Discord:</strong> <a href="https://discord.gg/h9qyrK8Jc8">@scikit-learn</a></li>
-          <li>Communication on all channels should respect <a href="https://www.python.org/psf/conduct/">PSF's code of conduct.</a></li>
+          <li>Communication on all channels should respect <a href="https://github.com/scikit-learn/scikit-learn/blob/main/CODE_OF_CONDUCT.md">our code of conduct.</a></li>
         </ul>
         <p>
           <a class="btn sk-btn-orange mb-1" href="https://numfocus.org/donate-to-scikit-learn">Help us, <strong>donate!</strong></a>


### PR DESCRIPTION
This adds a note to our CoC file, which is linked in the message sent to people who get banned from our org.

cc @scikit-learn/core-devs @scikit-learn/communication-team @scikit-learn/contributor-experience-team @scikit-learn/documentation-team 

So far when banning users from our org, I would avoid sending a message to them. With this, the automated message includes a link to our CoC file which has the info they need.