### PR TITLE
MNT Switch to absolute imports in sklearn/utils/_heap.pyx

### DIFF
--- a/sklearn/utils/_heap.pyx
+++ b/sklearn/utils/_heap.pyx
@@ -1,6 +1,6 @@
 from cython cimport floating
 
-from ._typedefs cimport intp_t
+from sklearn.utils._typedefs cimport intp_t
 
 
 cdef inline int heap_push(


### PR DESCRIPTION
### Reference Issues/PRs
Part of #32315.

### What does this implement/fix? Explain your changes.
This uses absolute imports in `sklearn/utils/_heap.pyx`

### Any other comments?
No