### PR TITLE
Fix power_iteration_normalizer parameter validation typo in TruncatedSVD

### DIFF
--- a/sklearn/decomposition/_truncated_svd.py
+++ b/sklearn/decomposition/_truncated_svd.py
@@ -163,7 +163,7 @@ class TruncatedSVD(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstima
         "algorithm": [StrOptions({"arpack", "randomized"})],
         "n_iter": [Interval(Integral, 0, None, closed="left")],
         "n_oversamples": [Interval(Integral, 1, None, closed="left")],
-        "power_iteration_normalizer": [StrOptions({"auto", "OR", "LU", "none"})],
+        "power_iteration_normalizer": [StrOptions({"auto", "QR", "LU", "none"})],
         "random_state": ["random_state"],
         "tol": [Interval(Real, 0, None, closed="left")],
     }


### PR DESCRIPTION
Fixes #33472

The documentation states 'QR' is a valid option for power_iteration_normalizer but the validation code only accepted 'OR'. This caused a validation error when users followed the documentation.

Changed 'OR' to 'QR' in the parameter validation to match the documentation and align with the rest of the codebase (PCA, randomized_svd in extmath).