### PR TITLE
FEA Add Array API support for sigmoid and isotonic in CalibratedClassifierCV

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.calibration/31869.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.calibration/31869.feature.rst
@@ -1,0 +1,6 @@
+- :class:`calibration.CalibratedClassifierCV` now supports the Array API for
+  ``method="sigmoid"`` and ``method="isotonic"`` in addition to the
+  previously supported ``method="temperature"``. Predictions are converted to
+  NumPy internally for calibration fitting and prediction, while the
+  underlying estimator can still operate on Array API arrays.
+  By :user:`veeceey <veeceey>`.

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -1365,3 +1365,79 @@ def test_temperature_scaling_array_api_with_str_y_estimator_not_prefit(
         )
         pred_xp = cal_clf_xp.predict(X_xp)
         assert_array_equal(pred_xp, pred_np)
+
+
+@pytest.mark.parametrize("method", ["sigmoid", "isotonic"])
+@pytest.mark.parametrize("ensemble", [False, True])
+@pytest.mark.parametrize("use_sample_weight", [False, True])
+@pytest.mark.parametrize(
+    "array_namespace, device_, dtype_name",
+    yield_namespace_device_dtype_combinations(),
+    ids=_get_namespace_device_dtype_ids,
+)
+def test_sigmoid_isotonic_array_api_compliance(
+    method, ensemble, use_sample_weight, array_namespace, device_, dtype_name
+):
+    """Check that `CalibratedClassifierCV` with sigmoid and isotonic methods
+    is compatible with the Array API by converting predictions to numpy
+    internally for calibration and converting back."""
+
+    xp = _array_api_for_tests(array_namespace, device_)
+    X, y = make_classification(
+        n_samples=1000,
+        n_features=10,
+        n_informative=10,
+        n_redundant=0,
+        n_classes=5,
+        n_clusters_per_class=1,
+        class_sep=2.0,
+        random_state=42,
+    )
+    X_train, X_cal, y_train, y_cal = train_test_split(X, y, random_state=42)
+
+    X_train = X_train.astype(dtype_name)
+    y_train = y_train.astype(dtype_name)
+    X_train_xp = xp.asarray(X_train, device=device_)
+    y_train_xp = xp.asarray(y_train, device=device_)
+
+    X_cal = X_cal.astype(dtype_name)
+    y_cal = y_cal.astype(dtype_name)
+    X_cal_xp = xp.asarray(X_cal, device=device_)
+    y_cal_xp = xp.asarray(y_cal, device=device_)
+
+    if use_sample_weight:
+        sample_weight = np.ones_like(y_cal)
+        sample_weight[1::2] = 2
+    else:
+        sample_weight = None
+
+    clf_np = LinearDiscriminantAnalysis()
+    clf_np.fit(X_train, y_train)
+    cal_clf_np = CalibratedClassifierCV(
+        FrozenEstimator(clf_np), cv=3, method=method, ensemble=ensemble
+    ).fit(X_cal, y_cal, sample_weight=sample_weight)
+
+    proba_np = cal_clf_np.predict_proba(X_train)
+    pred_np = cal_clf_np.predict(X_train)
+
+    with config_context(array_api_dispatch=True):
+        clf_xp = LinearDiscriminantAnalysis()
+        clf_xp.fit(X_train_xp, y_train_xp)
+        cal_clf_xp = CalibratedClassifierCV(
+            FrozenEstimator(clf_xp), cv=3, method=method, ensemble=ensemble
+        ).fit(X_cal_xp, y_cal_xp, sample_weight=sample_weight)
+
+        proba_xp = cal_clf_xp.predict_proba(X_train_xp)
+        pred_xp = cal_clf_xp.predict(X_train_xp)
+
+        # Check that the output is in the expected namespace
+        assert get_namespace(proba_xp)[0].__name__ == xp.__name__
+        assert device(proba_xp) == device(X_train_xp)
+
+        rtol = 2e-2 if dtype_name == "float32" else 5e-7
+        assert_allclose(
+            _convert_to_numpy(proba_xp, xp=xp),
+            proba_np,
+            rtol=rtol,
+        )
+        assert_allclose(_convert_to_numpy(pred_xp, xp=xp), pred_np)


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #31869 (partially - adds sigmoid and isotonic support)

Follows up on #32246 which added Array API support for temperature scaling.

## Summary

- Extends Array API support in `CalibratedClassifierCV` to `method="sigmoid"` (Platt scaling) and `method="isotonic"` calibration methods
- Since sigmoid calibration uses `scipy.optimize.minimize` (L-BFGS-B) and isotonic regression is implemented in Cython, both are inherently numpy-only. The approach converts predictions, labels, sample weights, and class arrays to numpy before fitting/predicting with these calibrators, then converts results back to the original array namespace
- The underlying estimator can still operate on Array API arrays (e.g., PyTorch tensors) for its `fit` and `predict` methods
- Removes the `method == "temperature"` restriction from `__sklearn_tags__` so all methods declare Array API support when the underlying estimator supports it
- Uses `xp.where` instead of boolean index assignment for Array API compatibility in the probability clamping step

## Test plan

- [x] Added `test_sigmoid_isotonic_array_api_compliance` test covering sigmoid and isotonic methods with Array API inputs
- [x] Test parametrized over: method (sigmoid, isotonic), ensemble (True, False), sample_weight (True, False), and all array namespace/device/dtype combinations
- [x] All 177 existing calibration tests pass (113 skipped due to missing backends like CUDA)
- [x] Verified numerical equivalence between numpy and array_api_strict results

🤖 Generated with [Claude Code](https://claude.com/claude-code)