### PR TITLE
MNT fix and refactor color handling in DecisionBoundaryDisplay - Part 1

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.inspection/33419.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.inspection/33419.fix.rst
@@ -1,0 +1,4 @@
+- In :class:`inspection.DecisionBoundaryDisplay`, a `ValueError` is now raised if the
+  colormap passed to `multiclass_colors` contains fewer colors than there are classes in
+  multiclass problems.
+  By :user:`Anne Beyer <AnneBeyer>`.

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -527,7 +527,6 @@ class DecisionBoundaryDisplay:
         <...>
         >>> plt.show()
         """
-        check_matplotlib_support(f"{cls.__name__}.from_estimator")
         check_is_fitted(estimator)
 
         if not grid_resolution > 1:

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -54,6 +54,75 @@ def _check_boundary_response_method(estimator, response_method):
     return prediction_method
 
 
+def _select_colors(mpl, multiclass_colors, n_classes):
+    """Select colors for multiclass decision boundary display.
+
+    Parameters
+    ----------
+    mpl : module
+        Imported `matplotlib` module.
+
+    multiclass_colors : list of color-like, str, or None
+        Color specification for multiclass plots.
+
+        - If `None`, defaults to `"tab10"` when `n_classes <= 10`, otherwise
+          `"gist_rainbow"`.
+        - If `str`, interpreted as a Matplotlib colormap name.
+        - If `list`, each entry must be a valid Matplotlib color-like value.
+
+    n_classes : int
+        Number of colors to select.
+
+    Returns
+    -------
+    colors : list or ndarray of shape (n_classes, 4)
+        RGBA colors, one per class.
+
+    """
+
+    if multiclass_colors is None:
+        multiclass_colors = "tab10" if n_classes <= 10 else "gist_rainbow"
+
+    if isinstance(multiclass_colors, str):
+        if multiclass_colors not in mpl.pyplot.colormaps():
+            raise ValueError(
+                "When 'multiclass_colors' is a string, it must be a valid "
+                f"Matplotlib colormap. Got: {multiclass_colors}"
+            )
+        cmap = mpl.pyplot.get_cmap(multiclass_colors)
+        if cmap.N < n_classes:
+            raise ValueError(
+                f"Colormap '{multiclass_colors}' only has {cmap.N} colors, but "
+                f"{n_classes} classes are to be displayed. Please specify a "
+                "different colormap or provide a list of colors via "
+                "'multiclass_colors'."
+            )
+        if cmap.N < 256:
+            # Special case for the qualitative colormaps that encode a
+            # discrete set of colors that are easily distinguishable, contrary to other
+            # colormaps that are continuous (for which `cmap.N` >= 256).
+            return mpl.colors.to_rgba_array(cmap.colors[:n_classes])
+        else:
+            return cmap(np.linspace(0, 1, n_classes))
+
+    elif isinstance(multiclass_colors, list):
+        if len(multiclass_colors) != n_classes:
+            raise ValueError(
+                "When 'multiclass_colors' is a list, it must be of the same "
+                f"length as the classes or labels to plot ({n_classes}), got: "
+                f"{len(multiclass_colors)}."
+            )
+        elif any(not mpl.colors.is_color_like(col) for col in multiclass_colors):
+            raise ValueError(
+                "When 'multiclass_colors' is a list, it can only contain valid"
+                f" Matplotlib color names. Got: {multiclass_colors}"
+            )
+        return [mpl.colors.to_rgba(color) for color in multiclass_colors]
+
+    else:
+        raise ValueError("'multiclass_colors' must be a list or a str.")
+
+
 class DecisionBoundaryDisplay:
     """Decisions boundary visualization.
 
@@ -257,34 +326,9 @@ class DecisionBoundaryDisplay:
                     )
                     del kwargs[kwarg]
 
-            if self.multiclass_colors is None or isinstance(
-                self.multiclass_colors, str
-            ):
-                if self.multiclass_colors is None:
-                    cmap = "tab10" if self.n_classes <= 10 else "gist_rainbow"
-                else:
-                    cmap = self.multiclass_colors
-
-                # Special case for the tab10 and tab20 colormaps that encode a
-                # discrete set of colors that are easily distinguishable
-                # contrary to other colormaps that are continuous.
-                if cmap == "tab10" and self.n_classes <= 10:
-                    colors = plt.get_cmap("tab10", 10).colors[: self.n_classes]
-                elif cmap == "tab20" and self.n_classes <= 20:
-                    colors = plt.get_cmap("tab20", 20).colors[: self.n_classes]
-                else:
-                    cmap = plt.get_cmap(cmap, self.n_classes)
-                    if not hasattr(cmap, "colors"):
-                        # Get `LinearSegmentedColormap` for non-qualitative cmaps
-                        colors = cmap(np.linspace(0, 1, self.n_classes))
-                    else:
-                        colors = cmap.colors
-            elif isinstance(self.multiclass_colors, list):
-                colors = [mpl.colors.to_rgba(color) for color in self.multiclass_colors]
-            else:
-                raise ValueError("'multiclass_colors' must be a list or a str.")
-
-            self.multiclass_colors_ = colors
+            self.multiclass_colors_ = _select_colors(
+                mpl, self.multiclass_colors, self.n_classes
+            )
 
             if self.response.ndim == 2:  # predict
                 # Set `levels` to ensure all classes are displayed in different colors
@@ -294,7 +338,7 @@ class DecisionBoundaryDisplay:
                     elif plot_method == "contourf":
                         kwargs["levels"] = np.arange(self.n_classes + 1) - 0.5
                 # `pcolormesh` requires cmap, for the others it makes no difference
-                cmap = mpl.colors.ListedColormap(colors)
+                cmap = mpl.colors.ListedColormap(self.multiclass_colors_)
                 self.surface_ = plot_func(
                     self.xx0, self.xx1, self.response, cmap=cmap, **kwargs
                 )
@@ -309,7 +353,7 @@ class DecisionBoundaryDisplay:
                     self.xx0,
                     self.xx1,
                     self.response.argmax(axis=2),
-                    colors=colors,
+                    colors=self.multiclass_colors_,
                     **kwargs,
                 )
             else:
@@ -318,7 +362,7 @@ class DecisionBoundaryDisplay:
                         f"colormap_{class_idx}",
                         [(1.0, 1.0, 1.0, 1.0), (r, g, b, 1.0)],
                     )
-                    for class_idx, (r, g, b, _) in enumerate(colors)
+                    for class_idx, (r, g, b, _) in enumerate(self.multiclass_colors_)
                 ]
                 self.surface_ = []
                 for class_idx, cmap in enumerate(multiclass_cmaps):
@@ -485,7 +529,6 @@ class DecisionBoundaryDisplay:
         """
         check_matplotlib_support(f"{cls.__name__}.from_estimator")
         check_is_fitted(estimator)
-        import matplotlib as mpl
 
         if not grid_resolution > 1:
             raise ValueError(
@@ -511,33 +554,6 @@ class DecisionBoundaryDisplay:
             raise ValueError(
                 f"n_features must be equal to 2. Got {num_features} instead."
             )
-
-        if (
-            response_method in ("predict_proba", "decision_function", "auto")
-            and multiclass_colors is not None
-            and hasattr(estimator, "classes_")
-            and (n_classes := len(estimator.classes_)) > 2
-        ):
-            if isinstance(multiclass_colors, list):
-                if len(multiclass_colors) != n_classes:
-                    raise ValueError(
-                        "When 'multiclass_colors' is a list, it must be of the same "
-                        f"length as 'estimator.classes_' ({n_classes}), got: "
-                        f"{len(multiclass_colors)}."
-                    )
-                elif any(
-                    not mpl.colors.is_color_like(col) for col in multiclass_colors
-                ):
-                    raise ValueError(
-                        "When 'multiclass_colors' is a list, it can only contain valid"
-                        f" Matplotlib color names. Got: {multiclass_colors}"
-                    )
-            if isinstance(multiclass_colors, str):
-                if multiclass_colors not in mpl.pyplot.colormaps():
-                    raise ValueError(
-                        "When 'multiclass_colors' is a string, it must be a valid "
-                        f"Matplotlib colormap. Got: {multiclass_colors}"
-                    )
 
         x0, x1 = _safe_indexing(X, 0, axis=1), _safe_indexing(X, 1, axis=1)
 

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -303,7 +303,6 @@ class DecisionBoundaryDisplay:
         """
         check_matplotlib_support("DecisionBoundaryDisplay.plot")
         import matplotlib as mpl
-        import matplotlib.pyplot as plt
 
         if plot_method not in ("contourf", "contour", "pcolormesh"):
             raise ValueError(
@@ -312,7 +311,7 @@ class DecisionBoundaryDisplay:
             )
 
         if ax is None:
-            _, ax = plt.subplots()
+            _, ax = mpl.pyplot.subplots()
 
         plot_func = getattr(ax, plot_method)
         if self.n_classes == 2:

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -120,7 +120,7 @@ def _select_colors(mpl, multiclass_colors, n_classes):
         return [mpl.colors.to_rgba(color) for color in multiclass_colors]
 
     else:
-        raise ValueError("'multiclass_colors' must be a list or a str.")
+        raise TypeError("'multiclass_colors' must be a list or a str.")
 
 
 class DecisionBoundaryDisplay:

--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -696,6 +696,8 @@ def test_multiclass_not_enough_colors_error(pyplot):
     """
     Check that an error is raised if a qualitative colormap doesn't have enough colors.
 
+    Non-regression test for PR 33419.
+
     Note: List length mismatch is already checked in
     `test_input_validation_errors_multiclass_colors`.
     """

--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -175,6 +175,10 @@ def test_input_validation_errors(pyplot, kwargs, error_msg, fitted_clf):
         ({"multiclass_colors": "not_cmap"}, "it must be a valid Matplotlib colormap"),
         ({"multiclass_colors": ["red", "green"]}, "it must be of the same length"),
         (
+            {"multiclass_colors": ["red", "green", "blue", "yellow"]},
+            "it must be of the same length",
+        ),
+        (
             {"multiclass_colors": ["red", "green", "not color"]},
             "it can only contain valid Matplotlib color names",
         ),
@@ -617,6 +621,7 @@ def test_multiclass_plot_max_class(pyplot, response_method):
         (None, 11),
         ("plasma", 3),
         ("Blues", 3),
+        ("tab20", 20),
         (["red", "green", "blue"], 3),
     ],
 )
@@ -652,14 +657,15 @@ def test_multiclass_colors_cmap(
 
     if multiclass_colors is None:
         if len(clf.classes_) <= 10:
-            colors = mpl.pyplot.get_cmap("tab10", 10).colors[: len(clf.classes_)]
+            multiclass_colors = "tab10"
         else:
-            cmap = mpl.pyplot.get_cmap("gist_rainbow", len(clf.classes_))
-            colors = cmap(np.linspace(0, 1, len(clf.classes_)))
-    elif multiclass_colors == "plasma":
-        colors = mpl.pyplot.get_cmap(multiclass_colors, len(clf.classes_)).colors
-    elif multiclass_colors == "Blues":
-        cmap = mpl.pyplot.get_cmap(multiclass_colors, len(clf.classes_))
+            multiclass_colors = "gist_rainbow"
+
+    if multiclass_colors in ["tab10", "tab20"]:
+        cmap = mpl.pyplot.get_cmap(multiclass_colors)
+        colors = mpl.colors.to_rgba_array(cmap.colors[: len(clf.classes_)])
+    elif multiclass_colors in ["Blues", "gist_rainbow", "plasma"]:
+        cmap = mpl.pyplot.get_cmap(multiclass_colors)
         colors = cmap(np.linspace(0, 1, len(clf.classes_)))
     else:
         colors = [mpl.colors.to_rgba(color) for color in multiclass_colors]
@@ -684,6 +690,35 @@ def test_multiclass_colors_cmap(
             assert quad.cmap == cmaps[idx]
     else:
         assert_allclose(disp.surface_.colors, colors)
+
+
+def test_multiclass_not_enough_colors_error(pyplot):
+    """
+    Check that an error is raised if a qualitative colormap doesn't have enough colors.
+
+    Note: List length mismatch is already checked in
+    `test_input_validation_errors_multiclass_colors`.
+    """
+    X = np.array(
+        [
+            [-1, -1],
+            [-2, -1],
+            [1, 1],
+            [2, 1],
+            [2, 2],
+            [3, 2],
+            [3, 3],
+            [4, 3],
+            [4, 4],
+            [5, 4],
+            [5, 5],
+        ]
+    )
+    y = np.arange(11)
+    clf = LogisticRegression().fit(X, y)
+    msg = "Colormap 'tab10' only has 10 colors, but 11 classes are to be displayed."
+    with pytest.raises(ValueError, match=msg):
+        DecisionBoundaryDisplay.from_estimator(clf, X, multiclass_colors="tab10")
 
 
 @pytest.mark.parametrize("y", [np.arange(6), [str(i) for i in np.arange(6)]])

--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -166,29 +166,42 @@ def test_input_validation_errors(pyplot, kwargs, error_msg, fitted_clf):
 
 
 @pytest.mark.parametrize(
-    "kwargs, error_msg",
+    "kwargs, error_type, error_msg",
     [
         (
             {"multiclass_colors": {"dict": "not_list"}},
+            TypeError,
             "'multiclass_colors' must be a list or a str.",
         ),
-        ({"multiclass_colors": "not_cmap"}, "it must be a valid Matplotlib colormap"),
-        ({"multiclass_colors": ["red", "green"]}, "it must be of the same length"),
+        (
+            {"multiclass_colors": "not_cmap"},
+            ValueError,
+            "it must be a valid Matplotlib colormap",
+        ),
+        (
+            {"multiclass_colors": ["red", "green"]},
+            ValueError,
+            "it must be of the same length",
+        ),
         (
             {"multiclass_colors": ["red", "green", "blue", "yellow"]},
+            ValueError,
             "it must be of the same length",
         ),
         (
             {"multiclass_colors": ["red", "green", "not color"]},
+            ValueError,
             "it can only contain valid Matplotlib color names",
         ),
     ],
 )
-def test_input_validation_errors_multiclass_colors(pyplot, kwargs, error_msg):
+def test_input_validation_errors_multiclass_colors(
+    pyplot, kwargs, error_type, error_msg
+):
     """Check input validation for `multiclass_colors` in `from_estimator`."""
     X, y = load_iris_2d_scaled()
     clf = LogisticRegression().fit(X, y)
-    with pytest.raises(ValueError, match=error_msg):
+    with pytest.raises(error_type, match=error_msg):
         DecisionBoundaryDisplay.from_estimator(clf, X, **kwargs)
 
 

--- a/sklearn/utils/_optional_dependencies.py
+++ b/sklearn/utils/_optional_dependencies.py
@@ -17,8 +17,8 @@ def check_matplotlib_support(caller_name):
         import matplotlib  # noqa: F401
     except ImportError as e:
         raise ImportError(
-            "{} requires matplotlib. You can install matplotlib with "
-            "`pip install matplotlib`".format(caller_name)
+            f"{caller_name} requires matplotlib. You can install matplotlib with "
+            "`pip install matplotlib`"
         ) from e
 
 
@@ -43,4 +43,4 @@ def check_pandas_support(caller_name):
 
         return pandas
     except ImportError as e:
-        raise ImportError("{} requires pandas.".format(caller_name)) from e
+        raise ImportError(f"{caller_name} requires pandas.") from e


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #33115
Specifically, this implements checkboxes 1, 2, part of 3, and 5 (see next section for details)

#### What does this implement/fix? Explain your changes.
This PR moves all parts related to color selection based on 'multiclass_colors' into a sepparate function (3,5), unifies and simplifies the color selection mechanism (2) and adds a check that enough distinct colors are available in the given colormap (1).

It also adds a non-regression test for the last point, which is the only functionality change.

See also the comments in the code for more details.

@ogrisel @lucyleeow @StefanieSenger @antoinebaker 

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding


#### Any other comments?
Unrelated small change:
I converted the error messages in `sklearn/utils/_optional_dependencies.py` to f-strings.

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
