### PR TITLE
MNT Switch to absolute imports in sklearn/metrics/cluster/_expected_mutual_info_fast.pyx

### DIFF
--- a/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
+++ b/sklearn/metrics/cluster/_expected_mutual_info_fast.pyx
@@ -3,7 +3,7 @@
 
 from libc.math cimport exp, lgamma
 
-from ...utils._typedefs cimport float64_t, int64_t
+from sklearn.utils._typedefs cimport float64_t, int64_t
 
 import numpy as np
 from scipy.special import gammaln


### PR DESCRIPTION
#### Reference Issues/PRs
Part of #32315.

#### What does this implement/fix?
This uses absolute imports in `sklearn/metrics/cluster/_expected_mutual_info_fast.pyx`

#### Any other comments?
No