### PR TITLE
DOC Tweak heading type

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -287,7 +287,7 @@ Other packages useful for data analysis and machine learning.
   Models are fully compatible with scikit-learn.
 
 Recommendation Engine packages
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 
 - `implicit <https://github.com/benfred/implicit>`_, Library for implicit
   feedback datasets.
@@ -299,7 +299,7 @@ Recommendation Engine packages
   datasets.
 
 Domain specific packages
-~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------
 
 - `scikit-network <https://scikit-network.readthedocs.io/>`_ Machine learning on graphs.
 


### PR DESCRIPTION
Right now "domain specific packages" and "Recommendation Engine packages" are subsections of "Statistical Learning". This seems odd. My guess is we just got the type of heading wrong.

Or, if we do want them to be subsections we should use the same style as we do in the "Other estimators and tasks" part (`**Domain specific packages**`)