### PR TITLE
Fix ConvergenceWarning in plot_gpr_on_structured_data example

### DIFF
--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -5,7 +5,7 @@ Gaussian processes on discrete data structures
 
 This example illustrates the use of Gaussian processes for regression and
 classification tasks on data that are not in fixed-length feature vector form.
-This is achieved through the use of kernel functions that operates directly
+This is achieved through the use of kernel functions that operate directly
 on discrete structures such as variable-length sequences, trees, and graphs.
 
 Specifically, here the input variables are some gene sequences stored as
@@ -149,7 +149,11 @@ X_train = np.array(["AGCT", "CGA", "TAAC", "TCG", "CTTT", "TGCT"])
 # whether there are 'A's in the sequence
 Y_train = np.array([True, True, True, False, False, False])
 
-gp = GaussianProcessClassifier(kernel)
+# Set baseline_similarity_bounds to "fixed" to prevent hyperparameter
+# optimization for this kernel. The optimizer pushes baseline_similarity
+# toward zero in this example, which triggers a ConvergenceWarning because
+# the optimal value sits at the lower bound of the search range.
+gp = GaussianProcessClassifier(SequenceKernel(baseline_similarity_bounds="fixed"))
 gp.fit(X_train, Y_train)
 
 X_test = ["AAA", "ATAG", "CTC", "CT", "C"]


### PR DESCRIPTION
Fixes #31164

## What changed

**`examples/gaussian_process/plot_gpr_on_structured_data.py`**

1. **Suppress ConvergenceWarning in classification section** - The `GaussianProcessClassifier` was receiving a `SequenceKernel` with `baseline_similarity_bounds=(1e-5, 1)`. The optimizer consistently pushes `baseline_similarity` toward zero, causing:
   ```
   ConvergenceWarning: The optimal value found for dimension 0 of parameter
   baseline_similarity is close to the specified lower bound 1e-5.
   ```
   Lowering the bound further results in an lbfgs `ABNORMAL` failure. The fix sets `baseline_similarity_bounds="fixed"` on the kernel passed to `GaussianProcessClassifier`, disabling hyperparameter optimization for this parameter. A comment is added explaining why.

2. **Fix grammatical typo** - "kernel functions that operates directly" -> "kernel functions that operate directly"

## How to verify

```python
python examples/gaussian_process/plot_gpr_on_structured_data.py
```

No `ConvergenceWarning` is raised. The three plots render correctly and the classification predictions are unchanged.