### PR TITLE
DOC Improve n_jobs docstrings for DBSCAN, HDBSCAN, and OPTICS

### DIFF
--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -269,7 +269,10 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         distance). When p=1, this is equivalent to Manhattan distance.
 
     n_jobs : int, default=None
-        The number of parallel jobs to run.
+        The number of parallel jobs to run for neighbors search during
+        :meth:`fit`. The radius neighbor query is parallelized across
+        samples. Has no effect when ``metric="precomputed"`` since
+        distances are already provided.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/cluster/_hdbscan/hdbscan.py
+++ b/sklearn/cluster/_hdbscan/hdbscan.py
@@ -493,9 +493,15 @@ class HDBSCAN(ClusterMixin, BaseEstimator):
         parameter. Ignored for `algorithm="brute"`.
 
     n_jobs : int, default=None
-        Number of jobs to run in parallel to calculate distances.
-        `None` means 1 unless in a :obj:`joblib.parallel_backend` context.
-        `-1` means using all processors. See :term:`Glossary <n_jobs>`
+        Number of jobs to run in parallel during :meth:`fit`. When
+        ``algorithm="brute"``, the pairwise distance matrix is split into
+        ``n_jobs`` row slices and computed in parallel. When
+        ``algorithm="kd_tree"`` or ``algorithm="ball_tree"``, the
+        nearest neighbor query is parallelized across samples. When
+        ``algorithm="auto"``, the behavior depends on which algorithm is
+        selected.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
 
     cluster_selection_method : {"eom", "leaf"}, default="eom"

--- a/sklearn/cluster/_mean_shift.py
+++ b/sklearn/cluster/_mean_shift.py
@@ -188,15 +188,13 @@ def mean_shift(
         operation terminates (for that seed point), if has not converged yet.
 
     n_jobs : int, default=None
-        The number of jobs to use for the computation. The following tasks benefit
-        from the parallelization:
+        The number of jobs to use for the computation. The following tasks
+        benefit from the parallelization:
 
         - The search of nearest neighbors for bandwidth estimation and label
           assignments. See the details in the docstring of the
           ``NearestNeighbors`` class.
         - Hill-climbing optimization for all seeds.
-
-        See :term:`Glossary <n_jobs>` for more details.
 
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
@@ -347,15 +345,13 @@ class MeanShift(ClusterMixin, BaseEstimator):
         If false, then orphans are given cluster label -1.
 
     n_jobs : int, default=None
-        The number of jobs to use for the computation. The following tasks benefit
-        from the parallelization:
+        The number of jobs to use for the computation. The following tasks
+        benefit from the parallelization:
 
         - The search of nearest neighbors for bandwidth estimation and label
           assignments. See the details in the docstring of the
           ``NearestNeighbors`` class.
         - Hill-climbing optimization for all seeds.
-
-        See :term:`Glossary <n_jobs>` for more details.
 
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -158,7 +158,9 @@ class OPTICS(ClusterMixin, BaseEstimator):
         path to the caching directory.
 
     n_jobs : int, default=None
-        The number of parallel jobs to run for neighbors search.
+        The number of parallel jobs to run for neighbors search. During
+        :meth:`fit`, the k-nearest neighbors query used to compute the
+        OPTICS reachability graph is parallelized across samples.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.


### PR DESCRIPTION
## Summary
- **DBSCAN**: clarifies that `n_jobs` parallelizes the radius neighbor query across samples during `fit`, and has no effect when `metric="precomputed"`
- **HDBSCAN**: explains the algorithm-dependent behavior — brute splits pairwise distance matrix into row slices, while kd_tree/ball_tree parallelize the kNN query across samples
- **OPTICS**: clarifies that the kNN query for the reachability graph is parallelized across samples during `fit`
- **MeanShift**: minor cleanup removing a duplicate Glossary reference (in both the class and function docstrings)

SpectralClustering is already well-documented and left unchanged.

Contributes to #14228.

## Test plan
- [ ] Verify rendered docstrings render correctly
- [ ] Confirm no test regressions in `sklearn/cluster/tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)