### PR TITLE
MNT Use absolute imports in sklearn/svm/_libsvm.pyx

### DIFF
--- a/sklearn/svm/_libsvm.pyx
+++ b/sklearn/svm/_libsvm.pyx
@@ -29,8 +29,8 @@ Authors
 
 import  numpy as np
 from libc.stdlib cimport free
-from ..utils._cython_blas cimport _dot
-from ..utils._typedefs cimport float64_t, int32_t, intp_t
+from sklearn.utils._cython_blas cimport _dot
+from sklearn.utils._typedefs cimport float64_t, int32_t, intp_t
 
 include "_libsvm.pxi"
 


### PR DESCRIPTION
#### Reference Issues/PRs
Part of #32315

***
#### What does this implement/fix? Explain your changes.
This pull request updates `sklearn/svm/_libsvm.pyx` to use absolute imports instead of relative ones.

Specifically, it changes the imports from `..utils` to the full `sklearn.utils` path, aligning with the code standardization goal outlined in the main issue.

***
#### Any other comments?
This is my first contribution to scikit-learn. Please let me know if any changes are needed!