### PR TITLE
MNT Bump Python to 3.12 in Binder environment

### DIFF
--- a/.binder/runtime.txt
+++ b/.binder/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9
+python-3.13

--- a/.binder/runtime.txt
+++ b/.binder/runtime.txt
@@ -1,1 +1,1 @@
-python-3.13
+python-3.12


### PR DESCRIPTION
Right now we are still using `python-3.9` so there is a failure when trying to `pip install` the development wheel. I originally tried `python-3.13` but it does not exist it seems for Binder yet.

Binder seems to work on my PR branch: https://mybinder.org/v2/gh/lesteve/scikit-learn/fix-binder