### PR TITLE
API Deprecate positional args for confusion_matrix_at_thresholds

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/33357.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/33357.api.rst
@@ -1,0 +1,4 @@
+- passing the `pos_label` and `sample_weight` parameters of
+  :func:`metrics.confusion_matrix_at_thresholds` as positional arguments is deprecated
+  and will be removed in 1.11.
+  By :user:`Jérémie du Boisberranger <jeremiedbb>`.

--- a/doc/whats_new/upcoming_changes/sklearn.metrics/33357.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/33357.api.rst
@@ -1,4 +1,4 @@
-- passing the `pos_label` and `sample_weight` parameters of
+- Passing the `pos_label` and `sample_weight` parameters of
   :func:`metrics.confusion_matrix_at_thresholds` as positional arguments is deprecated
-  and will be removed in 1.11.
+  and will be removed in v1.11.
   By :user:`Jérémie du Boisberranger <jeremiedbb>`.

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -38,7 +38,11 @@ from sklearn.utils._encode import _encode, _unique
 from sklearn.utils._param_validation import Interval, StrOptions, validate_params
 from sklearn.utils.multiclass import type_of_target
 from sklearn.utils.sparsefuncs import count_nonzero
-from sklearn.utils.validation import _check_pos_label_consistency, _check_sample_weight
+from sklearn.utils.validation import (
+    _check_pos_label_consistency,
+    _check_sample_weight,
+    _deprecate_positional_args,
+)
 
 
 @validate_params(
@@ -865,6 +869,7 @@ def _multiclass_roc_auc_score(
         )
 
 
+@_deprecate_positional_args(version="1.11")
 @validate_params(
     {
         "y_true": ["array-like"],
@@ -874,7 +879,9 @@ def _multiclass_roc_auc_score(
     },
     prefer_skip_nested_validation=True,
 )
-def confusion_matrix_at_thresholds(y_true, y_score, pos_label=None, sample_weight=None):
+def confusion_matrix_at_thresholds(
+    y_true, y_score, *, pos_label=None, sample_weight=None
+):
     """Calculate :term:`binary` confusion matrix terms per classification threshold.
 
     Read more in the :ref:`User Guide <confusion_matrix>`.

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -2305,3 +2305,11 @@ def test_roc_curve_with_probablity_estimates(global_random_seed):
     y_score = rng.rand(10)
     _, _, thresholds = roc_curve(y_true, y_score)
     assert np.isinf(thresholds[0])
+
+
+# TODO(1.11): remove this test
+def test_confusion_matrix_at_thresholds_positional_args_deprecation():
+    y_true = np.array([0, 1, 1, 0])
+    y_score = np.array([0.2, 0.1, 0.7, 0.7])
+    with pytest.warns(FutureWarning, match="Pass pos_label=None as keyword arg"):
+        confusion_matrix_at_thresholds(y_true, y_score, None)


### PR DESCRIPTION
When we made `confusion_matrix_at_thresholds` public (previously named `_binary_clf_curve`) we forgot to make optional args kwarg only. Since it's already released in 1.8 we need to do that with deprecation.

ping @lucyleeow 