### PR TITLE
TST Clean up `METRICS_WITH_LABELS` in `test_common.py`

### DIFF
--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -391,9 +391,6 @@ METRICS_WITH_POS_LABEL = {
 METRICS_WITH_LABELS = {
     "confusion_matrix",
     "normalized_confusion_matrix",
-    "roc_curve",
-    "precision_recall_curve",
-    "det_curve",
     "precision_score",
     "recall_score",
     "f1_score",


### PR DESCRIPTION

#### Reference Issues/PRs
Noticed while looking into https://github.com/scikit-learn/scikit-learn/pull/33473

Related #33505


#### What does this implement/fix? Explain your changes.
Remove metrics that do not have `labels` from `METRICS_WITH_LABELS`

Note `METRICS_WITH_LABELS` is only used in one test, and it was not failing because these wrongly included curve metrics were not part of the parametrization of that test.

This is the only test it is used in:

https://github.com/scikit-learn/scikit-learn/blob/ceeffc5d6e3494d4973472e7690ec8bce2f83b4e/sklearn/metrics/tests/test_common.py#L984-L987

and the curve metrics are not part of `CLASSIFICATION_METRICS`

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
