### PR TITLE
DOC Update the upper bounds policy in the making a release docs

### DIFF
--- a/doc/developers/maintainer.rst.template
+++ b/doc/developers/maintainer.rst.template
@@ -121,9 +121,7 @@ Reference Steps
         * [ ] Update the sklearn dev0 version in main branch
         {%- endif %}
         * [ ] Set the version number in the release branch
-        {%- if key == "rc" %}
         * [ ] Set an upper bound on build dependencies in the release branch
-        {%- endif %}
         * [ ] Generate the changelog in the release branch
         * [ ] Check that the wheels for the release can be built successfully
         * [ ] Merge the PR with `[cd build]` commit message to upload wheels to the staging repo
@@ -165,7 +163,6 @@ Reference Steps
     - In the release branch, change the version number `__version__` in
       `sklearn/__init__.py` to `{{ version_full }}`.
 
-    {% if key == "rc" %}
     - Still in the release branch, set or update the upper bound on the build
       dependencies in the `[build-system]` section of `pyproject.toml`. The goal is to
       prevent future backward incompatible releases of the dependencies to break the
@@ -174,7 +171,6 @@ Reference Steps
       The upper bounds should match the latest already-released minor versions of the
       dependencies and should allow future micro (bug-fix) versions. For instance, if
       numpy 2.2.5 is the most recent version, its upper bound should be set to <2.3.0.
-    {% endif %}
 
     - In the release branch, generate the changelog for the incoming version, i.e.,
       `doc/whats_new/{{ version_short }}.rst`.


### PR DESCRIPTION
Updates the policy about the upper bounds on dependencies in the maintenance branch. Initially I wrote it like it should only be done for the RC and not modified until the next major release. But it's sometimes necessary to do it at bug-fix release time because it happens that we include wheels for new configurations of plateform/python version in such releases (see https://github.com/scikit-learn/scikit-learn/pull/32092#issuecomment-3249901609). It's also a good thing for the ecosystem to not impose too strict constraints for too long, making the SAT problem easier :) (see https://github.com/scikit-learn/scikit-learn/pull/32092#issuecomment-3252547278).