### PR TITLE
MNT Use absolute import in sklearn/metrics/_pairwise_distances_reduction/_base.pyx.tp

### DIFF
--- a/sklearn/metrics/_pairwise_distances_reduction/_base.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_base.pyx.tp
@@ -103,7 +103,7 @@ cdef float64_t[::1] _sqeuclidean_row_norms64_sparse(
 
 {{for name_suffix in ["64", "32"]}}
 
-from ._datasets_pair cimport DatasetsPair{{name_suffix}}
+from sklearn.metrics._pairwise_distances_reduction._datasets_pair cimport DatasetsPair{{name_suffix}}
 
 
 cpdef float64_t[::1] _sqeuclidean_row_norms{{name_suffix}}(


### PR DESCRIPTION
This commit switches a relative Cython import to an absolute import in _base.pyx.tp, addressing Issue #32315.

Absolute imports enhance code readability, consistency, and future maintainability, making dependencies clearer between modules. This change follows project guidance for modern Cython and Python codebases and keeps scikit-learn aligned with current best practices.

#### What does this implement/fix? Explain your changes.

This implements the change from a relative to an absolute import in _base.pyx.tp as requested, improving clarity and maintainability in the Cython code.
