### PR TITLE
MNT Use absolute import in _gradient_boosting.pyx

### DIFF
--- a/sklearn/ensemble/_gradient_boosting.pyx
+++ b/sklearn/ensemble/_gradient_boosting.pyx
@@ -7,12 +7,12 @@ from libc.string cimport memset
 import numpy as np
 from scipy.sparse import issparse
 
-from ..utils._typedefs cimport float32_t, float64_t, intp_t, int32_t, uint8_t
+from sklearn.utils._typedefs cimport float32_t, float64_t, intp_t, int32_t, uint8_t
 # Note: _tree uses cimport numpy, cnp.import_array, so we need to include
 # numpy headers in the build configuration of this extension
-from ..tree._tree cimport Node
-from ..tree._tree cimport Tree
-from ..tree._utils cimport safe_realloc
+from sklearn.tree._tree cimport Node
+from sklearn.tree._tree cimport Tree
+from sklearn.tree._utils cimport safe_realloc
 
 
 # no namespace lookup for numpy dtype and array creation


### PR DESCRIPTION
Reference Issues/PRs
Part of issue https://github.com/scikit-learn/scikit-learn/issues/32315

What does this implement/fix? Explain your changes.
modified relative to absolute import paths in sklearn/ensemble/_gradient_boosting.pyx

Any other comments?