### PR TITLE
FIX _set_order for 1D SciPy sparse arrays (*_array) when converting to CSC/CSR

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -83,7 +83,9 @@ def _set_order(X, y, order="C"):
         else:
             X = np.asarray(X, order=order)
         if sparse_y:
-            y = y.asformat(sparse_format)
+            if getattr(y, "ndim") == 1:
+                y = y.reshape(-1, 1)
+            y = y.asformat(sparse_format, copy=False)
         else:
             y = np.asarray(y, order=order)
     return X, y

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -79,7 +79,6 @@ def test_set_order_sparse(order, input_order, coo_container):
     y = coo_container(np.array([0, 0, 0]))
     sparse_format = "csc" if input_order == "F" else "csr"
     X = X.asformat(sparse_format)
-    y = X.asformat(sparse_format)
     X2, y2 = _set_order(X, y, order=order)
 
     format = "csc" if order == "F" else "csr"

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -73,17 +73,23 @@ def test_set_order_dense(order, input_order):
 @pytest.mark.parametrize("order", ["C", "F"])
 @pytest.mark.parametrize("input_order", ["C", "F"])
 @pytest.mark.parametrize("coo_container", COO_CONTAINERS)
-def test_set_order_sparse(order, input_order, coo_container):
+@pytest.mark.parametrize("y_data", [np.array([0, 0, 0]), np.array([[0], [0], [0]])])
+def test_set_order_sparse(order, input_order, coo_container, y_data):
     """Check that _set_order returns sparse matrices in promised format."""
     X = coo_container(np.array([[0], [0], [0]]))
-    y = coo_container(np.array([0, 0, 0]))
+    y = coo_container(y_data)
+
     sparse_format = "csc" if input_order == "F" else "csr"
     X = X.asformat(sparse_format)
+
+    if getattr(y, "ndim", 2) == 2:
+        y = y.asformat(sparse_format)
+
     X2, y2 = _set_order(X, y, order=order)
 
-    format = "csc" if order == "F" else "csr"
-    assert sparse.issparse(X2) and X2.format == format
-    assert sparse.issparse(y2) and y2.format == format
+    expected_format = "csc" if order == "F" else "csr"
+    assert sparse.issparse(X2) and X2.format == expected_format
+    assert sparse.issparse(y2) and y2.format == expected_format
 
 
 def test_cython_solver_equivalence():


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #33029.
Related: #15436, #32991 

TLDR;
On recent SciPy versions, sparse **array** containers (`coo_array`, `csr_array`, etc.) can be **1-D** (shape `(n_samples,)`). However, In `_set_order`, when we convert sparse inputs to CSC the conversion fails for 1-D sparse arrays in SciPy with `ValueError: Cannot convert a 1d sparse array to csc format`.

This PR updates `_set_order` to handle this case by reshaping 1-D sparse `y` to a 2-D column vector before converting to the requested sparse format (CSC/CSR). This preserves existing behavior for dense arrays and sparse matrices while making `_set_order` compatible with SciPy sparse arrays.
