### PR TITLE
MNT Clean up dead code related to deprecated classes

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -209,9 +209,8 @@ class BaseEstimator(ReprHTMLMixin, _HTMLDocumentationLinkMixin, _MetadataRequest
     @classmethod
     def _get_param_names(cls):
         """Get parameter names for the estimator"""
-        # fetch the constructor or the original constructor before
-        # deprecation wrapping if any
-        init = getattr(cls.__init__, "deprecated_original", cls.__init__)
+        # fetch the constructor
+        init = cls.__init__
         if init is object.__init__:
             # No explicit constructor to introspect
             return []
@@ -285,8 +284,7 @@ class BaseEstimator(ReprHTMLMixin, _HTMLDocumentationLinkMixin, _MetadataRequest
         """
         out = self.get_params(deep=deep)
 
-        init_func = getattr(self.__init__, "deprecated_original", self.__init__)
-        init_default_params = inspect.signature(init_func).parameters
+        init_default_params = inspect.signature(self.__init__).parameters
         init_default_params = {
             name: param.default for name, param in init_default_params.items()
         }

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -194,8 +194,7 @@ class Kernel(metaclass=ABCMeta):
         # introspect the constructor arguments to find the model parameters
         # to represent
         cls = self.__class__
-        init = getattr(cls.__init__, "deprecated_original", cls.__init__)
-        init_sign = signature(init)
+        init_sign = signature(cls.__init__)
         args, varargs = [], []
         for parameter in init_sign.parameters.values():
             if parameter.kind != parameter.VAR_KEYWORD and parameter.name != "self":

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -3026,9 +3026,7 @@ def _pprint(params, offset=0, printer=repr):
 
 
 def _build_repr(self):
-    # XXX This is copied from BaseEstimator's get_params
-    cls = self.__class__
-    init = getattr(cls.__init__, "deprecated_original", cls.__init__)
+    init = self.__class__.__init__
     # Ignore varargs, kw and default values and pop self
     init_signature = signature(init)
     # Consider the constructor parameters excluding 'self'

--- a/sklearn/utils/_pprint.py
+++ b/sklearn/utils/_pprint.py
@@ -93,8 +93,7 @@ def _changed_params(estimator):
     estimator with non-default values."""
 
     params = estimator.get_params(deep=False)
-    init_func = getattr(estimator.__init__, "deprecated_original", estimator.__init__)
-    init_params = inspect.signature(init_func).parameters
+    init_params = inspect.signature(estimator.__init__).parameters
     init_params = {name: param.default for name, param in init_params.items()}
 
     def has_changed(k, v):

--- a/sklearn/utils/deprecation.py
+++ b/sklearn/utils/deprecation.py
@@ -77,7 +77,6 @@ class deprecated:
         cls.__new__ = wrapped
 
         wrapped.__name__ = "__new__"
-        wrapped.deprecated_original = new
         # Restore the original signature, see PEP 362.
         cls.__signature__ = sig
 

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -1778,9 +1778,6 @@ def _is_public_parameter(attr):
 @ignore_warnings(category=FutureWarning)
 def check_dont_overwrite_parameters(name, estimator_orig):
     # check that fit method only changes or sets private attributes
-    if hasattr(estimator_orig.__init__, "deprecated_original"):
-        # to not check deprecated classes
-        return
     estimator = clone(estimator_orig)
     rnd = np.random.RandomState(0)
     X = 3 * rnd.uniform(size=(20, 3))
@@ -3709,9 +3706,6 @@ def check_no_attributes_set_in_init(name, estimator_orig):
             f"Estimator {name} should store all parameters as an attribute during init."
         )
 
-    if hasattr(type(estimator).__init__, "deprecated_original"):
-        return
-
     init_params = _get_args(type(estimator).__init__)
     parents_init_params = [
         param
@@ -3880,8 +3874,7 @@ def check_parameters_default_constructible(name, estimator_orig):
         # We get the default parameters from init and then
         # compare these against the actual values of the attributes.
 
-        # this comes from getattr. Gets rid of deprecation decorator.
-        init = getattr(estimator.__init__, "deprecated_original", estimator.__init__)
+        init = estimator.__init__
 
         try:
 


### PR DESCRIPTION
We no longer modify the ``__init__`` when we deprecate classes but ``__new__`` instead. That was changed ~4 releases ago, but we left some legacy code which purpose was to retreive the original ``__init__``, and not the wrapped one, in different places. It can safely be removed. We always get the original __init__ since we don't modify it.

The ``deprecated_original`` attribute that was set on the wrapped init was defined to be able to retreive that original init and is thus not used anymore after this clean up so can be safely removed as well.