### PR TITLE
Simplify and condense RandomizedSearchCV docstring

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1613,351 +1613,131 @@ class GridSearchCV(BaseSearchCV):
 
 
 class RandomizedSearchCV(BaseSearchCV):
-    """Randomized search on hyper parameters.
-
-    RandomizedSearchCV implements a "fit" and a "score" method.
-    It also implements "score_samples", "predict", "predict_proba",
-    "decision_function", "transform" and "inverse_transform" if they are
-    implemented in the estimator used.
-
-    The parameters of the estimator used to apply these methods are optimized
-    by cross-validated search over parameter settings.
-
-    In contrast to GridSearchCV, not all parameter values are tried out, but
-    rather a fixed number of parameter settings is sampled from the specified
-    distributions. The number of parameter settings that are tried is
-    given by n_iter.
-
-    If all parameters are presented as a list,
-    sampling without replacement is performed. If at least one parameter
-    is given as a distribution, sampling with replacement is used.
-    It is highly recommended to use continuous distributions for continuous
-    parameters.
-
-    Read more in the :ref:`User Guide <randomized_parameter_search>`.
-
-    .. versionadded:: 0.14
-
-    Parameters
-    ----------
-    estimator : estimator object
-        An object of that type is instantiated for each grid point.
-        This is assumed to implement the scikit-learn estimator interface.
-        Either estimator needs to provide a ``score`` function,
-        or ``scoring`` must be passed.
-
-    param_distributions : dict or list of dicts
-        Dictionary with parameters names (`str`) as keys and distributions
-        or lists of parameters to try. Distributions must provide a ``rvs``
-        method for sampling (such as those from scipy.stats.distributions).
-        If a list is given, it is sampled uniformly.
-        If a list of dicts is given, first a dict is sampled uniformly, and
-        then a parameter is sampled using that dict as above.
-
-    n_iter : int, default=10
-        Number of parameter settings that are sampled. n_iter trades
-        off runtime vs quality of the solution.
-
-    scoring : str, callable, list, tuple or dict, default=None
-        Strategy to evaluate the performance of the cross-validated model on
-        the test set.
-
-        If `scoring` represents a single score, one can use:
-
-        - a single string (see :ref:`scoring_string_names`);
-        - a callable (see :ref:`scoring_callable`) that returns a single value;
-        - `None`, the `estimator`'s
-          :ref:`default evaluation criterion <scoring_api_overview>` is used.
-
-        If `scoring` represents multiple scores, one can use:
-
-        - a list or tuple of unique strings;
-        - a callable returning a dictionary where the keys are the metric
-          names and the values are the metric scores;
-        - a dictionary with metric names as keys and callables as values.
-
-        See :ref:`multimetric_grid_search` for an example.
-
-        If None, the estimator's score method is used.
-
-    n_jobs : int, default=None
-        Number of jobs to run in parallel.
-        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
-        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
-        for more details.
-
-        .. versionchanged:: v0.20
-           `n_jobs` default changed from 1 to None
-
-    refit : bool, str, or callable, default=True
-        Refit an estimator using the best found parameters on the whole
-        dataset.
-
-        For multiple metric evaluation, this needs to be a `str` denoting the
-        scorer that would be used to find the best parameters for refitting
-        the estimator at the end.
-
-        Where there are considerations other than maximum score in
-        choosing a best estimator, ``refit`` can be set to a function which
-        returns the selected ``best_index_`` given the ``cv_results_``. In that
-        case, the ``best_estimator_`` and ``best_params_`` will be set
-        according to the returned ``best_index_`` while the ``best_score_``
-        attribute will not be available.
-
-        The refitted estimator is made available at the ``best_estimator_``
-        attribute and permits using ``predict`` directly on this
-        ``RandomizedSearchCV`` instance.
-
-        Also for multiple metric evaluation, the attributes ``best_index_``,
-        ``best_score_`` and ``best_params_`` will only be available if
-        ``refit`` is set and all of them will be determined w.r.t this specific
-        scorer.
-
-        See ``scoring`` parameter to know more about multiple metric
-        evaluation.
-
-        See :ref:`this example
-        <sphx_glr_auto_examples_model_selection_plot_grid_search_refit_callable.py>`
-        for an example of how to use ``refit=callable`` to balance model
-        complexity and cross-validated score.
-
-        .. versionchanged:: 0.20
-            Support for callable added.
-
-    cv : int, cross-validation generator or an iterable, default=None
-        Determines the cross-validation splitting strategy.
-        Possible inputs for cv are:
-
-        - None, to use the default 5-fold cross validation,
-        - integer, to specify the number of folds in a `(Stratified)KFold`,
-        - :term:`CV splitter`,
-        - An iterable yielding (train, test) splits as arrays of indices.
-
-        For integer/None inputs, if the estimator is a classifier and ``y`` is
-        either binary or multiclass, :class:`StratifiedKFold` is used. In all
-        other cases, :class:`KFold` is used. These splitters are instantiated
-        with `shuffle=False` so the splits will be the same across calls.
-
-        Refer :ref:`User Guide <cross_validation>` for the various
-        cross-validation strategies that can be used here.
-
-        .. versionchanged:: 0.22
-            ``cv`` default value if None changed from 3-fold to 5-fold.
-
-    verbose : int
-        Controls the verbosity: the higher, the more messages.
-
-        - >1 : the computation time for each fold and parameter candidate is
-          displayed;
-        - >2 : the score is also displayed;
-        - >3 : the fold and candidate parameter indexes are also displayed
-          together with the starting time of the computation.
-
-    pre_dispatch : int, or str, default='2*n_jobs'
-        Controls the number of jobs that get dispatched during parallel
-        execution. Reducing this number can be useful to avoid an
-        explosion of memory consumption when more jobs get dispatched
-        than CPUs can process. This parameter can be:
-
-        - None, in which case all the jobs are immediately created and spawned. Use
-          this for lightweight and fast-running jobs, to avoid delays due to on-demand
-          spawning of the jobs
-        - An int, giving the exact number of total jobs that are spawned
-        - A str, giving an expression as a function of n_jobs, as in '2*n_jobs'
-
-    random_state : int, RandomState instance or None, default=None
-        Pseudo random number generator state used for random uniform sampling
-        from lists of possible values instead of scipy.stats distributions.
-        Pass an int for reproducible output across multiple
-        function calls.
-        See :term:`Glossary <random_state>`.
-
-    error_score : 'raise' or numeric, default=np.nan
-        Value to assign to the score if an error occurs in estimator fitting.
-        If set to 'raise', the error is raised. If a numeric value is given,
-        FitFailedWarning is raised. This parameter does not affect the refit
-        step, which will always raise the error.
-
-    return_train_score : bool, default=False
-        If ``False``, the ``cv_results_`` attribute will not include training
-        scores.
-        Computing training scores is used to get insights on how different
-        parameter settings impact the overfitting/underfitting trade-off.
-        However computing the scores on the training set can be computationally
-        expensive and is not strictly required to select the parameters that
-        yield the best generalization performance.
-
-        .. versionadded:: 0.19
-
-        .. versionchanged:: 0.21
-            Default value was changed from ``True`` to ``False``
-
-    Attributes
-    ----------
-    cv_results_ : dict of numpy (masked) ndarrays
-        A dict with keys as column headers and values as columns, that can be
-        imported into a pandas ``DataFrame``.
-
-        For instance the below given table
-
-        +--------------+-------------+-------------------+---+---------------+
-        | param_kernel | param_gamma | split0_test_score |...|rank_test_score|
-        +==============+=============+===================+===+===============+
-        |    'rbf'     |     0.1     |       0.80        |...|       1       |
-        +--------------+-------------+-------------------+---+---------------+
-        |    'rbf'     |     0.2     |       0.84        |...|       3       |
-        +--------------+-------------+-------------------+---+---------------+
-        |    'rbf'     |     0.3     |       0.70        |...|       2       |
-        +--------------+-------------+-------------------+---+---------------+
-
-        will be represented by a ``cv_results_`` dict of::
-
-            {
-            'param_kernel' : masked_array(data = ['rbf', 'rbf', 'rbf'],
-                                          mask = False),
-            'param_gamma'  : masked_array(data = [0.1 0.2 0.3], mask = False),
-            'split0_test_score'  : [0.80, 0.84, 0.70],
-            'split1_test_score'  : [0.82, 0.50, 0.70],
-            'mean_test_score'    : [0.81, 0.67, 0.70],
-            'std_test_score'     : [0.01, 0.24, 0.00],
-            'rank_test_score'    : [1, 3, 2],
-            'split0_train_score' : [0.80, 0.92, 0.70],
-            'split1_train_score' : [0.82, 0.55, 0.70],
-            'mean_train_score'   : [0.81, 0.74, 0.70],
-            'std_train_score'    : [0.01, 0.19, 0.00],
-            'mean_fit_time'      : [0.73, 0.63, 0.43],
-            'std_fit_time'       : [0.01, 0.02, 0.01],
-            'mean_score_time'    : [0.01, 0.06, 0.04],
-            'std_score_time'     : [0.00, 0.00, 0.00],
-            'params'             : [{'kernel' : 'rbf', 'gamma' : 0.1}, ...],
-            }
-
-        For an example of analysing ``cv_results_``,
-        see :ref:`sphx_glr_auto_examples_model_selection_plot_grid_search_stats.py`.
-
-        NOTE
-
-        The key ``'params'`` is used to store a list of parameter
-        settings dicts for all the parameter candidates.
-
-        The ``mean_fit_time``, ``std_fit_time``, ``mean_score_time`` and
-        ``std_score_time`` are all in seconds.
-
-        For multi-metric evaluation, the scores for all the scorers are
-        available in the ``cv_results_`` dict at the keys ending with that
-        scorer's name (``'_<scorer_name>'``) instead of ``'_score'`` shown
-        above. ('split0_test_precision', 'mean_train_precision' etc.)
-
-    best_estimator_ : estimator
-        Estimator that was chosen by the search, i.e. estimator
-        which gave highest score (or smallest loss if specified)
-        on the left out data. Not available if ``refit=False``.
-
-        For multi-metric evaluation, this attribute is present only if
-        ``refit`` is specified.
-
-        See ``refit`` parameter for more information on allowed values.
-
-    best_score_ : float
-        Mean cross-validated score of the best_estimator.
-
-        For multi-metric evaluation, this is not available if ``refit`` is
-        ``False``. See ``refit`` parameter for more information.
-
-        This attribute is not available if ``refit`` is a function.
-
-    best_params_ : dict
-        Parameter setting that gave the best results on the hold out data.
-
-        For multi-metric evaluation, this is not available if ``refit`` is
-        ``False``. See ``refit`` parameter for more information.
-
-    best_index_ : int
-        The index (of the ``cv_results_`` arrays) which corresponds to the best
-        candidate parameter setting.
-
-        The dict at ``search.cv_results_['params'][search.best_index_]`` gives
-        the parameter setting for the best model, that gives the highest
-        mean score (``search.best_score_``).
-
-        For multi-metric evaluation, this is not available if ``refit`` is
-        ``False``. See ``refit`` parameter for more information.
-
-    scorer_ : function or a dict
-        Scorer function used on the held out data to choose the best
-        parameters for the model.
-
-        For multi-metric evaluation, this attribute holds the validated
-        ``scoring`` dict which maps the scorer key to the scorer callable.
-
-    n_splits_ : int
-        The number of cross-validation splits (folds/iterations).
-
-    refit_time_ : float
-        Seconds used for refitting the best model on the whole dataset.
-
-        This is present only if ``refit`` is not False.
-
-        .. versionadded:: 0.20
-
-    multimetric_ : bool
-        Whether or not the scorers compute several metrics.
-
-    classes_ : ndarray of shape (n_classes,)
-        The classes labels. This is present only if ``refit`` is specified and
-        the underlying estimator is a classifier.
-
-    n_features_in_ : int
-        Number of features seen during :term:`fit`. Only defined if
-        `best_estimator_` is defined (see the documentation for the `refit`
-        parameter for more details) and that `best_estimator_` exposes
-        `n_features_in_` when fit.
-
-        .. versionadded:: 0.24
-
-    feature_names_in_ : ndarray of shape (`n_features_in_`,)
-        Names of features seen during :term:`fit`. Only defined if
-        `best_estimator_` is defined (see the documentation for the `refit`
-        parameter for more details) and that `best_estimator_` exposes
-        `feature_names_in_` when fit.
-
-        .. versionadded:: 1.0
-
-    See Also
-    --------
-    GridSearchCV : Does exhaustive search over a grid of parameters.
-    ParameterSampler : A generator over parameter settings, constructed from
-        param_distributions.
-
-    Notes
-    -----
-    The parameters selected are those that maximize the score of the held-out
-    data, according to the scoring parameter.
-
-    If `n_jobs` was set to a value higher than one, the data is copied for each
-    parameter setting(and not `n_jobs` times). This is done for efficiency
-    reasons if individual jobs take very little time, but may raise errors if
-    the dataset is large and not enough memory is available.  A workaround in
-    this case is to set `pre_dispatch`. Then, the memory is copied only
-    `pre_dispatch` many times. A reasonable value for `pre_dispatch` is `2 *
-    n_jobs`.
-
-    Examples
-    --------
-    >>> from sklearn.datasets import load_iris
-    >>> from sklearn.linear_model import LogisticRegression
-    >>> from sklearn.model_selection import RandomizedSearchCV
-    >>> from scipy.stats import uniform
-    >>> iris = load_iris()
-    >>> logistic = LogisticRegression(solver='saga', tol=1e-2, max_iter=200,
-    ...                               random_state=0)
-    >>> distributions = dict(C=uniform(loc=0, scale=4),
-    ...                      l1_ratio=[0, 1])
-    >>> clf = RandomizedSearchCV(logistic, distributions, random_state=0)
-    >>> search = clf.fit(iris.data, iris.target)
-    >>> search.best_params_
-    {'C': np.float64(2.195...), 'l1_ratio': 1}
-    """
+    """Randomized search on hyperparameters.
+
+The parameters of the estimator are optimized by cross-validated search over
+parameter settings. Unlike GridSearchCV, this does not try all parameter
+values, but samples a fixed number of settings from the specified
+distributions (defined by `n_iter`).
+
+This class implements a "fit" and a "score" method. It also implements
+"predict", "predict_proba", "decision_function", "transform" and
+"inverse_transform" if the underlying estimator supports them.
+
+Read more in the :ref:`User Guide <randomized_parameter_search>`.
+
+.. versionadded:: 0.14
+
+Parameters
+----------
+estimator : estimator object
+    The object to be instantiated for each grid point. Must implement the
+    scikit-learn estimator interface.
+
+param_distributions : dict or list of dicts
+    Dictionary with parameters names (`str`) as keys and distributions
+    or lists of parameters to try. Distributions must provide a ``rvs``
+    method for sampling (such as those from scipy.stats.distributions).
+    If a list is given, it is sampled uniformly.
+
+n_iter : int, default=10
+    Number of parameter settings that are sampled. Trades off runtime vs
+    quality of the solution.
+
+scoring : str, callable, list, tuple or dict, default=None
+    Strategy to evaluate the performance of the cross-validated model on
+    the test set. Can be a single string (e.g., 'accuracy'), a callable,
+    or a list/dict for multi-metric evaluation. If None, the estimator's
+    default scorer is used.
+
+n_jobs : int, default=None
+    Number of jobs to run in parallel. ``-1`` means using all processors.
+
+refit : bool, str, or callable, default=True
+    Refit an estimator using the best found parameters on the whole
+    dataset. For multiple metric evaluation, this must be a `str` denoting
+    the scorer used to find the best parameters.
+
+cv : int, cross-validation generator or an iterable, default=None
+    Determines the cross-validation splitting strategy.
+    Possible inputs for cv are:
+
+    - None: use the default 5-fold cross validation.
+    - integer: specify the number of folds.
+    - :term:`CV splitter` or an iterable yielding (train, test) splits.
+
+verbose : int
+    Controls the verbosity: the higher, the more messages.
+
+pre_dispatch : int, or str, default='2*n_jobs'
+    Controls the number of jobs that get dispatched during parallel
+    execution to prevent memory explosion.
+
+random_state : int, RandomState instance or None, default=None
+    Pseudo random number generator state used for random uniform sampling
+    from lists of possible values instead of scipy.stats distributions.
+
+error_score : 'raise' or numeric, default=np.nan
+    Value to assign to the score if an error occurs in estimator fitting.
+
+return_train_score : bool, default=False
+    If ``False``, the ``cv_results_`` attribute will not include training
+    scores to save computation time.
+
+Attributes
+----------
+cv_results_ : dict of numpy (masked) ndarrays
+    A dict with keys as column headers and values as columns, that can be
+    imported into a pandas ``DataFrame``. Contains logs for fit/score times,
+    param values, and test scores for each split.
+
+best_estimator_ : estimator
+    Estimator that was chosen by the search, i.e. estimator
+    which gave highest score (or smallest loss if specified)
+    on the left out data. Not available if ``refit=False``.
+
+best_score_ : float
+    Mean cross-validated score of the best_estimator.
+
+best_params_ : dict
+    Parameter setting that gave the best results on the hold out data.
+
+best_index_ : int
+    The index (of the ``cv_results_`` arrays) which corresponds to the best
+    candidate parameter setting.
+
+scorer_ : function or a dict
+    Scorer function used on the held out data to choose the best
+    parameters for the model.
+
+n_splits_ : int
+    The number of cross-validation splits (folds/iterations).
+
+refit_time_ : float
+    Seconds used for refitting the best model on the whole dataset.
+
+multimetric_ : bool
+    Whether or not the scorers compute several metrics.
+
+classes_ : ndarray of shape (n_classes,)
+    The classes labels. Present only if the estimator is a classifier.
+
+n_features_in_ : int
+    Number of features seen during :term:`fit`.
+
+feature_names_in_ : ndarray of shape (`n_features_in_`,)
+    Names of features seen during :term:`fit`.
+
+See Also
+--------
+GridSearchCV : Does exhaustive search over a grid of parameters.
+ParameterSampler : A generator over parameter settings.
+
+Notes
+-----
+The parameters selected are those that maximize the score of the held-out
+data, according to the scoring parameter.
+"""
 
     _parameter_constraints: dict = {
         **BaseSearchCV._parameter_constraints,

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1613,7 +1613,7 @@ class GridSearchCV(BaseSearchCV):
 
 
 class RandomizedSearchCV(BaseSearchCV):
-    """Randomized search on hyperparameters.
+   """Randomized search on hyperparameters.
 
 The parameters of the estimator are optimized by cross-validated search over
 parameter settings. Unlike GridSearchCV, this does not try all parameter


### PR DESCRIPTION
This PR refactors the docstring for RandomizedSearchCV to make it more concise and readable while retaining all technical accuracy. The original docstring contained redundant phrasing and excessive detail in parameter descriptions that is better suited for the User Guide.

Changes include:

Consolidated Method Descriptions: Grouped the listing of implemented methods (predict, transform, etc.) into a single, clearer paragraph.

Simplified Parameter Descriptions: Shortened the descriptions for scoring, refit, and cv by removing edge-case examples and deferring deep implementation details to the linked User Guide.

Reduced Verbosity: Removed tautological phrases (e.g., simplifying "An object of that type is instantiated..." to "The object to be instantiated").

Cleaned up cv_results_: Simplified the explanation of the results dictionary structure for better scannability.

AI usage disclosure
I used AI assistance for:

[ ] Code generation (e.g., when writing an implementation or fixing a bug)

[ ] Test/benchmark generation

[x] Documentation (including examples)

[x] Research and understanding