### PR TITLE
[Callbacks] ENH Start propatation depth at 0

### DIFF
--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -397,7 +397,7 @@ class CallbackContext:
             if isinstance(callback, AutoPropagatedCallback)
             and (
                 callback.max_propagation_depth is None
-                or self._propagation_depth < callback.max_propagation_depth - 1
+                or self._propagation_depth < callback.max_propagation_depth
             )
         ]
         if not callbacks_to_propagate:

--- a/sklearn/callback/_progressbar.py
+++ b/sklearn/callback/_progressbar.py
@@ -15,8 +15,9 @@ class ProgressBar:
 
     Parameters
     ----------
-    max_propagation_depth : int, default=2
-        The maximum number of nested levels of estimators to display progress bars for.
+    max_propagation_depth : int, default=1
+        The maximum depth of nested levels of estimators to display progress bars for.
+        0 means that the progress of only the outermost estimator is displayed.
         If set to None, all levels are displayed.
 
     Notes
@@ -25,7 +26,7 @@ class ProgressBar:
     unexpected crashes related to multiprocessing bugs on certain platforms.
     """
 
-    def __init__(self, max_propagation_depth=2):
+    def __init__(self, max_propagation_depth=1):
         if sys.version_info < (3, 12, 8):
             warnings.warn(
                 "The use of the ProgressBar callback on python versions inferior "


### PR DESCRIPTION
Now that the name of the attr for auto-propagated callbacks is `max_propagation_depth`, I find it a lot more natural that it starts at 0.

0 means that the callback is not propagated to sub-estimators (it's still set on the outermost estimator). 1 means that it's only propagated to the first level of nested sub-estimators, and so on...

What do you think @ogrisel @FrancoisPgm @StefanieSenger @lesteve ?