### PR TITLE
DOC Fix decision boundary colouring in the `plot_svm_tie_breaking.py` example

### DIFF
--- a/examples/svm/plot_svm_tie_breaking.py
+++ b/examples/svm/plot_svm_tie_breaking.py
@@ -48,7 +48,7 @@ for break_ties, title, ax in zip((False, True), titles, sub.flatten()):
     classes = [(0, 1), (0, 2), (1, 2)]
     line = np.linspace(X[:, 1].min() - 5, X[:, 1].max() + 5)
     ax.imshow(
-        -pred.reshape(xx.shape),
+        pred.reshape(xx.shape),
         cmap="Accent",
         alpha=0.2,
         extent=(xlim[0], xlim[1], ylim[1], ylim[0]),


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #32352 

#### What does this implement/fix? Explain your changes.
The grey and green regions in the [<code>plot_svm_tie_breaking.py</code>](https://scikit-learn.org/stable/auto_examples/svm/plot_svm_tie_breaking.html) example were swapped due to an incorrect minus sign. See [#32352 (comment)](https://github.com/scikit-learn/scikit-learn/issues/32352#issuecomment-3367638680) for details.

#### Any other comments?
N/A