### PR TITLE
fix(doc): fix mutable default arguments in doi_role.py

### DIFF
--- a/doc/sphinxext/doi_role.py
+++ b/doc/sphinxext/doi_role.py
@@ -18,7 +18,11 @@ from docutils import nodes, utils
 from sphinx.util.nodes import split_explicit_title
 
 
-def reference_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
+def reference_role(typ, rawtext, text, lineno, inliner, options=None, content=None):
+    if options is None:
+        options = {}
+    if content is None:
+        content = []
     text = utils.unescape(text)
     has_explicit_title, title, part = split_explicit_title(text)
     if typ in ["arXiv", "arxiv"]:


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes mutable default arguments in `doc/sphinxext/doi_role.py`.

#### What does this implement/fix? Explain your changes.
This PR replaces mutable default arguments (`options={}` and `content=[]`) with `None` in the `reference_role` function.

In Python, default arguments are evaluated once at definition time. Using mutable types (like lists or dicts) as default arguments can lead to state persisting across function calls, potentially causing unexpected side effects.

I have updated the function signature to use `None` and added the standard initialization check:
```python
if options is None:
    options = {}
if content is None:
    content = []