### PR TITLE
ci: add riscv64 wheel build using RISE native runners

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -155,6 +155,12 @@ jobs:
             platform_id: manylinux_aarch64
             manylinux_image: manylinux_2_28
 
+          # Linux riscv64
+          - os: ubuntu-24.04-riscv
+            python: 312
+            platform_id: manylinux_riscv64
+            manylinux_image: manylinux_2_39
+
           # MacOS x86_64
           - os: macos-15-intel
             python: 311
@@ -219,6 +225,7 @@ jobs:
           CIBW_ARCHS: all
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.manylinux_image }}
+          CIBW_MANYLINUX_RISCV64_IMAGE: ${{ matrix.manylinux_image }}
           # Needed on Windows CI to compile with Visual Studio compiler
           # otherwise Meson detects a MINGW64 platform and use MINGW64
           # toolchain


### PR DESCRIPTION
#### Reference Issues/PRs

Related: numpy/numpy#30995 (same approach — RISE native runners for riscv64 wheels)

#### What does this implement/fix? Explain your changes.

Add `manylinux_riscv64` to the wheel build matrix using native riscv64 runners (`ubuntu-24.04-riscv`) provided by the [RISE RISC-V Software Ecosystem](https://riscv.org/rise/) project.

**Changes:**
- Add riscv64 matrix entry (cp312, `manylinux_2_39` image) in `wheels.yml`
- Add `CIBW_MANYLINUX_RISCV64_IMAGE` env var
- Uses native RISE runners — no QEMU

**Why native runners:** QEMU-based builds are prohibitively slow for scikit-learn (scipy + Fortran compilation). Native RISE runners provide real hardware at no cost to the project. numpy builds in 3.5 minutes on RISE runners vs 38 minutes under QEMU.

**Evidence:**
- Built scikit-learn (with scipy from source) on native riscv64 hardware: BananaPi F3, SpacemiT K1, rv64gc, gfortran 14.2.0, OpenBLAS 0.3.29
- RISE runners validated on numpy (3.5 min build) and other projects

Note: this work is part of the [RISE Project](https://riseproject.dev/) effort to improve Python ecosystem support on riscv64 platforms. Thanks to Ludovic Henry and the RISE project for providing native runners.

#### AI usage disclosure

<!-- If AI tools were involved in creating this PR, please check all boxes that apply -->

- [ ] Code was generated or suggested by AI tools
- [ ] AI was used for code review or suggestions
- [x] AI was NOT used in the preparation of this PR