### PR TITLE
FEA Add array API support to `contingency_matrix`

### DIFF
--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -132,7 +132,8 @@ def contingency_matrix(
         .. versionadded:: 0.18
 
     dtype : numeric type, default=np.int64
-        Output dtype. Ignored if `eps` is not `None`.
+        Output dtype. Ignored if `eps` is not `None` or when using Array API dispatch
+        to non-NumPy namespaces.
 
         .. versionadded:: 0.24
 
@@ -192,23 +193,23 @@ def contingency_matrix(
             f"sparse=False for contingency_matrix."
         )
 
-    # dense array calculation using matmul
     float_dtype = _max_precision_float_dtype(xp, device_)
-    A = xp.astype(
+    classes_one_hot = xp.astype(
         class_idx[:, None]
         == xp.arange(n_classes, device=device_, dtype=class_idx.dtype),
         float_dtype,
     )
-    B = xp.astype(
+    clusters_one_hot = xp.astype(
         cluster_idx[:, None]
         == xp.arange(n_clusters, device=device_, dtype=cluster_idx.dtype),
         float_dtype,
     )
 
-    contingency = A.T @ B
+    contingency = classes_one_hot.T @ clusters_one_hot
 
     if eps is not None:
         contingency = contingency + eps
+
     return contingency
 
 

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -193,24 +193,22 @@ def contingency_matrix(
         )
 
     # dense array calculation using matmul
+    float_dtype = _max_precision_float_dtype(xp, device_)
     A = xp.astype(
         class_idx[:, None]
         == xp.arange(n_classes, device=device_, dtype=class_idx.dtype),
-        xp.int32,
+        float_dtype,
     )
     B = xp.astype(
         cluster_idx[:, None]
         == xp.arange(n_clusters, device=device_, dtype=cluster_idx.dtype),
-        xp.int32,
+        float_dtype,
     )
 
     contingency = A.T @ B
 
     if eps is not None:
-        contingency = (
-            xp.astype(contingency, _max_precision_float_dtype(xp, device_)) + eps
-        )
-
+        contingency = contingency + eps
     return contingency
 
 

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -26,6 +26,7 @@ from sklearn.metrics.cluster._supervised import (
     check_clusterings,
     entropy,
 )
+from sklearn.metrics.tests.test_common import check_array_api_metric
 from sklearn.utils import assert_all_finite
 from sklearn.utils._array_api import (
     _get_namespace_device_dtype_ids,
@@ -530,3 +531,33 @@ def test_fowlkes_mallows_sparse_deprecated(sparse):
         FutureWarning, match="The 'sparse' parameter was deprecated in 1.7"
     ):
         fowlkes_mallows_score([0, 1], [1, 1], sparse=sparse)
+
+
+@pytest.mark.parametrize(
+    "array_namespace, device, dtype_name",
+    yield_namespace_device_dtype_combinations(),
+    ids=_get_namespace_device_dtype_ids,
+)
+def test_array_api_metric_supervised(array_namespace, device, dtype_name):
+    labels_a = np.array([1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3])
+    labels_b = np.array([1, 1, 1, 1, 2, 1, 2, 2, 2, 2, 3, 1, 3, 3, 3, 2, 2])
+
+    check_array_api_metric(
+        contingency_matrix,
+        array_namespace,
+        device,
+        dtype_name,
+        a_np=labels_a,
+        b_np=labels_b,
+    )
+
+    eps = 0.1
+    check_array_api_metric(
+        contingency_matrix,
+        array_namespace,
+        device,
+        dtype_name,
+        a_np=labels_a,
+        b_np=labels_b,
+        eps=eps,
+    )


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #26024

#### What does this implement/fix? Explain your changes.
Add array API support to `contingency_matrix`

#### Any other comments?
This PR would unblock adding array API compliance for the following:

- `adjusted_rand_score`
- `completeness_score`
- `fowlkes_mallows_score`
- `homogeneity_completeness_v_measure`
- `homogeneity_score`
- `mutual_info_score`
- `normalized_mutual_info_score`
- `pair_confusion_matrix`
- `rand_score`
- `v_measure_score`