### PR TITLE
FIX HDBSCAN crash with cluster_selection_epsilon on tied distances

### DIFF
--- a/sklearn/cluster/_hdbscan/_tree.pyx
+++ b/sklearn/cluster/_hdbscan/_tree.pyx
@@ -585,14 +585,14 @@ cdef cnp.intp_t traverse_upwards(
     cdef cnp.float64_t parent_eps
 
     root = cluster_tree['parent'].min()
-    parent = cluster_tree[cluster_tree['child'] == leaf]['parent']
+    parent = cluster_tree[cluster_tree['child'] == leaf]['parent'][0]
     if parent == root:
         if allow_single_cluster:
             return parent
         else:
             return leaf  # return node closest to root
 
-    parent_eps = 1 / cluster_tree[cluster_tree['child'] == parent]['value']
+    parent_eps = 1 / cluster_tree[cluster_tree['child'] == parent]['value'][0]
     if parent_eps > cluster_selection_epsilon:
         return parent
     else:


### PR DESCRIPTION
Fixes #33219

#### What does this implement/fix?

`HDBSCAN.fit_predict()` raises `TypeError: only 0-dimensional arrays can be converted to Python scalars` when `cluster_selection_epsilon` is set and the input data contains tied distances.

The root cause is in `traverse_upwards` in `_tree.pyx`. Tied distances produce duplicate entries in the condensed tree, so filtering by child id can return multiple rows instead of one. The code assumed a scalar result from these lookups, which blows up when it gets an array instead.

The fix indexes `[0]` on both the parent lookup and the `parent_eps` computation. All duplicate entries for a given child share the same parent and lambda value, so taking the first match is correct.

#### How has this been tested?

Added a non-regression test `test_hdbscan_cluster_selection_epsilon_tied_distances` using both:
- The exact precomputed distance matrix from the issue report
- The synthetic Euclidean reproducer from the issue