### PR TITLE
MNT Update link to new build instruction location in `raise_build_error`

### DIFF
--- a/sklearn/__check_build/__init__.py
+++ b/sklearn/__check_build/__init__.py
@@ -42,7 +42,7 @@ It seems that scikit-learn has not been built correctly.
 
 If you have installed scikit-learn from source, please do not forget
 to build the package before using it. For detailed instructions, see:
-https://scikit-learn.org/dev/developers/advanced_installation.html#building-from-source
+https://scikit-learn.org/dev/developers/development_setup.html#install-editable-version-of-scikit-learn
 %s"""
         % (e, local_dir, "".join(dir_content).strip(), msg)
     )


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
leftover from the changes to the development setup docs https://github.com/scikit-learn/scikit-learn/pull/32509 
#### What does this implement/fix? Explain your changes.
update the link in the raised error message to point to the new location on information for building from source (old link location doesn't exist anymore)