### PR TITLE
TST: Add common test for transform() on different sparse formats

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1384,6 +1384,13 @@ def _check_estimator_sparse_container(name, estimator_orig, sparse_type):
                 else:
                     expected_probs_shape = (X.shape[0], 4)
                 assert probs.shape == expected_probs_shape
+            if hasattr(estimator, "transform"):
+                X_trans = estimator.transform(X)
+                # Check that transform returns output with the correct number of samples
+                assert X_trans.shape[0] == X.shape[0], (
+                    f"Estimator {name} transform output has {X_trans.shape[0]} "
+                    f"samples, expected {X.shape[0]} samples."
+                )
 
 
 def check_estimator_sparse_matrix(name, estimator_orig):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #14176

#### What does this implement/fix? Explain your changes.
This PR extends the common estimator test `_check_estimator_sparse_container` to test the `transform()` method on different sparse matrix formats (CSR, CSC, COO, LIL, DOK, DIA, BSR), similar to how it already tests `predict()` and `predict_proba()`.

The change adds a simple check that:
1. Verifies the estimator has a `transform` method
2. Calls `transform()` on sparse matrices
3. Asserts the output has the correct number of samples

This ensures all transformers in scikit-learn are tested with various sparse formats, making individual test files like `test_truncated_svd.py::test_sparse_formats` redundant.

#### AI usage disclosure
I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding