### PR TITLE
MNT use scipy.stats.yeojohnson in PowerTransformer

### DIFF
--- a/doc/whats_new/upcoming_changes/changed-models/33272.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/changed-models/33272.enhancement.rst
@@ -1,5 +1,5 @@
 - The :meth:`transform` method of :class:`preprocessing.PowerTransformer` with
   `method="yeo-johnson"` now uses the numerical more stable function
   `scipy.stats.yeojohnson` instead of an own implementation. The results may deviate in
-  numerical edge cases or within the precision of floating number arithmetic.
+  numerical edge cases or within the precision of floating-point arithmetic.
   By :user:`Christian Lorentzen <lorentzenchr>`.

--- a/doc/whats_new/upcoming_changes/changed-models/33272.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/changed-models/33272.enhancement.rst
@@ -1,0 +1,5 @@
+- The :meth:`transform` method of :class:`preprocessing.PowerTransformer` with
+  `method="yeo-johnson"` now uses the numerical more stable function
+  `scipy.stats.yeojohnson` instead of an own implementation. The results may deviate in
+  numerical edge cases or within the precision of floating number arithmetic.
+  By :user:`Christian Lorentzen <lorentzenchr>`.

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -3437,7 +3437,7 @@ class PowerTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
 
         transform_function = {
             "box-cox": boxcox,
-            "yeo-johnson": self._yeo_johnson_transform,
+            "yeo-johnson": stats.yeojohnson,
         }[self.method]
         for i, lmbda in enumerate(self.lambdas_):
             with np.errstate(invalid="ignore"):  # hide NaN warnings
@@ -3527,28 +3527,6 @@ class PowerTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
             x_inv[~pos] = 1 - np.exp(-x[~pos])
 
         return x_inv
-
-    def _yeo_johnson_transform(self, x, lmbda):
-        """Return transformed input x following Yeo-Johnson transform with
-        parameter lambda.
-        """
-
-        out = np.zeros_like(x)
-        pos = x >= 0  # binary mask
-
-        # when x >= 0
-        if abs(lmbda) < np.spacing(1.0):
-            out[pos] = np.log1p(x[pos])
-        else:  # lmbda != 0
-            out[pos] = (np.power(x[pos] + 1, lmbda) - 1) / lmbda
-
-        # when x < 0
-        if abs(lmbda - 2) > np.spacing(1.0):
-            out[~pos] = -(np.power(-x[~pos] + 1, 2 - lmbda) - 1) / (2 - lmbda)
-        else:  # lmbda == 2
-            out[~pos] = -np.log1p(-x[~pos])
-
-        return out
 
     def _box_cox_optimize(self, x):
         """Find and return optimal lambda parameter of the Box-Cox transform by

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -3392,7 +3392,7 @@ class PowerTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
 
         transform_function = {
             "box-cox": boxcox,
-            "yeo-johnson": self._yeo_johnson_transform,
+            "yeo-johnson": stats.yeojohnson,
         }[self.method]
 
         with np.errstate(invalid="ignore"):  # hide NaN warnings

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2756,7 +2756,7 @@ def test_power_transformer_constant_feature(standardize):
 
     for Xt_ in [Xft, Xt]:
         if standardize:
-            assert_allclose(Xt_, np.zeros_like(X))
+            assert_allclose(Xt_, np.zeros_like(X), atol=1e-14)
         else:
             assert_allclose(Xt_, X)
 


### PR DESCRIPTION
#### Reference Issues/PRs
See https://github.com/scipy/scipy/pull/24541.

#### What does this implement/fix? Explain your changes.
This PR removes our own implementation of the Yeo-Johnson transform, `_yeo_johnson_transform`, and replaces it with `scipy.stats.yeojohnson`.

#### AI usage disclosure
None

### Other comments
This even helps Array API support.