### PR TITLE
FIX Avoid LogisticRegression spurious warning with `C=np.inf`

### DIFF
--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1165,8 +1165,8 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
         if penalty == "elasticnet" and self.l1_ratio is None:
             raise ValueError("l1_ratio must be specified when penalty is elasticnet.")
 
-        if penalty is None:
-            if self.penalty is None and self.C != 1.0:
+        if self.penalty is None:
+            if self.C != 1.0:
                 warnings.warn(
                     "Setting penalty=None will ignore the C and l1_ratio parameters"
                 )

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1166,7 +1166,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
             raise ValueError("l1_ratio must be specified when penalty is elasticnet.")
 
         if penalty is None:
-            if self.C != 1.0:  # default values
+            if self.penalty is None and self.C != 1.0:
                 warnings.warn(
                     "Setting penalty=None will ignore the C and l1_ratio parameters"
                 )

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1166,7 +1166,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
             raise ValueError("l1_ratio must be specified when penalty is elasticnet.")
 
         if self.penalty is None:
-            if self.C != 1.0:
+            if self.C != 1.0:  # default value
                 warnings.warn(
                     "Setting penalty=None will ignore the C and l1_ratio parameters"
                 )

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -2267,9 +2267,10 @@ def test_c_inf_no_warning(solver):
     """
     X, y = make_classification(n_samples=100, n_redundant=0, random_state=42)
 
-    lr = LogisticRegression(C=np.inf, solver=solver, max_iter=300)
+    lr = LogisticRegression(C=np.inf, solver=solver)
     with warnings.catch_warnings():
         warnings.simplefilter("error")
+        warnings.filterwarnings("ignore", category=ConvergenceWarning)
         lr.fit(X, y)
 
 

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -2257,6 +2257,22 @@ def test_penalty_none(global_random_seed, solver):
     assert_array_equal(pred_none, pred_l2_C_inf)
 
 
+# TODO(1.10): remove whole test with the removal of penalty
+@pytest.mark.parametrize("solver", sorted(set(SOLVERS) - set(["liblinear"])))
+def test_c_inf_no_warning(solver):
+    """Test that C=np.inf (recommended approach) produces no warnings.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/32927
+    """
+    X, y = make_classification(n_samples=100, n_redundant=0, random_state=42)
+
+    lr = LogisticRegression(C=np.inf, solver=solver, max_iter=300)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        lr.fit(X, y)
+
+
 # XXX: investigate thread-safety bug that might be related to:
 # https://github.com/scikit-learn/scikit-learn/issues/31883
 @pytest.mark.thread_unsafe


### PR DESCRIPTION
Fix #32927. cc @lorentzenchr.