### PR TITLE
TST: fix `test_absolute_errors_precomputation_function` flakyness (float precision issue)

### DIFF
--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -2974,8 +2974,8 @@ def test_absolute_errors_precomputation_function(global_random_seed):
         if reverse:
             abs_errors_ = abs_errors_[::-1]
             medians_ = medians_[::-1]
-        assert_allclose(abs_errors, abs_errors_, atol=1e-12)
-        assert_allclose(medians, medians_, atol=1e-12)
+        assert_allclose(abs_errors, abs_errors_, atol=1e-11)
+        assert_allclose(medians, medians_, atol=1e-11)
 
     rng = np.random.default_rng(global_random_seed)
 


### PR DESCRIPTION
#### Reference Issues/PRs

Partially fixes #32725

#### What does this implement/fix? Explain your changes.

Just changed the `atol` to `1e-11` in some `assert_all_close` which was failing comparing 0 with very small values (~2e-12).
