### PR TITLE
Fix DictionaryLearner OMP crash when n_nonzero_coefs > n_components

### DIFF
--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -413,6 +413,8 @@ def _sparse_encode(
         regularization = n_nonzero_coefs
         if regularization is None:
             regularization = min(max(n_features / 10, 1), n_components)
+        else:
+            regularization = min(regularization, n_components)
     else:
         regularization = alpha
         if regularization is None:


### PR DESCRIPTION
## Summary

Fixes #33454

When `transform_algorithm='omp'` and `n_nonzero_coefs` exceeds `n_components`, the value passes through uncapped, causing a `ValueError` deep in the OMP solver.

The default branch (when `n_nonzero_coefs is None`) already caps to `n_components` at line 415, but explicitly set values were not validated.

## Fix

Cap `regularization` to `n_components` when explicitly set.

```python
# Before:
regularization = n_nonzero_coefs
if regularization is None:
    regularization = min(max(n_features / 10, 1), n_components)

# After:
regularization = n_nonzero_coefs
if regularization is None:
    regularization = min(max(n_features / 10, 1), n_components)
else:
    regularization = min(regularization, n_components)
```