### PR TITLE
FIX array API support when `pos_label=None` for brier score metrics

### DIFF
--- a/doc/whats_new/upcoming_changes/array-api/32923.fix.rst
+++ b/doc/whats_new/upcoming_changes/array-api/32923.fix.rst
@@ -1,3 +1,3 @@
-- Fixes inference of `pos_label`, when it is not provided, in metrics
+- Fixes how `pos_label` is inferred when `pos_label` is set to `None`, in
   :func:`sklearn.metrics.brier_score_loss` and
   :func:`sklearn.metrics.d2_brier_score`. By :user:`Lucy Liu <lucyleeow>`.

--- a/doc/whats_new/upcoming_changes/array-api/32923.fix.rst
+++ b/doc/whats_new/upcoming_changes/array-api/32923.fix.rst
@@ -1,0 +1,3 @@
+- Fixes inference of `pos_label`, when it is not provided, in metrics
+  :func:`sklearn.metrics.brier_score_loss` and
+  :func:`sklearn.metrics.d2_brier_score`. By :user:`Lucy Liu <lucyleeow>`.

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -3616,9 +3616,9 @@ def _validate_binary_probabilistic_prediction(y_true, y_prob, sample_weight, pos
     except ValueError:
         xp_y_true, _ = get_namespace(y_true)
         classes = xp_y_true.unique_values(y_true)
+        # For backward compatibility, if classes are not string then
+        # `pos_label` will correspond to the greater label.
         if not (_is_numpy_namespace(xp_y_true) and classes.dtype.kind in "OUS"):
-            # For backward compatibility, if classes are not string then
-            # `pos_label` will correspond to the greater label.
             pos_label = classes[-1]
         else:
             raise

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -3619,8 +3619,6 @@ def _validate_binary_probabilistic_prediction(y_true, y_prob, sample_weight, pos
         if not (_is_numpy_namespace(xp_y_true) and classes.dtype.kind in "OUS"):
             # For backward compatibility, if classes are not string then
             # `pos_label` will correspond to the greater label.
-            # Sort first, as array API spec does not specify order of unique values
-            classes = xp_y_true.sort(classes)
             pos_label = classes[-1]
         else:
             raise

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -3614,10 +3614,13 @@ def _validate_binary_probabilistic_prediction(y_true, y_prob, sample_weight, pos
     try:
         pos_label = _check_pos_label_consistency(pos_label, y_true)
     except ValueError:
-        classes = np.unique(y_true)
-        if classes.dtype.kind not in ("O", "U", "S"):
-            # for backward compatibility, if classes are not string then
-            # `pos_label` will correspond to the greater label
+        xp_y_true, _ = get_namespace(y_true)
+        classes = xp_y_true.unique_values(y_true)
+        if not (_is_numpy_namespace(xp_y_true) and classes.dtype.kind in "OUS"):
+            # For backward compatibility, if classes are not string then
+            # `pos_label` will correspond to the greater label.
+            # Sort first, as array API spec does not specify order or unique values
+            classes = xp_y_true.sort(classes)
             pos_label = classes[-1]
         else:
             raise

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -3619,7 +3619,7 @@ def _validate_binary_probabilistic_prediction(y_true, y_prob, sample_weight, pos
         if not (_is_numpy_namespace(xp_y_true) and classes.dtype.kind in "OUS"):
             # For backward compatibility, if classes are not string then
             # `pos_label` will correspond to the greater label.
-            # Sort first, as array API spec does not specify order or unique values
+            # Sort first, as array API spec does not specify order of unique values
             classes = xp_y_true.sort(classes)
             pos_label = classes[-1]
         else:

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -3760,7 +3760,7 @@ def test_pos_label_in_brier_score_metrics_array_api(
     # `pos_label` defaults to the largest label.
     xp = _array_api_for_tests(array_namespace, device_)
     y_true_pos_1 = xp.asarray(np.array([1, 0, 1, 0]), device=device_)
-    # Result should be the same when we use 2 for the label instead of 1
+    # Result should be the same when we use 2's for the label instead of 1's
     y_true_pos_2 = xp.asarray(np.array([2, 0, 2, 0]), device=device_)
     y_prob = xp.asarray(
         np.array([0.5, 0.2, 0.7, 0.6], dtype=dtype_name), device=device_

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -45,11 +45,12 @@ from sklearn.model_selection import cross_val_score
 from sklearn.preprocessing import LabelBinarizer, label_binarize
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.utils._array_api import (
-    device as array_api_device,
-)
-from sklearn.utils._array_api import (
+    _get_namespace_device_dtype_ids,
     get_namespace,
     yield_namespace_device_dtype_combinations,
+)
+from sklearn.utils._array_api import (
+    device as array_api_device,
 )
 from sklearn.utils._mocking import MockDataFrame
 from sklearn.utils._testing import (
@@ -3743,3 +3744,30 @@ def test_probabilistic_metrics_multilabel_array_api(
         metric_score_xp = prob_metric(y_true_xp, y_prob_xp, sample_weight=sample_weight)
 
     assert metric_score_xp == pytest.approx(metric_score_np)
+
+
+@pytest.mark.parametrize(
+    "array_namespace, device_, dtype_name",
+    yield_namespace_device_dtype_combinations(),
+    ids=_get_namespace_device_dtype_ids,
+)
+@pytest.mark.parametrize("prob_metric", [brier_score_loss, d2_brier_score])
+def test_pos_label_in_brier_score_metrics_array_api(
+    prob_metric, array_namespace, device_, dtype_name
+):
+    """Check `pos_label` handled correctly when labels not in {-1, 1} or {0, 1}."""
+    # For 'brier_score' metrics, when `pos_label=None` and labels are not strings,
+    # `pos_label` defaults to the largest label.
+    xp = _array_api_for_tests(array_namespace, device_)
+    y_true_pos_1 = xp.asarray(np.array([1, 0, 1, 0]), device=device_)
+    # Result should be the same when we use 2 for the label instead of 1
+    y_true_pos_2 = xp.asarray(np.array([2, 0, 2, 0]), device=device_)
+    y_prob = xp.asarray(
+        np.array([0.5, 0.2, 0.7, 0.6], dtype=dtype_name), device=device_
+    )
+
+    with config_context(array_api_dispatch=True):
+        metric_pos_1 = prob_metric(y_true_pos_1, y_prob)
+        metric_pos_2 = prob_metric(y_true_pos_2, y_prob)
+
+    assert metric_pos_1 == pytest.approx(metric_pos_2)


### PR DESCRIPTION

#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
As discussed in https://github.com/scikit-learn/scikit-learn/pull/32422/changes#r2575666004 , add array API handling to the case when `pos_label=None` and `y_true` is not string.

Also adds test.


#### AI usage disclosure

I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding


#### Any other comments?
This highlights again the inconsistency of `pos_label` handling, see longstanding issue #10010 - details here: https://github.com/scikit-learn/scikit-learn/issues/10010#issuecomment-1826133710 - would be great to get any movement/thoughts here!


cc @OmarManzoor, @ogrisel 
