### PR TITLE
MNT enable mixed array support for `accuracy_score`, `f1_score`, `multilabel_confusion_matrix`, `precision_score` and `recall_score`

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -741,7 +741,8 @@ def multilabel_confusion_matrix(
             [1, 2]]])
     """
     y_true, y_pred = attach_unique(y_true, y_pred)
-    xp, _, device_ = get_namespace_and_device(y_true, y_pred, sample_weight)
+    xp, _, device_ = get_namespace_and_device(y_pred)
+    y_true, sample_weight = move_to(y_true, sample_weight, xp=xp, device=device_)
     y_type, y_true, y_pred, sample_weight = _check_targets(
         y_true, y_pred, sample_weight
     )
@@ -2145,6 +2146,8 @@ def precision_recall_fscore_support(
      array([2, 2, 2]))
     """
     _check_zero_division(zero_division)
+    xp, _, device_ = get_namespace_and_device(y_pred)
+    y_true, sample_weight = move_to(y_true, sample_weight, xp=xp, device=device_)
     labels = _check_set_wise_labels(y_true, y_pred, average, labels, pos_label)
 
     # Calculate tp_sum, pred_sum, true_sum ###
@@ -2160,7 +2163,6 @@ def precision_recall_fscore_support(
     pred_sum = tp_sum + MCM[:, 0, 1]
     true_sum = tp_sum + MCM[:, 1, 0]
 
-    xp, _, device_ = get_namespace_and_device(y_true, y_pred)
     if average == "micro":
         tp_sum = xp.reshape(xp.sum(tp_sum), (1,))
         pred_sum = xp.reshape(xp.sum(pred_sum), (1,))

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -621,13 +621,18 @@ METRICS_WITH_LOG1P_Y = {
 # Metrics that support mixed namespace/device array API inputs
 # Mixed mixed namespace/device support is NOT planned for pairwise metrics
 METRICS_SUPPORTING_MIXED_NAMESPACE = [
+    "accuracy_score",
     "average_precision_score",
     "brier_score_loss",
     "confusion_matrix_at_thresholds",
     "d2_brier_score",
     "d2_log_loss_score",
+    "f1_score",
     "log_loss",
     "max_error",
+    "multilabel_confusion_matrix",
+    "precision_score",
+    "recall_score",
 ]
 
 

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -620,7 +620,7 @@ METRICS_WITH_LOG1P_Y = {
 }
 
 # Metrics that support mixed namespace/device array API inputs
-# Mixed mixed namespace/device support is NOT planned for pairwise metrics
+# Mixed namespace/device support is NOT planned for pairwise metrics
 METRICS_SUPPORTING_MIXED_NAMESPACE = [
     "accuracy_score",
     "average_precision_score",

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -100,6 +100,7 @@ from sklearn.utils._testing import (
     assert_array_equal,
     assert_array_less,
     ignore_warnings,
+    skip_if_array_api_compat_not_configured,
 )
 from sklearn.utils.fixes import COO_CONTAINERS, parse_version, sp_version
 from sklearn.utils.multiclass import type_of_target
@@ -2606,6 +2607,7 @@ def test_mixed_array_api_namespace_input_compliance(
         & (set(CLASSIFICATION_METRICS.keys()) - METRIC_UNDEFINED_BINARY)
     ),
 )
+@skip_if_array_api_compat_not_configured
 def test_array_api_classification_string_input(metric_name):
     """Check string inputs accepted with array API dispatch enabled.
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -2136,7 +2136,9 @@ def _check_sample_weight(
     sample_weight : ndarray of shape (n_samples,)
         Validated sample weight. It is guaranteed to be "C" contiguous.
     """
-    xp, is_array_api, device = get_namespace_and_device(X, remove_types=(int, float))
+    xp, is_array_api, device = get_namespace_and_device(
+        X, remove_types=(list, int, float)
+    )
 
     n_samples = _num_samples(X)
 


### PR DESCRIPTION


<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #26024
Follow up of #32755

#### What does this implement/fix? Explain your changes.
- Enables `accuracy_score`, `f1_score`, `multilabel_confusion_matrix`, `precision_score` and `recall_score` to work with mixed array API inputs.

#### AI usage disclosure
No AI


#### Any other comments?
CC: @lucyleeow @ogrisel 

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
