### PR TITLE
DOC: Add [all random seeds] commit marker to documentation

### DIFF
--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -273,6 +273,25 @@ admissible seeds on your local machine:
 
     SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest -v -k test_your_test_name
 
+Here is an example of a test using the `global_random_seed` fixture:
+
+.. code-block:: python
+
+    def test_your_test_name(global_random_seed):
+        # The fixture provides a random seed in the range [0, 99]
+        rng = np.random.RandomState(global_random_seed)
+
+        # Your test code using the random number generator
+        X = rng.randn(100, 10)
+        y = rng.randint(0, 2, size=100)
+
+        # Test your estimator
+        est = YourEstimator()
+        est.fit(X, y)
+
+        # Make assertions that should pass for any seed in [0, 99]
+        assert est.score(X, y) > 0.5
+
 `SKLEARN_SKIP_NETWORK_TESTS`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -584,6 +584,7 @@ Commit Message Marker  Action Taken by CI
 [pyodide]              Build & test with Pyodide
 [azure parallel]       Run Azure CI jobs in parallel
 [float32]              Run float32 tests by setting `SKLEARN_RUN_FLOAT32_TESTS=1`. See :ref:`environment_variable` for more details
+[all random seeds]     Run the specified tests with all random seeds (0-99) on all CI jobs. See `issue #28959 <https://github.com/scikit-learn/scikit-learn/issues/28959>`_ for details
 [doc skip]             Docs are not built
 [doc quick]            Docs built, but excludes example gallery plots
 [doc build]            Docs built including example gallery plots (very long)


### PR DESCRIPTION
This PR adds documentation for the [all random seeds] commit message marker.

**Changes**:
- Added [all random seeds] to the commit message markers table in the contributing guide with a link to issue #28959
- Added a Python code example showing how to write a test using the global_random_seed fixture in the parallelism documentation

Fixes #32551