### PR TITLE
DOC Add HTML repr related PR to existing changelog

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.utils/31564.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/31564.enhancement.rst
@@ -2,4 +2,4 @@
   more generally of estimators inheriting from :class:`base.BaseEstimator`
   now displays the parameter description as a tooltip and has a link to the online
   documentation for each parameter.
-  By :user:`Dea María Léon <DeaMariaLeon>`.
+  By :user:`Dea María Léon <DeaMariaLeon>`. :pr:`30763` and

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -148,4 +148,3 @@ def setup_module(module):
     print("I: Seeding RNGs with %r" % _random_seed)
     np.random.seed(_random_seed)
     random.seed(_random_seed)
-

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -148,3 +148,4 @@ def setup_module(module):
     print("I: Seeding RNGs with %r" % _random_seed)
     np.random.seed(_random_seed)
     random.seed(_random_seed)
+


### PR DESCRIPTION
Looking at the changelog and release highlights #30763 is not mentioned. Since this is the one that adds parameters to HTML repr, this is a bit of a shame.

For completeness:
- this way is a bit hacky but works fine: you add manually a `:pr:` with the right PR and the second PR is based on the number inside the filename. I noticed @lorentzenchr did it and that's actually a good idea!
- I think towncrier has a way to do something similar where you need to add the exact same changelog text in two different files and they will be grouped in the same changelog entry (they need to be in the same category e.g. enhancement otherwise it's not grouped). IMO this is too complicated so let's do it the simple manual way.