### PR TITLE
DOC: clarify error message for invalid estimator response method

### DIFF
--- a/sklearn/utils/_response.py
+++ b/sklearn/utils/_response.py
@@ -235,11 +235,12 @@ def _get_response_values(
     else:  # estimator is a regressor
         if response_method != "predict":
             raise ValueError(
-                f"{estimator.__class__.__name__} should either be a classifier to be "
-                f"used with response_method={response_method} or the response_method "
-                "should be 'predict'. Got a regressor with response_method="
-                f"{response_method} instead."
+                f"{estimator.__class__.__name__} does not provide a valid response method. "
+                f"Expected a classifier to be used with response_method={response_method} "
+                f"or an estimator with a 'predict' method. "
+                f"Got response_method={response_method} instead."
             )
+
         prediction_method = estimator.predict
         y_pred, pos_label = prediction_method(X), None
 

--- a/sklearn/utils/_response.py
+++ b/sklearn/utils/_response.py
@@ -234,12 +234,17 @@ def _get_response_values(
         y_pred, pos_label = prediction_method(X), None
     else:  # estimator is a regressor
         if response_method != "predict":
+            
             raise ValueError(
+                (
                 f"{estimator.__class__.__name__} does not provide a valid response method. "
-                f"Expected a classifier to be used with response_method={response_method} "
-                f"or an estimator with a 'predict' method. "
+                "Expected either:\n"
+                f"- a classifier used with response_method={response_method}, or\n"
+                "- an estimator with a 'predict' method.\n"
                 f"Got response_method={response_method} instead."
+                )
             )
+
 
         prediction_method = estimator.predict
         y_pred, pos_label = prediction_method(X), None


### PR DESCRIPTION
DOC: clarify error message when estimator response method is invalid

Fixes #33093

The previous error message incorrectly implied that an estimator without
a `predict` method was always a regressor. This change removes that
assumption and clarifies the expected behavior.

This improves clarity for users encountering this error.

