### PR TITLE
FIX rounding float numbers in fitted attributes HTML display 

### DIFF
--- a/sklearn/utils/_repr_html/fitted_attributes.py
+++ b/sklearn/utils/_repr_html/fitted_attributes.py
@@ -36,7 +36,7 @@ def _read_fitted_attr(value):
     r.maxstring = 9
 
     if isinstance(value, float):
-        value = round(value, 3)
+        return f"{value:.4g}"
 
     return html.escape(r.repr(value))
 

--- a/sklearn/utils/_repr_html/tests/test_attributes.py
+++ b/sklearn/utils/_repr_html/tests/test_attributes.py
@@ -4,7 +4,11 @@ import numpy as np
 import pytest
 
 from sklearn import config_context
-from sklearn.utils._repr_html.fitted_attributes import AttrsDict, _fitted_attr_html_repr
+from sklearn.utils._repr_html.fitted_attributes import (
+    AttrsDict,
+    _fitted_attr_html_repr,
+    _read_fitted_attr,
+)
 
 fitted_attrs = AttrsDict(
     fitted_attrs={
@@ -167,3 +171,15 @@ def test_pandas_series_fitted_attr():
         r"\s*</div>"
     )
     assert re.search(expected_html_fitted_attr, html_fitted_attr_out, flags=re.DOTALL)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (123.456, "123.5"),
+        (0.00123456, "0.001235"),
+        (1234567.0, "1.235e+06"),
+    ],
+)
+def test_read_fitted_attr_float_formatting(value, expected):
+    assert _read_fitted_attr(value) == expected


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes https://github.com/scikit-learn/scikit-learn/issues/33613

#### What does this implement/fix? Explain your changes.
Corrects rounding to 0 for very small numbers

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [X] Test/benchmark generation - but copilot suggested many more tests that I believe are not needed
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?
The snippet provided with the issue:
```from sklearn.linear_model import RidgeCV
import numpy as np


rng = np.random.RandomState(0)
y = rng.randn(100)
X = y[:, None]
alphas = np.logspace(-12, 12, 13)
regressor = RidgeCV(alphas=alphas).fit(X, y)
regressor
```
This is the rendered display now:
<img width="458" height="319" alt="Screenshot 2026-03-23 at 18 18 57" src="https://github.com/user-attachments/assets/c95628e9-2294-41b7-9b92-f4faf2d37689" />

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
