### PR TITLE
MNT: remove workaround for numpy bug fixed in 1.20

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2811,11 +2811,6 @@ class QuantileTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator)
             )
 
         self.quantiles_ = np.nanpercentile(X, references, axis=0)
-        # Due to floating-point precision error in `np.nanpercentile`,
-        # make sure that quantiles are monotonically increasing.
-        # Upstream issue in numpy:
-        # https://github.com/numpy/numpy/issues/14685
-        self.quantiles_ = np.maximum.accumulate(self.quantiles_)
 
     def _sparse_fit(self, X, random_state):
         """Compute percentiles for sparse matrices.

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2856,11 +2856,6 @@ class QuantileTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator)
             else:
                 self.quantiles_.append(np.nanpercentile(column_data, references))
         self.quantiles_ = np.transpose(self.quantiles_)
-        # due to floating-point precision error in `np.nanpercentile`,
-        # make sure the quantiles are monotonically increasing
-        # Upstream issue in numpy:
-        # https://github.com/numpy/numpy/issues/14685
-        self.quantiles_ = np.maximum.accumulate(self.quantiles_)
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X, y=None):

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1614,7 +1614,7 @@ def test_quantile_transformer_sorted_quantiles(array_type):
     # Non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/15733
     # Taken from upstream bug report:
-    # https://github.com/numpy/numpy/issues/14685
+    # https://github.com/numpy/numpy/issues/14685 (which has been resolved)
     X = np.array([0, 1, 1, 2, 2, 3, 3, 4, 5, 5, 1, 1, 9, 9, 9, 8, 8, 7] * 10)
     X = 0.1 * X.reshape(-1, 1)
     X = _convert_container(X, array_type)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1614,7 +1614,8 @@ def test_quantile_transformer_sorted_quantiles(array_type):
     # Non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/15733
     # Taken from upstream bug report:
-    # https://github.com/numpy/numpy/issues/14685 (which has been resolved)
+    # https://github.com/numpy/numpy/issues/14685
+    # (which has been resolved in numpy 1.20)
     X = np.array([0, 1, 1, 2, 2, 3, 3, 4, 5, 5, 1, 1, 9, 9, 9, 8, 8, 7] * 10)
     X = 0.1 * X.reshape(-1, 1)
     X = _convert_container(X, array_type)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1614,8 +1614,7 @@ def test_quantile_transformer_sorted_quantiles(array_type):
     # Non-regression test for:
     # https://github.com/scikit-learn/scikit-learn/issues/15733
     # Taken from upstream bug report:
-    # https://github.com/numpy/numpy/issues/14685
-    # (which has been resolved in numpy 1.20)
+    # https://github.com/numpy/numpy/issues/14685 (which was resolved in numpy 1.20)
     X = np.array([0, 1, 1, 2, 2, 3, 3, 4, 5, 5, 1, 1, 9, 9, 9, 8, 8, 7] * 10)
     X = 0.1 * X.reshape(-1, 1)
     X = _convert_container(X, array_type)


### PR DESCRIPTION
#### Reference Issues/PRs

Initial numpy issue: https://github.com/numpy/numpy/issues/14685
That propagated to sklearn: https://github.com/scikit-learn/scikit-learn/issues/15733

#### What does this implement/fix? Explain your changes.

Remove the code that was ensuring an ascending array even if numpy wasn't returning an ascending output.

#### Any other comments?

It was fixed in numpy by this commit: https://github.com/numpy/numpy/commit/4d5b2558c275a4a46b6ab0c486536d8e779651ce

And by running this in numpy repo: `git tag --contains 4d5b2558c275a4a46b6ab0c486536d8e779651ce` you'll see it was part of the 1.20 release.