### PR TITLE
FIX Resolve precompute in enet_path when check_input is False #32989

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/33014.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/33014.fix.rst
@@ -1,4 +1,4 @@
 - :func:`linear_model.enet_path` now correctly handles the ``precompute`` 
-  parameter when ``check_input=False``. Previously, this could lead to 
-  a ``ValueError`` regarding the truth value of an array.
+  parameter when ``check_input=False``. Previously, the value of
+  ``precompute`` was not properly treated which could lead to a ValueError.
   By :user:`Albert Dorador <adc-trust-ai>`

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/33014.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/33014.fix.rst
@@ -1,0 +1,3 @@
+- :func:`linear_model.enet_path` now correctly handles ``check_input=False`` 
+  when ``precompute="auto"``, ``precompute=True`` or ``precompute=False``.
+  By :user:`Albert Dorador <adc-trust-ai>`

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/33014.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/33014.fix.rst
@@ -1,3 +1,4 @@
-- :func:`linear_model.enet_path` now correctly handles ``check_input=False`` 
-  when ``precompute="auto"``, ``precompute=True`` or ``precompute=False``.
+- :func:`linear_model.enet_path` now correctly handles the ``precompute`` 
+  parameter when ``check_input=False``. Previously, this could lead to 
+  a ``ValueError`` regarding the truth value of an array.
   By :user:`Albert Dorador <adc-trust-ai>`

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/33014.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/33014.fix.rst
@@ -1,4 +1,6 @@
 - :func:`linear_model.enet_path` now correctly handles the ``precompute`` 
   parameter when ``check_input=False``. Previously, the value of
   ``precompute`` was not properly treated which could lead to a ValueError.
+  This also affects :class:`linear_model.ElasticNetCV`, :class:`linear_model.LassoCV`,
+  :class:`linear_model.MultiTaskElasticNetCV` and :class:`linear_model.MultiTaskLassoCV`.
   By :user:`Albert Dorador <adc-trust-ai>`

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -613,11 +613,6 @@ def enet_path(
 
     n_samples, n_features = X.shape
 
-    if not check_input:
-        _, _, _, _, _, precompute, Xy = _pre_fit(
-            X, y, Xy, precompute, fit_intercept=False, copy=False
-        )
-
     multi_output = False
     if y.ndim != 1:
         multi_output = True
@@ -638,7 +633,7 @@ def enet_path(
 
     # X should have been passed through _pre_fit already if function is called
     # from ElasticNet.fit
-    if check_input:
+    if check_input or precompute is not False:
         X, y, _, _, _, precompute, Xy = _pre_fit(
             X,
             y,

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -620,11 +620,13 @@ def enet_path(
             precompute = False
         elif precompute == "auto":
             precompute = n_samples > n_features
-        
+
         # Replicate _pre_fit logic: Convert 'True' to actual Gram matrix
         # enet_path solver expects an array, not a boolean True
         if precompute is True:
-            precompute = np.empty(shape=(n_features, n_features), dtype=X.dtype, order="C")
+            precompute = np.empty(
+                shape=(n_features, n_features), dtype=X.dtype, order="C"
+            )
             np.dot(X.T, X, out=precompute)
 
         # Replicate _pre_fit logic: Gram solver requires Xy
@@ -632,14 +634,18 @@ def enet_path(
             common_dtype = np.result_type(X.dtype, y.dtype)
             if y.ndim == 1:
                 # Xy is 1d, make sure it is contiguous.
-                Xy = np.empty(shape=n_features, dtype=common_dtype, order="C")
+                Xy = np.empty(
+                    shape=n_features, dtype=common_dtype, order="C"
+                )
                 np.dot(X.T, y, out=Xy)
             else:
                 # Make sure that Xy is always F contiguous even if X or y are not
                 # contiguous: the goal is to make it fast to extract the data for a
                 # specific target.
                 n_targets = y.shape[1]
-                Xy = np.empty(shape=(n_features, n_targets), dtype=common_dtype, order="F")
+                Xy = np.empty(
+                    shape=(n_features, n_targets), dtype=common_dtype, order="F"
+                )
                 np.dot(y.T, X, out=Xy.T)
 
     multi_output = False

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -634,9 +634,7 @@ def enet_path(
             common_dtype = np.result_type(X.dtype, y.dtype)
             if y.ndim == 1:
                 # Xy is 1d, make sure it is contiguous.
-                Xy = np.empty(
-                    shape=n_features, dtype=common_dtype, order="C"
-                )
+                Xy = np.empty(shape=n_features, dtype=common_dtype, order="C")
                 np.dot(X.T, y, out=Xy)
             else:
                 # Make sure that Xy is always F contiguous even if X or y are not

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -613,6 +613,35 @@ def enet_path(
 
     n_samples, n_features = X.shape
 
+    # Fixing issue #32989
+    if not check_input:
+        # Replicate _pre_fit logic: Sparse matrices cannot use precompute
+        if sparse.issparse(X):
+            precompute = False
+        elif precompute == "auto":
+            precompute = n_samples > n_features
+        
+        # Replicate _pre_fit logic: Convert 'True' to actual Gram matrix
+        # enet_path solver expects an array, not a boolean True
+        if precompute is True:
+            precompute = np.empty(shape=(n_features, n_features), dtype=X.dtype, order="C")
+            np.dot(X.T, X, out=precompute)
+
+        # Replicate _pre_fit logic: Gram solver requires Xy
+        if hasattr(precompute, "__array__") and Xy is None:
+            common_dtype = np.result_type(X.dtype, y.dtype)
+            if y.ndim == 1:
+                # Xy is 1d, make sure it is contiguous.
+                Xy = np.empty(shape=n_features, dtype=common_dtype, order="C")
+                np.dot(X.T, y, out=Xy)
+            else:
+                # Make sure that Xy is always F contiguous even if X or y are not
+                # contiguous: the goal is to make it fast to extract the data for a
+                # specific target.
+                n_targets = y.shape[1]
+                Xy = np.empty(shape=(n_features, n_targets), dtype=common_dtype, order="F")
+                np.dot(y.T, X, out=Xy.T)
+
     multi_output = False
     if y.ndim != 1:
         multi_output = True

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -641,7 +641,7 @@ def enet_path(
             precompute,
             fit_intercept=False,
             copy=False,
-            check_gram=True,
+            check_gram=check_input,
         )
     if alphas is None:
         # fit_intercept and sample_weight have already been dealt with in calling

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -618,7 +618,7 @@ def enet_path(
         # Replicate _pre_fit logic: Sparse matrices cannot use precompute
         if sparse.issparse(X):
             precompute = False
-        elif precompute == "auto":
+        elif isinstance(precompute, str) and precompute == "auto":
             precompute = n_samples > n_features
 
         # Replicate _pre_fit logic: Convert 'True' to actual Gram matrix
@@ -628,6 +628,9 @@ def enet_path(
                 shape=(n_features, n_features), dtype=X.dtype, order="C"
             )
             np.dot(X.T, X, out=precompute)
+
+        if not hasattr(precompute, "__array__"):
+            Xy = None  # cannot use Xy if precompute is not Gram
 
         # Replicate _pre_fit logic: Gram solver requires Xy
         if hasattr(precompute, "__array__") and Xy is None:

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1875,3 +1875,18 @@ def test_linear_model_cv_alphas(Estimator):
     else:
         clf.fit(X, y[:, 0])
     assert len(clf.alphas_) == 100
+
+def test_enet_path_check_input_false():
+    # Test for issue #32989
+    import numpy as np
+    from sklearn.linear_model import enet_path
+    from sklearn.datasets import make_regression
+
+    X, y = make_regression(n_samples=100, n_features=5, n_informative=2, random_state=0)
+    X = np.asfortranarray(X)
+    
+    # This used to raise ValueError, now it should run smoothly
+    alphas, coefs, gaps = enet_path(X, y, n_alphas=3, check_input=False)
+    
+    assert len(alphas) > 0
+    assert coefs.shape == (5, len(alphas))

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1903,5 +1903,6 @@ def test_enet_path_check_input_false():
         n_samples=100, n_features=5, n_targets=3, random_state=0
     )
     X_multi = np.asfortranarray(X_multi)
+    y_multi = np.asfortranarray(y_multi)
     alphas, _, _ = enet_path(X_multi, y_multi, n_alphas=3, check_input=False)
     assert len(alphas) == 3

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1877,28 +1877,9 @@ def test_linear_model_cv_alphas(Estimator):
     assert len(clf.alphas_) == 100
 
 
-def test_enet_path_check_input_false():
+@pytest.mark.parametrize("precompute", ["auto", True, False])
+def test_enet_path_check_input_false(precompute):
     """Test enet_path works with check_input=False and various precompute settings."""
     X, y = make_regression(n_samples=100, n_features=5, n_informative=2, random_state=0)
     X = np.asfortranarray(X)
-
-    # Case 1: Testing "auto"
-    alphas, _, _ = enet_path(X, y, n_alphas=3, check_input=False)
-    assert len(alphas) == 3
-
-    # Case 2: Testing True
-    alphas, _, _ = enet_path(X, y, n_alphas=3, check_input=False, precompute=True)
-    assert len(alphas) == 3
-
-    # Case 3: Testing False
-    alphas, _, _ = enet_path(X, y, n_alphas=3, check_input=False, precompute=False)
-    assert len(alphas) == 3
-
-    # Case 4: Testing Multi-output
-    X_multi, y_multi = make_regression(
-        n_samples=100, n_features=5, n_targets=3, random_state=0
-    )
-    X_multi = np.asfortranarray(X_multi)
-    y_multi = np.asfortranarray(y_multi)
-    alphas, _, _ = enet_path(X_multi, y_multi, n_alphas=3, check_input=False)
-    assert len(alphas) == 3
+    alphas, _, _ = enet_path(X, y, n_alphas=3, check_input=False, precompute=precompute)

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1876,6 +1876,7 @@ def test_linear_model_cv_alphas(Estimator):
         clf.fit(X, y[:, 0])
     assert len(clf.alphas_) == 100
 
+
 def test_enet_path_check_input_false():
     # Test for issue #32989
     import numpy as np
@@ -1884,9 +1885,9 @@ def test_enet_path_check_input_false():
 
     X, y = make_regression(n_samples=100, n_features=5, n_informative=2, random_state=0)
     X = np.asfortranarray(X)
-    
+
     # This used to raise ValueError, now it should run smoothly
     alphas, coefs, gaps = enet_path(X, y, n_alphas=3, check_input=False)
-    
+
     assert len(alphas) > 0
     assert coefs.shape == (5, len(alphas))

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1879,9 +1879,9 @@ def test_linear_model_cv_alphas(Estimator):
 
 def test_enet_path_check_input_false():
     # Test for issue #32989
-    import numpy as np
-    from sklearn.linear_model import enet_path
     from sklearn.datasets import make_regression
+    from sklearn.linear_model import enet_path
+    import numpy as np
 
     X, y = make_regression(n_samples=100, n_features=5, n_informative=2, random_state=0)
     X = np.asfortranarray(X)

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1897,3 +1897,11 @@ def test_enet_path_check_input_false():
     # Case 3: Testing False
     alphas, _, _ = enet_path(X, y, n_alphas=3, check_input=False, precompute=False)
     assert len(alphas) == 3
+
+    # Case 4: Testing Multi-output
+    X_multi, y_multi = make_regression(
+        n_samples=100, n_features=5, n_targets=3, random_state=0
+    )
+    X_multi = np.asfortranarray(X_multi)
+    alphas, _, _ = enet_path(X_multi, y_multi, n_alphas=3, check_input=False, precompute=True)
+    assert len(alphas) == 3

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1887,7 +1887,7 @@ def test_enet_path_check_input_false():
 
     # All of these used to raise ValueError, now they should run smoothly
     # Case 1: Testing "auto"
-    alphas, _, _ = enet_path(X, y, n_alphas=3, check_input=False, precompute="auto")
+    alphas, _, _ = enet_path(X, y, n_alphas=3, check_input=False)
     assert len(alphas) == 3
 
     # Case 2: Testing True

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1903,5 +1903,5 @@ def test_enet_path_check_input_false():
         n_samples=100, n_features=5, n_targets=3, random_state=0
     )
     X_multi = np.asfortranarray(X_multi)
-    alphas, _, _ = enet_path(X_multi, y_multi, n_alphas=3, check_input=False, precompute=True)
+    alphas, _, _ = enet_path(X_multi, y_multi, n_alphas=3, check_input=False)
     assert len(alphas) == 3

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1878,10 +1878,7 @@ def test_linear_model_cv_alphas(Estimator):
 
 
 def test_enet_path_check_input_false():
-    # Test for issue #32989
-    from sklearn.datasets import make_regression
-    from sklearn.linear_model import enet_path
-
+    """Test enet_path works with check_input=False and various precompute settings."""
     X, y = make_regression(n_samples=100, n_features=5, n_informative=2, random_state=0)
     X = np.asfortranarray(X)
 

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1886,8 +1886,8 @@ def test_enet_path_check_input_false():
     X = np.asfortranarray(X)
 
     # All of these used to raise ValueError, now they should run smoothly
-    # Case 1: Testing 'auto'
-    alphas, _, _ = enet_path(X, y, n_alphas=3, check_input=False, precompute='auto')
+    # Case 1: Testing "auto"
+    alphas, _, _ = enet_path(X, y, n_alphas=3, check_input=False, precompute="auto")
     assert len(alphas) == 3
 
     # Case 2: Testing True

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1882,7 +1882,6 @@ def test_enet_path_check_input_false():
     X, y = make_regression(n_samples=100, n_features=5, n_informative=2, random_state=0)
     X = np.asfortranarray(X)
 
-    # All of these used to raise ValueError, now they should run smoothly
     # Case 1: Testing "auto"
     alphas, _, _ = enet_path(X, y, n_alphas=3, check_input=False)
     assert len(alphas) == 3

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1879,9 +1879,9 @@ def test_linear_model_cv_alphas(Estimator):
 
 def test_enet_path_check_input_false():
     # Test for issue #32989
+    import numpy as np
     from sklearn.datasets import make_regression
     from sklearn.linear_model import enet_path
-    import numpy as np
 
     X, y = make_regression(n_samples=100, n_features=5, n_informative=2, random_state=0)
     X = np.asfortranarray(X)

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1885,8 +1885,15 @@ def test_enet_path_check_input_false():
     X, y = make_regression(n_samples=100, n_features=5, n_informative=2, random_state=0)
     X = np.asfortranarray(X)
 
-    # This used to raise ValueError, now it should run smoothly
-    alphas, coefs, gaps = enet_path(X, y, n_alphas=3, check_input=False)
+    # All of these used to raise ValueError, now they should run smoothly
+    # Case 1: Testing 'auto'
+    alphas, _, _ = enet_path(X, y, n_alphas=3, check_input=False, precompute='auto')
+    assert len(alphas) == 3
 
-    assert len(alphas) > 0
-    assert coefs.shape == (5, len(alphas))
+    # Case 2: Testing True
+    alphas, _, _ = enet_path(X, y, n_alphas=3, check_input=False, precompute=True)
+    assert len(alphas) == 3
+
+    # Case 3: Testing False
+    alphas, _, _ = enet_path(X, y, n_alphas=3, check_input=False, precompute=False)
+    assert len(alphas) == 3

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1879,7 +1879,6 @@ def test_linear_model_cv_alphas(Estimator):
 
 def test_enet_path_check_input_false():
     # Test for issue #32989
-    import numpy as np
     from sklearn.datasets import make_regression
     from sklearn.linear_model import enet_path
 


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #32989

#### What does this implement/fix? Explain your changes.
This PR fixes a `ValueError` in `enet_path` when `check_input=False`.

Because `_pre_fit` is skipped when `check_input=False`, the default value of the precompute parameter remained as the string 'auto', causing a crash in the solver dispatch logic. I have added a resolution block to handle 'auto', True, and sparse matrix constraints manually, ensuring the correct Gram matrix and Xy are available for the solver without duplicating the full validation suite.

A non-regression test has been added to `test_coordinate_descent.py`.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding


#### Any other comments?
First-time contributor here! I've followed the internal logic of `_pre_fit` as closely as possible while maintaining performance and memory efficiency.

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
