### PR TITLE
DOC Clarify that Nystroem does not support precomputed kernels

### DIFF
--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -860,7 +860,7 @@ class Nystroem(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator)
         Kernel map to be approximated. A callable should accept two arguments
         and the keyword arguments passed to this object as `kernel_params`, and
         should return a floating point number.
-        
+
         .. note::
            The 'precomputed' kernel is NOT supported. Despite appearing in some
            internal validation code, Nystroem cannot work with precomputed

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -860,6 +860,12 @@ class Nystroem(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator)
         Kernel map to be approximated. A callable should accept two arguments
         and the keyword arguments passed to this object as `kernel_params`, and
         should return a floating point number.
+        
+        .. note::
+           The 'precomputed' kernel is NOT supported. Despite appearing in some
+           internal validation code, Nystroem cannot work with precomputed
+           kernel matrices as it needs to compute the kernel between the randomly
+           sampled basis points and the input data.
 
     gamma : float, default=None
         Gamma parameter for the RBF, laplacian, polynomial, exponential chi2


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #19178

#### What does this implement/fix?
This PR clarifies in the Nystroem documentation that precomputed kernels are NOT supported, despite 'precomputed' appearing in parameter validation code and `_get_kernel_params` method.

#### Any other comments?
The current implementation is misleading - while "precomputed" appears as a valid option in the code, Nystroem cannot actually work with precomputed kernel matrices because it needs to compute the kernel between randomly sampled basis points and input data.

Added a clear note in the docstring to prevent user confusion.