### PR TITLE
CI Work-around for conda-lock hang in builds with pip packages

### DIFF
--- a/build_tools/shared.sh
+++ b/build_tools/shared.sh
@@ -65,6 +65,6 @@ create_conda_environment_from_lock_file() {
         conda create --quiet --name $ENV_NAME --file $LOCK_FILE
     else
         python -m pip install "$(get_dep conda-lock min)"
-        conda-lock install --log-level WARNING --name $ENV_NAME $LOCK_FILE
+        conda-lock install --name $ENV_NAME $LOCK_FILE
     fi
 }


### PR DESCRIPTION
Using the default logging level makes it a lot less likely for the hang to happen, see https://github.com/scikit-learn/scikit-learn/pull/32643#issuecomment-3587845466 for the summary and the debug PR for more info if you are curious. cc @ogrisel who nudged me towards not giving up my investigation :wink:.

The change was done in https://github.com/scikit-learn/scikit-learn/pull/32596 to reduce the verbosity of the command, but actually as noted in https://github.com/scikit-learn/scikit-learn/pull/32596#issuecomment-3455837859, the most noisy command is `conda create` that prints a lot of empty newlines, the `conda-lock install` is OKish [^1]. The PR was merged on October 29 and the debug PR showed I started to notice enough to open a debug PR on November 3.

[^1]: one of the most verbose build with plenty of pip packages is pylatest pandas that has ~30 lines see [build log](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=82973&view=logs&j=78a0bf4f-79e5-5387-94ec-13e67d216d6e&t=75a90307-b084-59e7-ba24-7f7161804495&l=188) 

More info: 
- this only happened for some reason in conda environments with pip packages, e.g. doc, doc-min-dependencies, pylatest_pip_openblas_pandas, pymin_conda_forge_openblas_min_dependencies, pylatest_pip_scipy_dev.
- I am going to wild-guess that this is some kind of dead-lock having to do with how conda-lock captures stdout/stderr and logs it again. I am not planning to understand it further :sweat_smile:. The conda-lock code has some mention of dead-lock https://github.com/conda/conda-lock/blob/61a623471e6468d70a037f145de150913e8a8ead/conda_lock/invoke_conda.py#L124-L127. Also this PR to fix what looks like a somewhat similar bug https://github.com/conda/conda-lock/pull/581.
