### PR TITLE
FIX avoid false DataConversionWarning in pairwise_distances_argmin with boolean metric

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -796,7 +796,8 @@ def pairwise_distances_argmin_min(
     array([1., 1.])
     """
     ensure_all_finite = "allow-nan" if metric == "nan_euclidean" else True
-    X, Y = check_pairwise_arrays(X, Y, ensure_all_finite=ensure_all_finite)
+    dtype = bool if metric in PAIRWISE_BOOLEAN_FUNCTIONS else None
+    X, Y = check_pairwise_arrays(X, Y, dtype=dtype, ensure_all_finite=ensure_all_finite)
 
     if axis == 0:
         X, Y = Y, X
@@ -937,7 +938,8 @@ def pairwise_distances_argmin(X, Y, *, axis=1, metric="euclidean", metric_kwargs
     array([0, 1])
     """
     ensure_all_finite = "allow-nan" if metric == "nan_euclidean" else True
-    X, Y = check_pairwise_arrays(X, Y, ensure_all_finite=ensure_all_finite)
+    dtype = bool if metric in PAIRWISE_BOOLEAN_FUNCTIONS else None
+    X, Y = check_pairwise_arrays(X, Y, dtype=dtype, ensure_all_finite=ensure_all_finite)
     xp, _ = get_namespace(X, Y)
 
     if axis == 0:

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -725,6 +725,24 @@ def test_pairwise_distances_argmin_min(dok_container, csr_container, global_dtyp
     assert_array_equal(argmin_C_contiguous, argmin_F_contiguous)
 
 
+def test_pairwise_distances_argmin_no_conversion_warning_bool_metric():
+    # Regression test for GitHub issue #32495:
+    # pairwise_distances_argmin and pairwise_distances_argmin_min should not
+    # emit a DataConversionWarning when both arrays are already bool and a
+    # boolean metric (e.g. jaccard) is used.
+    rng = np.random.RandomState(42)
+    X = rng.randint(0, 2, size=(5, 10)).astype(bool)
+    Y = rng.randint(0, 2, size=(8, 10)).astype(bool)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DataConversionWarning)
+        pairwise_distances_argmin_min(X, Y, metric="jaccard")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DataConversionWarning)
+        pairwise_distances_argmin(X, Y, metric="jaccard")
+
+
 def _reduce_func(dist, start):
     return dist[:, :100]
 


### PR DESCRIPTION
Fixes #32495. When metric requires boolean data, pass dtype=bool to check_pairwise_arrays in pairwise_distances_argmin and pairwise_distances_argmin_min so the original bool dtype is preserved through the call chain and no spurious DataConversionWarning is emitted.