### PR TITLE
MNT Switch to absolute imports in sklearn/preprocessing/_target_encoder_fast.pyx

### DIFF
--- a/sklearn/preprocessing/_target_encoder_fast.pyx
+++ b/sklearn/preprocessing/_target_encoder_fast.pyx
@@ -1,7 +1,7 @@
 from libc.math cimport isnan
 from libcpp.vector cimport vector
 
-from ..utils._typedefs cimport float32_t, float64_t, int32_t, int64_t
+from sklearn.utils._typedefs cimport float32_t, float64_t, int32_t, int64_t
 
 import numpy as np
 


### PR DESCRIPTION
This PR converts relative imports to absolute imports in sklearn/preprocessing/_target_encoder_fast.pyx

Change made:

* Line 4 : Changed from `from ..utils._typedefs cimport float32_t, float64_t, int32_t, int64_t` to `from sklearn.utils._typedefs cimport float32_t, float64_t, int32_t, int64_t`

Part of #32315