### PR TITLE
DOC Fix BNP Paribas logo path in footer

### DIFF
--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -292,7 +292,7 @@
           <img src="_static/probabl.png" title="Probabl">
           <img src="_static/inria-small.png" title="INRIA">
           <img src="_static/chanel-small.png" title="Chanel">
-          <img src="_static/bnp-paribas.png" title="BNP Paribas Group">
+          <img src="_images/bnp-paribas.jpg" title="BNP Paribas Group">
           <img src="_static/microsoft-small.png" title="Microsoft">
           <img src="_static/nvidia-small.png" title="Nvidia">
           <img src="_static/quansight-labs-small.png" title="Quansight Labs">


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #33256

#### What does this implement/fix? Explain your changes.

Fixes the BNP Paribas logo path in the funding footer of `doc/templates/index.html`.

Changed `_static/bnp-paribas.png` to `_images/bnp-paribas.jpg` to reference the correct existing image at `doc/images/bnp-paribas.jpg`.

#### AI usage disclosure

I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Any other comments?

The image file exists at `doc/images/bnp-paribas.jpg` but was incorrectly referenced as `_static/bnp-paribas.png` in the footer template.