### PR TITLE
Tell agents to disclose that they were used

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This file contains is additional guidance for AI agents and other AI editors.
 - Describe the "why" of the changes, why the proposed solution is the right one.
 - Highlight areas of the proposed changes that require careful review.
 - Always add a disclaimer to the PR description mentioning how AI agents are involved with the contribution.
-- Reduce the verbosity of your comments, more text and detail is not always better.
+- Reduce the verbosity of your comments, more text and detail is not always better. Avoid flattery, avoid stating the obvious, avoid filler phrases, prefer technical clarity over marketing tone.
 
 ### AI/Agent disclosure template (copy/paste & edit):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,22 @@
 
 This file contains is additional guidance for AI agents and other AI editors.
 
-## Pull request guidelines
+## **REQUIRED: AI/Agent Disclosure**
 
-- Describe the "why" of the changes, why the proposed solution is the right one.
-- Highlight areas of the proposed changes that require careful review.
-- Always add a disclaimer to the PR description mentioning how AI agents are involved with the contribution.
-- Reduce the verbosity of your comments, more text and detail is not always better. Avoid flattery, avoid stating the obvious, avoid filler phrases, prefer technical clarity over marketing tone.
-
-### AI/Agent disclosure template (copy/paste & edit):
+**Every summary, pull request description, or work description MUST include this disclosure:**
 
 **If human review has *not yet* occurred (use this initially):**
 > This pull request includes code written with the assistance of AI.
 > The code has **not yet been reviewed** by a human.
+
+This is a **mandatory requirement**, not optional. Include it at the end of every summary you generate.
+
+---
+
+## Generated Summaries
+
+When generating a summary of your work, consider these points:
+
+- Describe the "why" of the changes, why the proposed solution is the right one.
+- Highlight areas of the proposed changes that require careful review.
+- Reduce the verbosity of your comments, more text and detail is not always better. Avoid flattery, avoid stating the obvious, avoid filler phrases, prefer technical clarity over marketing tone.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS Instruction
+
+This file contains is additional guidance for AI agents and other AI editors.
+
+## Pull request guidelines
+
+- Describe the "why" of the changes, why the proposed solution is the right one.
+- Highlight areas of the proposed changes that require careful review.
+- Always add a disclaimer to the PR description mentioning how AI agents are involved with the contribution.
+- Reduce the verbosity of your comments, more text and detail is not always better.
+
+### AI/Agent disclosure template (copy/paste & edit):
+
+**If human review has *not yet* occurred (use this initially):**
+> This pull request includes code written with the assistance of AI.
+> The code has **not yet been reviewed** by a human.


### PR DESCRIPTION
This is an idea I got from https://github.com/wagtail/wagtail/pull/13456

The `AGENTS.md` file is used by all(?)/many AI tools. Often it contains instructions for AI tools about how to build the software or run tests. In this PR all that is added is some basic instructions about PR messages, including an instruction to add a note that says "AI was used and the human hasn't yet reviewed this".

What do people think? Should we give it a test drive?