### PR TITLE
MNT Switch to absolute imports in sklearn/metrics/_pairwise_distances_reduction/_argkmin_classmode.pyx.tp

### DIFF
--- a/sklearn/metrics/_pairwise_distances_reduction/_argkmin_classmode.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_argkmin_classmode.pyx.tp
@@ -3,16 +3,16 @@ from cython.parallel cimport parallel, prange
 from libcpp.map cimport map as cpp_map, pair as cpp_pair
 from libc.stdlib cimport free
 
-from ...utils._typedefs cimport intp_t, float64_t
-from ...utils.parallel import _get_threadpool_controller
+from sklearn.utils._typedefs cimport intp_t, float64_t
+from sklearn.utils.parallel import _get_threadpool_controller
 
 import numpy as np
 from scipy.sparse import issparse
-from ._classmode cimport WeightingStrategy
+from sklearn.metrics._pairwise_distances_reduction._classmode cimport WeightingStrategy
 
 {{for name_suffix in ["32", "64"]}}
-from ._argkmin cimport ArgKmin{{name_suffix}}
-from ._datasets_pair cimport DatasetsPair{{name_suffix}}
+from sklearn.metrics._pairwise_distances_reduction._argkmin cimport ArgKmin{{name_suffix}}
+from sklearn.metrics._pairwise_distances_reduction._datasets_pair cimport DatasetsPair{{name_suffix}}
 
 cdef class ArgKminClassMode{{name_suffix}}(ArgKmin{{name_suffix}}):
     """


### PR DESCRIPTION
This PR converts relative imports to absolute imports in sklearn/preprocessing/_csr_polynomial_expansion.pyx

Change made:

- Changed ...utils to absolute imports
- Changed . imports to absolute imports

Part of https://github.com/scikit-learn/scikit-learn/issues/32315

https://github.com/scikit-learn/scikit-learn/issues/32315#issuecomment-3381751205