### PR TITLE
DOC: Explain 'friedman_mse' regression criterion and when to use it (#32204)

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -560,12 +560,23 @@ Regression criteria
 -------------------
 
 If the target is a continuous value, then for node :math:`m`, common
-criteria to minimize as for determining locations for future splits are Mean
-Squared Error (MSE or L2 error), Poisson deviance as well as Mean Absolute
-Error (MAE or L1 error). MSE and Poisson deviance both set the predicted value
-of terminal nodes to the learned mean value :math:`\bar{y}_m` of the node
-whereas the MAE sets the predicted value of terminal nodes to the median
-:math:`median(y)_m`.
+criteria used to score candidate splits are Mean Squared Error (MSE or
+L2 error), Friedman MSE, Poisson deviance, as well as Mean Absolute
+Error (MAE or L1 error). MSE, Friedman MSE, and Poisson deviance all
+set the predicted value of terminal nodes to the learned mean value
+:math:`\bar{y}_m` of the node, whereas the MAE sets the predicted value
+of terminal nodes to the median :math:`median(y)_m`.
+
+Friedman MSE (``criterion="friedman_mse"``) is a variance-reduction
+criterion that evaluates a split using the improvement in squared error
+between the parent node and its children, rather than only the raw MSE
+of the children. It was originally proposed for gradient boosting
+regression trees and is the default in
+:class:`~sklearn.ensemble.GradientBoostingRegressor` and
+:class:`~sklearn.ensemble.HistGradientBoostingRegressor`. In practice it
+often yields better split decisions for additive ensembles. For
+standalone decision trees and random forests it typically behaves
+similarly to ``"squared_error"``.
 
 Mean Squared Error:
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #32204.

#### What does this implement/fix? Explain your changes.

This PR expands the "Regression criteria" subsection in `doc/modules/tree.rst` to document the `friedman_mse` criterion alongside the existing criteria (`squared_error`, Poisson deviance, and MAE).

Specifically:
- It explains that `criterion="friedman_mse"` scores a split using the improvement in squared error between the parent node and its children, rather than just the raw child node MSE.
- It clarifies that this criterion originated in gradient boosting regression trees and is the default in `GradientBoostingRegressor` and `HistGradientBoostingRegressor`.
- It notes when you would choose `friedman_mse` (often better split decisions in additive/boosting ensembles) and how it compares to `"squared_error"` for standalone trees / forests.
- It keeps the mathematical definitions and narrative for MSE, Poisson deviance, and MAE, and reorganizes the subsection so `friedman_mse` is described in the same place where users learn about the other regression criteria.

Motivation:
`friedman_mse` is exposed as a valid `criterion` in tree-based estimators, but prior to this PR the user guide did not explain what it is, why it exists, or when to use it. This made the parameter unclear for users. This PR addresses that gap in the documentation.

This PR is docs-only. It does not modify any estimator code, runtime behavior, defaults, or public API.

#### Any other comments?

No changelog entry is added because this is a documentation clarification with no behavioral or API change.