### PR TITLE
[16298]fixed LinearSVR 

### DIFF
--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -1034,7 +1034,7 @@ def _get_liblinear_solver_type(multi_class, penalty, loss, dual):
         "logistic_regression": {"l1": {False: 6}, "l2": {False: 0, True: 7}},
         "hinge": {"l2": {True: 3}},
         "squared_hinge": {"l1": {False: 5}, "l2": {False: 2, True: 1}},
-        "epsilon_insensitive": {"l2": {True: 13}},
+        "epsilon_insensitive": {"l2": {True: 12}},
         "squared_epsilon_insensitive": {"l2": {False: 11, True: 12}},
         "crammer_singer": 4,
     }


### PR DESCRIPTION


#### Reference Issues/PRs
 Fixes LinearSVR in  #16298.

#### What does this implement/fix? Explain your changes.
I have found that the solver selector referenced in this mr was wrong and selecting l1 instead of l2 loss.
First lets look at the LinearSVR and to be more specific the loss type at line 588. It is clearly shown that is 'l2'
<img width="1866" height="1472" alt="Screenshot from 2025-11-24 23-41-40" src="https://github.com/user-attachments/assets/ba0b84e5-e9d3-4af2-acd4-72da76142c57" />
If we dig deeper we can see that the selector or the _get_liblinear_solver_type function clearly returns in the original code the number 13 for epsilon_insensitive: l2 
<img width="1866" height="1472" alt="Screenshot from 2025-11-24 23-43-22" src="https://github.com/user-attachments/assets/9cf97ab6-4760-49a7-99a7-912197c0fdcb" />
But if we look further at the cpp implementation this will select for a l1 loss not l2 loss
<img width="2811" height="1149" alt="Screenshot from 2025-11-24 23-44-41" src="https://github.com/user-attachments/assets/39eeba06-420d-4774-8823-aab922d05d35" />
Without going in any more details this will lead for a bound for the update loss to be selected represented by the sample weights and the regularizing term for weights lambda to be zero. With my implementation the l2 loss is selected and there is no bound on the loss update ,the sample weights goes to the regularizing factor lambda and the test(mentioned in the 16298 the one with the notebook ) passes  with flying  colors.

#### Any other comments?
Earlier I have tried to set C to 0.001 and it worked but idk why exactly. My mentor mentioned that there is a possibility for
numerical instability and I am investigating this possibility