### PR TITLE
FIX Handle missing __sklearn_tags__ in is_regressor/is_classifier

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -1208,7 +1208,11 @@ def is_classifier(estimator):
     >>> is_classifier(kmeans)
     False
     """
-    return get_tags(estimator).estimator_type == "classifier"
+    try:
+        return get_tags(estimator).estimator_type == "classifier"
+    except AttributeError:
+        # For backward compatibility with estimators not inheriting from BaseEstimator
+        return getattr(estimator, "_estimator_type", None) == "classifier"
 
 
 def is_regressor(estimator):
@@ -1239,7 +1243,11 @@ def is_regressor(estimator):
     >>> is_regressor(kmeans)
     False
     """
-    return get_tags(estimator).estimator_type == "regressor"
+    try:
+        return get_tags(estimator).estimator_type == "regressor"
+    except AttributeError:
+        # For backward compatibility with estimators not inheriting from BaseEstimator
+        return getattr(estimator, "_estimator_type", None) == "regressor"
 
 
 def is_clusterer(estimator):
@@ -1272,7 +1280,11 @@ def is_clusterer(estimator):
     >>> is_clusterer(kmeans)
     True
     """
-    return get_tags(estimator).estimator_type == "clusterer"
+    try:
+        return get_tags(estimator).estimator_type == "clusterer"
+    except AttributeError:
+        # For backward compatibility with estimators not inheriting from BaseEstimator
+        return getattr(estimator, "_estimator_type", None) == "clusterer"
 
 
 def is_outlier_detector(estimator):
@@ -1288,7 +1300,11 @@ def is_outlier_detector(estimator):
     out : bool
         True if estimator is an outlier detector and False otherwise.
     """
-    return get_tags(estimator).estimator_type == "outlier_detector"
+    try:
+        return get_tags(estimator).estimator_type == "outlier_detector"
+    except AttributeError:
+        # For backward compatibility with estimators not inheriting from BaseEstimator
+        return getattr(estimator, "_estimator_type", None) == "outlier_detector"
 
 
 def _fit_context(*, prefer_skip_nested_validation):

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -1094,3 +1094,91 @@ def test_param_is_default(default_value, test_value):
     estimator = make_estimator_with_param(default_value)(param=test_value)
     non_default = estimator._get_params_html().non_default
     assert "param" not in non_default
+
+def test_is_regressor_classifier_without_sklearn_tags():
+    """Test is_regressor/is_classifier with estimators not inheriting from BaseEstimator.
+    
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/32394
+    """
+    from sklearn.base import is_classifier, is_regressor, is_clusterer, is_outlier_detector
+    
+    # Test with a custom estimator without __sklearn_tags__
+    class MyEstimator:
+        def __init__(self):
+            pass
+
+        def fit(self, X, y=None):
+            self.is_fitted_ = True
+            return self
+
+        def predict(self, X):
+            pass
+
+    # Should not raise AttributeError
+    est = MyEstimator()
+    assert not is_regressor(est)
+    assert not is_classifier(est)
+    assert not is_clusterer(est)
+    assert not is_outlier_detector(est)
+    
+    # Test with old-style estimator using _estimator_type attribute
+    class OldStyleRegressor:
+        _estimator_type = "regressor"
+        
+        def fit(self, X, y=None):
+            return self
+        
+        def predict(self, X):
+            pass
+    
+    est = OldStyleRegressor()
+    assert is_regressor(est)
+    assert not is_classifier(est)
+    assert not is_clusterer(est)
+    assert not is_outlier_detector(est)
+    
+    # Test with old-style classifier
+    class OldStyleClassifier:
+        _estimator_type = "classifier"
+        
+        def fit(self, X, y=None):
+            return self
+        
+        def predict(self, X):
+            pass
+    
+    est = OldStyleClassifier()
+    assert is_classifier(est)
+    assert not is_regressor(est)
+    assert not is_clusterer(est)
+    assert not is_outlier_detector(est)
+    
+    # Test with old-style clusterer
+    class OldStyleClusterer:
+        _estimator_type = "clusterer"
+        
+        def fit(self, X, y=None):
+            return self
+    
+    est = OldStyleClusterer()
+    assert is_clusterer(est)
+    assert not is_classifier(est)
+    assert not is_regressor(est)
+    assert not is_outlier_detector(est)
+    
+    # Test with old-style outlier detector
+    class OldStyleOutlierDetector:
+        _estimator_type = "outlier_detector"
+        
+        def fit(self, X, y=None):
+            return self
+        
+        def predict(self, X):
+            pass
+    
+    est = OldStyleOutlierDetector()
+    assert is_outlier_detector(est)
+    assert not is_classifier(est)
+    assert not is_regressor(est)
+    assert not is_clusterer(est)


### PR DESCRIPTION
Fixes #32394

### Reference Issue
This PR fixes the AttributeError raised when calling `is_regressor()` or `is_classifier()` on custom estimators that don't inherit from `BaseEstimator`.

### What does this implement/fix?
- Adds try-except handling in `is_regressor()` and `is_classifier()` to gracefully handle estimators without `__sklearn_tags__`
- Maintains backward compatibility by falling back to checking the `_estimator_type` attribute
- Adds tests to verify the fix works for custom estimators

### Checklist
- [x] I have read the CONTRIBUTING guidelines
- [x] Added tests for the fix
- [x] All tests pass locally