### PR TITLE
PERF: don't use stable sort in `_weighted_percentile`

### DIFF
--- a/sklearn/externals/array_api_extra/_lib/_funcs.py
+++ b/sklearn/externals/array_api_extra/_lib/_funcs.py
@@ -822,7 +822,7 @@ def nunique(x: Array, /, *, xp: ModuleType | None = None) -> Array:
 
     # xp does not have unique_counts; O(n*logn) complexity
     x = xp.reshape(x, (-1,))
-    x = xp.sort(x)
+    x = xp.sort(x, stable=False)
     mask = x != xp.roll(x, -1)
     default_int = default_dtype(xp, "integral", device=_compat.device(x))
     return xp.maximum(

--- a/sklearn/externals/array_api_extra/_lib/_funcs.py
+++ b/sklearn/externals/array_api_extra/_lib/_funcs.py
@@ -822,7 +822,7 @@ def nunique(x: Array, /, *, xp: ModuleType | None = None) -> Array:
 
     # xp does not have unique_counts; O(n*logn) complexity
     x = xp.reshape(x, (-1,))
-    x = xp.sort(x, stable=False)
+    x = xp.sort(x)
     mask = x != xp.roll(x, -1)
     default_int = default_dtype(xp, "integral", device=_compat.device(x))
     return xp.maximum(

--- a/sklearn/utils/stats.py
+++ b/sklearn/utils/stats.py
@@ -97,7 +97,7 @@ def _weighted_percentile(
     if array.shape != sample_weight.shape and array.shape[0] == sample_weight.shape[0]:
         sample_weight = xp.tile(sample_weight, (array.shape[1], 1)).T
     # Sort `array` and `sample_weight` along axis=0:
-    sorted_idx = xp.argsort(array, axis=0)
+    sorted_idx = xp.argsort(array, axis=0, stable=False)
     sorted_weights = xp.take_along_axis(sample_weight, sorted_idx, axis=0)
 
     # Set NaN values in `sample_weight` to 0. Only perform this operation if NaN


### PR DESCRIPTION
Note: This PR was initially about using unstable sort in every places where it was possible. But in the end, it focus only on `sklearn.utils.stats._weighted_percentile`.

### Reference Issues/PRs

Relates to https://github.com/scikit-learn/scikit-learn/issues/32283

### What does this implement/fix? Explain your changes.

`sklearn.externals.array_api_compat.numpy.{sort|argsort}` are different from `numpy.{sort|argsort}`: by default they are stable, while in numpy they're not. Stable sort is quite slower than "normal" sort (see the issue), hence it's important to precise `stable=False` when using `xp.sort` and stable sort is not needed.

Here is a quick intuition of why we don't need a stable argsort here:

The weighted quantile of some (x, w) vectors that contains some duplicates in x is same than the weighted quantile of the "x-deduplicated" vectors (x_uniqued, w_summed_over_x_duplicates).

Here is how you could get the "x-deduplicated" vectors in Python:
```Python
x_uniqued, w_summed_over_x_duplicates = pandas.Series(w).groupby(x).sum().reset_index().to_numpy().T
```

Below is a more detailed proof:

### Proof

Let $X$ be a sorted vector, and $W$ a vector of associated weights: $x_1 \leq x_2 \leq ... \leq x_n $. 

**Case 1:** $(X, W)$ has a unique weighted q-quantile $z$

Let's express the vector $W$ as the concatenation of three vectors: $W = [W_-; W_z; W_+]$ with:
- $W_- = [w_1, ..., w_{i-1}]$ 
- $W_z = [w_{i}, ..., w_{j}]$ where $i = \min \{k, x_k = z\}$ and $j = \max \{k, x_k = z\}$
- $W_- = [w_j+1, ..., w_n]$ 

We have the equivalence:

$z$ is the weighted q-quantile $\Longleftrightarrow$ $\sum (W_-) \leq q \sum (W)$ and $\sum (W_+) \leq (1 - q) \sum (W)$

The second proposition in this equivalence is not impacted by the order of values in $W_z$, so the sames stand for the part " $z$ is the weighted q-quantile ".

**Case 2:** All the values in the interval $[y, z]$ are weighted q-quantiles of $(X, W)$

With a similar logic than for case 1, let's express the vector $W$ as the concatenation of three vectors: $W = [W_-; W_y; W_z; W_+]$

Again, with have the equivalence: 

The values in $[y, z]$ are (all) the weighted q-quantiles of $(X, W)$ $\Longleftrightarrow$ $\sum (W_-) = q \sum (W)$ and $\sum (W_+) = (1 - q) \sum (W)$

Here a again, elements order in $W_y$ and $W_z$ have no impact.

**Conclusion:** the sort doesn't need to be stable, because for an ordered $X$ the ordering of elements in $W$ for duplicates of $X$ doesn't matter. 

Also we note that the ordering of $W_-$ and $W_+$ don't matter either. This proves that we don't need to sort $X$ but only to partition it around the quantile value(s). Which is what I use in my follow-up PR: https://github.com/scikit-learn/scikit-learn/pull/32288



