### PR TITLE
TST Fix test_min_dependencies_readme.py with upper bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ build-backend = "mesonpy"
 # Minimum requirements for the build system to execute.
 requires = [
     "meson-python>=0.17.1",
-    "Cython>=3.1.2",
+    "cython>=3.1.2",
     "numpy>=2",
     "scipy>=1.10.0",
 ]

--- a/sklearn/tests/test_min_dependencies_readme.py
+++ b/sklearn/tests/test_min_dependencies_readme.py
@@ -96,20 +96,19 @@ def check_pyproject_section(
         info = info[key]
 
     pyproject_build_min_versions = {}
+    # Assuming pyproject.toml build section has something like my-package>=<min_version>
+    # Warning: if you try to modify this regex, bear in mind that there can be upper
+    # bounds in release branches so my-package>=<min_version>,<max_version>
+    pattern = r"([\w-]+)\s*[>=]=\s*([\d\w.]+)"
     for requirement in info:
-        if ">=" in requirement:
-            package, version = requirement.split(">=")
-        elif "==" in requirement:
-            package, version = requirement.split("==")
-        else:
+        match = re.search(pattern, requirement)
+        if match is None:
             raise NotImplementedError(
-                f"{requirement} not supported yet in this test. "
+                f"{requirement} does not match expected regex {pattern!r}. "
                 "Only >= and == are supported for version requirements"
             )
 
-        # It's Cython in pyproject.toml but cython in _min_dependencies.py
-        if package == "Cython":
-            package = "cython"
+        package, version = match.group(1), match.group(2)
 
         pyproject_build_min_versions[package] = version
 

--- a/sklearn/tests/test_min_dependencies_readme.py
+++ b/sklearn/tests/test_min_dependencies_readme.py
@@ -96,9 +96,9 @@ def check_pyproject_section(
         info = info[key]
 
     pyproject_build_min_versions = {}
-    # Assuming pyproject.toml build section has something like my-package>=<min_version>
+    # Assuming pyproject.toml build section has something like "my-package>=min_version"
     # Warning: if you try to modify this regex, bear in mind that there can be upper
-    # bounds in release branches so my-package>=<min_version>,<max_version>
+    # bounds in release branches so "my-package>=min_version,<max_version"
     pattern = r"([\w-]+)\s*[>=]=\s*([\d\w.]+)"
     for requirement in info:
         match = re.search(pattern, requirement)

--- a/sklearn/tests/test_min_dependencies_readme.py
+++ b/sklearn/tests/test_min_dependencies_readme.py
@@ -96,9 +96,9 @@ def check_pyproject_section(
         info = info[key]
 
     pyproject_build_min_versions = {}
-    # Assuming pyproject.toml build section has something like "my-package>=min_version"
+    # Assuming pyproject.toml build section has something like "my-package>=2.3.0"
     # Warning: if you try to modify this regex, bear in mind that there can be upper
-    # bounds in release branches so "my-package>=min_version,<max_version"
+    # bounds in release branches so "my-package>=2.3.0,<2.5.0"
     pattern = r"([\w-]+)\s*[>=]=\s*([\d\w.]+)"
     for requirement in info:
         match = re.search(pattern, requirement)


### PR DESCRIPTION
Noticed when setting upper bounds in the 1.8 release candidate PR in https://github.com/scikit-learn/scikit-learn/pull/32766

I think the previous test was not testing anything which is probably why we never noticed see https://github.com/scikit-learn/scikit-learn/pull/31656/files#r2334147276 ...

cc @jeremiedbb 