### PR TITLE
DOC Add links to glossary for terms binary, multiclass, multilabel for ranking metrics

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -287,9 +287,10 @@ def det_curve(
 ):
     """Compute Detection Error Tradeoff (DET) for different probability thresholds.
 
-    .. note::
-       This metric is used for evaluation of ranking and error tradeoffs of
-       a binary classification task.
+    Note: this implementation is restricted to the :term:`binary` classification task.
+
+    DET curve is used for evaluation of ranking and error tradeoffs of binary
+    classification tasks.
 
     Read more in the :ref:`User Guide <det_curve>`.
 
@@ -492,8 +493,8 @@ def roc_auc_score(
     """Compute Area Under the Receiver Operating Characteristic Curve (ROC AUC) \
     from prediction scores.
 
-    Note: this implementation can be used with binary, multiclass and
-    multilabel classification, but some restrictions apply (see Parameters).
+    Note: this implementation can be used with :term:`binary`, :term:`multiclass` and
+    :term:`multilabel` classification, but some restrictions apply (see Parameters).
 
     Read more in the :ref:`User Guide <roc_metrics>`.
 
@@ -507,7 +508,7 @@ def roc_auc_score(
     y_score : array-like of shape (n_samples,) or (n_samples, n_classes)
         Target scores.
 
-        * In the binary case, it corresponds to an array of shape
+        * In the :term:`binary` case, it corresponds to an array of shape
           `(n_samples,)`. Both probability estimates and non-thresholded
           decision values can be provided. The probability estimates correspond
           to the **probability of the class with the greater label**,
@@ -515,7 +516,7 @@ def roc_auc_score(
           `estimator.predict_proba(X, y)[:, 1]`. The decision values
           corresponds to the output of `estimator.decision_function(X, y)`.
           See more information in the :ref:`User guide <roc_auc_binary>`;
-        * In the multiclass case, it corresponds to an array of shape
+        * In the :term:`multiclass` case, it corresponds to an array of shape
           `(n_samples, n_classes)` of probability estimates provided by the
           `predict_proba` method. The probability estimates **must**
           sum to 1 across the possible classes. In addition, the order of the
@@ -523,7 +524,7 @@ def roc_auc_score(
           if provided, or else to the numerical or lexicographical order of
           the labels in ``y_true``. See more information in the
           :ref:`User guide <roc_auc_multiclass>`;
-        * In the multilabel case, it corresponds to an array of shape
+        * In the :term:`multilabel` case, it corresponds to an array of shape
           `(n_samples, n_classes)`. Probability estimates are provided by the
           `predict_proba` method and the non-thresholded decision values by
           the `decision_function` method. The probability estimates correspond
@@ -849,7 +850,7 @@ def _multiclass_roc_auc_score(
     prefer_skip_nested_validation=True,
 )
 def confusion_matrix_at_thresholds(y_true, y_score, pos_label=None, sample_weight=None):
-    """Calculate binary confusion matrix terms per classification threshold.
+    """Calculate :term:`binary` confusion matrix terms per classification threshold.
 
     Read more in the :ref:`User Guide <confusion_matrix>`.
 
@@ -1003,7 +1004,7 @@ def precision_recall_curve(
 ):
     """Compute precision-recall pairs for different probability thresholds.
 
-    Note: this implementation is restricted to the binary classification task.
+    Note: this implementation is restricted to the :term:`binary` classification task.
 
     The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
     true positives and ``fp`` the number of false positives. The precision is
@@ -1156,7 +1157,7 @@ def roc_curve(
 ):
     """Compute Receiver operating characteristic (ROC).
 
-    Note: this implementation is restricted to the binary classification task.
+    Note: this implementation is restricted to the :term:`binary` classification task.
 
     Read more in the :ref:`User Guide <roc_metrics>`.
 

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -287,7 +287,8 @@ def det_curve(
 ):
     """Compute Detection Error Tradeoff (DET) for different probability thresholds.
 
-    Note: this implementation is restricted to the :term:`binary` classification task.
+    Note: Support beyond :term:`binary` classification tasks, via one-vs-rest or
+    one-vs-one, is not implemented.
 
     The DET curve is used for evaluation of ranking and error tradeoffs in binary
     classification tasks.
@@ -1004,7 +1005,8 @@ def precision_recall_curve(
 ):
     """Compute precision-recall pairs for different probability thresholds.
 
-    Note: this implementation is restricted to the :term:`binary` classification task.
+    Note: Support beyond :term:`binary` classification tasks, via one-vs-rest or
+    one-vs-one, is not implemented.
 
     The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
     true positives and ``fp`` the number of false positives. The precision is
@@ -1157,7 +1159,8 @@ def roc_curve(
 ):
     """Compute Receiver operating characteristic (ROC).
 
-    Note: this implementation is restricted to the :term:`binary` classification task.
+    Note: Support beyond :term:`binary` classification tasks, via one-vs-rest or
+    one-vs-one, is not implemented.
 
     Read more in the :ref:`User Guide <roc_metrics>`.
 

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -289,7 +289,7 @@ def det_curve(
 
     Note: this implementation is restricted to the :term:`binary` classification task.
 
-    DET curve is used for evaluation of ranking and error tradeoffs of binary
+    The DET curve is used for evaluation of ranking and error tradeoffs in binary
     classification tasks.
 
     Read more in the :ref:`User Guide <det_curve>`.


### PR DESCRIPTION
#### Reference Issues/PRs

Noticed while working on #32732 

#### What does this implement/fix? Explain your changes.

* add links to the glossary for terms binary, multiclass, multilabel 
* Minor update to `det_curve` to make it more consistent with `precision_recall_curve` and `roc_curve`

#### Any other comments?



