### PR TITLE
Fix #33454: validate OMP n_nonzero_coefs in sparse_encode

### DIFF
--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -369,6 +369,14 @@ def sparse_encode(
             "dictionary.shape: {} X.shape{}".format(dictionary.shape, X.shape)
         )
 
+    if algorithm == "omp" and n_nonzero_coefs is not None:
+        n_components = dictionary.shape[0]
+        if n_nonzero_coefs > n_components:
+            raise ValueError(
+                "For algorithm='omp', n_nonzero_coefs must be <= n_components "
+                f"(got n_nonzero_coefs={n_nonzero_coefs} and n_components={n_components})."
+            )
+
     _check_positive_coding(algorithm, positive)
 
     return _sparse_encode(

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -603,6 +603,14 @@ def test_sparse_encode_error_default_sparsity():
     code = ignore_warnings(sparse_encode)(X, D, algorithm="omp", n_nonzero_coefs=None)
     assert code.shape == (100, 2)
 
+def test_sparse_encode_omp_rejects_too_many_nonzero_coefs():
+    rng = np.random.RandomState(0)
+    X = rng.randn(2, 4)
+    dictionary = rng.randn(1, 4) # n_components = 1
+
+    err_msg = "n_nonzero_coefs must be <= n_components"
+    with pytest.raises(ValueError, match=err_msg):
+        sparse_encode(X, dictionary, algorithm="omp", n_nonzero_coefs=4)
 
 def test_sparse_coder_estimator():
     n_components = 12


### PR DESCRIPTION
When algorithm='omp', passing n_nonzero_coefs greater than the number of dictionary components currently fails deep in OMP with a confusing error. Add an early validation in sparse_encode with a clearer error message and a test.

<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
This patch improves input validation for sparse coding with algorithm="omp". When n_nonzero_coefs is larger than the number of dictionary components (n_components), the code previously failed deep in the OMP implementation with a confusing error message. I added an early check in sparse_encode to fail fast with a clear ValueError, and added a regression test (test_sparse_encode_omp_rejects_too_many_nonzero_coefs) to ensure the behavior stays correct.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding


#### Any other comments?
No

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
