### PR TITLE
FIX Update 20newsgroups dataset URL to fix 403 error. The current Fig…

### DIFF
--- a/sklearn/datasets/_twenty_newsgroups.py
+++ b/sklearn/datasets/_twenty_newsgroups.py
@@ -59,7 +59,7 @@ logger = logging.getLogger(__name__)
 # https://people.csail.mit.edu/jrennie/20Newsgroups/20news-bydate.tar.gz
 ARCHIVE = RemoteFileMetadata(
     filename="20news-bydate.tar.gz",
-    url="https://ndownloader.figshare.com/files/5975967",
+    url="http://people.csail.mit.edu/jrennie/20Newsgroups/20news-bydate.tar.gz",
     checksum="8f1b2514ca22a5ade8fbb9cfa5727df95fa587f4c87b786e15c759fa66d95610",
 )
 


### PR DESCRIPTION
## Description
Fixes #33002 - Updates the 20newsgroups dataset download URL to resolve 403 Forbidden errors.

## Changes
- Updated `ARCHIVE.url` in `sklearn/datasets/_twenty_newsgroups.py` from Figshare to MIT CSAIL mirror
- Verified checksum matches the expected value
- Tested download successfully completes

## Testing
- Manually tested download from new URL
- Ran `pytest sklearn/datasets/tests/test_20news.py` 
- Verified dataset loads correctly with `fetch_20newsgroups()`

<i>Note :
 Skipped tests in CI are expected if the dataset isn’t pre-downloaded.
This change resolves the download issue without affecting existing functionality.</i>
