### PR TITLE
BLD Improve dependency tracking in Cython meson generator

### DIFF
--- a/sklearn/meson.build
+++ b/sklearn/meson.build
@@ -182,6 +182,7 @@ cython_args = []
 cython_program = find_program(cython.cmd_array()[0])
 
 scikit_learn_cython_args = [
+  '--depfile',
   '-X language_level=3', '-X boundscheck=' + boundscheck, '-X wraparound=False',
   '-X initializedcheck=False', '-X nonecheck=False', '-X cdivision=True',
   '-X profile=False',
@@ -215,11 +216,13 @@ endif
 cython_gen = generator(cython_program,
   arguments : cython_args + ['@INPUT@', '--output-file', '@OUTPUT@'],
   output : '@BASENAME@.c',
+  depfile: '@BASENAME@.c.dep',
 )
 
 cython_gen_cpp = generator(cython_program,
   arguments : cython_args + ['--cplus', '@INPUT@', '--output-file', '@OUTPUT@'],
   output : '@BASENAME@.cpp',
+  depfile: '@BASENAME@.cpp.dep'
 )
 
 extensions = ['_isotonic']


### PR DESCRIPTION
Fix https://github.com/scikit-learn/scikit-learn/issues/32414.

I am not going to claim that I completely understanding what is going on but this seems to definitely improve the current situation ...

`cython --depfile` create a `.dep` file that lists the dependency of the generated `.c` files on `.pxd` files. Providing this `.dep` files to meson allows better dependency tracking.

Here is how it works on a simple example:
```bash
touch sklearn/tree/_partitioner.pxd
# tee is to expand all the steps otherwise you only see the 6/6 step ...
python -c "import sklearn" | tee /dev/null
```

```
meson-python: building scikit-learn: /home/lesteve/micromamba/envs/scikit-learn-dev/bin/ninja
[1/6] Generating 'sklearn/tree/_partitioner.cpython-313-x86_64-linux-gnu.so.p/_partitioner.c'
[2/6] Compiling C object sklearn/tree/_partitioner.cpython-313-x86_64-linux-gnu.so.p/meson-generated__partitioner.c.o
[3/6] Generating 'sklearn/tree/_splitter.cpython-313-x86_64-linux-gnu.so.p/_splitter.c'
[4/6] Compiling C object sklearn/tree/_splitter.cpython-313-x86_64-linux-gnu.so.p/meson-generated__splitter.c.o
[5/6] Linking target sklearn/tree/_partitioner.cpython-313-x86_64-linux-gnu.so
[6/6] Linking target sklearn/tree/_splitter.cpython-313-x86_64-linux-gnu.so
```

The files that are rebuilt make sense based on this `git grep`:
```
❯ git grep _partitioner                       
sklearn/tree/_partitioner.pxd:# See _partitioner.pyx for details.
sklearn/tree/_splitter.pyx:from sklearn.tree._partitioner cimport (
sklearn/tree/meson.build:  '_partitioner':
sklearn/tree/meson.build:    {'sources': [cython_gen.process('_partitioner.pyx')],
sklearn/tree/tests/test_tree.py:from sklearn.tree._partitioner import _py_sort
sklearn/tree/tests/test_tree.py:    # FEATURE_TRESHOLD=1e-7 is defined in sklearn/tree/_partitioner.pxd but not
```
