### PR TITLE
tests: move test_conditional_attrs_not_in_dir to test_base (#32374)

### DIFF
--- a/doc/whats_new/upcoming_changes/custom-top-level/no_user_api_change_move_test_fragment-ansh13579.rst
+++ b/doc/whats_new/upcoming_changes/custom-top-level/no_user_api_change_move_test_fragment-ansh13579.rst
@@ -1,0 +1,1 @@
+Fixed: Test housekeeping — removed unused imports and fixed minor lint issues in tests. (no user-facing API changes)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -53,6 +53,27 @@ class K(BaseEstimator):
         self.d = d
 
 
+def test_conditional_attrs_not_in_dir():
+    # Tests that BaseEstimator.__dir__ filters conditional methods so that
+    # only relevant attributes are present in dir(). This covers the
+    # behavior enabled by the `available_if` decorator. Regression test
+    # for issue #28558.
+
+    from sklearn.preprocessing import LabelEncoder
+
+    encoder = LabelEncoder()
+    assert "set_output" not in dir(encoder)
+
+    scalar = StandardScaler()
+    assert "set_output" in dir(scalar)
+
+    svc = SVC(probability=False)
+    assert "predict_proba" not in dir(svc)
+
+    svc.probability = True
+    assert "predict_proba" in dir(svc)
+
+
 class T(BaseEstimator):
     def __init__(self, a=None, b=None):
         self.a = a

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -29,7 +29,6 @@ from sklearn.multiclass import (
 from sklearn.naive_bayes import MultinomialNB
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.pipeline import Pipeline, make_pipeline
-from sklearn.preprocessing import LabelEncoder, StandardScaler
 from sklearn.svm import SVC, LinearSVC
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.utils import (
@@ -83,10 +82,7 @@ def test_check_classification_targets():
         check_classification_targets(y)
 
 
-def test_conditional_attrs_not_in_dir():
-    # NOTE: test moved to `sklearn/tests/test_base.py` since it checks
-    # BaseEstimator.__dir__ behavior. See gh-28558.
-    pytest.skip("test moved to test_base.py")
+
 
 
 def test_ovr_ties():

--- a/sklearn/tests/test_multiclass.py
+++ b/sklearn/tests/test_multiclass.py
@@ -84,19 +84,9 @@ def test_check_classification_targets():
 
 
 def test_conditional_attrs_not_in_dir():
-    # Test that __dir__ includes only relevant attributes. #28558
-
-    encoder = LabelEncoder()
-    assert "set_output" not in dir(encoder)
-
-    scalar = StandardScaler()
-    assert "set_output" in dir(scalar)
-
-    svc = SVC(probability=False)
-    assert "predict_proba" not in dir(svc)
-
-    svc.probability = True
-    assert "predict_proba" in dir(svc)
+    # NOTE: test moved to `sklearn/tests/test_base.py` since it checks
+    # BaseEstimator.__dir__ behavior. See gh-28558.
+    pytest.skip("test moved to test_base.py")
 
 
 def test_ovr_ties():


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Fixes #32374.
See also PR #31928 (root cause: test was added in the wrong module).
-->


#### What does this implement/fix? Explain your changes.
Move the location of function  test_conditional_attrs_not_in_dir from sklearn/tests/test_multiclass.py to sklearn/tests/test_base.py

