### PR TITLE
FIX TruncatedSVD: correct power_iteration_normalizer constraint from …

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.decomposition/33476.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.decomposition/33476.fix.rst
@@ -1,0 +1,6 @@
+- :class:`decomposition.TruncatedSVD` now correctly accepts ``'QR'`` as a
+  valid value for the ``power_iteration_normalizer`` parameter, fixing a bug
+  where the parameter constraint used ``'OR'`` instead of ``'QR'``, causing
+  an :class:`~sklearn.utils._param_validation.InvalidParameterError` when
+  passing the documented value.
+  By :user:`YOUR_GITHUB_USERNAME <YOUR_GITHUB_USERNAME>`.

--- a/sklearn/decomposition/_truncated_svd.py
+++ b/sklearn/decomposition/_truncated_svd.py
@@ -163,7 +163,7 @@ class TruncatedSVD(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstima
         "algorithm": [StrOptions({"arpack", "randomized"})],
         "n_iter": [Interval(Integral, 0, None, closed="left")],
         "n_oversamples": [Interval(Integral, 1, None, closed="left")],
-        "power_iteration_normalizer": [StrOptions({"auto", "OR", "LU", "none"})],
+        "power_iteration_normalizer": [StrOptions({"auto", "QR", "LU", "none"})],
         "random_state": ["random_state"],
         "tol": [Interval(Real, 0, None, closed="left")],
     }

--- a/sklearn/decomposition/tests/test_truncated_svd.py
+++ b/sklearn/decomposition/tests/test_truncated_svd.py
@@ -210,3 +210,16 @@ def test_fit_transform(X_sparse, algorithm, tol, kind):
     X_transformed_1 = svd.fit_transform(X)
     X_transformed_2 = svd.fit(X).transform(X)
     assert_allclose(X_transformed_1, X_transformed_2)
+
+
+@pytest.mark.parametrize("power_iteration_normalizer", ["auto", "QR", "LU", "none"])
+def test_power_iteration_normalizer(X_sparse, power_iteration_normalizer):
+    """Check that all valid power_iteration_normalizer values work with randomized."""
+    svd = TruncatedSVD(
+        n_components=5,
+        algorithm="randomized",
+        power_iteration_normalizer=power_iteration_normalizer,
+        random_state=42,
+    )
+    X_transformed = svd.fit_transform(X_sparse)
+    assert X_transformed.shape == (X_sparse.shape[0], 5)


### PR DESCRIPTION
Fixes #33472 

## What and Why

[TruncatedSVD](cci:2://file:///Users/hemant/Desktop/opensource/scikit-learn/sklearn/decomposition/_truncated_svd.py:27:0-321:40) has `power_iteration_normalizer='QR'` documented as a valid value, but the internal `_parameter_constraints` had `'OR'` instead of `'QR'` in its `StrOptions` set. This caused an `InvalidParameterError` to be raised before [fit_transform](cci:1://file:///Users/hemant/Desktop/opensource/scikit-learn/sklearn/decomposition/_truncated_svd.py:208:4-275:28) even ran, even though the user passed the exact value shown in the docs.

## Changes

- [sklearn/decomposition/_truncated_svd.py](cci:7://file:///Users/hemant/Desktop/opensource/scikit-learn/sklearn/decomposition/_truncated_svd.py:0:0-0:0): Fixed typo `'OR'` → `'QR'` in `_parameter_constraints`
- [sklearn/decomposition/tests/test_truncated_svd.py](cci:7://file:///Users/hemant/Desktop/opensource/scikit-learn/sklearn/decomposition/tests/test_truncated_svd.py:0:0-0:0): Added [test_power_iteration_normalizer](cci:1://file:///Users/hemant/Desktop/opensource/scikit-learn/sklearn/decomposition/tests/test_truncated_svd.py:214:0-224:56) parametrized over all valid values (`'auto'`, `'QR'`, `'LU'`, `'none'`) with `algorithm='randomized'`
- [doc/whats_new/upcoming_changes/sklearn.decomposition/33476.fix.rst](cci:7://file:///Users/hemant/Desktop/opensource/scikit-learn/doc/whats_new/upcoming_changes/sklearn.decomposition/33476.fix.rst:0:0-0:0): Changelog entry

## Reproducer

```python
import numpy as np, sklearn

X = np.random.randn(100, 26)
tsvd = sklearn.decomposition.TruncatedSVD(
    n_components=10, algorithm='randomized', power_iteration_normalizer='QR'
)
X_trans = tsvd.fit_transform(X)  # Previously raised InvalidParameterError
