### PR TITLE
[Callbacks] API Rename eval_on_fit_task_*

### DIFF
--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -67,18 +67,18 @@ from sklearn.callback._base import AutoPropagatedCallback
 #     @with_callbacks
 #     def fit(self, X, y):
 #         callback_ctx = self._init_callback_context(max_subtasks=self.max_iter)
-#         callback_ctx.eval_on_fit_task_begin()
+#         callback_ctx.call_on_fit_task_begin()
 #
 #         for i in range(self.max_iter):
 #             subcontext = callback_ctx.subcontext(task_id=i)
 #
 #             # Do something
 #
-#             subcontext.eval_on_fit_task_end(
+#             subcontext.call_on_fit_task_end(
 #                 data={"X_train": X, "y_train": y},
 #             )
 #
-#         callback_ctx.eval_on_fit_task_end(
+#         callback_ctx.call_on_fit_task_end(
 #             data={"X_train": X, "y_train": y},
 #         )
 #
@@ -314,8 +314,8 @@ class CallbackContext:
             max_subtasks=max_subtasks,
         )
 
-    def eval_on_fit_task_begin(self, **kwargs):
-        """Evaluate the `on_fit_task_begin` hook of the callbacks.
+    def call_on_fit_task_begin(self, **kwargs):
+        """Call the `on_fit_task_begin` hook of the callbacks.
 
         Parameters
         ----------
@@ -332,8 +332,8 @@ class CallbackContext:
 
         return self
 
-    def eval_on_fit_task_end(self, **kwargs):
-        """Evaluate the `on_fit_task_end` hook of the callbacks.
+    def call_on_fit_task_end(self, **kwargs):
+        """Call the `on_fit_task_end` hook of the callbacks.
 
         Parameters
         ----------

--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -79,7 +79,6 @@ from sklearn.callback._base import AutoPropagatedCallback
 #             subcontext.call_on_fit_task_end(X=X, y=y)
 #
 #         callback_ctx.call_on_fit_task_end(X=X, y=y)
-#
 #         return self
 #
 # It's also an object that is passed to the callback hooks to give them information

--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -76,8 +76,7 @@ from sklearn.callback._base import AutoPropagatedCallback
 #
 #             # Do something
 #
-#             subcontext.call_on_fit_task_end(X=X, y=y),
-#             )
+#             subcontext.call_on_fit_task_end(X=X, y=y)
 #
 #         callback_ctx.call_on_fit_task_end(X=X, y=y)
 #

--- a/sklearn/callback/_callback_support.py
+++ b/sklearn/callback/_callback_support.py
@@ -104,8 +104,8 @@ def callback_management_context(estimator):
     """Context manager to manage callback lifecycle around estimator fit.
 
     The context manager is responsible for calling the callbacks `teardown` hook in a
-    `try finally` block, which guarantees that callbacks teardown will always be
-    evaluated, whether the estimator's fit exits successfully or not.
+    `try finally` block, which guarantees that callbacks teardown will always be called,
+    whether the estimator's fit exits successfully or not.
 
     Parameters
     ----------
@@ -141,7 +141,7 @@ def with_callbacks(method):
 
     This decorator is responsible for calling the callbacks `teardown` hooks of
     callbacks in a `try finally` block, which guarantees that callbacks teardown will
-    always be evaluated, whether the estimator's method exits successfully or not.
+    always be called, whether the estimator's method exits successfully or not.
 
     It will only teardown callbacks that are not propagated from a meta-estimator.
 

--- a/sklearn/callback/tests/_utils.py
+++ b/sklearn/callback/tests/_utils.py
@@ -107,19 +107,19 @@ class MaxIterEstimator(CallbackSupportMixin, BaseEstimator):
     @_fit_context(prefer_skip_nested_validation=False)
     def fit(self, X=None, y=None):
         callback_ctx = self._init_callback_context(max_subtasks=self.max_iter)
-        callback_ctx.eval_on_fit_task_begin()
+        callback_ctx.call_on_fit_task_begin()
 
         for i in range(self.max_iter):
-            subcontext = callback_ctx.subcontext(task_id=i).eval_on_fit_task_begin()
+            subcontext = callback_ctx.subcontext(task_id=i).call_on_fit_task_begin()
 
             time.sleep(self.computation_intensity)  # Computation intensive task
 
-            if subcontext.eval_on_fit_task_end(
+            if subcontext.call_on_fit_task_end(
                 data={"X_train": X, "y_train": y},
             ):
                 break
 
-        callback_ctx.eval_on_fit_task_end(
+        callback_ctx.call_on_fit_task_end(
             data={"X_train": X, "y_train": y},
         )
 
@@ -143,15 +143,15 @@ class WhileEstimator(CallbackSupportMixin, BaseEstimator):
     @_fit_context(prefer_skip_nested_validation=False)
     def fit(self, X=None, y=None):
         callback_ctx = self._init_callback_context(max_subtasks=None)
-        callback_ctx.eval_on_fit_task_begin()
+        callback_ctx.call_on_fit_task_begin()
 
         i = 0
         while True:
-            subcontext = callback_ctx.subcontext(task_id=i).eval_on_fit_task_begin()
+            subcontext = callback_ctx.subcontext(task_id=i).call_on_fit_task_begin()
 
             time.sleep(self.computation_intensity)  # Computation intensive task
 
-            if subcontext.eval_on_fit_task_end(
+            if subcontext.call_on_fit_task_end(
                 data={"X_train": X, "y_train": y},
             ):
                 break
@@ -161,7 +161,7 @@ class WhileEstimator(CallbackSupportMixin, BaseEstimator):
 
             i += 1
 
-        callback_ctx.eval_on_fit_task_end(
+        callback_ctx.call_on_fit_task_end(
             data={"X_train": X, "y_train": y},
         )
 
@@ -180,19 +180,19 @@ class ThirdPartyEstimator(CallbackSupportMixin, BaseEstimator):
     @with_callbacks
     def fit(self, X=None, y=None):
         callback_ctx = self._init_callback_context(max_subtasks=self.max_iter)
-        callback_ctx.eval_on_fit_task_begin()
+        callback_ctx.call_on_fit_task_begin()
 
         for i in range(self.max_iter):
-            subcontext = callback_ctx.subcontext(task_id=i).eval_on_fit_task_begin()
+            subcontext = callback_ctx.subcontext(task_id=i).call_on_fit_task_begin()
 
             time.sleep(self.computation_intensity)  # Computation intensive task
 
-            if subcontext.eval_on_fit_task_end(
+            if subcontext.call_on_fit_task_end(
                 data={"X_train": X, "y_train": y},
             ):
                 break
 
-        callback_ctx.eval_on_fit_task_end(
+        callback_ctx.call_on_fit_task_end(
             data={"X_train": X, "y_train": y},
         )
 
@@ -250,7 +250,7 @@ class MetaEstimator(CallbackSupportMixin, BaseEstimator):
     @_fit_context(prefer_skip_nested_validation=False)
     def fit(self, X=None, y=None):
         callback_ctx = self._init_callback_context(max_subtasks=self.n_outer)
-        callback_ctx.eval_on_fit_task_begin()
+        callback_ctx.call_on_fit_task_begin()
 
         Parallel(n_jobs=self.n_jobs, prefer=self.prefer)(
             delayed(_fit_subestimator)(
@@ -265,7 +265,7 @@ class MetaEstimator(CallbackSupportMixin, BaseEstimator):
             for i in range(self.n_outer)
         )
 
-        callback_ctx.eval_on_fit_task_end(
+        callback_ctx.call_on_fit_task_end(
             data={"X_train": X, "y_train": y},
         )
 
@@ -273,22 +273,22 @@ class MetaEstimator(CallbackSupportMixin, BaseEstimator):
 
 
 def _fit_subestimator(meta_estimator, inner_estimator, X, y, *, outer_callback_ctx):
-    outer_callback_ctx.eval_on_fit_task_begin()
+    outer_callback_ctx.call_on_fit_task_begin()
 
     for i in range(meta_estimator.n_inner):
         est = clone(inner_estimator)
 
         inner_ctx = outer_callback_ctx.subcontext(task_name="inner", task_id=i)
         inner_ctx.propagate_callback_context(sub_estimator=est)
-        inner_ctx.eval_on_fit_task_begin()
+        inner_ctx.call_on_fit_task_begin()
 
         est.fit(X, y)
 
-        inner_ctx.eval_on_fit_task_end(
+        inner_ctx.call_on_fit_task_end(
             data={"X_train": X, "y_train": y},
         )
 
-    outer_callback_ctx.eval_on_fit_task_end(
+    outer_callback_ctx.call_on_fit_task_end(
         data={"X_train": X, "y_train": y},
     )
 
@@ -298,10 +298,10 @@ class NoSubtaskEstimator(CallbackSupportMixin, BaseEstimator):
 
     @with_callbacks
     def fit(self, X=None, y=None):
-        callback_ctx = self._init_callback_context().eval_on_fit_task_begin()
+        callback_ctx = self._init_callback_context().call_on_fit_task_begin()
 
         # No task performed
 
-        callback_ctx.eval_on_fit_task_end()
+        callback_ctx.call_on_fit_task_end()
 
         return self

--- a/sklearn/callback/tests/test_callback_context.py
+++ b/sklearn/callback/tests/test_callback_context.py
@@ -226,7 +226,7 @@ def test_estimator_without_subtask():
     """Check that callback support works for an estimator without subtasks.
 
     This test is about verifying that an estimator that does not call its callback
-    context's `eval_on_fit_task_end` does not cause a problem.
+    context's `call_on_fit_task_end` does not cause a problem.
     """
     estimator = NoSubtaskEstimator()
     estimator.set_callbacks([TestingCallback()])


### PR DESCRIPTION
As reported in https://github.com/scikit-learn/enhancement_proposals/pull/90#discussion_r2936924350, `eval` might evoke model evaluation since we're a ML library.

2 alternative names were proposed in different discussion channels: ``run_on_fit_task_*`` and ``call_on_fit_task_*``.
I also asked an ai to propose other alternatives. Here's its answer:
```
1. invoke_on_fit_task_begin / invoke_on_fit_task_end
“Invoke” clearly means “call the callbacks’ hooks.”
Common in callback/event APIs, and not overloaded like “eval.”

2. dispatch_on_fit_task_begin / dispatch_on_fit_task_end
“Dispatch” suggests sending an event to all registered callbacks.
Fits well if you think of this as dispatching a lifecycle event.

3. notify_on_fit_task_begin / notify_on_fit_task_end
“Notify” suggests informing listeners (the callbacks) that the task began/ended.
Slightly less explicit that you’re calling a method, but still clear.

4. call_on_fit_task_begin / call_on_fit_task_end
Most literal: we are calling the callbacks’ on_fit_task_* hooks.
Very clear, a bit plain.

5. run_on_fit_task_begin / run_on_fit_task_end
“Run” is simple and implies execution of the hooks.
Could be read as “run (something) when fit task begins” rather than 
“run the begin hooks,” so slightly less precise than “invoke” or “call.”

Recommendation: invoke_on_fit_task_begin / invoke_on_fit_task_end or
call_on_fit_task_begin / call_on_fit_task_end are the clearest and least ambiguous.
I’d lean to invoke_ for a public API and call_ if you want maximum literal clarity.
```

I don't like `dispatch` and `notify`.
I wasn't aware that `invoke` was common callback vocabulary. I think that we can assume that developers of estimator will be either, so `call` is probably a better call for us. Hence I went for `call`.
Let me know what's your preference.

ping @ogrisel @FrancoisPgm @StefanieSenger @lesteve 