### PR TITLE
Fix: Handle K_gradient undefined when eval_gradient=False in GaussianProcessClassifier

### DIFF
--- a/sklearn/gaussian_process/_gpc.py
+++ b/sklearn/gaussian_process/_gpc.py
@@ -371,6 +371,7 @@ class _BinaryGaussianProcessClassifierLaplace(BaseEstimator):
             kernel = self.kernel_
             kernel.theta = theta
 
+        K_gradient = None
         if eval_gradient:
             K, K_gradient = kernel(self.X_train_, eval_gradient=True)
         else:

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -96,6 +96,19 @@ def test_lml_without_cloning_kernel(kernel):
     assert_almost_equal(gpc.kernel_.theta, input_theta, 7)
 
 
+def test_lml_eval_gradient_false_does_not_require_kernel_gradient():
+    # Non-gradient LML evaluation should not access K_gradient.
+    X = np.array([[0.0], [1.0], [2.0]])
+    y = np.array([0, 1, 0])
+
+    gpc = GaussianProcessClassifier(kernel=RBF()).fit(X, y)
+    theta = gpc.kernel_.theta
+
+    lml = gpc.log_marginal_likelihood(theta, eval_gradient=False)
+
+    assert np.isscalar(lml)
+
+
 @pytest.mark.parametrize("kernel", non_fixed_kernels)
 def test_converged_to_local_maximum(kernel):
     # Test that we are in local maximum after hyperparameter-optimization.


### PR DESCRIPTION
## Summary
Fixes a `NameError` risk in `GaussianProcessClassifier.log_marginal_likelihood` when called with `eval_gradient=False` by ensuring `K_gradient` is always initialized before conditional assignment.

Also adds a regression test to verify that calling `log_marginal_likelihood(theta, eval_gradient=False)` works without requiring kernel gradients.

## Root cause
`K_gradient` was defined only in the `eval_gradient=True` branch, but later gradient-related logic references it. While non-gradient execution returns early, explicit initialization makes control flow robust and prevents undefined-variable regressions.

## Changes
- Initialize `K_gradient = None` before the `if eval_gradient:` block in `sklearn/gaussian_process/_gpc.py`.
- Add `test_lml_eval_gradient_false_does_not_require_kernel_gradient` in `sklearn/gaussian_process/tests/test_gpc.py`.

## Issue
Closes #33542

Issue link: https://github.com/scikit-learn/scikit-learn/issues/33542
