### PR TITLE
FIX score_params subset mismatch in learning_curve with incremental learning

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.model_selection/33284.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.model_selection/33284.fix.rst
@@ -1,0 +1,5 @@
+- :func:`model_selection.learning_curve` with
+  ``exploit_incremental_learning=True`` no longer returns NaN training scores
+  when scorer metadata (e.g. ``sample_weight``) is provided via the metadata
+  routing API.
+  By :user:`Juan Flores <juanf-0gravity>`.

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -2161,12 +2161,14 @@ def _incremental_fit_estimator(
     else:
         partial_fit_func = partial(estimator.partial_fit, classes=classes, **fit_params)
     score_params = score_params if score_params is not None else {}
-    score_params_train = _check_method_params(X, params=score_params, indices=train)
     score_params_test = _check_method_params(X, params=score_params, indices=test)
 
     for n_train_samples, partial_train in partitions:
         train_subset = train[:n_train_samples]
         X_train, y_train = _safe_split(estimator, X, y, train_subset)
+        score_params_train = _check_method_params(
+            X, params=score_params, indices=train_subset
+        )
         X_partial_train, y_partial_train = _safe_split(estimator, X, y, partial_train)
         X_test, y_test = _safe_split(estimator, X, y, test, train_subset)
         start_fit = time.time()


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #33283.

#### What does this implement/fix? Explain your changes.

When using `learning_curve` with `exploit_incremental_learning=True` and passing scorer metadata (e.g. `sample_weight`) via the routing API, all training scores except the last come back as NaN.

The problem is in `_incremental_fit_estimator` — `score_params_train` gets sliced once outside the loop with the full `train` indices, but `X_train` inside the loop uses `train_subset = train[:n_train_samples]` which grows each iteration. So you end up passing 100-element weights to a scorer that only has 30 samples, it throws, `_score` catches it and returns NaN.

The fix just moves that one `_check_method_params` call inside the loop so it slices with `train_subset` instead of `train`. `score_params_test` stays outside since the test set doesn't change.

Also added a regression test that reproduces the exact scenario from the issue — confirmed it fails on main and passes with the fix.

#### AI usage disclosure

- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

#### Any other comments?

Noticed this was introduced in 77fc72c39 when metadata routing was added to `learning_curve` — the pattern was likely copied from `_fit_and_score` where it works fine because `train` indices aren't further subsetted in a loop.