### PR TITLE
FIX Substitute validate_data when both _check_feature_names and _check_n_features are used

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.compose/32481.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.compose/32481.fix.rst
@@ -1,5 +1,0 @@
-Use
-  :func:`~sklearn.utils.validation.validate_data` instead of the internal
-  `_check_n_features` and `_check_feature_names` functions when both were used
-  together. This improves consistency with the common estimator validation API.
-  :pr:`<32481>` by :user:`Microcosmos22`.

--- a/doc/whats_new/upcoming_changes/sklearn.compose/32481.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.compose/32481.fix.rst
@@ -1,0 +1,5 @@
+Use
+  :func:`~sklearn.utils.validation.validate_data` instead of the internal
+  `_check_n_features` and `_check_feature_names` functions when both were used
+  together. This improves consistency with the common estimator validation API.
+  :pr:`<32481>` by :user:`Microcosmos22`.

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -44,14 +44,13 @@ from sklearn.utils.metadata_routing import (
 from sklearn.utils.metaestimators import _BaseComposition
 from sklearn.utils.parallel import Parallel, delayed
 from sklearn.utils.validation import (
-    _check_feature_names,
     _check_feature_names_in,
-    _check_n_features,
     _get_feature_names,
     _is_pandas_df,
     _num_samples,
     check_array,
     check_is_fitted,
+    validate_data,
 )
 
 __all__ = ["ColumnTransformer", "make_column_selector", "make_column_transformer"]
@@ -973,7 +972,6 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             sparse matrices.
         """
         _raise_for_params(params, self, "fit_transform")
-        _check_feature_names(self, X, reset=True)
 
         if self.force_int_remainder_cols != "deprecated":
             warnings.warn(
@@ -983,9 +981,9 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
                 FutureWarning,
             )
 
+        validate_data(self, X=X, skip_check_array=True)
         X = _check_X(X)
         # set n_features_in_ attribute
-        _check_n_features(self, X, reset=True)
         self._validate_transformers()
         n_samples = _num_samples(X)
 

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -45,6 +45,7 @@ from sklearn.utils.metaestimators import _BaseComposition
 from sklearn.utils.parallel import Parallel, delayed
 from sklearn.utils.validation import (
     _check_feature_names_in,
+    _check_n_features,
     _get_feature_names,
     _is_pandas_df,
     _num_samples,

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -21,10 +21,9 @@ from sklearn.utils._missing import is_scalar_nan
 from sklearn.utils._param_validation import Interval, RealNotInt, StrOptions
 from sklearn.utils._set_output import _get_output_config
 from sklearn.utils.validation import (
-    _check_feature_names,
     _check_feature_names_in,
-    _check_n_features,
     check_is_fitted,
+    validate_data,
 )
 
 __all__ = ["OneHotEncoder", "OrdinalEncoder"]
@@ -83,8 +82,7 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
         return_and_ignore_missing_for_infrequent=False,
     ):
         self._check_infrequent_enabled()
-        _check_n_features(self, X, reset=True)
-        _check_feature_names(self, X, reset=True)
+        validate_data(self, X=X, reset=True, skip_check_array=True)
         X_list, n_samples, n_features = self._check_X(
             X, ensure_all_finite=ensure_all_finite
         )
@@ -203,8 +201,7 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
         X_list, n_samples, n_features = self._check_X(
             X, ensure_all_finite=ensure_all_finite
         )
-        _check_feature_names(self, X, reset=False)
-        _check_n_features(self, X, reset=False)
+        validate_data(self, X=X, reset=False, skip_check_array=True)
 
         X_int = np.zeros((n_samples, n_features), dtype=int)
         X_mask = np.ones((n_samples, n_features), dtype=bool)


### PR DESCRIPTION
Partially resolves : https://github.com/scikit-learn/scikit-learn/issues/30389, applying the changes suggested by https://github.com/scikit-learn/scikit-learn/issues/30389#issuecomment-3308748961.

Whenever `_check_feature_names` and `_check_n_features` are both called, we substitute this by calling `validate_data`. Naturally, it will use `reset=True` for a fit and `reset=False` for a transform, thus only checking whether input data and estimator agree on the features.

Next steps will be to replace the remaining elements of the table in https://github.com/scikit-learn/scikit-learn/issues/30389#issuecomment-3308748961 with a refactored `validate_data`. Lastly, `_check_feature_names` and `_check_n_features`could be made publicly accessible by removing the underscore.

Its the first PR since we are separating https://github.com/scikit-learn/scikit-learn/pull/32441 into different PRs.
@j-hendricks @adrinjalali 
