### PR TITLE
DOC Improve the `SelectFromModel` docstring regarding `max_features`

### DIFF
--- a/sklearn/feature_selection/_from_model.py
+++ b/sklearn/feature_selection/_from_model.py
@@ -128,7 +128,7 @@ class SelectFromModel(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
         - If an integer, then it specifies the maximum number of features to
           allow.
         - If a callable, then it specifies how to calculate the maximum number of
-          features allowed by using the output of `max_features(X)`.
+          features allowed. The callable will receive `X` as input: `max_features(X)`.
         - If `None`, then all features are kept.
 
         To only select based on ``max_features``, set ``threshold=-np.inf``.


### PR DESCRIPTION
Before this it was not clear to me if the callable would receive `X` or some precomputed integer derived from `X` as argument. Even after reading the actual code it took me a moment to realise that the docstring was correct, it looked like it was wrong. What do people think? Is this an improvement?
