### PR TITLE
DOC Add note about startup overhead in parallelism

### DIFF
--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -36,6 +36,15 @@ When the underlying implementation uses joblib, the number of workers
 
 .. note::
 
+    **Startup Overhead**
+
+    When using ``n_jobs > 1`` (or ``n_jobs=-1``), you may observe a delay
+    the first time a parallel function is called. This is expected behavior
+    caused by the overhead of starting the Python worker processes.
+    Subsequent calls will be faster as they reuse the existing pool of workers.   
+
+.. note::
+
     Where (and how) parallelization happens in the estimators using joblib by
     specifying `n_jobs` is currently poorly documented.
     Please help us by improving our docs and tackle `issue 14228


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
Fixes #33112 

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This PR adds a .. note:: to the parallelism.rst documentation. It explains that a delay (startup overhead) is expected when calling parallel functions with n_jobs > 1 for the first time, due to the initialization of Python worker processes.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?
This clarification was requested to help users understand why the first call to cross_validate or other parallel estimators might be slower than subsequent calls.

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
