### PR TITLE
DOC Explain multi-output behavior in GaussianProcessRegressor

### DIFF
--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -180,6 +180,17 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
        "Gaussian Processes for Machine Learning",
        MIT Press 2006 <https://www.gaussianprocess.org/gpml/chapters/RW.pdf>`_
 
+    Notes
+    -----
+    For multi-output (multi-dimensional target values), the implementation
+    treats each output dimension independently. The model does **not** assume
+    correlations between different output dimensions (i.e., it does not perform
+    co-kriging or multi-task learning). Instead, it fits a separate Gaussian
+    Process for each target dimension by maximizing the sum of the
+    log-marginal likelihoods across all outputs (see equation 5.8 in [RW2006]_).
+    This approach is computationally efficient but does not model inter-output
+    dependencies.
+
     Examples
     --------
     >>> from sklearn.datasets import make_friedman2


### PR DESCRIPTION
This PR addresses #13989 by adding a Notes section to the GaussianProcessRegressor docstring explaining how multi-output regression is handled.

The documentation now clarifies that:
- Each output dimension is treated independently
- The model does NOT perform co-kriging or multi-task learning
- It does NOT model correlations between different output dimensions
- It maximizes the sum of log-marginal likelihoods across all outputs (equation 5.8 in Rasmussen & Williams 2006)

This answers the original question from @bread9 and provides the technical details identified by @JSestito in the comments.