### PR TITLE
MNT Switch to absolute imports in sklearn/metrics/_pairwise_distances_reduction/_base.pxd.tp

### DIFF
--- a/sklearn/metrics/_pairwise_distances_reduction/_base.pxd.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_base.pxd.tp
@@ -4,7 +4,7 @@ from sklearn.utils._typedefs cimport intp_t, float64_t
 
 {{for name_suffix in ['64', '32']}}
 
-from ._datasets_pair cimport DatasetsPair{{name_suffix}}
+from sklearn.metrics._pairwise_distances_reduction._datasets_pair cimport DatasetsPair{{name_suffix}}
 
 
 cpdef float64_t[::1] _sqeuclidean_row_norms{{name_suffix}}(


### PR DESCRIPTION
#### Reference Issues/PRs
Part of #32315.

#### What does this implement/fix?
This uses absolute imports in `sklearn/metrics/_pairwise_distances_reduction/_base.pxd.tp`

#### Any other comments?
No