### PR TITLE
TST Use clone to avoid failure for free-threaded

### DIFF
--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -978,6 +978,7 @@ def test_dict_learning_online_numerical_consistency(method):
 )
 def test_get_feature_names_out(estimator):
     """Check feature names for dict learning estimators."""
+    estimator = clone(estimator)
     estimator.fit(X)
     n_components = X.shape[1]
 


### PR DESCRIPTION
Seen in https://github.com/scikit-learn/scikit-learn/issues/33470#issuecomment-4030126298

I can reproduce the issue locally with
```
pytest sklearn/decomposition/tests/test_dict_learning.py -k test_get_feature_names_out --parallel-threads 4 --iterations 100
```

cc @ogrisel.