### PR TITLE
MNT Switch to absolute imports in sklearn/preprocessing/_csr_polynomial_expansion.pyx

### DIFF
--- a/sklearn/preprocessing/_csr_polynomial_expansion.pyx
+++ b/sklearn/preprocessing/_csr_polynomial_expansion.pyx
@@ -1,7 +1,7 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
-from ..utils._typedefs cimport uint8_t, int64_t, intp_t
+from sklearn.utils._typedefs cimport uint8_t, int64_t, intp_t
 
 ctypedef uint8_t FLAG_t
 


### PR DESCRIPTION
This PR converts relative imports to absolute imports in sklearn/preprocessing/_csr_polynomial_expansion.pyx

Change made:

* Line 4 : Changed from `from ..utils._typedefs cimport uint8_t, int64_t, intp_t` to `from sklearn.utils._typedefs cimport uint8_t, int64_t, intp_t`

Part of #32315