### PR TITLE
MNT Switch to absolute imports in sklearn/feature_extraction/_hashing_fast.pyx

### DIFF
--- a/sklearn/feature_extraction/_hashing_fast.pyx
+++ b/sklearn/feature_extraction/_hashing_fast.pyx
@@ -6,9 +6,9 @@ from libcpp.vector cimport vector
 
 cimport numpy as cnp
 import numpy as np
-from ..utils._typedefs cimport int32_t, int64_t
-from ..utils.murmurhash cimport murmurhash3_bytes_s32
-from ..utils._vector_sentinel cimport vector_to_nd_array
+from sklearn.utils._typedefs cimport int32_t, int64_t
+from sklearn.utils.murmurhash cimport murmurhash3_bytes_s32
+from sklearn.utils._vector_sentinel cimport vector_to_nd_array
 
 cnp.import_array()
 


### PR DESCRIPTION
#### Reference Issues/PRs
Part of https://github.com/scikit-learn/scikit-learn/issues/32315


#### What does this implement/fix? Explain your changes.
This changes relative imports to absolute imports in sklearn/cluster/_dbscan_inner.pyx

#### Any other comments?
No
