### PR TITLE
DOC fix colors and typos in example on Multinomial and One-vs-Rest Decision Boundaries

### DIFF
--- a/examples/linear_model/plot_logistic_multinomial.py
+++ b/examples/linear_model/plot_logistic_multinomial.py
@@ -25,14 +25,12 @@ the line when the probability estimate for a class is of 0.5.
 # more challenging. This results in a 2D dataset with three overlapping classes,
 # suitable for demonstrating the differences between multinomial and one-vs-rest
 # logistic regression.
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
 from sklearn.datasets import make_blobs
 
-# get the first three colors from the "tab10" colormap for easily distinguishable colors
-cmap = mpl.colors.ListedColormap((plt.get_cmap("tab10").colors[:3]))
+cmap = "coolwarm"
 
 centers = [[-5, 0], [0, 1.5], [5, -1]]
 X, y = make_blobs(n_samples=1_000, centers=centers, random_state=40)
@@ -90,7 +88,7 @@ for model, title, ax in [
         ax=ax,
         response_method="predict",
         alpha=0.8,
-        # "tab10" is the default multiclass colormap for < 10 classes
+        multiclass_colors=cmap,
     )
     scatter = ax.scatter(X[:, 0], X[:, 1], c=y, cmap=cmap, edgecolor="k")
     legend = ax.legend(*scatter.legend_elements(), title="Classes")
@@ -114,7 +112,7 @@ for model, title, ax in [
 #
 # We also visualize the hyperplanes that correspond to the line when the probability
 # estimate for a class is 0.5.
-def plot_hyperplanes(classifier, X, ax):
+def plot_hyperplanes(classifier, X, ax, colors):
     xmin, xmax = X[:, 0].min(), X[:, 0].max()
     ymin, ymax = X[:, 1].min(), X[:, 1].max()
     ax.set(xlim=(xmin, xmax), ylim=(ymin, ymax))
@@ -126,12 +124,12 @@ def plot_hyperplanes(classifier, X, ax):
         coef = classifier.coef_
         intercept = classifier.intercept_
 
-    for i in range(coef.shape[0]):
+    for i, color in zip(range(coef.shape[0]), colors):
         w = coef[i]
         a = -w[0] / w[1]
         xx = np.linspace(xmin, xmax)
         yy = a * xx - (intercept[i]) / w[1]
-        ax.plot(xx, yy, "--", linewidth=3, label=f"Class {i}")
+        ax.plot(xx, yy, "--", color=color, linewidth=3, label=f"Class {i}")
 
     return ax.get_legend_handles_labels()
 
@@ -147,7 +145,9 @@ for model, title, ax in [
     ),
     (logistic_regression_ovr, "One-vs-Rest Logistic Regression Hyperplanes", ax2),
 ]:
-    hyperplane_handles, hyperplane_labels = plot_hyperplanes(model, X, ax)
+    hyperplane_handles, hyperplane_labels = plot_hyperplanes(
+        model, X, ax, colors=["blue", "gray", "red"]
+    )
     scatter = ax.scatter(X[:, 0], X[:, 1], c=y, cmap=cmap, edgecolor="k")
     scatter_handles, scatter_labels = scatter.legend_elements()
 

--- a/examples/linear_model/plot_logistic_multinomial.py
+++ b/examples/linear_model/plot_logistic_multinomial.py
@@ -18,17 +18,21 @@ the line when the probability estimate for a class is of 0.5.
 # Dataset Generation
 # ------------------
 #
-# We generate a synthetic dataset using :func:`~sklearn.datasets.make_blobs` function.
-# The dataset consists of 1,000 samples from three different classes,
+# We generate a synthetic dataset using the :func:`~sklearn.datasets.make_blobs`
+# function. The dataset consists of 1,000 samples from three different classes,
 # centered around [-5, 0], [0, 1.5], and [5, -1]. After generation, we apply a linear
-# transformation to introduce some correlation between features and make the problem
+# transformation to introduce some correlation between the features to make the problem
 # more challenging. This results in a 2D dataset with three overlapping classes,
 # suitable for demonstrating the differences between multinomial and one-vs-rest
 # logistic regression.
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
 from sklearn.datasets import make_blobs
+
+# get the first three colors from the "tab10" colormap for easily distinguishable colors
+cmap = mpl.colors.ListedColormap((plt.get_cmap("tab10").colors[:3]))
 
 centers = [[-5, 0], [0, 1.5], [5, -1]]
 X, y = make_blobs(n_samples=1_000, centers=centers, random_state=40)
@@ -37,7 +41,7 @@ X = np.dot(X, transformation)
 
 fig, ax = plt.subplots(figsize=(6, 4))
 
-scatter = ax.scatter(X[:, 0], X[:, 1], c=y, edgecolor="black")
+scatter = ax.scatter(X[:, 0], X[:, 1], c=y, cmap=cmap, edgecolor="black")
 ax.set(title="Synthetic Dataset", xlabel="Feature 1", ylabel="Feature 2")
 _ = ax.legend(*scatter.legend_elements(), title="Classes")
 
@@ -86,8 +90,9 @@ for model, title, ax in [
         ax=ax,
         response_method="predict",
         alpha=0.8,
+        # "tab10" is the default multiclass colormap for < 10 classes
     )
-    scatter = ax.scatter(X[:, 0], X[:, 1], c=y, edgecolor="k")
+    scatter = ax.scatter(X[:, 0], X[:, 1], c=y, cmap=cmap, edgecolor="k")
     legend = ax.legend(*scatter.legend_elements(), title="Classes")
     ax.add_artist(legend)
     ax.set_title(title)
@@ -108,7 +113,7 @@ for model, title, ax in [
 # --------------------------
 #
 # We also visualize the hyperplanes that correspond to the line when the probability
-# estimate for a class is of 0.5.
+# estimate for a class is 0.5.
 def plot_hyperplanes(classifier, X, ax):
     xmin, xmax = X[:, 0].min(), X[:, 0].max()
     ymin, ymax = X[:, 1].min(), X[:, 1].max()
@@ -143,7 +148,7 @@ for model, title, ax in [
     (logistic_regression_ovr, "One-vs-Rest Logistic Regression Hyperplanes", ax2),
 ]:
     hyperplane_handles, hyperplane_labels = plot_hyperplanes(model, X, ax)
-    scatter = ax.scatter(X[:, 0], X[:, 1], c=y, edgecolor="k")
+    scatter = ax.scatter(X[:, 0], X[:, 1], c=y, cmap=cmap, edgecolor="k")
     scatter_handles, scatter_labels = scatter.legend_elements()
 
     all_handles = hyperplane_handles + scatter_handles

--- a/examples/linear_model/plot_logistic_multinomial.py
+++ b/examples/linear_model/plot_logistic_multinomial.py
@@ -129,7 +129,7 @@ def plot_hyperplanes(classifier, X, ax, colors):
         a = -w[0] / w[1]
         xx = np.linspace(xmin, xmax)
         yy = a * xx - (intercept[i]) / w[1]
-        ax.plot(xx, yy, "--", color=color, linewidth=3, label=f"Class {i}")
+        ax.plot(xx, yy, "--", color=color, linewidth=4, label=f"Class {i}")
 
     return ax.get_legend_handles_labels()
 
@@ -146,7 +146,7 @@ for model, title, ax in [
     (logistic_regression_ovr, "One-vs-Rest Logistic Regression Hyperplanes", ax2),
 ]:
     hyperplane_handles, hyperplane_labels = plot_hyperplanes(
-        model, X, ax, colors=["blue", "gray", "red"]
+        model, X, ax, colors=["blue", "dimgray", "red"]
     )
     scatter = ax.scatter(X[:, 0], X[:, 1], c=y, cmap=cmap, edgecolor="k")
     scatter_handles, scatter_labels = scatter.legend_elements()


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #33557 

#### What does this implement/fix? Explain your changes.
Fixes the color inconsistency between scatter plot and decision boundary/hyperplanes in the example on [Decision Boundaries of Multinomial and One-vs-Rest Logistic Regression](https://scikit-learn.org/dev/auto_examples/linear_model/plot_logistic_multinomial.html) (`plot_logistic_multinomial.py`) ~to use the first three colors of the `"tab10"` colormap consistently throughout the example. (This was set as the default for the `DecisionBoundaryDisplay` for multiclass with < 10 classes.)~
EDIT: After consulting with @adrinjalali, I changed it to use the `coolwarm` colormap, as orange and green can be hard to distinguishable in the scatterplot and hyperplanes (see also https://www.color-blindness.com/coblis-color-blindness-simulator/).

From
<img width="790" height="333" alt="image" src="https://github.com/user-attachments/assets/eaff4d4c-373d-4c0f-906c-991d3dd09298" />
to
<img width="534" height="391" alt="image" src="https://github.com/user-attachments/assets/f26b007f-4ed9-437f-bc68-cee0a146573f" />
and
<img width="980" height="466" alt="image" src="https://github.com/user-attachments/assets/fe56d194-95df-4c1f-a2cf-5af98f5c6f59" />
and 
<img width="980" height="449" alt="image" src="https://github.com/user-attachments/assets/d43fa52e-a055-41e2-bc8a-e6f89e05c857" />

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?

Also fixes some typos/wording on the side.

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
