### PR TITLE
MNT clean up double calls to `check_array` in `brier_score_loss`, `d2_brier_score` and `d2_log_loss_score`

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -284,10 +284,6 @@ def _validate_multiclass_probabilistic_prediction(
     """
     xp, _, device_ = get_namespace_and_device(y_prob)
 
-    y_prob = check_array(
-        y_prob, ensure_2d=False, dtype=supported_float_dtypes(xp, device=device_)
-    )
-
     if xp.max(y_prob) > 1:
         raise ValueError(f"y_prob contains values greater than 1: {xp.max(y_prob)}")
     if xp.min(y_prob) < 0:
@@ -326,7 +322,6 @@ def _validate_multiclass_probabilistic_prediction(
         )
 
     # Check if dimensions are consistent.
-    transformed_labels = check_array(transformed_labels)
     if len(lb_classes) != y_prob.shape[1]:
         if labels is None:
             raise ValueError(
@@ -3382,8 +3377,11 @@ def log_loss(y_true, y_pred, *, normalize=True, sample_weight=None, labels=None)
     ...          [[.1, .9], [.9, .1], [.8, .2], [.35, .65]])
     0.21616
     """
+    xp, _, device_ = get_namespace_and_device(y_pred)
+    y_pred = check_array(
+        y_pred, ensure_2d=False, dtype=supported_float_dtypes(xp, device=device_)
+    )
     if sample_weight is not None:
-        xp, _, device_ = get_namespace_and_device(y_pred)
         sample_weight = move_to(sample_weight, xp=xp, device=device_)
 
     transformed_labels, y_pred = _validate_multiclass_probabilistic_prediction(
@@ -3865,9 +3863,11 @@ def d2_log_loss_score(y_true, y_pred, *, sample_weight=None, labels=None):
         warnings.warn(msg, UndefinedMetricWarning)
         return float("nan")
 
-    y_pred = check_array(y_pred, ensure_2d=False, dtype="numeric")
+    xp, _, device_ = get_namespace_and_device(y_pred)
+    y_pred = check_array(
+        y_pred, ensure_2d=False, dtype=supported_float_dtypes(xp, device=device_)
+    )
     if sample_weight is not None:
-        xp, _, device_ = get_namespace_and_device(y_pred)
         sample_weight = move_to(sample_weight, xp=xp, device=device_)
 
     transformed_labels, y_pred = _validate_multiclass_probabilistic_prediction(

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -260,7 +260,7 @@ def _validate_multiclass_probabilistic_prediction(
     y_true : array-like or label indicator matrix
         Ground truth (correct) labels for n_samples samples.
 
-    y_prob : array-like of float, shape=(n_samples, n_classes) or (n_samples,)
+    y_prob : array of float, shape=(n_samples, n_classes) or (n_samples,)
         Predicted probabilities, as returned by a classifier's
         predict_proba method. If `y_prob.shape = (n_samples,)`
         the probabilities provided are assumed to be that of the

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -251,7 +251,7 @@ def _validate_multiclass_probabilistic_prediction(
     y_true : array-like or label indicator matrix
         Ground truth (correct) labels for n_samples samples.
 
-    y_prob : array of float, shape=(n_samples, n_classes) or (n_samples,)
+    y_prob : array of floats, shape=(n_samples, n_classes) or (n_samples,)
         Predicted probabilities, as returned by a classifier's
         predict_proba method. If `y_prob.shape = (n_samples,)`
         the probabilities provided are assumed to be that of the


### PR DESCRIPTION
#### Reference Issues/PRs
https://github.com/scikit-learn/scikit-learn/pull/32549#issuecomment-3428908083

#### What does this implement/fix? Explain your changes.
This PR cleans up double calls to `check_array(y_pred, ...)` in `brier_score_loss`, `d2_brier_score`  and `d2_log_loss_score`, that had been introduced probably by accident over the years.

In addition, I have seen that the call to `check_array(transformed_labels)` is probably unnecessary. I have checked `_one_hot_encoding_multiclass_target()` and there is no possibility of the return value not being a proper array, I think.

#### Details ####
Since, `y_pred` needs to be checked early in these scoring functions, I have decided to remove the second call to `check_array` from `_validate_multiclass_probabilistic_prediction` which is called later from of the functions. As an additional argument, `_validate_binary_probabilistic_prediction` doesn't check arrays either and the solution I have chosen is cleaner.

This required to add the check to `log_loss`, which previously had only relied on `_validate_multiclass_probabilistic_prediction` for checking `y_pred`.