### PR TITLE
FIX Make y and groups required in StratifiedGroupKFold.split()

### DIFF
--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -997,6 +997,37 @@ class StratifiedGroupKFold(GroupsConsumerMixin, _BaseKFold):
     def __init__(self, n_splits=5, shuffle=False, random_state=None):
         super().__init__(n_splits=n_splits, shuffle=shuffle, random_state=random_state)
 
+    def split(self, X, y, groups):
+        """Generate indices to split data into training and test set.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training data, where `n_samples` is the number of samples
+            and `n_features` is the number of features.
+
+        y : array-like of shape (n_samples,)
+            The target variable for supervised learning problems.
+            Stratification is done based on the y labels.
+
+        groups : array-like of shape (n_samples,)
+            Group labels for the samples used while splitting the dataset
+            into train/test set.
+
+        Yields
+        ------
+        train : ndarray
+            The training set indices for that split.
+
+        test : ndarray
+            The testing set indices for that split.
+        """
+        y = check_array(y, input_name="y", ensure_2d=False, dtype=None)
+        groups = check_array(
+            groups, input_name="groups", ensure_2d=False, dtype=None
+        )
+        return super().split(X, y, groups)
+
     def _iter_test_indices(self, X, y, groups):
         # Implementation is based on this kaggle kernel:
         # https://www.kaggle.com/jakubwasikowski/stratified-group-k-fold-cross-validation


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #30742.

#### What does this implement/fix? Explain your changes.

`StratifiedGroupKFold` inherits `split()` from `_BaseKFold`, where both `y` and `groups` have default values of `None`. However, `StratifiedGroupKFold._iter_test_indices()` requires both parameters to be non-None, leading to confusing errors when either is omitted:

- `groups=None` → `TypeError: iteration over a 0-d array`
- `y=None` → `ValueError: Supported target types are: ('binary', 'multiclass'). Got 'unknown' instead.`

This PR overrides `split()` in `StratifiedGroupKFold` to make both `y` and `groups` required parameters (no default values), with explicit validation via `check_array`. This follows the same pattern used by `StratifiedKFold.split()` for its required `y` parameter.

**Before:**
```python
sgkf.split(X)  # TypeError: iteration over a 0-d array (confusing)
sgkf.split(X, y)  # TypeError: iteration over a 0-d array (confusing)
```

**After:**
```python
sgkf.split(X)  # TypeError: split() missing required arguments: 'y' and 'groups'
sgkf.split(X, y)  # TypeError: split() missing required argument: 'groups'
```

#### AI usage disclosure

I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Research and understanding

#### Any other comments?

The fix follows the established pattern of `StratifiedKFold.split()` (same file, line 849) which also overrides the base class to make `y` required. Tests for this class already pass `y` and `groups` explicitly, so no existing tests should break.