### PR TITLE
fix: swap predict_proba columns when probA > 0 for binary SVC

### DIFF
--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -907,7 +907,22 @@ class BaseSVC(ClassifierMixin, BaseLibSVM, metaclass=ABCMeta):
         pred_proba = (
             self._sparse_predict_proba if self._sparse else self._dense_predict_proba
         )
-        return pred_proba(X)
+        pprob = pred_proba(X)
+
+        # In the binary case, libsvm's Platt calibration computes
+        # sigmoid_predict(raw_dec, probA, probB), where raw_dec is the
+        # *un-negated* internal decision value (positive raw_dec → class 0).
+        # sklearn's decision_function() negates this for binary classification
+        # so that positive values indicate class 1 (the second class in
+        # sorted order).  When probA > 0 the sigmoid is a decreasing function
+        # of raw_dec, which makes pprob[:,0] (class 0) *increase* with raw_dec
+        # — the opposite of the correct ordering.  Swapping the columns in
+        # that case restores consistency between predict_proba and
+        # decision_function.  See gh-31222.
+        if len(self.classes_) == 2 and self._probA[0] > 0:
+            pprob = pprob[:, ::-1]
+
+        return pprob
 
     @available_if(_check_proba)
     def predict_log_proba(self, X):

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -1524,3 +1524,43 @@ def test_probability_raises_futurewarning(Estimator, name, probability):
     X, y = make_classification()
     with pytest.warns(FutureWarning, match="probability.+parameter.+deprecated"):
         Estimator(probability=probability).fit(X, y)
+
+
+# TODO(1.11): remove once probability=True is removed from SVC/NuSVC.
+@pytest.mark.thread_unsafe
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+@pytest.mark.parametrize("kernel", ["rbf", "linear", "poly", "sigmoid"])
+def test_predict_proba_consistent_with_decision_function(kernel):
+    """predict_proba[:, 1] and decision_function must be monotonically consistent.
+
+    Non-regression test for gh-31222.  When the Platt-scaling parameter
+    probA > 0 (which can occur when the SVM does not generalise well, e.g.
+    on noise data), the column ordering returned by libsvm's
+    predict_probability was inverted relative to sklearn's decision_function
+    convention (positive score → class 1).  The fix swaps the probability
+    columns in that case so that predict_proba[:, 1] always increases
+    monotonically with decision_function for all kernels.
+    """
+    from scipy.stats import spearmanr
+
+    # Use a high-dimensional noise dataset where the SVM generalises poorly
+    # and probA > 0 is expected.
+    rng = np.random.default_rng(123)
+    X = rng.normal(size=(100, 100))
+    y = rng.integers(0, 2, size=100)
+    X_train, X_test, y_train, _ = train_test_split(X, y, random_state=0)
+
+    clf = svm.SVC(kernel=kernel, probability=True, random_state=0)
+    clf.fit(X_train, y_train)
+
+    y_proba = clf.predict_proba(X_test)
+    y_dec = clf.decision_function(X_test)
+
+    # predict_proba[:, 1] must be monotonically increasing with
+    # decision_function (Spearman rank correlation >= 0).
+    corr, _ = spearmanr(y_proba[:, 1], y_dec)
+    assert corr >= 0, (
+        f"kernel={kernel!r}: predict_proba[:, 1] is anti-correlated with "
+        f"decision_function (Spearman rho={corr:.3f}). "
+        "This indicates a sign flip in the Platt-calibrated probabilities."
+    )


### PR DESCRIPTION
## Summary

Fixes #31222.

When libsvm's Platt scaling learns a **positive** `probA` parameter — which occurs when the SVM does not generalise well (e.g. high-dimensional noise) — `predict_proba[:, 1]` becomes anti-correlated with `decision_function`. This makes ROC-AUC scores computed from the two methods approximately **1 − (each other)**.

### Root cause

sklearn's `decision_function()` **negates** the raw libsvm decision value for binary classification (line 584 of `_base.py`), so that a positive score means class 1. `predict_proba` does not apply this negation — it returns `sigmoid_predict(raw_dec, probA, probB)` directly from libsvm.

`sigmoid_predict` is a **decreasing** function of `raw_dec * probA + probB`. When `probA > 0`, higher `raw_dec` → lower probability → lower `pprob[:, 1]`, which is the opposite of what `decision_function` implies. When `probA < 0` (the common case for well-fitted SVMs), the two are consistent.

### Fix

In `BaseSVC.predict_proba()`, for binary classification, swap `pprob[:, 0]` and `pprob[:, 1]` whenever `self._probA[0] > 0`. This restores monotonic consistency between `predict_proba[:, 1]` and `decision_function` for all kernels and all data regimes.

### Verification

Before fix:
```
AUC (predict_proba)       = 0.5833
AUC (decision_function)   = 0.4295   # ≈ 1 - 0.5833
Spearman corr             = -0.9961  # nearly perfect inverse
```

After fix:
```
AUC (predict_proba)       = 0.4167
AUC (decision_function)   = 0.4295   # ✓ consistent
Spearman corr             = +0.9961  # ✓ positive
```

All 126 existing SVM tests continue to pass; 4 new parametrised tests cover all four kernels (`rbf`, `linear`, `poly`, `sigmoid`).

> **Note:** `probability=True` is deprecated in SVC/NuSVC (#32050, milestone 1.9). The new test carries a `# TODO(1.11)` removal marker consistent with the rest of the codebase.

## Test plan

- [x] Existing test suite: `pytest sklearn/svm/tests/test_svm.py` — 130 passed, 0 failed
- [x] New regression test `test_predict_proba_consistent_with_decision_function` — 4 variants (one per kernel)
- [x] Manually verified with the exact reproducer from #31222

🤖 Generated with [Claude Code](https://claude.com/claude-code)