### PR TITLE
DOC Fix broken link in california_housing.py

### DIFF
--- a/sklearn/datasets/_california_housing.py
+++ b/sklearn/datasets/_california_housing.py
@@ -43,7 +43,7 @@ from sklearn.utils import Bunch
 from sklearn.utils._param_validation import Interval, validate_params
 
 # Archived copy of the original dataset:
-# https://web.archive.org/web/20160205030432/http://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.tgz
+# https://lib.stat.cmu.edu/
 ARCHIVE = RemoteFileMetadata(
     filename="cal_housing.tgz",
     url="https://ndownloader.figshare.com/files/5976036",

--- a/sklearn/datasets/_california_housing.py
+++ b/sklearn/datasets/_california_housing.py
@@ -43,7 +43,7 @@ from sklearn.utils import Bunch
 from sklearn.utils._param_validation import Interval, validate_params
 
 # The original data can be found at:
-# https://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.tgz
+# https://web.archive.org/web/20160205030432/http://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.tgz
 ARCHIVE = RemoteFileMetadata(
     filename="cal_housing.tgz",
     url="https://ndownloader.figshare.com/files/5976036",

--- a/sklearn/datasets/_california_housing.py
+++ b/sklearn/datasets/_california_housing.py
@@ -42,7 +42,7 @@ from sklearn.datasets._base import (
 from sklearn.utils import Bunch
 from sklearn.utils._param_validation import Interval, validate_params
 
-# The original data can be found at:
+# Archived copy of the original dataset:
 # https://web.archive.org/web/20160205030432/http://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.tgz
 ARCHIVE = RemoteFileMetadata(
     filename="cal_housing.tgz",

--- a/sklearn/datasets/descr/california_housing.rst
+++ b/sklearn/datasets/descr/california_housing.rst
@@ -21,8 +21,8 @@ California Housing dataset
 
 :Missing Attribute Values: None
 
-This dataset was obtained from the StatLib repository.
-https://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.html
+This dataset was obtained from the StatLib repository (archived copy).
+https://web.archive.org/web/20160205030432/http://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.html
 
 The target variable is the median house value for California districts,
 expressed in hundreds of thousands of dollars ($100,000).

--- a/sklearn/datasets/descr/california_housing.rst
+++ b/sklearn/datasets/descr/california_housing.rst
@@ -21,8 +21,8 @@ California Housing dataset
 
 :Missing Attribute Values: None
 
-This dataset was obtained from the StatLib repository (archived copy).
-https://web.archive.org/web/20160205030432/http://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.html
+This dataset was obtained from the StatLib repository listed on the DATASETS page under the name house.zip (archived copy).
+https://lib.stat.cmu.edu/
 
 The target variable is the median house value for California districts,
 expressed in hundreds of thousands of dollars ($100,000).


### PR DESCRIPTION
Fixes #33231

The original link to the California Housing dataset (dcc.fc.up.pt) is down and returning a 504 Gateway Timeout.
This PR replaces the broken link in the comments with a working Wayback Machine archive link, as verified by manual download.