### PR TITLE
DOC Update news in 1.8.X branch

### DIFF
--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -206,15 +206,13 @@
       <div class="col-md-4">
         <h4 class="sk-landing-call-header">News</h4>
         <ul class="sk-landing-call-list list-unstyled">
-          <li><strong>On-going development:</strong> <a href="https://scikit-learn.org/dev/whats_new/v1.8.html#version-1-8-0">scikit-learn 1.8 (Changelog)</a>.</li>
+          <li><strong>On-going development:</strong> <a href="https://scikit-learn.org/dev/whats_new/v1.9.html#version-1-9-0">scikit-learn 1.9 (Changelog)</a>.</li>
+          <li><strong>December 2025.</strong> scikit-learn 1.8.0 is available for download (<a href="whats_new/v1.8.html#version-1-8-0">Changelog</a>).</li>
           <li><strong>September 2025.</strong> scikit-learn 1.7.2 is available for download (<a href="whats_new/v1.7.html#version-1-7-2">Changelog</a>).</li>
           <li><strong>July 2025.</strong> scikit-learn 1.7.1 is available for download (<a href="whats_new/v1.7.html#version-1-7-1">Changelog</a>).</li>
           <li><strong>June 2025.</strong> scikit-learn 1.7.0 is available for download (<a href="whats_new/v1.7.html#version-1-7-0">Changelog</a>).</li>
           <li><strong>January 2025.</strong> scikit-learn 1.6.1 is available for download (<a href="whats_new/v1.6.html#version-1-6-1">Changelog</a>).</li>
           <li><strong>December 2024.</strong> scikit-learn 1.6.0 is available for download (<a href="whats_new/v1.6.html#version-1-6-0">Changelog</a>).</li>
-          <li><strong>September 2024.</strong> scikit-learn 1.5.2 is available for download (<a href="whats_new/v1.5.html#version-1-5-2">Changelog</a>).</li>
-          <li><strong>July 2024.</strong> scikit-learn 1.5.1 is available for download (<a href="whats_new/v1.5.html#version-1-5-1">Changelog</a>).</li>
-          <li><strong>May 2024.</strong> scikit-learn 1.5.0 is available for download (<a href="whats_new/v1.5.html#version-1-5-0">Changelog</a>).</li>
           <li><strong>All releases:</strong> <a href="https://scikit-learn.org/dev/whats_new.html"><strong>What's new</strong> (Changelog)</a>.</li>
         </ul>
       </div>


### PR DESCRIPTION
Part of release process.

This should show the 1.8 in the news section of the [stable website](https://scikit-learn.org/stable)