### PR TITLE
FIX Fix EPSILON variable initialization in `quad_tree.pxd`

### DIFF
--- a/sklearn/neighbors/_quad_tree.pxd
+++ b/sklearn/neighbors/_quad_tree.pxd
@@ -12,7 +12,7 @@ from ..utils._typedefs cimport float32_t, intp_t
 cdef enum:
     DEBUGFLAG = 0
 
-cdef float EPSILON = 1e-6
+cdef const float EPSILON = 1e-6
 
 # XXX: Careful to not change the order of the arguments. It is important to
 # have is_leaf and max_width consecutive as it permits to avoid padding by

--- a/sklearn/neighbors/_quad_tree.pxd
+++ b/sklearn/neighbors/_quad_tree.pxd
@@ -12,8 +12,6 @@ from ..utils._typedefs cimport float32_t, intp_t
 cdef enum:
     DEBUGFLAG = 0
 
-cdef const float EPSILON = 1e-6
-
 # XXX: Careful to not change the order of the arguments. It is important to
 # have is_leaf and max_width consecutive as it permits to avoid padding by
 # the compiler and keep the size coherent for both C and numpy data structures.

--- a/sklearn/neighbors/_quad_tree.pyx
+++ b/sklearn/neighbors/_quad_tree.pyx
@@ -32,6 +32,8 @@ CELL_DTYPE = np.asarray(<Cell[:1]>(&dummy)).dtype
 
 assert CELL_DTYPE.itemsize == sizeof(Cell)
 
+cdef const float EPSILON = 1e-6
+
 
 cdef class _QuadTree:
     """Array-based representation of a QuadTree.

--- a/sklearn/neighbors/tests/test_quad_tree.py
+++ b/sklearn/neighbors/tests/test_quad_tree.py
@@ -86,10 +86,10 @@ def test_qt_insert_duplicate(n_dimensions):
     X = rng.random_sample((10, n_dimensions))
     # create some duplicates
     Xd = np.r_[X, X[:5]]
-    # add slight noise: duplicate detection should tolerate tiny numerical differences
     epsilon = 1e-6
-    # EPSILON=1e-6 is defined in sklearn/neighbors/_quad_tree.pxd but not
+    # EPSILON=1e-6 is defined in sklearn/neighbors/_quad_tree.pyx but not
     # accessible from Python
+    # add slight noise: duplicate detection should tolerate tiny numerical differences
     Xd += epsilon * (rng.rand(*Xd.shape) - 0.5)
     tree = _QuadTree(n_dimensions=n_dimensions, verbose=0)
     tree.build_tree(Xd)

--- a/sklearn/neighbors/tests/test_quad_tree.py
+++ b/sklearn/neighbors/tests/test_quad_tree.py
@@ -84,7 +84,10 @@ def test_qt_insert_duplicate(n_dimensions):
     rng = check_random_state(0)
 
     X = rng.random_sample((10, n_dimensions))
+    # create some duplicates
     Xd = np.r_[X, X[:5]]
+    # add slight noise: duplicate detection should tolerate tiny numerical differences
+    Xd += 1e-8 * (rng.rand(*Xd.shape) - 0.5)
     tree = _QuadTree(n_dimensions=n_dimensions, verbose=0)
     tree.build_tree(Xd)
 

--- a/sklearn/neighbors/tests/test_quad_tree.py
+++ b/sklearn/neighbors/tests/test_quad_tree.py
@@ -87,7 +87,10 @@ def test_qt_insert_duplicate(n_dimensions):
     # create some duplicates
     Xd = np.r_[X, X[:5]]
     # add slight noise: duplicate detection should tolerate tiny numerical differences
-    Xd += 1e-8 * (rng.rand(*Xd.shape) - 0.5)
+    epsilon = 1e-6
+    # EPSILON=1e-6 is defined in sklearn/neighbors/_quad_tree.pxd but not
+    # accessible from Python
+    Xd += epsilon * (rng.rand(*Xd.shape) - 0.5)
     tree = _QuadTree(n_dimensions=n_dimensions, verbose=0)
     tree.build_tree(Xd)
 


### PR DESCRIPTION
#### Reference Issues/PRs

Follow-up to comment https://github.com/scikit-learn/scikit-learn/pull/32259#issuecomment-3338224571 from @lesteve 

#### What does this implement/fix? Explain your changes.

Change the declaration to `const`, as suggested here: https://github.com/scikit-learn/scikit-learn/pull/32259#discussion_r2382905456
