### PR TITLE
DOC add link to plot_theilsen example in TheilSenRegressor docstring

### DIFF
--- a/sklearn/linear_model/_theil_sen.py
+++ b/sklearn/linear_model/_theil_sen.py
@@ -316,6 +316,9 @@ class TheilSenRegressor(RegressorMixin, LinearModel):
     0.9884
     >>> reg.predict(X[:1,])
     array([-31.5871])
+
+    For a comparison with other robust estimators, see
+    :ref:`sphx_glr_auto_examples_linear_model_plot_theilsen.py`.
     """
 
     _parameter_constraints: dict = {


### PR DESCRIPTION
Towards #30621

This PR adds a link to the plot_theilsen.py example in the TheilSenRegressor class docstring.

The example demonstrates how Theil-Sen regression is robust against outliers by comparing it with OLS and RANSAC on datasets with outliers. This comparison showcases the key advantage of TheilSenRegressor and helps users understand when to use it.