### PR TITLE
DOC: add train_test_split example for LogisticRegression

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -184,6 +184,28 @@ a linear kernel.
 
 * :ref:`sphx_glr_auto_examples_text_plot_document_classification_20newsgroups.py`
 
+.. code-block:: python
+
+    from sklearn.model_selection import train_test_split
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.datasets import load_iris
+    from sklearn.metrics import accuracy_score
+
+    # Load sample data
+    X, y = load_iris(return_X_y=True)
+
+    # Split data into train and test sets to avoid overfitting
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
+
+    # Create and train the model
+    model = LogisticRegression(max_iter=200)
+    model.fit(X_train, y_train)
+
+    # Predict and evaluate
+    y_pred = model.predict(X_test)
+    print("Accuracy:", accuracy_score(y_test, y_pred))
 
 Ridge Complexity
 ----------------


### PR DESCRIPTION
#### Reference Issues/PRs
N/A

#### What does this implement/fix? Explain your changes.

This PR adds a basic example showing how to use `train_test_split` with 
`LogisticRegression`. It demonstrates splitting the data, training the model, 
and evaluating accuracy. The goal is to help beginners understand the standard 
machine learning workflow more clearly.

#### AI usage disclosure
I used AI assistance for:
- [ ] Code generation
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [ ] Research and understanding

#### Any other comments?
Let me know if the example should be placed elsewhere or formatted differently.
