### PR TITLE
Fix: Ensure nan_euclidean_distances is symmetric for self-distances

### DIFF
--- a/doc/whats_new/upcoming_changes/32851.fix.rst
+++ b/doc/whats_new/upcoming_changes/32851.fix.rst
@@ -1,0 +1,2 @@
+:func:metrics.pairwise.nan_euclidean_distances now correctly handles
+edge cases to ensure symmetry.

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -558,6 +558,10 @@ def nan_euclidean_distances(
 
     if not squared:
         np.sqrt(distances, out=distances)
+        # FIX: Ensure symmetry when computing distance to self
+    if Y is None or Y is X:
+        distances = (distances + distances.T) / 2
+        np.fill_diagonal(distances, 0)
 
     return distances
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -560,7 +560,8 @@ def nan_euclidean_distances(
     # Determine pairs where BOTH vectors are all-NaNs (distance must be 0)
     both_nan = all_nan_X[:, None] & all_nan_Y[None, :]
 
-    # Create the final mask for corruption: overlap is 0 AND it's NOT the case both are all-NaNs
+    # Create the final mask for corruption: overlap is
+    #  0 AND it's NOT the case both are all-NaNs
     mask_to_nan = (present_count == 0) & ~both_nan
 
     distances[mask_to_nan] = np.nan

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -554,16 +554,16 @@ def nan_euclidean_distances(
     is_self_distance = Y is None or Y is X
 
     # Identify vectors that are entirely NaNs (no present features)
-    all_nan_X = (present_X.sum(axis=1) == 0)
-    all_nan_Y = (present_Y.sum(axis=1) == 0)
+    all_nan_X = present_X.sum(axis=1) == 0
+    all_nan_Y = present_Y.sum(axis=1) == 0
 
     # Determine pairs where BOTH vectors are all-NaNs (distance must be 0)
     both_nan = all_nan_X[:, None] & all_nan_Y[None, :]
-    
+
     # Create the final mask for corruption: overlap is 0 AND it's NOT the case both are all-NaNs
     mask_to_nan = (present_count == 0) & ~both_nan
 
-    distances[mask_to_nan] = np.nan 
+    distances[mask_to_nan] = np.nan
     # avoid divide by zero
     np.maximum(1, present_count, out=present_count)
     distances /= present_count
@@ -573,6 +573,7 @@ def nan_euclidean_distances(
         np.sqrt(distances, out=distances)
 
     return distances
+
 
 def _euclidean_distances_upcast(X, XX=None, Y=None, YY=None, batch_size=None):
     """Euclidean distances between X and Y.

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -1819,3 +1819,21 @@ def test_sparse_manhattan_readonly_dataset(csr_container):
     Parallel(n_jobs=2, max_nbytes=0)(
         delayed(manhattan_distances)(m1, m2) for m1, m2 in zip(matrices1, matrices2)
     )
+
+
+def test_nan_euclidean_distances_is_symmetric():
+    # Non-regression test for #32851
+    # Ensure that self-distances are symmetric even with NaNs
+    import numpy as np
+
+    from sklearn.metrics.pairwise import nan_euclidean_distances
+
+    rng = np.random.RandomState(0)
+    X = rng.randn(10, 10)
+    X[0, 0] = np.nan
+
+    # Calculate distance matrix
+    dist = nan_euclidean_distances(X, X)
+
+    # Check if the matrix is symmetric (dist[i, j] should equal dist[j, i])
+    assert np.allclose(dist, dist.T, equal_nan=True)


### PR DESCRIPTION
The nan_euclidean_distances function produced slightly asymmetric matrices (on the order of 1e-15) when computing distances between X and itself, causing issues with downstream tools like scipy.spatial.distance.squareform.
The Fix:
When Y is None or Y is X, the code now explicitly symmetrizes the result matrix (D + D.T) / 2 and sets the diagonal to 0, ensuring perfect symmetry.
Closes #32848
