### PR TITLE
TST Enable pytest faulthandler functionality

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,6 @@ jobs:
         COVERAGE: 'false'
         # Disable pytest-xdist to use multiple cores for stress-testing with pytest-run-parallel
         PYTEST_XDIST_VERSION: 'none'
-        SKLEARN_FAULTHANDLER_TIMEOUT: '1800'  # 30 * 60 seconds
 
 # Will run all the time regardless of linting outcome.
 - template: build_tools/azure/posix.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,12 @@ thread_unsafe_fixtures = [
   "tmp_path",  # does not isolate temporary directories across threads
   "pyplot",  # some tests might mutate some shared state of pyplot.
 ]
+# 10 min timeout per test: in case of timeout, dump the tracebacks of all
+# threads and terminate the whole test session if a test hangs for more than 10
+# min (likely due to a deadlock).
+# The second option requires pytest 9.0+ to be active.
+faulthandler_timeout = 600
+faulthandler_exit_on_timeout = true
 
 
 [tool.ruff]

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import builtins
-import faulthandler
 import platform
 import sys
 from contextlib import suppress
@@ -345,11 +344,6 @@ def pytest_configure(config):
         # https://github.com/pytest-dev/pytest/issues/3311#issuecomment-373177592
         for line in get_pytest_filterwarning_lines():
             config.addinivalue_line("filterwarnings", line)
-
-    faulthandler_timeout = int(environ.get("SKLEARN_FAULTHANDLER_TIMEOUT", "0"))
-    if faulthandler_timeout > 0:
-        faulthandler.enable()
-        faulthandler.dump_traceback_later(faulthandler_timeout, exit=True)
 
     if not PARALLEL_RUN_AVAILABLE:
         config.addinivalue_line(


### PR DESCRIPTION
Now that we use pytest 9.0.1 on the CI, we can enable:

- https://docs.pytest.org/en/9.0.x/reference/reference.html#confval-faulthandler_exit_on_timeout

This should make it possible to debug rare deadlocks more easily if they randomly happen on the CI. This might become more useful if we start to use Python threads more in the future, in particular with free-threaded Python.