### PR TITLE
DOC: Fix some typos in Lasso

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2039,7 +2039,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
         until it is smaller or equal to ``tol``.
 
     copy_X : bool, default=True
-        If ``True``, X will be copied; otherwise, it may be overwritten.
+        If ``True``, `X` will be copied; otherwise, it may be overwritten.
 
     cv : int, cross-validation generator or iterable, default=None
         Determines the cross-validation splitting strategy.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1284,12 +1284,12 @@ class Lasso(ElasticNet):
         Parameter vector (w in the cost function formula).
 
     dual_gap_ : float or ndarray of shape (n_targets,)
-        Given param alpha, the dual gaps at the end of the optimization,
+        Given parameter ``alpha``, the dual gaps at the end of the optimization,
         same shape as each observation of y.
 
     sparse_coef_ : sparse matrix of shape (n_features, 1) or \
             (n_targets, n_features)
-        Readonly property derived from ``coef_``.
+        Read-only property derived from ``coef_``.
 
     intercept_ : float or ndarray of shape (n_targets,)
         Independent term in decision function.
@@ -1332,7 +1332,7 @@ class Lasso(ElasticNet):
     :class:`~sklearn.svm.LinearSVC`.
 
     The precise stopping criteria based on `tol` are the following: First, check that
-    that maximum coordinate update, i.e. :math:`\\max_j |w_j^{new} - w_j^{old}|`
+    the maximum coordinate update, i.e. :math:`\\max_j |w_j^{new} - w_j^{old}|`
     is smaller or equal to `tol` times the maximum absolute coefficient,
     :math:`\\max_j |w_j|`. If so, then additionally check whether the dual gap is
     smaller or equal to `tol` times :math:`||y||_2^2 / n_{\\text{samples}}`.
@@ -2028,7 +2028,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
             (n_features, n_features), default='auto'
         Whether to use a precomputed Gram matrix to speed up
         calculations. If set to ``'auto'`` let us decide. The Gram
-        matrix can also be passed as argument.
+        matrix can also be passed as an argument.
 
     max_iter : int, default=1000
         The maximum number of iterations.
@@ -2039,7 +2039,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
         until it is smaller or equal to ``tol``.
 
     copy_X : bool, default=True
-        If ``True``, X will be copied; else, it may be overwritten.
+        If ``True``, X will be copied; otherwise, it may be overwritten.
 
     cv : int, cross-validation generator or iterable, default=None
         Determines the cross-validation splitting strategy.
@@ -2148,7 +2148,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
     regularization path. It tends to speed up the hyperparameter
     search.
 
-    The underlying coordinate descent solver uses gap safe screening rules to speedup
+    The underlying coordinate descent solver uses gap safe screening rules to speed up
     fitting time, see :ref:`User Guide on coordinate descent <coordinate_descent>`.
 
     Examples


### PR DESCRIPTION
Fixing some typos in the [Lasso documentation](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Lasso.html)