### PR TITLE
MNT remove _safe_indexing from api_reference.py

### DIFF
--- a/doc/api_reference.py
+++ b/doc/api_reference.py
@@ -1162,7 +1162,6 @@ API_REFERENCE = {
                 "title": None,
                 "autosummary": [
                     "Bunch",
-                    "_safe_indexing",
                     "as_float_array",
                     "assert_all_finite",
                     "deprecated",


### PR DESCRIPTION
#### Reference Issues/PRs
Relates to #27439.


#### What does this implement/fix? Explain your changes.
If right now, it is officially not public, let's remove it from the public API list.

#### Any other comments?

