### PR TITLE
fix: TunedThresholdClassifierCV split reuse bug with cv=float, refit=False

### DIFF
--- a/sklearn/model_selection/_classification_threshold.py
+++ b/sklearn/model_selection/_classification_threshold.py
@@ -753,14 +753,16 @@ class TunedThresholdClassifierCV(BaseThresholdClassifier):
         else:
             self.estimator_ = clone(self.estimator)
             classifier = clone(self.estimator)
-            splits = cv.split(X, y, **routed_params.splitter.split)
+            splits = list(cv.split(X, y, **routed_params.splitter.split))
 
             if self.refit:
                 # train on the whole dataset
                 X_train, y_train, fit_params_train = X, y, routed_params.estimator.fit
             else:
-                # single split cross-validation
-                train_idx, _ = next(cv.split(X, y, **routed_params.splitter.split))
+                # single split cross-validation: reuse the first split already
+                # materialized above so that `self.estimator_` and the threshold-
+                # tuning clone are always trained on the exact same data.
+                train_idx, _ = splits[0]
                 X_train = _safe_indexing(X, train_idx)
                 y_train = _safe_indexing(y, train_idx)
                 fit_params_train = _check_method_params(

--- a/sklearn/model_selection/tests/test_classification_threshold.py
+++ b/sklearn/model_selection/tests/test_classification_threshold.py
@@ -500,6 +500,45 @@ def test_tuned_threshold_classifier_cv_float():
     assert_allclose(tuned_model.estimator_.coef_, cloned_estimator.coef_)
 
 
+def test_tuned_threshold_classifier_cv_float_refit_false_same_split():
+    """Regression test for gh-33540.
+
+    With ``cv=float`` and ``refit=False``, ``best_threshold_`` must be tuned on
+    the same split that was used to train ``estimator_``.  Previously the
+    ``refit=False`` branch called ``cv.split(...)`` a second time, which could
+    yield a completely different split when ``random_state=None``, making the
+    returned estimator/threshold pair inconsistent.
+    """
+    X, y = make_classification(n_samples=200, random_state=42)
+
+    # Patch StratifiedShuffleSplit.split to count how many times it is called
+    # and record the train indices returned each time.
+    split_calls = []
+    original_split = StratifiedShuffleSplit.split
+
+    def tracking_split(self, X, y=None, groups=None):
+        for train_idx, val_idx in original_split(self, X, y, groups):
+            split_calls.append(train_idx.copy())
+            yield train_idx, val_idx
+
+    StratifiedShuffleSplit.split = tracking_split
+    try:
+        clf = TunedThresholdClassifierCV(
+            LogisticRegression(random_state=0),
+            cv=0.2,
+            refit=False,
+        )
+        clf.fit(X, y)
+    finally:
+        StratifiedShuffleSplit.split = original_split
+
+    # The split generator must be consumed exactly once (no second call).
+    assert len(split_calls) == 1, (
+        f"cv.split() was called {len(split_calls)} time(s); expected 1. "
+        "The refit=False branch must reuse the existing split."
+    )
+
+
 def test_tuned_threshold_classifier_error_constant_predictor():
     """Check that we raise a ValueError if the underlying classifier returns constant
     probabilities such that we cannot find any threshold.


### PR DESCRIPTION
## Summary

Fixes #33540.

When `TunedThresholdClassifierCV` is used with `cv=float` and `refit=False`, the `refit=False` branch was calling `cv.split(...)` a **second** time via `next(cv.split(...))` to obtain the training indices for `self.estimator_`. Because `StratifiedShuffleSplit.split` is stateful and the two calls are independent, a non-fixed `random_state` can yield completely different splits. This means `best_threshold_` could be tuned on one split while `estimator_` was trained on a different split — an inconsistent pair.

**Root cause** (`_classification_threshold.py`, `TunedThresholdClassifierCV._fit`):

```python
# Before (buggy): creates a fresh iterator — may yield different split
splits = cv.split(X, y, **routed_params.splitter.split)
...
train_idx, _ = next(cv.split(X, y, **routed_params.splitter.split))
```

**Fix**: materialise the generator into a list once and index it:

```python
# After (fixed): same list consumed by both branches
splits = list(cv.split(X, y, **routed_params.splitter.split))
...
train_idx, _ = splits[0]
```

## Changes

- `sklearn/model_selection/_classification_threshold.py`: Materialise `splits` to a `list` and use `splits[0]` in the `refit=False` branch instead of calling `cv.split()` a second time.
- `sklearn/model_selection/tests/test_classification_threshold.py`: Add regression test `test_tuned_threshold_classifier_cv_float_refit_false_same_split` that patches `StratifiedShuffleSplit.split` to count invocations and asserts it is called exactly once (fails on the buggy code, passes on the fix).

## Test plan

- [x] New regression test `test_tuned_threshold_classifier_cv_float_refit_false_same_split` — confirms `cv.split()` is called exactly once
- [x] Existing `test_tuned_threshold_classifier_cv_float` — still passes
- [x] Manually verified the regression test **fails** on the pre-fix code (`cv.split() called 2 time(s)`) and **passes** after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)