### PR TITLE
Fix #33146: Using `BisectingKMeans` with `init` raises a possibly dubiou

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.cluster/33146.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.cluster/33146.fix.rst
@@ -1,0 +1,4 @@
+- :class:`cluster.BisectingKMeans` now correctly validates the shape of centers
+  returned by a callable ``init`` against the number of centroids requested at
+  each bisection step (always 2) rather than the final ``n_clusters``.
+  By :user:`MAUK9086 <MAUK9086>`.

--- a/sklearn/cluster/_bisect_k_means.py
+++ b/sklearn/cluster/_bisect_k_means.py
@@ -104,7 +104,9 @@ class BisectingKMeans(_BaseKMeans):
         for the initial centroids.
 
         If a callable is passed, it should take arguments X, n_clusters and a
-        random state and return an initialization.
+        random state and return an initialization. For :class:`BisectingKMeans`,
+        the callable is called at each bisection step with `n_clusters=2`, so it
+        must return an array of shape `(2, n_features)`.
 
     n_init : int, default=1
         Number of time the inner k-means algorithm will be run with different

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -933,12 +933,14 @@ class _BaseKMeans(
             if has_vcomp and has_mkl:
                 self._warn_mkl_vcomp(n_active_threads)
 
-    def _validate_center_shape(self, X, centers):
+    def _validate_center_shape(self, X, centers, n_clusters=None):
         """Check if centers is compatible with X and n_clusters."""
-        if centers.shape[0] != self.n_clusters:
+        if n_clusters is None:
+            n_clusters = self.n_clusters
+        if centers.shape[0] != n_clusters:
             raise ValueError(
                 f"The shape of the initial centers {centers.shape} does not "
-                f"match the number of clusters {self.n_clusters}."
+                f"match the number of clusters {n_clusters}."
             )
         if centers.shape[1] != X.shape[1]:
             raise ValueError(
@@ -1037,7 +1039,7 @@ class _BaseKMeans(
         elif callable(init):
             centers = init(X, n_clusters, random_state=random_state)
             centers = check_array(centers, dtype=X.dtype, copy=False, order="C")
-            self._validate_center_shape(X, centers)
+            self._validate_center_shape(X, centers, n_clusters)
 
         if sp.issparse(centers):
             centers = centers.toarray()


### PR DESCRIPTION
Fixes #33146

## Summary
This PR fixes: Using `BisectingKMeans` with `init` raises a possibly dubious `ValueError`

## Changes
```
.../upcoming_changes/sklearn.cluster/33146.fix.rst |  4 ++++
 sklearn/cluster/_bisect_k_means.py                 |  4 +++-
 sklearn/cluster/_kmeans.py                         | 10 +++++----
 sklearn/cluster/tests/test_bisect_k_means.py       | 24 ++++++++++++++++++++++
 4 files changed, 37 insertions(+), 5 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: high. Happy to make any adjustments!*