### PR TITLE
ENH list all missing columns in _get_column_indices error message

### DIFF
--- a/sklearn/utils/_indexing.py
+++ b/sklearn/utils/_indexing.py
@@ -478,7 +478,11 @@ def _get_column_indices(X, key):
                 column_indices.append(col_idx)
 
         except KeyError as e:
-            raise ValueError("A given column is not a column of the dataframe") from e
+            missing = set(columns) - set(all_columns)
+            raise ValueError(
+                "A given column is not a column of the dataframe:"
+                f" {missing}"
+            ) from e
 
         return column_indices
 
@@ -514,7 +518,11 @@ def _get_column_indices_interchange(X_interchange, key, key_dtype):
         try:
             return [column_names.index(col) for col in selected_columns]
         except ValueError as e:
-            raise ValueError("A given column is not a column of the dataframe") from e
+            missing = set(selected_columns) - set(column_names)
+            raise ValueError(
+                "A given column is not a column of the dataframe:"
+                f" {missing}"
+            ) from e
 
 
 @validate_params(

--- a/sklearn/utils/tests/test_indexing.py
+++ b/sklearn/utils/tests/test_indexing.py
@@ -477,7 +477,7 @@ def test_safe_assign(array_type):
     "key, err_msg",
     [
         (10, r"all features must be in \[0, 2\]"),
-        ("whatever", "A given column is not a column of the dataframe"),
+        ("whatever", r"A given column is not a column of the dataframe:.*whatever"),
         (object(), "No valid specification of the columns"),
     ],
 )
@@ -487,6 +487,15 @@ def test_get_column_indices_error(key, err_msg):
 
     with pytest.raises(ValueError, match=err_msg):
         _get_column_indices(X_df, key)
+
+
+def test_get_column_indices_error_reports_all_missing_columns():
+    """Check that all missing column names appear in the error message."""
+    pd = pytest.importorskip("pandas")
+    X_df = pd.DataFrame(X_toy, columns=["col_0", "col_1", "col_2"])
+    with pytest.raises(ValueError, match=r"Missing Column 1") as exc_info:
+        _get_column_indices(X_df, ["col_0", "Missing Column 1", "Missing Column 2"])
+    assert "Missing Column 2" in str(exc_info.value)
 
 
 @pytest.mark.parametrize(
@@ -525,7 +534,7 @@ def test_get_column_indices_interchange():
     for key, result in key_results:
         assert _get_column_indices(df, key) == result
 
-    msg = "A given column is not a column of the dataframe"
+    msg = r"A given column is not a column of the dataframe:.*not_a_column"
     with pytest.raises(ValueError, match=msg):
         _get_column_indices(df, ["not_a_column"])
 


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #33569.

#### What does this implement/fix? Explain your changes.

When `ColumnTransformer` references columns that don't exist in a DataFrame, the `ValueError` from `_get_column_indices` and `_get_column_indices_interchange` now includes all missing column names instead of the generic "A given column is not a column of the dataframe" message.

**Before:**
```
ValueError: A given column is not a column of the dataframe
```

**After:**
```
ValueError: A given column is not a column of the dataframe: {'Missing Column 1', 'Missing Column 2'}
```

This makes debugging significantly easier in deep pipelines with multiple transformation steps, where identifying which column name is wrong can be time-consuming.

Tests have been updated and a new test added to verify multiple missing columns all appear in the error.

#### AI usage disclosure

I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Any other comments?

A previous PR (#33570) was opened for this issue but was closed. This PR takes the same approach (computing the set difference of requested vs. available columns) and applies it to both `_get_column_indices` and `_get_column_indices_interchange`.