### PR TITLE
[Callbacks] API explicit X, y instead of data in on_fit_task_*

### DIFF
--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -67,23 +67,19 @@ from sklearn.callback._base import AutoPropagatedCallback
 #     @with_callbacks
 #     def fit(self, X, y):
 #         callback_ctx = self._init_callback_context(max_subtasks=self.max_iter)
-#         callback_ctx.eval_on_fit_task_begin()
+#         callback_ctx.eval_on_fit_task_begin(X=X, y=y)
 #
 #         for i in range(self.max_iter):
-#             subcontext = callback_ctx.subcontext(task_id=i)
+#             subcontext = callback_ctx.subcontext(task_id=i).eval_on_fit_task_begin(
+#                X=X, y=y,
+#             )
 #
 #             # Do something
 #
-#             subcontext.eval_on_fit_task_end(
-#                 data={"X_train": X, "y_train": y},
-#             )
+#             subcontext.eval_on_fit_task_end(X=X, y=y)
 #
-#         callback_ctx.eval_on_fit_task_end(
-#             data={"X_train": X, "y_train": y},
-#         )
-#
+#         callback_ctx.eval_on_fit_task_end(X=X, y=y)
 #         return self
-#
 #
 # It's also an object that is passed to the callback hooks to give them information
 # about the task being executed and its position in the task tree.

--- a/sklearn/callback/tests/_utils.py
+++ b/sklearn/callback/tests/_utils.py
@@ -107,21 +107,19 @@ class MaxIterEstimator(CallbackSupportMixin, BaseEstimator):
     @_fit_context(prefer_skip_nested_validation=False)
     def fit(self, X=None, y=None):
         callback_ctx = self._init_callback_context(max_subtasks=self.max_iter)
-        callback_ctx.eval_on_fit_task_begin()
+        callback_ctx.eval_on_fit_task_begin(X=X, y=y)
 
         for i in range(self.max_iter):
-            subcontext = callback_ctx.subcontext(task_id=i).eval_on_fit_task_begin()
+            subcontext = callback_ctx.subcontext(task_id=i).eval_on_fit_task_begin(
+                X=X, y=y
+            )
 
             time.sleep(self.computation_intensity)  # Computation intensive task
 
-            if subcontext.eval_on_fit_task_end(
-                data={"X_train": X, "y_train": y},
-            ):
+            if subcontext.eval_on_fit_task_end(X=X, y=y):
                 break
 
-        callback_ctx.eval_on_fit_task_end(
-            data={"X_train": X, "y_train": y},
-        )
+        callback_ctx.eval_on_fit_task_end(X=X, y=y)
 
         self.n_iter_ = i + 1
 
@@ -143,17 +141,17 @@ class WhileEstimator(CallbackSupportMixin, BaseEstimator):
     @_fit_context(prefer_skip_nested_validation=False)
     def fit(self, X=None, y=None):
         callback_ctx = self._init_callback_context(max_subtasks=None)
-        callback_ctx.eval_on_fit_task_begin()
+        callback_ctx.eval_on_fit_task_begin(X=X, y=y)
 
         i = 0
         while True:
-            subcontext = callback_ctx.subcontext(task_id=i).eval_on_fit_task_begin()
+            subcontext = callback_ctx.subcontext(task_id=i).eval_on_fit_task_begin(
+                X=X, y=y
+            )
 
             time.sleep(self.computation_intensity)  # Computation intensive task
 
-            if subcontext.eval_on_fit_task_end(
-                data={"X_train": X, "y_train": y},
-            ):
+            if subcontext.eval_on_fit_task_end(X=X, y=y):
                 break
 
             if i == 20:
@@ -161,9 +159,7 @@ class WhileEstimator(CallbackSupportMixin, BaseEstimator):
 
             i += 1
 
-        callback_ctx.eval_on_fit_task_end(
-            data={"X_train": X, "y_train": y},
-        )
+        callback_ctx.eval_on_fit_task_end(X=X, y=y)
 
         return self
 
@@ -180,21 +176,19 @@ class ThirdPartyEstimator(CallbackSupportMixin, BaseEstimator):
     @with_callbacks
     def fit(self, X=None, y=None):
         callback_ctx = self._init_callback_context(max_subtasks=self.max_iter)
-        callback_ctx.eval_on_fit_task_begin()
+        callback_ctx.eval_on_fit_task_begin(X=X, y=y)
 
         for i in range(self.max_iter):
-            subcontext = callback_ctx.subcontext(task_id=i).eval_on_fit_task_begin()
+            subcontext = callback_ctx.subcontext(task_id=i).eval_on_fit_task_begin(
+                X=X, y=y
+            )
 
             time.sleep(self.computation_intensity)  # Computation intensive task
 
-            if subcontext.eval_on_fit_task_end(
-                data={"X_train": X, "y_train": y},
-            ):
+            if subcontext.eval_on_fit_task_end(X=X, y=y):
                 break
 
-        callback_ctx.eval_on_fit_task_end(
-            data={"X_train": X, "y_train": y},
-        )
+        callback_ctx.eval_on_fit_task_end(X=X, y=y)
 
         self.n_iter_ = i + 1
 
@@ -250,7 +244,7 @@ class MetaEstimator(CallbackSupportMixin, BaseEstimator):
     @_fit_context(prefer_skip_nested_validation=False)
     def fit(self, X=None, y=None):
         callback_ctx = self._init_callback_context(max_subtasks=self.n_outer)
-        callback_ctx.eval_on_fit_task_begin()
+        callback_ctx.eval_on_fit_task_begin(X=X, y=y)
 
         Parallel(n_jobs=self.n_jobs, prefer=self.prefer)(
             delayed(_fit_subestimator)(
@@ -265,32 +259,26 @@ class MetaEstimator(CallbackSupportMixin, BaseEstimator):
             for i in range(self.n_outer)
         )
 
-        callback_ctx.eval_on_fit_task_end(
-            data={"X_train": X, "y_train": y},
-        )
+        callback_ctx.eval_on_fit_task_end(X=X, y=y)
 
         return self
 
 
 def _fit_subestimator(meta_estimator, inner_estimator, X, y, *, outer_callback_ctx):
-    outer_callback_ctx.eval_on_fit_task_begin()
+    outer_callback_ctx.eval_on_fit_task_begin(X=X, y=y)
 
     for i in range(meta_estimator.n_inner):
         est = clone(inner_estimator)
 
         inner_ctx = outer_callback_ctx.subcontext(task_name="inner", task_id=i)
         inner_ctx.propagate_callback_context(sub_estimator=est)
-        inner_ctx.eval_on_fit_task_begin()
+        inner_ctx.eval_on_fit_task_begin(X=X, y=y)
 
         est.fit(X, y)
 
-        inner_ctx.eval_on_fit_task_end(
-            data={"X_train": X, "y_train": y},
-        )
+        inner_ctx.eval_on_fit_task_end(X=X, y=y)
 
-    outer_callback_ctx.eval_on_fit_task_end(
-        data={"X_train": X, "y_train": y},
-    )
+    outer_callback_ctx.eval_on_fit_task_end(X=X, y=y)
 
 
 class NoSubtaskEstimator(CallbackSupportMixin, BaseEstimator):
@@ -298,10 +286,10 @@ class NoSubtaskEstimator(CallbackSupportMixin, BaseEstimator):
 
     @with_callbacks
     def fit(self, X=None, y=None):
-        callback_ctx = self._init_callback_context().eval_on_fit_task_begin()
+        callback_ctx = self._init_callback_context().eval_on_fit_task_begin(X=X, y=y)
 
         # No task performed
 
-        callback_ctx.eval_on_fit_task_end()
+        callback_ctx.eval_on_fit_task_end(X=X, y=y)
 
         return self


### PR DESCRIPTION
I initially thought that `X_val` and `y_val` were not in the scope of the metadata routing so I had put (X, y, X_val, y_val) in data.
But looking back at the `transform_input` of the pipeline (https://scikit-learn.org/dev/modules/generated/sklearn.pipeline.Pipeline.html#:~:text=transform_input,-list%20of%20str%2C%20default%3DNone) and at this https://scikit-learn.org/stable/auto_examples/release_highlights/plot_release_highlights_1_6_0.html#transforming-data-other-than-x-in-a-pipeline, we realized that `X_val` and `y_val` are (and must be) routed using metadata routing.

So as discussed in the last meeting, we thought it made more sense to come back to an explicit `X, y` in the signature of the callback hooks.

ping @ogrisel @FrancoisPgm @StefanieSenger @lesteve 