### PR TITLE
Improve contribution guidelines to make it easier for maintainers to assess the user facing value of issues/PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,9 +10,11 @@ body:
       addressed by searching through [the past issues](https://github.com/scikit-learn/scikit-learn/issues).
 - type: textarea
   attributes:
-    label: Describe the bug
+    label: Describe the bug and give evidence about its user-facing impact
     description: >
-      A clear and concise description of what the bug is.
+      A clear and concise description of what the bug is and **how does it affect you as a scikit-learn user**? Please give a few details about the context of the discovery and why you care about getting it fixed.
+
+      The scikit-learn issue tracker is swamped by reports and pull-requests by GitHub accounts that are primarily interested in building contribution credentials rather than by the user facing value of their contributions. Stating the expected user impact is capital to help reviewers triage issues and allocate time and effort to review meaningful contributions.
   validations:
     required: true
 - type: textarea
@@ -36,13 +38,15 @@ body:
       model = lda_model.fit(lda_features)
       ```
 
+      If possible, craft a reproducer that only uses the public scikit-learn API or justify why you had to use some private API to trigger the problem. This helps us assess the user-facing impact of the bug.
+
       If the code is too long, feel free to put it in a public gist and link it in the issue: https://gist.github.com.
 
-      In short, **we are going to copy-paste your code** to run it and we expect to get the same result as you.
+      In short, **we want to be able to quickly copy-paste your code** to run it without modification and we expect to get the same result as you.
 
       We acknowledge that crafting a [minimal reproducible code example](https://scikit-learn.org/dev/developers/minimal_reproducer.html) requires some effort on your side but it really helps the maintainers quickly reproduce the problem and analyze its cause without any ambiguity. Ambiguous bug reports tend to be slower to fix because they will require more effort and back and forth discussion between the maintainers and the reporter to pin-point the precise conditions necessary to reproduce the problem.
     placeholder: |
-      ```
+      ```python
       Sample code to reproduce the problem
       ```
   validations:
@@ -87,6 +91,13 @@ body:
       ```python
       import sklearn; sklearn.show_versions()
       ```
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Interest in fixing the bug
+    description: >
+      If your issue is triaged by project maintainers as a bug that can be reproduced, would you be interested in working on a PR to resolve it? If so, please explain your analysis of the root cause of the bug and a strategy for a possible fix but please do not open the PR as long as the issue has not been triaged.
   validations:
     required: true
 - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,9 +12,9 @@ body:
   attributes:
     label: Describe the bug and give evidence about its user-facing impact
     description: >
-      A clear and concise description of what the bug is and **how it affects you as a scikit-learn user**. Please give a few details about the context of the discovery and why you care about getting it fixed.
+      A clear and concise description of what the bug is and **how it affects you as a scikit-learn user**. Please give a few details about the context of the discovery, why you care about getting it fixed. Please do not create issues for problems you don't actually care about.
 
-      The scikit-learn issue tracker is swamped by reports and pull-requests by GitHub accounts that are primarily interested in building contribution credentials rather than by the intrinsic value of their contributions. Stating the expected user impact is capital to help reviewers triage issues and allocate time and effort to review meaningful contributions.
+      The scikit-learn issue tracker is swamped by reports and pull-requests by GitHub accounts that are primarily interested in building contribution credentials rather than by the intrinsic value of their contributions. Stating the expected user impact is critical to help maintainers and other contributors focus time and effort to review meaningful contributions.
   validations:
     required: true
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
   attributes:
     label: Describe the bug and give evidence about its user-facing impact
     description: >
-      A clear and concise description of what the bug is and **how does it affect you as a scikit-learn user**? Please give a few details about the context of the discovery and why you care about getting it fixed.
+      A clear and concise description of what the bug is and **how it affects you as a scikit-learn user**. Please give a few details about the context of the discovery and why you care about getting it fixed.
 
       The scikit-learn issue tracker is swamped by reports and pull-requests by GitHub accounts that are primarily interested in building contribution credentials rather than by the user facing value of their contributions. Stating the expected user impact is capital to help reviewers triage issues and allocate time and effort to review meaningful contributions.
   validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,7 @@ body:
     description: >
       A clear and concise description of what the bug is and **how it affects you as a scikit-learn user**. Please give a few details about the context of the discovery, why you care about getting it fixed. Please do not create issues for problems you don't actually care about.
 
-      The scikit-learn issue tracker is swamped by reports and pull-requests by GitHub accounts that are primarily interested in building contribution credentials rather than by the intrinsic value of their contributions. Stating the expected user impact is critical to help maintainers and other contributors focus time and effort to review meaningful contributions.
+      The scikit-learn issue tracker is swamped by reports and pull-requests. Stating the expected user impact is critical to help maintainers and other contributors focus time and effort to review meaningful contributions.
   validations:
     required: true
 - type: textarea
@@ -42,7 +42,7 @@ body:
 
       If the code is too long, feel free to put it in a public gist and link it in the issue: https://gist.github.com.
 
-      In short, **we want to be able to quickly copy-paste your code** to run it without modification and we expect to get the same result as you.
+      In short, **we need to be able to quickly copy-paste your code** to run it without modification and we expect to get the same result as you.
 
       We acknowledge that crafting a [minimal reproducible code example](https://scikit-learn.org/dev/developers/minimal_reproducer.html) requires some effort on your side but it really helps the maintainers quickly reproduce the problem and analyze its cause without any ambiguity. Ambiguous bug reports tend to be slower to fix because they will require more effort and back and forth discussion between the maintainers and the reporter to pin-point the precise conditions necessary to reproduce the problem.
     placeholder: |
@@ -97,7 +97,8 @@ body:
   attributes:
     label: Interest in fixing the bug
     description: >
-      If your issue is triaged by project maintainers as a bug that can be reproduced, would you be interested in working on a PR to resolve it? If so, please explain your analysis of the root cause of the bug and a strategy for a possible fix but please do not open the PR as long as the issue has not been triaged.
+      If your issue is triaged by project maintainers as a bug that can be reproduced, would you be interested in working on a PR to resolve it? 
+      And if you already have an idea, please explain your analysis of the root cause of the bug and a strategy for a possible fix, but please do not open a PR as long as the issue has not been triaged.
   validations:
     required: true
 - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,7 @@ body:
     description: >
       A clear and concise description of what the bug is and **how it affects you as a scikit-learn user**. Please give a few details about the context of the discovery and why you care about getting it fixed.
 
-      The scikit-learn issue tracker is swamped by reports and pull-requests by GitHub accounts that are primarily interested in building contribution credentials rather than by the user facing value of their contributions. Stating the expected user impact is capital to help reviewers triage issues and allocate time and effort to review meaningful contributions.
+      The scikit-learn issue tracker is swamped by reports and pull-requests by GitHub accounts that are primarily interested in building contribution credentials rather than by the intrinsic value of their contributions. Stating the expected user impact is capital to help reviewers triage issues and allocate time and effort to review meaningful contributions.
   validations:
     required: true
 - type: textarea

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -407,7 +407,7 @@ complies with the following rules before marking a PR as "ready for review". The
 2. **Pull requests are expected to resolve one or more issues**.
    Please **do not open PRs for issues that are labeled as "Needs triage"** or with
    other kinds of "Needs ..." labels. Please do not open PRs for issues for which:
-   - the discussion has not settled done to an explicit resolution plan,
+   - the discussion has not settled down to an explicit resolution plan,
    - the reporter has already expressed interest in opening a PR,
    - there already exists cross-referenced and active PRs.
 

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -405,8 +405,9 @@ complies with the following rules before marking a PR as "ready for review". The
    good title.
 
 2. **Pull requests are expected to resolve one or more issues**.
-   Please **do not open PRs for issues that are labeled as "Needs triage"** or with
-   other kinds of "Needs ..." labels. Please do not open PRs for issues for which:
+   Please **do not open PRs for issues that are labeled as "Needs triage"**
+   (see :ref:`issues_tagged_needs_triage`) or with other kinds of "Needs ..."
+   labels. Please do not open PRs for issues for which:
    - the discussion has not settled down to an explicit resolution plan,
    - the reporter has already expressed interest in opening a PR,
    - there already exists cross-referenced and active PRs.

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -408,6 +408,7 @@ complies with the following rules before marking a PR as "ready for review". The
    Please **do not open PRs for issues that are labeled as "Needs triage"**
    (see :ref:`issues_tagged_needs_triage`) or with other kinds of "Needs ..."
    labels. Please do not open PRs for issues for which:
+
    - the discussion has not settled down to an explicit resolution plan,
    - the reporter has already expressed interest in opening a PR,
    - there already exists cross-referenced and active PRs.

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -246,13 +246,13 @@ feedback:
   this issue resolved will help the project maintainers invest time and effort
   on issues that actually impact users.
 
-- Please be tell us if you would be interested in opening a PR to resolve your issue
+- Please tell us if you would be interested in opening a PR to resolve your issue
   once triaged by a project maintainer.
 
 Note that the scikit-learn tracker receives `daily reports
 <https://github.com/scikit-learn/scikit-learn/issues?q=label%3Aspam>`_ by
-GitHub accounts that are mostly interested by increasing contribution
-statistics and show little interest for the expected end-user impact of their
+GitHub accounts that are mostly interested in increasing contribution
+statistics and show little interest in the expected end-user impact of their
 contributions. As project maintainers we want to be able to assess if our
 efforts are likely to have a meaningful and positive impact to our end users.
 Therefore, we ask you to avoid opening issues for things you don't actually
@@ -404,7 +404,7 @@ complies with the following rules before marking a PR as "ready for review". The
    cases "Fix <ISSUE TITLE>" is enough. "Fix #<ISSUE NUMBER>" is never a
    good title.
 
-2. **Pull requests are expected to resolve one or more other issues**.
+2. **Pull requests are expected to resolve one or more issues**.
    Please **do not open PRs for issues that are labeled as "Needs triage"** or with
    other kinds of "Needs ..." labels. Please do not open PRs for issues for which:
    - the discussion has not settled done to an explicit resolution plan,

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -243,7 +243,7 @@ feedback:
 
 - Please be explicit **how this issue impacts you as a scikit-learn user**. Giving
   some details (a short paragraph) about how you use scikit-learn and why you need
-  this issue resolved will help the project maintainers assess invest time and effort
+  this issue resolved will help the project maintainers invest time and effort
   on issues that actually impact users.
 
 - Please be tell us if you would be interested in opening a PR to resolve your issue

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -241,6 +241,21 @@ feedback:
   <https://help.github.com/articles/creating-and-highlighting-code-blocks>`_
   for more details.
 
+- Please be explicit **how this issue impacts you as a scikit-learn user**. Giving
+  some details (a short paragraph) about how you use scikit-learn and why you need
+  this issue resolved will help the project maintainers assess invest time and effort
+  on issues that actually impact users.
+
+- Please be tell us if you would be interested in opening a PR to resolve your issue
+  once triaged by a project maintainer.
+
+Note that the scikit-learn tracker receives daily reports (sometimes with the help of
+automated assistants) by GitHub accounts that are mostly interested by increasing contribution
+statistics and show little interest for the expected end-user impact of their contributions.
+As project maintainers we want to be able to assess if our efforts are likely to have a
+meaningful and positive impact to our end users. Therefore, we ask you to avoid opening issues
+for things you don't actually care about.
+
 If you want to help curate issues, read about :ref:`bug_triaging`.
 
 Contributing code and documentation
@@ -387,7 +402,23 @@ complies with the following rules before marking a PR as "ready for review". The
    cases "Fix <ISSUE TITLE>" is enough. "Fix #<ISSUE NUMBER>" is never a
    good title.
 
-2. **Make sure your code passes the tests**. The whole test suite can be run
+2. **Pull requests are expected to resolve one or more other issues**.
+   Please **do not open PRs for issues that are labeled as "Needs triage"** or with
+   other kinds of "Needs ..." labels. Please do not open PRs for issues for which:
+   - the discussion has not settled done to an explicit resolution plan,
+   - the reporter has already expressed interest in opening a PR,
+   - there already exists cross-referenced and active PRs.
+
+   If merging your pull request means that some other issues/PRs should be closed,
+   you should `use keywords to create link to them
+   <https://github.com/blog/1506-closing-issues-via-pull-requests/>`_
+   (e.g., ``Fixes #1234``; multiple issues/PRs are allowed as long as each
+   one is preceded by a keyword). Upon merging, those issues/PRs will
+   automatically be closed by GitHub. If your pull request is simply
+   related to some other issues/PRs, or it only partially resolves the target
+   issue, create a link to them without using the keywords (e.g., ``Towards #1234``).
+
+3. **Make sure your code passes the tests**. The whole test suite can be run
    with `pytest`, but it is usually not recommended since it takes a long
    time. It is often enough to only run the test related to your changes:
    for example, if you changed something in
@@ -410,12 +441,12 @@ complies with the following rules before marking a PR as "ready for review". The
    you don't need to run the whole test suite locally. For guidelines on how
    to use ``pytest`` efficiently, see the :ref:`pytest_tips`.
 
-3. **Make sure your code is properly commented and documented**, and **make
+4. **Make sure your code is properly commented and documented**, and **make
    sure the documentation renders properly**. To build the documentation, please
    refer to our :ref:`contribute_documentation` guidelines. The CI will also
    build the docs: please refer to :ref:`generated_doc_CI`.
 
-4. **Tests are necessary for enhancements to be
+5. **Tests are necessary for enhancements to be
    accepted**. Bug-fixes or new features should be provided with non-regression tests.
    These tests verify the correct behavior of the fix or feature. In this manner,
    further modifications on the code base are granted to be consistent with the
@@ -423,26 +454,16 @@ complies with the following rules before marking a PR as "ready for review". The
    non-regression tests should fail for the code base in the ``main`` branch
    and pass for the PR code.
 
-5. If your PR is likely to affect users, you need to add a changelog entry describing
+6. If your PR is likely to affect users, you need to add a changelog entry describing
    your PR changes. See the
    `README <https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md>`_
    for more details.
 
-6. Follow the :ref:`coding-guidelines`.
+7. Follow the :ref:`coding-guidelines`.
 
-7. When applicable, use the validation tools and scripts in the :mod:`sklearn.utils`
+8. When applicable, use the validation tools and scripts in the :mod:`sklearn.utils`
    module. A list of utility routines available for developers can be found in the
    :ref:`developers-utils` page.
-
-8. Often pull requests resolve one or more other issues (or pull requests).
-   If merging your pull request means that some other issues/PRs should
-   be closed, you should `use keywords to create link to them
-   <https://github.com/blog/1506-closing-issues-via-pull-requests/>`_
-   (e.g., ``Fixes #1234``; multiple issues/PRs are allowed as long as each
-   one is preceded by a keyword). Upon merging, those issues/PRs will
-   automatically be closed by GitHub. If your pull request is simply
-   related to some other issues/PRs, or it only partially resolves the target
-   issue, create a link to them without using the keywords (e.g., ``Towards #1234``).
 
 9. PRs should often substantiate the change, through benchmarks of
    performance and efficiency (see :ref:`monitoring_performances`) or through

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -249,12 +249,14 @@ feedback:
 - Please be tell us if you would be interested in opening a PR to resolve your issue
   once triaged by a project maintainer.
 
-Note that the scikit-learn tracker receives daily reports (sometimes with the help of
-automated assistants) by GitHub accounts that are mostly interested by increasing contribution
-statistics and show little interest for the expected end-user impact of their contributions.
-As project maintainers we want to be able to assess if our efforts are likely to have a
-meaningful and positive impact to our end users. Therefore, we ask you to avoid opening issues
-for things you don't actually care about.
+Note that the scikit-learn tracker receives `daily reports
+<https://github.com/scikit-learn/scikit-learn/issues?q=label%3Aspam>`_ by
+GitHub accounts that are mostly interested by increasing contribution
+statistics and show little interest for the expected end-user impact of their
+contributions. As project maintainers we want to be able to assess if our
+efforts are likely to have a meaningful and positive impact to our end users.
+Therefore, we ask you to avoid opening issues for things you don't actually
+care about.
 
 If you want to help curate issues, read about :ref:`bug_triaging`.
 


### PR DESCRIPTION
As a follow-up to the discussion at our monthly meeting.

I tried to explain the reasons we ask for all those requirements as @reshamas suggested.