### PR TITLE
MNT Replace archived mirrors-prettier pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,8 @@ repos:
     # possibility to pass a directory and use it as a check instead of auto-formatter.
     -   id: cython-lint
         args: [--ban-relative-imports]
--   repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+-   repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.5.3
     hooks:
     -   id: prettier
         files: ^doc/scss/|^doc/js/scripts/


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #29621.

#### What does this implement/fix? Explain your changes.

The `pre-commit/mirrors-prettier` repository has been archived and is no longer maintained. This PR replaces it with the actively maintained fork `rbubley/mirrors-prettier` and updates the version from `v2.7.1` to `v3.5.3`.

The hook configuration (files, exclude, types_or) remains unchanged.

#### AI usage disclosure

I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Any other comments?

This is a one-line config change. The `rbubley/mirrors-prettier` fork is the widely adopted replacement recommended by the pre-commit community.