### PR TITLE
CI Add GHA aggregate job

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,8 +19,8 @@ env:
   VIRTUALENV: testvenv
   TEST_DIR: ${{ github.workspace }}/tmp_folder
   CCACHE_DIR: ${{ github.workspace }}/ccache
-  COVERAGE: "true"
-  JUNITXML: "test-data.xml"
+  COVERAGE: 'true'
+  JUNITXML: 'test-data.xml'
 
 jobs:
   lint:
@@ -33,8 +33,8 @@ jobs:
         uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
-          cache: "pip"
+          python-version: '3.12'
+          cache: 'pip'
       - name: Install linters
         run: |
           source build_tools/shared.sh
@@ -132,7 +132,7 @@ jobs:
             DISTRIB: conda
             LOCK_FILE: build_tools/github/pylatest_conda_forge_mkl_linux-64_conda.lock
             COVERAGE: true
-            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 42 # default global random seed
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 42  # default global random seed
             SCIPY_ARRAY_API: 1
             # Tests that require large downloads over the networks are skipped in CI.
             # Here we make sure, that they are still run on a regular basis.
@@ -145,7 +145,7 @@ jobs:
             LOCK_FILE: build_tools/github/pymin_conda_forge_openblas_ubuntu_2204_linux-64_conda.lock
             SKLEARN_WARNINGS_AS_ERRORS: 1
             COVERAGE: false
-            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 0 # non-default seed
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 0  # non-default seed
 
           # Linux build with minimum supported version of dependencies
           - name: Linux x86-64 pymin_conda_forge_openblas_min_dependencies
@@ -158,7 +158,7 @@ jobs:
             # https://github.com/scikit-learn/scikit-learn/pull/24438
             SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES: 1
             SKLEARN_RUN_FLOAT32_TESTS: 1
-            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 2 # non-default seed
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 2  # non-default seed
 
           # Linux environment to test the latest available dependencies.
           # It runs tests requiring lightgbm, pandas and PyAMG.
@@ -166,7 +166,7 @@ jobs:
             os: ubuntu-24.04
             DISTRIB: conda
             LOCK_FILE: build_tools/github/pylatest_pip_openblas_pandas_linux-64_conda.lock
-            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 3 # non-default seed
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 3  # non-default seed
             SCIPY_ARRAY_API: 1
             CHECK_PYTEST_SOFT_DEPENDENCY: true
             SKLEARN_WARNINGS_AS_ERRORS: 1
@@ -184,13 +184,13 @@ jobs:
             DISTRIB: ubuntu
             LOCK_FILE: build_tools/github/ubuntu_atlas_lock.txt
             COVERAGE: false
-            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 1 # non-default seed
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 1  # non-default seed
 
           - name: macOS pylatest_conda_forge_arm
             os: macos-15
             DISTRIB: conda
             LOCK_FILE: build_tools/github/pylatest_conda_forge_osx-arm64_conda.lock
-            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 5 # non-default seed
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 5  # non-default seed
             SCIPY_ARRAY_API: 1
             PYTORCH_ENABLE_MPS_FALLBACK: 1
             CHECK_PYTEST_SOFT_DEPENDENCY: true
@@ -201,7 +201,7 @@ jobs:
             LOCK_FILE: build_tools/github/pylatest_conda_forge_mkl_no_openmp_osx-64_conda.lock
             SKLEARN_TEST_NO_OPENMP: true
             SKLEARN_SKIP_OPENMP_TEST: true
-            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 6 # non-default seed
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 6  # non-default seed
 
           - name: Windows x64 pymin_conda_forge_openblas
             os: windows-latest
@@ -219,7 +219,7 @@ jobs:
             # flag for pytest.
             # https://github.com/scikit-learn/scikit-learn/pull/24438
             SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES: 1
-            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 7 # non-default seed
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 7  # non-default seed
 
     env: ${{ matrix }}
 
@@ -320,7 +320,8 @@ jobs:
             --job-name "$JOB_NAME"
 
   free-threaded:
-    name: &free-threaded-job-name Linux x86-64 pylatest_free_threaded
+    name: &free-threaded-job-name
+      Linux x86-64 pylatest_free_threaded
     runs-on: ubuntu-latest
     needs: [lint, retrieve-commit-message, retrieve-selected-tests]
     if: contains(needs.retrieve-commit-message.outputs.message, '[free-threaded]') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -335,7 +336,8 @@ jobs:
     steps: *unit-tests-steps
 
   scipy-dev:
-    name: &scipy-dev-job-name Linux x86-64 pylatest_pip_scipy_dev
+    name: &scipy-dev-job-name 
+      Linux x86-64 pylatest_pip_scipy_dev
     runs-on: ubuntu-22.04
     needs: [lint, retrieve-commit-message, retrieve-selected-tests]
     if: contains(needs.retrieve-commit-message.outputs.message, '[scipy-dev]') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -349,13 +351,14 @@ jobs:
     steps: *unit-tests-steps
 
   debian-32bit:
-    name: &debian-32bit-job-name Linux i386 debian_32bit
+    name: &debian-32bit-job-name 
+      Linux i386 debian_32bit
     runs-on: ubuntu-24.04
     needs: [lint, retrieve-commit-message, retrieve-selected-tests]
     env:
       DISTRIB: debian-32
       LOCK_FILE: build_tools/github/debian_32bit_lock.txt
-      SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 4 # non-default seed
+      SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 4  # non-default seed
       DOCKER_CONTAINER: i386/debian:trixie
       # To be able to access the job name in the steps, it must be set as an env variable.
       JOB_NAME: *debian-32bit-job-name
@@ -484,4 +487,4 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-failures: free-threaded,scipy-dev
+          allowed-skips: free-threaded,scipy-dev

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -336,7 +336,7 @@ jobs:
     steps: *unit-tests-steps
 
   scipy-dev:
-    name: &scipy-dev-job-name 
+    name: &scipy-dev-job-name
       Linux x86-64 pylatest_pip_scipy_dev
     runs-on: ubuntu-22.04
     needs: [lint, retrieve-commit-message, retrieve-selected-tests]
@@ -351,7 +351,7 @@ jobs:
     steps: *unit-tests-steps
 
   debian-32bit:
-    name: &debian-32bit-job-name 
+    name: &debian-32bit-job-name
       Linux i386 debian_32bit
     runs-on: ubuntu-24.04
     needs: [lint, retrieve-commit-message, retrieve-selected-tests]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,8 +19,8 @@ env:
   VIRTUALENV: testvenv
   TEST_DIR: ${{ github.workspace }}/tmp_folder
   CCACHE_DIR: ${{ github.workspace }}/ccache
-  COVERAGE: 'true'
-  JUNITXML: 'test-data.xml'
+  COVERAGE: "true"
+  JUNITXML: "test-data.xml"
 
 jobs:
   lint:
@@ -33,8 +33,8 @@ jobs:
         uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
-          cache: 'pip'
+          python-version: "3.12"
+          cache: "pip"
       - name: Install linters
         run: |
           source build_tools/shared.sh
@@ -132,7 +132,7 @@ jobs:
             DISTRIB: conda
             LOCK_FILE: build_tools/github/pylatest_conda_forge_mkl_linux-64_conda.lock
             COVERAGE: true
-            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 42  # default global random seed
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 42 # default global random seed
             SCIPY_ARRAY_API: 1
             # Tests that require large downloads over the networks are skipped in CI.
             # Here we make sure, that they are still run on a regular basis.
@@ -145,7 +145,7 @@ jobs:
             LOCK_FILE: build_tools/github/pymin_conda_forge_openblas_ubuntu_2204_linux-64_conda.lock
             SKLEARN_WARNINGS_AS_ERRORS: 1
             COVERAGE: false
-            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 0  # non-default seed
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 0 # non-default seed
 
           # Linux build with minimum supported version of dependencies
           - name: Linux x86-64 pymin_conda_forge_openblas_min_dependencies
@@ -158,7 +158,7 @@ jobs:
             # https://github.com/scikit-learn/scikit-learn/pull/24438
             SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES: 1
             SKLEARN_RUN_FLOAT32_TESTS: 1
-            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 2  # non-default seed
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 2 # non-default seed
 
           # Linux environment to test the latest available dependencies.
           # It runs tests requiring lightgbm, pandas and PyAMG.
@@ -166,7 +166,7 @@ jobs:
             os: ubuntu-24.04
             DISTRIB: conda
             LOCK_FILE: build_tools/github/pylatest_pip_openblas_pandas_linux-64_conda.lock
-            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 3  # non-default seed
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 3 # non-default seed
             SCIPY_ARRAY_API: 1
             CHECK_PYTEST_SOFT_DEPENDENCY: true
             SKLEARN_WARNINGS_AS_ERRORS: 1
@@ -184,13 +184,13 @@ jobs:
             DISTRIB: ubuntu
             LOCK_FILE: build_tools/github/ubuntu_atlas_lock.txt
             COVERAGE: false
-            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 1  # non-default seed
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 1 # non-default seed
 
           - name: macOS pylatest_conda_forge_arm
             os: macos-15
             DISTRIB: conda
             LOCK_FILE: build_tools/github/pylatest_conda_forge_osx-arm64_conda.lock
-            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 5  # non-default seed
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 5 # non-default seed
             SCIPY_ARRAY_API: 1
             PYTORCH_ENABLE_MPS_FALLBACK: 1
             CHECK_PYTEST_SOFT_DEPENDENCY: true
@@ -201,7 +201,7 @@ jobs:
             LOCK_FILE: build_tools/github/pylatest_conda_forge_mkl_no_openmp_osx-64_conda.lock
             SKLEARN_TEST_NO_OPENMP: true
             SKLEARN_SKIP_OPENMP_TEST: true
-            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 6  # non-default seed
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 6 # non-default seed
 
           - name: Windows x64 pymin_conda_forge_openblas
             os: windows-latest
@@ -219,7 +219,7 @@ jobs:
             # flag for pytest.
             # https://github.com/scikit-learn/scikit-learn/pull/24438
             SKLEARN_ENABLE_DEBUG_CYTHON_DIRECTIVES: 1
-            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 7  # non-default seed
+            SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 7 # non-default seed
 
     env: ${{ matrix }}
 
@@ -320,8 +320,7 @@ jobs:
             --job-name "$JOB_NAME"
 
   free-threaded:
-    name: &free-threaded-job-name
-      Linux x86-64 pylatest_free_threaded
+    name: &free-threaded-job-name Linux x86-64 pylatest_free_threaded
     runs-on: ubuntu-latest
     needs: [lint, retrieve-commit-message, retrieve-selected-tests]
     if: contains(needs.retrieve-commit-message.outputs.message, '[free-threaded]') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -336,8 +335,7 @@ jobs:
     steps: *unit-tests-steps
 
   scipy-dev:
-    name: &scipy-dev-job-name
-      Linux x86-64 pylatest_pip_scipy_dev
+    name: &scipy-dev-job-name Linux x86-64 pylatest_pip_scipy_dev
     runs-on: ubuntu-22.04
     needs: [lint, retrieve-commit-message, retrieve-selected-tests]
     if: contains(needs.retrieve-commit-message.outputs.message, '[scipy-dev]') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -351,14 +349,13 @@ jobs:
     steps: *unit-tests-steps
 
   debian-32bit:
-    name: &debian-32bit-job-name
-      Linux i386 debian_32bit
+    name: &debian-32bit-job-name Linux i386 debian_32bit
     runs-on: ubuntu-24.04
     needs: [lint, retrieve-commit-message, retrieve-selected-tests]
     env:
       DISTRIB: debian-32
       LOCK_FILE: build_tools/github/debian_32bit_lock.txt
-      SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 4  # non-default seed
+      SKLEARN_TESTS_GLOBAL_RANDOM_SEED: 4 # non-default seed
       DOCKER_CONTAINER: i386/debian:trixie
       # To be able to access the job name in the steps, it must be set as an env variable.
       JOB_NAME: *debian-32bit-job-name
@@ -487,3 +484,4 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+          allowed-failures: free-threaded,scipy-dev

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -476,3 +476,14 @@ jobs:
             --junit-file $TEST_DIR/$JUNITXML \
             --auto-close false \
             --job-name "$JOB_NAME"
+
+  aggregate-tests:
+    name: Aggregate Unit Test Status
+    runs-on: ubuntu-latest
+    if: always() && github.repository == 'scikit-learn/scikit-learn'
+    needs: [lint, unit-tests, free-threaded, scipy-dev, debian-32bit]
+    steps:
+      - name: Check all job statuses
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -480,7 +480,7 @@ jobs:
   all-tests:
     name: all-tests
     runs-on: ubuntu-latest
-    if: always() && github.repository == 'scikit-learn/scikit-learn'
+    if: always()
     needs: [lint, unit-tests, free-threaded, scipy-dev, debian-32bit]
     steps:
       - name: Check all job statuses

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -477,14 +477,15 @@ jobs:
             --auto-close false \
             --job-name "$JOB_NAME"
 
-  all-tests:
-    name: all-tests
+  # This aggregates all unit test jobs status into a single status. This
+  # is useful to be able to have a single required check in GitHub
+  check-job-statuses:
+    name: Check all job statuses
     runs-on: ubuntu-latest
     if: always()
-    needs: [lint, unit-tests, free-threaded, scipy-dev, debian-32bit]
+    needs: [lint, unit-tests, debian-32bit, free-threaded, scipy-dev]
     steps:
-      - name: Check all job statuses
-        uses: re-actors/alls-green@release/v1
+      - uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: free-threaded,scipy-dev

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -477,8 +477,8 @@ jobs:
             --auto-close false \
             --job-name "$JOB_NAME"
 
-  aggregate-tests:
-    name: Aggregate Unit Test Status
+  all-tests:
+    name: all-tests
     runs-on: ubuntu-latest
     if: always() && github.repository == 'scikit-learn/scikit-learn'
     needs: [lint, unit-tests, free-threaded, scipy-dev, debian-32bit]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -477,8 +477,8 @@ jobs:
             --auto-close false \
             --job-name "$JOB_NAME"
 
-  # This aggregates all unit test jobs status into a single status. This
-  # is useful to be able to have a single required check in GitHub
+  # This aggregates all unit test jobs statuses into a single status. This is
+  # useful to be able to have a single required check in GitHub.
   check-job-statuses:
     name: Check all job statuses
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #33438

This PR adds an aggregating GitHub Actions job (`all-tests`) to summarize the
status of all unit test related jobs in the CI workflow.

The goal is to provide a single stable CI check that can be used as a required
status check instead of relying on multiple individual job names, which can be
brittle if jobs are renamed.

The new job depends on the following jobs:
- lint
- unit-tests
- free-threaded
- scipy-dev
- debian-32bit

The `all-tests` job uses the `re-actors/alls-green` GitHub Action to aggregate
the results of these jobs. The job succeeds only if all required jobs succeed
and fails if any of them fail. Skipped jobs are handled correctly by the action.

This provides a single aggregated CI status that can be used as a required
check for pull requests.

I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

Please let me know if the set of dependent jobs should be adjusted or if the
aggregating job should be placed in a different workflow.