### PR TITLE
CI Store datasets in a shared cache for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,10 @@ jobs:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh
       - restore_cache:
-          key: v1-doc-min-deps-datasets-{{ .Branch }}
+          keys:
+            - v1-doc-min-deps-datasets-{{ .Branch }}
+            - v1-doc-min-deps-datasets-main
+            - v1-doc-min-deps-datasets
       - restore_cache:
           keys:
             - doc-min-deps-ccache-{{ .Branch }}
@@ -43,10 +46,20 @@ jobs:
           paths:
             - ~/.ccache
             - ~/.cache/pip
-      - save_cache:
-          key: v1-doc-min-deps-datasets-{{ .Branch }}
-          paths:
-            - ~/scikit_learn_data
+      # Only save dataset cache on main and release branches to prevent
+      # cache poisoning from PR branches.
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+              - matches:
+                  pattern: "^[0-9]+\\.[0-9]+\\.X$"
+                  value: << pipeline.git.branch >>
+          steps:
+            - save_cache:
+                key: v1-doc-min-deps-datasets-{{ .Branch }}-{{ .BuildNum }}
+                paths:
+                  - ~/scikit_learn_data
       - store_artifacts:
           path: doc/_build/html/stable
           destination: doc
@@ -69,7 +82,10 @@ jobs:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh
       - restore_cache:
-          key: v1-doc-datasets-{{ .Branch }}
+          keys:
+            - v1-doc-datasets-{{ .Branch }}
+            - v1-doc-datasets-main
+            - v1-doc-datasets
       - restore_cache:
           keys:
             - doc-ccache-{{ .Branch }}
@@ -80,10 +96,20 @@ jobs:
           paths:
             - ~/.ccache
             - ~/.cache/pip
-      - save_cache:
-          key: v1-doc-datasets-{{ .Branch }}
-          paths:
-            - ~/scikit_learn_data
+      # Only save dataset cache on main and release branches to prevent
+      # cache poisoning from PR branches.
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+              - matches:
+                  pattern: "^[0-9]+\\.[0-9]+\\.X$"
+                  value: << pipeline.git.branch >>
+          steps:
+            - save_cache:
+                key: v1-doc-datasets-{{ .Branch }}-{{ .BuildNum }}
+                paths:
+                  - ~/scikit_learn_data
       - store_artifacts:
           path: doc/_build/html/stable
           destination: doc


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #32961


#### What does this implement/fix? Explain your changes.
Only jobs that run on `main` or a release branch can update the cache, all other jobs try to use it. We don't want jobs triggered by forks to write to the cache.

The goal is to implement a cache that is shared between all jobs, no matter which PR they belong to. The cache should contain the datasets that are downloaded from a remote host (eg figshare). Assuming that figshare and co are mostly available we should be able to populate the cache and then use it. During an outage the chances are that we have a full cache already and don't notice it. Even a run on `main` would use the existing cache, so shouldn't be effected by an outage.

🔴  From reading https://circleci.com/docs/guides/optimize/caching/#caching-and-open-source I am actually pretty sure that this setup doesn't achieve what I'd like. It sounds like different forks have different caches (even for the same cache key)?

One thing that I am not 100% sure about is the fact that we already had this kind of caching setup for the docs builds. Yet during the last outage of figshare we observed some failures. Maybe the explanation for this is that each PR had their own cache and if the PR was created before the outage started it had the datasets in cache, but newer PRs didn't.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

