### PR TITLE
MNT Add Python 3.14 to metadata of pyproject.toml

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -582,7 +582,7 @@ Commit Message Marker  Action Taken by CI
 [cd build]             CD is run (wheels and source distribution are built)
 [lint skip]            Azure pipeline skips linting
 [scipy-dev]            Build & test with our dependencies (numpy, scipy, etc.) development builds
-[free-threaded]        Build & test with CPython 3.13 free-threaded
+[free-threaded]        Build & test with CPython 3.14 free-threaded
 [pyodide]              Build & test with Pyodide
 [azure parallel]       Run Azure CI jobs in parallel
 [float32]              Run float32 tests by setting `SKLEARN_RUN_FLOAT32_TESTS=1`. See :ref:`environment_variable` for more details

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers=[
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #32213.

#### What does this implement/fix? Explain your changes.
At <https://github.com/scikit-learn/scikit-learn/releases/tag/1.7.2> it is stated that this new release 1.7.2 supports Python 3.14 but neither at <https://pypi.org/project/scikit-learn/> nor in the repo's readme file this is reflected.
This PR adds the missing version to the `pyproject.toml` file.

#### Any other comments?
