### PR TITLE
DOC: Fix double space formatting in related_projects.rst

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -65,7 +65,7 @@ enhance the functionality of scikit-learn's estimators.
   organize, log and reproduce experiments
 
 - `Scikit-Learn Laboratory
-  <https://skll.readthedocs.io/en/latest/index.html>`_  A command-line
+  <https://skll.readthedocs.io/en/latest/index.html>`_ A command-line
   wrapper around scikit-learn that makes it easy to run machine learning
   experiments with multiple learners and large feature sets.
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Remove extra space between link markup and description text for Scikit-Learn Laboratory entry to maintain consistency with other project listings.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?
Trying to get a feel of what it's like contributing to scikit-learn

