### PR TITLE
Fix standard scaler negative weights

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -921,10 +921,6 @@ class StandardScaler(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
         """
         # Reset internal state before fitting
         self._reset()
-        if sample_weight is not None:
-            sample_weight = _check_sample_weight(
-                sample_weight, X, dtype=X.dtype,ensure_non_negative=True
-            )
         return self.partial_fit(X, y, sample_weight)
 
     @_fit_context(prefer_skip_nested_validation=True)
@@ -974,7 +970,7 @@ class StandardScaler(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
 
         if sample_weight is not None:
             sample_weight = _check_sample_weight(
-                sample_weight, X, dtype=X.dtype,ensure_non_negative=True
+                sample_weight, X, dtype=X.dtype, ensure_non_negative=True
             )
 
         # Even in the case of `with_mean=False`, we update the mean anyway

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -921,6 +921,10 @@ class StandardScaler(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
         """
         # Reset internal state before fitting
         self._reset()
+        if sample_weight is not None:
+            sample_weight = _check_sample_weight(
+                sample_weight, X, dtype=X.dtype, ensure_non_negative=True
+            )
         return self.partial_fit(X, y, sample_weight)
 
     @_fit_context(prefer_skip_nested_validation=True)
@@ -969,7 +973,9 @@ class StandardScaler(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
         n_features = X.shape[1]
 
         if sample_weight is not None:
-            sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
+            sample_weight = _check_sample_weight(
+                sample_weight, X, dtype=X.dtype, ensure_non_negative=True
+            )
 
         # Even in the case of `with_mean=False`, we update the mean anyway
         # This is needed for the incremental computation of the var

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -923,7 +923,7 @@ class StandardScaler(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
         self._reset()
         if sample_weight is not None:
             sample_weight = _check_sample_weight(
-                sample_weight, X, ensure_non_negative=True
+                sample_weight, X, dtype=X.dtype,ensure_non_negative=True
             )
         return self.partial_fit(X, y, sample_weight)
 
@@ -974,7 +974,7 @@ class StandardScaler(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
 
         if sample_weight is not None:
             sample_weight = _check_sample_weight(
-                sample_weight, X, ensure_non_negative=True
+                sample_weight, X, dtype=X.dtype,ensure_non_negative=True
             )
 
         # Even in the case of `with_mean=False`, we update the mean anyway

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -923,7 +923,7 @@ class StandardScaler(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
         self._reset()
         if sample_weight is not None:
             sample_weight = _check_sample_weight(
-                sample_weight, X, dtype=X.dtype, ensure_non_negative=True
+                sample_weight, X, ensure_non_negative=True
             )
         return self.partial_fit(X, y, sample_weight)
 
@@ -974,7 +974,7 @@ class StandardScaler(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
 
         if sample_weight is not None:
             sample_weight = _check_sample_weight(
-                sample_weight, X, dtype=X.dtype, ensure_non_negative=True
+                sample_weight, X, ensure_non_negative=True
             )
 
         # Even in the case of `with_mean=False`, we update the mean anyway

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2834,14 +2834,19 @@ def test_yeojohnson_for_different_scipy_version():
     pt = PowerTransformer(method="yeo-johnson").fit(X_1col)
     pt.lambdas_[0] == pytest.approx(0.99546157, rel=1e-7)
 
+
 def test_standard_scaler_negative_sample_weight():
     """Check that StandardScaler fit and partial_fit reject negative weights."""
     X = np.array([[10.0], [0.0], [5.0]])
     sample_weight = np.array([-2.0, 1.0, 1.5])
     scaler = StandardScaler()
 
-    with pytest.raises(ValueError, match="Negative values in data passed to `sample_weight`"):
+    with pytest.raises(
+        ValueError, match="Negative values in data passed to `sample_weight`"
+    ):
         scaler.fit(X, sample_weight=sample_weight)
 
-    with pytest.raises(ValueError, match="Negative values in data passed to `sample_weight`"):
+    with pytest.raises(
+        ValueError, match="Negative values in data passed to `sample_weight`"
+    ):
         scaler.partial_fit(X, sample_weight=sample_weight)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2834,15 +2834,14 @@ def test_yeojohnson_for_different_scipy_version():
     pt = PowerTransformer(method="yeo-johnson").fit(X_1col)
     pt.lambdas_[0] == pytest.approx(0.99546157, rel=1e-7)
 
-
 def test_standard_scaler_negative_sample_weight():
     """Check that StandardScaler fit and partial_fit reject negative weights."""
     X = np.array([[10.0], [0.0], [5.0]])
     sample_weight = np.array([-2.0, 1.0, 1.5])
     scaler = StandardScaler()
 
-    with pytest.raises(ValueError, match="Sample weights have negative values"):
+    with pytest.raises(ValueError, match="Negative values in data passed to `sample_weight`"):
         scaler.fit(X, sample_weight=sample_weight)
 
-    with pytest.raises(ValueError, match="Sample weights have negative values"):
+    with pytest.raises(ValueError, match="Negative values in data passed to `sample_weight`"):
         scaler.partial_fit(X, sample_weight=sample_weight)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -2833,3 +2833,16 @@ def test_yeojohnson_for_different_scipy_version():
     """Check that the results are consistent across different SciPy versions."""
     pt = PowerTransformer(method="yeo-johnson").fit(X_1col)
     pt.lambdas_[0] == pytest.approx(0.99546157, rel=1e-7)
+
+
+def test_standard_scaler_negative_sample_weight():
+    """Check that StandardScaler fit and partial_fit reject negative weights."""
+    X = np.array([[10.0], [0.0], [5.0]])
+    sample_weight = np.array([-2.0, 1.0, 1.5])
+    scaler = StandardScaler()
+
+    with pytest.raises(ValueError, match="Sample weights have negative values"):
+        scaler.fit(X, sample_weight=sample_weight)
+
+    with pytest.raises(ValueError, match="Sample weights have negative values"):
+        scaler.partial_fit(X, sample_weight=sample_weight)


### PR DESCRIPTION
#### What does this implement/fix?
`StandardScaler.fit` and `.partial_fit` now reject negative `sample_weight`.

They now call `_check_sample_weight(..., ensure_non_negative=True)` 

This prevents negative weights from producing impossible negative variance, a RuntimeWarning, and silent `scale_=1` fallback.

#### Any other comments?
- Validation hardening: zero behavior change for valid (non-negative) weights.
- Added minimal test `test_standard_scaler_negative_sample_weight` covering both `fit` and `partial_fit`.

#### Notes
This is a gap in the preprocessing module (`sklearn.preprocessing`).  
Most estimators are solid with the `ensure_non_negative` flag. Preprocessing has not this flag.

**AI usage disclosure**  
I used AI assistance for:  
- [x] Code generation  
- [x] Test generation  
