### PR TITLE
[Callbacks] ENH Add callback support to KMeans and MiniBatchKMeans

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.cluster/33468.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.cluster/33468.enhancement.rst
@@ -1,0 +1,3 @@
+- :class:`cluster.MiniBatchKMeans` now supports callbacks during ``fit`` and
+  ``partial_fit`` when using the experimental callbacks API.
+  By :user:`gustavorubim`.

--- a/doc/whats_new/upcoming_changes/sklearn.cluster/33468.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.cluster/33468.enhancement.rst
@@ -1,3 +1,5 @@
-- :class:`cluster.MiniBatchKMeans` now supports callbacks during ``fit`` and
-  ``partial_fit`` when using the experimental callbacks API.
+- :class:`cluster.KMeans` and :class:`cluster.MiniBatchKMeans` now support
+  callbacks during ``fit`` when using the experimental callbacks API.
+  :class:`cluster.MiniBatchKMeans` also supports callbacks during
+  ``partial_fit``.
   By :user:`gustavorubim`.

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -468,6 +468,8 @@ def _kmeans_single_elkan(
     verbose=False,
     tol=1e-4,
     n_threads=1,
+    estimator=None,
+    callback_ctx=None,
 ):
     """A single run of k-means elkan, assumes preparation completed prior.
 
@@ -582,23 +584,39 @@ def _kmeans_single_elkan(
             print(f"Iteration {i}, inertia {inertia}")
 
         centers, centers_new = centers_new, centers
+        center_shift_tot = (center_shift**2).sum()
+        should_stop = False
 
         if np.array_equal(labels, labels_old):
             # First check the labels for strict convergence.
             if verbose:
                 print(f"Converged at iteration {i}: strict convergence.")
             strict_convergence = True
-            break
+            should_stop = True
         else:
             # No strict convergence, check for tol based convergence.
-            center_shift_tot = (center_shift**2).sum()
             if center_shift_tot <= tol:
                 if verbose:
                     print(
                         f"Converged at iteration {i}: center shift "
                         f"{center_shift_tot} within tolerance {tol}."
                     )
-                break
+                should_stop = True
+
+        callback_stop = _eval_kmeans_iter_task_end(
+            estimator,
+            callback_ctx,
+            task_id=i,
+            X=X,
+            sample_weight=sample_weight,
+            cluster_centers=centers,
+            labels=labels,
+            center_shift_tot=center_shift_tot,
+            strict_convergence=strict_convergence,
+        )
+
+        if should_stop or callback_stop:
+            break
 
         labels_old[:] = labels
 
@@ -636,6 +654,8 @@ def _kmeans_single_lloyd(
     verbose=False,
     tol=1e-4,
     n_threads=1,
+    estimator=None,
+    callback_ctx=None,
 ):
     """A single run of k-means lloyd, assumes preparation completed prior.
 
@@ -720,23 +740,39 @@ def _kmeans_single_lloyd(
             print(f"Iteration {i}, inertia {inertia}.")
 
         centers, centers_new = centers_new, centers
+        center_shift_tot = (center_shift**2).sum()
+        should_stop = False
 
         if np.array_equal(labels, labels_old):
             # First check the labels for strict convergence.
             if verbose:
                 print(f"Converged at iteration {i}: strict convergence.")
             strict_convergence = True
-            break
+            should_stop = True
         else:
             # No strict convergence, check for tol based convergence.
-            center_shift_tot = (center_shift**2).sum()
             if center_shift_tot <= tol:
                 if verbose:
                     print(
                         f"Converged at iteration {i}: center shift "
                         f"{center_shift_tot} within tolerance {tol}."
                     )
-                break
+                should_stop = True
+
+        callback_stop = _eval_kmeans_iter_task_end(
+            estimator,
+            callback_ctx,
+            task_id=i,
+            X=X,
+            sample_weight=sample_weight,
+            cluster_centers=centers,
+            labels=labels,
+            center_shift_tot=center_shift_tot,
+            strict_convergence=strict_convergence,
+        )
+
+        if should_stop or callback_stop:
+            break
 
         labels_old[:] = labels
 
@@ -757,6 +793,58 @@ def _kmeans_single_lloyd(
     inertia = _inertia(X, sample_weight, centers, labels, n_threads)
 
     return labels, inertia, centers, i + 1
+
+
+def _eval_kmeans_iter_task_end(
+    estimator,
+    callback_ctx,
+    *,
+    task_id,
+    X,
+    sample_weight,
+    cluster_centers,
+    labels,
+    center_shift_tot,
+    strict_convergence,
+):
+    """Evaluate callbacks for a completed KMeans iteration."""
+    if callback_ctx is None:
+        return False
+
+    subcontext = callback_ctx.subcontext(task_name="iter", task_id=task_id)
+    return subcontext.eval_on_fit_task_end(
+        estimator=estimator,
+        data={"X_train": X, "sample_weight": sample_weight},
+        cluster_centers=cluster_centers,
+        labels=labels,
+        center_shift_tot=center_shift_tot,
+        strict_convergence=strict_convergence,
+    )
+
+
+def _eval_kmeans_init_task_end(
+    estimator,
+    callback_ctx,
+    *,
+    X,
+    sample_weight,
+    cluster_centers,
+    labels,
+    inertia,
+    n_iter,
+):
+    """Evaluate callbacks for a completed KMeans initialization."""
+    if callback_ctx is None:
+        return False
+
+    return callback_ctx.eval_on_fit_task_end(
+        estimator=estimator,
+        data={"X_train": X, "sample_weight": sample_weight},
+        cluster_centers=cluster_centers,
+        labels=labels,
+        inertia=inertia,
+        n_iter=n_iter,
+    )
 
 
 def _labels_inertia(X, sample_weight, centers, n_threads=1, return_inertia=True):
@@ -1190,7 +1278,7 @@ class _BaseKMeans(
         return tags
 
 
-class KMeans(_BaseKMeans):
+class KMeans(CallbackSupportMixin, _BaseKMeans):
     """K-Means clustering.
 
     Read more in the :ref:`User Guide <k_means>`.
@@ -1500,8 +1588,13 @@ class KMeans(_BaseKMeans):
             self._check_mkl_vcomp(X, X.shape[0])
 
         best_inertia, best_labels = None, None
+        callback_ctx = self._init_callback_context(max_subtasks=self._n_init)
+        callback_ctx.eval_on_fit_begin(estimator=self)
 
         for i in range(self._n_init):
+            init_callback_ctx = callback_ctx.subcontext(
+                task_name="init", task_id=i, max_subtasks=self.max_iter
+            )
             # Initialize centers
             centers_init = self._init_centroids(
                 X,
@@ -1522,6 +1615,8 @@ class KMeans(_BaseKMeans):
                 verbose=self.verbose,
                 tol=self._tol,
                 n_threads=self._n_threads,
+                estimator=self,
+                callback_ctx=init_callback_ctx,
             )
 
             # determine if these results are the best so far
@@ -1537,6 +1632,18 @@ class KMeans(_BaseKMeans):
                 best_centers = centers
                 best_inertia = inertia
                 best_n_iter = n_iter_
+
+            if _eval_kmeans_init_task_end(
+                self,
+                init_callback_ctx,
+                X=X,
+                sample_weight=sample_weight,
+                cluster_centers=centers,
+                labels=labels,
+                inertia=inertia,
+                n_iter=n_iter_,
+            ):
+                break
 
         if not sp.issparse(X):
             if not self.copy_x:

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -17,6 +17,7 @@ from sklearn.base import (
     TransformerMixin,
     _fit_context,
 )
+from sklearn.callback._callback_support import CallbackSupportMixin
 from sklearn.cluster._k_means_common import (
     CHUNK_SIZE,
     _inertia_dense,
@@ -1681,7 +1682,7 @@ def _mini_batch_step(
     return inertia
 
 
-class MiniBatchKMeans(_BaseKMeans):
+class MiniBatchKMeans(CallbackSupportMixin, _BaseKMeans):
     """
     Mini-Batch K-Means clustering.
 
@@ -2033,6 +2034,32 @@ class MiniBatchKMeans(_BaseKMeans):
 
         return False
 
+    def _eval_minibatch_fit_task_end(
+        self,
+        callback_ctx,
+        *,
+        task_id,
+        X_batch,
+        sample_weight,
+        cluster_centers,
+        batch_inertia,
+        centers_squared_diff,
+    ):
+        """Evaluate callbacks for a completed minibatch update."""
+        mean_batch_inertia = batch_inertia / X_batch.shape[0]
+
+        subcontext = callback_ctx.subcontext(task_name="minibatch", task_id=task_id)
+        return subcontext.eval_on_fit_task_end(
+            estimator=self,
+            data={"X_batch": X_batch, "sample_weight": sample_weight},
+            batch_inertia=batch_inertia,
+            mean_batch_inertia=mean_batch_inertia,
+            ewa_inertia=getattr(self, "_ewa_inertia", None),
+            centers_squared_diff=centers_squared_diff,
+            no_improvement_count=getattr(self, "_no_improvement", 0),
+            cluster_centers=cluster_centers,
+        )
+
     def _random_reassign(self):
         """Check if a random reassignment needs to be done.
 
@@ -2090,7 +2117,7 @@ class MiniBatchKMeans(_BaseKMeans):
         random_state = check_random_state(self.random_state)
         sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
         self._n_threads = _openmp_effective_n_threads()
-        n_samples, n_features = X.shape
+        n_samples, _ = X.shape
 
         # Validate init array
         init = self.init
@@ -2158,6 +2185,8 @@ class MiniBatchKMeans(_BaseKMeans):
         n_steps = (self.max_iter * n_samples) // self._batch_size
         normalized_sample_weight = sample_weight / sum_of_weights
         unit_sample_weight = np.ones_like(sample_weight, shape=(self._batch_size,))
+        callback_ctx = self._init_callback_context(max_subtasks=n_steps)
+        callback_ctx.eval_on_fit_begin(estimator=self)
 
         with _get_threadpool_controller().limit(limits=1, user_api="blas"):
             # Perform the iterative optimization until convergence
@@ -2197,9 +2226,19 @@ class MiniBatchKMeans(_BaseKMeans):
                 centers, centers_new = centers_new, centers
 
                 # Monitor convergence and do early stopping if necessary
-                if self._mini_batch_convergence(
+                should_stop = self._mini_batch_convergence(
                     i, n_steps, n_samples, centers_squared_diff, batch_inertia
-                ):
+                )
+                callback_stop = self._eval_minibatch_fit_task_end(
+                    callback_ctx,
+                    task_id=i,
+                    X_batch=X[minibatch_indices],
+                    sample_weight=unit_sample_weight,
+                    cluster_centers=centers,
+                    batch_inertia=batch_inertia,
+                    centers_squared_diff=centers_squared_diff,
+                )
+                if should_stop or callback_stop:
                     break
 
         self.cluster_centers_ = centers
@@ -2247,6 +2286,10 @@ class MiniBatchKMeans(_BaseKMeans):
             Return updated estimator.
         """
         has_centers = hasattr(self, "cluster_centers_")
+        callback_ctx = self._init_callback_context(
+            task_name="partial_fit", max_subtasks=1
+        )
+        callback_ctx.eval_on_fit_begin(estimator=self)
 
         X = validate_data(
             self,
@@ -2297,7 +2340,7 @@ class MiniBatchKMeans(_BaseKMeans):
             self._n_since_last_reassign = 0
 
         with _get_threadpool_controller().limit(limits=1, user_api="blas"):
-            _mini_batch_step(
+            batch_inertia = _mini_batch_step(
                 X,
                 sample_weight=sample_weight,
                 centers=self.cluster_centers_,
@@ -2317,6 +2360,16 @@ class MiniBatchKMeans(_BaseKMeans):
                 self.cluster_centers_,
                 n_threads=self._n_threads,
             )
+
+        self._eval_minibatch_fit_task_end(
+            callback_ctx,
+            task_id=0,
+            X_batch=X,
+            sample_weight=sample_weight,
+            cluster_centers=self.cluster_centers_,
+            batch_inertia=batch_inertia,
+            centers_squared_diff=None,
+        )
 
         self.n_steps_ += 1
         self._n_features_out = self.cluster_centers_.shape[0]

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -383,6 +383,125 @@ def test_minibatch_kmeans_verbose():
         sys.stdout = old_stdout
 
 
+def test_minibatch_kmeans_callbacks_called():
+    class RecordingCallback:
+        def __init__(self):
+            self.n_fit_begin = 0
+            self.n_fit_end = 0
+            self.task_ids = []
+            self.task_names = []
+            self.payloads = []
+
+        def on_fit_begin(self, estimator):
+            self.n_fit_begin += 1
+
+        def on_fit_task_end(self, estimator, context, **kwargs):
+            self.task_ids.append(context.task_id)
+            self.task_names.append(context.task_name)
+            self.payloads.append(kwargs)
+            return False
+
+        def on_fit_end(self, estimator, context):
+            self.n_fit_end += 1
+
+    max_iter = 5
+    callback = RecordingCallback()
+    km = MiniBatchKMeans(
+        n_clusters=n_clusters,
+        batch_size=X.shape[0],
+        max_iter=max_iter,
+        max_no_improvement=None,
+        n_init=1,
+        random_state=0,
+        reassignment_ratio=0,
+        tol=0,
+    ).set_callbacks(callback)
+
+    km.fit(X)
+
+    assert callback.n_fit_begin == 1
+    assert callback.n_fit_end == 1
+    assert callback.task_ids == list(range(max_iter))
+    assert callback.task_names == ["minibatch"] * max_iter
+
+    payload = callback.payloads[0]
+    assert payload["batch_inertia"] > 0
+    assert payload["mean_batch_inertia"] > 0
+    assert payload["data"]["X_batch"].shape == X.shape
+    assert payload["data"]["sample_weight"].shape == (X.shape[0],)
+    assert payload["centers_squared_diff"] >= 0
+    assert payload["cluster_centers"].shape == (n_clusters, n_features)
+
+
+def test_minibatch_kmeans_callbacks_can_stop_fit():
+    class StopAfterCallback:
+        def __init__(self, stop_after):
+            self.stop_after = stop_after
+            self.task_ids = []
+
+        def on_fit_begin(self, estimator):
+            pass
+
+        def on_fit_task_end(self, estimator, context, **kwargs):
+            self.task_ids.append(context.task_id)
+            return context.task_id >= self.stop_after
+
+        def on_fit_end(self, estimator, context):
+            pass
+
+    stop_after = 1
+    callback = StopAfterCallback(stop_after=stop_after)
+    km = MiniBatchKMeans(
+        n_clusters=n_clusters,
+        batch_size=X.shape[0],
+        max_iter=10,
+        max_no_improvement=None,
+        n_init=1,
+        random_state=0,
+        reassignment_ratio=0,
+        tol=0,
+    ).set_callbacks(callback)
+
+    km.fit(X)
+
+    assert callback.task_ids == [0, 1]
+    assert km.n_steps_ == stop_after + 1
+    assert km.n_iter_ == stop_after + 1
+
+
+def test_minibatch_kmeans_callbacks_called_on_partial_fit():
+    class RecordingCallback:
+        def __init__(self):
+            self.n_fit_begin = 0
+            self.n_fit_end = 0
+            self.task_ids = []
+
+        def on_fit_begin(self, estimator):
+            self.n_fit_begin += 1
+
+        def on_fit_task_end(self, estimator, context, **kwargs):
+            self.task_ids.append(context.task_id)
+            return False
+
+        def on_fit_end(self, estimator, context):
+            self.n_fit_end += 1
+
+    callback = RecordingCallback()
+    km = MiniBatchKMeans(
+        n_clusters=n_clusters,
+        batch_size=X.shape[0],
+        n_init=1,
+        random_state=0,
+        reassignment_ratio=0,
+    ).set_callbacks(callback)
+
+    km.partial_fit(X)
+
+    assert callback.n_fit_begin == 1
+    assert callback.n_fit_end == 1
+    assert callback.task_ids == [0]
+
+
 @pytest.mark.parametrize("algorithm", ["lloyd", "elkan"])
 @pytest.mark.parametrize("tol", [1e-2, 0])
 def test_kmeans_verbose(algorithm, tol, capsys):
@@ -433,9 +552,7 @@ def test_minibatch_sensible_reassign(global_random_seed):
     # check that identical initial clusters are reassigned
     # also a regression test for when there are more desired reassignments than
     # samples.
-    zeroed_X, true_labels = make_blobs(
-        n_samples=100, centers=5, random_state=global_random_seed
-    )
+    zeroed_X, _ = make_blobs(n_samples=100, centers=5, random_state=global_random_seed)
     zeroed_X[::2, :] = 0
 
     km = MiniBatchKMeans(

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -10,6 +10,7 @@ from scipy import sparse as sp
 from threadpoolctl import threadpool_info
 
 from sklearn.base import clone
+from sklearn.callback._callback_context import get_context_path
 from sklearn.cluster import KMeans, MiniBatchKMeans, k_means, kmeans_plusplus
 from sklearn.cluster._k_means_common import (
     _euclidean_dense_dense_wrapper,
@@ -527,6 +528,148 @@ def test_kmeans_verbose(algorithm, tol, capsys):
         assert re.search(r"strict convergence", captured.out)
     else:
         assert re.search(r"center shift .* within tolerance", captured.out)
+
+
+@pytest.mark.parametrize("algorithm", ["lloyd", "elkan"])
+def test_kmeans_callbacks_called(algorithm):
+    class RecordingCallback:
+        def __init__(self):
+            self.n_fit_begin = 0
+            self.n_fit_end = 0
+            self.events = []
+
+        def on_fit_begin(self, estimator):
+            self.n_fit_begin += 1
+
+        def on_fit_task_end(self, estimator, context, **kwargs):
+            self.events.append(
+                {
+                    "path": [
+                        (ctx.task_name, ctx.task_id)
+                        for ctx in get_context_path(context)
+                    ],
+                    "payload": kwargs,
+                }
+            )
+            return False
+
+        def on_fit_end(self, estimator, context):
+            self.n_fit_end += 1
+
+    callback = RecordingCallback()
+    km = KMeans(
+        algorithm=algorithm,
+        n_clusters=n_clusters,
+        init="random",
+        n_init=2,
+        max_iter=1,
+        tol=0,
+        random_state=0,
+    ).set_callbacks(callback)
+
+    km.fit(X)
+
+    assert callback.n_fit_begin == 1
+    assert callback.n_fit_end == 1
+    assert [event["path"] for event in callback.events] == [
+        [("fit", 0), ("init", 0), ("iter", 0)],
+        [("fit", 0), ("init", 0)],
+        [("fit", 0), ("init", 1), ("iter", 0)],
+        [("fit", 0), ("init", 1)],
+    ]
+
+    iter_payload = callback.events[0]["payload"]
+    assert iter_payload["data"]["X_train"].shape == X.shape
+    assert iter_payload["data"]["sample_weight"].shape == (X.shape[0],)
+    assert iter_payload["cluster_centers"].shape == (n_clusters, n_features)
+    assert iter_payload["labels"].shape == (X.shape[0],)
+    assert iter_payload["center_shift_tot"] >= 0
+    assert isinstance(iter_payload["strict_convergence"], (bool, np.bool_))
+
+    init_payload = callback.events[1]["payload"]
+    assert init_payload["data"]["X_train"].shape == X.shape
+    assert init_payload["cluster_centers"].shape == (n_clusters, n_features)
+    assert init_payload["labels"].shape == (X.shape[0],)
+    assert init_payload["inertia"] >= 0
+    assert init_payload["n_iter"] == 1
+
+
+@pytest.mark.parametrize("algorithm", ["lloyd", "elkan"])
+def test_kmeans_iter_callbacks_can_stop_current_init(algorithm):
+    class StopAfterFirstIter:
+        def __init__(self):
+            self.iter_ids = []
+            self.init_ids = []
+
+        def on_fit_begin(self, estimator):
+            pass
+
+        def on_fit_task_end(self, estimator, context, **kwargs):
+            if context.task_name == "iter":
+                self.iter_ids.append((context.parent.task_id, context.task_id))
+                return True
+
+            if context.task_name == "init":
+                self.init_ids.append(context.task_id)
+
+            return False
+
+        def on_fit_end(self, estimator, context):
+            pass
+
+    callback = StopAfterFirstIter()
+    km = KMeans(
+        algorithm=algorithm,
+        n_clusters=n_clusters,
+        init="random",
+        n_init=2,
+        max_iter=10,
+        tol=0,
+        random_state=0,
+    ).set_callbacks(callback)
+
+    km.fit(X)
+
+    assert callback.iter_ids == [(0, 0), (1, 0)]
+    assert callback.init_ids == [0, 1]
+    assert km.n_iter_ == 1
+
+
+def test_kmeans_init_callbacks_can_stop_fit():
+    class StopAfterFirstInit:
+        def __init__(self):
+            self.task_names = []
+            self.init_ids = []
+
+        def on_fit_begin(self, estimator):
+            pass
+
+        def on_fit_task_end(self, estimator, context, **kwargs):
+            self.task_names.append(context.task_name)
+            if context.task_name == "init":
+                self.init_ids.append(context.task_id)
+                return True
+            return False
+
+        def on_fit_end(self, estimator, context):
+            pass
+
+    callback = StopAfterFirstInit()
+    km = KMeans(
+        algorithm="lloyd",
+        n_clusters=n_clusters,
+        init="random",
+        n_init=5,
+        max_iter=1,
+        tol=0,
+        random_state=0,
+    ).set_callbacks(callback)
+
+    km.fit(X)
+
+    assert callback.task_names == ["iter", "init"]
+    assert callback.init_ids == [0]
+    assert km.n_iter_ == 1
 
 
 def test_minibatch_kmeans_warning_init_size():


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #27676

#### What does this implement/fix? Explain your changes.
- add callback support to `KMeans` by emitting nested `init` and `iter` tasks during `fit`
- honor callback stop signals at both the iteration and initialization levels in `KMeans`
- add callback support to `MiniBatchKMeans` by emitting one callback task per minibatch step during `fit`
- honor callback stop signals to terminate `MiniBatchKMeans.fit` early
- emit a callback task from `MiniBatchKMeans.partial_fit` for consistency with `fit`
- add tests covering nested hook calls and callback-driven stopping

#### Any other comments?
This is intended as a first production estimator integration on top of the `callbacks` branch.

This pull request includes code written with the assistance of AI.
The code has been reviewed by a human.