### PR TITLE
DOC Improve n_jobs docstrings for dictionary learning estimators

### DIFF
--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1235,7 +1235,9 @@ class SparseCoder(_BaseSparseCoding, BaseEstimator):
         performance of downstream classifiers.
 
     n_jobs : int, default=None
-        Number of parallel jobs to run.
+        Number of parallel jobs to run. During :meth:`transform`, samples
+        are split into ``n_jobs`` slices and each slice is encoded against
+        the dictionary in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -1492,7 +1494,10 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
             When None, default value changed from 1.0 to `alpha`.
 
     n_jobs : int or None, default=None
-        Number of parallel jobs to run.
+        Number of parallel jobs to run. During both :meth:`fit` and
+        :meth:`transform`, the sparse encoding step splits samples into
+        ``n_jobs`` slices and encodes each slice against the dictionary in
+        parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -1799,7 +1804,10 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
           the estimated components are sparse.
 
     n_jobs : int, default=None
-        Number of parallel jobs to run.
+        Number of parallel jobs to run. During both :meth:`fit` and
+        :meth:`transform`, the sparse encoding step splits samples into
+        ``n_jobs`` slices and encodes each slice against the dictionary in
+        parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/decomposition/_sparse_pca.py
+++ b/sklearn/decomposition/_sparse_pca.py
@@ -197,7 +197,10 @@ class SparsePCA(_BaseSparsePCA):
         the estimated components are sparse.
 
     n_jobs : int, default=None
-        Number of parallel jobs to run.
+        Number of parallel jobs to run. During :meth:`fit`, the sparse
+        encoding step of the dictionary learning algorithm splits samples
+        into ``n_jobs`` slices and encodes each slice in parallel. Does not
+        affect :meth:`transform`.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -384,7 +387,10 @@ class MiniBatchSparsePCA(_BaseSparsePCA):
         Whether to shuffle the data before splitting it in batches.
 
     n_jobs : int, default=None
-        Number of parallel jobs to run.
+        Number of parallel jobs to run. During :meth:`fit`, the sparse
+        encoding step of the mini-batch dictionary learning algorithm splits
+        samples into ``n_jobs`` slices and encodes each slice in parallel.
+        Does not affect :meth:`transform`.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.


### PR DESCRIPTION
## Summary
- Updates `n_jobs` docstrings for 5 dictionary learning estimators: `DictionaryLearning`, `MiniBatchDictionaryLearning`, `SparseCoder`, `SparsePCA`, and `MiniBatchSparsePCA`
- Replaces generic "Number of parallel jobs to run" with specifics about what is parallelized: samples are split into `n_jobs` slices and each slice is sparse-encoded against the dictionary in parallel (via `sparse_encode()`)
- Clarifies which methods are affected: `SparsePCA` and `MiniBatchSparsePCA` only use `n_jobs` during `fit()` (not `transform()`), `SparseCoder` only during `transform()`, and `DictionaryLearning`/`MiniBatchDictionaryLearning` during both

Contributes to #14228.

## Test plan
- [ ] Verify rendered docstrings render correctly
- [ ] Confirm no test regressions in `sklearn/decomposition/tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)