### PR TITLE
FIX Make `get_namespace` handle pandas dataframe input

### DIFF
--- a/doc/whats_new/upcoming_changes/array-api/32838.fix.rst
+++ b/doc/whats_new/upcoming_changes/array-api/32838.fix.rst
@@ -1,0 +1,2 @@
+- Estimators with array API support no longer reject dataframe inputs when array API support is enabled.
+  By :user:`Tim Head <betatim>`

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -20,6 +20,7 @@ from sklearn.base import TransformerMixin, _fit_context, clone
 from sklearn.pipeline import _fit_transform_one, _name_estimators, _transform_one
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.utils import Bunch
+from sklearn.utils._dataframe import is_pandas_df
 from sklearn.utils._indexing import (
     _determine_key_type,
     _get_column_indices,
@@ -47,7 +48,6 @@ from sklearn.utils.validation import (
     _check_feature_names_in,
     _check_n_features,
     _get_feature_names,
-    _is_pandas_df,
     _num_samples,
     check_array,
     check_is_fitted,
@@ -773,7 +773,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         except ImportError:
             return
         for Xs, name in zip(result, names):
-            if not _is_pandas_df(Xs):
+            if not is_pandas_df(Xs):
                 continue
             for col_name, dtype in Xs.dtypes.to_dict().items():
                 if getattr(dtype, "na_value", None) is not pd.NA:
@@ -1064,7 +1064,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         # were not present in fit time, and the order of the columns doesn't
         # matter.
         fit_dataframe_and_transform_dataframe = hasattr(self, "feature_names_in_") and (
-            _is_pandas_df(X) or hasattr(X, "__dataframe__")
+            is_pandas_df(X) or hasattr(X, "__dataframe__")
         )
 
         n_samples = _num_samples(X)

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -40,6 +40,7 @@ from sklearn.metrics._scorer import _SCORERS
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import FunctionTransformer, LabelEncoder, OrdinalEncoder
 from sklearn.utils import check_random_state, compute_sample_weight, resample
+from sklearn.utils._dataframe import is_pandas_df
 from sklearn.utils._missing import is_scalar_nan
 from sklearn.utils._openmp_helpers import _openmp_effective_n_threads
 from sklearn.utils._param_validation import Interval, RealNotInt, StrOptions
@@ -48,7 +49,6 @@ from sklearn.utils.validation import (
     _check_monotonic_cst,
     _check_sample_weight,
     _check_y,
-    _is_pandas_df,
     check_array,
     check_consistent_length,
     check_is_fitted,
@@ -371,7 +371,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         # fixed in main and maybe included in 2.2.1, see
         # https://github.com/pandas-dev/pandas/pull/57173.
         # Also pandas versions < 1.5.1 do not support the dataframe interchange
-        if _is_pandas_df(X):
+        if is_pandas_df(X):
             X_is_dataframe = True
             categorical_columns_mask = np.asarray(X.dtypes == "category")
         elif hasattr(X, "__dataframe__"):

--- a/sklearn/feature_selection/_base.py
+++ b/sklearn/feature_selection/_base.py
@@ -12,11 +12,11 @@ from scipy.sparse import csc_matrix, issparse
 
 from sklearn.base import TransformerMixin
 from sklearn.utils import _safe_indexing, check_array, safe_sqr
+from sklearn.utils._dataframe import is_pandas_df
 from sklearn.utils._set_output import _get_output_config
 from sklearn.utils._tags import get_tags
 from sklearn.utils.validation import (
     _check_feature_names_in,
-    _is_pandas_df,
     check_is_fitted,
     validate_data,
 )
@@ -100,7 +100,7 @@ class SelectorMixin(TransformerMixin, metaclass=ABCMeta):
         # Preserve X when X is a dataframe and the output is configured to
         # be pandas.
         output_config_dense = _get_output_config("transform", estimator=self)["dense"]
-        preserve_X = output_config_dense != "default" and _is_pandas_df(X)
+        preserve_X = output_config_dense != "default" and is_pandas_df(X)
 
         # note: we use get_tags instead of __sklearn_tags__ because this is a
         # public Mixin.

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -8,13 +8,12 @@ import numpy as np
 from sklearn.base import is_regressor
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import _safe_indexing
+from sklearn.utils._dataframe import is_pandas_df, is_polars_df
 from sklearn.utils._optional_dependencies import check_matplotlib_support
 from sklearn.utils._response import _get_response_values
 from sklearn.utils._set_output import _get_adapter_from_container
 from sklearn.utils.validation import (
     _is_arraylike_not_scalar,
-    _is_pandas_df,
-    _is_polars_df,
     _num_features,
     check_is_fitted,
 )
@@ -496,7 +495,7 @@ class DecisionBoundaryDisplay:
         )
 
         X_grid = np.c_[xx0.ravel(), xx1.ravel()]
-        if _is_pandas_df(X) or _is_polars_df(X):
+        if is_pandas_df(X) or is_polars_df(X):
             adapter = _get_adapter_from_container(X)
             X_grid = adapter.create_container(
                 X_grid,

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -7,6 +7,7 @@ from functools import partial
 import numpy as np
 
 from sklearn.base import BaseEstimator, TransformerMixin, _fit_context
+from sklearn.utils._dataframe import is_pandas_df, is_polars_df
 from sklearn.utils._param_validation import StrOptions
 from sklearn.utils._repr_html.estimator import _VisualBlock
 from sklearn.utils._set_output import _get_adapter_from_container, _get_output_config
@@ -15,8 +16,6 @@ from sklearn.utils.validation import (
     _allclose_dense_sparse,
     _check_feature_names_in,
     _get_feature_names,
-    _is_pandas_df,
-    _is_polars_df,
     check_array,
     validate_data,
 )
@@ -302,9 +301,9 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
                 "a {0} DataFrame to follow the `set_output` API  or `feature_names_out`"
                 " should be defined."
             )
-            if output_config == "pandas" and not _is_pandas_df(out):
+            if output_config == "pandas" and not is_pandas_df(out):
                 warnings.warn(warn_msg.format("pandas"))
-            elif output_config == "polars" and not _is_polars_df(out):
+            elif output_config == "polars" and not is_polars_df(out):
                 warnings.warn(warn_msg.format("polars"))
 
         return out

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -6,7 +6,6 @@
 import itertools
 import math
 import os
-import sys
 
 import numpy
 import scipy
@@ -17,6 +16,7 @@ from sklearn._config import get_config
 from sklearn.externals import array_api_compat
 from sklearn.externals import array_api_extra as xpx
 from sklearn.externals.array_api_compat import numpy as np_compat
+from sklearn.utils._dataframe import is_pandas_df_or_series
 from sklearn.utils.fixes import parse_version
 
 # TODO: complete __all__
@@ -290,16 +290,6 @@ def supported_float_dtypes(xp, device=None):
     return tuple(valid_float_dtypes)
 
 
-# XXX Copied from sklearn.utils.validation.py to avoid circular import
-def _is_pandas_df_or_series(X):
-    """Return True if the X is a pandas dataframe or series."""
-    try:
-        pd = sys.modules["pandas"]
-    except KeyError:
-        return False
-    return isinstance(X, (pd.DataFrame, pd.Series))
-
-
 def _remove_non_arrays(*arrays, remove_none=True, remove_types=(str,)):
     """Filter arrays to exclude None and/or specific types.
 
@@ -331,7 +321,7 @@ def _remove_non_arrays(*arrays, remove_none=True, remove_types=(str,)):
             continue
         if sp.issparse(array):
             continue
-        if _is_pandas_df_or_series(array):
+        if is_pandas_df_or_series(array):
             continue
         filtered_arrays.append(array)
 

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -6,6 +6,7 @@
 import itertools
 import math
 import os
+import sys
 
 import numpy
 import scipy
@@ -289,6 +290,16 @@ def supported_float_dtypes(xp, device=None):
     return tuple(valid_float_dtypes)
 
 
+# XXX Copied from sklearn.utils.validation.py to avoid circular import
+def _is_pandas_df_or_series(X):
+    """Return True if the X is a pandas dataframe or series."""
+    try:
+        pd = sys.modules["pandas"]
+    except KeyError:
+        return False
+    return isinstance(X, (pd.DataFrame, pd.Series))
+
+
 def _remove_non_arrays(*arrays, remove_none=True, remove_types=(str,)):
     """Filter arrays to exclude None and/or specific types.
 
@@ -319,6 +330,8 @@ def _remove_non_arrays(*arrays, remove_none=True, remove_types=(str,)):
         if isinstance(array, remove_types):
             continue
         if sp.issparse(array):
+            continue
+        if _is_pandas_df_or_series(array):
             continue
         filtered_arrays.append(array)
 

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -16,7 +16,7 @@ from sklearn._config import get_config
 from sklearn.externals import array_api_compat
 from sklearn.externals import array_api_extra as xpx
 from sklearn.externals.array_api_compat import numpy as np_compat
-from sklearn.utils._dataframe import is_pandas_df_or_series
+from sklearn.utils._dataframe import is_df_or_series
 from sklearn.utils.fixes import parse_version
 
 # TODO: complete __all__
@@ -321,7 +321,7 @@ def _remove_non_arrays(*arrays, remove_none=True, remove_types=(str,)):
             continue
         if sp.issparse(array):
             continue
-        if is_pandas_df_or_series(array):
+        if is_df_or_series(array):
             continue
         filtered_arrays.append(array)
 

--- a/sklearn/utils/_dataframe.py
+++ b/sklearn/utils/_dataframe.py
@@ -1,0 +1,51 @@
+"""Functions to determine if an object is a dataframe or series."""
+
+# Authors: The scikit-learn developers
+# SPDX-License-Identifier: BSD-3-Clause
+
+import sys
+
+
+def is_pandas_df_or_series(X):
+    """Return True if the X is a pandas dataframe or series."""
+    try:
+        pd = sys.modules["pandas"]
+    except KeyError:
+        return False
+    return isinstance(X, (pd.DataFrame, pd.Series))
+
+
+def is_pandas_df(X):
+    """Return True if the X is a pandas dataframe."""
+    try:
+        pd = sys.modules["pandas"]
+    except KeyError:
+        return False
+    return isinstance(X, pd.DataFrame)
+
+
+def is_pyarrow_data(X):
+    """Return True if the X is a pyarrow Table, RecordBatch, Array or ChunkedArray."""
+    try:
+        pa = sys.modules["pyarrow"]
+    except KeyError:
+        return False
+    return isinstance(X, (pa.Table, pa.RecordBatch, pa.Array, pa.ChunkedArray))
+
+
+def is_polars_df_or_series(X):
+    """Return True if the X is a polars dataframe or series."""
+    try:
+        pl = sys.modules["polars"]
+    except KeyError:
+        return False
+    return isinstance(X, (pl.DataFrame, pl.Series))
+
+
+def is_polars_df(X):
+    """Return True if the X is a polars dataframe."""
+    try:
+        pl = sys.modules["polars"]
+    except KeyError:
+        return False
+    return isinstance(X, pl.DataFrame)

--- a/sklearn/utils/_dataframe.py
+++ b/sklearn/utils/_dataframe.py
@@ -6,6 +6,11 @@
 import sys
 
 
+def is_df_or_series(X):
+    """Return True if the X is a dataframe or series."""
+    return is_pandas_df_or_series(X) or is_polars_df_or_series(X) or is_pyarrow_data(X)
+
+
 def is_pandas_df_or_series(X):
     """Return True if the X is a pandas dataframe or series."""
     try:

--- a/sklearn/utils/_dataframe.py
+++ b/sklearn/utils/_dataframe.py
@@ -7,12 +7,34 @@ import sys
 
 
 def is_df_or_series(X):
-    """Return True if the X is a dataframe or series."""
+    """Return True if the X is a dataframe or series.
+
+    Parameters
+    ----------
+    X : {array-like, dataframe}
+        The array-like or dataframe object to check.
+
+    Returns
+    -------
+    bool
+        True if the X is a dataframe or series, False otherwise.
+    """
     return is_pandas_df_or_series(X) or is_polars_df_or_series(X) or is_pyarrow_data(X)
 
 
 def is_pandas_df_or_series(X):
-    """Return True if the X is a pandas dataframe or series."""
+    """Return True if the X is a pandas dataframe or series.
+
+    Parameters
+    ----------
+    X : {array-like, dataframe}
+        The array-like or dataframe object to check.
+
+    Returns
+    -------
+    bool
+        True if the X is a pandas dataframe or series, False otherwise.
+    """
     try:
         pd = sys.modules["pandas"]
     except KeyError:
@@ -21,7 +43,18 @@ def is_pandas_df_or_series(X):
 
 
 def is_pandas_df(X):
-    """Return True if the X is a pandas dataframe."""
+    """Return True if the X is a pandas dataframe.
+
+    Parameters
+    ----------
+    X : {array-like, dataframe}
+        The array-like or dataframe object to check.
+
+    Returns
+    -------
+    bool
+        True if the X is a pandas dataframe, False otherwise.
+    """
     try:
         pd = sys.modules["pandas"]
     except KeyError:
@@ -30,7 +63,19 @@ def is_pandas_df(X):
 
 
 def is_pyarrow_data(X):
-    """Return True if the X is a pyarrow Table, RecordBatch, Array or ChunkedArray."""
+    """Return True if the X is a pyarrow Table, RecordBatch, Array or ChunkedArray.
+
+    Parameters
+    ----------
+    X : {array-like, dataframe}
+        The array-like or dataframe object to check.
+
+    Returns
+    -------
+    bool
+        True if the X is a pyarrow Table, RecordBatch, Array or ChunkedArray,
+        False otherwise.
+    """
     try:
         pa = sys.modules["pyarrow"]
     except KeyError:
@@ -39,7 +84,18 @@ def is_pyarrow_data(X):
 
 
 def is_polars_df_or_series(X):
-    """Return True if the X is a polars dataframe or series."""
+    """Return True if the X is a polars dataframe or series.
+
+    Parameters
+    ----------
+    X : {array-like, dataframe}
+        The array-like or dataframe object to check.
+
+    Returns
+    -------
+    bool
+        True if the X is a polars dataframe or series, False otherwise.
+    """
     try:
         pl = sys.modules["polars"]
     except KeyError:
@@ -48,7 +104,18 @@ def is_polars_df_or_series(X):
 
 
 def is_polars_df(X):
-    """Return True if the X is a polars dataframe."""
+    """Return True if the X is a polars dataframe.
+
+    Parameters
+    ----------
+    X : {array-like, dataframe}
+        The array-like or dataframe object to check.
+
+    Returns
+    -------
+    bool
+        True if the X is a polarsdataframe, False otherwise.
+    """
     try:
         pl = sys.modules["polars"]
     except KeyError:

--- a/sklearn/utils/_indexing.py
+++ b/sklearn/utils/_indexing.py
@@ -16,15 +16,17 @@ from sklearn.utils._array_api import (
     get_namespace_and_device,
     move_to,
 )
+from sklearn.utils._dataframe import (
+    is_pandas_df,
+    is_polars_df_or_series,
+    is_pyarrow_data,
+)
 from sklearn.utils._param_validation import Interval, validate_params
 from sklearn.utils.extmath import _approximate_mode
 from sklearn.utils.fixes import PYARROW_VERSION_BELOW_17
 from sklearn.utils.validation import (
     _check_sample_weight,
     _is_arraylike_not_scalar,
-    _is_pandas_df,
-    _is_polars_df_or_series,
-    _is_pyarrow_data,
     _use_interchange_protocol,
     check_array,
     check_consistent_length,
@@ -325,21 +327,21 @@ def _safe_indexing(X, indices, *, axis=0):
     if (
         axis == 1
         and indices_dtype == "str"
-        and not (_is_pandas_df(X) or _use_interchange_protocol(X))
+        and not (is_pandas_df(X) or _use_interchange_protocol(X))
     ):
         raise ValueError(
             "Specifying the columns using strings is only supported for dataframes."
         )
 
     if hasattr(X, "iloc"):
-        # TODO: we should probably use _is_pandas_df_or_series(X) instead but:
+        # TODO: we should probably use is_pandas_df_or_series(X) instead but:
         # 1) Currently, it (probably) works for dataframes compliant to pandas' API.
         # 2) Updating would require updating some tests such as
         #    test_train_test_split_mock_pandas.
         return _pandas_indexing(X, indices, indices_dtype, axis=axis)
-    elif _is_polars_df_or_series(X):
+    elif is_polars_df_or_series(X):
         return _polars_indexing(X, indices, indices_dtype, axis=axis)
-    elif _is_pyarrow_data(X):
+    elif is_pyarrow_data(X):
         return _pyarrow_indexing(X, indices, indices_dtype, axis=axis)
     elif _use_interchange_protocol(X):  # pragma: no cover
         # Once the dataframe X is converted into its dataframe interchange protocol

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -85,6 +85,39 @@ def test_get_namespace_ndarray_with_dispatch():
 
 
 @skip_if_array_api_compat_not_configured
+def test_get_namespace_pandas_with_dispatch():
+    """Test get_namespace on pandas dataframes and series."""
+    pd = pytest.importorskip("pandas")
+
+    X_pd = pd.DataFrame([[1, 2, 3]])
+    X_pd_series = pd.Series([1, 2, 3])
+
+    with config_context(array_api_dispatch=True):
+        xp_out, is_array_api_compliant = get_namespace(X_pd)
+        assert not is_array_api_compliant
+
+        # When operating on pandas dataframes or series the Numpy namespace is
+        # the right thing to use.
+        assert xp_out is np_compat
+
+        xp_out, is_array_api_compliant = get_namespace(X_pd_series)
+        assert not is_array_api_compliant
+        assert xp_out is np_compat
+
+
+@skip_if_array_api_compat_not_configured
+def test_get_namespace_sparse_with_dispatch():
+    """Test get_namespace on sparse arrays."""
+    with config_context(array_api_dispatch=True):
+        xp_out, is_array_api_compliant = get_namespace(sp.csr_array([[1, 2, 3]]))
+        assert not is_array_api_compliant
+
+        # When operating on sparse arrays the Numpy namespace is
+        # the right thing to use.
+        assert xp_out is np_compat
+
+
+@skip_if_array_api_compat_not_configured
 def test_get_namespace_array_api(monkeypatch):
     """Test get_namespace for ArrayAPI arrays."""
     xp = pytest.importorskip("array_api_strict")

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -43,6 +43,7 @@ from sklearn.utils._array_api import (
 from sklearn.utils._testing import (
     SkipTest,
     _array_api_for_tests,
+    _convert_container,
     assert_array_equal,
     skip_if_array_api_compat_not_configured,
 )
@@ -85,23 +86,19 @@ def test_get_namespace_ndarray_with_dispatch():
 
 
 @skip_if_array_api_compat_not_configured
-def test_get_namespace_pandas_with_dispatch():
-    """Test get_namespace on pandas dataframes and series."""
-    pd = pytest.importorskip("pandas")
+@pytest.mark.parametrize(
+    "constructor_name", ["pyarrow", "dataframe", "polars", "series"]
+)
+def test_get_namespace_df_with_dispatch(constructor_name):
+    """Test get_namespace on dataframes and series."""
 
-    X_pd = pd.DataFrame([[1, 2, 3]])
-    X_pd_series = pd.Series([1, 2, 3])
-
+    df = _convert_container([[1, 4, 2], [3, 3, 6]], constructor_name)
     with config_context(array_api_dispatch=True):
-        xp_out, is_array_api_compliant = get_namespace(X_pd)
+        xp_out, is_array_api_compliant = get_namespace(df)
         assert not is_array_api_compliant
 
-        # When operating on pandas dataframes or series the Numpy namespace is
+        # When operating on dataframes or series the Numpy namespace is
         # the right thing to use.
-        assert xp_out is np_compat
-
-        xp_out, is_array_api_compliant = get_namespace(X_pd_series)
-        assert not is_array_api_compliant
         assert xp_out is np_compat
 
 

--- a/sklearn/utils/tests/test_dataframe.py
+++ b/sklearn/utils/tests/test_dataframe.py
@@ -1,0 +1,84 @@
+"""Tests for dataframe detection functions."""
+
+import numpy as np
+import pytest
+
+from sklearn._min_dependencies import dependent_packages
+from sklearn.utils._dataframe import is_df_or_series, is_pandas_df, is_polars_df
+from sklearn.utils._testing import _convert_container
+
+
+@pytest.mark.parametrize("constructor_name", ["pyarrow", "dataframe", "polars"])
+def test_is_df_or_series(constructor_name):
+    df = _convert_container([[1, 4, 2], [3, 3, 6]], constructor_name)
+
+    assert is_df_or_series(df)
+    assert not is_df_or_series(np.asarray([1, 2, 3]))
+
+
+@pytest.mark.parametrize("constructor_name", ["pyarrow", "dataframe", "polars"])
+def test_is_pandas_df_other_libraries(constructor_name):
+    df = _convert_container([[1, 4, 2], [3, 3, 6]], constructor_name)
+    if constructor_name in ("pyarrow", "polars"):
+        assert not is_pandas_df(df)
+    else:
+        assert is_pandas_df(df)
+
+
+def test_is_pandas_df():
+    """Check behavior of is_pandas_df when pandas is installed."""
+    pd = pytest.importorskip("pandas")
+    df = pd.DataFrame([[1, 2, 3]])
+    assert is_pandas_df(df)
+    assert not is_pandas_df(np.asarray([1, 2, 3]))
+    assert not is_pandas_df(1)
+
+
+def test_is_pandas_df_pandas_not_installed(hide_available_pandas):
+    """Check is_pandas_df when pandas is not installed."""
+
+    assert not is_pandas_df(np.asarray([1, 2, 3]))
+    assert not is_pandas_df(1)
+
+
+@pytest.mark.parametrize(
+    "constructor_name, minversion",
+    [
+        ("pyarrow", dependent_packages["pyarrow"][0]),
+        ("dataframe", dependent_packages["pandas"][0]),
+        ("polars", dependent_packages["polars"][0]),
+    ],
+)
+def test_is_polars_df_other_libraries(constructor_name, minversion):
+    df = _convert_container(
+        [[1, 4, 2], [3, 3, 6]],
+        constructor_name,
+        minversion=minversion,
+    )
+    if constructor_name in ("pyarrow", "dataframe"):
+        assert not is_polars_df(df)
+    else:
+        assert is_polars_df(df)
+
+
+def test_is_polars_df_for_duck_typed_polars_dataframe():
+    """Check is_polars_df for object that looks like a polars dataframe"""
+
+    class NotAPolarsDataFrame:
+        def __init__(self):
+            self.columns = [1, 2, 3]
+            self.schema = "my_schema"
+
+    not_a_polars_df = NotAPolarsDataFrame()
+    assert not is_polars_df(not_a_polars_df)
+
+
+def test_is_polars_df():
+    """Check that is_polars_df return False for non-dataframe objects."""
+
+    class LooksLikePolars:
+        def __init__(self):
+            self.columns = ["a", "b"]
+            self.schema = ["a", "b"]
+
+    assert not is_polars_df(LooksLikePolars())

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -14,7 +14,6 @@ from pytest import importorskip
 
 import sklearn
 from sklearn._config import config_context
-from sklearn._min_dependencies import dependent_packages
 from sklearn.base import BaseEstimator
 from sklearn.datasets import make_blobs
 from sklearn.ensemble import RandomForestRegressor
@@ -40,7 +39,6 @@ from sklearn.utils._array_api import (
     _is_numpy_namespace,
     yield_namespace_device_dtype_combinations,
 )
-from sklearn.utils._dataframe import is_pandas_df, is_polars_df
 from sklearn.utils._mocking import (
     MockDataFrame,
     _MockEstimatorOnOffPrediction,
@@ -1994,63 +1992,6 @@ def test_get_feature_names_dataframe_protocol(constructor_name, minversion):
     assert_array_equal(feature_names, columns)
 
 
-@pytest.mark.parametrize("constructor_name", ["pyarrow", "dataframe", "polars"])
-def test_is_pandas_df_other_libraries(constructor_name):
-    df = _convert_container([[1, 4, 2], [3, 3, 6]], constructor_name)
-    if constructor_name in ("pyarrow", "polars"):
-        assert not is_pandas_df(df)
-    else:
-        assert is_pandas_df(df)
-
-
-def test_is_pandas_df():
-    """Check behavior of is_pandas_df when pandas is installed."""
-    pd = pytest.importorskip("pandas")
-    df = pd.DataFrame([[1, 2, 3]])
-    assert is_pandas_df(df)
-    assert not is_pandas_df(np.asarray([1, 2, 3]))
-    assert not is_pandas_df(1)
-
-
-def test_is_pandas_df_pandas_not_installed(hide_available_pandas):
-    """Check is_pandas_df when pandas is not installed."""
-
-    assert not is_pandas_df(np.asarray([1, 2, 3]))
-    assert not is_pandas_df(1)
-
-
-@pytest.mark.parametrize(
-    "constructor_name, minversion",
-    [
-        ("pyarrow", dependent_packages["pyarrow"][0]),
-        ("dataframe", dependent_packages["pandas"][0]),
-        ("polars", dependent_packages["polars"][0]),
-    ],
-)
-def test_is_polars_df_other_libraries(constructor_name, minversion):
-    df = _convert_container(
-        [[1, 4, 2], [3, 3, 6]],
-        constructor_name,
-        minversion=minversion,
-    )
-    if constructor_name in ("pyarrow", "dataframe"):
-        assert not is_polars_df(df)
-    else:
-        assert is_polars_df(df)
-
-
-def test_is_polars_df_for_duck_typed_polars_dataframe():
-    """Check is_polars_df for object that looks like a polars dataframe"""
-
-    class NotAPolarsDataFrame:
-        def __init__(self):
-            self.columns = [1, 2, 3]
-            self.schema = "my_schema"
-
-    not_a_polars_df = NotAPolarsDataFrame()
-    assert not is_polars_df(not_a_polars_df)
-
-
 def test_get_feature_names_numpy():
     """Get feature names return None for numpy arrays."""
     X = np.array([[1, 2, 3], [4, 5, 6]])
@@ -2319,17 +2260,6 @@ def test_column_or_1d():
         else:
             with pytest.raises(ValueError):
                 column_or_1d(y)
-
-
-def test_is_polars_df():
-    """Check that is_polars_df return False for non-dataframe objects."""
-
-    class LooksLikePolars:
-        def __init__(self):
-            self.columns = ["a", "b"]
-            self.schema = ["a", "b"]
-
-    assert not is_polars_df(LooksLikePolars())
 
 
 def test_check_array_writeable_np():

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -40,6 +40,7 @@ from sklearn.utils._array_api import (
     _is_numpy_namespace,
     yield_namespace_device_dtype_combinations,
 )
+from sklearn.utils._dataframe import is_pandas_df, is_polars_df
 from sklearn.utils._mocking import (
     MockDataFrame,
     _MockEstimatorOnOffPrediction,
@@ -77,8 +78,6 @@ from sklearn.utils.validation import (
     _estimator_has,
     _get_feature_names,
     _is_fitted,
-    _is_pandas_df,
-    _is_polars_df,
     _num_features,
     _num_samples,
     _to_object_array,
@@ -1999,25 +1998,25 @@ def test_get_feature_names_dataframe_protocol(constructor_name, minversion):
 def test_is_pandas_df_other_libraries(constructor_name):
     df = _convert_container([[1, 4, 2], [3, 3, 6]], constructor_name)
     if constructor_name in ("pyarrow", "polars"):
-        assert not _is_pandas_df(df)
+        assert not is_pandas_df(df)
     else:
-        assert _is_pandas_df(df)
+        assert is_pandas_df(df)
 
 
 def test_is_pandas_df():
     """Check behavior of is_pandas_df when pandas is installed."""
     pd = pytest.importorskip("pandas")
     df = pd.DataFrame([[1, 2, 3]])
-    assert _is_pandas_df(df)
-    assert not _is_pandas_df(np.asarray([1, 2, 3]))
-    assert not _is_pandas_df(1)
+    assert is_pandas_df(df)
+    assert not is_pandas_df(np.asarray([1, 2, 3]))
+    assert not is_pandas_df(1)
 
 
 def test_is_pandas_df_pandas_not_installed(hide_available_pandas):
-    """Check _is_pandas_df when pandas is not installed."""
+    """Check is_pandas_df when pandas is not installed."""
 
-    assert not _is_pandas_df(np.asarray([1, 2, 3]))
-    assert not _is_pandas_df(1)
+    assert not is_pandas_df(np.asarray([1, 2, 3]))
+    assert not is_pandas_df(1)
 
 
 @pytest.mark.parametrize(
@@ -2035,13 +2034,13 @@ def test_is_polars_df_other_libraries(constructor_name, minversion):
         minversion=minversion,
     )
     if constructor_name in ("pyarrow", "dataframe"):
-        assert not _is_polars_df(df)
+        assert not is_polars_df(df)
     else:
-        assert _is_polars_df(df)
+        assert is_polars_df(df)
 
 
 def test_is_polars_df_for_duck_typed_polars_dataframe():
-    """Check _is_polars_df for object that looks like a polars dataframe"""
+    """Check is_polars_df for object that looks like a polars dataframe"""
 
     class NotAPolarsDataFrame:
         def __init__(self):
@@ -2049,7 +2048,7 @@ def test_is_polars_df_for_duck_typed_polars_dataframe():
             self.schema = "my_schema"
 
     not_a_polars_df = NotAPolarsDataFrame()
-    assert not _is_polars_df(not_a_polars_df)
+    assert not is_polars_df(not_a_polars_df)
 
 
 def test_get_feature_names_numpy():
@@ -2322,15 +2321,15 @@ def test_column_or_1d():
                 column_or_1d(y)
 
 
-def test__is_polars_df():
-    """Check that _is_polars_df return False for non-dataframe objects."""
+def test_is_polars_df():
+    """Check that is_polars_df return False for non-dataframe objects."""
 
     class LooksLikePolars:
         def __init__(self):
             self.columns = ["a", "b"]
             self.schema = ["a", "b"]
 
-    assert not _is_polars_df(LooksLikePolars())
+    assert not is_polars_df(LooksLikePolars())
 
 
 def test_check_array_writeable_np():

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -5,7 +5,6 @@
 
 import numbers
 import operator
-import sys
 import warnings
 from collections.abc import Sequence
 from contextlib import suppress
@@ -30,6 +29,7 @@ from sklearn.utils._array_api import (
     get_namespace,
     get_namespace_and_device,
 )
+from sklearn.utils._dataframe import is_pandas_df, is_pandas_df_or_series
 from sklearn.utils._isfinite import FiniteStatus, cy_isfinite
 from sklearn.utils._tags import get_tags
 from sklearn.utils.fixes import (
@@ -312,7 +312,7 @@ def _use_interchange_protocol(X):
     to ensure strict behavioral backward compatibility with older versions of
     scikit-learn.
     """
-    return not _is_pandas_df(X) and hasattr(X, "__dataframe__")
+    return not is_pandas_df(X) and hasattr(X, "__dataframe__")
 
 
 def _num_features(X):
@@ -1129,7 +1129,7 @@ def check_array(
             # ensure that the output is writeable, even if avoidable, to not overwrite
             # the user's data by surprise.
 
-            if _is_pandas_df_or_series(array_orig):
+            if is_pandas_df_or_series(array_orig):
                 try:
                     # In pandas >= 3, np.asarray(df), called earlier in check_array,
                     # returns a read-only intermediate array. It can be made writeable
@@ -2307,51 +2307,6 @@ def _check_method_params(X, params, indices=None):
     return method_params_validated
 
 
-def _is_pandas_df_or_series(X):
-    """Return True if the X is a pandas dataframe or series."""
-    try:
-        pd = sys.modules["pandas"]
-    except KeyError:
-        return False
-    return isinstance(X, (pd.DataFrame, pd.Series))
-
-
-def _is_pandas_df(X):
-    """Return True if the X is a pandas dataframe."""
-    try:
-        pd = sys.modules["pandas"]
-    except KeyError:
-        return False
-    return isinstance(X, pd.DataFrame)
-
-
-def _is_pyarrow_data(X):
-    """Return True if the X is a pyarrow Table, RecordBatch, Array or ChunkedArray."""
-    try:
-        pa = sys.modules["pyarrow"]
-    except KeyError:
-        return False
-    return isinstance(X, (pa.Table, pa.RecordBatch, pa.Array, pa.ChunkedArray))
-
-
-def _is_polars_df_or_series(X):
-    """Return True if the X is a polars dataframe or series."""
-    try:
-        pl = sys.modules["polars"]
-    except KeyError:
-        return False
-    return isinstance(X, (pl.DataFrame, pl.Series))
-
-
-def _is_polars_df(X):
-    """Return True if the X is a polars dataframe."""
-    try:
-        pl = sys.modules["polars"]
-    except KeyError:
-        return False
-    return isinstance(X, pl.DataFrame)
-
-
 def _get_feature_names(X):
     """Get feature names from X.
 
@@ -2375,7 +2330,7 @@ def _get_feature_names(X):
     feature_names = None
 
     # extract feature names for support array containers
-    if _is_pandas_df(X):
+    if is_pandas_df(X):
         # Make sure we can inspect columns names from pandas, even with
         # versions too old to expose a working implementation of
         # __dataframe__.column_names() and avoid introducing any


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #32836
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

A pandas DataFrame or Series does not have a namespace associated to it in the array API. As such we should filter it out, like we do for sparse arrays, before trying to determine the namespace. This means that for `get_namespace(a_df)` (with array API enabled) we get the NumPy compat namespace back as `xp`. I think this makes sense.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
	- Cursor's tab complete helped adapt the test cases from `test_get_namespace_ndarray_with_dispatch` which I used as starting point

#### Any other comments?

How do we solve the problem that we can't import `_is_pandas_df_or_series` from `sklearn.utils.validation` as it causes a circular import. Duplicating it feels a bit weird, but I can't think of a great alternative. We could use `hasattr(array, "iloc")` to detect "pandas-ness"?

Before discussing how we best detect "pandas-ness" we should agree that filtering `DataFrame` and `Series`out (like sparse arrays) is the right approach.

cc @ogrisel 