### PR TITLE
MNT Remove numpydoc version constraint in CI requirements

### DIFF
--- a/build_tools/update_environments_and_lock_files.py
+++ b/build_tools/update_environments_and_lock_files.py
@@ -86,7 +86,6 @@ docstring_test_dependencies = ["sphinx", "numpydoc"]
 default_package_constraints = {
     # TODO: remove once https://github.com/numpy/numpydoc/issues/638 is fixed
     # and released.
-    "numpydoc": "<1.9.0",
     # TODO: remove once when we're using the new way to enable coverage in subprocess
     # introduced in 7.0.0, see https://github.com/pytest-dev/pytest-cov?tab=readme-ov-file#upgrading-from-pytest-cov-63
     "pytest-cov": "<=6.3.0",


### PR DESCRIPTION
### Summary
This PR removes the `<1.9.0` version constraint for `numpydoc` in the CI environment configuration. 

### Rationale
The constraint was originally added due to an issue in `numpydoc` (issue #638). Since that issue has been resolved and a new version has been released, we can now allow the CI to use the latest version of `numpydoc`.

### Changes
- Modified `build_tools/update_environments_and_lock_files.py` to remove `numpydoc` from `default_package_constraints`.

Closes #32884