### PR TITLE
DOC: fix MacPorts package name typo in installation page

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -302,7 +302,7 @@ https://pkgsrc.se/math/py-scikit-learn
 MacPorts for Mac OSX
 --------------------
 
-The MacPorts package is named ``py<XY>-scikits-learn``,
+The MacPorts package is named ``py<XY>-scikit-learn``,
 where ``XY`` denotes the Python version.
 It can be installed by typing the following
 command:


### PR DESCRIPTION
#### Reference Issues/PRs
None.

#### What does this implement/fix? Explain your changes.
Fixes a typo in the MacPorts installation instructions.  
The package name was incorrectly documented as `py<XY>-scikits-learn`, while the actual MacPorts port is `py<XY>-scikit-learn`.  
Updated the documentation to reflect the correct package name.

#### Any other comments?
Documentation-only change. No impact on code or behavior.
