### PR TITLE
DOC Improve n_jobs docstrings for LarsCV, LassoLarsCV and OrthogonalMatchingPursuitCV

### DIFF
--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -1559,7 +1559,9 @@ class LarsCV(Lars):
         residuals in the cross-validation.
 
     n_jobs : int or None, default=None
-        Number of CPUs to use during the cross validation.
+        Number of CPUs to use during cross-validation. The LARS path
+        computation is parallelized across cross-validation folds, with
+        each fold fitted independently.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -1879,7 +1881,9 @@ class LassoLarsCV(LarsCV):
         residuals in the cross-validation.
 
     n_jobs : int or None, default=None
-        Number of CPUs to use during the cross validation.
+        Number of CPUs to use during cross-validation. The LARS path
+        computation is parallelized across cross-validation folds, with
+        each fold fitted independently.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -939,7 +939,9 @@ class OrthogonalMatchingPursuitCV(RegressorMixin, LinearModel):
             ``cv`` default value if None changed from 3-fold to 5-fold.
 
     n_jobs : int, default=None
-        Number of CPUs to use during the cross validation.
+        Number of CPUs to use during cross-validation. The OMP path
+        computation is parallelized across cross-validation folds, with
+        each fold fitted independently.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.


### PR DESCRIPTION
## Summary
- Improved `n_jobs` docstrings for `LarsCV`, `LassoLarsCV`, and `OrthogonalMatchingPursuitCV` to describe what is actually parallelized
- The docstrings now explain that the path computation is parallelized across cross-validation folds, with each fold fitted independently

## References
Addresses part of #14228.

## Test plan
- [ ] Verify docstrings render correctly
- [ ] Confirm no test regressions in `test_least_angle.py` and `test_omp.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)