### PR TITLE
PCA: Vectorize Minka's MLE implementation for 40-50x speedup on most problem sizes

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.decomposition/33602.efficiency.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.decomposition/33602.efficiency.rst
@@ -1,0 +1,4 @@
+- Vectorized the inner loop of Minka's MLE in :func:`_assess_dimension`,
+  speeding up :class:`decomposition.PCA` with ``n_components='mle'`` by
+  ~45x for typical problem sizes.
+  By :user:`Jonathan Berg <jberg5>`.

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -103,7 +103,10 @@ def _assess_dimension(spectrum, rank, n_samples):
         # (s_i - s_j) * (1/s_j - 1/s_i) = (s_i - s_j)^2 / (s_i * s_j)
         vals = (si - sj) ** 2 / (si * sj)
         # Mask to upper triangle to avoid double-counting and log(0) on diagonal
-        mask = xp.asarray(np.triu(np.ones((rank, rank), dtype=bool), k=1))
+        mask = xp.asarray(
+            np.triu(np.ones((rank, rank), dtype=bool), k=1),
+            device=vals.device,
+        )
         n_pairs = rank * (rank - 1) // 2
         pa += float(xp.sum(xp.log(vals[mask]))) + n_pairs * log(n_samples)
 

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -112,7 +112,8 @@ def _assess_dimension(spectrum, rank, n_samples):
     si_A = s_signal[:, None]
     sj_A = s_noise[None, :]
     terms = (si_A - sj_A) * (1.0 / v - 1.0 / si_A)
-    pa += float(xp.sum(xp.log(terms))) + terms.size * log(n_samples)
+    n_signal_noise_pairs = rank * (n_features - rank)
+    pa += float(xp.sum(xp.log(terms))) + n_signal_noise_pairs * log(n_samples)
 
     ll = pu + pl + pv + pp - pa / 2.0 - rank * log(n_samples) / 2.0
 

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -105,7 +105,7 @@ def _assess_dimension(spectrum, rank, n_samples):
         # Mask to upper triangle to avoid double-counting and log(0) on diagonal
         mask = xp.asarray(
             np.triu(np.ones((rank, rank), dtype=bool), k=1),
-            device=vals.device,
+            device=device(vals),
         )
         n_pairs = rank * (rank - 1) // 2
         pa += float(xp.sum(xp.log(vals[mask]))) + n_pairs * log(n_samples)

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -85,11 +85,28 @@ def _assess_dimension(spectrum, rank, n_samples):
     pa = 0.0
     spectrum_ = xp.asarray(spectrum, copy=True)
     spectrum_[rank:n_features] = v
-    for i in range(rank):
-        for j in range(i + 1, spectrum.shape[0]):
-            pa += log(
-                (spectrum[i] - spectrum[j]) * (1.0 / spectrum_[j] - 1.0 / spectrum_[i])
-            ) + log(n_samples)
+
+    s_signal = spectrum[:rank]
+
+    # Block B: both indices in signal part (i < j < rank)
+    if rank > 1:
+        si = s_signal[:, None]  # (rank, 1)
+        sj = s_signal[None, :]  # (1, rank)
+        # (s_i - s_j) * (1/s_j - 1/s_i) = (s_i - s_j)^2 / (s_i * s_j)
+        vals = (si - sj) ** 2 / (si * sj)
+        # Upper triangle mask: i < j
+        mask = np.triu(np.ones((rank, rank), dtype=bool), k=1)
+        n_pairs_B = int(mask.sum())
+        pa += float(xp.sum(xp.log(vals[mask]))) + n_pairs_B * log(n_samples)
+
+    # Block A: i < rank, j >= rank (spectrum_[j] = v)
+    if n_features - rank > 0:
+        s_noise = spectrum[rank:]  # (n_features - rank,)
+        si_A = s_signal[:, None]  # (rank, 1)
+        sj_A = s_noise[None, :]  # (1, n_noise)
+        term_A = (si_A - sj_A) * (1.0 / v - 1.0 / si_A)
+        n_pairs_A = term_A.size
+        pa += float(xp.sum(xp.log(term_A))) + n_pairs_A * log(n_samples)
 
     ll = pu + pl + pv + pp - pa / 2.0 - rank * log(n_samples) / 2.0
 

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -90,11 +90,12 @@ def _assess_dimension(spectrum, rank, n_samples):
     # A literal implementation involves two loops:
     # for i in range(rank):
     #     for j in range(i+1, n_features):
-    # This ends up being O(n_features^2). However, we can do better by
-    # exploiting the piecewise nature of spectrum - it's one thing below
-    # rank (the actual eigenvalues) and another thing above it (v).
-    # By splitting the problem on this boundary we can take advantage of
-    # numpy vectorization.
+    # This is O(n_features^2) per call, and _infer_dimension calls
+    # it for every candidate rank, making the total O(n_features^3).
+    # We can do much better by exploiting the piecewise nature of
+    # spectrum_: it equals spectrum[:rank] for signal eigenvalues
+    # and v for noise eigenvalues. Splitting on this boundary lets
+    # us replace the Python loops with numpy vectorization.
     # Signal-signal pairs (i < j < rank): both eigenvalues are signal
     if rank > 1:
         si = s_signal[:, None]

--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -83,30 +83,35 @@ def _assess_dimension(spectrum, rank, n_samples):
     pp = log(2.0 * xp.pi) * (m + rank) / 2.0
 
     pa = 0.0
-    spectrum_ = xp.asarray(spectrum, copy=True)
-    spectrum_[rank:n_features] = v
-
     s_signal = spectrum[:rank]
 
-    # Block B: both indices in signal part (i < j < rank)
+    # Equation (27) from the paper.
+    # |A_Z| = ∏∏ (λ̂_j⁻¹ - λ̂_i⁻¹)(λ_i - λ_j) · N
+    # A literal implementation involves two loops:
+    # for i in range(rank):
+    #     for j in range(i+1, n_features):
+    # This ends up being O(n_features^2). However, we can do better by
+    # exploiting the piecewise nature of spectrum - it's one thing below
+    # rank (the actual eigenvalues) and another thing above it (v).
+    # By splitting the problem on this boundary we can take advantage of
+    # numpy vectorization.
+    # Signal-signal pairs (i < j < rank): both eigenvalues are signal
     if rank > 1:
-        si = s_signal[:, None]  # (rank, 1)
-        sj = s_signal[None, :]  # (1, rank)
+        si = s_signal[:, None]
+        sj = s_signal[None, :]
         # (s_i - s_j) * (1/s_j - 1/s_i) = (s_i - s_j)^2 / (s_i * s_j)
         vals = (si - sj) ** 2 / (si * sj)
-        # Upper triangle mask: i < j
-        mask = np.triu(np.ones((rank, rank), dtype=bool), k=1)
-        n_pairs_B = int(mask.sum())
-        pa += float(xp.sum(xp.log(vals[mask]))) + n_pairs_B * log(n_samples)
+        # Mask to upper triangle to avoid double-counting and log(0) on diagonal
+        mask = xp.asarray(np.triu(np.ones((rank, rank), dtype=bool), k=1))
+        n_pairs = rank * (rank - 1) // 2
+        pa += float(xp.sum(xp.log(vals[mask]))) + n_pairs * log(n_samples)
 
-    # Block A: i < rank, j >= rank (spectrum_[j] = v)
-    if n_features - rank > 0:
-        s_noise = spectrum[rank:]  # (n_features - rank,)
-        si_A = s_signal[:, None]  # (rank, 1)
-        sj_A = s_noise[None, :]  # (1, n_noise)
-        term_A = (si_A - sj_A) * (1.0 / v - 1.0 / si_A)
-        n_pairs_A = term_A.size
-        pa += float(xp.sum(xp.log(term_A))) + n_pairs_A * log(n_samples)
+    # Signal-noise pairs (i < rank, j >= rank): noise eigenvalues are all v
+    s_noise = spectrum[rank:]
+    si_A = s_signal[:, None]
+    sj_A = s_noise[None, :]
+    terms = (si_A - sj_A) * (1.0 / v - 1.0 / si_A)
+    pa += float(xp.sum(xp.log(terms))) + terms.size * log(n_samples)
 
     ll = pu + pl + pv + pp - pa / 2.0 - rank * log(n_samples) / 2.0
 


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Not sure if these types of performance-related PRs typically have an associated issue. Happy to create one if appropriate.


#### What does this implement/fix? Explain your changes.

`PCA(n_components="mle")` will attempt to determine the number of principal components to be retained. This is roughly O(n_features^3), since it iterates over
- every possible rank in n_features
- `range(rank)`
- `range(i+1, n_features)`

Where the latter two loops are needed to implement equation 27 in https://proceedings.neurips.cc/paper/2000/file/7503cfacd12053d309b6bed5c89de212-Paper.pdf.
Doing this in Python loops is slow, but appears necessary from a literal interpretation of the equation. However, if we exploit the piecewise nature of the "spectrum" vector, we can treat the computation as two more easily vectorizable (is that a word?) subproblems. The only downside is that we now materialize a rank**2 intermediate matrix, which will have a memory cost, but I don't think this is significant at realistic problem sizes.

For a "small" but informative case of using 5 years of daily returns of S&P500 stocks, and running
```python
pca = PCA(n_components="mle")
# data.shape = (1255, 490), I dropped a few tickers with missing data
pca.fit(data)
```

Measured `fit` time drops from **16.3s** to **0.4s** on my macbook, which is a **40x speedup**. On a gcloud c3 instance (to get an x86 comparison), I see a **50x speedup** on the same problem.

https://gist.github.com/jberg5/63aaa9aebfb92be8ad9b47fa62ab28dc

<img width="2384" height="770" alt="image" src="https://github.com/user-attachments/assets/66b430a0-301d-4780-a2f6-2208b1e46db8" />


#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

Claude (Opus 4.6) was instrumental here. I asked it to look for vectorization opportunities, and it spotted this one. Its first implementation was good but not great, so I spent a lot of (human!) time understanding and refining, and the code in this PR is something I stand behind.

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
