### PR TITLE
MNT Move the too many classes warning into check_classification_targets

### DIFF
--- a/sklearn/utils/multiclass.py
+++ b/sklearn/utils/multiclass.py
@@ -13,7 +13,7 @@ from scipy.sparse import issparse
 from sklearn.utils._array_api import get_namespace
 from sklearn.utils._unique import attach_unique, cached_unique
 from sklearn.utils.fixes import VisibleDeprecationWarning
-from sklearn.utils.validation import _assert_all_finite, check_array
+from sklearn.utils.validation import _assert_all_finite, _num_samples, check_array
 
 
 def _unique_multiclass(y, xp=None):
@@ -224,6 +224,18 @@ def check_classification_targets(y):
             "regression target with continuous values."
         )
 
+    if "multiclass" in y_type:
+        n_samples = _num_samples(y)
+        if n_samples > 20 and cached_unique(y).shape[0] > round(0.5 * n_samples):
+            # Only raise the warning when we have at least 20 samples.
+            warnings.warn(
+                "The number of unique classes is greater than 50% of the number "
+                "of samples. `y` could represent a regression problem, not a "
+                "classification problem.",
+                UserWarning,
+                stacklevel=2,
+            )
+
 
 def type_of_target(y, input_name="", raise_unknown=False):
     """Determine the type of data indicated by the target.
@@ -417,17 +429,7 @@ def type_of_target(y, input_name="", raise_unknown=False):
     # Check multiclass
     if issparse(first_row_or_val):
         first_row_or_val = first_row_or_val.data
-    classes = cached_unique(y)
-    if y.shape[0] > 20 and y.shape[0] > classes.shape[0] > round(0.5 * y.shape[0]):
-        # Only raise the warning when we have at least 20 samples.
-        warnings.warn(
-            "The number of unique classes is greater than 50% of the number "
-            "of samples. `y` could represent a regression problem, not a "
-            "classification problem.",
-            UserWarning,
-            stacklevel=2,
-        )
-    if classes.shape[0] > 2 or (y.ndim == 2 and len(first_row_or_val) > 1):
+    if cached_unique(y).shape[0] > 2 or (y.ndim == 2 and len(first_row_or_val) > 1):
         # [1, 2, 3] or [[1., 2., 3]] or [[1, 2]]
         return "multiclass" + suffix
     else:

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -303,7 +303,7 @@ def test_check_classification_targets_too_many_unique_classes():
     """
 
     # Create array of unique labels. This does raise a warning.
-    y = np.arange(20)
+    y = np.arange(25)
     msg = r"The number of unique classes is greater than 50% of the number of samples."
     with pytest.warns(UserWarning, match=msg):
         check_classification_targets(y)

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -295,35 +295,24 @@ def test_unique_labels():
     assert_array_equal(unique_labels(np.ones((4, 5)), np.ones((5, 5))), np.arange(5))
 
 
-def test_type_of_target_too_many_unique_classes():
+def test_check_classification_targets_too_many_unique_classes():
     """Check that we raise a warning when the number of unique classes is greater than
     50% of the number of samples.
 
     We need to check that we don't raise if we have less than 20 samples.
     """
 
-    # Create array of unique labels, except '0', which appears twice.
-    # This does raise a warning.
-    # Note warning would not be raised if we passed only unique
-    # labels, which happens when `type_of_target` is passed `classes_`.
-    y = np.hstack((np.arange(20), [0]))
+    # Create array of unique labels. This does raise a warning.
+    y = np.arange(20)
     msg = r"The number of unique classes is greater than 50% of the number of samples."
     with pytest.warns(UserWarning, match=msg):
-        type_of_target(y)
+        check_classification_targets(y)
 
     # less than 20 samples, no warning should be raised
     y = np.arange(10)
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        type_of_target(y)
-
-    # More than 20 samples but only unique classes, simulating passing
-    # `classes_` to `type_of_target` (when number of classes is large).
-    # No warning should be raised
-    y = np.arange(25)
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        type_of_target(y)
+        check_classification_targets(y)
 
 
 def test_unique_labels_non_specific():


### PR DESCRIPTION
Currently in `type_of_target`, the warning brings a lot of confusion, as reported several times, for instance https://github.com/scikit-learn/scikit-learn/issues/31583, https://github.com/scikit-learn/scikit-learn/issues/32247, https://github.com/scikit-learn/scikit-learn/issues/31752...

The reason of the confusion is that `type_of_target` is not able to completely classify all types of problems. In particular, an array of integer floats will be inferred as "multiclass" (for a classification problem) but is not incompatible with "continuous" (for a regression problem).

The warning on too many classes is a warning about a classification problem so should only be raised in a classification setting, hence in `check_classification_targets` instead of `type_of_target`. This was the intended behavior requested in the original issue https://github.com/scikit-learn/scikit-learn/issues/16399.

The fact that the warning ended-up in `type_of_target` instead is due to this https://github.com/scikit-learn/scikit-learn/pull/26335#pullrequestreview-1415537852, but the argument of performance doesn't apply since we're relying on cached unique values.

Side note: it also allows to partially revert https://github.com/scikit-learn/scikit-learn/pull/31584 which was a kind of dirty workaround. I left the non-regression test that was added in that PR to show that the change from this PR doesn't bring back the unexpected behavior.

cc/ @StefanieSenger @lucyleeow 