### PR TITLE
Bump pillow to 12.1.1

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -4,7 +4,7 @@ matplotlib
 scikit-image
 pandas
 seaborn
-Pillow
+Pillow==12.1.1
 sphinx-gallery
 scikit-learn
 polars


### PR DESCRIPTION
A few dependencies in the requirements file have CVEs fixed in newer versions:

- `pillow` 11.3.0 -> 12.1.1 (CVE-2026-25990)

Bumped each one to the minimum safe version.