### PR TITLE
DOC Improve n_jobs docstring for LogisticRegressionCV

### DIFF
--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1607,7 +1607,11 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
            class_weight == 'balanced'
 
     n_jobs : int, default=None
-        Number of CPU cores used during the cross-validation loop.
+        Number of CPUs to use during cross-validation. The regularization
+        path computation is parallelized over the combination of
+        cross-validation folds and ``l1_ratios`` values. For the ``sag``
+        and ``saga`` solvers, a threading backend is used since they
+        release the GIL; other solvers use a process-based backend.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.


### PR DESCRIPTION
## Summary
- Improved `n_jobs` docstring for `LogisticRegressionCV` to describe what is actually parallelized
- The docstring now explains that the regularization path computation is parallelized over the combination of cross-validation folds and `l1_ratios` values, and that the backend choice depends on the solver (`sag`/`saga` use threading since they release the GIL, others use processes)

## References
Addresses part of #14228.

## Test plan
- [ ] Verify docstring renders correctly
- [ ] Confirm no test regressions in `test_logistic.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)