### PR TITLE
DOC Explain tol and max_iter in the SVM user guide

### DIFF
--- a/doc/modules/svm.rst
+++ b/doc/modules/svm.rst
@@ -4,15 +4,19 @@
 Support Vector Machines
 =======================
 
-.. TODO: Describe tol parameter
-.. TODO: Describe max_iter parameter
-
 .. currentmodule:: sklearn.svm
 
 **Support vector machines (SVMs)** are a set of supervised learning
 methods used for :ref:`classification <svm_classification>`,
 :ref:`regression <svm_regression>` and :ref:`outliers detection
 <svm_outlier_detection>`.
+
+The ``tol`` parameter controls the stopping criterion of the optimization:
+smaller values typically lead to a more accurate solution at the cost of longer
+fit times. The ``max_iter`` parameter controls how long the solver is allowed
+to run. If the solver reaches this limit before convergence, fitting stops
+early. In practice, reducing ``tol``, increasing ``max_iter``, and scaling the
+data can help when the solver struggles to converge.
 
 The advantages of support vector machines are:
 


### PR DESCRIPTION
#### Reference Issues/PRs

None.

#### What does this implement/fix? Explain your changes.

This PR replaces two placeholder TODOs in the SVM user guide with a short explanation of the `tol` and `max_iter` parameters.

The added text explains that:
- `tol` controls the stopping criterion of the optimization
- smaller `tol` values can improve convergence accuracy at the cost of longer fit times
- `max_iter` limits how long the solver is allowed to run
- scaling the data and adjusting `tol` or `max_iter` can help when the solver struggles to converge

This is a documentation-only change and does not modify any API behavior.

#### AI usage disclosure

I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [x] Research and understanding

#### Any other comments?

I reviewed the generated text manually and validated the docs build locally.