### PR TITLE
FIX ColumnTransformer KeyError('remainder') with metadata routing and remainder='passthrough' (#33614)

### DIFF
--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -1311,8 +1311,21 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         # might happen if no columns are selected for that transformer. We
         # request all metadata requested by all transformers.
         transformers = self.transformers
-        if self.remainder not in ("drop", "passthrough"):
-            transformers = chain(transformers, [("remainder", self.remainder, None)])
+        if self.remainder not in ("drop",):
+            # When remainder="passthrough", the transformer is converted to a
+            # FunctionTransformer at fit time in _call_func_on_transformers.
+            # We still need to add it to the router so that process_routing()
+            # produces a "remainder" key in routed_params; otherwise
+            # _call_func_on_transformers raises KeyError('remainder') when
+            # iterating over the fitted transformers list. A bare
+            # FunctionTransformer does not request any metadata, so the
+            # routing entry is effectively a no-op for passthrough columns.
+            remainder_step = (
+                FunctionTransformer()
+                if self.remainder == "passthrough"
+                else self.remainder
+            )
+            transformers = chain(transformers, [("remainder", remainder_step, None)])
         for name, step, _ in transformers:
             method_mapping = MethodMapping()
             if hasattr(step, "fit_transform"):

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -2887,5 +2887,58 @@ def test_unused_transformer_request_present():
     assert router.consumes("fit", ["metadata"]) == set(["metadata"])
 
 
+
+
+@config_context(enable_metadata_routing=True)
+def test_metadata_routing_remainder_passthrough_no_keyerror():
+    """Regression test for gh-33614.
+
+    ColumnTransformer.fit_transform should not raise KeyError('remainder')
+    when metadata routing is enabled, remainder='passthrough', and at least
+    one named transformer requests metadata (e.g. sample_weight).
+    """
+    import pandas as pd
+
+    X = pd.DataFrame(
+        {
+            "x1": [1.0, 2.0, 3.0],
+            "x2": [22.0, 38.0, 26.0],
+            "x3": [7.25, 71.28, 7.93],
+        }
+    )
+    y = np.array([0, 1, 1])
+    sample_weight = np.ones(3)
+
+    ct = ColumnTransformer(
+        [
+            (
+                "trans",
+                ConsumingTransformer().set_fit_request(sample_weight=True),
+                ["x1", "x2"],
+            )
+        ],
+        remainder="passthrough",
+    )
+    # Should not raise KeyError('remainder')
+    result = ct.fit_transform(X, y, sample_weight=sample_weight)
+    assert result.shape == (3, 3)  # 2 transformed + 1 passthrough column
+
+    # Also check the fit + transform path
+    ct2 = ColumnTransformer(
+        [
+            (
+                "trans",
+                ConsumingTransformer()
+                .set_fit_request(sample_weight=True)
+                .set_transform_request(sample_weight=True),
+                ["x1", "x2"],
+            )
+        ],
+        remainder="passthrough",
+    )
+    ct2.fit(X, y, sample_weight=sample_weight)
+    result2 = ct2.transform(X, sample_weight=sample_weight)
+    assert result2.shape == (3, 3)
+
 # End of Metadata Routing Tests
 # =============================


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #33614

#### What does this implement/fix? Explain your changes.

**Bug:** `ColumnTransformer.fit_transform` (and `fit` + `transform`) raises `KeyError('remainder')` in scikit-learn 1.8.0 when:

- `enable_metadata_routing=True` is set, **and**
- `remainder='passthrough'`, **and**
- at least one named transformer requests metadata (e.g. `sample_weight=True`).

This is a regression vs 1.7.2 where the same code worked correctly.

**Root cause:**

`get_metadata_routing()` excluded the `'remainder'` transformer from the metadata router whenever `remainder'` was `'passthrough'`:

```python
# before (broken)
if self.remainder not in ("drop", "passthrough"):
    transformers = chain(transformers, [("remainder", self.remainder, None)])
```

However, `_call_func_on_transformers` iterates over the fitted transformers list via `_iter()`, which **does** include the remainder transformer (with name `'remainder'`). When `process_routing()` builds `routed_params` it uses only what the router knows about — so `routed_params['remainder']` throws `KeyError`.

**Fix:**

Include a bare `FunctionTransformer()` as the `'remainder'` entry in the router when `remainder='passthrough'`. `FunctionTransformer` does not request any metadata, so this is a no-op for passthrough columns, but ensures the `'remainder'` key is always present in `routed_params`.

```python
# after (fixed)
if self.remainder not in ("drop",):
    remainder_step = (
        FunctionTransformer()
        if self.remainder == "passthrough"
        else self.remainder
    )
    transformers = chain(transformers, [("remainder", remainder_step, None)])
```

**Tests added:**

`test_metadata_routing_remainder_passthrough_no_keyerror` — reproduces the exact steps from #33614 using both `fit_transform` and `fit` + `transform` code paths.

#### AI usage disclosure

I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation

#### Any other comments?

The fix is minimal and surgical — only `get_metadata_routing()` is touched. The `_call_func_on_transformers` passthrough-to-FunctionTransformer conversion logic is unchanged.
