### PR TITLE
CI Set `COMMIT_MESSAGE` to allow commit markers detection in `unit-tests.yml`

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,6 @@ env:
   TEST_DIR: ${{ github.workspace }}/tmp_folder
   CCACHE_DIR: ${{ github.workspace }}/ccache
   COVERAGE: 'true'
-  SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
 jobs:
   lint:
@@ -51,12 +50,12 @@ jobs:
     steps:
     - uses: actions/checkout@v5
       with:
-        ref: ${{ env.SHA }}
+        ref: ${{ github.event.pull_request.head.sha }}
     - id: git-log
       shell: bash
       run: |
         set -eu
-        message=$(git log --format=%B -n 1 "${SHA}")
+        message=$(git log --format=%B -n 1)
         echo "message=${message}" >> "${GITHUB_OUTPUT}"
 
   unit-tests:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,6 +15,7 @@ env:
   TEST_DIR: ${{ github.workspace }}/tmp_folder
   CCACHE_DIR: ${{ github.workspace }}/ccache
   COVERAGE: 'true'
+  SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
 jobs:
   lint:
@@ -41,11 +42,28 @@ jobs:
           pip install ninja meson scipy
           python build_tools/check-meson-openmp-dependencies.py
 
+  retrieve-commit-message:
+    name: Retrieve the latest commit message
+    runs-on: ubuntu-latest
+    if: github.repository == 'scikit-learn/scikit-learn'
+    outputs:
+      message: ${{ steps.git-log.outputs.message }}
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        ref: ${{ env.SHA }}
+    - id: git-log
+      shell: bash
+      run: |
+        set -eu
+        message=$(git log --format=%B -n 1 "${SHA}")
+        echo "message=${message}" >> "${GITHUB_OUTPUT}"
+
   unit-tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     if: github.repository == 'scikit-learn/scikit-learn'
-    needs: [lint]
+    needs: [lint, retrieve-commit-message]
     strategy:
       # Ensures that all builds run to completion even if one of them fails
       fail-fast: false
@@ -88,6 +106,8 @@ jobs:
 
       - name: Run tests
         run: bash -l build_tools/azure/test_script.sh
+        env:
+          COMMIT_MESSAGE: ${{ needs.retrieve-commit-message.outputs.message }}
 
       - name: Combine coverage reports from parallel test runners
         run: bash -l build_tools/azure/combine_coverage_reports.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -48,21 +48,21 @@ jobs:
     outputs:
       message: ${{ steps.git-log.outputs.message }}
     steps:
-    - uses: actions/checkout@v5
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-    - id: git-log
-      shell: bash
-      run: |
-        set -eu
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - id: git-log
+        shell: bash
+        run: |
+          set -eu
 
-        message=$(git log --format=%B -n 1)
+          message=$(git log --format=%B -n 1)
 
-        {
-          echo 'message<<EOF'
-          echo "${message}"
-          echo EOF
-        } >> "${GITHUB_OUTPUT}"
+          {
+            echo 'message<<EOF'
+            echo "${message}"
+            echo EOF
+          } >> "${GITHUB_OUTPUT}"
 
   unit-tests:
     name: ${{ matrix.name }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -55,8 +55,14 @@ jobs:
       shell: bash
       run: |
         set -eu
+
         message=$(git log --format=%B -n 1)
-        echo "message=${message}" >> "${GITHUB_OUTPUT}"
+
+        {
+          echo 'message<<EOF'
+          echo "${message}"
+          echo EOF
+        } >> "${GITHUB_OUTPUT}"
 
   unit-tests:
     name: ${{ matrix.name }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - id: git-log
+        name: Set commit message job output
         shell: bash
         run: |
           set -eu

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -51,7 +51,7 @@ show_installed_libraries
 show_cpu_info
 
 NUM_CORES=$(python -c "import joblib; print(joblib.cpu_count())")
-TEST_CMD="python -m pytest -v --showlocals --durations=20 --junitxml=$JUNITXML -o junit_family=legacy"
+TEST_CMD="python -m pytest --showlocals --durations=20 --junitxml=$JUNITXML -o junit_family=legacy"
 
 if [[ "$COVERAGE" == "true" ]]; then
     # Note: --cov-report= is used to disable too long text output report in the

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -22,13 +22,13 @@ if [[ "$BUILD_REASON" == "Schedule" ]]; then
     export SKLEARN_RUN_FLOAT32_TESTS=1
 fi
 
-# In GitHub Action context (especially in `.github/workflows/unit-tests.yml`
-# which calls this script), the environment variable `COMMIT_MESSAGE` is
-# already set to the latest commit message.
+# In GitHub Action (especially in `.github/workflows/unit-tests.yml` which
+# calls this script), the environment variable `COMMIT_MESSAGE` is already set
+# to the latest commit message.
 if [[ -z "${COMMIT_MESSAGE+x}" ]]; then
     # If 'COMMIT_MESSAGE' is unset we are in Azure, and we retrieve the commit
     # message via the get_commit_message.py script which uses Azure-specific
-    # variable, for example 'BUILD_SOURCEVERSIONMESSAGE'.
+    # variables, for example 'BUILD_SOURCEVERSIONMESSAGE'.
     COMMIT_MESSAGE=$(python build_tools/azure/get_commit_message.py --only-show-message)
 fi
 

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -22,14 +22,13 @@ if [[ "$BUILD_REASON" == "Schedule" ]]; then
     export SKLEARN_RUN_FLOAT32_TESTS=1
 fi
 
+# In GitHub Action context (especially in `.github/workflows/unit-tests.yml`
+# which calls this script), the environment variable `COMMIT_MESSAGE` is
+# already set to the latest commit message.
 if [[ -z "${COMMIT_MESSAGE+x}" ]]; then
-    # In GHA context (especially in `.github/workflows/unit-tests.yml` which calls this
-    # script), the environment variable `COMMIT_MESSAGE` is automatically set to the
-    # latest commit message.
-    #
-    # In Azure context and for backward-compatibility, when the variable is unset, it
-    # substitutes its compute to `build_tools/azure/get_commit_message.py` which uses
-    # some Azure-specific variable (in particular `BUILD_SOURCEVERSIONMESSAGE`).
+    # If 'COMMIT_MESSAGE' is unset we are in Azure, and we retrieve the commit
+    # message via the get_commit_message.py script which uses Azure-specific
+    # variable, for example 'BUILD_SOURCEVERSIONMESSAGE'.
     COMMIT_MESSAGE=$(python build_tools/azure/get_commit_message.py --only-show-message)
 fi
 

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -23,6 +23,13 @@ if [[ "$BUILD_REASON" == "Schedule" ]]; then
 fi
 
 if [[ -z "${COMMIT_MESSAGE+x}" ]]; then
+    # In GHA context (especially in `.github/workflows/unit-tests.yml` which calls this
+    # script), the environment variable `COMMIT_MESSAGE` is automatically set to the
+    # latest commit message.
+    #
+    # In Azure context and for backward-compatibility, when the variable is unset, it
+    # substitutes its compute to `build_tools/azure/get_commit_message.py` which uses
+    # some Azure-specific variable (in particular `BUILD_SOURCEVERSIONMESSAGE`).
     COMMIT_MESSAGE=$(python build_tools/azure/get_commit_message.py --only-show-message)
 fi
 

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -51,7 +51,7 @@ show_installed_libraries
 show_cpu_info
 
 NUM_CORES=$(python -c "import joblib; print(joblib.cpu_count())")
-TEST_CMD="python -m pytest --showlocals --durations=20 --junitxml=$JUNITXML -o junit_family=legacy"
+TEST_CMD="python -m pytest -v --showlocals --durations=20 --junitxml=$JUNITXML -o junit_family=legacy"
 
 if [[ "$COVERAGE" == "true" ]]; then
     # Note: --cov-report= is used to disable too long text output report in the

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -22,7 +22,9 @@ if [[ "$BUILD_REASON" == "Schedule" ]]; then
     export SKLEARN_RUN_FLOAT32_TESTS=1
 fi
 
-COMMIT_MESSAGE=$(python build_tools/azure/get_commit_message.py --only-show-message)
+if [[ -z "${COMMIT_MESSAGE+x}" ]]; then
+    COMMIT_MESSAGE=$(python build_tools/azure/get_commit_message.py --only-show-message)
+fi
 
 if [[ "$COMMIT_MESSAGE" =~ \[float32\] ]]; then
     echo "float32 tests will be run due to commit message"


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Partially addresses https://github.com/scikit-learn/scikit-learn/issues/32434.

> changes of behaviour based on commit markers e.g. [float32], [all random seeds]. I had a look and my thinking so far would be to refrain from using CI-provider specific environment variable in bash scripts (e.g. Azure-specific BUILD_REASON is currently used in build_tools/test_script.sh or in build_tools/azure/get_commit_message.py but I would avoid doing a similar thing for GHA). Instead we should have a step in the yaml that sets environment variable (or job output if we think it's better to use job output), which the bash script can then use.
> 
>     [float32] seems the easiest thing to start with

#### What does this implement/fix? Explain your changes.

Retrieve and set the latest commit message as `COMMIT_MESSAGE` environment variable in `.github/workflows/unit-tests.yml` to allow commit markers detection in `build_tools/azure/test_script.sh`.