### PR TITLE
DOC Add "wikipedia self-edit rule" to inclusion criteria

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
 - type: markdown
   attributes:
     value: >
-      #### If you want to propose a new algorithm, please refer first to the [scikit-learn inclusion criterion](https://scikit-learn.org/stable/faq.html#what-are-the-inclusion-criteria-for-new-algorithms).
+      #### If you want to propose a new algorithm, please refer first to the [scikit-learn inclusion criterion](https://scikit-learn.org/dev/faq.html#what-are-the-inclusion-criteria-for-new-algorithms).
 - type: textarea
   attributes:
     label: Describe the workflow you want to enable

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -350,6 +350,9 @@ improvements, if any, with benchmarks and/or plots. It is expected that the
 proposed algorithm should outperform the methods that are already implemented
 in scikit-learn at least in some areas.
 
+Please do not propose algorithms you (your best friend, colleague or boss)
+created. scikit-learn is not a good venue for advertising your own work.
+
 Inclusion of a new algorithm speeding up an existing model is easier if:
 
 - it does not introduce new hyper-parameters (as it makes the library


### PR DESCRIPTION
Like for wikipedia (["Editing your own page"](https://en.wikipedia.org/wiki/Wikipedia:Editing_Your_Own_Page)) you should not propose your own work for inclusion in scikit-learn.

This adds to the inclusion criteria FAQ entry a sentence that states that you should not propose your own work for inclusion in scikit-learn. The idea is to make it clearer that scikit-learn does not want to be a platform for advertising new methods. scikit-learn wants to provide tried and tested methods in a format that practitioners from other fields can easily use ("machine-learning without the learning curve").

I wrote "Do not propose your own work" to leave the door open to experts/authors to contribute to the discussion and implementation. We want them to participate in this phase, but during the decision to (not) include their work they should probably not participate.

ping @glemaitre 