### PR TITLE
MNT remove leftover authors

### DIFF
--- a/benchmarks/bench_kernel_pca_solvers_time_vs_n_samples.py
+++ b/benchmarks/bench_kernel_pca_solvers_time_vs_n_samples.py
@@ -38,7 +38,8 @@ Solvers comparison benchmark: time vs n_components", where this time the number
 of examples is fixed, and the desired number of components varies.
 """
 
-# Author: Sylvain MARIE, Schneider Electric
+# Authors: The scikit-learn developers
+# SPDX-License-Identifier: BSD-3-Clause
 
 import time
 

--- a/benchmarks/bench_saga.py
+++ b/benchmarks/bench_saga.py
@@ -1,8 +1,10 @@
-"""Author: Arthur Mensch, Nelle Varoquaux
-
+"""
 Benchmarks of sklearn SAGA vs lightning SAGA vs Liblinear. Shows the gain
 in using multinomial logistic regression in term of learning time.
 """
+
+# Authors: The scikit-learn developers
+# SPDX-License-Identifier: BSD-3-Clause
 
 import json
 import os

--- a/doc/modules/density.rst
+++ b/doc/modules/density.rst
@@ -3,7 +3,6 @@
 ==================
 Density Estimation
 ==================
-.. sectionauthor:: Jake Vanderplas <vanderplas@astro.washington.edu>
 
 Density estimation walks the line between unsupervised learning, feature
 engineering, and data modeling.  Some of the most popular and useful

--- a/doc/modules/neighbors.rst
+++ b/doc/modules/neighbors.rst
@@ -4,8 +4,6 @@
 Nearest Neighbors
 =================
 
-.. sectionauthor:: Jake Vanderplas <vanderplas@astro.washington.edu>
-
 .. currentmodule:: sklearn.neighbors
 
 :mod:`sklearn.neighbors` provides functionality for unsupervised and
@@ -637,8 +635,6 @@ implementation with special data types. The precomputed neighbors
 
 Neighborhood Components Analysis
 ================================
-
-.. sectionauthor:: William de Vazelhes <william.de-vazelhes@inria.fr>
 
 Neighborhood Components Analysis (NCA, :class:`NeighborhoodComponentsAnalysis`)
 is a distance metric learning algorithm which aims to improve the accuracy of

--- a/sklearn/svm/_liblinear.pyx
+++ b/sklearn/svm/_liblinear.pyx
@@ -1,8 +1,9 @@
 """
 Wrapper for liblinear
-
-Author: fabian.pedregosa@inria.fr
 """
+
+# Authors: The scikit-learn developers
+# SPDX-License-Identifier: BSD-3-Clause
 
 import  numpy as np
 

--- a/sklearn/tests/test_init.py
+++ b/sklearn/tests/test_init.py
@@ -1,8 +1,7 @@
+# Authors: The scikit-learn developers
+# SPDX-License-Identifier: BSD-3-Clause
+
 # Basic unittests to test functioning of module's top-level
-
-
-__author__ = "Yaroslav Halchenko"
-__license__ = "BSD"
 
 
 try:


### PR DESCRIPTION
#### Reference Issues/PRs
Follow-up of PR #29477 / issue #20813.

#### What does this implement/fix? Explain your changes.
This PR removes some leftover author names.

#### AI usage disclosure
No.

#### Any other comments?
Remaining are:
- `sklearn.utils.optimize.py` (kind of a license redistribution notice)