### PR TITLE
DOC: clarify splitter='random' behavior in DecisionTree/ExtraTree docstrings

### DIFF
--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -718,7 +718,12 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
     splitter : {"best", "random"}, default="best"
         The strategy used to choose the split at each node. Supported
         strategies are "best" to choose the best split and "random" to choose
-        the best random split.
+        the best random split. When ``splitter="random"``, up to
+        ``max_features`` candidate features are drawn at random; for each
+        candidate a single threshold is drawn uniformly between that
+        feature's observed minimum and maximum values, and the
+        ``(feature, threshold)`` pair with the best impurity improvement
+        is selected.
 
     max_depth : int, default=None
         The maximum depth of the tree. If None, then nodes are expanded until
@@ -1133,7 +1138,12 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
     splitter : {"best", "random"}, default="best"
         The strategy used to choose the split at each node. Supported
         strategies are "best" to choose the best split and "random" to choose
-        the best random split.
+        the best random split. When ``splitter="random"``, up to
+        ``max_features`` candidate features are drawn at random; for each
+        candidate a single threshold is drawn uniformly between that
+        feature's observed minimum and maximum values, and the
+        ``(feature, threshold)`` pair with the best impurity improvement
+        is selected.
 
     max_depth : int, default=None
         The maximum depth of the tree. If None, then nodes are expanded until
@@ -1477,7 +1487,12 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
     splitter : {"random", "best"}, default="random"
         The strategy used to choose the split at each node. Supported
         strategies are "best" to choose the best split and "random" to choose
-        the best random split.
+        the best random split. When ``splitter="random"``, up to
+        ``max_features`` candidate features are drawn at random; for each
+        candidate a single threshold is drawn uniformly between that
+        feature's observed minimum and maximum values, and the
+        ``(feature, threshold)`` pair with the best impurity improvement
+        is selected.
 
     max_depth : int, default=None
         The maximum depth of the tree. If None, then nodes are expanded until
@@ -1775,7 +1790,12 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
     splitter : {"random", "best"}, default="random"
         The strategy used to choose the split at each node. Supported
         strategies are "best" to choose the best split and "random" to choose
-        the best random split.
+        the best random split. When ``splitter="random"``, up to
+        ``max_features`` candidate features are drawn at random; for each
+        candidate a single threshold is drawn uniformly between that
+        feature's observed minimum and maximum values, and the
+        ``(feature, threshold)`` pair with the best impurity improvement
+        is selected.
 
     max_depth : int, default=None
         The maximum depth of the tree. If None, then nodes are expanded until


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #33568

#### What does this implement/fix? Explain your changes.

The `splitter` parameter description for `'random'` previously read:

> "random" to choose the best random split

This is ambiguous — it does not explain how the random strategy actually
works. Based on the implementation in `sklearn/tree/_splitter.pyx`
(lines 594–706), the updated docstring explains the full process:

- Up to `max_features` candidate features are drawn at random.
- For each candidate feature, a single split threshold is sampled
  uniformly between that feature's observed minimum and maximum values.
- The `(feature, threshold)` pair with the best impurity improvement
  is selected.

The clarification is applied consistently to all four affected classes:
`DecisionTreeClassifier`, `DecisionTreeRegressor`,
`ExtraTreeClassifier`, and `ExtraTreeRegressor`.

#### Any other comments?

The existing opening sentence is preserved verbatim; the new detail is
appended as a follow-on sentence so the short summary continues to read
cleanly.

#### AI Generation Disclosure

Cursor (Claude) was used as a coding assistant. The assistant helped
locate the relevant source code and draft the docstring wording. All
changes were reviewed and accepted by the contributor before submission.

Made with [Cursor](https://cursor.com)