### PR TITLE
DOC: Clarify splitter strategies for DecisionTree and RandomForest

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -969,6 +969,13 @@ best split is found through an exhaustive search of the feature values of
 either all input features or a random subset of size ``max_features``.
 (See the :ref:`parameter tuning guidelines <random_forest_parameters>` for more details.)
 
+In scikit-learn, the underlying decision trees used in
+:class:`RandomForestClassifier` and :class:`RandomForestRegressor`
+always use the ``splitter="best"`` strategy. This means that all possible
+split thresholds are evaluated at each node, unlike in standalone
+decision trees where both ``splitter="best"`` and ``splitter="random"``
+are available.
+
 The purpose of these two sources of randomness is to decrease the variance of
 the forest estimator. Indeed, individual decision trees typically exhibit high
 variance and tend to overfit. The injected randomness in forests yield decision

--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -581,6 +581,28 @@ Mean Absolute Error:
 
 Note that it fits much slower than the MSE criterion.
 
+Splitter strategies
+===================
+
+In scikit-learn, decision trees support two strategies to choose how
+candidate splits are evaluated at each node:
+
+- ``splitter="best"`` (default): For each feature, all possible thresholds
+  between unique feature values are evaluated, and the split that maximizes
+  the chosen criterion (like Gini impurity, entropy, variance reduction)
+  is selected. This is an exhaustive search and can be computationally
+  expensive for large datasets, but it generally yields the most informative
+  splits.
+
+- ``splitter="random"``: For each feature, only a single threshold is drawn
+  at random and evaluated. This makes training faster and adds additional
+  randomness, which can sometimes help reduce overfitting but usually leads
+  to less optimal splits compared to ``"best"``.
+
+Note that ensemble methods such as :class:`RandomForestClassifier` and
+:class:`RandomForestRegressor` always use ``splitter="best"`` for their
+underlying decision trees.
+
 .. _tree_missing_value_support:
 
 Missing Values Support


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #27159

#### What does this implement/fix? Explain your changes.

This PR improves the user guide documentation:
- Added explanation of splitter strategies ("best" vs "random") in `doc/modules/tree.rst`.
- Clarified in `doc/modules/ensemble.rst` that RandomForestClassifier and RandomForestRegressor always use `splitter="best"`.

#### Any other comments?
I hope that my first contribution was useful. Thanks for the guidance in the issue discussion !
