### PR TITLE
ENH: More efficient calculation of sum of squared elements for univariate_selection

### DIFF
--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -15,7 +15,7 @@ from sklearn.feature_selection._base import SelectorMixin
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.utils import as_float_array, check_array, check_X_y, safe_mask
 from sklearn.utils._param_validation import Interval, StrOptions, validate_params
-from sklearn.utils.extmath import row_norms, safe_sparse_dot, axis_norms
+from sklearn.utils.extmath import axis_norms, row_norms, safe_sparse_dot
 from sklearn.utils.validation import check_is_fitted, validate_data
 
 
@@ -35,7 +35,7 @@ def _clean_nans(scores):
 # Scoring functions
 
 
-# The following function is a rewriting of scipy.stats.f_oneway
+# The following function is rewriting of scipy.stats.f_oneway
 # Contrary to the scipy.stats.f_oneway implementation it does not
 # copy the data while keeping the inputs unchanged.
 def f_oneway(*args):

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -13,7 +13,7 @@ from scipy.sparse import issparse
 from sklearn.base import BaseEstimator, _fit_context
 from sklearn.feature_selection._base import SelectorMixin
 from sklearn.preprocessing import LabelBinarizer
-from sklearn.utils import as_float_array, check_array, check_X_y, safe_mask, safe_sqr
+from sklearn.utils import as_float_array, check_array, check_X_y, safe_mask
 from sklearn.utils._param_validation import Interval, StrOptions, validate_params
 from sklearn.utils.extmath import row_norms, safe_sparse_dot, axis_norms
 from sklearn.utils.validation import check_is_fitted, validate_data

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -15,7 +15,7 @@ from sklearn.feature_selection._base import SelectorMixin
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.utils import as_float_array, check_array, check_X_y, safe_mask, safe_sqr
 from sklearn.utils._param_validation import Interval, StrOptions, validate_params
-from sklearn.utils.extmath import row_norms, safe_sparse_dot
+from sklearn.utils.extmath import row_norms, safe_sparse_dot, axis_norms
 from sklearn.utils.validation import check_is_fitted, validate_data
 
 
@@ -91,7 +91,7 @@ def f_oneway(*args):
     args = [as_float_array(a) for a in args]
     n_samples_per_class = np.array([a.shape[0] for a in args])
     n_samples = np.sum(n_samples_per_class)
-    ss_alldata = sum(safe_sqr(a).sum(axis=0) for a in args)
+    ss_alldata = sum(axis_norms(a, squared=False, axis=0) for a in args)
     sums_args = [np.asarray(a.sum(axis=0)) for a in args]
     square_of_sums_alldata = sum(sums_args) ** 2
     square_of_sums_args = [s**2 for s in sums_args]

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -91,7 +91,7 @@ def f_oneway(*args):
     args = [as_float_array(a) for a in args]
     n_samples_per_class = np.array([a.shape[0] for a in args])
     n_samples = np.sum(n_samples_per_class)
-    ss_alldata = sum(axis_norms(a, squared=False, axis=0) for a in args)
+    ss_alldata = sum(axis_norms(a, squared=True, axis=0) for a in args)
     sums_args = [np.asarray(a.sum(axis=0)) for a in args]
     square_of_sums_alldata = sum(sums_args) ** 2
     square_of_sums_args = [s**2 for s in sums_args]

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -35,7 +35,7 @@ def _clean_nans(scores):
 # Scoring functions
 
 
-# The following function is rewriting of scipy.stats.f_oneway
+# The following function is a rewriting of scipy.stats.f_oneway
 # Contrary to the scipy.stats.f_oneway implementation it does not
 # copy the data while keeping the inputs unchanged.
 def f_oneway(*args):

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -57,44 +57,6 @@ def squared_norm(x):
     return np.dot(x, x)
 
 
-def row_norms(X, squared=False):
-    """Row-wise (squared) Euclidean norm of X.
-
-    Equivalent to np.sqrt((X * X).sum(axis=1)), but also supports sparse
-    matrices and does not create an X.shape-sized temporary.
-
-    Performs no input validation.
-
-    Parameters
-    ----------
-    X : array-like
-        The input array.
-    squared : bool, default=False
-        If True, return squared norms.
-
-    Returns
-    -------
-    array-like
-        The row-wise (squared) Euclidean norm of X.
-    """
-    if sparse.issparse(X):
-        X = X.tocsr()
-        norms = csr_row_norms(X)
-        if not squared:
-            norms = np.sqrt(norms)
-    else:
-        xp, _ = get_namespace(X)
-        if _is_numpy_namespace(xp):
-            X = np.asarray(X)
-            norms = np.einsum("ij,ij->i", X, X)
-            norms = xp.asarray(norms)
-        else:
-            norms = xp.sum(xp.multiply(X, X), axis=1)
-        if not squared:
-            norms = xp.sqrt(norms)
-    return norms
-
-
 def axis_norms(X, squared=False, axis=0):
     """Axis-wise (squared) Euclidean norm of X.
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -93,8 +93,11 @@ def axis_norms(X, squared=False, axis=0):
         if _is_numpy_namespace(xp):
             X = np.asarray(X)
             axis = axis % X.ndim
-            Xview = np.moveaxis(X, axis, 0)
-            norms = np.einsum("i...,i...->...", Xview, Xview)
+            if axis == 0:
+                norms = np.einsum("i...,i...->...", X, X)
+            else:
+                Xview = np.moveaxis(X, axis, 0)
+                norms = np.einsum("i...,i...->...", Xview, Xview)
             norms = xp.asarray(norms)
         else:
             norms = xp.sum(xp.multiply(X, X), axis=axis)

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -25,7 +25,7 @@ from sklearn.utils._array_api import (
 from sklearn.utils._param_validation import Interval, StrOptions, validate_params
 from sklearn.utils.deprecation import deprecated
 from sklearn.utils.sparsefuncs import sparse_matmul_to_dense
-from sklearn.utils.sparsefuncs_fast import csr_row_norms, csc_col_norms
+from sklearn.utils.sparsefuncs_fast import csc_col_norms, csr_row_norms
 from sklearn.utils.validation import check_array, check_random_state
 
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -92,10 +92,9 @@ def axis_norms(X, squared=False, axis=0):
         xp, _ = get_namespace(X)
         if _is_numpy_namespace(xp):
             X = np.asarray(X)
-            if axis == 0:
-                norms = np.einsum("ij,ij->j", X, X)
-            else:
-                norms = np.einsum("ij,ij->i", X, X)
+            axis = axis % X.ndim
+            Xview = np.moveaxis(X, axis, 0)
+            norms = np.einsum("i...,i...->...", Xview, Xview)
             norms = xp.asarray(norms)
         else:
             norms = xp.sum(xp.multiply(X, X), axis=axis)

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -362,7 +362,7 @@ def test_col_norms(dtype, csc_container):
 
     for csc_index_dtype in [np.int32, np.int64]:
         Xcsc = csc_container(X, dtype=dtype)
-        # csc_matrix will use int32 indice by default,
+        # csc_matrix will use int32 indices by default,
         # up-casting those to int64 when necessary
         if csc_index_dtype is np.int64:
             Xcsc.indptr = Xcsc.indptr.astype(csc_index_dtype, copy=False)

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -39,10 +39,10 @@ from sklearn.utils.extmath import (
     _randomized_eigsh,
     _safe_accumulator_op,
     cartesian,
+    col_norms,
     density,
     randomized_range_finder,
     randomized_svd,
-    col_norms,
     row_norms,
     safe_sparse_dot,
     softmax,
@@ -362,7 +362,7 @@ def test_col_norms(dtype, csc_container):
 
     for csc_index_dtype in [np.int32, np.int64]:
         Xcsc = csc_container(X, dtype=dtype)
-        # csc_matrix will use int32 indices by default,
+        # csc_matrix will use int32 indice by default,
         # up-casting those to int64 when necessary
         if csc_index_dtype is np.int64:
             Xcsc.indptr = Xcsc.indptr.astype(csc_index_dtype, copy=False)

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -42,6 +42,7 @@ from sklearn.utils.extmath import (
     density,
     randomized_range_finder,
     randomized_svd,
+    col_norms,
     row_norms,
     safe_sparse_dot,
     softmax,
@@ -342,6 +343,34 @@ def test_row_norms(dtype, csr_container):
         assert Xcsr.indptr.dtype == csr_index_dtype
         assert_array_almost_equal(sq_norm, row_norms(Xcsr, squared=True), precision)
         assert_array_almost_equal(np.sqrt(sq_norm), row_norms(Xcsr), precision)
+
+
+@pytest.mark.parametrize("dtype", (np.float32, np.float64))
+@pytest.mark.parametrize("csc_container", CSC_CONTAINERS)
+def test_col_norms(dtype, csc_container):
+    X = np.random.RandomState(42).randn(100, 100)
+    if dtype is np.float32:
+        precision = 4
+    else:
+        precision = 5
+
+    X = X.astype(dtype, copy=False)
+    sq_norm = (X**2).sum(axis=0)
+
+    assert_array_almost_equal(sq_norm, col_norms(X, squared=True), precision)
+    assert_array_almost_equal(np.sqrt(sq_norm), col_norms(X), precision)
+
+    for csc_index_dtype in [np.int32, np.int64]:
+        Xcsc = csc_container(X, dtype=dtype)
+        # csc_matrix will use int32 indices by default,
+        # up-casting those to int64 when necessary
+        if csc_index_dtype is np.int64:
+            Xcsc.indptr = Xcsc.indptr.astype(csc_index_dtype, copy=False)
+            Xcsc.indices = Xcsc.indices.astype(csc_index_dtype, copy=False)
+        assert Xcsc.indices.dtype == csc_index_dtype
+        assert Xcsc.indptr.dtype == csc_index_dtype
+        assert_array_almost_equal(sq_norm, col_norms(Xcsc, squared=True), precision)
+        assert_array_almost_equal(np.sqrt(sq_norm), col_norms(Xcsc), precision)
 
 
 def test_randomized_svd_low_rank_with_noise():


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
In univariate selection, this new version does not require a copy of X, making it more efficient memory-wise.
The previous version required to calculate `X ** 2` (see `safe_sqr` in `sklearn.utils.extmath`), which made a copy of X