### PR TITLE
CI Fix scipy-dev build issues

### DIFF
--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -72,11 +72,14 @@ python_environment_install_and_activate() {
     if [[ "$DISTRIB" == "conda-pip-scipy-dev" ]]; then
         echo "Installing development dependency wheels"
         dev_anaconda_url=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-        dev_packages="numpy scipy pandas Cython"
+        dev_packages="numpy scipy pandas"
         pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url $dev_packages --only-binary :all:
 
         check_packages_dev_version $dev_packages
 
+        echo "Installing Cython from latest sources"
+        # NO_CYTHON_COMPILE install Cython as a pure Python package (faster install)
+        NO_CYTHON_COMPILE=true pip install https://github.com/cython/cython/archive/master.zip
         echo "Installing joblib from latest sources"
         pip install https://github.com/joblib/joblib/archive/master.zip
         echo "Installing pillow from latest sources"

--- a/build_tools/azure/install.sh
+++ b/build_tools/azure/install.sh
@@ -78,7 +78,7 @@ python_environment_install_and_activate() {
         check_packages_dev_version $dev_packages
 
         echo "Installing Cython from latest sources"
-        # NO_CYTHON_COMPILE install Cython as a pure Python package (faster install)
+        # NO_CYTHON_COMPILE=true installs Cython as a pure Python package (faster install)
         NO_CYTHON_COMPILE=true pip install https://github.com/cython/cython/archive/master.zip
         echo "Installing joblib from latest sources"
         pip install https://github.com/joblib/joblib/archive/master.zip

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1423,6 +1423,19 @@ def _get_warnings_filters_info_list():
         WarningInfo(
             "ignore", message="Attribute n is deprecated", category=DeprecationWarning
         ),
+        # numpy 2.5 DeprecationWarning in joblib, see
+        # https://github.com/joblib/joblib/issues/1772
+        WarningInfo(
+            "ignore",
+            message=(
+                "Setting the shape on a NumPy array has been deprecated"
+                r" in NumPy 2\.5"
+            ),
+            category=np.exceptions.VisibleDeprecationWarning,
+        ),
+        WarningInfo(
+            "ignore", message="Attribute n is deprecated", category=DeprecationWarning
+        ),
         # Python 3.12 warnings from sphinx-gallery fixed in master but not
         # released yet, see
         # https://github.com/sphinx-gallery/sphinx-gallery/pull/1242

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1431,10 +1431,7 @@ def _get_warnings_filters_info_list():
                 "Setting the shape on a NumPy array has been deprecated"
                 r" in NumPy 2\.5"
             ),
-            category=np.exceptions.VisibleDeprecationWarning,
-        ),
-        WarningInfo(
-            "ignore", message="Attribute n is deprecated", category=DeprecationWarning
+            category=DeprecationWarning,
         ),
         # Python 3.12 warnings from sphinx-gallery fixed in master but not
         # released yet, see

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1429,7 +1429,7 @@ def _get_warnings_filters_info_list():
             "ignore",
             message=(
                 "Setting the shape on a NumPy array has been deprecated"
-                r" in NumPy 2\.5"
+                r" in NumPy 2.5"
             ),
             category=DeprecationWarning,
         ),


### PR DESCRIPTION
Fix https://github.com/scikit-learn/scikit-learn/issues/33047
### Cython issue

According to https://github.com/cython/cython/pull/7427#issuecomment-3753646484 the Cython issue is fixed in master.

I think it's actually slightly better to use the install from source rather than the Cython wheel. The Cython wheel is not updated daily so there is a small timing difference between `master`. It also does not provide us much since it is a pure Python wheel so the same as installing from source with `NO_CYTHON_COMPILE=true`.

### numpy VisbibleDeprecationWarning from joblib
This adds the warning to our ignored filters with a note linking to the joblib issue