### PR TITLE
MNT Switch to absolute imports in sklearn/cluster/_dbscan_inner.pyx

### DIFF
--- a/sklearn/cluster/_dbscan_inner.pyx
+++ b/sklearn/cluster/_dbscan_inner.pyx
@@ -5,7 +5,7 @@
 
 from libcpp.vector cimport vector
 
-from ..utils._typedefs cimport uint8_t, intp_t
+from sklearn.utils._typedefs cimport uint8_t, intp_t
 
 
 def dbscan_inner(const uint8_t[::1] is_core,


### PR DESCRIPTION
#### Reference Issues/PRs
Part of #32315.

#### What does this implement/fix? Explain your changes.
This uses absolute imports in `sklearn/cluster/_dbscan_inner.pyx`

#### Any other comments?
No