### PR TITLE
ENH add partial_fit method to NearestCentroid

### DIFF
--- a/doc/whats_new/v1.7.rst
+++ b/doc/whats_new/v1.7.rst
@@ -622,3 +622,4 @@ Thomas Li, ThorbenMaa, Tim Head, Tingwei Zhu, TJ Norred, Umberto Fasci, UV,
 Vasco Pereira, Vassilis Margonis, Velislav Babatchev, Victoria Shevchenko,
 viktor765, Vipsa Kamani, VirenPassi, Virgil Chan, vpz, Xiao Yuan, Yaich
 Mohamed, Yair Shimony, Yao Xiao, Yaroslav Halchenko, Yulia Vilensky, Yuvi Panda
+- Added :meth:`NearestCentroid.partial_fit` method to support incremental learning. :pr:`33543` by :user:`raunak-pratap`.

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -29,6 +29,7 @@ class NearestCentroid(
     _parameter_constraints: dict = {
         "metric": [StrOptions({"euclidean", "manhattan"}), callable],
         "shrink_threshold": [Interval(Real, 0, None, closed="left"), None],
+        "priors": [StrOptions({"uniform", "empirical"}), "array-like", None],
     }
     """Nearest centroid classifier.
 

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -348,6 +348,7 @@ class NearestCentroid(
     predict_log_proba = available_if(_check_euclidean_metric)(
         DiscriminantAnalysisPredictionMixin.predict_log_proba
     )
+
     def partial_fit(self, X, y, classes=None):
         """Incrementally fit the NearestCentroid model.
 
@@ -398,6 +399,7 @@ class NearestCentroid(
             self.nk_[idx] = new_n
 
         return self
+
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = self.metric == "nan_euclidean"

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -348,6 +348,7 @@ class NearestCentroid(
         DiscriminantAnalysisPredictionMixin.predict_log_proba
     )
 
+    @_fit_context(prefer_skip_nested_validation=True)
     def partial_fit(self, X, y, classes=None):
         """Incrementally fit the NearestCentroid model.
 

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -348,7 +348,56 @@ class NearestCentroid(
     predict_log_proba = available_if(_check_euclidean_metric)(
         DiscriminantAnalysisPredictionMixin.predict_log_proba
     )
+    def partial_fit(self, X, y, classes=None):
+        """Incrementally fit the NearestCentroid model.
 
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training data.
+        y : array-like of shape (n_samples,)
+            Target values.
+        classes : array-like of shape (n_classes,), default=None
+            List of all the classes that can possibly appear in y.
+            Must be provided on the first call, optional on subsequent calls.
+
+        Returns
+        -------
+        self : object
+            Fitted estimator.
+        """
+        X, y = validate_data(self, X, y, reset=not hasattr(self, "centroids_"))
+
+        if classes is not None:
+            classes = np.asarray(classes)
+
+        if not hasattr(self, "centroids_"):
+            # First call — initialize
+            le = LabelEncoder()
+            if classes is not None:
+                le.fit(classes)
+            else:
+                le.fit(y)
+            self.classes_ = le.classes_
+            n_classes = len(self.classes_)
+            n_features = X.shape[1]
+            self.centroids_ = np.zeros((n_classes, n_features))
+            self.nk_ = np.zeros(n_classes, dtype=np.int64)
+
+        for idx, c in enumerate(self.classes_):
+            mask = y == c
+            X_c = X[mask]
+            n_new = X_c.shape[0]
+            if n_new == 0:
+                continue
+            old_n = self.nk_[idx]
+            new_n = old_n + n_new
+            self.centroids_[idx] = (
+                self.centroids_[idx] * old_n + X_c.sum(axis=0)
+            ) / new_n
+            self.nk_[idx] = new_n
+
+        return self
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = self.metric == "nan_euclidean"

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -133,12 +133,6 @@ class NearestCentroid(
     [1]
     """
 
-    _parameter_constraints: dict = {
-        "metric": [StrOptions({"manhattan", "euclidean"})],
-        "shrink_threshold": [Interval(Real, 0, None, closed="neither"), None],
-        "priors": ["array-like", StrOptions({"empirical", "uniform"})],
-    }
-
     def __init__(
         self,
         metric="euclidean",

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -391,6 +391,8 @@ class NearestCentroid(
             n_new = X_c.shape[0]
             if n_new == 0:
                 continue
+            if not hasattr(self, 'nk_'):
+                self.nk_ = np.zeros(len(self.classes_), dtype=np.int64)
             old_n = self.nk_[idx]
             new_n = old_n + n_new
             self.centroids_[idx] = (

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -391,7 +391,7 @@ class NearestCentroid(
             n_new = X_c.shape[0]
             if n_new == 0:
                 continue
-            if not hasattr(self, 'nk_'):
+            if not hasattr(self, "nk_"):
                 self.nk_ = np.zeros(len(self.classes_), dtype=np.int64)
             old_n = self.nk_[idx]
             new_n = old_n + n_new

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -26,6 +26,10 @@ from sklearn.utils.validation import check_is_fitted, validate_data
 class NearestCentroid(
     DiscriminantAnalysisPredictionMixin, ClassifierMixin, BaseEstimator
 ):
+    _parameter_constraints: dict = {
+        "metric": [StrOptions({"euclidean", "manhattan"}), callable],
+        "shrink_threshold": [Interval(Real, 0, None, closed="left"), None],
+    }
     """Nearest centroid classifier.
 
     Each class is represented by its centroid, with test samples classified to

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -235,3 +235,19 @@ def test_error_zero_variances(array_constructor):
     clf = NearestCentroid()
     with pytest.raises(ValueError, match="All features have zero variance"):
         clf.fit(X, y)
+def test_partial_fit():
+    """Test partial_fit method of NearestCentroid."""
+    X = np.array([[1, 0], [2, 0], [0, 1], [0, 2]])
+    y = np.array([0, 0, 1, 1])
+
+    # Test partial_fit gives same result as fit
+    clf_fit = NearestCentroid()
+    clf_fit.fit(X, y)
+
+    clf_partial = NearestCentroid()
+    clf_partial.partial_fit(X[:2], y[:2], classes=[0, 1])
+    clf_partial.partial_fit(X[2:], y[2:])
+
+    assert_array_equal(clf_fit.classes_, clf_partial.classes_)
+    assert_array_almost_equal(clf_fit.centroids_, clf_partial.centroids_)
+    

--- a/sklearn/neighbors/tests/test_nearest_centroid.py
+++ b/sklearn/neighbors/tests/test_nearest_centroid.py
@@ -235,6 +235,8 @@ def test_error_zero_variances(array_constructor):
     clf = NearestCentroid()
     with pytest.raises(ValueError, match="All features have zero variance"):
         clf.fit(X, y)
+
+
 def test_partial_fit():
     """Test partial_fit method of NearestCentroid."""
     X = np.array([[1, 0], [2, 0], [0, 1], [0, 2]])
@@ -250,4 +252,3 @@ def test_partial_fit():
 
     assert_array_equal(clf_fit.classes_, clf_partial.classes_)
     assert_array_almost_equal(clf_fit.centroids_, clf_partial.centroids_)
-    


### PR DESCRIPTION
Fixes #12952

## What does this implement?

Adds a `partial_fit` method to the `NearestCentroid` classifier,
enabling incremental learning on streaming or large datasets.

The centroids are updated incrementally using the weighted mean formula:
new_centroid = (old_centroid × old_count + new_sum) / (old_count + new_count)

## AI usage disclosure
I used AI assistance to help understand the codebase and implement this feature.