### PR TITLE
MNT Switch to absolute imports in sklearn/svm/_libsvm_sparse.pyx

### DIFF
--- a/sklearn/svm/_libsvm_sparse.pyx
+++ b/sklearn/svm/_libsvm_sparse.pyx
@@ -1,7 +1,7 @@
 import  numpy as np
 from scipy import sparse
-from ..utils._cython_blas cimport _dot
-from ..utils._typedefs cimport float64_t, int32_t, intp_t
+from sklearn.utils._cython_blas cimport _dot
+from sklearn.utils._typedefs cimport float64_t, int32_t, intp_t
 
 cdef extern from *:
     ctypedef char* const_char_p "const char*"


### PR DESCRIPTION
#### Reference Issues/PRs
Part of #32315

#### What does this implement/fix? Explain your changes.
This replaces relative imports with absolute imports in the file sklearn/svm/_libsvm_sparse.pyx.

