### PR TITLE
FIX deprecate `stable_cumsum`

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.utils/32258.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/32258.api.rst
@@ -1,3 +1,3 @@
 - :function:`utils.extmath.stable_cumsum` is deprecated and will be removed
-  in 1.10. Use `np.cumulative_sum` with the desired dtype directly instead.
+  in v1.10. Use `np.cumulative_sum` with the desired dtype directly instead.
   By :user:`Tiziano Zito <opossumnano>` :pr:`32258`.

--- a/doc/whats_new/upcoming_changes/sklearn.utils/32258.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/32258.api.rst
@@ -1,0 +1,3 @@
+- :function:`utils.extmath.stable_cumsum` is deprecated and will be removed
+  in 1.10. Use `np.cumulative_sum` with the desired dtype directly instead.
+  By :user:`Tiziano Zito <opossumnano>` :pr:`32258`.

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -23,6 +23,7 @@ from sklearn.utils._array_api import (
     get_namespace_and_device,
 )
 from sklearn.utils._param_validation import Interval, StrOptions, validate_params
+from sklearn.utils.deprecation import deprecated
 from sklearn.utils.sparsefuncs import sparse_matmul_to_dense
 from sklearn.utils.sparsefuncs_fast import csr_row_norms
 from sklearn.utils.validation import check_array, check_random_state
@@ -1281,8 +1282,18 @@ def _deterministic_vector_sign_flip(u):
     return u
 
 
+# TODO(1.10): Remove
+@deprecated(
+    "`sklearn.utils.extmath.stable_cumsum` is deprecated in version 1.8 and "
+    "will be removed in 1.10. Use `np.cumulative_sum` with the desired dtype "
+    "directly instead."
+)
 def stable_cumsum(arr, axis=None, rtol=1e-05, atol=1e-08):
     """Use high precision for cumsum and check that final value matches sum.
+
+    .. deprecated:: 1.8
+        This function is deprecated in version 1.8 and will be removed in 1.10.
+        Use `np.cumulative_sum` with the desired dtype directly instead.
 
     Warns if the final cumulative sum does not match the sum (up to the chosen
     tolerance).

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -996,17 +996,9 @@ def test_softmax():
     assert_array_almost_equal(softmax(X), exp_X / sum_exp_X)
 
 
-def test_stable_cumsum():
-    assert_array_equal(stable_cumsum([1, 2, 3]), np.cumsum([1, 2, 3]))
-    r = np.random.RandomState(0).rand(100000)
-    with pytest.warns(RuntimeWarning):
-        stable_cumsum(r, rtol=0, atol=0)
-
-    # test axis parameter
-    A = np.random.RandomState(36).randint(1000, size=(5, 5, 5))
-    assert_array_equal(stable_cumsum(A, axis=0), np.cumsum(A, axis=0))
-    assert_array_equal(stable_cumsum(A, axis=1), np.cumsum(A, axis=1))
-    assert_array_equal(stable_cumsum(A, axis=2), np.cumsum(A, axis=2))
+def test_stable_cumsum_deprecation():
+    with pytest.warns(FutureWarning, match="stable_cumsum.+is deprecated"):
+        stable_cumsum([1, 2, 3])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR deprecates the function `stable_cumsum` now that it is not used anymore in the code base. For context please refer to the discussion in https://github.com/scikit-learn/scikit-learn/issues/31533

closes #31533

`stable_cumsum` was not documented publicly so we don't need a note in the release notes, but given that is not named with a leading underscore it still requires a deprecation cycle before getting rid of it completely.

This PR is an alternative to #31997 