### PR TITLE
Return `'cpu'` for `device(numpy_array)` when dispatch is enabled

### DIFF
--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -153,8 +153,7 @@ def _check_array_api_dispatch(array_api_dispatch):
 def _single_array_device(array):
     """Hardware device where the array data resides on."""
     if (
-        isinstance(array, (numpy.ndarray, numpy.generic))
-        or not hasattr(array, "device")
+        not hasattr(array, "device")
         # When array API dispatch is disabled, we expect the scikit-learn code
         # to use np.asarray so that the resulting NumPy array will implicitly use the
         # CPU. In this case, scikit-learn should stay as device neutral as possible,

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -687,15 +687,17 @@ def test_add_to_diagonal(array_namespace, device_, dtype_name):
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 @pytest.mark.parametrize("dispatch", [True, False])
 def test_sparse_device(csr_container, dispatch):
+    # Before numpy 2, the device attribute is not available on numpy arrays.
+    expect_cpu_device = hasattr(numpy.array([[1]]), "device") and dispatch
     a, b = csr_container(numpy.array([[1]])), csr_container(numpy.array([[2]]))
     if dispatch and os.environ.get("SCIPY_ARRAY_API") is None:
         raise SkipTest("SCIPY_ARRAY_API is not set: not checking array_api input")
     with config_context(array_api_dispatch=dispatch):
         assert device(a, b) is None
-        assert device(a, numpy.array([1])) == ("cpu" if dispatch else None)
+        assert device(a, numpy.array([1])) == ("cpu" if expect_cpu_device else None)
         assert get_namespace_and_device(a, b)[2] is None
         assert get_namespace_and_device(a, numpy.array([1]))[2] == (
-            "cpu" if dispatch else None
+            "cpu" if expect_cpu_device else None
         )
 
 

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -687,18 +687,17 @@ def test_add_to_diagonal(array_namespace, device_, dtype_name):
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 @pytest.mark.parametrize("dispatch", [True, False])
 def test_sparse_device(csr_container, dispatch):
-    # Before numpy 2, the device attribute is not available on numpy arrays.
-    expect_cpu_device = hasattr(numpy.array([[1]]), "device") and dispatch
+    np_arr = numpy.array([1])
+    # For numpy < 2, the device attribute is not available on numpy arrays
+    expected_numpy_array_device = getattr(np_arr, "device", None) if dispatch else None
     a, b = csr_container(numpy.array([[1]])), csr_container(numpy.array([[2]]))
     if dispatch and os.environ.get("SCIPY_ARRAY_API") is None:
         raise SkipTest("SCIPY_ARRAY_API is not set: not checking array_api input")
     with config_context(array_api_dispatch=dispatch):
         assert device(a, b) is None
-        assert device(a, numpy.array([1])) == ("cpu" if expect_cpu_device else None)
+        assert device(a, np_arr) == expected_numpy_array_device
         assert get_namespace_and_device(a, b)[2] is None
-        assert get_namespace_and_device(a, numpy.array([1]))[2] == (
-            "cpu" if expect_cpu_device else None
-        )
+        assert get_namespace_and_device(a, np_arr)[2] == expected_numpy_array_device
 
 
 @pytest.mark.parametrize(

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -692,9 +692,11 @@ def test_sparse_device(csr_container, dispatch):
         raise SkipTest("SCIPY_ARRAY_API is not set: not checking array_api input")
     with config_context(array_api_dispatch=dispatch):
         assert device(a, b) is None
-        assert device(a, numpy.array([1])) is None
+        assert device(a, numpy.array([1])) == ("cpu" if dispatch else None)
         assert get_namespace_and_device(a, b)[2] is None
-        assert get_namespace_and_device(a, numpy.array([1]))[2] is None
+        assert get_namespace_and_device(a, numpy.array([1]))[2] == (
+            "cpu" if dispatch else None
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR will check using the CI whether we can change the current behavior for `device` to return `"cpu"` on numpy inputs when `array_api_dispatch is True`.

Context: https://github.com/scikit-learn/scikit-learn/pull/31829#issuecomment-3523758213