### PR TITLE
FIX: fix nan detection in trees

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.tree/33114.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.tree/33114.fix.rst
@@ -1,6 +1,6 @@
-- Fixed feature-wise NaN detection for trees and tree-based model.
-  Features could be seen as NaN-free for some very edge-casy patterns
-  which lead to not consider splits with NaNs on the left for those features.
+- Fixed feature-wise NaN detection in trees.
+  Features could be seen as NaN-free for some edge-case patterns, which led to
+  not considering splits with NaNs assigned to the left node for those features.
   This affects:
   - :class:`tree.DecisionTreeRegressor`
   - :class:`tree.ExtraTreeRegressor`

--- a/doc/whats_new/upcoming_changes/sklearn.tree/33114.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.tree/33114.fix.rst
@@ -1,0 +1,9 @@
+- Fixed feature-wise NaN detection for trees and tree-based model.
+  Features could be seen as NaN-free for some very edge-casy patterns
+  which lead to not consider splits with NaNs on the left for those features.
+  This affects:
+  - :class:`tree.DecisionTreeRegressor`
+  - :class:`tree.ExtraTreeRegressor`
+  - :class:`ensemble.RandomForestRegressor`
+  - :class:`ensemble.ExtraTreesRegressor`
+  By :user:`Arthur Lacote <cakedev0>`

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -35,7 +35,6 @@ from sklearn.tree._tree import (
     _build_pruned_tree_ccp,
     ccp_pruning_path,
 )
-from sklearn.tree._utils import _any_isnan_axis0
 from sklearn.utils import (
     Bunch,
     check_random_state,
@@ -228,7 +227,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         if not np.isnan(overall_sum):
             return None
 
-        missing_values_in_feature_mask = _any_isnan_axis0(X)
+        missing_values_in_feature_mask = np.isnan(X).any(axis=0)
         return missing_values_in_feature_mask
 
     def _fit(

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -227,7 +227,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         if not np.isnan(overall_sum):
             return None
 
-        missing_values_in_feature_mask = np.isnan(X).any(axis=0)
+        missing_values_in_feature_mask = np.isnan(X.sum(axis=0))
         return missing_values_in_feature_mask
 
     def _fit(

--- a/sklearn/tree/_utils.pyx
+++ b/sklearn/tree/_utils.pyx
@@ -4,10 +4,8 @@
 from libc.stdlib cimport free
 from libc.stdlib cimport realloc
 from libc.math cimport log as ln
-from libc.math cimport isnan
 from libc.string cimport memset
 
-import numpy as np
 cimport numpy as cnp
 cnp.import_array()
 
@@ -65,25 +63,6 @@ cdef inline float64_t rand_uniform(float64_t low, float64_t high,
 
 cdef inline float64_t log(float64_t x) noexcept nogil:
     return ln(x) / ln(2.0)
-
-
-def _any_isnan_axis0(const float32_t[:, :] X):
-    """Same as np.any(np.isnan(X), axis=0)"""
-    cdef:
-        intp_t i, j
-        intp_t n_samples = X.shape[0]
-        intp_t n_features = X.shape[1]
-        uint8_t[::1] isnan_out = np.zeros(X.shape[1], dtype=np.bool_)
-
-    with nogil:
-        for i in range(n_samples):
-            for j in range(n_features):
-                if isnan_out[j]:
-                    continue
-                if isnan(X[i, j]):
-                    isnan_out[j] = True
-                    break
-    return np.asarray(isnan_out)
 
 
 cdef class WeightedFenwickTree:


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #33113 

The bug was detected by the test from this PR: https://github.com/scikit-learn/scikit-learn/pull/32193/

#### What does this implement/fix? Explain your changes.

First, I considered removing the erroneous `break` (see the issue). 

But then I benchmarked `_any_isnan_axis0`, and I noticed it was not much faster than just `np.isnan(...).any(axis=0)` which anyway is incomparably fast compared to fitting a tree. So I propose to just remove this function.

#### AI usage disclosure

I used AI assistance for finding where the bug detected by my test came from.

#### Other comments

I didn't add a regression test as it's already covered by https://github.com/scikit-learn/scikit-learn/pull/32193/, but I can add one if needed.
