### PR TITLE
DOC use https for git clone in the doc

### DIFF
--- a/doc/developers/advanced_installation.rst
+++ b/doc/developers/advanced_installation.rst
@@ -57,7 +57,7 @@ feature, code or documentation improvement).
 
    .. prompt:: bash $
 
-     git clone git@github.com:scikit-learn/scikit-learn.git  # add --depth 1 if your connection is slow
+     git clone https://github.com/scikit-learn/scikit-learn.git  # add --depth 1 if your connection is slow
      cd scikit-learn
 
    If you plan on submitting a pull-request, you should clone from your fork

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -288,7 +288,7 @@ how to set up your git repository:
 
    .. prompt:: bash
 
-      git clone git@github.com:YourLogin/scikit-learn.git  # add --depth 1 if your connection is slow
+      git clone https://github.com/YourLogin/scikit-learn.git  # add --depth 1 if your connection is slow
       cd scikit-learn
 
 4. Follow steps 2-6 in :ref:`install_bleeding_edge` to build scikit-learn in
@@ -308,7 +308,7 @@ how to set up your git repository:
 
    .. prompt:: bash
 
-        git remote add upstream git@github.com:scikit-learn/scikit-learn.git
+        git remote add upstream https://github.com/scikit-learn/scikit-learn.git
 
 7. Check that the `upstream` and `origin` remote aliases are configured correctly
    by running:
@@ -321,10 +321,10 @@ how to set up your git repository:
 
    .. code-block:: text
 
-        origin    git@github.com:YourLogin/scikit-learn.git (fetch)
-        origin    git@github.com:YourLogin/scikit-learn.git (push)
-        upstream  git@github.com:scikit-learn/scikit-learn.git (fetch)
-        upstream  git@github.com:scikit-learn/scikit-learn.git (push)
+        origin    https://github.com/YourLogin/scikit-learn.git (fetch)
+        origin    https://github.com/YourLogin/scikit-learn.git (push)
+        upstream  https://github.com/scikit-learn/scikit-learn.git (fetch)
+        upstream  https://github.com/scikit-learn/scikit-learn.git (push)
 
 You should now have a working installation of scikit-learn, and your git repository
 properly configured. It could be useful to run some test to verify your installation.

--- a/doc/developers/maintainer.rst.template
+++ b/doc/developers/maintainer.rst.template
@@ -260,7 +260,7 @@ Reference Steps
       .. prompt:: bash
 
         git tag -a {{ version_full }}  # in the {{ version_short }}.X branch
-        git push git@github.com:scikit-learn/scikit-learn.git {{ version_full }}
+        git push https://github.com/scikit-learn/scikit-learn.git {{ version_full }}
 
       .. warning::
 
@@ -334,7 +334,7 @@ Reference Steps
       .. prompt:: bash
 
         cd /tmp
-        git clone --depth 1 --no-checkout git@github.com:scikit-learn/scikit-learn.github.io.git
+        git clone --depth 1 --no-checkout https://github.com/scikit-learn/scikit-learn.github.io.git
         cd scikit-learn.github.io
         echo stable > .git/info/sparse-checkout
         git checkout main


### PR DESCRIPTION
ssh git URLs can be confusing for first time contributors with no familiarity with ssh (especially on Windows).

Advanced git users probably already know what to do if they want to use the ssh-agent for credentials management.

