### PR TITLE
DOC fix typo in 1.8 changelog

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.base/32341.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.base/32341.fix.rst
@@ -1,2 +1,2 @@
 - Fixed the handling of pandas missing values in HTML display of all estimators.
-  By :user: `Dea María Léon <deamarialeon>`.
+  By :user:`Dea María Léon <deamarialeon>`.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Fixes a typo in the 1.8 changelog to display the following item properly:
<img width="783" height="84" alt="image" src="https://github.com/user-attachments/assets/7d42d663-7bac-4229-874b-ee370b371f12" />
cc @lesteve 