### PR TITLE
TST Work around free-threaded warnings race condition

### DIFF
--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -2415,6 +2415,7 @@ def test_onehotencoder_handle_unknown_warn_maps_to_infrequent():
     encoder_infreq.fit(train_data)
 
     warning_match = "unknown categories will be encoded as the infrequent category"
+    # The warning is raised because `drop is not None`.
     with pytest.warns(UserWarning, match=warning_match):
         result_infreq = encoder_infreq.transform(test_data)
 

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -2411,10 +2411,12 @@ def test_onehotencoder_handle_unknown_warn_maps_to_infrequent():
         min_frequency=2,
         drop="first",
     )
+
     encoder_infreq.fit(train_data)
-    result_infreq = encoder_infreq.transform(test_data)
 
     warning_match = "unknown categories will be encoded as the infrequent category"
+    with pytest.warns(UserWarning, match=warning_match):
+        result_infreq = encoder_infreq.transform(test_data)
 
     with pytest.warns(UserWarning, match=warning_match):
         result_warn = encoder_warn.transform(test_data)


### PR DESCRIPTION
This happens because the warning is emitted twice, once outside a `pytest.warns` context and once inside. There is some kind of race condition with the per-module `__warningregistry__` which is used to issue a warning only once (default behaviour).

The work-around is to make sure the first warnings also happens withing a `pytest.warns`.

See https://github.com/Quansight-Labs/pytest-run-parallel/issues/169 for more details.

With this work-around the test passes on my machine:
```
pytest sklearn/preprocessing/tests/test_encoders.py -k test_onehotencoder_handle_unknown_warn_maps_to_infrequent --parallel-threads 4 --iterations 500
```

This was seen in https://github.com/scikit-learn/scikit-learn/pull/33245.