### PR TITLE
Fix ValueError in KNeighborsClassifier with brute force and p=1

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.neighbors/33034.fix
+++ b/doc/whats_new/upcoming_changes/sklearn.neighbors/33034.fix
@@ -1,0 +1,1 @@
+Fixed a :class:~sklearn.neighbors.KNeighborsClassifier failure when using algorithm='brute', p=1 and string labels.

--- a/doc/whats_new/upcoming_changes/sklearn.neighbors/33034.fix
+++ b/doc/whats_new/upcoming_changes/sklearn.neighbors/33034.fix
@@ -1,1 +1,0 @@
-Fixed a :class:~sklearn.neighbors.KNeighborsClassifier failure when using algorithm='brute', p=1 and string labels.

--- a/doc/whats_new/upcoming_changes/sklearn.neighbors/33048.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.neighbors/33048.fix.rst
@@ -1,3 +1,4 @@
-- :class:`neighbors.KNeighborsClassifier` and :class:`neighbors.RadiusNeighborsClassier`
-  now work with string labels when `algorithm="brute".
+- :class:`neighbors.KNeighborsClassifier` and
+  :class:`neighbors.RadiusNeighborsClassifier` now work with string labels when
+  `algorithm="brute"`.
   By :user:`AAAZZZR <AAAZZZR>`.

--- a/doc/whats_new/upcoming_changes/sklearn.neighbors/33048.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.neighbors/33048.fix.rst
@@ -1,0 +1,3 @@
+- :class:`neighbors.KNeighborsClassifier` and :class:`neighbors.RadiusNeighborsClassier`
+  now work with string labels when `algorithm="brute".
+  By :user:`AAAZZZR <AAAZZZR>`.

--- a/sklearn/neighbors/_classification.py
+++ b/sklearn/neighbors/_classification.py
@@ -355,7 +355,7 @@ class KNeighborsClassifier(KNeighborsMixin, ClassifierMixin, NeighborsBase):
                     k=self.n_neighbors,
                     weights=self.weights,
                     Y_labels=self._y,
-                    unique_Y_labels=self.classes_,
+                    unique_Y_labels=np.arange(len(self.classes_), dtype=np.intp),
                     metric=metric,
                     metric_kwargs=metric_kwargs,
                     # `strategy="parallel_on_X"` has in practice be shown

--- a/sklearn/neighbors/_classification.py
+++ b/sklearn/neighbors/_classification.py
@@ -801,7 +801,7 @@ class RadiusNeighborsClassifier(RadiusNeighborsMixin, ClassifierMixin, Neighbors
                 radius=self.radius,
                 weights=self.weights,
                 Y_labels=self._y,
-                unique_Y_labels=self.classes_,
+                unique_Y_labels=np.arange(len(self.classes_), dtype=np.intp),
                 outlier_label=self.outlier_label,
                 metric=metric,
                 metric_kwargs=metric_kwargs,

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -2508,18 +2508,19 @@ def test_neighbor_regressors_loocv(nn_model, algorithm):
     nn_model.fit(X, y)
     assert_allclose(loocv, nn_model.predict(None))
 
+
 def test_kneighbors_classifier_brute_manhattan_string_labels():
     # Ensure KNeighborsClassifier works with algorithm='brute', p=1 and string labels
     X = rng.normal(size=(5, 3))
     # String label
-    y = np.array(['foo', 'bar', 'foo', 'bar', 'foo'])
-    
+    y = np.array(["foo", "bar", "foo", "bar", "foo"])
+
     # Condition: algorithm='brute' AND p=1
-    knn = neighbors.KNeighborsClassifier(algorithm='brute', p=1)
+    knn = neighbors.KNeighborsClassifier(algorithm="brute", p=1)
     knn.fit(X, y)
-    
+
     X_test = rng.normal(size=(2, 3))
     y_pred = knn.predict(X_test)
-   
+
     assert y_pred.shape == (2,)
-    assert y_pred.dtype.kind in ('U', 'S')  
+    assert y_pred.dtype.kind in ("U", "S")

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -2507,3 +2507,19 @@ def test_neighbor_regressors_loocv(nn_model, algorithm):
     loocv = cross_val_predict(nn_model, X, y, cv=LeaveOneOut())
     nn_model.fit(X, y)
     assert_allclose(loocv, nn_model.predict(None))
+
+def test_kneighbors_classifier_brute_manhattan_string_labels():
+    # Ensure KNeighborsClassifier works with algorithm='brute', p=1 and string labels
+    X = rng.normal(size=(5, 3))
+    # String label
+    y = np.array(['foo', 'bar', 'foo', 'bar', 'foo'])
+    
+    # Condition: algorithm='brute' AND p=1
+    knn = neighbors.KNeighborsClassifier(algorithm='brute', p=1)
+    knn.fit(X, y)
+    
+    X_test = rng.normal(size=(2, 3))
+    y_pred = knn.predict(X_test)
+   
+    assert y_pred.shape == (2,)
+    assert y_pred.dtype.kind in ('U', 'S')  

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -2509,18 +2509,23 @@ def test_neighbor_regressors_loocv(nn_model, algorithm):
     assert_allclose(loocv, nn_model.predict(None))
 
 
-def test_kneighbors_classifier_brute_manhattan_string_labels():
-    # Ensure KNeighborsClassifier works with algorithm='brute', p=1 and string labels
+@pytest.mark.parametrize("metric", COMMON_VALID_METRICS)
+@pytest.mark.parametrize(
+    "Estimator", [neighbors.KNeighborsClassifier, neighbors.RadiusNeighborsClassifier]
+)
+def test_neighbors_classifier_with_string_labels(metric, Estimator):
+    """Ensure KNeighborsClassifier(algorithm='brute') works with string labels.
+
+    Non-regression test for issue #33034.
+    """
     X = rng.normal(size=(5, 3))
     # String label
     y = np.array(["foo", "bar", "foo", "bar", "foo"])
 
-    # Condition: algorithm='brute' AND p=1
-    knn = neighbors.KNeighborsClassifier(algorithm="brute", p=1)
+    knn = Estimator(algorithm="brute", metric=metric)
     knn.fit(X, y)
 
-    X_test = rng.normal(size=(2, 3))
-    y_pred = knn.predict(X_test)
+    y_pred = knn.predict(X)
 
-    assert y_pred.shape == (2,)
-    assert y_pred.dtype.kind in ("U", "S")
+    assert y_pred.shape == (5,)
+    assert all(label in y for label in y_pred)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #33034

#### What does this implement/fix? Explain your changes.
When using `KNeighborsClassifier` with `algorithm="brute"` and `p=1` (Manhattan distance), the code path utilizes `ArgKminClassMode`. Previously, `self.classes_` (which can contain strings) was passed directly to the `unique_Y_labels` argument of the Cython method, causing a `ValueError` when it attempted to interpret strings as integers.

I have updated the call to pass `np.arange(len(self.classes_), dtype=np.intp)` instead, which provides the correct integer indices expected by the underlying Cython implementation.

#### Any other comments?
Added a regression test case in `sklearn/neighbors/tests/test_neighbors.py`.