### PR TITLE
Fix `log_loss` and `d2_log_loss_score` type promotion mismatch

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -3391,7 +3391,7 @@ def _log_loss(transformed_labels, y_pred, *, normalize=True, sample_weight=None)
     eps = xp.finfo(y_pred.dtype).eps
     y_pred = xp.clip(y_pred, eps, 1 - eps)
     transformed_labels = xp.astype(transformed_labels, y_pred.dtype, copy=False)
-    loss = -xp.sum(_xlogy(transformed_labels, y_pred), axis=1)
+    loss = -xp.sum(_xlogy(transformed_labels, y_pred, xp=xp), axis=1)
     return float(_average(loss, weights=sample_weight, normalize=normalize))
 
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -17,7 +17,6 @@ from numbers import Integral, Real
 
 import numpy as np
 from scipy.sparse import coo_matrix, csr_matrix, issparse
-from scipy.special import xlogy
 
 from sklearn.exceptions import UndefinedMetricWarning
 from sklearn.preprocessing import LabelBinarizer, LabelEncoder
@@ -40,6 +39,7 @@ from sklearn.utils._array_api import (
     _isin,
     _max_precision_float_dtype,
     _union1d,
+    _xlogy,
     get_namespace,
     get_namespace_and_device,
     move_to,
@@ -3390,7 +3390,8 @@ def _log_loss(transformed_labels, y_pred, *, normalize=True, sample_weight=None)
         sample_weight = move_to(sample_weight, xp=xp, device=device_)
     eps = xp.finfo(y_pred.dtype).eps
     y_pred = xp.clip(y_pred, eps, 1 - eps)
-    loss = -xp.sum(xlogy(transformed_labels, y_pred), axis=1)
+    transformed_labels = xp.astype(transformed_labels, y_pred.dtype, copy=False)
+    loss = -xp.sum(_xlogy(transformed_labels, y_pred), axis=1)
     return float(_average(loss, weights=sample_weight, normalize=normalize))
 
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
I was running `pytest -k "array_api and array_api_strict"` after updating `main` to check things were working. This came up with a group of failures like
```
FAILED sklearn/metrics/tests/test_classification.py::test_probabilistic_metrics_array_api[array_api_strict-device_1-float64-False-False-log_loss] - TypeError: array_api_strict.int64 and array_api_strict.float64 cannot be type promoted together
```

<details><summary>Full traceback for one test</summary>
<p>

```
_____________________________________________________ test_probabilistic_metrics_multilabel_array_api[array_api_strict-device_2-float32-True-d2_log_loss_score] ______________________________________________________

prob_metric = <function d2_log_loss_score at 0x155743600>, use_sample_weight = True, array_namespace = 'array_api_strict', device_ = array_api_strict.Device('device1'), dtype_name = 'float32'

    @pytest.mark.parametrize(
        "prob_metric", [brier_score_loss, log_loss, d2_brier_score, d2_log_loss_score]
    )
    @pytest.mark.parametrize("use_sample_weight", [False, True])
    @pytest.mark.parametrize(
        "array_namespace, device_, dtype_name", yield_namespace_device_dtype_combinations()
    )
    def test_probabilistic_metrics_multilabel_array_api(
        prob_metric, use_sample_weight, array_namespace, device_, dtype_name
    ):
        """Test that :func:`brier_score_loss`, :func:`log_loss`, func:`d2_brier_score`
        and :func:`d2_log_loss_score` work correctly with the array API for
        multi-label inputs.
        """
        xp = _array_api_for_tests(array_namespace, device_)
        sample_weight = np.array([1, 2, 3, 1]) if use_sample_weight else None
        y_true_np = np.array(
            [
                [0, 0, 1, 1],
                [1, 0, 1, 0],
                [0, 1, 0, 0],
                [1, 1, 0, 1],
            ],
            dtype=dtype_name,
        )
        y_true_xp = xp.asarray(y_true_np, device=device_)
        y_prob_np = np.array(
            [
                [0.15, 0.27, 0.46, 0.12],
                [0.33, 0.38, 0.06, 0.23],
                [0.06, 0.28, 0.03, 0.63],
                [0.14, 0.31, 0.26, 0.29],
            ],
            dtype=dtype_name,
        )
        y_prob_xp = xp.asarray(y_prob_np, device=device_)
        metric_score_np = prob_metric(y_true_np, y_prob_np, sample_weight=sample_weight)
        with config_context(array_api_dispatch=True):
>           metric_score_xp = prob_metric(y_true_xp, y_prob_xp, sample_weight=sample_weight)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

sklearn/metrics/tests/test_classification.py:3744:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
sklearn/utils/_param_validation.py:218: in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
sklearn/metrics/_classification.py:3869: in d2_log_loss_score
    numerator = _log_loss(
sklearn/metrics/_classification.py:3393: in _log_loss
    loss = -xp.sum(xlogy(transformed_labels, y_pred), axis=1)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../miniconda/envs/sklearn-py3.13/lib/python3.13/site-packages/scipy/special/_support_alternative_backends.py:167: in wrapped
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
../../miniconda/envs/sklearn-py3.13/lib/python3.13/site-packages/scipy/special/_support_alternative_backends.py:76: in __xlogy
    temp = x * xp.log(y)
           ^^^^^^^^^^^^^
../../miniconda/envs/sklearn-py3.13/lib/python3.13/site-packages/array_api_strict/_array_object.py:858: in __mul__
    other = self._check_allowed_dtypes(other, "numeric", "__mul__")
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../miniconda/envs/sklearn-py3.13/lib/python3.13/site-packages/array_api_strict/_array_object.py:215: in _check_allowed_dtypes
    res_dtype = _result_type(self.dtype, other.dtype)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

type1 = array_api_strict.int64, type2 = array_api_strict.float32

    def _result_type(type1: DType, type2: DType) -> DType:
        if (type1, type2) in _promotion_table:
            return _promotion_table[type1, type2]
>       raise TypeError(f"{type1} and {type2} cannot be type promoted together")
E       TypeError: array_api_strict.int64 and array_api_strict.float32 cannot be type promoted together

../../miniconda/envs/sklearn-py3.13/lib/python3.13/site-packages/array_api_strict/_dtypes.py:229: TypeError
```

</p>
</details> 

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding


#### Any other comments?

I am not sure why this doesn't happen in our CI. I use the same version of `array_api_strict` locally (2.4.1). Maybe it is because I use scipy 1.15.2 locally? This puzzles me.

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
