### PR TITLE
DOC Improve n_jobs docstrings for GridSearchCV, RandomizedSearchCV, and Halving variants

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1293,7 +1293,13 @@ class GridSearchCV(BaseSearchCV):
         See :ref:`multimetric_grid_search` for an example.
 
     n_jobs : int, default=None
-        Number of jobs to run in parallel.
+        Number of jobs to run in parallel. Each job fits and scores a
+        single parameter combination on a single CV fold, so the total
+        number of parallel tasks equals the number of parameter candidates
+        times the number of CV folds. Only affects :meth:`fit`, not
+        :meth:`predict` or :meth:`score` on the refitted estimator.
+        The ``pre_dispatch`` parameter controls how many jobs are
+        dispatched at once to limit memory usage.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -1682,7 +1688,13 @@ class RandomizedSearchCV(BaseSearchCV):
         If None, the estimator's score method is used.
 
     n_jobs : int, default=None
-        Number of jobs to run in parallel.
+        Number of jobs to run in parallel. Each job fits and scores a
+        single sampled parameter setting on a single CV fold, so the total
+        number of parallel tasks equals ``n_iter`` times the number of CV
+        folds. Only affects :meth:`fit`, not :meth:`predict` or
+        :meth:`score` on the refitted estimator. The ``pre_dispatch``
+        parameter controls how many jobs are dispatched at once to limit
+        memory usage.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/model_selection/_search_successive_halving.py
+++ b/sklearn/model_selection/_search_successive_halving.py
@@ -536,7 +536,10 @@ class HalvingGridSearchCV(BaseSuccessiveHalving):
         See :term:`Glossary <random_state>`.
 
     n_jobs : int or None, default=None
-        Number of jobs to run in parallel.
+        Number of jobs to run in parallel. Within each halving round,
+        each job fits and scores a single candidate on a single CV fold.
+        Successive halving rounds run sequentially, but the fit-and-score
+        operations within each round are parallelized.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -897,7 +900,10 @@ class HalvingRandomSearchCV(BaseSuccessiveHalving):
         See :term:`Glossary <random_state>`.
 
     n_jobs : int or None, default=None
-        Number of jobs to run in parallel.
+        Number of jobs to run in parallel. Within each halving round,
+        each job fits and scores a single candidate on a single CV fold.
+        Successive halving rounds run sequentially, but the fit-and-score
+        operations within each round are parallelized.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.


### PR DESCRIPTION
## Summary
- **GridSearchCV**: clarifies that each job fits and scores a single parameter combination on a single CV fold (candidates × folds), only affects `fit` not `predict`/`score` on the refitted estimator, and mentions `pre_dispatch` for memory control
- **RandomizedSearchCV**: same pattern but references `n_iter` instead of parameter grid size
- **HalvingGridSearchCV** and **HalvingRandomSearchCV**: explains that successive halving rounds run sequentially, but fit-and-score operations within each round are parallelized across candidates × folds

TunedThresholdClassifierCV already has a good docstring and is left unchanged.

Contributes to #14228.

## Test plan
- [ ] Verify rendered docstrings render correctly
- [ ] Confirm no test regressions in `sklearn/model_selection/tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)