### PR TITLE
MNT: Replace internal _searchsorted helper with api xp.searchsorted support

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -35,7 +35,6 @@ from sklearn.utils._array_api import (
     _find_matching_floating_dtype,
     _is_numpy_namespace,
     _max_precision_float_dtype,
-    _searchsorted,
     _tolist,
     _union1d,
     ensure_common_namespace_device,
@@ -804,7 +803,7 @@ def multilabel_confusion_matrix(
             )
 
         # Retain only selected labels
-        indices = _searchsorted(sorted_labels, labels[:n_labels], xp=xp)
+        indices = xp.searchsorted(sorted_labels, labels[:n_labels])
         tp_sum = xp.take(tp_sum, indices, axis=0)
         true_sum = xp.take(true_sum, indices, axis=0)
         pred_sum = xp.take(pred_sum, indices, axis=0)

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -906,21 +906,6 @@ def indexing_dtype(xp):
     return xp.asarray(0).dtype
 
 
-def _searchsorted(a, v, *, side="left", sorter=None, xp=None):
-    # Temporary workaround needed as long as searchsorted is not widely
-    # adopted by implementers of the Array API spec. This is a quite
-    # recent addition to the spec:
-    # https://data-apis.org/array-api/latest/API_specification/generated/array_api.searchsorted.html
-    xp, _ = get_namespace(a, v, xp=xp)
-    if hasattr(xp, "searchsorted"):
-        return xp.searchsorted(a, v, side=side, sorter=sorter)
-
-    a_np = _convert_to_numpy(a, xp=xp)
-    v_np = _convert_to_numpy(v, xp=xp)
-    indices = numpy.searchsorted(a_np, v_np, side=side, sorter=sorter)
-    return xp.asarray(indices, device=device(a))
-
-
 def _isin(element, test_elements, xp, assume_unique=False, invert=False):
     """Calculates ``element in test_elements``, broadcasting over `element`
     only.

--- a/sklearn/utils/_encode.py
+++ b/sklearn/utils/_encode.py
@@ -7,7 +7,7 @@ from typing import NamedTuple
 
 import numpy as np
 
-from sklearn.utils._array_api import _isin, _searchsorted, device, get_namespace, xpx
+from sklearn.utils._array_api import _isin, device, get_namespace, xpx
 from sklearn.utils._missing import is_scalar_nan
 
 
@@ -71,7 +71,7 @@ def _unique_np(values, return_inverse=False, return_counts=False):
     # np.unique will have duplicate missing values at the end of `uniques`
     # here we clip the nans and remove it from uniques
     if uniques.size and is_scalar_nan(uniques[-1]):
-        nan_idx = _searchsorted(uniques, xp.nan, xp=xp)
+        nan_idx = xp.searchsorted(uniques, xp.nan)
         uniques = uniques[: nan_idx + 1]
         if return_inverse:
             inverse[inverse > nan_idx] = nan_idx
@@ -234,7 +234,7 @@ def _encode(values, *, uniques, check_unknown=True):
             diff = _check_unknown(values, uniques)
             if diff:
                 raise ValueError(f"y contains previously unseen labels: {diff}")
-        return _searchsorted(uniques, values, xp=xp)
+        return xp.searchsorted(uniques, values)
 
 
 def _check_unknown(values, known_values, return_mask=False):


### PR DESCRIPTION
**Reference Issues/PRs:**
None (internal refactor, no open issue directly linked).

**What does this implement/fix? Explain your changes:**
This PR removes the internal `_searchsorted` helper function and replaces its usage with direct calls to `xp.searchsorted`.
The `_searchsorted` helper was introduced as a temporary workaround because `searchsorted` was not widely implemented by Array API backends at the time.

**With this PR:**
1. All calls to _searchsorted in _encode, classification and _unique_np are replaced by xp.searchsorted.
2. Consistent handling of nan values in _unique_np is preserved.
3. Internal code is simplified, reducing technical debt and aligning with the Array API specification.
4. There is no change to the public API and no change in user-facing behavior.

**Any other comments?**
This is an internal refactor only; downstream behavior remains unchanged.
No changelog entry is required since this does not affect user-facing functionality.