### PR TITLE
MNT Switch to absolute imports in sklearn/manifold/_utils.pyx

### DIFF
--- a/sklearn/manifold/_utils.pyx
+++ b/sklearn/manifold/_utils.pyx
@@ -3,7 +3,7 @@ import numpy as np
 from libc cimport math
 from libc.math cimport INFINITY
 
-from ..utils._typedefs cimport float32_t, float64_t
+from sklearn.utils._typedefs cimport float32_t, float64_t
 
 
 cdef float EPSILON_DBL = 1e-8


### PR DESCRIPTION
Reference Issues/PRs
Part of https://github.com/scikit-learn/scikit-learn/issues/32315.

What does this implement/fix? Explain your changes.
This uses absolute imports in sklearn/manifold/_utils.pyx

Any other comments?
No