### PR TITLE
MNT Use Pyodide 0.29 version to avoid micropip error inside JupyterLite

### DIFF
--- a/doc/jupyter-lite.json
+++ b/doc/jupyter-lite.json
@@ -3,7 +3,7 @@
   "jupyter-config-data": {
     "litePluginSettings": {
       "@jupyterlite/pyodide-kernel-extension:kernel": {
-        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.27.2/full/pyodide.js"
+        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.29.0/full/pyodide.js"
       }
     }
   }


### PR DESCRIPTION
Fix #32833.

Tested locally this works fine. Let's see if CI has something to say about it. Full disclosure: I don't remember whether the JupyterLite in CircleCI artifacts is functional or not ...

Quickly looking at the Pyodide [0.28](https://blog.pyodide.org/posts/0.28-release/) and [0.29](https://blog.pyodide.org/posts/0.29-release/) blog posts, I don't think there is anything unexpected that should break a lot of notebooks but I may try a few just to double-check.