### PR TITLE
Fixes small typo in convergence warning for newton solver.

### DIFF
--- a/sklearn/linear_model/_glm/_newton_solver.py
+++ b/sklearn/linear_model/_glm/_newton_solver.py
@@ -289,7 +289,7 @@ class NewtonSolver(ABC):
             warnings.warn(
                 (
                     f"Line search of Newton solver {self.__class__.__name__} at"
-                    f" iteration #{self.iteration} did no converge after 21 line search"
+                    f" iteration #{self.iteration} did not converge after 21 line search"
                     " refinement iterations. It will now resort to lbfgs instead."
                 ),
                 ConvergenceWarning,

--- a/sklearn/linear_model/_glm/_newton_solver.py
+++ b/sklearn/linear_model/_glm/_newton_solver.py
@@ -289,8 +289,8 @@ class NewtonSolver(ABC):
             warnings.warn(
                 (
                     f"Line search of Newton solver {self.__class__.__name__} at"
-                    f" iteration #{self.iteration} did not converge after 21 line search"
-                    " refinement iterations. It will now resort to lbfgs instead."
+                    f" iteration #{self.iteration} did not converge after 21 line "
+                    "search refinement iterations. It will now resort to lbfgs instead."
                 ),
                 ConvergenceWarning,
             )


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->



#### What does this implement/fix? Explain your changes.

This change fixes a typo in the Newton solver convergence warning - changing the wording from "did no converge" to "did not converge".


#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
