### PR TITLE
CI Move pylatest_pip_openblas_pandas to Github Actions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -130,7 +130,7 @@ jobs:
           # It runs tests requiring lightgbm, pandas and PyAMG.
           - name: Linux pylatest_pip_openblas_pandas
             os: ubuntu-24.04
-            DISTRIB: 'conda-pip-latest'
+            DISTRIB: 'conda'
             LOCK_FILE: './build_tools/azure/pylatest_pip_openblas_pandas_linux-64_conda.lock'
             SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 3  # non-default seed
             SCIPY_ARRAY_API: '1'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -130,26 +130,26 @@ jobs:
           # It runs tests requiring lightgbm, pandas and PyAMG.
           - name: Linux pylatest_pip_openblas_pandas
             os: ubuntu-24.04
-            DISTRIB: 'conda'
-            LOCK_FILE: './build_tools/azure/pylatest_pip_openblas_pandas_linux-64_conda.lock'
+            DISTRIB: conda
+            LOCK_FILE: build_tools/azure/pylatest_pip_openblas_pandas_linux-64_conda.lock
             SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 3  # non-default seed
-            SCIPY_ARRAY_API: '1'
-            CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-            SKLEARN_WARNINGS_AS_ERRORS: '1'
+            SCIPY_ARRAY_API: 1
+            CHECK_PYTEST_SOFT_DEPENDENCY: true
+            SKLEARN_WARNINGS_AS_ERRORS: 1
             # disable pytest-xdist to have 1 job where OpenMP and BLAS are not single
             # threaded because by default the tests configuration (sklearn/conftest.py)
             # makes sure that they are single threaded in each xdist subprocess.
-            PYTEST_XDIST_VERSION: 'none'
-            PIP_BUILD_ISOLATION: 'true'
+            PYTEST_XDIST_VERSION: none
+            PIP_BUILD_ISOLATION: true
 
           - name: macOS pylatest_conda_forge_arm
             os: macOS-15
             DISTRIB: conda
             LOCK_FILE: build_tools/azure/pylatest_conda_forge_osx-arm64_conda.lock
             SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 5  # non-default seed
-            SCIPY_ARRAY_API: '1'
-            PYTORCH_ENABLE_MPS_FALLBACK: '1'
-            CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+            SCIPY_ARRAY_API: 1
+            PYTORCH_ENABLE_MPS_FALLBACK: 1
+            CHECK_PYTEST_SOFT_DEPENDENCY: true
 
     env: ${{ matrix }}
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -147,8 +147,8 @@ jobs:
             DISTRIB: conda
             LOCK_FILE: build_tools/azure/pylatest_conda_forge_osx-arm64_conda.lock
             SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 5  # non-default seed
-            SCIPY_ARRAY_API: 1
-            PYTORCH_ENABLE_MPS_FALLBACK: 1
+            SCIPY_ARRAY_API: '1'
+            PYTORCH_ENABLE_MPS_FALLBACK: '1'
             CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
 
     env: ${{ matrix }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -133,6 +133,21 @@ jobs:
             SCIPY_ARRAY_API: 1
             PYTORCH_ENABLE_MPS_FALLBACK: 1
             CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+          # Linux environment to test the latest available dependencies.
+          # It runs tests requiring lightgbm, pandas and PyAMG.
+          - name: Linux pylatest_pip_openblas_pandas
+            os: ubuntu-24.04
+            DISTRIB: 'conda-pip-latest'
+            LOCK_FILE: './build_tools/azure/pylatest_pip_openblas_pandas_linux-64_conda.lock'
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 3  # non-default seed
+            SCIPY_ARRAY_API: '1'
+            CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+            SKLEARN_WARNINGS_AS_ERRORS: '1'
+            # disable pytest-xdist to have 1 job where OpenMP and BLAS are not single
+            # threaded because by default the tests configuration (sklearn/conftest.py)
+            # makes sure that they are single threaded in each xdist subprocess.
+            PYTEST_XDIST_VERSION: 'none'
+            PIP_BUILD_ISOLATION: 'true'
 
     env: ${{ matrix }}
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -125,14 +125,7 @@ jobs:
             os: ubuntu-24.04-arm
             DISTRIB: conda
             LOCK_FILE: build_tools/github/pymin_conda_forge_arm_linux-aarch64_conda.lock
-          - name: macOS pylatest_conda_forge_arm
-            os: macOS-15
-            DISTRIB: conda
-            LOCK_FILE: build_tools/azure/pylatest_conda_forge_osx-arm64_conda.lock
-            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 5  # non-default seed
-            SCIPY_ARRAY_API: 1
-            PYTORCH_ENABLE_MPS_FALLBACK: 1
-            CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
+
           # Linux environment to test the latest available dependencies.
           # It runs tests requiring lightgbm, pandas and PyAMG.
           - name: Linux pylatest_pip_openblas_pandas
@@ -148,6 +141,15 @@ jobs:
             # makes sure that they are single threaded in each xdist subprocess.
             PYTEST_XDIST_VERSION: 'none'
             PIP_BUILD_ISOLATION: 'true'
+
+          - name: macOS pylatest_conda_forge_arm
+            os: macOS-15
+            DISTRIB: conda
+            LOCK_FILE: build_tools/azure/pylatest_conda_forge_osx-arm64_conda.lock
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 5  # non-default seed
+            SCIPY_ARRAY_API: 1
+            PYTORCH_ENABLE_MPS_FALLBACK: 1
+            CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
 
     env: ${{ matrix }}
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -183,21 +183,6 @@ jobs:
         SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES: '1'
         SKLEARN_RUN_FLOAT32_TESTS: '1'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '2'  # non-default seed
-      # TODO: remove following test when it works on Github Actions
-      # Linux environment to test the latest available dependencies.
-      # It runs tests requiring lightgbm, pandas and PyAMG.
-      pylatest_pip_openblas_pandas:
-        DISTRIB: 'conda-pip-latest'
-        LOCK_FILE: './build_tools/azure/pylatest_pip_openblas_pandas_linux-64_conda.lock'
-        CHECK_PYTEST_SOFT_DEPENDENCY: 'true'
-        SKLEARN_WARNINGS_AS_ERRORS: '1'
-        SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '3'  # non-default seed
-        # disable pytest-xdist to have 1 job where OpenMP and BLAS are not single
-        # threaded because by default the tests configuration (sklearn/conftest.py)
-        # makes sure that they are single threaded in each xdist subprocess.
-        PYTEST_XDIST_VERSION: 'none'
-        PIP_BUILD_ISOLATION: 'true'
-        SCIPY_ARRAY_API: '1'
 
 - template: build_tools/azure/posix-docker.yml
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -183,6 +183,7 @@ jobs:
         SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES: '1'
         SKLEARN_RUN_FLOAT32_TESTS: '1'
         SKLEARN_TESTS_GLOBAL_RANDOM_SEED: '2'  # non-default seed
+      # TODO: remove following test when it works on Github Actions
       # Linux environment to test the latest available dependencies.
       # It runs tests requiring lightgbm, pandas and PyAMG.
       pylatest_pip_openblas_pandas:


### PR DESCRIPTION
This moves `pylatest_pip_openblas_pandas` job from Azure to Github Actions.

Worked on it together with @lesteve.

Part of #32434.