### PR TITLE
ENH Add argument to SelectFwe to choose between Bonferroni and Holm method

### DIFF
--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -1067,11 +1067,7 @@ class SelectFwe(_BaseFilter):
             h0_rejected[sorted_ids] = self.pvalues_[
                 sorted_ids
             ] < self.alpha / np.arange(len(self.pvalues_), 0, -1)
-        else:
-            raise ValueError(
-                f"Invalid fwe_control method: {self.fwe_control}. "
-                "Expected 'bonf' or 'holm'."
-            )
+        
         return h0_rejected
 
 

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -1051,7 +1051,7 @@ class SelectFwe(_BaseFilter):
         "fwe_control": [StrOptions({"bonf", "holm"})],
     }
 
-    def __init__(self, score_func=f_classif, *, alpha=5e-2, fwe_control='bonf'):
+    def __init__(self, score_func=f_classif, *, alpha=5e-2, fwe_control="bonf"):
         super().__init__(score_func=score_func)
         self.alpha = alpha
         self.fwe_control = fwe_control
@@ -1059,19 +1059,20 @@ class SelectFwe(_BaseFilter):
     def _get_support_mask(self):
         check_is_fitted(self)
 
-        if self.fwe_control == 'bonf':
+        if self.fwe_control == "bonf":
             h0_rejected = self.pvalues_ < self.alpha / len(self.pvalues_)
-        elif self.fwe_control == 'holm':
+        elif self.fwe_control == "holm":
             h0_rejected = np.zeros_like(self.pvalues_, dtype=bool)
             sorted_ids = np.argsort(self.pvalues_)
-            h0_rejected[sorted_ids] = self.pvalues_[sorted_ids] < \
-                self.alpha / np.arange(len(self.pvalues_), 0, -1)
+            h0_rejected[sorted_ids] = self.pvalues_[
+                sorted_ids
+            ] < self.alpha / np.arange(len(self.pvalues_), 0, -1)
         else:
-            raise ValueError(f"Invalid fwe_control method: {self.fwe_control}. "
-                             "Expected 'bonf' or 'holm'.")
+            raise ValueError(
+                f"Invalid fwe_control method: {self.fwe_control}. "
+                "Expected 'bonf' or 'holm'."
+            )
         return h0_rejected
-
-
 
 
 ######################################################################

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -1016,7 +1016,7 @@ class SelectFwe(_BaseFilter):
 
         .. versionadded:: 1.0
 
-    fwe_control = str
+    fwe_control : str
         Method to use for FWE control. 'bonf' for Bonferroni correction, 'holm'
         for Holm method.
 

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -1048,6 +1048,7 @@ class SelectFwe(_BaseFilter):
     _parameter_constraints: dict = {
         **_BaseFilter._parameter_constraints,
         "alpha": [Interval(Real, 0, 1, closed="both")],
+        "fwe_control": [StrOptions({"bonf", "holm"})],
     }
 
     def __init__(self, score_func=f_classif, *, alpha=5e-2, fwe_control='bonf'):

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -1064,7 +1064,7 @@ class SelectFwe(_BaseFilter):
             h0_rejected = np.zeros_like(self.pvalues_, dtype=bool)
             sorted_ids = np.argsort(self.pvalues_)
             h0_rejected[sorted_ids] = self.pvalues_[sorted_ids] < \
-                self.alpha / np.arange(1, len(self.pvalues_) + 1)
+                self.alpha / np.arange(len(self.pvalues_), 0, -1)
         else:
             raise ValueError(f"Invalid fwe_control method: {self.fwe_control}. "
                              "Expected 'bonf' or 'holm'.")

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -1067,7 +1067,7 @@ class SelectFwe(_BaseFilter):
             h0_rejected[sorted_ids] = self.pvalues_[
                 sorted_ids
             ] < self.alpha / np.arange(len(self.pvalues_), 0, -1)
-        
+
         return h0_rejected
 
 

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -733,6 +733,14 @@ def test_select_fwe_regression():
     assert_array_equal(support[:5], np.ones((5,), dtype=bool))
     assert np.sum(support[5:] == 1) < 2
 
+    # Check if the Holm method returns at least as many features as the Bonferroni method
+    X_r3 = SelectFwe(f_regression, alpha=0.01, fwe_control="holm").fit(X, y).transform(X)
+    assert X_r3.shape[1] >= X_r.shape[1]
+
+    msg = "The 'fwe_control' parameter of SelectFwe must be a str among {'bonf', 'holm'}. Got 'sidak' instead."
+    with pytest.raises(ValueError, match=msg):
+        _ = SelectFwe(f_regression, alpha=0.01, fwe_control="sidak").fit(X, y).transform(X)
+
 
 def test_selectkbest_tiebreaking():
     # Test whether SelectKBest actually selects k features in case of ties.

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -733,13 +733,15 @@ def test_select_fwe_regression():
     assert_array_equal(support[:5], np.ones((5,), dtype=bool))
     assert np.sum(support[5:] == 1) < 2
 
-    # Check if the Holm method returns at least as many features as the Bonferroni method
+    # Check if the Holm method returns at least as many features as the
+    # Bonferroni method
     X_r3 = (
         SelectFwe(f_regression, alpha=0.01, fwe_control="holm").fit(X, y).transform(X)
     )
     assert X_r3.shape[1] >= X_r.shape[1]
 
-    msg = "The 'fwe_control' parameter of SelectFwe must be a str among {'bonf', 'holm'}. Got 'sidak' instead."
+    msg = "The 'fwe_control' parameter of SelectFwe must be a str among "
+    "{'bonf', 'holm'}. Got 'sidak' instead."
     with pytest.raises(ValueError, match=msg):
         _ = (
             SelectFwe(f_regression, alpha=0.01, fwe_control="sidak")

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -734,12 +734,18 @@ def test_select_fwe_regression():
     assert np.sum(support[5:] == 1) < 2
 
     # Check if the Holm method returns at least as many features as the Bonferroni method
-    X_r3 = SelectFwe(f_regression, alpha=0.01, fwe_control="holm").fit(X, y).transform(X)
+    X_r3 = (
+        SelectFwe(f_regression, alpha=0.01, fwe_control="holm").fit(X, y).transform(X)
+    )
     assert X_r3.shape[1] >= X_r.shape[1]
 
     msg = "The 'fwe_control' parameter of SelectFwe must be a str among {'bonf', 'holm'}. Got 'sidak' instead."
     with pytest.raises(ValueError, match=msg):
-        _ = SelectFwe(f_regression, alpha=0.01, fwe_control="sidak").fit(X, y).transform(X)
+        _ = (
+            SelectFwe(f_regression, alpha=0.01, fwe_control="sidak")
+            .fit(X, y)
+            .transform(X)
+        )
 
 
 def test_selectkbest_tiebreaking():


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

##### Background
Feature selection is frequently used to reduce the dimensionality of large datasets. To this end, a univariate scoring function can be used to test if a feature correlates significantly with a variable of interest. However, testing  a large group of features introduces the multiple comparisons problem where the type I error probability (i.e., the probability of erroneously rejecting a  null hypothesis) exceeds the nominal error probability for the whole test family due to the large number of tests performed. A feature may thus appear to correlate with the target variable merely due to noise and end up getting selected erroneously.

`SelectFwe` implements the Bonferroni correction which ensures that the actual type I error probability corresponds to the nominal error probability by dividing the significance threshold for the _p_ value by the number of tests. This procedure, however, comes with the risk of increasing the type II error probability, i.e., the error of failing to reject the null hypothesis when it is in fact false. This may result in a failure to detect features although they are informative in reality.

The [Holm method](https://en.wikipedia.org/wiki/Holm–Bonferroni_method) (a.k.a. Holm-Bonferroni method) solves this problem by providing the same protection against type I errors as Bonferroni while reducing the probability of a type II  error. In other words, it controls the family-wise error rate as effectively as the Bonferroni correction but is more sensitive to informative features. Although the Holm method is more powerful than Bonferroni, it unfortunately is not currently implemented in `SelectFwe`. 

##### Solution
I modified `SelectFwe` so that it now accepts an additional input argument called `fwe_control` of type `str`. The user can choose between `bonf` for Bonferroni, which is its default setting for better backward compatibility, and `holm` for the Holm method. The Holm method sorts all _m_ null hypotheses of a test family by their corresponding _p_ values in ascending order $p_1 < p_2 < ... < p_m$ and applies a modified Bonferroni correction in a step-wise fashion. It rejects the first null hypothesis if $p_1 < \frac{\alpha}{m}$. If this null hypothesis is rejected, it rejects the second null hypothesis if $p_2 < \frac{\alpha}{m - 1}$. Generally, all subsequent null hypotheses are rejected if $p_i < \frac{\alpha}{m - i + 1}$ until a null hypothesis cannot be rejected anymore. All remaining null hypotheses are retained.

##### Demonstration
I verified that the Holm method is more powerful using the example that is provided in the documentation for `SelectFwe`.

```
import numpy as np
import matplotlib.pyplot as plt
from sklearn.datasets import load_breast_cancer
from sklearn.feature_selection import SelectFwe, chi2

ALPHAS = np.array([.001, .002, .005, .01, .02, .05, .1, .2])

X, y = load_breast_cancer(return_X_y=True)
X.shape

print(f"Original number of features: {X.shape[1]}")

n_sig_feat = np.zeros_like(ALPHAS, dtype=int)
n_sig_feat_holm = np.zeros_like(ALPHAS, dtype=int)
for thresh_num, alpha in enumerate(ALPHAS):
    X_new = SelectFwe(chi2, alpha=alpha).fit_transform(X, y)
    n_sig_feat[thresh_num] = X_new.shape[1]
    X_new_holm = SelectFwe(chi2, alpha=alpha, fwe_control="holm").fit_transform(X, y)
    n_sig_feat_holm[thresh_num] = X_new_holm.shape[1]

plt.plot(ALPHAS, n_sig_feat, marker="o", label="Bonferroni")
plt.plot(ALPHAS, n_sig_feat_holm, marker="s", label="Holm")
plt.xscale("log")
plt.xlabel("alpha")
plt.ylabel("number of significant features")
plt.legend()
plt.show()
```
<img width="585" height="437" alt="image" src="https://github.com/user-attachments/assets/3168f91e-9d7f-4a2c-b3ef-2945dde38113" />

The example shows that the Holm method controls the family-wise error rate while detecting more informative features compared to the Bonferroni correction. The difference between the two measures is expected to scale with the number of input features.


#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?

I tried to implement the new procedure with minimal changes to the existing code. Since the method has been well established in statistics and  unchanged for a long time, I expect it to require only little maintenance in the future as well. I verified that the tests completed without errors after applying these changes. Using the demonstration shown above, I provide an example of how the new functionality is used  and show that it behaves as expected. I am aware that non-regression tests should be carried out for new features. Unfortunately, I do not know what exactly a non-regression would entail in this case and how (or where) I should add it to the existing scikit-learn code. Help is very welcome.

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
