### PR TITLE
DOC Fix too short underline in 1.8 release highlights

### DIFF
--- a/examples/release_highlights/plot_release_highlights_1_8_0.py
+++ b/examples/release_highlights/plot_release_highlights_1_8_0.py
@@ -226,7 +226,7 @@ clf
 
 # %%
 # DecisionTreeRegressor with `criterion="absolute_error"`
-# ------------------------------------------------------
+# -------------------------------------------------------
 # :class:`tree.DecisionTreeRegressor` with `criterion="absolute_error"`
 # now runs much faster. It has now `O(n * log(n))` complexity compared to
 # `O(n**2)` previously, which allows to scale to millions of data points.


### PR DESCRIPTION
Noticed the warning in doc build