### PR TITLE
ENH add L1/enet capable solvers newton-cd and newton-cd-gram to LogisticRegression

### DIFF
--- a/benchmarks/bench_logreg.py
+++ b/benchmarks/bench_logreg.py
@@ -1,0 +1,248 @@
+import argparse
+import warnings
+from time import perf_counter
+
+import numpy as np
+
+from sklearn._loss import HalfBinomialLoss, HalfMultinomialLoss
+from sklearn.datasets import fetch_20newsgroups_vectorized, make_classification
+from sklearn.exceptions import ConvergenceWarning
+from sklearn.linear_model import LogisticRegression
+from sklearn.linear_model._linear_loss import LinearModelLoss
+from sklearn.model_selection import train_test_split
+
+
+def obj(clf, X, y):
+    """Objective function for Elastic-Net Logistic Regression."""
+    n_classes = len(clf.classes_)
+    fit_intercept = clf.fit_intercept
+    lml = LinearModelLoss(
+        base_loss=HalfBinomialLoss()
+        if n_classes < 3
+        else HalfMultinomialLoss(n_classes=n_classes),
+        fit_intercept=fit_intercept,
+    )
+    reg = 1 / (clf.C * X.shape[0])
+    l1_reg = clf.l1_ratio * reg
+    l2_reg = (1 - clf.l1_ratio) * reg
+    if fit_intercept:
+        if n_classes <= 2:
+            coef = np.r_[clf.coef_[0], clf.intercept_]
+        else:
+            coef = np.c_[clf.coef_, clf.intercept_]
+    else:
+        coef = clf.coef_ if n_classes >= 3 else clf.coef_[0]
+    return lml.loss(
+        coef=coef,
+        X=X,
+        y=y.astype(X.dtype),
+        l1_reg_strength=l1_reg,
+        l2_reg_strength=l2_reg,
+    )
+
+
+def fit_solvers(solvers, exclude_solvers, X, y, **params):
+    for solver in solvers:
+        if solver in exclude_solvers:
+            print(f"{solver:>15} was excluded")
+            continue
+
+        with warnings.catch_warnings(record=True) as record:
+            tic = perf_counter()
+            clf = LogisticRegression(solver=solver, **params).fit(X, y)
+            toc = perf_counter()
+        if len(record) > 0 and any(
+            issubclass(rec.category, ConvergenceWarning) for rec in record
+        ):
+            converged = False
+        else:
+            converged = True
+
+        objective = obj(clf, X, y)
+        msg = (
+            f"{solver:>15} iterations={clf.n_iter_[0]:6_d} in {toc - tic:6.3f} seconds"
+            f" at {objective=: 13.12f}"
+        )
+        if clf.l1_ratio > 0:
+            n_zeros = np.sum(clf.coef_ == 0)
+            msg += f" {n_zeros} of {clf.coef_.size} coefficients are zero."
+        msg += f" {converged=}"
+        print(msg)
+
+
+def fit_one_config(
+    n_classes=2,
+    n_samples=100,
+    n_features=5,
+    C=1,
+    l1_ratio=0,
+    fit_intercept=False,
+    tol=1e-5,
+    exclude_solvers=[],
+):
+    X, y = make_classification(
+        n_samples=n_samples,
+        n_classes=n_classes,
+        n_features=n_features,
+        n_informative=max(1, n_features // 2),
+        n_redundant=1,
+        random_state=42,
+    )
+    print(
+        f"\n{n_samples=:_d} {n_features=:_d} {n_classes=:d} {l1_ratio=} "
+        f"{tol=} {fit_intercept=}"
+    )
+    params = dict(
+        C=C,
+        fit_intercept=fit_intercept,
+        l1_ratio=l1_ratio,
+        tol=tol,
+        max_iter=10_000,
+        random_state=444,
+    )
+
+    # Make X hot in memory
+    X.max()
+
+    solvers = ["saga", "newton-cd-gram", "newton-cd"]
+    if n_classes == 2:
+        solvers += ["liblinear"]
+    if l1_ratio == 0:
+        solvers += ["newton-cg", "newton-cholesky", "lbfgs"]
+
+    fit_solvers(solvers, exclude_solvers, X, y, **params)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--penalty",
+        choices=["L2", "L1"],
+        default="L1",
+        type=str,
+        help="Penalty type. Solvers are selected automatically.",
+    )
+    parser.add_argument(
+        "--data",
+        choices=["make_classification", "20newsgroup"],
+        default="make_classification",
+        type=str,
+        help=(
+            "The data to use. Solvers are selected automatically.\n"
+            "Option 'make_classification' creates dense data with different number "
+            "of classes.\n"
+            "Option '20newsgroup' uses a down-sampled variant of the vectorized "
+            "20-news-group data, it is sparse and has 20 classes."
+        ),
+    )
+
+    args = parser.parse_args()
+
+    print("Start simple benchmarks for logistic regression.")
+
+    if args.data == "make_classification":
+        print("dataset from make_classification, tol=1e-5")
+        if args.penalty == "L2":
+            print("\nL2 logistic regression")
+            params = dict(n_samples=100_000, n_features=10, fit_intercept=False)
+            fit_one_config(n_classes=2, **params)
+            fit_one_config(n_classes=3, **params)
+            fit_one_config(n_classes=10, **params, exclude_solvers=["newton-cd"])
+
+            print()
+            params = dict(n_samples=100_000, n_features=10, fit_intercept=True)
+            fit_one_config(n_classes=2, **params)
+            fit_one_config(n_classes=3, **params)
+            fit_one_config(n_classes=10, **params, exclude_solvers=["newton-cd"])
+
+            print()
+            params = dict(n_samples=100, n_features=1000, fit_intercept=False)
+            fit_one_config(n_classes=2, **params)
+            fit_one_config(n_classes=3, **params)
+            fit_one_config(n_classes=10, **params, exclude_solvers=["newton-cd-gram"])
+
+            print()
+            params = dict(n_samples=100, n_features=1000, fit_intercept=True)
+            fit_one_config(n_classes=2, **params)
+            fit_one_config(n_classes=3, **params)
+            fit_one_config(n_classes=10, **params, exclude_solvers=["newton-cd-gram"])
+
+        else:  # args.penalty == "L1":
+            print("\nL1 logistic regression")
+            params = dict(
+                n_samples=10_000, n_features=10, l1_ratio=1, fit_intercept=False
+            )
+            fit_one_config(n_classes=2, **params)
+            fit_one_config(n_classes=3, **params)
+            fit_one_config(n_classes=10, **params)
+
+            print()
+            params = dict(
+                n_samples=10_000, n_features=10, l1_ratio=1, fit_intercept=True
+            )
+            fit_one_config(n_classes=2, **params)
+            fit_one_config(n_classes=3, **params)
+            fit_one_config(n_classes=10, **params)
+
+            print()
+            params = dict(
+                n_samples=100, n_features=1000, l1_ratio=1, fit_intercept=False
+            )
+            fit_one_config(n_classes=2, **params)
+            fit_one_config(n_classes=3, **params)
+            fit_one_config(n_classes=10, **params)
+
+            print()
+            params = dict(
+                n_samples=100, n_features=1000, l1_ratio=1, fit_intercept=True
+            )
+            fit_one_config(n_classes=2, **params)
+            fit_one_config(n_classes=3, **params)
+            fit_one_config(n_classes=10, **params)
+
+    else:
+        warnings.filterwarnings("ignore", category=ConvergenceWarning, module="sklearn")
+        # Turn down for faster run time
+        n_samples = 5000
+        X, y = fetch_20newsgroups_vectorized(subset="all", return_X_y=True)
+        X = X[:n_samples]
+        y = y[:n_samples]
+
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, random_state=42, stratify=y, test_size=0.1
+        )
+        train_samples, n_features = X_train.shape
+        n_classes = np.unique(y).shape[0]
+
+        print(
+            f"dataset 20newsgroup, {train_samples=:_}, {n_features=:_}, "
+            f"{n_classes=:_}, tol=1e-4"
+        )
+
+        exclude_solvers = ["newton-cd-gram"]  # too many features!!!
+        if args.penalty == "L2":
+            exclude_solvers += ["newton-cd"]  # takes long time
+            exclude_solvers += ["newton-cholesky"]  # too many features!!!
+            solvers = [
+                "saga",
+                "lbfgs",
+                "newton-cd",
+                "newton-cd-gram",
+                "newton-cg",
+                "newton-cholesky",
+                "lbfgs",
+            ]
+            l1_ratio = 0
+        else:
+            solvers = ["saga", "newton-cd"]
+            l1_ratio = 1
+        params = dict(
+            C=1,
+            fit_intercept=True,
+            l1_ratio=l1_ratio,
+            tol=1e-4,
+            max_iter=1_000,
+            random_state=444,
+        )
+
+        fit_solvers(solvers, exclude_solvers, X, y, **params)

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -274,6 +274,7 @@ def enet_coordinate_descent(
     bint random=0,
     bint positive=0,
     bint do_screening=1,
+    bint early_stopping=1,
 ):
     """
     Cython version of the coordinate descent algorithm for Elastic-Net regression.
@@ -417,7 +418,7 @@ def enet_coordinate_descent(
         gap, dual_norm_XtA = gap_enet(
             n_samples, n_features, w, alpha, beta, X, y, R, XtA, positive, False
         )
-        if gap <= tol:
+        if early_stopping and gap <= tol:
             with gil:
                 return np.asarray(w), gap, tol, 0
 
@@ -699,6 +700,7 @@ def sparse_enet_coordinate_descent(
     bint random=0,
     bint positive=0,
     bint do_screening=1,
+    bint early_stopping=1,
 ):
     """Cython version of the coordinate descent algorithm for Elastic-Net
 
@@ -869,7 +871,7 @@ def sparse_enet_coordinate_descent(
             positive,
             False,
         )
-        if gap <= tol:
+        if early_stopping and gap <= tol:
             with gil:
                 return np.asarray(w), gap, tol, 0
 
@@ -1152,6 +1154,7 @@ def enet_coordinate_descent_gram(
     bint random=0,
     bint positive=0,
     bint do_screening=1,
+    bint early_stopping=1,
 ):
     """Cython version of the coordinate descent algorithm
         for Elastic-Net regression
@@ -1226,7 +1229,7 @@ def enet_coordinate_descent_gram(
         gap, dual_norm_XtA = gap_enet_gram(
             n_features, w, alpha, beta, Qw, q, y_norm2, XtA, positive, False
         )
-        if 0 <= gap <= tol:
+        if early_stopping and 0 <= gap <= tol:
             # Only if gap >=0 as singular Q may cause dubious values of gap.
             with gil:
                 return np.asarray(w), gap, tol, 0
@@ -1497,6 +1500,7 @@ def enet_coordinate_descent_multi_task(
     object rng,
     bint random=0,
     bint do_screening=1,
+    bint early_stopping=1,
 ):
     """Cython version of the coordinate descent algorithm
         for Elastic-Net multi-task regression
@@ -1689,7 +1693,7 @@ def enet_coordinate_descent_multi_task(
             XtA_row_norms=XtA_row_norms,
             gap_smaller_eps=False,
         )
-        if gap <= tol:
+        if early_stopping and gap <= tol:
             with gil:
                 return np.asarray(W), gap, tol, 0
 

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -2,18 +2,26 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from libc.math cimport fabs, sqrt
+from libc.stdlib cimport free, malloc
+from libc.string cimport memset
+# from libc.time cimport time, time_t
 import numpy as np
 
 from cython cimport floating
 import warnings
+from scipy import sparse
 from sklearn.exceptions import ConvergenceWarning
 
+# Note: The use of BLAS can cause random results within floating point
+# arithmetic, e.g. the summation order is not deterministic.
 from sklearn.utils._cython_blas cimport (
     _axpy, _dot, _asum, _gemv, _nrm2, _copy, _scal
 )
 from sklearn.utils._cython_blas cimport ColMajor, Trans, NoTrans
-from sklearn.utils._typedefs cimport int32_t, uint8_t, uint32_t
+from sklearn.utils._typedefs cimport float64_t, int32_t, uint8_t, uint32_t
 from sklearn.utils._random cimport our_rand_r
+
+from sklearn.linear_model._linear_loss import Multinomial_LDL_Decomposition
 
 
 cdef extern from "<float.h>":
@@ -1906,3 +1914,972 @@ def enet_coordinate_descent_multi_task(
                 warnings.warn(message, ConvergenceWarning)
 
     return np.asarray(W), gap, tol, n_iter + 1
+
+
+cdef void inverse_L_sqrt_D_matmul(
+    const floating[::1, :] p,  # in
+    const floating[::1, :] q_inv,  # in
+    const floating[::1, :] sqrt_d,  # in
+    floating[::1, :] x,  # out
+    floating[::1] buffer,  # temporary memory buffer
+) noexcept nogil:
+    """Compute 1 / sqrt(D) L^(-1) x from the multinomial LDL' decomposition.
+
+    Same as Multinomial_LDL_Decomposition.inverse_L_sqrt_D_matmul
+
+    L^(-1) is again lower triangular and given by:
+        L^(-1)_ij = f[:, i] = p[:, i] / q[:, i-1]
+
+    For n_classes = 4, L^(-1) looks like:: text
+
+        L^(-1) = (1   0  0  0)
+                 (f1  1  0  0)
+                 (f2  f2 1  0)
+                 (f3  f3 f3 1)
+
+    Note that (L sqrt(D))^(-1) = 1/sqrt(D) L^(-1).
+
+    Parameters
+    ----------
+    p : memoryview of shape (n_samples, n_classes)
+        Probabilities.
+
+    q_inv : memoryview of shape (n_samples, n_classes)
+        Inverse of `q = 1 - np.cumsum(self.p, axis=1)`.
+
+    sqrt_d : memoryview of shape (n_samples, n_classes)
+        Square root of diagonal D, with D_ii = p_i * q_i / q_{i-1}.
+
+    x : memoryview of shape (n_samples, n_classes)
+        This array is overwritten with the result.
+
+    buffer : memoryview of shape (n_samples)
+        Used as temporary memory buffer.
+    """
+    cdef unsigned int n_samples = p.shape[0]
+    cdef unsigned int n_classes = p.shape[1]
+    cdef unsigned int i, k, t
+    cdef bint mask
+    cdef floating fj
+    cdef floating[::1] x_sum = buffer
+
+    # x_sum = np.sum(x[:, :-1], axis=1)  # precomputation
+    _copy(n_samples, &x[0, 0], 1, &x_sum[0], 1)
+    for k in range(1, n_classes - 1):
+        for t in range(n_samples):
+            x_sum[t] += x[t, k]
+
+    for i in range(n_classes - 1, 0, -1):  # row i, here i > 0.
+        # fj = p[:, i] * q_inv[:, i - 1]
+        # Using precomputation
+        # x[:, i] += fj * x_sum
+        # if i > 1:
+        #     x_sum -= x[:, i - 1]
+        for t in range(n_samples):
+            fj = p[t, i] * q_inv[t, i - 1]
+            x[t, i] += fj * x_sum[t]
+        if i > 1:
+            for t in range(n_samples):
+                x_sum[t] -= x[t, i - 1]
+
+    # x[:, :-1] /= sqrt_d[:, :-1]
+    for k in range(n_classes - 1):
+        for t in range(n_samples):
+            mask = (sqrt_d[t, k] == 0)
+            x[t, k] *= (not mask) / (sqrt_d[t, k] + mask)
+    # Important Note:
+    # Strictly speaking, the inverse of D does not exist.
+    # We use 0 as the inverse of 0 and just set:
+    # x[:, -1] = 0
+    memset(&x[0, n_classes - 1], 0, n_samples * sizeof(floating))
+
+
+cdef (floating, floating) gap_enet_multinomial(
+    const floating[::1, :] w,
+    floating alpha,  # L1 penalty
+    floating beta,  # L2 penalty
+    const floating[::1, :] X,
+    bint X_is_sparse,
+    floating[::1] X_data,
+    int32_t[::1] X_indices,
+    int32_t[::1] X_indptr,
+    const floating[::1, :] y,
+    const floating[::1, :] R,  # current residual b - A @ w
+    const floating[::1, :] LD_R,  # LD_R = LDL.L_sqrt_D_matmul(R.copy()) * sqrt_sw[:, None]
+    const floating[::1, :] H00_pinv_H0,
+    bint fit_intercept,
+    floating[::1, :] XtA,  # XtA = X.T @ R - beta * w is calculated inplace
+    bint gap_smaller_eps,
+) noexcept nogil:
+    """Compute dual gap for use in enet_coordinate_descent.
+
+    Note that X must always be replaced by A = sqrt(D) L' X
+    """
+    cdef floating gap, primal, dual
+    cdef floating scale  # Scaling factor to achieve dual feasible point.
+    cdef floating dual_norm_XtA
+    cdef floating R_norm2
+    cdef floating Ry
+    cdef floating w_l1_norm = 0.0
+    cdef floating w_l2_norm2 = 0.0
+    cdef unsigned int n_classes = w.shape[0]
+    cdef unsigned int n_features = w.shape[1]
+    cdef unsigned int n_samples = R.shape[0]
+    cdef floating* LD_R_sum0
+    cdef unsigned int i, j, k
+    cdef int32_t i_ind
+
+    if floating is float:
+        eps = FLT_EPSILON
+    else:
+        eps = DBL_EPSILON
+
+    if beta > 0:
+        # l2_norm2 = w @ w
+        w_l2_norm2 = _dot(n_classes * n_features, &w[0, 0], 1, &w[0, 0], 1)
+    if alpha > 0:
+        # w_l1_norm = np.sum(np.abs(w))
+        w_l1_norm = _asum(n_classes * n_features, &w[0, 0], 1)
+    # R_norm2 = np.linalg.norm(R, ord="fro") ** 2
+    R_norm2 = _dot(n_classes * n_samples, &R[0, 0], 1, &R[0, 0], 1)
+    if not (alpha == 0 and beta == 0):
+        # Ry = R.ravel(order="F") @ y.ravel(order="F")
+        Ry = _dot(n_classes * n_samples, &R[0, 0], 1, &y[0, 0], 1)
+
+    primal = 0.5 * R_norm2 + alpha * w_l1_norm + 0.5 * beta * w_l2_norm2
+
+    # XtA = X'R -> A'R = X' L sqrt(D) R
+    # XtA[:, :] = (X.T @ LD_R).T
+    if not X_is_sparse:
+        for k in range(n_classes):
+            # XtA[:, k] = X.T @ LD_R[:, k]
+            _gemv(
+                ColMajor, Trans, n_samples, n_features, 1.0, &X[0, 0],
+                n_samples, &LD_R[0, k], 1, 0.0, &XtA[k, 0], n_classes,
+            )
+    else:
+        # XtA[:, :] = 0
+        memset(&XtA[0, 0], 0, n_classes * n_features * sizeof(floating))
+        # XtA[:, :] = X.T @ LD_R
+        for j in range(n_features):
+            for i_ind in range(X_indptr[j], X_indptr[j + 1]):
+                for k in range(n_classes):
+                    XtA[k, j] += X_data[i_ind] * LD_R[X_indices[i_ind], k]
+
+    if fit_intercept:
+        # temporary memory
+        LD_R_sum0 = <floating *> malloc(sizeof(floating) * (n_classes - 1))
+        # XtA -= (H00_pinv_H0.T @ LD_R[:, :-1].sum(axis=0)).reshape(
+        #     n_classes, -1, order="F"
+        # )
+        for k in  range(n_classes - 1):
+            LD_R_sum0[k] = 0
+            for i in range(n_samples):
+                LD_R_sum0[k] += LD_R[i, k]
+        _gemv(
+            ColMajor, Trans, n_classes - 1, n_classes * n_features,
+            -1.0, &H00_pinv_H0[0, 0],
+            n_classes - 1, &LD_R_sum0[0], 1, 1.0, &XtA[0, 0], 1,
+        )
+        free(LD_R_sum0)
+
+    if alpha == 0:
+        # ||X'R||_2^2
+        # dual_norm_XtA = np.linalg.norm(XtA, ord="fro") ** 2
+        dual_norm_XtA = _dot(n_classes * n_features, &XtA[0, 0], 1, &XtA[0, 0], 1)
+        if beta == 0:
+            # This is OLS, no dual gap available. Resort to first order condition
+            #     X'R = 0
+            #     gap = ||X'R||_2^2
+            # Compare with stopping criterion of LSQR.
+            gap = dual_norm_XtA
+            return gap, dual_norm_XtA
+        # This is Ridge regression with primal objective
+        #     P(w) = 1/2 ||y - X w||_2^2 + beta/2 ||w||_2^2
+        # We use the "alternative" dual formulation with alpha=0, see
+        # https://github.com/scikit-learn/scikit-learn/issues/22836
+        #     D(v) = -1/2 ||v||_2^2 - v'y - 1/(2 beta) |||X'v||_2^2
+        # With v = Xw - y = -R (residual), the dual gap reads
+        #     G = P(w) - D(-R)
+        #       = ||R||_2^2  + beta/2 ||w||_2^2 - R'y + 1/(2 beta) ||X'R||_2^2
+        dual = -0.5 * R_norm2 + Ry - 1 / (2 * beta) * dual_norm_XtA
+    else:
+        # XtA = X.T @ R - beta * w
+        # XtA -= beta * w
+        _axpy(n_classes * n_features, -beta, &w[0, 0], 1, &XtA[0, 0], 1)
+        dual_norm_XtA = abs_max(n_classes * n_features, &XtA[0, 0])
+
+        if dual_norm_XtA > alpha:
+            scale = alpha / dual_norm_XtA
+        else:
+            scale = 1.0
+        dual = -0.5 * (scale**2) * (R_norm2 + beta * w_l2_norm2)
+        dual += scale * Ry
+
+    gap = primal - dual
+    if gap_smaller_eps and abs(gap) <= 2 * eps * primal:
+        gap = 0.0
+    return gap, dual_norm_XtA
+
+
+cdef inline void update_LD_R(
+    unsigned int k,
+    unsigned int j,
+    const floating w_kj,
+    const floating[::1, :] X,
+    bint X_is_sparse,
+    floating[::1] X_data,
+    int32_t[::1] X_indices,
+    int32_t[::1] X_indptr,
+    const floating[::1, :] sw_proba,
+    const floating[::1, :] proba,
+    const floating[::1, :] H00_pinv_H0,
+    bint fit_intercept,
+    floating[::1, :] LD_R,
+    floating[::1] x_k,
+    floating[::1, :] xx,
+) noexcept nogil:
+    """Update LD_R by X[:, j] * w_kj for class k and feature j.
+
+    Note:
+        - LDL = diag(proba) - proba proba', the last term being the outer product.
+        - We multiply by sample weights because we want the full hessian,
+          sw_proba = sample_weight * proba.
+    """
+    cdef unsigned int n_samples = LD_R.shape[0]
+    cdef unsigned int n_classes = LD_R.shape[1]
+    cdef int32_t i, l, i_ind
+    cdef int32_t startptr
+    cdef int32_t endptr
+
+    if X_is_sparse:
+        startptr = X_indptr[j]
+        endptr = X_indptr[j + 1]
+
+    # L sqrt(D) R += w * LDL[:, k] * X[:, j]
+    if not fit_intercept:
+        # numpy:
+        #   x_k[:] = w_kj * X[:, j] * sw_proba[:, k]
+        #   LD_R[:, k] += x_k
+        #   LD_R -= proba * x_k[:, None]
+        if not X_is_sparse:
+            for i in range(n_samples):
+                x_k[i] = w_kj * X[i, j] * sw_proba[i, k]
+                LD_R[i, k] += (1 - proba[i, k]) * x_k[i]
+        else:
+            memset(&x_k[0], 0, n_samples * sizeof(floating))
+            for i_ind in range(startptr, endptr):
+                i = X_indices[i_ind]
+                x_k[i] += X_data[i_ind] * w_kj * sw_proba[i, k]
+                LD_R[i, k] += (1 - proba[i, k]) * x_k[i]
+
+        for l in range(n_classes):
+            if l != k:
+                for i in range(n_samples):
+                    LD_R[i, l] -= proba[i, l] * x_k[i]
+    else:
+        # numpy:
+        #   xx[:, :-1] = -H00_pinv_H0[:, jn + k][None, :]
+        #   xx[:, -1] = 0
+        #   xx[:, k] += X[:, j]
+        #   xx *= w_kj * sw_proba
+        #   LD_R -= proba * np.sum(xx, axis=1)[:, None]
+        #   LD_R += xx
+
+        # x_k[:] = 0
+        memset(&x_k[0], 0, n_samples * sizeof(floating))
+        # xx[:, :] = 0
+        memset(&xx[0, 0], 0, n_samples * n_classes * sizeof(floating))
+        # xx[:, k] += X[:, j]
+        if not X_is_sparse:
+            _copy(n_samples, &X[0, j], 1, &xx[0, k], 1)
+        else:
+            for i_ind in range(startptr, endptr):
+                i = X_indices[i_ind]
+                xx[i] = X_data[i_ind]
+        for l in range(n_classes - 1):
+            for i in range(n_samples):
+                xx[i, l] -= H00_pinv_H0[l, k + n_classes * j]
+                xx[i, l] *= w_kj * sw_proba[i, l]
+                LD_R[i, l] += xx[i, l]
+                x_k[i] += xx[i, l]  # x_k = np.sum(xx, axis=1)
+        if k == n_classes - 1:  # H00_pinv_H0[k, :] == 0
+            l = n_classes - 1
+            for i in range(n_samples):
+                xx[i, l] *= w_kj * sw_proba[i, l]
+                LD_R[i, l] += xx[i, l]
+                x_k[i] += xx[i, l]  # x_k = np.sum(xx, axis=1)
+        for l in range(n_classes):
+            for i in range(n_samples):
+                LD_R[i, l] -= proba[i, l] * x_k[i]
+
+
+def enet_coordinate_descent_multinomial(
+    W,
+    float64_t alpha,
+    float64_t beta,
+    X,
+    sample_weight,
+    raw_prediction,
+    grad_pointwise,
+    proba,
+    bint fit_intercept,
+    unsigned int max_iter,
+    float64_t tol,
+    bint do_screening=True,
+    bint early_stopping=True,
+    int verbose=False,
+):
+    """Cython coordinate descent algorithm for Elastic-Net multinomial regression.
+
+    See function enet_coordinate_descent.
+    We minimize the primal
+
+        P(w) = 1/2 ||y - X w||_2^2 + alpha ||w||_1 + beta/2 ||w||_2^2
+
+    But we replace the variables y and X such that P(w) corresponds to the 2nd order
+    approximation of the multinomial loss
+
+        1/2 w' H w + (G' - coef' H) w + alpha ||w||_1 + beta/2 ||w||_2^2
+
+    - w = W.ravel(order="F")
+    - G = gradient = X.T @ (proba - Y)  with Y_k = (y==k)
+    - H = X' * (diag(p) - pp') * X, the full multinomial hessian
+      (* is kind of a Kronecker multiplication)
+
+    We use the analytical LDL decomposition of diag(p) - pp' = L D L' of
+    Tanabe & Sagae (1992) to replace
+
+        X -> A = sqrt(D) L' * X
+        y -> b = (L sqrt(D))^-1 (LDL' * X coef - g)
+               = A coef - (L sqrt(D))^-1 g
+
+    Which gives (up to a constant)
+
+        P(w) = 1/2 ||b - A w||_2^2 + alpha ||w||_1 + beta/2 ||w||_2^2
+
+    As the matrix A has n_samples * n_features * n_classes * n_classes entries, we
+    avoid to explicitly build it.
+
+    Note:
+        - H = A'A
+        - A'b = (coef' H - G') w
+
+    Intercepts
+    ----------
+    If intercepts w0 of shape (n_classes,) are included, we have
+
+        P(w) = 1/2 ||b - A w - A0 w0||_2^2 + alpha ||w||_1 + beta/2 ||w||_2^2
+
+    with A0 = sqrt(D) L' 1 and 1 = 1_{n_samples, n_classes} for the n_classes intercept
+    columns.
+
+    Minimizing for w0 gives
+
+        w0 = (A0' A0)^(-1) (A0' b - A0' A w)
+
+        P(w) = 1/2 ||(I - A0 (A0' A0)^(-1) A0') (b - A w)||_2^2 + ...
+             = 1/2 ||(b - A0 H00^(-1) q0) - (A - A0 H00^(-1) H0) w||_2^2 + ...
+
+    We therefore replace
+
+        A -> A - A0 H00^(-1) H0 = sqrt(D) L' (X - 1 H00^(-1) H0)
+
+        b -> b - A0 H00^(-1) q0 = sqrt(D) L' (X - 1 H00^(-1) H0) coef
+                                - (L sqrt(D))^-1 (I - LDL' 1 H00^(-1) 1') g
+
+    Note:
+        - A0 = sqrt(D) L' 1_{n_samples, n_classes}
+        - H00 = A0 A0', i.e. the part of the hessian for the the intercept alone
+        - H0 = A0' A, i.e. the part of the hessian mixing intercepts with the features:
+          H[-n_classes, :-n_classes]
+        - q0 = A0' b = 1' (LDL' X coef - g)
+
+    Tracking the Residual
+    ---------------------
+    Usually, CD tracks the residual R = y - X w -> b - Aw. In the multinomial case, it
+    is advantageous to track the rotated residual instead:
+
+        LD_R = L sqrt(D) R
+
+    This makes the coordinate update simple and fast involving just
+
+        X[:, j] @ LD_R[:, k]
+
+    The update of the rotated residual involves basically multiplying by the full
+    LDL = diag(p) - pp', i.e.
+
+        L sqrt(D) R -= (w_new_kj - w_old_kj) * LDL[:, k] * X[:, j]
+
+    with LDL[:, k] begin the k-th column of the LDL matrix, having shape
+    (n_sampels, n_classes).
+
+    Returns
+    -------
+    W : ndarray of shape (n_classes, n_features + fit_intercept)
+        ElasticNet coefficients.
+    gap : float
+        Achieved dual gap.
+    tol : float
+        Equals input `tol` times `np.dot(y, y)`. The tolerance used for the dual gap.
+    n_iter : int
+        Number of coordinate descent iterations.
+    """
+    dtype = X.dtype
+    # cdef time_t time_total = time(NULL)
+    # cdef time_t time_pre = 0
+    # cdef time_t time_gap = 0
+    # cdef time_t time_screen = 0
+    # cdef time_t time_w = 0
+    # cdef time_t time_r = 0
+    # cdef time_t tic = time(NULL)
+
+    # get the data information into easy vars
+    cdef unsigned int n_samples = X.shape[0]
+    cdef unsigned int n_features = X.shape[1]
+    cdef unsigned int n_classes = W.shape[0]
+    cdef bint X_is_sparse = sparse.issparse(X)
+
+    if not W.flags["F_CONTIGUOUS"]:
+        raise ValueError("Coefficient W must be F-contiguous.")
+
+    if sample_weight is None:
+        sw_sum = n_samples
+        sw = np.full(fill_value=1 / sw_sum, shape=n_samples, dtype=dtype)
+    else:
+        sw_sum = np.sum(sample_weight)
+        sw = sample_weight / sw_sum
+    sqrt_sw = np.sqrt(sw)
+    norm2_cols_X = np.empty((n_classes, n_features), dtype=dtype, order="C")
+    # Note: Full hessian H of LinearModelLoss.gradient_hessian(coef=W, X=X, y=y)
+    # divides by sw_sum. So each LDL.XXX_matmul computation must be multiplied by
+    # sqrt(samples_weight / sw_sum) = sqrt_sw, i.e. as if sqrt(D) would have
+    # been multiplied by sqrt_sw.
+    LDL = Multinomial_LDL_Decomposition(proba=proba)
+    XtA = np.zeros((n_classes, n_features), dtype=dtype, order="F")  # TODO: best order?
+    R = np.empty((n_samples, n_classes), dtype=dtype, order="F")
+    LD_R = np.empty_like(R, order="F")  # memory buffer for LDL.L_sqrt_D_matmul(R)
+    sw_proba = sw[:, None] * proba  # precompute this one
+    # memory buffers for temporaries
+    x_k = np.empty(n_samples, dtype=dtype)
+    xx = np.empty((n_samples, n_classes), dtype=dtype, order="F")
+    t_k = np.empty(n_samples, dtype=dtype)
+    if fit_intercept:
+        tt = np.empty((n_samples, n_classes), dtype=dtype, order="F")
+
+    cdef float64_t d_j
+    cdef float64_t Xj_theta
+    cdef float64_t tmp
+    cdef float64_t w_kj
+    cdef float64_t d_w_max
+    cdef float64_t w_max
+    cdef float64_t d_w_j
+    cdef float64_t gap = tol + 1.0
+    cdef float64_t d_w_tol = tol
+    cdef float64_t dual_norm_XtA
+    cdef uint32_t[::1] n_active = np.full(shape=n_classes, fill_value=n_features, dtype=np.uint32)
+    cdef uint32_t[:, ::1] active_set
+    # TODO: use binset instead of array of bools
+    cdef uint8_t[:, ::1] excluded_set
+    cdef unsigned int i, j, k, jn, l
+    cdef int32_t endptr, startptr, i_ind  # indexing sparse X
+    cdef unsigned int n_iter = 0
+    cdef bint at_least_one_feature_updated
+
+    if alpha <= 0:
+        do_screening = False
+
+    if do_screening:
+        # active_set maps [k, :n_active[k]] -> j
+        active_set = np.empty((n_classes, n_features), dtype=np.uint32)
+        excluded_set = np.empty((n_classes, n_features), dtype=np.uint8)
+
+    W_original = W
+    H00_pinv_H0 = None
+    if fit_intercept:
+        # See LinearModelLoss.gradient_hessian and NewtonCDGramSolver.inner_solve.
+        # We set the intercept of the last class to zero, loops and shapes often
+        # have n_classes - 1 instead of n_classes. The missing entries are all zeros,
+        # but we often do not add those zeros explicitly.
+        W0 = W[:, -1]
+        # W0[-1] = 0  # intercept of last class
+        W0[n_classes - 1] = 0  # Cython does not like negative indices
+        W = W[:, :-1]
+        # H00 = H[-n_classes:-1, -n_classes:-1] = Hessian part of intercepts
+        H00 = np.zeros((n_classes - 1, n_classes - 1), dtype=dtype)
+        # H0 = H[-n_classes:-1, :-n_classes] = Hessian part mixing intercepts with
+        # features
+        H0 = np.zeros((n_classes - 1, n_classes * n_features), dtype=dtype)
+        H0_coef = np.zeros((n_classes - 1,), dtype=dtype)  # 1' LDL raw_prediction
+        h = x_k
+        for k in range(n_classes - 1):
+            # Diagonal terms h_kk.
+            h[:] = proba[:, k] * (1 - proba[:, k]) * sw
+            H00[k, k] = h.sum()
+            H0[k, k::n_classes] = X.T @ h
+            H0_coef[k] += (h * raw_prediction[:, k]).sum()
+            # Off diagonal terms (in classes) hess_kl.
+            for l in range(k + 1, n_classes - 1):
+                # Upper triangle (in classes).
+                h[:] = -proba[:, k] * proba[:, l] * sw
+                H00[k, l] = h.sum()
+                H00[l, k] = H00[k, l]
+                H0[k, l::n_classes] = X.T @ h
+                H0[l, k::n_classes] = H0[k, l::n_classes]
+                H0_coef[k] += (h * raw_prediction[:, l]).sum()
+                H0_coef[l] += (h * raw_prediction[:, k]).sum()
+            # So far omitted term for last class where we still need it:
+            l = n_classes - 1
+            h[:] = -proba[:, k] * proba[:, l] * sw
+            H0[k, l::n_classes] = X.T @ h
+            H0_coef[k] += (h * raw_prediction[:, l]).sum()
+
+        H00_pinv = np.linalg.pinv(H00, hermitian=True)
+        # H0_coef is the same as:
+        # H0_coef = H0 @ W.ravel(order="F") + H00 @ W0
+        grad_p_sum = grad_pointwise[:, :-1].sum(axis=0)
+        q0 = H0_coef - grad_p_sum
+        # H00_pinv_H0 = H00_pinv @ H0  # shape (n_classes - 1, n_classes * n_features)
+        H00_pinv_H0 = np.zeros(
+            (n_classes - 1, n_classes * n_features), dtype=dtype, order="F"
+        )
+        # Double transpose to make the result F-contiguous.
+        np.dot(H0.T, H00_pinv.T, out=H00_pinv_H0.T)
+
+        # Centering X as
+        #   X -= (H00_pinv_H0)[None, :]
+        # is not an option because it would mean n_classes^2 copies of X.
+        # Center raw_prediction: += -intercepts - 1 H00^(-1) H0) coef
+        raw_prediction = raw_prediction - W0  # creates a copy
+        raw_prediction[:, :-1] -= (H00_pinv_H0 @ W.ravel(order="F"))[None, :]
+        # Center grad_pointwise: g -= LDL' 1 H00^(-1) 1' g
+        t = H00_pinv @ grad_p_sum  # H00^(-1) 1' g
+        for k in range(n_classes - 1):
+            h = proba[:, k] * (1 - proba[:, k]) * sw
+            grad_pointwise[:, k] -= h * t[k]
+            for l in range(k + 1, n_classes - 1):
+                h = -proba[:, k] * proba[:, l] * sw
+                grad_pointwise[:, k] -= h * t[l]
+                grad_pointwise[:, l] -= h * t[k]
+
+    # A w = sqrt(D) L' X w = sqrt(D) L' raw = sqrt_D_Lt_raw
+    sqrt_D_Lt_raw = LDL.sqrt_D_Lt_matmul(raw_prediction.copy(order="F")) * sqrt_sw[:, None]
+
+    # residual R = b - A w = -(L sqrt(D))^-1 g
+    # R[:, :] = LDL.inverse_L_sqrt_D_matmul(-grad_pointwise / sqrt_sw[:, None])
+    np.divide(-grad_pointwise, sqrt_sw[:, None], out=R)
+    LDL.inverse_L_sqrt_D_matmul(R)
+
+    # b = A w - (L sqrt(D))^-1 g
+    b = sqrt_D_Lt_raw + R  # shape (n_samples, n_classes)
+
+    # tol = tol * linalg.norm(Y, ord='fro') ** 2
+    tol = tol * np.linalg.norm(b, ord="fro") ** 2
+
+    # Rotated residual: L sqrt(D) R sqrt(sw)
+    # LD_R[:, :] = LDL.L_sqrt_D_matmul(R * sqrt_sw[:, None])
+    np.multiply(R, sqrt_sw[:, None], out=LD_R)
+    LDL.L_sqrt_D_matmul(LD_R)
+    # IMPORTANT NOTE: With fit_intercept=True, np.sum(LD_R, axis=0) == 0.
+
+    # Convention: memoryviews have a trailing underscore.
+    cdef float64_t[::1, :] W_ = W
+    cdef const float64_t[::1, :] X_
+    cdef float64_t[::1] X_data
+    cdef int32_t[::1] X_indices
+    cdef int32_t[::1] X_indptr
+    cdef float64_t[::1, :] b_ = b
+    cdef float64_t[::1] sqrt_sw_ = sqrt_sw
+    cdef float64_t[:, ::1] norm2_cols_X_ = norm2_cols_X
+    cdef float64_t[::1, :] R_ = R
+    cdef float64_t[::1, :] LD_R_ = LD_R
+    cdef float64_t[::1, :] proba_ = proba
+    cdef float64_t[::1, :] XtA_ = XtA
+    cdef float64_t[::1, :] H00_pinv_H0_ = H00_pinv_H0
+    cdef float64_t[::1, :] sw_proba_ = sw_proba
+    cdef float64_t[::1, :] q_inv_ = LDL.q_inv
+    cdef float64_t[::1, :] sqrt_d_ = LDL.sqrt_d
+    cdef float64_t[::1] t_k_ = t_k
+    cdef float64_t[::1] x_k_ = x_k
+    cdef float64_t[::1, :] tt_
+    cdef float64_t[::1, :] xx_ = xx
+    if fit_intercept:
+        tt_ = tt
+
+    if X_is_sparse:
+        if not (
+            X.data.flags.c_contiguous
+            and X.indices.flags.c_contiguous
+            and X.indptr.flags.c_contiguous
+        ):
+            raise ValueError("Sparse X must have contiguous underlying arrays.")
+        X_data = X.data
+        X_indices = X.indices
+        X_indptr = X.indptr
+    else:
+        X_ = X
+
+    # time_pre += time(NULL) - tic
+    # tic = time(NULL)
+
+    # Check convergence before entering the main loop.
+    gap, dual_norm_XtA = gap_enet_multinomial(
+        w=W_,
+        alpha=alpha,
+        beta=beta,
+        X=X_,
+        X_is_sparse=X_is_sparse,
+        X_data=X_data,
+        X_indices=X_indices,
+        X_indptr=X_indptr,
+        y=b_,
+        R=R_,
+        LD_R=LD_R_,
+        H00_pinv_H0=H00_pinv_H0_,
+        fit_intercept=fit_intercept,
+        XtA=XtA_,
+        gap_smaller_eps=False,
+    )
+    if early_stopping and gap <= tol:
+        if verbose:
+            print(
+                f"  inner coordinate descent solver stops early with gap={float(gap)}"
+                f"  <= tol={float(tol)}"
+            )
+        return np.asarray(W), gap, tol, 0
+
+    # time_gap += time(NULL) - tic
+    # tic = time(NULL)
+
+    # Compute squared norms of the columns of X.
+    # Same as norm2_cols_X = np.square(X).sum(axis=0)
+    # norm2_cols_X = np.einsum(
+    #     "ij,ij->j", X, X, dtype=dtype, order="C"
+    # )
+    # X -> sqrt(D) L' X = A
+    # sum_{i} X_{ij} X_{ij} -> sum_i X_{ij} LDL_i X_{ij}
+    # These are just the diagonal elements of the full hessian H.
+    # for k in range(n_classes):
+    #     h = proba[:, k] * (1 - proba[:, k]) * sw
+    #     norm2_cols_X[k, :] = np.einsum("ij, i, ij -> j", X, h, X)
+    np.subtract(1, proba, out=xx)  # xx = 1 - proba
+    xx *= sw_proba
+    if not X_is_sparse:
+        np.einsum("ij, ik, ij -> kj", X, xx, X, order="C", out=norm2_cols_X)
+    else:
+        memset(&norm2_cols_X_[0, 0], 0, n_classes * n_features * sizeof(float64_t))
+        for j in range(n_features):
+            startptr = X_indptr[j]
+            endptr = X_indptr[j + 1]
+            for i_ind in range(startptr, endptr):
+                i = X_indices[i_ind]
+                tmp = X_data[i_ind] ** 2
+                for k in range(n_classes):
+                    norm2_cols_X_[k, j] += tmp * xx_[i, k]
+    if fit_intercept:
+        # See Q_centered = Q - Q0.T @ Q00_inv @ Q0 in NewtonCDGramSolve.
+        norm2_cols_X -= np.einsum("ji, ji -> i", H0, H00_pinv_H0).reshape(
+            n_classes, -1, order="F"
+        )
+        # Guarantee norm2_cols_X >= 0:
+        norm2_cols_X[norm2_cols_X < 0] = 0
+
+    # time_pre += time(NULL) - tic
+    # tic = time(NULL)
+
+    # Gap Safe Screening Rules, see https://arxiv.org/abs/1802.07481, Eq. 11
+    if do_screening:
+        for k in range(n_classes):
+            n_active[k] = 0
+            for j in range(n_features):
+                if norm2_cols_X_[k, j] == 0:
+                    W_[k, j] = 0
+                    excluded_set[k, j] = 1
+                    continue
+                Xj_theta = XtA_[k, j] / fmax(alpha, dual_norm_XtA)  # X[:,j] @ dual_theta
+                d_j = (1 - fabs(Xj_theta)) / sqrt(norm2_cols_X_[k, j] + beta)
+                if d_j <= sqrt(2 * gap) / alpha:
+                    # include feature j of class k
+                    active_set[k, n_active[k]] = j
+                    excluded_set[k, j] = 0
+                    n_active[k] += 1
+                else:
+                    if W_[k, j] != 0:
+                        # R += w[j] * X[:,j] -> w[k, j] A[:, kj]
+                        # LD_R += w[k, j] * LDL[:, k] * X[:, j]
+                        update_LD_R(
+                            k=k, j=j, w_kj=W_[k, j], X=X_,
+                            X_is_sparse=X_is_sparse, X_data=X_data,
+                            X_indices=X_indices, X_indptr=X_indptr,
+                            sw_proba=sw_proba_,
+                            proba=proba_, H00_pinv_H0=H00_pinv_H0_,
+                            fit_intercept=fit_intercept, LD_R=LD_R_, x_k=x_k_, xx=xx_,
+                        )
+                        W_[k, j] = 0
+                    excluded_set[k, j] = 1
+        if np.sum(n_active) == 0:
+            # We want to guarantee at least one CD step.
+            # n_active[:] = n_features
+            # active_set[:, :] = np.arange(n_features, dtype=np.uint32)[None, :]
+            # excluded_set[:, :] = 0
+            for k in range(n_classes):
+                n_active[k] = n_features
+                for j in range(n_features):
+                    active_set[k, j] = j
+                    excluded_set[k, j] = 0
+
+    # time_screen += time(NULL) - tic
+
+    with nogil:
+        for n_iter in range(max_iter):
+            w_max = 0.0
+            d_w_max = 0.0
+            for k in range(n_classes):  # Loop over coordinates
+                # tic = time(NULL)
+                at_least_one_feature_updated = False
+                # t_k[:] = 0
+                memset(&t_k_[0], 0, n_samples * sizeof(float64_t))
+                if fit_intercept:
+                    # tt[:, :] = 0
+                    memset(&tt_[0, 0], 0, n_samples * n_classes * sizeof(float64_t))
+                # time_r += time(NULL) - tic
+
+                for j in range(n_active[k]):  # Loop over coordinates
+                    # tic = time(NULL)
+                    if do_screening:
+                        j = active_set[k, j]
+
+                    if norm2_cols_X_[k, j] == 0.0:
+                        continue
+                    w_kj = W_[k, j]  # Store previous value
+
+                    if X_is_sparse:
+                        startptr = X_indptr[j]
+                        endptr = X_indptr[j + 1]
+
+                    # tmp = X[:,j].T @ (R + w_j * X[:,j])
+                    #    -> A[:,jk].T @ (R + w_kj * A[:,kj])
+                    # With precomputed LD_R: A'R = X' L sqrt(D) R
+                    # tmp = X[:, j] @ LD_R[:, k] + w_kj * norm2_cols_X[k, j]
+                    if not X_is_sparse:
+                        tmp = _dot(n_samples, &X_[0, j], 1, &LD_R_[0, k], 1)
+                    else:
+                        tmp = 0.0
+                        for i_ind in range(startptr, endptr):
+                            i = X_indices[i_ind]
+                            tmp += LD_R_[i, k] * X_data[i_ind]
+                    tmp += w_kj * norm2_cols_X_[k, j]
+                    # Note: With fit_intercept=True, np.sum(LD_R, axis=0) == 0. So the
+                    # additional term
+                    #   tmp -= H00_pinv_H0[:, n_classes * j + k].T @ np.sum(LD_R, axis=0)
+                    # is zero.
+
+                    W_[k, j] = (
+                        fsign(tmp) * fmax(fabs(tmp) - alpha, 0)
+                        / (norm2_cols_X_[k, j] + beta)
+                    )
+                    # time_w += time(NULL) - tic
+                    # tic = time(NULL)
+
+                    if W_[k, j] != w_kj:
+                        at_least_one_feature_updated = True
+                        # Update residual
+                        # R -= (w[j] - w_j) * X[:,j] -> (w[kj] - w_kj) * A[:,kj]
+                        if not fit_intercept:
+                            # Update rotated residual LD_R instead of R
+                            # L sqrt(D) R -= (w[kj] - w_kj) * LDL[:, k] * X[:, j]
+                            # numpy:
+                            #   x_k[:] = (w_kj - W[k, j]) * X[:, j] * sw_proba[:, k]
+                            #   LD_R[:, k] += (1 - proba[:, k]) * x_k  # diagonal LDL
+                            #   for l in range(n_classes):
+                            #       if l != k:
+                            #           LD_R[:, l] -= proba[:, l] * x_k
+                            # faster version:
+                            #   LD_R[:, k] += x_k
+                            #   LD_R -= proba * x_k[:, None]
+                            if not X_is_sparse:
+                                for i in range(n_samples):
+                                    x_k_[i] = (w_kj - W_[k, j]) * X_[i, j] * sw_proba_[i, k]
+                                    t_k_[i] += x_k_[i]  # accumulation for postponed update
+                                    LD_R_[i, k] += (1 - proba_[i, k]) * x_k_[i]
+                            else:
+                                memset(&x_k_[0], 0, n_samples * sizeof(float64_t))
+                                for i_ind in range(startptr, endptr):
+                                    i = X_indices[i_ind]
+                                    x_k_[i] = (w_kj - W_[k, j]) * X_data[i_ind] * sw_proba_[i, k]
+                                    t_k_[i] += x_k_[i]
+                                    LD_R_[i, k] += (1 - proba_[i, k]) * x_k_[i]
+                            # Postpone updates of LD_R for classes != k.
+                            # for l in range(n_classes):
+                            #     if l != k:
+                            #         for i in range(n_samples):
+                            #             LD_R_[i, l] -= proba_[i, l] * x_k_[i]
+                        else:
+                            # Update rotated residual LD_R instead of R
+                            jn = n_classes * j
+                            # numpy:
+                            #   xx[:, :-1] = -H00_pinv_H0[:, jn + k][None, :]
+                            #   xx[:, -1] = 0
+                            #   xx[:, k] += X[:, j]
+                            #   xx *= (w_kj - W[k, j]) * sw_proba
+                            # L sqrt(D) R += LDL xx
+                            # numpy:
+                            #   for l in range(n_classes):
+                            #       LD_R[:, l] += (1 - proba[:, l]) * xx[:, l]
+                            #       for m in range(l + 1, n_classes):
+                            #           LD_R[:, l] -= proba[:, l] * xx[:, m]
+                            #           LD_R[:, m] -= proba[:, m] * xx[:, l]
+                            # faster version:
+                            #   LD_R -= proba * np.sum(xx, axis=1)[:, None]
+                            #   LD_R += xx
+
+                            # x_k[:] = 0
+                            memset(&x_k_[0], 0, n_samples * sizeof(float64_t))
+                            # xx[:, :] = 0
+                            memset(&xx_[0, 0], 0, n_samples * n_classes * sizeof(float64_t))
+                            # xx[:, k] += X[:, j]
+                            if not X_is_sparse:
+                                _copy(n_samples, &X_[0, j], 1, &xx_[0, k], 1)
+                            else:
+                                for i_ind in range(startptr, endptr):
+                                    i = X_indices[i_ind]
+                                    xx_[i, k] = X_data[i_ind]
+                            for l in range(n_classes - 1):
+                                for i in range(n_samples):
+                                    xx_[i, l] -= H00_pinv_H0_[l, jn + k]
+                                    xx_[i, l] *= (w_kj - W_[k, j]) * sw_proba_[i, l]
+                                    tt_[i, l] += xx_[i, l]
+                                    # LD_R_[i, l] += xx_[i, l]  # postponed
+                                    x_k_[i] += xx_[i, l]  # x_k = np.sum(xx, axis=1)
+                            if k == n_classes - 1:  # H00_pinv_H0[k, :] == 0
+                                l = n_classes - 1
+                                for i in range(n_samples):
+                                    xx_[i, l] *= (w_kj - W_[k, j]) * sw_proba_[i, l]
+                                    tt_[i, l] += xx_[i, l]
+                                    # LD_R_[i, l] += xx_[i, l]  # postponed
+                                    x_k_[i] += xx_[i, l]  # x_k = np.sum(xx, axis=1)
+                            # Postpone updates of LD_R for classes != k.
+                            for i in range(n_samples):
+                                LD_R_[i, k] += xx_[i, k] - proba_[i, k] * x_k_[i]
+                                t_k_[i] += x_k_[i]
+                            # The following is postponed.
+                            # for l in range(n_classes):
+                            #     for i in range(n_samples):
+                            #         LD_R_[i, l] -= proba_[i, l] * x_k_[i]
+
+                    # time_r += time(NULL) - tic
+
+                    # update the maximum absolute coefficient update
+                    d_w_j = fabs(W_[k, j] - w_kj)
+                    d_w_max = fmax(d_w_max, d_w_j)
+                    w_max = fmax(w_max, fabs(W_[k, j]))
+
+                # tic = time(NULL)
+
+                # Postponed updates of LD_R for classes != k .
+                if at_least_one_feature_updated:
+                    if not fit_intercept:
+                        # We accumulated t_k_ = (X @ (w_k - W[k, :])) * sw_proba[:, k]
+                        for l in range(n_classes):
+                            if l != k:
+                                for i in range(n_samples):
+                                    LD_R_[i, l] -= proba_[i, l] * t_k_[i]
+                    else:
+                        for l in range(n_classes):
+                            if l != k:
+                                for i in range(n_samples):
+                                    LD_R_[i, l] += tt_[i, l] - proba_[i, l] * t_k_[i]
+
+                # time_r += time(NULL) - tic
+
+            if w_max == 0.0 or d_w_max / w_max <= d_w_tol or n_iter == max_iter - 1:
+                # tic = time(NULL)
+
+                # The biggest coordinate update of this iteration was smaller than the
+                # tolerance: check the duality gap as ultimate stopping criterion.
+                for k in range(n_classes):
+                    for i in range(n_samples):
+                        R_[i, k] = LD_R_[i, k] / sqrt_sw_[i]
+                # LDL.inverse_L_sqrt_D_matmul(R)
+                inverse_L_sqrt_D_matmul(p=proba_, q_inv=q_inv_, sqrt_d=sqrt_d_, x=R_, buffer=x_k_)
+                gap, dual_norm_XtA = gap_enet_multinomial(
+                    w=W_,
+                    alpha=alpha,
+                    beta=beta,
+                    X=X_,
+                    X_is_sparse=X_is_sparse,
+                    X_data=X_data,
+                    X_indices=X_indices,
+                    X_indptr=X_indptr,
+                    y=b_,
+                    R=R_,
+                    LD_R=LD_R_,
+                    H00_pinv_H0=H00_pinv_H0_,
+                    fit_intercept=fit_intercept,
+                    XtA=XtA_,
+                    gap_smaller_eps=True,
+                )
+                if verbose:
+                    with gil:
+                        print(
+                            f"  inner coordinate descent solver at iter {n_iter} "
+                            f"checks for gap={float(gap)} <= tol={float(tol)} ? {gap <= tol}"
+                        )
+                # time_gap += time(NULL) - tic
+                # tic = time(NULL)
+                if gap <= tol:
+                    # return if we reached desired tolerance
+                    break
+
+                # Gap Safe Screening Rules, see https://arxiv.org/abs/1802.07481, Eq. 11
+                if do_screening:
+                    for k in range(n_classes):
+                        n_active[k] = 0
+                        for j in range(n_features):
+                            if excluded_set[k, j]:
+                                continue
+                            Xj_theta = XtA_[k, j] / fmax(alpha, dual_norm_XtA)  # X[:,j] @ dual_theta
+                            d_j = (1 - fabs(Xj_theta)) / sqrt(norm2_cols_X_[k, j] + beta)
+                            if d_j <= sqrt(2 * gap) / alpha:
+                                # include feature j of class k
+                                active_set[k, n_active[k]] = j
+                                excluded_set[k, j] = 0
+                                n_active[k] += 1
+                            else:
+                                if W_[k, j] != 0:
+                                    # R += w[j] * X[:,j] -> w[k, j] A[:, kj]
+                                    # LD_R += w[k, j] * LDL[:, k] * X[:, j]
+                                    update_LD_R(
+                                        k=k, j=j, w_kj=W_[k, j], X=X_,
+                                        X_is_sparse=X_is_sparse, X_data=X_data,
+                                        X_indices=X_indices, X_indptr=X_indptr,
+                                        sw_proba=sw_proba_,
+                                        proba=proba_, H00_pinv_H0=H00_pinv_H0_,
+                                        fit_intercept=fit_intercept, LD_R=LD_R_, x_k=x_k_, xx=xx_,
+                                    )
+                                W_[k, j] = 0
+                                excluded_set[k, j] = 1
+
+                # time_screen += time(NULL) - tic
+        else:
+            with gil:
+                # for/else, runs if for doesn't end with a `break`
+                message = (
+                    "Objective did not converge. You might want to increase "
+                    "the number of iterations, check the scale of the "
+                    "features or consider increasing regularisation."
+                    f" Duality gap: {gap:.6e}, tolerance: {tol:.3e}"
+                )
+                warnings.warn(message, ConvergenceWarning)
+
+    if fit_intercept:
+        # W0[:-1] = H00_pinv @ (q0 - H0 @ W.ravel(order="F"))
+        W0[:n_classes - 1] = H00_pinv @ (q0 - H0 @ W.ravel(order="F"))
+        # W0[-1] = 0  # was already set at the beginning.
+
+    # time_total = time(NULL) - time_total
+    # print(
+    #     f"{time_pre=:6.4f} {time_gap=:6.4f} {time_screen=:6.4f}\n"
+    #     f"{time_w=:6.4f} {time_r=:6.4f} {time_total=:6.4f}"
+    # )
+    return np.asarray(W_original), gap, tol, n_iter + 1

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -16,6 +16,10 @@ from sklearn.utils._typedefs cimport int32_t, uint8_t, uint32_t
 from sklearn.utils._random cimport our_rand_r
 
 
+cdef extern from "<float.h>":
+    const float FLT_EPSILON
+    const double DBL_EPSILON
+
 # The following two functions are shamelessly copied from the tree code.
 
 cdef enum:
@@ -143,10 +147,16 @@ cdef inline floating dual_gap_formulation_A(
     floating R_norm2,  # R @ R
     floating Ry,  # R @ y
     floating dual_norm_XtA,
+    bint gap_smaller_eps,
 ) noexcept nogil:
     """Compute dual gap according to formulation A."""
     cdef floating gap, primal, dual
     cdef floating scale  # Scaling factor to achieve dual feasible point.
+
+    if floating is float:
+        eps = FLT_EPSILON
+    else:
+        eps = DBL_EPSILON
 
     primal = 0.5 * (R_norm2 + beta * w_l2_norm2) + alpha * w_l1_norm
 
@@ -156,6 +166,8 @@ cdef inline floating dual_gap_formulation_A(
         scale = 1.0
     dual = -0.5 * (scale ** 2) * (R_norm2 + beta * w_l2_norm2) + scale * Ry
     gap = primal - dual
+    if gap_smaller_eps and abs(gap) <= 2 * eps * primal:
+        gap = 0.0
     return gap
 
 
@@ -170,6 +182,7 @@ cdef (floating, floating) gap_enet(
     const floating[::1] R,  # current residuals = y - X @ w
     floating[::1] XtA,  # XtA = X.T @ R - beta * w is calculated inplace
     bint positive,
+    bint gap_smaller_eps,
 ) noexcept nogil:
     """Compute dual gap for use in enet_coordinate_descent.
 
@@ -177,12 +190,17 @@ cdef (floating, floating) gap_enet(
     alpha = 0 & beta > 0: formulation B of the duality gap
     alpha = beta = 0:     OLS first order condition (=gradient)
     """
-    cdef floating gap = 0.0
+    cdef floating gap, primal, dual
     cdef floating dual_norm_XtA
     cdef floating R_norm2
     cdef floating Ry
     cdef floating w_l1_norm
     cdef floating w_l2_norm2 = 0.0
+
+    if floating is float:
+        eps = FLT_EPSILON
+    else:
+        eps = DBL_EPSILON
 
     # w_l2_norm2 = w @ w
     if beta > 0:
@@ -209,8 +227,11 @@ cdef (floating, floating) gap_enet(
             gap = dual_norm_XtA
             return gap, dual_norm_XtA
         # This is Ridge regression, we use formulation B for the dual gap.
-        gap = R_norm2 + 0.5 * beta * w_l2_norm2 - Ry
-        gap += 1 / (2 * beta) * dual_norm_XtA
+        primal = 0.5 * (R_norm2 + beta * w_l2_norm2)
+        dual = -0.5 * R_norm2 + Ry - 1 / (2 * beta) * dual_norm_XtA
+        gap = primal - dual
+        if gap_smaller_eps and abs(gap) <= 2 * eps * primal:
+            gap = 0.0
         return gap, dual_norm_XtA
 
     # XtA = X.T @ R - beta * w
@@ -236,6 +257,7 @@ cdef (floating, floating) gap_enet(
         R_norm2=R_norm2,
         Ry=Ry,
         dual_norm_XtA=dual_norm_XtA,
+        gap_smaller_eps=gap_smaller_eps,
     )
     return gap, dual_norm_XtA
 
@@ -393,7 +415,7 @@ def enet_coordinate_descent(
 
         # Check convergence before entering the main loop.
         gap, dual_norm_XtA = gap_enet(
-            n_samples, n_features, w, alpha, beta, X, y, R, XtA, positive
+            n_samples, n_features, w, alpha, beta, X, y, R, XtA, positive, False
         )
         if gap <= tol:
             with gil:
@@ -461,12 +483,13 @@ def enet_coordinate_descent(
                 w_max == 0.0
                 or d_w_max / w_max <= d_w_tol
                 or n_iter == max_iter - 1
+                or n_active <= 1  # We have an analytical exact solution.
             ):
                 # the biggest coordinate update of this iteration was smaller
                 # than the tolerance: check the duality gap as ultimate
                 # stopping criterion
                 gap, dual_norm_XtA = gap_enet(
-                    n_samples, n_features, w, alpha, beta, X, y, R, XtA, positive
+                    n_samples, n_features, w, alpha, beta, X, y, R, XtA, positive, True
                 )
                 if gap <= tol:
                     # return if we reached desired tolerance
@@ -560,6 +583,7 @@ cdef (floating, floating) gap_enet_sparse(
     floating R_sum,
     floating[::1] XtA,  # XtA = X.T @ R - beta * w is calculated inplace
     bint positive,
+    bint gap_smaller_eps,
 ) noexcept nogil:
     """Compute dual gap for use in sparse_enet_coordinate_descent.
 
@@ -567,13 +591,18 @@ cdef (floating, floating) gap_enet_sparse(
     alpha = 0 & beta > 0: formulation B of the duality gap
     alpha = beta = 0:     OLS first order condition (=gradient)
     """
-    cdef floating gap = 0.0
+    cdef floating gap, primal, dual
     cdef floating dual_norm_XtA
     cdef floating R_norm2
     cdef floating Ry
     cdef floating w_l1_norm
     cdef floating w_l2_norm2 = 0.0
     cdef int32_t i, i_ind, j
+
+    if floating is float:
+        eps = FLT_EPSILON
+    else:
+        eps = DBL_EPSILON
 
     # w_l2_norm2 = w @ w
     if beta > 0:
@@ -613,8 +642,11 @@ cdef (floating, floating) gap_enet_sparse(
             gap = dual_norm_XtA
             return gap, dual_norm_XtA
         # This is Ridge regression, we use formulation B for the dual gap.
-        gap = R_norm2 + 0.5 * beta * w_l2_norm2 - Ry
-        gap += 1 / (2 * beta) * dual_norm_XtA
+        primal = 0.5 * (R_norm2 + beta * w_l2_norm2)
+        dual = -0.5 * R_norm2 + Ry - 1 / (2 * beta) * dual_norm_XtA
+        gap = primal - dual
+        if gap_smaller_eps and abs(gap) <= 2 * eps * primal:
+            gap = 0.0
         return gap, dual_norm_XtA
 
     # XtA = X.T @ R - beta * w
@@ -646,6 +678,7 @@ cdef (floating, floating) gap_enet_sparse(
         R_norm2=R_norm2,
         Ry=Ry,
         dual_norm_XtA=dual_norm_XtA,
+        gap_smaller_eps=gap_smaller_eps,
     )
     return gap, dual_norm_XtA
 
@@ -834,6 +867,7 @@ def sparse_enet_coordinate_descent(
             R_sum,
             XtA,
             positive,
+            False,
         )
         if gap <= tol:
             with gil:
@@ -931,7 +965,12 @@ def sparse_enet_coordinate_descent(
 
                 w_max = fmax(w_max, fabs(w[j]))
 
-            if w_max == 0.0 or d_w_max / w_max <= d_w_tol or n_iter == max_iter - 1:
+            if (
+                w_max == 0.0
+                or d_w_max / w_max <= d_w_tol
+                or n_iter == max_iter - 1
+                or n_active <= 1  # We have an analytical exact solution.
+            ):
                 # the biggest coordinate update of this iteration was smaller than
                 # the tolerance: check the duality gap as ultimate stopping
                 # criterion
@@ -953,6 +992,7 @@ def sparse_enet_coordinate_descent(
                     R_sum,
                     XtA,
                     positive,
+                    True,
                 )
 
                 if gap <= tol:
@@ -1015,6 +1055,7 @@ cdef (floating, floating) gap_enet_gram(
     const floating y_norm2,
     floating[::1] XtA,  # XtA = X.T @ R - beta * w is calculated inplace
     bint positive,
+    bint gap_smaller_eps,
 ) noexcept nogil:
     """Compute dual gap for use in enet_coordinate_descent.
 
@@ -1022,7 +1063,7 @@ cdef (floating, floating) gap_enet_gram(
     alpha = 0 & beta > 0: formulation B of the duality gap
     alpha = beta = 0:     OLS first order condition (=gradient)
     """
-    cdef floating gap = 0.0
+    cdef floating gap, primal, dual
     cdef floating dual_norm_XtA
     cdef floating R_norm2
     cdef floating Ry
@@ -1031,6 +1072,11 @@ cdef (floating, floating) gap_enet_gram(
     cdef floating q_dot_w
     cdef floating wQw
     cdef unsigned int j
+
+    if floating is float:
+        eps = FLT_EPSILON
+    else:
+        eps = DBL_EPSILON
 
     # w_l2_norm2 = w @ w
     if beta > 0:
@@ -1060,8 +1106,11 @@ cdef (floating, floating) gap_enet_gram(
             gap = dual_norm_XtA
             return gap, dual_norm_XtA
         # This is Ridge regression, we use formulation B for the dual gap.
-        gap = R_norm2 + 0.5 * beta * w_l2_norm2 - Ry
-        gap += 1 / (2 * beta) * dual_norm_XtA
+        primal = 0.5 * (R_norm2 + beta * w_l2_norm2)
+        dual = -0.5 * R_norm2 + Ry - 1 / (2 * beta) * dual_norm_XtA
+        gap = primal - dual
+        if gap_smaller_eps and abs(gap) <= 2 * eps * primal:
+            gap = 0.0
         return gap, dual_norm_XtA
 
     # XtA = X.T @ R - beta * w = X.T @ y - X.T @ X @ w - beta * w
@@ -1085,6 +1134,7 @@ cdef (floating, floating) gap_enet_gram(
         R_norm2=R_norm2,
         Ry=Ry,
         dual_norm_XtA=dual_norm_XtA,
+        gap_smaller_eps=gap_smaller_eps,
     )
     return gap, dual_norm_XtA
 
@@ -1174,7 +1224,7 @@ def enet_coordinate_descent_gram(
 
         # Check convergence before entering the main loop.
         gap, dual_norm_XtA = gap_enet_gram(
-            n_features, w, alpha, beta, Qw, q, y_norm2, XtA, positive
+            n_features, w, alpha, beta, Qw, q, y_norm2, XtA, positive, False
         )
         if 0 <= gap <= tol:
             # Only if gap >=0 as singular Q may cause dubious values of gap.
@@ -1243,12 +1293,17 @@ def enet_coordinate_descent_gram(
                 if fabs(w[j]) > w_max:
                     w_max = fabs(w[j])
 
-            if w_max == 0.0 or d_w_max / w_max <= d_w_tol or n_iter == max_iter - 1:
+            if (
+                w_max == 0.0
+                or d_w_max / w_max <= d_w_tol
+                or n_iter == max_iter - 1
+                or n_active <= 1  # We have an analytical exact solution.
+            ):
                 # the biggest coordinate update of this iteration was smaller than
                 # the tolerance: check the duality gap as ultimate stopping
                 # criterion
                 gap, dual_norm_XtA = gap_enet_gram(
-                    n_features, w, alpha, beta, Qw, q, y_norm2, XtA, positive
+                    n_features, w, alpha, beta, Qw, q, y_norm2, XtA, positive, True
                 )
 
                 if gap <= tol:
@@ -1312,6 +1367,7 @@ cdef (floating, floating) gap_enet_multi_task(
     const floating[::1] R_sum,
     floating[:, ::1] XtA,  # out
     floating[::1] XtA_row_norms,  # out
+    bint gap_smaller_eps,
 ) noexcept nogil:
     """Compute dual gap for use in enet_coordinate_descent_multi_task.
 
@@ -1327,7 +1383,7 @@ cdef (floating, floating) gap_enet_multi_task(
     XtA_row_norms : memoryview of shape n_features
         Inplace calculated as np.sqrt(np.sum(XtA ** 2, axis=1))
     """
-    cdef floating gap = 0.0
+    cdef floating gap, primal, dual
     cdef floating dual_norm_XtA
     cdef floating R_norm2
     cdef floating Ry
@@ -1335,6 +1391,11 @@ cdef (floating, floating) gap_enet_multi_task(
     cdef floating w_l2_norm2 = 0.0
     cdef unsigned int t, j
     cdef int32_t i
+
+    if floating is float:
+        eps = FLT_EPSILON
+    else:
+        eps = DBL_EPSILON
 
     # w_l2_norm2 = linalg.norm(W, ord="fro") ** 2
     if beta > 0:
@@ -1375,8 +1436,11 @@ cdef (floating, floating) gap_enet_multi_task(
             gap = dual_norm_XtA
             return gap, dual_norm_XtA
         # This is Ridge regression, we use formulation B for the dual gap.
-        gap = R_norm2 + 0.5 * beta * w_l2_norm2 - Ry
-        gap += 1 / (2 * beta) * dual_norm_XtA
+        primal = 0.5 * (R_norm2 + beta * w_l2_norm2)
+        dual = -0.5 * R_norm2 + Ry - 1 / (2 * beta) * dual_norm_XtA
+        gap = primal - dual
+        if gap_smaller_eps and abs(gap) <= 2 * eps * primal:
+            gap = 0.0
         return gap, dual_norm_XtA
 
     # XtA = X.T @ R - beta * W.T
@@ -1411,6 +1475,7 @@ cdef (floating, floating) gap_enet_multi_task(
         R_norm2=R_norm2,
         Ry=Ry,
         dual_norm_XtA=dual_norm_XtA,
+        gap_smaller_eps=gap_smaller_eps,
     )
     return gap, dual_norm_XtA
 
@@ -1622,6 +1687,7 @@ def enet_coordinate_descent_multi_task(
             R_sum=R_sum,
             XtA=XtA,
             XtA_row_norms=XtA_row_norms,
+            gap_smaller_eps=False,
         )
         if gap <= tol:
             with gil:
@@ -1750,7 +1816,12 @@ def enet_coordinate_descent_multi_task(
                 if W_j_abs_max > w_max:
                     w_max = W_j_abs_max
 
-            if w_max == 0.0 or d_w_max / w_max <= d_w_tol or n_iter == max_iter - 1:
+            if (
+                w_max == 0.0
+                or d_w_max / w_max <= d_w_tol
+                or n_iter == max_iter - 1
+                or n_active <= 1  # We have an analytical exact solution.
+            ):
                 # the biggest coordinate update of this iteration was smaller than
                 # the tolerance: check the duality gap as ultimate stopping
                 # criterion
@@ -1775,6 +1846,7 @@ def enet_coordinate_descent_multi_task(
                     R_sum=R_sum,
                     XtA=XtA,
                     XtA_row_norms=XtA_row_norms,
+                    gap_smaller_eps=True,
                 )
                 if gap <= tol:
                     # return if we reached desired tolerance

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -670,6 +670,7 @@ def enet_path(
     random_state = params.pop("random_state", None)
     selection = params.pop("selection", "cyclic")
     do_screening = params.pop("do_screening", True)
+    early_stopping = params.pop("early_stopping", True)
 
     if len(params) > 0:
         raise ValueError("Unexpected parameters in params", params.keys())
@@ -797,6 +798,7 @@ def enet_path(
                 random=random,
                 positive=positive,
                 do_screening=do_screening,
+                early_stopping=early_stopping,
             )
         elif multi_output:
             model = cd_fast.enet_coordinate_descent_multi_task(
@@ -816,6 +818,7 @@ def enet_path(
                 rng=rng,
                 random=random,
                 do_screening=do_screening,
+                early_stopping=early_stopping,
             )
         elif isinstance(precompute, np.ndarray):
             # We expect precompute to be already Fortran ordered when bypassing
@@ -835,6 +838,7 @@ def enet_path(
                 random,
                 positive,
                 do_screening,
+                early_stopping,
             )
         elif precompute is False:
             model = cd_fast.enet_coordinate_descent(
@@ -849,6 +853,7 @@ def enet_path(
                 random,
                 positive,
                 do_screening,
+                early_stopping,
             )
         else:
             raise ValueError(

--- a/sklearn/linear_model/_glm/_newton_solver.py
+++ b/sklearn/linear_model/_glm/_newton_solver.py
@@ -14,9 +14,88 @@ import scipy.optimize
 
 from sklearn._loss.loss import HalfSquaredError
 from sklearn.exceptions import ConvergenceWarning
+from sklearn.linear_model._cd_fast import (
+    enet_coordinate_descent_gram,
+)
 from sklearn.linear_model._linear_loss import LinearModelLoss
 from sklearn.utils.fixes import _get_additional_lbfgs_options_dict
 from sklearn.utils.optimize import _check_optimize_result
+
+
+def min_norm_subgradient(alpha, gradient, coef, linear_loss):
+    """Component-wise minimum norm subgradient of the loss function.
+
+    The subgradient of f(x) + alpha ||x||_1 with the minimum L2 norm is defined
+    component-wise, i.e. for component j:
+
+        mn_sg(f(x) + alpha ||x||_1)_j =
+            f'(x)_j + alpha                        if x_j > 0
+            f'(x)_j - alpha                        if x_j < 0
+            sign(f'(x)_j) max(|f'(x)| - alpha, 0)  if x_j = 0
+
+    for positive alpha. See between equations (26) and (27) in
+    Yuan, Ho, Lin (2011).
+
+    Parameters
+    ----------
+    alpha : float
+        The L1 penalty strength.
+
+    gradient : ndarray of shape coef.shape
+        The gradient of f(coef), i.e. f'(coef)
+
+    coef : ndarray of shape (n_dof,) or (n_classes * n_dof,) or (n_classes, n_dof)
+
+    linear_loss: LinearModelLoss
+        Contains some meta information.
+
+    Returns
+    -------
+    ndarray of shape gradient.shape
+
+    References
+    ----------
+    - Yuan, G., Ho, C., & Lin, C. (2011). "An improved GLMNET for l1-regularized
+      logistic regression." Journal of machine learning research.
+      https://doi.org/10.1145/2020408.2020421
+    """
+    if alpha == 0:
+        return gradient
+
+    if gradient.shape != coef.shape or coef.ndim > 2:
+        raise ValueError(
+            "Shapes of 'gradient' and 'coef' must match, dimension must be smaller 3; "
+            f"got {gradient.shape=} and {coef.shape=}."
+        )
+    if gradient.ndim == 1:
+        result = gradient.copy()
+    else:
+        result = gradient.flatten(order="F")  # flatten returns a copy
+        coef = coef.ravel(order="F")
+    # mn_sgrad = minimum norm subgradient
+    if linear_loss.fit_intercept:
+        # For the intercept we just leave the gradient untouched.
+        if linear_loss.base_loss.is_multiclass:
+            n_classes = linear_loss.base_loss.n_classes
+            mn_sgrad = result[:-n_classes]  # mn_sgrad is a view
+        else:
+            mn_sgrad = result[:-1]  # mn_sgrad is a view
+    else:
+        mn_sgrad = result
+    weights, intercept = linear_loss.weight_intercept(coef)
+    # For multiclass, weights.shape = (n_classes, n_features), flatten again.
+    if linear_loss.base_loss.is_multiclass:
+        weights = weights.ravel(order="F")
+    mn_sgrad[weights > 0] += alpha
+    mn_sgrad[weights < 0] -= alpha
+    mask = weights == 0
+    mn_sgrad[mask] = np.sign(mn_sgrad[mask]) * np.fmax(
+        np.abs(mn_sgrad[mask]) - alpha, 0
+    )
+    if gradient.ndim == 1:
+        return result
+    else:
+        return result.reshape(gradient.shape, order="F")
 
 
 class NewtonSolver(ABC):
@@ -53,6 +132,15 @@ class NewtonSolver(ABC):
       Cambridge University Press, 2004.
       https://web.stanford.edu/~boyd/cvxbook/bv_cvxbook.pdf
 
+    - Lee, J., Sun, Y., & Saunders, M.A. (2012). "Proximal Newton-Type Methods for
+      Minimizing Composite Functions." SIAM J. Optim., 24, 1420-1443.
+      https://doi.org/10.1137/130921428
+      https://arxiv.org/abs/1206.1623
+
+    - Yuan, G., Ho, C., & Lin, C. (2011). "An improved GLMNET for l1-regularized
+      logistic regression." Journal of machine learning research.
+      https://doi.org/10.1145/2020408.2020421
+
     Parameters
     ----------
     coef : ndarray of shape (n_dof,), (n_classes, n_dof) or (n_classes * n_dof,)
@@ -63,6 +151,9 @@ class NewtonSolver(ABC):
 
     linear_loss : LinearModelLoss
         The loss to be minimized.
+
+    l1_reg_strength : float, default=0.0
+        L1 regularization strength. This needs special care as it is non-smooth.
 
     l2_reg_strength : float, default=0.0
         L2 regularization strength.
@@ -122,6 +213,7 @@ class NewtonSolver(ABC):
         *,
         coef,
         linear_loss=LinearModelLoss(base_loss=HalfSquaredError(), fit_intercept=True),
+        l1_reg_strength=0.0,
         l2_reg_strength=0.0,
         tol=1e-4,
         max_iter=100,
@@ -130,6 +222,7 @@ class NewtonSolver(ABC):
     ):
         self.coef = coef
         self.linear_loss = linear_loss
+        self.l1_reg_strength = l1_reg_strength
         self.l2_reg_strength = l2_reg_strength
         self.tol = tol
         self.max_iter = max_iter
@@ -151,6 +244,7 @@ class NewtonSolver(ABC):
             X=X,
             y=y,
             sample_weight=sample_weight,
+            l1_reg_strength=self.l1_reg_strength,
             l2_reg_strength=self.l2_reg_strength,
             n_threads=self.n_threads,
             raw_prediction=self.raw_prediction,
@@ -198,7 +292,7 @@ class NewtonSolver(ABC):
                 "ftol": 64 * np.finfo(np.float64).eps,
                 **_get_additional_lbfgs_options_dict("iprint", self.verbose - 1),
             },
-            args=(X, y, sample_weight, self.l2_reg_strength, self.n_threads),
+            args=(X, y, sample_weight, 0, self.l2_reg_strength, self.n_threads),
         )
         self.iteration += _check_optimize_result("lbfgs", opt_res, max_iter=max_iter)
         self.coef = opt_res.x
@@ -207,7 +301,11 @@ class NewtonSolver(ABC):
             self.coef = self.coef.reshape(coef_shape, order="F")
 
     def line_search(self, X, y, sample_weight):
-        """Backtracking line search.
+        """Backtracking line search with Armijo condition.
+
+        Backtracking line search with sufficient decrease condition, i.e. Armijo
+        condition, is enough, no curvature condition needed, see Algorithm 3.1 of
+        Nocedal & Wright 2nd ed.
 
         Sets:
             - self.coef_old
@@ -225,19 +323,29 @@ class NewtonSolver(ABC):
         eps = 16 * np.finfo(X.dtype).eps
         t = 1  # step size
 
-        # gradient_times_newton = self.gradient @ self.coef_newton
-        # was computed in inner_solve.
-        armijo_term = sigma * self.gradient_times_newton
-        _, _, raw_prediction_newton = self.linear_loss.weight_intercept_raw(
-            self.coef_newton, X
-        )
-
         self.coef_old = self.coef
         self.loss_value_old = self.loss_value
         self.gradient_old = self.gradient
 
+        # gradient_times_newton = self.gradient @ self.coef_newton
+        # was computed in inner_solve.
+        armijo_term = sigma * self.gradient_times_newton
+        if self.l1_reg_strength > 0:
+            # add ||coef||_1 - ||coef_old||_1, see Eq. 2.19 and 2.14 of
+            # Lee, Sun, Saunder (2012) "Proximal Newton-Type Methods"
+            L1 = self.linear_loss.l1_penalty(
+                self.coef + self.coef_newton, self.l1_reg_strength
+            )
+            L1_old = self.linear_loss.l1_penalty(self.coef_old, self.l1_reg_strength)
+            armijo_term += sigma * (L1 - L1_old)
+
+        _, _, raw_prediction_newton = self.linear_loss.weight_intercept_raw(
+            self.coef_newton, X
+        )
+
         # np.sum(np.abs(self.gradient_old))
-        sum_abs_grad_old = -1
+        sum_abs_grad_old = None
+        g_max_abs_old = None
 
         is_verbose = self.verbose >= 2
         if is_verbose:
@@ -252,6 +360,7 @@ class NewtonSolver(ABC):
                 X=X,
                 y=y,
                 sample_weight=sample_weight,
+                l1_reg_strength=self.l1_reg_strength,
                 l2_reg_strength=self.l2_reg_strength,
                 n_threads=self.n_threads,
                 raw_prediction=raw,
@@ -272,7 +381,39 @@ class NewtonSolver(ABC):
                 )
             if check:
                 break
-            # 2. Deal with relative loss differences around machine precision.
+            # 2. Deal with too small loss improvements (Armijo not satisfied) that
+            #    nevertheless result in a good reduction of the gradient norm which is
+            #    our final stopping criterion.
+            #    The author could not find justification in literature. It might be one
+            #    of those improvements only practical implementations incorporate.
+            #    The value of 1/8 = 0.125 is pure expert judgement, no derivation.
+            if g_max_abs_old is None:
+                mnsg_old = min_norm_subgradient(
+                    self.l1_reg_strength,
+                    self.gradient_old,
+                    self.coef_old,
+                    self.linear_loss,
+                )
+                sum_abs_grad_old = np.linalg.norm(mnsg_old.ravel(), ord=1)
+                g_max_abs_old = np.linalg.norm(mnsg_old.ravel(), ord=np.inf)
+            mnsg = min_norm_subgradient(
+                self.l1_reg_strength,
+                self.gradient,
+                self.coef,
+                self.linear_loss,
+            )
+            sum_abs_grad = np.linalg.norm(mnsg.ravel(), ord=1)
+            g_max_abs = np.linalg.norm(mnsg.ravel(), ord=np.inf)
+            check = (loss_improvement < 0) and (g_max_abs < 0.125 * g_max_abs_old)
+            if is_verbose:
+                print(
+                    f"      check loss improvement < 0: {loss_improvement} < 0; and "
+                    "max |gradient| <= 1/8 * max |gradient_old|: "
+                    f"{g_max_abs} <= {0.125 * g_max_abs_old} {check}"
+                )
+            if check:
+                break
+            # 3. Deal with relative loss differences around machine precision.
             tiny_loss = np.abs(self.loss_value_old * eps)
             check = np.abs(loss_improvement) <= tiny_loss
             if is_verbose:
@@ -281,10 +422,7 @@ class NewtonSolver(ABC):
                     f" {np.abs(loss_improvement)} <= {tiny_loss} {check}"
                 )
             if check:
-                if sum_abs_grad_old < 0:
-                    sum_abs_grad_old = scipy.linalg.norm(self.gradient_old, ord=1)
-                # 2.1 Check sum of absolute gradients as alternative condition.
-                sum_abs_grad = scipy.linalg.norm(self.gradient, ord=1)
+                # 3.1 Check sum of absolute gradients as alternative condition.
                 check = sum_abs_grad < sum_abs_grad_old
                 if is_verbose:
                     print(
@@ -331,11 +469,24 @@ class NewtonSolver(ABC):
         # check = change <= tol
 
         # 1. Criterion: maximum |gradient| <= tol
-        #    The gradient was already updated in line_search()
-        g_max_abs = np.max(np.abs(self.gradient))
+        #    With L1 penalty: maximum |minimum-norm subgradient| <= tol
+        #    Note: The gradient was already updated in line_search()
+        #    Note: Yuan, Ho, Lin (2011) argue for the L1-norm instead of the
+        #          infinity-norm. We do not find their argument that much convincing
+        #          and, as above, use the infinity norm.
+        mnsg = min_norm_subgradient(
+            self.l1_reg_strength, self.gradient, self.coef, self.linear_loss
+        )  # equals gradient if l1_reg_strength = 0.
+        g_max_abs = np.linalg.norm(mnsg.ravel(), ord=np.inf)
         check = g_max_abs <= self.tol
         if self.verbose:
-            print(f"    1. max |gradient| {g_max_abs} <= {self.tol} {check}")
+            if self.l1_reg_strength == 0:
+                print(f"    1. max |gradient| {g_max_abs} <= {self.tol} {check}")
+            else:
+                print(
+                    "    1. max |minimum L2-norm subgradient|"
+                    f" {g_max_abs} <= {self.tol} {check}"
+                )
         if not check:
             return
 
@@ -343,7 +494,7 @@ class NewtonSolver(ABC):
         #       d = sqrt(grad @ hessian^-1 @ grad)
         #         = sqrt(coef_newton @ hessian @ coef_newton)
         #    See Boyd, Vanderberghe (2009) "Convex Optimization" Chapter 9.5.1. and
-        #    Eq. 20 of Yuan, Ho, Lin (2011).
+        #    Eq. 2.14, 2.15 of Lee, Sun, Saunder (2012) "Proximal Newton-Type Methods".
         d2 = self.compute_d2(X, sample_weight=sample_weight)
         check = 0.5 * d2 <= self.tol
         if self.verbose:
@@ -357,6 +508,7 @@ class NewtonSolver(ABC):
                 X=X,
                 y=y,
                 sample_weight=sample_weight,
+                l1_reg_strength=self.l1_reg_strength,
                 l2_reg_strength=self.l2_reg_strength,
                 n_threads=self.n_threads,
             )
@@ -389,6 +541,8 @@ class NewtonSolver(ABC):
         coef : ndarray of shape (n_dof,), (n_classes, n_dof) or (n_classes * n_dof,)
             Solution of the optimization problem.
         """
+        if self.verbose:
+            print(self.__class__.__name__)
         # setup usually:
         #   - initializes self.coef if needed
         #   - initializes and calculates self.raw_predictions, self.loss_value
@@ -461,6 +615,28 @@ class NewtonCholeskySolver(NewtonSolver):
     solver.
     """
 
+    def __init__(
+        self,
+        *,
+        coef,
+        linear_loss=LinearModelLoss(base_loss=HalfSquaredError(), fit_intercept=True),
+        l2_reg_strength=0.0,
+        tol=1e-4,
+        max_iter=100,
+        n_threads=1,
+        verbose=0,
+    ):
+        super().__init__(
+            coef=coef,
+            linear_loss=linear_loss,
+            l1_reg_strength=0,
+            l2_reg_strength=l2_reg_strength,
+            tol=tol,
+            max_iter=max_iter,
+            n_threads=n_threads,
+            verbose=verbose,
+        )
+
     def setup(self, X, y, sample_weight):
         super().setup(X=X, y=y, sample_weight=sample_weight)
         if self.linear_loss.base_loss.is_multiclass:
@@ -519,24 +695,12 @@ class NewtonCholeskySolver(NewtonSolver):
             hess_pointwise_out=self.hess_pointwise,
         )
 
-    def inner_solve(self, X, y, sample_weight):
-        if self.hessian_warning:
-            warnings.warn(
-                (
-                    f"The inner solver of {self.__class__.__name__} detected a "
-                    "pointwise hessian with many negative values at iteration "
-                    f"#{self.iteration}. It will now resort to lbfgs instead."
-                ),
-                ConvergenceWarning,
-            )
-            if self.verbose:
-                print(
-                    "  The inner solver detected a pointwise Hessian with many "
-                    "negative values and resorts to lbfgs instead."
-                )
-            self.use_fallback_lbfgs_solve = True
-            return
+    def prepare_gradient_hessian(self):
+        """Prepare gradient and hessian, in particular for multiclass case.
 
+        This can't go into update_gradient_hessian because we need to keep the original
+        self.gradient and self.hessian for line search and convergence checks.
+        """
         # Note: The following case distinction could also be shifted to the
         # implementation of HalfMultinomialLoss instead of here within the solver.
         if self.is_multinomial_no_penalty:
@@ -587,6 +751,27 @@ class NewtonCholeskySolver(NewtonSolver):
             gradient, hessian = self.gradient[:-1], self.hessian[:-1, :-1]
         else:
             gradient, hessian = self.gradient, self.hessian
+        return gradient, hessian
+
+    def inner_solve(self, X, y, sample_weight):
+        if self.hessian_warning:
+            warnings.warn(
+                (
+                    f"The inner solver of {self.__class__.__name__} detected a "
+                    "pointwise hessian with many negative values at iteration "
+                    f"#{self.iteration}. It will now resort to lbfgs instead."
+                ),
+                ConvergenceWarning,
+            )
+            if self.verbose:
+                print(
+                    "  The inner solver detected a pointwise Hessian with many "
+                    "negative values and resorts to lbfgs instead."
+                )
+            self.use_fallback_lbfgs_solve = True
+            return
+
+        gradient, hessian = self.prepare_gradient_hessian()
 
         try:
             with warnings.catch_warnings():
@@ -595,6 +780,8 @@ class NewtonCholeskySolver(NewtonSolver):
                     hessian, -gradient, check_finite=False, assume_a="sym"
                 )
                 if self.is_multinomial_no_penalty:
+                    n_classes = self.linear_loss.base_loss.n_classes
+                    n_dof = self.coef.size // n_classes  # degree of freedom per class
                     self.coef_newton = np.c_[
                         self.coef_newton.reshape(n_dof, n_classes - 1), np.zeros(n_dof)
                     ].reshape(-1)
@@ -656,3 +843,326 @@ class NewtonCholeskySolver(NewtonSolver):
             # Only the intercept needs an update to the symmetric parametrization.
             n_classes = self.linear_loss.base_loss.n_classes
             self.coef[-n_classes:] -= np.mean(self.coef[-n_classes:])
+
+
+class NewtonCDGramSolver(NewtonCholeskySolver):
+    """Coordinate Descent Gram inner solver for a Newton solver.
+
+    This solver can deal with L1 and L2 penalties.
+
+    The inner solver for finding the Newton step H w_newton = -g uses coordinate
+    descent:
+
+        H @ coef_newton = -G
+
+    With an L1 penalty, it is better to write down the minimization problem and use
+    the 2nd order Taylor approximation only on the smooth parts (loss and L2), see
+    Eq. 13 of Yuan, Ho, Lin (2011)
+
+        min 1/2 d' H d + G' d + l1_reg ||coef + d||_1 - l1_reg ||coef||_1
+
+    with d = coef_newton and coef = current coefficients.
+    To circumvent the norm ||coef + d||_1, we instead minimized for
+    c = coef_new = coef + d. This gives, up to constant terms
+
+        min 1/2 c' H c + (G' - coef' H) c + l1_reg ||c||_1
+
+    with
+        c = coef_new = coef + coef_newton
+        coef = current coefficients
+        G = X.T @ g + l2_reg_strength * P @ coef
+        H = X.T @ diag(h) @ X + l2_reg_strength * P
+        g = loss.gradient = pointwise gradient
+        h = loss.hessian = pointwise hessian
+        P = penalty matrix in 1/2 w @ P @ w,
+            for a pure L2 penalty without intercept it equals the identity matrix.
+
+    This minimization problem is then solved by enet_coordinate_descent_gram.
+
+    Note that this solver can naturally deal with sparse X.
+    """
+
+    def __init__(
+        self,
+        *,
+        coef,
+        linear_loss=LinearModelLoss(base_loss=HalfSquaredError(), fit_intercept=True),
+        l1_reg_strength=0.0,
+        l2_reg_strength=0.0,
+        tol=1e-4,
+        max_iter=100,
+        n_threads=1,
+        verbose=0,
+    ):
+        super(NewtonCholeskySolver, self).__init__(
+            coef=coef,
+            linear_loss=linear_loss,
+            l1_reg_strength=l1_reg_strength,
+            l2_reg_strength=l2_reg_strength,
+            tol=tol,
+            max_iter=max_iter,
+            n_threads=n_threads,
+            verbose=verbose,
+        )
+        self.inner_tol = self.tol
+
+    def setup(self, X, y, sample_weight):
+        super().setup(X=X, y=y, sample_weight=sample_weight)
+        self.is_multinomial_no_penalty = (
+            self.linear_loss.base_loss.is_multiclass
+            and self.l1_reg_strength == 0
+            and self.l2_reg_strength == 0
+        )
+
+        # Memory buffers for Q_centered because it can be a large array.
+        if self.linear_loss.fit_intercept:
+            n_features = X.shape[1]
+            n_classes = self.linear_loss.base_loss.n_classes
+            if self.is_multinomial_no_penalty:
+                n = (n_classes - 1) * n_features
+            elif self.linear_loss.base_loss.is_multiclass:
+                n = n_classes * n_features
+            else:
+                n = n_features
+            self.Q_centered = np.empty(shape=(n, n), dtype=X.dtype, order="C")
+
+    def update_gradient_hessian(self, X, y, sample_weight):
+        # Same as NewtonCholesky but without the L2 penalty which is directly passed to
+        # the CD solver.
+        l2_reg = self.l2_reg_strength
+        self.l2_reg_strength = 0
+        super().update_gradient_hessian(X=X, y=y, sample_weight=sample_weight)
+        self.l2_reg_strength = l2_reg
+
+        if not self.linear_loss.base_loss.is_multiclass:
+            # For non-canonical link functions and far away from the optimum, the
+            # pointwise hessian can be negative.
+            # We need non-negative hessians as we take the square root.
+            # TODO: This should be done LinearModelLoss.gradient_hessian, as now we
+            # have a slight inconsistency between hess_pointwise and the full hessian.
+            np.maximum(0, self.hess_pointwise, out=self.hess_pointwise)
+
+    def fallback_lbfgs_solve(self, X, y, sample_weight):
+        if self.l1_reg_strength == 0:
+            super().fallback_lbfgs_solve(X, y, sample_weight)
+        else:
+            # TODO(newton-cd): For the time being, we just honestly fail.
+            cname = self.__class__.__name__
+            msg = (
+                f"This solver, {cname}, does not have a fallback for non-zero L1 "
+                "penalties."
+            )
+            raise ConvergenceWarning(msg)
+
+    def inner_solve(self, X, y, sample_weight):
+        if self.hessian_warning:
+            # TODO(newton-cd): Think about raising an error as there is no fallback.
+            raise warnings.warn(
+                (
+                    f"The inner solver of {self.__class__.__name__} detected a "
+                    "pointwise hessian with many negative values at iteration "
+                    f"#{self.iteration}."
+                ),
+                ConvergenceWarning,
+            )
+
+        n_samples, n_features = X.shape
+        gradient, hessian = self.prepare_gradient_hessian()
+
+        if self.linear_loss.base_loss.is_multiclass:
+            # Often needed variables for the multinomial.
+            n_classes = self.linear_loss.base_loss.n_classes
+            n_dof = self.coef.size // n_classes  # degree of freedom per class
+
+        # Set w (coefficient passed to enet-cd) and Hcoef = H @ coef.
+        if self.is_multinomial_no_penalty:
+            # This is similar to penalized multinomial, but on top the last class per
+            # feature was set to zero together with the corresponding elements in
+            # gradient and hessian.
+            coef = self.coef.reshape(-1, n_classes)[:, :-1].flatten()
+            Hcoef = hessian @ coef
+            if self.linear_loss.fit_intercept:
+                # n_pc = number of effective coefficients, we keep the name from below.
+                n_pc = (n_classes - 1) * (n_dof - 1)
+            else:
+                n_pc = (n_classes - 1) * n_dof
+            w = coef[:n_pc].copy()
+        elif self.is_multinomial_with_intercept:
+            Hcoef = hessian @ self.coef[:-1]
+            n_pc = n_classes * (n_dof - 1)  # number of penalized coefficients
+            w = self.coef[:n_pc].copy()
+        elif self.linear_loss.fit_intercept:
+            Hcoef = hessian @ self.coef
+            w = self.coef[:-1].copy()
+        else:
+            Hcoef = hessian @ self.coef
+            w = self.coef.copy()
+
+        # We minimize the 2. order Taylor approximation of the loss:
+        #   1/2 c' H c + (G' - coef' H) c + l1_reg ||c||_1
+        # c = coef_new = coef + coef_newton
+        # Expressed with c = coef_new instead of coef_newton, such that L1 penalty fits
+        # the formulation of our CD solver, which minimizes
+        #   1/2 w' Q w - q' w + alpha ||w||_1
+        # Neglecting intercepts and multiclass, this amounts to setting
+        #   q = coef' H - G'= hessian @ coef - gradient
+        #   Q = H
+        if not self.linear_loss.fit_intercept:
+            Q_centered = hessian
+            q_centered = Hcoef - gradient
+        elif not self.linear_loss.base_loss.is_multiclass:
+            # We need to separate the intercept c0. CD solver solves
+            #   min 1/2 w' Q w - q' w + alpha ||w||_1
+            # Write
+            #   Q_full = (Q  Q0')
+            #            (Q0 Q00)
+            # Optimizing only the intercept term w0 gives (unpenalized)
+            # w0_optimal  = argmin_{w0} 1/2 w0' Q00 w0 - (q0 - Q0' w) w0
+            #             = (q0 - Q0' w) / Q00
+            # Inserting w0_optimal back into the objective (min instead of argmin)
+            #   min_{w0} ... = -1/2 (q0 - Q0' w)' (q0 - Q0' w) / Q00
+            # Added to the objective without intercept, we get
+            #   obj = 1/2 w (Q - Q0 Q0' / Q00) w - (q - q0 Q0' / Q00) w + const
+            Hcoef = hessian @ self.coef
+            Q = hessian[:-1, :-1]  # shape (n_features, n_features)
+            Q0 = hessian[-1, :-1]  # shape (n_features,)
+            Q00 = hessian[-1, -1]  # float
+            q = Hcoef[:-1] - gradient[:-1]
+            q0 = Hcoef[-1] - gradient[-1]
+            # Q_centered = Q - np.outer(Q0, Q0 / Q00)
+            Q_centered = self.Q_centered  # use allocated memory
+            np.copyto(dst=Q_centered, src=Q)
+            Q_centered -= np.outer(Q0, Q0 / Q00)
+            q_centered = q - q0 / Q00 * Q0
+        else:
+            # For the general treatment of the multinomial case, see
+            # NewtonCholeskySolver.prepare_gradient_hessian.
+            # In principle, this is the same case as fit_intercept above. Note:
+            # - The intecept of the last class is set to zero and the corresponding
+            #   element/row/column has been removed from the arrays gradient and
+            #   hessian, see prepare_gradient_hessian.
+            # - The step of minimizing the intercept terms alone is more complicated
+            #   compared to above, because Q00 is now a 2-d array of shape
+            #   (n_classes - 1, n_classes - 1). As it is usually a small array, we dare
+            #   to compute its inverse (as it is used several times).
+            Q = hessian[:n_pc, :n_pc]  # shape (n_pc, n_pc)
+            Q0 = hessian[n_pc:, :n_pc]  # shape (n_classes - 1, n_pc)
+            Q00 = hessian[n_pc:, n_pc:]  # shape (n_classes - 1, n_classes - 1)
+            Q00_inv = np.linalg.pinv(Q00)
+            q = Hcoef[:n_pc] - gradient[:n_pc]  # shape (n_pc,)
+            q0 = Hcoef[n_pc:] - gradient[n_pc:]  # shape (n_classes - 1,)
+            Q0t_Q00_inv = Q0.T @ Q00_inv
+            # Q_centered = Q - Q0t_Q00_inv @ Q0
+            Q_centered = self.Q_centered  # use allocated memory
+            np.copyto(dst=Q_centered, src=Q)
+            Q_centered -= Q0t_Q00_inv @ Q0
+            q_centered = q - Q0t_Q00_inv @ q0
+
+        # Which "y" to pass to enet_coordinate_descent_gram? It only effects the
+        # stopping tolerance and the dual gap computation but not the coefficient
+        # updates. A simple np.ones(n_samples) works. But we want to take advantage of
+        # gap safe screening rules. Therefore, a correct dual gap is important.
+        # For 1-d targets we need to write the objective as weighted least squares
+        #   1/2 c' H c - q' c = 1/2 ||diag(sqrt(h))(y -  X c)||_2^2 + const
+        # This gives
+        #   y' diag(h) X c = q' c
+        #   y = -g / h + X coef
+        if self.linear_loss.base_loss.is_multiclass:
+            # TODO(newton-cd): This is still the simple solution.
+            y_cd = np.ones(shape=n_samples, dtype=X.dtype)
+        else:
+            y_cd = self.raw_prediction.copy()
+            h_zero = self.hess_pointwise != 0
+            y_cd[h_zero] -= self.grad_pointwise[h_zero] / self.hess_pointwise[h_zero]
+            if self.linear_loss.fit_intercept:
+                # As if applying _pre_fit(X, y_cd, ..).
+                y_cd -= np.average(y_cd, axis=0, weights=self.hess_pointwise)
+            y_cd *= np.sqrt(self.hess_pointwise)
+
+        with warnings.catch_warnings():
+            # Ignore warnings that add little information for users.
+            warnings.simplefilter("ignore", ConvergenceWarning)
+            w, gap, inner_tol, n_inner_iter = enet_coordinate_descent_gram(
+                w=w,
+                alpha=self.l1_reg_strength,
+                beta=self.l2_reg_strength,
+                Q=Q_centered,
+                q=q_centered,
+                y=y_cd,  # used in dual gap
+                max_iter=1000,  # TODO(newton-cd): improve
+                tol=self.inner_tol,
+                rng=np.random.RandomState(0),
+                random=False,
+                positive=False,
+                early_stopping=False,
+            )
+
+        # Set self.coef_newton and compute intercept terms.
+        if n_inner_iter == 0:
+            # Safeguard: if nothing changed nothing should change in this iter.
+            # Without it, intercept terms might change.
+            self.coef_newton = np.zeros_like(self.coef)
+        elif self.is_multinomial_no_penalty:
+            if self.linear_loss.fit_intercept:
+                # Add intercept tems but for the last class
+                intercepts = Q00_inv @ (q0 - Q0 @ w)
+                w = np.r_[w, intercepts]
+            # Add all zeros for the last class, intercept and coefficients.
+            w = w.reshape(-1, n_classes - 1)
+            w = np.c_[w, np.zeros(w.shape[0])].flatten()
+            self.coef_newton = w - self.coef
+        elif self.is_multinomial_with_intercept:
+            intercepts = Q00_inv @ (q0 - Q0 @ w)
+            self.coef_newton = np.r_[w, intercepts, 0] - self.coef
+        elif self.linear_loss.fit_intercept:
+            self.coef_newton = np.r_[w, (q0 - Q0 @ w) / Q00] - self.coef
+        else:
+            self.coef_newton = w - self.coef
+
+        # Tighten inner stopping criterion, see Chapter 6.1 of "An Improved GLMNET".
+        if n_inner_iter == 0:
+            self.inner_tol *= 0.1
+        elif n_inner_iter <= 4:  # "An Improved GLMNET" uses n_inner_iter <= 1
+            self.inner_tol *= 0.25
+        # elif n_inner_iter <= 8:
+        #     # TODO(newton-cd): Check if this improves convergence
+        #     self.inner_tol *= 0.5
+
+        if self.verbose >= 2:
+            print(
+                f"  Inner coordinate descent solver stopped with {n_inner_iter} "
+                f"iterations and a dualilty gap={float(gap)}."
+            )
+
+        if self.l2_reg_strength:
+            # We neglected the l2_reg_strength in update_gradient_hessian. We correct it
+            # now for the gradient.
+            weights, _ = self.linear_loss.weight_intercept(self.coef)
+            if self.linear_loss.base_loss.is_multiclass:
+                # weights.shape = (n_classes, n_dof)
+                self.gradient.reshape((n_classes, -1), order="F")[:, :n_features] += (
+                    self.l2_reg_strength * weights
+                )
+            else:
+                self.gradient[:n_features] += self.l2_reg_strength * weights
+
+        self.gradient_times_newton = self.gradient @ self.coef_newton
+        if self.gradient_times_newton > 0:
+            if self.verbose:
+                # TODO(newton-cd): What to do?
+                print(
+                    "  The inner solver found a Newton step that is not a "
+                    "descent direction."
+                )
+            return
+
+        return
+
+    def compute_d2(self, X, sample_weight):
+        """Compute square of Newton decrement."""
+        d2 = self.coef_newton @ self.hessian @ self.coef_newton
+        if self.l2_reg_strength > 0:
+            # We neglected the l2_reg_strength in update_gradient_hessian.
+            weights, intercept = self.linear_loss.weight_intercept(self.coef_newton)
+            d2 += 2 * self.linear_loss.l2_penalty(weights, self.l2_reg_strength)
+        return d2

--- a/sklearn/linear_model/_glm/_newton_solver.py
+++ b/sklearn/linear_model/_glm/_newton_solver.py
@@ -20,6 +20,7 @@ from sklearn.linear_model._base import _pre_fit
 from sklearn.linear_model._cd_fast import (
     enet_coordinate_descent,
     enet_coordinate_descent_gram,
+    enet_coordinate_descent_multinomial,
     sparse_enet_coordinate_descent,
 )
 from sklearn.linear_model._linear_loss import (
@@ -1466,23 +1467,21 @@ class NewtonCDSolver(NewtonSolver):
             with warnings.catch_warnings():
                 # Ignore warnings that add little information for users.
                 warnings.simplefilter("ignore", ConvergenceWarning)
-                _, gap, inner_tol, n_inner_iter = (
-                    enet_coordinate_descent_multinomial_py(
-                        W=w,
-                        alpha=self.l1_reg_strength,
-                        beta=self.l2_reg_strength,
-                        X=X,
-                        sample_weight=sample_weight,
-                        raw_prediction=self.raw_prediction,
-                        grad_pointwise=self.grad_pointwise,
-                        proba=proba,
-                        fit_intercept=self.linear_loss.fit_intercept,
-                        max_iter=1000,  # TODO(newton-cd): improve
-                        tol=self.inner_tol,
-                        do_screening=True,
-                        early_stopping=False,
-                        verbose=max(0, self.verbose - 3),  # True for verbose >= 4
-                    )
+                _, gap, inner_tol, n_inner_iter = enet_coordinate_descent_multinomial(
+                    W=w,
+                    alpha=self.l1_reg_strength,
+                    beta=self.l2_reg_strength,
+                    X=X,
+                    sample_weight=sample_weight,
+                    raw_prediction=self.raw_prediction,
+                    grad_pointwise=self.grad_pointwise,
+                    proba=proba,
+                    fit_intercept=self.linear_loss.fit_intercept,
+                    max_iter=1000,  # TODO(newton-cd): improve
+                    tol=self.inner_tol,
+                    do_screening=True,
+                    early_stopping=False,
+                    verbose=max(0, self.verbose - 3),  # True for verbose >= 4
                 )
 
             # Set self.coef_newton.

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -19,7 +19,11 @@ from sklearn._loss.loss import (
     HalfTweedieLossIdentity,
 )
 from sklearn.base import BaseEstimator, RegressorMixin, _fit_context
-from sklearn.linear_model._glm._newton_solver import NewtonCholeskySolver, NewtonSolver
+from sklearn.linear_model._glm._newton_solver import (
+    NewtonCDGramSolver,
+    NewtonCholeskySolver,
+    NewtonSolver,
+)
 from sklearn.linear_model._linear_loss import LinearModelLoss
 from sklearn.utils import check_array
 from sklearn.utils._array_api import (
@@ -154,6 +158,7 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
         "fit_intercept": ["boolean"],
         "solver": [
             StrOptions({"lbfgs", "newton-cholesky"}),
+            Hidden(StrOptions({"newton-cd"})),
             Hidden(type),
         ],
         "max_iter": [Interval(Integral, 1, None, closed="left")],
@@ -291,7 +296,7 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
                     "ftol": 64 * np.finfo(float).eps,
                     **_get_additional_lbfgs_options_dict("iprint", self.verbose - 1),
                 },
-                args=(X, y, sample_weight, l2_reg_strength, n_threads),
+                args=(X, y, sample_weight, 0, l2_reg_strength, n_threads),
             )
             self.n_iter_ = _check_optimize_result(
                 "lbfgs", opt_res, max_iter=self.max_iter
@@ -302,10 +307,16 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
                 dtype=X.dtype,
                 device=device_,
             )
-        elif self.solver == "newton-cholesky":
-            sol = NewtonCholeskySolver(
+        elif self.solver in ("newton-cd", "newton-cholesky"):
+            sol = (
+                NewtonCDGramSolver
+                if self.solver == "newton-cd"
+                else NewtonCholeskySolver
+            )
+            sol = sol(
                 coef=coef,
                 linear_loss=linear_loss,
+                # l1_reg_strength=0.0,  # default value for NewtonCDGramSolver
                 l2_reg_strength=l2_reg_strength,
                 tol=self.tol,
                 max_iter=self.max_iter,

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -21,6 +21,7 @@ from sklearn._loss.loss import (
 from sklearn.base import BaseEstimator, RegressorMixin, _fit_context
 from sklearn.linear_model._glm._newton_solver import (
     NewtonCDGramSolver,
+    NewtonCDSolver,
     NewtonCholeskySolver,
     NewtonSolver,
 )
@@ -158,7 +159,7 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
         "fit_intercept": ["boolean"],
         "solver": [
             StrOptions({"lbfgs", "newton-cholesky"}),
-            Hidden(StrOptions({"newton-cd"})),
+            Hidden(StrOptions({"newton-cd", "newton-cd-gram"})),
             Hidden(type),
         ],
         "max_iter": [Interval(Integral, 1, None, closed="left")],
@@ -211,8 +212,9 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
             self,
             X,
             y,
-            accept_sparse=["csc", "csr"],
+            accept_sparse="csc" if self.solver == "newton-cd" else ["csc", "csr"],
             dtype=[xp.float64, xp.float32],
+            order="F" if self.solver == "newton-cd" else None,
             y_numeric=True,
             multi_output=False,
         )
@@ -307,12 +309,12 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
                 dtype=X.dtype,
                 device=device_,
             )
-        elif self.solver in ("newton-cd", "newton-cholesky"):
-            sol = (
-                NewtonCDGramSolver
-                if self.solver == "newton-cd"
-                else NewtonCholeskySolver
-            )
+        elif self.solver in ("newton-cd", "newton-cd-gram", "newton-cholesky"):
+            sol = {
+                "newton-cd": NewtonCDSolver,
+                "newton-cd-gram": NewtonCDGramSolver,
+                "newton-cholesky": NewtonCholeskySolver,
+            }[self.solver]
             sol = sol(
                 coef=coef,
                 linear_loss=linear_loss,

--- a/sklearn/linear_model/_glm/tests/test_glm.py
+++ b/sklearn/linear_model/_glm/tests/test_glm.py
@@ -38,7 +38,7 @@ from sklearn.utils._array_api import (
 )
 from sklearn.utils._testing import _array_api_for_tests, assert_allclose
 
-SOLVERS = ["lbfgs", "newton-cd", "newton-cholesky"]
+SOLVERS = ["lbfgs", "newton-cd", "newton-cd-gram", "newton-cholesky"]
 
 
 class BinomialRegressor(_GeneralizedLinearRegressor):
@@ -358,8 +358,7 @@ def test_glm_regression_unpenalized(solver, fit_intercept, glm_dataset):
         alpha=alpha,
         fit_intercept=fit_intercept,
         solver=solver,
-        # TODO(newton-cd): Once the CD solver are better with ridge/ols.
-        tol=1e-13 if solver == "newton-cd" else 1e-12,
+        tol=1e-12,
         max_iter=1000,
     )
     is_newton_solver = solver.startswith("newton")
@@ -443,8 +442,7 @@ def test_glm_regression_unpenalized_hstacked_X(solver, fit_intercept, glm_datase
         alpha=alpha,
         fit_intercept=fit_intercept,
         solver=solver,
-        # TODO(newton-cd): Once the CD solver are better with ridge/ols.
-        tol=1e-13 if solver == "newton-cd" else 1e-12,
+        tol=1e-12,
         max_iter=1000,
     )
     is_newton_solver = solver.startswith("newton")
@@ -490,7 +488,7 @@ def test_glm_regression_unpenalized_hstacked_X(solver, fit_intercept, glm_datase
     if n_samples > n_features:
         assert model_intercept == pytest.approx(intercept)
         rtol = 1e-4
-        if solver == "newton-cd":
+        if solver in ["newton-cd", "newton-cd-gram"]:
             # This solver finds a solution, but a different linear combination.
             p = coef.shape[0]
             assert_allclose(model_coef[:p] + model_coef[p:], 2 * coef, rtol=rtol)
@@ -536,8 +534,7 @@ def test_glm_regression_unpenalized_vstacked_X(solver, fit_intercept, glm_datase
         alpha=alpha,
         fit_intercept=fit_intercept,
         solver=solver,
-        # TODO(newton-cd): Once the CD solver are better with ridge/ols.
-        tol=1e-13 if solver == "newton-cd" else 1e-12,
+        tol=1e-12,
         max_iter=1000,
     )
     is_newton_solver = solver.startswith("newton")
@@ -734,8 +731,7 @@ def test_glm_log_regression(solver, fit_intercept, estimator):
         alpha=0,
         fit_intercept=fit_intercept,
         solver=solver,
-        # TODO(newton-cd): Once the CD solver are better with ridge/ols.
-        tol=1e-13 if solver == "newton-cd" else 1e-8,
+        tol=1e-8,
     )
     if fit_intercept:
         res = glm.fit(X[:, :-1], y)

--- a/sklearn/linear_model/_glm/tests/test_glm.py
+++ b/sklearn/linear_model/_glm/tests/test_glm.py
@@ -38,7 +38,7 @@ from sklearn.utils._array_api import (
 )
 from sklearn.utils._testing import _array_api_for_tests, assert_allclose
 
-SOLVERS = ["lbfgs", "newton-cholesky"]
+SOLVERS = ["lbfgs", "newton-cd", "newton-cholesky"]
 
 
 class BinomialRegressor(_GeneralizedLinearRegressor):
@@ -358,9 +358,11 @@ def test_glm_regression_unpenalized(solver, fit_intercept, glm_dataset):
         alpha=alpha,
         fit_intercept=fit_intercept,
         solver=solver,
-        tol=1e-12,
+        # TODO(newton-cd): Once the CD solver are better with ridge/ols.
+        tol=1e-13 if solver == "newton-cd" else 1e-12,
         max_iter=1000,
     )
+    is_newton_solver = solver.startswith("newton")
 
     model = clone(model).set_params(**params)
     if fit_intercept:
@@ -371,7 +373,7 @@ def test_glm_regression_unpenalized(solver, fit_intercept, glm_dataset):
         intercept = 0
 
     with warnings.catch_warnings():
-        if solver.startswith("newton") and n_samples < n_features:
+        if solver == "newton-cholesky" and n_samples < n_features:
             # The newton solvers should warn and automatically fallback to LBFGS
             # in this case. The model should still converge.
             warnings.filterwarnings("ignore", category=scipy.linalg.LinAlgWarning)
@@ -393,13 +395,13 @@ def test_glm_regression_unpenalized(solver, fit_intercept, glm_dataset):
         # As it is an underdetermined problem, prediction = y. The following shows that
         # we get a solution, i.e. a (non-unique) minimum of the objective function ...
         rtol = 5e-5
-        if solver == "newton-cholesky":
+        if is_newton_solver:
             rtol = 5e-4
         assert_allclose(model.predict(X), y, rtol=rtol)
 
         norm_solution = np.linalg.norm(np.r_[intercept, coef])
         norm_model = np.linalg.norm(np.r_[model.intercept_, model.coef_])
-        if solver == "newton-cholesky":
+        if is_newton_solver:
             # XXX: This solver shows random behaviour. Sometimes it finds solutions
             # with norm_model <= norm_solution! So we check conditionally.
             if norm_model < (1 + 1e-12) * norm_solution:
@@ -441,9 +443,11 @@ def test_glm_regression_unpenalized_hstacked_X(solver, fit_intercept, glm_datase
         alpha=alpha,
         fit_intercept=fit_intercept,
         solver=solver,
-        tol=1e-12,
+        # TODO(newton-cd): Once the CD solver are better with ridge/ols.
+        tol=1e-13 if solver == "newton-cd" else 1e-12,
         max_iter=1000,
     )
+    is_newton_solver = solver.startswith("newton")
 
     model = clone(model).set_params(**params)
     if fit_intercept:
@@ -462,7 +466,7 @@ def test_glm_regression_unpenalized_hstacked_X(solver, fit_intercept, glm_datase
     assert np.linalg.matrix_rank(X) <= min(n_samples, n_features)
 
     with warnings.catch_warnings():
-        if solver.startswith("newton"):
+        if solver == "newton-cholesky":
             # The newton solvers should warn and automatically fallback to LBFGS
             # in this case. The model should still converge.
             warnings.filterwarnings("ignore", category=scipy.linalg.LinAlgWarning)
@@ -486,13 +490,18 @@ def test_glm_regression_unpenalized_hstacked_X(solver, fit_intercept, glm_datase
     if n_samples > n_features:
         assert model_intercept == pytest.approx(intercept)
         rtol = 1e-4
-        assert_allclose(model_coef, np.r_[coef, coef], rtol=rtol)
+        if solver == "newton-cd":
+            # This solver finds a solution, but a different linear combination.
+            p = coef.shape[0]
+            assert_allclose(model_coef[:p] + model_coef[p:], 2 * coef, rtol=rtol)
+        else:
+            assert_allclose(model_coef, np.r_[coef, coef], rtol=rtol)
     else:
         # As it is an underdetermined problem, prediction = y. The following shows that
         # we get a solution, i.e. a (non-unique) minimum of the objective function ...
         rtol = 1e-6 if solver == "lbfgs" else 5e-6
         assert_allclose(model.predict(X), y, rtol=rtol)
-        if (solver == "lbfgs" and fit_intercept) or solver == "newton-cholesky":
+        if (solver == "lbfgs" and fit_intercept) or is_newton_solver:
             # Same as in test_glm_regression_unpenalized.
             # But it is not the minimum norm solution. Otherwise the norms would be
             # equal.
@@ -527,9 +536,11 @@ def test_glm_regression_unpenalized_vstacked_X(solver, fit_intercept, glm_datase
         alpha=alpha,
         fit_intercept=fit_intercept,
         solver=solver,
-        tol=1e-12,
+        # TODO(newton-cd): Once the CD solver are better with ridge/ols.
+        tol=1e-13 if solver == "newton-cd" else 1e-12,
         max_iter=1000,
     )
+    is_newton_solver = solver.startswith("newton")
 
     model = clone(model).set_params(**params)
     if fit_intercept:
@@ -543,7 +554,7 @@ def test_glm_regression_unpenalized_vstacked_X(solver, fit_intercept, glm_datase
     y = np.r_[y, y]
 
     with warnings.catch_warnings():
-        if solver.startswith("newton") and n_samples < n_features:
+        if solver == "newton-cholesky" and n_samples < n_features:
             # The newton solvers should warn and automatically fallback to LBFGS
             # in this case. The model should still converge.
             warnings.filterwarnings("ignore", category=scipy.linalg.LinAlgWarning)
@@ -566,7 +577,7 @@ def test_glm_regression_unpenalized_vstacked_X(solver, fit_intercept, glm_datase
 
         norm_solution = np.linalg.norm(np.r_[intercept, coef])
         norm_model = np.linalg.norm(np.r_[model.intercept_, model.coef_])
-        if solver == "newton-cholesky":
+        if is_newton_solver:
             # XXX: This solver shows random behaviour. Sometimes it finds solutions
             # with norm_model <= norm_solution! So we check conditionally.
             if not (norm_model > (1 + 1e-12) * norm_solution):
@@ -578,7 +589,7 @@ def test_glm_regression_unpenalized_vstacked_X(solver, fit_intercept, glm_datase
             # equal.
             assert norm_model > (1 + 1e-12) * norm_solution
         else:
-            rtol = 1e-5 if solver == "newton-cholesky" else 1e-4
+            rtol = 1e-5 if is_newton_solver else 1e-4
             assert model.intercept_ == pytest.approx(intercept, rel=rtol)
             assert_allclose(model.coef_, coef, rtol=rtol)
 
@@ -723,7 +734,8 @@ def test_glm_log_regression(solver, fit_intercept, estimator):
         alpha=0,
         fit_intercept=fit_intercept,
         solver=solver,
-        tol=1e-8,
+        # TODO(newton-cd): Once the CD solver are better with ridge/ols.
+        tol=1e-13 if solver == "newton-cd" else 1e-8,
     )
     if fit_intercept:
         res = glm.fit(X[:, :-1], y)
@@ -864,7 +876,7 @@ def test_normal_ridge_comparison(
     assert_allclose(glm.predict(X_test), ridge.predict(X_test), rtol=2e-4)
 
 
-@pytest.mark.parametrize("solver", ["lbfgs", "newton-cholesky"])
+@pytest.mark.parametrize("solver", SOLVERS)
 def test_poisson_glmnet(solver):
     """Compare Poisson regression with L2 regularization and LogLink to glmnet"""
     # library("glmnet")

--- a/sklearn/linear_model/_glm/tests/test_newton_solver.py
+++ b/sklearn/linear_model/_glm/tests/test_newton_solver.py
@@ -1,0 +1,62 @@
+# Authors: The scikit-learn developers
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Most of the solvers are tested elsewhere. Here, we only test certrain low level
+# aspects.
+import numpy as np
+
+from sklearn._loss import HalfMultinomialLoss, HalfSquaredError
+from sklearn.linear_model._glm._newton_solver import (
+    min_norm_subgradient,
+)
+from sklearn.linear_model._linear_loss import LinearModelLoss
+from sklearn.utils._testing import assert_allclose
+
+
+def test_min_norm_subgradient():
+    coef = np.array([-2.0, 1, 0, 1])  # coef[-1] might be the intercept
+
+    # The test is mostly independent on the choice of base_loss, with the exception of
+    # shapes.
+    linear_loss = LinearModelLoss(base_loss=HalfSquaredError(), fit_intercept=True)
+    alpha = 8.0  # l1_reg_strength
+    grad = np.full_like(coef, 2.0)
+    mnsg = min_norm_subgradient(alpha, grad, coef, linear_loss)
+    assert_allclose(mnsg, [2 - 8, 2 + 8, 0, 2])
+
+    grad = np.full_like(coef, -9.0)
+    mnsg = min_norm_subgradient(alpha, grad, coef, linear_loss)
+    assert_allclose(mnsg, [-9 - 8, -9 + 8, -1 * (9 - 8), -9])
+
+    linear_loss = LinearModelLoss(base_loss=HalfSquaredError(), fit_intercept=False)
+    alpha = 1.0
+    grad = np.full_like(coef, 2.0)
+    mnsg = min_norm_subgradient(alpha, grad, coef, linear_loss)
+    assert_allclose(mnsg, [2 - 1, 2 + 1, +1 * (2 - 1), 2 + 1])
+
+    mnsg = min_norm_subgradient(alpha, -grad, coef, linear_loss)
+    assert_allclose(mnsg, [-2 - 1, -2 + 1, -1 * (2 - 1), -2 + 1])
+
+    grad = np.full_like(coef, -9.0)
+    mnsg = min_norm_subgradient(alpha, grad, coef, linear_loss)
+    assert_allclose(mnsg, [-9 - 1, -9 + 1, -1 * (9 - 1), -9 + 1])
+
+    n_classes = 3
+    coef = np.repeat(coef, n_classes)
+    linear_loss = LinearModelLoss(base_loss=HalfMultinomialLoss(), fit_intercept=True)
+    alpha = 1.0
+    grad = np.full_like(coef, 2.0)
+    mnsg = min_norm_subgradient(alpha, grad, coef, linear_loss)
+    expected = np.repeat([2 - 1, 2 + 1, +1 * (2 - 1), 2], 3)
+    assert_allclose(mnsg, expected)
+
+    # Same as above but with 2-dim coef, coef.shape = (n_classes, n_features)
+    coef = coef.reshape(n_classes, -1, order="F")
+    grad = grad.reshape(n_classes, -1, order="F")
+    expected = expected.reshape(n_classes, -1, order="F")
+    mnsg = min_norm_subgradient(alpha, grad, coef, linear_loss)
+    assert_allclose(mnsg, expected)
+
+    # alpha = 0
+    mnsg = min_norm_subgradient(0, grad, coef, linear_loss)
+    assert mnsg is grad

--- a/sklearn/linear_model/_glm/tests/test_newton_solver.py
+++ b/sklearn/linear_model/_glm/tests/test_newton_solver.py
@@ -4,13 +4,22 @@
 # Most of the solvers are tested elsewhere. Here, we only test certrain low level
 # aspects.
 import numpy as np
+import pytest
+from scipy import sparse
 
 from sklearn._loss import HalfMultinomialLoss, HalfSquaredError
+from sklearn.linear_model._cd_fast import enet_coordinate_descent_gram
 from sklearn.linear_model._glm._newton_solver import (
+    enet_coordinate_descent_multinomial_py,
     min_norm_subgradient,
 )
-from sklearn.linear_model._linear_loss import LinearModelLoss
+from sklearn.linear_model._linear_loss import (
+    LinearModelLoss,
+    Multinomial_LDL_Decomposition,
+)
 from sklearn.utils._testing import assert_allclose
+from sklearn.utils.extmath import softmax
+from sklearn.utils.fixes import parse_version, sp_version
 
 
 def test_min_norm_subgradient():
@@ -60,3 +69,168 @@ def test_min_norm_subgradient():
     # alpha = 0
     mnsg = min_norm_subgradient(0, grad, coef, linear_loss)
     assert mnsg is grad
+
+
+@pytest.mark.skipif(
+    sp_version < parse_version("1.17"),
+    reason="scipy version 1.17 required for sparse slicing",
+)
+@pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
+@pytest.mark.parametrize("cd_multinomial", [enet_coordinate_descent_multinomial_py])
+@pytest.mark.parametrize("sparse_X", [False, True])
+@pytest.mark.parametrize("alpha", [0, 1])
+@pytest.mark.parametrize("max_iter", [1, 5])
+def test_cd_multinomial(cd_multinomial, sparse_X, alpha, max_iter):
+    """Test that enet_coordinate_descent_multinomial is equivalent to
+    enet_coordinate_descent_gram."""
+    n_samples, n_features, n_classes = 5, 2, 3
+    beta = 1
+    W = np.zeros((n_classes, n_features), dtype=np.float64, order="F")
+    y = np.arange(n_samples, dtype=np.float64) % n_classes
+    X = np.zeros((n_samples, n_features), order="F")
+
+    W.flat = np.arange(n_classes * n_features)
+    W -= np.mean(W, axis=0)[None, :]
+    X[:, 0] = np.arange(n_samples)
+    X[:, 1] = 1
+    raw = np.asfortranarray(X @ W.T)
+    proba = np.asfortranarray(softmax(raw))
+    lin_loss = LinearModelLoss(
+        HalfMultinomialLoss(n_classes=n_classes), fit_intercept=False
+    )
+    grad_pointwise = lin_loss.base_loss.gradient(y_true=y, raw_prediction=raw)
+    grad_pointwise /= n_samples
+    LDL = Multinomial_LDL_Decomposition(proba=proba)
+    sqrt_D_Lt_raw = LDL.sqrt_D_Lt_matmul(raw.copy()) / np.sqrt(n_samples)
+    b = sqrt_D_Lt_raw - LDL.inverse_L_sqrt_D_matmul(grad_pointwise.copy()) * np.sqrt(
+        n_samples
+    )
+
+    # As in NewtonCDGramSolver, but correct y=b.
+    wflat = W.flatten(order="F")  # returns copy
+    G, H, _ = lin_loss.gradient_hessian(coef=wflat, X=X, y=y, l2_reg_strength=0)
+    # Note that we need to change the order of features and classes to mimic
+    # the CD loop order in enet_coordinate_descent_multinomial: first classes, then
+    # innermost features. Therefore we need to rearrange/reshape w, q and Q from F-
+    # to C-order.
+    w_gram, gap_gram, tol, n_iter = enet_coordinate_descent_gram(
+        w=wflat.reshape(n_classes, -1, order="F").ravel(order="C"),
+        alpha=alpha,
+        beta=beta,
+        Q=H.reshape(n_classes, n_features, n_classes, n_features, order="F").reshape(
+            n_classes * n_features, n_classes * n_features, order="C"
+        ),
+        q=(H @ wflat - G).reshape(n_classes, -1, order="F").ravel(order="C"),
+        y=b.ravel(),  # used in dual gap
+        max_iter=max_iter,
+        tol=1e-20,
+        rng=np.random.RandomState(0),
+        random=False,
+        positive=False,
+        early_stopping=False,
+    )
+    # As in NewtonCDSolver
+    w_cd, gap_cd, tol, n_iter = cd_multinomial(
+        W=W.copy(order="F"),
+        alpha=alpha,
+        beta=beta,
+        X=sparse.csc_array(X) if sparse_X else X,
+        sample_weight=None,
+        raw_prediction=raw,
+        grad_pointwise=grad_pointwise,
+        proba=proba,
+        fit_intercept=False,
+        max_iter=max_iter,
+        tol=1e-20,
+        early_stopping=False,
+    )
+    assert_allclose(w_cd, w_gram.reshape(n_classes, -1, order="C"))
+    assert gap_cd == pytest.approx(gap_gram, abs=5e-9)
+
+    # Now the same, but WITH INTERCEPT, such that we have the same raw_prediction and
+    # same proba as above.
+    X = np.asfortranarray(X[:, 0:1])
+    assert_allclose(X @ W[:, :-1].T + W[:, -1], raw)
+    # A0 = sqrt(D) L' 1
+    A0 = np.zeros((n_samples, n_classes, n_classes))
+    for k in range(n_classes):
+        A0[:, k, k] = LDL.sqrt_d[:, k]
+        for l in range(k + 1, n_classes):
+            A0[:, k, l] = -LDL.sqrt_d[:, k] * LDL.p[:, l] * LDL.q_inv[:, k]
+    A0 /= np.sqrt(n_samples)
+    A0tA0 = np.einsum("ijk,ijl->kl", A0, A0)
+    # is the same as
+    # A0tA0 = np.tensordot(A0, A0, axes=([0, 1], [0, 1]))
+    lin_loss = LinearModelLoss(
+        HalfMultinomialLoss(n_classes=n_classes), fit_intercept=True
+    )
+    G, H, _ = lin_loss.gradient_hessian(
+        coef=W.ravel(order="F"), X=X, y=y, l2_reg_strength=0
+    )
+    Hcoef = H @ W.ravel(order="F")
+    H0_coef = Hcoef[-n_classes:]
+    H0 = H[-n_classes:, :-n_classes]  # shape (n_classes, n_classes * n_features)
+    H00 = H[-n_classes:, -n_classes:]
+    H00_inv = np.linalg.pinv(H00)
+    H = H[:-n_classes, :-n_classes]  # only the part without intercepts
+    q = Hcoef[:-n_classes] - G[:-n_classes]
+    q0 = Hcoef[-n_classes:] - G[-n_classes:]
+    H_centered = H - H0.T @ H00_inv @ H0
+    q_centered = q - H0.T @ H00_inv @ q0
+
+    assert_allclose(A0tA0, H00)
+
+    H00_pinv_H0 = H00_inv @ H0
+    raw_centered = raw - W[:, -1]
+    raw_centered -= (H00_pinv_H0 @ W[:, :-1].ravel(order="F"))[None, :]
+    sqrt_D_Lt_raw = LDL.sqrt_D_Lt_matmul(raw_centered) / np.sqrt(n_samples)
+    t = H00_inv @ grad_pointwise.sum(axis=0)  # H00^(-1) 1' g
+    g_pointwise_centered = grad_pointwise.copy()
+    for k in range(n_classes):
+        h = proba[:, k] * (1 - proba[:, k]) / n_samples
+        g_pointwise_centered[:, k] -= h * t[k]
+        for l in range(k + 1, n_classes):
+            h = -proba[:, k] * proba[:, l] / n_samples
+            g_pointwise_centered[:, k] -= h * t[l]
+            g_pointwise_centered[:, l] -= h * t[k]
+    b = sqrt_D_Lt_raw - LDL.inverse_L_sqrt_D_matmul(g_pointwise_centered) * np.sqrt(
+        n_samples
+    )
+
+    # residual
+    R = b - sqrt_D_Lt_raw
+    # rotated residual
+    LD_R = LDL.L_sqrt_D_matmul(R / np.sqrt(n_samples))
+    # With fit_intercept, if should sum to zero over samples.
+    assert_allclose(np.sum(LD_R, axis=0), 0, atol=1e-14)
+
+    w_gram, gap_gram, tol, n_iter = enet_coordinate_descent_gram(
+        w=W[:, :-1].ravel(order="F").copy(),
+        alpha=alpha,
+        beta=beta,
+        Q=H_centered,  # only 1 feature, so no reshaping
+        q=q_centered,
+        y=b.ravel(),  # used in dual gap
+        max_iter=max_iter,
+        tol=1e-20,
+        rng=np.random.RandomState(0),
+        random=False,
+        positive=False,
+        early_stopping=False,
+    )
+    w_cd, gap_cd, tol, n_iter = cd_multinomial(
+        W=W.copy(order="F"),
+        alpha=alpha,
+        beta=beta,
+        X=sparse.csc_array(X) if sparse_X else X,
+        sample_weight=None,
+        raw_prediction=raw,
+        grad_pointwise=grad_pointwise,
+        proba=proba,
+        fit_intercept=True,
+        max_iter=max_iter,
+        tol=1e-20,
+        early_stopping=False,
+    )
+    assert_allclose(w_cd[:, :-1], w_gram.reshape(n_classes, -1, order="F"))
+    assert gap_cd == pytest.approx(gap_gram, abs=5e-9)

--- a/sklearn/linear_model/_glm/tests/test_newton_solver.py
+++ b/sklearn/linear_model/_glm/tests/test_newton_solver.py
@@ -8,7 +8,10 @@ import pytest
 from scipy import sparse
 
 from sklearn._loss import HalfMultinomialLoss, HalfSquaredError
-from sklearn.linear_model._cd_fast import enet_coordinate_descent_gram
+from sklearn.linear_model._cd_fast import (
+    enet_coordinate_descent_gram,
+    enet_coordinate_descent_multinomial,
+)
 from sklearn.linear_model._glm._newton_solver import (
     enet_coordinate_descent_multinomial_py,
     min_norm_subgradient,
@@ -76,7 +79,10 @@ def test_min_norm_subgradient():
     reason="scipy version 1.17 required for sparse slicing",
 )
 @pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
-@pytest.mark.parametrize("cd_multinomial", [enet_coordinate_descent_multinomial_py])
+@pytest.mark.parametrize(
+    "cd_multinomial",
+    [enet_coordinate_descent_multinomial, enet_coordinate_descent_multinomial_py],
+)
 @pytest.mark.parametrize("sparse_X", [False, True])
 @pytest.mark.parametrize("alpha", [0, 1])
 @pytest.mark.parametrize("max_iter", [1, 5])

--- a/sklearn/linear_model/_linear_loss.py
+++ b/sklearn/linear_model/_linear_loss.py
@@ -49,19 +49,23 @@ class LinearModelLoss:
 
     Note that raw_prediction is also known as linear predictor.
 
-    The loss is the average of per sample losses and includes a term for L2
+    The loss is the average of per sample losses and includes a term for L1 and L2
     regularization::
 
         loss = 1 / s_sum * sum_i s_i loss(y_i, X_i @ coef + intercept)
                + 1/2 * l2_reg_strength * ||coef||_2^2
+               + l1_reg_strength * ||coef||_1
 
     with sample weights s_i=1 if sample_weight=None and s_sum=sum_i s_i.
+    Note that the L1 penalty is not taken into account for gradient and hessian.
 
     Gradient and hessian, for simplicity without intercept, are::
 
         gradient = 1 / s_sum * X.T @ loss.gradient + l2_reg_strength * coef
         hessian = 1 / s_sum * X.T @ diag(loss.hessian) @ X
                   + l2_reg_strength * identity
+
+    The L1 penalty NEVER enters gradient or hessian, only loss.
 
     Conventions:
         if fit_intercept:
@@ -223,8 +227,17 @@ class LinearModelLoss:
 
         return weights, intercept, raw_prediction
 
+    def l1_penalty(self, weights, l1_reg_strength):
+        """Compute L1 penalty term l1_reg_strength * ||w||_1."""
+        if weights.ndim != 1:
+            # L1/L1 norm
+            norm1_w = np.sum(np.abs(weights))
+        else:
+            norm1_w = np.linalg.norm(weights, ord=1)
+        return float(l1_reg_strength * norm1_w)
+
     def l2_penalty(self, weights, l2_reg_strength):
-        """Compute L2 penalty term l2_reg_strength/2 *||w||_2^2."""
+        """Compute L2 penalty term l2_reg_strength / 2 * ||w||_2^2."""
         norm2_w = weights @ weights if weights.ndim == 1 else squared_norm(weights)
         return float(0.5 * l2_reg_strength * norm2_w)
 
@@ -234,6 +247,7 @@ class LinearModelLoss:
         X,
         y,
         sample_weight=None,
+        l1_reg_strength=0.0,
         l2_reg_strength=0.0,
         n_threads=1,
         raw_prediction=None,
@@ -253,6 +267,8 @@ class LinearModelLoss:
             Observed, true target values.
         sample_weight : None or contiguous array of shape (n_samples,), default=None
             Sample weights.
+        l1_reg_strength : float, default=0.0
+            L1 regularization strength
         l2_reg_strength : float, default=0.0
             L2 regularization strength
         n_threads : int, default=1
@@ -283,9 +299,10 @@ class LinearModelLoss:
         sw_sum = n_samples if sample_weight is None else xp.sum(sample_weight)
         loss = float(xp.sum(loss) / sw_sum)
 
+        if l1_reg_strength > 0:
+            loss += self.l1_penalty(weights, l1_reg_strength)
         if l2_reg_strength > 0:
             loss += self.l2_penalty(weights, l2_reg_strength)
-
         return loss
 
     def loss_gradient(
@@ -294,6 +311,7 @@ class LinearModelLoss:
         X,
         y,
         sample_weight=None,
+        l1_reg_strength=0.0,
         l2_reg_strength=0.0,
         n_threads=1,
         raw_prediction=None,
@@ -313,6 +331,8 @@ class LinearModelLoss:
             Observed, true target values.
         sample_weight : None or contiguous array of shape (n_samples,), default=None
             Sample weights.
+        l1_reg_strength : float, default=0.0
+            L1 regularization strength
         l2_reg_strength : float, default=0.0
             L2 regularization strength
         n_threads : int, default=1
@@ -347,7 +367,10 @@ class LinearModelLoss:
         xp, _ = get_namespace(X, y, sample_weight)
         sw_sum = n_samples if sample_weight is None else xp.sum(sample_weight)
         loss = float(xp.sum(loss) / sw_sum)
-        loss += self.l2_penalty(weights, l2_reg_strength)
+        if l1_reg_strength > 0:
+            loss += self.l1_penalty(weights, l1_reg_strength)
+        if l2_reg_strength > 0:
+            loss += self.l2_penalty(weights, l2_reg_strength)
 
         grad_pointwise /= sw_sum
 
@@ -378,12 +401,15 @@ class LinearModelLoss:
 
         return loss, grad
 
+    # Note: From here on, l1_reg_strength is unused. But we want to ensure the same
+    # function signature across all those functions.
     def gradient(
         self,
         coef,
         X,
         y,
         sample_weight=None,
+        l1_reg_strength=0.0,
         l2_reg_strength=0.0,
         n_threads=1,
         raw_prediction=None,
@@ -403,6 +429,8 @@ class LinearModelLoss:
             Observed, true target values.
         sample_weight : None or contiguous array of shape (n_samples,), default=None
             Sample weights.
+        l1_reg_strength : float, default=0.0
+            Unused L1 regularization strength.
         l2_reg_strength : float, default=0.0
             L2 regularization strength
         n_threads : int, default=1
@@ -457,6 +485,7 @@ class LinearModelLoss:
         X,
         y,
         sample_weight=None,
+        l1_reg_strength=0.0,
         l2_reg_strength=0.0,
         n_threads=1,
         gradient_out=None,
@@ -480,6 +509,8 @@ class LinearModelLoss:
             Observed, true target values.
         sample_weight : None or contiguous array of shape (n_samples,), default=None
             Sample weights.
+        l1_reg_strength : float, default=0.0
+            Unused L1 regularization strength.
         l2_reg_strength : float, default=0.0
             L2 regularization strength
         n_threads : int, default=1
@@ -722,7 +753,14 @@ class LinearModelLoss:
         return grad, hess, hessian_warning
 
     def gradient_hessian_product(
-        self, coef, X, y, sample_weight=None, l2_reg_strength=0.0, n_threads=1
+        self,
+        coef,
+        X,
+        y,
+        sample_weight=None,
+        l1_reg_strength=0.0,
+        l2_reg_strength=0.0,
+        n_threads=1,
     ):
         """Computes gradient and hessp (hessian product function) w.r.t. coef.
 
@@ -739,6 +777,8 @@ class LinearModelLoss:
             Observed, true target values.
         sample_weight : None or contiguous array of shape (n_samples,), default=None
             Sample weights.
+        l1_reg_strength : float, default=0.0
+            Unused L1 regularization strength.
         l2_reg_strength : float, default=0.0
             L2 regularization strength
         n_threads : int, default=1

--- a/sklearn/linear_model/_linear_loss.py
+++ b/sklearn/linear_model/_linear_loss.py
@@ -461,6 +461,8 @@ class LinearModelLoss:
         n_threads=1,
         gradient_out=None,
         hessian_out=None,
+        grad_pointwise_out=None,
+        hess_pointwise_out=None,
         raw_prediction=None,
     ):
         """Computes gradient and hessian w.r.t. coef.
@@ -489,6 +491,13 @@ class LinearModelLoss:
             (n_classes * n_dof, n_classes * n_dof)
             A location into which the hessian is stored. If None, a new array
             might be created.
+        grad_pointwise_out : None or ndarray of shape (n_samples,) or
+            (n_samples, n_classes)
+            Array into which the pointwise gradients are written.
+        hess_pointwise_out : None or ndarray of shape (n_samples,) or
+            (n_samples, n_classes)
+            Array into which the pointwise hessians are written. For the multinomial
+            loss, it is not the hessians but the predicted probabilities.
         raw_prediction : C-contiguous array of shape (n_samples,) or array of \
             shape (n_samples, n_classes)
             Raw prediction values (in link space). If provided, these are used. If
@@ -547,6 +556,8 @@ class LinearModelLoss:
                 y_true=y,
                 raw_prediction=raw_prediction,
                 sample_weight=sample_weight,
+                gradient_out=grad_pointwise_out,
+                hessian_out=hess_pointwise_out,
                 n_threads=n_threads,
             )
             grad_pointwise /= sw_sum
@@ -599,6 +610,8 @@ class LinearModelLoss:
                 y_true=y,
                 raw_prediction=raw_prediction,
                 sample_weight=sample_weight,
+                gradient_out=grad_pointwise_out,
+                proba_out=hess_pointwise_out,
                 n_threads=n_threads,
             )
             grad_pointwise /= sw_sum

--- a/sklearn/linear_model/_linear_loss.py
+++ b/sklearn/linear_model/_linear_loss.py
@@ -5,6 +5,8 @@ Loss functions for linear models with raw_prediction = X @ coef
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import warnings
+
 import numpy as np
 from scipy import sparse
 
@@ -913,3 +915,247 @@ class LinearModelLoss:
                 return grad.ravel(order="F"), hessp
 
         return grad, hessp
+
+
+class Multinomial_LDL_Decomposition:
+    """A class for symbolic LDL' decomposition of multinomial hessian.
+
+    The pointwise hessian of the multinomial loss with c = n_classes is given by
+        h = diag(p) - p' p        or with indices
+        h_ij = p_i * delta_ij - p_i * p_j    i and j are indices of classes.
+    This holds for every single point (sample). The LDL decomposition
+    of this 2-dim matrix is given in [1] for p_i > 0 and sum(p) <= 1 as (math indices)
+        h = L D L'   with lower triangular L and diagonal D:: text
+
+        q_0 = 1
+        q_i = 1 - sum(p_k, k=1..i)
+        L_ii = 1
+        for i > j:
+            L_ij = -p_i / q_j
+        D_ii = p_i * q_i / q_{i-1}
+
+    If the p_i sum to 1, then q_c = 0 and D_cc = 0, with c = n_classes.
+    The inverse L^-1 is also lower triangular and given by:: text
+
+        (L^-1)_ii = 1
+        for i > j:
+            (L^-1)_ij = f_i = p_i / q_{i-1} = -L_{i, i-1}
+
+    Note that with Python indices (zero-based), we have: p_i = p[:, i-1],
+    q_i = q[:, i-1] and we don't explicitly need q_0 = 1.
+
+    The trick is to apply this LDL decomposition to all points (samples) at the same
+    time. This class therefore provides methods to apply products with the matrices L
+    and D to vectors/matrices. All objects have the 0-th dimension for n_samples and
+    the 1st dimension for n_classes, i.e. shape (n_samples, n_classes).
+
+    Parameters
+    ----------
+        proba : ndarray of shape (n_samples, n_classes)
+            Array of predicted probabilities per class (and sample).
+
+    Attributes
+    ----------
+        p : ndarray of shape (n_samples, n_classes)
+            Array of predicted probabilities per class (and sample).
+
+        q_inv : ndarray of shape (n_samples, n_classes)
+            Helper array, inverse of q[:, j] = 1 - sum_{i=0}^j p[:, i], i.e. 1/q.
+
+        sqrt_d : ndarray of shape (n_samples, n_classes)
+            Square root of the diagonal matrix D, D_ii = p_i * q_i / q_{i-1}
+            with q_{-1} = 1.
+
+        proba_sum_to_1 : bool
+            True if probabilities p sum to 1. This is most often expected to be true.
+
+    References
+    ----------
+    .. [1] Kunio Tanabe and Masahiko Sagae. (1992) "An Exact Cholesky Decomposition and
+           the Generalized Inverse of the Variance-Covariance Matrix of the Multinomial
+           Distribution, with Applications"
+           https://doi.org/10.1111/j.2517-6161.1992.tb01875.x
+    """
+
+    def __init__(self, *, proba, proba_sum_to_1=True):
+        self.p = proba
+        q = 1 - np.cumsum(self.p, axis=1)  # contiguity of p
+        self.proba_sum_to_1 = proba_sum_to_1
+        if self.p.dtype == np.float32:
+            eps = 2 * np.finfo(np.float32).resolution
+        else:
+            eps = 2 * np.finfo(np.float64).resolution
+        if not np.allclose(q[:, -1], 0, atol=eps):
+            warnings.warn(
+                "Probabilities proba are assumed to sum to 1, but they don't.",
+                UserWarning,
+            )
+        if self.proba_sum_to_1:
+            # If np.sum(p, axis=1) = 1 then q[:, -1] = d[:, -1] = 0.
+            q[:, -1] = 0.0
+            # One might not need all classes for p to sum to 1, so we detect and
+            # correct all values close to zero.
+            q[q <= eps] = 0.0
+            self.p[self.p <= eps] = 0.0
+        d = self.p * q
+        # From now on, q is always used in the denominator. We handle q == 0 by
+        # setting q to 1 whenever q == 0 such that a division of q is a no-op in this
+        # case.
+        q[q == 0] = 1
+        # And we use the inverse of q, 1/q.
+        self.q_inv = 1 / q
+        if self.proba_sum_to_1:
+            # If q_{i - 1} = 0, then also q_i = 0.
+            d[:, 1:-1] *= self.q_inv[:, :-2]  # d[:, -1] = 0 anyway.
+        else:
+            d[:, 1:] *= self.q_inv[:, :-1]
+        self.sqrt_d = np.sqrt(d)
+
+    def sqrt_D_Lt_matmul(self, x):
+        """Compute sqrt(D) L' x from the multinomial LDL' decomposition.
+
+        L' is the transpose of L, Lij is the i-th row and j-th column of L:
+            Lij = -p[:, i] / q[:, j]
+
+        For n_classes = 4, L' looks like:: text
+
+            L' = (1 L10 L20 L30)
+                 (0   1 L21 L31)
+                 (0   0   1 L32)
+                 (0   0   0   1)
+
+        The carried out operation is matmul over n_classes (1st dimension) and
+        element-wise multiplication over n_samples (0th dimension):
+
+            x_ij = sum_k sqrt_d_{i, j} L'_{i, j, k} x_{i, k}
+
+        Parameters
+        ----------
+        x : ndarray of shape (n_samples, n_classes)
+            This array is overwritten with the result.
+
+        Return
+        ------
+        x : ndarray of shape (n_samples, n_classes)
+            Input array x, filled with the result.
+        """
+        n_classes = self.p.shape[1]
+        # precompute
+        px = np.einsum(
+            "ij,ij->i",
+            self.p[:, 1:],
+            x[:, 1:],
+            order="A",
+        )
+        for i in range(0, n_classes - 1):  # row i
+            # L_ij = -p_i / q_j, we need transpose L'
+            # for j in range(i + 1, n_classes):  # column j
+            #     x[:, i] -= self.p[:, j] / self.q[:, i] * x[:, j]
+            # The following is the same but faster.
+            # px = np.einsum(
+            #     "ij,ij->i",
+            #     self.p[:, i + 1 : n_classes],
+            #     x[:, i + 1 : n_classes],
+            #     order="A",
+            # )
+            # And using precomputed px:
+            x[:, i] -= px * self.q_inv[:, i]
+            if i < n_classes - 2:
+                px -= self.p[:, i + 1] * x[:, i + 1]
+        x *= self.sqrt_d
+        return x
+
+    def L_sqrt_D_matmul(self, x):
+        """Compute L sqrt(D) x from the multinomial LDL' decomposition.
+
+        L is lower triangular and given by Lij = -p[:, i] / q[:, j]
+
+        For n_classes = 4, L looks like:: text
+
+            L = (1     0   0 0)
+                (L10   1   0 0)
+                (L20 L21   1 0)
+                (L30 L31 L32 1)
+
+        The carried out operation is matmul over n_classes (1st dimension) and
+        element-wise multiplication over n_samples (0th dimension):
+
+            x_ij = sum_k L'_{i, j, k} sqrt_d_{i, k}  x_{i, k}
+
+        Parameters
+        ----------
+        x : ndarray of shape (n_samples, n_classes)
+            This array is overwritten with the result.
+
+        Return
+        ------
+        x : ndarray of shape (n_samples, n_classes)
+            Input array x, filled with the result.
+        """
+        n_classes = self.p.shape[1]
+        x *= self.sqrt_d
+        # precompute
+        qx = np.einsum("ij,ij->i", self.q_inv[:, :-1], x[:, :-1], order="A")
+        for i in range(n_classes - 1, 0, -1):  # row i
+            # L_ij = -p_i / q_j
+            # for j in range(0, i):  # column j
+            #     x[:, i] -= self.p[:, i] / self.q[:, j] * x[:, j]
+            # The following is the same but faster.
+            # qx = np.einsum("ij,ij->i", self.q_inv[:, :i], x[:, :i], order="A")
+            # And using precomputed qx:
+            x[:, i] -= qx * self.p[:, i]
+            if i > 1:
+                qx -= self.q_inv[:, i - 1] * x[:, i - 1]
+        return x
+
+    def inverse_L_sqrt_D_matmul(self, x):
+        """Compute 1/sqrt(D) L^(-1) x from the multinomial LDL' decomposition.
+
+        L^(-1) is again lower triangular and given by:
+            L^(-1)_ij = f[:, i] = p[:, i] / q[:, i-1]
+
+        For n_classes = 4, L^(-1) looks like:: text
+
+            L^(-1) = (1   0  0  0)
+                     (f1  1  0  0)
+                     (f2  f2 1  0)
+                     (f3  f3 f3 1)
+
+        Note that (L sqrt(D))^(-1) = 1/sqrt(D) L^(-1)
+
+        Parameters
+        ----------
+        x : ndarray of shape (n_samples, n_classes)
+            This array is overwritten with the result.
+
+        Return
+        ------
+        x : ndarray of shape (n_samples, n_classes)
+            Input array x, filled with the result.
+        """
+        n_classes = self.p.shape[1]
+        x_sum = np.sum(x[:, :-1], axis=1)  # precomputation
+        for i in range(n_classes - 1, 0, -1):  # row i, here i > 0.
+            fj = self.p[:, i] * self.q_inv[:, i - 1]
+            # for i = 0 we would set: fj = self.p[:, i]
+
+            # for j in range(0, i):  # column j
+            #     x[:, i] += fj * x[:, j]
+            # The following is the same but faster.
+            # x[:, i] += fj * np.sum(x[:, :i], axis=1)
+            # Using precomputation
+            x[:, i] += fj * x_sum
+            if i > 1:
+                x_sum -= x[:, i - 1]
+        if self.proba_sum_to_1:
+            # x[:, :-1] /= self.sqrt_d[:, :-1]
+            mask = self.sqrt_d[:, :-1] == 0
+            x[:, :-1] *= (~mask) / (self.sqrt_d[:, :-1] + mask)
+            # Important Note:
+            # Strictly speaking, the inverse of D does not exist.
+            # We use 0 as the inverse of 0 and just set:
+            # x[:, -1] = 0
+            x[:, -1] = 0
+        else:
+            x /= self.sqrt_d
+        return x

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -56,7 +56,11 @@ from sklearn.utils._array_api import (
 )
 from sklearn.utils._param_validation import Hidden, Interval, StrOptions
 from sklearn.utils.extmath import row_norms, softmax
-from sklearn.utils.fixes import _get_additional_lbfgs_options_dict
+from sklearn.utils.fixes import (
+    _get_additional_lbfgs_options_dict,
+    parse_version,
+    sp_version,
+)
 from sklearn.utils.metadata_routing import (
     MetadataRouter,
     MethodMapping,
@@ -435,12 +439,6 @@ def _logistic_regression_path(
             " (n_classes >= 3). Either use another solver or wrap the "
             "estimator in a OneVsRestClassifier to keep applying a "
             "one-versus-rest scheme."
-        )
-
-    if n_classes >= 3 and solver == "newton-cd" and sparse.issparse(X):
-        raise ValueError(
-            f"Solver 'newton-cd' does not support sparse X for multiclass settings"
-            f" (n_classes >= 3); got {n_classes=}."
         )
 
     random_state = check_random_state(random_state)
@@ -1564,6 +1562,15 @@ class LogisticRegression(
         n_classes = size(self.classes_)
         is_binary = n_classes == 2
 
+        if solver == "newton-cd" and n_classes >= 3 and sparse.issparse(X):
+            # TODO(scipy 1.17): remove once scipy >= 1.17 is minimal version.
+            if sp_version < parse_version("1.17.0"):
+                raise ValueError(
+                    "Solver 'newton-cd' supports sparse X in a multiclass setting "
+                    "(n_classes >= 3) only with scipy >= 1.17."
+                )
+            X = sparse.csc_array(X)
+
         # With lbfgs, the fit task will have a subtask even if max_iter is 0.
         # There's also always one extra empty subtask due to the scipy.optimize.minimize
         # callback logic.
@@ -1617,12 +1624,6 @@ class LogisticRegression(
                 "This solver needs samples of at least 2 classes"
                 " in the data, but the data contains only one"
                 " class: %r" % self.classes_[0]
-            )
-
-        if n_classes >= 3 and solver == "newton-cd" and sparse.issparse(X):
-            raise ValueError(
-                f"Solver 'newton-cd' does not support sparse X for multiclass settings"
-                f" (n_classes >= 3); got {n_classes=}."
             )
 
         if self.warm_start:
@@ -2324,11 +2325,14 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
                 f" class: {self.classes_[0]}."
             )
 
-        if n_classes >= 3 and solver == "newton-cd" and sparse.issparse(X):
-            raise ValueError(
-                f"Solver 'newton-cd' does not support sparse X for multiclass settings"
-                f" (n_classes >= 3); got {n_classes=}."
-            )
+        if solver == "newton-cd" and n_classes >= 3 and sparse.issparse(X):
+            # TODO(scipy 1.17): remove once scipy >= 1.17 is minimal version.
+            if sp_version < parse_version("1.17.0"):
+                raise ValueError(
+                    "Solver 'newton-cd' supports sparse X in a multiclass setting "
+                    "(n_classes >= 3) only with scipy >= 1.17."
+                )
+            X = sparse.csr_array(X)
 
         if solver in ["sag", "saga"]:
             max_squared_sum = row_norms(X, squared=True).max()

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -26,7 +26,10 @@ from sklearn.linear_model._base import (
     LinearClassifierMixin,
     SparseCoefMixin,
 )
-from sklearn.linear_model._glm.glm import NewtonCholeskySolver
+from sklearn.linear_model._glm._newton_solver import (
+    NewtonCDGramSolver,
+    NewtonCholeskySolver,
+)
 from sklearn.linear_model._linear_loss import LinearModelLoss
 from sklearn.linear_model._sag import sag_solver
 from sklearn.metrics import get_scorer, get_scorer_names, make_scorer
@@ -79,7 +82,7 @@ _LOGISTIC_SOLVER_CONVERGENCE_MSG = (
 
 
 def _check_solver(solver, penalty, dual):
-    if solver not in ["liblinear", "saga"] and penalty not in ("l2", None):
+    if solver not in ["liblinear", "newton-cd", "saga"] and penalty not in ("l2", None):
         raise ValueError(
             f"Solver {solver} supports only 'l2' or None penalties, got {penalty} "
             "penalty."
@@ -87,7 +90,7 @@ def _check_solver(solver, penalty, dual):
     if solver != "liblinear" and dual:
         raise ValueError(f"Solver {solver} supports only dual=False, got dual={dual}")
 
-    if penalty == "elasticnet" and solver != "saga":
+    if penalty == "elasticnet" and solver not in ("saga", "newton-cd"):
         raise ValueError(
             f"Only 'saga' solver supports elasticnet penalty, got solver={solver}."
         )
@@ -285,8 +288,8 @@ def _logistic_regression_path(
         For the liblinear and lbfgs solvers set verbose to any positive
         number for verbosity.
 
-    solver : {'lbfgs', 'liblinear', 'newton-cg', 'newton-cholesky', 'sag', 'saga'}, \
-            default='lbfgs'
+    solver : {'lbfgs', 'liblinear', 'newton-cd', 'newton-cg', 'newton-cholesky', \
+            'sag', 'saga'}, default='lbfgs'
         Numerical solver to use.
 
     coef : array-like of shape (n_classes, features + int(fit_intercept)) or \
@@ -401,7 +404,7 @@ def _logistic_regression_path(
             X,
             accept_sparse="csr",
             dtype=[xp.float64, xp.float32],
-            accept_large_sparse=solver not in ["liblinear", "sag", "saga"],
+            accept_large_sparse=solver not in ["liblinear", "sag", "saga", "newton-cd"],
         )
         y = check_array(y, ensure_2d=False, dtype=None)
         check_consistent_length(X, y)
@@ -467,7 +470,7 @@ def _logistic_regression_path(
     #     C * sum(pointwise_loss) + penalty
     # instead of (as LinearModelLoss does)
     #     mean(pointwise_loss) + 1/C * penalty
-    if solver in ["lbfgs", "newton-cg", "newton-cholesky"]:
+    if solver in ["lbfgs", "newton-cd", "newton-cg", "newton-cholesky"]:
         # This needs to be calculated after sample_weight is multiplied by
         # class_weight. It is even tested that passing class_weight is equivalent to
         # passing sample_weights according to class_weight.
@@ -532,7 +535,7 @@ def _logistic_regression_path(
             fit_intercept=fit_intercept,
         )
         target = Y_multi
-        if solver in ["lbfgs", "newton-cg", "newton-cholesky"]:
+        if solver in ["lbfgs", "newton-cd", "newton-cg", "newton-cholesky"]:
             # scipy.optimize.minimize and newton-cg accept only ravelled parameters,
             # i.e. 1d-arrays. LinearModelLoss expects classes to be contiguous and
             # reconstructs the 2d-array via w0.reshape((n_classes, -1), order="F").
@@ -586,7 +589,7 @@ def _logistic_regression_path(
                 w0,
                 method="L-BFGS-B",
                 jac=True,
-                args=(X, target, sample_weight, l2_reg_strength, n_threads),
+                args=(X, target, sample_weight, 0, l2_reg_strength, n_threads),
                 options={
                     "maxiter": max_iter,
                     "maxls": 50,  # default is 20
@@ -607,7 +610,7 @@ def _logistic_regression_path(
                 lbfgs_bridge.close()
         elif solver == "newton-cg":
             l2_reg_strength = 1.0 / (C * sw_sum)
-            args = (X, target, sample_weight, l2_reg_strength, n_threads)
+            args = (X, target, sample_weight, 0, l2_reg_strength, n_threads)
             w0, n_iter_i = _newton_cg(
                 grad_hess=hess,
                 func=func,
@@ -623,6 +626,25 @@ def _logistic_regression_path(
             sol = NewtonCholeskySolver(
                 coef=w0,
                 linear_loss=loss,
+                l2_reg_strength=l2_reg_strength,
+                tol=tol,
+                max_iter=max_iter,
+                n_threads=n_threads,
+                verbose=verbose,
+            )
+            w0 = sol.solve(X=X, y=target, sample_weight=sample_weight)
+            n_iter_i = sol.iteration
+        elif solver == "newton-cd":
+            if penalty == "l1":
+                l1_ratio = 1.0
+            elif penalty == "l2":
+                l1_ratio = 0
+            l1_reg_strength = l1_ratio / (C * sw_sum)
+            l2_reg_strength = (1.0 - l1_ratio) / (C * sw_sum)
+            sol = NewtonCDGramSolver(
+                coef=w0,
+                linear_loss=loss,
+                l1_reg_strength=l1_reg_strength,
                 l2_reg_strength=l2_reg_strength,
                 tol=tol,
                 max_iter=max_iter,
@@ -702,7 +724,7 @@ def _logistic_regression_path(
                 xp.asarray(w0.copy(order=coefs_order), dtype=X.dtype, device=device_)
             )
         else:
-            if solver in ["lbfgs", "newton-cg", "newton-cholesky"]:
+            if solver in ["lbfgs", "newton-cd", "newton-cg", "newton-cholesky"]:
                 multi_w0 = np.reshape(w0, (n_classes, -1), order="F")
             else:
                 multi_w0 = w0
@@ -1124,6 +1146,7 @@ class LogisticRegression(
            ================= ======================== ======================
            'lbfgs'           l1_ratio=0               yes
            'liblinear'       l1_ratio=1 or l1_ratio=0 no
+           'newton-cd'       0<=l1_ratio<=1           yes
            'newton-cg'       l1_ratio=0               yes
            'newton-cholesky' l1_ratio=0               yes
            'sag'             l1_ratio=0               yes
@@ -1287,7 +1310,15 @@ class LogisticRegression(
         "random_state": ["random_state"],
         "solver": [
             StrOptions(
-                {"lbfgs", "liblinear", "newton-cg", "newton-cholesky", "sag", "saga"}
+                {
+                    "lbfgs",
+                    "liblinear",
+                    "newton-cd",
+                    "newton-cg",
+                    "newton-cholesky",
+                    "sag",
+                    "saga",
+                }
             )
         ],
         "max_iter": [Interval(Integral, 0, None, closed="left")],
@@ -1463,7 +1494,7 @@ class LogisticRegression(
             accept_sparse="csr",
             dtype=[xp.float64, xp.float32],
             order="C",
-            accept_large_sparse=solver not in ["liblinear", "sag", "saga"],
+            accept_large_sparse=solver not in ["liblinear", "sag", "saga", "newton-cd"],
         )
         n_features = X.shape[1]
         check_classification_targets(y)
@@ -1790,6 +1821,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
            ================= ======================== ======================
            'lbfgs'           l1_ratio=0               yes
            'liblinear'       l1_ratio=1 or l1_ratio=0 no
+           'newton-cd'       0<=l1_ratio<=1           yes
            'newton-cg'       l1_ratio=0               yes
            'newton-cholesky' l1_ratio=0               yes
            'sag'             l1_ratio=0               yes
@@ -2201,7 +2233,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
             accept_sparse="csr",
             dtype=np.float64,
             order="C",
-            accept_large_sparse=solver not in ["liblinear", "sag", "saga"],
+            accept_large_sparse=solver not in ["liblinear", "sag", "saga", "newton-cd"],
         )
         n_features = X.shape[1]
         check_classification_targets(y)

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -11,7 +11,7 @@ import warnings
 from numbers import Integral, Real
 
 import numpy as np
-from scipy import optimize
+from scipy import optimize, sparse
 
 from sklearn._loss.loss import (
     HalfBinomialLoss,
@@ -28,6 +28,7 @@ from sklearn.linear_model._base import (
 )
 from sklearn.linear_model._glm._newton_solver import (
     NewtonCDGramSolver,
+    NewtonCDSolver,
     NewtonCholeskySolver,
 )
 from sklearn.linear_model._linear_loss import LinearModelLoss
@@ -82,7 +83,12 @@ _LOGISTIC_SOLVER_CONVERGENCE_MSG = (
 
 
 def _check_solver(solver, penalty, dual):
-    if solver not in ["liblinear", "newton-cd", "saga"] and penalty not in ("l2", None):
+    if solver not in [
+        "liblinear",
+        "newton-cd",
+        "newton-cd-gram",
+        "saga",
+    ] and penalty not in ("l2", None):
         raise ValueError(
             f"Solver {solver} supports only 'l2' or None penalties, got {penalty} "
             "penalty."
@@ -90,7 +96,11 @@ def _check_solver(solver, penalty, dual):
     if solver != "liblinear" and dual:
         raise ValueError(f"Solver {solver} supports only dual=False, got dual={dual}")
 
-    if penalty == "elasticnet" and solver not in ("saga", "newton-cd"):
+    if penalty == "elasticnet" and solver not in (
+        "saga",
+        "newton-cd",
+        "newton-cd-gram",
+    ):
         raise ValueError(
             f"Only 'saga' solver supports elasticnet penalty, got solver={solver}."
         )
@@ -288,8 +298,8 @@ def _logistic_regression_path(
         For the liblinear and lbfgs solvers set verbose to any positive
         number for verbosity.
 
-    solver : {'lbfgs', 'liblinear', 'newton-cd', 'newton-cg', 'newton-cholesky', \
-            'sag', 'saga'}, default='lbfgs'
+    solver : {'lbfgs', 'liblinear', 'newton-cd', 'newton-cd-gram', 'newton-cg', \
+            'newton-cholesky', 'sag', 'saga'}, default='lbfgs'
         Numerical solver to use.
 
     coef : array-like of shape (n_classes, features + int(fit_intercept)) or \
@@ -402,8 +412,9 @@ def _logistic_regression_path(
     if check_input:
         X = check_array(
             X,
-            accept_sparse="csr",
+            accept_sparse="csc" if solver == "newton-cd" else "csr",
             dtype=[xp.float64, xp.float32],
+            order="F" if solver == "newton-cd" else None,
             accept_large_sparse=solver not in ["liblinear", "sag", "saga", "newton-cd"],
         )
         y = check_array(y, ensure_2d=False, dtype=None)
@@ -424,6 +435,12 @@ def _logistic_regression_path(
             " (n_classes >= 3). Either use another solver or wrap the "
             "estimator in a OneVsRestClassifier to keep applying a "
             "one-versus-rest scheme."
+        )
+
+    if n_classes >= 3 and solver == "newton-cd" and sparse.issparse(X):
+        raise ValueError(
+            f"Solver 'newton-cd' does not support sparse X for multiclass settings"
+            f" (n_classes >= 3); got {n_classes=}."
         )
 
     random_state = check_random_state(random_state)
@@ -470,7 +487,13 @@ def _logistic_regression_path(
     #     C * sum(pointwise_loss) + penalty
     # instead of (as LinearModelLoss does)
     #     mean(pointwise_loss) + 1/C * penalty
-    if solver in ["lbfgs", "newton-cd", "newton-cg", "newton-cholesky"]:
+    if solver in [
+        "lbfgs",
+        "newton-cd",
+        "newton-cd-gram",
+        "newton-cg",
+        "newton-cholesky",
+    ]:
         # This needs to be calculated after sample_weight is multiplied by
         # class_weight. It is even tested that passing class_weight is equivalent to
         # passing sample_weights according to class_weight.
@@ -535,7 +558,13 @@ def _logistic_regression_path(
             fit_intercept=fit_intercept,
         )
         target = Y_multi
-        if solver in ["lbfgs", "newton-cd", "newton-cg", "newton-cholesky"]:
+        if solver in [
+            "lbfgs",
+            "newton-cd",
+            "newton-cd-gram",
+            "newton-cg",
+            "newton-cholesky",
+        ]:
             # scipy.optimize.minimize and newton-cg accept only ravelled parameters,
             # i.e. 1d-arrays. LinearModelLoss expects classes to be contiguous and
             # reconstructs the 2d-array via w0.reshape((n_classes, -1), order="F").
@@ -641,6 +670,25 @@ def _logistic_regression_path(
                 l1_ratio = 0
             l1_reg_strength = l1_ratio / (C * sw_sum)
             l2_reg_strength = (1.0 - l1_ratio) / (C * sw_sum)
+            sol = NewtonCDSolver(
+                coef=w0,
+                linear_loss=loss,
+                l1_reg_strength=l1_reg_strength,
+                l2_reg_strength=l2_reg_strength,
+                tol=tol,
+                max_iter=max_iter,
+                n_threads=n_threads,
+                verbose=verbose,
+            )
+            w0 = sol.solve(X=X, y=target, sample_weight=sample_weight)
+            n_iter_i = sol.iteration
+        elif solver == "newton-cd-gram":
+            if penalty == "l1":
+                l1_ratio = 1.0
+            elif penalty == "l2":
+                l1_ratio = 0
+            l1_reg_strength = l1_ratio / (C * sw_sum)
+            l2_reg_strength = (1.0 - l1_ratio) / (C * sw_sum)
             sol = NewtonCDGramSolver(
                 coef=w0,
                 linear_loss=loss,
@@ -724,7 +772,13 @@ def _logistic_regression_path(
                 xp.asarray(w0.copy(order=coefs_order), dtype=X.dtype, device=device_)
             )
         else:
-            if solver in ["lbfgs", "newton-cd", "newton-cg", "newton-cholesky"]:
+            if solver in [
+                "lbfgs",
+                "newton-cd",
+                "newton-cd-gram",
+                "newton-cg",
+                "newton-cholesky",
+            ]:
                 multi_w0 = np.reshape(w0, (n_classes, -1), order="F")
             else:
                 multi_w0 = w0
@@ -901,6 +955,12 @@ def _log_reg_scoring_path(
         sample_weight = _check_sample_weight(sample_weight, X)
         sw_train = sample_weight[train]
         sw_test = sample_weight[test]
+
+    if solver == "newton-cd":
+        if sparse.issparse(X_train):
+            X_train = X_train.tocsc()
+        else:
+            X_train = np.asfortranarray(X_train)
 
     # Note: We pass classes for the whole dataset to avoid inconsistencies,
     # i.e. different number of classes in different folds. This way, if a class
@@ -1147,6 +1207,7 @@ class LogisticRegression(
            'lbfgs'           l1_ratio=0               yes
            'liblinear'       l1_ratio=1 or l1_ratio=0 no
            'newton-cd'       0<=l1_ratio<=1           yes
+           'newton-cd-gram'  0<=l1_ratio<=1           yes
            'newton-cg'       l1_ratio=0               yes
            'newton-cholesky' l1_ratio=0               yes
            'sag'             l1_ratio=0               yes
@@ -1314,6 +1375,7 @@ class LogisticRegression(
                     "lbfgs",
                     "liblinear",
                     "newton-cd",
+                    "newton-cd-gram",
                     "newton-cg",
                     "newton-cholesky",
                     "sag",
@@ -1491,9 +1553,9 @@ class LogisticRegression(
             self,
             X,
             y,
-            accept_sparse="csr",
+            accept_sparse="csc" if solver == "newton-cd" else "csr",
             dtype=[xp.float64, xp.float32],
-            order="C",
+            order="F" if solver == "newton-cd" else "C",
             accept_large_sparse=solver not in ["liblinear", "sag", "saga", "newton-cd"],
         )
         n_features = X.shape[1]
@@ -1555,6 +1617,12 @@ class LogisticRegression(
                 "This solver needs samples of at least 2 classes"
                 " in the data, but the data contains only one"
                 " class: %r" % self.classes_[0]
+            )
+
+        if n_classes >= 3 and solver == "newton-cd" and sparse.issparse(X):
+            raise ValueError(
+                f"Solver 'newton-cd' does not support sparse X for multiclass settings"
+                f" (n_classes >= 3); got {n_classes=}."
             )
 
         if self.warm_start:
@@ -1822,6 +1890,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
            'lbfgs'           l1_ratio=0               yes
            'liblinear'       l1_ratio=1 or l1_ratio=0 no
            'newton-cd'       0<=l1_ratio<=1           yes
+           'newton-cd-gram'  0<=l1_ratio<=1           yes
            'newton-cg'       l1_ratio=0               yes
            'newton-cholesky' l1_ratio=0               yes
            'sag'             l1_ratio=0               yes
@@ -2232,7 +2301,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
             y,
             accept_sparse="csr",
             dtype=np.float64,
-            order="C",
+            order=None if solver == "newton-cd" else "C",
             accept_large_sparse=solver not in ["liblinear", "sag", "saga", "newton-cd"],
         )
         n_features = X.shape[1]
@@ -2253,6 +2322,12 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
                 "This solver needs samples of at least 2 classes"
                 " in the data, but the data contains only one"
                 f" class: {self.classes_[0]}."
+            )
+
+        if n_classes >= 3 and solver == "newton-cd" and sparse.issparse(X):
+            raise ValueError(
+                f"Solver 'newton-cd' does not support sparse X for multiclass settings"
+                f" (n_classes >= 3); got {n_classes=}."
             )
 
         if solver in ["sag", "saga"]:
@@ -2389,6 +2464,12 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
                 coef_init = np.mean(coefs_paths[0, :, *best_index, :], axis=0)
             else:
                 coef_init = np.mean(coefs_paths[:, :, *best_index, :], axis=1)
+
+            if solver == "newton-cd":
+                if sparse.issparse(X):
+                    X = X.tocsc()
+                else:
+                    X = np.asfortranarray(X)
 
             # Note that y is label encoded
             w, _, _ = _logistic_regression_path(

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -3,6 +3,7 @@
 
 import warnings
 from copy import deepcopy
+from functools import partial
 
 import joblib
 import numpy as np
@@ -101,6 +102,7 @@ def test_cython_solver_equivalence(sparse_csc_type):
         "rng": np.random.RandomState(0),  # not used, but needed as argument
         "random": False,
         "positive": False,
+        "early_stopping": True,
     }
 
     def zc():
@@ -166,6 +168,87 @@ def test_cython_solver_equivalence(sparse_csc_type):
             do_screening=do_screening,
         )
         assert_allclose(coef_4, coef_1)
+
+
+@pytest.mark.parametrize("cd", ["enet", "sparse_enet", "enet_gram", "enet_multi"])
+def test_cython_solver_early_stopping(cd):
+    """Test that early_stopping works correctly."""
+    X, y = make_regression()
+    X_mean = X.mean(axis=0)
+    X_centered = np.asfortranarray(X - X_mean)
+    y -= y.mean()
+    alpha_max = np.linalg.norm(X.T @ y, ord=np.inf)
+    params = {
+        "alpha": alpha_max / 100,
+        "beta": 0,
+        "max_iter": 100,
+        "tol": 1e-1,  # Set a high value on purpose.
+        "rng": np.random.RandomState(0),  # not used, but needed as argument
+        "random": False,
+    }
+    if cd == "enet":
+        cd_solve = partial(
+            cd_fast.enet_coordinate_descent,
+            X=X_centered,
+            y=y,
+            **params,
+        )
+    elif cd == "sparse_enet":
+        Xs = sparse.csc_matrix(X)
+        cd_solve = partial(
+            cd_fast.sparse_enet_coordinate_descent,
+            X_data=Xs.data,
+            X_indices=Xs.indices,
+            X_indptr=Xs.indptr,
+            y=y,
+            sample_weight=None,
+            X_mean=X_mean,
+            **params,
+        )
+    elif cd == "enet_gram":
+        cd_solve = partial(
+            cd_fast.enet_coordinate_descent_gram,
+            Q=X_centered.T @ X_centered,
+            q=X_centered.T @ y,
+            y=y,
+            **params,
+        )
+    elif cd == "enet_multi":
+
+        def cd_solve(w, early_stopping=True):
+            return cd_fast.enet_coordinate_descent_multi_task(
+                W=w,
+                X=X_centered,
+                X_is_sparse=False,
+                X_data=None,
+                X_indices=None,
+                X_indptr=None,
+                Y=np.asfortranarray(np.c_[y, y]),
+                sample_weight=None,
+                X_mean=None,
+                **params,
+                early_stopping=early_stopping,
+            )
+
+    if cd == "enet_multi":
+        coef_1 = np.zeros((2, X.shape[1]), order="F")
+    else:
+        coef_1 = np.zeros(X.shape[1])
+    _, gap_1, _, _ = cd_solve(w=coef_1)
+    assert np.sum(coef_1 != 0) > X.shape[1] / 4  # avoid all zeros
+
+    # With early stopping, the coefficients should stay unchanged.
+    coef_2 = coef_1.copy(order="F")
+    _, _, _, n_iter = cd_solve(w=coef_2, early_stopping=True)
+    assert n_iter == 0
+    assert_array_equal(coef_2, coef_1)
+
+    # Without early stopping, the coefficients should change.
+    coef_3 = coef_1.copy(order="F")
+    _, gap_3, _, n_iter = cd_solve(w=coef_3, early_stopping=False)
+    assert n_iter == 1
+    assert gap_3 < gap_1
+    assert not np.all(coef_3 == coef_1)
 
 
 def test_lasso_zero():

--- a/sklearn/linear_model/tests/test_linear_loss.py
+++ b/sklearn/linear_model/tests/test_linear_loss.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 from scipy import linalg, optimize
+from scipy.special import logit
 
 from sklearn._loss.loss import (
     HalfBinomialLoss,
@@ -16,7 +17,10 @@ from sklearn._loss.loss import (
     HalfPoissonLoss,
 )
 from sklearn.datasets import make_low_rank_matrix
-from sklearn.linear_model._linear_loss import LinearModelLoss
+from sklearn.linear_model._linear_loss import (
+    LinearModelLoss,
+    Multinomial_LDL_Decomposition,
+)
 from sklearn.utils.extmath import squared_norm
 from sklearn.utils.fixes import CSR_CONTAINERS
 
@@ -508,3 +512,247 @@ def test_linear_loss_gradient_hessian_raises_wrong_out_parameters():
             gradient_out=None,
             hessian_out=hessian_out,
         )
+
+
+def test_multinomial_LDL_decomposition_operates_inplace(global_random_seed):
+    n_samples, n_classes = 3, 5
+    rng = np.random.RandomState(global_random_seed)
+    p = rng.uniform(low=0, high=1, size=(n_samples, n_classes))
+    p /= np.sum(p, axis=1)[:, None]
+    assert_allclose(np.sum(p, axis=1), np.ones(shape=n_samples))
+
+    LDL = Multinomial_LDL_Decomposition(proba=p)
+    v = rng.standard_normal(size=(n_samples, n_classes))
+    res = LDL.sqrt_D_Lt_matmul(v)
+    assert res is v
+
+    v = rng.standard_normal(size=(n_samples, n_classes))
+    res = LDL.L_sqrt_D_matmul(v)
+    assert res is v
+
+    v = rng.standard_normal(size=(n_samples, n_classes))
+    res = LDL.inverse_L_sqrt_D_matmul(v)
+    assert res is v
+
+
+def test_multinomial_LDL_decomposition_binomial_single_point():
+    """Test LDL' decomposition of multinomial hessian for simple cases.
+
+    For the binomial case, we have p0 = 1 - p1
+    LDL = [p0 * (1 - p0),      -p0 * p1] = p0 * (1 - p0) * [1, -1]
+          [     -p0 * p1, p1 * (1 - p1)]                   [-1, 1]
+
+    L = [ 1, 0]    D = [p0 * (1 - p0), 0]
+        [-1, 1]        [            0, 0]
+    """
+    p0, p1 = 0.2, 0.8
+    p = np.array([[p0, p1]])
+    # Note that LDL sets q = 1 whenever q = 0 for easier handling of divisions by zero.
+    # We compare those values to "zero", to make that clear.
+    zero = 1
+
+    LDL = Multinomial_LDL_Decomposition(proba=p)
+    assert_allclose(1 / LDL.q_inv[0, :], [1 - p0, zero])
+    assert_allclose(LDL.sqrt_d[0, :] ** 2, [p0 * (1 - p0), 0])
+
+    # C = diag(D) L' x with x = [[1, 0]] (n_samples=1, n_classes=2)
+    C = LDL.sqrt_D_Lt_matmul(np.array([[1.0, 0.0]]))
+    assert_allclose(C[0, :], [np.sqrt(p0 * (1 - p0)), 0])
+
+    # C = diag(D) L' x with x = [[0, 1]] (n_samples=1, n_classes=2)
+    C = LDL.sqrt_D_Lt_matmul(np.array([[0.0, 1.0]]))
+    assert_allclose(C[0, :], [-np.sqrt(p1 * (1 - p1)), 0])
+
+    # Test with hessian product (hessp) of LinearModelLoss with X = [[1]] and coef such
+    # that probabilities are again (p0, p1).
+    # Hessian = X' LDL X
+    loss = LinearModelLoss(
+        base_loss=HalfMultinomialLoss(n_classes=2),
+        fit_intercept=False,
+    )
+    # Note that y has no effect on the hessian.
+    coef = 0.5 * np.array([[logit(p0)], [logit(p1)]])  # tested below
+    X = np.array([[1.0]])
+    raw = X @ coef.T  # raw.shape = (n_samples, n_classes) = (1, 2)
+    assert_allclose(loss.base_loss.predict_proba(raw), [[p0, p1]])
+    C = LDL.sqrt_D_Lt_matmul(raw.copy())
+    grad, hessp = loss.gradient_hessian_product(
+        coef=coef,
+        X=X,
+        y=np.array([0.0]),
+        l2_reg_strength=0.0,
+    )
+    # Note: hessp(coef).shape = (n_classes, n_features) = (2, 1)
+    assert_allclose(
+        hessp(coef),
+        p0
+        * (1 - p0)
+        * np.array([raw[0, 0] - raw[0, 1], -raw[0, 0] + raw[0, 1]])[:, None],
+    )
+    assert_allclose(C @ C.T, coef.T @ hessp(coef))
+
+
+def test_multinomial_LDL_decomposition_3_classes():
+    """Test LDL' decomposition of multinomial hessian for 3 classes and 2 points.
+
+    For n_classes = 3 and n_samples = 2, we have
+      p0 = [p0_0, p0_1]
+      p1 = [p1_0, p1_1]
+      p2 = [p2_0, p2_1]
+    and with 2 x 2 diagonal subblocks
+      LDL = [p0 * (1-p0),    -p0 * p1,    -p0 * p2]
+            [   -p0 * p1, p1 * (1-p1),    -p1 * p2]
+            [   -p0 * p2,    -p1 * p2, p2 * (1-p2)]
+
+      L = [         1,                 0, 0]
+          [-p1 / (1-p0),               1, 0]
+          [-p2 / (1-p0), -p2 / (1-p0-p1), 1]
+
+      D = [p0 * (1-p0),                       0, 0]
+          [          0, p1 * (1-p0-p1) / (1-p0), 0]
+          [          0,                       0, 0]
+    """
+    n = 2 * 3  # n_samples * n_classes
+    p0 = np.array([0.7, 0.6])
+    p1 = np.array([0.2, 0.25])
+    p2 = np.array([0.1, 0.15])
+    one = np.ones(2)
+    zero = np.zeros(2)
+    p0d, p1d, p2d, oned, zerod = (
+        np.diag(p0),
+        np.diag(p1),
+        np.diag(p2),
+        np.diag(one),
+        np.diag(zero),
+    )
+    H = np.block(
+        [
+            [p0d * (oned - p0d), -p0d * p1d, -p0d * p2d],
+            [-p0d * p1d, p1d * (oned - p1d), -p1d * p2d],
+            [-p0d * p2d, -p1d * p2d, p2d * (oned - p2d)],
+        ]
+    )
+    L = np.block(
+        [
+            [oned, zerod, zerod],
+            [np.diag(-p1 / (one - p0)), oned, zerod],
+            [np.diag(-p2 / (one - p0)), np.diag(-p2 / (one - p0 - p1)), oned],
+        ]
+    )
+    D = np.diag(np.r_[p0 * (1 - p0), p1 * (1 - p0 - p1) / (1 - p0), zero])
+    L_inv = np.block(
+        [
+            [oned, zerod, zerod],
+            [np.diag(p1 / (one - p0)), oned, zerod],
+            [np.diag(p2 / (one - p0 - p1)), np.diag(p2 / (one - p0 - p1)), oned],
+        ]
+    )
+    D_inv = np.zeros_like(D)
+    D_inv[D > 0] = 1 / np.sqrt(D[D > 0])
+
+    lu, d, perm = linalg.ldl(H)
+    assert_allclose(lu @ d @ lu.T, H)
+    assert_allclose(L @ D @ L.T, H)
+    assert_allclose(L, lu)
+    assert_allclose(D, d, atol=1e-14)
+    assert_allclose(L_inv @ L, np.eye(n), atol=1e-14)
+    assert_allclose(L @ L_inv, np.eye(n), atol=1e-14)
+
+    LDL = Multinomial_LDL_Decomposition(proba=np.c_[p0, p1, p2])
+    v = 1.0 + np.arange(2 * 3)
+    DLt_v = LDL.sqrt_D_Lt_matmul(v.copy().reshape((2, 3), order="F"))
+    assert_allclose(DLt_v.ravel(order="F"), np.sqrt(D) @ L.T @ v)
+    LDL_v = LDL.L_sqrt_D_matmul(DLt_v.copy())
+    assert_allclose(LDL_v.ravel(order="F"), H @ v)
+
+    LD_v = LDL.L_sqrt_D_matmul(v.copy().reshape((2, 3), order="F"))
+    assert_allclose(LD_v.ravel(order="F"), L @ np.sqrt(D) @ v)
+
+    x1 = LDL.inverse_L_sqrt_D_matmul(v.copy().reshape((2, 3), order="F"))
+    # This does not work as L @ D is singular.
+    #   x2 = linalg.solve(L @ np.sqrt(D), v)
+    # We can just neglect the last class as it is redundant.
+    x2 = linalg.solve(L[:-2, :-2] @ np.sqrt(D[:-2, :-2]), v[:-2])
+    assert_allclose(x1.ravel(order="F")[:-2], x2)
+    assert_allclose(x1.ravel(order="F"), D_inv @ L_inv @ v)
+
+    # Test consistency of L_sqrt_D_matmul, sqrt_D_Lt_matmul and inverse_L_sqrt_D_matmul,
+    # i.e. reconstructing the matrices based on X @ unit_vector and compare with
+    # explicit matrices D and L.
+    unit_vec = np.zeros(n)
+    for op, result in (
+        (LDL.sqrt_D_Lt_matmul, np.sqrt(D) @ L.T),
+        (LDL.L_sqrt_D_matmul, L @ np.sqrt(D)),
+        (LDL.inverse_L_sqrt_D_matmul, D_inv @ L_inv),
+    ):
+        X = np.zeros((n, n))
+        for i in range(n):
+            unit_vec[i] = 1
+            X[:, i] = op(unit_vec.copy().reshape((2, 3), order="F")).ravel(order="F")
+            unit_vec[i] = 0
+        assert_allclose(X, result)
+
+
+def test_multinomial_LDL_decomposition(global_random_seed):
+    """Test LDL' decomposition of multinomial hessian."""
+    n_samples, n_features, n_classes = 3, 4, 5
+    rng = np.random.RandomState(global_random_seed)
+    X = rng.standard_normal(size=(n_samples, n_features))
+    coef = rng.standard_normal(size=(n_classes, n_features))
+    raw_prediction = X @ coef.T  # shape = (n_samples, n_classes)
+    loss = LinearModelLoss(
+        base_loss=HalfMultinomialLoss(n_classes=n_classes),
+        fit_intercept=False,
+    )
+    p = loss.base_loss.predict_proba(raw_prediction=raw_prediction)
+    assert_allclose(np.sum(p, axis=1), np.ones(shape=n_samples))
+
+    LDL = Multinomial_LDL_Decomposition(proba=p)
+    # Note that LDL sets q = 1 whenever q = 0 for easier handling of divisions by zero.
+    # As q[:, -1] = 0 if p sums to 1, we do not compare the last values corresponding
+    # to the last class.
+    assert_allclose(1 / LDL.q_inv[:, :-1], 1 - np.cumsum(LDL.p, axis=1)[:, :-1])
+
+    # C = diag(D) L' x with x = X @ coef = raw_prediction
+    C = LDL.sqrt_D_Lt_matmul(raw_prediction.copy())
+
+    # Note that y has no effect on the hessian.
+    grad, hessp = loss.gradient_hessian_product(
+        coef=coef,
+        X=X,
+        y=rng.randint(low=0, high=n_classes, size=n_samples).astype(X.dtype),
+        l2_reg_strength=0.0,
+    )
+    # C.shape = (n_samples, n_classes), hessp(coef).shape = (n_classes, n_features)
+    # LinearModelLoss normalizes loss as 1 / n_samples * sum(loss_i), therefore, we
+    # need to divide C'C by 1/n_samples.
+    assert_allclose(
+        np.tensordot(C, C, axes=2) / n_samples, np.tensordot(coef, hessp(coef), axes=2)
+    )
+    CtC = LDL.L_sqrt_D_matmul(C.copy())
+    CtC = np.tensordot(raw_prediction, CtC, axes=2)
+    assert_allclose(CtC, np.tensordot(C, C, axes=2))
+
+
+def test_multinomial_LDL_inverse_sqrt_D_Lt_matmul(global_random_seed):
+    """Test inverse of LDL' decomposition of multinomial hessian."""
+    n_samples, n_classes = 4, 5
+    rng = np.random.RandomState(global_random_seed)
+    p = rng.uniform(low=0, high=1, size=(n_samples, n_classes))
+    p /= np.sum(p, axis=1)[:, None]
+    LDL = Multinomial_LDL_Decomposition(proba=p)
+    x = rng.standard_normal(size=(n_samples, n_classes))
+    # Without centering, the last class, x[:, -1] would fail in the assert below.
+    x -= np.mean(x, axis=1)[:, None]
+
+    invDL_x = LDL.inverse_L_sqrt_D_matmul(x.copy())
+    LD_invDL_x = LDL.L_sqrt_D_matmul(invDL_x.copy())
+    assert_allclose(LD_invDL_x, x)
+
+
+def test_multinomial_LDL_warning():
+    """Test that LDL warns if probabilities do not sum to 1."""
+    p = np.arange(4, dtype=float).reshape((2, 2))
+    msg = "Probabilities proba are assumed to sum to 1, but they don't."
+    with pytest.warns(UserWarning, match=msg):
+        Multinomial_LDL_Decomposition(proba=p, proba_sum_to_1=True)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -65,6 +65,7 @@ SOLVERS = (
     "lbfgs",
     "liblinear",
     "newton-cd",
+    "newton-cd-gram",
     "newton-cg",
     "newton-cholesky",
     "sag",
@@ -186,7 +187,7 @@ def test_logistic_glmnet_L2(solver):
 
 
 @pytest.mark.filterwarnings("error::sklearn.exceptions.ConvergenceWarning")
-@pytest.mark.parametrize("solver", ["saga", "newton-cd"])
+@pytest.mark.parametrize("solver", ["saga", "newton-cd", "newton-cd-gram"])
 def test_logistic_glmnet_L1(solver, global_random_seed):
     """Compare Logistic regression with L1 regularization to glmnet"""
     l1_reg = 0.5
@@ -240,11 +241,11 @@ def test_logistic_glmnet_L1(solver, global_random_seed):
     # change the value of the objective function nor the predictions.
     coef = r.x.reshape(3, -1).copy()
     coef[:, -1] -= coef[:, -1].mean()
-    # glm.intercept_ = [-0.070237,  0.140473, -0.070237]
+    # glm.intercept_ = [-0.07023662,  0.14047329, -0.07023667]
     assert_allclose(glm.intercept_, coef[:, -1], rtol=1e-4)
-    # glm.coef_ = [[-0.270748,  0.],
-    #              [ 0.      ,  0.],
-    #              [ 0.270748,  0.]])
+    # glm.coef_ = [[-0.27074806,  0.],
+    #              [ 0.        ,  0.],
+    #              [ 0.27074806,  0.]])
     assert_allclose(glm.coef_, coef[:, :-1], rtol=1e-5, atol=1e-8)
 
 
@@ -263,7 +264,7 @@ def test_check_solver_option(LR):
         with pytest.raises(ValueError, match=msg):
             lr.fit(X, y)
 
-    # all solvers except 'liblinear', 'newton-cd' and 'saga'
+    # all solvers except 'liblinear', 'newton-cd', 'newton-cd-gram' and 'saga'
     for solver in ["lbfgs", "newton-cg", "newton-cholesky", "sag"]:
         msg = "Solver %s supports only 'l2' or None penalties," % solver
         if LR == LogisticRegression:
@@ -297,6 +298,12 @@ def test_check_solver_option(LR):
         lr = LR(C=np.inf, solver="liblinear")
         with pytest.raises(ValueError, match=msg):
             lr.fit(X, y)
+
+    # newton-cd does not support sparse X for multiclass
+    msg = "Solver 'newton-cd' does not support sparse X for multiclass settings"
+    lr = LR(solver="newton-cd")
+    with pytest.raises(ValueError, match=msg):
+        lr.fit(sparse.csr_array(X), y)
 
 
 # TODO(1.11): remove filterwarnings with change of default scoring
@@ -392,7 +399,7 @@ def test_consistency_path(global_random_seed):
     f = ignore_warnings
     # can't test with fit_intercept=True since LIBLINEAR
     # penalizes the intercept
-    for solver in ["sag", "saga"]:  # TODO(newton-cd): add newton-cd solvers
+    for solver in ["sag", "saga", "newton-cd", "newton-cd-gram"]:
         coefs, Cs, _ = f(_logistic_regression_path)(
             X,
             y,
@@ -1058,7 +1065,8 @@ def test_logistic_regression_solvers_multiclass_unpenalized(
             max_iter=solver_max_iter.get(solver, 100),
             **params,
         ).fit(X, y)
-        for solver in set(SOLVERS) - set(["liblinear"])
+        # TODO(newton-cd): remove newton-cd when is supports multiclass
+        for solver in set(SOLVERS) - set(["liblinear", "newton-cd"])
     }
     for solver in regressors.keys():
         # See the docstring of test_multinomial_identifiability_on_iris for reference.
@@ -1153,7 +1161,8 @@ def test_logistic_regressioncv_class_weights(weight, class_weight, global_random
     with ignore_warnings(category=ConvergenceWarning):
         clf_lbfgs.fit(X, y)
 
-    for solver in set(SOLVERS) - set(["lbfgs", "liblinear", "newton-cholesky"]):
+    # TODO(newton-cd): remove newton-cd when is supports multiclass
+    for solver in set(SOLVERS) - set(["lbfgs", "liblinear", "newton-cd"]):
         clf = LogisticRegressionCV(
             solver=solver,
             scoring="neg_log_loss",  # TODO(1.11): remove because it is default now
@@ -1351,7 +1360,8 @@ def test_logistic_regression_class_weights(global_random_seed, csr_container):
     y = iris.target[45:]
     class_weight_dict = _compute_class_weight_dictionary(y)
 
-    for solver in set(SOLVERS) - set(["liblinear", "newton-cholesky"]):
+    # TODO(newton-cd): remove newton-cd when is supports multiclass
+    for solver in set(SOLVERS) - set(["liblinear", "newton-cd"]):
         params = dict(solver=solver, max_iter=2000, random_state=global_random_seed)
         clf1 = LogisticRegression(class_weight="balanced", **params)
         clf2 = LogisticRegression(class_weight=class_weight_dict, **params)
@@ -1430,9 +1440,10 @@ def test_logreg_l1(csr_container, fit_intercept, global_random_seed):
         random_state=global_random_seed,
         tol=1e-10,
     )
+    res = dict()
 
     lr_saga = LogisticRegression(solver="saga", max_iter=10_000, **params)
-    lr_saga.fit(X, y)
+    res["saga"] = lr_saga.fit(X, y)
 
     # Check that not all coefficients are zero. Otherwise we should choose a larger
     # (anti-)penalty C.
@@ -1441,28 +1452,35 @@ def test_logreg_l1(csr_container, fit_intercept, global_random_seed):
     if not fit_intercept:
         # Note that liblinear penalizes the intercept, the other solvers do
         # (rightfully) not do that.
-        lr_liblinear = LogisticRegression(
-            solver="liblinear", max_iter=10_000, **params
-        )
-        lr_liblinear.fit(X, y)
+        lr_liblinear = LogisticRegression(solver="liblinear", max_iter=10_000, **params)
+        res["liblinear"] = lr_liblinear.fit(X, y)
         assert_allclose(lr_saga.coef_, lr_liblinear.coef_, atol=0.3)
 
-    lr_cd = LogisticRegression(solver="newton-cd", max_iter=20, **params)
-    lr_cd.fit(X, y)
-    assert_allclose(lr_cd.coef_, lr_saga.coef_, rtol=1e-6)
+    for solver in ["newton-cd-gram", "newton-cd"]:
+        lr_cd = LogisticRegression(solver=solver, max_iter=20, **params)
+        res[solver] = lr_cd.fit(X, y)
+        # The 2 coefficients for X_constant are ideally the same. For predictions,
+        # only their sum matters. It might be that their effect on the objective
+        # is in the last floating point digits such that the solver estimates them
+        # as being different.
+        if lr_cd.coef_[0, -1] == lr_cd.coef_[0, -2]:
+            # This is the ideal path.
+            assert_allclose(lr_cd.coef_, lr_saga.coef_, atol=1e-5)
+        else:
+            # This may happen for some random seeds.
+            assert_allclose(
+                np.sum(lr_cd.coef_[0, -2:]), np.sum(lr_saga.coef_[0, -2:]), rtol=1e-6
+            )
+            assert_allclose(lr_cd.coef_[0, :-2], lr_saga.coef_[0, :-2], rtol=1e-5)
 
     # Check that solving on the sparse and dense data yield the same results
     X_sp = csr_container(X)
-    if not fit_intercept:
-        lr_liblinear_sp = LogisticRegression(
-            solver="liblinear", max_iter=10_000, **params
-        )
-        lr_liblinear_sp.fit(X_sp, y)
-        assert_allclose(lr_liblinear_sp.coef_, lr_liblinear.coef_)
-
-    lr_saga_sp = LogisticRegression(solver="saga", max_iter=10_000, **params)
-    lr_saga_sp.fit(X_sp, y)
-    assert_allclose(lr_saga_sp.coef_, lr_saga.coef_, rtol=1e-3)
+    for solver in res:
+        if fit_intercept and solver == "liblinear":
+            continue
+        lr_sp = LogisticRegression(solver=solver, max_iter=40_000, **params)
+        lr_sp.fit(X_sp, y)
+        assert_allclose(lr_sp.coef_, res[solver].coef_, rtol=1e-6, atol=1e-6)
 
 
 @pytest.mark.parametrize("l1_ratio", [1, 0])  # L1 and L2 penalty
@@ -1604,7 +1622,8 @@ def test_n_iter(solver, use_legacy_attributes):
         assert clf_cv.n_iter_.shape == (n_cv_fold, n_l1_ratios, n_Cs)
 
     # multinomial case
-    if solver in ("liblinear",):
+    # TODO(newton-cd): remove newton-cd when is supports multiclass
+    if solver in ("liblinear", "newton-cd"):
         # This solver only supports one-vs-rest multiclass classification.
         return
 
@@ -1620,7 +1639,10 @@ def test_n_iter(solver, use_legacy_attributes):
         assert clf_cv.n_iter_.shape == (n_cv_fold, n_l1_ratios, n_Cs)
 
 
-@pytest.mark.parametrize("solver", sorted(set(SOLVERS) - set(["liblinear"])))
+# TODO(newton-cd): remove newton-cd when is supports multiclass
+@pytest.mark.parametrize(
+    "solver", sorted(set(SOLVERS) - set(["liblinear", "newton-cd"]))
+)
 @pytest.mark.parametrize("warm_start", (True, False))
 @pytest.mark.parametrize("fit_intercept", (True, False))
 def test_warm_start(global_random_seed, solver, warm_start, fit_intercept):
@@ -1653,6 +1675,7 @@ def test_warm_start(global_random_seed, solver, warm_start, fit_intercept):
         assert cum_diff > 2.0, msg
 
 
+# TODO(newton-cd): Think about adding newton-cd solvers.
 @pytest.mark.parametrize("solver", ["newton-cholesky", "newton-cg"])
 @pytest.mark.parametrize("fit_intercept", (True, False))
 @pytest.mark.parametrize("C", (1, np.inf))
@@ -2329,6 +2352,7 @@ def test_c_inf_no_warning(solver):
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         warnings.filterwarnings("ignore", category=ConvergenceWarning)
+        warnings.filterwarnings("ignore", category=UserWarning)
         lr.fit(X, y)
 
 

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -12,6 +12,7 @@ from numpy.testing import (
 )
 from scipy import sparse
 from scipy.linalg import LinAlgWarning, svd
+from scipy.optimize import minimize
 
 from sklearn import config_context
 from sklearn._loss import HalfMultinomialLoss
@@ -23,6 +24,7 @@ from sklearn.callback.tests._utils import (
 from sklearn.datasets import load_iris, make_classification, make_low_rank_matrix
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import LogisticRegression, LogisticRegressionCV, SGDClassifier
+from sklearn.linear_model._linear_loss import LinearModelLoss
 from sklearn.linear_model._logistic import (
     _log_reg_scoring_path,
     _logistic_regression_path,
@@ -59,7 +61,15 @@ pytestmark = pytest.mark.filterwarnings(
     "ignore:The default value for l1_ratios.*:FutureWarning"
 )
 
-SOLVERS = ("lbfgs", "liblinear", "newton-cg", "newton-cholesky", "sag", "saga")
+SOLVERS = (
+    "lbfgs",
+    "liblinear",
+    "newton-cd",
+    "newton-cg",
+    "newton-cholesky",
+    "sag",
+    "saga",
+)
 X = [[-1, 0], [0, 1], [1, 1]]
 Y1 = [0, 1, 1]
 Y2 = [2, 1, 0]
@@ -106,7 +116,7 @@ def test_predict_3_classes(csr_container):
 
 @pytest.mark.filterwarnings("error::sklearn.exceptions.ConvergenceWarning")
 @pytest.mark.parametrize("solver", ["lbfgs", "newton-cholesky"])
-def test_logistic_glmnet(solver):
+def test_logistic_glmnet_L2(solver):
     """Compare Logistic regression with L2 regularization to glmnet"""
     # 2 classes
     # library("glmnet")
@@ -175,6 +185,69 @@ def test_logistic_glmnet(solver):
     )
 
 
+@pytest.mark.filterwarnings("error::sklearn.exceptions.ConvergenceWarning")
+@pytest.mark.parametrize("solver", ["saga", "newton-cd"])
+def test_logistic_glmnet_L1(solver, global_random_seed):
+    """Compare Logistic regression with L1 regularization to glmnet"""
+    l1_reg = 0.5
+    # 2 classes
+    # library("glmnet")
+    # options(digits=10)
+    # df <- data.frame(a=-4:4, b=c(0,0,1,0,1,1,1,0,0), y=c(0,0,0,1,1,1,1,1,1))
+    # x <- data.matrix(df[,c("a", "b")])
+    # y <- df$y
+    # fit <- glmnet(x=x, y=y, alpha=1, lambda=0.5, intercept=T, family="binomial",
+    #               standardize=F, thresh=1e-10, nlambda=1)
+    # coef(fit, s=0.5)
+    # (Intercept) 0.8509513371
+    # a           0.3862193646
+    # b           .
+    X = np.array([[-4, -3, -2, -1, 0, 1, 2, 3, 4], [0, 0, 1, 0, 1, 1, 1, 0, 0]]).T
+    y = np.array([0, 0, 0, 1, 1, 1, 1, 1, 1])
+    glm = LogisticRegression(
+        C=1 / l1_reg / y.shape[0],  # C=1.0 / penalty (Lasso) / n_samples
+        l1_ratio=1,
+        fit_intercept=True,
+        tol=1e-8,
+        max_iter=300,
+        solver=solver,
+        random_state=global_random_seed,
+    )
+    glm.fit(X, y)
+
+    rtol = 5e-4 if solver == "saga" else 1e-7
+    assert_allclose(glm.intercept_, 0.8509513371, rtol=rtol)
+    assert_allclose(glm.coef_, [[0.3862193646, 0]], rtol=rtol)
+
+    # 3 classes
+    # Unfortunately, glmnet seems to have a bug here. By comparing the objective
+    # function, our solver seems to find better solutions. We resort to scipy optimize.
+    y = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2], dtype=np.float64)
+    X = X.astype(np.float64)  # for LinearModelLoss
+    glm.fit(X, y)
+
+    lml = LinearModelLoss(base_loss=HalfMultinomialLoss(), fit_intercept=True)
+
+    def obj(coef):
+        return float(lml.loss(coef.reshape(3, -1), X=X, y=y, l1_reg_strength=l1_reg))
+
+    r = minimize(
+        obj, np.zeros(3 * 3), method="Powell", tol=1e-10, options={"maxfev": 2000}
+    )
+    assert r.success
+
+    # For better comparison, we symmetrize the unpenalized intercept. This does not
+    # change the value of the objective function nor the predictions.
+    coef = r.x.reshape(3, -1).copy()
+    coef[:, -1] -= coef[:, -1].mean()
+    # glm.intercept_ = [-0.070237,  0.140473, -0.070237]
+    assert_allclose(glm.intercept_, coef[:, -1], rtol=1e-4)
+    # glm.coef_ = [[-0.270748,  0.],
+    #              [ 0.      ,  0.],
+    #              [ 0.270748,  0.]])
+    assert_allclose(glm.coef_, coef[:, :-1], rtol=1e-5, atol=1e-8)
+
+
 # TODO(1.11): remove filterwarnings with change of default scoring
 @pytest.mark.filterwarnings("ignore:The default value.*scoring.*:FutureWarning")
 # TODO(1.10): remove filterwarnings with deprecation period of use_legacy_attributes
@@ -190,7 +263,7 @@ def test_check_solver_option(LR):
         with pytest.raises(ValueError, match=msg):
             lr.fit(X, y)
 
-    # all solvers except 'liblinear' and 'saga'
+    # all solvers except 'liblinear', 'newton-cd' and 'saga'
     for solver in ["lbfgs", "newton-cg", "newton-cholesky", "sag"]:
         msg = "Solver %s supports only 'l2' or None penalties," % solver
         if LR == LogisticRegression:
@@ -199,7 +272,7 @@ def test_check_solver_option(LR):
             lr = LR(solver=solver, l1_ratios=(1,))
         with pytest.raises(ValueError, match=msg):
             lr.fit(X, y)
-    for solver in ["lbfgs", "newton-cg", "newton-cholesky", "sag", "saga"]:
+    for solver in set(SOLVERS) - {"liblinear"}:
         msg = "Solver %s supports only dual=False, got dual=True" % solver
         lr = LR(solver=solver, dual=True)
         with pytest.raises(ValueError, match=msg):
@@ -319,7 +392,7 @@ def test_consistency_path(global_random_seed):
     f = ignore_warnings
     # can't test with fit_intercept=True since LIBLINEAR
     # penalizes the intercept
-    for solver in ["sag", "saga"]:
+    for solver in ["sag", "saga"]:  # TODO(newton-cd): add newton-cd solvers
         coefs, Cs, _ = f(_logistic_regression_path)(
             X,
             y,
@@ -347,7 +420,7 @@ def test_consistency_path(global_random_seed):
             )
 
     # test for fit_intercept=True
-    for solver in ("lbfgs", "newton-cg", "newton-cholesky", "liblinear", "sag", "saga"):
+    for solver in SOLVERS:
         Cs = [1e3]
         coefs, Cs, _ = f(_logistic_regression_path)(
             X,
@@ -1339,10 +1412,9 @@ def test_logreg_intercept_scaling_zero():
 # https://github.com/scikit-learn/scikit-learn/issues/31883
 @pytest.mark.thread_unsafe
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
-def test_logreg_l1(global_random_seed, csr_container):
-    # Because liblinear penalizes the intercept and saga does not, we do not
-    # fit the intercept to make it possible to compare the coefficients of
-    # the two models at convergence.
+@pytest.mark.parametrize("fit_intercept", [False, True])
+def test_logreg_l1(csr_container, fit_intercept, global_random_seed):
+    """Compare L1 solvers."""
     rng = np.random.RandomState(global_random_seed)
     n_samples = 100
     X, y = make_classification(
@@ -1354,28 +1426,43 @@ def test_logreg_l1(global_random_seed, csr_container):
     params = dict(
         l1_ratio=1,
         C=1.0,
-        fit_intercept=False,
-        max_iter=10000,
-        tol=1e-10,
+        fit_intercept=fit_intercept,
         random_state=global_random_seed,
+        tol=1e-10,
     )
-    lr_liblinear = LogisticRegression(solver="liblinear", **params)
-    lr_liblinear.fit(X, y)
 
-    lr_saga = LogisticRegression(solver="saga", **params)
+    lr_saga = LogisticRegression(solver="saga", max_iter=10_000, **params)
     lr_saga.fit(X, y)
 
-    assert_allclose(lr_saga.coef_, lr_liblinear.coef_, atol=0.3)
+    # Check that not all coefficients are zero. Otherwise we should choose a larger
+    # (anti-)penalty C.
+    assert np.sum(np.abs(lr_saga.coef_)) > 1e-2
+
+    if not fit_intercept:
+        # Note that liblinear penalizes the intercept, the other solvers do
+        # (rightfully) not do that.
+        lr_liblinear = LogisticRegression(
+            solver="liblinear", max_iter=10_000, **params
+        )
+        lr_liblinear.fit(X, y)
+        assert_allclose(lr_saga.coef_, lr_liblinear.coef_, atol=0.3)
+
+    lr_cd = LogisticRegression(solver="newton-cd", max_iter=20, **params)
+    lr_cd.fit(X, y)
+    assert_allclose(lr_cd.coef_, lr_saga.coef_, rtol=1e-6)
 
     # Check that solving on the sparse and dense data yield the same results
     X_sp = csr_container(X)
-    lr_liblinear_sp = LogisticRegression(solver="liblinear", **params)
-    lr_liblinear_sp.fit(X_sp, y)
-    assert_allclose(lr_liblinear_sp.coef_, lr_liblinear.coef_)
+    if not fit_intercept:
+        lr_liblinear_sp = LogisticRegression(
+            solver="liblinear", max_iter=10_000, **params
+        )
+        lr_liblinear_sp.fit(X_sp, y)
+        assert_allclose(lr_liblinear_sp.coef_, lr_liblinear.coef_)
 
-    lr_saga_sp = LogisticRegression(solver="saga", **params)
+    lr_saga_sp = LogisticRegression(solver="saga", max_iter=10_000, **params)
     lr_saga_sp.fit(X_sp, y)
-    assert_allclose(lr_saga_sp.coef_, lr_saga.coef_)
+    assert_allclose(lr_saga_sp.coef_, lr_saga.coef_, rtol=1e-3)
 
 
 @pytest.mark.parametrize("l1_ratio", [1, 0])  # L1 and L2 penalty
@@ -1736,7 +1823,8 @@ def test_warm_start_converge_LR(global_random_seed):
     assert_allclose(lr_no_ws_loss, lr_ws_loss, rtol=1e-5)
 
 
-def test_elastic_net_coeffs(global_random_seed):
+@pytest.mark.parametrize("solver", ["saga", "newton-cd"])
+def test_elastic_net_coeffs(global_random_seed, solver):
     # make sure elasticnet penalty gives different coefficients from l1 and l2
     # with saga solver (l1_ratio different from 0 or 1)
     X, y = make_classification(random_state=global_random_seed)
@@ -1747,7 +1835,7 @@ def test_elastic_net_coeffs(global_random_seed):
         lr = LogisticRegression(
             C=C,
             l1_ratio=l1_ratio,
-            solver="saga",
+            solver=solver,
             random_state=global_random_seed,
             tol=1e-3,
             max_iter=500,
@@ -1789,6 +1877,7 @@ def test_elastic_net_l1_l2_equivalence(global_random_seed, C, penalty, l1_ratio)
     assert_array_almost_equal(lr_enet.coef_, lr_expected.coef_)
 
 
+# TODO(newton-cd): improve test by using CD solvers instead of saga
 # FIXME: Random state is fixed in order to make the test pass
 @pytest.mark.parametrize("C", [0.001, 1, 100, 1e6])
 def test_elastic_net_vs_l1_l2(C):
@@ -1823,7 +1912,8 @@ def test_elastic_net_vs_l1_l2(C):
     assert gs.score(X_test, y_test) >= l2_clf.score(X_test, y_test)
 
 
-##FIXME: Random state is fixed in order to make the test pass
+# TODO(newton-cd): use CD solvers instead of saga?
+# FIXME: Random state is fixed in order to make the test pass
 @pytest.mark.parametrize("C", np.logspace(-3, 2, 4))
 @pytest.mark.parametrize("l1_ratio", [0.1, 0.5, 0.9])
 def test_LogisticRegression_elastic_net_objective(C, l1_ratio):
@@ -1867,8 +1957,9 @@ def test_LogisticRegression_elastic_net_objective(C, l1_ratio):
 
 
 # FIXME: Random state is fixed in order to make the test pass
+@pytest.mark.parametrize("solver", ("saga", "newton-cd"))
 @pytest.mark.parametrize("n_classes", (2, 3))
-def test_LogisticRegressionCV_GridSearchCV_elastic_net(n_classes):
+def test_LogisticRegressionCV_GridSearchCV_elastic_net(solver, n_classes):
     # make sure LogisticRegressionCV gives same best params (l1 and C) as
     # GridSearchCV when penalty is elasticnet
 
@@ -1887,7 +1978,7 @@ def test_LogisticRegressionCV_GridSearchCV_elastic_net(n_classes):
     lrcv = LogisticRegressionCV(
         l1_ratios=l1_ratios,
         Cs=Cs,
-        solver="saga",
+        solver=solver,
         cv=cv,
         random_state=0,
         tol=1e-2,
@@ -1898,7 +1989,7 @@ def test_LogisticRegressionCV_GridSearchCV_elastic_net(n_classes):
 
     param_grid = {"C": Cs, "l1_ratio": l1_ratios}
     lr = LogisticRegression(
-        solver="saga",
+        solver=solver,
         random_state=0,
         tol=1e-2,
     )
@@ -2042,7 +2133,7 @@ def test_l1_ratio_non_elasticnet():
         r" 'elasticnet'\. Got \(penalty=l1\)"
     )
     with pytest.warns(UserWarning, match=msg):
-        LogisticRegression(penalty="l1", solver="saga", l1_ratio=0.5).fit(X, Y1)
+        LogisticRegression(C=1e-1, penalty="l1", solver="saga", l1_ratio=0.5).fit(X, Y1)
 
 
 @pytest.mark.parametrize("C", np.logspace(-3, 2, 4))
@@ -2416,7 +2507,7 @@ def test_large_sparse_matrix(solver, csr_container):
     rng = np.random.RandomState(42)
     y = rng.randint(2, size=X.shape[0])
 
-    if solver in ["liblinear", "sag", "saga"]:
+    if solver in ["liblinear", "sag", "saga", "newton-cd"]:
         msg = "Only sparse matrices with 32-bit integer indices"
         with pytest.raises(ValueError, match=msg):
             LogisticRegression(solver=solver).fit(X, y)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -51,7 +51,13 @@ from sklearn.utils._array_api import (
     device as array_api_device,
 )
 from sklearn.utils._testing import _array_api_for_tests, ignore_warnings
-from sklearn.utils.fixes import _IS_32BIT, COO_CONTAINERS, CSR_CONTAINERS
+from sklearn.utils.fixes import (
+    _IS_32BIT,
+    COO_CONTAINERS,
+    CSR_CONTAINERS,
+    parse_version,
+    sp_version,
+)
 
 pytestmark = pytest.mark.filterwarnings(
     "error::sklearn.exceptions.ConvergenceWarning:sklearn.*"
@@ -298,12 +304,6 @@ def test_check_solver_option(LR):
         lr = LR(C=np.inf, solver="liblinear")
         with pytest.raises(ValueError, match=msg):
             lr.fit(X, y)
-
-    # newton-cd does not support sparse X for multiclass
-    msg = "Solver 'newton-cd' does not support sparse X for multiclass settings"
-    lr = LR(solver="newton-cd")
-    with pytest.raises(ValueError, match=msg):
-        lr.fit(sparse.csr_array(X), y)
 
 
 # TODO(1.11): remove filterwarnings with change of default scoring
@@ -1065,8 +1065,7 @@ def test_logistic_regression_solvers_multiclass_unpenalized(
             max_iter=solver_max_iter.get(solver, 100),
             **params,
         ).fit(X, y)
-        # TODO(newton-cd): remove newton-cd when is supports multiclass
-        for solver in set(SOLVERS) - set(["liblinear", "newton-cd"])
+        for solver in set(SOLVERS) - set(["liblinear"])
     }
     for solver in regressors.keys():
         # See the docstring of test_multinomial_identifiability_on_iris for reference.
@@ -1161,8 +1160,7 @@ def test_logistic_regressioncv_class_weights(weight, class_weight, global_random
     with ignore_warnings(category=ConvergenceWarning):
         clf_lbfgs.fit(X, y)
 
-    # TODO(newton-cd): remove newton-cd when is supports multiclass
-    for solver in set(SOLVERS) - set(["lbfgs", "liblinear", "newton-cd"]):
+    for solver in set(SOLVERS) - set(["lbfgs", "liblinear"]):
         clf = LogisticRegressionCV(
             solver=solver,
             scoring="neg_log_loss",  # TODO(1.11): remove because it is default now
@@ -1360,8 +1358,10 @@ def test_logistic_regression_class_weights(global_random_seed, csr_container):
     y = iris.target[45:]
     class_weight_dict = _compute_class_weight_dictionary(y)
 
-    # TODO(newton-cd): remove newton-cd when is supports multiclass
-    for solver in set(SOLVERS) - set(["liblinear", "newton-cd"]):
+    for solver in set(SOLVERS) - set(["liblinear"]):
+        if solver == "newton-cd" and sparse.issparse(X):
+            # TODO(scipy 1.17): remove once scipy >= 1.17 is minimal version.
+            continue
         params = dict(solver=solver, max_iter=2000, random_state=global_random_seed)
         clf1 = LogisticRegression(class_weight="balanced", **params)
         clf2 = LogisticRegression(class_weight=class_weight_dict, **params)
@@ -1382,6 +1382,9 @@ def test_logistic_regression_class_weights(global_random_seed, csr_container):
     class_weight_dict = _compute_class_weight_dictionary(y)
 
     for solver in SOLVERS:
+        if solver == "newton-cd" and sparse.issparse(X):
+            # TODO(scipy 1.17): remove once scipy >= 1.17 is minimal version.
+            continue
         params = dict(solver=solver, max_iter=1000, random_state=global_random_seed)
 
         clf1 = LogisticRegression(class_weight="balanced", **params)
@@ -1622,8 +1625,7 @@ def test_n_iter(solver, use_legacy_attributes):
         assert clf_cv.n_iter_.shape == (n_cv_fold, n_l1_ratios, n_Cs)
 
     # multinomial case
-    # TODO(newton-cd): remove newton-cd when is supports multiclass
-    if solver in ("liblinear", "newton-cd"):
+    if solver == "liblinear":
         # This solver only supports one-vs-rest multiclass classification.
         return
 
@@ -1639,10 +1641,7 @@ def test_n_iter(solver, use_legacy_attributes):
         assert clf_cv.n_iter_.shape == (n_cv_fold, n_l1_ratios, n_Cs)
 
 
-# TODO(newton-cd): remove newton-cd when is supports multiclass
-@pytest.mark.parametrize(
-    "solver", sorted(set(SOLVERS) - set(["liblinear", "newton-cd"]))
-)
+@pytest.mark.parametrize("solver", sorted(set(SOLVERS) - set(["liblinear"])))
 @pytest.mark.parametrize("warm_start", (True, False))
 @pytest.mark.parametrize("fit_intercept", (True, False))
 def test_warm_start(global_random_seed, solver, warm_start, fit_intercept):
@@ -3114,3 +3113,26 @@ def test_logistic_regression_callback_support_warning():
         match="Callbacks are only supported in LogisticRegression for solver='lbfgs'",
     ):
         LogisticRegression(solver="liblinear").set_callbacks(cb)
+
+
+# TODO(scipy 1.17): remove once scipy >= 1.17 is minimal version.
+@pytest.mark.skipif(
+    sp_version >= parse_version("1.17"),
+    reason="scipy version 1.17 required for sparse slicing",
+)
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_newton_cd_scipy_below_1_16_raises(csr_container):
+    """Tests that newton-cd with multiclass and sparse X raises for scipy<1.17"""
+    X, y = make_classification(n_classes=3, n_samples=50, n_informative=6)
+    X = csr_container(X)
+    msg = "Solver 'newton-cd' supports sparse X in a multiclass setting"
+    with pytest.raises(ValueError, match=msg):
+        LogisticRegression(solver="newton-cd").fit(X, y)
+
+    with pytest.raises(ValueError, match=msg):
+        LogisticRegressionCV(
+            solver="newton-cd",
+            l1_ratios=[0],
+            use_legacy_attributes=False,
+            scoring="neg_log_loss",
+        ).fit(X, y)


### PR DESCRIPTION
### Reference Issues/PRs
Contributes to #16637.

### What does this implement/fix? Explain your changes.
This PR implements two proximal Newton solvers relying on the available coordinate descent solvers:
- "newton-cd-gram" uses `enet_coordinate_descent_gram`
  Good for n_samples >> n_features
- "newton-cd" uses the other CD-solvers and a special new one for the multinomial case (n_classes >= 3).
  Good for L1 penalties in combination with n_features >> n_samples.

These solvers work for all GLMs, but this PR only makes them available in `LogisticRegression`.

#### Why 2 new solvers?
- They will add L1 penalties to PoissonRegressor etc.
- For LogisticRegression, there is room for high precision solvers:
  - Currently, the only L1 solver for multiclass is saga.
  - Currently, the only enet solver (L1 + L2 penalty) is saga.
- Originally, I wanted to combine both into a single one with automatic selection when to use which. This decision, however, is very tricky. So I went with having both options user facing.


#### AI usage disclosure
No AI usage.


#### Any other comments?
If we deem these 2 solvers a good addition, we might consider to retire liblinear.

Some further remarks:
- The development of these 2 solvers took about one year!
- If you ever develop optimization routines, line search is your friend, better not touch it because of failing tests.

### TODO
- [ ] remove python CD multinomial (keep Cython version)
- [ ] Improve doc on solver choice
- [ ] Add changelog
- [ ] Maybe: support float32 in Cython multinomial CD
- [ ] Maybe: openmp thread parallelism for multinomial CD
- [ ] Maybe: try different inner tolerance 

### Split in multiple smaller PRs:
- [x] #34285
- [x] #34336
- [x] #34345
- [x] #34337
- [x] #34377
- [x] #34523
- [x] #34561
- [ ] #34681