### PR TITLE
DOC add link to plot_omp example in OrthogonalMatchingPursuit docstring

### DIFF
--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -729,6 +729,10 @@ class OrthogonalMatchingPursuit(MultiOutputMixin, RegressorMixin, LinearModel):
     0.9991
     >>> reg.predict(X[:1,])
     array([-78.3854])
+
+    For an example of using Orthogonal Matching Pursuit for sparse signal
+    recovery, see
+    :ref:`sphx_glr_auto_examples_linear_model_plot_omp.py`.
     """
 
     _parameter_constraints: dict = {


### PR DESCRIPTION
Towards #30621

This PR adds a link to the plot_omp.py example in the OrthogonalMatchingPursuit class docstring.

The example demonstrates using Orthogonal Matching Pursuit for sparse signal recovery from noisy measurements, which is the primary use case for OrthogonalMatchingPursuit. This link helps users discover this practical example directly from the API documentation.