### PR TITLE
This PR updates `_chi2_kernel_fast` and `_sparse_manhattan` to use Cython fused types (`floating`) and enables native `float32` support for sparse Manhattan distances.

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/32875.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/32875.enhancement.rst
@@ -1,0 +1,4 @@
+:func:`metrics.pairwise.manhattan_distances`, :func:`metrics.pairwise.chi2_kernel`
+and :func:`metrics.pairwise.additive_chi2_kernel` now support ``float32`` data natively
+(dense and sparse), reducing memory usage by 50% for single-precision inputs.
+By :user:`23Tarandeep57`

--- a/sklearn/metrics/_pairwise_fast.pyx
+++ b/sklearn/metrics/_pairwise_fast.pyx
@@ -17,7 +17,8 @@ def _chi2_kernel_fast(floating[:, :] X,
     cdef intp_t n_samples_X = X.shape[0]
     cdef intp_t n_samples_Y = Y.shape[0]
     cdef intp_t n_features = X.shape[1]
-    cdef double res, nom, denom
+    # Use 'floating' instead of 'double' for internal math
+    cdef floating res, nom, denom
 
     with nogil:
         for i in range(n_samples_X):
@@ -38,7 +39,8 @@ def _sparse_manhattan(
     const floating[::1] Y_data,
     const int[:] Y_indices,
     const int[:] Y_indptr,
-    double[:, ::1] D,
+    # Output matrix D matches the input type (float or double)
+    floating[:, ::1] D,
 ):
     """Pairwise L1 distances for CSR matrices.
 
@@ -49,7 +51,8 @@ def _sparse_manhattan(
     ...                   D)
     """
     cdef intp_t px, py, i, j, ix, iy
-    cdef double d = 0.0
+    # Accumulator matches the fused type
+    cdef floating d = 0.0
 
     cdef int m = D.shape[0]
     cdef int n = D.shape[1]
@@ -85,6 +88,7 @@ def _sparse_manhattan(
                 iy = Y_indices[j]
 
                 if ix == iy:
+                    # Note: fabs returns double, but Cython handles the cast back to floating
                     d = d + fabs(X_data[i] - Y_data[j])
                     i = i + 1
                     j = j + 1

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1088,7 +1088,7 @@ def manhattan_distances(X, Y=None):
     array([[0., 2.],
            [4., 4.]])
     """
-    X, Y = check_pairwise_arrays(X, Y)
+    X, Y = check_pairwise_arrays(X, Y, accept_sparse=['csr', 'csc', 'coo'])
     n_x, n_y = X.shape[0], Y.shape[0]
 
     if issparse(X) or issparse(Y):
@@ -1096,7 +1096,7 @@ def manhattan_distances(X, Y=None):
         Y = csr_matrix(Y, copy=False)
         X.sum_duplicates()  # this also sorts indices in-place
         Y.sum_duplicates()
-        D = np.zeros((n_x, n_y))
+        D = np.zeros((n_x, n_y), dtype=X.dtype)
         _sparse_manhattan(X.data, X.indices, X.indptr, Y.data, Y.indices, Y.indptr, D)
         return D
 

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1088,7 +1088,7 @@ def manhattan_distances(X, Y=None):
     array([[0., 2.],
            [4., 4.]])
     """
-    X, Y = check_pairwise_arrays(X, Y, accept_sparse=['csr', 'csc', 'coo'])
+    X, Y = check_pairwise_arrays(X, Y, accept_sparse=["csr", "csc", "coo"])
     n_x, n_y = X.shape[0], Y.shape[0]
 
     if issparse(X) or issparse(Y):

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -220,7 +220,7 @@ def test_pairwise_distances_for_sparse_data(
     S = pairwise_distances(X_sparse, csc_container(Y), metric="manhattan")
     S2 = manhattan_distances(bsr_container(X), coo_container(Y))
     assert_allclose(S, S2)
-   
+
     # NOW FIXED: Manhattan works for both float64 and float32!
     assert S.dtype == S2.dtype == global_dtype
 

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -220,14 +220,9 @@ def test_pairwise_distances_for_sparse_data(
     S = pairwise_distances(X_sparse, csc_container(Y), metric="manhattan")
     S2 = manhattan_distances(bsr_container(X), coo_container(Y))
     assert_allclose(S, S2)
-    if global_dtype == np.float64:
-        assert S.dtype == S2.dtype == global_dtype
-    else:
-        # TODO Fix manhattan_distances to preserve dtype.
-        # currently pairwise_distances uses manhattan_distances but converts the result
-        # back to the input dtype
-        with pytest.raises(AssertionError):
-            assert S.dtype == S2.dtype == global_dtype
+   
+    # NOW FIXED: Manhattan works for both float64 and float32!
+    assert S.dtype == S2.dtype == global_dtype
 
     S2 = manhattan_distances(X, Y)
     assert_allclose(S, S2)


### PR DESCRIPTION
### Changes

1.   **Cython Backend (`sklearn/metrics/_pairwise_fast.pyx`):**
    - Refactored `_chi2_kernel_fast` and `_sparse_manhattan` to use `floating` fused types for internal accumulators.
    - Updated `_sparse_manhattan` to accept a `floating[:, ::1]` output buffer, preventing implicit casting to double.

2.  **Python Frontend (`sklearn/metrics/pairwise.py`):**
    - Updated `manhattan_distances` to allocate the output buffer `D` using `dtype=X.dtype` instead of defaulting to `float64`.
    - Updated manhattan_distances to allow sparse inputs in check_pairwise_arrays. Previously, the default accept_sparse=False would densify sparse matrices before the optimization check, causing the sparse path to be skipped entirely.

3.  **Tests (`sklearn/metrics/tests/test_pairwise.py`):**
    - Removed the `pytest.raises(AssertionError)` block in `test_pairwise_distances_for_sparse_data` for Manhattan distance, as it now correctly preserves `float32` precision.

## Verification
- Ran `SKLEARN_RUN_FLOAT32_TESTS=1 pytest sklearn/metrics/tests/test_pairwise.py`
- Result: 360 passed, 0 failed.