### PR TITLE
TST Add `log_loss` to `METRICS_WITH_NORMALIZE_OPTION` in `test_common.py`

### DIFF
--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -430,6 +430,7 @@ METRICS_WITH_LABELS = {
 # Metrics with a "normalize" option
 METRICS_WITH_NORMALIZE_OPTION = {
     "accuracy_score",
+    "log_loss",
     "top_k_accuracy_score",
     "zero_one_loss",
 }
@@ -1330,7 +1331,7 @@ def test_normalize_option_binary_classification(name):
 
     y_true = random_state.randint(0, n_classes, size=(n_samples,))
     y_pred = random_state.randint(0, n_classes, size=(n_samples,))
-    y_score = random_state.normal(size=y_true.shape)
+    y_score = random_state.uniform(size=y_true.shape)
 
     metrics = ALL_METRICS[name]
     pred = y_score if name in CONTINUOUS_CLASSIFICATION_METRICS else y_pred
@@ -1359,7 +1360,9 @@ def test_normalize_option_multiclass_classification(name):
 
     y_true = random_state.randint(0, n_classes, size=(n_samples,))
     y_pred = random_state.randint(0, n_classes, size=(n_samples,))
-    y_score = random_state.uniform(size=(n_samples, n_classes))
+    y_score = random_state.rand(n_samples, n_classes)
+    temp = np.exp(-y_score)
+    y_score = temp / temp.sum(axis=-1).reshape(-1, 1)
 
     metrics = ALL_METRICS[name]
     pred = y_score if name in CONTINUOUS_CLASSIFICATION_METRICS else y_pred


### PR DESCRIPTION

#### Reference Issues/PRs
Noticed while looking into #33473

#### What does this implement/fix? Explain your changes.
Add `log_loss` to `METRICS_WITH_NORMALIZE_OPTION` in `test_common.py`

Note that the only other metric with a `normalize` parameter is `confusion_matrix` but this is a bit of a special case (and the common tests won't work here) so I think it is fine to ignore.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?
cc @ogrisel 

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
