### PR TITLE
PERF limit the number of openmp threads when fitting HGB models

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -640,12 +640,12 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         # data.
         self._in_fit = True
 
-        # `_openmp_effective_n_threads` is used to take cgroups CPU quotes into
+        # `_openmp_effective_n_threads` is used to take cgroups CPU quotas into
         # account when determine the maximum number of threads to use. We
         # further limit the number of threads based on the input data shape to
         # avoid spawning too many threads for small datasets as it was
         # empirically found that using too many threads can slow down training.
-        self.n_threads_ = n_threads = min(
+        n_threads = min(
             _openmp_effective_n_threads(),
             min(
                 max(X.shape[0] * X.shape[1] // 1_000_000, 1),


### PR DESCRIPTION
Fixes #30662.

This is a draft PR to investigate a possible solution to the performance slowdown when letting OpenMP use too many threads on small to medium problems.

I found the following heuristic to work well on my Apple M4 CPU (4 performance cores and 6 efficiency cores). In particular, it makes the running tests of `sklearn/ensemble/_hist_gradient_boosting/tests` go from nearly 1 min on `main` down to less than 10 s on this branch (a factor of 7 speed-up).

I plan to check if this heuristic is suitable for other CPUs.

Note that there is a similar problem for the `_raw_predict` method that also uses all threads, independently of the `n_threads` value used at fit time.