### PR TITLE
DOC add link to plot_huber_vs_ridge example in HuberRegressor docstring

### DIFF
--- a/sklearn/linear_model/_huber.py
+++ b/sklearn/linear_model/_huber.py
@@ -141,6 +141,9 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
     The Huber loss function has the advantage of not being heavily influenced
     by the outliers while not completely ignoring their effect.
 
+    See :ref:`sphx_glr_auto_examples_linear_model_plot_huber_vs_ridge.py`
+    for a comparison with Ridge regression on a dataset with outliers.
+
     Read more in the :ref:`User Guide <huber_regression>`
 
     .. versionadded:: 0.18


### PR DESCRIPTION
Towards #30621

This PR adds a link to the `plot_huber_vs_ridge.py` example in the HuberRegressor class docstring.

The example demonstrates a comparison between HuberRegressor and Ridge on a dataset with outliers, which is a key use case for HuberRegressor. This link helps users discover this practical example directly from the API documentation.

Similar pattern exists in Ridge class which links to `plot_ridge_coeffs.py` in its docstring.