### PR TITLE
[Callbacks] FIX Supporting the instantiation of a Manager outside of the __main__ module

### DIFF
--- a/sklearn/callback/_callback_support.py
+++ b/sklearn/callback/_callback_support.py
@@ -3,8 +3,9 @@
 
 import functools
 from contextlib import contextmanager
-from multiprocessing import get_context
 from threading import Lock
+
+from joblib.externals.loky.backend import get_context
 
 from sklearn.callback._base import AutoPropagatedCallback, FitCallback
 from sklearn.callback._callback_context import CallbackContext
@@ -23,7 +24,7 @@ def get_callback_manager():
     if _CallbackManagerState.manager is None:
         with _CallbackManagerState.lock:
             if _CallbackManagerState.manager is None:
-                _CallbackManagerState.manager = get_context("fork").Manager()
+                _CallbackManagerState.manager = get_context().Manager()
 
     return _CallbackManagerState.manager
 

--- a/sklearn/callback/_callback_support.py
+++ b/sklearn/callback/_callback_support.py
@@ -3,7 +3,7 @@
 
 import functools
 from contextlib import contextmanager
-from multiprocessing import Manager
+from multiprocessing import get_context
 from threading import Lock
 
 from sklearn.callback._base import AutoPropagatedCallback, FitCallback
@@ -23,7 +23,7 @@ def get_callback_manager():
     if _CallbackManagerState.manager is None:
         with _CallbackManagerState.lock:
             if _CallbackManagerState.manager is None:
-                _CallbackManagerState.manager = Manager()
+                _CallbackManagerState.manager = get_context("fork").Manager()
 
     return _CallbackManagerState.manager
 

--- a/sklearn/callback/tests/test_callback_support.py
+++ b/sklearn/callback/tests/test_callback_support.py
@@ -1,6 +1,8 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import textwrap
+
 import pytest
 
 from sklearn.base import clone
@@ -11,6 +13,7 @@ from sklearn.callback.tests._utils import (
     TestingAutoPropagatedCallback,
     TestingCallback,
 )
+from sklearn.utils._testing import assert_run_python_script_without_output
 from sklearn.utils.parallel import Parallel, delayed
 
 
@@ -93,3 +96,13 @@ def test_function_no_callback_support(n_jobs, prefer, Callback):
     assert callback.count_hooks("on_fit_task_begin") == n_fits * (1 + max_iter)
     assert callback.count_hooks("on_fit_task_end") == n_fits * (1 + max_iter)
     assert callback.count_hooks("teardown") == n_fits
+
+
+def test_instantiate_manager_outside_main_module():
+    """Test instantiating the callbacks manager outside the __main__ module."""
+    code = """
+    from sklearn.callback.tests._utils import TestingCallback
+
+    callback = TestingCallback()
+    """
+    assert_run_python_script_without_output(textwrap.dedent(code))

--- a/sklearn/callback/tests/test_callback_support.py
+++ b/sklearn/callback/tests/test_callback_support.py
@@ -101,8 +101,8 @@ def test_function_no_callback_support(n_jobs, prefer, Callback):
 def test_instantiate_manager_outside_main_module():
     """Test instantiating the callbacks manager outside the __main__ module."""
     code = """
-    from sklearn.callback.tests._utils import TestingCallback
+    from sklearn.callback._callback_support import get_callback_manager
 
-    callback = TestingCallback()
+    get_callback_manager()
     """
     assert_run_python_script_without_output(textwrap.dedent(code))

--- a/sklearn/callback/tests/test_progressbar.py
+++ b/sklearn/callback/tests/test_progressbar.py
@@ -130,9 +130,15 @@ def test_progressbar_no_callback_support(backend):
         assert all(queue.empty() for queue in progressbar._run_queues.values())
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 12, 8),
+    reason="Race conditions can appear because of multiprocessing issues for python"
+    " < 3.12.8.",
+)
 @pytest.mark.parametrize("prefer", ["threads", "processes"])
-def test_outside_main_module(prefer):
-    """Test instantiating the progressbar outside the __main__ module."""
+@pytest.mark.parametrize("repeat", range(100))
+def test_progressbar_outside_main_module(prefer, repeat):
+    """Check that ProgressBar does not trigger spawn errors outside `__main__`."""
     pytest.importorskip("rich")
     code = f"""
     from sklearn.callback import ProgressBar
@@ -140,12 +146,11 @@ def test_outside_main_module(prefer):
 
     est = MaxIterEstimator()
     meta_est = MetaEstimator(
-        est, n_outer=2, n_inner=3, n_jobs=2, prefer='{prefer}'
+        est, n_outer=2, n_inner=1, n_jobs=2, prefer='{prefer}'
     )
     meta_est.set_callbacks(ProgressBar())
     meta_est.fit()
     """
-    # Running the script is expected to output the progressbars to stdout, so here the
-    # pattern arg should not be left to the default, but we are not trying to avoid any
-    # specific pattern, so here the pattern value has no concrete meaning.
-    assert_run_python_script_without_output(textwrap.dedent(code), pattern="xxx")
+
+    pattern = "An attempt has been made to start a new process"
+    assert_run_python_script_without_output(textwrap.dedent(code), pattern=pattern)

--- a/sklearn/callback/tests/test_progressbar.py
+++ b/sklearn/callback/tests/test_progressbar.py
@@ -6,8 +6,8 @@ import sys
 
 import pytest
 
-from sklearn.base import BaseEstimator, _fit_context, clone
-from sklearn.callback import CallbackSupportMixin, ProgressBar
+from sklearn.base import clone
+from sklearn.callback import ProgressBar
 from sklearn.callback.tests._utils import (
     MaxIterEstimator,
     MetaEstimator,
@@ -126,27 +126,3 @@ def test_progressbar_no_callback_support(backend):
         assert not any(mon.is_alive() for mon in progressbar._run_monitors.values())
         # All queues are empty.
         assert all(queue.empty() for queue in progressbar._run_queues.values())
-
-
-def test_estimator_class_not_imported():
-    class NotImportedEstimator(CallbackSupportMixin, BaseEstimator):
-        _parameter_constraints: dict = {}
-
-        @_fit_context(prefer_skip_nested_validation=False)
-        def fit(self, X=None, y=None):
-            callback_ctx = self._init_callback_context(max_subtasks=2)
-            callback_ctx.call_on_fit_task_begin(X=X, y=y)
-
-            for i in range(2):
-                subcontext = callback_ctx.subcontext(task_id=i).call_on_fit_task_begin(
-                    X=X, y=y
-                )
-                if subcontext.call_on_fit_task_end(X=X, y=y):
-                    break
-
-            callback_ctx.call_on_fit_task_end(X=X, y=y)
-            return self
-
-    estimator = NotImportedEstimator()
-    estimator.set_callbacks(ProgressBar())
-    estimator.fit()

--- a/sklearn/callback/tests/test_progressbar.py
+++ b/sklearn/callback/tests/test_progressbar.py
@@ -133,6 +133,7 @@ def test_progressbar_no_callback_support(backend):
 @pytest.mark.parametrize("prefer", ["threads", "processes"])
 def test_outside_main_module(prefer):
     """Test instantiating the progressbar outside the __main__ module."""
+    pytest.importorskip("rich")
     code = f"""
     from sklearn.callback import ProgressBar
     from sklearn.callback.tests._utils import MaxIterEstimator, MetaEstimator

--- a/sklearn/callback/tests/test_progressbar.py
+++ b/sklearn/callback/tests/test_progressbar.py
@@ -3,6 +3,7 @@
 
 import re
 import sys
+import textwrap
 
 import pytest
 
@@ -14,6 +15,7 @@ from sklearn.callback.tests._utils import (
     WhileEstimator,
 )
 from sklearn.utils._optional_dependencies import check_rich_support
+from sklearn.utils._testing import assert_run_python_script_without_output
 from sklearn.utils.parallel import Parallel, delayed
 
 
@@ -126,3 +128,23 @@ def test_progressbar_no_callback_support(backend):
         assert not any(mon.is_alive() for mon in progressbar._run_monitors.values())
         # All queues are empty.
         assert all(queue.empty() for queue in progressbar._run_queues.values())
+
+
+@pytest.mark.parametrize("prefer", ["threads", "processes"])
+def test_outside_main_module(prefer):
+    """Test instantiating the progressbar outside the __main__ module."""
+    code = f"""
+    from sklearn.callback import ProgressBar
+    from sklearn.callback.tests._utils import MaxIterEstimator, MetaEstimator
+
+    est = MaxIterEstimator()
+    meta_est = MetaEstimator(
+        est, n_outer=2, n_inner=3, n_jobs=2, prefer='{prefer}'
+    )
+    meta_est.set_callbacks(ProgressBar())
+    meta_est.fit()
+    """
+    # Running the script is expected to output the progressbars to stdout, so here the
+    # pattern arg should not be left to the default, but we are not trying to avoid any
+    # specific pattern, so here the pattern value has no concrete meaning.
+    assert_run_python_script_without_output(textwrap.dedent(code), pattern="xxx")

--- a/sklearn/callback/tests/test_progressbar.py
+++ b/sklearn/callback/tests/test_progressbar.py
@@ -136,8 +136,7 @@ def test_progressbar_no_callback_support(backend):
     " < 3.12.8.",
 )
 @pytest.mark.parametrize("prefer", ["threads", "processes"])
-@pytest.mark.parametrize("repeat", range(100))
-def test_progressbar_outside_main_module(prefer, repeat):
+def test_progressbar_outside_main_module(prefer):
     """Check that ProgressBar does not trigger spawn errors outside `__main__`."""
     pytest.importorskip("rich")
     code = f"""

--- a/sklearn/callback/tests/test_progressbar.py
+++ b/sklearn/callback/tests/test_progressbar.py
@@ -136,8 +136,7 @@ def test_progressbar_no_callback_support(backend):
     " < 3.12.8.",
 )
 @pytest.mark.parametrize("prefer", ["threads", "processes"])
-@pytest.mark.parametrize("repeat", range(100))
-def test_progressbar_outside_main_module(prefer, repeat):
+def test_progressbar_outside_main_module(prefer, global_random_seed):
     """Check that ProgressBar does not trigger spawn errors outside `__main__`."""
     pytest.importorskip("rich")
     code = f"""

--- a/sklearn/callback/tests/test_progressbar.py
+++ b/sklearn/callback/tests/test_progressbar.py
@@ -136,7 +136,8 @@ def test_progressbar_no_callback_support(backend):
     " < 3.12.8.",
 )
 @pytest.mark.parametrize("prefer", ["threads", "processes"])
-def test_progressbar_outside_main_module(prefer):
+@pytest.mark.parametrize("repeat", range(100))
+def test_progressbar_outside_main_module(prefer, repeat):
     """Check that ProgressBar does not trigger spawn errors outside `__main__`."""
     pytest.importorskip("rich")
     code = f"""
@@ -152,4 +153,6 @@ def test_progressbar_outside_main_module(prefer):
     """
 
     pattern = "An attempt has been made to start a new process"
-    assert_run_python_script_without_output(textwrap.dedent(code), pattern=pattern)
+    assert_run_python_script_without_output(
+        textwrap.dedent(code), pattern=pattern, timeout=120
+    )

--- a/sklearn/callback/tests/test_progressbar.py
+++ b/sklearn/callback/tests/test_progressbar.py
@@ -136,7 +136,7 @@ def test_progressbar_no_callback_support(backend):
     " < 3.12.8.",
 )
 @pytest.mark.parametrize("prefer", ["threads", "processes"])
-def test_progressbar_outside_main_module(prefer, global_random_seed):
+def test_progressbar_outside_main_module(prefer):
     """Check that ProgressBar does not trigger spawn errors outside `__main__`."""
     pytest.importorskip("rich")
     code = f"""

--- a/sklearn/callback/tests/test_progressbar.py
+++ b/sklearn/callback/tests/test_progressbar.py
@@ -6,8 +6,8 @@ import sys
 
 import pytest
 
-from sklearn.base import clone
-from sklearn.callback import ProgressBar
+from sklearn.base import BaseEstimator, _fit_context, clone
+from sklearn.callback import CallbackSupportMixin, ProgressBar
 from sklearn.callback.tests._utils import (
     MaxIterEstimator,
     MetaEstimator,
@@ -126,3 +126,27 @@ def test_progressbar_no_callback_support(backend):
         assert not any(mon.is_alive() for mon in progressbar._run_monitors.values())
         # All queues are empty.
         assert all(queue.empty() for queue in progressbar._run_queues.values())
+
+
+def test_estimator_class_not_imported():
+    class NotImportedEstimator(CallbackSupportMixin, BaseEstimator):
+        _parameter_constraints: dict = {}
+
+        @_fit_context(prefer_skip_nested_validation=False)
+        def fit(self, X=None, y=None):
+            callback_ctx = self._init_callback_context(max_subtasks=2)
+            callback_ctx.call_on_fit_task_begin(X=X, y=y)
+
+            for i in range(2):
+                subcontext = callback_ctx.subcontext(task_id=i).call_on_fit_task_begin(
+                    X=X, y=y
+                )
+                if subcontext.call_on_fit_task_end(X=X, y=y):
+                    break
+
+            callback_ctx.call_on_fit_task_end(X=X, y=y)
+            return self
+
+    estimator = NotImportedEstimator()
+    estimator.set_callbacks(ProgressBar())
+    estimator.fit()


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #27676


#### What does this implement/fix? Explain your changes.
**EDIT**: This PR now focuses on the error raised when a `Manager` is instanciated outside of the `__main__` module by a callback. The other related bug when trying to use a `ProgressBar` on an estimator class defined inside the __main__ module is still described below but it is addressed by removing the estimator attribute of the `CallbackContext` in #33664, and is now outside of the scope of this PR. 


- **Current issue**: 

When instantiating a `ProgressBar` outside of a `if __name__ == "__main__"` block, the instantiation of the manager attribute of the progressbar raises an error.

This error can be raised by the following code :
```py
from sklearn.callback import ProgressBar

callback = ProgressBar()
```
 and the error itself is :
 ```

RuntimeError:
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.

        To fix this issue, refer to the "Safe importing of main module"
        section in https://docs.python.org/3/library/multiprocessing.html
 ```
**Proposed solution**: to create the manager under a loky context.

- **Previous issue**, adressed by #33664 and now outside the scope of this PR :

In the `ProgressBar` callback, `CallabckContext` objects are shared between threads/processes to build the task tree. But a `CallabckContext` instance holds a reference to the estimator that created it. And if that estimator's class is defined in the executed code (in the `if __name__ == "__main__"` block or in a jupyter notebook cell) rather than being imported, sending it through the Manager breaks. 

This issue can be reproduced with the following code :
```py
from sklearn.callback import ProgressBar
from sklearn.base import BaseEstimator, _fit_context
from sklearn.callback import CallbackSupportMixin

if __name__ == "__main__":

    class NotImportedEstimator(CallbackSupportMixin, BaseEstimator):
        _parameter_constraints: dict = {}

        @_fit_context(prefer_skip_nested_validation=False)
        def fit(self, X=None, y=None):
            callback_ctx = self._init_callback_context(max_subtasks=2)
            callback_ctx.call_on_fit_task_begin(X=X, y=y)

            for i in range(2):
                subcontext = callback_ctx.subcontext(task_id=i).call_on_fit_task_begin(X=X, y=y)
                if subcontext.call_on_fit_task_end(X=X, y=y):
                    break

            callback_ctx.call_on_fit_task_end(X=X, y=y)
            return self

    estimator = NotImportedEstimator()
    estimator.set_callbacks(ProgressBar())
    estimator.fit()
```
Which gives the following error:
```py
Traceback (most recent call last):
  File "/Users/fpaugam/probabl/scikit-learn/../test_progressbar.py", line 33, in <module>
    estimator.fit()
    ~~~~~~~~~~~~~^^
  File "/Users/fpaugam/probabl/scikit-learn/sklearn/base.py", line 1396, in wrapper
    return fit_method(estimator, *args, **kwargs)
  File "/Users/fpaugam/probabl/scikit-learn/../test_progressbar.py", line 25, in fit
    if subcontext.call_on_fit_task_end(X=X, y=y):
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/Users/fpaugam/probabl/scikit-learn/sklearn/callback/_callback_context.py", line 419, in call_on_fit_task_end
    return self._call_hooks(hook_name="on_fit_task_end", **kwargs)
           ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/fpaugam/probabl/scikit-learn/sklearn/callback/_callback_context.py", line 388, in _call_hooks
    result |= bool(getattr(callback, hook_name)(self, **args_to_pass))
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/fpaugam/probabl/scikit-learn/sklearn/callback/_progressbar.py", line 71, in on_fit_task_end
    self._run_queues[context.root_uuid].put(context)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "<string>", line 2, in put
  File "/Users/fpaugam/miniforge3/envs/sklearn/lib/python3.13/multiprocessing/managers.py", line 847, in _callmethod
    raise convert_to_error(kind, result)
multiprocessing.managers.RemoteError:
---------------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/fpaugam/miniforge3/envs/sklearn/lib/python3.13/multiprocessing/managers.py", line 256, in serve_client
    request = recv()
  File "/Users/fpaugam/miniforge3/envs/sklearn/lib/python3.13/multiprocessing/connection.py", line 251, in recv
    return _ForkingPickler.loads(buf.getbuffer())
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
AttributeError: Can't get attribute 'NotImportedEstimator' on <module '__mp_main__' from '/Users/fpaugam/probabl/test_progressbar.py'>
---------------------------------------------------------------------------
```

Note that the error only happens when the class definition is inside the `if __name__ == "__main__"` and not when it is put outside of it.





#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding


#### Any other comments?
ping @jeremiedbb @ogrisel @StefanieSenger @lesteve 

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
