### PR TITLE
[Callbacks] ENH Add fit-level callback support to Pipeline

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.pipeline/33469.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.pipeline/33469.enhancement.rst
@@ -1,0 +1,4 @@
+- :class:`pipeline.Pipeline` now supports fit-level step callbacks when using
+  the experimental callbacks API, including for cached and ``"passthrough"``
+  steps.
+  By :user:`gustavorubim`.

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -11,6 +11,7 @@ import numpy as np
 from scipy import sparse
 
 from sklearn.base import TransformerMixin, _fit_context, clone
+from sklearn.callback._callback_support import CallbackSupportMixin
 from sklearn.exceptions import NotFittedError
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.utils import Bunch
@@ -89,7 +90,7 @@ def _cached_transform(
     return cache[param_name]
 
 
-class Pipeline(_BaseComposition):
+class Pipeline(CallbackSupportMixin, _BaseComposition):
     """
     A sequence of data transformers with an optional final predictor.
 
@@ -369,7 +370,7 @@ class Pipeline(_BaseComposition):
                 self.steps[ind], memory=self.memory, verbose=self.verbose
             )
         try:
-            name, est = self.steps[ind]
+            _, est = self.steps[ind]
         except TypeError:
             # Not an int, try get step by name
             return self.named_steps[ind]
@@ -402,6 +403,29 @@ class Pipeline(_BaseComposition):
         name, _ = self.steps[step_idx]
 
         return "(step %d of %d) Processing %s" % (step_idx + 1, len(self.steps), name)
+
+    def _get_callback_step_context(self, callback_ctx, *, step_idx, step_name):
+        """Create a callback context for a pipeline step."""
+        if callback_ctx is None:
+            return None
+
+        return callback_ctx.subcontext(task_name=step_name, task_id=step_idx)
+
+    def _eval_pipeline_step_task_end(
+        self, step_callback_ctx, *, X, y, step_name, step_estimator
+    ):
+        """Evaluate callbacks for a completed pipeline step."""
+        if step_callback_ctx is None:
+            return
+
+        # Pipeline step callbacks are observational only in phase 1 and do not
+        # influence control flow.
+        step_callback_ctx.eval_on_fit_task_end(
+            estimator=self,
+            data={"X_train": X, "y_train": y},
+            step_name=step_name,
+            step_estimator=step_estimator,
+        )
 
     def _check_method_params(self, method, props, **kwargs):
         if _routing_enabled():
@@ -511,7 +535,9 @@ class Pipeline(_BaseComposition):
 
     # Estimator interface
 
-    def _fit(self, X, y=None, routed_params=None, raw_params=None):
+    def _fit(
+        self, X, y=None, routed_params=None, raw_params=None, *, callback_ctx=None
+    ):
         """Fit the pipeline except the last step.
 
         routed_params is the output of `process_routing`
@@ -529,8 +555,19 @@ class Pipeline(_BaseComposition):
         for step_idx, name, transformer in self._iter(
             with_final=False, filter_passthrough=False
         ):
+            step_callback_ctx = self._get_callback_step_context(
+                callback_ctx, step_idx=step_idx, step_name=name
+            )
+            step_input = X
             if transformer is None or transformer == "passthrough":
                 with _print_elapsed_time("Pipeline", self._log_message(step_idx)):
+                    self._eval_pipeline_step_task_end(
+                        step_callback_ctx,
+                        X=step_input,
+                        y=y,
+                        step_name=name,
+                        step_estimator=transformer,
+                    )
                     continue
 
             if hasattr(memory, "location") and memory.location is None:
@@ -559,6 +596,13 @@ class Pipeline(_BaseComposition):
             # transformer. This is necessary when loading the transformer
             # from the cache.
             self.steps[step_idx] = (name, fitted_transformer)
+            self._eval_pipeline_step_task_end(
+                step_callback_ctx,
+                X=step_input,
+                y=y,
+                step_name=name,
+                step_estimator=fitted_transformer,
+            )
         return X
 
     @_fit_context(
@@ -612,8 +656,20 @@ class Pipeline(_BaseComposition):
             )
 
         routed_params = self._check_method_params(method="fit", props=params)
-        Xt = self._fit(X, y, routed_params, raw_params=params)
+        self.steps = list(self.steps)
+        self._validate_steps()
+        callback_ctx = self._init_callback_context(max_subtasks=len(self.steps))
+        callback_ctx.eval_on_fit_begin(estimator=self)
+        Xt = self._fit(
+            X, y, routed_params, raw_params=params, callback_ctx=callback_ctx
+        )
         with _print_elapsed_time("Pipeline", self._log_message(len(self.steps) - 1)):
+            final_step_name, final_step_estimator = self.steps[-1]
+            final_step_ctx = self._get_callback_step_context(
+                callback_ctx,
+                step_idx=len(self.steps) - 1,
+                step_name=final_step_name,
+            )
             if self._final_estimator != "passthrough":
                 last_step_params = self._get_metadata_for_step(
                     step_idx=len(self) - 1,
@@ -621,6 +677,14 @@ class Pipeline(_BaseComposition):
                     all_params=params,
                 )
                 self._final_estimator.fit(Xt, y, **last_step_params["fit"])
+
+            self._eval_pipeline_step_task_end(
+                final_step_ctx,
+                X=Xt,
+                y=y,
+                step_name=final_step_name,
+                step_estimator=final_step_estimator,
+            )
 
         return self
 

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -21,6 +21,7 @@ from sklearn.base import (
     is_classifier,
     is_regressor,
 )
+from sklearn.callback._callback_context import get_context_path
 from sklearn.cluster import KMeans
 from sklearn.datasets import load_iris
 from sklearn.decomposition import PCA, TruncatedSVD
@@ -1548,7 +1549,7 @@ def test_pipeline_feature_names_out_error_without_definition():
 def test_pipeline_param_error():
     clf = make_pipeline(LogisticRegression())
     with pytest.raises(
-        ValueError, match="Pipeline.fit does not accept the sample_weight parameter"
+        ValueError, match=r"Pipeline.fit does not accept the sample_weight parameter"
     ):
         clf.fit([[0], [0]], [0, 1], sample_weight=[1, 1])
 
@@ -1630,6 +1631,110 @@ def test_verbose(est, method, pattern, capsys):
     est.set_params(verbose=True)
     func(X, y)
     assert re.match(pattern, capsys.readouterr().out)
+
+
+def test_pipeline_callbacks_called_on_fit():
+    class RecordingCallback:
+        def __init__(self):
+            self.n_fit_begin = 0
+            self.n_fit_end = 0
+            self.paths = []
+            self.payloads = []
+
+        def on_fit_begin(self, estimator):
+            self.n_fit_begin += 1
+
+        def on_fit_task_end(self, estimator, context, **kwargs):
+            self.paths.append(
+                [(ctx.task_name, ctx.task_id) for ctx in get_context_path(context)]
+            )
+            self.payloads.append(kwargs)
+            return False
+
+        def on_fit_end(self, estimator, context):
+            self.n_fit_end += 1
+
+    X = np.array([[1, 2], [3, 4], [5, 6]])
+    y = np.array([0, 1, 0])
+    callback = RecordingCallback()
+    pipe = Pipeline([("double", Mult(2)), ("clf", FitParamT())]).set_callbacks(callback)
+
+    pipe.fit(X, y)
+
+    assert callback.n_fit_begin == 1
+    assert callback.n_fit_end == 1
+    assert callback.paths == [[("fit", 0), ("double", 0)], [("fit", 0), ("clf", 1)]]
+
+    double_payload, clf_payload = callback.payloads
+    assert_array_equal(double_payload["data"]["X_train"], X)
+    assert_array_equal(double_payload["data"]["y_train"], y)
+    assert double_payload["step_name"] == "double"
+    assert double_payload["step_estimator"] is pipe.named_steps["double"]
+
+    assert_array_equal(clf_payload["data"]["X_train"], 2 * X)
+    assert_array_equal(clf_payload["data"]["y_train"], y)
+    assert clf_payload["step_name"] == "clf"
+    assert clf_payload["step_estimator"] is pipe.named_steps["clf"]
+
+
+def test_pipeline_callbacks_ignore_stop_request_and_report_passthrough():
+    class StopRequestingCallback:
+        def __init__(self):
+            self.task_names = []
+
+        def on_fit_begin(self, estimator):
+            pass
+
+        def on_fit_task_end(self, estimator, context, **kwargs):
+            self.task_names.append(context.task_name)
+            return True
+
+        def on_fit_end(self, estimator, context):
+            pass
+
+    X = np.array([[1, 2], [3, 4], [5, 6]])
+    y = np.array([0, 1, 0])
+    callback = StopRequestingCallback()
+    pipe = Pipeline([("noop", "passthrough"), ("clf", FitParamT())]).set_callbacks(
+        callback
+    )
+
+    pipe.fit(X, y)
+
+    assert callback.task_names == ["noop", "clf"]
+    assert pipe.named_steps["clf"].fitted_
+
+
+def test_pipeline_callbacks_called_with_memory(tmp_path):
+    class RecordingCallback:
+        def __init__(self):
+            self.task_names = []
+            self.n_fit_begin = 0
+            self.n_fit_end = 0
+
+        def on_fit_begin(self, estimator):
+            self.n_fit_begin += 1
+
+        def on_fit_task_end(self, estimator, context, **kwargs):
+            self.task_names.append(context.task_name)
+            return False
+
+        def on_fit_end(self, estimator, context):
+            self.n_fit_end += 1
+
+    X = np.array([[1, 2], [3, 4], [5, 6]])
+    y = np.array([0, 1, 0])
+    callback = RecordingCallback()
+    pipe = Pipeline(
+        [("transf", DummyTransf()), ("clf", FitParamT())], memory=str(tmp_path)
+    ).set_callbacks(callback)
+
+    pipe.fit(X, y)
+    pipe.fit(X, y)
+
+    assert callback.n_fit_begin == 2
+    assert callback.n_fit_end == 2
+    assert callback.task_names == ["transf", "clf", "transf", "clf"]
 
 
 def test_n_features_in_pipeline():


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #27676

#### What does this implement/fix? Explain your changes.
- add callback support to `Pipeline.fit` by emitting one callback task per pipeline step
- keep the `Pipeline` step callbacks observational only: callback stop values are ignored
- support step callbacks for regular, `None` / `"passthrough"`, and cached steps
- add tests covering step payloads, passthrough steps, and `memory=` cache hits

#### Any other comments?
This is an intentionally narrow first `Pipeline` integration. It covers fit-level step callbacks only and does not propagate callbacks into sub-estimators.

This pull request includes code written with the assistance of AI.
The code has been reviewed by a human.