### PR TITLE
DOC: Add [all random seeds] commit marker and example for global_random_seed (#32551)

### DIFF
--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -273,6 +273,19 @@ admissible seeds on your local machine:
 
     SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest -v -k test_your_test_name
 
+For example, here is how to use the fixture in a test to ensure it passes for
+all admissible seeds:
+
+.. code-block:: python
+
+    import numpy as np
+
+    def test_my_randomized_logic(global_random_seed):
+        rng = np.random.RandomState(global_random_seed)
+        X = rng.randn(100, 3)
+        # exercise code under test, ensuring it works for any seed in [0, 99]
+        assert X.shape == (100, 3)
+
 `SKLEARN_SKIP_NETWORK_TESTS`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -584,6 +584,8 @@ Commit Message Marker  Action Taken by CI
 [pyodide]              Build & test with Pyodide
 [azure parallel]       Run Azure CI jobs in parallel
 [float32]              Run float32 tests by setting `SKLEARN_RUN_FLOAT32_TESTS=1`. See :ref:`environment_variable` for more details
+[all random seeds]     Run only the tests listed after this marker in the commit message and execute them for all
+                       seeds by setting `SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all"` (useful to reproduce flaky tests).
 [doc skip]             Docs are not built
 [doc quick]            Docs built, but excludes example gallery plots
 [doc build]            Docs built including example gallery plots (very long)


### PR DESCRIPTION
This PR addresses #32551 by:

- Documenting the  commit message marker in the developer guide commit marker table. It instructs CI to run only the listed tests for all seeds by setting .
- Adding a short Python snippet in the parallelism docs showing how to use the  fixture in a test.

Rationale:
- The marker is already supported by CI (see  and ).
- The fixture is documented, but a minimal code example improves discoverability.

No behavioral changes to code, documentation only.
