### PR TITLE
MNT Switch to absolute imports in sklearn/cluster/_k_means_common.pyx

### DIFF
--- a/sklearn/cluster/_k_means_common.pyx
+++ b/sklearn/cluster/_k_means_common.pyx
@@ -6,7 +6,7 @@ from cython cimport floating
 from cython.parallel cimport prange
 from libc.math cimport sqrt
 
-from ..utils.extmath import row_norms
+from sklearn.utils.extmath import row_norms
 
 
 # Number of samples per data chunk defined as a global constant.


### PR DESCRIPTION
#### Reference Issues/PRs
Part of #32315

#### What does this implement/fix? Explain your changes.
This replaces a relative import with an absolute import in the file `sklearn/cluster/_k_means_common.pyx`.

