### PR TITLE
Fix missing HTML escape in parameters repr

### DIFF
--- a/doc/whats_new/upcoming_changes/many-modules/32942.fix.rst
+++ b/doc/whats_new/upcoming_changes/many-modules/32942.fix.rst
@@ -1,0 +1,4 @@
+- Some parameter descriptions in the HTML representation of estimators
+  were not properly escaped, which could lead to malformed HTML if the
+  description contains characters like `<` or `>`.
+  By :user:`Olivier Grisel <ogrisel>`.

--- a/sklearn/utils/_repr_html/params.py
+++ b/sklearn/utils/_repr_html/params.py
@@ -113,8 +113,9 @@ def _params_html_repr(params):
         link = _generate_link_to_param_doc(params.estimator_class, row, params.doc_link)
         if param_numpydoc := param_map.get(row, None):
             param_description = (
-                f"{param_numpydoc.name}: {param_numpydoc.type}<br><br>"
-                f"{'<br>'.join(param_numpydoc.desc)}"
+                f"{html.escape(param_numpydoc.name)}: "
+                f"{html.escape(param_numpydoc.type)}<br><br>"
+                f"{'<br>'.join(html.escape(line) for line in param_numpydoc.desc)}"
             )
         else:
             param_description = None

--- a/sklearn/utils/_repr_html/tests/test_params.py
+++ b/sklearn/utils/_repr_html/tests/test_params.py
@@ -90,7 +90,8 @@ def test_params_html_repr_with_doc_links():
         Parameters
         ----------
         a : int
-            Description of a.
+            Description of a which can include `<formatted text
+            https://example.com>`_ that should not be confused with HTML tags.
         b : str
         """
 
@@ -115,7 +116,8 @@ def test_params_html_repr_with_doc_links():
         r'\s*<span class="param-doc-description"'
         r'\s*style="position-anchor: --doc-link-a;">\s*a:'
         r"\sint<br><br>"
-        r"Description of a\.</span>"
+        r"Description of a which can include `&lt;formatted text<br>"
+        r"https://example.com&gt;`_ that should not be confused with HTML tags.</span>"
         r"\s*</a>"
         r"\s*</td>"
     )


### PR DESCRIPTION
This PR fixes some missing calls to `html.escape`.

#### AI usage disclosure

I found the problem when prototyping a test refactoring with copilot but the final content of this PR was manually edited in the end.