### PR TITLE
FIX QuantileTransformer sparse subsampling with ignore_implicit_zeros

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.preprocessing/33358.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.preprocessing/33358.fix.rst
@@ -1,0 +1,4 @@
+- :class:`preprocessing.QuantileTransformer` with `ignore_implicit_zeros=True`
+  now correctly subsamples non-zero data for very sparse matrices. Previously,
+  the subsampling could produce empty arrays leading to all-zero quantiles.
+  By :user:`Adam Kuligowski <akuligowski9>`.


### PR DESCRIPTION
## Summary

Fixes #32585

- `QuantileTransformer(ignore_implicit_zeros=True)` subsampling was incorrectly computing the number of non-zero samples to keep as `subsample * nnz // n_samples`. For very sparse matrices (where `n_samples` vastly exceeds `nnz`), this evaluated to 0, producing empty arrays and all-zero quantiles.
- When `ignore_implicit_zeros=True`, implicit zeros are excluded from the quantile computation, so `n_samples` should be irrelevant to how many non-zero values are subsampled. The fix subsamples `subsample` elements directly from the non-zero data.
- The `ignore_implicit_zeros=False` path is unchanged but refactored to be scoped under its own branch for clarity.

## Test plan

- [x] Added non-regression test `test_quantile_transform_sparse_ignore_zeros_very_sparse` that constructs a very sparse matrix (nnz/n_samples ~ 1e-4) and verifies quantiles are non-degenerate
- [x] All 21 existing quantile-related tests pass
- [x] Pre-commit hooks pass (ruff, mypy, codespell)

## AI disclosure

AI tools (Claude Code) were used to assist with this contribution. All changes have been manually reviewed, tested, and are well understood by the contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)