### PR TITLE
FIX StratifiedGroupKFold raises ValueError when n_splits > n_groups

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.model_selection/33361.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.model_selection/33361.fix.rst
@@ -1,0 +1,5 @@
+- :class:`model_selection.StratifiedGroupKFold` now raises a ``ValueError``
+  when ``n_splits`` is greater than the number of groups, consistent with
+  :class:`model_selection.GroupKFold`. Previously, it silently produced
+  degenerate (empty) splits.
+  By :user:`Adam Kuligowski <akuligowski9>`.

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1045,6 +1045,12 @@ class StratifiedGroupKFold(GroupsConsumerMixin, _BaseKFold):
         _, groups_inv, groups_cnt = np.unique(
             groups, return_inverse=True, return_counts=True
         )
+        n_groups = len(groups_cnt)
+        if self.n_splits > n_groups:
+            raise ValueError(
+                "Cannot have number of splits n_splits=%d greater"
+                " than the number of groups: %d." % (self.n_splits, n_groups)
+            )
         y_counts_per_group = np.zeros((len(groups_cnt), n_classes))
         for class_idx, group_idx in zip(y_inv, groups_inv):
             y_counts_per_group[group_idx, class_idx] += 1

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -784,6 +784,24 @@ def test_stratified_group_kfold_against_group_kfold(cls_distr, n_groups):
     assert sgkf_entr <= gkf_entr
 
 
+def test_stratified_group_kfold_n_splits_greater_than_n_groups():
+    """Check that StratifiedGroupKFold raises when n_splits > n_groups.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/33085
+    """
+    y = [0, 2, 2, 2, 1, 2, 1, 1, 0, 0, 0, 0]
+    groups = [0, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1]
+    sgkf = StratifiedGroupKFold(n_splits=3)
+
+    with pytest.raises(
+        ValueError,
+        match="Cannot have number of splits n_splits=3 greater than the number"
+        " of groups: 2.",
+    ):
+        list(sgkf.split(X=y, y=y, groups=groups))
+
+
 def test_shuffle_split():
     ss1 = ShuffleSplit(test_size=0.2, random_state=0).split(X)
     ss2 = ShuffleSplit(test_size=2, random_state=0).split(X)


### PR DESCRIPTION
## Summary

Fixes #33085

- `StratifiedGroupKFold` silently produced degenerate (empty) splits when `n_splits` exceeded the number of groups. This adds the same validation check that `GroupKFold` already has, raising a `ValueError` with the same message format.

## Test plan

- [x] Added non-regression test `test_stratified_group_kfold_n_splits_greater_than_n_groups` using the exact reproducer from the issue
- [x] All 45 existing+new StratifiedGroupKFold tests pass
- [x] Pre-commit hooks pass (ruff, mypy, codespell)

## AI disclosure

AI tools (Claude Code) were used to assist with this contribution. All changes have been manually reviewed, tested, and are well understood by the contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)