### PR TITLE
DOC Correct textbook idf formula in documentation comment

### DIFF
--- a/doc/modules/feature_extraction.rst
+++ b/doc/modules/feature_extraction.rst
@@ -471,12 +471,11 @@ computed in scikit-learn's :class:`TfidfTransformer`
 and :class:`TfidfVectorizer` differ slightly from the standard textbook
 notation that defines the idf as
 
-:math:`\text{idf}(t) = \log{\frac{n}{1+\text{df}(t)}}.`
+:math:`\text{idf}(t) = \log{\frac{n}{\text{df}(t)}}.`
 
 
 In the :class:`TfidfTransformer` and :class:`TfidfVectorizer`
-with ``smooth_idf=False``, the
-"1" count is added to the idf instead of the idf's denominator:
+with ``smooth_idf=False``, a "1" count is added to the idf:
 
 :math:`\text{idf}(t) = \log{\frac{n}{\text{df}(t)}} + 1`
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1523,7 +1523,7 @@ class TfidfTransformer(
     ignored.
     (Note that the idf formula above differs from the standard textbook
     notation that defines the idf as
-    idf(t) = log [ n / (df(t) + 1) ]).
+    idf(t) = log [ n / df(t) ]).
 
     If ``smooth_idf=True`` (the default), the constant "1" is added to the
     numerator and denominator of the idf as if an extra document was seen


### PR DESCRIPTION
Maybe I misunderstood the documentation but from what I have seen the usual formula for idf is log(n/df(t)) and not log(n/(df(t)+1)). This is at least the standard definition in the Wikipedia [page](https://en.wikipedia.org/wiki/Tf%E2%80%93idf#Inverse_document_frequency) about tf-idf.