### PR TITLE
CI Test only 20 random seeds in nightly scheduled run

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -256,7 +256,7 @@ jobs:
 
       - name: Set random seed for nightly/manual runs
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        run: echo "SKLEARN_TESTS_GLOBAL_RANDOM_SEED=$((RANDOM % 100))" >> $GITHUB_ENV
+        run: echo "SKLEARN_TESTS_GLOBAL_RANDOM_SEED=$((RANDOM % 20))" >> $GITHUB_ENV
         shell: bash
 
       - name: Run tests
@@ -366,7 +366,7 @@ jobs:
 
       - name: Set random seed for nightly/manual runs
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        run: echo "SKLEARN_TESTS_GLOBAL_RANDOM_SEED=$((RANDOM % 100))" >> $GITHUB_ENV
+        run: echo "SKLEARN_TESTS_GLOBAL_RANDOM_SEED=$((RANDOM % 20))" >> $GITHUB_ENV
 
       - name: Start container
         # Environment variable are passed when starting the container rather

--- a/build_tools/azure/test_script.sh
+++ b/build_tools/azure/test_script.sh
@@ -11,7 +11,7 @@ if [[ "$BUILD_REASON" == "Schedule" ]]; then
     # Enable global random seed randomization to discover seed-sensitive tests
     # only on nightly builds.
     # https://scikit-learn.org/stable/computing/parallelism.html#environment-variables
-    export SKLEARN_TESTS_GLOBAL_RANDOM_SEED=$(($RANDOM % 100))
+    export SKLEARN_TESTS_GLOBAL_RANDOM_SEED=$(($RANDOM % 20))
     echo "To reproduce this test run, set the following environment variable:"
     echo "    SKLEARN_TESTS_GLOBAL_RANDOM_SEED=$SKLEARN_TESTS_GLOBAL_RANDOM_SEED",
     echo "See: https://scikit-learn.org/dev/computing/parallelism.html#sklearn-tests-global-random-seed"


### PR DESCRIPTION
Follow-up of https://github.com/scikit-learn/scikit-learn/issues/33033. Close #33033.

After the Azure -> GHA migration (or a dependency update hard to know for sure) there seems to be at least 2 tests that fail for a single random seed see https://github.com/scikit-learn/scikit-learn/issues/33274#issuecomment-3907658843 and https://github.com/scikit-learn/scikit-learn/issues/33244#issuecomment-3907806973.

This implements a middle-ground approach of only testing 20 global random seeds in the daily schedule run as mentioned in https://github.com/scikit-learn/scikit-learn/issues/33033#issuecomment-3750070779.
- this still detects somewhat flaky tests in the nightly run except with a higher detection threshold. This will reduce the time spent in chasing and "fixing" this kind of issues (raising the tolerance most of the time :shrug:).
- you can still use `SKLEARN_GLOBAL_RANDOM_SEED=all` to locally test global random seeds `0-99`. The `[all random seeds]` commit message also does test all random seeds (i.e. `0-99)`. We could also decide that "all" is 0-19 if we want to do this, no strong opinion to be honest. I guess using 0-99 for `all` makes you write a more robust/conservative test and is less likely to trigger a random failure in the CI where we tests for less seeds?

cc @jeremiedbb @ogrisel.

