### PR TITLE
ENH: add zero_division parameter to ndcg_score

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/29521.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/29521.enhancement.rst
@@ -1,0 +1,6 @@
+- :func:`~metrics.ndcg_score` now supports a ``zero_division`` parameter to
+  control the behavior when a sample has all-zero true relevance scores (IDCG = 0).
+  The default ``"warn"`` keeps the previous behavior of returning 0 but also
+  raises a :class:`~sklearn.exceptions.UndefinedMetricWarning`. Setting it to
+  ``0`` or ``1`` suppresses the warning and returns that value for such samples.
+  By :user:`Dhruvil Darji <dhruvildarji>`.

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -35,7 +35,12 @@ from sklearn.utils._array_api import (
     size,
 )
 from sklearn.utils._encode import _encode, _unique
-from sklearn.utils._param_validation import Interval, Options, StrOptions, validate_params
+from sklearn.utils._param_validation import (
+    Interval,
+    Options,
+    StrOptions,
+    validate_params,
+)
 from sklearn.utils.multiclass import type_of_target
 from sklearn.utils.sparsefuncs import count_nonzero
 from sklearn.utils.validation import _check_pos_label_consistency, _check_sample_weight
@@ -99,7 +104,7 @@ def auc(x, y):
         if np.all(dx <= 0):
             direction = -1
         else:
-            raise ValueError("x is neither increasing nor decreasing : {}.".format(x))
+            raise ValueError(f"x is neither increasing nor decreasing : {x}.")
 
     area = direction * trapezoid(y, x)
     if isinstance(area, np.memmap):
@@ -709,8 +714,8 @@ def roc_auc_score(
             raise ValueError(
                 "Partial AUC computation not available in "
                 "multiclass setting, 'max_fpr' must be"
-                " set to `None`, received `max_fpr={0}` "
-                "instead".format(max_fpr)
+                f" set to `None`, received `max_fpr={max_fpr}` "
+                "instead"
             )
         if multi_class == "raise":
             raise ValueError("multi_class must be in ('ovo', 'ovr')")
@@ -803,15 +808,15 @@ def _multiclass_roc_auc_score(
         average_options = ("micro",) + average_options
     if average not in average_options:
         raise ValueError(
-            "average must be one of {0} for multiclass problems".format(average_options)
+            f"average must be one of {average_options} for multiclass problems"
         )
 
     multiclass_options = ("ovo", "ovr")
     if multi_class not in multiclass_options:
         raise ValueError(
-            "multi_class='{0}' is not supported "
+            f"multi_class='{multi_class}' is not supported "
             "for multiclass ROC AUC, multi_class must be "
-            "in {1}".format(multi_class, multiclass_options)
+            f"in {multiclass_options}"
         )
 
     if average is None and multi_class == "ovo":
@@ -828,8 +833,8 @@ def _multiclass_roc_auc_score(
             raise ValueError("Parameter 'labels' must be ordered")
         if len(classes) != y_score.shape[1]:
             raise ValueError(
-                "Number of given labels, {0}, not equal to the number "
-                "of columns in 'y_score', {1}".format(len(classes), y_score.shape[1])
+                f"Number of given labels, {len(classes)}, not equal to the number "
+                f"of columns in 'y_score', {y_score.shape[1]}"
             )
         if len(np.setdiff1d(y_true, classes)):
             raise ValueError("'y_true' contains labels not in parameter 'labels'")
@@ -947,7 +952,7 @@ def confusion_matrix_at_thresholds(y_true, y_score, pos_label=None, sample_weigh
     # Check to make sure y_true is valid
     y_type = type_of_target(y_true, input_name="y_true")
     if not (y_type == "binary" or (y_type == "multiclass" and pos_label is not None)):
-        raise ValueError("{0} format is not supported".format(y_type))
+        raise ValueError(f"{y_type} format is not supported")
 
     xp, _, device = get_namespace_and_device(y_true, y_score, sample_weight)
 
@@ -1401,7 +1406,7 @@ def label_ranking_average_precision_score(y_true, y_score, *, sample_weight=None
     if y_type != "multilabel-indicator" and not (
         y_type == "binary" and y_true.ndim == 2
     ):
-        raise ValueError("{0} format is not supported".format(y_type))
+        raise ValueError(f"{y_type} format is not supported")
 
     if not issparse(y_true):
         y_true = csr_matrix(y_true)
@@ -1500,7 +1505,7 @@ def coverage_error(y_true, y_score, *, sample_weight=None):
 
     y_type = type_of_target(y_true, input_name="y_true")
     if y_type != "multilabel-indicator":
-        raise ValueError("{0} format is not supported".format(y_type))
+        raise ValueError(f"{y_type} format is not supported")
 
     if y_true.shape != y_score.shape:
         raise ValueError("y_true and y_score have different shape")
@@ -1579,7 +1584,7 @@ def label_ranking_loss(y_true, y_score, *, sample_weight=None):
 
     y_type = type_of_target(y_true, input_name="y_true")
     if y_type not in ("multilabel-indicator",):
-        raise ValueError("{0} format is not supported".format(y_type))
+        raise ValueError(f"{y_type} format is not supported")
 
     if y_true.shape != y_score.shape:
         raise ValueError("y_true and y_score have different shape")
@@ -1732,9 +1737,7 @@ def _check_dcg_target_type(y_true):
     )
     if y_type not in supported_fmt:
         raise ValueError(
-            "Only {} formats are supported. Got {} instead".format(
-                supported_fmt, y_type
-            )
+            f"Only {supported_fmt} formats are supported. Got {y_type} instead"
         )
 
 
@@ -1858,7 +1861,9 @@ def dcg_score(
     )
 
 
-def _ndcg_sample_scores(y_true, y_score, k=None, ignore_ties=False, zero_division="warn"):
+def _ndcg_sample_scores(
+    y_true, y_score, k=None, ignore_ties=False, zero_division="warn"
+):
     """Compute Normalized Discounted Cumulative Gain.
 
     Sum the true scores ranked in the order induced by the predicted scores,
@@ -1936,7 +1941,15 @@ def _ndcg_sample_scores(y_true, y_score, k=None, ignore_ties=False, zero_divisio
     },
     prefer_skip_nested_validation=True,
 )
-def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False, zero_division="warn"):
+def ndcg_score(
+    y_true,
+    y_score,
+    *,
+    k=None,
+    sample_weight=None,
+    ignore_ties=False,
+    zero_division="warn",
+):
     """Compute Normalized Discounted Cumulative Gain.
 
     Sum the true scores ranked in the order induced by the predicted scores,
@@ -1973,7 +1986,8 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
     zero_division : "warn", 0 or 1, default="warn"
         Sets the value to return when IDCG is zero (i.e., all true relevance
         scores for a sample are zero). If set to ``"warn"``, this acts as 0,
-        but warnings are also raised via :class:`~sklearn.exceptions.UndefinedMetricWarning`.
+        but warnings are also raised via
+        :class:`~sklearn.exceptions.UndefinedMetricWarning`.
         If set to 0, those samples contribute 0 to the average score (the
         current behavior, without warnings). If set to 1, those samples
         contribute 1 to the average score.

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -2018,6 +2018,7 @@ def test_ndcg_score_zero_division():
 
     # zero_division=0: no warning, zero sample contributes 0
     import warnings as _warnings
+
     with _warnings.catch_warnings(record=True) as caught:
         _warnings.simplefilter("always")
         result_zero = ndcg_score(y_true, y_score, zero_division=0)

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -139,7 +139,7 @@ def _average_precision(y_true, y_score):
             # Compute precision up to document i
             # i.e, percentage of relevant documents up to document i.
             prec = 0
-            for j in range(0, i + 1):
+            for j in range(i + 1):
                 if y_true[j] == pos_label:
                     prec += 1.0
             prec /= i + 1.0
@@ -505,7 +505,7 @@ def test_auc_errors():
     # x is not in order
     x = [2, 1, 3, 4]
     y = [5, 6, 7, 8]
-    error_message = "x is neither increasing nor decreasing : {}".format(np.array(x))
+    error_message = f"x is neither increasing nor decreasing : {np.array(x)}"
     with pytest.raises(ValueError, match=re.escape(error_message)):
         auc(x, y)
 


### PR DESCRIPTION
## Summary

Fixes #29521.

This PR adds a `zero_division` parameter to `ndcg_score` (and the internal `_ndcg_sample_scores`) to handle the case where all true relevance scores for a sample are zero (IDCG = 0, so NDCG is undefined).

This follows the pattern used by other scikit-learn metrics (e.g., `f1_score`, `precision_score`) and addresses the guidance from @glemaitre in the issue.

### Behavior

| `zero_division` | Behavior when IDCG = 0 |
|---|---|
| `"warn"` (default) | Returns `0` for that sample **and** raises `UndefinedMetricWarning` |
| `0` | Returns `0` silently (previous behavior, now without warning) |
| `1` | Returns `1` silently |

### Changes

- **`sklearn/metrics/_ranking.py`**: Added `zero_division` parameter to both `ndcg_score` and `_ndcg_sample_scores`. Updated `@validate_params` decorator to validate the new parameter using `StrOptions({"warn"})` and `Options(Real, {0, 1})`. Updated docstrings.
- **`sklearn/metrics/tests/test_ranking.py`**: Added `test_ndcg_score_zero_division` covering all three parameter values.
- **`doc/whats_new/upcoming_changes/sklearn.metrics/29521.enhancement.rst`**: Added changelog entry.

### Example

```python
import numpy as np
from sklearn.metrics import ndcg_score

y_true = np.array([[1.0, 0.0, 1.0], [0.0, 0.0, 0.0]])
y_score = np.array([[0.5, 0.2, 0.8], [0.1, 0.3, 0.6]])

# Default "warn": raises UndefinedMetricWarning, zero sample = 0
ndcg_score(y_true, y_score)  # UndefinedMetricWarning raised

# Explicit 0: silent, zero sample = 0
ndcg_score(y_true, y_score, zero_division=0)

# Explicit 1: silent, zero sample = 1
ndcg_score(y_true, y_score, zero_division=1)
```

Note: The previous default behavior was to silently set NDCG=0 for samples with all-zero true relevance. The new default `"warn"` preserves that return value but now raises a warning so users are informed that those samples are undefined. This is a minor behavioral change (new warning), consistent with how other metrics handle this case.