### PR TITLE
DOC add link to plot_multi_task_lasso_support example in MultiTaskLasso docstring

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2907,6 +2907,9 @@ class MultiTaskLasso(MultiTaskElasticNet):
     [0.         0.94592424]]
     >>> print(clf.intercept_)
     [-0.41888636 -0.87382323]
+
+    For an example of joint feature selection across multiple tasks, see
+    :ref:`sphx_glr_auto_examples_linear_model_plot_multi_task_lasso_support.py`.
     """
 
     _parameter_constraints: dict = {


### PR DESCRIPTION
Towards #30621

This PR adds a link to the plot_multi_task_lasso_support.py example in the MultiTaskLasso class docstring.

The example demonstrates joint feature selection across multiple tasks, which is the key feature of MultiTaskLasso - enforcing the same features to be selected across all tasks. This link helps users discover this practical example directly from the API documentation.