### PR TITLE
FIX: Tooltip position using CSS anchor positioning

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.utils/32887.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/32887.fix.rst
@@ -1,0 +1,6 @@
+- The parameter table in the HTML representation of all scikit-learn
+  estimators inheritiging from :class:`base.BaseEstimator`, displays
+  each parameter documentation as a tooltip. The last tooltip of a
+  parameter in the last table of any HTML representation was partially hidden.
+  This issue has been fixed.
+  By :user:`Dea María Léon <DeaMariaLeon>`

--- a/sklearn/utils/_repr_html/params.css
+++ b/sklearn/utils/_repr_html/params.css
@@ -94,7 +94,7 @@ a.param-doc-link::before {
 
 .param-doc-description {
     display: none;
-    position: absolute;
+    position: fixed;
     z-index: 9999;
     left: 0;
     padding: .5ex;
@@ -110,11 +110,12 @@ a.param-doc-link::before {
     background: var(--sklearn-color-unfitted-level-0);
     border: thin solid var(--sklearn-color-unfitted-level-3);
 
+    position-area: right;
     position-anchor: --doc-link;
-    top: anchor(bottom);
 
-    position-try-fallbacks: --bottom;
-    /*right: anchor(right);*/
+    position-try-fallbacks: top, top right, right,
+        bottom right, bottom,
+        bottom left, left;
 }
 
 /* Fitted state for parameter tooltips */

--- a/sklearn/utils/_repr_html/params.css
+++ b/sklearn/utils/_repr_html/params.css
@@ -81,6 +81,8 @@ a.param-doc-link:visited {
     color: inherit;
     display: block;
     padding: .5em;
+
+    anchor-name: --doc-link;
 }
 
 /* "hack" to make the entire area of the cell containing the link clickable */
@@ -107,6 +109,11 @@ a.param-doc-link::before {
     /* unfitted */
     background: var(--sklearn-color-unfitted-level-0);
     border: thin solid var(--sklearn-color-unfitted-level-3);
+
+    position-anchor: --doc-link;
+    top: anchor(bottom);
+    position-try-fallbacks: --bottom;
+    /*right: anchor(right);*/
 }
 
 /* Fitted state for parameter tooltips */
@@ -118,6 +125,11 @@ a.param-doc-link::before {
 
 .param-doc-link:hover .param-doc-description {
     display: block;
+}
+
+@position-try --bottom {
+    inset: auto;
+    top: calc(anchor(top) - 20rem);
 }
 
 .copy-paste-icon {

--- a/sklearn/utils/_repr_html/params.css
+++ b/sklearn/utils/_repr_html/params.css
@@ -81,8 +81,14 @@ a.param-doc-link:visited {
     color: inherit;
     display: block;
     padding: .5em;
+}
 
+@supports(anchor-name: --doc-link) {
+    a.param-doc-link,
+    a.param-doc-link:link,
+    a.param-doc-link:visited {
     anchor-name: --doc-link;
+    }
 }
 
 /* "hack" to make the entire area of the cell containing the link clickable */
@@ -94,21 +100,29 @@ a.param-doc-link::before {
 
 .param-doc-description {
     display: none;
-    position: fixed;
+    position: absolute;
     z-index: 9999;
     left: 0;
     padding: .5ex;
+    margin-left: 1.5em;
     color: var(--sklearn-color-text);
     box-shadow: .3em .3em .4em #999;
     width: max-content;
     text-align: left;
     max-height: 10em;
     overflow-y: auto;
-    position-area: center right;
 
     /* unfitted */
     background: var(--sklearn-color-unfitted-level-0);
     border: thin solid var(--sklearn-color-unfitted-level-3);
+}
+
+@supports(position-area: center right) {
+    .param-doc-description {
+    position-area: center right;
+    position: fixed;
+    margin-left: 0;
+    }
 }
 
 /* Fitted state for parameter tooltips */

--- a/sklearn/utils/_repr_html/params.css
+++ b/sklearn/utils/_repr_html/params.css
@@ -76,7 +76,7 @@
 a.param-doc-link,
 a.param-doc-link:link,
 a.param-doc-link:visited {
-    text-decoration: underline dashed !important;
+    text-decoration: underline dashed;
     text-underline-offset: .3em;
     color: inherit;
     display: block;
@@ -113,9 +113,9 @@ a.param-doc-link::before {
     position-area: center right;
     position-anchor: --doc-link;
 
-    /* position-try-fallbacks:
-    bottom right, bottom,
-    bottom left, left; */
+    position-try-fallbacks: --bottom
+        /*bottom right, bottom,
+        bottom left, left; */
 }
 
 /* Fitted state for parameter tooltips */
@@ -129,11 +129,11 @@ a.param-doc-link::before {
     display: block;
 }
 
-/* @position-try --bottom {
-     inset: auto;
-    top: anchor(top);
+@position-try --bottom {
+    inset: auto;
+    top: anchor(right);
 }
-*/
+
 
 .copy-paste-icon {
     background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0NDggNTEyIj48IS0tIUZvbnQgQXdlc29tZSBGcmVlIDYuNy4yIGJ5IEBmb250YXdlc29tZSAtIGh0dHBzOi8vZm9udGF3ZXNvbWUuY29tIExpY2Vuc2UgLSBodHRwczovL2ZvbnRhd2Vzb21lLmNvbS9saWNlbnNlL2ZyZWUgQ29weXJpZ2h0IDIwMjUgRm9udGljb25zLCBJbmMuLS0+PHBhdGggZD0iTTIwOCAwTDMzMi4xIDBjMTIuNyAwIDI0LjkgNS4xIDMzLjkgMTQuMWw2Ny45IDY3LjljOSA5IDE0LjEgMjEuMiAxNC4xIDMzLjlMNDQ4IDMzNmMwIDI2LjUtMjEuNSA0OC00OCA0OGwtMTkyIDBjLTI2LjUgMC00OC0yMS41LTQ4LTQ4bDAtMjg4YzAtMjYuNSAyMS41LTQ4IDQ4LTQ4ek00OCAxMjhsODAgMCAwIDY0LTY0IDAgMCAyNTYgMTkyIDAgMC0zMiA2NCAwIDAgNDhjMCAyNi41LTIxLjUgNDgtNDggNDhMNDggNTEyYy0yNi41IDAtNDgtMjEuNS00OC00OEwwIDE3NmMwLTI2LjUgMjEuNS00OCA0OC00OHoiLz48L3N2Zz4=);

--- a/sklearn/utils/_repr_html/params.css
+++ b/sklearn/utils/_repr_html/params.css
@@ -112,11 +112,9 @@ a.param-doc-link::before {
 
     position-area: center right;
 
-    position-try-fallbacks: --fallback;
-        /* top right, right,
-
+    /* position-try-fallbacks:
+        top right, right,
         top left, left; */
-
 }
 
 /* Fitted state for parameter tooltips */
@@ -129,12 +127,6 @@ a.param-doc-link::before {
 .param-doc-link:hover .param-doc-description {
     display: block;
 }
-
-@position-try --fallback {
-    inset: auto;
-    top: anchor(top);
-}
-
 
 .copy-paste-icon {
     background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0NDggNTEyIj48IS0tIUZvbnQgQXdlc29tZSBGcmVlIDYuNy4yIGJ5IEBmb250YXdlc29tZSAtIGh0dHBzOi8vZm9udGF3ZXNvbWUuY29tIExpY2Vuc2UgLSBodHRwczovL2ZvbnRhd2Vzb21lLmNvbS9saWNlbnNlL2ZyZWUgQ29weXJpZ2h0IDIwMjUgRm9udGljb25zLCBJbmMuLS0+PHBhdGggZD0iTTIwOCAwTDMzMi4xIDBjMTIuNyAwIDI0LjkgNS4xIDMzLjkgMTQuMWw2Ny45IDY3LjljOSA5IDE0LjEgMjEuMiAxNC4xIDMzLjlMNDQ4IDMzNmMwIDI2LjUtMjEuNSA0OC00OCA0OGwtMTkyIDBjLTI2LjUgMC00OC0yMS41LTQ4LTQ4bDAtMjg4YzAtMjYuNSAyMS41LTQ4IDQ4LTQ4ek00OCAxMjhsODAgMCAwIDY0LTY0IDAgMCAyNTYgMTkyIDAgMC0zMiA2NCAwIDAgNDhjMCAyNi41LTIxLjUgNDgtNDggNDhMNDggNTEyYy0yNi41IDAtNDgtMjEuNS00OC00OEwwIDE3NmMwLTI2LjUgMjEuNS00OCA0OC00OHoiLz48L3N2Zz4=);

--- a/sklearn/utils/_repr_html/params.css
+++ b/sklearn/utils/_repr_html/params.css
@@ -76,7 +76,7 @@
 a.param-doc-link,
 a.param-doc-link:link,
 a.param-doc-link:visited {
-    text-decoration: underline dashed;
+    text-decoration: underline dashed !important;
     text-underline-offset: .3em;
     color: inherit;
     display: block;
@@ -94,7 +94,7 @@ a.param-doc-link::before {
 
 .param-doc-description {
     display: none;
-    position: fixed;
+    position: absolute;
     z-index: 9999;
     left: 0;
     padding: .5ex;
@@ -110,10 +110,12 @@ a.param-doc-link::before {
     background: var(--sklearn-color-unfitted-level-0);
     border: thin solid var(--sklearn-color-unfitted-level-3);
 
-    position-area: right;
+    position-area: center right;
     position-anchor: --doc-link;
 
-    position-try-fallbacks: left;
+    position-try-fallbacks:
+    bottom right, bottom,
+    bottom left, left;
 }
 
 /* Fitted state for parameter tooltips */

--- a/sklearn/utils/_repr_html/params.css
+++ b/sklearn/utils/_repr_html/params.css
@@ -110,7 +110,7 @@ a.param-doc-link::before {
     background: var(--sklearn-color-unfitted-level-0);
     border: thin solid var(--sklearn-color-unfitted-level-3);
 
-    position-area: right;
+    position-area: center right;
     position-anchor: --doc-link;
 
     /* position-try-fallbacks:

--- a/sklearn/utils/_repr_html/params.css
+++ b/sklearn/utils/_repr_html/params.css
@@ -113,9 +113,7 @@ a.param-doc-link::before {
     position-area: right;
     position-anchor: --doc-link;
 
-    position-try-fallbacks: top, top right, right,
-        bottom right, bottom,
-        bottom left, left;
+    position-try-fallbacks: left;
 }
 
 /* Fitted state for parameter tooltips */
@@ -129,10 +127,11 @@ a.param-doc-link::before {
     display: block;
 }
 
-@position-try --bottom {
-    /* inset: auto; */
+/* @position-try --bottom {
+     inset: auto;
     top: anchor(top);
 }
+*/
 
 .copy-paste-icon {
     background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0NDggNTEyIj48IS0tIUZvbnQgQXdlc29tZSBGcmVlIDYuNy4yIGJ5IEBmb250YXdlc29tZSAtIGh0dHBzOi8vZm9udGF3ZXNvbWUuY29tIExpY2Vuc2UgLSBodHRwczovL2ZvbnRhd2Vzb21lLmNvbS9saWNlbnNlL2ZyZWUgQ29weXJpZ2h0IDIwMjUgRm9udGljb25zLCBJbmMuLS0+PHBhdGggZD0iTTIwOCAwTDMzMi4xIDBjMTIuNyAwIDI0LjkgNS4xIDMzLjkgMTQuMWw2Ny45IDY3LjljOSA5IDE0LjEgMjEuMiAxNC4xIDMzLjlMNDQ4IDMzNmMwIDI2LjUtMjEuNSA0OC00OCA0OGwtMTkyIDBjLTI2LjUgMC00OC0yMS41LTQ4LTQ4bDAtMjg4YzAtMjYuNSAyMS41LTQ4IDQ4LTQ4ek00OCAxMjhsODAgMCAwIDY0LTY0IDAgMCAyNTYgMTkyIDAgMC0zMiA2NCAwIDAgNDhjMCAyNi41LTIxLjUgNDgtNDggNDhMNDggNTEyYy0yNi41IDAtNDgtMjEuNS00OC00OEwwIDE3NmMwLTI2LjUgMjEuNS00OCA0OC00OHoiLz48L3N2Zz4=);

--- a/sklearn/utils/_repr_html/params.css
+++ b/sklearn/utils/_repr_html/params.css
@@ -111,11 +111,12 @@ a.param-doc-link::before {
     border: thin solid var(--sklearn-color-unfitted-level-3);
 
     position-area: center right;
-    position-anchor: --doc-link;
 
-    position-try-fallbacks: --bottom
-        /*bottom right, bottom,
-        bottom left, left; */
+    position-try-fallbacks: --fallback;
+        /* top right, right,
+
+        top left, left; */
+
 }
 
 /* Fitted state for parameter tooltips */
@@ -129,9 +130,9 @@ a.param-doc-link::before {
     display: block;
 }
 
-@position-try --bottom {
+@position-try --fallback {
     inset: auto;
-    top: anchor(right);
+    top: anchor(top);
 }
 
 

--- a/sklearn/utils/_repr_html/params.css
+++ b/sklearn/utils/_repr_html/params.css
@@ -105,13 +105,11 @@ a.param-doc-link::before {
     text-align: left;
     max-height: 10em;
     overflow-y: auto;
+    position-area: center right;
 
     /* unfitted */
     background: var(--sklearn-color-unfitted-level-0);
     border: thin solid var(--sklearn-color-unfitted-level-3);
-
-    position-area: center right;
-
 }
 
 /* Fitted state for parameter tooltips */

--- a/sklearn/utils/_repr_html/params.css
+++ b/sklearn/utils/_repr_html/params.css
@@ -112,9 +112,6 @@ a.param-doc-link::before {
 
     position-area: center right;
 
-    /* position-try-fallbacks:
-        top right, right,
-        top left, left; */
 }
 
 /* Fitted state for parameter tooltips */

--- a/sklearn/utils/_repr_html/params.css
+++ b/sklearn/utils/_repr_html/params.css
@@ -98,7 +98,6 @@ a.param-doc-link::before {
     z-index: 9999;
     left: 0;
     padding: .5ex;
-    margin-left: 1.5em;
     color: var(--sklearn-color-text);
     box-shadow: .3em .3em .4em #999;
     width: max-content;

--- a/sklearn/utils/_repr_html/params.css
+++ b/sklearn/utils/_repr_html/params.css
@@ -129,8 +129,8 @@ a.param-doc-link::before {
 }
 
 @position-try --bottom {
-    inset: auto;
-    top: calc(anchor(top) - 20rem);
+    /* inset: auto; */
+    top: anchor(top);
 }
 
 .copy-paste-icon {

--- a/sklearn/utils/_repr_html/params.css
+++ b/sklearn/utils/_repr_html/params.css
@@ -112,6 +112,7 @@ a.param-doc-link::before {
 
     position-anchor: --doc-link;
     top: anchor(bottom);
+
     position-try-fallbacks: --bottom;
     /*right: anchor(right);*/
 }

--- a/sklearn/utils/_repr_html/params.css
+++ b/sklearn/utils/_repr_html/params.css
@@ -94,7 +94,7 @@ a.param-doc-link::before {
 
 .param-doc-description {
     display: none;
-    position: absolute;
+    position: fixed;
     z-index: 9999;
     left: 0;
     padding: .5ex;
@@ -110,12 +110,12 @@ a.param-doc-link::before {
     background: var(--sklearn-color-unfitted-level-0);
     border: thin solid var(--sklearn-color-unfitted-level-3);
 
-    position-area: center right;
+    position-area: right;
     position-anchor: --doc-link;
 
-    position-try-fallbacks:
+    /* position-try-fallbacks:
     bottom right, bottom,
-    bottom left, left;
+    bottom left, left; */
 }
 
 /* Fitted state for parameter tooltips */

--- a/sklearn/utils/_repr_html/params.py
+++ b/sklearn/utils/_repr_html/params.py
@@ -88,11 +88,13 @@ def _params_html_repr(params):
     """
 
     PARAM_AVAILABLE_DOC_LINK_TEMPLATE = """
+
         <a class="param-doc-link"
             rel="noreferrer" target="_blank" href="{link}">
             {param_name}
-            <span class="param-doc-description">{param_description}</span>
+            <span class="param-doc-description"><div>{param_description}</div></span>
         </a>
+
     """
     estimator_class_docs = inspect.getdoc(params.estimator_class)
     if estimator_class_docs and (

--- a/sklearn/utils/_repr_html/params.py
+++ b/sklearn/utils/_repr_html/params.py
@@ -90,9 +90,12 @@ def _params_html_repr(params):
     PARAM_AVAILABLE_DOC_LINK_TEMPLATE = """
 
         <a class="param-doc-link"
+            style="anchor-name: --doc-link-{param_name};"
             rel="noreferrer" target="_blank" href="{link}">
             {param_name}
-            <span class="param-doc-description">{param_description}</span>
+            <span class="param-doc-description"
+            style="position-anchor: --doc-link-{param_name};">
+            {param_description}</span>
         </a>
 
     """

--- a/sklearn/utils/_repr_html/params.py
+++ b/sklearn/utils/_repr_html/params.py
@@ -88,7 +88,6 @@ def _params_html_repr(params):
     """
 
     PARAM_AVAILABLE_DOC_LINK_TEMPLATE = """
-
         <a class="param-doc-link"
             style="anchor-name: --doc-link-{param_name};"
             rel="noreferrer" target="_blank" href="{link}">
@@ -97,7 +96,6 @@ def _params_html_repr(params):
             style="position-anchor: --doc-link-{param_name};">
             {param_description}</span>
         </a>
-
     """
     estimator_class_docs = inspect.getdoc(params.estimator_class)
     if estimator_class_docs and (

--- a/sklearn/utils/_repr_html/params.py
+++ b/sklearn/utils/_repr_html/params.py
@@ -92,7 +92,7 @@ def _params_html_repr(params):
         <a class="param-doc-link"
             rel="noreferrer" target="_blank" href="{link}">
             {param_name}
-            <span class="param-doc-description"><div>{param_description}</div></span>
+            <span class="param-doc-description">{param_description}</span>
         </a>
 
     """

--- a/sklearn/utils/_repr_html/tests/test_params.py
+++ b/sklearn/utils/_repr_html/tests/test_params.py
@@ -104,7 +104,7 @@ def test_params_html_repr_with_doc_links():
         doc_link="mock_module.MockEstimator.html",
     )
     html_output = _params_html_repr(params)
-    print(html_output)
+
     html_param_a = (
         r'<td class="param">'
         r'\s*<a class="param-doc-link"'

--- a/sklearn/utils/_repr_html/tests/test_params.py
+++ b/sklearn/utils/_repr_html/tests/test_params.py
@@ -104,14 +104,17 @@ def test_params_html_repr_with_doc_links():
         doc_link="mock_module.MockEstimator.html",
     )
     html_output = _params_html_repr(params)
-
+    print(html_output)
     html_param_a = (
         r'<td class="param">'
         r'\s*<a class="param-doc-link"'
+        r'\s*style="anchor-name: --doc-link-a;"'
         r'\s*rel="noreferrer" target="_blank"'
         r'\shref="mock_module\.MockEstimator\.html#:~:text=a,-int">'
         r"\s*a"
-        r'\s*<span class="param-doc-description">a: int<br><br>'
+        r'\s*<span class="param-doc-description"'
+        r'\s*style="position-anchor: --doc-link-a;">\s*a:'
+        r"\sint<br><br>"
         r"Description of a\.</span>"
         r"\s*</a>"
         r"\s*</td>"
@@ -120,10 +123,13 @@ def test_params_html_repr_with_doc_links():
     html_param_b = (
         r'<td class="param">'
         r'.*<a class="param-doc-link"'
+        r'\s*style="anchor-name: --doc-link-b;"'
         r'\s*rel="noreferrer" target="_blank"'
         r'\shref="mock_module\.MockEstimator\.html#:~:text=b,-str">'
         r"\s*b"
-        r'\s*<span class="param-doc-description">b: str<br><br></span>'
+        r'\s*<span class="param-doc-description"'
+        r'\s*style="position-anchor: --doc-link-b;">\s*b:'
+        r"\sstr<br><br></span>"
         r"\s*</a>"
         r"\s*</td>"
     )


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
The documentation tooltip that we introduced with https://github.com/scikit-learn/scikit-learn/pull/31564 is hidden if the parameter name that it belongs to, is at the bottom of the table. It's visible only after scrolling down the cell. 
In this case, when we hover over `n_jobs`, we get:
<img width="300" height="250" alt="Screenshot 2025-12-11 at 14 23 33" src="https://github.com/user-attachments/assets/a8b5445a-20e9-402f-b126-2c19689efc38" />

Using [CSS anchor positioning:](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Anchor_positioning/Using), the result is the following (when hovering over `n_jobs`). No scroll-down needed:

<img width="400" height="250" alt="Screenshot 2025-12-11 at 14 21 36" src="https://github.com/user-attachments/assets/e4576a7b-b006-4855-a77b-116285566241" />

There is no opened issue for this. 

#### What does this implement/fix? Explain your changes.
For the record: The specs for `anchor-name` and `position-anchor` can't be placed in the `params.css` file. When I did that, the tooltip was always visible at the bottom of the table - not next to the parameter name. 
(It was @glemaitre's idea that the tooltip was getting fixed to the last parameter when using Chrome.)

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [x] Moving the style to `params.py` instead of keeping it on `params.css`. 
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?
I tried to set [Fallback options](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Anchor_positioning/Try_options_hiding) ~~but I haven't found the correct rule.~~

Edit: I think the UX would be annoying if I add the fallback options.

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
