### PR TITLE
CI Update to macOS-15-intel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -156,23 +156,23 @@ jobs:
             manylinux_image: manylinux_2_28
 
           # MacOS x86_64
-          - os: macos-13
+          - os: macos-15-intel
             python: 311
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15-intel
             python: 312
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15-intel
             python: 313
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15-intel
             python: 313t
             platform_id: macosx_x86_64
             cibw_enable: cpython-freethreading
-          - os: macos-13
+          - os: macos-15-intel
             python: 314
             platform_id: macosx_x86_64
-          - os: macos-13
+          - os: macos-15-intel
             python: 314t
             platform_id: macosx_x86_64
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -220,7 +220,7 @@ jobs:
 - template: build_tools/azure/posix.yml
   parameters:
     name: macOS
-    vmImage: macos-15-intel
+    vmImage: macOS-15
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
     # Runs when dependencies succeeded or skipped
     condition: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -220,7 +220,7 @@ jobs:
 - template: build_tools/azure/posix.yml
   parameters:
     name: macOS
-    vmImage: macOS-13
+    vmImage: macOS-15-intel
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
     # Runs when dependencies succeeded or skipped
     condition: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -220,7 +220,7 @@ jobs:
 - template: build_tools/azure/posix.yml
   parameters:
     name: macOS
-    vmImage: macOS-15-intel
+    vmImage: macos-15-intel
     dependsOn: [linting, git_commit, Ubuntu_Jammy_Jellyfish]
     # Runs when dependencies succeeded or skipped
     condition: |

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -99,9 +99,7 @@ scikit_learn_install() {
         # the conda environment.
         find $CONDA_PREFIX -name omp.h -delete -print
         # meson >= 1.5 detects OpenMP installed with brew and OpenMP may be installed
-        # with brew in CI runner. OpenMP was installed with brew in macOS-12 CI
-        # runners which doesn't seem to be the case in macOS-13 runners anymore,
-        # but we keep the next line just to be safe ...
+        # with brew in CI runner
         brew uninstall --ignore-dependencies --force libomp
     fi
 


### PR DESCRIPTION
Seen in https://github.com/scikit-learn/scikit-learn/pull/32646 [build log](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=82036&view=logs&j=8b4d29c4-7356-5617-94d6-7bef17a56394)

```
##[error]This is a scheduled macos-13 brownout. The macOS-13 based runner images are being deprecated. For more details, see https://github.com/actions/runner-images/issues/13046.
```

For more details: https://github.com/actions/runner-images/issues/13046