### PR TITLE
DOC clarify load_iris example output

### DIFF
--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -698,7 +698,8 @@ def load_iris(*, return_X_y=False, as_frame=False):
     Examples
     --------
     Let's say you are interested in the samples 10, 25, and 50, and want to
-    know their class name.
+    know their class name. The ``target`` array contains integer-encoded class
+    labels, which can be mapped to human-readable names using ``target_names``.
 
     >>> from sklearn.datasets import load_iris
     >>> data = load_iris()


### PR DESCRIPTION
This PR improves the load_iris example by explaining the use of the target array and how target_names maps integer-encoded labels to human-readable class names.

AI usage disclosure:
- Documentation (including examples)
