### PR TITLE
DOC add link to plot_quantile_regression example in QuantileRegressor docstring

### DIFF
--- a/sklearn/linear_model/_quantile.py
+++ b/sklearn/linear_model/_quantile.py
@@ -104,6 +104,9 @@ class QuantileRegressor(LinearModel, RegressorMixin, BaseEstimator):
     >>> reg = QuantileRegressor(quantile=0.8).fit(X, y)
     >>> np.mean(y <= reg.predict(X))
     np.float64(0.8)
+
+    For an example of predicting non-trivial conditional quantiles, see
+    :ref:`sphx_glr_auto_examples_linear_model_plot_quantile_regression.py`.
     """
 
     _parameter_constraints: dict = {


### PR DESCRIPTION
Towards #30621

This PR adds a link to the plot_quantile_regression.py example in the QuantileRegressor class docstring.

The example demonstrates how quantile regression can predict non-trivial conditional quantiles for datasets with heteroscedastic or asymmetric error distributions. This showcases the key use case for QuantileRegressor and helps users understand its advantages over standard regression.