### PR TITLE
Fix MDS returning wrong number of components when using ClassicalMDS initialization 

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.manifold/33318.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.manifold/33318.fix.rst
@@ -1,3 +1,3 @@
-- :class:`manifold.MDS` now returns the correct number of components when using 
-  `init="classical_mds"`.
+- :meth:`manifold.MDS.transform` returns the correct number of components when
+  using `init="classical_mds"`.
   By :user:`Ben Pedigo <bdpedigo>`.

--- a/doc/whats_new/upcoming_changes/sklearn.manifold/33318.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.manifold/33318.fix.rst
@@ -1,0 +1,3 @@
+- :class:`manifold.MDS` now returns the correct number of components when using 
+  `init="classical_mds"`.
+  By :user:`Ben Pedigo <bdpedigo>`.

--- a/sklearn/manifold/_mds.py
+++ b/sklearn/manifold/_mds.py
@@ -813,7 +813,7 @@ class MDS(BaseEstimator):
         if init is not None:
             init_array = init
         elif self._init == "classical_mds":
-            cmds = ClassicalMDS(metric="precomputed")
+            cmds = ClassicalMDS(metric="precomputed", n_components=self.n_components)
             init_array = cmds.fit_transform(self.dissimilarity_matrix_)
         else:
             init_array = None

--- a/sklearn/manifold/tests/test_mds.py
+++ b/sklearn/manifold/tests/test_mds.py
@@ -303,3 +303,12 @@ def test_classical_mds_init_to_mds():
     Z2 = mds1.fit_transform(X, init=Z_classical)
 
     assert_allclose(Z1, Z2)
+
+
+def test_classical_mds_init_correct_components():
+    X, _ = load_iris(return_X_y=True)
+
+    mds1 = mds.MDS(init="classical_mds", n_components=3, n_init=1)
+    Z1 = mds1.fit_transform(X)
+
+    assert Z1.shape[1] == 3

--- a/sklearn/manifold/tests/test_mds.py
+++ b/sklearn/manifold/tests/test_mds.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_almost_equal, assert_equal
 
-from sklearn.datasets import load_digits, load_iris
+from sklearn.datasets import load_digits, load_iris, make_blobs
 from sklearn.manifold import ClassicalMDS
 from sklearn.manifold import _mds as mds
 from sklearn.metrics import euclidean_distances
@@ -306,9 +306,9 @@ def test_classical_mds_init_to_mds():
 
 
 @pytest.mark.parametrize("init", ["random", "classical_mds"])
-@pytest.mark.parametrize("n_components", [1, 2, 3])
+@pytest.mark.parametrize("n_components", [1, 2, 5, 10])
 def test_correct_n_components(init, n_components):
-    X, _ = load_iris(return_X_y=True)
+    X, _ = make_blobs(n_features=10)
 
     model = mds.MDS(init=init, n_components=n_components, n_init=1)
     Z = model.fit_transform(X)

--- a/sklearn/manifold/tests/test_mds.py
+++ b/sklearn/manifold/tests/test_mds.py
@@ -305,10 +305,12 @@ def test_classical_mds_init_to_mds():
     assert_allclose(Z1, Z2)
 
 
-def test_classical_mds_init_correct_components():
+@pytest.mark.parametrize("init", ["random", "classical_mds"])
+@pytest.mark.parametrize("n_components", [1, 2, 3])
+def test_correct_n_components(init, n_components):
     X, _ = load_iris(return_X_y=True)
 
-    mds1 = mds.MDS(init="classical_mds", n_components=3, n_init=1)
-    Z1 = mds1.fit_transform(X)
+    model = mds.MDS(init=init, n_components=n_components, n_init=1)
+    Z = model.fit_transform(X)
 
-    assert Z1.shape[1] == 3
+    assert Z.shape[1] == n_components


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
Fixes #33305 


#### What does this implement/fix? Explain your changes.
Ensures MDS outputs specified number of components when using ClassicalMDS initialization

#### AI usage disclosure
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding