### PR TITLE
MNT cleanup old numpy workaround in metrics functions

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -39,7 +39,6 @@ from sklearn.utils._array_api import (
     _is_xp_namespace,
     _isin,
     _max_precision_float_dtype,
-    _tolist,
     _union1d,
     get_namespace,
     get_namespace_and_device,
@@ -1862,9 +1861,7 @@ def _check_set_wise_labels(y_true, y_pred, average, labels, pos_label):
 
     y_true, y_pred = attach_unique(y_true, y_pred)
     y_type, y_true, y_pred, _ = _check_targets(y_true, y_pred)
-    # Convert to Python primitive type to avoid NumPy type / Python str
-    # comparison. See https://github.com/numpy/numpy/issues/6784
-    present_labels = _tolist(unique_labels(y_true, y_pred))
+    present_labels = unique_labels(y_true, y_pred)
     if average == "binary":
         if y_type == "binary":
             if pos_label not in present_labels:

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -239,9 +239,7 @@ def average_precision_score(
 
     y_type = type_of_target(y_true, input_name="y_true")
 
-    # Convert to Python primitive type to avoid NumPy type / Python str
-    # comparison. See https://github.com/numpy/numpy/issues/6784
-    present_labels = np.unique(y_true).tolist()
+    present_labels = np.unique(y_true)
 
     if y_type == "binary":
         if len(present_labels) == 2 and pos_label not in present_labels:

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1571,7 +1571,7 @@ def test_multilabel_hamming_loss():
 def test_jaccard_score_validation():
     y_true = np.array([0, 1, 0, 1, 1])
     y_pred = np.array([0, 1, 0, 1, 1])
-    err_msg = r"pos_label=2 is not a valid label. It should be one of \[0, 1\]"
+    err_msg = re.escape("pos_label=2 is not a valid label. It should be one of [0 1]")
     with pytest.raises(ValueError, match=err_msg):
         jaccard_score(y_true, y_pred, average="binary", pos_label=2)
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1966,8 +1966,8 @@ def test_metrics_pos_label_error_str(metric, y_pred_threshold, dtype_y_str):
         "specified: either make y_true take value in {0, 1} or {-1, 1} or "
         "pass pos_label explicit"
     )
-    err_msg_pos_label_1 = (
-        r"pos_label=1 is not a valid label. It should be one of \['eggs', 'spam'\]"
+    err_msg_pos_label_1 = re.escape(
+        "pos_label=1 is not a valid label. It should be one of ['eggs' 'spam']"
     )
 
     pos_label_default = signature(metric).parameters["pos_label"].default

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1191,7 +1191,7 @@ def test_average_precision_score_binary_pos_label_errors():
     # Raise an error when pos_label is not in binary y_true
     y_true = np.array([0, 1])
     y_pred = np.array([0, 1])
-    err_msg = r"pos_label=2 is not a valid label. It should be one of \[0, 1\]"
+    err_msg = re.escape("pos_label=2 is not a valid label. It should be one of [0 1]")
     with pytest.raises(ValueError, match=err_msg):
         average_precision_score(y_true, y_pred, pos_label=2)
 

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -1104,14 +1104,6 @@ def _bincount(array, weights=None, minlength=None, xp=None):
     return xp.asarray(bin_out, device=device(array))
 
 
-def _tolist(array, xp=None):
-    xp, _ = get_namespace(array, xp=xp)
-    if _is_numpy_namespace(xp):
-        return array.tolist()
-    array_np = _convert_to_numpy(array, xp=xp)
-    return [element.item() for element in array_np]
-
-
 def _logsumexp(array, axis=None, xp=None):
     # TODO replace by scipy.special.logsumexp when
     # https://github.com/scipy/scipy/pull/22683 is part of a release.


### PR DESCRIPTION
#### Reference Issues/PRs
discovered while working on #32909


#### What does this implement/fix? Explain your changes.
This cleans up an old workaround, that had been fixed in numpy three years ago, see https://github.com/numpy/numpy/issues/6784#issuecomment-1341719384. I think this fix went into numpy 1.24.1 or earlier.

It makes sense to keep `present_labels` as an array instead of turning it into a list.


#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
