### PR TITLE
[BUG] Fix manhattan_distances dtype preservation for float32 inputs

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/33676.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/33676.fix.rst
@@ -1,0 +1,1 @@
+- Fix `sklearn.metrics.pairwise.manhattan_distances` dtype preservation for float32 input in sparse and dense paths. By :user:`machinelearningprodigy <machinelearningprodigy>`.

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1099,14 +1099,16 @@ def manhattan_distances(X, Y=None):
         Y = csr_array(Y, copy=False)
         X.sum_duplicates()  # this also sorts indices in-place
         Y.sum_duplicates()
-        D = np.zeros((n_x, n_y))
+        float_dtype = _find_matching_floating_dtype(X, Y, xp=np)
+        D = np.zeros((n_x, n_y), dtype=float_dtype)
         _sparse_manhattan(X.data, X.indices, X.indptr, Y.data, Y.indices, Y.indptr, D)
         return D
 
     xp, _, device_ = get_namespace_and_device(X, Y)
 
     if _is_numpy_namespace(xp):
-        return distance.cdist(X, Y, "cityblock")
+        float_dtype = _find_matching_floating_dtype(X, Y, xp=xp)
+        return distance.cdist(X, Y, "cityblock").astype(float_dtype, copy=False)
 
     # array API support
     float_dtype = _find_matching_floating_dtype(X, Y, xp=xp)

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -218,25 +218,11 @@ def test_pairwise_distances_for_sparse_data(
     S = pairwise_distances(X_sparse, csc_container(Y), metric="manhattan")
     S2 = manhattan_distances(bsr_container(X), coo_container(Y))
     assert_allclose(S, S2)
-    if global_dtype == np.float64:
-        assert S.dtype == S2.dtype == global_dtype
-    else:
-        # TODO Fix manhattan_distances to preserve dtype.
-        # currently pairwise_distances uses manhattan_distances but converts the result
-        # back to the input dtype
-        with pytest.raises(AssertionError):
-            assert S.dtype == S2.dtype == global_dtype
+    assert S.dtype == S2.dtype == global_dtype
 
     S2 = manhattan_distances(X, Y)
     assert_allclose(S, S2)
-    if global_dtype == np.float64:
-        assert S.dtype == S2.dtype == global_dtype
-    else:
-        # TODO Fix manhattan_distances to preserve dtype.
-        # currently pairwise_distances uses manhattan_distances but converts the result
-        # back to the input dtype
-        with pytest.raises(AssertionError):
-            assert S.dtype == S2.dtype == global_dtype
+    assert S.dtype == S2.dtype == global_dtype
 
     # Test with scipy.spatial.distance metric, with a kwd
     kwds = {"p": 2.0}


### PR DESCRIPTION
## Summary
Fix dtype preservation in `sklearn.metrics.pairwise.manhattan_distances` for `float32` inputs across both dense and sparse execution paths.

## Issue
Currently, when `float32` inputs are provided, the output of `manhattan_distances` may be returned as `float64` in some code paths (notably sparse computations and the `cdist` branch). This leads to inconsistent dtype behavior compared to other pairwise distance implementations and may break downstream workflows relying on dtype stability.

## Proposed Change
Ensure the output dtype matches the input floating dtype (`float32` or `float64`) consistently.

### Implementation details

**pairwise.py**
- Use `_find_matching_floating_dtype` in the sparse branch to determine the correct floating dtype.
- Explicitly cast the result of `distance.cdist(..., metric="cityblock")` using:

```python
.astype(float_dtype, copy=False)