### PR TITLE
FIX Decision trees decision path: fix/add handling of missing values

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.tree/32280.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.tree/32280.fix.rst
@@ -1,0 +1,4 @@
+- Fix handling of missing values in method :func:`decision_path` of trees
+  (:class:`ensemble.DecisionTreeClassifier`, :class:`ensemble.DecisionTreeRegressor`,
+  :class:`ensemble.ExtraTreeClassifier` and :class:`ensemble.ExtraTreeRegressor`)
+  By :user:`Arthur Lacote <cakedev0>`.

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -1087,6 +1087,7 @@ cdef class Tree:
         # Extract input
         cdef const float32_t[:, :] X_ndarray = X
         cdef intp_t n_samples = X.shape[0]
+        cdef float32_t X_i_node_feature
 
         # Initialize output
         cdef intp_t[:] indptr = np.zeros(n_samples + 1, dtype=np.intp)
@@ -1109,7 +1110,13 @@ cdef class Tree:
                     indices[indptr[i + 1]] = <intp_t>(node - self.nodes)
                     indptr[i + 1] += 1
 
-                    if X_ndarray[i, node.feature] <= node.threshold:
+                    X_i_node_feature = X_ndarray[i, node.feature]
+                    if isnan(X_i_node_feature):
+                        if node.missing_go_to_left:
+                            node = &self.nodes[node.left_child]
+                        else:
+                            node = &self.nodes[node.right_child]
+                    elif X_i_node_feature <= node.threshold:
                         node = &self.nodes[node.left_child]
                     else:
                         node = &self.nodes[node.right_child]

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1614,11 +1614,21 @@ def test_public_apply_sparse_trees(name, csr_container):
 
 
 def test_decision_path_hardcoded():
+    # 1st example
     X = iris.data
     y = iris.target
     est = DecisionTreeClassifier(random_state=0, max_depth=1).fit(X, y)
     node_indicator = est.decision_path(X[:2]).toarray()
     assert_array_equal(node_indicator, [[1, 1, 0], [1, 0, 1]])
+
+    # 2nd example (toy dataset)
+    # was failing before the fix in PR
+    X = [0, np.nan, np.nan, 2, 3]
+    y = [0, 0, 0, 1, 1]
+    X = np.array(X).reshape(-1, 1)
+    tree = DecisionTreeRegressor().fit(X, y)
+    n_node_samples = tree.decision_path(X).toarray().sum(axis=0)
+    assert_array_equal(n_node_samples, tree.tree_.n_node_samples)
 
 
 @pytest.mark.parametrize("name", ALL_TREES)

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1623,6 +1623,7 @@ def test_decision_path_hardcoded():
 
     # 2nd example (toy dataset)
     # was failing before the fix in PR
+    # https://github.com/scikit-learn/scikit-learn/pull/32280
     X = [0, np.nan, np.nan, 2, 3]
     y = [0, 0, 0, 1, 1]
     X = np.array(X).reshape(-1, 1)

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -1627,7 +1627,7 @@ def test_decision_path_hardcoded():
     X = [0, np.nan, np.nan, 2, 3]
     y = [0, 0, 0, 1, 1]
     X = np.array(X).reshape(-1, 1)
-    tree = DecisionTreeRegressor().fit(X, y)
+    tree = DecisionTreeRegressor(random_state=0).fit(X, y)
     n_node_samples = tree.decision_path(X).toarray().sum(axis=0)
     assert_array_equal(n_node_samples, tree.tree_.n_node_samples)
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes https://github.com/scikit-learn/scikit-learn/issues/32284

#### What does this implement/fix? Explain your changes.

I copied the NaNs-handling logic from `_apply_dense` into `_decision_path_dense`. And NaNs aren't supported for sparse inputs.

I also added a test that fails without this fix.

