### PR TITLE
FIX preserve signed dtype in label_binarize for uint targets (#33390)

### DIFF
--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -590,7 +590,7 @@ def label_binarize(y, *, classes, neg_label=0, pos_label=1, sparse_output=False)
 
     n_samples = y.shape[0] if hasattr(y, "shape") else len(y)
     n_classes = classes.shape[0]
-    if hasattr(y, "dtype") and xp.isdtype(y.dtype, "integral"):
+    if hasattr(y, "dtype") and xp.isdtype(y.dtype, "signed integer"):
         int_dtype_ = y.dtype
     else:
         int_dtype_ = indexing_dtype(xp)

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -716,6 +716,20 @@ def test_label_binarize_multiclass():
         )
 
 
+def test_label_binarize_uint_overflow():
+    y = np.array([0, 1, 0], dtype=np.uint64)
+
+    Y = label_binarize(
+        y,
+        classes=np.array([0, 1], dtype=np.uint64),
+        neg_label=-1,
+        pos_label=1,
+    )
+
+    assert np.issubdtype(Y.dtype, np.signedinteger)
+    assert_array_equal(Y, np.array([[-1], [1], [-1]]))
+
+
 @pytest.mark.parametrize(
     "arr_type",
     [np.array]


### PR DESCRIPTION

#### Reference Issues/PRs

Fixes #33390

#### What does this implement/fix? Explain your changes.

This PR fixes a numerical stability issue where `RidgeClassifier` produced incorrect (extreme) decision values when the input labels `y` were of an unsigned integer dtype (e.g., `uint64`).

**The Root Cause:**
In `sklearn/preprocessing/_label.py`, the `label_binarize` function was preserving the input's "integral" dtype. However, `RidgeClassifier` often uses a `neg_label` of `-1`. When `-1` is cast to an unsigned integer type (like `uint64`), it causes an integer overflow, resulting in a very large positive value (e.g., $2^{64}-1$).

**The Fix:**
I modified the dtype selection logic in `label_binarize` to only preserve the input dtype if it is a **signed integer**. If the input is unsigned, it now defaults to the system's standard indexing integer dtype (typically `int64`), which safely handles negative labels.

**Changes:**

* Updated `sklearn/preprocessing/_label.py` to use `xp.isdtype(y.dtype, "signed integer")`.
* Added a regression test in `sklearn/preprocessing/tests/test_label.py` that specifically checks for `uint64` inputs with negative labels.

#### AI usage disclosure

I used AI assistance for:

* [x] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [x] Documentation (including examples)
* [x] Research and understanding

#### Any other comments?

This fix ensures compatibility with the Python Array API standards by using explicit `isdtype` checks. I have verified that this restores parity between signed and unsigned integer inputs for `RidgeClassifier`.
