### PR TITLE
Avoid redundant validation in Binarizer.transform

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2261,6 +2261,7 @@ def binarize(X, *, threshold=0.0, copy=True):
     return _binarize_no_validation(X, threshold=threshold)
 
 
+
 def _binarize_no_validation(X, *, threshold):
     """Binarize data assuming X has already been validated.
 

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2258,6 +2258,16 @@ def binarize(X, *, threshold=0.0, copy=True):
            [1., 0., 0.]])
     """
     X = check_array(X, accept_sparse=["csr", "csc"], force_writeable=True, copy=copy)
+    return _binarize_no_validation(X, threshold=threshold)
+
+
+def _binarize_no_validation(X, *, threshold):
+    """Binarize data assuming X has already been validated.
+
+    This avoids repeated validation when ``binarize`` is called from
+    :meth:`Binarizer.transform`, which already runs ``validate_data``.
+    """
+
     if sparse.issparse(X):
         if threshold < 0:
             raise ValueError("Cannot binarize a sparse matrix with threshold < 0")
@@ -2408,7 +2418,7 @@ class Binarizer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
             copy=copy,
             reset=False,
         )
-        return binarize(X, threshold=self.threshold, copy=False)
+        return _binarize_no_validation(X, threshold=self.threshold)
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -2261,7 +2261,6 @@ def binarize(X, *, threshold=0.0, copy=True):
     return _binarize_no_validation(X, threshold=threshold)
 
 
-
 def _binarize_no_validation(X, *, threshold):
     """Binarize data assuming X has already been validated.
 


### PR DESCRIPTION
#### Reference Issues/PRs
None.

#### What does this implement/fix? Explain your changes.
- add `_binarize_no_validation` to reuse the binarization logic without re-validating inputs
- call the helper from `Binarizer.transform` after `validate_data`, removing the second validation/copy while keeping public behavior unchanged

#### AI usage disclosure
I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

#### Any other comments?
Tests attempted: `python3 -m pytest sklearn/preprocessing/tests/test_data.py -k binarizer --maxfail=1` (currently blocked locally until the package is built: ImportError for `sklearn.__check_build`).
