### PR TITLE
MNT Use absolute imports in sklearn/svm/_liblinear.pyx

### DIFF
--- a/sklearn/svm/_liblinear.pyx
+++ b/sklearn/svm/_liblinear.pyx
@@ -6,8 +6,8 @@ Author: fabian.pedregosa@inria.fr
 
 import  numpy as np
 
-from ..utils._cython_blas cimport _dot, _axpy, _scal, _nrm2
-from ..utils._typedefs cimport float32_t, float64_t, int32_t
+from sklearn.utils._cython_blas cimport _dot, _axpy, _scal, _nrm2
+from sklearn.utils._typedefs cimport float32_t, float64_t, int32_t
 
 include "_liblinear.pxi"
 


### PR DESCRIPTION
#### Reference Issues/PRs
Part of #32315

***
#### What does this implement/fix? Explain your changes.
This pull request updates `sklearn/svm/_liblinear.pyx` to use absolute imports instead of relative ones.

Specifically, it changes the imports from `..utils` to the full `sklearn.utils` path, aligning with the code standardization goal outlined in the main issue.