### PR TITLE
MNT Switch to absolute imports in sklearn/metrics/_pairwise_distances_reduction/_argkmin.pxd.tp

### DIFF
--- a/sklearn/metrics/_pairwise_distances_reduction/_argkmin.pxd.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_argkmin.pxd.tp
@@ -1,9 +1,9 @@
-from ...utils._typedefs cimport intp_t, float64_t
+from sklearn.utils._typedefs cimport intp_t, float64_t
 
 {{for name_suffix in ['64', '32']}}
 
-from ._base cimport BaseDistancesReduction{{name_suffix}}
-from ._middle_term_computer cimport MiddleTermComputer{{name_suffix}}
+from sklearn.metrics._pairwise_distances_reduction._base cimport BaseDistancesReduction{{name_suffix}}
+from sklearn.metrics._pairwise_distances_reduction._middle_term_computer cimport MiddleTermComputer{{name_suffix}}
 
 cdef class ArgKmin{{name_suffix}}(BaseDistancesReduction{{name_suffix}}):
     """float{{name_suffix}} implementation of the ArgKmin."""


### PR DESCRIPTION
#### Reference Issues/PRs
Part of #32315.

#### What does this implement/fix?
This uses absolute imports in `sklearn/metrics/_pairwise_distances_reduction/_argkmin.pxd.tp`

#### Any other comments?
No