### PR TITLE
Fix brute KNeighborsClassifier p=1 with non‑numeric labels

### DIFF
--- a/sklearn/neighbors/_classification.py
+++ b/sklearn/neighbors/_classification.py
@@ -355,7 +355,7 @@ class KNeighborsClassifier(KNeighborsMixin, ClassifierMixin, NeighborsBase):
                     k=self.n_neighbors,
                     weights=self.weights,
                     Y_labels=self._y,
-                    unique_Y_labels=self.classes_,
+                    unique_Y_labels=np.unique(self._y),
                     metric=metric,
                     metric_kwargs=metric_kwargs,
                     # `strategy="parallel_on_X"` has in practice be shown
@@ -801,7 +801,7 @@ class RadiusNeighborsClassifier(RadiusNeighborsMixin, ClassifierMixin, Neighbors
                 radius=self.radius,
                 weights=self.weights,
                 Y_labels=self._y,
-                unique_Y_labels=self.classes_,
+                unique_Y_labels=np.unique(self._y),
                 outlier_label=self.outlier_label,
                 metric=metric,
                 metric_kwargs=metric_kwargs,

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -752,6 +752,21 @@ def test_kneighbors_classifier_predict_proba(global_dtype):
     assert_allclose(real_prob, y_prob)
 
 
+def test_kneighbors_classifier_brute_manhattan_non_numeric_labels(global_dtype):
+    """`algorithm=\"brute\"` with p=1 should work with string labels."""
+    rng = np.random.RandomState(0)
+    X = rng.normal(size=(6, 4)).astype(global_dtype, copy=False)
+    y = np.array(["foo", "bar", "foo", "bar", "foo", "bar"])
+
+    clf = neighbors.KNeighborsClassifier(algorithm="brute", p=1)
+    clf.fit(X, y)
+
+    proba = clf.predict_proba(X[:2])
+    assert proba.shape == (2, 2)
+    assert_allclose(proba.sum(axis=1), 1)
+    assert_array_equal(clf.classes_, np.array(["bar", "foo"]))
+
+
 @pytest.mark.parametrize("algorithm", ALGORITHMS)
 @pytest.mark.parametrize("weights", WEIGHTS)
 def test_radius_neighbors_classifier(


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #33034.

#### What does this implement/fix? Explain your changes.
- pass encoded label indices to ArgKminClassMode so brute+p=1 handles non-numeric labels
- align RadiusNeighbors brute fast path to use the same encoded indices
- add a regression test covering brute Manhattan KNN with string labels

#### AI usage disclosure
I used AI assistance for:
- [x] Code generation
- [ ] Test/benchmark generation
- [ ] Documentation
- [ ] Research and understanding

#### Testing
- python3 -m pytest sklearn/neighbors/tests/test_neighbors.py -k brute_manhattan_non_numeric_labels
  (locally blocked until scikit-learn is built: ImportError for sklearn.__check_build)