### PR TITLE
FIX Guess theme based on estimator parent node color

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -352,6 +352,7 @@ html_js_files = [
     "scripts/dropdown.js",
     "scripts/version-switcher.js",
     "scripts/sg_plotly_resize.js",
+    "scripts/theme-observer.js",
 ]
 
 # Compile scss files into css files using sphinxcontrib-sass

--- a/doc/js/scripts/theme-observer.js
+++ b/doc/js/scripts/theme-observer.js
@@ -1,0 +1,23 @@
+(function () {
+  const observer = new MutationObserver((mutationsList) => {
+    for (const mutation of mutationsList) {
+      if (
+        mutation.type === "attributes" &&
+        mutation.attributeName === "data-theme"
+      ) {
+        document
+          .querySelectorAll(".sk-top-container")
+          .forEach((estimatorElement) => {
+            const newTheme = detectTheme(estimatorElement);
+            estimatorElement.classList.remove("light", "dark");
+            estimatorElement.classList.add(newTheme);
+          });
+      }
+    }
+  });
+
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["data-theme"],
+  });
+})();

--- a/sklearn/utils/_repr_html/estimator.js
+++ b/sklearn/utils/_repr_html/estimator.js
@@ -74,11 +74,15 @@ function detectTheme(element) {
         return 'light';
     }
 
-    // Guess based on a reference element's color
-    const color = window.getComputedStyle(element, null).getPropertyValue('color');
+    // Guess based on a parent element's color
+    const color = window.getComputedStyle(element.parentNode, null).getPropertyValue('color');
     const match = color.match(/^rgb\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)\s*$/i);
     if (match) {
-        const [r, g, b] = [match[1], match[2], match[3]];
+        const [r, g, b] = [
+            parseFloat(match[1]),
+            parseFloat(match[2]),
+            parseFloat(match[3])
+        ];
 
         // https://en.wikipedia.org/wiki/HSL_and_HSV#Lightness
         const luma = 0.299 * r + 0.587 * g + 0.114 * b;


### PR DESCRIPTION
Closes #32354.

Instead of guessing theme color by looking at current element color, this PR uses estimator element parent color to do so.

As a bonus / test I've added an observer to documentations pages.
This observer watches for the html tag attribute changes and force theme of estimators in the page.

# Doc preview video

https://github.com/user-attachments/assets/69e467f1-c3f5-4fec-9820-7e09bb8b9cfb

> [!NOTE]  
> I did not add such an observer directly in the estimator javascript to avoid leaks in notebooks. I feel that we need more test before doing so.

