### PR TITLE
Fix #30310: Allow sparse intermediate outputs in ColumnTransformer with pandas output

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -1022,9 +1022,9 @@ class OneHotEncoder(_BaseEncoder):
             returned.
         """
         check_is_fitted(self)
-        
+
         transform_output = _get_output_config("transform", estimator=self)
-        
+
         original_transform_output = transform_output
 
         if self.handle_unknown == "warn":
@@ -1035,7 +1035,7 @@ class OneHotEncoder(_BaseEncoder):
                 "infrequent_if_exist",
             }
             handle_unknown = self.handle_unknown
-        
+
         X_int, X_mask = self._transform(
             X,
             handle_unknown=handle_unknown,
@@ -1078,12 +1078,12 @@ class OneHotEncoder(_BaseEncoder):
         # ====================================================================
         # This happens AFTER building X_out, not BEFORE like the old code.
         # This allows intermediate sparse outputs in pipelines to work correctly.
-        
+
         if original_transform_output != "default" and self.sparse_output:
             # Sparse output is requested, but pandas output is configured
             # Auto-convert to dense array to allow this in pipelines
-            X_out = X_out.toarray() #.reshape(-1, 1)
-            
+            X_out = X_out.toarray()  # .reshape(-1, 1)
+
             # Warn user about automatic conversion (optional but recommended)
             warnings.warn(
                 "OneHotEncoder produced sparse output but it was automatically "
@@ -1091,11 +1091,11 @@ class OneHotEncoder(_BaseEncoder):
                 "Consider setting `sparse_output=False` for better performance, "
                 "or use `set_output(transform='default')` to keep sparse output.",
                 UserWarning,
-                stacklevel=2
+                stacklevel=2,
             )
         elif not self.sparse_output:
             # User explicitly requested dense output
-            X_out = X_out.toarray() #.reshape(-1, 1)
+            X_out = X_out.toarray()  # .reshape(-1, 1)
 
         return X_out
 

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -1023,23 +1023,10 @@ class OneHotEncoder(_BaseEncoder):
         """
         check_is_fitted(self)
         
-        # Get output configuration
         transform_output = _get_output_config("transform", estimator=self)
         
-        # ====================================================================
-        # BUG FIX #30310: INSTEAD OF RAISING ERROR, AUTO-CONVERT SPARSE
-        # ====================================================================
-        # Original problematic code:
-        #     if transform_output != "default" and self.sparse_output:
-        #         raise ValueError(f"{capitalize_transform_output} output does not...")
-        #
-        # Fixed code: Defer the sparse check until after we build X_out.
-        # This allows downstream transformers to densify the sparse output if needed.
-        
-        # Store the original transform_output config for later use
         original_transform_output = transform_output
 
-        # validation of X happens in _check_X called by _transform
         if self.handle_unknown == "warn":
             warn_on_unknown, handle_unknown = True, "infrequent_if_exist"
         else:

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -2436,6 +2436,7 @@ def test_onehotencoder_sparse_output_with_pandas_set_output():
     Now it should auto-convert sparse to dense and emit a UserWarning.
     """
     import pandas as pd
+
     from sklearn.datasets import load_diabetes
 
     # Setup
@@ -2465,6 +2466,7 @@ def test_onehotencoder_in_pipeline_with_sparse_and_pandas_output():
     downstream transformers to work correctly.
     """
     import pandas as pd
+
     from sklearn.datasets import load_diabetes
     from sklearn.decomposition import TruncatedSVD
     from sklearn.pipeline import Pipeline
@@ -2497,6 +2499,7 @@ def test_onehotencoder_in_columntransformer_with_sparse_and_pandas_output():
     This is the main use case from issue #30310.
     """
     import pandas as pd
+
     from sklearn.compose import ColumnTransformer
     from sklearn.datasets import load_diabetes
     from sklearn.decomposition import TruncatedSVD
@@ -2540,7 +2543,9 @@ def test_onehotencoder_sparse_false_no_warning():
     no warning is raised even with pandas set_output.
     """
     import warnings
+
     import pandas as pd
+
     from sklearn.datasets import load_diabetes
 
     ds = load_diabetes()
@@ -2570,9 +2575,11 @@ def test_onehotencoder_sparse_output_default_transform_output():
     """
     Test that sparse output behavior differs between pandas and default output.
     """
-    import pandas as pd
-    from sklearn.datasets import load_diabetes
     import warnings
+
+    import pandas as pd
+
+    from sklearn.datasets import load_diabetes
 
     ds = load_diabetes()
     df = pd.DataFrame(ds["data"], columns=ds["feature_names"])

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -2420,3 +2420,174 @@ def test_onehotencoder_handle_unknown_warn_maps_to_infrequent():
         result_warn = encoder_warn.transform(test_data)
 
     assert_allclose(result_warn[2], result_infreq[2])
+
+
+def test_onehotencoder_sparse_output_with_pandas_set_output():
+    """
+    Test that OneHotEncoder with sparse_output=True works correctly when
+    pandas output is configured via set_output(transform='pandas').
+    
+    This is a regression test for GitHub issue #30310.
+    https://github.com/scikit-learn/scikit-learn/issues/30310
+    
+    Previously, this would raise:
+    ValueError: Pandas output does not support sparse data...
+    
+    Now it should auto-convert sparse to dense and emit a UserWarning.
+    """
+    import warnings
+    import pandas as pd
+    from sklearn.datasets import load_diabetes
+    
+    # Setup
+    ds = load_diabetes()
+    df = pd.DataFrame(ds['data'], columns=ds['feature_names'])
+    
+    # Test: OneHotEncoder with sparse output and pandas set_output
+    ohe = OneHotEncoder(sparse_output=True)
+    ohe.set_output(transform='pandas')
+    
+    # Should raise UserWarning about auto-conversion
+    with pytest.warns(UserWarning, match="automatically converted to dense"):
+        result = ohe.fit_transform(df[['s6']])
+    
+    # Verify result is pandas DataFrame (not sparse)
+    assert isinstance(result, pd.DataFrame)
+    assert result.shape[0] == len(df)
+    assert result.shape[1] > 0
+
+
+def test_onehotencoder_in_pipeline_with_sparse_and_pandas_output():
+    """
+    Test OneHotEncoder with sparse output in a Pipeline when pandas
+    set_output is configured.
+    
+    The sparse output should be auto-converted to dense to allow
+    downstream transformers to work correctly.
+    """
+    import pandas as pd
+    from sklearn.datasets import load_diabetes
+    from sklearn.decomposition import TruncatedSVD
+    from sklearn.pipeline import Pipeline
+    
+    ds = load_diabetes()
+    df = pd.DataFrame(ds['data'], columns=ds['feature_names'])
+    
+    # Pipeline with OneHotEncoder (sparse) → TruncatedSVD
+    pipeline = Pipeline([
+        ('ohe', OneHotEncoder(sparse_output=True)),
+        ('tsvd', TruncatedSVD(n_components=2, random_state=42))
+    ])
+    pipeline.set_output(transform='pandas')
+    
+    result = pipeline.fit_transform(df[['s6']])
+    
+    # Verify
+    assert isinstance(result, pd.DataFrame)
+    assert result.shape[0] == len(df)
+    assert result.shape[1] == 2  # TruncatedSVD output
+
+
+def test_onehotencoder_in_columntransformer_with_sparse_and_pandas_output():
+    """
+    Test OneHotEncoder with sparse output in ColumnTransformer when
+    pandas set_output is configured.
+    
+    This is the main use case from issue #30310.
+    """
+    import pandas as pd
+    from sklearn.datasets import load_diabetes
+    from sklearn.decomposition import TruncatedSVD
+    from sklearn.preprocessing import MinMaxScaler
+    from sklearn.compose import ColumnTransformer
+    from sklearn.pipeline import Pipeline
+    
+    ds = load_diabetes()
+    df = pd.DataFrame(ds['data'], columns=ds['feature_names'])
+    
+    # ColumnTransformer with sparse intermediate output
+    ct = ColumnTransformer([
+        ('ohe_tsvd', Pipeline([
+            ('ohe', OneHotEncoder(sparse_output=True)),
+            ('tsvd', TruncatedSVD(n_components=2, random_state=42))
+        ]), ['s6']),
+        ('mm', MinMaxScaler(), ['age', 'bmi', 'bp', 's1', 's2', 's3', 's4', 's5']),
+    ])
+    ct.set_output(transform='pandas')
+    
+    result = ct.fit_transform(df)
+    
+    # Verify
+    assert isinstance(result, pd.DataFrame)
+    assert result.shape[0] == len(df)
+    # 2 from tsvd + 8 from mm = 10
+    assert result.shape[1] == 10
+    assert not result.isna().any().any()
+
+
+def test_onehotencoder_sparse_false_no_warning():
+    """
+    Test that when sparse_output=False (dense output requested),
+    no warning is raised even with pandas set_output.
+    """
+    import warnings
+    import pandas as pd
+    from sklearn.datasets import load_diabetes
+    
+    ds = load_diabetes()
+    df = pd.DataFrame(ds['data'], columns=ds['feature_names'])
+    
+    # sparse_output=False, so no warning expected
+    ohe = OneHotEncoder(sparse_output=False)
+    ohe.set_output(transform='pandas')
+    
+    # Use warnings.catch_warnings() instead of pytest.warns(None)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = ohe.fit_transform(df[['s6']])
+        
+        # Filter for our specific warning
+        our_warnings = [warning for warning in w 
+                        if "automatically converted to dense" in str(warning.message)]
+        assert len(our_warnings) == 0, "Should not warn when sparse_output=False"
+    
+    assert isinstance(result, pd.DataFrame)
+
+def test_onehotencoder_sparse_output_default_transform_output():
+    """
+    Test that sparse output behavior differs between pandas and default output.
+    """
+    import scipy.sparse as sp
+    import pandas as pd
+    from sklearn.datasets import load_diabetes
+    import warnings
+    
+    ds = load_diabetes()
+    df = pd.DataFrame(ds['data'], columns=ds['feature_names'])
+    
+    # Case 1: pandas output - sparse gets converted to dense
+    ohe_pandas = OneHotEncoder(sparse_output=True)
+    ohe_pandas.set_output(transform='pandas')
+    
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result_pandas = ohe_pandas.fit_transform(df[['s6']])
+        
+        assert len(w) > 0, "Expected UserWarning about auto-conversion"
+        assert "automatically converted to dense" in str(w[0].message)
+    
+    assert isinstance(result_pandas, pd.DataFrame)
+    
+    # Case 2: dense output - no warning
+    ohe_dense = OneHotEncoder(sparse_output=False)
+    ohe_dense.set_output(transform='pandas')
+    
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result_dense = ohe_dense.fit_transform(df[['s6']])
+        
+        our_warnings = [warning for warning in w 
+                        if "automatically converted to dense" in str(warning.message)]
+        assert len(our_warnings) == 0
+    
+    assert isinstance(result_dense, pd.DataFrame)

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -2435,7 +2435,6 @@ def test_onehotencoder_sparse_output_with_pandas_set_output():
 
     Now it should auto-convert sparse to dense and emit a UserWarning.
     """
-    import warnings
     import pandas as pd
     from sklearn.datasets import load_diabetes
 
@@ -2498,11 +2497,11 @@ def test_onehotencoder_in_columntransformer_with_sparse_and_pandas_output():
     This is the main use case from issue #30310.
     """
     import pandas as pd
+    from sklearn.compose import ColumnTransformer
     from sklearn.datasets import load_diabetes
     from sklearn.decomposition import TruncatedSVD
-    from sklearn.preprocessing import MinMaxScaler
-    from sklearn.compose import ColumnTransformer
     from sklearn.pipeline import Pipeline
+    from sklearn.preprocessing import MinMaxScaler
 
     ds = load_diabetes()
     df = pd.DataFrame(ds["data"], columns=ds["feature_names"])
@@ -2571,7 +2570,6 @@ def test_onehotencoder_sparse_output_default_transform_output():
     """
     Test that sparse output behavior differs between pandas and default output.
     """
-    import scipy.sparse as sp
     import pandas as pd
     from sklearn.datasets import load_diabetes
     import warnings

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -2426,31 +2426,31 @@ def test_onehotencoder_sparse_output_with_pandas_set_output():
     """
     Test that OneHotEncoder with sparse_output=True works correctly when
     pandas output is configured via set_output(transform='pandas').
-    
+
     This is a regression test for GitHub issue #30310.
     https://github.com/scikit-learn/scikit-learn/issues/30310
-    
+
     Previously, this would raise:
     ValueError: Pandas output does not support sparse data...
-    
+
     Now it should auto-convert sparse to dense and emit a UserWarning.
     """
     import warnings
     import pandas as pd
     from sklearn.datasets import load_diabetes
-    
+
     # Setup
     ds = load_diabetes()
-    df = pd.DataFrame(ds['data'], columns=ds['feature_names'])
-    
+    df = pd.DataFrame(ds["data"], columns=ds["feature_names"])
+
     # Test: OneHotEncoder with sparse output and pandas set_output
     ohe = OneHotEncoder(sparse_output=True)
-    ohe.set_output(transform='pandas')
-    
+    ohe.set_output(transform="pandas")
+
     # Should raise UserWarning about auto-conversion
     with pytest.warns(UserWarning, match="automatically converted to dense"):
-        result = ohe.fit_transform(df[['s6']])
-    
+        result = ohe.fit_transform(df[["s6"]])
+
     # Verify result is pandas DataFrame (not sparse)
     assert isinstance(result, pd.DataFrame)
     assert result.shape[0] == len(df)
@@ -2461,7 +2461,7 @@ def test_onehotencoder_in_pipeline_with_sparse_and_pandas_output():
     """
     Test OneHotEncoder with sparse output in a Pipeline when pandas
     set_output is configured.
-    
+
     The sparse output should be auto-converted to dense to allow
     downstream transformers to work correctly.
     """
@@ -2469,19 +2469,21 @@ def test_onehotencoder_in_pipeline_with_sparse_and_pandas_output():
     from sklearn.datasets import load_diabetes
     from sklearn.decomposition import TruncatedSVD
     from sklearn.pipeline import Pipeline
-    
+
     ds = load_diabetes()
-    df = pd.DataFrame(ds['data'], columns=ds['feature_names'])
-    
+    df = pd.DataFrame(ds["data"], columns=ds["feature_names"])
+
     # Pipeline with OneHotEncoder (sparse) → TruncatedSVD
-    pipeline = Pipeline([
-        ('ohe', OneHotEncoder(sparse_output=True)),
-        ('tsvd', TruncatedSVD(n_components=2, random_state=42))
-    ])
-    pipeline.set_output(transform='pandas')
-    
-    result = pipeline.fit_transform(df[['s6']])
-    
+    pipeline = Pipeline(
+        [
+            ("ohe", OneHotEncoder(sparse_output=True)),
+            ("tsvd", TruncatedSVD(n_components=2, random_state=42)),
+        ]
+    )
+    pipeline.set_output(transform="pandas")
+
+    result = pipeline.fit_transform(df[["s6"]])
+
     # Verify
     assert isinstance(result, pd.DataFrame)
     assert result.shape[0] == len(df)
@@ -2492,7 +2494,7 @@ def test_onehotencoder_in_columntransformer_with_sparse_and_pandas_output():
     """
     Test OneHotEncoder with sparse output in ColumnTransformer when
     pandas set_output is configured.
-    
+
     This is the main use case from issue #30310.
     """
     import pandas as pd
@@ -2501,22 +2503,30 @@ def test_onehotencoder_in_columntransformer_with_sparse_and_pandas_output():
     from sklearn.preprocessing import MinMaxScaler
     from sklearn.compose import ColumnTransformer
     from sklearn.pipeline import Pipeline
-    
+
     ds = load_diabetes()
-    df = pd.DataFrame(ds['data'], columns=ds['feature_names'])
-    
+    df = pd.DataFrame(ds["data"], columns=ds["feature_names"])
+
     # ColumnTransformer with sparse intermediate output
-    ct = ColumnTransformer([
-        ('ohe_tsvd', Pipeline([
-            ('ohe', OneHotEncoder(sparse_output=True)),
-            ('tsvd', TruncatedSVD(n_components=2, random_state=42))
-        ]), ['s6']),
-        ('mm', MinMaxScaler(), ['age', 'bmi', 'bp', 's1', 's2', 's3', 's4', 's5']),
-    ])
-    ct.set_output(transform='pandas')
-    
+    ct = ColumnTransformer(
+        [
+            (
+                "ohe_tsvd",
+                Pipeline(
+                    [
+                        ("ohe", OneHotEncoder(sparse_output=True)),
+                        ("tsvd", TruncatedSVD(n_components=2, random_state=42)),
+                    ]
+                ),
+                ["s6"],
+            ),
+            ("mm", MinMaxScaler(), ["age", "bmi", "bp", "s1", "s2", "s3", "s4", "s5"]),
+        ]
+    )
+    ct.set_output(transform="pandas")
+
     result = ct.fit_transform(df)
-    
+
     # Verify
     assert isinstance(result, pd.DataFrame)
     assert result.shape[0] == len(df)
@@ -2533,25 +2543,29 @@ def test_onehotencoder_sparse_false_no_warning():
     import warnings
     import pandas as pd
     from sklearn.datasets import load_diabetes
-    
+
     ds = load_diabetes()
-    df = pd.DataFrame(ds['data'], columns=ds['feature_names'])
-    
+    df = pd.DataFrame(ds["data"], columns=ds["feature_names"])
+
     # sparse_output=False, so no warning expected
     ohe = OneHotEncoder(sparse_output=False)
-    ohe.set_output(transform='pandas')
-    
+    ohe.set_output(transform="pandas")
+
     # Use warnings.catch_warnings() instead of pytest.warns(None)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        result = ohe.fit_transform(df[['s6']])
-        
+        result = ohe.fit_transform(df[["s6"]])
+
         # Filter for our specific warning
-        our_warnings = [warning for warning in w 
-                        if "automatically converted to dense" in str(warning.message)]
+        our_warnings = [
+            warning
+            for warning in w
+            if "automatically converted to dense" in str(warning.message)
+        ]
         assert len(our_warnings) == 0, "Should not warn when sparse_output=False"
-    
+
     assert isinstance(result, pd.DataFrame)
+
 
 def test_onehotencoder_sparse_output_default_transform_output():
     """
@@ -2561,33 +2575,36 @@ def test_onehotencoder_sparse_output_default_transform_output():
     import pandas as pd
     from sklearn.datasets import load_diabetes
     import warnings
-    
+
     ds = load_diabetes()
-    df = pd.DataFrame(ds['data'], columns=ds['feature_names'])
-    
+    df = pd.DataFrame(ds["data"], columns=ds["feature_names"])
+
     # Case 1: pandas output - sparse gets converted to dense
     ohe_pandas = OneHotEncoder(sparse_output=True)
-    ohe_pandas.set_output(transform='pandas')
-    
+    ohe_pandas.set_output(transform="pandas")
+
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        result_pandas = ohe_pandas.fit_transform(df[['s6']])
-        
+        result_pandas = ohe_pandas.fit_transform(df[["s6"]])
+
         assert len(w) > 0, "Expected UserWarning about auto-conversion"
         assert "automatically converted to dense" in str(w[0].message)
-    
+
     assert isinstance(result_pandas, pd.DataFrame)
-    
+
     # Case 2: dense output - no warning
     ohe_dense = OneHotEncoder(sparse_output=False)
-    ohe_dense.set_output(transform='pandas')
-    
+    ohe_dense.set_output(transform="pandas")
+
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        result_dense = ohe_dense.fit_transform(df[['s6']])
-        
-        our_warnings = [warning for warning in w 
-                        if "automatically converted to dense" in str(warning.message)]
+        result_dense = ohe_dense.fit_transform(df[["s6"]])
+
+        our_warnings = [
+            warning
+            for warning in w
+            if "automatically converted to dense" in str(warning.message)
+        ]
         assert len(our_warnings) == 0
-    
+
     assert isinstance(result_dense, pd.DataFrame)


### PR DESCRIPTION

## Problem
When using ColumnTransformer.set_output(transform='pandas'), scikit-learn raises a ValueError if OneHotEncoder is configured with sparse_output=True, even when downstream transformers (like TruncatedSVD) convert the sparse output to dense.

> ValueError: Pandas output does not support sparse data. 
> Set sparse_output=False to output pandas dataframes or 
> disable Pandas output via `ohe.set_output(transform="default")`.



## Root Cause
The sparse compatibility check in OneHotEncoder.transform() happens at the start and doesn't account for pipeline composition where sparse intermediate outputs are normal.

## Solution
Moved the check to the END of the method (after sparse matrix construction)

Auto-convert sparse to dense using .toarray() instead of raising error

Added UserWarning guiding users to use sparse_output=False for better performance

<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fix #30310 

#### What does this implement/fix? Explain your changes.

File: sklearn/preprocessing/_encoders.py

* Removed: Error-raising code that checked if transform_output != "default" and self.sparse_output:

* Added (after sparse matrix construction): Auto-conversion logic that converts sparse to dense when pandas output is configured

* Added: UserWarning with guidance on using sparse_output=False for better performance

File: sklearn/preprocessing/tests/test_encoders.py
Added 5 comprehensive regression tests for issue #30310:

* test_onehotencoder_sparse_output_with_pandas_set_output() - Standalone OneHotEncoder with sparse + pandas output

* test_onehotencoder_in_pipeline_with_sparse_and_pandas_output() - OneHotEncoder in Pipeline

* test_onehotencoder_in_columntransformer_with_sparse_and_pandas_output() - Main use case from issue (ColumnTransformer)

* test_onehotencoder_sparse_false_no_warning() - No warning when sparse_output=False

* test_onehotencoder_sparse_output_default_transform_output() - Behavior comparison between pandas and default output


#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding


#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
