### PR TITLE
MNT Switch to absolute imports in sklearn/tree/_criterion.pxd

### DIFF
--- a/sklearn/tree/_criterion.pxd
+++ b/sklearn/tree/_criterion.pxd
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 # See _criterion.pyx for implementation details.
-from ..utils._typedefs cimport float64_t, int8_t, intp_t
+from sklearn.utils._typedefs cimport float64_t, int8_t, intp_t
 
 
 cdef class Criterion:


### PR DESCRIPTION
#### Reference Issues/PRs
Part of #32315

#### What does this implement/fix? Explain your changes.
This replaces relative imports with absolute imports in the file sklearn/tree/_criterion.pxd.
