### PR TITLE
MNT Switch to absolute imports in sklearn/cluster/_hdbscan/_tree.pxd

### DIFF
--- a/sklearn/cluster/_hdbscan/_tree.pxd
+++ b/sklearn/cluster/_hdbscan/_tree.pxd
@@ -27,7 +27,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from ...utils._typedefs cimport intp_t, float64_t, uint8_t
+from sklearn.utils._typedefs cimport intp_t, float64_t, uint8_t
 cimport numpy as cnp
 
 # This corresponds to the scipy.cluster.hierarchy format


### PR DESCRIPTION
#### Reference Issues/PRs
Part of #32315.

#### What does this implement/fix?
This uses absolute imports in `sklearn/cluster/_hdbscan/_tree.pxd`

#### Any other comments?
No