### PR TITLE
DOC update California housing source link

### DIFF
--- a/sklearn/datasets/_california_housing.py
+++ b/sklearn/datasets/_california_housing.py
@@ -42,8 +42,8 @@ from sklearn.datasets._base import (
 from sklearn.utils import Bunch
 from sklearn.utils._param_validation import Interval, validate_params
 
-# The original data can be found at:
-# https://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.tgz
+# The original data comes from the StatLib repository:
+# https://lib.stat.cmu.edu/datasets/
 ARCHIVE = RemoteFileMetadata(
     filename="cal_housing.tgz",
     url="https://ndownloader.figshare.com/files/5976036",

--- a/sklearn/datasets/descr/california_housing.rst
+++ b/sklearn/datasets/descr/california_housing.rst
@@ -22,7 +22,7 @@ California Housing dataset
 :Missing Attribute Values: None
 
 This dataset was obtained from the StatLib repository.
-https://www.dcc.fc.up.pt/~ltorgo/Regression/cal_housing.html
+https://lib.stat.cmu.edu/datasets/
 
 The target variable is the median house value for California districts,
 expressed in hundreds of thousands of dollars ($100,000).


### PR DESCRIPTION
## Summary
- replace the broken California housing source URL in the dataset description with the StatLib repository URL
- update the source comment in `sklearn/datasets/_california_housing.py` accordingly

## Why
Issue #33231 reports that the old URL times out and is no longer reliably reachable.

Closes #33231
