### PR TITLE
DOC Add undocumented developer guidelines

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -603,6 +603,13 @@ Finally, we have to re-generate the environment and lock files for the CIs by ru
 
   python build_tools/update_environments_and_lock_files.py
 
+Fix CI failures on automated lock file update PRs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If CI tasks fail on an automated lock file update PR (created by the bot), do
+not push fixes directly to the bot's branch. Instead, create a new branch based
+on the bot's PR, add the required fixes there, and open a new PR.
+
 .. _stalled_pull_request:
 
 Stalled pull requests
@@ -901,6 +908,11 @@ additions in the following areas:
 
   * Be aware that dropdowns break cross-references. If that makes sense, hide the
     reference along with the text mentioning it. Else, do not use dropdown.
+
+  * Avoid unintended indentation of lists, references, or paragraphs in
+    reStructuredText files and docstrings. In RST, indented text is rendered as
+    a block quote. Ensure lists and references are flush-left with the
+    surrounding text unless a block quote is explicitly intended.
 
 
 .. dropdown:: Guidelines for writing references

--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -603,13 +603,6 @@ Finally, we have to re-generate the environment and lock files for the CIs by ru
 
   python build_tools/update_environments_and_lock_files.py
 
-Fix CI failures on automated lock file update PRs
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If CI tasks fail on an automated lock file update PR (created by the bot), do
-not push fixes directly to the bot's branch. Instead, create a new branch based
-on the bot's PR, add the required fixes there, and open a new PR.
-
 .. _stalled_pull_request:
 
 Stalled pull requests

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -674,6 +674,10 @@ In addition, we add the following guidelines:
   <https://divmod.readthedocs.io/en/latest/products/pyflakes.html>`_ to automatically
   find bugs in scikit-learn.
 
+* Use f-strings for string interpolation instead of the ``str.format()``
+  method or ``%`` formatting. f-strings are more readable, concise, and
+  performant.
+
 * Use the `numpy docstring standard
   <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_
   in all your docstrings.


### PR DESCRIPTION
#### Reference Issues/PRs

None.

This came out of a live discussion with @adrinjalali .

#### What does this implement/fix? Explain your changes.

Adds three pieces of guidance to the developer docs that were previously
undocumented:

- RST indentation pitfall: warns contributors that indented text in RST is rendered as a block quote (added to the RST guidelines dropdown in  contributing.rst)
- f-string preference: documents the project's preference for f-strings over str.format() or % formatting (added to coding guidelines in develop.rst)
- Bot PR fix workflow: documents that fixes for failed CI on automated lock file update PRs should go on a new branch, not pushed to the bot's branch (added near the existing lock file conflict section in contributing.rst)

#### AI usage disclosure

I used AI assistance for:
- [x] Documentation (including examples)

These doc improvements are the result of a research-stage AI pipeline I and my team are building as part of helping OSS projects understand the state of their codebase and the quality of contributions. These 3 additions were the highest confidence results from that pipeline and verified as high support during a training period and repeatedly validated by maintainer behavior in the test period.

I, as the human author, have read the outputs of the pipeline and guided these surgical additions to be helpful to future contributors to scikit-learn. 

#### Any other comments?

All changes are documentation-only. Verified with doc8 and pre-commit.