### PR TITLE
DOC clarify that Lasso.path() defaults to Elastic Net path

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1352,11 +1352,13 @@ class Lasso(ElasticNet):
     fitting time, see :ref:`User Guide on coordinate descent <coordinate_descent>`.
 
     .. note::
-    The :meth:`path` static method is inherited from :class:`ElasticNet` and
-    computes the Elastic Net regularization path. Its default ``l1_ratio=0.5``
-    differs from the Lasso's implicit ``l1_ratio=1.0`` (pure L1 penalty).
-    To compute a true Lasso regularization path, use :func:`lasso_path` or
-    explicitly set ``l1_ratio=1.0`` when calling :meth:`path`.
+    The :meth:`~sklearn.linear_model.ElasticNet.path` static method is inherited
+    from :class:`~sklearn.linear_model.ElasticNet` and computes the Elastic Net
+    regularization path. Its default ``l1_ratio=0.5`` differs from the Lasso's
+    implicit ``l1_ratio=1.0`` (pure L1 penalty).
+    To compute a true Lasso regularization path, use
+    :func:`~sklearn.linear_model.lasso_path` or explicitly set ``l1_ratio=1.0``
+    when calling :meth:`~sklearn.linear_model.ElasticNet.path`.
 
     Examples
     --------

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1312,7 +1312,8 @@ class Lasso(ElasticNet):
     See Also
     --------
     lars_path : Regularization path using LARS.
-    lasso_path : Regularization path using Lasso.
+    lasso_path : Compute Lasso path with coordinate descent using pure L1 penalty.
+        Recommended over the :meth:`path` method for computing true Lasso paths.
     LassoLars : Lasso Path along the regularization parameter using LARS algorithm.
     LassoCV : Lasso alpha parameter by cross-validation.
     LassoLarsCV : Lasso least angle parameter algorithm by cross-validation.
@@ -1349,6 +1350,13 @@ class Lasso(ElasticNet):
 
     The underlying coordinate descent solver uses gap safe screening rules to speedup
     fitting time, see :ref:`User Guide on coordinate descent <coordinate_descent>`.
+
+    .. note::
+    The :meth:`path` static method is inherited from :class:`ElasticNet` and
+    computes the Elastic Net regularization path. Its default ``l1_ratio=0.5``
+    differs from the Lasso's implicit ``l1_ratio=1.0`` (pure L1 penalty).
+    To compute a true Lasso regularization path, use :func:`lasso_path` or
+    explicitly set ``l1_ratio=1.0`` when calling :meth:`path`.
 
     Examples
     --------


### PR DESCRIPTION
## Reference Issues/PRs

Fixes #17181

## What does this implement/fix?

This PR clarifies the documentation for `Lasso.path()` to address the 
confusion around the default `l1_ratio=0.5` parameter.

### Problem

The `Lasso.path()` method is inherited from `ElasticNet` and defaults to 
`l1_ratio=0.5`. This is inconsistent with the `Lasso` estimator itself, 
which optimizes with an implicit `l1_ratio=1.0` (pure L1 penalty).

### Changes

- Added a `.. note::` in the `Lasso` class docstring explaining that 
  `path()` is inherited from `ElasticNet` with `l1_ratio=0.5` default
- Updated `lasso_path` description in "See Also" to recommend it for 
  computing true Lasso paths