### PR TITLE
DOC Improve n_jobs docstrings for LinearModelCV subclasses and TheilSenRegressor

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2062,7 +2062,9 @@ class LassoCV(RegressorMixin, LinearModelCV):
         Amount of verbosity.
 
     n_jobs : int, default=None
-        Number of CPUs to use during the cross validation.
+        Number of CPUs to use during cross-validation. The regularization
+        path computation is parallelized over the combination of ``l1_ratio``
+        values and cross-validation folds, using a threading backend.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -2335,7 +2337,9 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         Amount of verbosity.
 
     n_jobs : int, default=None
-        Number of CPUs to use during the cross validation.
+        Number of CPUs to use during cross-validation. The regularization
+        path computation is parallelized across cross-validation folds
+        using a threading backend.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -3033,8 +3037,10 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         Amount of verbosity.
 
     n_jobs : int, default=None
-        Number of CPUs to use during the cross validation. Note that this is
-        used only if multiple values for l1_ratio are given.
+        Number of CPUs to use during cross-validation. When multiple
+        ``l1_ratio`` values are provided, the regularization path
+        computation is parallelized over the combination of ``l1_ratio``
+        values and cross-validation folds, using a threading backend.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -3288,8 +3294,9 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
         Amount of verbosity.
 
     n_jobs : int, default=None
-        Number of CPUs to use during the cross validation. Note that this is
-        used only if multiple values for l1_ratio are given.
+        Number of CPUs to use during cross-validation. The regularization
+        path computation is parallelized across cross-validation folds
+        using a threading backend.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/linear_model/_theil_sen.py
+++ b/sklearn/linear_model/_theil_sen.py
@@ -256,7 +256,9 @@ class TheilSenRegressor(RegressorMixin, LinearModel):
         See :term:`Glossary <random_state>`.
 
     n_jobs : int, default=None
-        Number of CPUs to use during the cross validation.
+        Number of CPUs to use during fitting. The random subsampling
+        iterations are split across workers, with each worker fitting
+        least-squares estimates on its share of the subsampled data.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.


### PR DESCRIPTION
## Summary
- Improved `n_jobs` docstrings for `ElasticNetCV`, `LassoCV`, `MultiTaskElasticNetCV`, `MultiTaskLassoCV`, and `TheilSenRegressor` to describe what is actually parallelized
- For the `LinearModelCV` subclasses, the docstrings now explain that the regularization path computation is parallelized over cross-validation folds (and `l1_ratio` values where applicable), using a threading backend
- Fixed a factual error in `TheilSenRegressor`: the old docstring said "cross validation" but the estimator uses random subsampling, not CV

## References
Addresses part of #14228.

## Test plan
- [ ] Verify docstrings render correctly
- [ ] Confirm no test regressions in `test_coordinate_descent.py` and `test_theil_sen.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)