### PR TITLE
DOC correct error message when checking response values of an estimator

### DIFF
--- a/sklearn/utils/_response.py
+++ b/sklearn/utils/_response.py
@@ -237,9 +237,8 @@ def _get_response_values(
         y_pred, pos_label = prediction_method(X), None
     else:
         raise ValueError(
-            f"{estimator.__class__.__name__} is not recognized as an estimator with "
-            "response values. It should be a classifier, an outlier detector or a "
-            "regressor."
+            f"{estimator.__class__.__name__} is not recognized as a classifier, "
+            "an outlier detector or a regressor."
         )
 
     if return_response_method_used:

--- a/sklearn/utils/_response.py
+++ b/sklearn/utils/_response.py
@@ -194,10 +194,10 @@ def _get_response_values(
     ValueError
         If `pos_label` is not a valid label.
         If the shape of `y_pred` is not consistent for binary classifier.
-        If the response method can be applied to a classifier only and
-        `estimator` is a regressor.
+        If `estimator` is not recognized as a classifier, an outlier detector,
+        or a regressor.
     """
-    from sklearn.base import is_classifier, is_outlier_detector
+    from sklearn.base import is_classifier, is_outlier_detector, is_regressor
 
     if is_classifier(estimator):
         prediction_method = _check_response_method(estimator, response_method)
@@ -232,16 +232,15 @@ def _get_response_values(
     elif is_outlier_detector(estimator):
         prediction_method = _check_response_method(estimator, response_method)
         y_pred, pos_label = prediction_method(X), None
-    else:  # estimator is a regressor
-        if response_method != "predict":
-            raise ValueError(
-                f"{estimator.__class__.__name__} should either be a classifier to be "
-                f"used with response_method={response_method} or the response_method "
-                "should be 'predict'. Got a regressor with response_method="
-                f"{response_method} instead."
-            )
+    elif is_regressor(estimator):
         prediction_method = estimator.predict
         y_pred, pos_label = prediction_method(X), None
+    else:
+        raise ValueError(
+            f"{estimator.__class__.__name__} is not recognized as an estimator with "
+            "response values. It should be a classifier, an outlier detector or a "
+            "regressor."
+        )
 
     if return_response_method_used:
         return y_pred, pos_label, prediction_method.__name__


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Current function that checks response values of an estimator
(`_get_response_values` in `scikit-learn/sklearn/utils/_response.py`)
assumes that if the estimator is not a classifier or an outlier detector, then it is a regressor.

In the latter case, if it doesn't find the `predict` function, 
it raises an error stating that the estimator is a regressor: `ValueError: ... Got a regressor...`.

However, the estimator might be something other than a regressor.

For example, it can be a classification `Pipeline` with a MRO issue, see https://github.com/NeuroTechX/moabb/issues/815

Many other GitHub repositories have reported this ambiguous error:
https://github.com/dreamquark-ai/tabnet/issues/584
https://github.com/rasbt/mlxtend/issues/1129
https://github.com/dmlc/xgboost/issues/11284
https://github.com/mljar/mljar-supervised/issues/640
https://github.com/csinva/imodels/issues/221
[etc](https://github.com/search?q=should+either+be+a+classifier+to+be+used+with+response_method%3D&type=issues&p=1)

The goal of this pull-request is to correct the message by making it clearer,
specifically by no longer assuming that it is a regressor.


#### AI usage disclosure

I did **not** use AI assistance.

#### Any other comments?
