### PR TITLE
Fix _cross_val_predict to allow non-partitioning split method like TimeSeriesSplit with StackingRegressor 

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -1633,6 +1633,40 @@ computationally expensive.
     ...       .format(multi_layer_regressor.score(X_test, y_test)))
     R2 score: 0.53
 
+.. note:: 
+  For time series data, use :class:`~sklearn.model_selection.TimeSeriesSplit`
+  to ensure predictions respect temporal ordering and avoid data leakage. This
+  is critical for time-ordered data where future information must not be used
+  to predict the past::
+
+    >>> from sklearn.linear_model import LinearRegression, Ridge
+    >>> from sklearn.ensemble import StackingRegressor
+    >>> from sklearn.model_selection import TimeSeriesSplit
+    >>> import numpy as np
+    >>> 
+    >>> # Generate time series data
+    >>> n_samples = 200
+    >>> X_ts = np.random.randn(n_samples, 5)
+    >>> y_ts = np.random.randn(n_samples)
+    >>> 
+    >>> # Use TimeSeriesSplit for temporal cross-validation
+    >>> tscv = TimeSeriesSplit(n_splits=5)
+    >>> stacker = StackingRegressor(
+    ...     estimators=[('lr', LinearRegression()), ('ridge', Ridge())],
+    ...     final_estimator=LinearRegression(),
+    ...     cv=tscv
+    ... )
+    >>> stacker.fit(X_ts, y_ts)
+    StackingRegressor(...)
+    >>> 
+    >>> # Predictions maintain temporal validity
+    >>> y_pred = stacker.predict(X_ts[-50:])
+
+  When using :class:`~sklearn.model_selection.TimeSeriesSplit`, only samples
+  that appear in test folds will be used to train the final estimator. This
+  ensures no future data leaks into past predictions while still leveraging
+  the full dataset for training base estimators.
+
 .. rubric:: Examples
 
 * :ref:`sphx_glr_auto_examples_ensemble_plot_stack_predictors.py`

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -265,12 +265,12 @@ class _BaseStacking(TransformerMixin, _BaseHeterogeneousEnsemble, metaclass=ABCM
                 if est != "drop"
             )
 
-            # Identify samples that have predictions. Some CV strategies like 
+            # Identify samples that have predictions. Some CV strategies like
             # TimeSeriesSplit may not include all samples in any test set.
             test_indices = np.concatenate([test for _, test in cv.split(X, y)])
             used_samples = np.sort(np.unique(test_indices))
 
-            # If some samples were never in a test set, we must filter y (and X 
+            # If some samples were never in a test set, we must filter y (and X
             # for passthrough) so they match the predictions from cross_val_predict.
             if len(used_samples) < X.shape[0]:
                 y = y[used_samples]

--- a/sklearn/ensemble/_stacking.py
+++ b/sklearn/ensemble/_stacking.py
@@ -265,6 +265,18 @@ class _BaseStacking(TransformerMixin, _BaseHeterogeneousEnsemble, metaclass=ABCM
                 if est != "drop"
             )
 
+            # Identify samples that have predictions. Some CV strategies like 
+            # TimeSeriesSplit may not include all samples in any test set.
+            test_indices = np.concatenate([test for _, test in cv.split(X, y)])
+            used_samples = np.sort(np.unique(test_indices))
+
+            # If some samples were never in a test set, we must filter y (and X 
+            # for passthrough) so they match the predictions from cross_val_predict.
+            if len(used_samples) < X.shape[0]:
+                y = y[used_samples]
+                if self.passthrough:
+                    X = X[used_samples]
+
         # Only not None or not 'drop' estimators will be used in transform.
         # Remove the None from the method as well.
         self.stack_method_ = [

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -1437,7 +1437,7 @@ def _check_cv_is_valid_for_predict(splits, n_samples):
 
     A valid splitter for cross_val_predict must satisfy following conditions :
     - Splits must not overlap with train and test
-    - Each sample appears in atmost one test set
+    - Each sample appears in at most one test set
     - At least some samples must appear in test set
 
     This allows both partitioning splitter and non-partitioning splitters.
@@ -1488,7 +1488,7 @@ def _check_cv_is_valid_for_predict(splits, n_samples):
 
         test_indices.extend(test)
 
-    # Check 2 : Each sample appears atmost one time in test sets
+    # Check 2 : Each sample appears at most one time in test sets
     test_indices = np.array(test_indices)
     if len(test_indices) != len(np.unique(test_indices)):
         return False

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -1011,12 +1011,12 @@ def cross_val_predict(
     """Generate cross-validated estimates for each input data point.
 
     The data is split according to the cv parameter. For each sample that
-    appears in a test set, its prediction is computed with an estimator 
-    fitted on the corresponding training set. Each sample appears in at 
+    appears in a test set, its prediction is computed with an estimator
+    fitted on the corresponding training set. Each sample appears in at
     most one test set.
 
-    Note: Some cross-validation strategies like TimeSeriesSplit may not 
-    include all samples in test sets. In such cases, predictions are 
+    Note: Some cross-validation strategies like TimeSeriesSplit may not
+    include all samples in test sets. In such cases, predictions are
     returned only for samples that appear in test sets.
 
     Passing these predictions into an evaluation metric may not be a valid
@@ -1248,7 +1248,7 @@ def cross_val_predict(
         predictions = xp.concat(predictions)
 
     # Reorder predictions to match the original order of indices in X.
-    # We use np.argsort because the test set indices in CV can be arbitrary 
+    # We use np.argsort because the test set indices in CV can be arbitrary
     # and may not form a complete permutation of 0..N-1 (e.g., TimeSeriesSplit).
     sort_idx = np.argsort(test_indices)
     if isinstance(predictions, list):
@@ -1431,15 +1431,16 @@ def _check_is_permutation(indices, n_samples):
         return False
     return True
 
+
 def _check_cv_is_valid_for_predict(splits, n_samples):
-    """ Check whether CV split is valid for cross_val_predict
+    """Check whether CV split is valid for cross_val_predict
 
     A valid splitter for cross_val_predict must satisfy following conditions :
-    - Splits must not overlap with train and test 
+    - Splits must not overlap with train and test
     - Each sample appears in atmost one test set
     - At least some samples must appear in test set
 
-    This allows both partitioning splitter and non-partitioning splitters. 
+    This allows both partitioning splitter and non-partitioning splitters.
 
     Parameters
     -----------
@@ -1447,25 +1448,25 @@ def _check_cv_is_valid_for_predict(splits, n_samples):
         The train/test splits from the CV splitter
     n_samples : int
         Total number of samples
-    
+
     Returns
     -------
     is_valid : bool
         True if the CV splitter is valid for cross_val_predict
-        
+
     Examples
     --------
     >>> from sklearn.model_selection import KFold, TimeSeriesSplit
     >>> import numpy as np
     >>> X = np.random.randn(100, 5)
     >>> y = np.random.randn(100)
-    
+
     # KFold creates a partition
     >>> kf = KFold(n_splits=5)
     >>> splits = list(kf.split(X, y))
     >>> _check_cv_is_valid_for_predict(splits, len(X))
     True
-    
+
     # TimeSeriesSplit creates a valid non-partition
     >>> tscv = TimeSeriesSplit(n_splits=5)
     >>> splits = list(tscv.split(X, y))
@@ -1475,7 +1476,7 @@ def _check_cv_is_valid_for_predict(splits, n_samples):
 
     if len(splits) == 0:
         return False
-    
+
     test_indices = []
 
     for train, test in splits:
@@ -1484,19 +1485,20 @@ def _check_cv_is_valid_for_predict(splits, n_samples):
             overlap = np.intersect1d(train, test)
             if len(overlap) > 0:
                 return False
-    
+
         test_indices.extend(test)
-    
+
     # Check 2 : Each sample appears atmost one time in test sets
     test_indices = np.array(test_indices)
     if len(test_indices) != len(np.unique(test_indices)):
         return False
-    
+
     # Check 3 : At least some sample have predictions
     if len(test_indices) == 0:
         return False
-    
+
     return True
+
 
 @validate_params(
     {

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -55,13 +55,13 @@ from sklearn.model_selection import (
     LeavePGroupsOut,
     ShuffleSplit,
     StratifiedKFold,
+    TimeSeriesSplit,
     cross_val_predict,
     cross_val_score,
     cross_validate,
     learning_curve,
     permutation_test_score,
     validation_curve,
-    TimeSeriesSplit
 )
 from sklearn.model_selection._validation import (
     _check_is_permutation,
@@ -2748,39 +2748,38 @@ def test_cross_val_predict_array_api_compliance(
         _convert_to_numpy(pred_xp, xp), pred_np, atol=_atol_for_type(dtype_name)
     )
 
+
 def test_cross_val_predict_with_time_series_split():
     """Test cross_val_predict works with TimeSeriesSplit."""
     X = np.random.randn(100, 5)
     y = np.random.randn(100)
-    
+
     tscv = TimeSeriesSplit(n_splits=5)
     lr = LinearRegression()
 
     predictions = cross_val_predict(lr, X, y, cv=tscv)
-    
+
     expected_n_predictions = sum(len(test) for _, test in tscv.split(X))
     assert len(predictions) == expected_n_predictions
-    
+
     # Predictions will be for the later samples
     assert len(predictions) < len(X)  # Not all samples have predictions
+
 
 def test_stacking_regressor_with_time_series_split():
     """Test that StackingRegressor works with TimeSeriesSplit."""
 
     X = np.random.randn(100, 5)
     y = np.random.randn(100)
-    
-    estimators = [
-        ('lr', LinearRegression()),
-        ('ridge', Ridge())
-    ]
-    
+
+    estimators = [("lr", LinearRegression()), ("ridge", Ridge())]
+
     stacker = StackingRegressor(
         estimators=estimators,
         final_estimator=LinearRegression(),
-        cv=TimeSeriesSplit(n_splits=5)
+        cv=TimeSeriesSplit(n_splits=5),
     )
-    
+
     stacker.fit(X, y)
 
     predictions = stacker.predict(X)


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#### Reference Issues/PRs
Fixes #32614

#### What does this implement/fix? Explain your changes.

This PR fixes the incompatibility between `StackingRegressor`/`StackingClassifier` and `TimeSeriesSplit` (and other non-partitioning cross-validation strategies).

**Problem:**
Previously, `cross_val_predict` required that the CV splitter creates a perfect partition where every sample appears in exactly one test set. This check rejected valid time-series CV strategies like `TimeSeriesSplit`, which intentionally reserves early samples for training only to maintain temporal order and prevent data leakage.

**Solution:**
The strict partition check has been replaced with a more flexible validation that allows non-partitioning CV splitters while still ensuring:
1. No overlap between train and test sets in any split
2. Each sample appears in at most one test set
3. At least some samples generate predictions

**Changes:**
- Added `_check_cv_is_valid_for_predict()` function to validate CV splitters with relaxed requirements
- Updated `cross_val_predict()` to use the new validation function
- Added comprehensive tests for `TimeSeriesSplit` with `cross_val_predict`, `StackingRegressor`, and `StackingClassifier`

**Impact:**
This enables proper time-series stacking without data leakage, allowing users to:
- Use `StackingRegressor`/`StackingClassifier` with `TimeSeriesSplit`
- Leverage ensemble methods for time-series forecasting
- Maintain temporal validity in cross-validation

**Backward Compatibility:**
All existing CV strategies (KFold, StratifiedKFold, etc.) continue to work exactly as before. The change only relaxes the validation to accept additional valid strategies.

**Example Usage (now works):**
```python
from sklearn.ensemble import StackingRegressor
from sklearn.linear_model import LinearRegression, Ridge
from sklearn.model_selection import TimeSeriesSplit

estimators = [
    ('lr', LinearRegression()),
    ('ridge', Ridge())
]

stacker = StackingRegressor(
    estimators=estimators,
    final_estimator=LinearRegression(),
    cv=TimeSeriesSplit(n_splits=5)  # Now supported!
)
stacker.fit(X, y)
```

#### AI usage disclosure

I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [x] Research and understanding

#### Any other comments?

**Testing:**
- All existing tests pass without modification
- Manually tested with the reproducer from issue #32614
- Verified backward compatibility with traditional CV splitters

**Note on Partial Predictions:**
When using non-partitioning CV splitters like `TimeSeriesSplit`, `cross_val_predict` returns predictions only for samples that appear in test sets. This is the correct behavior for time series, as it prevents future data from leaking into past predictions while still using all available data to train base estimators.

I'm happy to address any feedback or make adjustments as needed. Thank you for reviewing!

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
