### PR TITLE
ENH: Add min_cardinality and max_cardinality to make_column_selector

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -1623,13 +1623,9 @@ class make_column_selector:
         if self.min_cardinality is not None or self.max_cardinality is not None:
             cardinalities = df[cols].nunique()
             if self.min_cardinality is not None:
-                cardinalities = cardinalities[
-                    cardinalities >= self.min_cardinality
-                ]
+                cardinalities = cardinalities[cardinalities >= self.min_cardinality]
             if self.max_cardinality is not None:
-                cardinalities = cardinalities[
-                    cardinalities <= self.max_cardinality
-                ]
+                cardinalities = cardinalities[cardinalities <= self.max_cardinality]
             cols = cardinalities.index.tolist()
         return cols
 

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1468,6 +1468,41 @@ def test_column_transformer_with_make_column_selector():
     assert_allclose(X_selector, X_direct)
 
 
+def test_make_column_selector_with_cardinality():
+    pd = pytest.importorskip("pandas")
+
+    X_df = pd.DataFrame(
+        {
+            "col_low": ["a", "a", "b", "b"],
+            "col_mid": ["a", "b", "c", "c"],
+            "col_high": ["a", "b", "c", "d"],
+            "col_num": [1, 2, 3, 4],
+        }
+    )
+
+    # max_cardinality: select columns with <= 2 unique values
+    selector = make_column_selector(max_cardinality=2)
+    assert selector(X_df) == ["col_low"]
+
+    # min_cardinality: select columns with >= 4 unique values
+    selector = make_column_selector(min_cardinality=4)
+    assert selector(X_df) == ["col_high", "col_num"]
+
+    # both min and max cardinality
+    selector = make_column_selector(min_cardinality=2, max_cardinality=3)
+    assert selector(X_df) == ["col_low", "col_mid"]
+
+    # combined with dtype_include
+    selector = make_column_selector(
+        dtype_include=object, max_cardinality=3
+    )
+    assert selector(X_df) == ["col_low", "col_mid"]
+
+    # combined with pattern
+    selector = make_column_selector(pattern="col_", min_cardinality=3)
+    assert selector(X_df) == ["col_mid", "col_high", "col_num"]
+
+
 def test_make_column_selector_error():
     selector = make_column_selector(dtype_include=np.number)
     X = np.array([[0.1, 0.2]])

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -1493,9 +1493,7 @@ def test_make_column_selector_with_cardinality():
     assert selector(X_df) == ["col_low", "col_mid"]
 
     # combined with dtype_include
-    selector = make_column_selector(
-        dtype_include=object, max_cardinality=3
-    )
+    selector = make_column_selector(dtype_include=object, max_cardinality=3)
     assert selector(X_df) == ["col_low", "col_mid"]
 
     # combined with pattern


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #15873. See also #22923.

#### What does this implement/fix?

Adds `min_cardinality` and `max_cardinality` parameters to `make_column_selector`, enabling cardinality-based column selection. This addresses the feature request in #15873 and incorporates the API feedback from maintainers on #22923 (using `min_cardinality`/`max_cardinality` instead of `cardinality`/`cardinality_threshold`).

**New parameters:**
- `min_cardinality`: minimum number of unique values a column must have (inclusive)
- `max_cardinality`: maximum number of unique values a column must have (inclusive)

Both parameters work with the existing `dtype_include`, `dtype_exclude`, and `pattern` filters (all criteria must match).

**Example usage:**
```python
# Select low-cardinality columns for one-hot encoding
make_column_selector(dtype_include=object, max_cardinality=10)

# Select high-cardinality columns for target encoding
make_column_selector(dtype_include=object, min_cardinality=11)
```

#### Changes
- `sklearn/compose/_column_transformer.py`: Added `min_cardinality` and `max_cardinality` params to `make_column_selector`
- `sklearn/compose/tests/test_column_transformer.py`: Added tests for cardinality filtering (standalone, combined with dtype, combined with pattern)