### PR TITLE
MNT Use absolute imports in sklearn/metrics/cluster/_expected_mutual_info_fast.pyx

### DIFF
--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -3,7 +3,7 @@
 
 from libc.math cimport exp, lgamma
 
-from ...utils._typedefs cimport float64_t, int64_t
+from sklearn.utils._typedefs cimport float64_t, int64_t
 
 import numpy as np
 from scipy.special import gammaln

--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -3,7 +3,7 @@
 
 from libc.math cimport exp, lgamma
 
-from ...utils._typedefs cimport float64_t, int64_t
+from sklearn.utils.utils._typedefs cimport float64_t, int64_t
 
 import numpy as np
 from scipy.special import gammaln

--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -3,7 +3,7 @@
 
 from libc.math cimport exp, lgamma
 
-from sklearn.utils.utils._typedefs cimport float64_t, int64_t
+from ...utils._typedefs cimport float64_t, int64_t
 
 import numpy as np
 from scipy.special import gammaln


### PR DESCRIPTION
#### Reference Issues/PRs
Part of #32315

***
#### What does this implement/fix? Explain your changes.
This pull request updates `sklearn/metrics/cluster/_expected_mutual_info_fast.pyx` to use absolute imports instead of relative ones.

Specifically, it changes the imports from `..utils` to the full `sklearn.utils` path, aligning with the code standardization goal outlined in the main issue.
