### PR TITLE
Align docstring of is_classifier and is_clusterer

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1181,7 +1181,7 @@ def is_classifier(estimator):
 
     Parameters
     ----------
-    estimator : object
+    estimator : estimator instance
         Estimator object to test.
 
     Returns
@@ -1245,7 +1245,7 @@ def is_clusterer(estimator):
 
     Parameters
     ----------
-    estimator : object
+    estimator : estimator instance
         Estimator object to test.
 
     Returns


### PR DESCRIPTION
Since PRs #30122 and #31344, these functions only accept estimators (as opposed to arbitrary objects). This PR aligns their docstring with `is_regressor` and `is_outlier_detector`. Cf. #32394. @jeremiedbb 