### PR TITLE
FIX example with OneHotEncoder involving int32 index arrays for sparse arrrays

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -20,6 +20,7 @@ from sklearn.utils._mask import _get_mask
 from sklearn.utils._missing import is_scalar_nan
 from sklearn.utils._param_validation import Interval, RealNotInt, StrOptions
 from sklearn.utils._set_output import _get_output_config
+from sklearn.utils.fixes import _ensure_sparse_index_int32
 from sklearn.utils.validation import (
     _check_feature_names_in,
     check_is_fitted,
@@ -1087,6 +1088,7 @@ class OneHotEncoder(_BaseEncoder):
             dtype=self.dtype,
         )
         if self.sparse_output:
+            _ensure_sparse_index_int32(out)
             return _align_api_if_sparse(out)
         else:
             return out.toarray()

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -39,6 +39,16 @@ def test_one_hot_encoder_sparse_dense():
     assert_array_equal(X_trans_sparse.toarray(), X_trans_dense)
 
 
+def test_one_hot_encoder_sparse_index_array_int32():
+    X = np.array([[3, 2, 1], [0, 1, 1]])
+    enc_sparse = OneHotEncoder(sparse_output=True)
+
+    X_trans_sparse = enc_sparse.fit_transform(X)
+    assert X_trans_sparse.format == "csr"
+    assert X_trans_sparse.indices.dtype == np.int32
+    assert X_trans_sparse.indptr.dtype == np.int32
+
+
 @pytest.mark.parametrize("handle_unknown", ["ignore", "infrequent_if_exist", "warn"])
 def test_one_hot_encoder_handle_unknown(handle_unknown):
     X = np.array([[0, 2, 1], [1, 0, 3], [1, 0, 2]])


### PR DESCRIPTION
`examples/preprocessing/plot_discretization_classification.py` is currently failing on main.

This PR fixes that. It is much simpler than the three options being discussed on #33528 
I think this should alleviate any short term issues. And we can decide if this is all that is needed
without any time pressures.

The problem arose due to #31177 which changed `csr_matrix` to `csr_array` three lines above the change in this PR. The problem arose because `csr_array` does not downcast input index arrays as `csr_matrix` does. So the fix here is to use the helper function `_ensure_sparse_index_int32` to do the downcasting.