### PR TITLE
[Callbacks] Rename with_fit_callbacks -> with_callbacks

### DIFF
--- a/doc/api_reference.py
+++ b/doc/api_reference.py
@@ -154,6 +154,7 @@ API_REFERENCE = {
                     "Callback",
                     "CallbackSupportMixin",
                     "ProgressBar",
+                    "with_callbacks",
                 ],
             },
         ],

--- a/sklearn/callback/__init__.py
+++ b/sklearn/callback/__init__.py
@@ -8,7 +8,7 @@ callbacks for scikit-learn estimators.
 
 from sklearn.callback._base import AutoPropagatedCallback, FitCallback
 from sklearn.callback._callback_context import CallbackContext
-from sklearn.callback._callback_support import CallbackSupportMixin, with_fit_callbacks
+from sklearn.callback._callback_support import CallbackSupportMixin, with_callbacks
 from sklearn.callback._progressbar import ProgressBar
 
 __all__ = [
@@ -17,5 +17,5 @@ __all__ = [
     "CallbackSupportMixin",
     "FitCallback",
     "ProgressBar",
-    "with_fit_callbacks",
+    "with_callbacks",
 ]

--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -64,7 +64,7 @@ from sklearn.callback._base import AutoPropagatedCallback
 #     def __init__(self, max_iter):
 #         self.max_iter = max_iter
 #
-#     @with_fit_callbacks
+#     @with_callbacks
 #     def fit(self, X, y):
 #         callback_ctx = self._init_callback_context(max_subtasks=self.max_iter)
 #         callback_ctx.eval_on_fit_task_begin()

--- a/sklearn/callback/_callback_support.py
+++ b/sklearn/callback/_callback_support.py
@@ -1,6 +1,7 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import functools
 from contextlib import contextmanager
 from multiprocessing import Manager
 from threading import Lock
@@ -135,28 +136,29 @@ def callback_management_context(estimator):
                 del estimator._parent_callback_ctx
 
 
-def with_fit_callbacks(fit_method):
-    """Decorator to run the fit methods within a callback context manager.
+def with_callbacks(method):
+    """Decorator to run the method within a callback context manager.
 
     This decorator is responsible for calling the callbacks `teardown` hooks of
     callbacks in a `try finally` block, which guarantees that callbacks teardown will
-    always be evaluated, whether the estimator's fit exits successfully or not.
+    always be evaluated, whether the estimator's method exits successfully or not.
 
     It will only teardown callbacks that are not propagated from a meta-estimator.
 
     Parameters
     ----------
-    fit_method : method
-        The fit method to decorate.
+    method : method
+        The method to decorate.
 
     Returns
     -------
-    decorated_fit_method : method
-        The decorated fit method.
+    decorated_method : method
+        The decorated method.
     """
 
-    def callback_managed_fit_method(estimator, *args, **kwargs):
+    @functools.wraps(method)
+    def callback_managed_method(estimator, *args, **kwargs):
         with callback_management_context(estimator):
-            return fit_method(estimator, *args, **kwargs)
+            return method(estimator, *args, **kwargs)
 
-    return callback_managed_fit_method
+    return callback_managed_method

--- a/sklearn/callback/tests/_utils.py
+++ b/sklearn/callback/tests/_utils.py
@@ -4,7 +4,7 @@
 import time
 
 from sklearn.base import BaseEstimator, _fit_context, clone
-from sklearn.callback import CallbackSupportMixin, with_fit_callbacks
+from sklearn.callback import CallbackSupportMixin, with_callbacks
 from sklearn.callback._callback_support import get_callback_manager
 from sklearn.utils.parallel import Parallel, delayed
 
@@ -177,7 +177,7 @@ class ThirdPartyEstimator(CallbackSupportMixin, BaseEstimator):
         self.max_iter = max_iter
         self.computation_intensity = computation_intensity
 
-    @with_fit_callbacks
+    @with_callbacks
     def fit(self, X=None, y=None):
         callback_ctx = self._init_callback_context(max_subtasks=self.max_iter)
         callback_ctx.eval_on_fit_task_begin()
@@ -296,7 +296,7 @@ def _fit_subestimator(meta_estimator, inner_estimator, X, y, *, outer_callback_c
 class NoSubtaskEstimator(CallbackSupportMixin, BaseEstimator):
     """A class mimicking an estimator without subtasks in fit."""
 
-    @with_fit_callbacks
+    @with_callbacks
     def fit(self, X=None, y=None):
         callback_ctx = self._init_callback_context().eval_on_fit_task_begin()
 


### PR DESCRIPTION
As reported in https://github.com/scikit-learn/enhancement_proposals/pull/90#discussion_r2936920141 in the SLEP, the current name, `with_fit_callbacks`, is too specific since we'll likely want to reuse this decorator for other methods when we extend the callback API.

So let's directly go with a generic `with_callbacks`.
Since, as a decorator, it receives the decorated method as first arg, it will be easy to use it for methods other than fit in the future, specializing the behavior for the different methods if needed.

(note that the `callback_management_context` context manager used inside the decorator is currently dedicated to fit, but that's fine because this one is private, so we'll be able to modify it later as needed without touching the public api)

ping @ogrisel @FrancoisPgm @StefanieSenger @lesteve 