### PR TITLE
DOC Fix typo in naive_bayes.rst

### DIFF
--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -12,7 +12,7 @@ based on applying Bayes' theorem with the "naive" assumption of
 conditional independence between every pair of features given the
 value of the class variable. Bayes' theorem states the following
 relationship, given class variable :math:`y` and dependent feature
-vector :math:`x_1` through :math:`x_n`, :
+vector :math:`x_1` through :math:`x_n`:
 
 .. math::
 
@@ -61,7 +61,7 @@ the references below.)
 Naive Bayes learners and classifiers can be extremely fast compared to more
 sophisticated methods.
 The decoupling of the class conditional feature distributions means that each
-distribution can be independently estimated as a one dimensional distribution.
+distribution can be independently estimated as a one-dimensional distribution.
 This in turn helps to alleviate problems stemming from the curse of
 dimensionality.
 


### PR DESCRIPTION
#### Reference Issues/PRs
N/A - Minor typo fixes not tied to an open issue.

#### What does this implement/fix? Explain your changes.
This PR fixes a few minor typographical errors in `naive_bayes.rst`:
- Removed an extra comma before a colon in the introductory paragraph.
- Added a missing hyphen to correct "one dimensional" to "one-dimensional".

#### AI usage disclosure
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Any other comments?
These are just some minor polish edits I noticed while reading through the documentation.