### PR TITLE
MNT Use absolute import in _random.pxd

### DIFF
--- a/sklearn/utils/_random.pxd
+++ b/sklearn/utils/_random.pxd
@@ -1,7 +1,7 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
-from ._typedefs cimport uint32_t
+from sklearn.utils._typedefs cimport uint32_t
 
 
 cdef inline uint32_t DEFAULT_SEED = 1


### PR DESCRIPTION
Reference Issues/PRs
Part of issue https://github.com/scikit-learn/scikit-learn/issues/32315

modified relative to absolute import paths in sklearn/utils/_random.pxd