### PR TITLE
DOC Remove PR from changelog that was already in 1.7

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.utils/31564.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/31564.enhancement.rst
@@ -2,4 +2,4 @@
   more generally of estimators inheriting from :class:`base.BaseEstimator`
   now displays the parameter description as a tooltip and has a link to the online
   documentation for each parameter.
-  By :user:`Dea María Léon <DeaMariaLeon>`. :pr:`30763` and
+  By :user:`Dea María Léon <DeaMariaLeon>`.


### PR DESCRIPTION
Reverting #32831 

PR https://github.com/scikit-learn/scikit-learn/pull/30763 was listed already in version 1.7 [release highlights](https://scikit-learn.org/stable/auto_examples/release_highlights/plot_release_highlights_1_7_0.html#release-highlights-for-scikit-learn-1-7:~:text=estimator%E2%80%99s%20HTML%20representation-,%23,-The%20HTML%20representation) and it was going to be added to release 1.8. For more info, please see https://github.com/scikit-learn/scikit-learn/pull/32809#issuecomment-3612869819