### PR TITLE
FIX tarfile path traversal protection for Python < 3.12

### DIFF
--- a/doc/whats_new/upcoming_changes/security/33667.fix.rst
+++ b/doc/whats_new/upcoming_changes/security/33667.fix.rst
@@ -1,0 +1,3 @@
+- Fixed path traversal vulnerability in :func:`utils.fixes.tarfile_extractall`
+  for Python < 3.12 by validating tar members before extraction.
+  By :user:`Dmitry Dube <dunkin-dee>`.

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -7,9 +7,9 @@ at which the fix is no longer needed.
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import os
 import platform
 import struct
-import os
 
 import numpy as np
 import scipy
@@ -361,14 +361,10 @@ def _validate_tar_members(tar, dest_path):
                 f"Tar member {member.name!r} would extract outside destination"
             )
         if not (member.isreg() or member.isdir() or member.issym() or member.islnk()):
-            raise ValueError(
-                f"Tar member {member.name!r} is a special file type"
-            )
+            raise ValueError(f"Tar member {member.name!r} is a special file type")
         if member.islnk() or member.issym():
             if os.path.isabs(member.linkname):
-                raise ValueError(
-                    f"Tar member {member.name!r} has absolute link target"
-                )
+                raise ValueError(f"Tar member {member.name!r} has absolute link target")
             if member.issym():
                 link_target = os.path.join(
                     dest_path, os.path.dirname(name), member.linkname

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -9,6 +9,7 @@ at which the fix is no longer needed.
 
 import platform
 import struct
+import os
 
 import numpy as np
 import scipy
@@ -340,6 +341,48 @@ else:
 
 
 # TODO: Remove when Python min version >= 3.12.
+def _validate_tar_members(tar, dest_path):
+    """Validate tar members against path traversal for Python < 3.12.
+
+    Replicates the path-safety checks from CPython's _get_filtered_attrs
+    (Lib/tarfile.py) that are enabled via filter='data' in Python 3.12+.
+    """
+
+    dest_path = os.path.realpath(dest_path)
+    for member in tar.getmembers():
+        name = member.name
+        if name.startswith(("/", os.sep)):
+            name = name.lstrip("/" + os.sep)
+        if os.path.isabs(name):
+            raise ValueError(f"Absolute path in tar member: {member.name!r}")
+        target_path = os.path.realpath(os.path.join(dest_path, name))
+        if os.path.commonpath([target_path, dest_path]) != dest_path:
+            raise ValueError(
+                f"Tar member {member.name!r} would extract outside destination"
+            )
+        if not (member.isreg() or member.isdir() or member.issym() or member.islnk()):
+            raise ValueError(
+                f"Tar member {member.name!r} is a special file type"
+            )
+        if member.islnk() or member.issym():
+            if os.path.isabs(member.linkname):
+                raise ValueError(
+                    f"Tar member {member.name!r} has absolute link target"
+                )
+            if member.issym():
+                link_target = os.path.join(
+                    dest_path, os.path.dirname(name), member.linkname
+                )
+            else:
+                link_target = os.path.join(dest_path, member.linkname)
+            real_link = os.path.realpath(link_target)
+            if os.path.commonpath([real_link, dest_path]) != dest_path:
+                raise ValueError(
+                    f"Tar member {member.name!r} links outside destination"
+                )
+
+
+# TODO: Remove when Python min version >= 3.12.
 def tarfile_extractall(tarfile, path):
     try:
         # Use filter="data" to prevent the most dangerous security issues.
@@ -347,6 +390,7 @@ def tarfile_extractall(tarfile, path):
         # https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractall
         tarfile.extractall(path, filter="data")
     except TypeError:
+        _validate_tar_members(tarfile, path)
         tarfile.extractall(path)
 
 

--- a/sklearn/utils/tests/test_fixes.py
+++ b/sklearn/utils/tests/test_fixes.py
@@ -1,6 +1,10 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import io
+import tarfile
+import tempfile
+
 import numpy as np
 import pytest
 import scipy as sp
@@ -10,7 +14,73 @@ from sklearn.utils.fixes import (
     _ensure_sparse_index_int32,
     _object_dtype_isnan,
     _smallest_admissible_index_dtype,
+    _validate_tar_members,
 )
+
+
+def _make_tar(members):
+    """Create an in-memory tar archive with the given members.
+
+    Each member is a (name, content) or (name, content, kind) tuple.
+    kind is one of "file" (default), "symlink", or "hardlink".
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for item in members:
+            name, content = item[0], item[1]
+            kind = item[2] if len(item) > 2 else "file"
+            info = tarfile.TarInfo(name=name)
+            if kind == "symlink":
+                info.type = tarfile.SYMTYPE
+                info.linkname = content
+                tf.addfile(info)
+            elif kind == "hardlink":
+                info.type = tarfile.LNKTYPE
+                info.linkname = content
+                tf.addfile(info)
+            else:
+                data = content if isinstance(content, bytes) else content.encode()
+                info.size = len(data)
+                tf.addfile(info, io.BytesIO(data))
+    buf.seek(0)
+    return buf
+
+
+def test_validate_tar_members_safe(tmp_path):
+    """A well-formed archive passes validation without error."""
+    buf = _make_tar([("subdir/file.txt", b"hello")])
+    with tarfile.open(fileobj=buf) as tf:
+        _validate_tar_members(tf, str(tmp_path))  # should not raise
+
+
+@pytest.mark.parametrize(
+    "members, match",
+    [
+        ([("../../evil.txt", b"pwned")], "outside destination"),
+        ([("link", "../../outside", "symlink")], "links outside destination"),
+        ([("link", "/etc/passwd", "symlink")], "absolute link target"),
+        ([("link", "../../outside", "hardlink")], "links outside destination"),
+    ],
+)
+def test_validate_tar_members_rejects_unsafe(members, match, tmp_path):
+    """Path traversal, absolute paths, and unsafe links are rejected."""
+    buf = _make_tar(members)
+    with tarfile.open(fileobj=buf) as tf:
+        with pytest.raises(ValueError, match=match):
+            _validate_tar_members(tf, str(tmp_path))
+
+
+def test_validate_tar_members_special_file(tmp_path):
+    """Special file types (e.g. FIFO) are rejected."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        info = tarfile.TarInfo(name="fifo")
+        info.type = tarfile.FIFOTYPE
+        tf.addfile(info)
+    buf.seek(0)
+    with tarfile.open(fileobj=buf) as tf:
+        with pytest.raises(ValueError, match="special file type"):
+            _validate_tar_members(tf, str(tmp_path))
 
 
 @pytest.mark.parametrize("dtype, val", ([object, 1], [object, "a"], [float, 1]))

--- a/sklearn/utils/tests/test_fixes.py
+++ b/sklearn/utils/tests/test_fixes.py
@@ -3,7 +3,6 @@
 
 import io
 import tarfile
-import tempfile
 
 import numpy as np
 import pytest


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #33556.

#### What does this implement/fix? Explain your changes.

Adds `_validate_tar_members` to `sklearn/utils/fixes.py` to prevent path
traversal (zip slip) attacks in the `tarfile_extractall` fallback used on
Python < 3.12.

`tarfile.extractall(filter="data")` was introduced in Python 3.12. The
existing `except TypeError` fallback called `extractall` with no member
validation, allowing a malicious archive to write files outside the
extraction directory.

The fix backports the path-safety checks from CPython's `filter="data"`:
- Strips leading slashes, then rejects any remaining absolute paths
- Rejects members that would extract outside the destination (zip slip)
- Rejects special file types (devices, FIFOs)
- Validates symlink and hardlink targets stay within the destination

The function is marked `TODO: Remove when Python min version >= 3.12`.
The call sites (`_lfw.py`, `_twenty_newsgroups.py`) already use
`tarfile_extractall` and required no changes.

#### AI usage disclosure

I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

#### Any other comments?

The absolute path guard (`os.path.isabs`) is included as a defensive check
for archives created by non-Python tools, even though Python's own tarfile
reader strips leading slashes on read. No test covers this branch for that
reason.
