### PR TITLE
FIX monkeypatch.settattr raising AttributeError

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -11,7 +11,7 @@ import pytest
 from joblib.numpy_pickle import NumpyPickler
 from numpy.testing import assert_allclose, assert_array_equal
 
-import sklearn
+import sklearn.ensemble._hist_gradient_boosting.gradient_boosting as hgb_module
 from sklearn._loss.loss import (
     AbsoluteError,
     HalfBinomialLoss,
@@ -870,11 +870,7 @@ def test_early_stopping_with_sample_weights(monkeypatch):
         assert scoring == "neg_median_absolute_error"
         return mock_scorer
 
-    monkeypatch.setattr(
-        sklearn.ensemble._hist_gradient_boosting.gradient_boosting,
-        "check_scoring",
-        mock_check_scoring,
-    )
+    monkeypatch.setattr(hgb_module, "check_scoring", mock_check_scoring)
 
     X, y = make_regression(random_state=0)
     sample_weight = np.ones_like(y)


### PR DESCRIPTION
For some reason, I got an `AttributeError` when running `test_early_stopping_with_sample_weights` locally (with pytest 9.0.2). This test is not failing on our CI for some reason (maybe the `monkeypatch` fixture has changed in pytest 9)?

I am not sure if this is a bug of pytest or not but since I might not be the only one annoyed by this failure while it's easy to workaround.