### PR TITLE
MNT Bump Python to 3.12 in Binder environment for 1.7 branch

### DIFF
--- a/.binder/runtime.txt
+++ b/.binder/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9
+python-3.12


### PR DESCRIPTION
Backport #32267 to `1.7.X` branch to fix Binder link on the stable website.