### PR TITLE
FIX LabelBinarizer overflow with unsigned integer dtypes

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.preprocessing/33391.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.preprocessing/33391.fix.rst
@@ -1,0 +1,4 @@
+- :func:`preprocessing.label_binarize` and :class:`preprocessing.LabelBinarizer`
+  no longer silently overflow when the target array ``y`` has an unsigned integer
+  dtype and ``neg_label`` is negative (e.g. in :class:`linear_model.RidgeClassifier`).
+  By :user:`worksbyfriday <worksbyfriday>`.

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -590,7 +590,7 @@ def label_binarize(y, *, classes, neg_label=0, pos_label=1, sparse_output=False)
 
     n_samples = y.shape[0] if hasattr(y, "shape") else len(y)
     n_classes = classes.shape[0]
-    if hasattr(y, "dtype") and xp.isdtype(y.dtype, "integral"):
+    if hasattr(y, "dtype") and xp.isdtype(y.dtype, "signed integer"):
         int_dtype_ = y.dtype
     else:
         int_dtype_ = indexing_dtype(xp)

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -125,6 +125,23 @@ def test_label_binarizer_set_label_encoding():
     assert_array_equal(lb.inverse_transform(got), inp)
 
 
+@pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.uint32, np.uint64])
+def test_label_binarizer_unsigned_int_dtype(dtype):
+    """LabelBinarizer should handle unsigned integer targets correctly.
+
+    When neg_label is negative (e.g. -1 in RidgeClassifier), converting to
+    an unsigned dtype causes overflow. The binarizer should use a signed dtype
+    internally to avoid this.
+
+    Non-regression test for gh-33390.
+    """
+    y = np.array([0, 1, 1, 0], dtype=dtype)
+    lb = LabelBinarizer(pos_label=1, neg_label=-1)
+    Y = lb.fit_transform(y)
+    expected = np.array([[-1, 1, 1, -1]]).T
+    assert_array_equal(Y, expected)
+
+
 @pytest.mark.parametrize("dtype", ["Int64", "Float64", "boolean"])
 @pytest.mark.parametrize("unique_first", [True, False])
 def test_label_binarizer_pandas_nullable(dtype, unique_first):


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #33390

#### What does this implement/fix? Explain your changes.

When `y` has an unsigned integer dtype (e.g. `uint64`) and `neg_label` is negative (e.g. `-1` in `RidgeClassifier`), `label_binarize()` preserves the unsigned dtype as `int_dtype_`. The cast at line 675 (`xp.astype(Y, int_dtype_, copy=False)`) then silently overflows `-1` to the unsigned maximum (e.g. `18446744073709551615` for `uint64`).

The fix changes the dtype check from `"integral"` to `"signed integer"` so unsigned types fall through to `indexing_dtype(xp)`, which returns a platform-appropriate signed integer type.

#### Any other comments?

The same `"integral"` pattern at line 755 (in `_inverse_binarize_thresholding`) is not affected because it only casts boolean comparison results (`> threshold`) which are always 0 or 1.

A changelog entry will be added once the PR number is assigned.