### PR TITLE
FIX Warn when SVM kernel hyperparameters are set for an incompatible kernel

### DIFF
--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -45,6 +45,33 @@ from sklearn.utils.validation import (
 LIBSVM_IMPL = ["c_svc", "nu_svc", "one_class", "epsilon_svr", "nu_svr"]
 
 
+def _check_kernel_params(kernel, degree, gamma, coef0):
+    """Warn if kernel hyperparameters are set for an incompatible kernel."""
+    if callable(kernel):
+        return
+    if gamma != "scale" and kernel not in {"rbf", "poly", "sigmoid"}:
+        warnings.warn(
+            f"Parameter `gamma` is not used when `kernel='{kernel}'`. "
+            "Setting it has no effect on the model.",
+            UserWarning,
+            stacklevel=4,
+        )
+    if degree != 3 and kernel != "poly":
+        warnings.warn(
+            f"Parameter `degree` is not used when `kernel='{kernel}'`. "
+            "Setting it has no effect on the model.",
+            UserWarning,
+            stacklevel=4,
+        )
+    if coef0 != 0.0 and kernel not in {"poly", "sigmoid"}:
+        warnings.warn(
+            f"Parameter `coef0` is not used when `kernel='{kernel}'`. "
+            "Setting it has no effect on the model.",
+            UserWarning,
+            stacklevel=4,
+        )
+
+
 def _one_vs_one_coef(dual_coef, n_support, support_vectors):
     """Generate primal coefficients from dual coefficients
     for the one-vs-one multi class LibSVM in the case
@@ -202,6 +229,8 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
         matrices as input.
         """
         rnd = check_random_state(self.random_state)
+
+        _check_kernel_params(self.kernel, self.degree, self.gamma, self.coef0)
 
         sparse = sp.issparse(X)
         if sparse and self.kernel == "precomputed":

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -4,6 +4,8 @@ Testing for Support Vector Machine module (sklearn.svm)
 TODO: remove hard coded numerical results when possible
 """
 
+import warnings
+
 import numpy as np
 import pytest
 from numpy.testing import (
@@ -1535,3 +1537,47 @@ def test_svc_nusvc_probA_probB_deprecated(est):
         _ = est.probA_
     with pytest.warns(FutureWarning, match="Attribute `probB_` was deprecated"):
         _ = est.probB_
+
+
+def test_svc_invalid_kernel_params():
+    """Test that warnings are issued for kernel params irrelevant to the kernel."""
+    from sklearn.datasets import load_iris
+
+    X_iris, y_iris = load_iris(return_X_y=True)
+
+    # gamma with a kernel that does not use it
+    with pytest.warns(UserWarning, match="gamma"):
+        svm.SVC(kernel="linear", gamma=1e-6).fit(X_iris, y_iris)
+
+    # degree with a kernel that does not use it
+    with pytest.warns(UserWarning, match="degree"):
+        svm.SVC(kernel="linear", degree=4).fit(X_iris, y_iris)
+
+    # coef0 with a kernel that does not use it
+    with pytest.warns(UserWarning, match="coef0"):
+        svm.SVC(kernel="linear", coef0=1.0).fit(X_iris, y_iris)
+
+    # Valid combinations — should NOT warn
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        svm.SVC(kernel="rbf", gamma=0.1).fit(X_iris, y_iris)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        svm.SVC(kernel="poly", degree=4).fit(X_iris, y_iris)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        svm.SVC(kernel="linear").fit(X_iris, y_iris)
+
+    # Callable kernel should NOT warn regardless of params
+    def linear_kernel(X, Y):
+        return X @ Y.T
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        svm.SVC(kernel=linear_kernel, gamma=1e-6).fit(X_iris, y_iris)
+
+    # SVR shares BaseLibSVM and should warn too
+    with pytest.warns(UserWarning, match="gamma"):
+        svm.SVR(kernel="linear", gamma=1e-6).fit(X_iris, y_iris)


### PR DESCRIPTION
#### Reference Issues/PRs                                                                                                                           
                                                                                                                                                      
Fixes #19614                                                                                                                                        
              
#### What does this implement/fix? Explain your changes.
                                                                                                                                                      
When users set kernel hyperparameters for a kernel that doesn't use them (e.g., `gamma=1e-6` with `kernel='linear'`), scikit-learn silently ignores them. This adds UserWarnings for those cases, following the rules discussed in #19614:                                                              
                                                                                        
- Warn if `gamma != 'scale'` and kernel not in `{'rbf', 'poly', 'sigmoid'}`                                                                         
- Warn if `degree != 3` and kernel != `'poly'`                             
- Warn if `coef0 != 0.0` and kernel not in `{'poly', 'sigmoid'}`
- Skip warnings for callable kernels and default parameter values                                                                                   
                                                                   
Added `_check_kernel_params()` in `_base.py`, called from `BaseLibSVM.fit()`. Added tests covering warn and no-warn cases.                          
                                                                                                                                                      
#### AI usage disclosure
                                                                                                                                                      
I used AI assistance for:
  - [x] Code generation (e.g., when writing an implementation or fixing a bug)
  - [x] Test/benchmark generation                                             
  - [ ] Documentation (including examples)
  - [x] Research and understanding        
                                                                                                                                                      
#### Any other comments?
                                                                                                                                                      
All existing tests pass. All pre-commit hooks pass.