### PR TITLE
MNT Switch to absolute imports in sklearn/tree/_tree.pyx

### DIFF
--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -23,8 +23,8 @@ cnp.import_array()
 from scipy.sparse import issparse
 from scipy.sparse import csr_matrix
 
-from ._utils cimport safe_realloc
-from ._utils cimport sizet_ptr_to_ndarray
+from sklearn.tree._utils cimport safe_realloc
+from sklearn.tree._utils cimport sizet_ptr_to_ndarray
 
 cdef extern from "numpy/arrayobject.h":
     object PyArray_NewFromDescr(PyTypeObject* subtype, cnp.dtype descr,


### PR DESCRIPTION
#### Reference Issues/PRs
Part of #32315

#### What does this implement/fix? Explain your changes.
This uses absolute imports in `sklearn/tree/_tree.pyx`

#### Any other comments?
No.
