### PR TITLE
ENH make `_loss.link.py` array API compatible

### DIFF
--- a/sklearn/_loss/link.py
+++ b/sklearn/_loss/link.py
@@ -191,8 +191,7 @@ class HalfLogitLink(BaseLink):
     interval_y_pred = Interval(0, 1, False, False)
 
     def link(self, y_pred):
-        out = 0.5 * _logit(y_pred)
-        return out
+        return 0.5 * _logit(y_pred)
 
     def inverse(self, raw_prediction):
         return _expit(2 * raw_prediction)

--- a/sklearn/_loss/link.py
+++ b/sklearn/_loss/link.py
@@ -86,7 +86,7 @@ def _inclusive_low_high(interval, dtype=np_compat.float64, xp=np_compat):
     else:
         high = interval.high * (1 - eps) - eps
 
-    return low, high
+    return float(low), float(high)
 
 
 class BaseLink(ABC):

--- a/sklearn/_loss/link.py
+++ b/sklearn/_loss/link.py
@@ -69,7 +69,7 @@ def _inclusive_low_high(interval, dtype=None, xp=None):
     low, high : tuple
         The returned values low and high lie within the interval.
     """
-    xp, _ = get_namespace(interval)
+    xp, _ = get_namespace(np.array([interval.low, interval.high]), xp=xp)
     dtype = dtype or xp.float64
     eps = 10 * xp.finfo(dtype).eps
     if interval.low == -xp.inf:

--- a/sklearn/_loss/link.py
+++ b/sklearn/_loss/link.py
@@ -12,6 +12,8 @@ import numpy as np
 from scipy.special import expit, logit
 from scipy.stats import gmean
 
+from sklearn.externals.array_api_compat import numpy as np_compat
+from sklearn.utils._array_api import get_namespace
 from sklearn.utils.extmath import softmax
 
 
@@ -41,24 +43,25 @@ class Interval:
         -------
         result : bool
         """
+        xp, _ = get_namespace(x)
         if self.low_inclusive:
-            low = np.greater_equal(x, self.low)
+            low = xp.greater_equal(x, self.low)
         else:
-            low = np.greater(x, self.low)
+            low = xp.greater(x, self.low)
 
-        if not np.all(low):
+        if not xp.all(low):
             return False
 
         if self.high_inclusive:
-            high = np.less_equal(x, self.high)
+            high = xp.less_equal(x, self.high)
         else:
-            high = np.less(x, self.high)
+            high = xp.less(x, self.high)
 
         # Note: np.all returns numpy.bool_
-        return bool(np.all(high))
+        return bool(xp.all(high))
 
 
-def _inclusive_low_high(interval, dtype=np.float64):
+def _inclusive_low_high(interval, dtype=np_compat.float64, xp=np_compat):
     """Generate values low and high to be within the interval range.
 
     This is used in tests only.
@@ -68,15 +71,15 @@ def _inclusive_low_high(interval, dtype=np.float64):
     low, high : tuple
         The returned values low and high lie within the interval.
     """
-    eps = 10 * np.finfo(dtype).eps
-    if interval.low == -np.inf:
+    eps = 10 * xp.finfo(dtype).eps
+    if interval.low == -xp.inf:
         low = -1e10
     elif interval.low < 0:
         low = interval.low * (1 - eps) + eps
     else:
         low = interval.low * (1 + eps) + eps
 
-    if interval.high == np.inf:
+    if interval.high == xp.inf:
         high = 1e10
     elif interval.high < 0:
         high = interval.high * (1 + eps) - eps
@@ -109,7 +112,7 @@ class BaseLink(ABC):
     interval_y_pred = Interval(-np.inf, np.inf, False, False)
 
     @abstractmethod
-    def link(self, y_pred, out=None):
+    def link(self, y_pred):
         """Compute the link function g(y_pred).
 
         The link function maps (predicted) target values to raw predictions,
@@ -119,19 +122,15 @@ class BaseLink(ABC):
         ----------
         y_pred : array
             Predicted target values.
-        out : array
-            A location into which the result is stored. If provided, it must
-            have a shape that the inputs broadcast to. If not provided or None,
-            a freshly-allocated array is returned.
 
         Returns
         -------
-        out : array
+        array
             Output array, element-wise link function.
         """
 
     @abstractmethod
-    def inverse(self, raw_prediction, out=None):
+    def inverse(self, raw_prediction):
         """Compute the inverse link function h(raw_prediction).
 
         The inverse link function maps raw predictions to predicted target
@@ -141,14 +140,10 @@ class BaseLink(ABC):
         ----------
         raw_prediction : array
             Raw prediction values (in link space).
-        out : array
-            A location into which the result is stored. If provided, it must
-            have a shape that the inputs broadcast to. If not provided or None,
-            a freshly-allocated array is returned.
 
         Returns
         -------
-        out : array
+        array
             Output array, element-wise inverse link function.
         """
 
@@ -156,12 +151,8 @@ class BaseLink(ABC):
 class IdentityLink(BaseLink):
     """The identity link function g(x)=x."""
 
-    def link(self, y_pred, out=None):
-        if out is not None:
-            np.copyto(out, y_pred)
-            return out
-        else:
-            return y_pred
+    def link(self, y_pred):
+        return y_pred  # TODO: Should we copy?
 
     inverse = link
 
@@ -171,11 +162,13 @@ class LogLink(BaseLink):
 
     interval_y_pred = Interval(0, np.inf, False, False)
 
-    def link(self, y_pred, out=None):
-        return np.log(y_pred, out=out)
+    def link(self, y_pred):
+        xp, _ = get_namespace(y_pred)
+        return xp.log(y_pred)
 
-    def inverse(self, raw_prediction, out=None):
-        return np.exp(raw_prediction, out=out)
+    def inverse(self, raw_prediction):
+        xp, _ = get_namespace(raw_prediction)
+        return xp.exp(raw_prediction)
 
 
 class LogitLink(BaseLink):
@@ -183,11 +176,11 @@ class LogitLink(BaseLink):
 
     interval_y_pred = Interval(0, 1, False, False)
 
-    def link(self, y_pred, out=None):
-        return logit(y_pred, out=out)
+    def link(self, y_pred):
+        return logit(y_pred)
 
-    def inverse(self, raw_prediction, out=None):
-        return expit(raw_prediction, out=out)
+    def inverse(self, raw_prediction):
+        return expit(raw_prediction)
 
 
 class HalfLogitLink(BaseLink):
@@ -198,13 +191,12 @@ class HalfLogitLink(BaseLink):
 
     interval_y_pred = Interval(0, 1, False, False)
 
-    def link(self, y_pred, out=None):
-        out = logit(y_pred, out=out)
-        out *= 0.5
+    def link(self, y_pred):
+        out = 0.5 * logit(y_pred)
         return out
 
-    def inverse(self, raw_prediction, out=None):
-        return expit(2 * raw_prediction, out)
+    def inverse(self, raw_prediction):
+        return expit(2 * raw_prediction)
 
 
 class MultinomialLogit(BaseLink):
@@ -257,20 +249,17 @@ class MultinomialLogit(BaseLink):
     interval_y_pred = Interval(0, 1, False, False)
 
     def symmetrize_raw_prediction(self, raw_prediction):
-        return raw_prediction - np.mean(raw_prediction, axis=1)[:, np.newaxis]
+        xp, _ = get_namespace(raw_prediction)
+        return raw_prediction - xp.mean(raw_prediction, axis=1)[:, None]
 
-    def link(self, y_pred, out=None):
+    def link(self, y_pred):
+        xp, _ = get_namespace(y_pred)
         # geometric mean as reference category
         gm = gmean(y_pred, axis=1)
-        return np.log(y_pred / gm[:, np.newaxis], out=out)
+        return np.log(y_pred / gm[:, None])
 
-    def inverse(self, raw_prediction, out=None):
-        if out is None:
-            return softmax(raw_prediction, copy=True)
-        else:
-            np.copyto(out, raw_prediction)
-            softmax(out, copy=False)
-            return out
+    def inverse(self, raw_prediction):
+        return softmax(raw_prediction)
 
 
 _LINKS = {

--- a/sklearn/_loss/link.py
+++ b/sklearn/_loss/link.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass
 import numpy as np
 from scipy.stats import gmean
 
-from sklearn.externals.array_api_compat import numpy as np_compat
 from sklearn.utils._array_api import _expit, _logit, get_namespace
 from sklearn.utils.extmath import softmax
 
@@ -60,7 +59,7 @@ class Interval:
         return bool(xp.all(high))
 
 
-def _inclusive_low_high(interval, dtype=np_compat.float64, xp=np_compat):
+def _inclusive_low_high(interval, dtype=None, xp=None):
     """Generate values low and high to be within the interval range.
 
     This is used in tests only.
@@ -70,6 +69,8 @@ def _inclusive_low_high(interval, dtype=np_compat.float64, xp=np_compat):
     low, high : tuple
         The returned values low and high lie within the interval.
     """
+    xp, _ = get_namespace(interval)
+    dtype = dtype or xp.float64
     eps = 10 * xp.finfo(dtype).eps
     if interval.low == -xp.inf:
         low = -1e10

--- a/sklearn/_loss/link.py
+++ b/sklearn/_loss/link.py
@@ -9,11 +9,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 import numpy as np
-from scipy.special import expit, logit
 from scipy.stats import gmean
 
 from sklearn.externals.array_api_compat import numpy as np_compat
-from sklearn.utils._array_api import get_namespace
+from sklearn.utils._array_api import _expit, _logit, get_namespace
 from sklearn.utils.extmath import softmax
 
 
@@ -177,10 +176,10 @@ class LogitLink(BaseLink):
     interval_y_pred = Interval(0, 1, False, False)
 
     def link(self, y_pred):
-        return logit(y_pred)
+        return _logit(y_pred)
 
     def inverse(self, raw_prediction):
-        return expit(raw_prediction)
+        return _expit(raw_prediction)
 
 
 class HalfLogitLink(BaseLink):
@@ -192,11 +191,11 @@ class HalfLogitLink(BaseLink):
     interval_y_pred = Interval(0, 1, False, False)
 
     def link(self, y_pred):
-        out = 0.5 * logit(y_pred)
+        out = 0.5 * _logit(y_pred)
         return out
 
     def inverse(self, raw_prediction):
-        return expit(2 * raw_prediction)
+        return _expit(2 * raw_prediction)
 
 
 class MultinomialLogit(BaseLink):
@@ -256,7 +255,7 @@ class MultinomialLogit(BaseLink):
         xp, _ = get_namespace(y_pred)
         # geometric mean as reference category
         gm = gmean(y_pred, axis=1)
-        return np.log(y_pred / gm[:, None])
+        return xp.log(y_pred / gm[:, None])
 
     def inverse(self, raw_prediction):
         return softmax(raw_prediction)

--- a/sklearn/_loss/link.py
+++ b/sklearn/_loss/link.py
@@ -7,8 +7,8 @@ Module contains classes for invertible (and differentiable) link functions.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from math import ulp
 
-import numpy as np
 from scipy.stats import gmean
 
 from sklearn.utils._array_api import _expit, _logit, get_namespace
@@ -59,27 +59,25 @@ class Interval:
         return bool(xp.all(high))
 
 
-def _inclusive_low_high(interval, dtype=None, xp=None):
+def _inclusive_low_high(interval):
     """Generate values low and high to be within the interval range.
 
     This is used in tests only.
 
     Returns
     -------
-    low, high : tuple
+    low, high : tuple of floats
         The returned values low and high lie within the interval.
     """
-    xp, _ = get_namespace(interval)
-    dtype = dtype or xp.float64
-    eps = 10 * xp.finfo(dtype).eps
-    if interval.low == -xp.inf:
+    eps = 10 * ulp(1)
+    if interval.low == -float("inf"):
         low = -1e10
     elif interval.low < 0:
         low = interval.low * (1 - eps) + eps
     else:
         low = interval.low * (1 + eps) + eps
 
-    if interval.high == xp.inf:
+    if interval.high == float("inf"):
         high = 1e10
     elif interval.high < 0:
         high = interval.high * (1 + eps) - eps
@@ -108,8 +106,8 @@ class BaseLink(ABC):
 
     # Usually, raw_prediction may be any real number and y_pred is an open
     # interval.
-    # interval_raw_prediction = Interval(-np.inf, np.inf, False, False)
-    interval_y_pred = Interval(-np.inf, np.inf, False, False)
+    # interval_raw_prediction = Interval(-float("inf"), float("inf"), False, False)
+    interval_y_pred = Interval(-float("inf"), float("inf"), False, False)
 
     @abstractmethod
     def link(self, y_pred):
@@ -160,7 +158,7 @@ class IdentityLink(BaseLink):
 class LogLink(BaseLink):
     """The log link function g(x)=log(x)."""
 
-    interval_y_pred = Interval(0, np.inf, False, False)
+    interval_y_pred = Interval(0, float("inf"), False, False)
 
     def link(self, y_pred):
         xp, _ = get_namespace(y_pred)

--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -60,13 +60,16 @@ def test_is_in_range(namespace, device, dtype_name, interval):
     assert interval.includes(x)
 
     # x contains lower bound
-    assert interval.includes(xp.concat((x, [interval.low]))) == interval.low_inclusive
+    x_test = xp.concat((x, xp.asarray([interval.low], dtype=x.dtype)))
+    assert interval.includes(x_test) == interval.low_inclusive
 
     # x contains upper bound
-    assert interval.includes(xp.concat((x, [interval.high]))) == interval.high_inclusive
+    x_test = xp.concat((x, xp.asarray([interval.high], dtype=x.dtype)))
+    assert interval.includes(x_test) == interval.high_inclusive
 
     # x contains upper and lower bound
-    assert interval.includes(xp.concat((x, [interval.low, interval.high]))) == (
+    x_test = xp.concat((x, xp.asarray([interval.low, interval.high], dtype=x.dtype)))
+    assert interval.includes(x_test) == (
         interval.low_inclusive and interval.high_inclusive
     )
 

--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
+from sklearn import config_context
 from sklearn._loss.link import (
     _LINKS,
     HalfLogitLink,
@@ -49,26 +50,29 @@ def test_interval_raises():
         Interval(-10, -1, True, True),
     ],
 )
+@config_context(array_api_dispatch=True)
 def test_is_in_range(namespace, device, dtype_name, interval):
     """Test that low and high are always within the interval used for linspace."""
     xp = _array_api_for_tests(namespace, device)
     dtype = xp.float32 if dtype_name == "float32" else xp.float64
+    params = dict(device=device, dtype=dtype)
 
     low, high = _inclusive_low_high(interval, dtype=dtype, xp=xp)
 
-    x = xp.linspace(low, high, num=10, device=device)
+    x = xp.linspace(low, high, num=10, **params)
+
     assert interval.includes(x)
 
     # x contains lower bound
-    x_test = xp.concat((x, xp.asarray([interval.low], dtype=x.dtype)))
+    x_test = xp.concat((x, xp.asarray([interval.low], **params)))
     assert interval.includes(x_test) == interval.low_inclusive
 
     # x contains upper bound
-    x_test = xp.concat((x, xp.asarray([interval.high], dtype=x.dtype)))
+    x_test = xp.concat((x, xp.asarray([interval.high], **params)))
     assert interval.includes(x_test) == interval.high_inclusive
 
     # x contains upper and lower bound
-    x_test = xp.concat((x, xp.asarray([interval.low, interval.high], dtype=x.dtype)))
+    x_test = xp.concat((x, xp.asarray([interval.low, interval.high], **params)))
     assert interval.includes(x_test) == (
         interval.low_inclusive and interval.high_inclusive
     )
@@ -80,6 +84,7 @@ def test_is_in_range(namespace, device, dtype_name, interval):
     ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize("link", LINK_FUNCTIONS)
+@config_context(array_api_dispatch=True)
 def test_link_inverse_identity(namespace, device, dtype_name, link, global_random_seed):
     """Test that link of inverse gives identity."""
     xp = _array_api_for_tests(namespace, device)
@@ -100,6 +105,9 @@ def test_link_inverse_identity(namespace, device, dtype_name, link, global_rando
 
     if dtype_name == "float32":
         raw_prediction *= 0.5  # avoid overflow
+        rtol = 1e-3 if n_classes else 1e-4
+    else:
+        rtol = 1e-8
     raw_prediction = xp.asarray(raw_prediction, dtype=dtype, device=device)
 
     if isinstance(link, MultinomialLogit):
@@ -108,9 +116,11 @@ def test_link_inverse_identity(namespace, device, dtype_name, link, global_rando
     assert_allclose(
         _convert_to_numpy(link.link(link.inverse(raw_prediction)), xp=xp),
         _convert_to_numpy(raw_prediction, xp=xp),
+        rtol=rtol,
     )
     y_pred = link.inverse(raw_prediction)
     assert_allclose(
         _convert_to_numpy(link.inverse(link.link(y_pred)), xp=xp),
         _convert_to_numpy(y_pred, xp=xp),
+        rtol=rtol,
     )

--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -58,7 +58,6 @@ def test_is_in_range(namespace, device, dtype_name, interval):
 
     with config_context(array_api_dispatch=True):
         low, high = _inclusive_low_high(interval, dtype=dtype, xp=xp)
-
         x = xp.linspace(low, high, num=10, **params)
 
         assert interval.includes(x)

--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose, assert_array_equal
+from numpy.testing import assert_allclose
 
 from sklearn._loss.link import (
     _LINKS,
@@ -9,6 +9,12 @@ from sklearn._loss.link import (
     MultinomialLogit,
     _inclusive_low_high,
 )
+from sklearn.utils._array_api import (
+    _convert_to_numpy,
+    _get_namespace_device_dtype_ids,
+    yield_namespace_device_dtype_combinations,
+)
+from sklearn.utils._testing import _array_api_for_tests
 
 LINK_FUNCTIONS = list(_LINKS.values())
 
@@ -21,6 +27,11 @@ def test_interval_raises():
         Interval(1, 0, False, False)
 
 
+@pytest.mark.parametrize(
+    "namespace, device, dtype",
+    yield_namespace_device_dtype_combinations(),
+    ids=_get_namespace_device_dtype_ids,
+)
 @pytest.mark.parametrize(
     "interval",
     [
@@ -38,28 +49,36 @@ def test_interval_raises():
         Interval(-10, -1, True, True),
     ],
 )
-def test_is_in_range(interval):
-    # make sure low and high are always within the interval, used for linspace
-    low, high = _inclusive_low_high(interval)
+def test_is_in_range(namespace, device, dtype, interval):
+    """Test that low and high are always within the interval used for linspace."""
+    xp = _array_api_for_tests(namespace, device)
 
-    x = np.linspace(low, high, num=10)
+    low, high = _inclusive_low_high(interval, dtype=dtype, xp=xp)
+
+    x = xp.linspace(low, high, num=10, device=device)
     assert interval.includes(x)
 
     # x contains lower bound
-    assert interval.includes(np.r_[x, interval.low]) == interval.low_inclusive
+    assert interval.includes(xp.concat(x, [interval.low])) == interval.low_inclusive
 
     # x contains upper bound
-    assert interval.includes(np.r_[x, interval.high]) == interval.high_inclusive
+    assert interval.includes(xp.concat(x, [interval.high])) == interval.high_inclusive
 
     # x contains upper and lower bound
-    assert interval.includes(np.r_[x, interval.low, interval.high]) == (
+    assert interval.includes(xp.concat(x, [interval.low, interval.high])) == (
         interval.low_inclusive and interval.high_inclusive
     )
 
 
+@pytest.mark.parametrize(
+    "namespace, device, dtype",
+    yield_namespace_device_dtype_combinations(),
+    ids=_get_namespace_device_dtype_ids,
+)
 @pytest.mark.parametrize("link", LINK_FUNCTIONS)
-def test_link_inverse_identity(link, global_random_seed):
-    # Test that link of inverse gives identity.
+def test_link_inverse_identity(namespace, device, dtype, link, global_random_seed):
+    """Test that link of inverse gives identity."""
+    xp = _array_api_for_tests(namespace, device)
     rng = np.random.RandomState(global_random_seed)
     link = link()
     n_samples, n_classes = 100, None
@@ -69,43 +88,22 @@ def test_link_inverse_identity(link, global_random_seed):
     if link.is_multiclass:
         n_classes = 10
         raw_prediction = rng.uniform(low=-20, high=20, size=(n_samples, n_classes))
-        if isinstance(link, MultinomialLogit):
-            raw_prediction = link.symmetrize_raw_prediction(raw_prediction)
     elif isinstance(link, HalfLogitLink):
         raw_prediction = rng.uniform(low=-10, high=10, size=(n_samples))
     else:
         raw_prediction = rng.uniform(low=-20, high=20, size=(n_samples))
 
-    assert_allclose(link.link(link.inverse(raw_prediction)), raw_prediction)
+    raw_prediction = xp.asarray(raw_prediction, dtype=dtype, device=device)
+
+    if isinstance(link, MultinomialLogit):
+        raw_prediction = link.symmetrize_raw_prediction(raw_prediction)
+
+    assert_allclose(
+        _convert_to_numpy(link.link(link.inverse(raw_prediction))),
+        _convert_to_numpy(raw_prediction),
+    )
     y_pred = link.inverse(raw_prediction)
-    assert_allclose(link.inverse(link.link(y_pred)), y_pred)
-
-
-@pytest.mark.parametrize("link", LINK_FUNCTIONS)
-def test_link_out_argument(link):
-    # Test that out argument gets assigned the result.
-    rng = np.random.RandomState(42)
-    link = link()
-    n_samples, n_classes = 100, None
-    if link.is_multiclass:
-        n_classes = 10
-        raw_prediction = rng.normal(loc=0, scale=10, size=(n_samples, n_classes))
-        if isinstance(link, MultinomialLogit):
-            raw_prediction = link.symmetrize_raw_prediction(raw_prediction)
-    else:
-        # So far, the valid interval of raw_prediction is (-inf, inf) and
-        # we do not need to distinguish.
-        raw_prediction = rng.uniform(low=-10, high=10, size=(n_samples))
-
-    y_pred = link.inverse(raw_prediction, out=None)
-    out = np.empty_like(raw_prediction)
-    y_pred_2 = link.inverse(raw_prediction, out=out)
-    assert_allclose(y_pred, out)
-    assert_array_equal(out, y_pred_2)
-    assert np.shares_memory(out, y_pred_2)
-
-    out = np.empty_like(y_pred)
-    raw_prediction_2 = link.link(y_pred, out=out)
-    assert_allclose(raw_prediction, out)
-    assert_array_equal(out, raw_prediction_2)
-    assert np.shares_memory(out, raw_prediction_2)
+    assert_allclose(
+        _convert_to_numpy(link.inverse(link.link(y_pred))),
+        _convert_to_numpy(y_pred),
+    )

--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -87,7 +87,6 @@ def test_is_in_range(namespace, device, dtype_name, interval):
 def test_link_inverse_identity(namespace, device, dtype_name, link, global_random_seed):
     """Test that link of inverse gives identity."""
     xp = _array_api_for_tests(namespace, device)
-    dtype = xp.float32 if dtype_name == "float32" else xp.float64
     rng = np.random.RandomState(global_random_seed)
     link = link()
     n_samples, n_classes = 100, None
@@ -109,7 +108,7 @@ def test_link_inverse_identity(namespace, device, dtype_name, link, global_rando
         rtol = 1e-8
 
     with config_context(array_api_dispatch=True):
-        raw_prediction = xp.asarray(raw_prediction, dtype=dtype, device=device)
+        raw_prediction = xp.asarray(raw_prediction.astype(dtype_name), device=device)
 
         if isinstance(link, MultinomialLogit):
             raw_prediction = link.symmetrize_raw_prediction(raw_prediction)

--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -71,14 +71,15 @@ def test_is_in_range(namespace, device, dtype, interval):
 
 
 @pytest.mark.parametrize(
-    "namespace, device, dtype",
+    "namespace, device, dtype_name",
     yield_namespace_device_dtype_combinations(),
     ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize("link", LINK_FUNCTIONS)
-def test_link_inverse_identity(namespace, device, dtype, link, global_random_seed):
+def test_link_inverse_identity(namespace, device, dtype_name, link, global_random_seed):
     """Test that link of inverse gives identity."""
     xp = _array_api_for_tests(namespace, device)
+    dtype = xp.float32 if dtype_name == "float32" else xp.float64
     rng = np.random.RandomState(global_random_seed)
     link = link()
     n_samples, n_classes = 100, None

--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -64,15 +64,9 @@ def test_is_in_range(interval):
     )
 
 
-@pytest.mark.parametrize(
-    "namespace, device, dtype_name",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
-)
 @pytest.mark.parametrize("link", LINK_FUNCTIONS)
-def test_link_inverse_identity(namespace, device, dtype_name, link, global_random_seed):
+def test_link_inverse_identity(link, global_random_seed):
     """Test that link of inverse gives identity."""
-    xp = _array_api_for_tests(namespace, device)
     rng = np.random.RandomState(global_random_seed)
     link = link()
     n_samples, n_classes = 100, None
@@ -82,31 +76,63 @@ def test_link_inverse_identity(namespace, device, dtype_name, link, global_rando
     if link.is_multiclass:
         n_classes = 10
         raw_prediction = rng.uniform(low=-20, high=20, size=(n_samples, n_classes))
+        if isinstance(link, MultinomialLogit):
+            raw_prediction = link.symmetrize_raw_prediction(raw_prediction)
     elif isinstance(link, HalfLogitLink):
         raw_prediction = rng.uniform(low=-10, high=10, size=(n_samples))
     else:
         raw_prediction = rng.uniform(low=-20, high=20, size=(n_samples))
 
-    if dtype_name == "float32":
+    assert_allclose(link.link(link.inverse(raw_prediction)), raw_prediction)
+    y_pred = link.inverse(raw_prediction)
+    assert_allclose(link.inverse(link.link(y_pred)), y_pred)
+
+
+@pytest.mark.parametrize(
+    "namespace, device, dtype_name",
+    yield_namespace_device_dtype_combinations(),
+    ids=_get_namespace_device_dtype_ids,
+)
+@pytest.mark.parametrize("link", LINK_FUNCTIONS)
+def test_link_inverse_array_api(
+    namespace, device, dtype_name, link, global_random_seed
+):
+    """Test that link and inverse link give same result for array API inputs."""
+    rng = np.random.RandomState(global_random_seed)
+    link = link()
+    n_samples, n_classes = 100, None
+    # The values for `raw_prediction` are limited from -20 to 20 because in the
+    # class `LogitLink` the term `expit(x)` comes very close to 1 for large
+    # positive x and therefore loses precision.
+    if link.is_multiclass:
+        n_classes = 10
+        raw_prediction = rng.uniform(low=-20, high=20, size=(n_samples, n_classes))
+        if isinstance(link, MultinomialLogit):
+            raw_prediction = link.symmetrize_raw_prediction(raw_prediction)
+    elif isinstance(link, HalfLogitLink):
+        raw_prediction = rng.uniform(low=-10, high=10, size=(n_samples))
+    else:
+        raw_prediction = rng.uniform(low=-20, high=20, size=(n_samples))
+
+    xp = _array_api_for_tests(namespace, device)
+    if dtype_name != "float64":
         raw_prediction *= 0.5  # avoid overflow
         rtol = 1e-3 if n_classes else 1e-4
     else:
         rtol = 1e-8
 
     with config_context(array_api_dispatch=True):
-        raw_prediction = xp.asarray(raw_prediction.astype(dtype_name), device=device)
-
-        if isinstance(link, MultinomialLogit):
-            raw_prediction = link.symmetrize_raw_prediction(raw_prediction)
-
+        raw_prediction_xp = xp.asarray(raw_prediction.astype(dtype_name), device=device)
         assert_allclose(
-            _convert_to_numpy(link.link(link.inverse(raw_prediction)), xp=xp),
-            _convert_to_numpy(raw_prediction, xp=xp),
+            _convert_to_numpy(link.inverse(raw_prediction_xp), xp=xp),
+            link.inverse(raw_prediction),
             rtol=rtol,
         )
+
         y_pred = link.inverse(raw_prediction)
+        y_pred_xp = xp.asarray(y_pred.astype(dtype_name), device=device)
         assert_allclose(
-            _convert_to_numpy(link.inverse(link.link(y_pred)), xp=xp),
-            _convert_to_numpy(y_pred, xp=xp),
+            _convert_to_numpy(link.link(y_pred_xp), xp=xp),
+            link.link(y_pred),
             rtol=rtol,
         )

--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -29,52 +29,39 @@ def test_interval_raises():
 
 
 @pytest.mark.parametrize(
-    "namespace, device, dtype_name",
-    yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
-)
-@pytest.mark.parametrize(
     "interval",
     [
         Interval(0, 1, False, False),
         Interval(0, 1, False, True),
         Interval(0, 1, True, False),
         Interval(0, 1, True, True),
-        Interval(-np.inf, np.inf, False, False),
-        Interval(-np.inf, np.inf, False, True),
-        Interval(-np.inf, np.inf, True, False),
-        Interval(-np.inf, np.inf, True, True),
+        Interval(-float("inf"), float("inf"), False, False),
+        Interval(-float("inf"), float("inf"), False, True),
+        Interval(-float("inf"), float("inf"), True, False),
+        Interval(-float("inf"), float("inf"), True, True),
         Interval(-10, -1, False, False),
         Interval(-10, -1, False, True),
         Interval(-10, -1, True, False),
         Interval(-10, -1, True, True),
     ],
 )
-def test_is_in_range(namespace, device, dtype_name, interval):
+def test_is_in_range(interval):
     """Test that low and high are always within the interval used for linspace."""
-    xp = _array_api_for_tests(namespace, device)
-    dtype = xp.float32 if dtype_name == "float32" else xp.float64
-    params = dict(device=device, dtype=dtype)
+    low, high = _inclusive_low_high(interval)
+    x = np.linspace(low, high, num=10)
 
-    with config_context(array_api_dispatch=True):
-        low, high = _inclusive_low_high(interval, dtype=dtype, xp=xp)
-        x = xp.linspace(low, high, num=10, **params)
+    assert interval.includes(x)
 
-        assert interval.includes(x)
+    # x contains lower bound
+    assert interval.includes(np.r_[x, interval.low]) == interval.low_inclusive
 
-        # x contains lower bound
-        x_test = xp.concat((x, xp.asarray([interval.low], **params)))
-        assert interval.includes(x_test) == interval.low_inclusive
+    # x contains upper bound
+    assert interval.includes(np.r_[x, interval.high]) == interval.high_inclusive
 
-        # x contains upper bound
-        x_test = xp.concat((x, xp.asarray([interval.high], **params)))
-        assert interval.includes(x_test) == interval.high_inclusive
-
-        # x contains upper and lower bound
-        x_test = xp.concat((x, xp.asarray([interval.low, interval.high], **params)))
-        assert interval.includes(x_test) == (
-            interval.low_inclusive and interval.high_inclusive
-        )
+    # x contains upper and lower bound
+    assert interval.includes(np.r_[x, interval.low, interval.high]) == (
+        interval.low_inclusive and interval.high_inclusive
+    )
 
 
 @pytest.mark.parametrize(

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -6,6 +6,7 @@ import pytest
 import scipy
 import scipy.sparse as sp
 from numpy.testing import assert_allclose
+from scipy.special import expit, logit
 
 from sklearn._config import config_context
 from sklearn._loss import HalfMultinomialLoss
@@ -18,11 +19,13 @@ from sklearn.utils._array_api import (
     _convert_to_numpy,
     _count_nonzero,
     _estimator_with_converted_arrays,
+    _expit,
     _fill_diagonal,
     _get_namespace_device_dtype_ids,
     _half_multinomial_loss,
     _is_numpy_namespace,
     _isin,
+    _logit,
     _logsumexp,
     _matching_numpy_dtype,
     _max_precision_float_dtype,
@@ -822,6 +825,31 @@ def test_median(namespace, device, dtype_name, axis):
             assert get_namespace(result_xp)[0] == xp
             assert result_xp.device == X_xp.device
     assert_allclose(result_np, _convert_to_numpy(result_xp, xp=xp))
+
+
+@pytest.mark.parametrize(
+    "namespace, device, dtype_name", yield_namespace_device_dtype_combinations()
+)
+@config_context(array_api_dispatch=True)
+def test_expit_logit(namespace, device, dtype_name):
+    rtol = 1e-6 if "float32" in str(dtype_name) else 1e-12
+    xp = _array_api_for_tests(namespace, device)
+
+    x_np = numpy.linspace(-20, 20, 1000).astype(dtype_name)
+    x_xp = xp.asarray(x_np, device=device)
+    assert_allclose(
+        _convert_to_numpy(_expit(x_xp), xp=xp),
+        expit(x_np),
+        rtol=rtol,
+    )
+
+    x_np = numpy.linspace(0, 1, 1000).astype(dtype_name)
+    x_xp = xp.asarray(x_np, device=device)
+    assert_allclose(
+        _convert_to_numpy(_logit(x_xp), xp=xp),
+        logit(x_np),
+        rtol=rtol,
+    )
 
 
 @pytest.mark.parametrize(

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -830,26 +830,26 @@ def test_median(namespace, device, dtype_name, axis):
 @pytest.mark.parametrize(
     "namespace, device, dtype_name", yield_namespace_device_dtype_combinations()
 )
-@config_context(array_api_dispatch=True)
 def test_expit_logit(namespace, device, dtype_name):
     rtol = 1e-6 if "float32" in str(dtype_name) else 1e-12
     xp = _array_api_for_tests(namespace, device)
 
-    x_np = numpy.linspace(-20, 20, 1000).astype(dtype_name)
-    x_xp = xp.asarray(x_np, device=device)
-    assert_allclose(
-        _convert_to_numpy(_expit(x_xp), xp=xp),
-        expit(x_np),
-        rtol=rtol,
-    )
+    with config_context(array_api_dispatch=True):
+        x_np = numpy.linspace(-20, 20, 1000).astype(dtype_name)
+        x_xp = xp.asarray(x_np, device=device)
+        assert_allclose(
+            _convert_to_numpy(_expit(x_xp), xp=xp),
+            expit(x_np),
+            rtol=rtol,
+        )
 
-    x_np = numpy.linspace(0, 1, 1000).astype(dtype_name)
-    x_xp = xp.asarray(x_np, device=device)
-    assert_allclose(
-        _convert_to_numpy(_logit(x_xp), xp=xp),
-        logit(x_np),
-        rtol=rtol,
-    )
+        x_np = numpy.linspace(0, 1, 1000).astype(dtype_name)
+        x_xp = xp.asarray(x_np, device=device)
+        assert_allclose(
+            _convert_to_numpy(_logit(x_xp), xp=xp),
+            logit(x_np),
+            rtol=rtol,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference Issues/PRs
Contributes to #26024.

#### What does this implement/fix? Explain your changes.
This makes the link functions in the private loss module array API compliant (for recent versions of scipy).

#### AI usage disclosure
None

#### Any other comments?
