### PR TITLE
DOC clean up docs around `get_n_splits` in splitters

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1341,7 +1341,8 @@ Methods
     ``get_n_splits``
         On a :term:`CV splitter` (not an estimator), returns the number of
         elements one would get if iterating through the return value of
-        :term:`split` given the same parameters.
+        :term:`split` given the same parameters. Takes the same parameters as
+        split.
 
     ``get_params``
         Gets all :term:`parameters`, and their values, that can be set using

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -940,10 +940,10 @@ Class APIs and Estimator Types
         :class:`ensemble.BaggingClassifier`.
 
         In a meta-estimator's :term:`fit` method, any contained estimators
-        should be :term:`cloned` before they are fit. 
-        
+        should be :term:`cloned` before they are fit.
+
         .. FIXME: Pipeline and FeatureUnion do not do this currently
-        
+
         An exception to this is
         that an estimator may explicitly document that it accepts a pre-fitted
         estimator (e.g. using ``prefit=True`` in
@@ -1341,8 +1341,7 @@ Methods
     ``get_n_splits``
         On a :term:`CV splitter` (not an estimator), returns the number of
         elements one would get if iterating through the return value of
-        :term:`split` given the same parameters.  Takes the same parameters as
-        split.
+        :term:`split` given the same parameters.
 
     ``get_params``
         Gets all :term:`parameters`, and their values, that can be set using
@@ -1864,7 +1863,7 @@ See concept :term:`sample property`.
         .. FIXME: Is this interpretation always the case in practice? We have no common tests.
 
         Some estimators, such as decision trees, support negative weights.
-        
+
         .. FIXME: This feature or its absence may not be tested or documented in many estimators.
 
         This is not entirely the case where other parameters of the model

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -68,11 +68,11 @@ class _UnsupportedGroupCVMixin:
             Training data, where `n_samples` is the number of samples
             and `n_features` is the number of features.
 
-        y : array-like of shape (n_samples,)
+        y : array-like of shape (n_samples,), default=None
             The target variable for supervised learning problems.
 
-        groups : object
-            Always ignored, exists for compatibility.
+        groups : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
         Yields
         ------
@@ -231,11 +231,11 @@ class LeaveOneOut(_UnsupportedGroupCVMixin, BaseCrossValidator):
             Training data, where `n_samples` is the number of samples
             and `n_features` is the number of features.
 
-        y : object
-            Always ignored, exists for compatibility.
+        y : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
-        groups : object
-            Always ignored, exists for compatibility.
+        groups : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
         Returns
         -------
@@ -328,11 +328,11 @@ class LeavePOut(_UnsupportedGroupCVMixin, BaseCrossValidator):
             Training data, where `n_samples` is the number of samples
             and `n_features` is the number of features.
 
-        y : object
-            Always ignored, exists for compatibility.
+        y : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
-        groups : object
-            Always ignored, exists for compatibility.
+        groups : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
         """
         if X is None:
             raise ValueError("The 'X' parameter should not be None.")
@@ -417,14 +417,14 @@ class _BaseKFold(BaseCrossValidator, metaclass=ABCMeta):
 
         Parameters
         ----------
-        X : object
-            Always ignored, exists for compatibility.
+        X : array-like of shape (n_samples, n_features), default=None
+            Always ignored, exists for API compatibility.
 
-        y : object
-            Always ignored, exists for compatibility.
+        y : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
-        groups : object
-            Always ignored, exists for compatibility.
+        groups : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
         Returns
         -------
@@ -863,8 +863,8 @@ class StratifiedKFold(_BaseKFold):
             The target variable for supervised learning problems.
             Stratification is done based on the y labels.
 
-        groups : object
-            Always ignored, exists for compatibility.
+        groups : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
         Yields
         ------
@@ -1238,11 +1238,11 @@ class TimeSeriesSplit(_BaseKFold):
             Training data, where `n_samples` is the number of samples
             and `n_features` is the number of features.
 
-        y : array-like of shape (n_samples,)
-            Always ignored, exists for compatibility.
+        y : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
-        groups : array-like of shape (n_samples,)
-            Always ignored, exists for compatibility.
+        groups : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
         Yields
         ------
@@ -1382,13 +1382,13 @@ class LeaveOneGroupOut(GroupsConsumerMixin, BaseCrossValidator):
 
         Parameters
         ----------
-        X : object
-            Always ignored, exists for compatibility.
+        X : array-like of shape (n_samples, n_features), default=None
+            Always ignored, exists for API compatibility.
 
-        y : object
-            Always ignored, exists for compatibility.
+        y : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
-        groups : array-like of shape (n_samples,)
+        groups : array-like of shape (n_samples,), default=None
             Group labels for the samples used while splitting the dataset into
             train/test set. This 'groups' parameter must always be specified to
             calculate the number of splits, though the other parameters can be
@@ -1513,13 +1513,13 @@ class LeavePGroupsOut(GroupsConsumerMixin, BaseCrossValidator):
 
         Parameters
         ----------
-        X : object
-            Always ignored, exists for compatibility.
+        X : array-like of shape (n_samples, n_features), default=None
+            Always ignored, exists for API compatibility.
 
-        y : object
-            Always ignored, exists for compatibility.
+        y : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
-        groups : array-like of shape (n_samples,)
+        groups : array-like of shape (n_samples,), default=None
             Group labels for the samples used while splitting the dataset into
             train/test set. This 'groups' parameter must always be specified to
             calculate the number of splits, though the other parameters can be
@@ -1645,14 +1645,14 @@ class _RepeatedSplits(_MetadataRequester, metaclass=ABCMeta):
 
         Parameters
         ----------
-        X : object, default=None
-            Always ignored, exists for compatibility.
+        X : array-like of shape (n_samples, n_features), default=None
+            Always ignored, exists for API compatibility.
 
-        y : object, default=None
-            Always ignored, exists for compatibility.
+        y : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
         groups : array-like of shape (n_samples,), default=None
-            Always ignored, exists for compatibility.
+            Always ignored, exists for API compatibility.
 
         Returns
         -------
@@ -1825,8 +1825,8 @@ class RepeatedStratifiedKFold(_UnsupportedGroupCVMixin, _RepeatedSplits):
             The target variable for supervised learning problems.
             Stratification is done based on the y labels.
 
-        groups : object
-            Always ignored, exists for compatibility.
+        groups : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
         Yields
         ------
@@ -1946,14 +1946,14 @@ class BaseShuffleSplit(_MetadataRequester, metaclass=ABCMeta):
 
         Parameters
         ----------
-        X : object
-            Always ignored, exists for compatibility.
+        X : array-like of shape (n_samples, n_features), default=None
+            Always ignored, exists for API compatibility.
 
-        y : object
-            Always ignored, exists for compatibility.
+        y : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
-        groups : object
-            Always ignored, exists for compatibility.
+        groups : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
         Returns
         -------
@@ -2400,8 +2400,8 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
             The target variable for supervised learning problems.
             Stratification is done based on the y labels.
 
-        groups : object
-            Always ignored, exists for compatibility.
+        groups : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
         Yields
         ------
@@ -2554,14 +2554,14 @@ class PredefinedSplit(BaseCrossValidator):
 
         Parameters
         ----------
-        X : object
-            Always ignored, exists for compatibility.
+        X : array-like of shape (n_samples, n_features), default=None
+            Always ignored, exists for API compatibility.
 
-        y : object
-            Always ignored, exists for compatibility.
+        y : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
-        groups : object
-            Always ignored, exists for compatibility.
+        groups : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
         Yields
         ------
@@ -2608,14 +2608,14 @@ class PredefinedSplit(BaseCrossValidator):
 
         Parameters
         ----------
-        X : object
-            Always ignored, exists for compatibility.
+        X : array-like of shape (n_samples, n_features), default=None
+            Always ignored, exists for API compatibility.
 
-        y : object
-            Always ignored, exists for compatibility.
+        y : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
-        groups : object
-            Always ignored, exists for compatibility.
+        groups : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
         Returns
         -------
@@ -2636,14 +2636,14 @@ class _CVIterableWrapper(BaseCrossValidator):
 
         Parameters
         ----------
-        X : object
-            Always ignored, exists for compatibility.
+        X : array-like of shape (n_samples, n_features), default=None
+            Always ignored, exists for API compatibility.
 
-        y : object
-            Always ignored, exists for compatibility.
+        y : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
-        groups : object
-            Always ignored, exists for compatibility.
+        groups : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
         Returns
         -------
@@ -2657,14 +2657,14 @@ class _CVIterableWrapper(BaseCrossValidator):
 
         Parameters
         ----------
-        X : object
-            Always ignored, exists for compatibility.
+        X : array-like of shape (n_samples, n_features), default=None
+            Always ignored, exists for API compatibility.
 
-        y : object
-            Always ignored, exists for compatibility.
+        y : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
-        groups : object
-            Always ignored, exists for compatibility.
+        groups : array-like of shape (n_samples,), default=None
+            Always ignored, exists for API compatibility.
 
         Yields
         ------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -474,7 +474,7 @@ class KFold(_UnsupportedGroupCVMixin, _BaseKFold):
     >>> X = np.array([[1, 2], [3, 4], [1, 2], [3, 4]])
     >>> y = np.array([1, 2, 3, 4])
     >>> kf = KFold(n_splits=2)
-    >>> kf.get_n_splits(X)
+    >>> kf.get_n_splits()
     2
     >>> print(kf)
     KFold(n_splits=2, random_state=None, shuffle=False)
@@ -579,7 +579,7 @@ class GroupKFold(GroupsConsumerMixin, _BaseKFold):
     >>> y = np.array([1, 2, 3, 4, 5, 6])
     >>> groups = np.array([0, 0, 2, 2, 3, 3])
     >>> group_kfold = GroupKFold(n_splits=2)
-    >>> group_kfold.get_n_splits(X, y, groups)
+    >>> group_kfold.get_n_splits()
     2
     >>> print(group_kfold)
     GroupKFold(n_splits=2, random_state=None, shuffle=False)
@@ -730,7 +730,7 @@ class StratifiedKFold(_BaseKFold):
     >>> X = np.array([[1, 2], [3, 4], [1, 2], [3, 4]])
     >>> y = np.array([0, 0, 1, 1])
     >>> skf = StratifiedKFold(n_splits=2)
-    >>> skf.get_n_splits(X, y)
+    >>> skf.get_n_splits()
     2
     >>> print(skf)
     StratifiedKFold(n_splits=2, random_state=None, shuffle=False)
@@ -944,7 +944,7 @@ class StratifiedGroupKFold(GroupsConsumerMixin, _BaseKFold):
     >>> y = np.array([0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0])
     >>> groups = np.array([1, 1, 2, 2, 3, 3, 3, 4, 5, 5, 5, 5, 6, 6, 7, 8, 8])
     >>> sgkf = StratifiedGroupKFold(n_splits=3)
-    >>> sgkf.get_n_splits(X, y)
+    >>> sgkf.get_n_splits()
     3
     >>> print(sgkf)
     StratifiedGroupKFold(n_splits=3, random_state=None, shuffle=False)
@@ -1340,9 +1340,7 @@ class LeaveOneGroupOut(GroupsConsumerMixin, BaseCrossValidator):
     >>> y = np.array([1, 2, 1, 2])
     >>> groups = np.array([1, 1, 2, 2])
     >>> logo = LeaveOneGroupOut()
-    >>> logo.get_n_splits(X, y, groups)
-    2
-    >>> logo.get_n_splits(groups=groups)  # 'groups' is always required
+    >>> logo.get_n_splits(groups=groups)
     2
     >>> print(logo)
     LeaveOneGroupOut()
@@ -1462,9 +1460,7 @@ class LeavePGroupsOut(GroupsConsumerMixin, BaseCrossValidator):
     >>> y = np.array([1, 2, 1])
     >>> groups = np.array([1, 2, 3])
     >>> lpgo = LeavePGroupsOut(n_groups=2)
-    >>> lpgo.get_n_splits(X, y, groups)
-    3
-    >>> lpgo.get_n_splits(groups=groups)  # 'groups' is always required
+    >>> lpgo.get_n_splits(groups=groups)
     3
     >>> print(lpgo)
     LeavePGroupsOut(n_groups=2)
@@ -1647,17 +1643,16 @@ class _RepeatedSplits(_MetadataRequester, metaclass=ABCMeta):
 
         Parameters
         ----------
-        X : object
+        X : object, default=None
             Always ignored, exists for compatibility.
             ``np.zeros(n_samples)`` may be used as a placeholder.
 
-        y : object
+        y : object, default=None
             Always ignored, exists for compatibility.
             ``np.zeros(n_samples)`` may be used as a placeholder.
 
         groups : array-like of shape (n_samples,), default=None
-            Group labels for the samples used while splitting the dataset into
-            train/test set.
+            Always ignored, exists for compatibility.
 
         Returns
         -------
@@ -1699,7 +1694,7 @@ class RepeatedKFold(_UnsupportedGroupCVMixin, _RepeatedSplits):
     >>> X = np.array([[1, 2], [3, 4], [1, 2], [3, 4]])
     >>> y = np.array([0, 0, 1, 1])
     >>> rkf = RepeatedKFold(n_splits=2, n_repeats=2, random_state=2652124)
-    >>> rkf.get_n_splits(X, y)
+    >>> rkf.get_n_splits()
     4
     >>> print(rkf)
     RepeatedKFold(n_repeats=2, n_splits=2, random_state=2652124)
@@ -1772,7 +1767,7 @@ class RepeatedStratifiedKFold(_UnsupportedGroupCVMixin, _RepeatedSplits):
     >>> y = np.array([0, 0, 1, 1])
     >>> rskf = RepeatedStratifiedKFold(n_splits=2, n_repeats=2,
     ...     random_state=36851234)
-    >>> rskf.get_n_splits(X, y)
+    >>> rskf.get_n_splits()
     4
     >>> print(rskf)
     RepeatedStratifiedKFold(n_repeats=2, n_splits=2, random_state=36851234)
@@ -2016,7 +2011,7 @@ class ShuffleSplit(_UnsupportedGroupCVMixin, BaseShuffleSplit):
     >>> X = np.array([[1, 2], [3, 4], [5, 6], [7, 8], [3, 4], [5, 6]])
     >>> y = np.array([1, 2, 1, 2, 1, 2])
     >>> rs = ShuffleSplit(n_splits=5, test_size=.25, random_state=0)
-    >>> rs.get_n_splits(X)
+    >>> rs.get_n_splits()
     5
     >>> print(rs)
     ShuffleSplit(n_splits=5, random_state=0, test_size=0.25, train_size=None)
@@ -2277,7 +2272,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     >>> X = np.array([[1, 2], [3, 4], [1, 2], [3, 4], [1, 2], [3, 4]])
     >>> y = np.array([0, 0, 0, 1, 1, 1])
     >>> sss = StratifiedShuffleSplit(n_splits=5, test_size=0.5, random_state=0)
-    >>> sss.get_n_splits(X, y)
+    >>> sss.get_n_splits()
     5
     >>> print(sss)
     StratifiedShuffleSplit(n_splits=5, random_state=0, ...)

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -412,7 +412,8 @@ class _BaseKFold(BaseCrossValidator, metaclass=ABCMeta):
             yield train, test
 
     def get_n_splits(self, X=None, y=None, groups=None):
-        """Returns the number of splitting iterations in the cross-validator.
+        """Returns the number of splitting iterations as set with the `n_splits` param
+        when instantiating the cross-validator.
 
         Parameters
         ----------
@@ -1639,17 +1640,16 @@ class _RepeatedSplits(_MetadataRequester, metaclass=ABCMeta):
                 yield train_index, test_index
 
     def get_n_splits(self, X=None, y=None, groups=None):
-        """Returns the number of splitting iterations in the cross-validator.
+        """Returns the number of splitting iterations as set with the `n_splits` param
+        when instantiating the cross-validator.
 
         Parameters
         ----------
         X : object, default=None
             Always ignored, exists for compatibility.
-            ``np.zeros(n_samples)`` may be used as a placeholder.
 
         y : object, default=None
             Always ignored, exists for compatibility.
-            ``np.zeros(n_samples)`` may be used as a placeholder.
 
         groups : array-like of shape (n_samples,), default=None
             Always ignored, exists for compatibility.
@@ -1941,7 +1941,8 @@ class BaseShuffleSplit(_MetadataRequester, metaclass=ABCMeta):
             yield ind_train, ind_test
 
     def get_n_splits(self, X=None, y=None, groups=None):
-        """Returns the number of splitting iterations in the cross-validator.
+        """Returns the number of splitting iterations as set with the `n_splits` param
+        when instantiating the cross-validator.
 
         Parameters
         ----------

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1017,6 +1017,9 @@ def test_group_shuffle_split():
         # Make sure the repr works
         repr(slo)
 
+        # Test that the length is correct
+        assert slo.get_n_splits(X, y, groups=groups_i) == n_splits
+
         l_unique = np.unique(groups_i)
         l = np.asarray(groups_i)
 

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -1017,9 +1017,6 @@ def test_group_shuffle_split():
         # Make sure the repr works
         repr(slo)
 
-        # Test that the length is correct
-        assert slo.get_n_splits(X, y, groups=groups_i) == n_splits
-
         l_unique = np.unique(groups_i)
         l = np.asarray(groups_i)
 


### PR DESCRIPTION
This PR simplifies the documentation around `get_n_splits` for different splitters. 

In the examples, usages of ignored parameters are removed, to avoid the impression that they have any effect.
```
-    >>> kf.get_n_splits(X)
+    >>> kf.get_n_splits()
```

Specifically, the methods does not always calculate based on the same params as those that can be passed into `split` and instead use the shortcut to simply rely on the user-set (or default value) of `n_splits` param.
