### PR TITLE
Add array API support for `FeatureUnion`

### DIFF
--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -157,6 +157,7 @@ Meta-estimators that accept Array API inputs conditioned on the fact that the
 base estimator also does:
 
 - :class:`calibration.CalibratedClassifierCV` (with `method="temperature"`)
+- :class:`pipeline.FeatureUnion`
 - :class:`model_selection.GridSearchCV`
 - :class:`model_selection.RandomizedSearchCV`
 - :class:`model_selection.HalvingGridSearchCV`

--- a/doc/whats_new/upcoming_changes/array-api/33263.feature.rst
+++ b/doc/whats_new/upcoming_changes/array-api/33263.feature.rst
@@ -1,0 +1,2 @@
+- :class:`pipeline.FeatureUnion` now supports Array API compliant inputs when all
+  its transformers do. By :user:`Olivier Grisel <ogrisel>`.

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -14,6 +14,7 @@ from sklearn.base import TransformerMixin, _fit_context, clone
 from sklearn.exceptions import NotFittedError
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.utils import Bunch
+from sklearn.utils._array_api import get_namespace, get_namespace_and_device
 from sklearn.utils._metadata_requests import METHODS
 from sklearn.utils._param_validation import HasMethods, Hidden
 from sklearn.utils._repr_html.estimator import _VisualBlock
@@ -1909,7 +1910,8 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         results = self._parallel_func(X, y, _fit_transform_one, routed_params)
         if not results:
             # All transformers are None
-            return np.zeros((X.shape[0], 0))
+            xp, _, device = get_namespace_and_device(X)
+            return xp.zeros((X.shape[0], 0), device=device)
 
         Xs, transformers = zip(*results)
         self._update_transformer_list(transformers)
@@ -1979,11 +1981,13 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         )
         if not Xs:
             # All transformers are None
-            return np.zeros((X.shape[0], 0))
+            xp, _, device = get_namespace_and_device(X)
+            return xp.zeros((X.shape[0], 0), device=device)
 
         return self._hstack(Xs)
 
     def _hstack(self, Xs):
+        xp, _ = get_namespace(*Xs)
         # Check if Xs dimensions are valid
         for X, (name, _) in zip(Xs, self.transformer_list):
             if hasattr(X, "shape") and len(X.shape) != 2:
@@ -2000,7 +2004,7 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
         if any(sparse.issparse(f) for f in Xs):
             return sparse.hstack(Xs).tocsr()
 
-        return np.hstack(Xs)
+        return xp.concat(Xs, axis=1)
 
     def _update_transformer_list(self, transformers):
         transformers = iter(transformers)
@@ -2074,6 +2078,12 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
                 get_tags(trans).input_tags.sparse
                 for name, trans in self.transformer_list
                 if trans not in {"passthrough", "drop"}
+            )
+            tags.array_api_support = all(
+                True
+                if trans in {"passthrough", "drop"}
+                else get_tags(trans).array_api_support
+                for name, trans in self.transformer_list
             )
         except Exception:
             # If `transformer_list` does not comply with our API (list of tuples)

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -34,6 +34,7 @@ from sklearn.exceptions import NotFittedError, UnsetMetadataPassedError
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.feature_selection import SelectKBest, f_classif
 from sklearn.impute import SimpleImputer
+from sklearn.kernel_approximation import Nystroem
 from sklearn.linear_model import Lasso, LinearRegression, LogisticRegression
 from sklearn.metrics import accuracy_score, r2_score
 from sklearn.model_selection import train_test_split
@@ -48,11 +49,18 @@ from sklearn.tests.metadata_routing_common import (
     check_recorded_metadata,
 )
 from sklearn.utils import get_tags
+from sklearn.utils._array_api import (
+    _atol_for_type,
+    _convert_to_numpy,
+    get_namespace_and_device,
+    yield_namespace_device_dtype_combinations,
+)
 from sklearn.utils._metadata_requests import COMPOSITE_METHODS, METHODS
 from sklearn.utils._testing import (
     MinimalClassifier,
     MinimalRegressor,
     MinimalTransformer,
+    _array_api_for_tests,
     assert_allclose,
     assert_array_almost_equal,
     assert_array_equal,
@@ -1943,6 +1951,84 @@ def test_feature_union_1d_output():
                 ("b", FunctionTransformer(lambda X: X[:, 1])),
             ]
         ).fit_transform(X)
+
+
+@pytest.mark.parametrize(
+    "array_namespace, device, dtype_name",
+    yield_namespace_device_dtype_combinations(),
+)
+def test_feature_union_array_api_compliance(array_namespace, device, dtype_name):
+    """Test that FeatureUnion with Array API-compatible transformers works."""
+    xp = _array_api_for_tests(array_namespace, device)
+    rnd = np.random.RandomState(0)
+    n_samples, n_features = 20, 10
+    X_np = rnd.uniform(size=(n_samples, n_features)).astype(dtype_name)
+    X_xp = xp.asarray(X_np, device=device)
+
+    n_components_1, n_components_2 = 5, 8
+    union = FeatureUnion(
+        [
+            ("nystroem1", Nystroem(n_components=n_components_1, random_state=0)),
+            ("nystroem2", Nystroem(n_components=n_components_2, random_state=1)),
+        ]
+    )
+
+    X_np_transformed = union.fit_transform(X_np)
+
+    with config_context(array_api_dispatch=True):
+        X_xp_transformed = union.fit_transform(X_xp)
+        X_xp_transformed_np = _convert_to_numpy(X_xp_transformed, xp=xp)
+
+        for name, trans in union.transformer_list:
+            for attr in ["components_", "normalization_"]:
+                if hasattr(trans, attr):
+                    trans_xp, _, trans_device = get_namespace_and_device(
+                        getattr(trans, attr)
+                    )
+                    assert trans_xp is xp
+                    assert trans_device == get_namespace_and_device(X_xp)[2]
+
+    atol = _atol_for_type(dtype_name)
+    assert_allclose(X_np_transformed, X_xp_transformed_np, atol=atol)
+    assert X_xp_transformed_np.shape == (
+        n_samples,
+        n_components_1 + n_components_2,
+    )
+
+
+def test_feature_union_array_api_support_tag():
+    """Check that FeatureUnion.array_api_support tag reflects its transformers."""
+    # All transformers support Array API -> union supports it
+    union = FeatureUnion(
+        [
+            ("scaler", StandardScaler()),
+            ("nystroem", Nystroem(n_components=5, random_state=0)),
+        ]
+    )
+    assert get_tags(union).array_api_support is True
+
+    # One transformer does not support Array API -> union does not
+    union = FeatureUnion(
+        [
+            ("scaler", StandardScaler()),
+            ("svd", TruncatedSVD(n_components=2)),
+        ]
+    )
+    assert get_tags(union).array_api_support is False
+
+    # passthrough/drop are treated as supporting Array API
+    union = FeatureUnion(
+        [
+            ("scaler", StandardScaler()),
+            ("pass", "passthrough"),
+            ("dropped", "drop"),
+        ]
+    )
+    assert get_tags(union).array_api_support is True
+
+    # Only drop and passthrough -> True
+    union = make_union("drop", "passthrough")
+    assert get_tags(union).array_api_support is True
 
 
 # transform_input tests


### PR DESCRIPTION
While working on an array API demo, I realized that `FeatureUnion` did not support array API even when the underlying transformers do. Here is a fix.

#### AI usage disclosure

I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

I used cursor but manually reviewed and improved the generated code.

