### PR TITLE
DOC Add fix for extra whitespace

### DIFF
--- a/doc/modules/covariance.rst
+++ b/doc/modules/covariance.rst
@@ -290,11 +290,11 @@ Minimum Covariance Determinant
 ------------------------------
 
 The Minimum Covariance Determinant estimator is a robust estimator of
-a data set's covariance introduced by P.J. Rousseeuw in [3]_.  The idea
+a data set's covariance introduced by P.J. Rousseeuw in [3]_. The idea
 is to find a given proportion (h) of "good" observations which are not
-outliers and compute their empirical covariance matrix.  This
+outliers and compute their empirical covariance matrix. This
 empirical covariance matrix is then rescaled to compensate the
-performed selection of observations ("consistency step").  Having
+performed selection of observations ("consistency step"). Having
 computed the Minimum Covariance Determinant estimator, one can give
 weights to observations according to their Mahalanobis distance,
 leading to a reweighted estimate of the covariance matrix of the data


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
This PR removes a few instances of extra whitespace (two spaces instead of one) after periods in the documentation for `sklearn.covariance`. Specifically, it fixes these in the `doc/modules/covariance.rst` file.

#### Any other comments?
This is my first contribution. 😊