### PR TITLE
TST Use assert_allclose to compare floats

### DIFF
--- a/sklearn/utils/tests/test_response.py
+++ b/sklearn/utils/tests/test_response.py
@@ -16,7 +16,7 @@ from sklearn.multioutput import ClassifierChain
 from sklearn.preprocessing import scale
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.utils._response import _get_response_values, _get_response_values_binary
-from sklearn.utils._testing import assert_allclose, assert_array_equal
+from sklearn.utils._testing import assert_allclose
 
 X, y = load_iris(return_X_y=True)
 # scale the data to avoid ConvergenceWarning with LogisticRegression

--- a/sklearn/utils/tests/test_response.py
+++ b/sklearn/utils/tests/test_response.py
@@ -78,7 +78,7 @@ def test_estimator_get_response_values(
         response_method[0] if isinstance(response_method, list) else response_method
     )
     prediction_method = getattr(estimator, chosen_response_method)
-    assert_array_equal(results[0], prediction_method(X))
+    assert_allclose(results[0], prediction_method(X))
     assert results[1] is None
     if return_response_method_used:
         assert results[2] == chosen_response_method


### PR DESCRIPTION
The test `test_estimator_get_response_values` was modified recently (e.g. [here](https://github.com/scikit-learn/scikit-learn/actions/runs/21750614826/job/62747443149?pr=33224)) and now fails sometimes because of numerical precision. `assert_allclose` should be used to compare floats