### PR TITLE
MNT Remove tomli additional dependency from .pre-commit.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,5 +38,3 @@ repos:
   rev: v2.4.1
   hooks:
   - id: codespell
-    additional_dependencies:
-    - tomli  # for python_version < '3.11'


### PR DESCRIPTION
Our minimum supported Python will be 3.11 for scikit-learn 1.8. tom. tomli is a back-port of tomlib which was introduced in the stdlib in Python 3.11 see [this](https://pypi.org/project/tomli/).

We are in the process of moving e.g. https://github.com/scikit-learn/scikit-learn/pull/32522 but I think it is fine to do it now.

FWI I tried to use pre-commit in a python 3.10 environment without the tomli additional dependencies and it seems to work so maybe this wasn't needed anyway :thinking:.
