### PR TITLE
Refactor array API testing to always pass device and dtype names

### DIFF
--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -12,7 +12,6 @@ from sklearn._loss.link import (
 )
 from sklearn.utils._array_api import (
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._testing import _array_api_for_tests
@@ -89,13 +88,12 @@ def test_link_inverse_identity(link, global_random_seed):
 
 
 @pytest.mark.parametrize(
-    "namespace, device, dtype_name",
+    "namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize("link", LINK_FUNCTIONS)
 def test_link_inverse_array_api(
-    namespace, device, dtype_name, link, global_random_seed
+    namespace, device_name, dtype_name, link, global_random_seed
 ):
     """Test that link and inverse link give same result for array API inputs."""
     rng = np.random.RandomState(global_random_seed)
@@ -114,7 +112,7 @@ def test_link_inverse_array_api(
     else:
         raw_prediction = rng.uniform(low=-20, high=20, size=(n_samples))
 
-    xp = _array_api_for_tests(namespace, device)
+    xp, device = _array_api_for_tests(namespace, device_name)
     if dtype_name != "float64":
         raw_prediction *= 0.5  # avoid overflow
         rtol = 1e-3 if n_classes else 1e-4

--- a/sklearn/_loss/tests/test_loss.py
+++ b/sklearn/_loss/tests/test_loss.py
@@ -36,9 +36,10 @@ from sklearn.utils import assert_all_finite
 from sklearn.utils._array_api import (
     _atol_for_type,
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
-    device,
     yield_namespace_device_dtype_combinations,
+)
+from sklearn.utils._array_api import (
+    device as array_api_device,
 )
 from sklearn.utils._testing import (
     _array_api_for_tests,
@@ -1388,9 +1389,8 @@ def test_tweedie_log_identity_consistency(p):
 )
 @pytest.mark.parametrize("use_sample_weight", [False, True])
 @pytest.mark.parametrize(
-    "namespace, device_, dtype_name",
+    "namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 def test_loss_array_api(
     array_api_loss_class,
@@ -1398,7 +1398,7 @@ def test_loss_array_api(
     method_name,
     use_sample_weight,
     namespace,
-    device_,
+    device_name,
     dtype_name,
 ):
     def _assert_array_api_result(
@@ -1408,14 +1408,14 @@ def test_loss_array_api(
             _convert_to_numpy(result_xp, xp=xp), result_np, rtol=rtol, atol=atol
         )
         assert result_xp.dtype == raw_prediction_xp.dtype
-        assert device(result_xp) == device(raw_prediction_xp)
+        assert array_api_device(result_xp) == array_api_device(raw_prediction_xp)
 
-    xp = _array_api_for_tests(namespace, device_)
+    xp, device = _array_api_for_tests(namespace, device_name)
     atol = _atol_for_type(dtype_name)
     rtol = 1e-6 if dtype_name == "float32" else 1e-11
     random_seed = 42
     n_samples = 100
-    array_api_loss_instance = array_api_loss_class(xp=xp, device=device_)
+    array_api_loss_instance = array_api_loss_class(xp=xp, device=device)
     loss_instance = loss_class()
     y_true, raw_prediction = random_y_true_raw_prediction(
         loss=loss_instance,
@@ -1426,14 +1426,14 @@ def test_loss_array_api(
     )
     y_true = y_true.astype(dtype_name)
     raw_prediction = raw_prediction.astype(dtype_name)
-    y_true_xp = xp.asarray(y_true, device=device_)
-    raw_prediction_xp = xp.asarray(raw_prediction, device=device_)
+    y_true_xp = xp.asarray(y_true, device=device)
+    raw_prediction_xp = xp.asarray(raw_prediction, device=device)
     if use_sample_weight:
         rng = np.random.RandomState(random_seed)
         sample_weight_np = (
             rng.uniform(-1, 5, size=n_samples).clip(0, None).astype(dtype_name)
         )
-        sample_weight_xp = xp.asarray(sample_weight_np, device=device_)
+        sample_weight_xp = xp.asarray(sample_weight_np, device=device)
     else:
         sample_weight_np = None
         sample_weight_xp = None
@@ -1476,20 +1476,19 @@ def test_loss_array_api(
 
 
 @pytest.mark.parametrize(
-    "namespace, device_, dtype_name",
+    "namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
-def test_log1pexp(namespace, device_, dtype_name):
+def test_log1pexp(namespace, device_name, dtype_name):
     mpmath = pytest.importorskip("mpmath")
     mpmath.mp.prec = 100  # Significantly more precise reference than float64.
     values_to_test = np.linspace(-40, 40, 300)
-    xp = _array_api_for_tests(namespace, device_)
+    xp, device = _array_api_for_tests(namespace, device_name)
     for value in values_to_test:
         if dtype_name == "float32":
-            x = xp.asarray(value, dtype=xp.float32, device=device_)
+            x = xp.asarray(value, dtype=xp.float32, device=device)
         else:
-            x = xp.asarray(value, dtype=xp.float64, device=device_)
+            x = xp.asarray(value, dtype=xp.float64, device=device)
 
         result_xp = float(
             _log1pexp(

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -14,7 +14,6 @@ from sklearn.decomposition._pca import _assess_dimension, _infer_dimension
 from sklearn.utils._array_api import (
     _atol_for_type,
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._array_api import device as array_device
@@ -936,8 +935,10 @@ def test_variance_correctness(copy):
     np.testing.assert_allclose(pca_var, true_var)
 
 
-def check_array_api_get_precision(name, estimator, array_namespace, device, dtype_name):
-    xp = _array_api_for_tests(array_namespace, device)
+def check_array_api_get_precision(
+    name, estimator, array_namespace, device_name, dtype_name
+):
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     iris_np = iris.data.astype(dtype_name)
     iris_xp = xp.asarray(iris_np, device=device)
 
@@ -971,9 +972,8 @@ def check_array_api_get_precision(name, estimator, array_namespace, device, dtyp
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize(
     "check",
@@ -998,17 +998,22 @@ def check_array_api_get_precision(name, estimator, array_namespace, device, dtyp
     ids=_get_check_estimator_ids,
 )
 def test_pca_array_api_compliance(
-    estimator, check, array_namespace, device, dtype_name
+    estimator, check, array_namespace, device_name, dtype_name
 ):
     name = estimator.__class__.__name__
     estimator = clone(estimator)
-    check(name, estimator, array_namespace, device=device, dtype_name=dtype_name)
+    check(
+        name,
+        estimator,
+        array_namespace,
+        device_name=device_name,
+        dtype_name=dtype_name,
+    )
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize(
     "check",
@@ -1028,14 +1033,20 @@ def test_pca_array_api_compliance(
     ids=_get_check_estimator_ids,
 )
 def test_pca_mle_array_api_compliance(
-    estimator, check, array_namespace, device, dtype_name
+    estimator, check, array_namespace, device_name, dtype_name
 ):
     name = estimator.__class__.__name__
-    check(name, estimator, array_namespace, device=device, dtype_name=dtype_name)
+    check(
+        name,
+        estimator,
+        array_namespace,
+        device_name=device_name,
+        dtype_name=dtype_name,
+    )
 
     # Simpler variant of the generic check_array_api_input checker tailored for
     # the specific case of PCA with mle-trimmed components.
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     X, y = make_classification(random_state=42)
     X = X.astype(dtype_name, copy=False)

--- a/sklearn/linear_model/_glm/tests/test_glm.py
+++ b/sklearn/linear_model/_glm/tests/test_glm.py
@@ -31,9 +31,10 @@ from sklearn.model_selection import train_test_split
 from sklearn.utils._array_api import (
     _atol_for_type,
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
-    device,
     yield_namespace_device_dtype_combinations,
+)
+from sklearn.utils._array_api import (
+    device as array_api_device,
 )
 from sklearn.utils._testing import _array_api_for_tests, assert_allclose
 
@@ -1152,18 +1153,17 @@ def test_newton_solver_verbosity(capsys, verbose):
 
 @pytest.mark.parametrize("use_sample_weight", [False, True])
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.filterwarnings("error::sklearn.exceptions.ConvergenceWarning")
 def test_poisson_regressor_array_api_compliance(
     use_sample_weight,
     array_namespace,
-    device_,
+    device_name,
     dtype_name,
 ):
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     X_np, y_np = make_regression(
         n_samples=107, n_features=20, n_informative=20, noise=0.5, random_state=2
     )
@@ -1172,8 +1172,8 @@ def test_poisson_regressor_array_api_compliance(
     n_samples = X_np.shape[0]
     X_np = X_np.astype(dtype_name, copy=False)
     y_np = y_np.astype(dtype_name, copy=False)
-    X_xp = xp.asarray(X_np, device=device_)
-    y_xp = xp.asarray(y_np, device=device_)
+    X_xp = xp.asarray(X_np, device=device)
+    y_xp = xp.asarray(y_np, device=device)
 
     if use_sample_weight:
         sample_weight = (
@@ -1208,7 +1208,7 @@ def test_poisson_regressor_array_api_compliance(
                 _convert_to_numpy(attr_xp, xp=xp), attr_np, rtol=rtol, atol=atol
             )
             assert attr_xp.dtype == X_xp.dtype
-            assert device(attr_xp) == device(X_xp)
+            assert array_api_device(attr_xp) == array_api_device(X_xp)
 
         predict_xp = glm_xp.predict(X_xp)
         assert_allclose(
@@ -1218,18 +1218,17 @@ def test_poisson_regressor_array_api_compliance(
             atol=atol,
         )
         assert predict_xp.dtype == X_xp.dtype
-        assert device(predict_xp) == device(X_xp)
+        assert array_api_device(predict_xp) == array_api_device(X_xp)
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.filterwarnings("error::sklearn.exceptions.ConvergenceWarning")
 def test_poisson_regressor_array_api_warm_start(
     array_namespace,
-    device_,
+    device_name,
     dtype_name,
 ):
     """Test that incremental fitting of PoissonRegressor works correctly
@@ -1238,9 +1237,9 @@ def test_poisson_regressor_array_api_warm_start(
     X = rng.standard_normal((200, 5)).astype(dtype_name)
     y = np.abs(rng.standard_normal(200)) + 0.1
     y = y.astype(dtype_name)
-    xp = _array_api_for_tests(array_namespace, device_)
-    X_xp = xp.asarray(X, device=device_)
-    y_xp = xp.asarray(y, device=device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
+    X_xp = xp.asarray(X, device=device)
+    y_xp = xp.asarray(y, device=device)
     with config_context(array_api_dispatch=True):
         reg_xp = PoissonRegressor(
             alpha=1.0, solver="lbfgs", max_iter=300, warm_start=True

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -2850,20 +2850,19 @@ def test_get_default_scorer():
 
 @pytest.mark.parametrize("binary", [True, False])
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.filterwarnings("error::sklearn.exceptions.ConvergenceWarning")
 def test_logistic_regression_array_api_warm_start(
     binary,
     array_namespace,
-    device_,
+    device_name,
     dtype_name,
 ):
     """Test that warm_start=True works with array API inputs across
     multiple fit calls for both binary and multiclass classification."""
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device_ = _array_api_for_tests(array_namespace, device_name)
     X_np = iris.data.astype(dtype_name, copy=True)
     if binary:
         y_np = (iris.target > 0).astype(dtype_name)

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -39,9 +39,10 @@ from sklearn.utils import compute_class_weight, shuffle
 from sklearn.utils._array_api import (
     _atol_for_type,
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
-    device,
     yield_namespace_device_dtype_combinations,
+)
+from sklearn.utils._array_api import (
+    device as array_api_device,
 )
 from sklearn.utils._testing import _array_api_for_tests, ignore_warnings
 from sklearn.utils.fixes import _IS_32BIT, COO_CONTAINERS, CSR_CONTAINERS
@@ -2688,9 +2689,8 @@ def test_logisticregression_warns_with_n_jobs():
 @pytest.mark.parametrize("use_sample_weight", [False, True])
 @pytest.mark.parametrize("class_weight", [None, "balanced", "dict"])
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.filterwarnings("error::sklearn.exceptions.ConvergenceWarning")
 def test_logistic_regression_array_api_compliance(
@@ -2699,13 +2699,13 @@ def test_logistic_regression_array_api_compliance(
     use_sample_weight,
     class_weight,
     array_namespace,
-    device_,
+    device_name,
     dtype_name,
 ):
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     X_np = iris.data.astype(dtype_name, copy=True)
     n_samples, _ = X_np.shape
-    X_xp = xp.asarray(X_np, device=device_)
+    X_xp = xp.asarray(X_np, device=device)
     if use_str_y:
         if binary:
             target = (iris.target > 0).astype(np.int64)
@@ -2728,7 +2728,7 @@ def test_logistic_regression_array_api_compliance(
             if class_weight == "dict":
                 class_weight = {0: 1.0, 1: 2.0, 2: 3.0}
         y_np = target.astype(dtype_name)
-        y_xp_or_np = xp.asarray(y_np, device=device_)
+        y_xp_or_np = xp.asarray(y_np, device=device)
 
     if use_sample_weight:
         sample_weight = (
@@ -2789,7 +2789,7 @@ def test_logistic_regression_array_api_compliance(
                 _convert_to_numpy(attr_xp, xp=xp), attr_np, rtol=rtol, atol=atol
             )
             assert attr_xp.dtype == X_xp.dtype
-            assert device(attr_xp) == device(X_xp)
+            assert array_api_device(attr_xp) == array_api_device(X_xp)
 
         predict_proba_xp = lr_xp.predict_proba(X_xp)
         assert_allclose(
@@ -2799,7 +2799,7 @@ def test_logistic_regression_array_api_compliance(
             atol=atol,
         )
         assert predict_proba_xp.dtype == X_xp.dtype
-        assert device(predict_proba_xp) == device(X_xp)
+        assert array_api_device(predict_proba_xp) == array_api_device(X_xp)
 
         predict_log_proba_xp = lr_xp.predict_log_proba(X_xp)
         assert_allclose(
@@ -2809,7 +2809,7 @@ def test_logistic_regression_array_api_compliance(
             atol=atol,
         )
         assert predict_log_proba_xp.dtype == X_xp.dtype
-        assert device(predict_log_proba_xp) == device(X_xp)
+        assert array_api_device(predict_log_proba_xp) == array_api_device(X_xp)
 
         prediction_xp = lr_xp.predict(X_xp)
         if not use_str_y:

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -45,7 +45,6 @@ from sklearn.utils._array_api import (
     _NUMPY_NAMESPACE_NAMES,
     _atol_for_type,
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
     yield_namespace_device_dtype_combinations,
     yield_namespaces,
 )
@@ -1409,9 +1408,9 @@ def _test_tolerance(sparse_container):
 
 
 def check_array_api_attributes(
-    name, estimator, array_namespace, device, dtype_name, rtol=None
+    name, estimator, array_namespace, device_name, dtype_name, rtol=None
 ):
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     X_iris_np = X_iris.astype(dtype_name)
     y_iris_np = y_iris.astype(dtype_name)
@@ -1448,9 +1447,8 @@ def check_array_api_attributes(
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize(
     "check",
@@ -1469,32 +1467,36 @@ def check_array_api_attributes(
     ids=_get_check_estimator_ids,
 )
 def test_ridge_array_api_compliance(
-    estimator, check, array_namespace, device, dtype_name
+    estimator, check, array_namespace, device_name, dtype_name
 ):
     name = estimator.__class__.__name__
-    xp = _array_api_for_tests(array_namespace, device)
-    check(name, estimator, array_namespace, device=device, dtype_name=dtype_name)
+    check(
+        name,
+        estimator,
+        array_namespace,
+        device_name=device_name,
+        dtype_name=dtype_name,
+    )
 
 
 @pytest.mark.parametrize(
     "estimator", [RidgeClassifier(solver="svd"), RidgeClassifierCV()]
 )
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 def test_ridge_classifier_multilabel_array_api(
-    estimator, array_namespace, device_, dtype_name
+    estimator, array_namespace, device_name, dtype_name
 ):
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     X, y = make_multilabel_classification(random_state=0)
     X_np = X.astype(dtype_name)
     y_np = y.astype(dtype_name)
     ridge_np = estimator.fit(X_np, y_np)
     pred_np = ridge_np.predict(X_np)
     with config_context(array_api_dispatch=True):
-        X_xp, y_xp = xp.asarray(X_np, device=device_), xp.asarray(y_np, device=device_)
+        X_xp, y_xp = xp.asarray(X_np, device=device), xp.asarray(y_np, device=device)
         ridge_xp = estimator.fit(X_xp, y_xp)
         pred_xp = ridge_xp.predict(X_xp)
         assert pred_xp.shape == pred_np.shape == y.shape
@@ -1505,7 +1507,7 @@ def test_ridge_classifier_multilabel_array_api(
     "array_namespace", yield_namespaces(include_numpy_namespaces=False)
 )
 def test_array_api_error_and_warnings_for_solver_parameter(array_namespace):
-    xp = _array_api_for_tests(array_namespace, device=None)
+    xp, _ = _array_api_for_tests(array_namespace, device_name=None)
 
     X_iris_xp = xp.asarray(X_iris[:5])
     y_iris_xp = xp.asarray(y_iris[:5])
@@ -1548,7 +1550,7 @@ def test_array_api_error_and_warnings_for_solver_parameter(array_namespace):
 
 @pytest.mark.parametrize("array_namespace", sorted(_NUMPY_NAMESPACE_NAMES))
 def test_array_api_numpy_namespace_no_warning(array_namespace):
-    xp = _array_api_for_tests(array_namespace, device=None)
+    xp, _ = _array_api_for_tests(array_namespace, device_name=None)
 
     X_iris_xp = xp.asarray(X_iris[:5])
     y_iris_xp = xp.asarray(y_iris[:5])

--- a/sklearn/metrics/cluster/tests/test_common.py
+++ b/sklearn/metrics/cluster/tests/test_common.py
@@ -20,7 +20,6 @@ from sklearn.metrics.cluster import (
 )
 from sklearn.metrics.tests.test_common import check_array_api_metric
 from sklearn.utils._array_api import (
-    _get_namespace_device_dtype_ids,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._testing import assert_allclose
@@ -239,14 +238,16 @@ def test_returned_value_consistency(name):
     assert not isinstance(score, (np.float64, np.float32))
 
 
-def check_array_api_unsupervised_metric(metric, array_namespace, device, dtype_name):
+def check_array_api_unsupervised_metric(
+    metric, array_namespace, device_name, dtype_name
+):
     y_pred = np.array([1, 0, 1, 0, 1, 1, 0])
     X = np.random.randint(10, size=(7, 10))
 
     check_array_api_metric(
         metric,
         array_namespace,
-        device,
+        device_name,
         dtype_name,
         a_np=X,
         b_np=y_pred,
@@ -270,10 +271,11 @@ def yield_metric_checker_combinations(metric_checkers=array_api_metric_checkers)
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize("metric, check_func", yield_metric_checker_combinations())
-def test_array_api_compliance(metric, array_namespace, device, dtype_name, check_func):
-    check_func(metric, array_namespace, device, dtype_name)
+def test_array_api_compliance(
+    metric, array_namespace, device_name, dtype_name, check_func
+):
+    check_func(metric, array_namespace, device_name, dtype_name)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -28,7 +28,6 @@ from sklearn.metrics.cluster._supervised import (
 )
 from sklearn.utils import assert_all_finite
 from sklearn.utils._array_api import (
-    _get_namespace_device_dtype_ids,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._testing import _array_api_for_tests, assert_almost_equal
@@ -284,12 +283,11 @@ def test_entropy():
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
-def test_entropy_array_api(array_namespace, device, dtype_name):
-    xp = _array_api_for_tests(array_namespace, device)
+def test_entropy_array_api(array_namespace, device_name, dtype_name):
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     float_labels = xp.asarray(np.asarray([0, 0, 42.0], dtype=dtype_name), device=device)
     empty_int32_labels = xp.asarray([], dtype=xp.int32, device=device)
     int_labels = xp.asarray([1, 1, 1, 1], device=device)

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -46,12 +46,11 @@ from sklearn.model_selection import cross_val_score
 from sklearn.preprocessing import LabelBinarizer, label_binarize
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.utils._array_api import (
-    _get_namespace_device_dtype_ids,
-    get_namespace,
-    yield_namespace_device_dtype_combinations,
+    device as array_api_device,
 )
 from sklearn.utils._array_api import (
-    device as array_api_device,
+    get_namespace,
+    yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._mocking import MockDataFrame
 from sklearn.utils._testing import (
@@ -3683,12 +3682,13 @@ def test_d2_brier_score_warning_on_less_than_two_samples():
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, _", yield_namespace_device_dtype_combinations()
+    "array_namespace, device_name, dtype_name",
+    yield_namespace_device_dtype_combinations(),
 )
-def test_confusion_matrix_array_api(array_namespace, device, _):
+def test_confusion_matrix_array_api(array_namespace, device_name, dtype_name):
     """Test that `confusion_matrix` works for all array types when `labels` are passed
     such that the inner boolean `need_index_conversion` evaluates to `True`."""
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     y_true = xp.asarray([1, 2, 3], device=device)
     y_pred = xp.asarray([4, 5, 6], device=device)
@@ -3706,16 +3706,22 @@ def test_confusion_matrix_array_api(array_namespace, device, _):
 @pytest.mark.parametrize("str_y_true", [False, True])
 @pytest.mark.parametrize("use_sample_weight", [False, True])
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name", yield_namespace_device_dtype_combinations()
+    "array_namespace, device_name, dtype_name",
+    yield_namespace_device_dtype_combinations(),
 )
 def test_probabilistic_metrics_array_api(
-    prob_metric, str_y_true, use_sample_weight, array_namespace, device_, dtype_name
+    prob_metric,
+    str_y_true,
+    use_sample_weight,
+    array_namespace,
+    device_name,
+    dtype_name,
 ):
     """Test that :func:`brier_score_loss`, :func:`log_loss`, :func:`d2_brier_score`
     and :func:`d2_log_loss_score` work correctly with the array API for binary
     and multi-class inputs.
     """
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     sample_weight = np.array([1, 2, 3, 1]) if use_sample_weight else None
 
     # binary case
@@ -3729,10 +3735,10 @@ def test_probabilistic_metrics_array_api(
             extra_kwargs["pos_label"] = "yes"
     else:
         y_true_np = np.array([1, 0, 1, 0])
-        y_true_xp_or_np = xp.asarray(y_true_np, device=device_)
+        y_true_xp_or_np = xp.asarray(y_true_np, device=device)
 
     y_prob_np = np.array([0.5, 0.2, 0.7, 0.6], dtype=dtype_name)
-    y_prob_xp = xp.asarray(y_prob_np, device=device_)
+    y_prob_xp = xp.asarray(y_prob_np, device=device)
     metric_score_np = prob_metric(
         y_true_np, y_prob_np, sample_weight=sample_weight, **extra_kwargs
     )
@@ -3749,7 +3755,7 @@ def test_probabilistic_metrics_array_api(
         y_true_xp_or_np = np.asarray(y_true_np)
     else:
         y_true_np = np.array([0, 1, 2, 3])
-        y_true_xp_or_np = xp.asarray(y_true_np, device=device_)
+        y_true_xp_or_np = xp.asarray(y_true_np, device=device)
 
     y_prob_np = np.array(
         [
@@ -3760,7 +3766,7 @@ def test_probabilistic_metrics_array_api(
         ],
         dtype=dtype_name,
     )
-    y_prob_xp = xp.asarray(y_prob_np, device=device_)
+    y_prob_xp = xp.asarray(y_prob_np, device=device)
     metric_score_np = prob_metric(y_true_np, y_prob_np)
     with config_context(array_api_dispatch=True):
         metric_score_xp = prob_metric(y_true_xp_or_np, y_prob_xp)
@@ -3773,16 +3779,21 @@ def test_probabilistic_metrics_array_api(
 )
 @pytest.mark.parametrize("use_sample_weight", [False, True])
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name", yield_namespace_device_dtype_combinations()
+    "array_namespace, device_name, dtype_name",
+    yield_namespace_device_dtype_combinations(),
 )
 def test_probabilistic_metrics_multilabel_array_api(
-    prob_metric, use_sample_weight, array_namespace, device_, dtype_name
+    prob_metric,
+    use_sample_weight,
+    array_namespace,
+    device_name,
+    dtype_name,
 ):
     """Test that :func:`brier_score_loss`, :func:`log_loss`, :func:`d2_brier_score`
     and :func:`d2_log_loss_score` work correctly with the array API for
     multi-label inputs.
     """
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     sample_weight = np.array([1, 2, 3, 1]) if use_sample_weight else None
     y_true_np = np.array(
         [
@@ -3793,7 +3804,7 @@ def test_probabilistic_metrics_multilabel_array_api(
         ],
         dtype=dtype_name,
     )
-    y_true_xp = xp.asarray(y_true_np, device=device_)
+    y_true_xp = xp.asarray(y_true_np, device=device)
     y_prob_np = np.array(
         [
             [0.15, 0.27, 0.46, 0.12],
@@ -3803,7 +3814,7 @@ def test_probabilistic_metrics_multilabel_array_api(
         ],
         dtype=dtype_name,
     )
-    y_prob_xp = xp.asarray(y_prob_np, device=device_)
+    y_prob_xp = xp.asarray(y_prob_np, device=device)
     metric_score_np = prob_metric(y_true_np, y_prob_np, sample_weight=sample_weight)
     with config_context(array_api_dispatch=True):
         metric_score_xp = prob_metric(y_true_xp, y_prob_xp, sample_weight=sample_weight)
@@ -3812,24 +3823,21 @@ def test_probabilistic_metrics_multilabel_array_api(
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize("prob_metric", [brier_score_loss, d2_brier_score])
 def test_pos_label_in_brier_score_metrics_array_api(
-    prob_metric, array_namespace, device_, dtype_name
+    prob_metric, array_namespace, device_name, dtype_name
 ):
     """Check `pos_label` handled correctly when labels not in {-1, 1} or {0, 1}."""
     # For 'brier_score' metrics, when `pos_label=None` and labels are not strings,
     # `pos_label` defaults to the largest label.
-    xp = _array_api_for_tests(array_namespace, device_)
-    y_true_pos_1 = xp.asarray(np.array([1, 0, 1, 0]), device=device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
+    y_true_pos_1 = xp.asarray(np.array([1, 0, 1, 0]), device=device)
     # Result should be the same when we use 2's for the label instead of 1's
-    y_true_pos_2 = xp.asarray(np.array([2, 0, 2, 0]), device=device_)
-    y_prob = xp.asarray(
-        np.array([0.5, 0.2, 0.7, 0.6], dtype=dtype_name), device=device_
-    )
+    y_true_pos_2 = xp.asarray(np.array([2, 0, 2, 0]), device=device)
+    y_prob = xp.asarray(np.array([0.5, 0.2, 0.7, 0.6], dtype=dtype_name), device=device)
 
     with config_context(array_api_dispatch=True):
         metric_pos_1 = prob_metric(y_true_pos_1, y_prob)

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -2556,8 +2556,7 @@ def test_mixed_array_api_namespace_input_compliance(
     is correct, as detailed above.
     """
     xp_to, device_to = _array_api_for_tests(
-        to_ns_and_device.xp,
-        device_name=to_ns_and_device.device,
+        to_ns_and_device.xp, device_name=to_ns_and_device.device
     )
     xp_from, device_from = _array_api_for_tests(
         from_ns_and_device.xp, device_name=from_ns_and_device.device

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -2600,21 +2600,19 @@ def test_mixed_array_api_namespace_input_compliance(
         for data_case in data_cases:
             y1, y2 = data_all[data_case]
 
-            dtype = _get_dtype(y1, xp_from, from_ns_and_device.device)
-            y1_xp = xp_from.asarray(y1, device=from_ns_and_device.device, dtype=dtype)
+            dtype = _get_dtype(y1, xp_from, device_from)
+            y1_xp = xp_from.asarray(y1, device=device_from, dtype=dtype)
 
             metric_kwargs_xp = metric_kwargs_np = {}
             if metric_name not in METRICS_WITHOUT_SAMPLE_WEIGHT:
                 # use `from_ns_and_device` for `sample_weight` as well
                 sample_weight_np = np.array(sample_weight)
                 metric_kwargs_np = {"sample_weight": sample_weight_np}
-                sample_weight_xp = xp_from.asarray(
-                    sample_weight_np, device=from_ns_and_device.device
-                )
+                sample_weight_xp = xp_from.asarray(sample_weight_np, device=device_from)
                 metric_kwargs_xp = {"sample_weight": sample_weight_xp}
 
-            dtype = _get_dtype(y2, xp_to, to_ns_and_device.device)
-            y2_xp = xp_to.asarray(y2, device=to_ns_and_device.device, dtype=dtype)
+            dtype = _get_dtype(y2, xp_to, device_to)
+            y2_xp = xp_to.asarray(y2, device=device_to, dtype=dtype)
 
             metric_xp = metric(y1_xp, y2_xp, **metric_kwargs_xp)
             metric_np = metric(y1, y2, **metric_kwargs_np)

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -86,12 +86,13 @@ from sklearn.utils import shuffle
 from sklearn.utils._array_api import (
     _atol_for_type,
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
     _max_precision_float_dtype,
-    device,
     get_namespace,
     yield_mixed_namespace_input_permutations,
     yield_namespace_device_dtype_combinations,
+)
+from sklearn.utils._array_api import (
+    device as array_api_device,
 )
 from sklearn.utils._testing import (
     _array_api_for_tests,
@@ -2025,9 +2026,9 @@ def test_metrics_pos_label_error_str(metric, y_pred_threshold, dtype_y_str):
 
 
 def check_array_api_metric(
-    metric, array_namespace, device, dtype_name, a_np, b_np, **metric_kwargs
+    metric, array_namespace, device_name, dtype_name, a_np, b_np, **metric_kwargs
 ):
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     a_xp = xp.asarray(a_np, device=device)
     b_xp = xp.asarray(b_np, device=device)
@@ -2104,7 +2105,7 @@ def check_array_api_metric(
 
 
 def check_array_api_binary_classification_metric(
-    metric, array_namespace, device, dtype_name
+    metric, array_namespace, device_name, dtype_name
 ):
     y_true_np = np.array([0, 0, 1, 1])
     y_pred_np = np.array([0, 1, 0, 1])
@@ -2116,7 +2117,7 @@ def check_array_api_binary_classification_metric(
     check_array_api_metric(
         metric,
         array_namespace,
-        device,
+        device_name,
         dtype_name,
         a_np=y_true_np,
         b_np=y_pred_np,
@@ -2129,7 +2130,7 @@ def check_array_api_binary_classification_metric(
     check_array_api_metric(
         metric,
         array_namespace,
-        device,
+        device_name,
         dtype_name,
         a_np=y_true_np,
         b_np=y_pred_np,
@@ -2139,7 +2140,7 @@ def check_array_api_binary_classification_metric(
 
 
 def check_array_api_multiclass_classification_metric(
-    metric, array_namespace, device, dtype_name
+    metric, array_namespace, device_name, dtype_name
 ):
     y_true_np = np.array([0, 1, 2, 3])
     y_pred_np = np.array([0, 1, 0, 2])
@@ -2169,7 +2170,7 @@ def check_array_api_multiclass_classification_metric(
         check_array_api_metric(
             metric,
             array_namespace,
-            device,
+            device_name,
             dtype_name,
             a_np=y_true_np,
             b_np=y_pred_np,
@@ -2182,7 +2183,7 @@ def check_array_api_multiclass_classification_metric(
         check_array_api_metric(
             metric,
             array_namespace,
-            device,
+            device_name,
             dtype_name,
             a_np=y_true_np,
             b_np=y_pred_np,
@@ -2192,7 +2193,7 @@ def check_array_api_multiclass_classification_metric(
 
 
 def check_array_api_multilabel_classification_metric(
-    metric, array_namespace, device, dtype_name
+    metric, array_namespace, device_name, dtype_name
 ):
     y_true_np = np.array([[1, 1], [0, 1], [0, 0]], dtype=dtype_name)
     y_pred_np = np.array([[1, 1], [1, 1], [1, 1]], dtype=dtype_name)
@@ -2209,7 +2210,7 @@ def check_array_api_multilabel_classification_metric(
         check_array_api_metric(
             metric,
             array_namespace,
-            device,
+            device_name,
             dtype_name,
             a_np=y_true_np,
             b_np=y_pred_np,
@@ -2222,7 +2223,7 @@ def check_array_api_multilabel_classification_metric(
         check_array_api_metric(
             metric,
             array_namespace,
-            device,
+            device_name,
             dtype_name,
             a_np=y_true_np,
             b_np=y_pred_np,
@@ -2231,7 +2232,7 @@ def check_array_api_multilabel_classification_metric(
         )
 
 
-def check_array_api_regression_metric(metric, array_namespace, device, dtype_name):
+def check_array_api_regression_metric(metric, array_namespace, device_name, dtype_name):
     func_name = metric.func.__name__ if isinstance(metric, partial) else metric.__name__
     if func_name == "mean_poisson_deviance" and sp_version < parse_version("1.14.0"):
         pytest.skip(
@@ -2250,7 +2251,7 @@ def check_array_api_regression_metric(metric, array_namespace, device, dtype_nam
     check_array_api_metric(
         metric,
         array_namespace,
-        device,
+        device_name,
         dtype_name,
         a_np=y_true_np,
         b_np=y_pred_np,
@@ -2265,7 +2266,7 @@ def check_array_api_regression_metric(metric, array_namespace, device, dtype_nam
         check_array_api_metric(
             metric,
             array_namespace,
-            device,
+            device_name,
             dtype_name,
             a_np=y_true_np,
             b_np=y_pred_np,
@@ -2274,7 +2275,7 @@ def check_array_api_regression_metric(metric, array_namespace, device, dtype_nam
 
 
 def check_array_api_regression_metric_multioutput(
-    metric, array_namespace, device, dtype_name
+    metric, array_namespace, device_name, dtype_name
 ):
     y_true_np = np.array([[1, 3, 2], [1, 2, 2]], dtype=dtype_name)
     y_pred_np = np.array([[1, 4, 4], [1, 1, 1]], dtype=dtype_name)
@@ -2282,7 +2283,7 @@ def check_array_api_regression_metric_multioutput(
     check_array_api_metric(
         metric,
         array_namespace,
-        device,
+        device_name,
         dtype_name,
         a_np=y_true_np,
         b_np=y_pred_np,
@@ -2294,7 +2295,7 @@ def check_array_api_regression_metric_multioutput(
     check_array_api_metric(
         metric,
         array_namespace,
-        device,
+        device_name,
         dtype_name,
         a_np=y_true_np,
         b_np=y_pred_np,
@@ -2304,7 +2305,7 @@ def check_array_api_regression_metric_multioutput(
     check_array_api_metric(
         metric,
         array_namespace,
-        device,
+        device_name,
         dtype_name,
         a_np=y_true_np,
         b_np=y_pred_np,
@@ -2314,7 +2315,7 @@ def check_array_api_regression_metric_multioutput(
     check_array_api_metric(
         metric,
         array_namespace,
-        device,
+        device_name,
         dtype_name,
         a_np=y_true_np,
         b_np=y_pred_np,
@@ -2322,7 +2323,7 @@ def check_array_api_regression_metric_multioutput(
     )
 
 
-def check_array_api_metric_pairwise(metric, array_namespace, device, dtype_name):
+def check_array_api_metric_pairwise(metric, array_namespace, device_name, dtype_name):
     X_np = np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], dtype=dtype_name)
     Y_np = np.array([[0.2, 0.3, 0.4], [0.5, 0.6, 0.7]], dtype=dtype_name)
 
@@ -2332,7 +2333,7 @@ def check_array_api_metric_pairwise(metric, array_namespace, device, dtype_name)
         check_array_api_metric(
             metric,
             array_namespace,
-            device,
+            device_name,
             dtype_name,
             a_np=X_np,
             b_np=Y_np,
@@ -2343,7 +2344,7 @@ def check_array_api_metric_pairwise(metric, array_namespace, device, dtype_name)
     check_array_api_metric(
         metric,
         array_namespace,
-        device,
+        device_name,
         dtype_name,
         a_np=X_np,
         b_np=Y_np,
@@ -2511,13 +2512,14 @@ def yield_metric_checker_combinations(metric_checkers=array_api_metric_checkers)
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize("metric, check_func", yield_metric_checker_combinations())
-def test_array_api_compliance(metric, array_namespace, device, dtype_name, check_func):
-    check_func(metric, array_namespace, device, dtype_name)
+def test_array_api_compliance(
+    metric, array_namespace, device_name, dtype_name, check_func
+):
+    check_func(metric, array_namespace, device_name, dtype_name)
 
 
 def _check_output(out_np, out_xp, xp_to, y2_xp):
@@ -2526,7 +2528,7 @@ def _check_output(out_np, out_xp, xp_to, y2_xp):
     elif hasattr(out_np, "shape"):
         assert hasattr(out_xp, "shape")
         assert get_namespace(out_xp)[0] == xp_to
-        assert device(out_xp) == device(y2_xp)
+        assert array_api_device(out_xp) == array_api_device(y2_xp)
     # `classification_report` returns str (with default `output_dict=False`)
     elif isinstance(out_np, str):
         assert isinstance(out_xp, str)
@@ -2553,8 +2555,13 @@ def test_mixed_array_api_namespace_input_compliance(
     If the output is a tuple, checks that each element, whether float or array,
     is correct, as detailed above.
     """
-    xp_to = _array_api_for_tests(to_ns_and_device.xp, to_ns_and_device.device)
-    xp_from = _array_api_for_tests(from_ns_and_device.xp, from_ns_and_device.device)
+    xp_to, device_to = _array_api_for_tests(
+        to_ns_and_device.xp,
+        device_name=to_ns_and_device.device,
+    )
+    xp_from, device_from = _array_api_for_tests(
+        from_ns_and_device.xp, device_name=from_ns_and_device.device
+    )
 
     metric = ALL_METRICS[metric_name]
 
@@ -2657,9 +2664,8 @@ def test_array_api_classification_string_input(metric_name):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 # All continuous classification metrics, minus multilabel ranking metrics
 # (`METRIC_UNDEFINED_BINARY`), which take label indicator input (and thus never
@@ -2675,7 +2681,7 @@ def test_array_api_classification_string_input(metric_name):
     ),
 )
 def test_array_api_classification_mixed_string_numeric_input(
-    metric_name, array_namespace, device, dtype_name
+    metric_name, array_namespace, device_name, dtype_name
 ):
     """Check string inputs and numeric inputs from mixed namespace and devices accepted.
 
@@ -2683,7 +2689,7 @@ def test_array_api_classification_mixed_string_numeric_input(
     a mix of string and numeric inputs (numeric input should be able to be of
     any supported namespace/device), with array API dispatch enabled.
     """
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     metric = ALL_METRICS[metric_name]
 
     # Binary

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -50,7 +50,6 @@ from sklearn.metrics.pairwise import (
 from sklearn.preprocessing import normalize
 from sklearn.utils._array_api import (
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
     get_namespace,
     xpx,
     yield_namespace_device_dtype_combinations,
@@ -152,14 +151,13 @@ def test_pairwise_distances_for_dense_data(global_dtype):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize("metric", ["cosine", "euclidean", "manhattan"])
-def test_pairwise_distances_array_api(array_namespace, device, dtype_name, metric):
+def test_pairwise_distances_array_api(array_namespace, device_name, dtype_name, metric):
     # Test array API support in pairwise_distances.
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     rng = np.random.RandomState(0)
     # Euclidean distance should be equivalent to calling the function.
@@ -390,9 +388,8 @@ def test_pairwise_parallel(func, metric, kwds, dtype):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize(
     "func, metric, kwds",
@@ -405,9 +402,9 @@ def test_pairwise_parallel(func, metric, kwds, dtype):
     ],
 )
 def test_pairwise_parallel_array_api(
-    func, metric, kwds, array_namespace, device, dtype_name
+    func, metric, kwds, array_namespace, device_name, dtype_name
 ):
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     rng = np.random.RandomState(0)
     X_np = np.array(5 * rng.random_sample((5, 4)), dtype=dtype_name)
     Y_np = np.array(5 * rng.random_sample((3, 4)), dtype=dtype_name)
@@ -482,17 +479,16 @@ def test_pairwise_kernels(metric, csr_container):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize(
     "metric",
     ["rbf", "sigmoid", "polynomial", "linear", "laplacian", "chi2", "additive_chi2"],
 )
-def test_pairwise_kernels_array_api(metric, array_namespace, device, dtype_name):
+def test_pairwise_kernels_array_api(metric, array_namespace, device_name, dtype_name):
     # Test array API support in pairwise_kernels.
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     rng = np.random.RandomState(0)
     X_np = 10 * rng.random_sample((5, 4))

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -32,10 +32,11 @@ from sklearn.mixture._gaussian_mixture import (
 )
 from sklearn.utils._array_api import (
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
-    device,
     get_namespace,
     yield_namespace_device_dtype_combinations,
+)
+from sklearn.utils._array_api import (
+    device as array_api_device,
 )
 from sklearn.utils._testing import (
     _array_api_for_tests,
@@ -1486,32 +1487,31 @@ def test_gaussian_mixture_all_init_does_not_estimate_gaussian_parameters(
 @pytest.mark.parametrize("init_params", ["random", "random_from_data"])
 @pytest.mark.parametrize("covariance_type", ["full", "tied", "diag", "spherical"])
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize("use_gmm_array_constructor_arguments", [False, True])
 def test_gaussian_mixture_array_api_compliance(
     init_params,
     covariance_type,
     array_namespace,
-    device_,
-    dtype,
+    device_name,
+    dtype_name,
     use_gmm_array_constructor_arguments,
 ):
     """Test that array api works in GaussianMixture.fit()."""
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     rng = np.random.RandomState(0)
     rand_data = RandomData(rng)
     X = rand_data.X[covariance_type]
-    X = X.astype(dtype)
+    X = X.astype(dtype_name)
 
     if use_gmm_array_constructor_arguments:
         additional_kwargs = {
-            "means_init": rand_data.means.astype(dtype),
-            "precisions_init": rand_data.precisions[covariance_type].astype(dtype),
-            "weights_init": rand_data.weights.astype(dtype),
+            "means_init": rand_data.means.astype(dtype_name),
+            "precisions_init": rand_data.precisions[covariance_type].astype(dtype_name),
+            "weights_init": rand_data.weights.astype(dtype_name),
         }
     else:
         additional_kwargs = {}
@@ -1525,20 +1525,20 @@ def test_gaussian_mixture_array_api_compliance(
     )
     gmm.fit(X)
 
-    X_xp = xp.asarray(X, device=device_)
+    X_xp = xp.asarray(X, device=device)
 
     with sklearn.config_context(array_api_dispatch=True):
         gmm_xp = sklearn.clone(gmm)
         for param_name, param_value in additional_kwargs.items():
-            arg_xp = xp.asarray(param_value, device=device_)
+            arg_xp = xp.asarray(param_value, device=device)
             setattr(gmm_xp, param_name, arg_xp)
 
         gmm_xp.fit(X_xp)
 
         assert get_namespace(gmm_xp.means_)[0] == xp
         assert get_namespace(gmm_xp.covariances_)[0] == xp
-        assert device(gmm_xp.means_) == device(X_xp)
-        assert device(gmm_xp.covariances_) == device(X_xp)
+        assert array_api_device(gmm_xp.means_) == array_api_device(X_xp)
+        assert array_api_device(gmm_xp.covariances_) == array_api_device(X_xp)
 
         predict_xp = gmm_xp.predict(X_xp)
         predict_proba_xp = gmm_xp.predict_proba(X_xp)
@@ -1557,15 +1557,15 @@ def test_gaussian_mixture_array_api_compliance(
         ]
         for result in results:
             assert get_namespace(result)[0] == xp
-            assert device(result) == device(X_xp)
+            assert array_api_device(result) == array_api_device(X_xp)
 
         for score in [score_xp, aic_xp, bic_xp]:
             assert isinstance(score, float)
 
     # Define specific rtol to make tests pass
-    default_rtol = 1e-4 if dtype == "float32" else 1e-7
-    increased_atol = 5e-4 if dtype == "float32" else 0
-    increased_rtol = 1e-3 if dtype == "float32" else 1e-7
+    default_rtol = 1e-4 if dtype_name == "float32" else 1e-7
+    increased_atol = 5e-4 if dtype_name == "float32" else 0
+    increased_rtol = 1e-3 if dtype_name == "float32" else 1e-7
 
     # Check fitted attributes
     assert_allclose(gmm.means_, _convert_to_numpy(gmm_xp.means_, xp=xp))
@@ -1617,12 +1617,11 @@ def test_gaussian_mixture_array_api_compliance(
 @skip_if_array_api_compat_not_configured
 @pytest.mark.parametrize("init_params", ["kmeans", "k-means++"])
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 def test_gaussian_mixture_raises_where_array_api_not_implemented(
-    init_params, array_namespace, device_, dtype
+    init_params, array_namespace, device_name, dtype_name
 ):
     X, _ = make_blobs(
         n_samples=100,

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -83,7 +83,6 @@ from sklearn.tests.metadata_routing_common import (
 )
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from sklearn.utils._array_api import (
-    _get_namespace_device_dtype_ids,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._mocking import CheckingClassifier, MockDataFrame
@@ -2863,19 +2862,20 @@ def test_cv_results_multi_size_array():
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize("SearchCV", [GridSearchCV, RandomizedSearchCV])
-def test_array_api_search_cv_classifier(SearchCV, array_namespace, device, dtype):
-    xp = _array_api_for_tests(array_namespace, device)
+def test_array_api_search_cv_classifier(
+    SearchCV, array_namespace, device_name, dtype_name
+):
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     X = np.arange(100).reshape((10, 10))
-    X_np = X.astype(dtype)
+    X_np = X.astype(dtype_name)
     X_xp = xp.asarray(X_np, device=device)
 
-    # y should always be an integer, no matter what `dtype` is
+    # y should always be an integer, no matter what `dtype_name` is
     y_np = np.array([0] * 5 + [1] * 5)
     y_xp = xp.asarray(y_np, device=device)
 

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -43,7 +43,6 @@ from sklearn.svm import SVC
 from sklearn.tests.metadata_routing_common import assert_request_is_empty
 from sklearn.utils._array_api import (
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
     get_namespace,
     yield_namespace_device_dtype_combinations,
 )
@@ -1342,9 +1341,8 @@ def test_train_test_split_default_test_size(train_size, exp_train, exp_test):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize(
     "shuffle,stratify",
@@ -1356,9 +1354,9 @@ def test_train_test_split_default_test_size(train_size, exp_train, exp_test):
     ),
 )
 def test_array_api_train_test_split(
-    shuffle, stratify, array_namespace, device, dtype_name
+    shuffle, stratify, array_namespace, device_name, dtype_name
 ):
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     X = np.arange(100).reshape((10, 10))
     y = np.arange(10)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -85,7 +85,6 @@ from sklearn.utils import shuffle
 from sklearn.utils._array_api import (
     _atol_for_type,
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._mocking import CheckingClassifier, MockDataFrame
@@ -2713,17 +2712,16 @@ def test_learning_curve_exploit_incremental_learning_routing():
 )
 @pytest.mark.parametrize("cv", [None, 3, 5])
 @pytest.mark.parametrize(
-    "namespace, device_, dtype_name",
+    "namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 def test_cross_val_predict_array_api_compliance(
-    estimator, cv, namespace, device_, dtype_name
+    estimator, cv, namespace, device_name, dtype_name
 ):
     """Test that `cross_val_predict` functions correctly with the array API
     with both a classifier and a regressor."""
 
-    xp = _array_api_for_tests(namespace, device_)
+    xp, device = _array_api_for_tests(namespace, device_name)
     if is_classifier(estimator):
         X, y = make_classification(
             n_samples=1000, n_features=5, n_classes=3, n_informative=3, random_state=42
@@ -2735,8 +2733,8 @@ def test_cross_val_predict_array_api_compliance(
 
     X_np = X.astype(dtype_name)
     y_np = y.astype(dtype_name)
-    X_xp = xp.asarray(X_np, device=device_)
-    y_xp = xp.asarray(y_np, device=device_)
+    X_xp = xp.asarray(X_np, device=device)
+    y_xp = xp.asarray(y_np, device=device)
 
     with config_context(array_api_dispatch=True):
         pred_xp = cross_val_predict(estimator, X_xp, y_xp, cv=cv)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -40,7 +40,6 @@ from sklearn.svm import SVR
 from sklearn.utils import gen_batches, shuffle
 from sklearn.utils._array_api import (
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._testing import (
@@ -170,22 +169,21 @@ def test_standard_scaler_sample_weight(Xw, X, sample_weight, array_constructor):
 
 @pytest.mark.parametrize(["Xw", "X", "sample_weight"], _yield_xw_x_sampleweight())
 @pytest.mark.parametrize(
-    "namespace, dev, dtype",
+    "namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 def test_standard_scaler_sample_weight_array_api(
-    Xw, X, sample_weight, namespace, dev, dtype
+    Xw, X, sample_weight, namespace, device_name, dtype_name
 ):
     # N.B. The sample statistics for Xw w/ sample_weight should match
     #      the statistics of X w/ uniform sample_weight.
-    xp = _array_api_for_tests(namespace, dev)
+    xp, device = _array_api_for_tests(namespace, device_name)
 
-    X = np.array(X).astype(dtype, copy=False)
-    y = np.ones(X.shape[0]).astype(dtype, copy=False)
-    Xw = np.array(Xw).astype(dtype, copy=False)
-    yw = np.ones(Xw.shape[0]).astype(dtype, copy=False)
-    X_test = np.array([[1.5, 2.5, 3.5], [3.5, 4.5, 5.5]]).astype(dtype, copy=False)
+    X = np.array(X).astype(dtype_name, copy=False)
+    y = np.ones(X.shape[0]).astype(dtype_name, copy=False)
+    Xw = np.array(Xw).astype(dtype_name, copy=False)
+    yw = np.ones(Xw.shape[0]).astype(dtype_name, copy=False)
+    X_test = np.array([[1.5, 2.5, 3.5], [3.5, 4.5, 5.5]]).astype(dtype_name, copy=False)
 
     scaler = StandardScaler()
     scaler.fit(X, y)
@@ -194,12 +192,12 @@ def test_standard_scaler_sample_weight_array_api(
     scaler_w.fit(Xw, yw, sample_weight=sample_weight)
 
     # Test array-api support and correctness.
-    X_xp = xp.asarray(X, device=dev)
-    y_xp = xp.asarray(y, device=dev)
-    Xw_xp = xp.asarray(Xw, device=dev)
-    yw_xp = xp.asarray(yw, device=dev)
-    X_test_xp = xp.asarray(X_test, device=dev)
-    sample_weight_xp = xp.asarray(sample_weight, device=dev)
+    X_xp = xp.asarray(X, device=device)
+    y_xp = xp.asarray(y, device=device)
+    Xw_xp = xp.asarray(Xw, device=device)
+    yw_xp = xp.asarray(yw, device=device)
+    X_test_xp = xp.asarray(X_test, device=device)
+    sample_weight_xp = xp.asarray(sample_weight, device=device)
 
     scaler_w_xp = StandardScaler()
     with config_context(array_api_dispatch=True):
@@ -764,9 +762,8 @@ def test_standard_check_array_of_inverse_transform():
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize(
     "check",
@@ -789,16 +786,21 @@ def test_standard_check_array_of_inverse_transform():
     ids=_get_check_estimator_ids,
 )
 def test_preprocessing_array_api_compliance(
-    estimator, check, array_namespace, device, dtype_name
+    estimator, check, array_namespace, device_name, dtype_name
 ):
     name = estimator.__class__.__name__
-    check(name, estimator, array_namespace, device=device, dtype_name=dtype_name)
+    check(
+        name,
+        estimator,
+        array_namespace,
+        device_name=device_name,
+        dtype_name=dtype_name,
+    )
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize(
     "check",
@@ -807,7 +809,7 @@ def test_preprocessing_array_api_compliance(
 )
 @pytest.mark.parametrize("sample_weight", [True, None])
 def test_standard_scaler_array_api_compliance(
-    check, sample_weight, array_namespace, device, dtype_name
+    check, sample_weight, array_namespace, device_name, dtype_name
 ):
     estimator = StandardScaler()
     name = estimator.__class__.__name__
@@ -815,7 +817,7 @@ def test_standard_scaler_array_api_compliance(
         name,
         estimator,
         array_namespace,
-        device=device,
+        device_name=device_name,
         dtype_name=dtype_name,
         check_sample_weight=sample_weight,
     )
@@ -2107,11 +2109,12 @@ def test_binarizer(constructor):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name", yield_namespace_device_dtype_combinations()
+    "array_namespace, device_name, dtype_name",
+    yield_namespace_device_dtype_combinations(),
 )
-def test_binarizer_array_api_int(array_namespace, device, dtype_name):
+def test_binarizer_array_api_int(array_namespace, device_name, dtype_name):
     # Checks that Binarizer works with integer elements and float threshold
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     for dtype_name_ in [dtype_name, "int32", "int64"]:
         X_np = np.reshape(np.asarray([0, 1, 2, 3, 4], dtype=dtype_name_), (-1, 1))
         X_xp = xp.asarray(X_np, device=device)

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -13,11 +13,12 @@ from sklearn.preprocessing._label import (
 )
 from sklearn.utils._array_api import (
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
     _is_numpy_namespace,
-    device,
     get_namespace,
     yield_namespace_device_dtype_combinations,
+)
+from sklearn.utils._array_api import (
+    device as array_api_device,
 )
 from sklearn.utils._testing import (
     _array_api_for_tests,
@@ -238,20 +239,21 @@ def test_label_binarizer_sparse_errors(csr_container):
     ],
 )
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name", yield_namespace_device_dtype_combinations()
+    "array_namespace, device_name, dtype_name",
+    yield_namespace_device_dtype_combinations(),
 )
 def test_label_binarizer_array_api_compliance(
-    y, classes, expected, array_namespace, device_, dtype_name
+    y, classes, expected, array_namespace, device_name, dtype_name
 ):
     """Test that :class:`LabelBinarizer` works correctly with the Array API for binary
     and multi-class inputs for numerical labels and non-sparse outputs.
     """
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     y_np = np.asarray(y)
 
     with config_context(array_api_dispatch=True):
-        y = xp.asarray(y, device=device_)
+        y = xp.asarray(y, device=device)
 
         # `sparse_output=True` is not allowed for non-NumPy namespaces.
         # Similarly, if `LabelBinarizer` is fitted on a sparse matrix,
@@ -272,7 +274,7 @@ def test_label_binarizer_array_api_compliance(
                 "`LabelBinarizer` was fitted on a sparse matrix, and therefore cannot"
             )
             with pytest.raises(ValueError, match=sparse_input_msg):
-                lb_sparse.inverse_transform(xp.asarray(expected, device=device_))
+                lb_sparse.inverse_transform(xp.asarray(expected, device=device))
 
         # Shouldn't raise error in both `fit` and `transform` when `sparse_output=False`
         lb_xp = LabelBinarizer()
@@ -280,22 +282,22 @@ def test_label_binarizer_array_api_compliance(
         binarized = lb_xp.fit_transform(y)
         assert get_namespace(binarized)[0].__name__ == xp.__name__
         assert "int" in str(binarized.dtype)
-        assert device(binarized) == device(y)
+        assert array_api_device(binarized) == array_api_device(y)
         assert_array_equal(_convert_to_numpy(binarized, xp=xp), np.asarray(expected))
 
         fitted_classes = lb_xp.classes_
         assert get_namespace(fitted_classes)[0].__name__ == xp.__name__
-        assert device(fitted_classes) == device(y)
+        assert array_api_device(fitted_classes) == array_api_device(y)
         assert "int" in str(fitted_classes.dtype)
         assert_array_equal(
             _convert_to_numpy(fitted_classes, xp=xp), np.asarray(classes)
         )
 
-        expected_xp = xp.asarray(expected, device=device_)
+        expected_xp = xp.asarray(expected, device=device)
         binarized_inverse = lb_xp.inverse_transform(expected_xp)
         assert get_namespace(binarized_inverse)[0].__name__ == xp.__name__
         assert "int" in str(binarized_inverse.dtype)
-        assert device(binarized_inverse) == device(y)
+        assert array_api_device(binarized_inverse) == array_api_device(y)
         assert_array_equal(
             _convert_to_numpy(binarized_inverse, xp=xp), _convert_to_numpy(y, xp=xp)
         )
@@ -764,22 +766,23 @@ def test_invalid_input_label_binarize():
     ],
 )
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name", yield_namespace_device_dtype_combinations()
+    "array_namespace, device_name, dtype_name",
+    yield_namespace_device_dtype_combinations(),
 )
 def test_label_binarize_array_api_compliance(
-    y, classes, expected, array_namespace, device_, dtype_name
+    y, classes, expected, array_namespace, device_name, dtype_name
 ):
     """Test that :func:`label_binarize` works correctly with the Array API for binary
     and multi-class inputs for numerical labels and non-sparse outputs.
     """
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     xp_is_numpy = _is_numpy_namespace(xp)
     numeric_dtype = np.issubdtype(np.asarray(y).dtype, np.integer) and np.issubdtype(
         np.asarray(classes).dtype, np.integer
     )
 
     with config_context(array_api_dispatch=True):
-        y = xp.asarray(y, device=device_)
+        y = xp.asarray(y, device=device)
 
         if numeric_dtype:
             # `sparse_output=True` is not allowed for non-NumPy namespaces
@@ -793,7 +796,7 @@ def test_label_binarize_array_api_compliance(
             expected = np.asarray(expected, dtype=int)
 
             assert get_namespace(binarized)[0].__name__ == xp.__name__
-            assert device(binarized) == device(y)
+            assert array_api_device(binarized) == array_api_device(y)
             assert "int" in str(binarized.dtype)
             assert_array_equal(_convert_to_numpy(binarized, xp=xp), expected)
 
@@ -838,9 +841,8 @@ def test_label_encoders_do_not_have_set_output(encoder):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize(
     "y",
@@ -850,8 +852,10 @@ def test_label_encoders_do_not_have_set_output(encoder):
         np.array([3, 5, 9, 5, 9, 3]),
     ],
 )
-def test_label_encoder_array_api_compliance(y, array_namespace, device, dtype):
-    xp = _array_api_for_tests(array_namespace, device)
+def test_label_encoder_array_api_compliance(
+    y, array_namespace, device_name, dtype_name
+):
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     xp_y = xp.asarray(y, device=device)
     with config_context(array_api_dispatch=True):
         xp_label = LabelEncoder()

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -21,11 +21,12 @@ from sklearn.preprocessing._csr_polynomial_expansion import (
 )
 from sklearn.utils._array_api import (
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
     _is_numpy_namespace,
-    device,
     get_namespace,
     yield_namespace_device_dtype_combinations,
+)
+from sklearn.utils._array_api import (
+    device as array_api_device,
 )
 from sklearn.utils._mask import _get_mask
 from sklearn.utils._testing import (
@@ -1332,9 +1333,8 @@ def test_csr_polynomial_expansion_windows_fail(csr_container):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize("interaction_only", [True, False])
 @pytest.mark.parametrize("include_bias", [True, False])
@@ -1345,14 +1345,14 @@ def test_polynomial_features_array_api_compliance(
     include_bias,
     interaction_only,
     array_namespace,
-    device_,
+    device_name,
     dtype_name,
 ):
     """Test array API compliance for PolynomialFeatures on 2 features up to degree 3."""
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     X, _ = two_features_degree3
     X_np = X.astype(dtype_name)
-    X_xp = xp.asarray(X_np, device=device_)
+    X_xp = xp.asarray(X_np, device=device)
     with config_context(array_api_dispatch=True):
         tf_np = PolynomialFeatures(
             degree=degree, include_bias=include_bias, interaction_only=interaction_only
@@ -1365,23 +1365,22 @@ def test_polynomial_features_array_api_compliance(
         out_xp = tf_xp.transform(X_xp)
         assert_allclose(_convert_to_numpy(out_xp, xp=xp), out_np)
         assert get_namespace(out_xp)[0].__name__ == xp.__name__
-        assert device(out_xp) == device(X_xp)
+        assert array_api_device(out_xp) == array_api_device(X_xp)
         assert out_xp.dtype == X_xp.dtype
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 def test_polynomial_features_array_api_raises_on_order_F(
-    array_namespace, device_, dtype_name
+    array_namespace, device_name, dtype_name
 ):
     """Test that PolynomialFeatures with order='F' raises ValueError on
     array API namespaces other than numpy."""
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     X = np.arange(6).reshape((3, 2)).astype(dtype_name)
-    X_xp = xp.asarray(X, device=device_)
+    X_xp = xp.asarray(X, device=device)
     msg = "PolynomialFeatures does not support order='F' for non-numpy arrays"
     with config_context(array_api_dispatch=True):
         pf = PolynomialFeatures(order="F").fit(X_xp)

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -49,10 +49,11 @@ from sklearn.svm import LinearSVC
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.utils._array_api import (
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
-    device,
     get_namespace,
     yield_namespace_device_dtype_combinations,
+)
+from sklearn.utils._array_api import (
+    device as array_api_device,
 )
 from sklearn.utils._mocking import CheckingClassifier
 from sklearn.utils._tags import get_tags
@@ -1221,17 +1222,16 @@ def test_error_less_class_samples_than_folds():
 @pytest.mark.parametrize("ensemble", [False, True])
 @pytest.mark.parametrize("use_sample_weight", [False, True])
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 def test_temperature_scaling_array_api_compliance(
-    ensemble, use_sample_weight, array_namespace, device_, dtype_name
+    ensemble, use_sample_weight, array_namespace, device_name, dtype_name
 ):
     """Check that `CalibratedClassifierCV` with temperature scaling is compatible
     with the array API"""
 
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     X, y = make_classification(
         n_samples=1000,
         n_features=10,
@@ -1246,13 +1246,13 @@ def test_temperature_scaling_array_api_compliance(
 
     X_train = X_train.astype(dtype_name)
     y_train = y_train.astype(dtype_name)
-    X_train_xp = xp.asarray(X_train, device=device_)
-    y_train_xp = xp.asarray(y_train, device=device_)
+    X_train_xp = xp.asarray(X_train, device=device)
+    y_train_xp = xp.asarray(y_train, device=device)
 
     X_cal = X_cal.astype(dtype_name)
     y_cal = y_cal.astype(dtype_name)
-    X_cal_xp = xp.asarray(X_cal, device=device_)
-    y_cal_xp = xp.asarray(y_cal, device=device_)
+    X_cal_xp = xp.asarray(X_cal, device=device)
+    y_cal_xp = xp.asarray(y_cal, device=device)
 
     if use_sample_weight:
         sample_weight = np.ones_like(y_cal)
@@ -1279,7 +1279,7 @@ def test_temperature_scaling_array_api_compliance(
         rtol = 1e-3 if dtype_name == "float32" else 1e-7
         assert get_namespace(calibrator_xp.beta_)[0].__name__ == xp.__name__
         assert calibrator_xp.beta_.dtype == X_cal_xp.dtype
-        assert device(calibrator_xp.beta_) == device(X_cal_xp)
+        assert array_api_device(calibrator_xp.beta_) == array_api_device(X_cal_xp)
         assert_allclose(
             _convert_to_numpy(calibrator_xp.beta_, xp=xp),
             calibrator_np.beta_,
@@ -1292,12 +1292,11 @@ def test_temperature_scaling_array_api_compliance(
 @pytest.mark.parametrize("ensemble", [False, True])
 @pytest.mark.parametrize("use_sample_weight", [False, True])
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 def test_temperature_scaling_array_api_with_str_y_estimator_not_prefit(
-    ensemble, use_sample_weight, array_namespace, device_, dtype_name
+    ensemble, use_sample_weight, array_namespace, device_name, dtype_name
 ):
     """Check that `CalibratedClassifierCV` with temperature scaling is compatible
     with the array API when `y` is an ndarray of strings and the estimator is not
@@ -1308,7 +1307,7 @@ def test_temperature_scaling_array_api_with_str_y_estimator_not_prefit(
     #  the array API when `y` is an ndarray of strings and we fit
     #  `LinearDiscriminantAnalysis` beforehand. In this regard
     #  `LinearDiscriminantAnalysis` will also need modifications.
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     X, y = make_classification(
         n_samples=500,
         n_features=10,
@@ -1322,7 +1321,7 @@ def test_temperature_scaling_array_api_with_str_y_estimator_not_prefit(
     str_mapping = np.asarray(["a", "b", "c", "d", "e"])
     X = X.astype(dtype_name)
     y_str = str_mapping[y]
-    X_xp = xp.asarray(X, device=device_)
+    X_xp = xp.asarray(X, device=device)
 
     if use_sample_weight:
         sample_weight = np.ones_like(y)
@@ -1351,7 +1350,7 @@ def test_temperature_scaling_array_api_with_str_y_estimator_not_prefit(
         rtol = 1e-3 if dtype_name == "float32" else 1e-7
         assert get_namespace(calibrator_xp.beta_)[0].__name__ == xp.__name__
         assert calibrator_xp.beta_.dtype == X_xp.dtype
-        assert device(calibrator_xp.beta_) == device(X_xp)
+        assert array_api_device(calibrator_xp.beta_) == array_api_device(X_xp)
         assert_allclose(
             _convert_to_numpy(calibrator_xp.beta_, xp=xp),
             calibrator_np.beta_,

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -350,16 +350,17 @@ def test_nystroem_approximation():
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name", yield_namespace_device_dtype_combinations()
+    "array_namespace, device_name, dtype_name",
+    yield_namespace_device_dtype_combinations(),
 )
 @pytest.mark.parametrize(
     "kernel", list(kernel_metrics()) + [_linear_kernel, "precomputed"]
 )
 @pytest.mark.parametrize("n_components", [2, 100])
 def test_nystroem_approximation_array_api(
-    array_namespace, device, dtype_name, kernel, n_components
+    array_namespace, device_name, dtype_name, kernel, n_components
 ):
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     rnd = np.random.RandomState(0)
     n_samples = 10
     # Ensure full-rank linear kernel to limit the impact of device-specific

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -17,9 +17,10 @@ from sklearn.naive_bayes import (
 )
 from sklearn.utils._array_api import (
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
-    device,
     yield_namespace_device_dtype_combinations,
+)
+from sklearn.utils._array_api import (
+    device as array_api_device,
 )
 from sklearn.utils._testing import (
     _array_api_for_tests,
@@ -995,23 +996,22 @@ def test_categorical_input_tag(Estimator):
 @pytest.mark.parametrize("use_str_y", [False, True])
 @pytest.mark.parametrize("use_sample_weight", [False, True])
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 def test_gnb_array_api_compliance(
-    use_str_y, use_sample_weight, array_namespace, device_, dtype_name
+    use_str_y, use_sample_weight, array_namespace, device_name, dtype_name
 ):
     """Tests that :class:`GaussianNB` works correctly with array API inputs."""
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     X_np = X.astype(dtype_name)
-    X_xp = xp.asarray(X_np, device=device_)
+    X_xp = xp.asarray(X_np, device=device)
     if use_str_y:
         y_np = np.array(["a", "a", "a", "b", "b", "b"])
         y_xp_or_np = np.array(["a", "a", "a", "b", "b", "b"])
     else:
         y_np = y.astype(dtype_name)
-        y_xp_or_np = xp.asarray(y_np, device=device_)
+        y_xp_or_np = xp.asarray(y_np, device=device)
 
     if use_sample_weight:
         sample_weight = np.array([1, 2, 3, 1, 2, 3])
@@ -1028,24 +1028,24 @@ def test_gnb_array_api_compliance(
             xp_attr = getattr(clf_xp, fitted_attr)
             np_attr = getattr(clf_np, fitted_attr)
             assert xp_attr.dtype == X_xp.dtype
-            assert device(xp_attr) == device(X_xp)
+            assert array_api_device(xp_attr) == array_api_device(X_xp)
             assert_allclose(_convert_to_numpy(xp_attr, xp=xp), np_attr)
 
         y_pred_xp = clf_xp.predict(X_xp)
         if not use_str_y:
-            assert device(y_pred_xp) == device(X_xp)
+            assert array_api_device(y_pred_xp) == array_api_device(X_xp)
             y_pred_xp = _convert_to_numpy(y_pred_xp, xp=xp)
         assert_array_equal(y_pred_xp, y_pred_np)
         assert y_pred_xp.dtype == y_pred_np.dtype
 
         y_pred_proba_xp = clf_xp.predict_proba(X_xp)
         assert y_pred_proba_xp.dtype == X_xp.dtype
-        assert device(y_pred_proba_xp) == device(X_xp)
+        assert array_api_device(y_pred_proba_xp) == array_api_device(X_xp)
         assert_allclose(_convert_to_numpy(y_pred_proba_xp, xp=xp), y_pred_proba_np)
 
         y_pred_log_proba_xp = clf_xp.predict_log_proba(X_xp)
         assert y_pred_log_proba_xp.dtype == X_xp.dtype
-        assert device(y_pred_log_proba_xp) == device(X_xp)
+        assert array_api_device(y_pred_log_proba_xp) == array_api_device(X_xp)
         assert_allclose(
             _convert_to_numpy(y_pred_log_proba_xp, xp=xp), y_pred_log_proba_np
         )

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -1961,12 +1961,12 @@ def test_feature_union_1d_output():
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
 )
-def test_feature_union_array_api_compliance(array_namespace, device, dtype_name):
+def test_feature_union_array_api_compliance(array_namespace, device_name, dtype_name):
     """Test that FeatureUnion with Array API-compatible transformers works."""
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     rnd = np.random.RandomState(0)
     n_samples, n_features = 20, 10
     X_np = rnd.uniform(size=(n_samples, n_features)).astype(dtype_name)

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -63,11 +63,11 @@ def yield_namespaces(include_numpy_namespaces=True):
 
 
 def yield_namespace_device_dtype_combinations(include_numpy_namespaces=True):
-    """Yield supported namespace, device, dtype tuples for testing.
+    """Yield supported namespace, device_name, dtype_name tuples for testing.
 
     Use this to test that an estimator works with all combinations.
-    Use in conjunction with `ids=_get_namespace_device_dtype_ids` to give
-    clearer pytest parametrization ID names.
+    Pass the yielded values to `_array_api_for_tests` which returns (xp, device)
+    for array allocation.
 
     Parameters
     ----------
@@ -79,7 +79,7 @@ def yield_namespace_device_dtype_combinations(include_numpy_namespaces=True):
     array_namespace : str
         The name of the Array API namespace.
 
-    device : str
+    device_name : str or None
         The name of the device on which to allocate the arrays. Can be None to
         indicate that the default value should be used.
 
@@ -91,43 +91,19 @@ def yield_namespace_device_dtype_combinations(include_numpy_namespaces=True):
         include_numpy_namespaces=include_numpy_namespaces
     ):
         if array_namespace == "torch":
-            for device, dtype in itertools.product(
+            for device_name, dtype in itertools.product(
                 ("cpu", "cuda", "xpu"), ("float64", "float32")
             ):
-                yield array_namespace, device, dtype
+                yield array_namespace, device_name, dtype
             yield array_namespace, "mps", "float32"
 
         elif array_namespace == "array_api_strict":
-            try:
-                import array_api_strict
-
-                yield array_namespace, array_api_strict.Device("CPU_DEVICE"), "float64"
-                yield array_namespace, array_api_strict.Device("device1"), "float32"
-            except ImportError:
-                # Those combinations will typically be skipped by pytest if
-                # array_api_strict is not installed but we still need to see them in
-                # the test output.
-                yield array_namespace, "CPU_DEVICE", "float64"
-                yield array_namespace, "device1", "float32"
+            # Always yield strings for consistent parametrization; _array_api_for_tests
+            # creates Device objects when needed.
+            yield array_namespace, "CPU_DEVICE", "float64"
+            yield array_namespace, "device1", "float32"
         else:
             yield array_namespace, None, None
-
-
-def _get_namespace_device_dtype_ids(param):
-    """Get pytest parametrization IDs for `yield_namespace_device_dtype_combinations`"""
-    # Gives clearer IDs for array-api-strict devices, see #31042 for details
-    try:
-        import array_api_strict
-    except ImportError:
-        # `None` results in the default pytest representation
-        return None
-    else:
-        if param == array_api_strict.Device("CPU_DEVICE"):
-            return "CPU_DEVICE"
-        if param == array_api_strict.Device("device1"):
-            return "device1"
-        if param == array_api_strict.Device("device2"):
-            return "device2"
 
 
 def yield_mixed_namespace_input_permutations():

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -145,17 +145,8 @@ def yield_mixed_namespace_input_permutations():
         "numpy to torch mps",
     )
 
-    try:
-        import array_api_strict
-
-        device = array_api_strict.Device("device1")
-    except ImportError:
-        # This case will generally be skipped when `array_api_strict` is not installed
-        # but we still include it so it shows in the test output.
-        device = None
-
     yield (
-        NamespaceAndDevice("array_api_strict", device),
+        NamespaceAndDevice("array_api_strict", "device1"),
         NamespaceAndDevice("torch", "cpu"),
         "array_api_strict to torch cpu",
     )

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1302,7 +1302,23 @@ class MinimalTransformer:
         )
 
 
-def _array_api_for_tests(array_namespace, device):
+def _array_api_for_tests(array_namespace, device_name=None):
+    """Return (xp, device) for array API testing.
+
+    Parameters
+    ----------
+    array_namespace : str
+        The array module namespace (e.g. "numpy", "torch", "array_api_strict").
+    device_name : str or None, default=None
+        The device name for array allocation. Can be None for default device.
+
+    Returns
+    -------
+    xp : tuple
+        The array namespace for the given array module.
+    device : str, Device or None
+        The device to pass to xp.asarray(..., device=device).
+    """
     try:
         array_mod = importlib.import_module(array_namespace)
     except (ModuleNotFoundError, ImportError):
@@ -1319,14 +1335,15 @@ def _array_api_for_tests(array_namespace, device):
     # corresponding (compatibility wrapped) array namespace based on it.
     # This is because `cupy` is not the same as the compatibility wrapped
     # namespace of a CuPy array.
+    device = None
     xp = get_namespace(array_mod.asarray(1))
     if (
         array_namespace == "torch"
-        and device == "cuda"
+        and device_name == "cuda"
         and not xp.backends.cuda.is_built()
     ):
         raise SkipTest("PyTorch test requires cuda, which is not available")
-    elif array_namespace == "torch" and device == "mps":
+    elif array_namespace == "torch" and device_name == "mps":
         if os.getenv("PYTORCH_ENABLE_MPS_FALLBACK") != "1":
             # For now we need PYTORCH_ENABLE_MPS_FALLBACK=1 for all estimators to work
             # when using the MPS device.
@@ -1339,7 +1356,7 @@ def _array_api_for_tests(array_namespace, device):
                 "MPS is not available because the current PyTorch install was not "
                 "built with MPS enabled."
             )
-    elif array_namespace == "torch" and device == "xpu":  # pragma: nocover
+    elif array_namespace == "torch" and device_name == "xpu":  # pragma: nocover
         if not hasattr(xp, "xpu"):
             # skip xpu testing for PyTorch <2.4
             raise SkipTest(
@@ -1355,7 +1372,16 @@ def _array_api_for_tests(array_namespace, device):
 
         if cupy.cuda.runtime.getDeviceCount() == 0:
             raise SkipTest("CuPy test requires cuda, which is not available")
-    return xp
+    elif array_namespace == "array_api_strict":
+        # device_name can be a string ("CPU_DEVICE", "device1") or a Device object
+        # from yield_mixed_namespace_input_permutations
+        if device_name is not None:
+            if isinstance(device_name, str):
+                device = xp.Device(device_name)
+            else:
+                device = device_name  # Already a Device object
+
+    return xp, device_name if device is None else device
 
 
 def _get_warnings_filters_info_list():

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1317,8 +1317,9 @@ def _array_api_for_tests(array_namespace, device_name=None):
     xp : module
         The module object for the requested array namespace.
     device : object or None
-        The library specific device object to pass to
-        xp.asarray(..., device=device).
+        The library specific device object that can be passed to
+        xp.asarray(..., device=device). This might be a string and not
+        a library specific device object.
     """
     try:
         array_mod = importlib.import_module(array_namespace)
@@ -1379,6 +1380,10 @@ def _array_api_for_tests(array_namespace, device_name=None):
         if device_name is not None:
             device = xp.Device(device_name)
 
+    # Right now only array_api_strict uses a library specific device
+    # object. For all other libraries we return a string or `None`.
+    # This works because strings are accepted as arguments to
+    # xp.asarray(..., device=) in those libraries.
     return xp, device_name if device is None else device
 
 

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1316,8 +1316,9 @@ def _array_api_for_tests(array_namespace, device_name=None):
     -------
     xp : tuple
         The array namespace for the given array module.
-    device : str, Device or None
-        The device to pass to xp.asarray(..., device=device).
+    device : object or None
+        The library specific device object to pass to
+        xp.asarray(..., device=device).
     """
     try:
         array_mod = importlib.import_module(array_namespace)

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1376,10 +1376,7 @@ def _array_api_for_tests(array_namespace, device_name=None):
         # device_name can be a string ("CPU_DEVICE", "device1") or a Device object
         # from yield_mixed_namespace_input_permutations
         if device_name is not None:
-            if isinstance(device_name, str):
-                device = xp.Device(device_name)
-            else:
-                device = device_name  # Already a Device object
+            device = xp.Device(device_name)
 
     return xp, device_name if device is None else device
 

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1308,14 +1308,14 @@ def _array_api_for_tests(array_namespace, device_name=None):
     Parameters
     ----------
     array_namespace : str
-        The array module namespace (e.g. "numpy", "torch", "array_api_strict").
+        The importable name of the array namespace module.
     device_name : str or None, default=None
         The device name for array allocation. Can be None for default device.
 
     Returns
     -------
-    xp : tuple
-        The array namespace for the given array module.
+    xp : module
+        The module object for the requested array namespace.
     device : object or None
         The library specific device object to pass to
         xp.asarray(..., device=device).

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -355,14 +355,14 @@ def _yield_array_api_checks(estimator, only_numpy=False):
         # array API support in their tags.
         for (
             array_namespace,
-            device,
+            device_name,
             dtype_name,
         ) in yield_namespace_device_dtype_combinations():
             yield partial(
                 check_array_api_input,
                 array_namespace=array_namespace,
+                device_name=device_name,
                 dtype_name=dtype_name,
-                device=device,
             )
 
 
@@ -1060,7 +1060,7 @@ def check_array_api_input(
     name,
     estimator_orig,
     array_namespace,
-    device=None,
+    device_name=None,
     dtype_name="float64",
     check_values=False,
     check_sample_weight=False,
@@ -1083,7 +1083,7 @@ def check_array_api_input(
     behavior of any estimator fed with NumPy inputs, even for estimators that
     do not support array API.
     """
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     X, y = make_classification(n_samples=30, n_features=10, random_state=42)
     X = X.astype(dtype_name, copy=False)
@@ -1266,7 +1266,7 @@ def check_array_api_input_and_values(
     name,
     estimator_orig,
     array_namespace,
-    device=None,
+    device_name=None,
     dtype_name="float64",
     check_sample_weight=False,
 ):
@@ -1274,7 +1274,7 @@ def check_array_api_input_and_values(
         name,
         estimator_orig,
         array_namespace=array_namespace,
-        device=device,
+        device_name=device_name,
         dtype_name=dtype_name,
         check_values=True,
         check_sample_weight=check_sample_weight,

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -21,7 +21,6 @@ from sklearn.utils._array_api import (
     _estimator_with_converted_arrays,
     _expit,
     _fill_diagonal,
-    _get_namespace_device_dtype_ids,
     _half_multinomial_loss,
     _is_numpy_namespace,
     _isin,
@@ -35,7 +34,6 @@ from sklearn.utils._array_api import (
     _nanmin,
     _ravel,
     _validate_diagonal_args,
-    device,
     get_namespace,
     get_namespace_and_device,
     indexing_dtype,
@@ -44,6 +42,9 @@ from sklearn.utils._array_api import (
     supported_float_dtypes,
     yield_mixed_namespace_input_permutations,
     yield_namespace_device_dtype_combinations,
+)
+from sklearn.utils._array_api import (
+    device as array_api_device,
 )
 from sklearn.utils._testing import (
     SkipTest,
@@ -154,27 +155,29 @@ def test_get_namespace_array_api(monkeypatch):
 )
 def test_move_to_array_api_conversions(array_input, reference):
     """Check conversion between various namespace-device-pairs."""
-    xp_to = _array_api_for_tests(reference.xp, reference.device)
-    xp_from = _array_api_for_tests(array_input[0], array_input[1])
+    xp_to, device_to = _array_api_for_tests(reference.xp, device_name=reference.device)
+    xp_from, device_from = _array_api_for_tests(
+        array_input.xp, device_name=array_input.device
+    )
 
     with config_context(array_api_dispatch=True):
-        array_in = xp_from.asarray([1, 2, 3], device=array_input.device)
-        device_reference = device(xp_to.asarray([1], device=reference.device))
+        array_in = xp_from.asarray([1, 2, 3], device=device_from)
+        device_reference = array_api_device(xp_to.asarray(1, device=device_to))
         array_out = move_to(array_in, xp=xp_to, device=device_reference)
         assert get_namespace(array_out)[0] == xp_to
-        assert device(array_out) == device_reference
+        assert array_api_device(array_out) == device_reference
 
 
 def test_move_to_sparse():
     """Check sparse inputs are handled correctly."""
-    xp_numpy = _array_api_for_tests("numpy", None)
-    xp_torch = _array_api_for_tests("torch", "cpu")
+    xp_numpy, _ = _array_api_for_tests("numpy", device_name=None)
+    xp_torch, device = _array_api_for_tests("torch", device_name="cpu")
 
     sparse1 = sp.csr_array([0, 1, 2, 3])
     numpy_array = numpy.array([1, 2, 3])
 
     with config_context(array_api_dispatch=True):
-        device_cpu = xp_torch.asarray([1]).device
+        device_cpu = device
 
         # sparse and None to NumPy
         result1, result2 = move_to(sparse1, None, xp=xp_numpy, device=None)
@@ -202,9 +205,8 @@ def test_asarray_with_order(array_api):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize(
     "weights, axis, normalize, expected",
@@ -236,14 +238,14 @@ def test_asarray_with_order(array_api):
     ],
 )
 def test_average(
-    array_namespace, device_, dtype_name, weights, axis, normalize, expected
+    array_namespace, device_name, dtype_name, weights, axis, normalize, expected
 ):
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     array_in = numpy.asarray([[1, 2, 3], [4, 5, 6]], dtype=dtype_name)
-    array_in = xp.asarray(array_in, device=device_)
+    array_in = xp.asarray(array_in, device=device)
     if weights is not None:
         weights = numpy.asarray(weights, dtype=dtype_name)
-        weights = xp.asarray(weights, device=device_)
+        weights = xp.asarray(weights, device=device)
 
     with config_context(array_api_dispatch=True):
         result = _average(array_in, axis=axis, weights=weights, normalize=normalize)
@@ -251,19 +253,18 @@ def test_average(
         if np_version < parse_version("2.0.0") or np_version >= parse_version("2.1.0"):
             # NumPy 2.0 has a problem with the device attribute of scalar arrays:
             # https://github.com/numpy/numpy/issues/26850
-            assert device(array_in) == device(result)
+            assert array_api_device(array_in) == array_api_device(result)
 
     result = _convert_to_numpy(result, xp)
     assert_allclose(result, expected, atol=_atol_for_type(dtype_name))
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(include_numpy_namespaces=False),
-    ids=_get_namespace_device_dtype_ids,
 )
-def test_average_raises_with_wrong_dtype(array_namespace, device, dtype_name):
-    xp = _array_api_for_tests(array_namespace, device)
+def test_average_raises_with_wrong_dtype(array_namespace, device_name, dtype_name):
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     array_in = numpy.asarray([2, 0], dtype=dtype_name) + 1j * numpy.asarray(
         [4, 3], dtype=dtype_name
@@ -284,9 +285,8 @@ def test_average_raises_with_wrong_dtype(array_namespace, device, dtype_name):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(include_numpy_namespaces=True),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize(
     "axis, weights, error, error_msg",
@@ -314,9 +314,9 @@ def test_average_raises_with_wrong_dtype(array_namespace, device, dtype_name):
     ),
 )
 def test_average_raises_with_invalid_parameters(
-    array_namespace, device, dtype_name, axis, weights, error, error_msg
+    array_namespace, device_name, dtype_name, axis, weights, error, error_msg
 ):
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     array_in = numpy.asarray([[1, 2, 3], [4, 5, 6]], dtype=dtype_name)
     array_in = xp.asarray(array_in, device=device)
@@ -329,9 +329,9 @@ def test_average_raises_with_invalid_parameters(
 
 
 def test_device_none_if_no_input():
-    assert device() is None
+    assert array_api_device() is None
 
-    assert device(None, "name") is None
+    assert array_api_device(None, "name") is None
 
 
 @skip_if_array_api_compat_not_configured
@@ -364,22 +364,22 @@ def test_device_inspection():
     # early for different devices would prevent the np.asarray conversion to
     # happen. For example, `r2_score(np.ones(5), torch.ones(5))` should work
     # fine with array API disabled.
-    assert device(Array("cpu"), Array("mygpu")) is None
+    assert array_api_device(Array("cpu"), Array("mygpu")) is None
 
     # Test that ValueError is raised if on different devices and array API dispatch is
     # enabled.
     err_msg = "Input arrays use different devices: cpu, mygpu"
     with config_context(array_api_dispatch=True):
         with pytest.raises(ValueError, match=err_msg):
-            device(Array("cpu"), Array("mygpu"))
+            array_api_device(Array("cpu"), Array("mygpu"))
 
         # Test expected value is returned otherwise
         array1 = Array("device")
         array2 = Array("device")
 
-        assert array1.device == device(array1)
-        assert array1.device == device(array1, array2)
-        assert array1.device == device(array1, array1, array2)
+        assert array1.device == array_api_device(array1)
+        assert array1.device == array_api_device(array1, array2)
+        assert array1.device == array_api_device(array1, array1, array2)
 
 
 # TODO: add cupy to the list of libraries once the following upstream issue
@@ -443,15 +443,14 @@ def test_nan_reductions(library, X, reduction, expected):
 
 
 @pytest.mark.parametrize(
-    "namespace, _device, _dtype",
+    "namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
-def test_ravel(namespace, _device, _dtype):
-    xp = _array_api_for_tests(namespace, _device)
+def test_ravel(namespace, device_name, dtype_name):
+    xp, device = _array_api_for_tests(namespace, device_name)
 
     array = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]
-    array_xp = xp.asarray(array, device=_device)
+    array_xp = xp.asarray(array, device=device)
     with config_context(array_api_dispatch=True):
         result = _ravel(array_xp)
 
@@ -532,12 +531,11 @@ def test_convert_estimator_to_array_api():
 
 
 @pytest.mark.parametrize(
-    "namespace, _device, _dtype",
+    "namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
-def test_indexing_dtype(namespace, _device, _dtype):
-    xp = _array_api_for_tests(namespace, _device)
+def test_indexing_dtype(namespace, device_name, dtype_name):
+    xp, device = _array_api_for_tests(namespace, device_name)
 
     if _IS_32BIT:
         assert indexing_dtype(xp) == xp.int32
@@ -546,29 +544,33 @@ def test_indexing_dtype(namespace, _device, _dtype):
 
 
 @pytest.mark.parametrize(
-    "namespace, _device, _dtype",
+    "namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
-def test_max_precision_float_dtype(namespace, _device, _dtype):
-    xp = _array_api_for_tests(namespace, _device)
-    expected_dtype = xp.float32 if _device == "mps" else xp.float64
-    assert _max_precision_float_dtype(xp, _device) == expected_dtype
+def test_max_precision_float_dtype(namespace, device_name, dtype_name):
+    xp, device = _array_api_for_tests(namespace, device_name)
+    expected_dtype = xp.float32 if device_name == "mps" else xp.float64
+    assert _max_precision_float_dtype(xp, device) == expected_dtype
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, _",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize("invert", [True, False])
 @pytest.mark.parametrize("assume_unique", [True, False])
 @pytest.mark.parametrize("element_size", [6, 10, 14])
 @pytest.mark.parametrize("int_dtype", ["int16", "int32", "int64", "uint8"])
 def test_isin(
-    array_namespace, device, _, invert, assume_unique, element_size, int_dtype
+    array_namespace,
+    device_name,
+    dtype_name,
+    invert,
+    assume_unique,
+    element_size,
+    int_dtype,
 ):
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     r = element_size // 2
     element = 2 * numpy.arange(element_size).reshape((r, 2)).astype(int_dtype)
     test_elements = numpy.array(numpy.arange(14), dtype=int_dtype)
@@ -623,19 +625,23 @@ def test_get_namespace_and_device():
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 @pytest.mark.parametrize("axis", [0, 1, None, -1, -2])
 @pytest.mark.parametrize("sample_weight_type", [None, "int", "float"])
 def test_count_nonzero(
-    array_namespace, device_, dtype_name, csr_container, axis, sample_weight_type
+    array_namespace,
+    device_name,
+    dtype_name,
+    csr_container,
+    axis,
+    sample_weight_type,
 ):
     from sklearn.utils.sparsefuncs import count_nonzero as sparse_count_nonzero
 
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     array = numpy.array([[0, 3, 0], [2, -1, 0], [0, 0, 0], [9, 8, 7], [4, 0, 5]])
     if sample_weight_type == "int":
         sample_weight = numpy.asarray([1, 2, 2, 3, 1])
@@ -646,11 +652,11 @@ def test_count_nonzero(
     expected = sparse_count_nonzero(
         csr_container(array), axis=axis, sample_weight=sample_weight
     )
-    array_xp = xp.asarray(array, device=device_)
+    array_xp = xp.asarray(array, device=device)
 
     with config_context(array_api_dispatch=True):
         result = _count_nonzero(
-            array_xp, axis=axis, sample_weight=sample_weight, xp=xp, device=device_
+            array_xp, axis=axis, sample_weight=sample_weight, xp=xp, device=device
         )
 
     assert_allclose(_convert_to_numpy(result, xp=xp), expected)
@@ -658,7 +664,7 @@ def test_count_nonzero(
     if np_version < parse_version("2.0.0") or np_version >= parse_version("2.1.0"):
         # NumPy 2.0 has a problem with the device attribute of scalar arrays:
         # https://github.com/numpy/numpy/issues/26850
-        assert device(array_xp) == device(result)
+        assert array_api_device(array_xp) == array_api_device(result)
 
 
 @pytest.mark.parametrize(
@@ -676,7 +682,7 @@ def test_count_nonzero(
 )
 def test_validate_diagonal_args(array, value, match):
     """Check `_validate_diagonal_args` raises the correct errors."""
-    xp = _array_api_for_tests("numpy", None)
+    xp, _ = _array_api_for_tests("numpy", device_name=None)
     with pytest.raises(ValueError, match=match):
         _validate_diagonal_args(array, value, xp)
 
@@ -685,7 +691,7 @@ def test_validate_diagonal_args(array, value, match):
 @pytest.mark.parametrize("c_contiguity", [True, False])
 def test_fill_and_add_to_diagonal(c_contiguity, function):
     """Check `_fill/add_to_diagonal` behaviour correct with numpy arrays."""
-    xp = _array_api_for_tests("numpy", None)
+    xp, _ = _array_api_for_tests("numpy", device_name=None)
     if c_contiguity:
         array = numpy.zeros((3, 4))
     else:
@@ -718,23 +724,22 @@ def test_fill_and_add_to_diagonal(c_contiguity, function):
 
 @pytest.mark.parametrize("array", ["standard", "transposed", "non-contiguous"])
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
-def test_fill_diagonal(array, array_namespace, device_, dtype_name):
+def test_fill_diagonal(array, array_namespace, device_name, dtype_name):
     """Check array API `_fill_diagonal` consistent with `numpy._fill_diagonal`."""
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     array_np = numpy.zeros((4, 5), dtype=dtype_name)
 
     if array == "transposed":
-        array_xp = xp.asarray(array_np.copy(), device=device_).T
+        array_xp = xp.asarray(array_np.copy(), device=device).T
         array_np = array_np.T
     elif array == "non-contiguous":
-        array_xp = xp.asarray(array_np.copy(), device=device_)[::2, ::2]
+        array_xp = xp.asarray(array_np.copy(), device=device)[::2, ::2]
         array_np = array_np[::2, ::2]
     else:
-        array_xp = xp.asarray(array_np.copy(), device=device_)
+        array_xp = xp.asarray(array_np.copy(), device=device)
 
     numpy.fill_diagonal(array_np, val=1)
     with config_context(array_api_dispatch=True):
@@ -744,17 +749,16 @@ def test_fill_diagonal(array, array_namespace, device_, dtype_name):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
-def test_add_to_diagonal(array_namespace, device_, dtype_name):
+def test_add_to_diagonal(array_namespace, device_name, dtype_name):
     """Check `_add_to_diagonal` consistent between array API xp and numpy namespace."""
-    xp = _array_api_for_tests(array_namespace, device_)
-    np_xp = _array_api_for_tests("numpy", None)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
+    np_xp, _ = _array_api_for_tests("numpy", device_name=None)
 
     array_np = numpy.zeros((3, 4), dtype=dtype_name)
-    array_xp = xp.asarray(array_np.copy(), device=device_)
+    array_xp = xp.asarray(array_np.copy(), device=device)
 
     add_val = [1, 2, 3]
     _fill_diagonal(array_np, value=add_val, xp=np_xp)
@@ -774,25 +778,24 @@ def test_sparse_device(csr_container, dispatch):
     if dispatch and os.environ.get("SCIPY_ARRAY_API") is None:
         raise SkipTest("SCIPY_ARRAY_API is not set: not checking array_api input")
     with config_context(array_api_dispatch=dispatch):
-        assert device(a, b) is None
-        assert device(a, np_arr) == expected_numpy_array_device
+        assert array_api_device(a, b) is None
+        assert array_api_device(a, np_arr) == expected_numpy_array_device
         assert get_namespace_and_device(a, b)[2] is None
         assert get_namespace_and_device(a, np_arr)[2] == expected_numpy_array_device
 
 
 @pytest.mark.parametrize(
-    "namespace, device, dtype_name",
+    "namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize("axis", [None, 0, 1])
-def test_median(namespace, device, dtype_name, axis):
+def test_median(namespace, device_name, dtype_name, axis):
     # Note: depending on the value of `axis`, this test will compare median
     # computations on arrays of even (4) or odd (5) numbers of elements, hence
     # will test for median computation with and without interpolation to check
     # that array API namespaces yield consistent results even when the median is
     # not mathematically uniquely defined.
-    xp = _array_api_for_tests(namespace, device)
+    xp, device = _array_api_for_tests(namespace, device_name)
     rng = numpy.random.RandomState(0)
 
     X_np = rng.uniform(low=0.0, high=1.0, size=(5, 4)).astype(dtype_name)
@@ -811,11 +814,12 @@ def test_median(namespace, device, dtype_name, axis):
 
 
 @pytest.mark.parametrize(
-    "namespace, device, dtype_name", yield_namespace_device_dtype_combinations()
+    "namespace, device_name, dtype_name",
+    yield_namespace_device_dtype_combinations(),
 )
-def test_expit_logit(namespace, device, dtype_name):
+def test_expit_logit(namespace, device_name, dtype_name):
     rtol = 1e-6 if "float32" in str(dtype_name) else 1e-12
-    xp = _array_api_for_tests(namespace, device)
+    xp, device = _array_api_for_tests(namespace, device_name)
 
     with config_context(array_api_dispatch=True):
         x_np = numpy.linspace(-20, 20, 1000).astype(dtype_name)
@@ -836,11 +840,12 @@ def test_expit_logit(namespace, device, dtype_name):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name", yield_namespace_device_dtype_combinations()
+    "array_namespace, device_name, dtype_name",
+    yield_namespace_device_dtype_combinations(),
 )
 @pytest.mark.parametrize("axis", [0, 1, None])
-def test_logsumexp_like_scipy_logsumexp(array_namespace, device_, dtype_name, axis):
-    xp = _array_api_for_tests(array_namespace, device_)
+def test_logsumexp_like_scipy_logsumexp(array_namespace, device_name, dtype_name, axis):
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     array_np = numpy.asarray(
         [
             [0, 3, 1000],
@@ -851,7 +856,7 @@ def test_logsumexp_like_scipy_logsumexp(array_namespace, device_, dtype_name, ax
         ],
         dtype=dtype_name,
     )
-    array_xp = xp.asarray(array_np, device=device_)
+    array_xp = xp.asarray(array_np, device=device)
 
     res_np = scipy.special.logsumexp(array_np, axis=axis)
 
@@ -859,8 +864,8 @@ def test_logsumexp_like_scipy_logsumexp(array_namespace, device_, dtype_name, ax
 
     # if torch on CPU or array api strict on default device
     # check that _logsumexp works when array API dispatch is disabled
-    if (array_namespace == "torch" and device_ == "cpu") or (
-        array_namespace == "array_api_strict" and "CPU" in str(device_)
+    if (array_namespace == "torch" and device_name == "cpu") or (
+        array_namespace == "array_api_strict" and "CPU" in str(device_name)
     ):
         assert_allclose(_logsumexp(array_xp, axis=axis), res_np, rtol=rtol)
 
@@ -880,7 +885,7 @@ def test_logsumexp_like_scipy_logsumexp(array_namespace, device_, dtype_name, ax
         ],
         dtype=dtype_name,
     )
-    array_xp_2 = xp.asarray(array_np_2, device=device_)
+    array_xp_2 = xp.asarray(array_np_2, device=device)
 
     res_np_2 = scipy.special.logsumexp(array_np_2, axis=axis)
 
@@ -901,17 +906,18 @@ def test_logsumexp_like_scipy_logsumexp(array_namespace, device_, dtype_name, ax
     ],
 )
 def test_supported_float_types(namespace, device_, expected_types):
-    xp = _array_api_for_tests(namespace, device_)
-    float_types = supported_float_dtypes(xp, device=device_)
+    xp, device = _array_api_for_tests(namespace, device_name=device_)
+    float_types = supported_float_dtypes(xp, device=device)
     expected = tuple(getattr(xp, dtype_name) for dtype_name in expected_types)
     assert float_types == expected
 
 
 @pytest.mark.parametrize("use_sample_weight", [False, True])
 @pytest.mark.parametrize(
-    "namespace, device_, dtype_name", yield_namespace_device_dtype_combinations()
+    "namespace, device_name, dtype_name",
+    yield_namespace_device_dtype_combinations(),
 )
-def test_half_multinomial_loss(use_sample_weight, namespace, device_, dtype_name):
+def test_half_multinomial_loss(use_sample_weight, namespace, device_name, dtype_name):
     """Check that the array API version of :func:`_half_multinomial_loss` works
     correctly and matches the results produced by :class:`HalfMultinomialLoss`
     of the private `_loss` module.
@@ -921,13 +927,13 @@ def test_half_multinomial_loss(use_sample_weight, namespace, device_, dtype_name
     rng = numpy.random.RandomState(42)
     y = rng.randint(0, n_classes, n_samples).astype(dtype_name)
     pred = rng.rand(n_samples, n_classes).astype(dtype_name)
-    xp = _array_api_for_tests(namespace, device_)
-    y_xp = xp.asarray(y, device=device_)
-    pred_xp = xp.asarray(pred, device=device_)
+    xp, device = _array_api_for_tests(namespace, device_name)
+    y_xp = xp.asarray(y, device=device)
+    pred_xp = xp.asarray(pred, device=device)
     if use_sample_weight:
         sample_weight = numpy.ones_like(y)
         sample_weight[1::2] = 2
-        sample_weight_xp = xp.asarray(sample_weight, device=device_)
+        sample_weight_xp = xp.asarray(sample_weight, device=device)
     else:
         sample_weight, sample_weight_xp = None, None
 
@@ -943,11 +949,12 @@ def test_half_multinomial_loss(use_sample_weight, namespace, device_, dtype_name
 
 
 @pytest.mark.parametrize(
-    "namespace, device_, dtype_name", yield_namespace_device_dtype_combinations()
+    "namespace, device_name, dtype_name",
+    yield_namespace_device_dtype_combinations(),
 )
-def test_matching_numpy_dtype(namespace, device_, dtype_name):
-    xp = _array_api_for_tests(namespace, device_)
+def test_matching_numpy_dtype(namespace, device_name, dtype_name):
+    xp, device = _array_api_for_tests(namespace, device_name)
     X_np = numpy.arange(1000).astype(dtype_name)
-    X_xp = xp.asarray(X_np, device=device_)
+    X_xp = xp.asarray(X_np, device=device)
     ret_dtype = _matching_numpy_dtype(X_xp, xp=xp)
     assert ret_dtype == X_np.dtype

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -15,7 +15,6 @@ from sklearn.utils import gen_batches
 from sklearn.utils._arpack import _init_arpack_v0
 from sklearn.utils._array_api import (
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
     _max_precision_float_dtype,
     get_namespace,
     yield_namespace_device_dtype_combinations,
@@ -703,18 +702,17 @@ def test_incremental_weighted_mean_and_variance_simple(dtype, as_list):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 def test_incremental_weighted_mean_and_variance_array_api(
-    array_namespace, device, dtype
+    array_namespace, device_name, dtype_name
 ):
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     rng = np.random.RandomState(42)
     mult = 10
-    X = rng.rand(1000, 20).astype(dtype) * mult
-    sample_weight = rng.rand(X.shape[0]).astype(dtype) * mult
+    X = rng.rand(1000, 20).astype(dtype_name) * mult
+    sample_weight = rng.rand(X.shape[0]).astype(dtype_name) * mult
     mean, var, _ = _incremental_mean_and_var(X, 0, 0, 0, sample_weight=sample_weight)
 
     X_xp = xp.asarray(X, device=device)
@@ -1104,18 +1102,17 @@ def test_approximate_mode():
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
-def test_randomized_svd_array_api_compliance(array_namespace, device, dtype):
-    xp = _array_api_for_tests(array_namespace, device)
+def test_randomized_svd_array_api_compliance(array_namespace, device_name, dtype_name):
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     rng = np.random.RandomState(0)
-    X = rng.normal(size=(30, 10)).astype(dtype)
+    X = rng.normal(size=(30, 10)).astype(dtype_name)
     X_xp = xp.asarray(X, device=device)
     n_components = 5
-    atol = 1e-5 if dtype == "float32" else 0
+    atol = 1e-5 if dtype_name == "float32" else 0
 
     with config_context(array_api_dispatch=True):
         u_np, s_np, vt_np = randomized_svd(X, n_components, random_state=0)
@@ -1131,19 +1128,20 @@ def test_randomized_svd_array_api_compliance(array_namespace, device, dtype):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
-def test_randomized_range_finder_array_api_compliance(array_namespace, device, dtype):
-    xp = _array_api_for_tests(array_namespace, device)
+def test_randomized_range_finder_array_api_compliance(
+    array_namespace, device_name, dtype_name
+):
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     rng = np.random.RandomState(0)
-    X = rng.normal(size=(30, 10)).astype(dtype)
+    X = rng.normal(size=(30, 10)).astype(dtype_name)
     X_xp = xp.asarray(X, device=device)
     size = 5
     n_iter = 10
-    atol = 1e-5 if dtype == "float32" else 0
+    atol = 1e-5 if dtype_name == "float32" else 0
 
     with config_context(array_api_dispatch=True):
         Q_np = randomized_range_finder(X, size=size, n_iter=n_iter, random_state=0)

--- a/sklearn/utils/tests/test_indexing.py
+++ b/sklearn/utils/tests/test_indexing.py
@@ -11,10 +11,11 @@ from sklearn.externals._packaging.version import parse as parse_version
 from sklearn.utils import _safe_indexing, resample, shuffle
 from sklearn.utils._array_api import (
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
-    device,
     move_to,
     yield_namespace_device_dtype_combinations,
+)
+from sklearn.utils._array_api import (
+    device as array_api_device,
 )
 from sklearn.utils._indexing import (
     _determine_key_type,
@@ -112,22 +113,21 @@ def test_determine_key_type_slice_error():
 
 @skip_if_array_api_compat_not_configured
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
-def test_determine_key_type_array_api(array_namespace, device_, dtype_name):
-    xp = _array_api_for_tests(array_namespace, device_)
+def test_determine_key_type_array_api(array_namespace, device_name, dtype_name):
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     with sklearn.config_context(array_api_dispatch=True):
-        int_array_key = xp.asarray([1, 2, 3], device=device_)
+        int_array_key = xp.asarray([1, 2, 3], device=device)
         assert _determine_key_type(int_array_key) == "int"
 
-        bool_array_key = xp.asarray([True, False, True], device=device_)
+        bool_array_key = xp.asarray([True, False, True], device=device)
         assert _determine_key_type(bool_array_key) == "bool"
 
         try:
-            complex_array_key = xp.asarray([1 + 1j, 2 + 2j, 3 + 3j], device=device_)
+            complex_array_key = xp.asarray([1 + 1j, 2 + 2j, 3 + 3j], device=device)
         except TypeError:
             # Complex numbers are not supported by all Array API libraries.
             complex_array_key = None
@@ -139,9 +139,8 @@ def test_determine_key_type_array_api(array_namespace, device_, dtype_name):
 
 @skip_if_array_api_compat_not_configured
 @pytest.mark.parametrize(
-    "array_namespace, device_, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize(
     "indexing_key",
@@ -157,17 +156,17 @@ def test_determine_key_type_array_api(array_namespace, device_, dtype_name):
 )
 @pytest.mark.parametrize("axis", [0, 1])
 def test_safe_indexing_array_api_support(
-    array_namespace, device_, dtype_name, indexing_key, axis
+    array_namespace, device_name, dtype_name, indexing_key, axis
 ):
-    xp = _array_api_for_tests(array_namespace, device_)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     array_to_index_np = np.arange(16).reshape(4, 4)
     expected_result = _safe_indexing(array_to_index_np, indexing_key, axis=axis)
-    array_to_index_xp = move_to(array_to_index_np, xp=xp, device=device_)
+    array_to_index_xp = move_to(array_to_index_np, xp=xp, device=device)
 
     with sklearn.config_context(array_api_dispatch=True):
         indexed_array_xp = _safe_indexing(array_to_index_xp, indexing_key, axis=axis)
-        assert device(indexed_array_xp) == device(array_to_index_xp)
+        assert array_api_device(indexed_array_xp) == array_api_device(array_to_index_xp)
         assert indexed_array_xp.dtype == array_to_index_xp.dtype
 
     assert_allclose(_convert_to_numpy(indexed_array_xp, xp=xp), expected_result)

--- a/sklearn/utils/tests/test_multiclass.py
+++ b/sklearn/utils/tests/test_multiclass.py
@@ -9,7 +9,6 @@ from sklearn import config_context, datasets
 from sklearn.model_selection import ShuffleSplit
 from sklearn.svm import SVC
 from sklearn.utils._array_api import (
-    _get_namespace_device_dtype_ids,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._testing import (
@@ -404,12 +403,11 @@ def test_is_multilabel():
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
-def test_is_multilabel_array_api_compliance(array_namespace, device, dtype_name):
-    xp = _array_api_for_tests(array_namespace, device)
+def test_is_multilabel_array_api_compliance(array_namespace, device_name, dtype_name):
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     for group, group_examples in ARRAY_API_EXAMPLES.items():
         dense_exp = group == "multilabel-indicator"

--- a/sklearn/utils/tests/test_stats.py
+++ b/sklearn/utils/tests/test_stats.py
@@ -259,7 +259,8 @@ def test_weighted_percentile_2d(global_random_seed, percentile_rank, average):
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, dtype_name", yield_namespace_device_dtype_combinations()
+    "array_namespace, device_name, dtype_name",
+    yield_namespace_device_dtype_combinations(),
 )
 @pytest.mark.parametrize(
     "data, weights, percentile",
@@ -289,10 +290,16 @@ def test_weighted_percentile_2d(global_random_seed, percentile_rank, average):
     ],
 )
 def test_weighted_percentile_array_api_consistency(
-    global_random_seed, array_namespace, device, dtype_name, data, weights, percentile
+    global_random_seed,
+    array_namespace,
+    device_name,
+    dtype_name,
+    data,
+    weights,
+    percentile,
 ):
     """Check `_weighted_percentile` gives consistent results with array API."""
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     # Skip test for percentile=0 edge case (#20528) on namespace/device where
     # xp.nextafter is broken. This is the case for torch with MPS device:

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -35,7 +35,6 @@ from sklearn.utils import (
 )
 from sklearn.utils._array_api import (
     _convert_to_numpy,
-    _get_namespace_device_dtype_ids,
     _is_numpy_namespace,
     yield_namespace_device_dtype_combinations,
 )
@@ -1037,13 +1036,12 @@ def test_check_consistent_length():
 
 
 @pytest.mark.parametrize(
-    "array_namespace, device, _",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
-def test_check_consistent_length_array_api(array_namespace, device, _):
+def test_check_consistent_length_array_api(array_namespace, device_name, dtype_name):
     """Test that check_consistent_length works with different array types."""
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
 
     with config_context(array_api_dispatch=True):
         check_consistent_length(
@@ -1057,7 +1055,8 @@ def test_check_consistent_length_array_api(array_namespace, device, _):
 
         with pytest.raises(ValueError, match="inconsistent numbers of samples"):
             check_consistent_length(
-                xp.asarray([1, 2], device=device), xp.asarray([1], device=device)
+                xp.asarray([1, 2], device=device),
+                xp.asarray([1], device=device),
             )
 
 
@@ -1662,10 +1661,11 @@ def test_check_sample_weight():
 
 
 @pytest.mark.parametrize(
-    "array_namespace,device,dtype", yield_namespace_device_dtype_combinations()
+    "array_namespace, device_name, dtype_name",
+    yield_namespace_device_dtype_combinations(),
 )
-def test_check_sample_weight_array_api(array_namespace, device, dtype):
-    xp = _array_api_for_tests(array_namespace, device)
+def test_check_sample_weight_array_api(array_namespace, device_name, dtype_name):
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     with config_context(array_api_dispatch=True):
         # check array order
         sample_weight = xp.ones(10)[::2]
@@ -1684,13 +1684,14 @@ def test_check_pos_label_consistency(y_true):
 
 
 @pytest.mark.parametrize(
-    "array_namespace,device,dtype",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize("y_true", [[0], [0, 1], [-1, 1], [1, 1, 1], [-1, -1, -1]])
-def test_check_pos_label_consistency_array_api(array_namespace, device, dtype, y_true):
-    xp = _array_api_for_tests(array_namespace, device)
+def test_check_pos_label_consistency_array_api(
+    array_namespace, device_name, dtype_name, y_true
+):
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     with config_context(array_api_dispatch=True):
         arr = xp.asarray(y_true, device=device)
         assert _check_pos_label_consistency(None, arr) == 1
@@ -1705,15 +1706,14 @@ def test_check_pos_label_consistency_invalid(y_true):
 
 
 @pytest.mark.parametrize(
-    "array_namespace,device,dtype",
+    "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
-    ids=_get_namespace_device_dtype_ids,
 )
 @pytest.mark.parametrize("y_true", [[2, 3, 4], [-10], [0, -1]])
 def test_check_pos_label_consistency_invalid_array_api(
-    array_namespace, device, dtype, y_true
+    array_namespace, device_name, dtype_name, y_true
 ):
-    xp = _array_api_for_tests(array_namespace, device)
+    xp, device = _array_api_for_tests(array_namespace, device_name)
     with config_context(array_api_dispatch=True):
         arr = xp.asarray(y_true, device=device)
         with pytest.raises(ValueError, match="y_true takes value in"):


### PR DESCRIPTION
I let cursor extract the test refactoring I initially did as part of #29647 and adapt it on top of the current `main`. I think this change makes array API testing simpler and nicer to use:

The purpose is to make it more explicit when `device` is a device name or an object and only parametrize tests with names so that we don't need to use `ids=_get_namespace_device_dtype_ids` anymore.

This also normalizes naming conventions across array API tests.