### PR TITLE
FIX _predict_proba_lr in LinearClassifierMixin

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/33168.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/33168.fix.rst
@@ -1,0 +1,4 @@
+- Fixed a bug in :class:`linear_model.SGDClassifier` for multiclass settings where
+  large negative values of :method:`decision_function` could lead to NaN values. In
+  this case, this fix assigns equal probability for each class.
+  By :user:`Christian Lorentzen <lorentzenchr>`.

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -405,7 +405,14 @@ class LinearClassifierMixin(ClassifierMixin):
             return np.vstack([1 - prob, prob]).T
         else:
             # OvR normalization, like LibLinear's predict_probability
-            prob /= prob.sum(axis=1).reshape((prob.shape[0], -1))
+            prob_sum = prob.sum(axis=1)
+            all_zero = prob_sum == 0
+            if np.any(all_zero):
+                # The above might assign zero to all classes, which doesn't
+                # normalize neatly; work around this to produce uniform probabilities.
+                prob[all_zero, :] = 1
+                prob_sum[all_zero] = prob.shape[1]  # n_classes
+            prob /= prob_sum.reshape((prob.shape[0], -1))
             return prob
 
 

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -7,9 +7,11 @@ import numpy as np
 import pytest
 from scipy import linalg, sparse
 
+from sklearn.base import BaseEstimator
 from sklearn.datasets import load_iris, make_regression, make_sparse_uncorrelated
 from sklearn.linear_model import LinearRegression
 from sklearn.linear_model._base import (
+    LinearClassifierMixin,
     _preprocess_data,
     _rescale_data,
     make_dataset,
@@ -844,3 +846,27 @@ def test_linear_regression_sample_weight_consistency(
     assert_allclose(reg1.coef_, reg2.coef_, rtol=1e-6)
     if fit_intercept:
         assert_allclose(reg1.intercept_, reg2.intercept_)
+
+
+def test_predict_proba_lr_large_values():
+    """Test that _predict_proba_lr of LinearClassifierMixin deals with large values.
+
+    Note that exp(-1000) = 0.
+    """
+
+    class MockClassifier(LinearClassifierMixin, BaseEstimator):
+        def __init__(self):
+            pass
+
+        def fit(self, X, y):
+            self.__sklearn_is_fitted__ = True
+
+        def decision_function(self, X):
+            n_samples = X.shape[0]
+            return np.tile([-1000.0] * 4, [n_samples, 1])
+
+    clf = MockClassifier()
+    clf.fit(X=None, y=None)
+
+    proba = clf._predict_proba_lr(np.ones(5))
+    assert_allclose(np.sum(proba, axis=1), 1)

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -849,7 +849,8 @@ def test_linear_regression_sample_weight_consistency(
 
 
 def test_predict_proba_lr_large_values():
-    """Test that _predict_proba_lr of LinearClassifierMixin deals with large values.
+    """Test that _predict_proba_lr of LinearClassifierMixin deals with large
+    negative values.
 
     Note that exp(-1000) = 0.
     """


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #17978.

#### What does this implement/fix? Explain your changes.
`LinearClassifierMixin._predict_proba_lr` might return nan or inf if `decision_function` returns large negative values, because all probabilities are zero in floating point arithmetic (e.g. exp(-1000) = 0).

#### AI usage disclosure
None

#### Any other comments?
I guess the only estimator is `SGDClassifier`, not 100% sure.