### PR TITLE
FIX BisectingKMeans callable init validation uses n_centroids instead of n_clusters

### DIFF
--- a/sklearn/cluster/_bisect_k_means.py
+++ b/sklearn/cluster/_bisect_k_means.py
@@ -104,7 +104,8 @@ class BisectingKMeans(_BaseKMeans):
         for the initial centroids.
 
         If a callable is passed, it should take arguments X, n_clusters and a
-        random state and return an initialization.
+        random state and return an initialization. For BisectingKMeans, the
+        callable is invoked at each bisection step with n_clusters=2.
 
     n_init : int, default=1
         Number of time the inner k-means algorithm will be run with different

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -933,12 +933,14 @@ class _BaseKMeans(
             if has_vcomp and has_mkl:
                 self._warn_mkl_vcomp(n_active_threads)
 
-    def _validate_center_shape(self, X, centers):
+    def _validate_center_shape(self, X, centers, n_clusters=None):
         """Check if centers is compatible with X and n_clusters."""
-        if centers.shape[0] != self.n_clusters:
+        if n_clusters is None:
+            n_clusters = self.n_clusters
+        if centers.shape[0] != n_clusters:
             raise ValueError(
                 f"The shape of the initial centers {centers.shape} does not "
-                f"match the number of clusters {self.n_clusters}."
+                f"match the number of clusters {n_clusters}."
             )
         if centers.shape[1] != X.shape[1]:
             raise ValueError(
@@ -1037,7 +1039,7 @@ class _BaseKMeans(
         elif callable(init):
             centers = init(X, n_clusters, random_state=random_state)
             centers = check_array(centers, dtype=X.dtype, copy=False, order="C")
-            self._validate_center_shape(X, centers)
+            self._validate_center_shape(X, centers, n_clusters)
 
         if sp.issparse(centers):
             centers = centers.toarray()


### PR DESCRIPTION
Fixes #33146

## Problem

When using `BisectingKMeans` with a callable `init`, `_validate_center_shape` always checked the shape of the returned centers against `self.n_clusters` (the total number of clusters). But for bisecting k-means, each bisection step passes `n_centroids=2` to `_init_centroids`, so the callable correctly receives and returns 2 centers. The validation then fails because it expects `self.n_clusters` (e.g., 6) centers instead of 2.

## Fix

Added an optional `n_clusters` parameter to `_validate_center_shape` so `_init_centroids` can pass the actual number of centroids being requested. When not provided, it defaults to `self.n_clusters` which preserves existing behavior for `KMeans` and `MiniBatchKMeans`.

Also updated the `BisectingKMeans.init` docstring to clarify that the callable is always invoked with `n_clusters=2` at each bisection step.

## Tests

Added two non-regression tests:
- `test_callable_init_with_bisecting_kmeans`: verifies a callable init works with `BisectingKMeans` and always receives `n_clusters=2`
- `test_callable_init_wrong_shape_raises`: verifies that a callable returning the wrong number of centers still raises `ValueError`