### PR TITLE
DOC update the list of scikit-learn members

### DIFF
--- a/doc/contributor_experience_team.rst
+++ b/doc/contributor_experience_team.rst
@@ -14,10 +14,6 @@
     <p>Juan Carlos Alfaro Jiménez</p>
     </div>
     <div>
-    <a href='https://github.com/lucyleeow'><img src='https://avatars.githubusercontent.com/u/23182829?v=4' class='avatar' /></a> <br />
-    <p>Lucy Liu</p>
-    </div>
-    <div>
     <a href='https://github.com/MaxwellLZH'><img src='https://avatars.githubusercontent.com/u/16646940?v=4' class='avatar' /></a> <br />
     <p>Maxwell Liu</p>
     </div>
@@ -26,16 +22,16 @@
     <p>Juan Martin Loyola</p>
     </div>
     <div>
+    <a href='https://github.com/DeaMariaLeon'><img src='https://avatars.githubusercontent.com/u/11835246?v=4' class='avatar' /></a> <br />
+    <p>Dea María Léon</p>
+    </div>
+    <div>
     <a href='https://github.com/smarie'><img src='https://avatars.githubusercontent.com/u/3236794?v=4' class='avatar' /></a> <br />
     <p>Sylvain Marié</p>
     </div>
     <div>
     <a href='https://github.com/norbusan'><img src='https://avatars.githubusercontent.com/u/1735589?v=4' class='avatar' /></a> <br />
     <p>Norbert Preining</p>
-    </div>
-    <div>
-    <a href='https://github.com/StefanieSenger'><img src='https://avatars.githubusercontent.com/u/91849487?v=4' class='avatar' /></a> <br />
-    <p>Stefanie Senger</p>
     </div>
     <div>
     <a href='https://github.com/reshamas'><img src='https://avatars.githubusercontent.com/u/2507232?v=4' class='avatar' /></a> <br />

--- a/doc/maintainers.rst
+++ b/doc/maintainers.rst
@@ -66,6 +66,10 @@
     <p>Omar Salman</p>
     </div>
     <div>
+    <a href='https://github.com/StefanieSenger'><img src='https://avatars.githubusercontent.com/u/91849487?v=4' class='avatar' /></a> <br />
+    <p>Stefanie Senger</p>
+    </div>
+    <div>
     <a href='https://github.com/GaelVaroquaux'><img src='https://avatars.githubusercontent.com/u/208217?v=4' class='avatar' /></a> <br />
     <p>Gael Varoquaux</p>
     </div>

--- a/doc/maintainers_emeritus.rst
+++ b/doc/maintainers_emeritus.rst
@@ -18,7 +18,7 @@
 - Arnaud Joly
 - Thouis (Ray) Jones
 - Kyle Kastner
-- Manoj kumar
+- Manoj Kumar
 - Robert Layton
 - Wei Li
 - Paolo Losi

--- a/doc/maintainers_emeritus.rst
+++ b/doc/maintainers_emeritus.rst
@@ -18,7 +18,7 @@
 - Arnaud Joly
 - Thouis (Ray) Jones
 - Kyle Kastner
-- Manoj Kumar
+- Manoj kumar
 - Robert Layton
 - Wei Li
 - Paolo Losi


### PR DESCRIPTION
We recently added @DeaMariaLeon in the contributor experience team.

This PR update the authors by running the `make authors` command from the `build_tools` director. Apparently, we forgot to run it recently. @StefanieSenger is moved to the right team now :)