### PR TITLE
DOC Add release highlights link in 1.8 changelog

### DIFF
--- a/doc/whats_new/v1.8.rst
+++ b/doc/whats_new/v1.8.rst
@@ -8,19 +8,8 @@
 Version 1.8
 ===========
 
-..
-  -- UNCOMMENT WHEN 1.8.0 IS RELEASED --
-  For a short description of the main highlights of the release, please refer to
-  :ref:`sphx_glr_auto_examples_release_highlights_plot_release_highlights_1_7_0.py`.
-
-
-..
-  DELETE WHEN 1.8.0 IS RELEASED
-  Since October 2024, DO NOT add your changelog entry in this file.
-..
-  Instead, create a file named `<PR_NUMBER>.<TYPE>.rst` in the relevant sub-folder in
-  `doc/whats_new/upcoming_changes/`. For full details, see:
-  https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
+For a short description of the main highlights of the release, please refer to
+:ref:`sphx_glr_auto_examples_release_highlights_plot_release_highlights_1_7_0.py`.
 
 .. include:: changelog_legend.inc
 

--- a/doc/whats_new/v1.8.rst
+++ b/doc/whats_new/v1.8.rst
@@ -9,7 +9,7 @@ Version 1.8
 ===========
 
 For a short description of the main highlights of the release, please refer to
-:ref:`sphx_glr_auto_examples_release_highlights_plot_release_highlights_1_7_0.py`.
+:ref:`sphx_glr_auto_examples_release_highlights_plot_release_highlights_1_8_0.py`.
 
 .. include:: changelog_legend.inc
 


### PR DESCRIPTION
Looks like I skipped this when following the release process documentation :sweat_smile:. The release highlights are not in the [dev website changelog](https://scikit-learn.org/dev/whats_new/v1.8.html) and not in the [stable one](https://scikit-learn.org/stable/whats_new/v1.8.html). Compare to [1.7 changelog](https://scikit-learn.org/dev/whats_new/v1.7.html) which has the link to the release highlights at the beginning.

I will backport this in 1.8.X branch once this PR is merged.

The [rendered doc](https://output.circle-artifacts.com/output/job/911294a3-def7-4b9f-9645-745e35570543/artifacts/0/doc/whats_new/v1.8.html) looks good with the release highlights link at the top.