### PR TITLE
FIX SimpleImputer.inverse_transform column order with empty features

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.impute/27012.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.impute/27012.fix.rst
@@ -1,0 +1,5 @@
+- :meth:`impute.SimpleImputer.inverse_transform` now correctly re-inserts
+  columns that were all-missing at fit time (and thus dropped during
+  ``transform``). Previously, the remaining columns were shifted left,
+  producing incorrect results.
+  By :user:`worksbyfriday <worksbyfriday>`.

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1511,6 +1511,43 @@ def test_simple_imputation_inverse_transform_exceptions(missing_value):
         imputer.inverse_transform(X_1_trans)
 
 
+def test_simple_imputation_inverse_transform_empty_features():
+    """inverse_transform should handle columns that were all-missing at fit time.
+
+    When keep_empty_features=False (default), columns with all missing values
+    are dropped during transform. inverse_transform must re-insert these
+    columns filled with missing_values at the correct positions, rather than
+    shifting remaining columns left.
+
+    Non-regression test for gh-27012.
+    """
+    X_fit = np.array(
+        [
+            [np.nan, 2.0, 3.0],
+            [np.nan, 2.0, 3.0],
+        ]
+    )
+    X_test = np.array(
+        [
+            [1.0, 2.0, 3.0],
+            [1.0, 2.0, 3.0],
+        ]
+    )
+
+    imputer = SimpleImputer(add_indicator=True)
+    imputer.fit(X_fit)
+    X_trans = imputer.transform(X_test)
+    X_inv = imputer.inverse_transform(X_trans)
+
+    expected = np.array(
+        [
+            [np.nan, 2.0, 3.0],
+            [np.nan, 2.0, 3.0],
+        ]
+    )
+    assert_array_equal(X_inv, expected)
+
+
 @pytest.mark.parametrize(
     "expected,array,dtype,extra_value,n_repeat",
     [


### PR DESCRIPTION
## Reference Issues/PRs

Fixes #27012

## What does this implement/fix? Explain your changes.

`SimpleImputer.inverse_transform` produces incorrect results when `keep_empty_features=False` (the default) and some columns were all-missing at fit time. Those columns are dropped during `transform`, but `inverse_transform` fails to re-insert them, causing the remaining columns to shift left.

**Root cause**: The existing code used `np.all(X_original[:, original_idx])` to decide whether a column should be skipped during reconstruction. This checks the *test data* indicator values, not whether the column was dropped at fit time.

**Fix**: Use `_get_mask(self.statistics_, np.nan)` to identify which features had no valid statistics at fit time (and were therefore dropped during `transform`). These columns are filled with `missing_values` during reconstruction, preserving correct column alignment.

**Example**:

```python
import numpy as np
from sklearn.impute import SimpleImputer

X_fit = np.array([[np.nan, 2.0, 3.0],
                  [np.nan, 2.0, 3.0]])

imputer = SimpleImputer(add_indicator=True)
imputer.fit(X_fit)

X_test = np.array([[1.0, 2.0, 3.0],
                   [1.0, 2.0, 3.0]])
X_trans = imputer.transform(X_test)

# Before fix: columns shifted left, incorrect
# After fix: dropped column correctly re-inserted as NaN
X_inv = imputer.inverse_transform(X_trans)
# array([[nan,  2.,  3.],
#        [nan,  2.,  3.]])
```

Includes a regression test.