### PR TITLE
FIX activate gap safe screening in MultiTaskElasticNet and MultiTaskLasso

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2763,6 +2763,7 @@ class MultiTaskElasticNet(Lasso):
             self.tol,
             check_random_state(self.random_state),
             random,
+            do_screening=True,
         )
 
         # account for different objective scaling here and in cd_fast


### PR DESCRIPTION
#### Reference Issues/PRs
Aftermath of #32014 and #32811

#### What does this implement/fix? Explain your changes.
In current main, screening is not activated for `MultiTaskElasticNet` and `MultiTaskLasso` because they do not call `enet_path` but `enet_coordinate_descent_multi_task` directly.


#### Any other comments?
This does **not** change/fix the findings in https://github.com/scikit-learn/scikit-learn/pull/32811#pullrequestreview-3530261027.