### PR TITLE
FEAT let RFE(CV) accept validation samples for `permutation_importance`

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.feature_selection/32340.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.feature_selection/32340.feature.rst
@@ -1,0 +1,6 @@
+- The :func:`fit()` method of :class:`feature_selection.RFE` and :class:`feature_selection.RFECV`
+  now has optional parameters `X_val` and `y_val` to provide validation samples.
+  These validation samples are passed to :attr:`importance_getter` when a callable
+  that can accept them. This allows using methods that need external data to be accurate
+  like :func:`permutation_importance`.
+  By :user:`Gaétan de Castellane <GaetandeCast>`.

--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -42,7 +42,7 @@ X, y = make_classification(
 # ----------------------------
 #
 # We create the RFE object and compute the cross-validated scores. The scoring
-# strategy "accuracy" optimizes the proportion of correctly classified samples.
+# strategy "neg_log_loss" optimizes the negative log loss of the predicted probas.
 
 from sklearn.feature_selection import RFECV
 from sklearn.linear_model import LogisticRegression
@@ -56,7 +56,7 @@ rfecv = RFECV(
     estimator=clf,
     step=1,
     cv=cv,
-    scoring="accuracy",
+    scoring="neg_log_loss",
     min_features_to_select=min_features_to_select,
     n_jobs=2,
 )
@@ -82,7 +82,7 @@ data = {
 cv_results = pd.DataFrame(data)
 plt.figure()
 plt.xlabel("Number of features selected")
-plt.ylabel("Mean test accuracy")
+plt.ylabel("Mean test neg log loss")
 plt.errorbar(
     x=cv_results["n_features"],
     y=cv_results["mean_test_score"],
@@ -96,7 +96,7 @@ plt.show()
 # (similar mean value and overlapping errorbars) for 3 to 5 selected features.
 # This is the result of introducing correlated features. Indeed, the optimal
 # model selected by the RFE can lie within this range, depending on the
-# cross-validation technique. The test accuracy decreases above 5 selected
+# cross-validation technique. The test negative log loss decreases above 5 selected
 # features, this is, keeping non-informative features leads to over-fitting and
 # is therefore detrimental for the statistical performance of the models.
 
@@ -149,7 +149,7 @@ rfecv = RFECV(
     estimator=clf,
     step=1,
     cv=cv,
-    scoring="accuracy",
+    scoring="neg_log_loss",
     min_features_to_select=min_features_to_select,
     n_jobs=2,
     importance_getter=lambda model, X_val, y_val: permutation_importance_getter(
@@ -172,7 +172,7 @@ data = {
 cv_results = pd.DataFrame(data)
 plt.figure()
 plt.xlabel("Number of features selected")
-plt.ylabel("Mean test accuracy")
+plt.ylabel("Mean test neg log loss")
 plt.errorbar(
     x=cv_results["n_features"],
     y=cv_results["mean_test_score"],

--- a/examples/feature_selection/plot_rfe_with_cross_validation.py
+++ b/examples/feature_selection/plot_rfe_with_cross_validation.py
@@ -113,3 +113,74 @@ for i in range(cv.n_splits):
 # In the five folds, the selected features are consistent. This is good news,
 # it means that the selection is stable across folds, and it confirms that
 # these features are the most informative ones.
+
+# %%
+# Using `permutation_importance` to select features
+# -------------------------------------------------
+# The `importance_getter` parameter in RFE and RFECV uses by default the `coef_` (e.g.
+# in linear models) or the `feature_importances_` attributes of an estimator to derive
+# feature importance. These importance measures are used to choose which features to
+# eliminate first.
+#
+# We show here how to use a callable to compute the `permutation_importance` instead.
+# This callable must accept a fitted model and the external validation samples that we
+# pass in `fit()`.
+
+# %%
+from sklearn.inspection import permutation_importance
+from sklearn.model_selection import train_test_split
+
+# Extract validation samples for permutation importance
+X_train, X_val, y_train, y_val = train_test_split(X, y, test_size=0.2)
+
+
+def permutation_importance_getter(model, X_val, y_val, random_state):
+    return permutation_importance(
+        model,
+        X_val,
+        y_val,
+        n_repeats=10,
+        n_jobs=2,
+        random_state=random_state,
+    ).importances_mean
+
+
+rfecv = RFECV(
+    estimator=clf,
+    step=1,
+    cv=cv,
+    scoring="accuracy",
+    min_features_to_select=min_features_to_select,
+    n_jobs=2,
+    importance_getter=lambda model, X_val, y_val: permutation_importance_getter(
+        model, X_val, y_val, 0
+    ),
+).fit(
+    X_train,
+    y_train,
+    X_val=X_val,
+    y_val=y_val,
+)
+print(f"Optimal number of features: {rfecv.n_features_}")
+
+# %%
+data = {
+    key: value
+    for key, value in rfecv.cv_results_.items()
+    if key in ["n_features", "mean_test_score", "std_test_score"]
+}
+cv_results = pd.DataFrame(data)
+plt.figure()
+plt.xlabel("Number of features selected")
+plt.ylabel("Mean test accuracy")
+plt.errorbar(
+    x=cv_results["n_features"],
+    y=cv_results["mean_test_score"],
+    yerr=cv_results["std_test_score"],
+)
+plt.title("Recursive Feature Elimination \nwith correlated features")
+plt.show()
+
+# %%
+# We see that we obtain very similar results with this model agnostic feature importance
+# method.

--- a/sklearn/feature_selection/_base.py
+++ b/sklearn/feature_selection/_base.py
@@ -258,7 +258,6 @@ def _get_feature_importances(
         importances = getter(estimator)
     else:  # callable
         param_names = list(inspect.signature(getter).parameters.keys())
-        print(param_names)
         if "X_val" in param_names and "y_val" in param_names:
             importances = getter(estimator, X_val, y_val)
         else:

--- a/sklearn/feature_selection/_base.py
+++ b/sklearn/feature_selection/_base.py
@@ -214,6 +214,14 @@ def _get_feature_importances(
         An attribute or a callable to get the feature importance. If `"auto"`,
         `estimator` is expected to expose `coef_` or `feature_importances`.
 
+    X_val : {array-like, sparse matrix} of shape (n_samples_val, n_features), \
+            default=None
+        Optional validation samples that can be used when using a callable
+        `getter` such as `permutation_importance`.
+
+    y_val : array-like of shape (n_samples_val,), default=None
+        The target values of the validation samples.
+
     transform_func : {"norm", "square"}, default=None
         The transform to apply to the feature importances. By default (`None`)
         no transformation is applied.

--- a/sklearn/feature_selection/_base.py
+++ b/sklearn/feature_selection/_base.py
@@ -250,7 +250,8 @@ def _get_feature_importances(
         importances = getter(estimator)
     else:  # callable
         param_names = list(inspect.signature(getter).parameters.keys())
-        if ["X", "y"] in param_names:
+        print(param_names)
+        if "X_val" in param_names and "y_val" in param_names:
             importances = getter(estimator, X_val, y_val)
         else:
             importances = getter(estimator)

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -124,13 +124,22 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         For example, give `regressor_.coef_` in case of
         :class:`~sklearn.compose.TransformedTargetRegressor`  or
         `named_steps.clf.feature_importances_` in case of
-        class:`~sklearn.pipeline.Pipeline` with its last step named `clf`.
+        :class:`~sklearn.pipeline.Pipeline` with its last step named `clf`.
 
         If `callable`, overrides the default feature importance getter.
         The callable is passed with the fitted estimator and it should
-        return importance for each feature.
+        return importance for each feature. If the callable also accept
+        `X_val` and `y_val`, it will be passed the validation samples provided
+        in `fit`.
+        This is useful for feature importance methods that require external
+        data to provide accurate results, such as `permutation_importance`. See
+        :ref:`sphx_glr_auto_examples_feature_selection_plot_rfe_with_cross_validation.py`
+        for an example on how to use this feature.
 
         .. versionadded:: 0.24
+
+        .. versionchanged:: 1.8
+            Add support for passing validation samples given during fit.
 
     Attributes
     ----------
@@ -255,7 +264,17 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
             The training input samples.
 
         y : array-like of shape (n_samples,)
-            The target values.
+            The target values of the training samples.
+
+        X_val : {array-like, sparse matrix} of shape (n_samples_val, n_features), \
+                default=None
+            Optional validation samples that can be used when using a custom
+            `importance_getter` such as `permutation_importance`. See
+            :ref:`sphx_glr_auto_examples_feature_selection_plot_rfe_with_cross_validation.py`.
+            for an example of usage.
+
+        y_val : array-like of shape (n_samples_val,), default=None
+            The target values of the validation samples.
 
         **fit_params : dict
             - If `enable_metadata_routing=False` (default): Parameters directly passed
@@ -652,9 +671,18 @@ class RFECV(RFE):
 
         If `callable`, overrides the default feature importance getter.
         The callable is passed with the fitted estimator and it should
-        return importance for each feature.
+        return importance for each feature. If the callable also accept
+        `X_val` and `y_val`, it will be passed the validation samples provided
+        in `fit`.
+        This is useful for feature importance methods that require external
+        data to provide accurate results, such as `permutation_importance`. See
+        :ref:`sphx_glr_auto_examples_feature_selection_plot_rfe_with_cross_validation.py`
+        for an example on how to use this feature.
 
         .. versionadded:: 0.24
+
+        .. versionchanged:: 1.8
+            Add support for passing validation samples given during fit.
 
     Attributes
     ----------
@@ -818,6 +846,16 @@ class RFECV(RFE):
         y : array-like of shape (n_samples,)
             Target values (integers for classification, real numbers for
             regression).
+
+        X_val : {array-like, sparse matrix} of shape (n_samples_val, n_features), \
+                default=None
+            Optional validation samples that can be used when using a custom
+            `importance_getter` such as `permutation_importance`. See
+            :ref:`sphx_glr_auto_examples_feature_selection_plot_rfe_with_cross_validation.py`.
+            for an example of usage.
+
+        y_val : array-like of shape (n_samples_val,), default=None
+            The target values of the validation samples.
 
         groups : array-like of shape (n_samples,) or None, default=None
             Group labels for the samples used while splitting the dataset into

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -242,7 +242,7 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         # RFE.estimator is not validated yet
         prefer_skip_nested_validation=False
     )
-    def fit(self, X, y, **fit_params):
+    def fit(self, X, y, X_val=None, y_val=None, **fit_params):
         """Fit the RFE model and then the underlying estimator on the selected features.
 
         Parameters
@@ -274,9 +274,9 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
         else:
             routed_params = Bunch(estimator=Bunch(fit=fit_params))
 
-        return self._fit(X, y, **routed_params.estimator.fit)
+        return self._fit(X, y, X_val, y_val, **routed_params.estimator.fit)
 
-    def _fit(self, X, y, step_score=None, **fit_params):
+    def _fit(self, X, y, X_val=None, y_val=None, step_score=None, **fit_params):
         # Parameter step_score controls the calculation of self.step_scores_
         # step_score is not exposed to users and is used when implementing RFECV
         # self.step_scores_ will not be calculated when calling _fit through fit
@@ -346,6 +346,8 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
             importances = _get_feature_importances(
                 estimator,
                 self.importance_getter,
+                X_val[:, features],
+                y_val,
                 transform_func="square",
             )
             ranks = np.argsort(importances)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #32201, alternative to #32251 (see https://github.com/scikit-learn/scikit-learn/pull/32251#discussion_r2394515480)

#### What does this implement/fix? Explain your changes.
Allows passing `X_val` and `y_val` to `RFE(CV).fit()` that can be used in the `importance_getter` to compute feature importance. This is useful for methods that need additional external data to produce reliable feature importance such as `permutation_importance`. 

#### Any other comments?
@jeremiedbb @ogrisel 
