### PR TITLE
DOC Add hint that example gallery images are clickable

### DIFF
--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -272,28 +272,15 @@ div.sk-text-image-grid-large {
   }
 }
 
-//* ============================================
+/* ============================================
    Fix: Gallery thumbnail overlay blocks clicks
    Related issue: #30596
    ============================================ */
 
-/* Hover overlay must not intercept clicks */
 .sphx-glr-thumbcontainer::after {
-  pointer-events: none !important;
+  pointer-events: none;
 }
 
-/* The title link must not stretch over the whole card */
-.sphx-glr-thumbcontainer p a.reference.internal {
-  display: inline !important;
-  position: static !important;
-}
-
-/* Ensure "Click for source code" stays clickable */
-.sphx-glr-thumbcontainer .sphx-glr-thumbnail-title a {
-  pointer-events: auto !important;
-  position: relative;
-  z-index: 5;
-}
 
 
 

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -293,19 +293,29 @@ div.sk-text-image-grid-large {
   box-shadow: 0 0 0 0.15rem var(--pst-color-secondary);
 }
 
-/* Hide the existing [source] label (it overlaps) */
+/* Hide the existing [source] label */
 .sphx-glr-thumbcontainer a span.doc {
   display: none !important;
 }
 
-/* Add a cleaner replacement hint */
-.sphx-glr-thumbcontainer a::after {
+/* Stack thumbnail + title + hint vertically */
+.sphx-glr-thumbcontainer a.reference.internal {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Add hint at the bottom of the card */
+.sphx-glr-thumbcontainer a.reference.internal::after {
   content: "Click for source code";
   display: block;
-  font-size: 0.8em;
+
+  margin-top: auto;
+  padding-top: 0.4rem;
+
+  font-size: 0.75em;
   font-weight: var(--pst-font-weight-caption);
-  opacity: 0.75;
-  margin-top: 0.3rem;
+  opacity: 0.7;
+
   text-align: center;
 }
 

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -272,14 +272,16 @@ div.sk-text-image-grid-large {
   }
 }
 
-/* Hint that example gallery images are clickable */
+/* Hint that example gallery images are clickable
+   See issue #30596
+*/
 
-.sphx-glr-thumbcontainer a.reference.internal:hover img {
+.sphx-glr-thumbcontainer .figure a:hover img {
   border-radius: 0.3rem;
   box-shadow: 0 0 0 0.15rem var(--pst-color-secondary);
 }
 
-.sphx-glr-thumbcontainer a.reference.internal::after {
+.sphx-glr-thumbcontainer .figure a::after {
   content: "[source]";
   display: block;
   text-align: center;
@@ -288,4 +290,5 @@ div.sk-text-image-grid-large {
   margin-top: 0.2rem;
   opacity: 0.7;
 }
+
 

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -272,29 +272,29 @@ div.sk-text-image-grid-large {
   }
 }
 
-/* ============================================
-   Fix: Gallery thumbnail overlay blocks
-   "Click for source code" link
+//* ============================================
+   Fix: Gallery thumbnail overlay blocks clicks
    Related issue: #30596
    ============================================ */
 
-/* 1. The hover overlay must not intercept clicks */
+/* Hover overlay must not intercept clicks */
 .sphx-glr-thumbcontainer::after {
-  pointer-events: none;
+  pointer-events: none !important;
 }
 
-/* 2. The title link should NOT cover the whole caption area */
+/* The title link must not stretch over the whole card */
 .sphx-glr-thumbcontainer p a.reference.internal {
-  display: inline !important;   /* shrink link to text only */
-  position: static !important;  /* remove overlay-like positioning */
-  width: auto !important;
-  height: auto !important;
+  display: inline !important;
+  position: static !important;
 }
 
-/* 3. Keep hover styling normal */
-.sphx-glr-thumbcontainer p a.reference.internal:hover {
-  text-decoration: underline;
+/* Ensure "Click for source code" stays clickable */
+.sphx-glr-thumbcontainer .sphx-glr-thumbnail-title a {
+  pointer-events: auto !important;
+  position: relative;
+  z-index: 5;
 }
+
 
 
 

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -273,31 +273,23 @@ div.sk-text-image-grid-large {
 }
 
 /* ============================================
-   Fix: Example gallery hover overlay blocks
-   "Click for source code" link
+   Fix: Gallery thumbnail link overlay issue
    ============================================ */
 
-.sphx-glr-thumbnailcontainer {
-  position: relative;
+/* The caption <p> must not be fully clickable */
+.sphx-glr-thumbcontainer p a.reference.internal {
+  display: inline !important;     /* shrink link to text only */
+  position: static !important;    /* remove overlay positioning */
+  width: auto !important;
+  height: auto !important;
 }
 
-/* The overlay text block that appears on hover */
-.sphx-glr-thumbnailcontainer::after {
-  pointer-events: none; /* overlay will NOT block clicks */
+/* Optional: keep normal hover underline */
+.sphx-glr-thumbcontainer p a.reference.internal:hover {
+  text-decoration: underline;
 }
 
-/* The "Click for source code" link */
-.sphx-glr-thumbnailcontainer a.reference.internal {
-  position: relative;
-  z-index: 10; /* bring link ABOVE overlay */
-  display: inline-block;
-}
 
-/* Optional: ensure caption area stays clickable */
-.sphx-glr-thumbnailcontainer p {
-  position: relative;
-  z-index: 10;
-}
 
 
 

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -272,23 +272,39 @@ div.sk-text-image-grid-large {
   }
 }
 
-/* Hint that example gallery images are clickable
+/* ------------------------------------------------------------
+   Hint that example gallery images are clickable
    See issue #30596
-*/
+------------------------------------------------------------ */
 
-.sphx-glr-thumbcontainer .figure a:hover img {
+.sphx-glr-thumbcontainer a:hover img {
   border-radius: 0.3rem;
   box-shadow: 0 0 0 0.15rem var(--pst-color-secondary);
 }
 
-.sphx-glr-thumbcontainer .figure a::after {
+/* Make the [source] hint clearly visible and prevent overlap */
+.sphx-glr-thumbcontainer {
+  padding-bottom: 1rem;
+}
+
+.sphx-glr-thumbcontainer a::after {
   content: "[source]";
   display: block;
-  text-align: center;
+
+  font-size: 0.8em;
   font-weight: var(--pst-font-weight-caption);
-  font-size: 0.85em;
-  margin-top: 0.2rem;
-  opacity: 0.7;
+
+  text-align: center;
+
+  margin-top: 0.4rem;
+  padding-bottom: 0.3rem;
+
+  color: var(--pst-color-primary);
+  opacity: 1;
+
+  position: relative;
+  z-index: 20;
 }
+
 
 

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -271,3 +271,25 @@ div.sk-text-image-grid-large {
     height: 130%;
   }
 }
+
+
+/* ------------------------------------------------------------
+   Clickable images hint in the user guide
+   See issue #30596
+------------------------------------------------------------ */
+
+/* Add a visible hover effect for clickable images */
+figure > a:hover > img {
+  border-radius: 0.3rem;
+  box-shadow: 0 0 0 0.15rem var(--pst-color-secondary);
+}
+
+/* Add helper text below clickable images */
+figure > a::after {
+  content: "Click to see the code that generated this plot";
+  display: block;
+  font-weight: var(--pst-font-weight-caption);
+  font-size: 0.9em;
+  margin-top: 0.3rem;
+  opacity: 0.8;
+}

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -282,29 +282,48 @@ div.sk-text-image-grid-large {
   box-shadow: 0 0 0 0.15rem var(--pst-color-secondary);
 }
 
-/* Make the [source] hint clearly visible and prevent overlap */
-.sphx-glr-thumbcontainer {
-  padding-bottom: 1rem;
+/* ------------------------------------------------------------
+   Hint that example gallery images are clickable
+   See issue #30596
+------------------------------------------------------------ */
+
+.sphx-glr-thumbcontainer a {
+  position: relative;
+  display: inline-block;
 }
 
+/* Hover highlight */
+.sphx-glr-thumbcontainer a:hover img {
+  border-radius: 0.3rem;
+  box-shadow: 0 0 0 0.15rem var(--pst-color-secondary);
+}
+
+/* Overlay [source] badge (NO overlap possible) */
 .sphx-glr-thumbcontainer a::after {
   content: "[source]";
-  display: block;
 
-  font-size: 0.8em;
-  font-weight: var(--pst-font-weight-caption);
+  position: absolute;
+  bottom: 0.4rem;
+  right: 0.4rem;
 
-  text-align: center;
+  background: rgba(0, 0, 0, 0.65);
+  color: white;
 
-  margin-top: 0.4rem;
-  padding-bottom: 0.3rem;
+  font-size: 0.75em;
+  font-weight: 600;
 
-  color: var(--pst-color-primary);
-  opacity: 1;
+  padding: 0.15rem 0.4rem;
+  border-radius: 0.25rem;
 
-  position: relative;
-  z-index: 20;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
 }
+
+/* Show badge on hover */
+.sphx-glr-thumbcontainer a:hover::after {
+  opacity: 1;
+}
+
 
 
 

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -273,31 +273,29 @@ div.sk-text-image-grid-large {
 }
 
 /* ============================================
-   Fix: Gallery thumbnail link overlay issue
+   Fix: Gallery thumbnail overlay blocks
+   "Click for source code" link
+   Related issue: #30596
    ============================================ */
 
-/*
-Problem:
-The caption link inside sphinx-gallery thumbnails is being stretched,
-making the entire <p> area clickable and blocking the
-"Click for source code" link.
+/* 1. The hover overlay must not intercept clicks */
+.sphx-glr-thumbcontainer::after {
+  pointer-events: none;
+}
 
-Fix:
-Force the caption link to behave like normal inline text.
-Only the text should be clickable, not the whole card.
-*/
-
+/* 2. The title link should NOT cover the whole caption area */
 .sphx-glr-thumbcontainer p a.reference.internal {
-  display: inline !important;     /* shrink link to text only */
-  position: static !important;    /* remove overlay positioning */
+  display: inline !important;   /* shrink link to text only */
+  position: static !important;  /* remove overlay-like positioning */
   width: auto !important;
   height: auto !important;
 }
 
-/* Optional: normal underline on hover */
+/* 3. Keep hover styling normal */
 .sphx-glr-thumbcontainer p a.reference.internal:hover {
   text-decoration: underline;
 }
+
 
 
 

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -272,24 +272,21 @@ div.sk-text-image-grid-large {
   }
 }
 
-
 /* ------------------------------------------------------------
-   Clickable images hint in the user guide
+   Hint that example gallery images are clickable
    See issue #30596
 ------------------------------------------------------------ */
 
-/* Add a visible hover effect for clickable images */
-figure > a:hover > img {
+.sphx-glr-thumbcontainer a.reference.internal:hover img {
   border-radius: 0.3rem;
   box-shadow: 0 0 0 0.15rem var(--pst-color-secondary);
 }
 
-/* Add helper text below clickable images */
-figure > a::after {
-  content: "Click to see the code that generated this plot";
+.sphx-glr-thumbcontainer a.reference.internal::after {
+  content: "[source]";
   display: block;
   font-weight: var(--pst-font-weight-caption);
-  font-size: 0.9em;
-  margin-top: 0.3rem;
-  opacity: 0.8;
+  font-size: 0.85em;
+  margin-top: 0.2rem;
+  opacity: 0.7;
 }

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -277,16 +277,20 @@ div.sk-text-image-grid-large {
    See issue #30596
 ------------------------------------------------------------ */
 
-.sphx-glr-thumbcontainer a.reference.internal:hover img {
+/* Hover effect on clickable thumbnails */
+.sphx-glr-thumbcontainer figure > a:hover img {
   border-radius: 0.3rem;
   box-shadow: 0 0 0 0.15rem var(--pst-color-secondary);
 }
 
-.sphx-glr-thumbcontainer a.reference.internal::after {
+/* Put the [source] label ONLY under the thumbnail image */
+.sphx-glr-thumbcontainer figure > a::after {
   content: "[source]";
   display: block;
+  text-align: center;
   font-weight: var(--pst-font-weight-caption);
   font-size: 0.85em;
   margin-top: 0.2rem;
   opacity: 0.7;
 }
+

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -287,41 +287,26 @@ div.sk-text-image-grid-large {
    See issue #30596
 ------------------------------------------------------------ */
 
-.sphx-glr-thumbcontainer a {
-  position: relative;
-  display: inline-block;
-}
-
-/* Hover highlight */
+/* Hover highlight around clickable thumbnails */
 .sphx-glr-thumbcontainer a:hover img {
   border-radius: 0.3rem;
   box-shadow: 0 0 0 0.15rem var(--pst-color-secondary);
 }
 
-/* Overlay [source] badge (NO overlap possible) */
-.sphx-glr-thumbcontainer a::after {
-  content: "[source]";
-
-  position: absolute;
-  bottom: 0.4rem;
-  right: 0.4rem;
-
-  background: rgba(0, 0, 0, 0.65);
-  color: white;
-
-  font-size: 0.75em;
-  font-weight: 600;
-
-  padding: 0.15rem 0.4rem;
-  border-radius: 0.25rem;
-
-  opacity: 0;
-  transition: opacity 0.2s ease-in-out;
+/* Hide the existing [source] label (it overlaps) */
+.sphx-glr-thumbcontainer a span.doc {
+  display: none !important;
 }
 
-/* Show badge on hover */
-.sphx-glr-thumbcontainer a:hover::after {
-  opacity: 1;
+/* Add a cleaner replacement hint */
+.sphx-glr-thumbcontainer a::after {
+  content: "Click for source code";
+  display: block;
+  font-size: 0.8em;
+  font-weight: var(--pst-font-weight-caption);
+  opacity: 0.75;
+  margin-top: 0.3rem;
+  text-align: center;
 }
 
 

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -276,7 +276,17 @@ div.sk-text-image-grid-large {
    Fix: Gallery thumbnail link overlay issue
    ============================================ */
 
-/* The caption <p> must not be fully clickable */
+/*
+Problem:
+The caption link inside sphinx-gallery thumbnails is being stretched,
+making the entire <p> area clickable and blocking the
+"Click for source code" link.
+
+Fix:
+Force the caption link to behave like normal inline text.
+Only the text should be clickable, not the whole card.
+*/
+
 .sphx-glr-thumbcontainer p a.reference.internal {
   display: inline !important;     /* shrink link to text only */
   position: static !important;    /* remove overlay positioning */
@@ -284,10 +294,11 @@ div.sk-text-image-grid-large {
   height: auto !important;
 }
 
-/* Optional: keep normal hover underline */
+/* Optional: normal underline on hover */
 .sphx-glr-thumbcontainer p a.reference.internal:hover {
   text-decoration: underline;
 }
+
 
 
 

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -272,19 +272,14 @@ div.sk-text-image-grid-large {
   }
 }
 
-/* ------------------------------------------------------------
-   Hint that example gallery images are clickable
-   See issue #30596
------------------------------------------------------------- */
+/* Hint that example gallery images are clickable */
 
-/* Hover effect on clickable thumbnails */
-.sphx-glr-thumbcontainer figure > a:hover img {
+.sphx-glr-thumbcontainer a.reference.internal:hover img {
   border-radius: 0.3rem;
   box-shadow: 0 0 0 0.15rem var(--pst-color-secondary);
 }
 
-/* Put the [source] label ONLY under the thumbnail image */
-.sphx-glr-thumbcontainer figure > a::after {
+.sphx-glr-thumbcontainer a.reference.internal::after {
   content: "[source]";
   display: block;
   text-align: center;

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -272,52 +272,33 @@ div.sk-text-image-grid-large {
   }
 }
 
-/* ------------------------------------------------------------
-   Hint that example gallery images are clickable
-   See issue #30596
------------------------------------------------------------- */
+/* ============================================
+   Fix: Example gallery hover overlay blocks
+   "Click for source code" link
+   ============================================ */
 
-.sphx-glr-thumbcontainer a:hover img {
-  border-radius: 0.3rem;
-  box-shadow: 0 0 0 0.15rem var(--pst-color-secondary);
+.sphx-glr-thumbnailcontainer {
+  position: relative;
 }
 
-/* ------------------------------------------------------------
-   Hint that example gallery images are clickable
-   See issue #30596
------------------------------------------------------------- */
-
-/* Hover highlight around clickable thumbnails */
-.sphx-glr-thumbcontainer a:hover img {
-  border-radius: 0.3rem;
-  box-shadow: 0 0 0 0.15rem var(--pst-color-secondary);
+/* The overlay text block that appears on hover */
+.sphx-glr-thumbnailcontainer::after {
+  pointer-events: none; /* overlay will NOT block clicks */
 }
 
-/* Hide the existing [source] label */
-.sphx-glr-thumbcontainer a span.doc {
-  display: none !important;
+/* The "Click for source code" link */
+.sphx-glr-thumbnailcontainer a.reference.internal {
+  position: relative;
+  z-index: 10; /* bring link ABOVE overlay */
+  display: inline-block;
 }
 
-/* Stack thumbnail + title + hint vertically */
-.sphx-glr-thumbcontainer a.reference.internal {
-  display: flex;
-  flex-direction: column;
+/* Optional: ensure caption area stays clickable */
+.sphx-glr-thumbnailcontainer p {
+  position: relative;
+  z-index: 10;
 }
 
-/* Add hint at the bottom of the card */
-.sphx-glr-thumbcontainer a.reference.internal::after {
-  content: "Click for source code";
-  display: block;
-
-  margin-top: auto;
-  padding-top: 0.4rem;
-
-  font-size: 0.75em;
-  font-weight: var(--pst-font-weight-caption);
-  opacity: 0.7;
-
-  text-align: center;
-}
 
 
 

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -273,55 +273,14 @@ div.sk-text-image-grid-large {
 }
 
 /* ============================================
-   Fix: Gallery thumbnail title link covers card
+   Fix: Gallery hover overlay blocks clicks
    Related issue: #30596
    ============================================ */
 
-/* The title link must NOT stretch over the whole thumbnail */
-.sphx-glr-thumbcontainer p a.reference.internal {
-  display: inline !important;
-  position: static !important;
-  width: auto !important;
-  height: auto !important;
-}
-
-/* The hover overlay must not intercept clicks */
 .sphx-glr-thumbcontainer::after {
   pointer-events: none !important;
 }
 
-/* Keep "Click for source code" clickable */
-.sphx-glr-thumbnail-title {
-  position: relative;
-  z-index: 5;
-}
-
-
-/* Make the "Click for source code" link always clickable with higher priority */
-.sphx-glr-thumbnail-title {
-  position: relative;
-  z-index: 10;
-  pointer-events: auto !important;
-  
-  a {
-    pointer-events: auto !important;
-    position: relative;
-    z-index: 1;
-    display: inline-block;
-  }
-}
-
-/* Alternative fix: If the issue is with the paragraph containing the title */
-.sphx-glr-thumbcontainer > p {
-  position: relative;
-  z-index: 1;
-  pointer-events: none;
-  
-  /* But allow the text/link itself to be clicked */
-  > * {
-    pointer-events: auto;
-  }
-}
 
 
 

--- a/doc/scss/custom.scss
+++ b/doc/scss/custom.scss
@@ -273,12 +273,54 @@ div.sk-text-image-grid-large {
 }
 
 /* ============================================
-   Fix: Gallery thumbnail overlay blocks clicks
+   Fix: Gallery thumbnail title link covers card
    Related issue: #30596
    ============================================ */
 
+/* The title link must NOT stretch over the whole thumbnail */
+.sphx-glr-thumbcontainer p a.reference.internal {
+  display: inline !important;
+  position: static !important;
+  width: auto !important;
+  height: auto !important;
+}
+
+/* The hover overlay must not intercept clicks */
 .sphx-glr-thumbcontainer::after {
+  pointer-events: none !important;
+}
+
+/* Keep "Click for source code" clickable */
+.sphx-glr-thumbnail-title {
+  position: relative;
+  z-index: 5;
+}
+
+
+/* Make the "Click for source code" link always clickable with higher priority */
+.sphx-glr-thumbnail-title {
+  position: relative;
+  z-index: 10;
+  pointer-events: auto !important;
+  
+  a {
+    pointer-events: auto !important;
+    position: relative;
+    z-index: 1;
+    display: inline-block;
+  }
+}
+
+/* Alternative fix: If the issue is with the paragraph containing the title */
+.sphx-glr-thumbcontainer > p {
+  position: relative;
+  z-index: 1;
   pointer-events: none;
+  
+  /* But allow the text/link itself to be clicked */
+  > * {
+    pointer-events: auto;
+  }
 }
 
 


### PR DESCRIPTION
This PR implements the UI hint discussed in issue #30596.

### Changes
- Adds a hover box-shadow effect to clickable example gallery thumbnails
- Adds a small `[source]` label using `figure > a::after`

### Motivation
Clickable images currently look like normal static plots, so users often miss that they link to the full example code.

This makes the interaction clearer while keeping the UI minimal.
