### PR TITLE
FIX check_array TypeError with pandas StringDType

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.utils/33392.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/33392.fix.rst
@@ -1,0 +1,4 @@
+- :func:`utils.validation.check_array` and :func:`utils.validation.column_or_1d`
+  no longer raise ``TypeError`` when called with a pandas ``StringDType`` as the
+  ``dtype`` parameter.
+  By :user:`worksbyfriday <worksbyfriday>`.

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -2269,6 +2269,18 @@ def test_column_or_1d():
                 column_or_1d(y)
 
 
+def test_column_or_1d_pandas_string_dtype():
+    """check_array should handle pandas StringDType without raising TypeError.
+
+    Non-regression test for gh-33383.
+    """
+    pd = pytest.importorskip("pandas", minversion="3.0.0")
+
+    df = pd.DataFrame({"y": ["a", "b", "a", "c"]})
+    result = column_or_1d(df["y"], dtype=df["y"].dtype)
+    assert_array_equal(result, np.array(["a", "b", "a", "c"], dtype=object))
+
+
 def test_check_array_writeable_np():
     """Check the behavior of check_array when a writeable array is requested
     without copy if possible, on numpy arrays.

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -949,7 +949,13 @@ def check_array(
 
     if dtype is not None and _is_numpy_namespace(xp):
         # convert to dtype object to conform to Array API to be use `xp.isdtype` later
-        dtype = np.dtype(dtype)
+        try:
+            dtype = np.dtype(dtype)
+        except (TypeError, KeyError):
+            # dtype is not a NumPy-compatible type (e.g. pandas StringDType).
+            # Use object dtype for NumPy validation checks; _asarray_with_order
+            # will handle the actual conversion.
+            dtype = np.dtype("object")
 
     estimator_name = _check_estimator_name(estimator)
     context = " by %s" % estimator_name if estimator is not None else ""


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #33383

#### What does this implement/fix? Explain your changes.

Since Pandas 3, `StringDType` is no longer a valid NumPy dtype. `check_array()` unconditionally calls `np.dtype(dtype)` to normalize the dtype parameter for downstream `xp.isdtype()` checks. This raises `TypeError` for non-NumPy-compatible dtypes like pandas `StringDType`.

The fix wraps the `np.dtype()` call in a try/except and falls back to `np.dtype("object")` when the conversion fails. This is correct because:
- String data in NumPy is represented as `object` dtype
- `object` dtype is not integral or floating, so it takes the correct code path through validation (the `else` branch at line 1027)
- `_asarray_with_order` handles the actual array conversion

#### Any other comments?

A changelog entry will be added once the PR number is assigned.