### PR TITLE
MNT Switch to absolute imports in sklearn/utils/_fast_dict.pyx

### DIFF
--- a/sklearn/utils/_fast_dict.pyx
+++ b/sklearn/utils/_fast_dict.pyx
@@ -12,7 +12,7 @@ from libcpp.map cimport map as cpp_map
 
 import numpy as np
 
-from ._typedefs cimport float64_t, intp_t
+from sklearn.utils._typedefs cimport float64_t, intp_t
 
 
 ###############################################################################


### PR DESCRIPTION
 This PR converts relative imports to absolute imports in sklearn/utils/_fast_dict.pyx as part of the PyData Paris sprint (#32315).

**Change made:**
- Line 15: Changed `from ._typedefs cimport float64_t, intp_t` to `from sklearn.utils._typedefs cimport float64_t, intp_t`

**Context:**
- This is part of issue #32315, a coordinated effort to switch all Cython files to absolute imports
- I manually reviewed the file and identified the single relative import that needed conversion
- Following the pattern from the example PR #32316

Part of #32315