### PR TITLE
DOC update LightGBM links

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -55,7 +55,7 @@ Histogram-Based Gradient Boosting
 Scikit-learn 0.21 introduced two new implementations of
 gradient boosted trees, namely :class:`HistGradientBoostingClassifier`
 and :class:`HistGradientBoostingRegressor`, inspired by
-`LightGBM <https://github.com/Microsoft/LightGBM>`__ (See [LightGBM]_).
+`LightGBM <https://github.com/lightgbm-org/LightGBM>`__ (See [LightGBM]_).
 
 These histogram-based estimators can be **orders of magnitude faster**
 than :class:`GradientBoostingClassifier` and

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1493,7 +1493,7 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
     usecase example of this feature.
 
     This implementation is inspired by
-    `LightGBM <https://github.com/Microsoft/LightGBM>`_.
+    `LightGBM <https://github.com/lightgbm-org/LightGBM>`_.
 
     Read more in the :ref:`User Guide <histogram_based_gradient_boosting>`.
 
@@ -1894,7 +1894,7 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
     missing values are mapped to whichever child has the most samples.
 
     This implementation is inspired by
-    `LightGBM <https://github.com/Microsoft/LightGBM>`_.
+    `LightGBM <https://github.com/lightgbm-org/LightGBM>`_.
 
     Read more in the :ref:`User Guide <histogram_based_gradient_boosting>`.
 

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -661,7 +661,7 @@ class TreeGrower:
         / \ / \      Right split at feature 2 has only group {1, 2} from now on.
 
         LightGBM uses the same logic for overlapping groups. See
-        https://github.com/microsoft/LightGBM/issues/4481 for details.
+        https://github.com/lightgbm-org/LightGBM/issues/4481 for details.
 
         Parameters:
         ----------

--- a/sklearn/ensemble/_hist_gradient_boosting/utils.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/utils.py
@@ -72,7 +72,7 @@ def get_equivalent_estimator(estimator, lib="lightgbm", n_classes=None):
         # LightGBM 3.0 introduced a different scaling of the hessian for the multiclass
         # case.
         # It is equivalent of scaling the learning rate.
-        # See https://github.com/microsoft/LightGBM/pull/3256.
+        # See https://github.com/lightgbm-org/LightGBM/pull/3256.
         if n_classes is not None:
             lightgbm_params["learning_rate"] *= n_classes / (n_classes - 1)
 


### PR DESCRIPTION
#### Reference Issues/PRs

https://github.com/lightgbm-org/LightGBM/issues/7187

#### What does this implement/fix? Explain your changes.

LightGBM has moved to a new GitHub organization, `lightgbm-org/LightGBM`.

This updates links in documentation to reflect that.

#### AI usage disclosure

N/A - no AI tools used

#### Any other comments?

I intentionally skipped these old release notes, which I assume you don't want updates to:

https://github.com/scikit-learn/scikit-learn/blob/3acced3fdb9e008726d48321a8b20c5e45a0a0c9/doc/whats_new/v0.21.rst?plain=1#L411

Please let me know if you'd like that to be updated as well.

Thanks for your time and consideration.