### PR TITLE
DOC Improve var_smoothing parameter documentation in GaussianNB

### DIFF
--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -179,7 +179,13 @@ class GaussianNB(_BaseNB):
 
     var_smoothing : float, default=1e-9
         Portion of the largest variance of all features that is added to
-        variances for calculation stability.
+        variances for calculation stability. This parameter prevents zero
+        or very small variances that can cause numerical issues during
+        probability calculations. The absolute value added to variances
+        is computed as `var_smoothing * max(var(X, axis=0))` and stored
+        in the `epsilon_` attribute. Larger values provide more smoothing
+        but may reduce model accuracy. The default value of 1e-9 works well
+        for most use cases.
 
         .. versionadded:: 0.20
 


### PR DESCRIPTION
This PR addresses #14054 by expanding the documentation for the var_smoothing parameter in GaussianNB.

The enhanced description now explains:
- What the parameter does: prevents zero or very small variances that cause numerical issues
- How it's calculated: `var_smoothing * max(var(X, axis=0))`
- Where the result is stored: `epsilon_` attribute
- The trade-off: larger values provide more smoothing but may reduce accuracy
- That the default value of 1e-9 works well for most cases

This provides users with sufficient detail to understand when and how to adjust this parameter, addressing the "not documented" part of the issue.