### PR TITLE
CI Make test_predict_joint_proba more stable for different random seeds

### DIFF
--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -980,7 +980,7 @@ def test_predict_joint_proba(Estimator, global_random_seed):
     jll = est.predict_joint_log_proba(X2)
     log_prob_x = logsumexp(jll, axis=1)
     log_prob_x_y = jll - np.atleast_2d(log_prob_x).T
-    assert_allclose(est.predict_log_proba(X2), log_prob_x_y)
+    assert_allclose(est.predict_log_proba(X2), log_prob_x_y, atol=1e-12)
 
 
 @pytest.mark.parametrize("Estimator", ALL_NAIVE_BAYES_CLASSES)


### PR DESCRIPTION
Close #32906

Hi @lesteve ,  

This PR fixes the flaky failure in the min-dependencies OpenBLAS CI job for test_predict_joint_proba (#32906 and #29909). With the default rtol and atol, I hit intermittent assert_allclose failures. 

<img width="1113" height="443" alt="image" src="https://github.com/user-attachments/assets/c73f6b52-9474-46ee-a0ef-bd6c381583cd" />



I first tried atol=1e-14, but still reproduced a failure with max abs diff ~1e-13. Bumping the assertion to use atol=1e-12 fixed it. Here's the run [link ](https://dev.azure.com/scikit-learn/scikit-learn/_build/results?buildId=83661&view=logs&jobId=85dc54f1-b746-54c6-aaa8-29d3ad6201c9&j=85dc54f1-b746-54c6-aaa8-29d3ad6201c9&t=29b4082b-c348-5d75-9100-2eb67283d8d6) 
