### PR TITLE
MNT Switch to absolute imports in sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp

### DIFF
--- a/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp
@@ -15,7 +15,7 @@ import numpy as np
 
 from cython cimport final
 
-from ...utils._typedefs cimport float64_t, float32_t, intp_t
+from sklearn.utils._typedefs cimport float64_t, float32_t, intp_t
 
 from scipy.sparse import issparse, csr_matrix
 


### PR DESCRIPTION
Reference Issues/PRs
Part of #32315

What does this implement/fix? Explain your changes.
Switches to absolute imports in sklearn/metrics/_pairwise_distances_reduction/_datasets_pair.pyx.tp

Any other comments?
No