### PR TITLE
FIX HDBSCAN TypeError when using cluster_selection_epsilon

### DIFF
--- a/sklearn/cluster/_hdbscan/_tree.pyx
+++ b/sklearn/cluster/_hdbscan/_tree.pyx
@@ -585,14 +585,14 @@ cdef cnp.intp_t traverse_upwards(
     cdef cnp.float64_t parent_eps
 
     root = cluster_tree['parent'].min()
-    parent = cluster_tree[cluster_tree['child'] == leaf]['parent']
+    parent = cluster_tree[cluster_tree['child'] == leaf]['parent'][0]
     if parent == root:
         if allow_single_cluster:
             return parent
         else:
             return leaf  # return node closest to root
 
-    parent_eps = 1 / cluster_tree[cluster_tree['child'] == parent]['value']
+    parent_eps = 1 / cluster_tree[cluster_tree['child'] == parent]['value'][0]
     if parent_eps > cluster_selection_epsilon:
         return parent
     else:

--- a/sklearn/cluster/tests/test_hdbscan.py
+++ b/sklearn/cluster/tests/test_hdbscan.py
@@ -359,6 +359,31 @@ def test_hdbscan_allow_single_cluster_with_epsilon():
     assert counts[unique_labels == -1] == 2
 
 
+def test_hdbscan_cluster_selection_epsilon():
+    """
+    Test that HDBSCAN works correctly with cluster_selection_epsilon.
+    Non-regression test for https://github.com/scikit-learn/scikit-learn/issues/33219.
+    """
+    rng = np.random.default_rng(0)
+
+    X = np.vstack([
+        rng.normal(0, 0.2, size=(20, 2)),
+        rng.normal(1, 0.2, size=(21, 2)),
+    ])
+
+    # This used to raise TypeError due to array vs scalar comparison
+    hdb = HDBSCAN(
+        min_cluster_size=5,
+        min_samples=1,
+        copy=True,
+        allow_single_cluster=True,
+        cluster_selection_epsilon=1,
+    )
+    labels = hdb.fit_predict(X)
+    # Basic sanity check - should produce some labels
+    assert len(labels) == len(X)
+
+
 def test_hdbscan_better_than_dbscan():
     """
     Validate that HDBSCAN can properly cluster this difficult synthetic


### PR DESCRIPTION
Fixes #33219

#### Reference Issues/PRs
Fixes #33219

#### What does this implement/fix? Explain your changes.

Fixed a bug in HDBSCAN's `traverse_upwards` function that caused a `TypeError: only 0-dimensional arrays can be converted to Python scalars` when using `cluster_selection_epsilon`.

The issue was that the function was returning arrays instead of scalars when indexing `cluster_tree` with boolean masks. When comparing these arrays to scalar values (like `root` or `cluster_selection_epsilon`), Cython attempted to convert them to Python scalars, which failed for non-0-dimensional arrays.

The fix adds `[0]` indexing to extract scalar values from the array results, consistent with how similar operations are done in the `epsilon_search` function (e.g., line 623: `eps = 1 / distances[leaf_nodes][0]`).

**Changes:**
- `sklearn/cluster/_hdbscan/_tree.pyx`: Added `[0]` indexing on lines 588 and 595 to extract scalar values from array results
- `sklearn/cluster/tests/test_hdbscan.py`: Added non-regression test based on the issue's reproducible example

#### AI usage disclosure
I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation

#### Any other comments?

The bug was triggered in specific cases where the cluster tree structure caused the boolean indexing to return array results instead of being implicitly converted to scalars. The fix ensures consistent scalar extraction behavior.

```
 sklearn/cluster/_hdbscan/_tree.pyx    |  4 ++--
 sklearn/cluster/tests/test_hdbscan.py | 25 +++++++++++++++++++++++++
 2 files changed, 27 insertions(+), 2 deletions(-)
```