### PR TITLE
FIX: Resolve precompute='auto' when check_input=False in enet_path

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -643,6 +643,12 @@ def enet_path(
             copy=False,
             check_gram=True,
         )
+    else:
+    # Resolve 'auto' precompute when check_input=False
+    # to maintain consistency with check_input=True behavior
+        if precompute == 'auto':
+            precompute = (n_samples > n_features)
+            
     if alphas is None:
         # fit_intercept and sample_weight have already been dealt with in calling
         # methods like ElasticNet.fit.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -644,11 +644,11 @@ def enet_path(
             check_gram=True,
         )
     else:
-    # Resolve 'auto' precompute when check_input=False
-    # to maintain consistency with check_input=True behavior
-        if precompute == 'auto':
-            precompute = (n_samples > n_features)
-            
+        # Resolve 'auto' precompute when check_input=False
+        # to maintain consistency with check_input=True behavior
+        if precompute == "auto":
+            precompute = n_samples > n_features
+
     if alphas is None:
         # fit_intercept and sample_weight have already been dealt with in calling
         # methods like ElasticNet.fit.

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1875,3 +1875,20 @@ def test_linear_model_cv_alphas(Estimator):
     else:
         clf.fit(X, y[:, 0])
     assert len(clf.alphas_) == 100
+
+def test_enet_path_check_input_false_with_auto_precompute():
+    """Test enet_path with check_input=False and precompute='auto'.
+
+    Non-regression test for issue where precompute='auto' was not
+    resolved when check_input=False, causing ValueError.
+    """
+    X, y = make_regression(n_samples=100, n_features=5, n_informative=2,
+                          random_state=0)
+    X = np.asfortranarray(X)
+
+    # Should not raise ValueError
+    alphas, coefs, dual_gaps = enet_path(X, y, n_alphas=3, check_input=False)
+
+    assert alphas.shape == 3
+    assert coefs.shape == (5, 3)
+    assert dual_gaps.shape == 3

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1876,14 +1876,14 @@ def test_linear_model_cv_alphas(Estimator):
         clf.fit(X, y[:, 0])
     assert len(clf.alphas_) == 100
 
+
 def test_enet_path_check_input_false_with_auto_precompute():
     """Test enet_path with check_input=False and precompute='auto'.
 
     Non-regression test for issue where precompute='auto' was not
     resolved when check_input=False, causing ValueError.
     """
-    X, y = make_regression(n_samples=100, n_features=5, n_informative=2,
-                          random_state=0)
+    X, y = make_regression(n_samples=100, n_features=5, n_informative=2, random_state=0)
     X = np.asfortranarray(X)
 
     # Should not raise ValueError


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding


## Description
Fixes a bug where `enet_path` raises `ValueError` when called with `check_input=False` and `precompute='auto'` (the default value).

## Problem
When `check_input=True` (default), the `_pre_fit` function resolves `precompute='auto'` to a boolean based on data dimensions. However, when `check_input=False`, `_pre_fit` is bypassed, leaving `precompute` as the string `'auto'`. The subsequent solver selection logic does not handle this string value, causing a `ValueError`.

## Solution
Added an `else` block after the `check_input` conditional to resolve `precompute='auto'` to a boolean even when `check_input=False`, maintaining consistency with the default behavior.

## Changes
- Modified `sklearn/linear_model/_coordinate_descent.py`:
  - Added logic to resolve `precompute='auto'` when `check_input=False`
- Added regression test in `sklearn/linear_model/tests/test_coordinate_descent.py`:
  - `test_enet_path_check_input_false_with_auto_precompute()`

## Reproduction
```python
import numpy as np
from sklearn.linear_model import enet_path
from sklearn.datasets import make_regression

X, y = make_regression(n_samples=100, n_features=5, n_informative=2, random_state=0)
X = np.asfortranarray(X)

# Previously raised ValueError, now works correctly
alphas, coefs, dual_gaps = enet_path(X, y, n_alphas=3, check_input=False)


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
