### PR TITLE
MNT Switch to absolute imports in sklearn/utils/_fast_dict.pxd

### DIFF
--- a/sklearn/utils/_fast_dict.pxd
+++ b/sklearn/utils/_fast_dict.pxd
@@ -8,7 +8,7 @@ integers, and values float.
 
 from libcpp.map cimport map as cpp_map
 
-from ._typedefs cimport float64_t, intp_t
+from sklearn.utils._typedefs cimport float64_t, intp_t
 
 
 ###############################################################################


### PR DESCRIPTION

This PR converts relative imports to absolute imports in sklearn/utils/_fast_dict.pxd

**Change made:**
- Line 11 : Changed `from ._typedefs cimport float64_t, intp_t` to `from sklearn.utils._typedefs cimport float64_t, intp_t`

Part of #32315