### PR TITLE
CI Revert pytest<9 pin in wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -231,7 +231,7 @@ jobs:
           # TODO Remove scipy<1.16.2 when hang on macOS_x86_64 has been fixed.
           # See https://github.com/scikit-learn/scikit-learn/issues/32279 for
           # more details.
-          CIBW_TEST_REQUIRES: ${{ contains(matrix.python, '314') && 'pytest<9' || 'pytest<9 pandas' }} scipy<1.16.2
+          CIBW_TEST_REQUIRES: ${{ contains(matrix.python, '314') && 'pytest' || 'pytest pandas' }} scipy<1.16.2
           # On Windows, we use a custom Docker image and CIBW_TEST_REQUIRES_WINDOWS
           # does not make sense because it would install dependencies in the host
           # rather than inside the Docker image

--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -22,11 +22,6 @@ if [[ $FREE_THREADED_BUILD == "False" && "$PLATFORM_ID" != "win_arm64" ]]; then
     # Dot the Python version for identifying the base Docker image
     PYTHON_DOCKER_IMAGE_PART=$(echo ${PYTHON_VERSION:0:1}.${PYTHON_VERSION:1:2})
 
-    # TODO Remove this when Python 3.14 is released and there is a Docker image
-    if [[ "$PYTHON_DOCKER_IMAGE_PART" == "3.14" ]]; then
-        PYTHON_DOCKER_IMAGE_PART="3.14-rc"
-    fi
-
     # We could have all of the following logic in a Dockerfile but it's a lot
     # easier to do it in bash rather than figure out how to do it in Powershell
     # inside the Dockerfile ...

--- a/build_tools/github/build_minimal_windows_image.sh
+++ b/build_tools/github/build_minimal_windows_image.sh
@@ -22,6 +22,11 @@ if [[ $FREE_THREADED_BUILD == "False" && "$PLATFORM_ID" != "win_arm64" ]]; then
     # Dot the Python version for identifying the base Docker image
     PYTHON_DOCKER_IMAGE_PART=$(echo ${PYTHON_VERSION:0:1}.${PYTHON_VERSION:1:2})
 
+    # TODO Remove this when Python 3.14 is released and there is a Docker image
+    if [[ "$PYTHON_DOCKER_IMAGE_PART" == "3.14" ]]; then
+        PYTHON_DOCKER_IMAGE_PART="3.14-rc"
+    fi
+
     # We could have all of the following logic in a Dockerfile but it's a lot
     # easier to do it in bash rather than figure out how to do it in Powershell
     # inside the Dockerfile ...
@@ -45,5 +50,5 @@ else
     # TODO When pandas has a release with a Windows free-threaded wheel we can
     # replace the next line with
     # python -m pip install CIBW_TEST_REQUIRES
-    python -m pip install 'pytest<9'
+    python -m pip install pytest
 fi

--- a/build_tools/github/test_source.sh
+++ b/build_tools/github/test_source.sh
@@ -9,7 +9,7 @@ python -m venv test_env
 source test_env/bin/activate
 
 python -m pip install scikit-learn/scikit-learn/dist/*.tar.gz
-python -m pip install 'pytest<9' pandas
+python -m pip install pytest pandas
 
 # Run the tests on the installed source distribution
 mkdir tmp_for_test


### PR DESCRIPTION
Follow-up of #32688.

pytest 9.0.1 has been released 2 hours ago, which should fix the issue. Let's see if the wheels build is successful.

Edit: the wheels build was successful see [build log](https://github.com/scikit-learn/scikit-learn/actions/runs/19301332929/job/55196353527?pr=32698).