### PR TITLE
DOC Add reference to OpenMP parallelism in MiniBatchKMeans doc

### DIFF
--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -74,6 +74,8 @@ that increasing the number of workers is always a good thing. In some cases
 it can be highly detrimental to performance to run multiple copies of some
 estimators or functions in parallel (see :ref:`oversubscription<oversubscription>` below).
 
+.. _lower-level-parallelism-with-openmp:
+
 Lower-level parallelism with OpenMP
 ...................................
 

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1724,7 +1724,7 @@ class MiniBatchKMeans(_BaseKMeans):
     batch_size : int, default=1024
         Size of the mini batches.
         For faster computations, you can set the ``batch_size`` greater than
-        256 * number of cores to enable [parallelism](https://scikit-learn.org/stable/computing/parallelism.html#lower-level-parallelism-with-openmp) on all cores.
+        256 * number of cores to enable :ref:`parallelism <_lower-level-parallelism-with-openmp>` on all cores.
 
         .. versionchanged:: 1.0
            `batch_size` default changed from 100 to 1024.

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1723,7 +1723,7 @@ class MiniBatchKMeans(_BaseKMeans):
 
     batch_size : int, default=1024
         Size of the mini batches.
-        For faster computations, you can set `batch_size > 256 * number of cores`
+        For faster computations, you can set `batch_size > 256 * number_of_cores`
         to enable :ref:`parallelism <lower-level-parallelism-with-openmp>`
         on all cores.
 

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1724,7 +1724,7 @@ class MiniBatchKMeans(_BaseKMeans):
     batch_size : int, default=1024
         Size of the mini batches.
         For faster computations, you can set the ``batch_size`` greater than
-        256 * number of cores to enable parallelism on all cores.
+        256 * number of cores to enable [parallelism](https://scikit-learn.org/stable/computing/parallelism.html#lower-level-parallelism-with-openmp) on all cores.
 
         .. versionchanged:: 1.0
            `batch_size` default changed from 100 to 1024.

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1724,7 +1724,8 @@ class MiniBatchKMeans(_BaseKMeans):
     batch_size : int, default=1024
         Size of the mini batches.
         For faster computations, you can set the ``batch_size`` greater than
-        256 * number of cores to enable :ref:`parallelism <_lower-level-parallelism-with-openmp>` on all cores.
+        256 * number of cores to enable
+        :ref:`parallelism <lower-level-parallelism-with-openmp>` on all cores.
 
         .. versionchanged:: 1.0
            `batch_size` default changed from 100 to 1024.

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1723,9 +1723,9 @@ class MiniBatchKMeans(_BaseKMeans):
 
     batch_size : int, default=1024
         Size of the mini batches.
-        For faster computations, you can set the ``batch_size`` greater than
-        256 * number of cores to enable
-        :ref:`parallelism <lower-level-parallelism-with-openmp>` on all cores.
+        For faster computations, you can set `batch_size > 256 * number of cores`
+        to enable :ref:`parallelism <lower-level-parallelism-with-openmp>`
+        on all cores.
 
         .. versionchanged:: 1.0
            `batch_size` default changed from 100 to 1024.


### PR DESCRIPTION
#### Reference Issues/PRs
Fix for #32503


#### What does this implement/fix? Explain your changes.

When reading the docs for MiniBatchKMeans, you might not be aware of OpenMP parallelization. This should help them discover it, while being a minimal change to the documentation.

However, as @lesteve suggests, it might still be the case that:

> We [sklearn] could document better in estimators when OpenMP is used for parallelism? 

However, I couldn't find any other issues on the matter.
