### PR TITLE
Use pre-commit hooks in linting CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,12 +33,8 @@ jobs:
       - name: Install dependencies
         run: |
           source build_tools/shared.sh
-          # Include pytest compatibility with mypy
-          pip install pytest $(get_dep ruff min) $(get_dep mypy min) cython-lint
-          # we save the versions of the linters to be used in the error message later.
-          python -c "from importlib.metadata import version; print(f\"ruff={version('ruff')}\")" >> /tmp/versions.txt
-          python -c "from importlib.metadata import version; print(f\"mypy={version('mypy')}\")" >> /tmp/versions.txt
-          python -c "from importlib.metadata import version; print(f\"cython-lint={version('cython-lint')}\")" >> /tmp/versions.txt
+          pip install pre-commit
+          touch /tmp/versions.txt
 
       - name: Run linting
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,9 +37,7 @@ jobs:
           cache: 'pip'
       - name: Install linters
         run: |
-          source build_tools/shared.sh
-          # Include pytest compatibility with mypy
-          pip install pytest $(get_dep ruff min) $(get_dep mypy min) cython-lint
+          pip install pre-commit
       - name: Run linters
         run: ./build_tools/linting.sh
       - name: Run Meson OpenMP checks

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,8 +34,7 @@ jobs:
         versionSpec: '3.12'
     - bash: |
         source build_tools/shared.sh
-        # Include pytest compatibility with mypy
-        pip install pytest $(get_dep ruff min) $(get_dep mypy min) cython-lint
+        pip install pre-commit
       displayName: Install linters
     - bash: |
         ./build_tools/linting.sh

--- a/build_tools/get_comment.py
+++ b/build_tools/get_comment.py
@@ -20,8 +20,17 @@ def get_versions(versions_file):
     versions : dict
         A dictionary with the versions of the packages.
     """
+    if not os.path.exists(versions_file):
+        return {}
     with open(versions_file, "r") as f:
         return dict(line.strip().split("=") for line in f)
+
+
+def fmt_version(versions, key, label):
+    value = versions.get(key)
+    if value:
+        return f" Note that the installed `{label}` version is `{label}={value}`."
+    return ""
 
 
 def get_step_message(log, start, end, title, message, details):
@@ -99,8 +108,8 @@ def get_message(log_file, repo_str, pr_number, sha, run_id, details, versions):
         message=(
             "`ruff` detected issues. Please run "
             "`ruff check --fix --output-format=full` locally, fix the remaining "
-            "issues, and push the changes. Here you can see the detected issues. Note "
-            f"that the installed `ruff` version is `ruff={versions['ruff']}`."
+            "issues, and push the changes. Here you can see the detected issues."
+            + fmt_version(versions, "ruff", "ruff")
         ),
         details=details,
     )
@@ -113,8 +122,8 @@ def get_message(log_file, repo_str, pr_number, sha, run_id, details, versions):
         title="`ruff format`",
         message=(
             "`ruff` detected issues. Please run `ruff format` locally and push "
-            "the changes. Here you can see the detected issues. Note that the "
-            f"installed `ruff` version is `ruff={versions['ruff']}`."
+            "the changes. Here you can see the detected issues."
+            + fmt_version(versions, "ruff", "ruff")
         ),
         details=details,
     )
@@ -127,8 +136,8 @@ def get_message(log_file, repo_str, pr_number, sha, run_id, details, versions):
         title="`mypy`",
         message=(
             "`mypy` detected issues. Please fix them locally and push the changes. "
-            "Here you can see the detected issues. Note that the installed `mypy` "
-            f"version is `mypy={versions['mypy']}`."
+            "Here you can see the detected issues."
+            + fmt_version(versions, "mypy", "mypy")
         ),
         details=details,
     )
@@ -141,9 +150,8 @@ def get_message(log_file, repo_str, pr_number, sha, run_id, details, versions):
         title="`cython-lint`",
         message=(
             "`cython-lint` detected issues. Please fix them locally and push "
-            "the changes. Here you can see the detected issues. Note that the "
-            "installed `cython-lint` version is "
-            f"`cython-lint={versions['cython-lint']}`."
+            "the changes. Here you can see the detected issues."
+            + fmt_version(versions, "cython-lint", "cython-lint")
         ),
         details=details,
     )

--- a/build_tools/linting.sh
+++ b/build_tools/linting.sh
@@ -11,7 +11,7 @@ set -o pipefail
 global_status=0
 
 echo -e "### Running the ruff linter ###\n"
-ruff check --output-format=full
+pre-commit run ruff-check --all-files --show-diff-on-failure --color=never
 status=$?
 if [[ $status -eq 0 ]]
 then
@@ -22,7 +22,7 @@ else
 fi
 
 echo -e "### Running the ruff formatter ###\n"
-ruff format --diff
+pre-commit run ruff-format --all-files --show-diff-on-failure --color=never
 status=$?
 if [[ $status -eq 0 ]]
 then
@@ -33,7 +33,7 @@ else
 fi
 
 echo -e "### Running mypy ###\n"
-mypy sklearn/
+pre-commit run mypy --all-files --color=never
 status=$?
 if [[ $status -eq 0 ]]
 then
@@ -44,7 +44,7 @@ else
 fi
 
 echo -e "### Running cython-lint ###\n"
-cython-lint --ban-relative-imports sklearn/
+pre-commit run cython-lint --all-files --color=never
 status=$?
 if [[ $status -eq 0 ]]
 then


### PR DESCRIPTION
## Summary\n- switch linting.sh to run pre-commit hooks (ruff, ruff-format, mypy, cython-lint)\n- update linting CI jobs (GitHub Actions + Azure Pipelines) to install pre-commit\n- make lint comment helper resilient when versions file is missing\n\n## Testing\n- ### Running the ruff linter ###

Problems detected by ruff check, please fix them

### Running the ruff formatter ###

Problems detected by ruff format, please run ruff format and commit the result

### Running mypy ###

Problems detected by mypy, please fix them

### Running cython-lint ###

Problems detected by cython-lint, please fix them

### Checking for bad deprecation order ###

No problems detected related to deprecation order

### Checking for default doctest directives ###

No problems detected related to doctest directives

### Checking for joblib imports ###

No problems detected related to joblib imports

### Linting completed ###

Linting failed\n