### PR TITLE
ENH add partial_fit method to NearestCentroid classifier

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.neighbors/33057.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.neighbors/33057.feature.rst
@@ -1,0 +1,1 @@
+Added :meth:`partial_fit` method to :class:`neighbors.NearestCentroid` for incremental learning on batches of data.

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -18,7 +18,10 @@ from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import get_tags
 from sklearn.utils._available_if import available_if
 from sklearn.utils._param_validation import Interval, StrOptions
-from sklearn.utils.multiclass import check_classification_targets, _check_partial_fit_first_call
+from sklearn.utils.multiclass import (
+    check_classification_targets,
+    _check_partial_fit_first_call,
+)
 from sklearn.utils.sparsefuncs import csc_median_axis_0
 from sklearn.utils.validation import check_is_fitted, validate_data
 
@@ -303,9 +306,7 @@ class NearestCentroid(
             Fitted estimator.
         """
         first_call = _check_partial_fit_first_call(self, classes)
-        ensure_all_finite = (
-            "allow-nan" if get_tags(self).input_tags.allow_nan else True
-        )
+        ensure_all_finite = "allow-nan" if get_tags(self).input_tags.allow_nan else True
         X, y = validate_data(
             self,
             X,

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -17,11 +17,11 @@ from sklearn.metrics.pairwise import pairwise_distances, pairwise_distances_argm
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import get_tags
 from sklearn.utils._available_if import available_if
-from sklearn.utils._param_validation import Interval, StrOptions
 from sklearn.utils.multiclass import (
     check_classification_targets,
     _check_partial_fit_first_call,
 )
+from sklearn.utils._param_validation import Interval, StrOptions
 from sklearn.utils.sparsefuncs import csc_median_axis_0
 from sklearn.utils.validation import check_is_fitted, validate_data
 
@@ -219,6 +219,7 @@ class NearestCentroid(
 
         # Number of clusters in each class.
         nk = np.zeros(n_classes)
+        self.nk_ = nk
 
         for cur_class in range(n_classes):
             center_mask = y_ind == cur_class

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -258,5 +258,7 @@ def test_partial_fit_manhattan_error():
     """Check that partial_fit raises error for manhattan metric."""
     X, y = make_blobs(n_samples=50, centers=2, random_state=42)
     nc = NearestCentroid(metric="manhattan")
-    with pytest.raises(ValueError, match="partial_fit does not support the 'manhattan' metric"):
+    with pytest.raises(
+        ValueError, match="partial_fit does not support the 'manhattan' metric"
+    ):
         nc.partial_fit(X, y, classes=[0, 1])


### PR DESCRIPTION

**Fixes #12952**

Added `partial_fit` to NearestCentroid so you can train it on data in batches.

**What it does:**
- You can now feed data to NearestCentroid bit by bit
- Updates the class centers as new data comes in
- Works like GaussianNB's partial_fit

**What I changed:**
- Added the partial_fit method
- Keeps track of how many samples per class we've seen
- Lets you add new classes later if they show up
- Still works with sparse data