### PR TITLE
FIX always pass `fill_value` to `xp.full` as per array API spec

### DIFF
--- a/doc/whats_new/upcoming_changes/array-api/33437.fix.rst
+++ b/doc/whats_new/upcoming_changes/array-api/33437.fix.rst
@@ -1,0 +1,5 @@
+- :func:`linear_model.ridge_regression` now correctly passes a Python scalar as
+  ``fill_value`` to ``xp.full`` when broadcasting alpha for multi-target
+  regression, ensuring compliance with the array API specification. This fixes
+  compatibility issues with some array API backends.
+  By :user:`Olivier Grisel <ogrisel>`.

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/33437.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/33437.fix.rst
@@ -1,0 +1,5 @@
+- :func:`linear_model.ridge_regression` now correctly passes a Python scalar as
+  ``fill_value`` to ``xp.full`` when broadcasting alpha for multi-target
+  regression, ensuring compliance with the array API specification. This fixes
+  compatibility issues with some array API backends.
+  By :user:`Olivier Grisel <ogrisel>`

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/33437.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/33437.fix.rst
@@ -2,4 +2,4 @@
   ``fill_value`` to ``xp.full`` when broadcasting alpha for multi-target
   regression, ensuring compliance with the array API specification. This fixes
   compatibility issues with some array API backends.
-  By :user:`Olivier Grisel <ogrisel>`
+  By :user:`Olivier Grisel <ogrisel>`.

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -721,7 +721,10 @@ def _ridge_regression(
 
     if alpha.shape[0] == 1 and n_targets > 1:
         alpha = xp.full(
-            shape=(n_targets,), fill_value=alpha[0], dtype=alpha.dtype, device=device_
+            shape=(n_targets,),
+            fill_value=float(alpha[0]),
+            dtype=alpha.dtype,
+            device=device_,
         )
 
     n_iter = None


### PR DESCRIPTION
As discussed in https://github.com/data-apis/array-api-strict/issues/55, passing 0d arrays as `fill_value` to `xp.full` is not guaranteed to work for all array API libraries, hence `array-api-strict` started to reject such inputs as of version 2.5.

This PR should fix the failures discovered in the related lockfile update PRS: #33434 and #33432.