### PR TITLE
DOC add link to plot_ridge_coeffs example

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -334,6 +334,10 @@ score should increase the probability of getting approved for a loan.
 Monotonic constraints allow you to incorporate such prior knowledge into the
 model.
 
+See :ref:`Monotonic constraints example
+<sphx_glr_auto_examples_ensemble_plot_monotonic_constraints.py>`
+for more details.
+
 For a predictor :math:`F` with two features:
 
 - a **monotonic increase constraint** is a constraint of the form:

--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -843,6 +843,10 @@ is based on the algorithm described in Appendix A of (Tipping, 2001)
 where the update of the parameters :math:`\alpha` and :math:`\lambda` is done
 as suggested in (MacKay, 1992). The initial value of the maximization procedure
 can be set with the hyperparameters ``alpha_init`` and ``lambda_init``.
+See :ref:`Ridge coefficients as a function of the L2 Regularization
+<sphx_glr_auto_examples_linear_model_plot_ridge_coeffs.py>`
+for more details.
+
 
 There are four more hyperparameters, :math:`\alpha_1`, :math:`\alpha_2`,
 :math:`\lambda_1` and :math:`\lambda_2` of the gamma prior distributions over


### PR DESCRIPTION
This PR adds a direct link to the plot_ridge_coeffs example in the user guide to improve discoverability for user reading about Ridge regularization. 

#### AI usage disclosure
- [x] Documentation (including examples)
