### PR TITLE
FIX PrecisionRecallDisplay chance level wrong with non-NumPy y_true

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/33342.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/33342.fix.rst
@@ -1,0 +1,6 @@
+- :class:`metrics.PrecisionRecallDisplay` now correctly computes
+  ``prevalence_pos_label`` when ``y_true`` is a non-NumPy array-like (e.g.
+  PyTorch tensor or plain list). Previously, using ``Counter`` caused incorrect
+  chance level lines when array elements did not match ``pos_label`` by
+  identity.
+  By :user:`worksbyfriday <worksbyfriday>`.

--- a/sklearn/metrics/_plot/precision_recall_curve.py
+++ b/sklearn/metrics/_plot/precision_recall_curve.py
@@ -1,8 +1,6 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
-from collections import Counter
-
 import numpy as np
 
 from sklearn.metrics._ranking import average_precision_score, precision_recall_curve
@@ -713,8 +711,10 @@ class PrecisionRecallDisplay(_BinaryClassifierCurveDisplayMixin):
             y_true, y_score, pos_label=pos_label, sample_weight=sample_weight
         )
 
-        class_count = Counter(y_true)
-        prevalence_pos_label = class_count[pos_label] / sum(class_count.values())
+        y_true_array = np.asarray(y_true)
+        prevalence_pos_label = np.count_nonzero(
+            y_true_array == pos_label
+        ) / y_true_array.shape[0]
 
         viz = cls(
             precision=precision,

--- a/sklearn/metrics/_plot/tests/test_precision_recall_display.py
+++ b/sklearn/metrics/_plot/tests/test_precision_recall_display.py
@@ -691,3 +691,25 @@ def test_y_score_and_y_pred_specified_error(pyplot):
 
     with pytest.warns(FutureWarning, match="y_pred was deprecated in 1.8"):
         PrecisionRecallDisplay.from_predictions(y_true, y_pred=y_score)
+
+
+def test_precision_recall_chance_level_non_numpy_y_true(pyplot):
+    """Check that prevalence_pos_label is correct for non-numpy array-like y_true.
+
+    Counter-based computation failed when y_true elements had types where
+    equality checks with pos_label did not match (e.g. PyTorch tensors).
+    Using np.asarray handles all array-like inputs uniformly.
+
+    Non-regression test for gh-33342.
+    """
+    y_true = [0, 0, 0, 1, 1]  # prevalence = 2/5 = 0.4
+    y_score = [0.1, 0.2, 0.3, 0.8, 0.9]
+
+    display = PrecisionRecallDisplay.from_predictions(
+        y_true, y_score, plot_chance_level=True
+    )
+    chance_line = display.chance_level_
+    # The chance level line should be at y = prevalence = 0.4
+    ydata = chance_line.get_ydata()
+    assert ydata[0] == pytest.approx(0.4)
+    assert ydata[1] == pytest.approx(0.4)


### PR DESCRIPTION
Fixes #33342.

## What does this PR do?

`PrecisionRecallDisplay.from_predictions` computed `prevalence_pos_label` using `Counter(y_true)`, which fails for non-NumPy array-like inputs (e.g. PyTorch tensors). `Counter` creates keys that are tensor elements, so looking up `class_count[pos_label]` (where `pos_label` is a Python int) returns 0 — drawing the chance level line at y=0 instead of the true prevalence.

## Fix

Replace the `Counter` approach with `np.asarray` + `np.count_nonzero`, matching the pattern already used in `from_cv_results` (line 903-904). This handles all array-like inputs uniformly.

```python
# Before
class_count = Counter(y_true)
prevalence_pos_label = class_count[pos_label] / sum(class_count.values())

# After
y_true_array = np.asarray(y_true)
prevalence_pos_label = np.count_nonzero(y_true_array == pos_label) / y_true_array.shape[0]
```

The unused `from collections import Counter` import is also removed.

## Test

Added regression test that verifies the chance level line is drawn at the correct prevalence (0.4 for 2/5 positive labels).