### PR TITLE
FIX Exclude all-zero relevance samples from NDCG computation (#29521)

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -2041,7 +2041,7 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
         )
     _check_dcg_target_type(y_true)
     gain = _ndcg_sample_scores(y_true, y_score, k=k, ignore_ties=ignore_ties)
-    
+
     # Exclude samples where all items are irrelevant (all relevances are 0)
     # For these samples, NDCG is undefined (0/0) and should not contribute
     # to the average. This ensures ndcg_score(y, y) == 1.0 always holds.
@@ -2072,7 +2072,7 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
             if sample_weight is not None:
                 sample_weight = np.asarray(sample_weight)[mask]
             return float(np.average(gain[mask], weights=sample_weight))
-    
+
     return float(np.average(gain, weights=sample_weight))
 
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1980,6 +1980,38 @@ def test_ndcg_error_single_document():
         ndcg_score([[1]], [[1]])
 
 
+def test_ndcg_all_zero_relevance():
+    """Test that ndcg_score(y, y) == 1 even when some samples have all-zero relevances.
+    
+    Regression test for issue #29521.
+    When all items are irrelevant (all relevances are 0) for a sample,
+    NDCG is undefined (0/0). Such samples should be excluded from averaging
+    to ensure ndcg_score(y, y) == 1.0 always holds.
+    """
+    # Case 1: Mix of relevant and all-zero samples
+    y = np.array([[1.0, 0.0, 1.0], [0.0, 0.0, 0.0]])
+    with pytest.warns(UserWarning, match="All ground truth relevances are zero"):
+        score = ndcg_score(y, y)
+    assert score == pytest.approx(1.0)
+    
+    # Case 2: All samples have all-zero relevances  
+    y_all_zero = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+    with pytest.warns(UserWarning, match="All ground truth relevances are zero"):
+        score = ndcg_score(y_all_zero, y_all_zero)
+    assert np.isnan(score)
+    
+    # Case 3: Single sample with all-zero relevance
+    y_single = np.array([[0.0, 0.0, 0.0]])
+    with pytest.warns(UserWarning, match="All ground truth relevances are zero"):
+        score = ndcg_score(y_single, y_single)
+    assert np.isnan(score)
+    
+    # Case 4: Normal case - should not warn and should return 1.0
+    y_normal = np.array([[1.0, 0.0, 1.0], [2.0, 1.0, 3.0]])
+    score = ndcg_score(y_normal, y_normal)
+    assert score == pytest.approx(1.0)
+
+
 def test_ndcg_score():
     _, y_true = make_multilabel_classification(random_state=0, n_classes=10)
     y_score = -y_true + 1

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1982,7 +1982,7 @@ def test_ndcg_error_single_document():
 
 def test_ndcg_all_zero_relevance():
     """Test that ndcg_score(y, y) == 1 even when some samples have all-zero relevances.
-    
+
     Regression test for issue #29521.
     When all items are irrelevant (all relevances are 0) for a sample,
     NDCG is undefined (0/0). Such samples should be excluded from averaging
@@ -1993,19 +1993,19 @@ def test_ndcg_all_zero_relevance():
     with pytest.warns(UserWarning, match="All ground truth relevances are zero"):
         score = ndcg_score(y, y)
     assert score == pytest.approx(1.0)
-    
-    # Case 2: All samples have all-zero relevances  
+
+    # Case 2: All samples have all-zero relevances
     y_all_zero = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
     with pytest.warns(UserWarning, match="All ground truth relevances are zero"):
         score = ndcg_score(y_all_zero, y_all_zero)
     assert np.isnan(score)
-    
+
     # Case 3: Single sample with all-zero relevance
     y_single = np.array([[0.0, 0.0, 0.0]])
     with pytest.warns(UserWarning, match="All ground truth relevances are zero"):
         score = ndcg_score(y_single, y_single)
     assert np.isnan(score)
-    
+
     # Case 4: Normal case - should not warn and should return 1.0
     y_normal = np.array([[1.0, 0.0, 1.0], [2.0, 1.0, 3.0]])
     score = ndcg_score(y_normal, y_normal)


### PR DESCRIPTION
## Description

Fixes #29521 

When all ground truth relevances are zero for a sample, both DCG and IDCG are 0, making NDCG undefined (0/0). Previously, such samples were assigned a score of 0 and included in averaging, causing `ndcg_score(y, y)` to return values less than 1.0.

According to the original 2002 Jarvelin & Kekalainen paper that introduced NDCG:
> The (D)CG vectors for each IR technique can be normalized by dividing them by the corresponding ideal (D)CG vectors, component by component. In this way, for any vector position, the normalized value 1 represents ideal performance...

This means `ndcg_score(y, y)` must always equal 1.0.

## Changes

**sklearn/metrics/_ranking.py:**
- Added detection for samples where all relevances are 0
- Raises `UserWarning` when such samples are encountered
- Excludes these samples from the averaging calculation
- Returns `np.nan` if all samples have all-zero relevances
- Updated docstring with `versionchanged` notes explaining the new behavior

**sklearn/metrics/tests/test_ranking.py:**
- Added `test_ndcg_all_zero_relevance()` with comprehensive test cases:
  - Mix of relevant and all-zero samples (should return 1.0)
  - All samples with all-zero relevances (should return NaN)
  - Single sample with all-zero relevance (should return NaN)
  - Normal case without all-zero samples (should return 1.0)

## Example

Before this fix:
```python
import numpy as np
from sklearn.metrics import ndcg_score

y = np.array([[1.0, 0.0, 1.0], [0.0, 0.0, 0.0]])
ndcg_score(y, y)  # Returns 0.5 (WRONG)
```

After this fix:
```python
import numpy as np
from sklearn.metrics import ndcg_score

y = np.array([[1.0, 0.0, 1.0], [0.0, 0.0, 0.0]])
# UserWarning: All ground truth relevances are zero for at least one sample...
ndcg_score(y, y)  # Returns 1.0 (CORRECT)
```