### PR TITLE
fix: validate transform_n_nonzero_coefs for OMP in DictionaryLearning

### DIFF
--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1094,6 +1094,16 @@ class _BaseSparseCoding(ClassNamePrefixFeaturesOutMixin, TransformerMixin):
         SparseCoder."""
         X = validate_data(self, X, reset=False)
 
+        if self.transform_algorithm == "omp":
+            n_components = dictionary.shape[0]
+            n_nonzero = self.transform_n_nonzero_coefs
+            if n_nonzero is not None and n_nonzero > n_components:
+                raise ValueError(
+                    "transform_n_nonzero_coefs (%d) cannot be greater than "
+                    "n_components (%d) when using transform_algorithm='omp'."
+                    % (n_nonzero, n_components)
+                )
+
         if hasattr(self, "alpha") and self.transform_alpha is None:
             transform_alpha = self.alpha
         else:

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -133,6 +133,22 @@ def test_dict_learning_lars_positive_parameter():
         dict_learning(X, n_components, alpha=alpha, positive_code=True)
 
 
+
+def test_dict_learning_omp_transform_n_nonzero_coefs_validation():
+    """Check that transform_n_nonzero_coefs > n_components raises clear error."""
+    n_components = 5
+    dico = DictionaryLearning(
+        n_components=n_components,
+        transform_algorithm="omp",
+        transform_n_nonzero_coefs=10,
+        random_state=0,
+    )
+    dico.fit(X)
+    err_msg = "transform_n_nonzero_coefs \(10\) cannot be greater than n_components \(5\)"
+    with pytest.raises(ValueError, match=err_msg):
+        dico.transform(X)
+
+
 @pytest.mark.parametrize(
     "transform_algorithm",
     [

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -144,7 +144,10 @@ def test_dict_learning_omp_transform_n_nonzero_coefs_validation():
         random_state=0,
     )
     dico.fit(X)
-    err_msg = "transform_n_nonzero_coefs \(10\) cannot be greater than n_components \(5\)"
+    err_msg = (
+        r"transform_n_nonzero_coefs \(10\) cannot be greater than "
+        r"n_components \(5\)"
+    )
     with pytest.raises(ValueError, match=err_msg):
         dico.transform(X)
 


### PR DESCRIPTION
## Summary
Fixes #33454.
**Root cause:** `DictionaryLearning` with `transform_algorithm=omp` and `transform_n_nonzero_coefs > n_components` raised a confusing error from `orthogonal_mp_gram` ("The number of atoms cannot be more than the number of features") instead of validating the constraint upfront.
**Fix:** Added validation in the transform method to raise a clear `ValueError` when `transform_n_nonzero_coefs > n_components` with OMP algorithm.
## Changes
- `sklearn/decomposition/_dict_learning.py`: Added parameter validation for OMP algorithm constraints in `_transform`
- `sklearn/decomposition/tests/test_dict_learning.py`: Added regression test
## Testing
- Verified fix provides a clear error message for the reported scenario
- Change is minimal and follows existing validation patterns