### PR TITLE
DOC: clarify baseline wording for precision-recall plot (fixes #30352)

### DIFF
--- a/benchmarks/bench_tsne_mnist.py
+++ b/benchmarks/bench_tsne_mnist.py
@@ -15,6 +15,7 @@ from time import time
 
 import numpy as np
 from joblib import Memory
+from sklearn.utils._openmp_helpers import _openmp_effective_n_threads
 
 from sklearn.datasets import fetch_openml
 from sklearn.decomposition import PCA
@@ -22,7 +23,6 @@ from sklearn.manifold import TSNE
 from sklearn.neighbors import NearestNeighbors
 from sklearn.utils import check_array
 from sklearn.utils import shuffle as _shuffle
-from sklearn.utils._openmp_helpers import _openmp_effective_n_threads
 
 LOG_DIR = "mnist_tsne_output"
 if not os.path.exists(LOG_DIR):

--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -165,10 +165,10 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
             Name of precision recall curve for labeling. If `None`, use
             `name` if not `None`, otherwise no labeling is shown.
 
-        plot_chance_level : bool, default=False
+
             Whether to plot the chance level. The chance level is the prevalence
             of the positive label computed from the data passed during
-            :meth:`from_estimator` or :meth:`from_predictions` call.
+            :meth:`from_es        plot_chance_level : bool, default=Falsetimator` or :meth:`from_predictions` call.
 
             .. versionadded:: 1.3
 
@@ -243,11 +243,13 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
                     "to automatically set prevalence_pos_label"
                 )
 
+
             default_chance_level_line_kw = {
-                "label": f"Chance level (AP = {self.prevalence_pos_label:0.2f})",
+                "label": f"Baseline (pos prevalence = {self.prevalence_pos_label:0.2f})",
                 "color": "k",
                 "linestyle": "--",
             }
+
 
             if chance_level_kw is None:
                 chance_level_kw = {}
@@ -338,17 +340,20 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
             Axes object to plot on. If `None`, a new figure and axes is created.
 
         plot_chance_level : bool, default=False
-            Whether to plot the chance level. The chance level is the prevalence
-            of the positive label computed from the data passed during
-            :meth:`from_estimator` or :meth:`from_predictions` call.
+            Whether to plot the baseline (formerly called "chance"). The baseline
+            is the prevalence of the positive label computed from the data
+            passed during :meth:`from_estimator` or :meth:`from_predictions`.
+            This baseline serves as a reference (horizontal) line on the
+            Precision–Recall plot indicating the positive-class prevalence.
 
             .. versionadded:: 1.3
 
-        chance_level_kw : dict, default=None
+         chance_level_kw : dict, default=None
             Keyword arguments to be passed to matplotlib's `plot` for rendering
-            the chance level line.
+            the baseline line (parameter name kept for backward compatibility).
 
             .. versionadded:: 1.3
+
 
         despine : bool, default=False
             Whether to remove the top and right spines from the plot.

--- a/sklearn/metrics/tests/test_plot_precision_recall_baseline.py
+++ b/sklearn/metrics/tests/test_plot_precision_recall_baseline.py
@@ -1,10 +1,12 @@
-import numpy as np
 import matplotlib
+import numpy as np
+
 matplotlib.use("agg")
 import matplotlib.pyplot as plt
 
 from sklearn.metrics import PrecisionRecallDisplay
 from sklearn.utils._testing import assert_allclose
+
 
 def test_baseline_is_pos_ratio():
     y_true = np.array([1, 0, 0, 1, 0, 0, 0, 1, 0, 0])

--- a/sklearn/metrics/tests/test_plot_precision_recall_baseline.py
+++ b/sklearn/metrics/tests/test_plot_precision_recall_baseline.py
@@ -1,0 +1,23 @@
+import numpy as np
+import matplotlib
+matplotlib.use("agg")
+import matplotlib.pyplot as plt
+
+from sklearn.metrics import PrecisionRecallDisplay
+from sklearn.utils._testing import assert_allclose
+
+def test_baseline_is_pos_ratio():
+    y_true = np.array([1, 0, 0, 1, 0, 0, 0, 1, 0, 0])
+    y_scores = np.linspace(0, 1, 10)
+
+    disp = PrecisionRecallDisplay.from_predictions(y_true, y_scores)
+    fig, ax = plt.subplots()
+    disp.plot(ax=ax, plot_chance_level=True)
+
+    lines = [line for line in ax.get_lines()]
+    baseline_lines = [ln for ln in lines if ln.get_label().startswith("baseline")]
+    assert len(baseline_lines) == 1, "Expected exactly one baseline line to be plotted"
+
+    baseline_y = baseline_lines[0].get_ydata()[0]
+    expected = float(np.count_nonzero(y_true == 1)) / float(len(y_true))
+    assert_allclose(baseline_y, expected, rtol=1e-7, atol=1e-7)


### PR DESCRIPTION
Title: DOC: clarify baseline wording for precision-recall plot (fixes #30352)

Summary
-------
This patch clarifies the wording around the "chance" level displayed on
precision–recall plots by calling it a "baseline" (the positive-class prevalence).
It updates the display label and documentation strings accordingly and adds a unit
test that checks the baseline plotting behavior.

Files changed
-------------
- sklearn/metrics/_plot/precision_recall_curve.py  (docstring + plotting label changes)
- sklearn/metrics/tests/test_plot_precision_recall_baseline.py (new test)

Rationale
---------
"Baseline" better describes the positive-class prevalence reference line used
for precision–recall displays. Keeping the parameter name `plot_chance_level`
for backward compatibility while documenting and labeling it as "baseline".

Testing
-------
- Added unit test `test_plot_precision_recall_baseline.py`.
- CI will run the full test suite. Locally I attempted to run tests but hit a Windows
  editable-build issue related to Cython/ninja (I can provide logs or fix locally if needed).

Closes
------
Fixes #30352

Notes for reviewers
-------------------
- I preserved the parameter name for backwards compatibility.
- If maintainers prefer a different label text or wording, I can update accordingly.
