### PR TITLE
FIX nan_euclidean_distances returns asymmetric matrix with missing values

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/33359.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/33359.fix.rst
@@ -1,0 +1,4 @@
+- :func:`metrics.pairwise.nan_euclidean_distances` now returns an exactly
+  symmetric distance matrix when computing pairwise distances of a single
+  array with missing values.
+  By :user:`Adam Kuligowski <akuligowski9>`.

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -557,6 +557,11 @@ def nan_euclidean_distances(
     distances /= present_count
     distances *= X.shape[1]
 
+    if X is Y:
+        # Enforce symmetry: floating point rounding in the intermediate
+        # dot products and subtractions can cause dist[i,j] != dist[j,i].
+        distances = (distances + distances.T) / 2
+
     if not squared:
         np.sqrt(distances, out=distances)
 

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -1257,6 +1257,25 @@ def test_nan_euclidean_distances_not_trival(missing_value):
     assert_allclose(D6, D7)
 
 
+def test_nan_euclidean_distances_symmetric():
+    """Check that nan_euclidean_distances(X) returns an exactly symmetric matrix.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/32848
+    """
+    rng = np.random.RandomState(42)
+    mat = rng.rand(10, 20)
+    missing = rng.choice(mat.size, 50, replace=False)
+    mat.ravel()[missing] = np.nan
+
+    dist = nan_euclidean_distances(mat)
+
+    # The distance matrix should be exactly symmetric, not just approximately.
+    assert_array_equal(dist, dist.T)
+    # The diagonal should be exactly zero.
+    assert_array_equal(np.diag(dist), 0.0)
+
+
 @pytest.mark.parametrize("missing_value", [np.nan, -1])
 def test_nan_euclidean_distances_one_feature_match_positive(missing_value):
     # First feature is the only feature that is non-nan and in both


### PR DESCRIPTION
## Summary

Fixes #32848

- `nan_euclidean_distances(X)` could return an asymmetric distance matrix when `X` contains missing values, due to floating point rounding in intermediate dot products and subtractions.
- Fix enforces exact symmetry via `(D + D.T) / 2` when computing pairwise distances of a single array (`X is Y`).

## Test plan

- [x] Added non-regression test `test_nan_euclidean_distances_symmetric` that verifies exact (not approximate) symmetry
- [x] All 29 existing+new nan_euclidean tests pass
- [x] Pre-commit hooks pass (ruff, mypy, codespell)

## AI disclosure

AI tools (Claude Code) were used to assist with this contribution. All changes have been manually reviewed, tested, and are well understood by the contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)