### PR TITLE
Minor: remove duplicate docs extra and clean up comments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ docs = [
     "sphinxext-opengraph>=0.9.1",
     "plotly>=5.14.0",
     "polars>=0.20.30",
-    "sphinx-design>=0.5.0",
     "sphinx-design>=0.6.0",
     "sphinxcontrib-sass>=0.3.4",
     "pydata-sphinx-theme>=0.15.3",

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -1099,7 +1099,8 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # XXX: nan is only supported for dense arrays, but we set this for common test to
+        # XXX: nan is only supported for dense arrays, but we set this for
+        # common test to
         # pass, specifically: check_estimators_nan_inf
         allow_nan = self.splitter in ("best", "random") and self.criterion in {
             "gini",
@@ -1442,7 +1443,8 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # XXX: nan is only supported for dense arrays, but we set this for common test to
+        # XXX: nan is only supported for dense arrays, but we set this for
+        # common test to
         # pass, specifically: check_estimators_nan_inf
         allow_nan = self.splitter in ("best", "random") and self.criterion in {
             "squared_error",

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -1100,8 +1100,7 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         # XXX: nan is only supported for dense arrays, but we set this for
-        # common test to
-        # pass, specifically: check_estimators_nan_inf
+        # common test to pass, specifically: check_estimators_nan_inf
         allow_nan = self.splitter in ("best", "random") and self.criterion in {
             "gini",
             "log_loss",
@@ -1444,8 +1443,7 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         # XXX: nan is only supported for dense arrays, but we set this for
-        # common test to
-        # pass, specifically: check_estimators_nan_inf
+        # common test to pass, specifically: check_estimators_nan_inf
         allow_nan = self.splitter in ("best", "random") and self.criterion in {
             "squared_error",
             "friedman_mse",

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -1099,7 +1099,7 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # XXX: nan is only support for dense arrays, but we set this for common test to
+        # XXX: nan is only supported for dense arrays, but we set this for common test to
         # pass, specifically: check_estimators_nan_inf
         allow_nan = self.splitter in ("best", "random") and self.criterion in {
             "gini",
@@ -1442,7 +1442,7 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
-        # XXX: nan is only support for dense arrays, but we set this for common test to
+        # XXX: nan is only supported for dense arrays, but we set this for common test to
         # pass, specifically: check_estimators_nan_inf
         allow_nan = self.splitter in ("best", "random") and self.criterion in {
             "squared_error",

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -68,7 +68,7 @@ def _mode(a, axis=0):
     return scipy.stats.mode(a, axis=axis)
 
 
-# TODO: Remove when Scipy 1.12 is the minimum supported version
+# TODO: Remove when SciPy 1.12 is the minimum supported version
 if sp_base_version >= parse_version("1.12.0"):
     _sparse_linalg_cg = scipy.sparse.linalg.cg
 else:
@@ -81,7 +81,7 @@ else:
         return scipy.sparse.linalg.cg(A, b, **kwargs)
 
 
-# TODO : remove this when required minimum version of scipy >= 1.9.0
+# TODO : remove this when required minimum version of SciPy >= 1.9.0
 def _yeojohnson_lambda(_neg_log_likelihood, x):
     """Estimate the optimal Yeo-Johnson transformation parameter (lambda).
 
@@ -114,7 +114,7 @@ def _yeojohnson_lambda(_neg_log_likelihood, x):
 
 
 # TODO: Fuse the modern implementations of _sparse_min_max and _sparse_nan_min_max
-# into the public min_max_axis function when Scipy 1.11 is the minimum supported
+# into the public min_max_axis function when SciPy 1.11 is the minimum supported
 # version and delete the backport in the else branch below.
 if sp_base_version >= parse_version("1.11.0"):
 
@@ -352,7 +352,7 @@ def _smallest_admissible_index_dtype(arrays=(), maxval=None, check_contents=Fals
     return np.int32
 
 
-# TODO: Remove when Scipy 1.12 is the minimum supported version
+# TODO: Remove when SciPy 1.12 is the minimum supported version
 if sp_version < parse_version("1.12"):
     from sklearn.externals._scipy.sparse.csgraph import laplacian
 else:


### PR DESCRIPTION
Minor: remove duplicate docs extra and clean up comments

- pyproject.toml: drop duplicate sphinx-design entry in docs extras (keep >=0.6.0)
- sklearn/tree/_classes.py: grammar fix in comments ("nan is only supported")
- sklearn/utils/fixes.py: standardize "SciPy" capitalization in TODOs

<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
N/A

#### What does this implement/fix? Explain your changes.
- Removes a duplicate `sphinx-design` entry in `[project.optional-dependencies].docs` (retains newer version spec).
- Fixes minor comment grammar in `sklearn/tree/_classes.py`.
- Standardizes "SciPy" capitalization in TODO comments in `sklearn/utils/fixes.py`.
- No behavior changes; docs/dependency list cleanliness only.

#### Any other comments?
- Label suggestion: "No Changelog Needed".
- Verified no linter issues locally.