### PR TITLE
fix: skip SGD partial_fit update when all sample_weights are zero

### DIFF
--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -655,6 +655,11 @@ class BaseSGDClassifier(LinearClassifierMixin, BaseSGD, metaclass=ABCMeta):
         if not hasattr(self, "t_"):
             self.t_ = 1.0
 
+        # If all sample weights are zero, skip the gradient update to preserve
+        # the current model state (see issue #33436).
+        if not np.any(sample_weight):
+            return self
+
         # delegate to concrete training procedure
         if n_classes > 2:
             self._fit_multiclass(
@@ -1531,6 +1536,11 @@ class BaseSGDRegressor(RegressorMixin, BaseSGD):
         if self.average > 0 and getattr(self, "_average_coef", None) is None:
             self._average_coef = np.zeros(n_features, dtype=X.dtype, order="C")
             self._average_intercept = np.zeros(1, dtype=X.dtype, order="C")
+
+        # If all sample weights are zero, skip the gradient update to preserve
+        # the current model state (see issue #33436).
+        if not np.any(sample_weight):
+            return self
 
         self._fit_regressor(X, y, alpha, loss, learning_rate, sample_weight, max_iter)
 
@@ -2465,6 +2475,11 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
         self._loss_function_ = self._get_loss_function(loss)
         if not hasattr(self, "t_"):
             self.t_ = 1.0
+
+        # If all sample weights are zero, skip the gradient update to preserve
+        # the current model state (see issue #33436).
+        if not np.any(sample_weight):
+            return self
 
         # delegate to concrete training procedure
         self._fit_one_class(

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -2342,6 +2342,7 @@ def test_sgd_one_class_svm_formulation_with_scipy_minimize():
 
 # ---- Non-regression tests for issue #33436 ----
 
+
 @pytest.mark.parametrize("klass", [SGDClassifier, SparseSGDClassifier])
 def test_partial_fit_zero_sample_weight_classifier(klass):
     """SGDClassifier.partial_fit must not mutate the model when all

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -2338,3 +2338,74 @@ def test_sgd_one_class_svm_formulation_with_scipy_minimize():
 
     assert_allclose(model.coef_, expected_coef, rtol=5e-3)
     assert_allclose(model.offset_, expected_offset, rtol=1e-2)
+
+
+# ---- Non-regression tests for issue #33436 ----
+
+@pytest.mark.parametrize("klass", [SGDClassifier, SparseSGDClassifier])
+def test_partial_fit_zero_sample_weight_classifier(klass):
+    """SGDClassifier.partial_fit must not mutate the model when all
+    sample_weight values are zero (GH #33436)."""
+    X_train, y_train = iris.data, iris.target
+    classes = np.unique(y_train)
+
+    # Fit the model on real data first
+    clf = klass(random_state=0, max_iter=5)
+    clf.partial_fit(X_train, y_train, classes=classes)
+
+    coef_before = clf.coef_.copy()
+    t_before = clf.t_
+
+    # Call partial_fit with all-zero sample weights
+    zero_weight = np.zeros(X_train.shape[0])
+    clf.partial_fit(X_train, y_train, sample_weight=zero_weight)
+
+    assert_array_equal(clf.coef_, coef_before)
+    assert clf.t_ == t_before, (
+        f"t_ changed from {t_before} to {clf.t_} with all-zero sample_weight"
+    )
+
+
+def test_partial_fit_zero_sample_weight_regressor():
+    """SGDRegressor.partial_fit must not mutate the model when all
+    sample_weight values are zero (GH #33436)."""
+    from sklearn.linear_model import SGDRegressor
+
+    rng = np.random.RandomState(0)
+    X_train = rng.randn(50, 4)
+    y_train = rng.randn(50)
+
+    reg = SGDRegressor(random_state=0, max_iter=5)
+    reg.partial_fit(X_train, y_train)
+
+    coef_before = reg.coef_.copy()
+    t_before = reg.t_
+
+    zero_weight = np.zeros(X_train.shape[0])
+    reg.partial_fit(X_train, y_train, sample_weight=zero_weight)
+
+    assert_array_equal(reg.coef_, coef_before)
+    assert reg.t_ == t_before, (
+        f"t_ changed from {t_before} to {reg.t_} with all-zero sample_weight"
+    )
+
+
+def test_partial_fit_zero_sample_weight_one_class_svm():
+    """SGDOneClassSVM.partial_fit must not mutate the model when all
+    sample_weight values are zero (GH #33436)."""
+    rng = np.random.RandomState(0)
+    X_train = rng.randn(50, 4)
+
+    clf = SGDOneClassSVM(random_state=0, max_iter=5)
+    clf.partial_fit(X_train)
+
+    coef_before = clf.coef_.copy()
+    t_before = clf.t_
+
+    zero_weight = np.zeros(X_train.shape[0])
+    clf.partial_fit(X_train, sample_weight=zero_weight)
+
+    assert_array_equal(clf.coef_, coef_before)
+    assert clf.t_ == t_before, (
+        f"t_ changed from {t_before} to {clf.t_} with all-zero sample_weight"
+    )


### PR DESCRIPTION
## Description

Fix **issue #33436**: `SGDClassifier.partial_fit` (and `SGDRegressor.partial_fit`, `SGDOneClassSVM.partial_fit`) mutate the model even when all `sample_weight` values are zero.

When every sample weight is `0.0`, no gradient information should flow into the model. Before this fix, the Cython training loop was still executed, causing `coef_` and `t_` to change — which violates the expectation that zero-weight samples have no effect.

### Root cause

The three `_partial_fit` implementations delegate unconditionally to Cython routines (`_fit_binary`, `_fit_multiclass`, `_fit_regressor`, `_fit_one_class`). Those routines update `t_` (and potentially `coef_`) even when every sample weight is zero.

### Fix

Add an early-return guard in each `_partial_fit` **after** parameter memory is allocated (so first-call initialization still happens) but **before** the Cython training routines are invoked:

```python
# If all sample weights are zero, skip the gradient update to preserve
# the current model state (see issue #33436).
if not np.any(sample_weight):
    return self
```

This is consistent with the existing behaviour when `early_stopping=True`, where a warning is raised for all-zero validation weights (see `_make_validation_split`).

### Files changed

- `sklearn/linear_model/_stochastic_gradient.py` — three `_partial_fit` methods (classifier, regressor, one-class SVM)
- `sklearn/linear_model/tests/test_sgd.py` — three non-regression tests

### Minimal reproducer

```python
import numpy as np
from sklearn.linear_model import SGDClassifier
from sklearn.datasets import load_iris

X, y = load_iris(return_X_y=True)
clf = SGDClassifier(random_state=0).fit(X, y)
coef_before = clf.coef_.copy()
t_before = clf.t_

# All weights zero — model should stay unchanged
clf.partial_fit(X, y, sample_weight=np.zeros(len(y)))

assert np.array_equal(clf.coef_, coef_before)  # fails before fix
assert clf.t_ == t_before                        # fails before fix
```

Closes #33436
