### PR TITLE
DOC remove incorrect integral dtype requirement from clustering metrics

### DIFF
--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -209,10 +209,10 @@ def pair_confusion_matrix(labels_true, labels_pred):
 
     Parameters
     ----------
-    labels_true : array-like of shape (n_samples,), dtype=integral
+    labels_true : array-like of shape (n_samples,), 
         Ground truth class labels to be used as a reference.
 
-    labels_pred : array-like of shape (n_samples,), dtype=integral
+    labels_pred : array-like of shape (n_samples,), 
         Cluster labels to evaluate.
 
     Returns
@@ -295,10 +295,10 @@ def rand_score(labels_true, labels_pred):
 
     Parameters
     ----------
-    labels_true : array-like of shape (n_samples,), dtype=integral
+    labels_true : array-like of shape (n_samples,), 
         Ground truth class labels to be used as a reference.
 
-    labels_pred : array-like of shape (n_samples,), dtype=integral
+    labels_pred : array-like of shape (n_samples,), 
         Cluster labels to evaluate.
 
     Returns
@@ -384,10 +384,10 @@ def adjusted_rand_score(labels_true, labels_pred):
 
     Parameters
     ----------
-    labels_true : array-like of shape (n_samples,), dtype=int
+    labels_true : array-like of shape (n_samples,), 
         Ground truth class labels to be used as a reference.
 
-    labels_pred : array-like of shape (n_samples,), dtype=int
+    labels_pred : array-like of shape (n_samples,), 
         Cluster labels to evaluate.
 
     Returns
@@ -855,11 +855,11 @@ def mutual_info_score(labels_true, labels_pred, *, contingency=None):
 
     Parameters
     ----------
-    labels_true : array-like of shape (n_samples,), dtype=integral
+    labels_true : array-like of shape (n_samples,), 
         A clustering of the data into disjoint subsets, called :math:`U` in
         the above formula.
 
-    labels_pred : array-like of shape (n_samples,), dtype=integral
+    labels_pred : array-like of shape (n_samples,), 
         A clustering of the data into disjoint subsets, called :math:`V` in
         the above formula.
 
@@ -1218,10 +1218,10 @@ def fowlkes_mallows_score(labels_true, labels_pred, *, sparse="deprecated"):
 
     Parameters
     ----------
-    labels_true : array-like of shape (n_samples,), dtype=int
+    labels_true : array-like of shape (n_samples,), 
         A clustering of the data into disjoint subsets.
 
-    labels_pred : array-like of shape (n_samples,), dtype=int
+    labels_pred : array-like of shape (n_samples,), 
         A clustering of the data into disjoint subsets.
 
     sparse : bool, default=False
@@ -1288,7 +1288,7 @@ def _entropy(labels):
 
     Parameters
     ----------
-    labels : array-like of shape (n_samples,), dtype=int
+    labels : array-like of shape (n_samples,), 
         The labels.
 
     Returns
@@ -1326,7 +1326,7 @@ def entropy(labels):
 
     Parameters
     ----------
-    labels : array-like of shape (n_samples,), dtype=int
+    labels : array-like of shape (n_samples,), 
         The labels.
 
     Returns

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -209,10 +209,10 @@ def pair_confusion_matrix(labels_true, labels_pred):
 
     Parameters
     ----------
-    labels_true : array-like of shape (n_samples,), 
+    labels_true : array-like of shape (n_samples,)
         Ground truth class labels to be used as a reference.
 
-    labels_pred : array-like of shape (n_samples,), 
+    labels_pred : array-like of shape (n_samples,)
         Cluster labels to evaluate.
 
     Returns
@@ -295,7 +295,7 @@ def rand_score(labels_true, labels_pred):
 
     Parameters
     ----------
-    labels_true : array-like of shape (n_samples,), 
+    labels_true : array-like of shape (n_samples,)
         Ground truth class labels to be used as a reference.
 
     labels_pred : array-like of shape (n_samples,), 
@@ -1218,7 +1218,7 @@ def fowlkes_mallows_score(labels_true, labels_pred, *, sparse="deprecated"):
 
     Parameters
     ----------
-    labels_true : array-like of shape (n_samples,), 
+    labels_true : array-like of shape (n_samples,)
         A clustering of the data into disjoint subsets.
 
     labels_pred : array-like of shape (n_samples,), 


### PR DESCRIPTION
Fixes #32930

#### What does this implement/fix? Explain your changes.
->
This PR updates the docstrings for supervised clustering metrics in sklearn/metrics/cluster/_supervised.py. Previously, the parameters labels_true and labels_pred incorrectly specified dtype=integral (or int).

Since these metric functions support any array-like of discrete labels (including strings and discrete floats), I have removed the strict integer dtype requirement from the docstrings to prevent confusion and accurately reflect the underlying implementation.

#### AI usage disclosure
->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [✅] Documentation (including examples)
- [✅] Research and understanding


#### Any other comments?
-> NIL

