### PR TITLE
ENH: make _unique_np NaN handling independent of ordering

### DIFF
--- a/sklearn/utils/_encode.py
+++ b/sklearn/utils/_encode.py
@@ -67,25 +67,7 @@ def _unique_np(values, return_inverse=False, return_counts=False):
         uniques, counts = xp.unique_counts(values)
     else:
         uniques = xp.unique_values(values)
-    # Array API does not guarantee ordering of unique values.
-    # Explicitly remove NaNs without assuming their position.
-    if uniques.size:
-        nan_mask = ~xp.isnan(uniques)
-
-        if return_inverse:
-            # Map indices pointing to NaNs to a single NaN index if present
-            nan_indices = xp.where(~nan_mask)[0]
-            if nan_indices.size:
-                nan_index = nan_indices[0]
-                inverse[inverse == nan_index] = nan_index
-
-        if return_counts:
-            if xp.any(~nan_mask):
-                nan_count = xp.sum(counts[~nan_mask])
-                counts = counts[nan_mask]
-                counts = xp.concatenate([counts, xp.asarray([nan_count])])
-
-        uniques = uniques[nan_mask]
+    
 
     ret = (uniques,)
 

--- a/sklearn/utils/_encode.py
+++ b/sklearn/utils/_encode.py
@@ -67,18 +67,25 @@ def _unique_np(values, return_inverse=False, return_counts=False):
         uniques, counts = xp.unique_counts(values)
     else:
         uniques = xp.unique_values(values)
+    # Array API does not guarantee ordering of unique values.
+    # Explicitly remove NaNs without assuming their position.
+    if uniques.size:
+        nan_mask = ~xp.isnan(uniques)
 
-    # np.unique will have duplicate missing values at the end of `uniques`
-    # here we clip the nans and remove it from uniques
-    if uniques.size and is_scalar_nan(uniques[-1]):
-        nan_idx = xp.searchsorted(uniques, xp.nan)
-        uniques = uniques[: nan_idx + 1]
         if return_inverse:
-            inverse[inverse > nan_idx] = nan_idx
+            # Map indices pointing to NaNs to a single NaN index if present
+            nan_indices = xp.where(~nan_mask)[0]
+            if nan_indices.size:
+                nan_index = nan_indices[0]
+                inverse[inverse == nan_index] = nan_index
 
         if return_counts:
-            counts[nan_idx] = xp.sum(counts[nan_idx:])
-            counts = counts[: nan_idx + 1]
+            if xp.any(~nan_mask):
+                nan_count = xp.sum(counts[~nan_mask])
+                counts = counts[nan_mask]
+                counts = xp.concatenate([counts, xp.asarray([nan_count])])
+
+        uniques = uniques[nan_mask]
 
     ret = (uniques,)
 

--- a/sklearn/utils/tests/test_encode.py
+++ b/sklearn/utils/tests/test_encode.py
@@ -272,3 +272,15 @@ def test_check_unknown_with_both_missing_values():
 def test_get_counts(values, uniques, expected_counts):
     counts = _get_counts(values, uniques)
     assert_array_equal(counts, expected_counts)
+
+def test_unique_np_removes_nan_without_order_assumption():
+    import numpy as np
+    from sklearn.utils._encode import _unique_np
+
+    values = np.array([1.0, np.nan, 2.0, np.nan])
+
+    uniques = _unique_np(values)
+
+    # NaNs should be removed regardless of position
+    assert not np.any(np.isnan(uniques))
+    assert set(uniques.tolist()) == {1.0, 2.0}


### PR DESCRIPTION
The Array API specification does not guarantee any ordering for values
returned by unique operations.

In _unique_np, the current implementation assumes that NaN values appear
at the end of the uniques array, which is not guaranteed for Array API
compliant backends. This PR removes that assumption by explicitly
filtering NaN values instead of relying on positional ordering.

This change makes the behavior robust across NumPy and alternative
Array API backends, while preserving existing semantics for
return_inverse and return_counts.
