### PR TITLE
FIX Validate_data instead of checks

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.compose/32441.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.compose/32441.fix.rst
@@ -1,0 +1,6 @@
+- Internal validation logic across several modules has been updated to use
+  :func:`~sklearn.utils.validation.validate_data` instead of the internal
+  `_check_n_features` and `_check_feature_names` functions when both were used
+  together. This improves consistency with the common estimator validation API.
+  :pr:`<your-PR-number>` by :user:`Microcosmos22`.
+- Made the :func: `check_n_features` and `check_feature_names` public across the project.

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -44,14 +44,14 @@ from sklearn.utils.metadata_routing import (
 from sklearn.utils.metaestimators import _BaseComposition
 from sklearn.utils.parallel import Parallel, delayed
 from sklearn.utils.validation import (
-    _check_feature_names,
     _check_feature_names_in,
-    _check_n_features,
     _get_feature_names,
     _is_pandas_df,
     _num_samples,
     check_array,
     check_is_fitted,
+    check_n_features,
+    validate_data,
 )
 
 __all__ = ["ColumnTransformer", "make_column_selector", "make_column_transformer"]
@@ -973,7 +973,6 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             sparse matrices.
         """
         _raise_for_params(params, self, "fit_transform")
-        _check_feature_names(self, X, reset=True)
 
         if self.force_int_remainder_cols != "deprecated":
             warnings.warn(
@@ -983,9 +982,10 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
                 FutureWarning,
             )
 
+        validate_data(self, X=X, skip_check_array=True)
         X = _check_X(X)
         # set n_features_in_ attribute
-        _check_n_features(self, X, reset=True)
+
         self._validate_transformers()
         n_samples = _num_samples(X)
 
@@ -1090,7 +1090,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         else:
             # ndarray was used for fitting or transforming, thus we only
             # check that n_features_in_ is consistent
-            _check_n_features(self, X, reset=False)
+            check_n_features(self, X, reset=False)
 
         if _routing_enabled():
             routed_params = process_routing(self, "transform", **params)

--- a/sklearn/feature_selection/_from_model.py
+++ b/sklearn/feature_selection/_from_model.py
@@ -19,8 +19,8 @@ from sklearn.utils.metadata_routing import (
 )
 from sklearn.utils.metaestimators import available_if
 from sklearn.utils.validation import (
-    _check_feature_names,
     _estimator_has,
+    check_feature_names,
     check_is_fitted,
     check_scalar,
 )
@@ -378,7 +378,7 @@ class SelectFromModel(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
         if hasattr(self.estimator_, "feature_names_in_"):
             self.feature_names_in_ = self.estimator_.feature_names_in_
         else:
-            _check_feature_names(self, X, reset=True)
+            check_feature_names(self, X, reset=True)
 
         return self
 
@@ -461,7 +461,7 @@ class SelectFromModel(MetaEstimatorMixin, SelectorMixin, BaseEstimator):
         if hasattr(self.estimator_, "feature_names_in_"):
             self.feature_names_in_ = self.estimator_.feature_names_in_
         else:
-            _check_feature_names(self, X, reset=first_call)
+            check_feature_names(self, X, reset=first_call)
 
         return self
 

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -20,8 +20,8 @@ from sklearn.utils.sparsefuncs import _get_median
 from sklearn.utils.validation import (
     FLOAT_DTYPES,
     _check_feature_names_in,
-    _check_n_features,
     check_is_fitted,
+    check_n_features,
     validate_data,
 )
 
@@ -1005,7 +1005,7 @@ class MissingIndicator(TransformerMixin, BaseEstimator):
             X = self._validate_input(X, in_fit=True)
         else:
             # only create `n_features_in_` in the precomputed case
-            _check_n_features(self, X, reset=True)
+            check_n_features(self, X, reset=True)
 
         self._n_features = X.shape[1]
 

--- a/sklearn/metrics/_pairwise_distances_reduction/_argkmin_classmode.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_argkmin_classmode.pyx.tp
@@ -3,16 +3,16 @@ from cython.parallel cimport parallel, prange
 from libcpp.map cimport map as cpp_map, pair as cpp_pair
 from libc.stdlib cimport free
 
-from ...utils._typedefs cimport intp_t, float64_t
-from ...utils.parallel import _get_threadpool_controller
+from sklearn.utils._typedefs cimport intp_t, float64_t
+from sklearn.utils.parallel import _get_threadpool_controller
 
 import numpy as np
 from scipy.sparse import issparse
-from ._classmode cimport WeightingStrategy
+from sklearn.metrics._pairwise_distances_reduction._classmode cimport WeightingStrategy
 
 {{for name_suffix in ["32", "64"]}}
-from ._argkmin cimport ArgKmin{{name_suffix}}
-from ._datasets_pair cimport DatasetsPair{{name_suffix}}
+from sklearn.metrics._pairwise_distances_reduction._argkmin cimport ArgKmin{{name_suffix}}
+from sklearn.metrics._pairwise_distances_reduction._datasets_pair cimport DatasetsPair{{name_suffix}}
 
 cdef class ArgKminClassMode{{name_suffix}}(ArgKmin{{name_suffix}}):
     """

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -20,9 +20,9 @@ from sklearn.utils._param_validation import Interval
 from sklearn.utils.extmath import safe_sparse_dot
 from sklearn.utils.multiclass import _check_partial_fit_first_call
 from sklearn.utils.validation import (
-    _check_n_features,
     _check_sample_weight,
     check_is_fitted,
+    check_n_features,
     check_non_negative,
     validate_data,
 )
@@ -1527,7 +1527,7 @@ class CategoricalNB(_BaseDiscreteNB):
         self.feature_log_prob_ = feature_log_prob
 
     def _joint_log_likelihood(self, X):
-        _check_n_features(self, X, reset=False)
+        check_n_features(self, X, reset=False)
         jll = np.zeros((X.shape[0], self.class_count_.shape[0]))
         for i in range(self.n_features_in_):
             indices = X[:, i]

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -21,10 +21,9 @@ from sklearn.utils._missing import is_scalar_nan
 from sklearn.utils._param_validation import Interval, RealNotInt, StrOptions
 from sklearn.utils._set_output import _get_output_config
 from sklearn.utils.validation import (
-    _check_feature_names,
     _check_feature_names_in,
-    _check_n_features,
     check_is_fitted,
+    validate_data,
 )
 
 __all__ = ["OneHotEncoder", "OrdinalEncoder"]
@@ -83,8 +82,8 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
         return_and_ignore_missing_for_infrequent=False,
     ):
         self._check_infrequent_enabled()
-        _check_n_features(self, X, reset=True)
-        _check_feature_names(self, X, reset=True)
+        validate_data(self, X=X, reset=True, skip_check_array=True)
+
         X_list, n_samples, n_features = self._check_X(
             X, ensure_all_finite=ensure_all_finite
         )
@@ -203,8 +202,7 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
         X_list, n_samples, n_features = self._check_X(
             X, ensure_all_finite=ensure_all_finite
         )
-        _check_feature_names(self, X, reset=False)
-        _check_n_features(self, X, reset=False)
+        validate_data(self, X=X, reset=False, skip_check_array=True)
 
         X_int = np.zeros((n_samples, n_features), dtype=int)
         X_mask = np.ones((n_samples, n_features), dtype=bool)

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -36,7 +36,7 @@ from sklearn.utils._testing import (
     _convert_container,
     assert_array_equal,
 )
-from sklearn.utils.validation import _check_n_features, validate_data
+from sklearn.utils.validation import check_n_features, validate_data
 
 
 #############################################################################
@@ -706,28 +706,28 @@ def test_repr_html_wraps():
 
 
 def test_n_features_in_validation():
-    """Check that `_check_n_features` validates data when reset=False"""
+    """Check that `check_n_features` validates data when reset=False"""
     est = MyEstimator()
     X_train = [[1, 2, 3], [4, 5, 6]]
-    _check_n_features(est, X_train, reset=True)
+    check_n_features(est, X_train, reset=True)
 
     assert est.n_features_in_ == 3
 
     msg = "X does not contain any features, but MyEstimator is expecting 3 features"
     with pytest.raises(ValueError, match=msg):
-        _check_n_features(est, "invalid X", reset=False)
+        check_n_features(est, "invalid X", reset=False)
 
 
 def test_n_features_in_no_validation():
-    """Check that `_check_n_features` does not validate data when
+    """Check that `check_n_features` does not validate data when
     n_features_in_ is not defined."""
     est = MyEstimator()
-    _check_n_features(est, "invalid X", reset=True)
+    check_n_features(est, "invalid X", reset=True)
 
     assert not hasattr(est, "n_features_in_")
 
     # does not raise
-    _check_n_features(est, "invalid X", reset=False)
+    check_n_features(est, "invalid X", reset=False)
 
 
 def test_feature_names_in():

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -58,7 +58,7 @@ from sklearn.utils._testing import (
     assert_array_equal,
 )
 from sklearn.utils.fixes import CSR_CONTAINERS
-from sklearn.utils.validation import _check_feature_names, check_is_fitted
+from sklearn.utils.validation import check_feature_names, check_is_fitted
 
 # Load a shared tests data sets for the tests in this module. Mark them
 # read-only to avoid unintentional in-place modifications that would introduce
@@ -1460,7 +1460,7 @@ def test_make_pipeline_memory():
 
 class FeatureNameSaver(BaseEstimator):
     def fit(self, X, y=None):
-        _check_feature_names(self, X, reset=True)
+        check_feature_names(self, X, reset=True)
         return self
 
     def transform(self, X, y=None):

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -45,10 +45,10 @@ from sklearn.utils._param_validation import Hidden, Interval, RealNotInt, StrOpt
 from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import (
     _assert_all_finite_element_wise,
-    _check_n_features,
     _check_sample_weight,
     assert_all_finite,
     check_is_fitted,
+    check_n_features,
     validate_data,
 )
 
@@ -503,7 +503,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
                 raise ValueError("No support for np.int64 index based sparse matrices")
         else:
             # The number of features is checked regardless of `check_input`
-            _check_n_features(self, X, reset=False)
+            check_n_features(self, X, reset=False)
         return X
 
     def predict(self, X, check_input=True):

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -2740,7 +2740,7 @@ def _to_object_array(sequence):
     return out
 
 
-def _check_feature_names(estimator, X, *, reset):
+def check_feature_names(estimator, X, *, reset):
     """Set or check the `feature_names_in_` attribute of an estimator.
 
     .. versionadded:: 1.0
@@ -2839,7 +2839,7 @@ def _check_feature_names(estimator, X, *, reset):
         raise ValueError(message)
 
 
-def _check_n_features(estimator, X, reset):
+def check_n_features(estimator, X, reset):
     """Set the `n_features_in_` attribute, or check against it on an estimator.
 
     .. note::
@@ -2984,7 +2984,7 @@ def validate_data(
         The validated input. A tuple is returned if both `X` and `y` are
         validated.
     """
-    _check_feature_names(_estimator, X, reset=reset)
+    check_feature_names(_estimator, X, reset=reset)
     tags = get_tags(_estimator)
     if y is None and tags.target_tags.required:
         raise ValueError(
@@ -3030,6 +3030,6 @@ def validate_data(
         out = X, y
 
     if not no_val_X and check_params.get("ensure_2d", True):
-        _check_n_features(_estimator, X, reset=reset)
+        check_n_features(_estimator, X, reset=reset)
 
     return out


### PR DESCRIPTION
My first easy PR !

Resolves: https://github.com/scikit-learn/scikit-learn/issues/30389, I applied mainly the changes:

- Made `_check_n_features` and `_check_feature_names` public across all project files (following https://github.com/scikit-learn/scikit-learn/pull/31966#issue-3332325649)
-  When both of the above functions are used in the same block, we replace them with `validate_data(skip_check_array=True)` (following https://github.com/scikit-learn/scikit-learn/issues/30389#issuecomment-3308748961). Naturally this has `reset=True` in the _encoders._fit() (save `n_features_in_`) and `reset=False` in _encoders._transform() (check that input is equal to the encoders `n_features_in_`).

_______________

Sorry for the (old and redundant but working) MNT commit.
Let me know if something else is required.
@adrinjalali