### PR TITLE
DOC: explain why __ is used instead of . for nested params (#33428)

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -277,6 +277,15 @@ General Concepts
         :term:`sample properties` to the ``fit`` methods of estimators in
         the pipeline.
 
+        The double underscore (``__``) is used instead of a dot (``.``)
+        because :term:`set_params` accepts Python keyword arguments
+        (``**kwargs``), and Python does not allow dots in keyword argument
+        names (e.g., ``pipe.set_params(clf.C=10)`` would be a
+        ``SyntaxError``). Because ``param_grid`` keys in
+        :class:`~sklearn.model_selection.GridSearchCV` are ultimately passed
+        to :term:`set_params`, the same ``__`` convention is used
+        consistently throughout scikit-learn.
+
     dtype
     data type
         NumPy arrays assume a homogeneous data type throughout, available in

--- a/doc/modules/grid_search.rst
+++ b/doc/modules/grid_search.rst
@@ -599,7 +599,18 @@ parameters of composite or nested estimators such as
 :class:`~sklearn.compose.ColumnTransformer`,
 :class:`~sklearn.ensemble.VotingClassifier` or
 :class:`~sklearn.calibration.CalibratedClassifierCV` using a dedicated
-``<estimator>__<parameter>`` syntax::
+``<estimator>__<parameter>`` syntax.
+
+.. note::
+
+   The double underscore (``__``) is used as a separator instead of a dot
+   (``.``) because :meth:`~sklearn.base.BaseEstimator.set_params` accepts
+   Python keyword arguments (``**kwargs``), and Python does not allow dots in
+   keyword argument names. For example, ``pipe.set_params(clf.C=10)`` would
+   raise a ``SyntaxError``. Since ``param_grid`` keys are passed to
+   ``set_params`` internally, the same ``__`` convention applies.
+
+Example::
 
   >>> from sklearn.model_selection import GridSearchCV
   >>> from sklearn.calibration import CalibratedClassifierCV

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1272,6 +1272,14 @@ class GridSearchCV(BaseSearchCV):
         in the list are explored. This enables searching over any sequence
         of parameter settings.
 
+        When the estimator is a composite estimator such as
+        :class:`~sklearn.pipeline.Pipeline`, nested parameters can be
+        specified using the ``<estimator>__<parameter>`` syntax (double
+        underscore). For example,
+        ``{'clf__C': [0.1, 1, 10]}`` tunes parameter ``C`` of step
+        ``clf``.  See :ref:`composite_grid_search` and
+        :term:`double underscore` for details.
+
     scoring : str, callable, list, tuple or dict, default=None
         Strategy to evaluate the performance of the cross-validated model on
         the test set.


### PR DESCRIPTION
### What
Clarified why double underscore (`__`) is used instead of dot (`.`) for nested parameters in GridSearchCV.  
Changes applied to:
- Glossary
- User Guide
- GridSearchCV docstring

### Why
The previous wording was unclear and could confuse users when setting parameters in a Pipeline.  
This documentation update helps beginners understand the correct syntax.

### Notes
No code behavior is changed; this is purely documentation.