### PR TITLE
Fix LogisticRegressionCV scoring when CV folds miss class labels

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/33207.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/33207.fix.rst
@@ -1,0 +1,4 @@
+- :class:`linear_model.LogisticRegressionCV` now correctly handles probabilistic 
+  scorers (like ``neg_brier_score`` or ``neg_log_loss``) when some cross-validation 
+  folds are missing class labels.
+  By :user:`unique <un1u3>`

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -5,13 +5,13 @@ Logistic Regression
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import copy
 import numbers
 import warnings
+from inspect import signature
 from numbers import Integral, Real
 
 import numpy as np
-import copy
-from inspect import signature
 from scipy import optimize
 
 from sklearn._loss.loss import HalfBinomialLoss, HalfMultinomialLoss
@@ -720,8 +720,9 @@ def _log_reg_scoring_path(
             try:
                 if "labels" in signature(scorer_func).parameters:
                     if "labels" not in scorer._kwargs:
-                        # Mutate a copy to avoid affecting the original user-provided scorer
-                        # which might be used later with different classes.
+                        # Mutate a copy to avoid affecting the original
+                        # user-provided scorer which might be used later
+                        # with different classes.
                         scorer = copy.copy(scorer)
                         scorer._kwargs = scorer._kwargs.copy()
                         scorer._kwargs["labels"] = classes
@@ -729,8 +730,9 @@ def _log_reg_scoring_path(
                 pass
         else:
             # For other callables (like the MockScorer in tests), we check if they
-            # accept 'labels' and pass it in current_score_params. We avoid copying
-            # to allow the caller to track state if they desire (e.g. counting calls).
+            # accept 'labels' and pass it in current_score_params. We avoid
+            # copying to allow the caller to track state if they desire
+            # (e.g. counting calls).
             try:
                 if "labels" in signature(scorer).parameters:
                     score_params = score_params or {}

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -2590,7 +2590,7 @@ def test_lr_penalty_l1ratio_incompatible(penalty, l1_ratio):
 def test_logistic_regression_cv_brier_score_missing_classes():
     # Test that LogisticRegressionCV works with neg_brier_score when some
     # classes are missing in a fold's test set.
-    # This is a regression test for #24448.
+    # This is a regression test for ##33207
     X, y = make_classification(
         n_samples=90,
         n_features=8,

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -229,7 +229,7 @@ def test_elasticnet_l1_ratio_err_helpful(LR, arg):
 @pytest.mark.parametrize("coo_container", COO_CONTAINERS)
 def test_sparsify(coo_container):
     # Test sparsify and densify members.
-    n_samples, n_features = iris.data.shape
+    _, _ = iris.data.shape
     target = iris.target_names[iris.target]
     X = scale(iris.data)
     clf = LogisticRegression().fit(X, target)
@@ -289,7 +289,7 @@ def test_nan():
     Xnan[0, 1] = np.nan
     clf = LogisticRegression()
 
-    with pytest.raises(ValueError, match="Input X contains NaN."):
+    with pytest.raises(ValueError, match=r"Input X contains NaN."):
         clf.fit(Xnan, Y1)
 
 
@@ -615,7 +615,7 @@ def test_multinomial_logistic_regression_string_inputs():
 def test_multinomial_cv_iris(use_legacy_attributes):
     # Test that multinomial LogisticRegressionCV is correct using the iris dataset.
     X, y = iris.data, iris.target
-    n_samples, n_features = X.shape
+    _, n_features = X.shape
 
     # The cv indices from stratified kfold
     n_cv = 2
@@ -859,7 +859,7 @@ def test_logistic_regression_solvers_multiclass_unpenalized(
     )
     if fit_intercept:
         X[:, -1] = 1
-    U, s, Vt = svd(X)
+    _, s, _ = svd(X)
     assert np.all(s > 1e-3)  # to be sure that X is not singular
     assert np.max(s) / np.min(s) < 100  # condition number of X
     if fit_intercept:
@@ -2587,10 +2587,11 @@ def test_lr_penalty_l1ratio_incompatible(penalty, l1_ratio):
     with pytest.warns(UserWarning, match=msg):
         lr.fit(X, y)
 
+
 def test_logistic_regression_cv_brier_score_missing_classes():
     # Test that LogisticRegressionCV works with neg_brier_score when some
     # classes are missing in a fold's test set.
-    # This is a regression test for ##33207
+    # This is a regression test for #33207
     X, y = make_classification(
         n_samples=90,
         n_features=8,


### PR DESCRIPTION
fixes #33207
`LogisticRegressionCV` can fail with probabilistic scorers such as `neg_brier_score` and `neg_log_loss` when a cross-validation test fold does not contain all class labels.

The failure occurs because `_log_reg_scoring_path` calls the scorer without passing the full set of class labels. In this case, `y_true` has fewer classes than the predicted probability matrix, causing a shape mismatch inside the scorer.

Changes
- Update `_log_reg_scoring_path` to pass `labels=classes` to scorers that support it.
- For built-in sklearn scorers, inject `labels` into a shallow copy of the scorer’s internal keyword arguments to avoid mutating user objects.
- For custom callable scorers, pass `labels` only if explicitly supported by the callable signature.
- Add a regression test covering missing-class folds for probabilistic scorers.
### Result
Prevents crashes when CV folds lack class labels.
Preserves existing scorer behavior and state.
Resolves the `FIXME` noted in` _log_reg_scoring_path`.

### Tests
-  sklearn/linear_model: 2,346 passed
- sklearn/metrics: 3,083 passed
- New Regression Test: Verified & passed