### PR TITLE
Fixes #33135

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -4473,6 +4473,7 @@ def check_requires_y_none(name, estimator_orig):
         "requires y to be passed, but the target y is None",
         "Expected array-like (array or non-string sequence), got None",
         "y should be a 1d array",
+        "must be an array-like. Got None instead",
     )
 
     try:


### PR DESCRIPTION
#### Fixes #33135.

This PR fixes a false negative in `check_estimator`, specifically in `check_requires_y_none`, for estimators that validate `y` using the `validate_params` decorator with an `array-like` constraint.

When `y=None`, `validate_params` raises an error of the form:
“The 'y' parameter of ... must be an array-like. Got None instead.”

This message was not matched by the set of accepted error patterns in `check_requires_y_none`, causing estimators that correctly reject `None` values to still fail the check.

Changes:
, Extend the accepted error patterns to include the `validate_params` wording for the `array-like` constraint (“must be an array-like. Got None instead”).
, Add a regression test to ensure estimators using `validate_params` for `y` validation pass `check_requires_y_none` while still rejecting `y=None`.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
