### PR TITLE
MNT: Correct sparse validation of index array dtypes

### DIFF
--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -44,7 +44,12 @@ from sklearn.utils._array_api import (
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._testing import _array_api_for_tests, ignore_warnings
-from sklearn.utils.fixes import _IS_32BIT, COO_CONTAINERS, CSR_CONTAINERS
+from sklearn.utils.fixes import (
+    _IS_32BIT,
+    COO_CONTAINERS,
+    CSR_CONTAINERS,
+    _sparse_random_array,
+)
 
 pytestmark = pytest.mark.filterwarnings(
     "error::sklearn.exceptions.ConvergenceWarning:sklearn.*"
@@ -2328,13 +2333,18 @@ def test_large_sparse_matrix(solver, csr_container):
     # Non-regression test for pull-request #21093.
 
     # generate sparse matrix with int64 indices
-    X = csr_container(sparse.rand(20, 10, random_state=42))
+    X = csr_container(_sparse_random_array((20, 10), rng=42))
     for attr in ["indices", "indptr"]:
         setattr(X, attr, getattr(X, attr).astype("int64"))
     rng = np.random.RandomState(42)
     y = rng.randint(2, size=X.shape[0])
 
     if solver in ["liblinear", "sag", "saga"]:
+        # first ensure that validation casts the indices to int32 when it can.
+        LogisticRegression(solver=solver).fit(X.copy(), y)
+        # now make the indices big enough to require int64 and casting will raise
+        assert X.indices.dtype == np.int64
+        X.indices[1] = 2**34
         msg = "Only sparse matrices with 32-bit integer indices"
         with pytest.raises(ValueError, match=msg):
             LogisticRegression(solver=solver).fit(X, y)

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -1087,6 +1087,7 @@ class OneHotEncoder(_BaseEncoder):
             dtype=self.dtype,
         )
         if self.sparse_output:
+            # out.indices, out.indptr = sparse.safely_cast_index_arrays(out)
             return _align_api_if_sparse(out)
         else:
             return out.toarray()

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -1255,7 +1255,7 @@ def _fit_liblinear(
 
     # Liblinear doesn't support 64bit sparse matrix indices yet
     if sp.issparse(X):
-        _check_large_sparse(X)
+        X = _check_large_sparse(X)
 
     # LibLinear wants targets as doubles, even for classification
     y_ind = np.asarray(y_ind, dtype=np.float64).ravel()

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -504,9 +504,8 @@ def _safely_cast_index_arrays(A, idx_dtype=np.int32, msg=""):
         if A.indptr[-1] > max_value:
             raise ValueError(f"indptr values too large for {msg}")
         # check shape vs dtype
-        if max(*A.shape) > max_value:
-            if (A.indices > max_value).any():
-                raise ValueError(f"indices values too large for {msg}")
+        if (max(A.shape) > max_value) or (A.indices > max_value).any():
+            raise ValueError(f"indices values too large for {msg}")
 
         indices = A.indices.astype(idx_dtype, copy=False)
         indptr = A.indptr.astype(idx_dtype, copy=False)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -704,23 +704,23 @@ def test_check_array_accept_sparse_no_exception():
 
 @pytest.fixture(params=["csr", "csc", "coo", "bsr"])
 def X_64bit(request):
-    X = _sparse_random_array((20, 10), format=request.param)
-
     if request.param == "coo":
-        if hasattr(X, "coords"):
-            # for scipy >= 1.13 .coords is a new attribute and is a tuple. The
-            # .col and .row attributes do not seem to be able to change the
-            # dtype, for more details see https://github.com/scipy/scipy/pull/18530/
-            # and https://github.com/scipy/scipy/pull/20003 where .indices was
-            # renamed to .coords
-            X.coords = tuple(v.astype("int64") for v in X.coords)
-        else:
-            # scipy < 1.13
-            X.row = X.row.astype("int64")
-            X.col = X.col.astype("int64")
+        X = sp.coo_array(([1, 1], ([0, 1], [0, 2**33])), shape=(2, 2**35))
+        assert X.row.dtype == np.int64
+        assert X.col.dtype == np.int64
     else:
-        X.indices = X.indices.astype("int64")
-        X.indptr = X.indptr.astype("int64")
+        if request.param == "bsr":
+            indices = [0, 2**33]
+            indptr = [0, 0, 2]
+            data = [[[1]], [[1]]]
+            X = sp.bsr_array((data, indices, indptr), shape=(2, 2**33))
+        else:
+            X = sp.csr_array(([1, 1], [0, 2**33], [0, 0, 2]), shape=(2, 2**34))
+            if request.param == "csc":
+                X = X.T  # converts to "csc" format
+        assert X.format == request.param
+        assert X.indices.dtype == np.int64
+        assert X.indptr.dtype == np.int64
 
     yield X
 
@@ -732,10 +732,7 @@ def test_check_array_accept_large_sparse_no_exception(X_64bit):
 
 def test_check_array_accept_large_sparse_raise_exception(X_64bit):
     # When large sparse are not allowed
-    msg = (
-        "Only sparse matrices with 32-bit integer indices "
-        "are accepted. Got int64 indices. Please do report"
-    )
+    msg = "Only sparse matrices with 32-bit integer indices are accepted."
     with pytest.raises(ValueError, match=msg):
         check_array(X_64bit, accept_sparse=True, accept_large_sparse=False)
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -598,8 +598,16 @@ def _ensure_sparse_format(
     if isinstance(accept_sparse, str):
         accept_sparse = [accept_sparse]
 
-    # Indices dtype validation
-    _check_large_sparse(sparse_container, accept_large_sparse)
+    # Index array dtype validation
+    # if not accept_large_sparse:
+    #     # convert index arrays to np.int32 if safe to do so
+    #     if sparse_container.format in ("csc", "csr", "bsr"):
+    #         indices, indptr = sp.safely_cast_index_arrays(sparse_container)
+    #         sparse_container.indices, sparse_container.indptr = indices, indptr
+    #     elif sparse_container.format == "coo":
+    #         coords = sp.safely_cast_index_arrays(sparse_container)
+    #         sparse_container.coords = coords
+    sparse_container = _check_large_sparse(sparse_container, accept_large_sparse)
 
     if accept_sparse is False:
         padded_input = " for " + input_name if input_name else ""
@@ -1150,25 +1158,27 @@ def check_array(
 
 
 def _check_large_sparse(X, accept_large_sparse=False):
-    """Raise a ValueError if X has 64bit indices and accept_large_sparse=False"""
+    """Raise a ValueError if accept_large_sparse=False and X cannot safely be
+    downcast to int32 index arrays"""
     if not accept_large_sparse:
         supported_indices = ["int32"]
+        try:
+            index_arrays = sp.safely_cast_index_arrays(X)
+        except ValueError as err:
+            raise ValueError(
+                "Only sparse matrices with 32-bit integer indices are accepted."
+                f"X.{err.msg}. Please do report a minimal"
+                " reproducer on scikit-learn issue tracker so that support for"
+                " your use-case can be studied by maintainers. See:"
+                " https://scikit-learn.org/dev/developers/minimal_reproducer.html"
+            )
+
         if X.format == "coo":
-            index_keys = ["col", "row"]
+            X.coords = index_arrays
         elif X.format in ["csr", "csc", "bsr"]:
-            index_keys = ["indices", "indptr"]
-        else:
-            return
-        for key in index_keys:
-            indices_datatype = getattr(X, key).dtype
-            if indices_datatype not in supported_indices:
-                raise ValueError(
-                    "Only sparse matrices with 32-bit integer indices are accepted."
-                    f" Got {indices_datatype} indices. Please do report a minimal"
-                    " reproducer on scikit-learn issue tracker so that support for"
-                    " your use-case can be studied by maintainers. See:"
-                    " https://scikit-learn.org/dev/developers/minimal_reproducer.html"
-                )
+            X.indices, X.indptr = index_arrays
+
+    return X
 
 
 def check_X_y(

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -34,6 +34,7 @@ from sklearn.utils._isfinite import FiniteStatus, cy_isfinite
 from sklearn.utils._tags import get_tags
 from sklearn.utils.fixes import (
     ComplexWarning,
+    _ensure_sparse_index_int32,
     _object_dtype_isnan,
     _preserve_dia_indices_dtype,
 )
@@ -1162,21 +1163,18 @@ def _check_large_sparse(X, accept_large_sparse=False):
     downcast to int32 index arrays"""
     if not accept_large_sparse:
         supported_indices = ["int32"]
+        if X.format in ("dok", "lil"):
+            return X  # no index arrays to check for dok and lil
         try:
-            index_arrays = sp.safely_cast_index_arrays(X)
+            _ensure_sparse_index_int32(X)
         except ValueError as err:
             raise ValueError(
                 "Only sparse matrices with 32-bit integer indices are accepted."
-                f"X.{err.msg}. Please do report a minimal"
+                f"X.{err}. Please do report a minimal"
                 " reproducer on scikit-learn issue tracker so that support for"
                 " your use-case can be studied by maintainers. See:"
                 " https://scikit-learn.org/dev/developers/minimal_reproducer.html"
             )
-
-        if X.format == "coo":
-            X.coords = index_arrays
-        elif X.format in ["csr", "csc", "bsr"]:
-            X.indices, X.indptr = index_arrays
 
     return X
 


### PR DESCRIPTION
This is a follow-up from https://github.com/scikit-learn/scikit-learn/pull/31177
See https://github.com/scikit-learn/scikit-learn/pull/31177#issuecomment-4037194663

#### What does this implement/fix? Explain your changes.
An example is failing due to index arrays for sparse matrices having dtype int64 instead of int32.
This fixes that example and proposes a fix that could help other users who might use the same idiom for creating sparse arrays.

Basic issue:   Sparse arrays do not downcast index array inputs (unlike the sparse matrix approach).
In this case, the input arrays are int64 (created by `np.arange(...)`). So the csr_matrix version
of the code downcast those input arrays to int32. And the csr_array version leaves the input index
arrays untouched.

The int64 index arrays are caught via validation checks `_check_large_sparse` or `_ensure_sparse_format`.  We need to use `scipy.spares.safely_cast_index_arrays()` to cast them to int32.  But when should we do this? When the index arrays are first constructed, or when validated?

Three approaches:    (more details in comments on the diff)
   1) The simplest fix casts the index arrays just after creation. This shows the trouble (`np.arange(..)` creates np.int64 dtype by default).  But each user would have to make this fix in their code.

   2) We can cast the index arrays in `_ensure_sparse_format` just before it calls `_check_large_sparse`. This applies the casting to user created index arrays if needed. It also leaves `_check_large_sparse` as a function with no return value. But it doesn't help those who call `_check_large_sparse` directly.

   3) We can cast the index arrays in `_check_large_sparse` and raise a ValueError if they both are int64 index arrays **and** can't safely be cast to np.int32.  This puts the casting closest to the need for int32. It has two changes to the (private function) api though.  First, `_check_large_sparse` now returns the validated sparse object instead of returning nothing. Second, if people input int64 index arrays with values that can be safely cast, they are cast without raising ValueError. The previous function would raise ValueError without trying to cast first.

This PR currently contains all 3 versions with 1) and 2) commented out.  I will remove whichever two versions we decide not to use once a decision is clear.

#### AI usage disclosure
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding