### PR TITLE
CI Tweak autoclose script to add more debug info

### DIFF
--- a/build_tools/github/autoclose_prs.py
+++ b/build_tools/github/autoclose_prs.py
@@ -3,21 +3,23 @@
 Called from .github/workflows/autoclose-schedule.yml."""
 
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from pprint import pprint
 
 from github import Github
 
-CUTOFF_DAYS = 14
-
 
 def get_labeled_last_time(pr, label):
-    labeled_time = None
+    labeled_time = datetime.max
     for event in pr.get_events():
         if event.event == "labeled" and event.label.name == label:
             labeled_time = event.created_at
 
     return labeled_time
 
+
+dry_run = False
+cutoff_days = 14
 
 gh_repo = "scikit-learn/scikit-learn"
 github_token = os.getenv("GITHUB_TOKEN")
@@ -29,13 +31,20 @@ repo = gh.get_repo(gh_repo)
 now = datetime.now(timezone.utc)
 label = "autoclose"
 prs = [
-    each
-    for each in repo.get_issues(labels=[label])
-    if each.pull_request is not None
-    and (now - get_labeled_last_time(each, label)).days > CUTOFF_DAYS
+    each for each in repo.get_issues(labels=[label]) if each.pull_request is not None
 ]
-pr_numbers = [pr.number for pr in prs]
-print(f"Found {len(prs)} PRs to autoclose: {pr_numbers}")
+prs_info = [f"{pr.title}: {pr.html_url}" for pr in prs]
+print(f"Found {len(prs)} opened PRs with label {label}")
+pprint(prs_info)
+
+prs = [
+    pr
+    for pr in prs
+    if (now - get_labeled_last_time(pr, label)) > timedelta(days=cutoff_days)
+]
+prs_info = [f"{pr.title} {pr.html_url}" for pr in prs]
+print(f"Found {len(prs)} PRs to autoclose")
+pprint(prs_info)
 
 message = (
     "Thank you for your interest in contributing to scikit-learn, but we cannot "
@@ -49,5 +58,6 @@ message = (
 
 for pr in prs:
     print(f"Closing PR #{pr.number} with comment")
-    pr.create_comment(message)
-    pr.edit(state="closed")
+    if not dry_run:
+        pr.create_comment(message)
+        pr.edit(state="closed")

--- a/build_tools/github/autoclose_prs.py
+++ b/build_tools/github/autoclose_prs.py
@@ -6,7 +6,7 @@ import os
 from datetime import datetime, timedelta, timezone
 from pprint import pprint
 
-from github import Github
+from github import Auth, Github
 
 
 def get_labeled_last_time(pr, label):
@@ -24,7 +24,8 @@ cutoff_days = 14
 gh_repo = "scikit-learn/scikit-learn"
 github_token = os.getenv("GITHUB_TOKEN")
 
-gh = Github(github_token)
+auth = Auth.Token(github_token)
+gh = Github(auth=auth)
 repo = gh.get_repo(gh_repo)
 
 

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -70,6 +70,9 @@ from sklearn import __check_build, _distributor_init  # noqa: E402 F401
 from sklearn.base import clone  # noqa: E402
 from sklearn.utils._show_versions import show_versions  # noqa: E402
 
+
+
+
 _submodules = [
     "calibration",
     "cluster",

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -70,9 +70,6 @@ from sklearn import __check_build, _distributor_init  # noqa: E402 F401
 from sklearn.base import clone  # noqa: E402
 from sklearn.utils._show_versions import show_versions  # noqa: E402
 
-
-
-
 _submodules = [
     "calibration",
     "cluster",


### PR DESCRIPTION
Main changes:
- more debug info to print opened PRs with autoclose label and then the number of PRs to close. This would allow to monitor the action before it can close its first PR https://github.com/scikit-learn/scikit-learn/pull/32743
- add `dry_run` variable to be able to set it to `False` and run the script locally without worrying about closing PRs
- use `timedelta` rather than difference of days
- more minor stuff

cc @StefanieSenger 

Here is the output if I run it locally:
```
❯ python build_tools/github/autoclose_prs.py
Found 1 opened PRs with label autoclose
['Test autoclose in PR: '
 'https://github.com/scikit-learn/scikit-learn/pull/32743']
Found 0 PRs to autoclose
[]
```