### PR TITLE
MNT Use absolute imports in sklearn/cluster Cython files

### DIFF
--- a/sklearn/cluster/_k_means_elkan.pyx
+++ b/sklearn/cluster/_k_means_elkan.pyx
@@ -6,19 +6,19 @@ from cython.parallel import prange, parallel
 from libc.stdlib cimport calloc, free
 from libc.string cimport memset
 
-from ..utils._openmp_helpers cimport omp_lock_t
-from ..utils._openmp_helpers cimport omp_init_lock
-from ..utils._openmp_helpers cimport omp_destroy_lock
-from ..utils._openmp_helpers cimport omp_set_lock
-from ..utils._openmp_helpers cimport omp_unset_lock
-from ..utils.extmath import row_norms
-from ._k_means_common import CHUNK_SIZE
-from ._k_means_common cimport _relocate_empty_clusters_dense
-from ._k_means_common cimport _relocate_empty_clusters_sparse
-from ._k_means_common cimport _euclidean_dense_dense
-from ._k_means_common cimport _euclidean_sparse_dense
-from ._k_means_common cimport _average_centers
-from ._k_means_common cimport _center_shift
+from sklearn.utils._openmp_helpers cimport omp_lock_t
+from sklearn.utils._openmp_helpers cimport omp_init_lock
+from sklearn.utils._openmp_helpers cimport omp_destroy_lock
+from sklearn.utils._openmp_helpers cimport omp_set_lock
+from sklearn.utils._openmp_helpers cimport omp_unset_lock
+from sklearn.utils.extmath import row_norms
+from sklearn.cluster._k_means_common import CHUNK_SIZE
+from sklearn.cluster._k_means_common cimport _relocate_empty_clusters_dense
+from sklearn.cluster._k_means_common cimport _relocate_empty_clusters_sparse
+from sklearn.cluster._k_means_common cimport _euclidean_dense_dense
+from sklearn.cluster._k_means_common cimport _euclidean_sparse_dense
+from sklearn.cluster._k_means_common cimport _average_centers
+from sklearn.cluster._k_means_common cimport _center_shift
 
 
 def init_bounds_dense(

--- a/sklearn/cluster/_k_means_lloyd.pyx
+++ b/sklearn/cluster/_k_means_lloyd.pyx
@@ -6,18 +6,18 @@ from libc.stdlib cimport malloc, calloc, free
 from libc.string cimport memset
 from libc.float cimport DBL_MAX, FLT_MAX
 
-from ..utils._openmp_helpers cimport omp_lock_t
-from ..utils._openmp_helpers cimport omp_init_lock
-from ..utils._openmp_helpers cimport omp_destroy_lock
-from ..utils._openmp_helpers cimport omp_set_lock
-from ..utils._openmp_helpers cimport omp_unset_lock
-from ..utils.extmath import row_norms
-from ..utils._cython_blas cimport _gemm
-from ..utils._cython_blas cimport RowMajor, Trans, NoTrans
-from ._k_means_common import CHUNK_SIZE
-from ._k_means_common cimport _relocate_empty_clusters_dense
-from ._k_means_common cimport _relocate_empty_clusters_sparse
-from ._k_means_common cimport _average_centers, _center_shift
+from sklearn.utils._openmp_helpers cimport omp_lock_t
+from sklearn.utils._openmp_helpers cimport omp_init_lock
+from sklearn.utils._openmp_helpers cimport omp_destroy_lock
+from sklearn.utils._openmp_helpers cimport omp_set_lock
+from sklearn.utils._openmp_helpers cimport omp_unset_lock
+from sklearn.utils.extmath import row_norms
+from sklearn.utils._cython_blas cimport _gemm
+from sklearn.utils._cython_blas cimport RowMajor, Trans, NoTrans
+from sklearn.cluster._k_means_common import CHUNK_SIZE
+from sklearn.cluster._k_means_common cimport _relocate_empty_clusters_dense
+from sklearn.cluster._k_means_common cimport _relocate_empty_clusters_sparse
+from sklearn.cluster._k_means_common cimport _average_centers, _center_shift
 
 
 def lloyd_iter_chunked_dense(


### PR DESCRIPTION
#### Reference Issues/PRs
Part of #32315

***
#### What does this implement/fix? Explain your changes.
This pull request updates `sklearn/cluster/_k_means_elkan.pyx` and `sklearn/cluster/_k_means_lloyd.pyx` to use absolute imports instead of relative ones.

Specifically, it changes the imports from `..utils` to the full `sklearn.utils` path, aligning with the code standardization goal outlined in the main issue.