### PR TITLE
[Callbacks] Add debugger-only fallback for callback manager

### DIFF
--- a/sklearn/callback/_callback_support.py
+++ b/sklearn/callback/_callback_support.py
@@ -2,10 +2,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import functools
+import os
+import sys
 from contextlib import contextmanager
+from multiprocessing import get_context as get_multiprocessing_context
 from threading import Lock
 
-from joblib.externals.loky.backend import get_context
+from joblib.externals.loky.backend import get_context as get_loky_context
 
 from sklearn.callback._base import AutoPropagatedCallback, FitCallback
 from sklearn.callback._callback_context import CallbackContext
@@ -16,6 +19,54 @@ class _CallbackManagerState:
     lock = Lock()
 
 
+def _is_debugger_session_active():
+    """Return True when running under an active debugpy/pydevd session."""
+    if not any(
+        module_name in sys.modules
+        for module_name in ("debugpy", "pydevd", "_pydevd_bundle")
+    ):
+        return False
+
+    if sys.gettrace() is not None:
+        return True
+
+    # debugpy can keep a live pydevd debugger without installing a sys.gettrace hook.
+    pydevd = sys.modules.get("pydevd")
+    get_global_debugger = getattr(pydevd, "get_global_debugger", None)
+    return get_global_debugger is not None and get_global_debugger() is not None
+
+
+def _get_fork_context():
+    """Return a multiprocessing fork context when it is available."""
+    if os.name != "posix":
+        return None
+
+    try:
+        return get_multiprocessing_context("fork")
+    except ValueError:
+        return None
+
+
+def _create_callback_manager():
+    """Create the callbacks manager.
+
+    Use loky by default. Under an active debugpy/pydevd session, retry once with a
+    POSIX fork context to avoid debugger-only manager startup failures.
+    """
+
+    try:
+        return get_loky_context().Manager()
+    except EOFError:
+        if not _is_debugger_session_active():
+            raise
+
+        fork_context = _get_fork_context()
+        if fork_context is None:
+            raise
+
+        return fork_context.Manager()
+
+
 def get_callback_manager():
     """Return the global multiprocessing manager dedicated to callbacks.
 
@@ -24,7 +75,7 @@ def get_callback_manager():
     if _CallbackManagerState.manager is None:
         with _CallbackManagerState.lock:
             if _CallbackManagerState.manager is None:
-                _CallbackManagerState.manager = get_context().Manager()
+                _CallbackManagerState.manager = _create_callback_manager()
 
     return _CallbackManagerState.manager
 

--- a/sklearn/callback/tests/test_callback_support.py
+++ b/sklearn/callback/tests/test_callback_support.py
@@ -5,6 +5,7 @@ import textwrap
 
 import pytest
 
+import sklearn.callback._callback_support as callback_support
 from sklearn.base import clone
 from sklearn.callback.tests._utils import (
     FailingCallback,
@@ -106,3 +107,119 @@ def test_instantiate_manager_outside_main_module():
     get_callback_manager()
     """
     assert_run_python_script_without_output(textwrap.dedent(code))
+
+
+def test_is_debugger_session_active_requires_trace_and_debug_module(monkeypatch):
+    monkeypatch.setattr(callback_support.sys, "gettrace", lambda: object())
+    monkeypatch.setitem(callback_support.sys.modules, "debugpy", object())
+
+    assert callback_support._is_debugger_session_active()
+
+    monkeypatch.setattr(callback_support.sys, "gettrace", lambda: None)
+    assert not callback_support._is_debugger_session_active()
+
+    monkeypatch.setattr(callback_support.sys, "gettrace", lambda: object())
+    monkeypatch.delitem(callback_support.sys.modules, "debugpy", raising=False)
+    monkeypatch.delitem(callback_support.sys.modules, "pydevd", raising=False)
+    monkeypatch.delitem(callback_support.sys.modules, "_pydevd_bundle", raising=False)
+    assert not callback_support._is_debugger_session_active()
+
+
+def test_is_debugger_session_active_with_pydevd_global_debugger(monkeypatch):
+    class DummyPydevd:
+        @staticmethod
+        def get_global_debugger():
+            return object()
+
+    monkeypatch.setattr(callback_support.sys, "gettrace", lambda: None)
+    monkeypatch.setitem(callback_support.sys.modules, "pydevd", DummyPydevd())
+
+    assert callback_support._is_debugger_session_active()
+
+
+def test_create_callback_manager_prefers_loky(monkeypatch):
+    calls = []
+
+    class DummyLokyContext:
+        def Manager(self):
+            calls.append("loky")
+            return "loky-manager"
+
+    monkeypatch.setattr(
+        callback_support, "get_loky_context", lambda: DummyLokyContext()
+    )
+    monkeypatch.setattr(
+        callback_support,
+        "_get_fork_context",
+        lambda: pytest.fail("fork fallback should not be used"),
+    )
+
+    assert callback_support._create_callback_manager() == "loky-manager"
+    assert calls == ["loky"]
+
+
+def test_create_callback_manager_reraises_outside_debugger(monkeypatch):
+    error = EOFError("loky bootstrap failed")
+
+    class DummyLokyContext:
+        def Manager(self):
+            raise error
+
+    monkeypatch.setattr(
+        callback_support, "get_loky_context", lambda: DummyLokyContext()
+    )
+    monkeypatch.setattr(callback_support, "_is_debugger_session_active", lambda: False)
+    monkeypatch.setattr(
+        callback_support,
+        "_get_fork_context",
+        lambda: pytest.fail("fork fallback should not be used"),
+    )
+
+    with pytest.raises(EOFError) as exc_info:
+        callback_support._create_callback_manager()
+
+    assert exc_info.value is error
+
+
+def test_create_callback_manager_retries_with_fork_in_debugger(monkeypatch):
+    calls = []
+
+    class DummyLokyContext:
+        def Manager(self):
+            calls.append("loky")
+            raise EOFError("loky bootstrap failed")
+
+    class DummyForkContext:
+        def Manager(self):
+            calls.append("fork")
+            return "fork-manager"
+
+    monkeypatch.setattr(
+        callback_support, "get_loky_context", lambda: DummyLokyContext()
+    )
+    monkeypatch.setattr(callback_support, "_is_debugger_session_active", lambda: True)
+    monkeypatch.setattr(
+        callback_support, "_get_fork_context", lambda: DummyForkContext()
+    )
+
+    assert callback_support._create_callback_manager() == "fork-manager"
+    assert calls == ["loky", "fork"]
+
+
+def test_create_callback_manager_reraises_without_fork_context(monkeypatch):
+    error = EOFError("loky bootstrap failed")
+
+    class DummyLokyContext:
+        def Manager(self):
+            raise error
+
+    monkeypatch.setattr(
+        callback_support, "get_loky_context", lambda: DummyLokyContext()
+    )
+    monkeypatch.setattr(callback_support, "_is_debugger_session_active", lambda: True)
+    monkeypatch.setattr(callback_support, "_get_fork_context", lambda: None)
+
+    with pytest.raises(EOFError) as exc_info:
+        callback_support._create_callback_manager()
+
+    assert exc_info.value is error

--- a/sklearn/callback/tests/test_callback_support.py
+++ b/sklearn/callback/tests/test_callback_support.py
@@ -137,6 +137,44 @@ def test_is_debugger_session_active_with_pydevd_global_debugger(monkeypatch):
     assert callback_support._is_debugger_session_active()
 
 
+def test_get_fork_context_returns_none_on_non_posix(monkeypatch):
+    monkeypatch.setattr(callback_support.os, "name", "nt")
+    monkeypatch.setattr(
+        callback_support,
+        "get_multiprocessing_context",
+        lambda *_: pytest.fail("fork context should not be requested"),
+    )
+
+    assert callback_support._get_fork_context() is None
+
+
+def test_get_fork_context_returns_none_when_fork_is_unavailable(monkeypatch):
+    monkeypatch.setattr(callback_support.os, "name", "posix")
+
+    def raise_value_error(name):
+        assert name == "fork"
+        raise ValueError
+
+    monkeypatch.setattr(
+        callback_support, "get_multiprocessing_context", raise_value_error
+    )
+
+    assert callback_support._get_fork_context() is None
+
+
+def test_get_fork_context_returns_context(monkeypatch):
+    sentinel = object()
+
+    monkeypatch.setattr(callback_support.os, "name", "posix")
+    monkeypatch.setattr(
+        callback_support,
+        "get_multiprocessing_context",
+        lambda name: sentinel,
+    )
+
+    assert callback_support._get_fork_context() is sentinel
+
+
 def test_create_callback_manager_prefers_loky(monkeypatch):
     calls = []
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes [#33710](https://github.com/scikit-learn/scikit-learn/issues/33710). See also [#33649](https://github.com/scikit-learn/scikit-learn/pull/33649).

#### What does this implement/fix? Explain your changes.

This PR just adds specific debugger-only fallback when creating the global callback
manager.

The default behavior ( that was introduced in the PR [#33649](https://github.com/scikit-learn/scikit-learn/pull/33649) ) is preserved: callback manager creation still uses the loky-backed manager first. The only changeis that if loky manager startup raises `EOFError` during an active debugpy/pydevd session, callback manager creation retries once with a POSIX `fork` context when available.

The fix does not change the callback API or broader callback flow.

I also added focused tests in `sklearn/callback/tests/test_callback_support.py` covering:
- successful loky manager creation without fallback
- re-raising `EOFError` outside a debugger session
- retrying with `fork` when `EOFError` happens in a debugger session
- re-raising when `fork` is unavailable
- debugger-session detection behavior

The existing test that validates manager instantiation outside `__main__` are unchanged. 

#### AI usage disclosure

I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding


#### Any other comments?

This PR is intentionally made to the debugger-only callback manager failure reported in the [#33710](https://github.com/scikit-learn/scikit-learn/issues/33710). I had no intention to address the broader interaction of debugpy/loky outside of this bootstrap path


