### PR TITLE
DOC Document BallTree's component-wise centroid calculation assumption

### DIFF
--- a/sklearn/neighbors/_binary_tree.pxi.tp
+++ b/sklearn/neighbors/_binary_tree.pxi.tp
@@ -231,6 +231,14 @@ CLASS_DOC = """{BinaryTree} for fast generalized N-point problems
 
 Read more in the :ref:`User Guide <unsupervised_neighbors>`.
 
+.. note::
+   {BinaryTree} computes node centroids by averaging sample coordinates
+   component-wise. This assumes that component-wise averaging produces
+   valid points in the sample space. For custom metrics where this
+   assumption does not hold (e.g., samples on manifolds or in non-Euclidean
+   spaces), consider using a brute-force approach or implementing a custom
+   data structure that uses representative points (medoids) instead of means.
+
 Parameters
 ----------
 X : array-like of shape (n_samples, n_features)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #12697

#### What does this implement/fix?
This PR documents that BallTree computes node centroids by averaging sample coordinates component-wise, which assumes such averaging produces valid points in the sample space.

#### Any other comments?
This assumption may not hold for custom metrics where samples live in non-Euclidean spaces or on manifolds (e.g., directional data, graphs, etc.). In such cases, component-wise averaging might produce invalid or meaningless centroids.

Added a note in the BinaryTree docstring (which BallTree inherits) to:
- Clarify this assumption
- Suggest alternatives (brute-force or medoid-based approaches) when the assumption is violated

This helps users understand the limitations when using BallTree with custom metrics.