### PR TITLE
DOC VotingClassifier: clarify that estimators_ are fitted on integer-encoded labels

### DIFF
--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -246,7 +246,10 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
     ----------
     estimators_ : list of classifiers
         The collection of fitted sub-estimators as defined in ``estimators``
-        that are not 'drop'.
+        that are not 'drop'. Note that sub-estimators are always fitted on
+        integer-encoded labels (see ``le_`` attribute). When ``y`` contains
+        non-integer class labels (e.g. strings), use ``le_.inverse_transform``
+        to map predictions back to the original label space.
 
     named_estimators_ : :class:`~sklearn.utils.Bunch`
         Attribute to access any fitted sub-estimators by name.
@@ -255,7 +258,8 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
 
     le_ : :class:`~sklearn.preprocessing.LabelEncoder`
         Transformer used to encode the labels during fit and decode during
-        prediction.
+        prediction. Sub-estimators in ``estimators_`` are fitted on the
+        integer-encoded labels produced by this encoder.
 
     classes_ : ndarray of shape (n_classes,)
         The classes labels.


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #12189

#### What does this implement/fix? Explain your changes.

`VotingClassifier.estimators_` is documented as "the collection of fitted sub-estimators" but does not mention that sub-estimators are **always** fitted on integer-encoded labels (via `le_`), not on the original class labels. This surprises users who expect to call `estimators_[i].predict()` and receive the same label type as the original `y`.

This PR adds a note to `estimators_` and expands the `le_` docstring so both attributes cross-reference each other. The change is documentation-only with no behaviour changes.

**Before (estimators_ docs):**
```
The collection of fitted sub-estimators as defined in estimators that are not 'drop'.
```

**After:**
```
The collection of fitted sub-estimators as defined in estimators that are not 'drop'.
Note that sub-estimators are always fitted on integer-encoded labels (see le_ attribute).
When y contains non-integer class labels (e.g. strings), use le_.inverse_transform to
map predictions back to the original label space.
```

#### Any other comments?

Documentation-only change. No tests added (no behaviour change). Follows the existing docstring style in this file.

---

> **AI Assistance Disclosure** (required per [AGENTS.md](https://github.com/scikit-learn/scikit-learn/blob/main/AGENTS.md))
> This pull request includes code written with the assistance of AI (Claude Code).
> All changes have been read, understood, and verified by the human contributor (Rudrendu Paul).