### PR TITLE
CI Make 'conda create' command less verbose'

### DIFF
--- a/build_tools/shared.sh
+++ b/build_tools/shared.sh
@@ -62,7 +62,7 @@ create_conda_environment_from_lock_file() {
     # https://conda.github.io/conda-lock/output/#explicit-lockfile
     lock_file_has_pip_packages=$(grep -q files.pythonhosted.org $LOCK_FILE && echo "true" || echo "false")
     if [[ "$lock_file_has_pip_packages" == "false" ]]; then
-        conda create --name $ENV_NAME --file $LOCK_FILE
+        conda create --quiet --name $ENV_NAME --file $LOCK_FILE
     else
         python -m pip install "$(get_dep conda-lock min)"
         conda-lock install --log-level WARNING --name $ENV_NAME $LOCK_FILE

--- a/build_tools/shared.sh
+++ b/build_tools/shared.sh
@@ -65,6 +65,6 @@ create_conda_environment_from_lock_file() {
         conda create --name $ENV_NAME --file $LOCK_FILE
     else
         python -m pip install "$(get_dep conda-lock min)"
-        conda-lock install --name $ENV_NAME $LOCK_FILE
+        conda-lock install --log-level WARNING --name $ENV_NAME $LOCK_FILE
     fi
 }


### PR DESCRIPTION
`conda-lock install` is not super useful with plenty of empty lines in the CI log, see [this log](https://github.com/scikit-learn/scikit-learn/actions/runs/18863675724/job/53827210748#step:5:43) for example.

Let's see what setting the log level to WARNING does.

Noticed with @StefanieSenger and @DeaMariaLeon the other day.