### PR TITLE
DOC Clarify LARS Lasso mathematical formulation

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -717,10 +717,11 @@ or :func:`lars_path_gram`.
   increased in a direction equiangular to each one's correlations with
   the residual.
 
-  Instead of giving a vector result, the LARS solution consists of a
-  curve denoting the solution for each value of the :math:`\ell_1` norm of the
-  parameter vector. The full coefficients path is stored in the array
-  ``coef_path_`` of shape `(n_features, max_features + 1)`. The first
+  Instead of returning a single vector of parameters, the LARS algorithm
+  computes the full regularization path. The result is stored in the array
+  ``coef_path_`` of shape ``(n_features, max_features + 1)``, where each
+  column contains the coefficient vector at a critical point along the path
+  as the :math:`\ell_1` norm of the parameter vector increases. The first
   column is always zero.
 
   .. rubric:: References


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #32083.

#### What does this implement/fix? Explain your changes.

The previous description in the LARS Lasso section stated that "the LARS solution consists of a curve denoting the solution for each value of the ℓ₁ norm of the parameter vector." This is misleading because:

- The LARS algorithm computes a discrete set of critical points, not a continuous curve
- The solution is not computed at every value of the ℓ₁ norm, only at breakpoints where the active set changes
- The phrasing "for each value" implies infinitely many solutions

Updated the wording to accurately describe that LARS computes the full regularization path as a 2D array (`coef_path_`), where each column corresponds to the coefficient vector at a critical point along the path as the ℓ₁ norm increases. Also fixed the backtick formatting for the shape tuple.

#### AI usage disclosure

I used AI assistance for:
- [x] Documentation (including examples)
- [x] Research and understanding

#### Any other comments?

This is a minimal documentation clarification. No code logic changes.