### PR TITLE
MNT Use absolute import in sklearn/cluster/_hierarchical_fast.pxd

### DIFF
--- a/sklearn/cluster/_hierarchical_fast.pxd
+++ b/sklearn/cluster/_hierarchical_fast.pxd
@@ -1,4 +1,4 @@
-from ..utils._typedefs cimport intp_t
+from sklearn.utils._typedefs cimport intp_t
 
 cdef class UnionFind:
     cdef intp_t next_label


### PR DESCRIPTION
Reference Issues/PRs
Part of issue [#32315](https://github.com/scikit-learn/scikit-learn/issues/32315)

modified relative to absolute import paths in sklearn/cluster/_hierarchical_fast.pxd