### PR TITLE
MAINT only run the cuda tests on the CUDA CI runner

### DIFF
--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -66,6 +66,9 @@ jobs:
           conda activate sklearn
           python -c "import sklearn; sklearn.show_versions()"
 
-          SCIPY_ARRAY_API=1 pytest --pyargs sklearn -k 'array_api' -vl
+          # Since we are billed GPU usage by the minute, we only run the tests that
+          # are likely to exercise the CUDA GPU and rely on free CI runners to run
+          # the tests with PyTorch on non-CUDA devices.
+          SCIPY_ARRAY_API=1 pytest --pyargs sklearn -k 'cuda' -k 'cupy' -vl
         # Run in /home/runner to not load sklearn from the checkout repo
         working-directory: /home/runner

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -69,6 +69,6 @@ jobs:
           # Since we are billed GPU usage by the minute, we only run the tests that
           # are likely to exercise the CUDA GPU and rely on free CI runners to run
           # the tests with PyTorch on non-CUDA devices.
-          SCIPY_ARRAY_API=1 pytest --pyargs sklearn -k 'cuda' -k 'cupy' -vl
+          SCIPY_ARRAY_API=1 pytest --pyargs sklearn -k 'cuda or cupy' -vl
         # Run in /home/runner to not load sklearn from the checkout repo
         working-directory: /home/runner


### PR DESCRIPTION
Since the number of array API related tests is growing quite quickly and since we already run all tests for non-CUDA devices on other CI hosts, I figured we could change the pytest filter for this config.

This will also allow use to have more freedom in the naming of test functions parametrized for array API namespace testing and as a result have more freedom to evolve our array API testing policy:

https://github.com/scikit-learn/scikit-learn/pull/33345/changes#r2845855747