### PR TITLE
feat: Multithreading tree

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.tree/33601.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.tree/33601.enhancement.rst
@@ -1,0 +1,5 @@
+- Add an ``n_threads`` parameter to :class:`tree.DecisionTreeClassifier`,
+  :class:`tree.DecisionTreeRegressor`, :class:`tree.ExtraTreeClassifier`, and
+  :class:`tree.ExtraTreeRegressor` to control the number of OpenMP threads used
+  during fitting.
+  By :user:`aaronzuo`.

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1513,6 +1513,7 @@ class RandomForestClassifier(ForestClassifier):
         ],
     }
     _parameter_constraints.pop("splitter")
+    _parameter_constraints.pop("n_threads")
 
     def __init__(
         self,
@@ -1891,6 +1892,7 @@ class RandomForestRegressor(ForestRegressor):
         **DecisionTreeRegressor._parameter_constraints,
     }
     _parameter_constraints.pop("splitter")
+    _parameter_constraints.pop("n_threads")
 
     def __init__(
         self,
@@ -2288,6 +2290,7 @@ class ExtraTreesClassifier(ForestClassifier):
         ],
     }
     _parameter_constraints.pop("splitter")
+    _parameter_constraints.pop("n_threads")
 
     def __init__(
         self,
@@ -2645,6 +2648,7 @@ class ExtraTreesRegressor(ForestRegressor):
         **DecisionTreeRegressor._parameter_constraints,
     }
     _parameter_constraints.pop("splitter")
+    _parameter_constraints.pop("n_threads")
 
     def __init__(
         self,
@@ -2908,7 +2912,13 @@ class RandomTreesEmbedding(TransformerMixin, BaseForest):
         **BaseDecisionTree._parameter_constraints,
         "sparse_output": ["boolean"],
     }
-    for param in ("max_features", "ccp_alpha", "splitter", "monotonic_cst"):
+    for param in (
+        "max_features",
+        "ccp_alpha",
+        "splitter",
+        "monotonic_cst",
+        "n_threads",
+    ):
         _parameter_constraints.pop(param)
 
     criterion = "squared_error"

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1309,6 +1309,12 @@ class RandomForestClassifier(ForestClassifier):
         context. ``-1`` means using all processors. See :term:`Glossary
         <n_jobs>` for more details.
 
+    n_threads : int, default=None
+        Number of OpenMP threads to use for parts of the tree fitting procedure
+        that support OpenMP-based parallelism. This parameter is forwarded to
+        the underlying tree estimators. If scikit-learn is built without OpenMP
+        support, this parameter has no effect and 1 thread is used.
+
     random_state : int, RandomState instance or None, default=None
         Controls both the randomness of the bootstrapping of the samples used
         when building trees (if ``bootstrap=True``) and the sampling of the
@@ -1513,7 +1519,6 @@ class RandomForestClassifier(ForestClassifier):
         ],
     }
     _parameter_constraints.pop("splitter")
-    _parameter_constraints.pop("n_threads")
 
     def __init__(
         self,
@@ -1530,6 +1535,7 @@ class RandomForestClassifier(ForestClassifier):
         bootstrap=True,
         oob_score=False,
         n_jobs=None,
+        n_threads=None,
         random_state=None,
         verbose=0,
         warm_start=False,
@@ -1551,6 +1557,7 @@ class RandomForestClassifier(ForestClassifier):
                 "max_leaf_nodes",
                 "min_impurity_decrease",
                 "random_state",
+                "n_threads",
                 "ccp_alpha",
                 "monotonic_cst",
             ),
@@ -1574,6 +1581,7 @@ class RandomForestClassifier(ForestClassifier):
         self.min_impurity_decrease = min_impurity_decrease
         self.monotonic_cst = monotonic_cst
         self.ccp_alpha = ccp_alpha
+        self.n_threads = n_threads
 
 
 class RandomForestRegressor(ForestRegressor):
@@ -1728,6 +1736,12 @@ class RandomForestRegressor(ForestRegressor):
         trees. ``None`` means 1 unless in a :obj:`joblib.parallel_backend`
         context. ``-1`` means using all processors. See :term:`Glossary
         <n_jobs>` for more details.
+
+    n_threads : int, default=None
+        Number of OpenMP threads to use for parts of the tree fitting procedure
+        that support OpenMP-based parallelism. This parameter is forwarded to
+        the underlying tree estimators. If scikit-learn is built without OpenMP
+        support, this parameter has no effect and 1 thread is used.
 
     random_state : int, RandomState instance or None, default=None
         Controls both the randomness of the bootstrapping of the samples used
@@ -1892,7 +1906,6 @@ class RandomForestRegressor(ForestRegressor):
         **DecisionTreeRegressor._parameter_constraints,
     }
     _parameter_constraints.pop("splitter")
-    _parameter_constraints.pop("n_threads")
 
     def __init__(
         self,
@@ -1909,6 +1922,7 @@ class RandomForestRegressor(ForestRegressor):
         bootstrap=True,
         oob_score=False,
         n_jobs=None,
+        n_threads=None,
         random_state=None,
         verbose=0,
         warm_start=False,
@@ -1929,6 +1943,7 @@ class RandomForestRegressor(ForestRegressor):
                 "max_leaf_nodes",
                 "min_impurity_decrease",
                 "random_state",
+                "n_threads",
                 "ccp_alpha",
                 "monotonic_cst",
             ),
@@ -1961,6 +1976,7 @@ class RandomForestRegressor(ForestRegressor):
         self.min_impurity_decrease = min_impurity_decrease
         self.ccp_alpha = ccp_alpha
         self.monotonic_cst = monotonic_cst
+        self.n_threads = n_threads
 
 
 class ExtraTreesClassifier(ForestClassifier):
@@ -2093,6 +2109,12 @@ class ExtraTreesClassifier(ForestClassifier):
         trees. ``None`` means 1 unless in a :obj:`joblib.parallel_backend`
         context. ``-1`` means using all processors. See :term:`Glossary
         <n_jobs>` for more details.
+
+    n_threads : int, default=None
+        Number of OpenMP threads to use for parts of the tree fitting procedure
+        that support OpenMP-based parallelism. This parameter is forwarded to
+        the underlying tree estimators. If scikit-learn is built without OpenMP
+        support, this parameter has no effect and 1 thread is used.
 
     random_state : int, RandomState instance or None, default=None
         Controls 3 sources of randomness:
@@ -2290,7 +2312,6 @@ class ExtraTreesClassifier(ForestClassifier):
         ],
     }
     _parameter_constraints.pop("splitter")
-    _parameter_constraints.pop("n_threads")
 
     def __init__(
         self,
@@ -2307,6 +2328,7 @@ class ExtraTreesClassifier(ForestClassifier):
         bootstrap=False,
         oob_score=False,
         n_jobs=None,
+        n_threads=None,
         random_state=None,
         verbose=0,
         warm_start=False,
@@ -2328,6 +2350,7 @@ class ExtraTreesClassifier(ForestClassifier):
                 "max_leaf_nodes",
                 "min_impurity_decrease",
                 "random_state",
+                "n_threads",
                 "ccp_alpha",
                 "monotonic_cst",
             ),
@@ -2351,6 +2374,7 @@ class ExtraTreesClassifier(ForestClassifier):
         self.min_impurity_decrease = min_impurity_decrease
         self.ccp_alpha = ccp_alpha
         self.monotonic_cst = monotonic_cst
+        self.n_threads = n_threads
 
 
 class ExtraTreesRegressor(ForestRegressor):
@@ -2496,6 +2520,12 @@ class ExtraTreesRegressor(ForestRegressor):
         trees. ``None`` means 1 unless in a :obj:`joblib.parallel_backend`
         context. ``-1`` means using all processors. See :term:`Glossary
         <n_jobs>` for more details.
+
+    n_threads : int, default=None
+        Number of OpenMP threads to use for parts of the tree fitting procedure
+        that support OpenMP-based parallelism. This parameter is forwarded to
+        the underlying tree estimators. If scikit-learn is built without OpenMP
+        support, this parameter has no effect and 1 thread is used.
 
     random_state : int, RandomState instance or None, default=None
         Controls 3 sources of randomness:
@@ -2648,7 +2678,6 @@ class ExtraTreesRegressor(ForestRegressor):
         **DecisionTreeRegressor._parameter_constraints,
     }
     _parameter_constraints.pop("splitter")
-    _parameter_constraints.pop("n_threads")
 
     def __init__(
         self,
@@ -2665,6 +2694,7 @@ class ExtraTreesRegressor(ForestRegressor):
         bootstrap=False,
         oob_score=False,
         n_jobs=None,
+        n_threads=None,
         random_state=None,
         verbose=0,
         warm_start=False,
@@ -2685,6 +2715,7 @@ class ExtraTreesRegressor(ForestRegressor):
                 "max_leaf_nodes",
                 "min_impurity_decrease",
                 "random_state",
+                "n_threads",
                 "ccp_alpha",
                 "monotonic_cst",
             ),
@@ -2717,6 +2748,7 @@ class ExtraTreesRegressor(ForestRegressor):
         self.min_impurity_decrease = min_impurity_decrease
         self.ccp_alpha = ccp_alpha
         self.monotonic_cst = monotonic_cst
+        self.n_threads = n_threads
 
 
 class RandomTreesEmbedding(TransformerMixin, BaseForest):
@@ -2818,6 +2850,12 @@ class RandomTreesEmbedding(TransformerMixin, BaseForest):
         context. ``-1`` means using all processors. See :term:`Glossary
         <n_jobs>` for more details.
 
+    n_threads : int, default=None
+        Number of OpenMP threads to use for parts of the tree fitting procedure
+        that support OpenMP-based parallelism. This parameter is forwarded to
+        the underlying tree estimators. If scikit-learn is built without OpenMP
+        support, this parameter has no effect and 1 thread is used.
+
     random_state : int, RandomState instance or None, default=None
         Controls the generation of the random `y` used to fit the trees
         and the draw of the splits for each feature at the trees' nodes.
@@ -2917,7 +2955,6 @@ class RandomTreesEmbedding(TransformerMixin, BaseForest):
         "ccp_alpha",
         "splitter",
         "monotonic_cst",
-        "n_threads",
     ):
         _parameter_constraints.pop(param)
 
@@ -2936,6 +2973,7 @@ class RandomTreesEmbedding(TransformerMixin, BaseForest):
         min_impurity_decrease=0.0,
         sparse_output=True,
         n_jobs=None,
+        n_threads=None,
         random_state=None,
         verbose=0,
         warm_start=False,
@@ -2953,6 +2991,7 @@ class RandomTreesEmbedding(TransformerMixin, BaseForest):
                 "max_leaf_nodes",
                 "min_impurity_decrease",
                 "random_state",
+                "n_threads",
             ),
             bootstrap=False,
             oob_score=False,
@@ -2970,6 +3009,7 @@ class RandomTreesEmbedding(TransformerMixin, BaseForest):
         self.max_leaf_nodes = max_leaf_nodes
         self.min_impurity_decrease = min_impurity_decrease
         self.sparse_output = sparse_output
+        self.n_threads = n_threads
 
     def _set_oob_score_and_attributes(self, X, y, scoring_function=None):
         raise NotImplementedError("OOB score not supported by tree embedding")

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -342,9 +342,9 @@ class VerboseReporter:
                 (est.n_estimators - (j + 1)) * (time() - self.start_time) / float(i + 1)
             )
             if remaining_time > 60:
-                remaining_time = "{0:.2f}m".format(remaining_time / 60.0)
+                remaining_time = f"{remaining_time / 60.0:.2f}m"
             else:
-                remaining_time = "{0:.2f}s".format(remaining_time)
+                remaining_time = f"{remaining_time:.2f}s"
             print(
                 self.verbose_fmt.format(
                     iter=j + 1,
@@ -378,7 +378,6 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
     }
     _parameter_constraints.pop("splitter")
     _parameter_constraints.pop("monotonic_cst")
-    _parameter_constraints.pop("n_threads")
 
     @abstractmethod
     def __init__(
@@ -397,6 +396,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         max_features,
         ccp_alpha,
         random_state,
+        n_threads=None,
         alpha=0.9,
         verbose=0,
         max_leaf_nodes=None,
@@ -420,6 +420,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         self.ccp_alpha = ccp_alpha
         self.init = init
         self.random_state = random_state
+        self.n_threads = n_threads
         self.alpha = alpha
         self.verbose = verbose
         self.max_leaf_nodes = max_leaf_nodes
@@ -490,6 +491,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                 max_features=self.max_features,
                 max_leaf_nodes=self.max_leaf_nodes,
                 random_state=random_state,
+                n_threads=self.n_threads,
                 ccp_alpha=self.ccp_alpha,
             )
 
@@ -590,8 +592,8 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         total_n_estimators = self.n_estimators
         if total_n_estimators < self.estimators_.shape[0]:
             raise ValueError(
-                "resize with smaller n_estimators %d < %d"
-                % (total_n_estimators, self.estimators_[0])
+                f"resize with smaller n_estimators {total_n_estimators} < "
+                f"{self.estimators_.shape[0]}"
             )
 
         self.estimators_ = np.resize(
@@ -713,17 +715,16 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                 test_size=self.validation_fraction,
                 stratify=stratify,
             )
-            if is_classifier(self):
-                if self.n_classes_ != np.unique(y_train).shape[0]:
-                    # We choose to error here. The problem is that the init
-                    # estimator would be trained on y, which has some missing
-                    # classes now, so its predictions would not have the
-                    # correct shape.
-                    raise ValueError(
-                        "The training data after the early stopping split "
-                        "is missing some classes. Try using another random "
-                        "seed."
-                    )
+            if is_classifier(self) and self.n_classes_ != np.unique(y_train).shape[0]:
+                # We choose to error here. The problem is that the init
+                # estimator would be trained on y, which has some missing
+                # classes now, so its predictions would not have the
+                # correct shape.
+                raise ValueError(
+                    "The training data after the early stopping split "
+                    "is missing some classes. Try using another random "
+                    "seed."
+                )
         else:
             X_train, y_train, sample_weight_train = X, y, sample_weight
             X_val = y_val = sample_weight_val = None
@@ -747,8 +748,8 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                     self.init_.fit(X_train, y_train)
                 else:
                     msg = (
-                        "The initial estimator {} does not support sample "
-                        "weights.".format(self.init_.__class__.__name__)
+                        f"The initial estimator {self.init_.__class__.__name__} does "
+                        "not support sample weights."
                     )
                     try:
                         self.init_.fit(
@@ -785,9 +786,9 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             # invariant: warm_start = True
             if self.n_estimators < self.estimators_.shape[0]:
                 raise ValueError(
-                    "n_estimators=%d must be larger or equal to "
-                    "estimators_.shape[0]=%d when "
-                    "warm_start==True" % (self.n_estimators, self.estimators_.shape[0])
+                    f"n_estimators={self.n_estimators} must be larger or equal to "
+                    f"estimators_.shape[0]={self.estimators_.shape[0]} when "
+                    "warm_start==True"
                 )
             begin_at_stage = self.estimators_.shape[0]
             # The requirements of _raw_predict
@@ -1082,7 +1083,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             warnings.warn(
                 "Using recursion method with a non-constant init predictor "
                 "will lead to incorrect partial dependence values. "
-                "Got init=%s." % self.init,
+                f"Got init={self.init}.",
                 UserWarning,
             )
         grid = np.asarray(grid, dtype=DTYPE, order="C")
@@ -1271,6 +1272,12 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         validation set if `n_iter_no_change` is not None.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
+
+    n_threads : int, default=None
+        Number of OpenMP threads to use for parts of the tree fitting procedure
+        that support OpenMP-based parallelism. This parameter is forwarded to
+        the underlying tree estimators. If scikit-learn is built without OpenMP
+        support, this parameter has no effect and 1 thread is used.
 
     max_features : {'sqrt', 'log2'}, int or float, default=None
         The number of features to consider when looking for the best split:
@@ -1497,6 +1504,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         min_impurity_decrease=0.0,
         init=None,
         random_state=None,
+        n_threads=None,
         max_features=None,
         verbose=0,
         max_leaf_nodes=None,
@@ -1519,6 +1527,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
             subsample=subsample,
             max_features=max_features,
             random_state=random_state,
+            n_threads=n_threads,
             verbose=verbose,
             max_leaf_nodes=max_leaf_nodes,
             min_impurity_decrease=min_impurity_decrease,
@@ -1553,9 +1562,9 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
 
         if n_trim_classes < 2:
             raise ValueError(
-                "y contains %d class after sample_weight "
-                "trimmed classes with zero weights, while a "
-                "minimum of 2 classes are required." % n_trim_classes
+                f"y contains {n_trim_classes} class after sample_weight trimmed "
+                "classes with zero weights, while a minimum of 2 classes are "
+                "required."
             )
         return encoded_y
 
@@ -1750,7 +1759,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
             raise
         except AttributeError as e:
             raise AttributeError(
-                "loss=%r does not support predict_proba" % self.loss
+                f"loss={self.loss!r} does not support predict_proba"
             ) from e
 
 
@@ -1883,6 +1892,12 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         validation set if `n_iter_no_change` is not None.
         Pass an int for reproducible output across multiple function calls.
         See :term:`Glossary <random_state>`.
+
+    n_threads : int, default=None
+        Number of OpenMP threads to use for parts of the tree fitting procedure
+        that support OpenMP-based parallelism. This parameter is forwarded to
+        the underlying tree estimators. If scikit-learn is built without OpenMP
+        support, this parameter has no effect and 1 thread is used.
 
     max_features : {'sqrt', 'log2'}, int or float, default=None
         The number of features to consider when looking for the best split:
@@ -2102,6 +2117,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         min_impurity_decrease=0.0,
         init=None,
         random_state=None,
+        n_threads=None,
         max_features=None,
         alpha=0.9,
         verbose=0,
@@ -2126,6 +2142,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
             max_features=max_features,
             min_impurity_decrease=min_impurity_decrease,
             random_state=random_state,
+            n_threads=n_threads,
             alpha=alpha,
             verbose=verbose,
             max_leaf_nodes=max_leaf_nodes,

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -378,6 +378,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
     }
     _parameter_constraints.pop("splitter")
     _parameter_constraints.pop("monotonic_cst")
+    _parameter_constraints.pop("n_threads")
 
     @abstractmethod
     def __init__(

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -119,6 +119,50 @@ CLF_CRITERIONS = ("gini", "log_loss")
 REG_CRITERIONS = ("squared_error", "absolute_error", "friedman_mse", "poisson")
 
 
+@pytest.mark.parametrize(
+    "Forest",
+    [
+        RandomForestClassifier,
+        ExtraTreesClassifier,
+        RandomForestRegressor,
+        ExtraTreesRegressor,
+    ],
+)
+def test_forest_n_threads_forwarded_to_trees(Forest):
+    if Forest in (RandomForestClassifier, ExtraTreesClassifier):
+        X, y = make_classification(n_samples=50, n_features=10, random_state=0)
+    else:
+        X, y = make_regression(n_samples=50, n_features=10, random_state=0)
+
+    est = Forest(n_estimators=3, n_jobs=1, random_state=0, n_threads=2).fit(X, y)
+    assert {tree.n_threads for tree in est.estimators_} == {2}
+
+
+def test_random_trees_embedding_n_threads_forwarded_to_trees():
+    X, _ = make_classification(n_samples=50, n_features=10, random_state=0)
+    est = RandomTreesEmbedding(n_estimators=3, n_jobs=1, random_state=0, n_threads=2)
+    est.fit(X)
+    assert {tree.n_threads for tree in est.estimators_} == {2}
+
+
+@pytest.mark.parametrize(
+    "Forest",
+    [
+        RandomForestClassifier,
+        ExtraTreesClassifier,
+        RandomForestRegressor,
+        ExtraTreesRegressor,
+        RandomTreesEmbedding,
+    ],
+)
+def test_forest_n_threads_zero_raises(Forest):
+    X, y = make_classification(n_samples=50, n_features=10, random_state=0)
+    if Forest is RandomTreesEmbedding:
+        y = None
+    with pytest.raises(ValueError, match="n_threads = 0 is invalid"):
+        Forest(n_estimators=1, n_jobs=1, random_state=0, n_threads=0).fit(X, y)
+
+
 @pytest.mark.parametrize("name", FOREST_CLASSIFIERS)
 def test_classification_toy(name):
     """Check classification on a toy dataset."""

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -75,6 +75,38 @@ def test_raise_if_init_has_no_predict_proba():
         clf.fit(X, y)
 
 
+@pytest.mark.parametrize(
+    "GB",
+    [
+        GradientBoostingClassifier,
+        GradientBoostingRegressor,
+    ],
+)
+def test_gradient_boosting_n_threads_forwarded_to_trees(GB):
+    if GB is GradientBoostingClassifier:
+        X, y = make_classification(n_samples=100, n_features=10, random_state=0)
+    else:
+        X, y = make_regression(n_samples=100, n_features=10, random_state=0)
+
+    est = GB(n_estimators=3, random_state=0, n_threads=2).fit(X, y)
+    assert {tree.n_threads for tree in est.estimators_.ravel()} == {2}
+
+
+@pytest.mark.parametrize(
+    "GB",
+    [
+        GradientBoostingClassifier,
+        GradientBoostingRegressor,
+    ],
+)
+def test_gradient_boosting_n_threads_zero_raises(GB):
+    X, y = make_classification(n_samples=100, n_features=10, random_state=0)
+    if GB is GradientBoostingRegressor:
+        X, y = make_regression(n_samples=100, n_features=10, random_state=0)
+    with pytest.raises(ValueError, match="n_threads = 0 is invalid"):
+        GB(n_estimators=3, random_state=0, n_threads=0).fit(X, y)
+
+
 @pytest.mark.parametrize("loss", ("log_loss", "exponential"))
 def test_classification_toy(loss, global_random_seed):
     # Check classification on a toy dataset.

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -795,9 +795,9 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
 
     n_threads : int, default=None
         Number of OpenMP threads to use for parts of the fitting procedure that
-        support OpenMP-based parallelism. ``None`` uses the default number of
-        threads (taking ``OMP_NUM_THREADS`` into account). ``n_threads=0`` is
-        invalid.
+        support OpenMP-based parallelism. If scikit-learn is built without
+        OpenMP support, this parameter has no effect and 1 thread is used.
+        ``n_threads=0`` is invalid.
 
     max_leaf_nodes : int, default=None
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.
@@ -1219,9 +1219,9 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
 
     n_threads : int, default=None
         Number of OpenMP threads to use for parts of the fitting procedure that
-        support OpenMP-based parallelism. ``None`` uses the default number of
-        threads (taking ``OMP_NUM_THREADS`` into account). ``n_threads=0`` is
-        invalid.
+        support OpenMP-based parallelism. If scikit-learn is built without
+        OpenMP support, this parameter has no effect and 1 thread is used.
+        ``n_threads=0`` is invalid.
 
     max_leaf_nodes : int, default=None
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.
@@ -1563,9 +1563,9 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
 
     n_threads : int, default=None
         Number of OpenMP threads to use for parts of the fitting procedure that
-        support OpenMP-based parallelism. ``None`` uses the default number of
-        threads (taking ``OMP_NUM_THREADS`` into account). ``n_threads=0`` is
-        invalid.
+        support OpenMP-based parallelism. If scikit-learn is built without
+        OpenMP support, this parameter has no effect and 1 thread is used.
+        ``n_threads=0`` is invalid.
 
     max_leaf_nodes : int, default=None
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.
@@ -1869,9 +1869,9 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
 
     n_threads : int, default=None
         Number of OpenMP threads to use for parts of the fitting procedure that
-        support OpenMP-based parallelism. ``None`` uses the default number of
-        threads (taking ``OMP_NUM_THREADS`` into account). ``n_threads=0`` is
-        invalid.
+        support OpenMP-based parallelism. If scikit-learn is built without
+        OpenMP support, this parameter has no effect and 1 thread is used.
+        ``n_threads=0`` is invalid.
 
     min_impurity_decrease : float, default=0.0
         A node will be split if this split induces a decrease of the impurity

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -41,6 +41,7 @@ from sklearn.utils import (
     compute_sample_weight,
     metadata_routing,
 )
+from sklearn.utils._openmp_helpers import _openmp_effective_n_threads
 from sklearn.utils._param_validation import Hidden, Interval, RealNotInt, StrOptions
 from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import (
@@ -124,6 +125,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         "min_impurity_decrease": [Interval(Real, 0.0, None, closed="left")],
         "ccp_alpha": [Interval(Real, 0.0, None, closed="left")],
         "monotonic_cst": ["array-like", None],
+        "n_threads": [None, Integral],
     }
 
     @abstractmethod
@@ -143,6 +145,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         class_weight=None,
         ccp_alpha=0.0,
         monotonic_cst=None,
+        n_threads=None,
     ):
         self.criterion = criterion
         self.splitter = splitter
@@ -157,6 +160,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         self.class_weight = class_weight
         self.ccp_alpha = ccp_alpha
         self.monotonic_cst = monotonic_cst
+        self.n_threads = n_threads
 
     def get_depth(self):
         """Return the depth of the decision tree.
@@ -210,7 +214,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             are no missing values, return None.
         """
         estimator_name = estimator_name or self.__class__.__name__
-        common_kwargs = dict(estimator_name=estimator_name, input_name="X")
+        common_kwargs = {"estimator_name": estimator_name, "input_name": "X"}
 
         if not self._support_missing_values(X):
             assert_all_finite(X, **common_kwargs)
@@ -239,6 +243,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         missing_values_in_feature_mask=None,
     ):
         random_state = check_random_state(self.random_state)
+        self._n_threads = _openmp_effective_n_threads(self.n_threads)
 
         if check_input:
             # Need to validate separately here.
@@ -247,10 +252,12 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
 
             # _compute_missing_values_in_feature_mask will check for finite values and
             # compute the missing mask if the tree supports missing values
-            check_X_params = dict(
-                dtype=DTYPE, accept_sparse="csc", ensure_all_finite=False
-            )
-            check_y_params = dict(ensure_2d=False, dtype=None)
+            check_X_params = {
+                "dtype": DTYPE,
+                "accept_sparse": "csc",
+                "ensure_all_finite": False,
+            }
+            check_y_params = {"ensure_2d": False, "dtype": None}
             X, y = validate_data(
                 self, X, y, validate_separately=(check_X_params, check_y_params)
             )
@@ -355,8 +362,8 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
 
         if len(y) != n_samples:
             raise ValueError(
-                "Number of labels=%d does not match number of samples=%d"
-                % (len(y), n_samples)
+                f"Number of labels={len(y)} does not match number of "
+                f"samples={n_samples}"
             )
 
         if sample_weight is not None:
@@ -406,8 +413,8 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             monotonic_cst = np.asarray(self.monotonic_cst)
             if monotonic_cst.shape[0] != X.shape[1]:
                 raise ValueError(
-                    "monotonic_cst has shape {} but the input data "
-                    "X has {} features.".format(monotonic_cst.shape[0], X.shape[1])
+                    f"monotonic_cst has shape {monotonic_cst.shape[0]} but the input "
+                    f"data X has {X.shape[1]} features."
                 )
             valid_constraints = np.isin(monotonic_cst, (-1, 0, 1))
             if not np.all(valid_constraints):
@@ -438,6 +445,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
                 min_weight_leaf,
                 random_state,
                 monotonic_cst,
+                self._n_threads,
             )
 
         if is_classifier(self):
@@ -785,6 +793,12 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
         during fitting, ``random_state`` has to be fixed to an integer.
         See :term:`Glossary <random_state>` for details.
 
+    n_threads : int, default=None
+        Number of OpenMP threads to use for parts of the fitting procedure that
+        support OpenMP-based parallelism. ``None`` uses the default number of
+        threads (taking ``OMP_NUM_THREADS`` into account). ``n_threads=0`` is
+        invalid.
+
     max_leaf_nodes : int, default=None
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.
         Best nodes are defined as relative reduction in impurity.
@@ -970,6 +984,7 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
         min_weight_fraction_leaf=0.0,
         max_features=None,
         random_state=None,
+        n_threads=None,
         max_leaf_nodes=None,
         min_impurity_decrease=0.0,
         class_weight=None,
@@ -987,6 +1002,7 @@ class DecisionTreeClassifier(ClassifierMixin, BaseDecisionTree):
             max_leaf_nodes=max_leaf_nodes,
             class_weight=class_weight,
             random_state=random_state,
+            n_threads=n_threads,
             min_impurity_decrease=min_impurity_decrease,
             monotonic_cst=monotonic_cst,
             ccp_alpha=ccp_alpha,
@@ -1201,6 +1217,12 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
         during fitting, ``random_state`` has to be fixed to an integer.
         See :term:`Glossary <random_state>` for details.
 
+    n_threads : int, default=None
+        Number of OpenMP threads to use for parts of the fitting procedure that
+        support OpenMP-based parallelism. ``None`` uses the default number of
+        threads (taking ``OMP_NUM_THREADS`` into account). ``n_threads=0`` is
+        invalid.
+
     max_leaf_nodes : int, default=None
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.
         Best nodes are defined as relative reduction in impurity.
@@ -1349,6 +1371,7 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
         min_weight_fraction_leaf=0.0,
         max_features=None,
         random_state=None,
+        n_threads=None,
         max_leaf_nodes=None,
         min_impurity_decrease=0.0,
         ccp_alpha=0.0,
@@ -1374,6 +1397,7 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
             max_features=max_features,
             max_leaf_nodes=max_leaf_nodes,
             random_state=random_state,
+            n_threads=n_threads,
             min_impurity_decrease=min_impurity_decrease,
             ccp_alpha=ccp_alpha,
             monotonic_cst=monotonic_cst,
@@ -1536,6 +1560,12 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
     random_state : int, RandomState instance or None, default=None
         Used to pick randomly the `max_features` used at each split.
         See :term:`Glossary <random_state>` for details.
+
+    n_threads : int, default=None
+        Number of OpenMP threads to use for parts of the fitting procedure that
+        support OpenMP-based parallelism. ``None`` uses the default number of
+        threads (taking ``OMP_NUM_THREADS`` into account). ``n_threads=0`` is
+        invalid.
 
     max_leaf_nodes : int, default=None
         Grow a tree with ``max_leaf_nodes`` in best-first fashion.
@@ -1706,6 +1736,7 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
         min_weight_fraction_leaf=0.0,
         max_features="sqrt",
         random_state=None,
+        n_threads=None,
         max_leaf_nodes=None,
         min_impurity_decrease=0.0,
         class_weight=None,
@@ -1724,6 +1755,7 @@ class ExtraTreeClassifier(DecisionTreeClassifier):
             class_weight=class_weight,
             min_impurity_decrease=min_impurity_decrease,
             random_state=random_state,
+            n_threads=n_threads,
             ccp_alpha=ccp_alpha,
             monotonic_cst=monotonic_cst,
         )
@@ -1834,6 +1866,12 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
     random_state : int, RandomState instance or None, default=None
         Used to pick randomly the `max_features` used at each split.
         See :term:`Glossary <random_state>` for details.
+
+    n_threads : int, default=None
+        Number of OpenMP threads to use for parts of the fitting procedure that
+        support OpenMP-based parallelism. ``None`` uses the default number of
+        threads (taking ``OMP_NUM_THREADS`` into account). ``n_threads=0`` is
+        invalid.
 
     min_impurity_decrease : float, default=0.0
         A node will be split if this split induces a decrease of the impurity
@@ -1964,6 +2002,7 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
         min_weight_fraction_leaf=0.0,
         max_features=1.0,
         random_state=None,
+        n_threads=None,
         min_impurity_decrease=0.0,
         max_leaf_nodes=None,
         ccp_alpha=0.0,
@@ -1980,6 +2019,7 @@ class ExtraTreeRegressor(DecisionTreeRegressor):
             max_leaf_nodes=max_leaf_nodes,
             min_impurity_decrease=min_impurity_decrease,
             random_state=random_state,
+            n_threads=n_threads,
             ccp_alpha=ccp_alpha,
             monotonic_cst=monotonic_cst,
         )

--- a/sklearn/tree/_partitioner.pxd
+++ b/sklearn/tree/_partitioner.pxd
@@ -77,7 +77,7 @@ cdef class DensePartitioner:
     cdef char[::1] swap_buffer
 
     cdef void sort_samples_and_feature_values(
-        self, intp_t current_feature
+        self, intp_t current_feature, int n_threads
     ) noexcept nogil
     cdef void shift_missing_to_the_left(self) noexcept nogil
     cdef void init_node_split(
@@ -131,7 +131,7 @@ cdef class SparsePartitioner:
     cdef const uint8_t[::1] missing_values_in_feature_mask
 
     cdef void sort_samples_and_feature_values(
-        self, intp_t current_feature
+        self, intp_t current_feature, int n_threads
     ) noexcept nogil
     cdef void shift_missing_to_the_left(self) noexcept nogil
     cdef void init_node_split(

--- a/sklearn/tree/_partitioner.pyx
+++ b/sklearn/tree/_partitioner.pyx
@@ -22,6 +22,8 @@ from scipy.sparse import issparse
 
 from sklearn.tree._splitter cimport SplitRecord
 
+from cython.parallel cimport prange
+
 # Constant to switch between algorithm non zero value extract algorithm
 # in SparsePartitioner
 cdef float32_t EXTRACT_NNZ_SWITCH = 0.1
@@ -59,7 +61,7 @@ cdef class DensePartitioner:
         self.n_missing = 0
 
     cdef inline void sort_samples_and_feature_values(
-        self, intp_t current_feature
+        self, intp_t current_feature, int n_threads
     ) noexcept nogil:
         """Simultaneously sort based on the feature_values.
 
@@ -99,7 +101,7 @@ cdef class DensePartitioner:
         else:
             # When there are no missing values, we only need to copy the data into
             # feature_values
-            for i in range(self.start, self.end):
+            for i in prange(self.start, self.end, nogil=True, num_threads=n_threads):
                 feature_values[i] = X[samples[i], current_feature]
 
         sort(&feature_values[self.start], &samples[self.start], self.end - self.start - n_missing)
@@ -323,7 +325,8 @@ cdef class SparsePartitioner:
 
     cdef inline void sort_samples_and_feature_values(
         self,
-        intp_t current_feature
+        intp_t current_feature,
+        int n_threads,
     ) noexcept nogil:
         """Simultaneously sort based on the feature_values."""
         cdef:

--- a/sklearn/tree/_splitter.pxd
+++ b/sklearn/tree/_splitter.pxd
@@ -36,6 +36,7 @@ cdef class Splitter:
     cdef public intp_t max_features      # Number of features to test
     cdef public intp_t min_samples_leaf  # Min samples in a leaf
     cdef public float64_t min_weight_leaf   # Minimum weight in a leaf
+    cdef public int n_threads
 
     cdef object random_state             # Random state
     cdef uint32_t rand_r_state           # sklearn_rand_r random number state

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -68,6 +68,7 @@ cdef class Splitter:
         float64_t min_weight_leaf,
         object random_state,
         const int8_t[:] monotonic_cst,
+        int n_threads=1,
     ):
         """
         Parameters
@@ -104,6 +105,7 @@ cdef class Splitter:
         self.max_features = max_features
         self.min_samples_leaf = min_samples_leaf
         self.min_weight_leaf = min_weight_leaf
+        self.n_threads = n_threads
         self.random_state = random_state
         self.monotonic_cst = monotonic_cst
         self.with_monotonic_cst = monotonic_cst is not None
@@ -120,7 +122,8 @@ cdef class Splitter:
                              self.min_samples_leaf,
                              self.min_weight_leaf,
                              self.random_state,
-                             self.monotonic_cst), self.__getstate__())
+                             self.monotonic_cst,
+                             self.n_threads), self.__getstate__())
 
     cdef int init(
         self,
@@ -366,7 +369,7 @@ cdef inline int node_split_best(
         f_j += n_found_constants
         # f_j in the interval [n_total_constants, f_i[
         current_split.feature = features[f_j]
-        partitioner.sort_samples_and_feature_values(current_split.feature)
+        partitioner.sort_samples_and_feature_values(current_split.feature, splitter.n_threads)
         n_missing = partitioner.n_missing
         end_non_missing = end - n_missing
 

--- a/sklearn/tree/meson.build
+++ b/sklearn/tree/meson.build
@@ -7,6 +7,7 @@ tree_extension_metadata = {
      'override_options': ['optimization=3']},
   '_partitioner':
     {'sources': [cython_gen.process('_partitioner.pyx')],
+     'dependencies': [openmp_dep],
      'override_options': ['optimization=3']},
   '_criterion':
     {'sources': [cython_gen.process('_criterion.pyx')],
@@ -20,7 +21,7 @@ foreach ext_name, ext_dict : tree_extension_metadata
   py.extension_module(
     ext_name,
     [ext_dict.get('sources'), utils_cython_tree],
-    dependencies: [np_dep],
+    dependencies: [np_dep] + ext_dict.get('dependencies', []),
     override_options : ext_dict.get('override_options', []),
     subdir: 'sklearn/tree',
     install: true

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -79,6 +79,50 @@ CLF_TREES = {
     "ExtraTreeClassifier": ExtraTreeClassifier,
 }
 
+
+@pytest.mark.parametrize(
+    "Tree",
+    [
+        DecisionTreeClassifier,
+        DecisionTreeRegressor,
+        ExtraTreeClassifier,
+        ExtraTreeRegressor,
+    ],
+)
+@pytest.mark.parametrize("n_threads", [1, 2, 16, 64])
+def test_tree_n_threads_parameter(Tree, n_threads):
+    X, y = datasets.make_classification(
+        n_samples=50, n_features=5, n_informative=3, random_state=0
+    )
+    est = Tree(random_state=0, n_threads=n_threads)
+    est.fit(X, y)
+
+
+def test_tree_n_threads_zero_raises():
+    X, y = datasets.make_classification(
+        n_samples=50, n_features=5, n_informative=3, random_state=0
+    )
+    with pytest.raises(ValueError, match="n_threads = 0 is invalid"):
+        DecisionTreeClassifier(random_state=0, n_threads=0).fit(X, y)
+
+
+@pytest.mark.parametrize(
+    "Tree",
+    [
+        DecisionTreeClassifier,
+        ExtraTreeClassifier,
+    ],
+)
+def test_tree_results_equal_in_different_n_threads(Tree):
+    X, y = datasets.make_classification(
+        n_samples=100, n_features=10, n_informative=5, random_state=0
+    )
+    pred_1 = Tree(random_state=0, n_threads=1).fit(X, y).predict(X)
+    for n_threads in [2, 16, 64]:
+        pred = Tree(random_state=0, n_threads=n_threads).fit(X, y).predict(X)
+        assert_array_equal(pred_1, pred)
+
+
 REG_TREES = {
     "DecisionTreeRegressor": DecisionTreeRegressor,
     "ExtraTreeRegressor": ExtraTreeRegressor,


### PR DESCRIPTION
#### Reference Issues/PRs
See #33559

#### What does this implement/fix? Explain your changes.
This PR adds an `n_threads` parameter to tree estimators to enable OpenMP-based parallelism in parts of the tree fitting procedure.

User-facing API:
- `DecisionTreeClassifier`, `DecisionTreeRegressor`, `ExtraTreeClassifier`, and `ExtraTreeRegressor` now accept `n_threads` (default `None`).
- `n_threads=None` uses the default OpenMP thread setting (including `OMP_NUM_THREADS`); `n_threads=0` raises.

Implementation overview:
- Computes an effective thread count at fit time via `sklearn.utils._openmp_helpers._openmp_effective_n_threads` and stores it internally.
- Plumbs the thread count into the Cython splitter/partitioner stack.
- Parallelizes the dense feature-value extraction loop in the partitioner using `cython.parallel.prange(..., num_threads=n_threads)`. (Sorting remains single-threaded; this targets the data extraction step.)
- Ensures the `_partitioner` extension is built with OpenMP support when available.

Backwards compatibility:
- The Cython `Splitter` constructor keeps backward compatibility by providing a default for the newly-added `n_threads` argument, so existing call sites (including serialization-related tests) continue to work.

#### How was this tested?
- `python -m pytest sklearn/tree/tests/test_tree.py`
- In particular, the added tests cover multiple thread counts:
  - Parameter acceptance and fit for `n_threads` in `[1, 2, 16, 64]`.
  - Deterministic predictions across `n_threads` in `[1, 2, 16, 64]` for classifiers.

#### Any other comments?
Reviewers may want to pay particular attention to API consistency (naming vs `n_jobs` elsewhere), OpenMP availability/fallback behavior (OpenMP-disabled builds remain sequential), and determinism across thread counts.
