### PR TITLE
Fix LogisticRegression with array API and warm start

### DIFF
--- a/doc/whats_new/upcoming_changes/array-api/33567.fix.rst
+++ b/doc/whats_new/upcoming_changes/array-api/33567.fix.rst
@@ -1,0 +1,2 @@
+- Fix :class:`linear_model.LogisticRegression` when `warm_start=True`.
+  By :user:`Tim Head <betatim>`.

--- a/doc/whats_new/upcoming_changes/array-api/33567.fix.rst
+++ b/doc/whats_new/upcoming_changes/array-api/33567.fix.rst
@@ -1,2 +1,0 @@
-- Fix :class:`linear_model.LogisticRegression` when `warm_start=True`.
-  By :user:`Tim Head <betatim>`.

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -40,6 +40,7 @@ from sklearn.utils import (
     compute_class_weight,
 )
 from sklearn.utils._array_api import (
+    _convert_to_numpy,
     _is_numpy_namespace,
     _matching_numpy_dtype,
     get_namespace,
@@ -1326,10 +1327,13 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
             warm_start_coef = getattr(self, "coef_", None)
         else:
             warm_start_coef = None
-        if warm_start_coef is not None and self.fit_intercept:
-            warm_start_coef = xp.concat(
-                [warm_start_coef, self.intercept_[:, None]], axis=1
-            )
+        if warm_start_coef is not None:
+            warm_start_coef = _convert_to_numpy(warm_start_coef, xp=xp)
+            if self.fit_intercept:
+                intercept_np = _convert_to_numpy(self.intercept_, xp=xp)
+                warm_start_coef = np.concatenate(
+                    [warm_start_coef, intercept_np[:, np.newaxis]], axis=1
+                )
 
         # TODO: enable multi-threading if benchmarks show a positive effect,
         # see https://github.com/scikit-learn/scikit-learn/issues/32162

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1332,7 +1332,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
             if self.fit_intercept:
                 intercept_np = _convert_to_numpy(self.intercept_, xp=xp)
                 warm_start_coef = np.concatenate(
-                    [warm_start_coef, intercept_np[:, np.newaxis]], axis=1
+                    [warm_start_coef, intercept_np[:, None]], axis=1
                 )
 
         # TODO: enable multi-threading if benchmarks show a positive effect,

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -2846,3 +2846,35 @@ def test_get_default_scorer():
     """Test that LogisticRegressionCV gets correct default scorer."""
     lr = LogisticRegressionCV()
     assert lr._get_scorer()._score_func.__name__ == "accuracy_score"
+
+
+@pytest.mark.parametrize("binary", [True, False])
+@pytest.mark.parametrize(
+    "array_namespace, device_, dtype_name",
+    yield_namespace_device_dtype_combinations(),
+    ids=_get_namespace_device_dtype_ids,
+)
+@pytest.mark.filterwarnings("error::sklearn.exceptions.ConvergenceWarning")
+def test_logistic_regression_array_api_warm_start(
+    binary,
+    array_namespace,
+    device_,
+    dtype_name,
+):
+    """Test that warm_start=True works with array API inputs across
+    multiple fit calls for both binary and multiclass classification."""
+    xp = _array_api_for_tests(array_namespace, device_)
+    X_np = iris.data.astype(dtype_name, copy=True)
+    if binary:
+        y_np = (iris.target > 0).astype(dtype_name)
+    else:
+        y_np = iris.target.astype(dtype_name)
+
+    X_xp = xp.asarray(X_np, device=device_)
+    y_xp = xp.asarray(y_np, device=device_)
+
+    with config_context(array_api_dispatch=True):
+        lr = LogisticRegression(C=1e-2, solver="lbfgs", max_iter=300, warm_start=True)
+        lr.fit(X_xp, y_xp)
+        lr.predict(X_xp)
+        lr.fit(X_xp, y_xp)


### PR DESCRIPTION

#### Reference Issues/PRs
Related to #33348 where we found a similar problem for `PoissonRegressor`.

#### What does this implement/fix? Explain your changes.
When warm starting the `coef_` attribute gets re-used. It needs explicitly converting to a Numpy array before the solver can use it. 


#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

cc @OmarManzoor 
