### PR TITLE
Fix: GPR can predict std and cov with different target scales in a multioutput case

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.gaussian_process/32956.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.gaussian_process/32956.fix.rst
@@ -1,0 +1,5 @@
+- By default,
+  in the case of multiple targets,
+  :class:`~sklearn.gaussian_process.GaussianProcessRegressor` normalizes the target values during fitting
+  to make the standard deviation and covariance dependent on the target scales.
+  By :user:`Matthias De Lozzo <mdelozzo>`.

--- a/doc/whats_new/upcoming_changes/sklearn.gaussian_process/32956.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.gaussian_process/32956.fix.rst
@@ -1,5 +1,3 @@
-- By default,
-  in the case of multiple targets,
-  :class:`~sklearn.gaussian_process.GaussianProcessRegressor` normalizes the target values during fitting
-  to make the standard deviation and covariance dependent on the target scales.
+- class:`~sklearn.gaussian_process.GaussianProcessRegressor` takes into account the scales of the targets
+  when predicting the standard deviation, variance and covariance, regardless of the value of `normalize_y`.
   By :user:`Matthias De Lozzo <mdelozzo>`.

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -279,7 +279,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         # the targets have the same scale as the first target in the default case of normalize_y=False
         # for normalize_y=True targets are normalised using standard scaling.
         # y_unscale ensures that
-        # the posterior statistics have the same scales as in the training data.
+        # the posterior statistics have the same scales as in the original target data.
         if self.normalize_y:
             y = (y - self._y_train_mean) / self._y_train_std
             self.__y_scale = np.ones(self._y_train_std.size)

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -111,10 +111,11 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         run is performed.
 
     normalize_y : bool, default=False
-        Whether :meth:`fit` must normalize the training target values `y`
-        by removing the mean and scaling to unit-variance.
-        This is recommended
-        when zero-mean, unit-variance priors are used.
+        Whether or not to normalize the target values `y` by removing the mean
+        and scaling to unit-variance. This is recommended for cases where
+        zero-mean, unit-variance priors are used. Note that, in this
+        implementation, the normalisation is reversed before the GP predictions
+        are reported.
 
         .. versionchanged:: 0.23
 
@@ -193,7 +194,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
     >>> gpr.score(X, y)
     0.3680...
     >>> gpr.predict(X[:2,:], return_std=True)
-    (array([653.0, 592.1]), array([316.6, 316.6]))
+    (array([653.08792288, 592.16905327]), array([316.68016218, 316.65121679]))
     """
 
     _parameter_constraints: dict = {
@@ -277,13 +278,24 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                 f"`n_targets`. Got {n_targets_seen} != {self.n_targets}."
             )
 
-        self._y_train_mean = np.mean(y, axis=0)
-        self._y_train_std = np.atleast_1d(
-            _handle_zeros_in_scale(np.std(y, axis=0), copy=False)
-        )
+        n_targets = 1 if y.ndim == 1 else y.shape[1]
+        if n_targets == 1:
+            self._y_min = 0
+            self._y_range = 1
+        else:
+            self._y_min = y.min(0)
+            self._y_range = _handle_zeros_in_scale(y.max(0) - self._y_min)
+            y = (y - self._y_min) / self._y_range
 
         if self.normalize_y:
+            self._y_train_mean = np.mean(y, axis=0)
+            self._y_train_std = _handle_zeros_in_scale(np.std(y, axis=0), copy=False)
+
+            # Remove mean and make unit variance
             y = (y - self._y_train_mean) / self._y_train_std
+        else:
+            self._y_train_mean = np.zeros(n_targets)
+            self._y_train_std = np.ones(n_targets)
 
         if np.iterable(self.alpha) and self.alpha.shape[0] != y.shape[0]:
             if self.alpha.shape[0] == 1:
@@ -447,9 +459,9 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             K_trans = self.kernel_(X, self.X_train_)
             y_mean = K_trans @ self.alpha_
 
-            if self.normalize_y:
-                # undo normalisation
-                y_mean = self._y_train_std * y_mean + self._y_train_mean
+            # undo normalisation
+            y_mean = y_mean * self._y_train_std + self._y_train_mean
+            y_mean = y_mean * self._y_range + self._y_min
 
             # if y_mean has shape (n_samples, 1), reshape to (n_samples,)
             if y_mean.ndim > 1 and y_mean.shape[1] == 1:
@@ -466,8 +478,11 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             if return_cov:
                 # Alg 2.1, page 19, line 6 -> K(X_test, X_test) - v^T. v
                 y_cov = self.kernel_(X) - V.T @ V
-                y_cov = np.outer(y_cov, self._y_train_std**2).reshape(*y_cov.shape, -1)
 
+                # undo normalisation
+                y_cov = np.outer(
+                    y_cov, self._y_train_std**2 * self._y_range**2
+                ).reshape(*y_cov.shape, -1)
                 # if y_cov has shape (n_samples, n_samples, 1), reshape to
                 # (n_samples, n_samples)
                 if y_cov.shape[2] == 1:
@@ -491,7 +506,10 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                     )
                     y_var[y_var_negative] = 0.0
 
-                y_var = np.outer(y_var, self._y_train_std**2).reshape(*y_var.shape, -1)
+                # undo normalisation
+                y_var = np.outer(
+                    y_var, self._y_train_std**2 * self._y_range**2
+                ).reshape(*y_var.shape, -1)
 
                 # if y_var has shape (n_samples, 1), reshape to (n_samples,)
                 if y_var.shape[1] == 1:
@@ -598,8 +616,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             y_train = y_train[:, np.newaxis]
 
         # Alg 2.1, page 19, line 3 -> alpha = L^T \ (L \ y)
-        scale = 1 if self.normalize_y else self._y_train_std / self._y_train_std[0]
-        alpha = cho_solve((L, GPR_CHOLESKY_LOWER), y_train / scale, check_finite=False)
+        alpha = cho_solve((L, GPR_CHOLESKY_LOWER), y_train, check_finite=False)
 
         # Alg 2.1, page 19, line 7
         # -0.5 . y^T . alpha - sum(log(diag(L))) - n_samples / 2 log(2*pi)

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -282,22 +282,8 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             _handle_zeros_in_scale(np.std(y, axis=0), copy=False)
         )
 
-        # y_scale ensures that in the likelihood calculation,
-        # the targets have the same scale as the first target
-        # in the default case of normalize_y=False;
-        # for normalize_y=True targets are normalised using standard scaling.
-        # y_unscale ensures that
-        # the posterior statistics have the same scales as in the original target data.
         if self.normalize_y:
             y = (y - self._y_train_mean) / self._y_train_std
-            self.__y_scale = np.ones(self._y_train_std.size)
-            self.__y_unscale = self._y_train_std
-        elif self.optimizer is None:
-            self.__y_scale = np.ones(self._y_train_std.size)
-            self.__y_unscale = self._y_train_std / self._y_train_std[0]
-        else:
-            self.__y_scale = self._y_train_std / self._y_train_std[0]
-            self.__y_unscale = self.__y_scale
 
         if np.iterable(self.alpha) and self.alpha.shape[0] != y.shape[0]:
             if self.alpha.shape[0] == 1:
@@ -480,7 +466,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             if return_cov:
                 # Alg 2.1, page 19, line 6 -> K(X_test, X_test) - v^T. v
                 y_cov = self.kernel_(X) - V.T @ V
-                y_cov = np.outer(y_cov, self.__y_unscale**2).reshape(*y_cov.shape, -1)
+                y_cov = np.outer(y_cov, self._y_train_std**2).reshape(*y_cov.shape, -1)
 
                 # if y_cov has shape (n_samples, n_samples, 1), reshape to
                 # (n_samples, n_samples)
@@ -505,7 +491,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                     )
                     y_var[y_var_negative] = 0.0
 
-                y_var = np.outer(y_var, self.__y_unscale**2).reshape(*y_var.shape, -1)
+                y_var = np.outer(y_var, self._y_train_std**2).reshape(*y_var.shape, -1)
 
                 # if y_var has shape (n_samples, 1), reshape to (n_samples,)
                 if y_var.shape[1] == 1:
@@ -612,9 +598,8 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             y_train = y_train[:, np.newaxis]
 
         # Alg 2.1, page 19, line 3 -> alpha = L^T \ (L \ y)
-        alpha = cho_solve(
-            (L, GPR_CHOLESKY_LOWER), y_train / self.__y_scale, check_finite=False
-        )
+        scale = 1 if self.normalize_y else self._y_train_std / self._y_train_std[0]
+        alpha = cho_solve((L, GPR_CHOLESKY_LOWER), y_train / scale, check_finite=False)
 
         # Alg 2.1, page 19, line 7
         # -0.5 . y^T . alpha - sum(log(diag(L))) - n_samples / 2 log(2*pi)

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -276,7 +276,8 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         )
 
         # y_scale ensures that in the likelihood calculation,
-        # the targets have the same scale as the first target in the default case of normalize_y=False
+        # the targets have the same scale as the first target
+        # in the default case of normalize_y=False;
         # for normalize_y=True targets are normalised using standard scaling.
         # y_unscale ensures that
         # the posterior statistics have the same scales as in the original target data.

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -276,7 +276,8 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         )
 
         # y_scale ensures that in the likelihood calculation,
-        # the targets have the same scale as the first target.
+        # the targets have the same scale as the first target in the default case of normalize_y=False
+        # for normalize_y=True targets are normalised using standard scaling.
         # y_unscale ensures that
         # the posterior statistics have the same scales as in the training data.
         if self.normalize_y:

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -115,8 +115,6 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         by removing the mean and scaling to unit-variance.
         This is recommended
         when zero-mean, unit-variance priors are used.
-        This argument is ignored when the target is multidimensional;
-        normalization is performed whatever the value of `normalization_y`.
 
         .. versionchanged:: 0.23
 
@@ -226,7 +224,6 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         self.optimizer = optimizer
         self.n_restarts_optimizer = n_restarts_optimizer
         self.normalize_y = normalize_y
-        self._normalize_y = normalize_y
         self.copy_X_train = copy_X_train
         self.n_targets = n_targets
         self.random_state = random_state
@@ -273,28 +270,25 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                 f"`n_targets`. Got {n_targets_seen} != {self.n_targets}."
             )
 
-        if n_targets_seen > 1:
-            # This class merges targets when applying Alg 2.1, page 19.
-            # By doing so,
-            # it assumes that the targets are instances of the same GP,
-            # with prior covariance function k.
-            # Therefore,
-            # the targets would have the same posterior covariance function
-            # (see Alg 2.1, page 19, line 6 -> K(X_test, X_test) - v^T. v)
-            # if we applied the algorithm as is to the raw data.
-            # To avoid this pitfall,
-            # we standardize the targets during the training.
-            self._normalize_y = True
-
         self._y_train_mean = np.mean(y, axis=0)
-        self._y_train_std = _handle_zeros_in_scale(np.std(y, axis=0), copy=False)
+        self._y_train_std = np.atleast_1d(
+            _handle_zeros_in_scale(np.std(y, axis=0), copy=False)
+        )
 
-        if self._normalize_y:
+        # y_scale ensures that in the likelihood calculation,
+        # the targets have the same scale as the first target.
+        # y_unscale ensures that
+        # the posterior statistics have the same scales as in the training data.
+        if self.normalize_y:
             y = (y - self._y_train_mean) / self._y_train_std
-            self.__y_scale = self._y_train_std
+            self.__y_scale = np.ones(self._y_train_std.size)
+            self.__y_unscale = self._y_train_std
+        elif self.optimizer is None:
+            self.__y_scale = np.ones(self._y_train_std.size)
+            self.__y_unscale = self._y_train_std / self._y_train_std[0]
         else:
-            shape_y_stats = (y.shape[1],) if y.ndim == 2 else 1
-            self.__y_scale = np.ones(shape=shape_y_stats)
+            self.__y_scale = self._y_train_std / self._y_train_std[0]
+            self.__y_unscale = self.__y_scale
 
         if np.iterable(self.alpha) and self.alpha.shape[0] != y.shape[0]:
             if self.alpha.shape[0] == 1:
@@ -458,7 +452,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             K_trans = self.kernel_(X, self.X_train_)
             y_mean = K_trans @ self.alpha_
 
-            if self._normalize_y:
+            if self.normalize_y:
                 # undo normalisation
                 y_mean = self._y_train_std * y_mean + self._y_train_mean
 
@@ -477,7 +471,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             if return_cov:
                 # Alg 2.1, page 19, line 6 -> K(X_test, X_test) - v^T. v
                 y_cov = self.kernel_(X) - V.T @ V
-                y_cov = np.outer(y_cov, self.__y_scale**2).reshape(*y_cov.shape, -1)
+                y_cov = np.outer(y_cov, self.__y_unscale**2).reshape(*y_cov.shape, -1)
 
                 # if y_cov has shape (n_samples, n_samples, 1), reshape to
                 # (n_samples, n_samples)
@@ -502,7 +496,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                     )
                     y_var[y_var_negative] = 0.0
 
-                y_var = np.outer(y_var, self.__y_scale**2).reshape(*y_var.shape, -1)
+                y_var = np.outer(y_var, self.__y_unscale**2).reshape(*y_var.shape, -1)
 
                 # if y_var has shape (n_samples, 1), reshape to (n_samples,)
                 if y_var.shape[1] == 1:
@@ -609,7 +603,9 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             y_train = y_train[:, np.newaxis]
 
         # Alg 2.1, page 19, line 3 -> alpha = L^T \ (L \ y)
-        alpha = cho_solve((L, GPR_CHOLESKY_LOWER), y_train, check_finite=False)
+        alpha = cho_solve(
+            (L, GPR_CHOLESKY_LOWER), y_train / self.__y_scale, check_finite=False
+        )
 
         # Alg 2.1, page 19, line 7
         # -0.5 . y^T . alpha - sum(log(diag(L))) - n_samples / 2 log(2*pi)

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -228,6 +228,11 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         self.n_targets = n_targets
         self.random_state = random_state
 
+    @staticmethod
+    def _create_default_kernel():
+        """Create a default kernel."""
+        return C() * RBF()
+
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X, y):
         """Fit Gaussian process regression model.
@@ -245,7 +250,9 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         self : object
             GaussianProcessRegressor class instance.
         """
-        self.kernel_ = C() * RBF() if self.kernel is None else clone(self.kernel)
+        self.kernel_ = (
+            self._create_default_kernel() if self.kernel is None else clone(self.kernel)
+        )
 
         self._rng = check_random_state(self.random_state)
 

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -110,12 +110,14 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         must be finite. Note that `n_restarts_optimizer == 0` implies that one
         run is performed.
 
-    normalize_y : bool, default=False
-        Whether or not to normalize the target values `y` by removing the mean
-        and scaling to unit-variance. This is recommended for cases where
-        zero-mean, unit-variance priors are used. Note that, in this
-        implementation, the normalisation is reversed before the GP predictions
-        are reported.
+    normalize_y : bool, default=None
+        Whether :meth:`fit` must normalize the training target values `y`
+        by removing the mean and scaling to unit-variance.
+        This is recommended
+        when zero-mean, unit-variance priors are used
+        or when the target is multidimensional.
+        If `None` and the target is scalar, normalization is performed.
+        If `None` and the target is multidimensional, normalization is not performed.
 
         .. versionchanged:: 0.23
 
@@ -202,7 +204,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         "alpha": [Interval(Real, 0, None, closed="left"), np.ndarray],
         "optimizer": [StrOptions({"fmin_l_bfgs_b"}), callable, None],
         "n_restarts_optimizer": [Interval(Integral, 0, None, closed="left")],
-        "normalize_y": ["boolean"],
+        "normalize_y": [None, "boolean"],
         "copy_X_train": ["boolean"],
         "n_targets": [Interval(Integral, 1, None, closed="left"), None],
         "random_state": ["random_state"],
@@ -215,7 +217,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         alpha=1e-10,
         optimizer="fmin_l_bfgs_b",
         n_restarts_optimizer=0,
-        normalize_y=False,
+        normalize_y=None,
         copy_X_train=True,
         n_targets=None,
         random_state=None,
@@ -225,6 +227,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         self.optimizer = optimizer
         self.n_restarts_optimizer = n_restarts_optimizer
         self.normalize_y = normalize_y
+        self._normalize_y = normalize_y
         self.copy_X_train = copy_X_train
         self.n_targets = n_targets
         self.random_state = random_state
@@ -271,18 +274,18 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                 f"`n_targets`. Got {n_targets_seen} != {self.n_targets}."
             )
 
-        # Normalize target value
-        if self.normalize_y:
-            self._y_train_mean = np.mean(y, axis=0)
-            self._y_train_std = _handle_zeros_in_scale(np.std(y, axis=0), copy=False)
+        if self._normalize_y is None:
+            self._normalize_y = n_targets_seen > 1
 
-            # Remove mean and make unit variance
+        self._y_train_mean = np.mean(y, axis=0)
+        self._y_train_std = _handle_zeros_in_scale(np.std(y, axis=0), copy=False)
+
+        if self._normalize_y:
             y = (y - self._y_train_mean) / self._y_train_std
-
+            self.__y_scale = self._y_train_std
         else:
             shape_y_stats = (y.shape[1],) if y.ndim == 2 else 1
-            self._y_train_mean = np.zeros(shape=shape_y_stats)
-            self._y_train_std = np.ones(shape=shape_y_stats)
+            self.__y_scale = np.ones(shape=shape_y_stats)
 
         if np.iterable(self.alpha) and self.alpha.shape[0] != y.shape[0]:
             if self.alpha.shape[0] == 1:
@@ -446,8 +449,9 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             K_trans = self.kernel_(X, self.X_train_)
             y_mean = K_trans @ self.alpha_
 
-            # undo normalisation
-            y_mean = self._y_train_std * y_mean + self._y_train_mean
+            if self._normalize_y:
+                # undo normalisation
+                y_mean = self._y_train_std * y_mean + self._y_train_mean
 
             # if y_mean has shape (n_samples, 1), reshape to (n_samples,)
             if y_mean.ndim > 1 and y_mean.shape[1] == 1:
@@ -464,9 +468,8 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             if return_cov:
                 # Alg 2.1, page 19, line 6 -> K(X_test, X_test) - v^T. v
                 y_cov = self.kernel_(X) - V.T @ V
+                y_cov = np.outer(y_cov, self.__y_scale**2).reshape(*y_cov.shape, -1)
 
-                # undo normalisation
-                y_cov = np.outer(y_cov, self._y_train_std**2).reshape(*y_cov.shape, -1)
                 # if y_cov has shape (n_samples, n_samples, 1), reshape to
                 # (n_samples, n_samples)
                 if y_cov.shape[2] == 1:
@@ -490,8 +493,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                     )
                     y_var[y_var_negative] = 0.0
 
-                # undo normalisation
-                y_var = np.outer(y_var, self._y_train_std**2).reshape(*y_var.shape, -1)
+                y_var = np.outer(y_var, self.__y_scale**2).reshape(*y_var.shape, -1)
 
                 # if y_var has shape (n_samples, 1), reshape to (n_samples,)
                 if y_var.shape[1] == 1:

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -110,14 +110,13 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         must be finite. Note that `n_restarts_optimizer == 0` implies that one
         run is performed.
 
-    normalize_y : bool, default=None
+    normalize_y : bool, default=False
         Whether :meth:`fit` must normalize the training target values `y`
         by removing the mean and scaling to unit-variance.
         This is recommended
-        when zero-mean, unit-variance priors are used
-        or when the target is multidimensional.
-        If `None` and the target is scalar, normalization is performed.
-        If `None` and the target is multidimensional, normalization is not performed.
+        when zero-mean, unit-variance priors are used.
+        This argument is ignored when the target is multidimensional;
+        normalization is performed whatever the value of `normalization_y`.
 
         .. versionchanged:: 0.23
 
@@ -204,7 +203,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         "alpha": [Interval(Real, 0, None, closed="left"), np.ndarray],
         "optimizer": [StrOptions({"fmin_l_bfgs_b"}), callable, None],
         "n_restarts_optimizer": [Interval(Integral, 0, None, closed="left")],
-        "normalize_y": [None, "boolean"],
+        "normalize_y": ["boolean"],
         "copy_X_train": ["boolean"],
         "n_targets": [Interval(Integral, 1, None, closed="left"), None],
         "random_state": ["random_state"],
@@ -217,7 +216,7 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         alpha=1e-10,
         optimizer="fmin_l_bfgs_b",
         n_restarts_optimizer=0,
-        normalize_y=None,
+        normalize_y=False,
         copy_X_train=True,
         n_targets=None,
         random_state=None,
@@ -274,8 +273,18 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                 f"`n_targets`. Got {n_targets_seen} != {self.n_targets}."
             )
 
-        if self._normalize_y is None:
-            self._normalize_y = n_targets_seen > 1
+        if n_targets_seen > 1:
+            # This class merges targets when applying Alg 2.1, page 19.
+            # By doing so,
+            # it assumes that the targets are instances of the same GP,
+            # with prior covariance function k.
+            # Therefore,
+            # the targets would have the same posterior covariance function
+            # (see Alg 2.1, page 19, line 6 -> K(X_test, X_test) - v^T. v)
+            # if we applied the algorithm as is to the raw data.
+            # To avoid this pitfall,
+            # we standardize the targets during the training.
+            self._normalize_y = True
 
         self._y_train_mean = np.mean(y, axis=0)
         self._y_train_std = _handle_zeros_in_scale(np.std(y, axis=0), copy=False)

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -364,7 +364,9 @@ def test_large_variance_y():
 def test_y_multioutput(normalize_y):
     # Test that GPR can deal with multi-dimensional target values
     scale = 2
-    y_2d = np.vstack((y, y * scale)).T
+    y1 = y
+    y2 = y * scale
+    y_2d = np.vstack((y1, y2)).T
 
     # Test for fixed kernel that first dimension of 2d GP equals the output
     # of 1d GP and that second dimension is twice as large
@@ -373,12 +375,12 @@ def test_y_multioutput(normalize_y):
     gpr_1 = GaussianProcessRegressor(
         kernel=kernel, optimizer=None, normalize_y=normalize_y
     )
-    gpr_1.fit(X, y_2d[:, 0])
+    gpr_1.fit(X, (y1 - y1.min()) / (y1.max() - y1.min()))
 
     gpr_2 = GaussianProcessRegressor(
         kernel=kernel, optimizer=None, normalize_y=normalize_y
     )
-    gpr_2.fit(X, y_2d[:, 1])
+    gpr_2.fit(X, (y2 - y2.min()) / (y2.max() - y2.min()))
 
     gpr_12 = GaussianProcessRegressor(
         kernel=kernel, optimizer=None, normalize_y=normalize_y
@@ -391,6 +393,12 @@ def test_y_multioutput(normalize_y):
     _, y_cov_1 = gpr_1.predict(X2, return_cov=True)
     _, y_cov_2 = gpr_2.predict(X2, return_cov=True)
     _, y_cov_12 = gpr_12.predict(X2, return_cov=True)
+    y_pred_1 = y_pred_1 * (y1.max() - y1.min()) + y1.min()
+    y_pred_2 = y_pred_2 * (y2.max() - y2.min()) + y2.min()
+    y_std_1 = y_std_1 * (y1.max() - y1.min())
+    y_std_2 = y_std_2 * (y2.max() - y2.min())
+    y_cov_1 = y_cov_1 * (y1.max() - y1.min()) ** 2
+    y_cov_2 = y_cov_2 * (y2.max() - y2.min()) ** 2
 
     assert_almost_equal(y_pred_12[:, 0], y_pred_1)
     assert_almost_equal(y_std_12[..., 0], y_std_1)
@@ -403,7 +411,7 @@ def test_y_multioutput(normalize_y):
     assert_almost_equal(y_cov_12[..., 1], y_cov_2)
     assert_almost_equal(y_cov_12[..., 1], y_cov_1 * scale**2)
 
-    y_sample_1 = gpr_1.sample_y(X2, n_samples=10)
+    y_sample_1 = gpr_1.sample_y(X2, n_samples=10) * (y1.max() - y1.min()) + y1.min()
     y_sample_12 = gpr_12.sample_y(X2, n_samples=10)
 
     assert y_sample_1.shape == (5, 10)

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -884,7 +884,7 @@ def test_gpr_predict_no_cov_no_std_return(kernel):
 
 
 @pytest.mark.parametrize("normalize_y", [None, False, True])
-@pytest.mark.parametrize("kernel", [None, RBF(), 1 * RBF()])
+@pytest.mark.parametrize("kernel", kernels)
 def test_gpr_multioutput_normalization(normalize_y, kernel):
     """Check the robustness of the training wrt the normalization policy
     in the case of a multioutput use case."""

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -373,7 +373,6 @@ def test_y_multioutput():
     kernel = RBF(length_scale=1.0)
 
     # Set normalize_y to True because gpr_2d will normalize the target values.
-    # Otherwise, change the tolerance in assert_almost_equal below.
     gpr = GaussianProcessRegressor(kernel=kernel, optimizer=None, normalize_y=True)
     gpr.fit(X, y)
 
@@ -887,7 +886,7 @@ def test_gpr_predict_no_cov_no_std_return(kernel):
     assert_allclose(y_pred, y)
 
 
-@pytest.mark.parametrize("normalize_y", [None, False, True])
+@pytest.mark.parametrize("normalize_y", [False, True])
 @pytest.mark.parametrize("kernel", kernels)
 def test_gpr_multioutput_normalization(normalize_y, kernel):
     """Check the robustness of the training wrt the normalization policy
@@ -901,7 +900,7 @@ def test_gpr_multioutput_normalization(normalize_y, kernel):
     mean, std = gpr.predict(np.array([[0.25]]), return_std=True)
     _, cov = gpr.predict(np.array([[0.25]]), return_cov=True)
 
-    scale = 1 if normalize_y is False else 10
+    scale = 10
     assert_almost_equal(mean[:, 1], mean[:, 0] * 10)
     assert_almost_equal(std[:, 1], std[:, 0] * scale)
     assert_almost_equal(cov[:, :, 1], cov[:, :, 0] * scale**2)

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -876,3 +876,29 @@ def test_gpr_predict_no_cov_no_std_return(kernel):
     y_pred = gpr.predict(X, return_cov=False, return_std=False)
 
     assert_allclose(y_pred, y)
+
+
+@pytest.mark.parametrize("normalize_y", [False, True])
+def test_gpr_multioutput_normalization(normalize_y):
+    """Check the robustness of the training wrt the normalization policy."""
+    X_train = np.array([[0.0], [0.5], [1.0]])
+    X_train_squared = X_train**2
+    scale = 10
+    y_train = np.hstack((X_train_squared, scale * X_train_squared))
+    # Note that the 2nd output is equal to 10 times the 1st.
+
+    gpr = GaussianProcessRegressor(normalize_y=normalize_y)
+    gpr.fit(X_train, y_train)
+    mean, std = gpr.predict(np.array([[0.25]]), return_std=True)
+    _, cov = gpr.predict(np.array([[0.25]]), return_cov=True)
+    assert_almost_equal(mean[:, 1], mean[:, 0] * scale)
+    # As expected,
+    # the mean of the 2nd output is equal to 10 times that of the 1st.
+
+    assert_almost_equal(std[:, 1], std[:, 0] * scale)
+    # As expected,
+    # the standard deviation of the 2nd output is equal to 10 times that of the 1st.
+
+    assert_almost_equal(cov[:, :, 1], cov[:, :, 0] * scale**2)
+    # As expected,
+    # the covariance of the 2nd output is equal to 100 times that of the 1st.

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -42,6 +42,8 @@ y = f(X).ravel()
 
 fixed_kernel = RBF(length_scale=1.0, length_scale_bounds="fixed")
 kernels = [
+    # None is the default value of the `kernel` argument of GaussianProcessRegressor.
+    None,
     RBF(length_scale=1.0),
     fixed_kernel,
     RBF(length_scale=1.0, length_scale_bounds=(1e-3, 1e3)),
@@ -51,7 +53,9 @@ kernels = [
     C(0.1, (1e-2, 1e2)) * RBF(length_scale=1.0, length_scale_bounds=(1e-3, 1e3))
     + C(1e-5, (1e-5, 1e2)),
 ]
-non_fixed_kernels = [kernel for kernel in kernels if kernel != fixed_kernel]
+# Some test functions require kernel.theta and so do not support None.
+kernels_except_none = kernels[1:]
+non_fixed_kernels = [kernel for kernel in kernels_except_none if kernel != fixed_kernel]
 
 
 @pytest.mark.parametrize("kernel", kernels)
@@ -168,7 +172,7 @@ def test_lml_gradient(kernel, length_scale):
     assert_allclose(lml_gradient, lml_gradient_approx, rtol=1e-4, atol=epsilon * 100)
 
 
-@pytest.mark.parametrize("kernel", kernels)
+@pytest.mark.parametrize("kernel", kernels_except_none)
 def test_prior(kernel):
     # Test that GP prior has mean 0 and identical variances.
     gpr = GaussianProcessRegressor(kernel=kernel)

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -363,7 +363,7 @@ def test_large_variance_y():
     assert_allclose(y_pred_std, y_pred_std_gpy, rtol=0.15, atol=0)
 
 @pytest.mark.parametrize("normalize_y", [False, True])
-def test_y_multioutput():
+def test_y_multioutput(normalise_y):
     # Test that GPR can deal with multi-dimensional target values
     scale = 2
     y_2d = np.vstack((y, y * scale)).T

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -362,8 +362,9 @@ def test_large_variance_y():
     # made by GPy.
     assert_allclose(y_pred_std, y_pred_std_gpy, rtol=0.15, atol=0)
 
+
 @pytest.mark.parametrize("normalize_y", [False, True])
-def test_y_multioutput(normalise_y):
+def test_y_multioutput(normalize_y):
     # Test that GPR can deal with multi-dimensional target values
     scale = 2
     y_2d = np.vstack((y, y * scale)).T
@@ -372,52 +373,57 @@ def test_y_multioutput(normalise_y):
     # of 1d GP and that second dimension is twice as large
     kernel = RBF(length_scale=1.0)
 
-    gpr = GaussianProcessRegressor(kernel=kernel, optimizer=None)
-    gpr.fit(X, y)
-gpr_2 = GaussianProcessRegressor(
+    gpr_1 = GaussianProcessRegressor(
         kernel=kernel, optimizer=None, normalize_y=normalize_y
     )
-    gpr_2.fit(X, y * scale)
-    gpr_2d = GaussianProcessRegressor(kernel=kernel, optimizer=None)
-    gpr_2d.fit(X, y_2d)
+    gpr_1.fit(X, y_2d[:, 0])
 
-    y_pred_1d, y_std_1d = gpr.predict(X2, return_std=True)
-    y_pred_2d, y_std_2d = gpr_2d.predict(X2, return_std=True)
-      y_pred_2, y_std_2 = gpr_2.predict(X2, return_std=True)
+    gpr_2 = GaussianProcessRegressor(
+        kernel=kernel, optimizer=None, normalize_y=normalize_y
+    )
+    gpr_2.fit(X, y_2d[:, 1])
+
+    gpr_12 = GaussianProcessRegressor(
+        kernel=kernel, optimizer=None, normalize_y=normalize_y
+    )
+    gpr_12.fit(X, y_2d)
+
+    y_pred_1, y_std_1 = gpr_1.predict(X2, return_std=True)
+    y_pred_2, y_std_2 = gpr_2.predict(X2, return_std=True)
+    y_pred_12, y_std_12 = gpr_12.predict(X2, return_std=True)
+    _, y_cov_1 = gpr_1.predict(X2, return_cov=True)
     _, y_cov_2 = gpr_2.predict(X2, return_cov=True)
-    _, y_cov_1d = gpr.predict(X2, return_cov=True)
-    _, y_cov_2d = gpr_2d.predict(X2, return_cov=True)
+    _, y_cov_12 = gpr_12.predict(X2, return_cov=True)
 
-    assert_almost_equal(y_pred_1d, y_pred_2d[:, 0])
-    assert_almost_equal(y_std_1d, y_std_2d[..., 0])
-    assert_almost_equal(y_cov_1d, y_cov_2d[..., 0])
-assert_almost_equal(y_pred_2d[:, 1], y_pred_2)
-assert_almost_equal(y_std_2d[:, 1], y_std_2)
-assert_almost_equal(y_cov_2d[..., 1], y_cov_2)
+    assert_almost_equal(y_pred_12[:, 0], y_pred_1)
+    assert_almost_equal(y_std_12[..., 0], y_std_1)
+    assert_almost_equal(y_cov_12[..., 0], y_cov_1)
 
-    # The second output is equal to the first one, up to a scale factor.
-    assert_almost_equal(y_pred_2d[:, 1], y_pred_1d * scale)
-    assert_almost_equal(y_std_2d[..., 1], y_std_1d * scale)
-    assert_almost_equal(y_cov_2d[..., 1], y_cov_1d * scale**2)
+    assert_almost_equal(y_pred_12[:, 1], y_pred_2)
+    assert_almost_equal(y_pred_12[:, 1], y_pred_1 * scale)
+    assert_almost_equal(y_std_12[..., 1], y_std_2)
+    assert_almost_equal(y_std_12[..., 1], y_std_1 * scale)
+    assert_almost_equal(y_cov_12[..., 1], y_cov_2)
+    assert_almost_equal(y_cov_12[..., 1], y_cov_1 * scale**2)
 
-    y_sample_1d = gpr.sample_y(X2, n_samples=10)
-    y_sample_2d = gpr_2d.sample_y(X2, n_samples=10)
+    y_sample_1 = gpr_1.sample_y(X2, n_samples=10)
+    y_sample_12 = gpr_12.sample_y(X2, n_samples=10)
 
-    assert y_sample_1d.shape == (5, 10)
-    assert y_sample_2d.shape == (5, 2, 10)
+    assert y_sample_1.shape == (5, 10)
+    assert y_sample_12.shape == (5, 2, 10)
     # Only the first target will be equal
-    assert_almost_equal(y_sample_1d, y_sample_2d[:, 0, :])
-    assert not np.allclose(y_sample_1d, y_sample_2d[:, 1, :])
+    assert_almost_equal(y_sample_1, y_sample_12[:, 0, :])
+    assert not np.allclose(y_sample_1, y_sample_12[:, 1, :])
 
     # Test hyperparameter optimization
     for kernel in kernels:
-        gpr = GaussianProcessRegressor(kernel=kernel, normalize_y=True)
-        gpr.fit(X, y)
+        gpr_1 = GaussianProcessRegressor(kernel=kernel, normalize_y=True)
+        gpr_1.fit(X, y)
 
-        gpr_2d = GaussianProcessRegressor(kernel=kernel, normalize_y=True)
-        gpr_2d.fit(X, np.vstack((y, y)).T)
+        gpr_12 = GaussianProcessRegressor(kernel=kernel, normalize_y=True)
+        gpr_12.fit(X, np.vstack((y, y)).T)
 
-        assert_almost_equal(gpr.kernel_.theta, gpr_2d.kernel_.theta, 4)
+        assert_almost_equal(gpr_1.kernel_.theta, gpr_12.kernel_.theta, 4)
 
 
 @pytest.mark.parametrize("kernel", non_fixed_kernels)

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -42,8 +42,7 @@ y = f(X).ravel()
 
 fixed_kernel = RBF(length_scale=1.0, length_scale_bounds="fixed")
 kernels = [
-    # None is the default value of the `kernel` argument of GaussianProcessRegressor.
-    None,
+    GaussianProcessRegressor._create_default_kernel(),
     RBF(length_scale=1.0),
     fixed_kernel,
     RBF(length_scale=1.0, length_scale_bounds=(1e-3, 1e3)),
@@ -53,9 +52,7 @@ kernels = [
     C(0.1, (1e-2, 1e2)) * RBF(length_scale=1.0, length_scale_bounds=(1e-3, 1e3))
     + C(1e-5, (1e-5, 1e2)),
 ]
-# Some test functions require kernel.theta and so do not support None.
-kernels_except_none = kernels[1:]
-non_fixed_kernels = [kernel for kernel in kernels_except_none if kernel != fixed_kernel]
+non_fixed_kernels = [kernel for kernel in kernels if kernel != fixed_kernel]
 
 
 @pytest.mark.parametrize("kernel", kernels)
@@ -172,7 +169,7 @@ def test_lml_gradient(kernel, length_scale):
     assert_allclose(lml_gradient, lml_gradient_approx, rtol=1e-4, atol=epsilon * 100)
 
 
-@pytest.mark.parametrize("kernel", kernels_except_none)
+@pytest.mark.parametrize("kernel", kernels)
 def test_prior(kernel):
     # Test that GP prior has mean 0 and identical variances.
     gpr = GaussianProcessRegressor(kernel=kernel)

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -362,7 +362,7 @@ def test_large_variance_y():
     # made by GPy.
     assert_allclose(y_pred_std, y_pred_std_gpy, rtol=0.15, atol=0)
 
-
+@pytest.mark.parametrize("normalize_y", [False, True])
 def test_y_multioutput():
     # Test that GPR can deal with multi-dimensional target values
     scale = 2

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -372,8 +372,7 @@ def test_y_multioutput():
     # of 1d GP and that second dimension is twice as large
     kernel = RBF(length_scale=1.0)
 
-    # Set normalize_y to True because gpr_2d will normalize the target values.
-    gpr = GaussianProcessRegressor(kernel=kernel, optimizer=None, normalize_y=True)
+    gpr = GaussianProcessRegressor(kernel=kernel, optimizer=None)
     gpr.fit(X, y)
 
     gpr_2d = GaussianProcessRegressor(kernel=kernel, optimizer=None)
@@ -901,6 +900,6 @@ def test_gpr_multioutput_normalization(normalize_y, kernel):
     _, cov = gpr.predict(np.array([[0.25]]), return_cov=True)
 
     scale = 10
-    assert_almost_equal(mean[:, 1], mean[:, 0] * 10)
+    assert_almost_equal(mean[:, 1], mean[:, 0] * scale)
     assert_almost_equal(std[:, 1], std[:, 0] * scale)
     assert_almost_equal(cov[:, :, 1], cov[:, :, 0] * scale**2)

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -374,18 +374,26 @@ def test_y_multioutput(normalise_y):
 
     gpr = GaussianProcessRegressor(kernel=kernel, optimizer=None)
     gpr.fit(X, y)
-
+gpr_2 = GaussianProcessRegressor(
+        kernel=kernel, optimizer=None, normalize_y=normalize_y
+    )
+    gpr_2.fit(X, y * scale)
     gpr_2d = GaussianProcessRegressor(kernel=kernel, optimizer=None)
     gpr_2d.fit(X, y_2d)
 
     y_pred_1d, y_std_1d = gpr.predict(X2, return_std=True)
     y_pred_2d, y_std_2d = gpr_2d.predict(X2, return_std=True)
+      y_pred_2, y_std_2 = gpr_2.predict(X2, return_std=True)
+    _, y_cov_2 = gpr_2.predict(X2, return_cov=True)
     _, y_cov_1d = gpr.predict(X2, return_cov=True)
     _, y_cov_2d = gpr_2d.predict(X2, return_cov=True)
 
     assert_almost_equal(y_pred_1d, y_pred_2d[:, 0])
     assert_almost_equal(y_std_1d, y_std_2d[..., 0])
     assert_almost_equal(y_cov_1d, y_cov_2d[..., 0])
+assert_almost_equal(y_pred_2d[:, 1], y_pred_2)
+assert_almost_equal(y_std_2d[:, 1], y_std_2)
+assert_almost_equal(y_cov_2d[..., 1], y_cov_2)
 
     # The second output is equal to the first one, up to a scale factor.
     assert_almost_equal(y_pred_2d[:, 1], y_pred_1d * scale)

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -361,16 +361,19 @@ def test_large_variance_y():
 
 def test_y_multioutput():
     # Test that GPR can deal with multi-dimensional target values
-    y_2d = np.vstack((y, y * 2)).T
+    scale = 2
+    y_2d = np.vstack((y, y * scale)).T
 
     # Test for fixed kernel that first dimension of 2d GP equals the output
     # of 1d GP and that second dimension is twice as large
     kernel = RBF(length_scale=1.0)
 
-    gpr = GaussianProcessRegressor(kernel=kernel, optimizer=None, normalize_y=False)
+    # Set normalize_y to True because gpr_2d will normalize the target values.
+    # Otherwise, change the tolerance in assert_almost_equal below.
+    gpr = GaussianProcessRegressor(kernel=kernel, optimizer=None, normalize_y=True)
     gpr.fit(X, y)
 
-    gpr_2d = GaussianProcessRegressor(kernel=kernel, optimizer=None, normalize_y=False)
+    gpr_2d = GaussianProcessRegressor(kernel=kernel, optimizer=None)
     gpr_2d.fit(X, y_2d)
 
     y_pred_1d, y_std_1d = gpr.predict(X2, return_std=True)
@@ -379,12 +382,13 @@ def test_y_multioutput():
     _, y_cov_2d = gpr_2d.predict(X2, return_cov=True)
 
     assert_almost_equal(y_pred_1d, y_pred_2d[:, 0])
-    assert_almost_equal(y_pred_1d, y_pred_2d[:, 1] / 2)
+    assert_almost_equal(y_std_1d, y_std_2d[..., 0])
+    assert_almost_equal(y_cov_1d, y_cov_2d[..., 0])
 
-    # Standard deviation and covariance do not depend on output
-    for target in range(y_2d.shape[1]):
-        assert_almost_equal(y_std_1d, y_std_2d[..., target])
-        assert_almost_equal(y_cov_1d, y_cov_2d[..., target])
+    # The second output is equal to the first one, up to a scale factor.
+    assert_almost_equal(y_pred_2d[:, 1], y_pred_1d * scale)
+    assert_almost_equal(y_std_2d[..., 1], y_std_1d * scale)
+    assert_almost_equal(y_cov_2d[..., 1], y_cov_1d * scale**2)
 
     y_sample_1d = gpr.sample_y(X2, n_samples=10)
     y_sample_2d = gpr_2d.sample_y(X2, n_samples=10)
@@ -393,6 +397,7 @@ def test_y_multioutput():
     assert y_sample_2d.shape == (5, 2, 10)
     # Only the first target will be equal
     assert_almost_equal(y_sample_1d, y_sample_2d[:, 0, :])
+    assert not np.allclose(y_sample_1d, y_sample_2d[:, 1, :])
 
     # Test hyperparameter optimization
     for kernel in kernels:
@@ -878,27 +883,21 @@ def test_gpr_predict_no_cov_no_std_return(kernel):
     assert_allclose(y_pred, y)
 
 
-@pytest.mark.parametrize("normalize_y", [False, True])
-def test_gpr_multioutput_normalization(normalize_y):
-    """Check the robustness of the training wrt the normalization policy."""
+@pytest.mark.parametrize("normalize_y", [None, False, True])
+@pytest.mark.parametrize("kernel", [None, RBF(), 1 * RBF()])
+def test_gpr_multioutput_normalization(normalize_y, kernel):
+    """Check the robustness of the training wrt the normalization policy
+    in the case of a multioutput use case."""
     X_train = np.array([[0.0], [0.5], [1.0]])
     X_train_squared = X_train**2
-    scale = 10
-    y_train = np.hstack((X_train_squared, scale * X_train_squared))
-    # Note that the 2nd output is equal to 10 times the 1st.
+    y_train = np.hstack((X_train_squared, 10 * X_train_squared))
 
-    gpr = GaussianProcessRegressor(normalize_y=normalize_y)
+    gpr = GaussianProcessRegressor(normalize_y=normalize_y, kernel=kernel)
     gpr.fit(X_train, y_train)
     mean, std = gpr.predict(np.array([[0.25]]), return_std=True)
     _, cov = gpr.predict(np.array([[0.25]]), return_cov=True)
-    assert_almost_equal(mean[:, 1], mean[:, 0] * scale)
-    # As expected,
-    # the mean of the 2nd output is equal to 10 times that of the 1st.
 
+    scale = 1 if normalize_y is False else 10
+    assert_almost_equal(mean[:, 1], mean[:, 0] * 10)
     assert_almost_equal(std[:, 1], std[:, 0] * scale)
-    # As expected,
-    # the standard deviation of the 2nd output is equal to 10 times that of the 1st.
-
     assert_almost_equal(cov[:, :, 1], cov[:, :, 0] * scale**2)
-    # As expected,
-    # the covariance of the 2nd output is equal to 100 times that of the 1st.

--- a/sklearn/gaussian_process/tests/test_gpr.py
+++ b/sklearn/gaussian_process/tests/test_gpr.py
@@ -484,7 +484,7 @@ def test_duplicate_input(kernel):
     y_pred_similar, y_std_similar = gpr_similar_inputs.predict(X_test, return_std=True)
 
     assert_almost_equal(y_pred_equal, y_pred_similar)
-    assert_almost_equal(y_std_equal, y_std_similar)
+    assert_almost_equal(y_std_equal, y_std_similar, decimal=6)
 
 
 def test_no_fit_default_predict():


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs

Fixes #29697

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

In a multioutput context, `GaussianProcessRegressor` does not take target scales into account when predicting standard deviation and covariance if `normalize_y=False`, as illustrated in #29697. From my understanding, when `normalize_y=False`, the objective function is the sum of the log-likelihoods associated with different target scales and there is a risk that the hyperparameters will be biased by a dominant component. This can be confusing for users like me. I think `GaussianProcessRegressor` should scale the targets so that they are on the same scale. More precisely, I propose to scale the targets in [0,1] using a min-max scaling strategy, regardless of the value of `normalize_y`..

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
