### PR TITLE
MNT Use absolute imports in sklearn/metrics/_dist_metrics.pxd.tp

### DIFF
--- a/sklearn/metrics/_dist_metrics.pxd.tp
+++ b/sklearn/metrics/_dist_metrics.pxd.tp
@@ -11,7 +11,7 @@ implementation_specific_values = [
 }}
 from libc.math cimport sqrt, exp
 
-from ..utils._typedefs cimport float64_t, float32_t, int32_t, intp_t
+from sklearn.utils._typedefs cimport float64_t, float32_t, int32_t, intp_t
 
 cdef class DistanceMetric:
     pass

--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -3,7 +3,7 @@
 
 from libc.math cimport exp, lgamma
 
-from ...utils._typedefs cimport float64_t, int64_t
+from sklearn.utils.utils._typedefs cimport float64_t, int64_t
 
 import numpy as np
 from scipy.special import gammaln

--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -3,7 +3,7 @@
 
 from libc.math cimport exp, lgamma
 
-from sklearn.utils.utils._typedefs cimport float64_t, int64_t
+from ...utils._typedefs cimport float64_t, int64_t
 
 import numpy as np
 from scipy.special import gammaln


### PR DESCRIPTION
#### Reference Issues/PRs
Part of #32315

***
#### What does this implement/fix? Explain your changes.
This pull request updates `klearn/metrics/_dist_metrics.pxd.tp` to use absolute imports instead of relative ones.

Specifically, it changes the imports from `..utils` to the full `sklearn.utils` path, aligning with the code standardization goal outlined in the main issue.
