### PR TITLE
MNT Switch to absolute imports in sklearn\utils\arrayfuncs.pyx

### DIFF
--- a/sklearn/utils/arrayfuncs.pyx
+++ b/sklearn/utils/arrayfuncs.pyx
@@ -4,7 +4,7 @@ from cython cimport floating
 from libc.math cimport fabs
 from libc.float cimport DBL_MAX, FLT_MAX
 
-from ._cython_blas cimport _copy, _rotg, _rot
+from sklearn.utils._cython_blas cimport _copy, _rotg, _rot
 
 
 ctypedef fused real_numeric:


### PR DESCRIPTION
**Reference Issues/PRs**
Part of https://github.com/scikit-learn/scikit-learn/issues/32315

**What does this implement/fix? Explain your changes.**
This uses absolute imports in `sklearn/utils/arrayfuncs.pyx`
