### PR TITLE
Fix ConvergenceWarning and typo in plot_gpr_on_structured_data.py

### DIFF
--- a/examples/gaussian_process/plot_gpr_on_structured_data.py
+++ b/examples/gaussian_process/plot_gpr_on_structured_data.py
@@ -5,7 +5,7 @@ Gaussian processes on discrete data structures
 
 This example illustrates the use of Gaussian processes for regression and
 classification tasks on data that are not in fixed-length feature vector form.
-This is achieved through the use of kernel functions that operates directly
+This is achieved through the use of kernel functions that operate directly
 on discrete structures such as variable-length sequences, trees, and graphs.
 
 Specifically, here the input variables are some gene sequences stored as
@@ -54,7 +54,7 @@ class SequenceKernel(GenericKernelMixin, Kernel):
     A minimal (but valid) convolutional kernel for sequences of variable
     lengths."""
 
-    def __init__(self, baseline_similarity=0.5, baseline_similarity_bounds=(1e-5, 1)):
+    def __init__(self, baseline_similarity=0.5, baseline_similarity_bounds=(1e-2, 1)):
         self.baseline_similarity = baseline_similarity
         self.baseline_similarity_bounds = baseline_similarity_bounds
 


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #31164

#### What does this implement/fix? Explain your changes.
- Fixed ConvergenceWarning by changing `baseline_similarity_bounds` 
  from `(1e-5, 1)` to `(1e-2, 1)` in the custom kernel
- Fixed typo: "use of kernel functions that operates" → 
  "use of kernel functions that operate"

#### AI usage disclosure
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Any other comments?
This is my first contribution to scikit-learn as part of 
my GSoC 2026 application.