### PR TITLE
FIX LogisticRegressionCV with CV split with missing class labels

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/32747.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/32747.fix.rst
@@ -1,0 +1,4 @@
+- :class:`linear_model.LogisticRegressionCV` is able to handle CV splits where
+  some class labels are missing in some folds. Before, it raised an error whenever a
+  class label were missing in a fold.
+  By :user:`Christian Lorentzen <lorentzenchr>

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -276,12 +276,12 @@ def _logistic_regression_path(
 
     random_state = check_random_state(random_state)
 
-    le = LabelEncoder()
+    le = LabelEncoder().fit(classes)
     if class_weight is not None:
         class_weight_ = compute_class_weight(
             class_weight, classes=classes, y=y, sample_weight=sample_weight
         )
-        sample_weight *= class_weight_[le.fit_transform(y)]
+        sample_weight *= class_weight_[le.transform(y)]
 
     if is_binary:
         w0 = np.zeros(n_features + int(fit_intercept), dtype=X.dtype)
@@ -297,7 +297,7 @@ def _logistic_regression_path(
         # All solvers capable of a multinomial need LabelEncoder, not LabelBinarizer,
         # i.e. y as a 1d-array of integers. LabelEncoder also saves memory
         # compared to LabelBinarizer, especially when n_classes is large.
-        Y_multi = le.fit_transform(y).astype(X.dtype, copy=False)
+        Y_multi = le.transform(y).astype(X.dtype, copy=False)
         # It is important that w0 is F-contiguous.
         w0 = np.zeros(
             (classes.size, n_features + int(fit_intercept)), order="F", dtype=X.dtype
@@ -721,6 +721,9 @@ def _log_reg_scoring_path(
         else:
             score_params = score_params or {}
             score_params = _check_method_params(X=X, params=score_params, indices=test)
+            # FIXME: If scoring = "neg_brier_score" and if not all class labels
+            # are present in y_test, the following fails. Maybe we can pass
+            # "labels=classes" to the call of scoring.
             scores.append(scoring(log_reg, X_test, y_test, **score_params))
     return coefs, Cs, np.array(scores), n_iter
 

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -676,9 +676,10 @@ def _log_reg_scoring_path(
         sw_train = sample_weight[train]
         sw_test = sample_weight[test]
 
-    # Note: We pass classes for the whole dataset to avoid inconsistencies, i.e.
-    # different number of classes in different folds. This way, if a class is empty
-    # in a fold, _logistic_regression_path will initialize it to zero and not change.
+    # Note: We pass classes for the whole dataset to avoid inconsistencies,
+    # i.e. different number of classes in different folds. This way, if a class
+    # is not present in a fold, _logistic_regression_path will still return
+    # coefficients associated to this class.
     coefs, Cs, n_iter = _logistic_regression_path(
         X_train,
         y_train,

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -737,8 +737,7 @@ def test_multinomial_cv_iris(use_legacy_attributes):
                 # Note that we have to exclude the intercept, hence the ':-1'
                 # on the last dimension
                 coefs = clf_multi.coefs_paths_[fold, 0, :, :, :-1]
-                coefs = coefs.reshape(len(clf_multi.Cs_), -1)
-                norms = np.sum(coefs * coefs, axis=1)  # L2 norm for each C
+                norms = np.sum(coefs * coefs, axis=(-2, -1))  # L2 norm for each C
                 assert np.all(np.diff(norms) >= 0)
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fix #32748 and #30832

Leftover from https://github.com/scikit-learn/scikit-learn/pull/32073#discussion_r2537432774.

#### What does this implement/fix? Explain your changes.
If a CV fold in `LogisticRegressionCV` has not all classes present, the result is more or less random (certain solvers emit convergence warnings). This PR adds a test (CI will first fail) and then fix the test.

#### Any other comments?
