### PR TITLE
FIX add quickfix for pandas warning causing CI error

### DIFF
--- a/sklearn/preprocessing/tests/test_target_encoder.py
+++ b/sklearn/preprocessing/tests/test_target_encoder.py
@@ -725,7 +725,7 @@ def test_pandas_copy_on_write():
                 message="Copy-on-Write can no longer be disabled, "
                 "setting to False has no impact. This option will "
                 "be removed in pandas 4.0.",
-                category=pd.errors.Pandas4Warning,
+                category=DeprecationWarning,
             )
             with pd.option_context("mode.copy_on_write", True):
                 df = pd.DataFrame({"x": ["a", "b", "b"], "y": [4.0, 5.0, 6.0]})

--- a/sklearn/preprocessing/tests/test_target_encoder.py
+++ b/sklearn/preprocessing/tests/test_target_encoder.py
@@ -1,6 +1,5 @@
 import re
 import warnings
-from importlib.metadata import version
 
 import numpy as np
 import pytest
@@ -22,6 +21,7 @@ from sklearn.preprocessing import (
     LabelEncoder,
     TargetEncoder,
 )
+from sklearn.utils.fixes import parse_version
 
 
 def _encode_target(X_ordinal, y_numeric, n_categories, smooth):
@@ -715,7 +715,7 @@ def test_pandas_copy_on_write():
     # (and copy-on-write will always be enabled).
     # see https://github.com/scikit-learn/scikit-learn/issues/32829
     # TODO: remove this workaround when pandas 4 is our minimum version
-    if int(version("pandas").split(".")[0]) >= 4:
+    if parse_version(pd.__version__) >= parse_version("4.0"):
         df = pd.DataFrame({"x": ["a", "b", "b"], "y": [4.0, 5.0, 6.0]})
         TargetEncoder(target_type="continuous").fit(df[["x"]], df["y"])
     else:

--- a/sklearn/preprocessing/tests/test_target_encoder.py
+++ b/sklearn/preprocessing/tests/test_target_encoder.py
@@ -720,12 +720,15 @@ def test_pandas_copy_on_write():
         TargetEncoder(target_type="continuous").fit(df[["x"]], df["y"])
     else:
         with warnings.catch_warnings():
+            expected_message = (
+                "Copy-on-Write can no longer be disabled, "
+                "setting to False has no impact. This option will "
+                "be removed in pandas 4.0."
+            )
             warnings.filterwarnings(
                 "ignore",
-                message="Copy-on-Write can no longer be disabled, "
-                "setting to False has no impact. This option will "
-                "be removed in pandas 4.0.",
-                category=pd.errors.Pandas4Warning,
+                message=re.escape(expected_message),
+                category=DeprecationWarning,
             )
             with pd.option_context("mode.copy_on_write", True):
                 df = pd.DataFrame({"x": ["a", "b", "b"], "y": [4.0, 5.0, 6.0]})


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #32829 

#### What does this implement/fix? Explain your changes.
Catches the `Pandas4Warning` that causes a CI failure. 

#### Any other comments?
I'm not sure if this makes sense, but AFAIU the main thing the test is checking is whether `TargetEncoder` works when `y` is read-only, so maybe the test could even be changed into explicitly creating a read-only `y` without the implicit pandas conversion? 

Edit: I changed the version check to use `sklearn.externals._packaging.version`.

@lesteve 

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
