### PR TITLE
MNT Switch to absolute imports in sklearn/linear_model/_sgd_fast.pyx.tp

### DIFF
--- a/sklearn/linear_model/_sgd_fast.pyx.tp
+++ b/sklearn/linear_model/_sgd_fast.pyx.tp
@@ -28,7 +28,7 @@ from time import time
 from cython cimport floating
 from libc.math cimport exp, fabs, isfinite, log, pow, INFINITY
 
-from sklearn.linear_model._loss._loss cimport CyLossFunction
+from sklearn._loss._loss cimport CyLossFunction
 from sklearn.utils._typedefs cimport uint32_t, uint8_t
 from sklearn.utils._weight_vector cimport WeightVector32, WeightVector64
 from sklearn.utils._seq_dataset cimport SequentialDataset32, SequentialDataset64

--- a/sklearn/linear_model/_sgd_fast.pyx.tp
+++ b/sklearn/linear_model/_sgd_fast.pyx.tp
@@ -28,11 +28,10 @@ from time import time
 from cython cimport floating
 from libc.math cimport exp, fabs, isfinite, log, pow, INFINITY
 
-from .._loss._loss cimport CyLossFunction
-from ..utils._typedefs cimport uint32_t, uint8_t
-from ..utils._weight_vector cimport WeightVector32, WeightVector64
-from ..utils._seq_dataset cimport SequentialDataset32, SequentialDataset64
-
+from sklearn.linear_model._loss._loss cimport CyLossFunction
+from sklearn.utils._typedefs cimport uint32_t, uint8_t
+from sklearn.utils._weight_vector cimport WeightVector32, WeightVector64
+from sklearn.utils._seq_dataset cimport SequentialDataset32, SequentialDataset64
 
 cdef extern from *:
     """


### PR DESCRIPTION
Part of #32315

This PR converts relative imports to absolute imports in `sklearn/linear_model/_sgd_fast.pyx.tp`.

**Changes made:**
- `from .._loss._loss` → `from sklearn.linear_model._loss._loss`
- `from ..utils._typedefs` → `from sklearn.utils._typedefs`
- `from ..utils._weight_vector` → `from sklearn.utils._weight_vector`
- `from ..utils._seq_dataset` → `from sklearn.utils._seq_dataset`