### PR TITLE
CI Test full doc build to assess OpenML status after November 24-28 maintenance

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -20,6 +20,9 @@ set -x
 # defines the get_dep and show_installed_libraries functions
 source build_tools/shared.sh
 
+du -sh ~/scikit_learn_data || echo no cache
+rm -rf ~/scikit_learn_data || echo no cache
+
 if [ -n "$GITHUB_ACTION" ]
 then
     # Map the variables from Github Action to CircleCI


### PR DESCRIPTION
Test that full doc build actually works after OpenML maintenance issues see https://github.com/scikit-learn/scikit-learn/pull/32795#issuecomment-3580123311