### PR TITLE
DOC Fix indentation in _logistic.py docstrings

### DIFF
--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -861,7 +861,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
           class of problems.
         - For :term:`multiclass` problems (`n_classes >= 3`), all solvers except
           'liblinear' minimize the full multinomial loss, 'liblinear' will raise an
-           error.
+          error.
         - 'newton-cholesky' is a good choice for
           `n_samples` >> `n_features * n_classes`, especially with one-hot encoded
           categorical features with rare categories. Be aware that the memory usage
@@ -1465,7 +1465,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
           class of problems.
         - For :term:`multiclass` problems (`n_classes >= 3`), all solvers except
           'liblinear' minimize the full multinomial loss, 'liblinear' will raise an
-           error.
+          error.
         - 'newton-cholesky' is a good choice for
           `n_samples` >> `n_features * n_classes`, especially with one-hot encoded
           categorical features with rare categories. Be aware that the memory usage


### PR DESCRIPTION
Notice because of a warning in doc build
```

/home/circleci/project/sklearn/linear_model/_logistic.py:docstring of sklearn.linear_model._logistic.LogisticRegression:127: ERROR: Unexpected indentation. [docutils]
/home/circleci/project/sklearn/linear_model/_logistic.py:docstring of sklearn.linear_model._logistic.LogisticRegressionCV:104: ERROR: Unexpected indentation. [docutils]
```

[HTML doc](https://scikit-learn.org/dev/modules/generated/sklearn.linear_model.LogisticRegression.html)
<img width="765" height="267" alt="image" src="https://github.com/user-attachments/assets/e322f049-1110-4a37-9571-d3a1af48e5b1" />
