### PR TITLE
DOC remove sklearn-evaluation from related projects

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -77,11 +77,6 @@ enhance the functionality of scikit-learn's estimators.
 - `model-diagnostics <https://lorentzenchr.github.io/model-diagnostics/>`_ Tools for
   diagnostics and assessment of (machine learning) models (in Python).
 
-- `sklearn-evaluation <https://github.com/ploomber/sklearn-evaluation>`_
-  Machine learning model evaluation made easy: plots, tables, HTML reports,
-  experiment tracking and Jupyter notebook analysis. Visual analysis, model
-  selection, evaluation and diagnostics.
-
 - `yellowbrick <https://github.com/DistrictDataLabs/yellowbrick>`_ A suite of
   custom matplotlib visualizers for scikit-learn estimators to support visual feature
   analysis, model selection, evaluation, and diagnostics.


### PR DESCRIPTION
#### Reference Issues/PRs
None


#### What does this implement/fix? Explain your changes.
This removes https://github.com/ploomber/sklearn-evaluation from the related projects site. It is archives as of 28 Febr 2025.

#### AI usage disclosure
None


#### Any other comments?
