### PR TITLE
FIX avoid repeated third-party deprecation warnings in process-based Parallel

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.utils/33257.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/33257.fix.rst
@@ -1,0 +1,6 @@
+- Fixed repeated third-party deprecation warnings in process-based parallel
+  execution. When :class:`utils.parallel.Parallel` propagates warning filters
+  to workers, warning categories are now restored without implicit imports of
+  third-party modules. This avoids repeated warning noise such as
+  ``pkg_resources is deprecated as an API`` in some workflows.
+  By :user:`Fang <gufarui>`

--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -17,7 +17,12 @@ from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils.fixes import _IS_WASM
-from sklearn.utils.parallel import Parallel, delayed
+from sklearn.utils.parallel import (
+    Parallel,
+    _pack_warning_filter,
+    _unpack_warning_filter,
+    delayed,
+)
 
 
 def get_working_memory():
@@ -226,3 +231,38 @@ def test_filter_warning_no_implicit_third_party_import_in_loky_workers(
 
     captured = capfd.readouterr()
     assert "module imported" not in captured.err
+
+
+def test_pack_warning_filter_with_warning_category():
+    packed_filter = _pack_warning_filter(
+        ("ignore", None, ConvergenceWarning, None, 0)
+    )
+    assert packed_filter[2] == ("sklearn.exceptions", "ConvergenceWarning")
+
+
+def test_unpack_warning_filter_from_loaded_warning_module():
+    unpacked_filter = _unpack_warning_filter(
+        ("ignore", None, ("sklearn.exceptions", "ConvergenceWarning"), None, 0)
+    )
+    assert unpacked_filter["category"] is ConvergenceWarning
+
+
+def test_unpack_warning_filter_with_unloaded_module_returns_none():
+    unpacked_filter = _unpack_warning_filter(
+        ("ignore", None, ("this.module.does.not.exist", "X"), None, 0)
+    )
+    assert unpacked_filter is None
+
+
+def test_unpack_warning_filter_with_unknown_attr_returns_none():
+    unpacked_filter = _unpack_warning_filter(
+        ("ignore", None, ("time", "MissingWarningClass"), None, 0)
+    )
+    assert unpacked_filter is None
+
+
+def test_unpack_warning_filter_with_non_warning_class_returns_none():
+    unpacked_filter = _unpack_warning_filter(
+        ("ignore", None, ("collections", "Counter"), None, 0)
+    )
+    assert unpacked_filter is None

--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -234,9 +234,7 @@ def test_filter_warning_no_implicit_third_party_import_in_loky_workers(
 
 
 def test_pack_warning_filter_with_warning_category():
-    packed_filter = _pack_warning_filter(
-        ("ignore", None, ConvergenceWarning, None, 0)
-    )
+    packed_filter = _pack_warning_filter(("ignore", None, ConvergenceWarning, None, 0))
     assert packed_filter[2] == ("sklearn.exceptions", "ConvergenceWarning")
 
 


### PR DESCRIPTION
## Summary

This PR reduces repeated third-party deprecation warnings in process-based parallel runs.

Related to #33230.

The issue can be reproduced with `permutation_importance(..., n_jobs=-1)` after importing `hyperopt`.
Before this change, the same `pkg_resources` deprecation warning is emitted many times from multiprocessing queue result loading.

## Root cause

`sklearn.utils.parallel.Parallel` propagates `warnings.filters` to workers.
Some filter categories are third-party warning class objects. Sending those classes to workers can trigger implicit module imports during unpickling, and those imports can emit warnings again.

## What changed

- In `sklearn/utils/parallel.py`:
  - Added `_pack_warning_filter` to serialize warning categories as `(module, qualname)` references.
  - Added `_unpack_warning_filter` to restore categories from already-loaded modules only.
  - Skips filter entries that would require implicit imports.
- Added regression test in `sklearn/utils/tests/test_parallel.py`:
  - `test_filter_warning_no_implicit_third_party_import_in_loky_workers`

## Validation

Ran locally:

```bash
python -m pytest --color=no sklearn/utils/tests/test_parallel.py -q
python -m pytest --color=no sklearn/inspection/tests/test_permutation_importance.py -q
```

Results:

- `16 passed, 2 skipped`
- `23 passed, 12 skipped`

In local reproduction, repeated warnings from `multiprocessing/queues.py:122` disappear after this patch, while the original third-party import warning remains once.

