### PR TITLE
MNT ensure `_average` respects `xp` in all metrics

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -389,7 +389,7 @@ def accuracy_score(y_true, y_pred, *, normalize=True, sample_weight=None):
     else:
         score = y_true == y_pred
 
-    return float(_average(score, weights=sample_weight, normalize=normalize))
+    return float(_average(score, weights=sample_weight, normalize=normalize, xp=xp))
 
 
 @validate_params(
@@ -3235,7 +3235,9 @@ def hamming_loss(y_true, y_pred, *, sample_weight=None):
         )
 
     elif y_type in ["binary", "multiclass"]:
-        return float(_average(y_true != y_pred, weights=sample_weight, normalize=True))
+        return float(
+            _average(y_true != y_pred, weights=sample_weight, normalize=True, xp=xp)
+        )
     else:
         raise ValueError("{0} is not supported".format(y_type))
 

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -300,7 +300,7 @@ def mean_absolute_error(
     # a scalar array that we convert to a Python float to
     # consistently return the same eager evaluated value.
     # Therefore, `axis=None`.
-    mean_absolute_error = _average(output_errors, weights=multioutput)
+    mean_absolute_error = _average(output_errors, weights=multioutput, xp=xp)
 
     return float(mean_absolute_error)
 
@@ -387,7 +387,7 @@ def mean_pinball_loss(
     diff = y_true - y_pred
     sign = xp.astype(diff >= 0, diff.dtype)
     loss = alpha * sign * diff - (1 - alpha) * (1 - sign) * diff
-    output_errors = _average(loss, weights=sample_weight, axis=0)
+    output_errors = _average(loss, weights=sample_weight, axis=0, xp=xp)
 
     if isinstance(multioutput, str) and multioutput == "raw_values":
         return output_errors
@@ -401,7 +401,7 @@ def mean_pinball_loss(
     # a scalar array that we convert to a Python float to
     # consistently return the same eager evaluated value.
     # Therefore, `axis=None`.
-    return float(_average(output_errors, weights=multioutput))
+    return float(_average(output_errors, weights=multioutput, xp=xp))
 
 
 @validate_params(
@@ -492,7 +492,7 @@ def mean_absolute_percentage_error(
     epsilon = xp.asarray(xp.finfo(xp.float64).eps, dtype=y_true.dtype, device=device_)
     y_true_abs = xp.abs(y_true)
     mape = xp.abs(y_pred - y_true) / xp.maximum(y_true_abs, epsilon)
-    output_errors = _average(mape, weights=sample_weight, axis=0)
+    output_errors = _average(mape, weights=sample_weight, axis=0, xp=xp)
     if isinstance(multioutput, str):
         if multioutput == "raw_values":
             return output_errors
@@ -505,7 +505,7 @@ def mean_absolute_percentage_error(
     # a scalar array that we convert to a Python float to
     # consistently return the same eager evaluated value.
     # Therefore, `axis=None`.
-    mean_absolute_percentage_error = _average(output_errors, weights=multioutput)
+    mean_absolute_percentage_error = _average(output_errors, weights=multioutput, xp=xp)
 
     return float(mean_absolute_percentage_error)
 
@@ -580,7 +580,9 @@ def mean_squared_error(
             y_true, y_pred, sample_weight, multioutput, xp=xp
         )
     )
-    output_errors = _average((y_true - y_pred) ** 2, axis=0, weights=sample_weight)
+    output_errors = _average(
+        (y_true - y_pred) ** 2, axis=0, weights=sample_weight, xp=xp
+    )
 
     if isinstance(multioutput, str):
         if multioutput == "raw_values":
@@ -594,7 +596,7 @@ def mean_squared_error(
     # a scalar array that we convert to a Python float to
     # consistently return the same eager evaluated value.
     # Therefore, `axis=None`.
-    mean_squared_error = _average(output_errors, weights=multioutput)
+    mean_squared_error = _average(output_errors, weights=multioutput, xp=xp)
 
     return float(mean_squared_error)
 
@@ -678,7 +680,7 @@ def root_mean_squared_error(
     # a scalar array that we convert to a Python float to
     # consistently return the same eager evaluated value.
     # Therefore, `axis=None`.
-    root_mean_squared_error = _average(output_errors, weights=multioutput)
+    root_mean_squared_error = _average(output_errors, weights=multioutput, xp=xp)
 
     return float(root_mean_squared_error)
 
@@ -931,7 +933,7 @@ def median_absolute_error(
             # pass None as weights to np.average: uniform mean
             multioutput = None
 
-    return float(_average(output_errors, weights=multioutput))
+    return float(_average(output_errors, weights=multioutput, xp=xp))
 
 
 def _assemble_r2_explained_variance(
@@ -978,7 +980,7 @@ def _assemble_r2_explained_variance(
     else:
         avg_weights = multioutput
 
-    result = _average(output_scores, weights=avg_weights)
+    result = _average(output_scores, weights=avg_weights, xp=xp)
     if size(result) == 1:
         return float(result)
     return result
@@ -1109,13 +1111,15 @@ def explained_variance_score(
         )
     )
 
-    y_diff_avg = _average(y_true - y_pred, weights=sample_weight, axis=0)
+    y_diff_avg = _average(y_true - y_pred, weights=sample_weight, axis=0, xp=xp)
     numerator = _average(
-        (y_true - y_pred - y_diff_avg) ** 2, weights=sample_weight, axis=0
+        (y_true - y_pred - y_diff_avg) ** 2, weights=sample_weight, axis=0, xp=xp
     )
 
-    y_true_avg = _average(y_true, weights=sample_weight, axis=0)
-    denominator = _average((y_true - y_true_avg) ** 2, weights=sample_weight, axis=0)
+    y_true_avg = _average(y_true, weights=sample_weight, axis=0, xp=xp)
+    denominator = _average(
+        (y_true - y_true_avg) ** 2, weights=sample_weight, axis=0, xp=xp
+    )
 
     return _assemble_r2_explained_variance(
         numerator=numerator,
@@ -1352,7 +1356,7 @@ def max_error(y_true, y_pred):
 
 def _mean_tweedie_deviance(y_true, y_pred, sample_weight, power):
     """Mean Tweedie deviance regression loss."""
-    xp, _, device_ = get_namespace_and_device(y_true, y_pred)
+    xp, _ = get_namespace(y_true, y_pred)
     p = power
     if p < 0:
         # 'Extreme stable', y any real number, y_pred > 0
@@ -1380,7 +1384,7 @@ def _mean_tweedie_deviance(y_true, y_pred, sample_weight, power):
             - y_true * xp.pow(y_pred, 1 - p) / (1 - p)
             + xp.pow(y_pred, 2 - p) / (2 - p)
         )
-    return float(_average(dev, weights=sample_weight))
+    return float(_average(dev, weights=sample_weight, xp=xp))
 
 
 @validate_params(

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -1105,14 +1105,3 @@ def _linalg_solve(cov_chol, eye_matrix, xp):
         return scipy.linalg.solve_triangular(cov_chol, eye_matrix, lower=True)
     else:
         return xp.linalg.solve(cov_chol, eye_matrix)
-
-
-def _half_multinomial_loss(y, pred, sample_weight=None, xp=None):
-    """A version of the multinomial loss that is compatible with the array API"""
-    xp, _ = get_namespace(y, pred, sample_weight)
-    device_ = device(y, pred, sample_weight)
-    log_sum_exp = special.logsumexp(pred, axis=1)
-    y = xp.asarray(y, dtype=xp.int64, device=device_)
-    class_margins = xp.asarray(xp.arange(y.shape[0], device=device_)) * pred.shape[1]
-    label_predictions = xp.take(_ravel(pred), y + class_margins)
-    return float(_average(log_sum_exp - label_predictions, weights=sample_weight))


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #32278.

#### What does this implement/fix? Explain your changes.

This PR ensures that the input parameter `xp` is correctly used in the [<code>_average</code>](https://github.com/scikit-learn/scikit-learn/blob/4fd34545e517d164881126ce539aa8bfabae86d2/sklearn/utils/_array_api.py#L621) function by passing it to the internally called `get_namespace_and_device` function.

#### Any other comments?

The Array-API-supported metrics (regression and classification) that call `_average` have also been updated to utilise the `xp` parameter.