### PR TITLE
DOC Shorten PR template and improve PR attention FAQ

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,7 +29,9 @@ is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
 
 
 <!--
-Please be aware that we are a team of volunteers and we appreciate your patience during the review process.
+Thank you for your patience. Changes to scikit-learn require careful
+attention, but with limited maintainer time, not every contribution can be reviewed
+quickly.
 For more information and tips on improving your pull request, see:
 https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,13 +29,8 @@ is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
 
 
 <!--
-Please be aware that we are a loose team of volunteers so patience is
-necessary; assistance handling other issues is very welcome. We value
-all user contributions, no matter how minor they are. If we are slow to
-review, either the pull request needs some benchmarking, tinkering,
-convincing, etc. or more likely the reviewers are simply busy. In either
-case, we ask for your understanding during the review process.
-For more information, see our FAQ on this topic:
+Please be aware that we are a team of volunteers and we appreciate your patience during the review process.
+For more information and tips on improving your pull request, see:
 https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.
 
 Thanks for contributing!

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -572,6 +572,8 @@ them over is a great service for the project. A good etiquette to take over is:
   new PR to the old one. The new PR should be created by pulling from the
   old one.
 
+.. _stalled_unclaimed_issues:
+
 Stalled and Unclaimed Issues
 ----------------------------
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -321,9 +321,10 @@ be reviewed, you can try:
 
 For your pull requests specifically, the following will make it easier to review:
 
-* ensure your PR satisfies all items in the :ref:`Pull request checklist <pr_checklist>`
-* ensure your PR addresses an issue for which there is clear consensus on the solution
-* ensure the changes are minimal and directly relevant to the described issue
+* ensure your PR satisfies all items in the
+  :ref:`Pull request checklist <pr_checklist>`.
+* ensure your PR addresses an issue for which there is clear consensus on the solution.
+* ensure the changes are minimal and directly relevant to the described issue.
 
 What does the "spam" label for issues or pull requests mean?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -339,7 +340,8 @@ issue that is still under discussion. Please wait for the discussion to
 converge before opening a PR.
 
 If your issue or PR was labeled as spam and not closed, see :ref:`improve_issue_pr`
-for tips on improving your issue or pull request.
+for tips on improving your issue or pull request and increasing the likelihood
+of the label being removed.
 
 .. _new_algorithms_inclusion_criteria:
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -308,8 +308,8 @@ reviewed quickly, see :ref:`improve_issue_pr`.
 How do I improve my issue or pull request?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To help your issue receive attention or your pull request be more likely to
-be reviewed, you can try:
+To help your issue receive attention or improve the likelihood of your pull request
+being reviewed, you can try:
 
 * follow our :ref:`contribution guidelines <contributing>`, in particular
   :ref:`automated_contributions_policy`, :ref:`filing_bugs`,

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -300,6 +300,31 @@ reviewers are busy. We ask for your understanding and request that you
 not close your pull request or discontinue your work solely because of
 this reason.
 
+For tips on how to make your pull request easier to review and more likely to be
+reviewed quickly, see :ref:`improve_issue_pr`.
+
+.. _improve_issue_pr:
+
+How do I improve my issue or pull request?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To help your issue receive attention or your pull request be more likely to
+be reviewed, you can try:
+
+* follow our :ref:`contribution guidelines <contributing>`, in particular
+  :ref:`automated_contributions_policy`, :ref:`filing_bugs`,
+  :ref:`stalled_pull_request` and :ref:`stalled_unclaimed_issues`.
+* complete the provided issue and pull request templates, including a clear and
+  concise description of the issue or motivation for the pull request.
+* ensure the title clearly describes the issue or pull request and does not include
+  an issue number.
+
+For your pull requests specifically, the following will make it easier to review:
+
+* ensure your PR satisfies all items in the :ref:`Pull request checklist <pr_checklist>`
+* ensure your PR addresses an issue for which there is clear consensus on the solution
+* ensure the changes are minimal and directly relevant to the described issue
+
 What does the "spam" label for issues or pull requests mean?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -313,19 +338,8 @@ is final. A common reason for this happening is when people open a PR for an
 issue that is still under discussion. Please wait for the discussion to
 converge before opening a PR.
 
-If your issue or PR was labeled as spam and not closed the following steps
-can increase the chances of the label being removed:
-
-- follow the :ref:`contribution guidelines <contributing>` and use the provided
-  issue and pull request templates
-- improve the formatting and grammar of the text of the title and description of the issue/PR
-- improve the diff to remove noise and unrelated changes
-- improve the issue or pull request title to be more descriptive
-- self review your code, especially if :ref:`you used AI tools to generate it <automated_contributions_policy>`
-- refrain from opening PRs that paraphrase existing code or documentation
-  without actually improving the correctness, clarity or educational
-  value of the existing code or documentation.
-
+If your issue or PR was labeled as spam and not closed, see :ref:`improve_issue_pr`
+for tips on improving your issue or pull request.
 
 .. _new_algorithms_inclusion_criteria:
 


### PR DESCRIPTION

#### Reference Issues/PRs
Motivated by reading our PR template while opening a PR and wondering if it was a bit long. I think there is truth in the idea that the longer we make something, the less likely people are to read it.
Related #32566

#### What does this implement/fix? Explain your changes.

* Shortens the section in the PR template asking for patience and suggesting ways to improve the PR. Opted for improving the FAQ that is linked to instead.
   * I also had a look at the PR templates of [numpy](https://raw.githubusercontent.com/numpy/numpy/refs/heads/main/.github/PULL_REQUEST_TEMPLATE.md) and [scipy](https://raw.githubusercontent.com/scipy/scipy/refs/heads/main/.github/PULL_REQUEST_TEMPLATE.md) for inspiration - which are shorter
* added a section in the FAQ on ways to improve PR or issue - I noticed that there we say similar things in a few places now: [spam FAQ](https://scikit-learn.org/dev/faq.html#what-does-the-spam-label-for-issues-or-pull-requests-mean) and in the auto-close comment (#32504). I think having it in one place and linking it will shorten messages and make it easier for us to amend things in future.
   * I am not sure where this best belongs. Potentially there could be a place for it in the contributing guide, but currently, I think the FAQ section is okay. As noted by @lesteve, our contributing guide is very long and covers many disparate topics (see: https://github.com/scikit-learn/scikit-learn/pull/32343#issuecomment-3371376718), and could do with a clean up to improve 


#### Any other comments?

cc @StefanieSenger @adrinjalali @betatim 
