### PR TITLE
DOC Add link to glossary "label indicator matrix" for classification metric docstrings

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -527,6 +527,9 @@ General Concepts
         corresponds to a class, and each element is 1 if the sample is labeled
         with the class and 0 if not.
 
+        :class:`LabelBinarizer` can be used to create a multilabel indicator matrix
+        from :term:`multiclass` labels.
+
     leakage
     data leakage
         A problem in cross validation where generalization performance can be

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -518,11 +518,12 @@ General Concepts
         :term:`memory mapping`. See :ref:`parallelism` for more
         information.
 
+    label indicator format
     label indicator matrix
     multilabel indicator matrix
     multilabel indicator matrices
-        The format used to represent multilabel data, where each row of a 2d
-        array or sparse matrix corresponds to a sample, each column
+        This format can be used to represent binary or multilabel data. Each row of
+        a 2d array or sparse matrix corresponds to a sample, each column
         corresponds to a class, and each element is 1 if the sample is labeled
         with the class and 0 if not.
 

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -527,8 +527,8 @@ General Concepts
         corresponds to a class, and each element is 1 if the sample is labeled
         with the class and 0 if not.
 
-        :class:`LabelBinarizer` can be used to create a multilabel indicator matrix
-        from :term:`multiclass` labels.
+        :ref:`LabelBinarizer <preprocessing_targets>` can be used to create a
+        multilabel indicator matrix from :term:`multiclass` labels.
 
     leakage
     data leakage

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -504,7 +504,7 @@ def roc_auc_score(
     y_true : array-like of shape (n_samples,) or (n_samples, n_classes)
         True labels or :term:`label indicator matrix`. The binary and multiclass cases
         expect labels with shape (n_samples,) while the multilabel case expects
-        :term:`multilabel indicator matrix` with shape (n_samples, n_classes).
+        a :term:`multilabel indicator matrix` with shape (n_samples, n_classes).
 
     y_score : array-like of shape (n_samples,) or (n_samples, n_classes)
         Target scores.

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -142,7 +142,7 @@ def average_precision_score(
     Parameters
     ----------
     y_true : array-like of shape (n_samples,) or (n_samples, n_classes)
-        True binary labels or binary label indicators.
+        True binary labels or :term:`multilabel indicator matrix`.
 
     y_score : array-like of shape (n_samples,) or (n_samples, n_classes)
         Target scores, can either be probability estimates of the positive
@@ -502,9 +502,9 @@ def roc_auc_score(
     Parameters
     ----------
     y_true : array-like of shape (n_samples,) or (n_samples, n_classes)
-        True labels or binary label indicators. The binary and multiclass cases
+        True labels or :term:`label indicator matrix`. The binary and multiclass cases
         expect labels with shape (n_samples,) while the multilabel case expects
-        binary label indicators with shape (n_samples, n_classes).
+        :term:`multilabel indicator matrix` with shape (n_samples, n_classes).
 
     y_score : array-like of shape (n_samples,) or (n_samples, n_classes)
         Target scores.
@@ -1337,7 +1337,7 @@ def label_ranking_average_precision_score(y_true, y_score, *, sample_weight=None
     Parameters
     ----------
     y_true : {array-like, sparse matrix} of shape (n_samples, n_labels)
-        True binary labels in binary indicator format.
+        True binary labels in :term:`label indicator format`.
 
     y_score : array-like of shape (n_samples, n_labels)
         Target scores, can either be probability estimates of the positive
@@ -1439,7 +1439,7 @@ def coverage_error(y_true, y_score, *, sample_weight=None):
     Parameters
     ----------
     y_true : array-like of shape (n_samples, n_labels)
-        True binary labels in binary indicator format.
+        True binary labels in :term:`label indicator format`.
 
     y_score : array-like of shape (n_samples, n_labels)
         Target scores, can either be probability estimates of the positive
@@ -1516,7 +1516,7 @@ def label_ranking_loss(y_true, y_score, *, sample_weight=None):
     Parameters
     ----------
     y_true : {array-like, sparse matrix} of shape (n_samples, n_labels)
-        True binary labels in binary indicator format.
+        True binary labels in :term:`label indicator format`.
 
     y_score : array-like of shape (n_samples, n_labels)
         Target scores, can either be probability estimates of the positive


### PR DESCRIPTION
#### Reference Issues/PRs
Noticed while working on #32755

#### What does this implement/fix? Explain your changes.
Adds reference to the glossary term https://scikit-learn.org/dev/glossary.html#term-label-indicator-matrix for classification metrics 

Not sure about the best term to use.

* Avoided use of 'binary' i.e., binary indicator - binary here is talking about the indicator being 0 or 1, not about the data being binary. This *may* be confusing and this term is not included as an alias in the glossary so I have avoided it
* when talking about binary data, I have used the term "label indicator format“ / ”label indicator matrix“ (depending on how best the wording fits into the sentence), to avoid use of 'multilabel' (as the data is not multilabel).
* used 'multilabel indicator matrix' when talking about multilabel data

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
