### PR TITLE
DOC add link to plot_lasso_dense_vs_sparse_data in Lasso docstring

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1247,7 +1247,8 @@ class Lasso(ElasticNet):
         calculations. The Gram matrix can also be passed as argument.
         For sparse input this option is always ``False`` to preserve sparsity.
 
-        See :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_dense_vs_sparse_data.py`
+        See
+        :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_dense_vs_sparse_data.py`
         for a comparison of dense and sparse data performance.
 
     copy_X : bool, default=True

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1247,6 +1247,9 @@ class Lasso(ElasticNet):
         calculations. The Gram matrix can also be passed as argument.
         For sparse input this option is always ``False`` to preserve sparsity.
 
+        See :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_dense_vs_sparse_data.py`
+        for a comparison of dense and sparse data performance.
+
     copy_X : bool, default=True
         If ``True``, X will be copied; else, it may be overwritten.
 


### PR DESCRIPTION
Towards #30621

This PR adds a link to the `plot_lasso_dense_vs_sparse_data.py` example in the Lasso class docstring, specifically in the `precompute` parameter description.

The example demonstrates performance differences between dense and sparse data formats, which is directly relevant to the `precompute` parameter that behaves differently for sparse data.

This helps users understand when to use sparse vs dense data formats with Lasso.