### PR TITLE
DOC Improve n_jobs docstrings for Isomap, LocallyLinearEmbedding, and SpectralEmbedding

### DIFF
--- a/sklearn/manifold/_isomap.py
+++ b/sklearn/manifold/_isomap.py
@@ -80,7 +80,12 @@ class Isomap(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         passed to neighbors.NearestNeighbors instance.
 
     n_jobs : int or None, default=None
-        The number of parallel jobs to run.
+        The number of parallel jobs to run. During :meth:`fit`, the
+        neighbor search and neighbor graph construction are parallelized
+        across samples. The kernel matrix computation used for the
+        final embedding is also parallelized. During :meth:`transform`,
+        the neighbor search for new points uses ``n_jobs`` as well.
+        The shortest path computation is not parallelized.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/manifold/_locally_linear.py
+++ b/sklearn/manifold/_locally_linear.py
@@ -674,7 +674,10 @@ class LocallyLinearEmbedding(
         across multiple function calls. See :term:`Glossary <random_state>`.
 
     n_jobs : int or None, default=None
-        The number of parallel jobs to run.
+        The number of parallel jobs to run. During :meth:`fit`, the
+        neighbor search and barycenter weight computation are parallelized
+        across samples. The eigenvalue decomposition used for the final
+        embedding is not parallelized.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -541,7 +541,12 @@ class SpectralEmbedding(BaseEstimator):
         If None, n_neighbors will be set to max(n_samples/10, 1).
 
     n_jobs : int, default=None
-        The number of parallel jobs to run.
+        The number of parallel jobs to run. Only used when
+        ``affinity="nearest_neighbors"`` or
+        ``affinity="precomputed_nearest_neighbors"``, in which case the
+        neighbor search for constructing the affinity matrix is
+        parallelized across samples during :meth:`fit`. Has no effect for
+        other affinity types.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.


### PR DESCRIPTION
## Summary
- **Isomap**: explains that `n_jobs` parallelizes neighbor search, neighbor graph construction, and kernel matrix computation during `fit`, plus neighbor search during `transform`. Notes that shortest path computation is not parallelized.
- **LocallyLinearEmbedding**: clarifies that neighbor search and barycenter weight computation are parallelized across samples during `fit`, and that the eigenvalue decomposition is not parallelized.
- **SpectralEmbedding**: documents that `n_jobs` only applies when `affinity="nearest_neighbors"` or `affinity="precomputed_nearest_neighbors"`, with no effect for other affinity types.

MDS and TSNE already have good docstrings and are left unchanged.

Contributes to #14228.

## Test plan
- [ ] Verify rendered docstrings render correctly
- [ ] Confirm no test regressions in `sklearn/manifold/tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)