### PR TITLE
FIX screening in enet_coordinate_descent_multi_task

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/32811.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/32811.fix.rst
@@ -1,0 +1,5 @@
+- A small bug in the coordinate descent solver of
+  :class:`linear_model.MultiTaskElasticNetCV` and
+  :class:`linear_model.MultiTaskLassoCV` was fixed. The algorithm now correctly uses
+  the "exclude set" for the (gap safe) screened features.
+  By :user:`Christian Lorentzen <lorentzenchr>`.

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/32811.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/32811.fix.rst
@@ -1,5 +1,0 @@
-- A small bug in the coordinate descent solver of
-  :class:`linear_model.MultiTaskElasticNetCV` and
-  :class:`linear_model.MultiTaskLassoCV` was fixed. The algorithm now correctly uses
-  the "exclude set" for the (gap safe) screened features.
-  By :user:`Christian Lorentzen <lorentzenchr>`.

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -1434,7 +1434,7 @@ def enet_coordinate_descent_multi_task(
                 if do_screening:
                     n_active = 0
                     for j in range(n_features):
-                        if norm2_cols_X[j] == 0:
+                        if excluded_set[j]:
                             continue
                         # Xj_theta = ||X[:,j] @ dual_theta||_2
                         Xj_theta = XtA_row_norms[j] / fmax(l1_reg, dual_norm_XtA)


### PR DESCRIPTION
#### Reference Issues/PRs
Aftermath of #32014.

#### What does this implement/fix? Explain your changes.
This fixes a tiny code bug. I think it does (almost never) influence fitting an estimator.

#### Any other comments?
