### PR TITLE
TST: fix `test_mincovdet_bias_on_normal` flakyness by using random seed

### DIFF
--- a/sklearn/covariance/tests/test_robust_covariance.py
+++ b/sklearn/covariance/tests/test_robust_covariance.py
@@ -187,7 +187,12 @@ def test_mincovdet_bias_on_normal(n_samples, n_features, global_random_seed):
     # Assume centered data, to reduce test complexity
     var_emp = empirical_covariance(x.T, assume_centered=True).diagonal()
     cov_mcd = (
-        MinCovDet(support_fraction=1.0, store_precision=False, assume_centered=True)
+        MinCovDet(
+            support_fraction=1.0,
+            store_precision=False,
+            assume_centered=True,
+            random_state=global_random_seed,
+        )
         .fit(x.T)
         .covariance_
     )

--- a/sklearn/covariance/tests/test_robust_covariance.py
+++ b/sklearn/covariance/tests/test_robust_covariance.py
@@ -182,7 +182,8 @@ def test_mincovdet_bias_on_normal(n_samples, n_features, global_random_seed):
     https://github.com/scikit-learn/scikit-learn/issues/23162
     """
     threshold = 0.985  # threshold for variance underesitmation
-    x = np.random.randn(n_features, n_samples)
+    rng = np.random.default_rng(global_random_seed)
+    x = rng.normal(size=(n_features, n_samples))
     # Assume centered data, to reduce test complexity
     var_emp = empirical_covariance(x.T, assume_centered=True).diagonal()
     cov_mcd = (


### PR DESCRIPTION
#### Reference Issues/PRs

Partially fixes #32725 

#### What does this implement/fix? Explain your changes.

Use `global_random_seed` to avoid the test to randomly fail due to bad luck (only happens on some platforms like debian 32 bits, and something like once every 300-500 runs...).