### PR TITLE
ENH list all missing columns in _get_column_indices error message

### DIFF
--- a/sklearn/utils/_indexing.py
+++ b/sklearn/utils/_indexing.py
@@ -478,7 +478,10 @@ def _get_column_indices(X, key):
                 column_indices.append(col_idx)
 
         except KeyError as e:
-            raise ValueError("A given column is not a column of the dataframe") from e
+            missing = set(columns) - set(all_columns)
+            raise ValueError(
+                f"A given column is not a column of the dataframe: {missing}"
+            ) from e
 
         return column_indices
 
@@ -514,7 +517,10 @@ def _get_column_indices_interchange(X_interchange, key, key_dtype):
         try:
             return [column_names.index(col) for col in selected_columns]
         except ValueError as e:
-            raise ValueError("A given column is not a column of the dataframe") from e
+            missing = set(selected_columns) - set(column_names)
+            raise ValueError(
+                f"A given column is not a column of the dataframe: {missing}"
+            ) from e
 
 
 @validate_params(


### PR DESCRIPTION
Closes #33569

## What changed
Modified `_get_column_indices` and `_get_column_indices_interchange` in
`sklearn/utils/_indexing.py` to report all missing columns in the
`ValueError`, instead of only the first one.

## Before
ValueError: A given column is not a column of the dataframe

## After
ValueError: A given column is not a column of the dataframe: {'Missing Column 1', 'Missing Column 2'}
