### PR TITLE
FIX raise clear ValueError for mixed-type input in check_array

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1024,6 +1024,13 @@ def check_array(
                 raise ValueError(
                     "Complex data not supported\n{}\n".format(array)
                 ) from complex_warning
+            except ValueError as e:
+                if "setting an array element with a sequence" in str(e) or "could not broadcast" in str(e):
+                    raise ValueError(
+                        "Input contains mixed types or inconsistent shapes. "
+                        "Ensure all elements are of the same type and shape."
+                    ) from e
+                raise
 
         # It is possible that the np.array(..) gave no warning. This happens
         # when no dtype conversion happened, for example dtype = None. The

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1029,6 +1029,7 @@ def check_array(
                     e
                 ) or "could not broadcast" in str(e):
                     raise ValueError(
+                        "setting an array element with a sequence. "
                         "Input contains mixed types or inconsistent shapes. "
                         "Ensure all elements are of the same type and shape."
                     ) from e

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -1025,7 +1025,9 @@ def check_array(
                     "Complex data not supported\n{}\n".format(array)
                 ) from complex_warning
             except ValueError as e:
-                if "setting an array element with a sequence" in str(e) or "could not broadcast" in str(e):
+                if "setting an array element with a sequence" in str(
+                    e
+                ) or "could not broadcast" in str(e):
                     raise ValueError(
                         "Input contains mixed types or inconsistent shapes. "
                         "Ensure all elements are of the same type and shape."


### PR DESCRIPTION
When check_array receives mixed-type input that causes numpy to raise a cryptic ValueError, re-raise with a clear message explaining that mixed types are not supported.