### PR TITLE
CI Revert pytest verbose and skipped summary

### DIFF
--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -42,7 +42,7 @@ show_installed_libraries
 show_cpu_info
 
 NUM_CORES=$(python -c "import joblib; print(joblib.cpu_count())")
-TEST_CMD="python -m pytest --showlocals --durations=20 --junitxml=$JUNITXML -o junit_family=legacy -rs -v"
+TEST_CMD="python -m pytest --showlocals --durations=20 --junitxml=$JUNITXML -o junit_family=legacy"
 
 if [[ "$COVERAGE" == "true" ]]; then
     # Note: --cov-report= is used to disable too long text output report in the


### PR DESCRIPTION
Follow-up of https://github.com/scikit-learn/scikit-learn/pull/32349#issuecomment-3376715453. `pytest -v` was supposed to be a temporary thing to make sure that the `mps` tests were run. With it the pytest output is way too verbose.

`pytest -rs` adds ~450 lines of skipped tests, I would say too much noise for what it is worth ...

cc @OmarManzoor 