### PR TITLE
DOC Improve n_jobs docstrings to explain what is parallelized

### DIFF
--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -759,7 +759,8 @@ class BaggingClassifier(ClassifierMixin, BaseBagging):
 
     n_jobs : int, default=None
         The number of jobs to run in parallel for both :meth:`fit` and
-        :meth:`predict`. ``None`` means 1 unless in a
+        :meth:`predict`. Each base estimator is built and predictions are
+        computed in parallel. ``None`` means 1 unless in a
         :obj:`joblib.parallel_backend` context. ``-1`` means using all
         processors. See :term:`Glossary <n_jobs>` for more details.
 
@@ -1268,7 +1269,8 @@ class BaggingRegressor(RegressorMixin, BaseBagging):
 
     n_jobs : int, default=None
         The number of jobs to run in parallel for both :meth:`fit` and
-        :meth:`predict`. ``None`` means 1 unless in a
+        :meth:`predict`. Each base estimator is built and predictions are
+        computed in parallel. ``None`` means 1 unless in a
         :obj:`joblib.parallel_backend` context. ``-1`` means using all
         processors. See :term:`Glossary <n_jobs>` for more details.
 

--- a/sklearn/neighbors/_classification.py
+++ b/sklearn/neighbors/_classification.py
@@ -115,6 +115,7 @@ class KNeighborsClassifier(KNeighborsMixin, ClassifierMixin, NeighborsBase):
 
     n_jobs : int, default=None
         The number of parallel jobs to run for neighbors search.
+        Each of the k-neighbors queries is computed in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -540,6 +541,7 @@ class RadiusNeighborsClassifier(RadiusNeighborsMixin, ClassifierMixin, Neighbors
 
     n_jobs : int, default=None
         The number of parallel jobs to run for neighbors search.
+        Each of the radius-neighbors queries is computed in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -100,6 +100,7 @@ class KNeighborsRegressor(KNeighborsMixin, RegressorMixin, NeighborsBase):
 
     n_jobs : int, default=None
         The number of parallel jobs to run for neighbors search.
+        Each of the k-neighbors queries is computed in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -348,6 +349,7 @@ class RadiusNeighborsRegressor(RadiusNeighborsMixin, RegressorMixin, NeighborsBa
 
     n_jobs : int, default=None
         The number of parallel jobs to run for neighbors search.
+        Each of the radius-neighbors queries is computed in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #14228 (partially). See also #14628 (previously merged, covered `_forest.py`).

#### What does this implement/fix? Explain your changes.

The `n_jobs` parameter docstrings across scikit-learn estimators are often unhelpfully generic, saying only "The number of jobs to run in parallel" without explaining *what* is parallelized. This PR improves the docstrings for several key estimators:

- **`KNeighborsClassifier`** / **`KNeighborsRegressor`**: "Each of the k-neighbors queries is computed in parallel."
- **`RadiusNeighborsClassifier`** / **`RadiusNeighborsRegressor`**: "Each of the radius-neighbors queries is computed in parallel."
- **`BaggingClassifier`** / **`BaggingRegressor`**: "Each base estimator is built and predictions are computed in parallel."

This follows the pattern established in PR #14628, which improved the `n_jobs` docstring for `RandomForestClassifier`/`RandomForestRegressor`.

#### AI usage disclosure

I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [x] Research and understanding

#### Any other comments?

This is a documentation-only change. No API or behavioral changes.