### PR TITLE
FIX check_array raises IndexError when dtype is an empty list/tuple

### DIFF
--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -617,6 +617,20 @@ def test_check_array_dtype_stability():
     assert check_array(X, ensure_2d=False).dtype.kind == "i"
 
 
+def test_check_array_empty_dtype_list():
+    """Check that an empty list/tuple for dtype raises a ValueError."""
+    X = np.array([[1, 2], [3, 4]])
+    with pytest.raises(ValueError, match="dtype must not be an empty list"):
+        check_array(X, dtype=[])
+
+
+def test_check_array_empty_dtype_tuple():
+    """Check that an empty tuple for dtype raises a ValueError."""
+    X = np.array([[1, 2], [3, 4]])
+    with pytest.raises(ValueError, match="dtype must not be an empty list"):
+        check_array(X, dtype=())
+
+
 def test_check_array_dtype_warning():
     X_int_list = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     X_float32 = np.asarray(X_int_list, dtype=np.float32)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -928,6 +928,10 @@ def check_array(
             dtype = None
 
     if isinstance(dtype, (list, tuple)):
+        if not dtype:
+            raise ValueError(
+                "dtype must not be an empty list or tuple."
+            )
         if dtype_orig is not None and dtype_orig in dtype:
             # no dtype conversion required
             dtype = None


### PR DESCRIPTION
Closes #33582

## What does this fix?

When `check_array` receives an empty `dtype` list or tuple (e.g., `dtype=[]` or `dtype=()`), it raises an unhelpful `IndexError` instead of a clear `ValueError`. This happens because the code tries to access `dtype[0]` without first checking whether `dtype` is empty.

## Changes

- **sklearn/utils/validation.py**: Added a guard that raises a `ValueError` with a clear message when `dtype` is an empty list or tuple.
- **sklearn/utils/tests/test_validation.py**: Added two tests to verify that empty lists and tuples for `dtype` raise `ValueError`.

## Reproduction

```python
from sklearn.utils.validation import check_array
import numpy as np
check_array(np.array([1]), dtype=[])  # IndexError -> ValueError
```
