### PR TITLE
DOC Add statement on supported versions for array API

### DIFF
--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -54,7 +54,7 @@ For more details, refer to SciPy's `Array API documentation
 
 The array API functionality assumes that the latest versions of scikit-learn's dependencies are
 installed. Older versions might work, but we make no promises. While array API support is marked
-as experimental backwards compatibility is not guaranteed. In particular when a newer version
+as experimental, backwards compatibility is not guaranteed. In particular, when a newer version
 of a dependency fixes a bug we will not introduce additional code to backport the fix or
 maintain compatibility with older versions.
 

--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -12,17 +12,6 @@ Scikit-learn vendors pinned copies of
 `array-api-compat <https://github.com/data-apis/array-api-compat>`__
 and `array-api-extra <https://github.com/data-apis/array-api-extra>`__.
 
-Scikit-learn's support for the array API standard requires the environment variable
-`SCIPY_ARRAY_API` to be set to `1` before importing `scipy` and `scikit-learn`:
-
-.. prompt:: bash $
-
-   export SCIPY_ARRAY_API=1
-
-Please note that this environment variable is intended for temporary use.
-For more details, refer to SciPy's `Array API documentation
-<https://docs.scipy.org/doc/scipy/dev/api-dev/array_api.html#using-array-api-standard-support>`_.
-
 Some scikit-learn estimators that primarily rely on NumPy (as opposed to using
 Cython) to implement the algorithmic logic of their `fit`, `predict` or
 `transform` methods can be configured to accept any Array API compatible input
@@ -51,6 +40,23 @@ behaviour and prevent accidental mixing of array namespaces.
 Note that in the examples below, we use a context manager (:func:`config_context`)
 to avoid having to reset it to `False` at the end of every code snippet, so as to
 not affect the rest of the documentation.
+
+Scikit-learn's support for the array API standard requires the environment variable
+`SCIPY_ARRAY_API` to be set to `1` before importing `scipy` and `scikit-learn`:
+
+.. prompt:: bash $
+
+   export SCIPY_ARRAY_API=1
+
+Please note that this environment variable is intended for temporary use.
+For more details, refer to SciPy's `Array API documentation
+<https://docs.scipy.org/doc/scipy/dev/api-dev/array_api.html#using-array-api-standard-support>`_.
+
+The array API functionality assumes that the latest versions of scikit-learn's dependencies are
+installed. Older versions might work, but we make no promises. While array API support is marked
+as experimental backwards compatibility is not guaranteed. In particular when a newer version
+of a dependency fixes a bug we will not introduce additional code to backport the fix or
+maintain compatibility with older versions.
 
 Scikit-learn accepts :term:`array-like` inputs for all :mod:`metrics`
 and some estimators. When `array_api_dispatch=False`, these inputs are converted


### PR DESCRIPTION
Clarify that we develop against the latest versions of dependencies for array API work and will not introduce code to backport fixes that are available in newer versions of our dependencies.

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
For example https://github.com/scikit-learn/scikit-learn/issues/32552#issuecomment-3782563204 and https://github.com/scikit-learn/scikit-learn/pull/33022, but we've discussed "what versions do we support?" a few times already in various issues and PRs.


#### What does this implement/fix? Explain your changes.

This adds a statement to the array API documentation stating that we only support the latest version of scikit-learn's dependencies. It also says that we will not introduce changes that backport things to older versions of dependencies - which is kind of redundant but given https://github.com/scikit-learn/scikit-learn/pull/33022 maybe worth stating explicitly (aka I shouldn't have made that PR).

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?

I moved the environment variable paragraph as I was missing it in the "Enable array API support" section. In this case I went directly to that section without reading the page from the top. To me it makes sense to have it all in one place. Looking at it from a different angle: why is the env var thing mentioned at the very top, but how to enable it isn't? They both seem equally important.
