### PR TITLE
[DOC] Improve n_jobs docstrings for RandomForest, GridSearchCV, and MultiOutputClassifier

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1303,7 +1303,7 @@ class RandomForestClassifier(ForestClassifier):
         :ref:`sphx_glr_auto_examples_ensemble_plot_ensemble_oob.py`.
 
     n_jobs : int, default=None
-        Number of jobs to run in parallel. :meth:`fit`, :meth:`predict`,
+        The number of jobs to run in parallel. :meth:`fit`, :meth:`predict`,
         :meth:`decision_path` and :meth:`apply` are all parallelized over
         the trees. ``None`` means 1 unless in a
         :obj:`joblib.parallel_backend` context. ``-1`` means using all
@@ -1722,7 +1722,7 @@ class RandomForestRegressor(ForestRegressor):
         :ref:`sphx_glr_auto_examples_ensemble_plot_ensemble_oob.py`.
 
     n_jobs : int, default=None
-        Number of jobs to run in parallel. :meth:`fit`, :meth:`predict`,
+        The number of jobs to run in parallel. :meth:`fit`, :meth:`predict`,
         :meth:`decision_path` and :meth:`apply` are all parallelized over
         the trees. ``None`` means 1 unless in a
         :obj:`joblib.parallel_backend` context. ``-1`` means using all

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1303,11 +1303,11 @@ class RandomForestClassifier(ForestClassifier):
         :ref:`sphx_glr_auto_examples_ensemble_plot_ensemble_oob.py`.
 
     n_jobs : int, default=None
-        The number of jobs to run in parallel. :meth:`fit`, :meth:`predict`,
-        :meth:`decision_path` and :meth:`apply` are all parallelized over the
-        trees. ``None`` means 1 unless in a :obj:`joblib.parallel_backend`
-        context. ``-1`` means using all processors. See :term:`Glossary
-        <n_jobs>` for more details.
+        Number of jobs to run in parallel. :meth:`fit`, :meth:`predict`,
+        :meth:`decision_path` and :meth:`apply` are all parallelized over
+        the trees. ``None`` means 1 unless in a
+        :obj:`joblib.parallel_backend` context. ``-1`` means using all
+        processors. See :term:`Glossary <n_jobs>` for more details.
 
     random_state : int, RandomState instance or None, default=None
         Controls both the randomness of the bootstrapping of the samples used
@@ -1722,11 +1722,11 @@ class RandomForestRegressor(ForestRegressor):
         :ref:`sphx_glr_auto_examples_ensemble_plot_ensemble_oob.py`.
 
     n_jobs : int, default=None
-        The number of jobs to run in parallel. :meth:`fit`, :meth:`predict`,
-        :meth:`decision_path` and :meth:`apply` are all parallelized over the
-        trees. ``None`` means 1 unless in a :obj:`joblib.parallel_backend`
-        context. ``-1`` means using all processors. See :term:`Glossary
-        <n_jobs>` for more details.
+        Number of jobs to run in parallel. :meth:`fit`, :meth:`predict`,
+        :meth:`decision_path` and :meth:`apply` are all parallelized over
+        the trees. ``None`` means 1 unless in a
+        :obj:`joblib.parallel_backend` context. ``-1`` means using all
+        processors. See :term:`Glossary <n_jobs>` for more details.
 
     random_state : int, RandomState instance or None, default=None
         Controls both the randomness of the bootstrapping of the samples used

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1293,7 +1293,8 @@ class GridSearchCV(BaseSearchCV):
         See :ref:`multimetric_grid_search` for an example.
 
     n_jobs : int, default=None
-        Number of jobs to run in parallel.
+        Number of jobs to run in parallel. The search over ``param_grid``
+        is parallelized over all candidates and cross-validation splits.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -457,18 +457,15 @@ class MultiOutputClassifier(ClassifierMixin, _MultiOutputEstimator):
         A :term:`predict_proba` method will be exposed only if `estimator` implements
         it.
 
-    n_jobs : int or None, optional (default=None)
-        The number of jobs to run in parallel.
-        :meth:`fit`, :meth:`predict` and :meth:`partial_fit` (if supported
-        by the passed estimator) will be parallelized for each target.
-
-        When individual estimators are fast to train or predict,
-        using ``n_jobs > 1`` can result in slower performance due
-        to the parallelism overhead.
-
-        ``None`` means `1` unless in a :obj:`joblib.parallel_backend` context.
-        ``-1`` means using all available processes / threads.
-        See :term:`Glossary <n_jobs>` for more details.
+    n_jobs : int, default=None
+        Number of jobs to run in parallel. :meth:`fit`, :meth:`predict`
+        and :meth:`partial_fit` (if supported by the passed estimator) are
+        parallelized over the output targets. When individual estimators are
+        fast to train or predict, using ``n_jobs > 1`` can result in slower
+        performance due to the parallelism overhead.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend`
+        context. ``-1`` means using all processors. See
+        :term:`Glossary <n_jobs>` for more details.
 
         .. versionchanged:: 0.20
             `n_jobs` default changed from `1` to `None`.


### PR DESCRIPTION
Related to #14228

## What does this implement / fix?

Improves `n_jobs` docstrings for three estimators to explain what work
is actually parallelized, rather than the generic "number of jobs to
run in parallel" wording that has been flagged since 2019.

This PR addresses a focused subset of #14228 —
`RandomForestClassifier`/`RandomForestRegressor`, `GridSearchCV`, and
`MultiOutputClassifier` only — intentionally scoped for a clean,
reviewable first PR.

## Estimators updated

- `RandomForestClassifier` / `RandomForestRegressor`
  (`sklearn/ensemble/_forest.py`) — clarifies that `fit`, `predict`,
  `decision_path` and `apply` are parallelized over trees
- `GridSearchCV` (`sklearn/model_selection/_search.py`) — clarifies
  that candidate evaluation is parallelized over all parameter
  candidates and cross-validation splits
- `MultiOutputClassifier` (`sklearn/multioutput.py`) — clarifies that
  `fit`, `predict` and `partial_fit` are parallelized over output
  targets; preserves the existing parallelism-overhead caveat

## Accuracy verification

Wording was verified against the actual `Parallel(n_jobs=...)` call
sites in each estimator before updating the docstrings.

Natural follow-ups (out of scope for this PR):
- `RandomizedSearchCV` — same generic wording as GridSearchCV before
- `MultiOutputRegressor` — older style n_jobs block
- Other forest estimators in `_forest.py`

## Checklist

- [x] I have written docstrings for any new functions/classes
- [x] I have updated existing docstrings
- [x] Documentation only — no logic or behavior changes