### PR TITLE
FIX deprecated decorator for classes

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.utils/33304.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/33304.fix.rst
@@ -1,0 +1,3 @@
+- Fixed a bug in :class:`utils.deprecation.deprecated` so that the signature of a
+  subclass of a deprecated class can be correctly introspected.
+  By :user:`Jérémie du Boisberranger <jeremiedbb>`.

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -209,9 +209,8 @@ class BaseEstimator(ReprHTMLMixin, _HTMLDocumentationLinkMixin, _MetadataRequest
     @classmethod
     def _get_param_names(cls):
         """Get parameter names for the estimator"""
-        # fetch the constructor or the original constructor before
-        # deprecation wrapping if any
-        init = getattr(cls.__init__, "deprecated_original", cls.__init__)
+        # fetch the constructor
+        init = cls.__init__
         if init is object.__init__:
             # No explicit constructor to introspect
             return []
@@ -285,8 +284,7 @@ class BaseEstimator(ReprHTMLMixin, _HTMLDocumentationLinkMixin, _MetadataRequest
         """
         out = self.get_params(deep=deep)
 
-        init_func = getattr(self.__init__, "deprecated_original", self.__init__)
-        init_default_params = inspect.signature(init_func).parameters
+        init_default_params = inspect.signature(self.__init__).parameters
         init_default_params = {
             name: param.default for name, param in init_default_params.items()
         }

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -194,8 +194,7 @@ class Kernel(metaclass=ABCMeta):
         # introspect the constructor arguments to find the model parameters
         # to represent
         cls = self.__class__
-        init = getattr(cls.__init__, "deprecated_original", cls.__init__)
-        init_sign = signature(init)
+        init_sign = signature(cls.__init__)
         args, varargs = [], []
         for parameter in init_sign.parameters.values():
             if parameter.kind != parameter.VAR_KEYWORD and parameter.name != "self":

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -3026,9 +3026,7 @@ def _pprint(params, offset=0, printer=repr):
 
 
 def _build_repr(self):
-    # XXX This is copied from BaseEstimator's get_params
-    cls = self.__class__
-    init = getattr(cls.__init__, "deprecated_original", cls.__init__)
+    init = self.__class__.__init__
     # Ignore varargs, kw and default values and pop self
     init_signature = signature(init)
     # Consider the constructor parameters excluding 'self'

--- a/sklearn/utils/_pprint.py
+++ b/sklearn/utils/_pprint.py
@@ -93,8 +93,7 @@ def _changed_params(estimator):
     estimator with non-default values."""
 
     params = estimator.get_params(deep=False)
-    init_func = getattr(estimator.__init__, "deprecated_original", estimator.__init__)
-    init_params = inspect.signature(init_func).parameters
+    init_params = inspect.signature(estimator.__init__).parameters
     init_params = {name: param.default for name, param in init_params.items()}
 
     def has_changed(k, v):

--- a/sklearn/utils/deprecation.py
+++ b/sklearn/utils/deprecation.py
@@ -3,7 +3,6 @@
 
 import functools
 import warnings
-from inspect import signature
 
 __all__ = ["deprecated"]
 
@@ -65,8 +64,8 @@ class deprecated:
             msg += "; %s" % self.extra
 
         new = cls.__new__
-        sig = signature(cls)
 
+        @functools.wraps(new)
         def wrapped(cls, *args, **kwargs):
             warnings.warn(msg, category=FutureWarning)
             if new is object.__new__:
@@ -75,11 +74,6 @@ class deprecated:
             return new(cls, *args, **kwargs)
 
         cls.__new__ = wrapped
-
-        wrapped.__name__ = "__new__"
-        wrapped.deprecated_original = new
-        # Restore the original signature, see PEP 362.
-        cls.__signature__ = sig
 
         return cls
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1778,9 +1778,6 @@ def _is_public_parameter(attr):
 @ignore_warnings(category=FutureWarning)
 def check_dont_overwrite_parameters(name, estimator_orig):
     # check that fit method only changes or sets private attributes
-    if hasattr(estimator_orig.__init__, "deprecated_original"):
-        # to not check deprecated classes
-        return
     estimator = clone(estimator_orig)
     rnd = np.random.RandomState(0)
     X = 3 * rnd.uniform(size=(20, 3))
@@ -3709,9 +3706,6 @@ def check_no_attributes_set_in_init(name, estimator_orig):
             f"Estimator {name} should store all parameters as an attribute during init."
         )
 
-    if hasattr(type(estimator).__init__, "deprecated_original"):
-        return
-
     init_params = _get_args(type(estimator).__init__)
     parents_init_params = [
         param
@@ -3880,8 +3874,7 @@ def check_parameters_default_constructible(name, estimator_orig):
         # We get the default parameters from init and then
         # compare these against the actual values of the attributes.
 
-        # this comes from getattr. Gets rid of deprecation decorator.
-        init = getattr(estimator.__init__, "deprecated_original", estimator.__init__)
+        init = estimator.__init__
 
         try:
 

--- a/sklearn/utils/tests/test_deprecation.py
+++ b/sklearn/utils/tests/test_deprecation.py
@@ -12,7 +12,8 @@ from sklearn.utils.deprecation import _is_deprecated, deprecated
 
 @deprecated("qwerty")
 class MockClass1:
-    pass
+    def __init__(self, a, b=1, c=2):
+        pass
 
 
 class MockClass2:
@@ -40,8 +41,8 @@ class MockClass4:
 class MockClass5(MockClass1):
     """Inherit from deprecated class but does not call super().__init__."""
 
-    def __init__(self, a):
-        self.a = a
+    def __init__(self, a, b=1, d=2):
+        pass
 
 
 @deprecated("a message")
@@ -60,7 +61,7 @@ def mock_function():
 
 def test_deprecated():
     with pytest.warns(FutureWarning, match="qwerty"):
-        MockClass1()
+        MockClass1(42)
     with pytest.warns(FutureWarning, match="mockclass2_method"):
         MockClass2().method()
     with pytest.warns(FutureWarning, match="deprecated"):
@@ -90,9 +91,7 @@ def test_pickle():
 
 
 def test_deprecated_class_signature():
-    @deprecated()
-    class MockClass:
-        def __init__(self, a, b=1, c=2):
-            pass
-
-    assert list(signature(MockClass).parameters.keys()) == ["a", "b", "c"]
+    """Check that we can inspect the signature of a deprecated class."""
+    assert list(signature(MockClass1).parameters.keys()) == ["a", "b", "c"]
+    # And of a subclass of a deprecated class.
+    assert list(signature(MockClass5).parameters.keys()) == ["a", "b", "d"]


### PR DESCRIPTION
In https://github.com/scikit-learn/scikit-learn/pull/30145, the decorator was fixed to correctly work with ``signature``. However ``signature`` is still broken for subclasses of a deprecated class because the added ``__signature__`` attribute is then inherited by the subclass (and ``signature`` relies on that primarily). The test amended in ``test_deprecation.py`` illustrates that and fails on ``main``.

On the way, I removed all legacy code where we used to try to retreive the original ``__init__``. We no longer wrap ``__init__`` since ~4 releases, but ``__new__`` instead. This code is now just dead code that can safely be removed.
