### PR TITLE
FIX: Raise error for zero sample_weight classes in compute_class_weight

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.utils/32941.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/32941.fix.rst
@@ -1,0 +1,4 @@
+- :func:`utils.class_weight.compute_class_weight` now raises a `ValueError`
+  when `sample_weight` zeros out an entire class, instead of silently
+  returning `inf` values that would propagate through training.
+  By :user:`Devarshi <codeMaestro78>`

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -78,6 +78,17 @@ def compute_class_weight(class_weight, *, classes, y, sample_weight=None):
 
         sample_weight = _check_sample_weight(sample_weight, y)
         weighted_class_counts = np.bincount(y_ind, weights=sample_weight)
+
+        # Check for classes with zero total weight - this would cause division by zero
+        zero_weight_classes_mask = weighted_class_counts == 0
+        if np.any(zero_weight_classes_mask):
+            zero_weight_classes = le.classes_[zero_weight_classes_mask]
+            raise ValueError(
+                f"The following classes have zero total sample_weight, which would "
+                f"result in undefined class weights: {zero_weight_classes.tolist()}. "
+                f"Ensure all classes have at least some positive sample_weight."
+            )
+
         recip_freq = weighted_class_counts.sum() / (
             len(le.classes_) * weighted_class_counts
         )

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -172,7 +172,9 @@ def test_compute_class_weight_balanced_zero_sample_weight_class():
     sample_weight = np.array([1.0, 1.0, 0.0, 0.0, 1.0, 1.0])
 
     with pytest.raises(ValueError, match="zero total sample_weight"):
-        compute_class_weight("balanced", classes=classes, y=y, sample_weight=sample_weight)
+        compute_class_weight(
+            "balanced", classes=classes, y=y, sample_weight=sample_weight
+        )
 
 
 def test_compute_class_weight_balanced_zero_sample_weight_multiple_classes():
@@ -183,7 +185,9 @@ def test_compute_class_weight_balanced_zero_sample_weight_multiple_classes():
     sample_weight = np.array([0.0, 0.0, 1.0, 1.0, 0.0, 0.0])
 
     with pytest.raises(ValueError, match=r"\[0, 2\]"):
-        compute_class_weight("balanced", classes=classes, y=y, sample_weight=sample_weight)
+        compute_class_weight(
+            "balanced", classes=classes, y=y, sample_weight=sample_weight
+        )
 
 
 def test_compute_class_weight_balanced_unordered():

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -157,6 +157,35 @@ def test_compute_class_weight_balanced_sample_weight_equivalence():
     assert_allclose(class_weights_weighted, class_weights_repeated)
 
 
+def test_compute_class_weight_balanced_zero_sample_weight_class():
+    """Check that zero total sample_weight for a class raises an error.
+
+    When sample_weight zeros out an entire class, the weighted class count
+    becomes zero, which would cause division by zero and produce inf values.
+    This test ensures we raise a clear error instead.
+
+    Non-regression test for silent division by zero bug.
+    """
+    classes = np.array([0, 1, 2])
+    y = np.array([0, 0, 1, 1, 2, 2])
+    # sample_weight zeros out class 1 entirely
+    sample_weight = np.array([1.0, 1.0, 0.0, 0.0, 1.0, 1.0])
+
+    with pytest.raises(ValueError, match="zero total sample_weight"):
+        compute_class_weight("balanced", classes=classes, y=y, sample_weight=sample_weight)
+
+
+def test_compute_class_weight_balanced_zero_sample_weight_multiple_classes():
+    """Check error message lists all zero-weight classes."""
+    classes = np.array([0, 1, 2])
+    y = np.array([0, 0, 1, 1, 2, 2])
+    # sample_weight zeros out classes 0 and 2
+    sample_weight = np.array([0.0, 0.0, 1.0, 1.0, 0.0, 0.0])
+
+    with pytest.raises(ValueError, match=r"\[0, 2\]"):
+        compute_class_weight("balanced", classes=classes, y=y, sample_weight=sample_weight)
+
+
 def test_compute_class_weight_balanced_unordered():
     # Test compute_class_weight when classes are unordered
     classes = np.array([1, 0, 3])

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -158,14 +158,14 @@ def test_compute_class_weight_balanced_sample_weight_equivalence():
 
 
 def test_compute_class_weight_balanced_zero_sample_weight_class():
-    """Check that zero total sample_weight for a class raises an error.
+    # Check that zero total sample_weight for a class raises an error.
 
-    When sample_weight zeros out an entire class, the weighted class count
-    becomes zero, which would cause division by zero and produce inf values.
-    This test ensures we raise a clear error instead.
+    # When sample_weight zeros out an entire class, the weighted class count
+    # becomes zero, which would cause division by zero and produce inf values.
+    # This test ensures we raise a clear error instead.
 
-    Non-regression test for silent division by zero bug.
-    """
+    # Non-regression test for silent division by zero bug.
+
     classes = np.array([0, 1, 2])
     y = np.array([0, 0, 1, 1, 2, 2])
     # sample_weight zeros out class 1 entirely
@@ -176,7 +176,7 @@ def test_compute_class_weight_balanced_zero_sample_weight_class():
 
 
 def test_compute_class_weight_balanced_zero_sample_weight_multiple_classes():
-    """Check error message lists all zero-weight classes."""
+    # Check error message lists all zero-weight classes.
     classes = np.array([0, 1, 2])
     y = np.array([0, 0, 1, 1, 2, 2])
     # sample_weight zeros out classes 0 and 2

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -165,6 +165,7 @@ def test_compute_class_weight_balanced_zero_sample_weight_class():
     # This test ensures we raise a clear error instead.
 
     # Non-regression test for silent division by zero bug.
+    # Non-regression test: zero total sample_weight for a class should raise an error.
 
     classes = np.array([0, 1, 2])
     y = np.array([0, 0, 1, 1, 2, 2])


### PR DESCRIPTION

When sample_weight zeros out an entire class, weighted_class_counts becomes zero for that class, causing division by zero and producing inf values that silently propagate through the training pipeline.

This fix adds explicit validation to detect classes with zero total sample_weight and raises a clear ValueError instead of silently returning inf values.

Includes regression tests for both single and multiple zero-weight classes.

---

#### Reference Issues/PRs

None (discovered during code review)

---

#### What does this implement/fix? Explain your changes.

**Problem:** In `compute_class_weight()`, when `class_weight="balanced"` and `sample_weight` zeros out an entire class, the weighted class count becomes zero. The subsequent division:

```python
recip_freq = weighted_class_counts.sum() / (len(le.classes_) * weighted_class_counts)
```

produces `inf` values that silently propagate through training, causing incorrect model behavior.

**Reproduction:**
```python
from sklearn.utils.class_weight import compute_class_weight
import numpy as np

classes = np.array([0, 1])
y = np.array([0, 0, 1, 1])
sample_weight = np.array([1.0, 1.0, 0.0, 0.0])  # Class 1 zeroed out

# Before fix: silently returns [0.5, inf]
# After fix: raises ValueError with clear message
compute_class_weight("balanced", classes=classes, y=y, sample_weight=sample_weight)
```

**Solution:** Added explicit validation after computing `weighted_class_counts` to check for zero values and raise a descriptive `ValueError` listing all affected classes:

```python
zero_weight_classes_mask = weighted_class_counts == 0
if np.any(zero_weight_classes_mask):
    zero_weight_classes = le.classes_[zero_weight_classes_mask]
    raise ValueError(
        f"The following classes have zero total sample_weight, which would "
        f"result in undefined class weights: {zero_weight_classes.tolist()}. "
        f"Ensure all classes have at least some positive sample_weight."
    )
```

**Files changed:**
- `sklearn/utils/class_weight.py` - Added zero-weight validation before division
- `sklearn/utils/tests/test_class_weight.py` - Added 2 regression tests

---

#### AI usage disclosure

I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

---

#### Any other comments?

This is a small, isolated fix that prevents silent data corruption. The error message is actionable and lists all affected classes to help users debug their `sample_weight` arrays.
