### PR TITLE
DOC fix DecisionBoundaryDisplay color consistency in plot_linearsvc_support_vectors example

### DIFF
--- a/examples/svm/plot_linearsvc_support_vectors.py
+++ b/examples/svm/plot_linearsvc_support_vectors.py
@@ -43,7 +43,7 @@ for i, C in enumerate([1, 100]):
         ax=ax,
         grid_resolution=50,
         plot_method="contour",
-        colors="k",
+        multiclass_colors="viridis",
         levels=[-1, 0, 1],
         alpha=0.5,
         linestyles=["--", "-", "--"],


### PR DESCRIPTION
#### Reference Issues/PRs
Towards Issue #33557 

#### What does this implement/fix? Explain your changes.
The PR addresses the multiclass colors consistent issue for
DecisionBoundaryDisplay and uses multiclass_colors="viridis" instead for
examples/svm/plot_linearsvc_support_vectors.py

#### AI usage disclosure
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

