### PR TITLE
FIX handle pandas StringDtype in check_array

### DIFF
--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -2269,6 +2269,21 @@ def test_column_or_1d():
                 column_or_1d(y)
 
 
+def test_column_or_1d_with_pandas_string_dtype():
+    """Check that column_or_1d works with pandas StringDtype.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/33383
+    """
+    pd = pytest.importorskip("pandas")
+
+    # Enable string dtype inference for pandas 2.x compatibility
+    with pd.option_context("future.infer_string", True):
+        df = pd.DataFrame({"y": ["a", "b", "a", "c"]})
+        result = column_or_1d(df["y"], dtype=df["y"].dtype)
+        assert result.shape == (4,)
+
+
 def test_check_array_writeable_np():
     """Check the behavior of check_array when a writeable array is requested
     without copy if possible, on numpy arrays.

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -949,7 +949,11 @@ def check_array(
 
     if dtype is not None and _is_numpy_namespace(xp):
         # convert to dtype object to conform to Array API to be use `xp.isdtype` later
-        dtype = np.dtype(dtype)
+        try:
+            dtype = np.dtype(dtype)
+        except TypeError:
+            # dtype is not a valid numpy dtype, e.g. pandas StringDtype
+            pass
 
     estimator_name = _check_estimator_name(estimator)
     context = " by %s" % estimator_name if estimator is not None else ""


### PR DESCRIPTION
Fixes #33383

#### Reference Issues/PRs
Fixes #33383

#### What does this implement/fix? Explain your changes.
Since pandas 3.0, `StringDtype` is no longer a valid NumPy data type. This caused `check_array` to crash when called with that type as the `dtype` parameter, because `np.dtype(dtype)` raises a `TypeError` for non-NumPy dtypes.

The fix wraps the `np.dtype(dtype)` call in a try-except block to catch `TypeError` when the dtype cannot be interpreted as a NumPy dtype (e.g., pandas `StringDtype`). When the conversion fails, the dtype is left unchanged, which allows the rest of the validation logic to proceed.

Changes:
- Added try-except around `np.dtype(dtype)` in `check_array` to handle non-NumPy dtypes gracefully
- Added a test case for `column_or_1d` with pandas `StringDtype`

#### AI usage disclosure
I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

#### Any other comments?
```bash
$ git diff --stat HEAD~1
 sklearn/utils/tests/test_validation.py | 15 +++++++++++++++
 sklearn/utils/validation.py            |  6 +++++-
 2 files changed, 20 insertions(+), 1 deletion(-)
```