### PR TITLE
MNT Add example dependencies to version bumping script

### DIFF
--- a/maint_tools/bump-dependencies-versions.py
+++ b/maint_tools/bump-dependencies-versions.py
@@ -76,7 +76,9 @@ def get_min_python_version(scikit_learn_release_date_str="today"):
     ]
 
 
-def get_min_version_pure_python(package_name, scikit_learn_release_date_str="today"):
+def get_min_version_pure_python_or_example_dependency(
+    package_name, scikit_learn_release_date_str="today"
+):
     # for pure Python dependencies we want the most recent minor release that
     # is at least 2 years old
     if scikit_learn_release_date_str == "today":
@@ -138,7 +140,15 @@ def get_current_min_python_version():
 def show_versions_update(scikit_learn_release_date="today"):
     future_versions = {"python": get_min_python_version(scikit_learn_release_date)}
 
-    compiled_dependencies = ["numpy", "scipy", "pandas", "matplotlib", "pyamg"]
+    compiled_dependencies = [
+        "numpy",
+        "scipy",
+        "pandas",
+        "matplotlib",
+        "pyamg",
+        "polars",
+        "pyarrow",
+    ]
     future_versions.update(
         {
             dep: get_min_version_with_wheel(dep, future_versions["python"])
@@ -146,11 +156,22 @@ def show_versions_update(scikit_learn_release_date="today"):
         }
     )
 
-    pure_python_dependencies = ["joblib", "threadpoolctl"]
+    pure_python_or_example_dependencies = [
+        "joblib",
+        "threadpoolctl",
+        "scikit-image",
+        "seaborn",
+        "polars",
+        "Pillow",
+        "pooch",
+        "plotly",
+    ]
     future_versions.update(
         {
-            dep: get_min_version_pure_python(dep, scikit_learn_release_date)
-            for dep in pure_python_dependencies
+            dep: get_min_version_pure_python_or_example_dependency(
+                dep, scikit_learn_release_date
+            )
+            for dep in pure_python_or_example_dependencies
         }
     )
 
@@ -158,7 +179,7 @@ def show_versions_update(scikit_learn_release_date="today"):
     current_versions.update(
         {
             dep: get_current_dependencies_version(dep)
-            for dep in compiled_dependencies + pure_python_dependencies
+            for dep in compiled_dependencies + pure_python_or_example_dependencies
         }
     )
 


### PR DESCRIPTION
I think it's fine for example dependencies to have the same rule than our pure-Python core dependencies: at the time of release, the minimum supported version should be roughly two years old.

If we target a release on December 1st, this is what the script says:
```
❯ python maint_tools/bump-dependencies-versions.py 2025-12-01
For future release at date 2025-12-01
- python: 3.10 -> 3.11
- numpy: 1.24.1 -> 1.24.0
- matplotlib: 3.6.1 -> 3.6.0
- polars: 0.20.30 -> 0.19.0
- pyarrow: 12.0.0 -> 11.0.0
- scikit-image: 0.19.0 -> 0.22.0
- seaborn: 0.9.1 -> 0.13.0
- Pillow: 8.4.0 -> 10.1.0
- pooch: 1.6.0 -> 1.8.0
- plotly: 5.14.0 -> 5.18.0
```

cc @DeaMariaLeon in case there is agreement on this, you could use these versions for bumping the doc_min_dependencies versions.

Note that for polars and pyarrow, we are not following our rule, but I guess that's life.