### PR TITLE
WIP datasets: Refactor make_classification for consistent distribution

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.datasets/32476.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.datasets/32476.fix.rst
@@ -1,0 +1,3 @@
+- Fix in :func:`~sklearn.datasets.make_classification` to ensure that for a given
+  ``random_state``, the generated distribution's underlying parameters are
+  consistent regardless of ``n_samples``. :issue:`32405` by :user:`KoolDrip`.

--- a/sklearn/datasets/_samples_generator.py
+++ b/sklearn/datasets/_samples_generator.py
@@ -312,15 +312,10 @@ def make_classification(
     sample_positions = (np.arange(n_samples) + 0.5) / n_samples
     cluster_boundaries = np.cumsum(cluster_proportions)
     cluster_ids = np.searchsorted(cluster_boundaries, sample_positions)
-    ]
-
-    for i in range(n_samples - sum(n_samples_per_cluster)):
-        n_samples_per_cluster[i % n_clusters] += 1
 
     # Initialize X and y
     X = np.zeros((n_samples, n_features))
     y = np.zeros(n_samples, dtype=int)
-
 
     # Create each cluster using pre-generated transformations
     for i in range(n_samples):
@@ -328,11 +323,10 @@ def make_classification(
         y[i] = cluster_id % n_classes
 
         # Draw random values for THIS sample's informative features
-        sample_randoms = generator.standard_normal(size=n_informative)
+        sample_random = generator.standard_normal(size=n_informative)
         X[i, :n_informative] = (
-            np.dot(sample_randoms, A_matrices[cluster_id]) + centroids[cluster_id]
+            np.dot(sample_random, A_matrices[cluster_id]) + centroids[cluster_id]
         )
-
 
     # Create redundant features using pre-generated B
     if n_redundant > 0:


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #32405

#### What does this implement/fix? Explain your changes.

This is a work-in-progress PR to fix the issue where `make_classification` produces different underlying distributions for the same `random_state` if `n_samples` is changed.

The root cause was that the generation of the distribution's structural parameters (e.g., cluster transformation matrices, feature permutations) was interleaved with the `n_samples`-dependent generation of the data points. This desynchronized the random number generator's state, leading to different results.

The changes in this PR successfully refactor the function's logic to decouple the generation of the main distribution parameters from the number of samples. Specifically, the following are now generated *before* any `n_samples`-dependent operations:
-   Cluster centroids
-   Transformation matrices `A` (for covariance) and `B` (for redundant features)
-   Random `shift` and `scale` values

This correctly makes the *shape* of the distribution independent of `n_samples`.

#### Any other comments?

This PR is currently a draft, and I'm looking for feedback on the final steps before marking it as "Ready for Review."

1.  The current implementation still uses two separate calls to `generator.standard_normal` for the `informative` and `useless` (`n_random`) features. I believe the final step should be to **combine these into a single, contiguous block of random data** to ensure full determinism. Is this the correct approach to take?
2. I have not yet added a non-regression test. Once the approach above is confirmed, **should I add a test** that checks for exact equality between two datasets of different sizes to lock in this behavior?
3. A changelog entry has been added as per the new `towncrier` process.
4. The `mypy` check passes (ignoring pre-existing errors unrelated to this change).


Thanks for the guidance!