### PR TITLE
MNT Switch to absolute imports in sklearn/manifold/_barnes_hut_tsne.pyx

### DIFF
--- a/sklearn/manifold/_barnes_hut_tsne.pyx
+++ b/sklearn/manifold/_barnes_hut_tsne.pyx
@@ -13,7 +13,7 @@ from libc.stdlib cimport malloc, free
 from libc.time cimport clock, clock_t
 from cython.parallel cimport prange, parallel
 
-from ..neighbors._quad_tree cimport _QuadTree
+from sklearn.neighbors._quad_tree cimport _QuadTree
 
 cnp.import_array()
 


### PR DESCRIPTION
Reference Issues/PRs
Part of https://github.com/scikit-learn/scikit-learn/issues/32315.

What does this implement/fix? Explain your changes.
This uses absolute imports in sklearn/manifold/_barnes_hut_tsne.pyx

Any other comments?
No