### PR TITLE
[Callbacks] FEA Add callbacks when cloning an estimator

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -139,7 +139,7 @@ def _clone_parametrized(estimator, *, safe=True):
     if hasattr(estimator, "_skl_callbacks"):
         # TODO(callbacks): Figure out the exact behavior we want when cloning an
         # estimator with callbacks.
-        new_object._skl_callbacks = clone(estimator._skl_callbacks, safe=False)
+        new_object._skl_callbacks = estimator._skl_callbacks
 
     # quick sanity check of the parameters of the clone
     for name in new_object_params:

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -49,6 +49,9 @@ def clone(estimator, *, safe=True):
     without actually copying attached data. It returns a new estimator
     with the same parameters that has not been fitted on any data.
 
+    If callbacks are attached to the estimator via a `_skl_callbacks` attribute, a copy
+    of the attribute is attached to the clone.
+
     .. versionchanged:: 1.3
         Delegates to `estimator.__sklearn_clone__` if the method exists.
 
@@ -137,8 +140,6 @@ def _clone_parametrized(estimator, *, safe=True):
 
     # attach callbacks to the new estimator
     if hasattr(estimator, "_skl_callbacks"):
-        # TODO(callbacks): Figure out the exact behavior we want when cloning an
-        # estimator with callbacks.
         new_object._skl_callbacks = estimator._skl_callbacks
 
     # quick sanity check of the parameters of the clone

--- a/sklearn/callback/tests/test_progressbar.py
+++ b/sklearn/callback/tests/test_progressbar.py
@@ -6,6 +6,7 @@ import sys
 
 import pytest
 
+from sklearn import clone
 from sklearn.callback import ProgressBar
 from sklearn.callback.tests._utils import (
     MaxIterEstimator,
@@ -67,3 +68,10 @@ def test_progressbar_requires_rich_error():
         err_msg = "Progressbar requires rich"
         with pytest.raises(ImportError, match=err_msg):
             ProgressBar()
+
+
+def test_clone_after_fit():
+    """Smoke test for cloning after fit with a progressbar attached."""
+    pytest.importorskip("rich")
+    est = MaxIterEstimator().set_callbacks(ProgressBar()).fit()
+    clone(est)


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #33323
Alternative to #33340 and #33421.

#### What does this implement/fix? Explain your changes.
Fixes `clone()` if an estimator comes with a callback.

Opening this PR for completeness, because we had forgotten to discuss this simple alternative.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding