### PR TITLE
[Callbacks] Rename propagate_callbacks into propagate_callback_context

### DIFF
--- a/sklearn/callback/tests/_utils.py
+++ b/sklearn/callback/tests/_utils.py
@@ -214,7 +214,7 @@ def _func(meta_estimator, inner_estimator, X, y, *, outer_callback_ctx):
 
         inner_ctx = outer_callback_ctx.subcontext(
             task_name="inner", task_id=i
-        ).propagate_callbacks(sub_estimator=est)
+        ).propagate_callback_context(sub_estimator=est)
 
         est.fit(X, y)
 

--- a/sklearn/callback/tests/test_callback_context.py
+++ b/sklearn/callback/tests/test_callback_context.py
@@ -17,8 +17,8 @@ from sklearn.callback.tests._utils import (
 )
 
 
-def test_propagate_callbacks():
-    """Sanity check for the `propagate_callbacks` method."""
+def test_propagate_callback_context():
+    """Sanity check for the `propagate_callback_context` method."""
     not_propagated_callback = TestingCallback()
     propagated_callback = TestingAutoPropagatedCallback()
 
@@ -27,14 +27,14 @@ def test_propagate_callbacks():
     metaestimator.set_callbacks([not_propagated_callback, propagated_callback])
 
     callback_ctx = CallbackContext._from_estimator(metaestimator, "fit", 0, 0)
-    callback_ctx.propagate_callbacks(estimator)
+    callback_ctx.propagate_callback_context(estimator)
 
     assert hasattr(estimator, "_parent_callback_ctx")
     assert not_propagated_callback not in estimator._skl_callbacks
     assert propagated_callback in estimator._skl_callbacks
 
 
-def test_propagate_callback_no_callback():
+def test_propagate_callback_context_no_callback():
     """Check that no callback is propagated if there's no callback."""
     estimator = MaxIterEstimator()
     metaestimator = MetaEstimator(estimator)
@@ -42,7 +42,7 @@ def test_propagate_callback_no_callback():
     callback_ctx = CallbackContext._from_estimator(metaestimator, "fit", 0, 0)
     assert len(callback_ctx._callbacks) == 0
 
-    callback_ctx.propagate_callbacks(estimator)
+    callback_ctx.propagate_callback_context(estimator)
 
     assert not hasattr(metaestimator, "_skl_callbacks")
     assert not hasattr(estimator, "_skl_callbacks")


### PR DESCRIPTION
to be more explicit about what this method does because it propagates the context and the callbacks.

Extracted from https://github.com/scikit-learn/scikit-learn/pull/33340 because we decided to not couple propagate_callback_context and clone.

ping @lesteve @StefanieSenger 