### PR TITLE
MNT Switch to absolute imports in sklearn/metrics/_pairwise_distances_reduction/_base.pyx.tp

### DIFF
--- a/sklearn/metrics/_pairwise_distances_reduction/_base.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_base.pyx.tp
@@ -8,13 +8,13 @@ from numbers import Integral
 import numpy as np
 from scipy.sparse import issparse
 
-from ...utils._cython_blas cimport _dot
-from ...utils._openmp_helpers cimport omp_get_thread_num
-from ...utils._typedefs cimport intp_t, float32_t, float64_t, int32_t
+from sklearn.utils._cython_blas cimport _dot
+from sklearn.utils._openmp_helpers cimport omp_get_thread_num
+from sklearn.utils._typedefs cimport intp_t, float32_t, float64_t, int32_t
 
-from ... import get_config
-from ...utils import check_scalar
-from ...utils._openmp_helpers import _openmp_effective_n_threads
+from sklearn import get_config
+from sklearn.utils import check_scalar
+from sklearn.utils._openmp_helpers import _openmp_effective_n_threads
 
 #####################
 


### PR DESCRIPTION
**Reference Issues/PRs**
Part of #32315

**What does this implement/fix? Explain your changes.**
This uses absolute imports in `sklearn/metrics/_pairwise_distances_reduction/_base.pyx.tp`