### PR TITLE
FIX: move_to should handle BufferError and ValueError to support PyTorch 2.9 with array API enabled

### DIFF
--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -527,7 +527,15 @@ def move_to(*arrays, xp, device):
                     # kwargs in the from_dlpack method and their expected
                     # meaning by namespaces implementing the array API spec.
                     # TODO: try removing this once DLPack v1 more widely supported
-                except (AttributeError, TypeError, NotImplementedError):
+                    # TODO: ValueError should not be needed but is in practice:
+                    # https://github.com/numpy/numpy/issues/30341
+                except (
+                    AttributeError,
+                    TypeError,
+                    NotImplementedError,
+                    BufferError,
+                    ValueError,
+                ):
                     # Converting to numpy is tricky, handle this via dedicated function
                     if _is_numpy_namespace(xp):
                         array_converted = _convert_to_numpy(array, xp_array)


### PR DESCRIPTION
This fixes `move_to` (introduced in #31829) to make it work with PyTorch 2.9 and NumPy 2.3:

- we need to catch `BufferError` as per the [`__dlpack__` spec](https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__dlpack__.html#:~:text=dl_device,-(Optional)
- we also need to catch `ValuError` (at least for now) because of https://github.com/numpy/numpy/issues/30341. 


I tested locally, and this fixes our test failures with PyTorch 2.9.1 (see https://github.com/scikit-learn/scikit-learn/pull/32824).

