### PR TITLE
Validate estimator methods in TunedThresholdClassifierCV and add tests

### DIFF
--- a/sklearn/model_selection/_classification_threshold.py
+++ b/sklearn/model_selection/_classification_threshold.py
@@ -720,6 +720,14 @@ class TunedThresholdClassifierCV(BaseThresholdClassifier):
         self : object
             Returns an instance of self.
         """
+        if not (hasattr(self.estimator, "predict_proba") or 
+                hasattr(self.estimator, "decision_function")):
+            raise ValueError(
+                f"The estimator {self.estimator.__class__.__name__} must implement "
+                "either 'predict_proba' or 'decision_function' to be used with "
+                "TunedThresholdClassifierCV."
+            )
+        
         if isinstance(self.cv, Real) and 0 < self.cv < 1:
             cv = StratifiedShuffleSplit(
                 n_splits=1, test_size=self.cv, random_state=self.random_state

--- a/sklearn/model_selection/tests/test_classification_threshold.py
+++ b/sklearn/model_selection/tests/test_classification_threshold.py
@@ -616,3 +616,21 @@ def test_fixed_threshold_classifier_classes_():
     classifier = LogisticRegression().fit(X, y)
     fixed_threshold_classifier = FixedThresholdClassifier(estimator=classifier)
     assert_array_equal(fixed_threshold_classifier.classes_, classifier.classes_)
+
+def test_tuned_threshold_classifier_error_no_predict_methods():
+    """Check that we raise a clear ValueError if the estimator has no 
+    predict_proba or decision_function."""
+    import pytest
+    from sklearn.linear_model import PassiveAggressiveClassifier
+    from sklearn.model_selection import TunedThresholdClassifierCV
+    import numpy as np
+
+    X = np.array([[1, 2], [3, 4]])
+    y = np.array([0, 1])
+    
+    # PassiveAggressiveClassifier lacks both required methods
+    clf = TunedThresholdClassifierCV(PassiveAggressiveClassifier())
+    
+    msg = "must implement either 'predict_proba' or 'decision_function'"
+    with pytest.raises(ValueError, match=msg):
+        clf.fit(X, y)


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
This is a proactive improvement to catch incompatible estimators early in TunedThresholdClassifierCV. No specific issue number was identified, but it follows best practices for developer experience
-->


#### What does this implement/fix? Explain your changes.
Currently, TunedThresholdClassifierCV fails with an unhelpful error if the base estimator does not support probability/decision methods.

This PR implements an explicit validation check within the _fit method:

Validation Logic: Added a check in sklearn/model_selection/_classification_threshold.py that uses hasattr to ensure the estimator has either predict_proba or decision_function. If both are missing, it raises a descriptive ValueError.

New Test Case: Added test_tuned_threshold_classifier_error_no_predict_methods to sklearn/model_selection/tests/test_classification_threshold.py. This test uses PassiveAggressiveClassifier to confirm the correct error message is triggered during fit.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding