### PR TITLE
DOC: clarify SimpleImputer docstring example

### DIFF
--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -285,14 +285,14 @@ class SimpleImputer(_BaseImputer):
     --------
     >>> import numpy as np
     >>> from sklearn.impute import SimpleImputer
-    >>> imp_mean = SimpleImputer(missing_values=np.nan, strategy='mean')
-    >>> imp_mean.fit([[7, 2, 3], [4, np.nan, 6], [10, 5, 9]])
+    >>> imp = SimpleImputer(missing_values=np.nan, strategy='mean')
+    >>> X = [[1, 24], [2, np.nan], [4, 16]]
+    >>> imp.fit(X)
     SimpleImputer()
-    >>> X = [[np.nan, 2, 3], [4, np.nan, 6], [10, np.nan, 9]]
-    >>> print(imp_mean.transform(X))
-    [[ 7.   2.   3. ]
-     [ 4.   3.5  6. ]
-     [10.   3.5  9. ]]
+    >>> print(imp.transform(X))
+    [[ 1. 24.]
+     [ 2. 20.]
+     [ 4. 16.]]
 
     For a more detailed example see
     :ref:`sphx_glr_auto_examples_impute_plot_missing_values.py`.


### PR DESCRIPTION
Reference Issues/PRs
Fixes #32957

What does this implement/fix? Explain your changes.
This PR improves the clarity of the first SimpleImputer example in the docstrings found in sklearn/impute/_base.py.

As highlighted in issue #32957, the previous example was confusing because it performed a fit on one array but then applied the transform to a different, newly defined array. This made it difficult for users to mentally verify the mean imputation logic.

I have updated the example to:

Use a single variable X for both the fit and transform methods.

Provide clear, easy-to-verify numerical outputs where the mean of the second column (24 and 16) results in 20.0.

Ensure the code remains valid and follows the existing scikit-learn documentation style.

AI usage disclosure
I used AI assistance for:

[ ] Code generation (e.g., when writing an implementation or fixing a bug)

[ ] Test/benchmark generation

[] Documentation (including examples)

[x] Research and understanding

Any other comments?
This is my first contribution to scikit-learn. I have verified that the updated example is mathematically correct and clear for beginners.