### PR TITLE
DOC Fix swapped axes in linear model coefficient plots (Issue #32706)

### DIFF
--- a/examples/inspection/plot_linear_model_coefficient_interpretation.py
+++ b/examples/inspection/plot_linear_model_coefficient_interpretation.py
@@ -388,12 +388,12 @@ plt.subplots_adjust(left=0.3)
 #
 # .. _covariation:
 
-plt.ylabel("Age coefficient")
-plt.xlabel("Experience coefficient")
+plt.xlabel("Age coefficient")
+plt.ylabel("Experience coefficient")
 plt.grid(True)
 plt.xlim(-0.4, 0.5)
 plt.ylim(-0.4, 0.5)
-plt.scatter(coefs["EXPERIENCE"], coefs["AGE"])
+plt.scatter(coefs["AGE"], coefs["EXPERIENCE"])
 _ = plt.title("Co-variations of coefficients for AGE and EXPERIENCE across folds")
 
 # %%
@@ -624,12 +624,12 @@ coefs = pd.DataFrame(
 )
 
 # %%
-plt.ylabel("Age coefficient")
-plt.xlabel("Experience coefficient")
+plt.xlabel("Age coefficient")
+plt.ylabel("Experience coefficient")
 plt.grid(True)
 plt.xlim(-0.4, 0.5)
 plt.ylim(-0.4, 0.5)
-plt.scatter(coefs["EXPERIENCE"], coefs["AGE"])
+plt.scatter(coefs["AGE"], coefs["EXPERIENCE"])
 _ = plt.title("Co-variations of coefficients for AGE and EXPERIENCE across folds")
 
 # %%

--- a/examples/inspection/plot_linear_model_coefficient_interpretation.py
+++ b/examples/inspection/plot_linear_model_coefficient_interpretation.py
@@ -393,7 +393,7 @@ plt.xlabel("Experience coefficient")
 plt.grid(True)
 plt.xlim(-0.4, 0.5)
 plt.ylim(-0.4, 0.5)
-plt.scatter(coefs["AGE"], coefs["EXPERIENCE"])
+plt.scatter(coefs["EXPERIENCE"], coefs["AGE"])
 _ = plt.title("Co-variations of coefficients for AGE and EXPERIENCE across folds")
 
 # %%
@@ -629,7 +629,7 @@ plt.xlabel("Experience coefficient")
 plt.grid(True)
 plt.xlim(-0.4, 0.5)
 plt.ylim(-0.4, 0.5)
-plt.scatter(coefs["AGE"], coefs["EXPERIENCE"])
+plt.scatter(coefs["EXPERIENCE"], coefs["AGE"])
 _ = plt.title("Co-variations of coefficients for AGE and EXPERIENCE across folds")
 
 # %%


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #32706.

#### What does this implement/fix? Explain your changes.

Corrected two instances where AGE and EXPERIENCE coefficients were plotted in the wrong order. 
This aligns the scatter plots with the axis labels and fixes the inconsistency raised in Issue #32706.

This PR updates two `plt.scatter()` calls in the linear model coefficient interpretation example where 
`AGE` and `EXPERIENCE` were plotted in the wrong order. 

According to the axis labeling (Experience on the x-axis and Age on the y-axis), the arguments to 
`plt.scatter()` needed to be swapped. Both plots have now been corrected for consistency.

#### Any other comments?
The modification affects only example documentation code and does not change any library behavior.
