### PR TITLE
[Callbacks] Make testing estimator not inherit from BaseEstimator

### DIFF
--- a/sklearn/callback/tests/_utils.py
+++ b/sklearn/callback/tests/_utils.py
@@ -208,7 +208,7 @@ class WhileEstimator(CallbackSupportMixin, BaseEstimator):
         return self
 
 
-class ThirdPartyEstimator(CallbackSupportMixin, BaseEstimator):
+class ThirdPartyEstimator(CallbackSupportMixin):
     """A class that mimics a third-party estimator with callback support only using
     public API.
     """


### PR DESCRIPTION
ref https://github.com/scikit-learn/scikit-learn/pull/33322#discussion_r3022996661
To make it explicit (and tested) that callback support can be achieved without inheriting from BaseEstimator.
Documenting that will be done in a different PR