### PR TITLE
MNT Switch to absolute import in _middle_term_computer.pxd.tp

### DIFF
--- a/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pxd.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pxd.tp
@@ -15,7 +15,7 @@ implementation_specific_values = [
 }}
 from libcpp.vector cimport vector
 
-from ...utils._typedefs cimport float64_t, float32_t, int32_t, intp_t
+from sklearn.utils._typedefs cimport float64_t, float32_t, int32_t, intp_t
 
 
 cdef void _middle_term_sparse_sparse_64(


### PR DESCRIPTION
Reference Issues/PRs
Part of https://github.com/scikit-learn/scikit-learn/issues/32315

What does this implement/fix? Explain your changes.
This changes relative imports to absolute imports in sklearn/metrics/_pairwise_distances_reduction/_middle_term_computer.pxd.tp

Any other comments?
No