### PR TITLE
DOC: Fix duplicate words in comments and docstrings

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -533,7 +533,7 @@ def confusion_matrix(
         ensure_min_samples=0,
     )
     # Convert the input arrays to NumPy (on CPU) irrespective of the original
-    # namespace and device so as to be able to leverage the the efficient
+    # namespace and device so as to be able to leverage the efficient
     # counting operations implemented by SciPy in the coo_matrix constructor.
     # The final results will be converted back to the input namespace and device
     # for the sake of consistency with other metric functions with array API support.

--- a/sklearn/utils/_plotting.py
+++ b/sklearn/utils/_plotting.py
@@ -427,7 +427,7 @@ def _check_param_lengths(required, optional, class_name):
 
 # TODO(1.10): remove after the end of the deprecation period of `y_pred`
 def _deprecate_y_pred_parameter(y_score, y_pred, version):
-    """Deprecate `y_pred` in favour of of `y_score`."""
+    """Deprecate `y_pred` in favour of `y_score`."""
     version = parse_version(version)
     version_remove = f"{version.major}.{version.minor + 2}"
     if y_score is not None and not (isinstance(y_pred, str) and y_pred == "deprecated"):


### PR DESCRIPTION
## Reference Issues/PRs
N/A

## What does this implement/fix? Explain your changes.
Fixed two typos where words were accidentally duplicated:

- Line 536 in `sklearn/metrics/_classification.py`: Changed "the the" to "the" in comment
- Line 430 in `sklearn/utils/_plotting.py`: Changed "of of" to "of" in docstring

These are simple typo corrections with no functional changes.

## AI usage disclosure
I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Documentation (including examples)

## Any other comments?
This is my first contribution to scikit-learn. Thank you for maintaining this excellent library!

---

> This pull request includes code written with the assistance of AI.
> The code has been reviewed by a human.