### PR TITLE
DOC: Fix typo in API reference description

### DIFF
--- a/doc/api_reference.py
+++ b/doc/api_reference.py
@@ -41,7 +41,7 @@ API_REFERENCE maps each module name to a dictionary that consists of the followi
 components:
 
 short_summary (required)
-    The text to be printed on the index page; it has nothing to do the API reference
+    The text to be printed on the index page; it has nothing to do with the API reference
     page of each module.
 description (required, `None` if not needed)
     The additional description for the module to be placed under the module

--- a/doc/api_reference.py
+++ b/doc/api_reference.py
@@ -41,8 +41,8 @@ API_REFERENCE maps each module name to a dictionary that consists of the followi
 components:
 
 short_summary (required)
-    The text to be printed on the index page; it has nothing to do with the API reference
-    page of each module.
+    The text to be printed on the index page; it has nothing to do with
+    the API reference page of each module.
 description (required, `None` if not needed)
     The additional description for the module to be placed under the module
     docstring, before the sections start.


### PR DESCRIPTION
Fixes a small typo in the API reference configuration documentation.
No functional changes.
