### PR TITLE
MNT align type of `multiclass_colors_` for list and colormap in `DecisionBoundaryDisplay`

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.inspection/33651.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.inspection/33651.fix.rst
@@ -1,0 +1,3 @@
+- In :class:`inspection.DecisionBoundaryDisplay`, `multiclass_colors_` now always stores
+  the colors for multiclass problems as a numpy array.
+  By :user:`Anne Beyer <AnneBeyer>`.

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -117,7 +117,7 @@ def _select_colors(mpl, multiclass_colors, n_classes):
                 "When 'multiclass_colors' is a list, it can only contain valid"
                 f" Matplotlib color names. Got: {multiclass_colors}"
             )
-        return [mpl.colors.to_rgba(color) for color in multiclass_colors]
+        return mpl.colors.to_rgba_array([color for color in multiclass_colors])
 
     else:
         raise TypeError("'multiclass_colors' must be a list or a str.")

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -117,7 +117,7 @@ def _select_colors(mpl, multiclass_colors, n_classes):
                 "When 'multiclass_colors' is a list, it can only contain valid"
                 f" Matplotlib color names. Got: {multiclass_colors}"
             )
-        return mpl.colors.to_rgba_array([color for color in multiclass_colors])
+        return mpl.colors.to_rgba_array(multiclass_colors)
 
     else:
         raise TypeError("'multiclass_colors' must be a list or a str.")

--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -666,6 +666,9 @@ def test_multiclass_colors_cmap(
         multiclass_colors=multiclass_colors,
     )
 
+    # Non-regression test for PR #33651
+    assert isinstance(disp.multiclass_colors_, np.ndarray)
+
     if multiclass_colors is None:
         if len(clf.classes_) <= 10:
             multiclass_colors = "tab10"
@@ -679,7 +682,7 @@ def test_multiclass_colors_cmap(
         cmap = mpl.pyplot.get_cmap(multiclass_colors)
         colors = cmap(np.linspace(0, 1, len(clf.classes_)))
     else:
-        colors = [mpl.colors.to_rgba(color) for color in multiclass_colors]
+        colors = mpl.colors.to_rgba_array(multiclass_colors)
 
     # Make sure the colormap has enough distinct colors.
     assert disp.n_classes == len(np.unique(colors, axis=0))


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Noticed while playing around with https://github.com/scikit-learn/scikit-learn/pull/33612, also related to #33115

#### What does this implement/fix? Explain your changes.
When `muticlass_colors` is passed as a list, it was stored as list internally in `multiclass_colors_` as well, whereas when passing a colormap reference, it was converted into a numpy array.
Now, all paths use the same type for storing internally, which makes the code more consistent and will also facilitate https://github.com/scikit-learn/scikit-learn/issues/33094.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
