### PR TITLE
DOC Adding link to ecosystem page "scikit-learn central" on /stable

### DIFF
--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -227,6 +227,7 @@
           <li><strong>Blog:</strong> <a href="https://blog.scikit-learn.org">blog.scikit-learn.org</a></li>
           <li><strong>Logos & Branding:</strong> <a href="https://github.com/scikit-learn/scikit-learn/tree/main/doc/logos">logos and branding</a></li>
           <li><strong>Calendar:</strong> <a href="https://blog.scikit-learn.org/calendar/">calendar</a></li>
+          <li><strong>Ecosystem:</strong> <a href="https://scikit-learn-central.probabl.ai">scikit-learn central</a></li>
           <li><strong>LinkedIn:</strong> <a href="https://www.linkedin.com/company/scikit-learn">linkedin/scikit-learn</a></li>
           <li><strong>Bluesky:</strong> <a href="https://bsky.app/profile/scikit-learn.org">bluesky/scikit-learn.org</a></li>
           <li><strong>Mastodon:</strong> <a href="https://mastodon.social/@sklearn@fosstodon.org">@sklearn</a></li>


### PR DESCRIPTION
This is a backport of 273a01dde292a196909303e2a8ac87d9a7d0fd2f (see #33527) to the 1.8.X branch to update the stable website.