### PR TITLE
DOC Improve n_jobs docstrings for neighbors estimators

### DIFF
--- a/sklearn/neighbors/_classification.py
+++ b/sklearn/neighbors/_classification.py
@@ -114,11 +114,14 @@ class KNeighborsClassifier(KNeighborsMixin, ClassifierMixin, NeighborsBase):
         Additional keyword arguments for the metric function.
 
     n_jobs : int, default=None
-        The number of parallel jobs to run for neighbors search.
+        The number of parallel jobs to run for neighbors search. Query
+        samples are split across workers, with each worker searching for
+        neighbors independently. Affects :meth:`predict`,
+        :meth:`predict_proba`, :meth:`kneighbors`, and
+        :meth:`kneighbors_graph`. Does not affect :meth:`fit`.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
-        Doesn't affect :meth:`fit` method.
 
     Attributes
     ----------
@@ -539,7 +542,11 @@ class RadiusNeighborsClassifier(RadiusNeighborsMixin, ClassifierMixin, Neighbors
         Additional keyword arguments for the metric function.
 
     n_jobs : int, default=None
-        The number of parallel jobs to run for neighbors search.
+        The number of parallel jobs to run for neighbors search. Query
+        samples are split across workers, with each worker finding
+        neighbors within the radius independently. Affects :meth:`predict`,
+        :meth:`predict_proba`, :meth:`radius_neighbors`, and
+        :meth:`radius_neighbors_graph`. Does not affect :meth:`fit`.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/neighbors/_graph.py
+++ b/sklearn/neighbors/_graph.py
@@ -329,8 +329,13 @@ class KNeighborsTransformer(
         Additional keyword arguments for the metric function.
 
     n_jobs : int, default=None
-        The number of parallel jobs to run for neighbors search.
-        If ``-1``, then the number of jobs is set to the number of CPU cores.
+        The number of parallel jobs to run for neighbors search. Query
+        samples are split across workers, with each worker searching for
+        neighbors independently. Affects :meth:`transform` and
+        :meth:`fit_transform`.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
+        for more details.
 
     Attributes
     ----------
@@ -556,8 +561,13 @@ class RadiusNeighborsTransformer(
         Additional keyword arguments for the metric function.
 
     n_jobs : int, default=None
-        The number of parallel jobs to run for neighbors search.
-        If ``-1``, then the number of jobs is set to the number of CPU cores.
+        The number of parallel jobs to run for neighbors search. Query
+        samples are split across workers, with each worker finding
+        neighbors within the radius independently. Affects :meth:`transform`
+        and :meth:`fit_transform`.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
+        for more details.
 
     Attributes
     ----------

--- a/sklearn/neighbors/_lof.py
+++ b/sklearn/neighbors/_lof.py
@@ -108,7 +108,12 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
         .. versionadded:: 0.20
 
     n_jobs : int, default=None
-        The number of parallel jobs to run for neighbors search.
+        The number of parallel jobs to run for neighbors search. Query
+        samples are split across workers, with each worker searching for
+        neighbors independently. Unlike most neighbors estimators, this
+        affects :meth:`fit` (which computes neighbor distances for local
+        reachability density), as well as :meth:`score_samples` and
+        :meth:`predict` when ``novelty=True``.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -99,11 +99,14 @@ class KNeighborsRegressor(KNeighborsMixin, RegressorMixin, NeighborsBase):
         Additional keyword arguments for the metric function.
 
     n_jobs : int, default=None
-        The number of parallel jobs to run for neighbors search.
+        The number of parallel jobs to run for neighbors search. Query
+        samples are split across workers, with each worker searching for
+        neighbors independently. Affects :meth:`predict`,
+        :meth:`kneighbors`, and :meth:`kneighbors_graph`. Does not affect
+        :meth:`fit`.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
-        Doesn't affect :meth:`fit` method.
 
     Attributes
     ----------
@@ -347,7 +350,11 @@ class RadiusNeighborsRegressor(RadiusNeighborsMixin, RegressorMixin, NeighborsBa
         Additional keyword arguments for the metric function.
 
     n_jobs : int, default=None
-        The number of parallel jobs to run for neighbors search.
+        The number of parallel jobs to run for neighbors search. Query
+        samples are split across workers, with each worker finding
+        neighbors within the radius independently. Affects :meth:`predict`,
+        :meth:`radius_neighbors`, and :meth:`radius_neighbors_graph`. Does
+        not affect :meth:`fit`.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/neighbors/_unsupervised.py
+++ b/sklearn/neighbors/_unsupervised.py
@@ -69,7 +69,11 @@ class NearestNeighbors(KNeighborsMixin, RadiusNeighborsMixin, NeighborsBase):
         Additional keyword arguments for the metric function.
 
     n_jobs : int, default=None
-        The number of parallel jobs to run for neighbors search.
+        The number of parallel jobs to run for neighbors search. Query
+        samples are split across workers, with each worker searching for
+        neighbors independently. Affects :meth:`kneighbors`,
+        :meth:`kneighbors_graph`, :meth:`radius_neighbors`, and
+        :meth:`radius_neighbors_graph`. Does not affect :meth:`fit`.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.


### PR DESCRIPTION
## Summary
Updates `n_jobs` docstrings for all 8 neighbors estimators, explaining that query samples are split across workers for parallel neighbor search, and listing which methods are affected:

- **KNeighborsClassifier**: `predict`, `predict_proba`, `kneighbors`, `kneighbors_graph` (not `fit`)
- **KNeighborsRegressor**: `predict`, `kneighbors`, `kneighbors_graph` (not `fit`)
- **KNeighborsTransformer**: `transform`, `fit_transform`
- **RadiusNeighborsClassifier**: `predict`, `predict_proba`, `radius_neighbors`, `radius_neighbors_graph` (not `fit`)
- **RadiusNeighborsRegressor**: `predict`, `radius_neighbors`, `radius_neighbors_graph` (not `fit`)
- **RadiusNeighborsTransformer**: `transform`, `fit_transform`
- **NearestNeighbors**: all four query methods (not `fit`)
- **LocalOutlierFactor**: notably *does* affect `fit` (computes neighbor distances for local reachability density), plus `score_samples` and `predict` when `novelty=True`

Also normalizes the Glossary reference for `KNeighborsTransformer` and `RadiusNeighborsTransformer`, which previously had a non-standard format.

Contributes to #14228.

## Test plan
- [ ] Verify rendered docstrings render correctly
- [ ] Confirm no test regressions in `sklearn/neighbors/tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)