### PR TITLE
MAINT Clean up after Scipy min version to 1.10

### DIFF
--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -56,24 +56,17 @@ if parse_version(pytest.__version__) < parse_version(PYTEST_MIN_VERSION):
         f" should have pytest >= {PYTEST_MIN_VERSION} installed."
     )
 
-scipy_datasets_require_network = sp_version >= parse_version("1.10")
-
 
 def raccoon_face_or_skip():
     # SciPy >= 1.10 requires network to access to get data
-    if scipy_datasets_require_network:
-        run_network_tests = environ.get("SKLEARN_SKIP_NETWORK_TESTS", "1") == "0"
-        if not run_network_tests:
-            raise SkipTest("test is enabled when SKLEARN_SKIP_NETWORK_TESTS=0")
-
-        try:
-            import pooch  # noqa: F401
-        except ImportError:
-            raise SkipTest("test requires pooch to be installed")
-
-        from scipy.datasets import face
-    else:
-        from scipy.misc import face
+    run_network_tests = environ.get("SKLEARN_SKIP_NETWORK_TESTS", "1") == "0"
+    if not run_network_tests:
+        raise SkipTest("test is enabled when SKLEARN_SKIP_NETWORK_TESTS=0")
+    try:
+        import pooch  # noqa: F401
+    except ImportError:
+        raise SkipTest("test requires pooch to be installed")
+    from scipy.datasets import face
 
     return face(gray=True)
 
@@ -91,8 +84,7 @@ dataset_fetchers = {
     "fetch_species_distributions_fxt": fetch_species_distributions,
 }
 
-if scipy_datasets_require_network:
-    dataset_fetchers["raccoon_face_fxt"] = raccoon_face_or_skip
+dataset_fetchers["raccoon_face_fxt"] = raccoon_face_or_skip
 
 _SKIP32_MARK = pytest.mark.skipif(
     environ.get("SKLEARN_RUN_FLOAT32_TESTS", "0") != "1",

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -14,6 +14,7 @@ import joblib
 import numpy as np
 import pytest
 from _pytest.doctest import DoctestItem
+from scipy.datasets import face
 from threadpoolctl import threadpool_limits
 
 from sklearn._min_dependencies import PYTEST_MIN_VERSION
@@ -58,7 +59,7 @@ if parse_version(pytest.__version__) < parse_version(PYTEST_MIN_VERSION):
 
 
 def raccoon_face_or_skip():
-    # SciPy >= 1.10 requires network to access to get data
+    # SciPy requires network to access to get data
     run_network_tests = environ.get("SKLEARN_SKIP_NETWORK_TESTS", "1") == "0"
     if not run_network_tests:
         raise SkipTest("test is enabled when SKLEARN_SKIP_NETWORK_TESTS=0")
@@ -66,7 +67,6 @@ def raccoon_face_or_skip():
         import pooch  # noqa: F401
     except ImportError:
         raise SkipTest("test requires pooch to be installed")
-    from scipy.datasets import face
 
     return face(gray=True)
 

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -59,7 +59,7 @@ if parse_version(pytest.__version__) < parse_version(PYTEST_MIN_VERSION):
 
 
 def raccoon_face_or_skip():
-    # SciPy requires network to access to get data
+    # SciPy requires network access to get data
     run_network_tests = environ.get("SKLEARN_SKIP_NETWORK_TESTS", "1") == "0"
     if not run_network_tests:
         raise SkipTest("test is enabled when SKLEARN_SKIP_NETWORK_TESTS=0")

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -35,7 +35,6 @@ from sklearn.utils._param_validation import (
     validate_params,
 )
 from sklearn.utils.extmath import _incremental_mean_and_var, row_norms
-from sklearn.utils.fixes import _yeojohnson_lambda
 from sklearn.utils.sparsefuncs import (
     incr_mean_variance_axis,
     inplace_column_scale,
@@ -3595,8 +3594,8 @@ class PowerTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
         # the computation of lambda is influenced by NaNs so we need to
         # get rid of them
         x = x[~np.isnan(x)]
-
-        return _yeojohnson_lambda(_neg_log_likelihood, x)
+        _, lmbda = stats.yeojohnson(x, lmbda=None)
+        return lmbda
 
     def _check_input(self, X, in_fit, check_positive=False, check_shape=False):
         """Validate the input before fit and transform.

--- a/sklearn/preprocessing/_polynomial.py
+++ b/sklearn/preprocessing/_polynomial.py
@@ -29,7 +29,6 @@ from sklearn.utils._array_api import (
 )
 from sklearn.utils._mask import _get_mask
 from sklearn.utils._param_validation import Interval, StrOptions
-from sklearn.utils.fixes import parse_version, sp_version
 from sklearn.utils.stats import _weighted_percentile
 from sklearn.utils.validation import (
     FLOAT_DTYPES,
@@ -1010,18 +1009,10 @@ class SplineTransformer(TransformerMixin, BaseEstimator):
         n_splines = self.bsplines_[0].c.shape[1]
         degree = self.degree
 
-        # TODO: Remove this condition, once scipy 1.10 is the minimum version.
-        #       Only scipy >= 1.10 supports design_matrix(.., extrapolate=..).
-        #       The default (implicit in scipy < 1.10) is extrapolate=False.
-        scipy_1_10 = sp_version >= parse_version("1.10.0")
         # Note: self.bsplines_[0].extrapolate is True for extrapolation in
         # ["periodic", "continue"]
-        if scipy_1_10:
-            use_sparse = self.sparse_output
-            kwargs_extrapolate = {"extrapolate": self.bsplines_[0].extrapolate}
-        else:
-            use_sparse = self.sparse_output and not self.bsplines_[0].extrapolate
-            kwargs_extrapolate = dict()
+        use_sparse = self.sparse_output
+        kwargs_extrapolate = {"extrapolate": self.bsplines_[0].extrapolate}
 
         # Note that scipy BSpline returns float64 arrays and converts input
         # x=X[:, i] to c-contiguous float64.

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -36,8 +36,6 @@ from sklearn.utils._testing import (
 from sklearn.utils.fixes import (
     CSC_CONTAINERS,
     CSR_CONTAINERS,
-    parse_version,
-    sp_version,
 )
 
 
@@ -1196,21 +1194,6 @@ def test_csr_polynomial_expansion_index_overflow(
             pf.fit(X)
         return
 
-    # When `n_features>=65535`, `scipy.sparse.hstack` may not use the right
-    # dtype for representing indices and indptr if `n_features` is still
-    # small enough so that each block matrix's indices and indptr arrays
-    # can be represented with `np.int32`. We test `n_features==65535`
-    # since it is guaranteed to run into this bug.
-    if (
-        sp_version < parse_version("1.9.2")
-        and n_features == 65535
-        and degree == 2
-        and not interaction_only
-    ):  # pragma: no cover
-        msg = r"In scipy versions `<1.9.2`, the function `scipy.sparse.hstack`"
-        with pytest.raises(ValueError, match=msg):
-            X_trans = pf.fit_transform(X)
-        return
     X_trans = pf.fit_transform(X)
 
     expected_dtype = np.int64 if num_combinations > np.iinfo(np.int32).max else np.int32

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -103,7 +103,7 @@ def _yeojohnson_lambda(_neg_log_likelihood, x):
     lmbda : float
         The estimated lambda parameter for the Yeo-Johnson transformation.
     """
-    min_scipy_version = "1.9.0"
+    min_scipy_version = "1.10.0"
 
     if sp_version < parse_version(min_scipy_version):
         # choosing bracket -2, 2 like for boxcox

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -14,7 +14,6 @@ import numpy as np
 import scipy
 import scipy.sparse.linalg
 import scipy.stats
-from scipy import optimize
 
 try:
     import pandas as pd
@@ -79,38 +78,6 @@ else:
         if "atol" not in kwargs:
             kwargs["atol"] = "legacy"
         return scipy.sparse.linalg.cg(A, b, **kwargs)
-
-
-# TODO : remove this when required minimum version of SciPy >= 1.9.0
-def _yeojohnson_lambda(_neg_log_likelihood, x):
-    """Estimate the optimal Yeo-Johnson transformation parameter (lambda).
-
-    This function provides a compatibility workaround for versions of SciPy
-    older than 1.9.0, where `scipy.stats.yeojohnson` did not return
-    the estimated lambda directly.
-
-    Parameters
-    ----------
-    _neg_log_likelihood : callable
-        A function that computes the negative log-likelihood of the Yeo-Johnson
-        transformation for a given lambda. Used only for SciPy versions < 1.9.0.
-
-    x : array-like
-        Input data to estimate the Yeo-Johnson transformation parameter.
-
-    Returns
-    -------
-    lmbda : float
-        The estimated lambda parameter for the Yeo-Johnson transformation.
-    """
-    min_scipy_version = "1.10.0"
-
-    if sp_version < parse_version(min_scipy_version):
-        # choosing bracket -2, 2 like for boxcox
-        return optimize.brent(_neg_log_likelihood, brack=(-2, 2))
-
-    _, lmbda = scipy.stats.yeojohnson(x, lmbda=None)
-    return lmbda
 
 
 # TODO: Fuse the modern implementations of _sparse_min_max and _sparse_nan_min_max


### PR DESCRIPTION
Removed specific code used when `scipy` min version was < 1.10.

@lesteve 
