### PR TITLE
TST Add `confusion_matrix_at_thresholds` to common tests

### DIFF
--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1627,9 +1627,7 @@ def check_sample_weight_invariance(name, metric, y1, y2, sample_weight=None):
     )
 
     # Check the score is invariant under scaling of weights by a constant factor
-    if not (
-        name.startswith("unnormalized") or name == "confusion_matrix_at_thresholds"
-    ):
+    if name not in WEIGHT_SCALE_DEPENDENT_METRICS:
         # Numerical instability of floating points in `cumulative_sum` in
         # `median_absolute_error`, and in `diff` when in calculating collinear points
         # and points in between to drop `roc_curve` means they are not always

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -18,6 +18,7 @@ from sklearn.metrics import (
     classification_report,
     cohen_kappa_score,
     confusion_matrix,
+    confusion_matrix_at_thresholds,
     coverage_error,
     d2_absolute_error_score,
     d2_brier_score,
@@ -240,6 +241,7 @@ def precision_recall_curve_padded_thresholds(*args, **kwargs):
 
 
 CURVE_METRICS = {
+    "confusion_matrix_at_thresholds": confusion_matrix_at_thresholds,
     "roc_curve": roc_curve,
     "precision_recall_curve": precision_recall_curve_padded_thresholds,
     "det_curve": det_curve,
@@ -327,6 +329,7 @@ METRIC_UNDEFINED_MULTICLASS = {
     "f2_score",
     "f0.5_score",
     # curves
+    "confusion_matrix_at_thresholds",
     "roc_curve",
     "precision_recall_curve",
     "det_curve",
@@ -356,6 +359,7 @@ CONTINOUS_CLASSIFICATION_METRICS_WITH_AVERAGING = {
 
 # Metrics with a "pos_label" argument
 METRICS_WITH_POS_LABEL = {
+    "confusion_matrix_at_thresholds",
     "roc_curve",
     "precision_recall_curve",
     "det_curve",
@@ -540,6 +544,7 @@ NOT_SYMMETRIC_METRICS = {
     "r2_score",
     "unnormalized_confusion_matrix",
     "normalized_confusion_matrix",
+    "confusion_matrix_at_thresholds",
     "roc_curve",
     "precision_recall_curve",
     "det_curve",


### PR DESCRIPTION
#### Reference Issues/PRs



#### What does this implement/fix? Explain your changes.
`confusion_matrix_at_thresholds` was amended to a public function added in #30134. I think it would be worth adding to the common metric tests in `test_common.py`.
This would also fix one of the test failures in #32755

Also fixes `test_binary_sample_weight_invariance` - the curve metrics, as well as `CONTINUOUS_CLASSIFICATION_METRICS`, should also take `y_score` (i.e. unthresholded scores) NOT `y_pred`


#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding


#### Any other comments?

cc @ogrisel because this is related to #32755 and @adrinjalali and @jeremiedbb  who reviewed #30134