### PR TITLE
DOC Document 'all random seeds' commit marker

### DIFF
--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -273,26 +273,6 @@ admissible seeds on your local machine:
 
     SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest -v -k test_your_test_name
 
-For example, to write a test that uses the ``global_random_seed`` fixture:
-
-.. code-block:: python
-
-    def test_random_behavior(global_random_seed):
-        import numpy as np
-        rng = np.random.RandomState(global_random_seed)
-        value = rng.rand()
-        assert 0 <= value < 1
-
-Run this test locally across all admissible random seeds with:
-
-.. prompt:: bash $
-
-    SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest -v -k test_random_behavior
-
-This ensures the test is deterministic and passes for any seed values
-from 0 to 99.
-
-
 `SKLEARN_SKIP_NETWORK_TESTS`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -273,6 +273,25 @@ admissible seeds on your local machine:
 
     SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest -v -k test_your_test_name
 
+For example, to write a test that uses the ``global_random_seed`` fixture:
+
+.. code-block:: python
+
+    def test_random_behavior(global_random_seed):
+        import numpy as np
+        rng = np.random.RandomState(global_random_seed)
+        value = rng.rand()
+        assert 0 <= value < 1
+
+Run this test locally across all admissible random seeds with:
+
+.. prompt:: bash $
+
+    SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest -v -k test_random_behavior
+
+This ensures the test is deterministic for all seed values from 0 to 99.
+
+
 `SKLEARN_SKIP_NETWORK_TESTS`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -289,7 +289,8 @@ Run this test locally across all admissible random seeds with:
 
     SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest -v -k test_random_behavior
 
-This ensures the test is deterministic for all seed values from 0 to 99.
+This ensures the test is deterministic and passes for any seed values
+from 0 to 99.
 
 
 `SKLEARN_SKIP_NETWORK_TESTS`

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -584,6 +584,7 @@ Commit Message Marker  Action Taken by CI
 [pyodide]              Build & test with Pyodide
 [azure parallel]       Run Azure CI jobs in parallel
 [float32]              Run float32 tests by setting `SKLEARN_RUN_FLOAT32_TESTS=1`. See :ref:`environment_variable` for more details
+[all random seeds]     Run tests with the `global_random_seed` fixture using all supported random seeds
 [doc skip]             Docs are not built
 [doc quick]            Docs built, but excludes example gallery plots
 [doc build]            Docs built including example gallery plots (very long)

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -584,7 +584,7 @@ Commit Message Marker  Action Taken by CI
 [pyodide]              Build & test with Pyodide
 [azure parallel]       Run Azure CI jobs in parallel
 [float32]              Run float32 tests by setting `SKLEARN_RUN_FLOAT32_TESTS=1`. See :ref:`environment_variable` for more details
-[all random seeds]     Run tests with the `global_random_seed` fixture using all supported random seeds . See `issue #28959 <https://github.com/scikit-learn/scikit-learn/issues/28959>`_ for details.
+[all random seeds]     Run tests with the `global_random_seed` fixture using all supported random seeds. See `issue #28959 <https://github.com/scikit-learn/scikit-learn/issues/28959>`_ for details.
 [doc skip]             Docs are not built
 [doc quick]            Docs built, but excludes example gallery plots
 [doc build]            Docs built including example gallery plots (very long)

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -584,7 +584,9 @@ Commit Message Marker  Action Taken by CI
 [pyodide]              Build & test with Pyodide
 [azure parallel]       Run Azure CI jobs in parallel
 [float32]              Run float32 tests by setting `SKLEARN_RUN_FLOAT32_TESTS=1`. See :ref:`environment_variable` for more details
-[all random seeds]     Run tests with the `global_random_seed` fixture using all supported random seeds. See `issue #28959 <https://github.com/scikit-learn/scikit-learn/issues/28959>`_ for details.
+[all random seeds]     Run tests using the `global_random_seed` fixture with all random seeds.
+                       See `this <https://github.com/scikit-learn/scikit-learn/issues/28959>`_
+                       for more details about the commit message format
 [doc skip]             Docs are not built
 [doc quick]            Docs built, but excludes example gallery plots
 [doc build]            Docs built including example gallery plots (very long)

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -584,7 +584,7 @@ Commit Message Marker  Action Taken by CI
 [pyodide]              Build & test with Pyodide
 [azure parallel]       Run Azure CI jobs in parallel
 [float32]              Run float32 tests by setting `SKLEARN_RUN_FLOAT32_TESTS=1`. See :ref:`environment_variable` for more details
-[all random seeds]     Run tests with the `global_random_seed` fixture using all supported random seeds
+[all random seeds]     Run tests with the `global_random_seed` fixture using all supported random seeds . See `issue #28959 <https://github.com/scikit-learn/scikit-learn/issues/28959>`_ for details.
 [doc skip]             Docs are not built
 [doc quick]            Docs built, but excludes example gallery plots
 [doc build]            Docs built including example gallery plots (very long)


### PR DESCRIPTION
This PR addresses issue #32551 by documenting the `[all random seeds]` commit message marker in the developer guide under commit message markers. 

- Adds the `[all random seeds]` marker to the commit message markers table in `doc/developers/contributing.rst`, matching the concise style of existing markers.
- Adds an example test function demonstrating the use of the `global_random_seed` fixture and instructions for running this test locally with all admissible seeds to `doc/computing/parallelism.rst`.

These additions clarify the purpose and usage of the marker, helping contributors understand how to write and test seed-dependent tests robustly.

Due to build environment limitations on my local setup, I have not built the docs locally, but rely on scikit-learn's CI to validate documentation builds and formatting.

Looking forward to the maintainers review and feedback.
