### PR TITLE
MAINT: Fix C warnings in Cython modules `_kd_tree.pyx.tp`, `_binary_tree.pxi.tp` and `_ball_tree.pyx.tp`

### DIFF
--- a/sklearn/neighbors/_ball_tree.pyx.tp
+++ b/sklearn/neighbors/_ball_tree.pyx.tp
@@ -100,8 +100,7 @@ cdef int init_node{{name_suffix}}(
 
     cdef const intp_t* idx_array = &tree.idx_array[0]
     cdef const {{INPUT_DTYPE_t}}* data = &tree.data[0, 0]
-    cdef {{INPUT_DTYPE_t}}* centroid = &tree.node_bounds[0, i_node, 0]
-
+    cdef {{INPUT_DTYPE_t}}* centroid = <{{INPUT_DTYPE_t}}*> &tree.node_bounds[0, i_node, 0]
     cdef bint with_sample_weight = tree.sample_weight is not None
     cdef const {{INPUT_DTYPE_t}}* sample_weight
     cdef float64_t sum_weight_node

--- a/sklearn/neighbors/_binary_tree.pxi.tp
+++ b/sklearn/neighbors/_binary_tree.pxi.tp
@@ -1046,7 +1046,7 @@ cdef class BinaryTree{{name_suffix}}:
         cdef intp_t n_features = self.data.shape[1]
         cdef intp_t n_points = idx_end - idx_start
         cdef intp_t n_mid = n_points / 2
-        cdef intp_t* idx_array = &self.idx_array[idx_start]
+        cdef intp_t* idx_array = <intp_t*> &self.idx_array[idx_start]
         cdef const {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
 
         # initialize node data
@@ -1912,7 +1912,7 @@ cdef class BinaryTree{{name_suffix}}:
     ) noexcept nogil:
         """recursive single-tree radius query, depth-first"""
         cdef const {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
-        cdef intp_t* idx_array = &self.idx_array[0]
+        cdef intp_t* idx_array = <intp_t*> &self.idx_array[0]
         cdef intp_t n_features = self.data.shape[1]
         cdef NodeData_t node_info = self.node_data[i_node]
 
@@ -2007,7 +2007,7 @@ cdef class BinaryTree{{name_suffix}}:
         cdef const {{INPUT_DTYPE_t}}* sample_weight
         if with_sample_weight:
             sample_weight = &self.sample_weight[0]
-        cdef intp_t* idx_array = &self.idx_array[0]
+        cdef intp_t* idx_array = <intp_t*> &self.idx_array[0]
         cdef const NodeData_t* node_data = &self.node_data[0]
         cdef float64_t N
         cdef float64_t log_weight
@@ -2176,7 +2176,7 @@ cdef class BinaryTree{{name_suffix}}:
         cdef float64_t log_weight
         if with_sample_weight:
             sample_weight = &self.sample_weight[0]
-        cdef intp_t* idx_array = &self.idx_array[0]
+        cdef intp_t* idx_array = <intp_t*> &self.idx_array[0]
         cdef intp_t n_features = self.data.shape[1]
 
         cdef NodeData_t node_info = self.node_data[i_node]
@@ -2299,7 +2299,7 @@ cdef class BinaryTree{{name_suffix}}:
     ) except -1:
         """recursive single-tree two-point correlation function query"""
         cdef const {{INPUT_DTYPE_t}}* data = &self.data[0, 0]
-        cdef intp_t* idx_array = &self.idx_array[0]
+        cdef intp_t* idx_array = <intp_t*> &self.idx_array[0]
         cdef intp_t n_features = self.data.shape[1]
         cdef NodeData_t node_info = self.node_data[i_node]
 
@@ -2356,8 +2356,8 @@ cdef class BinaryTree{{name_suffix}}:
         """recursive dual-tree two-point correlation function query"""
         cdef const {{INPUT_DTYPE_t}}* data1 = &self.data[0, 0]
         cdef const {{INPUT_DTYPE_t}}* data2 = &other.data[0, 0]
-        cdef intp_t* idx_array1 = &self.idx_array[0]
-        cdef intp_t* idx_array2 = &other.idx_array[0]
+        cdef intp_t* idx_array1 = <intp_t*> &self.idx_array[0]
+        cdef intp_t* idx_array2 = <intp_t*> &other.idx_array[0]
         cdef NodeData_t node_info1 = self.node_data[i_node1]
         cdef NodeData_t node_info2 = other.node_data[i_node2]
 

--- a/sklearn/neighbors/_kd_tree.pyx.tp
+++ b/sklearn/neighbors/_kd_tree.pyx.tp
@@ -82,8 +82,8 @@ cdef int init_node{{name_suffix}}(
     cdef intp_t i, j
     cdef float64_t rad = 0
 
-    cdef {{INPUT_DTYPE_t}}* lower_bounds = &tree.node_bounds[0, i_node, 0]
-    cdef {{INPUT_DTYPE_t}}* upper_bounds = &tree.node_bounds[1, i_node, 0]
+    cdef {{INPUT_DTYPE_t}}* lower_bounds = <{{INPUT_DTYPE_t}}*> &tree.node_bounds[0, i_node, 0]
+    cdef {{INPUT_DTYPE_t}}* upper_bounds = <{{INPUT_DTYPE_t}}*> &tree.node_bounds[1, i_node, 0]
     cdef const {{INPUT_DTYPE_t}}* data = &tree.data[0, 0]
     cdef const intp_t* idx_array = &tree.idx_array[0]
 


### PR DESCRIPTION
#### Reference Issues/PRs
No issue involved.

#### What does this implement/fix? Explain your changes.
While compiling sk-learn, we get the following warnings for modules `_binary_tree.pyx.tp` and `_kd_tree.pxi.tp`:

```
  [1/4] Generating sklearn/neighbors/_kd_tree_pyx with a custom command
  [2/4] Generating 'sklearn/neighbors/_kd_tree.cpython-312-x86_64-linux-musl.so.p/_kd_tree.c'
  warning: sklearn/neighbors/_binary_tree.pxi:1091:8: Assigning to 'intp_t *' from 'const intp_t *' discards const qualifier
  warning: sklearn/neighbors/_binary_tree.pxi:1957:8: Assigning to 'intp_t *' from 'const intp_t *' discards const qualifier
  warning: sklearn/neighbors/_binary_tree.pxi:2052:8: Assigning to 'intp_t *' from 'const intp_t *' discards const qualifier
  warning: sklearn/neighbors/_binary_tree.pxi:2221:8: Assigning to 'intp_t *' from 'const intp_t *' discards const qualifier
  warning: sklearn/neighbors/_binary_tree.pxi:2344:8: Assigning to 'intp_t *' from 'const intp_t *' discards const qualifier
  warning: sklearn/neighbors/_binary_tree.pxi:2401:8: Assigning to 'intp_t *' from 'const intp_t *' discards const qualifier
  warning: sklearn/neighbors/_binary_tree.pxi:2402:8: Assigning to 'intp_t *' from 'const intp_t *' discards const qualifier
  warning: sklearn/neighbors/_binary_tree.pxi:2726:8: Assigning to 'intp_t *' from 'const intp_t *' discards const qualifier
  warning: sklearn/neighbors/_binary_tree.pxi:3592:8: Assigning to 'intp_t *' from 'const intp_t *' discards const qualifier
  warning: sklearn/neighbors/_binary_tree.pxi:3687:8: Assigning to 'intp_t *' from 'const intp_t *' discards const qualifier
  warning: sklearn/neighbors/_binary_tree.pxi:3856:8: Assigning to 'intp_t *' from 'const intp_t *' discards const qualifier
  warning: sklearn/neighbors/_binary_tree.pxi:3979:8: Assigning to 'intp_t *' from 'const intp_t *' discards const qualifier
  warning: sklearn/neighbors/_binary_tree.pxi:4036:8: Assigning to 'intp_t *' from 'const intp_t *' discards const qualifier
  warning: sklearn/neighbors/_binary_tree.pxi:4037:8: Assigning to 'intp_t *' from 'const intp_t *' discards const qualifier
  warning: sklearn/neighbors/_kd_tree.pyx:75:4: Assigning to 'float64_t *' from 'const float64_t *' discards const qualifier
  warning: sklearn/neighbors/_kd_tree.pyx:76:4: Assigning to 'float64_t *' from 'const float64_t *' discards const qualifier
  warning: sklearn/neighbors/_kd_tree.pyx:344:4: Assigning to 'float32_t *' from 'const float32_t *' discards const qualifier
  warning: sklearn/neighbors/_kd_tree.pyx:345:4: Assigning to 'float32_t *' from 'const float32_t *' discards const qualifier
  [3/4] Compiling C object sklearn/neighbors/_kd_tree.cpython-312-x86_64-linux-musl.so.p/meson-generated__kd_tree.c.o
```

This PR fixes the

- `Assigning to 'intp_t *' from 'const intp_t *' discards const qualifier`
- `Assigning to 'float64_t *' from 'const float64_t *' discards const qualifier`

warnings which leads to:

```
  [1/9] Generating sklearn/neighbors/_binary_tree_pxi with a custom command
  [2/9] Generating sklearn/neighbors/_ball_tree_pyx with a custom command
  [3/9] Generating sklearn/neighbors/_kd_tree_pyx with a custom command
  [4/9] Generating 'sklearn/neighbors/_ball_tree.cpython-312-x86_64-linux-musl.so.p/_ball_tree.c'
  [5/9] Generating 'sklearn/neighbors/_kd_tree.cpython-312-x86_64-linux-musl.so.p/_kd_tree.c'
  [6/9] Compiling C object sklearn/neighbors/_ball_tree.cpython-312-x86_64-linux-musl.so.p/meson-generated__ball_tree.c.o
```