### PR TITLE
Docs: Fix minor typo in README

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -4,3 +4,6 @@ This directory contains the full manual and website as displayed at
 https://scikit-learn.org. See
 https://scikit-learn.org/dev/developers/contributing.html#documentation for
 detailed information about the documentation.
+
+
+Docs: Fix typo in installation instructions.


### PR DESCRIPTION
I was reading the documentation and noticed a small typo on line 42. This PR corrects 'algorithim' to 'algorithm