### PR TITLE
FIX TruncatedSVD hang on Linux kernel 6.19+ due to threading issues

### DIFF
--- a/sklearn/decomposition/_truncated_svd.py
+++ b/sklearn/decomposition/_truncated_svd.py
@@ -19,6 +19,7 @@ from sklearn.utils import check_array, check_random_state
 from sklearn.utils._arpack import _init_arpack_v0
 from sklearn.utils._param_validation import Interval, StrOptions
 from sklearn.utils.extmath import _randomized_svd, safe_sparse_dot, svd_flip
+from sklearn.utils.parallel import _threadpool_controller_decorator
 from sklearn.utils.sparsefuncs import mean_variance_axis
 from sklearn.utils.validation import check_is_fitted, validate_data
 
@@ -207,6 +208,7 @@ class TruncatedSVD(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstima
         return self
 
     @_fit_context(prefer_skip_nested_validation=True)
+    @_threadpool_controller_decorator(limits=1, user_api="blas")
     def fit_transform(self, X, y=None):
         """Fit model to X and perform dimensionality reduction on X.
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #33541

#### What does this implement/fix? Explain your changes.

Wraps  with  to limit BLAS threads during SVD computation. This prevents OpenMP/BLAS threading oversubscription that causes infinite hangs on Linux kernel 6.19+ when using the randomized algorithm.

The root cause is a threading deadlock between OpenMP (used by scikit-learn) and BLAS (used by scipy.linalg.svd). The same fix pattern is already used in .

#### AI usage disclosure

I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

#### Any other comments?

Tested with all 46 TruncatedSVD tests passing, plus 432 decomposition tests with no regressions.