### PR TITLE
DOC use the HTML output of pandas in the tweedie regression example

### DIFF
--- a/examples/linear_model/plot_tweedie_regression_insurance_claims.py
+++ b/examples/linear_model/plot_tweedie_regression_insurance_claims.py
@@ -265,9 +265,7 @@ df["PurePremium"] = df["ClaimAmount"] / df["Exposure"]
 # Frequency times the average claim amount per claim:
 df["Frequency"] = df["ClaimNb"] / df["Exposure"]
 df["AvgClaimAmount"] = df["ClaimAmount"] / np.fmax(df["ClaimNb"], 1)
-
-with pd.option_context("display.max_columns", 15):
-    print(df[df.ClaimAmount > 0].head())
+df[df.ClaimAmount > 0]
 
 # %%
 #


### PR DESCRIPTION
Quick readability improvement.

I think the pandas output naturally horizontally scrolls to display all the columns by default.

I also removed the `.head()` because the default value has an ellipsis on the rows to only display the head and the tail by default, along with the shape information of the full dataframe.