### PR TITLE
fix(compose): handle remainder='passthrough' correctly with metadata routing

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -1311,7 +1311,17 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         # might happen if no columns are selected for that transformer. We
         # request all metadata requested by all transformers.
         transformers = self.transformers
-        if self.remainder not in ("drop", "passthrough"):
+        if self.remainder == "passthrough":
+            # When remainder='passthrough', a FunctionTransformer is used at
+            # runtime (see _call_func_on_transformers). We add a proxy entry
+            # here so that process_routing produces a 'remainder' key and
+            # _call_func_on_transformers does not raise KeyError. The
+            # FunctionTransformer requests no metadata by default, which is
+            # correct because 'passthrough' simply forwards columns unchanged.
+            transformers = chain(
+                transformers, [("remainder", FunctionTransformer(), None)]
+            )
+        elif self.remainder != "drop":
             transformers = chain(transformers, [("remainder", self.remainder, None)])
         for name, step, _ in transformers:
             method_mapping = MethodMapping()

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -2887,5 +2887,49 @@ def test_unused_transformer_request_present():
     assert router.consumes("fit", ["metadata"]) == set(["metadata"])
 
 
+@config_context(enable_metadata_routing=True)
+def test_metadata_routing_remainder_passthrough_with_sample_weight():
+    """Regression test for https://github.com/scikit-learn/scikit-learn/issues/33614
+
+    ColumnTransformer.fit raised KeyError('remainder') when metadata routing
+    was enabled, a child transformer requested sample_weight, and
+    remainder='passthrough'. The routing code did not register any router
+    entry for the 'passthrough' sentinel, so process_routing returned a Bunch
+    without a 'remainder' key, causing the KeyError.
+    """
+    import pandas as pd
+
+    rng = np.random.RandomState(0)
+    X = pd.DataFrame({"x1": rng.randn(10), "x2": rng.randn(10)})
+    y = rng.randn(10)
+    sample_weight = rng.rand(10)
+
+    class WeightConsumingTransformer(TransformerMixin, BaseEstimator):
+        """A transformer that explicitly requests sample_weight on fit."""
+
+        def fit(self, X, y=None, sample_weight=None):
+            self.sample_weight_ = sample_weight
+            return self
+
+        def transform(self, X):
+            return X
+
+    wt = WeightConsumingTransformer().set_fit_request(sample_weight=True)
+
+    # remainder='passthrough' + metadata-requesting transformer must not raise
+    ct = ColumnTransformer([("model", wt, ["x1"])], remainder="passthrough")
+    # This used to raise KeyError('remainder') before the fix.
+    ct.fit(X, y, sample_weight=sample_weight)
+
+    # Verify that sample_weight was actually forwarded to the transformer.
+    np.testing.assert_array_equal(ct.named_transformers_["model"].sample_weight_, sample_weight)
+
+    # Also verify fit_transform works correctly.
+    ct2 = ColumnTransformer([("model", wt, ["x1"])], remainder="passthrough")
+    result = ct2.fit_transform(X, y, sample_weight=sample_weight)
+    # Output should have both x1 (transformed) and x2 (passthrough) columns.
+    assert result.shape == (10, 2)
+
+
 # End of Metadata Routing Tests
 # =============================


### PR DESCRIPTION
## Summary

Fixes #33614

`ColumnTransformer.fit` raised `KeyError('remainder')` when:
- `enable_metadata_routing=True`
- A child transformer requested `sample_weight` (or any metadata)
- `remainder='passthrough'`

## Root Cause

In `get_metadata_routing()`, the router only skipped `'remainder'` when `remainder` was `'drop'` or `'passthrough'`. This means when `remainder='passthrough'`, no `'remainder'` key was registered in the router.

However, `_call_func_on_transformers()` iterates all transformers via `_iter()`, which **does** include the remainder transformer when there are remainder columns. It then accesses `routed_params[name]` where `name='remainder'` — causing `KeyError: 'remainder'`.

## Fix

In `get_metadata_routing()`, when `remainder='passthrough'`, register a proxy `FunctionTransformer()` under the `'remainder'` key. This matches what `_call_func_on_transformers` does at runtime (it also replaces the `'passthrough'` sentinel with a `FunctionTransformer`). Since `FunctionTransformer` requests no metadata by default, no metadata is incorrectly routed to the passthrough step.

## Reproducer

```python
import numpy as np
import pandas as pd
from sklearn import set_config
from sklearn.compose import ColumnTransformer
from sklearn.base import BaseEstimator, TransformerMixin

set_config(enable_metadata_routing=True)

class MyTransformer(TransformerMixin, BaseEstimator):
    def fit(self, X, y=None, sample_weight=None):
        return self
    def transform(self, X):
        return X

rng = np.random.RandomState(0)
X = pd.DataFrame({'x1': rng.randn(10), 'x2': rng.randn(10)})
y = rng.randn(10)
sample_weight = rng.rand(10)

mt = MyTransformer().set_fit_request(sample_weight=True)
ct = ColumnTransformer([("model", mt, ["x1"])], remainder="passthrough")
ct.fit(X, y, sample_weight=sample_weight)  # Previously: KeyError: 'remainder'
```

## Changes

- `sklearn/compose/_column_transformer.py`: Fixed `get_metadata_routing()` to register a `FunctionTransformer` proxy for the `'remainder'` key when `remainder='passthrough'`.
- `sklearn/compose/tests/test_column_transformer.py`: Added regression test `test_metadata_routing_remainder_passthrough_with_sample_weight`.