### PR TITLE
DOC Clarify LinearRegression docstring to mention intercept

### DIFF
--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -492,8 +492,10 @@ class LinearRegression(MultiOutputMixin, RegressorMixin, LinearModel):
     Ordinary least squares Linear Regression.
 
     LinearRegression fits a linear model with coefficients w = (w1, ..., wp)
-    to minimize the residual sum of squares between the observed targets in
-    the dataset, and the targets predicted by the linear approximation.
+    and an intercept term w0 (by default) to minimize the residual sum of
+    squares between the observed targets in the dataset, and the targets
+    predicted by the linear approximation. The coefficients are stored in
+    ``coef_`` and the intercept in ``intercept_``.
 
     Parameters
     ----------


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #22551.

#### What does this implement/fix? Explain your changes.

The `LinearRegression` class docstring only mentioned fitting coefficients `w = (w1, ..., wp)` without mentioning the intercept term, making it appear that the model does not fit an intercept by default. This could mislead users into thinking `fit_intercept=True` has no effect.

Updated the class description to:
- Mention the intercept term `w0`
- Reference both the `coef_` and `intercept_` attributes where the results are stored

This is a minimal, targeted fix to the class docstring only. The broader user guide notation improvements discussed in the issue are left for a separate PR.

#### AI usage disclosure

I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [x] Research and understanding