### PR TITLE
DOC Improve n_jobs docstrings for KernelPCA and LatentDirichletAllocation

### DIFF
--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -154,7 +154,9 @@ class KernelPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator
         .. versionadded:: 0.18
 
     n_jobs : int, default=None
-        The number of parallel jobs to run.
+        The number of parallel jobs to run. The kernel matrix computation
+        is split into ``n_jobs`` row slices and each slice is computed in
+        parallel. Affects both :meth:`fit` and :meth:`transform`.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/decomposition/_lda.py
+++ b/sklearn/decomposition/_lda.py
@@ -246,7 +246,11 @@ class LatentDirichletAllocation(
         the E-step.
 
     n_jobs : int, default=None
-        The number of jobs to use in the E-step.
+        The number of jobs to use in the E-step. Documents are split into
+        ``n_jobs`` slices, and the topic distribution for each slice is
+        updated independently in parallel. This applies during :meth:`fit`,
+        :meth:`partial_fit`, and :meth:`transform`. The M-step is not
+        parallelized.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.


### PR DESCRIPTION
## Summary
- **KernelPCA**: clarifies that the kernel matrix computation is split into `n_jobs` row slices computed in parallel, affecting both `fit` and `transform`
- **LatentDirichletAllocation**: expands the existing E-step mention to explain that documents are split into `n_jobs` slices with topic distributions updated in parallel, notes this applies during `fit`, `partial_fit`, and `transform`, and that the M-step is not parallelized

Contributes to #14228.

## Test plan
- [ ] Verify rendered docstrings render correctly
- [ ] Confirm no test regressions in `sklearn/decomposition/tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)