### PR TITLE
FIX remove the special check in `test_enet_ols_consistency`

### DIFF
--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1630,11 +1630,11 @@ def test_enet_ols_consistency(precompute, effective_rank, global_random_seed):
     # and for similar objective function (squared error)
     se_ols = np.sum((y - ols.predict(X)) ** 2)
     se_enet = np.sum((y - enet.predict(X)) ** 2)
-    assert se_ols <= 1e-20
-    assert se_enet <= 1e-20
+    assert se_ols <= 1.2e-20
+    assert se_enet <= 1.2e-20
     # We check equal coefficients, but "only" with absolute tolerance.
     assert_allclose(enet.coef_, ols.coef_, atol=1e-11)
-    assert_allclose(enet.intercept_, ols.intercept_, atol=1e-12)
+    assert_allclose(enet.intercept_, ols.intercept_, atol=1.2e-12)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1607,9 +1607,9 @@ def test_enet_ridge_consistency(ridge_alpha, precompute, n_targets):
 @pytest.mark.filterwarnings("ignore:With alpha=0, this algorithm:UserWarning")
 @pytest.mark.parametrize("precompute", [False, True])
 @pytest.mark.parametrize("effective_rank", [None, 10])
-def test_enet_ols_consistency(precompute, effective_rank):
+def test_enet_ols_consistency(precompute, effective_rank, global_random_seed):
     """Test that ElasticNet(alpha=0) converges to the same solution as OLS."""
-    rng = np.random.RandomState(42)
+    rng = np.random.RandomState(global_random_seed)
     n_samples = 300
     X, y = make_regression(
         n_samples=n_samples,
@@ -1630,11 +1630,8 @@ def test_enet_ols_consistency(precompute, effective_rank):
     # and for similar objective function (squared error)
     se_ols = np.sum((y - ols.predict(X)) ** 2)
     se_enet = np.sum((y - enet.predict(X)) ** 2)
-    if precompute:
-        assert se_ols <= 1e-20
-        assert se_enet <= 1e-20
-    else:
-        assert se_enet <= se_ols <= 1e-20  # Who would have thought that?
+    assert se_ols <= 1e-20
+    assert se_enet <= 1e-20
     # We check equal coefficients, but "only" with absolute tolerance.
     assert_allclose(enet.coef_, ols.coef_, atol=1e-11)
     assert_allclose(enet.intercept_, ols.intercept_, atol=1e-12)

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1628,13 +1628,13 @@ def test_enet_ols_consistency(precompute, effective_rank, global_random_seed):
     # Might be a singular problem, so check for same predictions
     assert_allclose(enet.predict(X), ols.predict(X))
     # and for similar objective function (squared error)
-    se_ols = np.sum((y - ols.predict(X)) ** 2)
-    se_enet = np.sum((y - enet.predict(X)) ** 2)
-    assert se_ols <= 1.2e-20
-    assert se_enet <= 1.2e-20
+    se_ols = np.sum(sw * (y - ols.predict(X)) ** 2)
+    se_enet = np.sum(sw * (y - enet.predict(X)) ** 2)
+    assert se_ols <= 1e-19
+    assert se_enet <= 1e-19
     # We check equal coefficients, but "only" with absolute tolerance.
     assert_allclose(enet.coef_, ols.coef_, atol=1e-11)
-    assert_allclose(enet.intercept_, ols.intercept_, atol=1.2e-12)
+    assert_allclose(enet.intercept_, ols.intercept_, atol=1e-11)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #32987

#### What does this implement/fix? Explain your changes.
- This removes the special condition that checks `se_enet <= se_ols`

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding


#### Any other comments?
CC: @lorentzenchr 

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
