### PR TITLE
CI Do not close automated wheels issue when tests pass

### DIFF
--- a/.github/workflows/update_tracking_issue.yml
+++ b/.github/workflows/update_tracking_issue.yml
@@ -48,4 +48,5 @@ jobs:
             "$GITHUB_WORKFLOW" \
             "$GITHUB_REPOSITORY" \
             https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID \
-            --tests-passed $TESTS_PASSED
+            --tests-passed $TESTS_PASSED \
+            --auto-close false


### PR DESCRIPTION
Right now we have intermittent issues related on Windows arm64 wheels, see https://github.com/scikit-learn/scikit-learn/issues/32393 https://github.com/scikit-learn/scikit-learn/issues/32491 https://github.com/scikit-learn/scikit-learn/issues/32492.

It would be nice to keep a same issue to track this, except that the issue gets closed automatically so I need to remember to reopen it.

This PR takes the easiest route of never closing the issue and a maintainer will look at it and close it manually if relevant. Note we are already using `--auto-close false` for scheduled runs with a random global random each day.

Alternatively but needs a bit more work, we could also set a `keep-automated-issue-open` or something similar and if set do no close the issue ...