### PR TITLE
FIX TunedThresholdClassifierCV split reuse with refit=False

### DIFF
--- a/sklearn/model_selection/_classification_threshold.py
+++ b/sklearn/model_selection/_classification_threshold.py
@@ -753,14 +753,18 @@ class TunedThresholdClassifierCV(BaseThresholdClassifier):
         else:
             self.estimator_ = clone(self.estimator)
             classifier = clone(self.estimator)
-            splits = cv.split(X, y, **routed_params.splitter.split)
+            # Materialize splits to avoid consuming the generator twice.
+            # When refit=False, the first split is used for training
+            # estimator_ and the same splits are reused for threshold
+            # tuning, ensuring consistency (see #33540).
+            splits = list(cv.split(X, y, **routed_params.splitter.split))
 
             if self.refit:
                 # train on the whole dataset
                 X_train, y_train, fit_params_train = X, y, routed_params.estimator.fit
             else:
                 # single split cross-validation
-                train_idx, _ = next(cv.split(X, y, **routed_params.splitter.split))
+                train_idx, _ = splits[0]
                 X_train = _safe_indexing(X, train_idx)
                 y_train = _safe_indexing(y, train_idx)
                 fit_params_train = _check_method_params(


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #33540

#### What does this implement/fix? Explain your changes.

When `TunedThresholdClassifierCV` is used with `cv=float` and `refit=False`, the `_fit` method calls `cv.split()` twice independently:

1. Line 756: `splits = cv.split(X, y, ...)` — creates a generator for threshold tuning
2. Line 763: `next(cv.split(X, y, ...))` — creates a **new** generator and takes its first element for training `estimator_`

With non-deterministic splitters (e.g. `StratifiedShuffleSplit` without fixed `random_state`), these two generators produce different splits, so `estimator_` is trained on a different subset than the one used for threshold tuning. This makes `best_threshold_` inconsistent with `estimator_`.

**Fix:** Materialize `splits` into a `list` before use, then index `splits[0]` in the `refit=False` branch instead of calling `cv.split()` a second time. This guarantees the same splits are used for both training and threshold tuning.

#### AI usage disclosure

I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Any other comments?

The fix is a 4-line change. Materializing the generator into a list has negligible memory overhead since the number of splits is small (typically 1 for `cv=float`).