### PR TITLE
DOC Fix misleading parameter docs for `n_clusters` in Spectral Clustering

### DIFF
--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -404,7 +404,7 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
     Parameters
     ----------
     n_clusters : int, default=8
-        The dimension of the projection subspace.
+        Number of clusters to extract.
 
     eigen_solver : {'arpack', 'lobpcg', 'amg'}, default=None
         The eigenvalue decomposition strategy to use. AMG requires pyamg


### PR DESCRIPTION
"Number of clusters to extract." is more representative compared to "The dimension of the projection subspace."