### PR TITLE
DOC clarify set_params behavior after fit (closes #33666)

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1513,6 +1513,18 @@ Methods
         The method is overridden in :class:`pipeline.Pipeline` and related
         estimators.
 
+        Note
+        ----
+        Parameters may be modified between construction and fitting using
+        :meth:`set_params`.
+
+        Changing parameters after an estimator has been fitted is allowed,
+        but its effect is estimator-dependent and should generally be
+        considered undefined behavior. Calling :meth:`set_params` after
+        ``fit`` does not recompute learned attributes (those ending with '_').
+        To obtain fitted attributes that reflect new parameter values, call
+        :meth:`fit` again.
+
     ``split``
         On a :term:`CV splitter` (not an estimator), this method accepts
         parameters (:term:`X`, :term:`y`, :term:`groups`), where all may be

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -401,6 +401,18 @@ class BaseEstimator(ReprHTMLMixin, _HTMLDocumentationLinkMixin, _MetadataRequest
         -------
         self : estimator instance
             Estimator instance.
+
+        Notes
+        -----
+        Parameters may be modified between construction and fitting using
+        this method.
+
+        Changing parameters after an estimator has been fitted is allowed,
+        but its effect is estimator-dependent and should generally be
+        considered undefined behavior. Calling this method after ``fit``
+        does not recompute learned attributes (those ending with '_').
+        To obtain fitted attributes that reflect new parameter values,
+        call ``fit`` again.
         """
         if not params:
             # Simple optimization to gain speed (inspect is slow)
@@ -1093,7 +1105,6 @@ class DensityMixin:
         -------
         score : float
         """
-        pass
 
 
 class OutlierMixin:


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
Fixes #33666. See also #17158.

#### What does this implement/fix? Explain your changes.
This PR clarifies the behavior of `set_params` when called after an estimator has already been fitted.

- Updates the glossary entry for `set_params` to explicitly state that modifying parameters post-fit is allowed but its effect is estimator-dependent and undefined.
- Updates the `BaseEstimator.set_params` docstring with a short Notes section to match the glossary.
- Emphasizes that `set_params` does not recompute learned attributes (those ending with '_'); calling `fit` again is required to obtain updated fitted attributes.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?
This PR is documentation-only and does not change any functionality.
It reflects the discussion in issue #33666 and aligns with the intended behavior described by maintainers.

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
