### PR TITLE
TST missing random state seed in test_ridge_regression_check_arguments_validity

### DIFF
--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1900,6 +1900,7 @@ def test_ridge_regression_check_arguments_validity(
                 return_intercept=return_intercept,
                 positive=positive,
                 tol=tol,
+                random_state=rng,
             )
         return
 
@@ -1912,6 +1913,7 @@ def test_ridge_regression_check_arguments_validity(
         positive=positive,
         return_intercept=return_intercept,
         tol=tol,
+        random_state=rng,
     )
 
     if return_intercept:


### PR DESCRIPTION
Fix a rare, random test failure observed on the CI of #29661.