### PR TITLE
CI Work-around hang in macOS Intel wheels with scipy 1.16.2

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -224,7 +224,8 @@ jobs:
           CIBW_BEFORE_TEST_WINDOWS: bash build_tools/github/build_minimal_windows_image.sh ${{ matrix.python }}
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
           # TODO Put back pandas when there is a pandas release with Python 3.14 wheels
-          CIBW_TEST_REQUIRES: ${{ contains(matrix.python, '314') && 'pytest' || 'pytest pandas' }}
+          # TODO Remove scipy<1.16.2 when hang on macOS_x86_64 has been fixed
+          CIBW_TEST_REQUIRES: ${{ contains(matrix.python, '314') && 'pytest' || 'pytest pandas' }} scipy<1.16.2
           # On Windows, we use a custom Docker image and CIBW_TEST_REQUIRES_WINDOWS
           # does not make sense because it would install dependencies in the host
           # rather than inside the Docker image

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -224,7 +224,9 @@ jobs:
           CIBW_BEFORE_TEST_WINDOWS: bash build_tools/github/build_minimal_windows_image.sh ${{ matrix.python }}
           CIBW_ENVIRONMENT_PASS_LINUX: RUNNER_OS
           # TODO Put back pandas when there is a pandas release with Python 3.14 wheels
-          # TODO Remove scipy<1.16.2 when hang on macOS_x86_64 has been fixed
+          # TODO Remove scipy<1.16.2 when hang on macOS_x86_64 has been fixed.
+          # See https://github.com/scikit-learn/scikit-learn/issues/32279 for
+          # more details.
           CIBW_TEST_REQUIRES: ${{ contains(matrix.python, '314') && 'pytest' || 'pytest pandas' }} scipy<1.16.2
           # On Windows, we use a custom Docker image and CIBW_TEST_REQUIRES_WINDOWS
           # does not make sense because it would install dependencies in the host


### PR DESCRIPTION
Close https://github.com/scikit-learn/scikit-learn/issues/32171.

As noted in https://github.com/scikit-learn/scikit-learn/issues/32171#issuecomment-3323361410 scipy 1.16.2 has OpenBLAS 0.3.29dev and scipy 1.16.1 has OpenBLAS 0.3.28.

My wild guess is that this is a OpenBLAS within OpenMP kind of issue but let's fix the wheels first and then we can investigate the issue in more detais.

