### PR TITLE
FEAT Add RollingTimeSeriesSplit class and tests

### DIFF
--- a/sklearn/model_selection/__init__.py
+++ b/sklearn/model_selection/__init__.py
@@ -34,6 +34,7 @@ from sklearn.model_selection._split import (
     StratifiedKFold,
     StratifiedShuffleSplit,
     TimeSeriesSplit,
+    RollingTimeSeriesSplit,
     check_cv,
     train_test_split,
 )
@@ -81,6 +82,7 @@ __all__ = [
     "StratifiedKFold",
     "StratifiedShuffleSplit",
     "TimeSeriesSplit",
+    "RollingTimeSeriesSplit",
     "TunedThresholdClassifierCV",
     "ValidationCurveDisplay",
     "check_cv",

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -18,8 +18,6 @@ from math import ceil, floor
 import numpy as np
 from scipy.special import comb
 
-from sklearn.model_selection import BaseCrossValidator
-
 from sklearn.utils import (
     _safe_indexing,
     check_random_state,
@@ -50,6 +48,7 @@ __all__ = [
     "PredefinedSplit",
     "RepeatedKFold",
     "RepeatedStratifiedKFold",
+    "RollingTimeSeriesSplit",
     "ShuffleSplit",
     "StratifiedGroupKFold",
     "StratifiedKFold",

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -18,6 +18,8 @@ from math import ceil, floor
 import numpy as np
 from scipy.special import comb
 
+from sklearn.model_selection import BaseCrossValidator
+
 from sklearn.utils import (
     _safe_indexing,
     check_random_state,
@@ -1319,6 +1321,134 @@ class TimeSeriesSplit(_BaseKFold):
                     indices[test_start : test_start + test_size],
                 )
 
+
+class RollingTimeSeriesSplit(BaseCrossValidator):
+    """Rolling Window Cross-Validator.
+
+    Provides train/test indices to split time-series data using a fixed-size
+    sliding window. Unlike the standard TimeSeriesSplit, this class:
+    1. Uses fixed `train_size` and `test_size` instead of `n_splits`.
+    2. Is right-aligned (anchored to the end of the dataset) to prioritize
+       recent data.
+    3. Adds any historical remainder (data too old to fit a full block)
+       to the first training set.
+
+    Parameters
+    ----------
+    train_size : int
+        Size of the training set in each split.
+
+    test_size : int
+        Size of the test set in each split.
+
+    step_size : int, optional
+        Number of samples to shift the window between splits.
+        - If None, defaults to `train_size` (resulting in disjoint training
+          sets).
+        - If equal to `test_size`, results in a standard rolling window where
+          the test set of split N becomes part of the train set of split N+1.
+
+    gap : int, default=0
+        Number of samples to exclude from the end of each train set before
+        the test set.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.model_selection import RollingTimeSeriesSplit
+    >>> X = np.arange(14)
+    >>> # User case: Train=4, Test=1, Disjoint (step=4)
+    >>> cv = RollingTimeSeriesSplit(train_size=4, test_size=1, step_size=4)
+    >>> for i, (train, test) in enumerate(cv.split(X)):
+    ...     print(f"Split {i}: Train={train}, Test={test}")
+    Split 0: Train=[0 1 2 3 4], Test=[5]
+    Split 1: Train=[5 6 7 8], Test=[9]
+    Split 2: Train=[9 10 11 12], Test=[13]
+    """
+
+    def __init__(self, train_size, test_size, step_size=None, gap=0):
+        self.train_size = train_size
+        self.test_size = test_size
+        self.step_size = step_size
+        self.gap = gap
+
+    def get_n_splits(self, X=None, y=None, groups=None):
+        """Returns the number of splitting iterations in the cross-validator."""
+        if X is None:
+            raise ValueError(
+                "The 'X' parameter is required to calculate n_splits."
+            )
+
+        n_samples = _num_samples(X)
+
+        # Default step to train_size for disjoint behavior if not specified
+        step = (
+            self.step_size
+            if self.step_size is not None
+            else self.train_size
+        )
+
+        # Minimal size required for one split
+        min_len = self.train_size + self.gap + self.test_size
+
+        if n_samples < min_len:
+            return 0
+
+        # Calculation: (Total - First_Window_Size) // Step + 1
+        # This accounts for the fixed window sliding from the end.
+        return (n_samples - min_len) // step + 1
+
+    def split(self, X, y=None, groups=None):
+        """Generate indices to split data into training and test set."""
+        X, y, groups = indexable(X, y, groups)
+        n_samples = _num_samples(X)
+        indices = np.arange(n_samples)
+
+        step = (
+            self.step_size
+            if self.step_size is not None
+            else self.train_size
+        )
+        gap = self.gap
+
+        n_splits = self.get_n_splits(X, y, groups)
+
+        if n_splits <= 0:
+            raise ValueError(
+                f"n_samples={n_samples} is too small for the "
+                "given parameters."
+            )
+
+        # --- Right-Alignment Logic ---
+
+        # 1. Total length covered by the structured splits (perfect blocks)
+        #    Length = One_Block + (N_Splits - 1) * Step
+        block_len = self.train_size + gap + self.test_size
+        total_covered = block_len + (n_splits - 1) * step
+
+        # 2. The remainder is the indices at the start that don't fit a
+        # full step
+        remainder = n_samples - total_covered
+
+        # 3. Generate splits forward
+        for i in range(n_splits):
+            # Calculate theoretical start based on step
+            base_start = remainder + (i * step)
+
+            if i == 0:
+                # The first split absorbs the remainder (history extension)
+                train_start = 0
+            else:
+                train_start = base_start
+
+            # End of train is always relative to base_start to maintain fixed
+            # size (except for the first split which is effectively larger)
+            train_end = base_start + self.train_size
+
+            test_start = train_end + gap
+            test_end = test_start + self.test_size
+
+            yield indices[train_start:train_end], indices[test_start:test_end]
 
 class LeaveOneGroupOut(GroupsConsumerMixin, BaseCrossValidator):
     """Leave One Group Out cross-validator.

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -30,6 +30,7 @@ from sklearn.model_selection import (
     StratifiedKFold,
     StratifiedShuffleSplit,
     TimeSeriesSplit,
+    RollingTimeSeriesSplit,
     check_cv,
     cross_val_score,
     train_test_split,
@@ -917,9 +918,9 @@ def test_stratified_shuffle_split_even():
         bf = stats.binom(n_splits, p)
         for count in idx_counts:
             prob = bf.pmf(count)
-            assert prob > threshold, (
-                "An index is not drawn with chance corresponding to even draws"
-            )
+            assert (
+                prob > threshold
+            ), "An index is not drawn with chance corresponding to even draws"
 
     for n_samples in (6, 22):
         groups = np.array((n_samples // 2) * [0, 1])
@@ -2132,3 +2133,104 @@ def test_stratified_splitter_without_y(cv):
     msg = "missing 1 required positional argument: 'y'"
     with pytest.raises(TypeError, match=msg):
         cv.split(X)
+
+
+def test_rolling_time_series_split_basics():
+    """Test standard disjoint behavior of RollingTimeSeriesSplit."""
+    X = np.arange(14)
+    # Train=4, Test=1. Default step=4 (disjoint).
+    # Logic: 14 samples.
+    # Block size = 5 (4 train + 1 test).
+    # Fits 2 full blocks (indices 4-8, 9-13).
+    # Remainder logic: The first block absorbs the history.
+
+    cv = RollingTimeSeriesSplit(train_size=4, test_size=1)
+    splits = list(cv.split(X))
+
+    assert len(splits) == 3
+
+    # Split 0: Absorbs remainder (14 - 13 used = 1 remainder).
+    # Train normal (4) + Remainder (1) = 5.
+    assert_array_equal(splits[0][0], [0, 1, 2, 3, 4])
+    assert_array_equal(splits[0][1], [5])
+
+    # Split 1: Disjoint strict
+    assert_array_equal(splits[1][0], [5, 6, 7, 8])
+    assert_array_equal(splits[1][1], [9])
+
+    # Split 2: Anchored to end
+    assert_array_equal(splits[2][0], [9, 10, 11, 12])
+    assert_array_equal(splits[2][1], [13])
+
+
+def test_rolling_time_series_split_overlap():
+    """Test overlapping windows with explicit step_size."""
+    X = np.arange(10)
+    # Train=3, Test=1, Step=1 (High overlap)
+    cv = RollingTimeSeriesSplit(train_size=3, test_size=1, step_size=1)
+    splits = list(cv.split(X))
+
+    # Min length = 4. 10 - 4 = 6 steps possible + 1 initial = 7 splits.
+    assert len(splits) == 7
+
+    # Check last split (Right aligned)
+    assert_array_equal(splits[-1][0], [6, 7, 8])
+    assert_array_equal(splits[-1][1], [9])
+
+    # Check previous split
+    assert_array_equal(splits[-2][0], [5, 6, 7])
+    assert_array_equal(splits[-2][1], [8])
+
+
+def test_rolling_time_series_split_gap():
+    """Test gap parameter with RollingTimeSeriesSplit."""
+    X = np.arange(10)
+    # Train=2, Gap=2, Test=1. Total block = 5. Step default=2.
+    cv = RollingTimeSeriesSplit(train_size=2, test_size=1, gap=2, step_size=2)
+    splits = list(cv.split(X))
+
+    # Expected:
+    # Last split: Test=[9]. Gap=[7,8]. Train=[5,6].
+    # Prev split: Test=[7]. Gap=[5,6]. Train=[3,4].
+    # First split: Test=[5]. Gap=[3,4]. Train=[0,1,2] (Absorbs remainder of 1).
+
+    assert len(splits) == 3
+
+    # Check last split
+    assert_array_equal(splits[-1][0], [5, 6])
+    assert_array_equal(splits[-1][1], [9])
+
+    # Check first split (remainder handling)
+    assert_array_equal(splits[0][0], [0, 1, 2])
+    assert_array_equal(splits[0][1], [5])
+
+
+def test_rolling_time_series_split_validation():
+    """Test input validation for RollingTimeSeriesSplit."""
+    X = np.arange(5)
+
+    # Error: Data too small
+    with pytest.raises(ValueError, match="too small"):
+        cv = RollingTimeSeriesSplit(train_size=10, test_size=1)
+        next(cv.split(X))
+
+    # Error: Step size 0 or negative (if not handled by init, check split)
+    # Assuming step_size must be positive if implemented in check_cv or logic
+    # This depends on your implementation details, but usually good to check.
+
+
+def test_rolling_time_series_split_compatibility():
+    """Check compatibility with generic scikit-learn utilities."""
+    X = np.random.randn(20, 2)
+    y = np.random.randint(0, 2, 20)
+
+    cv = RollingTimeSeriesSplit(train_size=10, test_size=5)
+
+    # Should work with cross_val_score
+    scores = cross_val_score(DummyClassifier(), X, y, cv=cv)
+    assert len(scores) > 0
+
+    # Should work with check_cv (generic validator)
+    # Note: check_cv calls split(), so this validates API conformance
+    cv_checked = check_cv(cv, y, classifier=True)
+    assert cv_checked is cv


### PR DESCRIPTION
### **Reference Issues/PRs : Fixes #33520**
Addresses a common need for fixed-window cross-validation (rolling origin) in time series, distinct from the expanding window strategy of `TimeSeriesSplit`.

### **What does this implement/fix? Explain your changes.**
This PR introduces a new cross-validator: `RollingTimeSeriesSplit`.

### **Motivation:**
The current `TimeSeriesSplit` implements an expanding window strategy (the training set grows over time). However, in many time-series applications (finance, physics, demand forecasting), it is standard to use a **fixed sliding window** (Walk-Forward Validation) to detect concept drift and validate model performance on strictly recent history.

While `TimeSeriesSplit` accepts a `max_train_size`, forcing it to behave like a strict rolling window with a specific step size is currently unintuitive and requires complex calculations of n_splits based on the dataset length.

### **Proposed Solution:**
`RollingTimeSeriesSplit` allows defining:

- `train_size` (fixed)
- `test_size` (fixed)
- `step_size` (optional, defaults to train_size for disjoint windows)
- `gap` (optional, for embargo/purge)

### **Key Feature - Right Alignment:**
Unlike standard implementations that might drop recent data if the division isn't perfect, this implementation is **right-aligned**. It anchors the splits to the end of the dataset (most recent data). Any historical "remainder" (indices at the start that don't fit a full fold) is added to the first training set. This ensures the model is always validated on the latest available data.

### **AI usage disclosure**
I used AI assistance for:

- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

### **Any other comments?**
I have added unit tests in `sklearn/model_selection/tests/test_split.py` covering:

- Disjoint windows (`step_size` = `train_size`)
- Overlapping windows (`step_size` < `train_size`)
- The `gap` parameter
- The right-alignment logic (remainder handling)

### **Example usage:**
```
import numpy as np
from sklearn.model_selection import RollingTimeSeriesSplit

X = np.arange(14)
# Scenario: Train on 4 samples, Test on 1 sample. 
# Default step=4 (disjoint). 
# Remainder (1 sample) goes to the first train set.

cv = RollingTimeSeriesSplit(train_size=4, test_size=1)

for i, (train, test) in enumerate(cv.split(X)):
    print(f"Split {i}: Train={train}, Test={test}")

# Output:
# Split 0: Train=[0 1 2 3 4], Test=[5]  <-- Absorbs index 0 (remainder)
# Split 1: Train=[5 6 7 8], Test=[9]
# Split 2: Train=[9 10 11 12], Test=[13] <-- Perfectly aligned with end
```
