### PR TITLE
CI Add link to changelog instructions when check-changelog fails

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -34,3 +34,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BOT_USERNAME: changelog-bot
+
+      - name: Link to changelog instructions
+        if: failure()
+        run: |
+          echo "see changelog instructions at https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md"
+          exit 1

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -38,5 +38,15 @@ jobs:
       - name: Link to changelog instructions
         if: failure()
         run: |
-          echo "see changelog instructions at https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md"
+
+          cat << EOF
+          - if your PR is likely to affect users, you will need to add a changelog entry
+            describing your PR changes.
+          - otherwise you don't need to do anything, a maintainer will set the relevant label
+            to make this CI build pass.
+
+          See instructions on how to write a changelog entry:
+          https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md"
+          EOF
+
           exit 1

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -40,13 +40,12 @@ jobs:
         run: |
 
           cat << EOF
-          - if your PR is likely to affect users, you will need to add a changelog entry
-            describing your PR changes.
-          - otherwise you don't need to do anything, a maintainer will set the relevant label
-            to make this CI build pass.
+          - if your PR is likely to affect users, you will need to add a changelog entry describing your PR changes
+          - otherwise you don't need to do anything, a maintainer will set the relevant label to make this CI build pass
 
           See instructions on how to write a changelog entry:
-          https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md"
+          https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
+
           EOF
 
           exit 1

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -42,7 +42,6 @@ from sklearn.utils.validation import _check_n_features, validate_data
 #############################################################################
 # A few test classes
 class MyEstimator(BaseEstimator):
-    # changed a test file
     def __init__(self, l1=0, empty=None):
         self.l1 = l1
         self.empty = empty

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -42,6 +42,7 @@ from sklearn.utils.validation import _check_n_features, validate_data
 #############################################################################
 # A few test classes
 class MyEstimator(BaseEstimator):
+    # changed a test file
     def __init__(self, l1=0, empty=None):
         self.l1 = l1
         self.empty = empty


### PR DESCRIPTION
#### Reference Issues/PRs
As mentioned in [this comment](https://github.com/scikit-learn/scikit-learn/pull/29661#issuecomment-3155031617) in #29661 


#### What does this implement/fix? Explain your changes.
Add a link to changelog instructions when the CI is failing because of this in PRs

#### Any other comments?
Thank you @ogrisel @lesteve and @StefanieSenger 
