### PR TITLE
FIX Fix free-threaded failure because dictionary changed size during iteration

### DIFF
--- a/sklearn/utils/_metadata_requests.py
+++ b/sklearn/utils/_metadata_requests.py
@@ -1494,7 +1494,12 @@ class _MetadataRequester:
         # their parents.
         substr = f"__metadata_request__{method}"
         for base_class in reversed(inspect.getmro(cls)):
-            for attr, value in vars(base_class).items():
+            # Copy is needed with free-threaded context to avoid
+            # RuntimeError: dictionary changed size during iteration.
+            # copy.deepcopy applied on an instance of base_class adds
+            # __slotnames__ attribute to base_class.
+            base_class_items = vars(base_class).copy().items()
+            for attr, value in base_class_items:
                 # we don't check for equivalence since python prefixes attrs
                 # starting with __ with the `_ClassName`.
                 if substr not in attr:


### PR DESCRIPTION
Fix #32087 

This was seen in #32087 in different test functions but the problematic code is the same in `sklearn/utils/_metadata_requests.py`. 

I can reproduce locally with the following (it fails ~5-10 times out of 20 on my machine on `main`):
```
for i in $(seq 20); do pytest --parallel-threads 10 --iterations 1 sklearn/tests/test_pipeline.py -k 'test_metadata_routing_for_pipeline[decision_function]'; done
```

<details>
<summary>Failure details</summary>

```
____________________________________________________________________________________________________________________________ ERROR at call of test_metadata_routing_for_pipeline[decision_function] ____________________________________________________________________________________________________________________________

method = 'decision_function'

    @pytest.mark.parametrize("method", sorted(set(METHODS) - {"split", "partial_fit"}))
    @config_context(enable_metadata_routing=True)
    def test_metadata_routing_for_pipeline(method):
        """Test that metadata is routed correctly for pipelines."""
    
        def set_request(est, method, **kwarg):
            """Set requests for a given method.
    
            If the given method is a composite method, set the same requests for
            all the methods that compose it.
            """
            if method in COMPOSITE_METHODS:
                methods = COMPOSITE_METHODS[method]
            else:
                methods = [method]
    
            for method in methods:
                getattr(est, f"set_{method}_request")(**kwarg)
            return est
    
        X, y = np.array([[1]]), np.array([1])
        sample_weight, prop, metadata = [1], "a", "b"
    
        # test that metadata is routed correctly for pipelines when requested
        est = SimpleEstimator()
>       est = set_request(est, method, sample_weight=True, prop=True)

sklearn/tests/test_pipeline.py:2233: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sklearn/tests/test_pipeline.py:2225: in set_request
    getattr(est, f"set_{method}_request")(**kwarg)
sklearn/utils/_metadata_requests.py:1352: in func
    requests = _instance._get_metadata_request()
sklearn/utils/_metadata_requests.py:1540: in _get_metadata_request
    requests=self._get_class_level_metadata_request_values(method),
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cls = <class 'sklearn.tests.test_pipeline.SimpleEstimator'>, method = 'predict'

    @classmethod
    def _get_class_level_metadata_request_values(cls, method: str):
        """Get class level metadata request values.
    
        This method first checks the `method`'s signature for passable metadata and then
        updates these with the metadata request values set at class level via the
        ``__metadata_request__{method}`` class attributes.
    
        This method (being a class-method), does not take request values set at
        instance level into account.
        """
        # Here we use `isfunction` instead of `ismethod` because calling `getattr`
        # on a class instead of an instance returns an unbound function.
        if not hasattr(cls, method) or not inspect.isfunction(getattr(cls, method)):
            return dict()
        # ignore the first parameter of the method, which is usually "self"
        signature_items = list(
            inspect.signature(getattr(cls, method)).parameters.items()
        )[1:]
        params = defaultdict(
            str,
            {
                param_name: None
                for param_name, param_info in signature_items
                if param_name not in {"X", "y", "Y", "Xt", "yt"}
                and param_info.kind
                not in {param_info.VAR_POSITIONAL, param_info.VAR_KEYWORD}
            },
        )
        # Then overwrite those defaults with the ones provided in
        # `__metadata_request__{method}` class attributes, which take precedence over
        # signature sniffing.
    
        # need to go through the MRO since this is a classmethod and
        # ``vars`` doesn't report the parent class attributes. We go through
        # the reverse of the MRO so that child classes have precedence over
        # their parents.
        substr = f"__metadata_request__{method}"
        for base_class in reversed(inspect.getmro(cls)):
>           for attr, value in vars(base_class).items():
E           RuntimeError: dictionary changed size during iteration

sklearn/utils/_metadata_requests.py:1497: RuntimeError
```

</details>

Here is my current understanding of the problem:
- when debugging what has changed in the dictionary when it fails, it's always the `__slotnames__` attribute has been added
- `__slotnames__` attribute is added to a class when `copy.deepcopy` is called on an instance of this class and the metadata routing code is using `copy.deepcopy`.
- in this metadata routing code, we only care about attributes that starts with `__metadata_request__`. We don't care whether `__slotnames__` has been added or not.

If we want to avoid doing a copy, I guess another option would be to use a lock lock to ensure that the `for` loop and the `copy.deepcopy` can not happen at the same time but it seems a bit more complicated than making the copy.

