### PR TITLE
FIX: fix deprecation of "friedman_mse" criterion in forests

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1928,6 +1928,16 @@ class RandomForestRegressor(ForestRegressor):
             max_samples=max_samples,
         )
 
+        if isinstance(criterion, str) and criterion == "friedman_mse":
+            # TODO(1.11): remove support of "friedman_mse" criterion.
+            criterion = "squared_error"
+            warn(
+                'Value `"friedman_mse"` for `criterion` is deprecated and will be '
+                'removed in 1.11. It maps to `"squared_error"` as both '
+                'were always equivalent. Use `criterion="squared_error"` '
+                "to remove this warning.",
+                FutureWarning,
+            )
         self.criterion = criterion
         self.max_depth = max_depth
         self.min_samples_split = min_samples_split
@@ -2662,6 +2672,16 @@ class ExtraTreesRegressor(ForestRegressor):
             max_samples=max_samples,
         )
 
+        if isinstance(criterion, str) and criterion == "friedman_mse":
+            # TODO(1.11): remove support of "friedman_mse" criterion.
+            criterion = "squared_error"
+            warn(
+                'Value `"friedman_mse"` for `criterion` is deprecated and will be '
+                'removed in 1.11. It maps to `"squared_error"` as both '
+                'were always equivalent. Use `criterion="squared_error"` '
+                "to remove this warning.",
+                FutureWarning,
+            )
         self.criterion = criterion
         self.max_depth = max_depth
         self.min_samples_split = min_samples_split

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1870,6 +1870,8 @@ def test_non_supported_criterion_raises_error_with_missing_values(Forest):
         forest.fit(X, y)
 
 
+
+# TODO(1.11): remove test with the deprecation of friedman_mse criterion
 @pytest.mark.parametrize("Forest", FOREST_REGRESSORS.values())
 def test_friedman_mse_deprecation(Forest):
     with pytest.warns(FutureWarning, match="friedman_mse"):

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1870,7 +1870,6 @@ def test_non_supported_criterion_raises_error_with_missing_values(Forest):
         forest.fit(X, y)
 
 
-
 # TODO(1.11): remove test with the deprecation of friedman_mse criterion
 @pytest.mark.parametrize("Forest", FOREST_REGRESSORS.values())
 def test_friedman_mse_deprecation(Forest):

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1864,3 +1864,9 @@ def test_non_supported_criterion_raises_error_with_missing_values(Forest):
     msg = ".*does not accept missing values"
     with pytest.raises(ValueError, match=msg):
         forest.fit(X, y)
+
+
+@pytest.mark.parametrize("Forest", FOREST_REGRESSORS.values())
+def test_friedman_mse_deprecation(Forest):
+    with pytest.warns(FutureWarning, match="friedman_mse"):
+        _ = Forest(criterion="friedman_mse")

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -157,8 +157,12 @@ def test_iris_criterion(name, criterion):
     assert score > 0.5, "Failed with criterion %s and score = %f" % (criterion, score)
 
 
+# TODO(1.11): remove the deprecated friedman_mse criterion parametrization
+@pytest.mark.filterwarnings("ignore:.*friedman_mse.*:FutureWarning")
 @pytest.mark.parametrize("name", FOREST_REGRESSORS)
-@pytest.mark.parametrize("criterion", ("squared_error", "absolute_error"))
+@pytest.mark.parametrize(
+    "criterion", ("squared_error", "friedman_mse", "absolute_error")
+)
 def test_regression_criterion(name, criterion):
     # Check consistency on regression dataset.
     ForestRegressor = FOREST_REGRESSORS[name]


### PR DESCRIPTION
Fixing my own mess :sweat_smile: 

#### Reference Issues/PRs

Related to issue #32700.

Follow-up from PR #32708: While writing the PR #32708, I didn't anticipated that tree-related parameters will be validated before being passed down to trees (and it's where the deprecation warning is raised, and where the value of the criterion is modified from "friedman_mse" to "squared_error").

#### What does this implement/fix? Explain your changes.

The bug is explained above.

The proposed fix: copy the warning & criterion-value-rewrite in `RandomForestRegressor` and `ExtraTreesRegressor`. I think it's fine to repeat this small piece of code, it will not live too long in the code base.

#### AI usage: no

#### TODO?

More tests?