### PR TITLE
DOC: Improve distance metric documentation for BinaryTree

### DIFF
--- a/sklearn/neighbors/_binary_tree.pxi.tp
+++ b/sklearn/neighbors/_binary_tree.pxi.tp
@@ -253,15 +253,18 @@ metric : str or DistanceMetric64 object, default='minkowski'
     Metric to use for distance computation. Default is "minkowski", which
     results in the standard Euclidean distance when p = 2.
     A list of valid metrics for {BinaryTree} is given by the attribute
-    `valid_metrics`.
-    See the documentation of `scipy.spatial.distance
-    <https://docs.scipy.org/doc/scipy/reference/spatial.distance.html>`_ and
-    the metrics listed in :class:`~sklearn.metrics.pairwise.distance_metrics` for
-    more information on any distance metric.
+    `valid_metrics`. See the documentation of `scipy.spatial.distance
+    <https://docs.scipy.org/doc/scipy/reference/spatial.distance.html>`_ for
+    more information on any distance metric. Note that the actual valid metrics 
+    for each algorithm can be found using the `valid_metrics` attribute (e.g., 
+    `KDTree.valid_metrics` or `BallTree.valid_metrics`), as different algorithms 
+    support different sets of metrics.
 
 Additional keywords are passed to the distance metric class.
-Note: Callable functions in the metric parameter are NOT supported for KDTree
-and Ball Tree. Function call overhead will result in very poor performance.
+
+.. note::
+    Callable functions in the metric parameter are NOT supported for KDTree
+    and Ball Tree. Function call overhead will result in very poor performance.
 
 Attributes
 ----------


### PR DESCRIPTION
# Overview
This PR improves the documentation for the distance metric parameter in BinaryTree classes (KDTree and BallTree) to provide clearer guidance on valid metrics and address the limitation with callable functions.

# Checklist
- [x] Code changes made
- [x] Documentation updated
- [ ] Tests not applicable (documentation-only change)

# Proof
The documentation has been updated to clarify that:
- The valid metrics for each algorithm can be found using the `valid_metrics` attribute
- Different algorithms support different sets of metrics
- Callable functions are not supported due to performance issues

The changes make the documentation more precise and helpful for users trying to understand which metrics are available for each tree implementation.

Closes #32686