### PR TITLE
`__package__` → `__spec__.parent`

### DIFF
--- a/sklearn/externals/array_api_compat/cupy/__init__.py
+++ b/sklearn/externals/array_api_compat/cupy/__init__.py
@@ -9,8 +9,8 @@ from ._aliases import * # noqa: F403
 from ._info import __array_namespace_info__  # noqa: F401
 
 # See the comment in the numpy __init__.py
-__import__(__package__ + '.linalg')
-__import__(__package__ + '.fft')
+__import__(__spec__.parent + '.linalg')
+__import__(__spec__.parent + '.fft')
 
 __array_api_version__: Final = '2024.12'
 

--- a/sklearn/externals/array_api_compat/dask/array/__init__.py
+++ b/sklearn/externals/array_api_compat/dask/array/__init__.py
@@ -13,8 +13,8 @@ __array_api_version__: Final = "2024.12"
 del Final
 
 # See the comment in the numpy __init__.py
-__import__(__package__ + '.linalg')
-__import__(__package__ + '.fft')
+__import__(__spec__.parent + '.linalg')
+__import__(__spec__.parent + '.fft')
 
 __all__ = sorted(
     set(__all__)

--- a/sklearn/externals/array_api_compat/numpy/__init__.py
+++ b/sklearn/externals/array_api_compat/numpy/__init__.py
@@ -20,9 +20,8 @@ from ._info import __array_namespace_info__  # noqa: F401
 #
 # It doesn't overwrite np.linalg from above. The import is generated
 # dynamically so that the library can be vendored.
-__import__(__package__ + ".linalg")
-
-__import__(__package__ + ".fft")
+__import__(__spec__.parent + ".linalg")
+__import__(__spec__.parent + ".fft")
 
 from .linalg import matrix_transpose, vecdot  # type: ignore[no-redef]  # noqa: F401
 

--- a/sklearn/externals/array_api_compat/torch/__init__.py
+++ b/sklearn/externals/array_api_compat/torch/__init__.py
@@ -10,8 +10,8 @@ from ._aliases import * # noqa: F403
 from ._info import __array_namespace_info__  # noqa: F401
 
 # See the comment in the numpy __init__.py
-__import__(__package__ + '.linalg')
-__import__(__package__ + '.fft')
+__import__(__spec__.parent + '.linalg')
+__import__(__spec__.parent + '.fft')
 
 __array_api_version__: Final = '2024.12'
 


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.

Remove deprecated `__package__`, scheduled for [removal in Python 3.15](https://docs.python.org/3.15/reference/datamodel.html#module.__package__).

#### AI usage disclosure

I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
