### PR TITLE
FIX Fix LogisticRegressionCV bug when a fold does not contain all classes

### DIFF
--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -276,12 +276,12 @@ def _logistic_regression_path(
 
     random_state = check_random_state(random_state)
 
-    le = LabelEncoder()
+    le = LabelEncoder().fit(classes)
     if class_weight is not None:
         class_weight_ = compute_class_weight(
             class_weight, classes=classes, y=y, sample_weight=sample_weight
         )
-        sample_weight *= class_weight_[le.fit_transform(y)]
+        sample_weight *= class_weight_[le.transform(y)]
 
     if is_binary:
         w0 = np.zeros(n_features + int(fit_intercept), dtype=X.dtype)
@@ -297,7 +297,7 @@ def _logistic_regression_path(
         # All solvers capable of a multinomial need LabelEncoder, not LabelBinarizer,
         # i.e. y as a 1d-array of integers. LabelEncoder also saves memory
         # compared to LabelBinarizer, especially when n_classes is large.
-        Y_multi = le.fit_transform(y).astype(X.dtype, copy=False)
+        Y_multi = le.transform(y).astype(X.dtype, copy=False)
         # It is important that w0 is F-contiguous.
         w0 = np.zeros(
             (classes.size, n_features + int(fit_intercept)), order="F", dtype=X.dtype


### PR DESCRIPTION
Addresses https://github.com/scikit-learn/scikit-learn/issues/32748 following suggestions by @lorentzenchr.

I guess I would still need to add a test checking that the coefficients are zero for the absent class.