### PR TITLE
Always try to use dlpack-capable `move_to` for NumPy conversions and only use `_convert_to_numpy` as a fallback

### DIFF
--- a/doc/whats_new/upcoming_changes/array-api/33623.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/array-api/33623.enhancement.rst
@@ -1,0 +1,5 @@
+- Internal NumPy CPU conversions now always attempt a generic DLPack-based
+  transfer and only fallback to library-specific methods when necessary. This
+  should ease support for additional array API and DLPack compliant input types
+  without extending the ad hoc conversion helpers.
+  By :user:`Olivier Grisel <ogrisel>`.

--- a/sklearn/_loss/tests/test_link.py
+++ b/sklearn/_loss/tests/test_link.py
@@ -11,7 +11,7 @@ from sklearn._loss.link import (
     _inclusive_low_high,
 )
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
+    move_to,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._testing import _array_api_for_tests
@@ -122,7 +122,7 @@ def test_link_inverse_array_api(
     with config_context(array_api_dispatch=True):
         raw_prediction_xp = xp.asarray(raw_prediction.astype(dtype_name), device=device)
         assert_allclose(
-            _convert_to_numpy(link.inverse(raw_prediction_xp), xp=xp),
+            move_to(link.inverse(raw_prediction_xp), xp=np, device="cpu"),
             link.inverse(raw_prediction),
             rtol=rtol,
         )
@@ -130,7 +130,7 @@ def test_link_inverse_array_api(
         y_pred = link.inverse(raw_prediction)
         y_pred_xp = xp.asarray(y_pred.astype(dtype_name), device=device)
         assert_allclose(
-            _convert_to_numpy(link.link(y_pred_xp), xp=xp),
+            move_to(link.link(y_pred_xp), xp=np, device="cpu"),
             link.link(y_pred),
             rtol=rtol,
         )

--- a/sklearn/_loss/tests/test_loss.py
+++ b/sklearn/_loss/tests/test_loss.py
@@ -35,7 +35,7 @@ from sklearn._loss.loss import (
 from sklearn.utils import assert_all_finite
 from sklearn.utils._array_api import (
     _atol_for_type,
-    _convert_to_numpy,
+    move_to,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._array_api import (
@@ -1405,7 +1405,7 @@ def test_loss_array_api(
         result_xp, result_np, raw_prediction_xp, xp, rtol, atol
     ):
         assert_allclose(
-            _convert_to_numpy(result_xp, xp=xp), result_np, rtol=rtol, atol=atol
+            move_to(result_xp, xp=np, device="cpu"), result_np, rtol=rtol, atol=atol
         )
         assert result_xp.dtype == raw_prediction_xp.dtype
         assert array_api_device(result_xp) == array_api_device(raw_prediction_xp)

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -33,7 +33,6 @@ from sklearn.preprocessing import LabelEncoder, label_binarize
 from sklearn.svm import LinearSVC
 from sklearn.utils import Bunch, _safe_indexing, column_or_1d, get_tags, indexable
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
     _is_numpy_namespace,
     get_namespace,
     get_namespace_and_device,
@@ -556,7 +555,7 @@ class CalibratedClassifierCV(ClassifierMixin, MetaEstimatorMixin, BaseEstimator)
         check_is_fitted(self)
         class_indices = xp.argmax(self.predict_proba(X), axis=1)
         if isinstance(self.classes_[0], str):
-            class_indices = _convert_to_numpy(class_indices, xp=xp)
+            class_indices = move_to(class_indices, xp=np, device="cpu")
 
         return self.classes_[class_indices]
 

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -13,7 +13,7 @@ from sklearn.decomposition import PCA
 from sklearn.decomposition._pca import _assess_dimension, _infer_dimension
 from sklearn.utils._array_api import (
     _atol_for_type,
-    _convert_to_numpy,
+    move_to,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._array_api import device as array_device
@@ -954,7 +954,7 @@ def check_array_api_get_precision(
         assert precision_xp.dtype == iris_xp.dtype
 
         assert_allclose(
-            _convert_to_numpy(precision_xp, xp=xp),
+            move_to(precision_xp, xp=np, device="cpu"),
             precision_np,
             rtol=rtol,
             atol=_atol_for_type(dtype_name),
@@ -964,7 +964,7 @@ def check_array_api_get_precision(
         assert covariance_xp.dtype == iris_xp.dtype
 
         assert_allclose(
-            _convert_to_numpy(covariance_xp, xp=xp),
+            move_to(covariance_xp, xp=np, device="cpu"),
             covariance_np,
             rtol=rtol,
             atol=_atol_for_type(dtype_name),
@@ -1067,11 +1067,11 @@ def test_pca_mle_array_api_compliance(
         est_xp.fit(X_xp, y_xp)
         components_xp = est_xp.components_
         assert array_device(components_xp) == array_device(X_xp)
-        components_xp_np = _convert_to_numpy(components_xp, xp=xp)
+        components_xp_np = move_to(components_xp, xp=np, device="cpu")
 
         explained_variance_xp = est_xp.explained_variance_
         assert array_device(explained_variance_xp) == array_device(X_xp)
-        explained_variance_xp_np = _convert_to_numpy(explained_variance_xp, xp=xp)
+        explained_variance_xp_np = move_to(explained_variance_xp, xp=np, device="cpu")
 
     assert components_xp_np.dtype == components_np.dtype
     assert components_xp_np.shape[1] == components_np.shape[1]

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -25,12 +25,12 @@ from sklearn.utils import _align_api_if_sparse, check_array, check_random_state
 from sklearn.utils._array_api import (
     _asarray_with_order,
     _average,
-    _convert_to_numpy,
     _expit,
     _is_numpy_namespace,
     get_namespace,
     get_namespace_and_device,
     indexing_dtype,
+    move_to,
     supported_float_dtypes,
 )
 from sklearn.utils._param_validation import Interval
@@ -396,7 +396,7 @@ class LinearClassifierMixin(ClassifierMixin):
         # predictions according to the namespace of `self.classes_` i.e. numpy.
         xp_classes, _ = get_namespace(self.classes_)
         if _is_numpy_namespace(xp_classes):
-            indices = _convert_to_numpy(indices, xp=xp)
+            indices = move_to(indices, xp=np, device="cpu")
 
         return xp_classes.take(self.classes_, indices, axis=0)
 

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -24,7 +24,6 @@ from sklearn.linear_model._linear_loss import LinearModelLoss
 from sklearn.utils import check_array
 from sklearn.utils._array_api import (
     _average,
-    _convert_to_numpy,
     _is_numpy_namespace,
     _matching_numpy_dtype,
     get_namespace,
@@ -256,10 +255,10 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
         loss_dtype_np = _matching_numpy_dtype(X, xp=xp)
         if self.warm_start and hasattr(self, "coef_"):
             coef_xp, _ = get_namespace(self.coef_)
-            coef = _convert_to_numpy(self.coef_, xp=coef_xp)
+            coef = move_to(self.coef_, xp=np, device="cpu")
             if self.fit_intercept:
                 # LinearModelLoss needs intercept at the end of coefficient array.
-                intercept = _convert_to_numpy(self.intercept_, xp=coef_xp)
+                intercept = move_to(self.intercept_, xp=np, device="cpu")
                 coef = np.concatenate((coef, np.array([intercept])))
             coef = coef.astype(loss_dtype_np, copy=False)
         else:

--- a/sklearn/linear_model/_glm/tests/test_glm.py
+++ b/sklearn/linear_model/_glm/tests/test_glm.py
@@ -30,7 +30,7 @@ from sklearn.metrics import d2_tweedie_score, mean_poisson_deviance
 from sklearn.model_selection import train_test_split
 from sklearn.utils._array_api import (
     _atol_for_type,
-    _convert_to_numpy,
+    move_to,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._array_api import (
@@ -1205,14 +1205,14 @@ def test_poisson_regressor_array_api_compliance(
             attr_xp = getattr(glm_xp, attr_name)
             attr_np = getattr(glm_np, attr_name)
             assert_allclose(
-                _convert_to_numpy(attr_xp, xp=xp), attr_np, rtol=rtol, atol=atol
+                move_to(attr_xp, xp=np, device="cpu"), attr_np, rtol=rtol, atol=atol
             )
             assert attr_xp.dtype == X_xp.dtype
             assert array_api_device(attr_xp) == array_api_device(X_xp)
 
         predict_xp = glm_xp.predict(X_xp)
         assert_allclose(
-            _convert_to_numpy(predict_xp, xp=xp),
+            move_to(predict_xp, xp=np, device="cpu"),
             predict_np,
             rtol=rtol,
             atol=atol,

--- a/sklearn/linear_model/_linear_loss.py
+++ b/sklearn/linear_model/_linear_loss.py
@@ -9,9 +9,9 @@ import numpy as np
 from scipy import sparse
 
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
     get_namespace,
     get_namespace_and_device,
+    move_to,
 )
 from sklearn.utils._sparse import _align_api_if_sparse
 from sklearn.utils.extmath import safe_sparse_dot, squared_norm
@@ -355,7 +355,7 @@ class LinearModelLoss:
             grad = np.empty_like(coef, dtype=weights.dtype)
             X_grad = X.T @ grad_pointwise
             grad[:n_features] = (
-                _convert_to_numpy(X_grad, xp=xp) + l2_reg_strength * weights
+                move_to(X_grad, xp=np, device="cpu") + l2_reg_strength * weights
             )
             if self.fit_intercept:
                 grad[-1] = xp.sum(grad_pointwise)
@@ -367,10 +367,12 @@ class LinearModelLoss:
             # grad_pointwise.shape = (n_samples, n_classes)
             grad_X = grad_pointwise.T @ X
             grad[:, :n_features] = (
-                _convert_to_numpy(grad_X, xp) + l2_reg_strength * weights
+                move_to(grad_X, xp=np, device="cpu") + l2_reg_strength * weights
             )
             if self.fit_intercept:
-                grad[:, -1] = _convert_to_numpy(xp.sum(grad_pointwise, axis=0), xp=xp)
+                grad[:, -1] = move_to(
+                    xp.sum(grad_pointwise, axis=0), xp=np, device="cpu"
+                )
             if coef.ndim == 1:
                 grad = grad.ravel(order="F")
 

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -40,11 +40,11 @@ from sklearn.utils import (
     compute_class_weight,
 )
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
     _is_numpy_namespace,
     _matching_numpy_dtype,
     get_namespace,
     get_namespace_and_device,
+    move_to,
     size,
 )
 from sklearn.utils._param_validation import Hidden, Interval, StrOptions
@@ -1328,9 +1328,9 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
         else:
             warm_start_coef = None
         if warm_start_coef is not None:
-            warm_start_coef = _convert_to_numpy(warm_start_coef, xp=xp)
+            warm_start_coef = move_to(warm_start_coef, xp=np, device="cpu")
             if self.fit_intercept:
-                intercept_np = _convert_to_numpy(self.intercept_, xp=xp)
+                intercept_np = move_to(self.intercept_, xp=np, device="cpu")
                 warm_start_coef = np.concatenate(
                     [warm_start_coef, intercept_np[:, None]], axis=1
                 )

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -38,7 +38,7 @@ from sklearn.svm import l1_min_c
 from sklearn.utils import compute_class_weight, shuffle
 from sklearn.utils._array_api import (
     _atol_for_type,
-    _convert_to_numpy,
+    move_to,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._array_api import (
@@ -2786,14 +2786,14 @@ def test_logistic_regression_array_api_compliance(
             attr_xp = getattr(lr_xp, attr_name)
             attr_np = getattr(lr_np, attr_name)
             assert_allclose(
-                _convert_to_numpy(attr_xp, xp=xp), attr_np, rtol=rtol, atol=atol
+                move_to(attr_xp, xp=np, device="cpu"), attr_np, rtol=rtol, atol=atol
             )
             assert attr_xp.dtype == X_xp.dtype
             assert array_api_device(attr_xp) == array_api_device(X_xp)
 
         predict_proba_xp = lr_xp.predict_proba(X_xp)
         assert_allclose(
-            _convert_to_numpy(predict_proba_xp, xp=xp),
+            move_to(predict_proba_xp, xp=np, device="cpu"),
             predict_proba_np,
             rtol=rtol,
             atol=atol,
@@ -2803,7 +2803,7 @@ def test_logistic_regression_array_api_compliance(
 
         predict_log_proba_xp = lr_xp.predict_log_proba(X_xp)
         assert_allclose(
-            _convert_to_numpy(predict_log_proba_xp, xp=xp),
+            move_to(predict_log_proba_xp, xp=np, device="cpu"),
             preditct_log_proba_np,
             rtol=rtol,
             atol=atol,
@@ -2813,7 +2813,7 @@ def test_logistic_regression_array_api_compliance(
 
         prediction_xp = lr_xp.predict(X_xp)
         if not use_str_y:
-            prediction_xp = _convert_to_numpy(prediction_xp, xp=xp)
+            prediction_xp = move_to(prediction_xp, xp=np, device="cpu")
         assert_array_equal(prediction_xp, prediction_np)
 
 

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -44,7 +44,7 @@ from sklearn.utils import check_random_state
 from sklearn.utils._array_api import (
     _NUMPY_NAMESPACE_NAMES,
     _atol_for_type,
-    _convert_to_numpy,
+    move_to,
     yield_namespace_device_dtype_combinations,
     yield_namespaces,
 )
@@ -1429,7 +1429,7 @@ def check_array_api_attributes(
         assert coef_xp.dtype == X_iris_xp.dtype
 
         assert_allclose(
-            _convert_to_numpy(coef_xp, xp=xp),
+            move_to(coef_xp, xp=np, device="cpu"),
             coef_np,
             rtol=rtol,
             atol=_atol_for_type(dtype_name),
@@ -1439,7 +1439,7 @@ def check_array_api_attributes(
         assert intercept_xp.dtype == X_iris_xp.dtype
 
         assert_allclose(
-            _convert_to_numpy(intercept_xp, xp=xp),
+            move_to(intercept_xp, xp=np, device="cpu"),
             intercept_np,
             rtol=rtol,
             atol=_atol_for_type(dtype_name),
@@ -1500,7 +1500,7 @@ def test_ridge_classifier_multilabel_array_api(
         ridge_xp = estimator.fit(X_xp, y_xp)
         pred_xp = ridge_xp.predict(X_xp)
         assert pred_xp.shape == pred_np.shape == y.shape
-        assert_allclose(_convert_to_numpy(pred_xp, xp=xp), pred_np)
+        assert_allclose(move_to(pred_xp, xp=np, device="cpu"), pred_np)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -31,7 +31,6 @@ from sklearn.utils import (
 from sklearn.utils._array_api import (
     _average,
     _bincount,
-    _convert_to_numpy,
     _count_nonzero,
     _fill_diagonal,
     _find_matching_floating_dtype,
@@ -538,12 +537,12 @@ def confusion_matrix(
     # counting operations implemented by SciPy in the coo_matrix constructor.
     # The final results will be converted back to the input namespace and device
     # for the sake of consistency with other metric functions with array API support.
-    y_true = _convert_to_numpy(y_true, xp)
-    y_pred = _convert_to_numpy(y_pred, xp)
+    y_true = move_to(y_true, xp=np, device="cpu")
+    y_pred = move_to(y_pred, xp=np, device="cpu")
     if sample_weight is None:
         sample_weight = np.ones(y_true.shape[0], dtype=np.int64)
     else:
-        sample_weight = _convert_to_numpy(sample_weight, xp)
+        sample_weight = move_to(sample_weight, xp=np, device="cpu")
 
     if len(sample_weight) > 0:
         y_type, y_true, y_pred, sample_weight = _check_targets(
@@ -564,7 +563,7 @@ def confusion_matrix(
     if labels is None:
         labels = unique_labels(y_true, y_pred)
     else:
-        labels = _convert_to_numpy(labels, xp)
+        labels = move_to(labels, xp=np, device="cpu")
         n_labels = labels.size
         if n_labels == 0:
             raise ValueError("'labels' should contain at least one label.")

--- a/sklearn/metrics/cluster/_unsupervised.py
+++ b/sklearn/metrics/cluster/_unsupervised.py
@@ -19,10 +19,10 @@ from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import _safe_indexing, check_random_state, check_X_y
 from sklearn.utils._array_api import (
     _average,
-    _convert_to_numpy,
     _is_numpy_namespace,
     _max_precision_float_dtype,
     get_namespace_and_device,
+    move_to,
     xpx,
 )
 from sklearn.utils._param_validation import Interval, StrOptions, validate_params
@@ -376,7 +376,7 @@ def calinski_harabasz_score(X, labels):
     if _is_numpy_namespace(xp) and not is_numpy_array(X):
         # This is required to handle the case where `array_api_dispatch` is False but
         # we are still dealing with `X` as a non-NumPy array e.g. a PyTorch tensor.
-        X = _convert_to_numpy(X, xp=xp)
+        X = move_to(X, xp=np, device="cpu")
     else:
         X = xp.astype(X, _max_precision_float_dtype(xp, device_), copy=False)
     X, labels = check_X_y(X, labels)

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -85,9 +85,9 @@ from sklearn.preprocessing import LabelBinarizer
 from sklearn.utils import shuffle
 from sklearn.utils._array_api import (
     _atol_for_type,
-    _convert_to_numpy,
     _max_precision_float_dtype,
     get_namespace,
+    move_to,
     yield_mixed_namespace_input_permutations,
     yield_namespace_device_dtype_combinations,
 )
@@ -2061,7 +2061,7 @@ def check_array_api_metric(
 
     def _check_metric_matches(metric_a, metric_b, convert_a=False):
         if convert_a:
-            metric_a = _convert_to_numpy(xp.asarray(metric_a), xp)
+            metric_a = move_to(xp.asarray(metric_a), xp=np, device="cpu")
         assert_allclose(metric_a, metric_b, atol=_atol_for_type(dtype_name))
 
     def _check_each_metric_matches(metric_a, metric_b, convert_a=False):

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -49,8 +49,8 @@ from sklearn.metrics.pairwise import (
 )
 from sklearn.preprocessing import normalize
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
     get_namespace,
+    move_to,
     xpx,
     yield_namespace_device_dtype_combinations,
 )
@@ -169,7 +169,7 @@ def test_pairwise_distances_array_api(array_namespace, device_name, dtype_name, 
     with config_context(array_api_dispatch=True):
         # Test with Y=None
         D_xp = pairwise_distances(X_xp, metric=metric)
-        D_xp_np = _convert_to_numpy(D_xp, xp=xp)
+        D_xp_np = move_to(D_xp, xp=np, device="cpu")
         assert get_namespace(D_xp)[0].__name__ == xp.__name__
         assert D_xp.device == X_xp.device
         assert D_xp.dtype == X_xp.dtype
@@ -179,7 +179,7 @@ def test_pairwise_distances_array_api(array_namespace, device_name, dtype_name, 
 
         # Test with Y=Y_np/Y_xp
         D_xp = pairwise_distances(X_xp, Y=Y_xp, metric=metric)
-        D_xp_np = _convert_to_numpy(D_xp, xp=xp)
+        D_xp_np = move_to(D_xp, xp=np, device="cpu")
         assert get_namespace(D_xp)[0].__name__ == xp.__name__
         assert D_xp.device == X_xp.device
         assert D_xp.dtype == X_xp.dtype
@@ -417,13 +417,13 @@ def test_pairwise_parallel_array_api(
             Y_np = None if y_val is None else Y_np
 
             n_job1_xp = func(X_xp, Y_xp, metric=metric, n_jobs=1, **kwds)
-            n_job1_xp_np = _convert_to_numpy(n_job1_xp, xp=xp)
+            n_job1_xp_np = move_to(n_job1_xp, xp=np, device="cpu")
             assert get_namespace(n_job1_xp)[0].__name__ == xp.__name__
             assert n_job1_xp.device == X_xp.device
             assert n_job1_xp.dtype == X_xp.dtype
 
             n_job2_xp = func(X_xp, Y_xp, metric=metric, n_jobs=2, **kwds)
-            n_job2_xp_np = _convert_to_numpy(n_job2_xp, xp=xp)
+            n_job2_xp_np = move_to(n_job2_xp, xp=np, device="cpu")
             assert get_namespace(n_job2_xp)[0].__name__ == xp.__name__
             assert n_job2_xp.device == X_xp.device
             assert n_job2_xp.dtype == X_xp.dtype
@@ -501,7 +501,7 @@ def test_pairwise_kernels_array_api(metric, array_namespace, device_name, dtype_
     with config_context(array_api_dispatch=True):
         # Test with Y=None
         K_xp = pairwise_kernels(X_xp, metric=metric)
-        K_xp_np = _convert_to_numpy(K_xp, xp=xp)
+        K_xp_np = move_to(K_xp, xp=np, device="cpu")
         assert get_namespace(K_xp)[0].__name__ == xp.__name__
         assert K_xp.device == X_xp.device
         assert K_xp.dtype == X_xp.dtype
@@ -511,7 +511,7 @@ def test_pairwise_kernels_array_api(metric, array_namespace, device_name, dtype_
 
         # Test with Y=Y_np/Y_xp
         K_xp = pairwise_kernels(X_xp, Y=Y_xp, metric=metric)
-        K_xp_np = _convert_to_numpy(K_xp, xp=xp)
+        K_xp_np = move_to(K_xp, xp=np, device="cpu")
         assert get_namespace(K_xp)[0].__name__ == xp.__name__
         assert K_xp.device == X_xp.device
         assert K_xp.dtype == X_xp.dtype

--- a/sklearn/mixture/_base.py
+++ b/sklearn/mixture/_base.py
@@ -17,12 +17,12 @@ from sklearn.cluster import kmeans_plusplus
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils import check_random_state
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
     _is_numpy_namespace,
     _logsumexp,
     _max_precision_float_dtype,
     get_namespace,
     get_namespace_and_device,
+    move_to,
 )
 from sklearn.utils._param_validation import Interval, StrOptions
 from sklearn.utils.validation import check_is_fitted, validate_data
@@ -459,7 +459,7 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
         _, n_features = self.means_.shape
         rng = check_random_state(self.random_state)
         n_samples_comp = rng.multinomial(
-            n_samples, _convert_to_numpy(self.weights_, xp)
+            n_samples, move_to(self.weights_, xp=np, device="cpu")
         )
 
         if self.covariance_type == "full":
@@ -467,8 +467,8 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
                 [
                     rng.multivariate_normal(mean, covariance, int(sample))
                     for (mean, covariance, sample) in zip(
-                        _convert_to_numpy(self.means_, xp),
-                        _convert_to_numpy(self.covariances_, xp),
+                        move_to(self.means_, xp=np, device="cpu"),
+                        move_to(self.covariances_, xp=np, device="cpu"),
                         n_samples_comp,
                     )
                 ]
@@ -477,10 +477,12 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
             X = np.vstack(
                 [
                     rng.multivariate_normal(
-                        mean, _convert_to_numpy(self.covariances_, xp), int(sample)
+                        mean,
+                        move_to(self.covariances_, xp=np, device="cpu"),
+                        int(sample),
                     )
                     for (mean, sample) in zip(
-                        _convert_to_numpy(self.means_, xp), n_samples_comp
+                        move_to(self.means_, xp=np, device="cpu"), n_samples_comp
                     )
                 ]
             )
@@ -491,8 +493,8 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
                     + rng.standard_normal(size=(sample, n_features))
                     * np.sqrt(covariance)
                     for (mean, covariance, sample) in zip(
-                        _convert_to_numpy(self.means_, xp),
-                        _convert_to_numpy(self.covariances_, xp),
+                        move_to(self.means_, xp=np, device="cpu"),
+                        move_to(self.covariances_, xp=np, device="cpu"),
                         n_samples_comp,
                     )
                 ]

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -31,12 +31,12 @@ from sklearn.mixture._gaussian_mixture import (
     _estimate_gaussian_parameters,
 )
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
-    get_namespace,
-    yield_namespace_device_dtype_combinations,
+    device as array_api_device,
 )
 from sklearn.utils._array_api import (
-    device as array_api_device,
+    get_namespace,
+    move_to,
+    yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._testing import (
     _array_api_for_tests,
@@ -1568,40 +1568,41 @@ def test_gaussian_mixture_array_api_compliance(
     increased_rtol = 1e-3 if dtype_name == "float32" else 1e-7
 
     # Check fitted attributes
-    assert_allclose(gmm.means_, _convert_to_numpy(gmm_xp.means_, xp=xp))
-    assert_allclose(gmm.weights_, _convert_to_numpy(gmm_xp.weights_, xp=xp))
+    assert_allclose(gmm.means_, move_to(gmm_xp.means_, xp=np, device="cpu"))
+    assert_allclose(gmm.weights_, move_to(gmm_xp.weights_, xp=np, device="cpu"))
     assert_allclose(
         gmm.covariances_,
-        _convert_to_numpy(gmm_xp.covariances_, xp=xp),
+        move_to(gmm_xp.covariances_, xp=np, device="cpu"),
         atol=increased_atol,
         rtol=increased_rtol,
     )
     assert_allclose(
         gmm.precisions_cholesky_,
-        _convert_to_numpy(gmm_xp.precisions_cholesky_, xp=xp),
+        move_to(gmm_xp.precisions_cholesky_, xp=np, device="cpu"),
         atol=increased_atol,
         rtol=increased_rtol,
     )
     assert_allclose(
         gmm.precisions_,
-        _convert_to_numpy(gmm_xp.precisions_, xp=xp),
+        move_to(gmm_xp.precisions_, xp=np, device="cpu"),
         atol=increased_atol,
         rtol=increased_rtol,
     )
 
     # Check methods
     assert (
-        adjusted_rand_score(gmm.predict(X), _convert_to_numpy(predict_xp, xp=xp)) > 0.95
+        adjusted_rand_score(gmm.predict(X), move_to(predict_xp, xp=np, device="cpu"))
+        > 0.95
     )
     assert_allclose(
         gmm.predict_proba(X),
-        _convert_to_numpy(predict_proba_xp, xp=xp),
+        move_to(predict_proba_xp, xp=np, device="cpu"),
         rtol=increased_rtol,
         atol=increased_atol,
     )
     assert_allclose(
         gmm.score_samples(X),
-        _convert_to_numpy(score_samples_xp, xp=xp),
+        move_to(score_samples_xp, xp=np, device="cpu"),
         rtol=increased_rtol,
     )
     # comparing Python float so need explicit rtol when X has dtype float32
@@ -1610,8 +1611,10 @@ def test_gaussian_mixture_array_api_compliance(
     assert_allclose(gmm.bic(X), bic_xp, rtol=default_rtol)
     sample_X, sample_y = gmm.sample(10)
     # generated samples are float64 so need explicit rtol when X has dtype float32
-    assert_allclose(sample_X, _convert_to_numpy(sample_X_xp, xp=xp), rtol=default_rtol)
-    assert_allclose(sample_y, _convert_to_numpy(sample_y_xp, xp=xp))
+    assert_allclose(
+        sample_X, move_to(sample_X_xp, xp=np, device="cpu"), rtol=default_rtol
+    )
+    assert_allclose(sample_y, move_to(sample_y_xp, xp=np, device="cpu"))
 
 
 @skip_if_array_api_compat_not_configured

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -25,7 +25,6 @@ from sklearn.utils import (
     metadata_routing,
 )
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
     get_namespace,
     get_namespace_and_device,
     move_to,
@@ -780,7 +779,7 @@ class StratifiedKFold(_BaseKFold):
         # we need the following explicit conversion:
         xp, is_array_api = get_namespace(y)
         if is_array_api:
-            y = _convert_to_numpy(y, xp)
+            y = move_to(y, xp=np, device="cpu")
         else:
             y = np.asarray(y)
         type_of_target_y = type_of_target(y)
@@ -2329,7 +2328,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
         # `y` is probably never a very large array, which means that converting it
         # should be cheap
         xp, _ = get_namespace(y)
-        y = _convert_to_numpy(y, xp=xp)
+        y = move_to(y, xp=np, device="cpu")
 
         if y.ndim == 2:
             # for multi-label y, map each distinct row to a string repr

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -27,7 +27,6 @@ from sklearn.model_selection._split import check_cv
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import Bunch, _safe_indexing, check_random_state, indexable
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
     device,
     get_namespace,
     get_namespace_and_device,
@@ -1320,7 +1319,7 @@ def _fit_and_predict(estimator, X, y, train, test, fit_params, method):
             # A 2D y array should be a binary label indicator matrix
             xp, _ = get_namespace(X, y)
             n_classes = (
-                len(set(_convert_to_numpy(y, xp=xp))) if y.ndim == 1 else y.shape[1]
+                len(set(move_to(y, xp=np, device="cpu"))) if y.ndim == 1 else y.shape[1]
             )
             predictions = _enforce_prediction_order(
                 estimator.classes_, predictions, n_classes, method

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -42,12 +42,12 @@ from sklearn.model_selection._split import (
 from sklearn.svm import SVC
 from sklearn.tests.metadata_routing_common import assert_request_is_empty
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
-    get_namespace,
-    yield_namespace_device_dtype_combinations,
+    device as array_api_device,
 )
 from sklearn.utils._array_api import (
-    device as array_api_device,
+    get_namespace,
+    move_to,
+    yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._mocking import MockDataFrame
 from sklearn.utils._testing import (
@@ -1398,11 +1398,11 @@ def test_array_api_train_test_split(
     assert y_test_xp.dtype == y_xp.dtype
 
     assert_allclose(
-        _convert_to_numpy(X_train_xp, xp=xp),
+        move_to(X_train_xp, xp=np, device="cpu"),
         X_train_np,
     )
     assert_allclose(
-        _convert_to_numpy(X_test_xp, xp=xp),
+        move_to(X_test_xp, xp=np, device="cpu"),
         X_test_np,
     )
 

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -84,7 +84,7 @@ from sklearn.tests.metadata_routing_common import (
 from sklearn.utils import shuffle
 from sklearn.utils._array_api import (
     _atol_for_type,
-    _convert_to_numpy,
+    move_to,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._mocking import CheckingClassifier, MockDataFrame
@@ -2741,5 +2741,5 @@ def test_cross_val_predict_array_api_compliance(
 
     pred_np = cross_val_predict(estimator, X_np, y_np, cv=cv)
     assert_allclose(
-        _convert_to_numpy(pred_xp, xp), pred_np, atol=_atol_for_type(dtype_name)
+        move_to(pred_xp, xp=np, device="cpu"), pred_np, atol=_atol_for_type(dtype_name)
     )

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -18,12 +18,12 @@ from sklearn.base import BaseEstimator, ClassifierMixin, _fit_context
 from sklearn.preprocessing import LabelBinarizer, binarize, label_binarize
 from sklearn.utils._array_api import (
     _average,
-    _convert_to_numpy,
     _find_matching_floating_dtype,
     _isin,
     _logsumexp,
     get_namespace,
     get_namespace_and_device,
+    move_to,
     size,
 )
 from sklearn.utils._param_validation import Interval
@@ -113,7 +113,7 @@ class _BaseNB(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
         jll = self._joint_log_likelihood(X)
         pred_indices = xp.argmax(jll, axis=1)
         if isinstance(self.classes_[0], str):
-            pred_indices = _convert_to_numpy(pred_indices, xp=xp)
+            pred_indices = move_to(pred_indices, xp=np, device="cpu")
         return self.classes_[pred_indices]
 
     def predict_log_proba(self, X):

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -13,7 +13,6 @@ import scipy.sparse as sp
 from sklearn.base import BaseEstimator, TransformerMixin, _fit_context
 from sklearn.utils import _align_api_if_sparse, column_or_1d
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
     _find_matching_floating_dtype,
     _is_numpy_namespace,
     _isin,
@@ -21,6 +20,7 @@ from sklearn.utils._array_api import (
     get_namespace,
     get_namespace_and_device,
     indexing_dtype,
+    move_to,
     xpx,
 )
 from sklearn.utils._encode import _encode, _unique
@@ -636,9 +636,9 @@ def label_binarize(y, *, classes, neg_label=0, pos_label=1, sparse_output=False)
         # Use NumPy to construct the sparse matrix of one-hot labels
         Y = sp.csr_array(
             (
-                _convert_to_numpy(data, xp=xp),
-                _convert_to_numpy(indices, xp=xp),
-                _convert_to_numpy(indptr, xp=xp),
+                move_to(data, xp=np, device="cpu"),
+                move_to(indices, xp=np, device="cpu"),
+                move_to(indptr, xp=np, device="cpu"),
             ),
             shape=(n_samples, n_classes),
         )

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -39,7 +39,7 @@ from sklearn.preprocessing._data import BOUNDS_THRESHOLD, _handle_zeros_in_scale
 from sklearn.svm import SVR
 from sklearn.utils import gen_batches, shuffle
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
+    move_to,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._testing import (
@@ -202,8 +202,8 @@ def test_standard_scaler_sample_weight_array_api(
     scaler_w_xp = StandardScaler()
     with config_context(array_api_dispatch=True):
         scaler_w_xp.fit(Xw_xp, yw_xp, sample_weight=sample_weight_xp)
-        w_mean = _convert_to_numpy(scaler_w_xp.mean_, xp=xp)
-        w_var = _convert_to_numpy(scaler_w_xp.var_, xp=xp)
+        w_mean = move_to(scaler_w_xp.mean_, xp=np, device="cpu")
+        w_var = move_to(scaler_w_xp.var_, xp=np, device="cpu")
 
     assert_allclose(scaler_w.mean_, w_mean)
     assert_allclose(scaler_w.var_, w_var)
@@ -212,8 +212,8 @@ def test_standard_scaler_sample_weight_array_api(
     scaler_xp = StandardScaler()
     with config_context(array_api_dispatch=True):
         scaler_xp.fit(X_xp, y_xp)
-        uw_mean = _convert_to_numpy(scaler_xp.mean_, xp=xp)
-        uw_var = _convert_to_numpy(scaler_xp.var_, xp=xp)
+        uw_mean = move_to(scaler_xp.mean_, xp=np, device="cpu")
+        uw_var = move_to(scaler_xp.var_, xp=np, device="cpu")
 
     assert_allclose(scaler.mean_, uw_mean)
     assert_allclose(scaler.var_, uw_var)
@@ -223,8 +223,8 @@ def test_standard_scaler_sample_weight_array_api(
     assert_allclose(uw_var, w_var)
     with config_context(array_api_dispatch=True):
         assert_allclose(
-            _convert_to_numpy(scaler_xp.transform(X_test_xp), xp=xp),
-            _convert_to_numpy(scaler_w_xp.transform(X_test_xp), xp=xp),
+            move_to(scaler_xp.transform(X_test_xp), xp=np, device="cpu"),
+            move_to(scaler_w_xp.transform(X_test_xp), xp=np, device="cpu"),
         )
 
 
@@ -2121,7 +2121,7 @@ def test_binarizer_array_api_int(array_namespace, device_name, dtype_name):
         binarized_np = Binarizer(threshold=2.5).fit_transform(X_np)
         with config_context(array_api_dispatch=True):
             binarized_xp = Binarizer(threshold=2.5).fit_transform(X_xp)
-        assert_array_equal(_convert_to_numpy(binarized_xp, xp), binarized_np)
+        assert_array_equal(move_to(binarized_xp, xp=np, device="cpu"), binarized_np)
 
 
 def test_center_kernel():

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -12,9 +12,9 @@ from sklearn.preprocessing._label import (
     label_binarize,
 )
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
     _is_numpy_namespace,
     get_namespace,
+    move_to,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._array_api import (
@@ -283,14 +283,16 @@ def test_label_binarizer_array_api_compliance(
         assert get_namespace(binarized)[0].__name__ == xp.__name__
         assert "int" in str(binarized.dtype)
         assert array_api_device(binarized) == array_api_device(y)
-        assert_array_equal(_convert_to_numpy(binarized, xp=xp), np.asarray(expected))
+        assert_array_equal(
+            move_to(binarized, xp=np, device="cpu"), np.asarray(expected)
+        )
 
         fitted_classes = lb_xp.classes_
         assert get_namespace(fitted_classes)[0].__name__ == xp.__name__
         assert array_api_device(fitted_classes) == array_api_device(y)
         assert "int" in str(fitted_classes.dtype)
         assert_array_equal(
-            _convert_to_numpy(fitted_classes, xp=xp), np.asarray(classes)
+            move_to(fitted_classes, xp=np, device="cpu"), np.asarray(classes)
         )
 
         expected_xp = xp.asarray(expected, device=device)
@@ -299,7 +301,8 @@ def test_label_binarizer_array_api_compliance(
         assert "int" in str(binarized_inverse.dtype)
         assert array_api_device(binarized_inverse) == array_api_device(y)
         assert_array_equal(
-            _convert_to_numpy(binarized_inverse, xp=xp), _convert_to_numpy(y, xp=xp)
+            move_to(binarized_inverse, xp=np, device="cpu"),
+            move_to(y, xp=np, device="cpu"),
         )
 
 
@@ -798,7 +801,7 @@ def test_label_binarize_array_api_compliance(
             assert get_namespace(binarized)[0].__name__ == xp.__name__
             assert array_api_device(binarized) == array_api_device(y)
             assert "int" in str(binarized.dtype)
-            assert_array_equal(_convert_to_numpy(binarized, xp=xp), expected)
+            assert_array_equal(move_to(binarized, xp=np, device="cpu"), expected)
 
         if not xp_is_numpy and not numeric_dtype:
             msg = "`classes` contains unsupported dtype for array API "
@@ -868,9 +871,11 @@ def test_label_encoder_array_api_compliance(
         assert get_namespace(xp_transformed)[0].__name__ == xp.__name__
         assert get_namespace(xp_inv_transformed)[0].__name__ == xp.__name__
         assert get_namespace(xp_label.classes_)[0].__name__ == xp.__name__
-        assert_array_equal(_convert_to_numpy(xp_transformed, xp), np_transformed)
-        assert_array_equal(_convert_to_numpy(xp_inv_transformed, xp), y)
-        assert_array_equal(_convert_to_numpy(xp_label.classes_, xp), np_label.classes_)
+        assert_array_equal(move_to(xp_transformed, xp=np, device="cpu"), np_transformed)
+        assert_array_equal(move_to(xp_inv_transformed, xp=np, device="cpu"), y)
+        assert_array_equal(
+            move_to(xp_label.classes_, xp=np, device="cpu"), np_label.classes_
+        )
 
         xp_label = LabelEncoder()
         np_label = LabelEncoder()
@@ -878,5 +883,7 @@ def test_label_encoder_array_api_compliance(
         np_transformed = np_label.fit_transform(y)
         assert get_namespace(xp_transformed)[0].__name__ == xp.__name__
         assert get_namespace(xp_label.classes_)[0].__name__ == xp.__name__
-        assert_array_equal(_convert_to_numpy(xp_transformed, xp), np_transformed)
-        assert_array_equal(_convert_to_numpy(xp_label.classes_, xp), np_label.classes_)
+        assert_array_equal(move_to(xp_transformed, xp=np, device="cpu"), np_transformed)
+        assert_array_equal(
+            move_to(xp_label.classes_, xp=np, device="cpu"), np_label.classes_
+        )

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -20,9 +20,9 @@ from sklearn.preprocessing._csr_polynomial_expansion import (
     _get_sizeof_LARGEST_INT_t,
 )
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
     _is_numpy_namespace,
     get_namespace,
+    move_to,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._array_api import (
@@ -1363,7 +1363,7 @@ def test_polynomial_features_array_api_compliance(
         ).fit(X_xp)
         out_np = tf_np.transform(X_np)
         out_xp = tf_xp.transform(X_xp)
-        assert_allclose(_convert_to_numpy(out_xp, xp=xp), out_np)
+        assert_allclose(move_to(out_xp, xp=np, device="cpu"), out_np)
         assert get_namespace(out_xp)[0].__name__ == xp.__name__
         assert array_api_device(out_xp) == array_api_device(X_xp)
         assert out_xp.dtype == X_xp.dtype

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -48,12 +48,12 @@ from sklearn.preprocessing import LabelEncoder, StandardScaler
 from sklearn.svm import LinearSVC
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
-    get_namespace,
-    yield_namespace_device_dtype_combinations,
+    device as array_api_device,
 )
 from sklearn.utils._array_api import (
-    device as array_api_device,
+    get_namespace,
+    move_to,
+    yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._mocking import CheckingClassifier
 from sklearn.utils._tags import get_tags
@@ -1281,12 +1281,12 @@ def test_temperature_scaling_array_api_compliance(
         assert calibrator_xp.beta_.dtype == X_cal_xp.dtype
         assert array_api_device(calibrator_xp.beta_) == array_api_device(X_cal_xp)
         assert_allclose(
-            _convert_to_numpy(calibrator_xp.beta_, xp=xp),
+            move_to(calibrator_xp.beta_, xp=np, device="cpu"),
             calibrator_np.beta_,
             rtol=rtol,
         )
         pred_xp = cal_clf_xp.predict(X_train_xp)
-        assert_allclose(_convert_to_numpy(pred_xp, xp=xp), pred_np)
+        assert_allclose(move_to(pred_xp, xp=np, device="cpu"), pred_np)
 
 
 @pytest.mark.parametrize("ensemble", [False, True])
@@ -1352,7 +1352,7 @@ def test_temperature_scaling_array_api_with_str_y_estimator_not_prefit(
         assert calibrator_xp.beta_.dtype == X_xp.dtype
         assert array_api_device(calibrator_xp.beta_) == array_api_device(X_xp)
         assert_allclose(
-            _convert_to_numpy(calibrator_xp.beta_, xp=xp),
+            move_to(calibrator_xp.beta_, xp=np, device="cpu"),
             calibrator_np.beta_,
             rtol=rtol,
         )

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -20,8 +20,8 @@ from sklearn.metrics.pairwise import (
 )
 from sklearn.utils._array_api import (
     _atol_for_type,
-    _convert_to_numpy,
     get_namespace_and_device,
+    move_to,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._array_api import (
@@ -377,7 +377,7 @@ def test_nystroem_approximation_array_api(
 
     with config_context(array_api_dispatch=True):
         X_xp_transformed = nystroem.fit_transform(X_xp)
-        X_xp_transformed_np = _convert_to_numpy(X_xp_transformed, xp=xp)
+        X_xp_transformed_np = move_to(X_xp_transformed, xp=np, device="cpu")
 
         for attribute_name in ["components_", "normalization_"]:
             xp_attr, _, device_attr = get_namespace_and_device(

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -16,11 +16,11 @@ from sklearn.naive_bayes import (
     MultinomialNB,
 )
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
-    yield_namespace_device_dtype_combinations,
+    device as array_api_device,
 )
 from sklearn.utils._array_api import (
-    device as array_api_device,
+    move_to,
+    yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._testing import (
     _array_api_for_tests,
@@ -1029,23 +1029,23 @@ def test_gnb_array_api_compliance(
             np_attr = getattr(clf_np, fitted_attr)
             assert xp_attr.dtype == X_xp.dtype
             assert array_api_device(xp_attr) == array_api_device(X_xp)
-            assert_allclose(_convert_to_numpy(xp_attr, xp=xp), np_attr)
+            assert_allclose(move_to(xp_attr, xp=np, device="cpu"), np_attr)
 
         y_pred_xp = clf_xp.predict(X_xp)
         if not use_str_y:
             assert array_api_device(y_pred_xp) == array_api_device(X_xp)
-            y_pred_xp = _convert_to_numpy(y_pred_xp, xp=xp)
+            y_pred_xp = move_to(y_pred_xp, xp=np, device="cpu")
         assert_array_equal(y_pred_xp, y_pred_np)
         assert y_pred_xp.dtype == y_pred_np.dtype
 
         y_pred_proba_xp = clf_xp.predict_proba(X_xp)
         assert y_pred_proba_xp.dtype == X_xp.dtype
         assert array_api_device(y_pred_proba_xp) == array_api_device(X_xp)
-        assert_allclose(_convert_to_numpy(y_pred_proba_xp, xp=xp), y_pred_proba_np)
+        assert_allclose(move_to(y_pred_proba_xp, xp=np, device="cpu"), y_pred_proba_np)
 
         y_pred_log_proba_xp = clf_xp.predict_log_proba(X_xp)
         assert y_pred_log_proba_xp.dtype == X_xp.dtype
         assert array_api_device(y_pred_log_proba_xp) == array_api_device(X_xp)
         assert_allclose(
-            _convert_to_numpy(y_pred_log_proba_xp, xp=xp), y_pred_log_proba_np
+            move_to(y_pred_log_proba_xp, xp=np, device="cpu"), y_pred_log_proba_np
         )

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -51,8 +51,8 @@ from sklearn.tests.metadata_routing_common import (
 from sklearn.utils import get_tags
 from sklearn.utils._array_api import (
     _atol_for_type,
-    _convert_to_numpy,
     get_namespace_and_device,
+    move_to,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._metadata_requests import COMPOSITE_METHODS, METHODS
@@ -1984,7 +1984,7 @@ def test_feature_union_array_api_compliance(array_namespace, device_name, dtype_
 
     with config_context(array_api_dispatch=True):
         X_xp_transformed = union.fit_transform(X_xp)
-        X_xp_transformed_np = _convert_to_numpy(X_xp_transformed, xp=xp)
+        X_xp_transformed_np = move_to(X_xp_transformed, xp=np, device="cpu")
 
         for name, trans in union.transformer_list:
             for attr in ["components_", "normalization_"]:

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -990,7 +990,8 @@ def _convert_to_numpy(array, xp):
     ndarray on the CPU. It is only meant as a fallback when move_to fails to use the
     DLPACK protocol.
 
-    Code should instead use `move_to(array, xp=np, device="cpu")` instead.
+    This function is not meant to be called directly and
+    `move_to(array, xp=np, device="cpu")` should be used instead.
     """
     if _is_xp_namespace(xp, "torch"):
         return array.cpu().numpy()

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -857,9 +857,8 @@ def _median(x, axis=None, keepdims=False, xp=None):
     if hasattr(xp, "median"):
         return xp.median(x, axis=axis, keepdims=keepdims)
 
-    # Intended mostly for array-api-strict (which as no "median", as per the spec)
-    # as `_convert_to_numpy` does not necessarily work for all array types.
-    x_np = _convert_to_numpy(x, xp=xp)
+    # Intended mostly for array-api-strict (which has no "median", as per the spec).
+    x_np = move_to(x, xp=numpy, device="cpu")
     return xp.asarray(numpy.median(x_np, axis=axis, keepdims=keepdims), device=device)
 
 
@@ -1188,9 +1187,9 @@ def _bincount(array, weights=None, minlength=0, xp=None):
     if hasattr(xp, "bincount"):
         return xp.bincount(array, weights=weights, minlength=minlength)
 
-    array_np = _convert_to_numpy(array, xp=xp)
+    array_np = move_to(array, xp=numpy, device="cpu")
     if weights is not None:
-        weights_np = _convert_to_numpy(weights, xp=xp)
+        weights_np = move_to(weights, xp=numpy, device="cpu")
     else:
         weights_np = None
     bin_out = numpy.bincount(array_np, weights=weights_np, minlength=minlength)

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -985,7 +985,14 @@ def _ravel(array, xp=None):
 
 
 def _convert_to_numpy(array, xp):
-    """Convert X into a NumPy ndarray on the CPU."""
+    """Convert X into a NumPy ndarray on the CPU.
+
+    This function uses library-specific methods to convert the array to a NumPy
+    ndarray on the CPU. It is only meant as a fallback when move_to fails to use the
+    DLPACK protocol.
+
+    Code should instead use `move_to(array, xp=np, device="cpu")` instead.
+    """
     if _is_xp_namespace(xp, "torch"):
         return array.cpu().numpy()
     elif _is_xp_namespace(xp, "cupy"):  # pragma: nocover

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -8,11 +8,10 @@ from scipy import sparse
 
 from sklearn.utils._array_api import (
     _bincount,
-    _convert_to_numpy,
     _is_numpy_namespace,
     _isin,
-    get_namespace,
     get_namespace_and_device,
+    move_to,
     size,
 )
 from sklearn.utils._param_validation import StrOptions, validate_params
@@ -75,7 +74,9 @@ def compute_class_weight(class_weight, *, classes, y, sample_weight=None):
 
     xp, _, device_ = get_namespace_and_device(y, classes)
     unique_y = xp.unique_values(y)
-    if set(_convert_to_numpy(unique_y, xp)) - set(_convert_to_numpy(classes, xp)):
+    if set(move_to(unique_y, xp=np, device="cpu")) - set(
+        move_to(classes, xp=np, device="cpu")
+    ):
         raise ValueError("classes should include all valid labels that can be in y")
     if class_weight is None or len(class_weight) == 0:
         # uniform class weights
@@ -88,8 +89,7 @@ def compute_class_weight(class_weight, *, classes, y, sample_weight=None):
             raise ValueError("classes should have valid labels that are in y")
 
         if _is_numpy_namespace(xp) and sample_weight is not None:
-            xp_sw, _ = get_namespace(sample_weight)
-            sample_weight = _convert_to_numpy(sample_weight, xp_sw)
+            sample_weight = move_to(sample_weight, xp=np, device="cpu")
 
         sample_weight = _check_sample_weight(sample_weight, y)
         weighted_class_counts = _bincount(y_ind, weights=sample_weight, xp=xp)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -62,8 +62,8 @@ from sklearn.preprocessing import StandardScaler, scale
 from sklearn.utils import _safe_indexing, shuffle
 from sklearn.utils._array_api import (
     _atol_for_type,
-    _convert_to_numpy,
     get_namespace,
+    move_to,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._array_api import device as array_device
@@ -1129,7 +1129,7 @@ def check_array_api_input(
         with config_context(array_api_dispatch=True):
             assert array_device(est_xp_param) == array_device(X_xp)
 
-        est_xp_param_np = _convert_to_numpy(est_xp_param, xp=xp)
+        est_xp_param_np = move_to(est_xp_param, xp=np, device="cpu")
         if check_values:
             assert_allclose(
                 attribute,
@@ -1222,7 +1222,7 @@ def check_array_api_input(
             with config_context(array_api_dispatch=True):
                 assert array_device(result_xp) == array_device(X_xp)
 
-            result_xp_np = _convert_to_numpy(result_xp, xp=xp)
+            result_xp_np = move_to(result_xp, xp=np, device="cpu")
             if check_values:
                 assert_allclose(
                     result,
@@ -1249,7 +1249,7 @@ def check_array_api_input(
                 with config_context(array_api_dispatch=True):
                     assert array_device(result_xp) == array_device(X_xp)
 
-                inverse_result_xp_np = _convert_to_numpy(inverse_result_xp, xp=xp)
+                inverse_result_xp_np = move_to(inverse_result_xp, xp=np, device="cpu")
                 if check_values:
                     assert_allclose(
                         inverse_result,

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -255,7 +255,7 @@ def test_average(
             # https://github.com/numpy/numpy/issues/26850
             assert array_api_device(array_in) == array_api_device(result)
 
-    result = _convert_to_numpy(result, xp)
+    result = move_to(result, xp=numpy, device="cpu")
     assert_allclose(result, expected, atol=_atol_for_type(dtype_name))
 
 
@@ -438,7 +438,7 @@ def test_nan_reductions(library, X, reduction, expected):
     with config_context(array_api_dispatch=True):
         result = reduction(xp.asarray(X))
 
-    result = _convert_to_numpy(result, xp)
+    result = move_to(result, xp=numpy, device="cpu")
     assert_allclose(result, expected)
 
 
@@ -454,7 +454,7 @@ def test_ravel(namespace, device_name, dtype_name):
     with config_context(array_api_dispatch=True):
         result = _ravel(array_xp)
 
-    result = _convert_to_numpy(result, xp)
+    result = move_to(result, xp=numpy, device="cpu")
     expected = numpy.ravel(array, order="C")
 
     assert_allclose(expected, result)
@@ -591,7 +591,7 @@ def test_isin(
             invert=invert,
         )
 
-    assert_array_equal(_convert_to_numpy(result, xp=xp), expected)
+    assert_array_equal(move_to(result, xp=numpy, device="cpu"), expected)
 
 
 @pytest.mark.skipif(
@@ -659,7 +659,7 @@ def test_count_nonzero(
             array_xp, axis=axis, sample_weight=sample_weight, xp=xp, device=device
         )
 
-    assert_allclose(_convert_to_numpy(result, xp=xp), expected)
+    assert_allclose(move_to(result, xp=numpy, device="cpu"), expected)
 
     if np_version < parse_version("2.0.0") or np_version >= parse_version("2.1.0"):
         # NumPy 2.0 has a problem with the device attribute of scalar arrays:
@@ -745,7 +745,7 @@ def test_fill_diagonal(array, array_namespace, device_name, dtype_name):
     with config_context(array_api_dispatch=True):
         _fill_diagonal(array_xp, value=1, xp=xp)
 
-    assert_array_equal(_convert_to_numpy(array_xp, xp=xp), array_np)
+    assert_array_equal(move_to(array_xp, xp=numpy, device="cpu"), array_np)
 
 
 @pytest.mark.parametrize(
@@ -765,7 +765,7 @@ def test_add_to_diagonal(array_namespace, device_name, dtype_name):
     with config_context(array_api_dispatch=True):
         _fill_diagonal(array_xp, value=add_val, xp=xp)
 
-    assert_array_equal(_convert_to_numpy(array_xp, xp=xp), array_np)
+    assert_array_equal(move_to(array_xp, xp=numpy, device="cpu"), array_np)
 
 
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
@@ -810,7 +810,7 @@ def test_median(namespace, device_name, dtype_name, axis):
             # part of the Array API spec
             assert get_namespace(result_xp)[0] == xp
             assert result_xp.device == X_xp.device
-    assert_allclose(result_np, _convert_to_numpy(result_xp, xp=xp))
+    assert_allclose(result_np, move_to(result_xp, xp=numpy, device="cpu"))
 
 
 @pytest.mark.parametrize(
@@ -825,7 +825,7 @@ def test_expit_logit(namespace, device_name, dtype_name):
         x_np = numpy.linspace(-20, 20, 1000).astype(dtype_name)
         x_xp = xp.asarray(x_np, device=device)
         assert_allclose(
-            _convert_to_numpy(_expit(x_xp), xp=xp),
+            move_to(_expit(x_xp), xp=numpy, device="cpu"),
             expit(x_np),
             rtol=rtol,
         )
@@ -833,7 +833,7 @@ def test_expit_logit(namespace, device_name, dtype_name):
         x_np = numpy.linspace(0, 1, 1000).astype(dtype_name)
         x_xp = xp.asarray(x_np, device=device)
         assert_allclose(
-            _convert_to_numpy(_logit(x_xp), xp=xp),
+            move_to(_logit(x_xp), xp=numpy, device="cpu"),
             logit(x_np),
             rtol=rtol,
         )
@@ -871,7 +871,7 @@ def test_logsumexp_like_scipy_logsumexp(array_namespace, device_name, dtype_name
 
     with config_context(array_api_dispatch=True):
         res_xp = _logsumexp(array_xp, axis=axis)
-        res_xp = _convert_to_numpy(res_xp, xp)
+        res_xp = move_to(res_xp, xp=numpy, device="cpu")
         assert_allclose(res_np, res_xp, rtol=rtol)
 
     # Test with NaNs and +np.inf
@@ -891,7 +891,7 @@ def test_logsumexp_like_scipy_logsumexp(array_namespace, device_name, dtype_name
 
     with config_context(array_api_dispatch=True):
         res_xp_2 = _logsumexp(array_xp_2, axis=axis)
-        res_xp_2 = _convert_to_numpy(res_xp_2, xp)
+        res_xp_2 = move_to(res_xp_2, xp=numpy, device="cpu")
         assert_allclose(res_np_2, res_xp_2, rtol=rtol)
 
 

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -14,9 +14,9 @@ from sklearn.datasets import make_low_rank_matrix, make_sparse_spd_matrix
 from sklearn.utils import gen_batches
 from sklearn.utils._arpack import _init_arpack_v0
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
     _max_precision_float_dtype,
     get_namespace,
+    move_to,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._array_api import (
@@ -730,8 +730,8 @@ def test_incremental_weighted_mean_and_variance_array_api(
     assert array_device(var_xp) == array_device(X_xp)
     assert var_xp.dtype == _max_precision_float_dtype(xp, device=device)
 
-    mean_xp = _convert_to_numpy(mean_xp, xp=xp)
-    var_xp = _convert_to_numpy(var_xp, xp=xp)
+    mean_xp = move_to(mean_xp, xp=np, device="cpu")
+    var_xp = move_to(var_xp, xp=np, device="cpu")
 
     assert_allclose(mean, mean_xp)
     assert_allclose(var, var_xp)
@@ -1122,9 +1122,9 @@ def test_randomized_svd_array_api_compliance(array_namespace, device_name, dtype
         assert get_namespace(s_xp)[0].__name__ == xp.__name__
         assert get_namespace(vt_xp)[0].__name__ == xp.__name__
 
-        assert_allclose(_convert_to_numpy(u_xp, xp), u_np, atol=atol)
-        assert_allclose(_convert_to_numpy(s_xp, xp), s_np, atol=atol)
-        assert_allclose(_convert_to_numpy(vt_xp, xp), vt_np, atol=atol)
+        assert_allclose(move_to(u_xp, xp=np, device="cpu"), u_np, atol=atol)
+        assert_allclose(move_to(s_xp, xp=np, device="cpu"), s_np, atol=atol)
+        assert_allclose(move_to(vt_xp, xp=np, device="cpu"), vt_np, atol=atol)
 
 
 @pytest.mark.parametrize(
@@ -1148,4 +1148,4 @@ def test_randomized_range_finder_array_api_compliance(
         Q_xp = randomized_range_finder(X_xp, size=size, n_iter=n_iter, random_state=0)
 
         assert get_namespace(Q_xp)[0].__name__ == xp.__name__
-        assert_allclose(_convert_to_numpy(Q_xp, xp), Q_np, atol=atol)
+        assert_allclose(move_to(Q_xp, xp=np, device="cpu"), Q_np, atol=atol)

--- a/sklearn/utils/tests/test_indexing.py
+++ b/sklearn/utils/tests/test_indexing.py
@@ -10,12 +10,11 @@ import sklearn
 from sklearn.externals._packaging.version import parse as parse_version
 from sklearn.utils import _safe_indexing, resample, shuffle
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
-    move_to,
-    yield_namespace_device_dtype_combinations,
+    device as array_api_device,
 )
 from sklearn.utils._array_api import (
-    device as array_api_device,
+    move_to,
+    yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._indexing import (
     _determine_key_type,
@@ -169,7 +168,7 @@ def test_safe_indexing_array_api_support(
         assert array_api_device(indexed_array_xp) == array_api_device(array_to_index_xp)
         assert indexed_array_xp.dtype == array_to_index_xp.dtype
 
-    assert_allclose(_convert_to_numpy(indexed_array_xp, xp=xp), expected_result)
+    assert_allclose(move_to(indexed_array_xp, xp=np, device="cpu"), expected_result)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/utils/tests/test_stats.py
+++ b/sklearn/utils/tests/test_stats.py
@@ -4,12 +4,12 @@ from numpy.testing import assert_allclose, assert_array_equal
 from pytest import approx
 
 from sklearn._config import config_context
+from sklearn.utils._array_api import device as array_device
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
     get_namespace,
+    move_to,
     yield_namespace_device_dtype_combinations,
 )
-from sklearn.utils._array_api import device as array_device
 from sklearn.utils.estimator_checks import _array_api_for_tests
 from sklearn.utils.fixes import np_version, parse_version
 from sklearn.utils.stats import _weighted_percentile
@@ -324,7 +324,7 @@ def test_weighted_percentile_array_api_consistency(
         result_xp = _weighted_percentile(X_xp, weights_xp, percentile)
         assert array_device(result_xp) == array_device(X_xp)
         assert get_namespace(result_xp)[0] == get_namespace(X_xp)[0]
-        result_xp_np = _convert_to_numpy(result_xp, xp=xp)
+        result_xp_np = move_to(result_xp, xp=np, device="cpu")
 
     assert result_xp_np.dtype == result_np.dtype
     assert result_xp_np.shape == result_np.shape

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -34,8 +34,8 @@ from sklearn.utils import (
     deprecated,
 )
 from sklearn.utils._array_api import (
-    _convert_to_numpy,
     _is_numpy_namespace,
+    move_to,
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._mocking import (
@@ -1608,11 +1608,11 @@ def _check_sample_weight_common(xp):
     # for check_sample_weight
     # check None input
     sample_weight = _check_sample_weight(None, X=xp.ones((5, 2)))
-    assert_allclose(_convert_to_numpy(sample_weight, xp), np.ones(5))
+    assert_allclose(move_to(sample_weight, xp=np, device="cpu"), np.ones(5))
 
     # check numbers input
     sample_weight = _check_sample_weight(2.0, X=xp.ones((5, 2)))
-    assert_allclose(_convert_to_numpy(sample_weight, xp), 2 * np.ones(5))
+    assert_allclose(move_to(sample_weight, xp=np, device="cpu"), 2 * np.ones(5))
 
     # check wrong number of dimensions
     with pytest.raises(ValueError, match=r"Sample weights must be 1D array or scalar"):

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -23,11 +23,11 @@ from sklearn.exceptions import (
 )
 from sklearn.utils._array_api import (
     _asarray_with_order,
-    _convert_to_numpy,
     _is_numpy_namespace,
     _max_precision_float_dtype,
     get_namespace,
     get_namespace_and_device,
+    move_to,
 )
 from sklearn.utils._dataframe import is_pandas_df, is_pandas_df_or_series
 from sklearn.utils._isfinite import FiniteStatus, cy_isfinite
@@ -2598,7 +2598,7 @@ def _check_pos_label_consistency(pos_label, y_true):
                 or xp.all(classes == xp.asarray([1], device=device))
             )
         ):
-            classes = _convert_to_numpy(classes, xp=xp)
+            classes = move_to(classes, xp=np, device="cpu")
             classes_repr = ", ".join([repr(c) for c in classes.tolist()])
             raise ValueError(
                 f"y_true takes value in {{{classes_repr}}} and pos_label is not "


### PR DESCRIPTION
This should make it possible to support any other array API and dlpack compliant namespaces even we do not explicitly support them yet in our library specific `_convert_to_numpy` utility.

Fixes: #33590.

Note: I wrote the first commit and then asked cursor to generalize to the rest of the code base. I marked this PR as draft to review the diff before asking others to review it.

EDIT: I reviewed the change. This is ready for review.