### PR TITLE
Enh 33380 remove fmi sparse

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/00000.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/00000.api.rst
@@ -1,2 +1,0 @@
-- Removed the deprecated `sparse` parameter from
-  :func:`~metrics.fowlkes_mallows_score`.

--- a/doc/whats_new/upcoming_changes/sklearn.metrics/00000.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/00000.api.rst
@@ -1,0 +1,2 @@
+- Removed the deprecated `sparse` parameter from
+  :func:`~metrics.fowlkes_mallows_score`.

--- a/doc/whats_new/upcoming_changes/sklearn.metrics/33380.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/33380.api.rst
@@ -1,0 +1,3 @@
+- :func:`metrics.fowlkes_mallows_score` removed the deprecated `sparse` parameter,
+  which had no effect.
+  By :user:`Unique Shrestha <un1u3>`.

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -23,7 +23,6 @@ from sklearn.utils._array_api import (
     get_namespace_and_device,
 )
 from sklearn.utils._param_validation import (
-    Hidden,
     Interval,
     StrOptions,
     validate_params,
@@ -1189,11 +1188,10 @@ def normalized_mutual_info_score(
     {
         "labels_true": ["array-like"],
         "labels_pred": ["array-like"],
-        "sparse": ["boolean", Hidden(StrOptions({"deprecated"}))],
     },
     prefer_skip_nested_validation=True,
 )
-def fowlkes_mallows_score(labels_true, labels_pred, *, sparse="deprecated"):
+def fowlkes_mallows_score(labels_true, labels_pred):
     """Measure the similarity of two clusterings of a set of points.
 
     .. versionadded:: 0.18
@@ -1223,13 +1221,6 @@ def fowlkes_mallows_score(labels_true, labels_pred, *, sparse="deprecated"):
 
     labels_pred : array-like of shape (n_samples,), dtype=int
         A clustering of the data into disjoint subsets.
-
-    sparse : bool, default=False
-        Compute contingency matrix internally with sparse matrix.
-
-        .. deprecated:: 1.7
-            The ``sparse`` parameter is deprecated and will be removed in 1.9. It has
-            no effect.
 
     Returns
     -------
@@ -1264,14 +1255,6 @@ def fowlkes_mallows_score(labels_true, labels_pred, *, sparse="deprecated"):
       >>> fowlkes_mallows_score([0, 0, 0, 0], [0, 1, 2, 3])
       0.0
     """
-    # TODO(1.9): remove the sparse parameter
-    if sparse != "deprecated":
-        warnings.warn(
-            "The 'sparse' parameter was deprecated in 1.7 and will be removed in 1.9. "
-            "It has no effect. Leave it to its default value to silence this warning.",
-            FutureWarning,
-        )
-
     labels_true, labels_pred = check_clusterings(labels_true, labels_pred)
     (n_samples,) = labels_true.shape
 

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -520,13 +520,3 @@ def test_normalized_mutual_info_score_bounded(average_method):
     # non constant, non perfect matching labels
     nmi = normalized_mutual_info_score(labels2, labels3, average_method=average_method)
     assert 0 <= nmi < 1
-
-
-# TODO(1.9): remove
-@pytest.mark.parametrize("sparse", [True, False])
-def test_fowlkes_mallows_sparse_deprecated(sparse):
-    """Check deprecation warning for 'sparse' parameter of fowlkes_mallows_score."""
-    with pytest.warns(
-        FutureWarning, match="The 'sparse' parameter was deprecated in 1.7"
-    ):
-        fowlkes_mallows_score([0, 1], [1, 1], sparse=sparse)


### PR DESCRIPTION
Closes #33380
- [x] Triaged TODO(1.9) items and completed this one.
- [x] Removed deprecated `sparse` parameter from `metrics.fowlkes_mallows_score`.
- [x] Removed deprecated warning/handling path.
- [x] Removed related deprecation test.
- [x] Updated parameter validation/docstring accordingly.