### PR TITLE
CI: Restrict all-tests job to run only in main repository

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -482,7 +482,7 @@ jobs:
   check-job-statuses:
     name: Check all job statuses
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && github.repository == 'scikit-learn/scikit-learn'
     needs: [lint, unit-tests, debian-32bit, free-threaded, scipy-dev]
     steps:
       - uses: re-actors/alls-green@release/v1


### PR DESCRIPTION
Follow-up to #33438.

This PR restricts the all-tests job to run only in the main repository
(scikit-learn/scikit-learn) by adding a condition on github.repository.

This avoids unnecessary failures and notifications in forks where some
jobs are skipped by default.