### PR TITLE
Fix response_method='auto' for clusterers in DecisionBoundaryDisplay

### DIFF
--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -20,38 +20,6 @@ from sklearn.utils.validation import (
 )
 
 
-# def _check_boundary_response_method(estimator, response_method):
-#     """Validate the response methods to be used with the fitted estimator.
-
-#     Parameters
-#     ----------
-#     estimator : object
-#         Fitted estimator to check.
-
-#     response_method : {'auto', 'decision_function', 'predict_proba', 'predict'}
-#         Specifies whether to use :term:`decision_function`, :term:`predict_proba`,
-#         :term:`predict` as the target response. If set to 'auto', the response method is
-#         tried in the before mentioned order.
-
-#     Returns
-#     -------
-#     prediction_method : list of str or str
-#         The name or list of names of the response methods to use.
-#     """
-#     has_classes = hasattr(estimator, "classes_")
-#     if has_classes and _is_arraylike_not_scalar(estimator.classes_[0]):
-#         msg = "Multi-label and multi-output multi-class classifiers are not supported"
-#         raise ValueError(msg)
-
-#     if response_method == "auto":
-#         if is_regressor(estimator):
-#             prediction_method = "predict"
-#         else:
-#             prediction_method = ["decision_function", "predict_proba", "predict"]
-#     else:
-#         prediction_method = response_method
-
-#     return prediction_method
 
 def _check_boundary_response_method(estimator, response_method):
     """Validate the response methods to be used with the fitted estimator.

--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -2,6 +2,7 @@ import warnings
 
 import numpy as np
 import pytest
+pytest.importorskip("matplotlib")
 
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.datasets import (
@@ -10,6 +11,7 @@ from sklearn.datasets import (
     make_classification,
     make_multilabel_classification,
 )
+from sklearn.cluster import DBSCAN, KMeans
 from sklearn.ensemble import IsolationForest
 from sklearn.inspection import DecisionBoundaryDisplay
 from sklearn.inspection._plot.decision_boundary import _check_boundary_response_method
@@ -701,3 +703,18 @@ def test_subclass_named_constructors_return_type_is_subclass(pyplot):
     curve = SubclassOfDisplay.from_estimator(estimator=clf, X=X)
 
     assert isinstance(curve, SubclassOfDisplay)
+    
+def test_from_estimator_auto_clusterer_with_predict():
+    X = np.array([[0, 0], [0, 1], [1, 0], [5, 5], [5, 6], [6, 5]])
+    est = KMeans(n_clusters=2, random_state=0).fit(X)
+
+    disp = DecisionBoundaryDisplay.from_estimator(est, X, response_method="auto")
+    assert disp is not None
+
+
+def test_from_estimator_auto_clusterer_without_predict_raises():
+    X = np.array([[0, 0], [0, 1], [1, 0], [5, 5], [5, 6], [6, 5]])
+    est = DBSCAN(eps=1.5, min_samples=2).fit(X)
+
+    with pytest.raises(ValueError, match="do not implement `predict`"):
+        DecisionBoundaryDisplay.from_estimator(est, X, response_method="auto")


### PR DESCRIPTION
Support clusterers in DecisionBoundaryDisplay when response_method="auto".

When the estimator is a clusterer, "auto" now selects "predict" when available
(e.g. KMeans).

If the clusterer does not implement predict (e.g. DBSCAN),
DecisionBoundaryDisplay.from_estimator raises a clear and explicit error
indicating that a decision boundary cannot be computed.

Added tests covering both cases.
