### PR TITLE
DOC: Fix 'the the' typos in loss.py

### DIFF
--- a/sklearn/_loss/loss.py
+++ b/sklearn/_loss/loss.py
@@ -1352,7 +1352,7 @@ def _log1pexp(raw_prediction, raw_prediction_exp, xp):
 
 
 class HalfBinomialLossArrayAPI(ArrayAPILossMixin, HalfBinomialLoss):
-    """A version of the the HalfBinomialLoss that is compatible with
+    """A version of the HalfBinomialLoss that is compatible with
     the array API.
     """
 
@@ -1456,7 +1456,7 @@ class HalfBinomialLossArrayAPI(ArrayAPILossMixin, HalfBinomialLoss):
 
 
 class HalfMultinomialLossArrayAPI(ArrayAPILossMixin, HalfMultinomialLoss):
-    """A version of the the HalfMultinomialLoss that is compatible with
+    """A version of the HalfMultinomialLoss that is compatible with
     the array API.
 
     Parameters

--- a/sklearn/_loss/loss.py
+++ b/sklearn/_loss/loss.py
@@ -114,7 +114,7 @@ class BaseLoss:
         Indicates whether or not loss function is differentiable in
         raw_prediction everywhere.
     need_update_leaves_values : bool
-        Indicates whether decision trees in gradient boosting need to uptade
+        Indicates whether decision trees in gradient boosting need to update
         leave values after having been fit to the (negative) gradients.
     approx_hessian : bool
         Indicates whether the hessian is approximated or exact. If,

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -918,7 +918,7 @@ def test_cohen_kappa_undefined(test_case, replace_undefined_by):
     """Test that cohen_kappa_score handles divisions by 0 correctly by returning the
     `replace_undefined_by` param. (The first test case covers the first possible
     location in the function for an occurrence of a division by zero, the last three
-    test cases cover a zero division in the the second possible location in the
+    test cases cover a zero division in the second possible location in the
     function."""
 
     y1, y2, labels, weights = test_case

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -3708,9 +3708,9 @@ def test_confusion_matrix_array_api(array_namespace, device, _):
 def test_probabilistic_metrics_array_api(
     prob_metric, str_y_true, use_sample_weight, array_namespace, device_, dtype_name
 ):
-    """Test that :func:`brier_score_loss`, :func:`log_loss`, func:`d2_brier_score`
+    """Test that :func:`brier_score_loss`, :func:`log_loss`, :func:`d2_brier_score`
     and :func:`d2_log_loss_score` work correctly with the array API for binary
-    and mutli-class inputs.
+    and multi-class inputs.
     """
     xp = _array_api_for_tests(array_namespace, device_)
     sample_weight = np.array([1, 2, 3, 1]) if use_sample_weight else None
@@ -3775,7 +3775,7 @@ def test_probabilistic_metrics_array_api(
 def test_probabilistic_metrics_multilabel_array_api(
     prob_metric, use_sample_weight, array_namespace, device_, dtype_name
 ):
-    """Test that :func:`brier_score_loss`, :func:`log_loss`, func:`d2_brier_score`
+    """Test that :func:`brier_score_loss`, :func:`log_loss`, :func:`d2_brier_score`
     and :func:`d2_log_loss_score` work correctly with the array API for
     multi-label inputs.
     """

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -216,7 +216,7 @@ def precision_recall_curve_padded_thresholds(*args, **kwargs):
     """
     The dimensions of precision-recall pairs and the threshold array as
     returned by the precision_recall_curve do not match. See
-    func:`sklearn.metrics.precision_recall_curve`
+    :func:`sklearn.metrics.precision_recall_curve`
 
     This prevents implicit conversion of return value triple to a higher
     dimensional np.array of dtype('float64') (it will be of dtype('object)


### PR DESCRIPTION
This PR fixes multiple 'the the' typos in docstrings and comments in sklearn/_loss/loss.py.