### PR TITLE
FIX: Set `levels` explicitly to plot all classes in distinct colors in `DecisionBoundaryDisplay`

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.inspection/33300.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.inspection/33300.fix.rst
@@ -1,0 +1,5 @@
+- :class:`inspection.DecisionBoundaryDisplay` now displays all class boundaries when
+  using ``plot_method="contour"`` with all response_methods, and displays all classes
+  in distinct colors when using ``plot_method="contourf"`` with
+  ``response_method="predict"``.
+  By :user:`Anne Beyer <AnneBeyer>` and :user:`Levente Csibi <leweex95>`.

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -287,6 +287,12 @@ class DecisionBoundaryDisplay:
             self.multiclass_colors_ = colors
 
             if self.response.ndim == 2:  # predict
+                # Set `levels` to ensure all classes are displayed in different colors
+                if "levels" not in kwargs:
+                    if plot_method == "contour":
+                        kwargs["levels"] = self.n_classes
+                    elif plot_method == "contourf":
+                        kwargs["levels"] = np.arange(self.n_classes + 1) - 0.5
                 # `pcolormesh` requires cmap, for the others it makes no difference
                 cmap = mpl.colors.ListedColormap(colors)
                 self.surface_ = plot_func(
@@ -295,6 +301,9 @@ class DecisionBoundaryDisplay:
 
             # predict_proba and decision_function differ for plotting methods
             elif plot_method == "contour":
+                # Set `levels` to ensure all classes are displayed in different colors
+                if "levels" not in kwargs:
+                    kwargs["levels"] = self.n_classes
                 # Plot only integer class values
                 self.surface_ = plot_func(
                     self.xx0,

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -290,7 +290,7 @@ class DecisionBoundaryDisplay:
                 # Set `levels` to ensure all classes are displayed in different colors
                 if "levels" not in kwargs:
                     if plot_method == "contour":
-                        kwargs["levels"] = self.n_classes
+                        kwargs["levels"] = np.arange(self.n_classes)
                     elif plot_method == "contourf":
                         kwargs["levels"] = np.arange(self.n_classes + 1) - 0.5
                 # `pcolormesh` requires cmap, for the others it makes no difference
@@ -303,7 +303,7 @@ class DecisionBoundaryDisplay:
             elif plot_method == "contour":
                 # Set `levels` to ensure all classes are displayed in different colors
                 if "levels" not in kwargs:
-                    kwargs["levels"] = self.n_classes
+                    kwargs["levels"] = np.arange(self.n_classes)
                 # Plot only integer class values
                 self.surface_ = plot_func(
                     self.xx0,

--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -715,7 +715,7 @@ def test_multiclass_levels(pyplot, y, response_method, plot_method):
     else:
         expected_levels = np.arange(7) - 0.5
 
-    assert np.array_equal(disp.surface_.levels, expected_levels)
+    assert_allclose(disp.surface_.levels, expected_levels)
 
 
 # estimator classes for non-regression test cases for issue #33194

--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -685,9 +685,37 @@ def test_multiclass_colors_cmap(
     else:
         assert_allclose(disp.surface_.colors, colors)
 
-    # non-regression test for issue #32866 (currently still fails)
-    # if hasattr(disp.surface_, "levels"):
-    #    assert len(disp.surface_.levels) >= disp.n_classes
+
+@pytest.mark.parametrize("y", [np.arange(6), [str(i) for i in np.arange(6)]])
+@pytest.mark.parametrize(
+    "response_method, plot_method",
+    [
+        ("decision_function", "contour"),
+        ("predict_proba", "contour"),
+        ("predict", "contour"),
+        ("predict", "contourf"),
+    ],
+)
+def test_multiclass_levels(pyplot, y, response_method, plot_method):
+    # non-regression test for issue #32866
+
+    X = np.array([[-1, -1], [-2, -1], [1, 1], [2, 1], [2, 2], [3, 2]])
+
+    clf = LogisticRegression().fit(X, y)
+
+    disp = DecisionBoundaryDisplay.from_estimator(
+        clf,
+        X,
+        response_method=response_method,
+        plot_method=plot_method,
+    )
+
+    if plot_method == "contour":
+        expected_levels = np.arange(6)
+    else:
+        expected_levels = np.arange(7) - 0.5
+
+    assert np.array_equal(disp.surface_.levels, expected_levels)
 
 
 # estimator classes for non-regression test cases for issue #33194


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #32866 (supersedes #32867)

#### What does this implement/fix? Explain your changes.
Continuing the proposed fix from #32867, this sets the `levels` parameter explicitly to the unique target values for `contour` and extends them for `contourf` with `response_method=predict` (the other `contourf` cases are handles differently by plotting every class on a different surface, so they're not affected by this bug). This ensures, that all classes (and class boundaries, respectively) are displayed in different colors.

Note that in #33015 we noticed that this can also occur when `n_classes < 7`. This happens because the default values for the levels don't necessarily correspond to the target classes. I used the data from the example in #33015 for the non-regression test here.

@ogrisel @lucyleeow @ThexXTURBOXx @leweex95 

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

#### Any other comments?

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
