### PR TITLE
DOC Fix deprecated kwargs in `PrecisionRecallDisplay` in example

### DIFF
--- a/examples/model_selection/plot_cost_sensitive_learning.py
+++ b/examples/model_selection/plot_cost_sensitive_learning.py
@@ -304,10 +304,9 @@ def plot_roc_pr_curves(vanilla_model, tuned_model, *, title):
             X_test,
             y_test,
             pos_label=pos_label,
-            linestyle=linestyle,
-            color=color,
             ax=axs[0],
             name=name,
+            curve_kwargs={"linestyle": linestyle, "color": color},
         )
         axs[0].plot(
             scoring["recall"](est, X_test, y_test),
@@ -322,7 +321,7 @@ def plot_roc_pr_curves(vanilla_model, tuned_model, *, title):
             X_test,
             y_test,
             pos_label=pos_label,
-            curve_kwargs=dict(linestyle=linestyle, color=color),
+            curve_kwargs={"linestyle": linestyle, "color": color},
             ax=axs[1],
             name=name,
             plot_chance_level=idx == 1,


### PR DESCRIPTION
#### Reference Issues/PRs
https://github.com/scikit-learn/scikit-learn/pull/30508#issuecomment-3950312489


#### What does this implement/fix? Explain your changes.
Missed in #30508

Uses the new `curve_kwargs` instead of passing plot kwargs as **kwargs, to avoid deprecation warning.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
