### PR TITLE
fix: honor copy=False for y in mutual_info and clarify docstring

### DIFF
--- a/sklearn/feature_selection/_mutual_info.py
+++ b/sklearn/feature_selection/_mutual_info.py
@@ -307,7 +307,7 @@ def _estimate_mi(
         )
 
     if not discrete_target:
-        y = scale(y, with_mean=False)
+        y = scale(y, with_mean=False, copy=copy)
         y += (
             1e-10
             * np.maximum(1, np.mean(np.abs(y)))
@@ -380,7 +380,8 @@ def mutual_info_regression(
 
     copy : bool, default=True
         Whether to make a copy of the given data. If set to False, the initial
-        data will be overwritten.
+        data will be overwritten. Only affects continuous features in `X` and
+        a continuous `y`; discrete features are not modified in-place.
 
     random_state : int, RandomState instance or None, default=None
         Determines random number generation for adding small noise to
@@ -508,7 +509,8 @@ def mutual_info_classif(
 
     copy : bool, default=True
         Whether to make a copy of the given data. If set to False, the initial
-        data will be overwritten.
+        data will be overwritten. Only affects continuous features in `X`;
+        `y` is discrete for this function and is not modified in-place.
 
     random_state : int, RandomState instance or None, default=None
         Determines random number generation for adding small noise to


### PR DESCRIPTION
Fixes #28793.

**Problem:** The `copy` parameter docstring for `mutual_info_regression` and `mutual_info_classif` states "If set to False, the initial data will be overwritten", but `y` was never overwritten because `scale(y, with_mean=False)` did not pass `copy=copy` (defaulting to `copy=True`).

**Changes:**
- Pass `copy=copy` to `scale(y, with_mean=False, copy=copy)` in `_estimate_mi` so the parameter is honored for continuous `y` in `mutual_info_regression`
- Clarify the `copy` docstring in both `mutual_info_regression` and `mutual_info_classif` to accurately describe which data is affected