### PR TITLE
Add missing stacklevel to all 226 warnings.warn() calls

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -515,6 +515,7 @@ class BaseEstimator(ReprHTMLMixin, _HTMLDocumentationLinkMixin, _MetadataRequest
                         current_sklearn_version=__version__,
                         original_sklearn_version=pickle_version,
                     ),
+                    stacklevel=2,
                 )
         try:
             super().__setstate__(state)
@@ -949,6 +950,7 @@ class TransformerMixin(_SetOutputMixin):
                         " disable metadata routed to `transform`, if that's an option."
                     ),
                     UserWarning,
+                    stacklevel=2,
                 )
 
         if y is None:
@@ -1172,6 +1174,7 @@ class OutlierMixin:
                         "`predict`, if that's an option."
                     ),
                     UserWarning,
+                    stacklevel=2,
                 )
 
         # override for transductive outlier detectors like LocalOulierFactor

--- a/sklearn/calibration.py
+++ b/sklearn/calibration.py
@@ -400,7 +400,8 @@ class CalibratedClassifierCV(ClassifierMixin, MetaEstimatorMixin, BaseEstimator)
                     " more details:"
                     " https://github.com/scikit-learn/scikit-learn/issues/21134."
                     " Be warned that the result of the calibration is likely to be"
-                    " incorrect."
+                    " incorrect.",
+                    stacklevel=2,
                 )
             routed_params = Bunch()
             routed_params.splitter = Bunch(split={})  # no routing for splitter

--- a/sklearn/cluster/_affinity_propagation.py
+++ b/sklearn/cluster/_affinity_propagation.py
@@ -49,7 +49,8 @@ def _affinity_propagation(
         # n_samples clusters, depending on preferences
         warnings.warn(
             "All samples have mutually equal similarities. "
-            "Returning arbitrary cluster center(s)."
+            "Returning arbitrary cluster center(s).",
+            stacklevel=2,
         )
         if preference.flat[0] > S.flat[n_samples - 1]:
             return (
@@ -143,6 +144,7 @@ def _affinity_propagation(
                     "may return degenerate cluster centers and labels."
                 ),
                 ConvergenceWarning,
+                stacklevel=2,
             )
         c = np.argmax(S[:, I], axis=1)
         c[I] = np.arange(K)  # Identify clusters
@@ -165,6 +167,7 @@ def _affinity_propagation(
                 "will not have any cluster centers."
             ),
             ConvergenceWarning,
+            stacklevel=2,
         )
         labels = np.array([-1] * n_samples)
         cluster_centers_indices = []
@@ -582,6 +585,7 @@ class AffinityPropagation(ClusterMixin, BaseEstimator):
                     "Labeling every sample as '-1'."
                 ),
                 ConvergenceWarning,
+                stacklevel=2,
             )
             return np.array([-1] * X.shape[0])
 

--- a/sklearn/cluster/_birch.py
+++ b/sklearn/cluster/_birch.py
@@ -713,6 +713,7 @@ class Birch(
                     "than (%d). Decrease the threshold."
                     % (len(centroids), self.n_clusters),
                     ConvergenceWarning,
+                    stacklevel=2,
                 )
         else:
             # The global clustering step that clusters the subclusters of

--- a/sklearn/cluster/_bisect_k_means.py
+++ b/sklearn/cluster/_bisect_k_means.py
@@ -259,7 +259,8 @@ class BisectingKMeans(_BaseKMeans):
             "BisectingKMeans is known to have a memory leak on Windows "
             "with MKL, when there are less chunks than available "
             "threads. You can avoid it by setting the environment"
-            f" variable OMP_NUM_THREADS={n_active_threads}."
+            f" variable OMP_NUM_THREADS={n_active_threads}.",
+            stacklevel=2,
         )
 
     def _inertia_per_cluster(self, X, centers, labels, sample_weight):

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -1420,6 +1420,7 @@ class KMeans(_BaseKMeans):
                     "cluster. Using 'lloyd' instead."
                 ),
                 RuntimeWarning,
+                stacklevel=2,
             )
             self._algorithm = "lloyd"
 
@@ -1429,7 +1430,8 @@ class KMeans(_BaseKMeans):
             "KMeans is known to have a memory leak on Windows "
             "with MKL, when there are less chunks than available "
             "threads. You can avoid it by setting the environment"
-            f" variable OMP_NUM_THREADS={n_active_threads}."
+            f" variable OMP_NUM_THREADS={n_active_threads}.",
+            stacklevel=2,
         )
 
     @_fit_context(prefer_skip_nested_validation=True)
@@ -1968,7 +1970,8 @@ class MiniBatchKMeans(_BaseKMeans):
             "available threads. You can prevent it by setting "
             f"batch_size >= {self._n_threads * CHUNK_SIZE} or by "
             "setting the environment variable "
-            f"OMP_NUM_THREADS={n_active_threads}"
+            f"OMP_NUM_THREADS={n_active_threads}",
+            stacklevel=2,
         )
 
     def _mini_batch_convergence(

--- a/sklearn/cluster/_mean_shift.py
+++ b/sklearn/cluster/_mean_shift.py
@@ -290,7 +290,8 @@ def get_bin_seeds(X, bin_size, min_bin_freq=1):
     if len(bin_seeds) == len(X):
         warnings.warn(
             "Binning data failed with provided bin_size=%f, using data points as seeds."
-            % bin_size
+            % bin_size,
+            stacklevel=2,
         )
         return X
     bin_seeds = bin_seeds * bin_size

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -331,7 +331,7 @@ class OPTICS(ClusterMixin, BaseEstimator):
                 f" metric {self.metric}, to avoid this warning,"
                 " you may convert the data prior to calling fit."
             )
-            warnings.warn(msg, DataConversionWarning)
+            warnings.warn(msg, DataConversionWarning, stacklevel=2)
 
         X = validate_data(self, X, dtype=dtype, accept_sparse="csr")
         if self.metric == "precomputed" and issparse(X):
@@ -665,6 +665,7 @@ def compute_optics_graph(
                 " max_eps or all data will be considered outliers."
             ),
             UserWarning,
+            stacklevel=2,
         )
     return ordering, core_distances_, reachability_, predecessor_
 

--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -707,7 +707,8 @@ class SpectralClustering(ClusterMixin, BaseEstimator):
                 "The spectral clustering API has changed. ``fit``"
                 "now constructs an affinity matrix from data. To use"
                 " a custom affinity matrix, "
-                "set ``affinity=precomputed``."
+                "set ``affinity=precomputed``.",
+                stacklevel=2,
             )
 
         if self.affinity == "nearest_neighbors":

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -986,6 +986,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
                 "removed in 1.9. It has no effect. Leave it to its default value to "
                 "avoid this warning.",
                 FutureWarning,
+                stacklevel=2,
             )
 
         validate_data(self, X=X, skip_check_array=True)

--- a/sklearn/compose/_target.py
+++ b/sklearn/compose/_target.py
@@ -215,6 +215,7 @@ class TransformedTargetRegressor(RegressorMixin, BaseEstimator):
                         ", set 'check_inverse=False'"
                     ),
                     UserWarning,
+                    stacklevel=2,
                 )
 
     @_fit_context(

--- a/sklearn/covariance/_empirical_covariance.py
+++ b/sklearn/covariance/_empirical_covariance.py
@@ -98,7 +98,8 @@ def empirical_covariance(X, *, assume_centered=False):
 
     if X.shape[0] == 1:
         warnings.warn(
-            "Only one sample available. You may want to reshape your data array"
+            "Only one sample available. You may want to reshape your data array",
+            stacklevel=2,
         )
 
     if assume_centered:

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -200,6 +200,7 @@ def _graphical_lasso(
                 "graphical_lasso: did not converge after %i iteration: dual gap: %.3e"
                 % (max_iter, d_gap),
                 ConvergenceWarning,
+                stacklevel=2,
             )
     except FloatingPointError as e:
         e.args = (e.args[0] + ". The system is too ill-conditioned for this solver",)

--- a/sklearn/covariance/_robust_covariance.py
+++ b/sklearn/covariance/_robust_covariance.py
@@ -192,6 +192,7 @@ def _c_step(
             "support_fraction (current value: %.3f)."
             % (det, previous_det, n_support / n_samples),
             RuntimeWarning,
+            stacklevel=2,
         )
         results = (
             previous_location,
@@ -791,7 +792,8 @@ class MinCovDet(EmpiricalCovariance):
         # check that the empirical covariance is full rank
         if (linalg.svdvals(np.dot(X.T, X)) > 1e-8).sum() != n_features:
             warnings.warn(
-                "The covariance matrix associated to your dataset is not full rank"
+                "The covariance matrix associated to your dataset is not full rank",
+                stacklevel=2,
             )
         # compute and store raw estimates
         raw_location, raw_covariance, raw_support, raw_dist = fast_mcd(

--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -347,7 +347,8 @@ def ledoit_wolf_shrinkage(X, assume_centered=False, block_size=1000):
 
     if X.shape[0] == 1:
         warnings.warn(
-            "Only one sample available. You may want to reshape your data array"
+            "Only one sample available. You may want to reshape your data array",
+            stacklevel=2,
         )
     n_samples, n_features = X.shape
 

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -101,7 +101,9 @@ def _get_first_singular_vectors_power_method(
 
     n_iter = i + 1
     if n_iter == max_iter:
-        warnings.warn("Maximum number of iterations reached", ConvergenceWarning, stacklevel=2)
+        warnings.warn(
+            "Maximum number of iterations reached", ConvergenceWarning, stacklevel=2
+        )
 
     return x_weights, y_weights, n_iter
 
@@ -305,7 +307,9 @@ class _PLS(
                 except StopIteration as e:
                     if str(e) != "y residual is constant":
                         raise
-                    warnings.warn(f"y residual is constant at iteration {k}", stacklevel=2)
+                    warnings.warn(
+                        f"y residual is constant at iteration {k}", stacklevel=2
+                    )
                     break
 
                 self.n_iter_.append(n_iter_)

--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -101,7 +101,7 @@ def _get_first_singular_vectors_power_method(
 
     n_iter = i + 1
     if n_iter == max_iter:
-        warnings.warn("Maximum number of iterations reached", ConvergenceWarning)
+        warnings.warn("Maximum number of iterations reached", ConvergenceWarning, stacklevel=2)
 
     return x_weights, y_weights, n_iter
 
@@ -305,7 +305,7 @@ class _PLS(
                 except StopIteration as e:
                     if str(e) != "y residual is constant":
                         raise
-                    warnings.warn(f"y residual is constant at iteration {k}")
+                    warnings.warn(f"y residual is constant at iteration {k}", stacklevel=2)
                     break
 
                 self.n_iter_.append(n_iter_)

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1486,7 +1486,8 @@ def _fetch_remote(remote, dirname=None, n_retries=3, delay=1):
             warnings.warn(
                 f"SHA256 checksum of existing local file {file_path.name} "
                 f"({checksum}) differs from expected ({remote.checksum}): "
-                f"re-downloading from {remote.url} ."
+                f"re-downloading from {remote.url} .",
+                stacklevel=2,
             )
 
     # We create a temporary file dedicated to this particular download to avoid
@@ -1516,7 +1517,7 @@ def _fetch_remote(remote, dirname=None, n_retries=3, delay=1):
                 if n_retries == 0:
                     # If no more retries are left, re-raise the caught exception.
                     raise
-                warnings.warn(f"Retry downloading from url: {remote.url}")
+                warnings.warn(f"Retry downloading from url: {remote.url}", stacklevel=2)
                 n_retries -= 1
                 time.sleep(delay)
 

--- a/sklearn/decomposition/_factor_analysis.py
+++ b/sklearn/decomposition/_factor_analysis.py
@@ -298,6 +298,7 @@ class FactorAnalysis(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEsti
                 " You might want"
                 " to increase the number of iterations.",
                 ConvergenceWarning,
+                stacklevel=2,
             )
 
         self.components_ = W

--- a/sklearn/decomposition/_fastica.py
+++ b/sklearn/decomposition/_fastica.py
@@ -135,6 +135,7 @@ def _ica_par(X, tol, g, fun_args, max_iter, w_init):
                 "tolerance or the maximum number of iterations."
             ),
             ConvergenceWarning,
+            stacklevel=2,
         )
 
     return W, ii + 1
@@ -597,14 +598,15 @@ class FastICA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         n_components = self.n_components
         if not self.whiten and n_components is not None:
             n_components = None
-            warnings.warn("Ignoring n_components with whiten=False.")
+            warnings.warn("Ignoring n_components with whiten=False.", stacklevel=2)
 
         if n_components is None:
             n_components = min(n_samples, n_features)
         if n_components > min(n_samples, n_features):
             n_components = min(n_samples, n_features)
             warnings.warn(
-                "n_components is too large: it will be set to %s" % n_components
+                "n_components is too large: it will be set to %s" % n_components,
+                stacklevel=2,
             )
 
         if self.whiten:
@@ -623,7 +625,8 @@ class FastICA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
                     warnings.warn(
                         "There are some small singular values, using "
                         "whiten_solver = 'svd' might lead to more "
-                        "accurate results."
+                        "accurate results.",
+                        stacklevel=2,
                     )
                 d[degenerate_idx] = eps  # For numerical issues
                 np.sqrt(d, out=d)

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -1205,6 +1205,7 @@ class _BaseNMF(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator,
                 warnings.warn(
                     "When update_H=False, the provided initial W is not used.",
                     RuntimeWarning,
+                    stacklevel=2,
                 )
 
             _check_init(H, (self._n_components, n_features), "NMF (input H)")
@@ -1233,6 +1234,7 @@ class _BaseNMF(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator,
                         " init='custom' to use them as initialization."
                     ),
                     RuntimeWarning,
+                    stacklevel=2,
                 )
 
             if self._n_components == "auto":
@@ -1579,6 +1581,7 @@ class NMF(_BaseNMF):
                     "You may try init='nndsvda' or init='nndsvdar' instead."
                 ),
                 UserWarning,
+                stacklevel=2,
             )
 
         return self
@@ -1722,6 +1725,7 @@ class NMF(_BaseNMF):
                 "Maximum number of iterations %d reached. Increase "
                 "it to improve convergence." % self.max_iter,
                 ConvergenceWarning,
+                stacklevel=2,
             )
 
         return W, H, n_iter
@@ -2310,6 +2314,7 @@ class MiniBatchNMF(_BaseNMF):
                     "Increase it to improve convergence."
                 ),
                 ConvergenceWarning,
+                stacklevel=2,
             )
 
         return W, H, n_iter, n_steps

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -685,7 +685,7 @@ class LinearDiscriminantAnalysis(
             raise ValueError("priors must be non-negative")
 
         if xp.abs(xp.sum(self.priors_) - 1.0) > 1e-5:
-            warnings.warn("The priors do not sum to 1. Renormalizing", UserWarning)
+            warnings.warn("The priors do not sum to 1. Renormalizing", UserWarning, stacklevel=2)
             self.priors_ = self.priors_ / self.priors_.sum()
 
         # Maximum number of components no matter what n_components is

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -685,7 +685,9 @@ class LinearDiscriminantAnalysis(
             raise ValueError("priors must be non-negative")
 
         if xp.abs(xp.sum(self.priors_) - 1.0) > 1e-5:
-            warnings.warn("The priors do not sum to 1. Renormalizing", UserWarning, stacklevel=2)
+            warnings.warn(
+                "The priors do not sum to 1. Renormalizing", UserWarning, stacklevel=2
+            )
             self.priors_ = self.priors_ / self.priors_.sum()
 
         # Maximum number of components no matter what n_components is

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -192,6 +192,7 @@ class DummyClassifier(MultiOutputMixin, ClassifierMixin, BaseEstimator):
                     "and would be slower."
                 ),
                 UserWarning,
+                stacklevel=2,
             )
 
         self.sparse_output_ = sp.issparse(y)

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -87,7 +87,9 @@ def _safe_divide(numerator, denominator):
         # on `np.errstate` that is not supported by Pyodide.
         result = float(numerator) / float(denominator)
         if math.isinf(result):
-            warnings.warn("overflow encountered in _safe_divide", RuntimeWarning, stacklevel=2)
+            warnings.warn(
+                "overflow encountered in _safe_divide", RuntimeWarning, stacklevel=2
+            )
         return result
 
 

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -87,7 +87,7 @@ def _safe_divide(numerator, denominator):
         # on `np.errstate` that is not supported by Pyodide.
         result = float(numerator) / float(denominator)
         if math.isinf(result):
-            warnings.warn("overflow encountered in _safe_divide", RuntimeWarning)
+            warnings.warn("overflow encountered in _safe_divide", RuntimeWarning, stacklevel=2)
         return result
 
 
@@ -668,6 +668,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                 "removed in 1.11. It has no effect. Leave it to its default value to "
                 "avoid this warning.",
                 FutureWarning,
+                stacklevel=2,
             )
 
         # Check input
@@ -1083,6 +1084,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                 "will lead to incorrect partial dependence values. "
                 "Got init=%s." % self.init,
                 UserWarning,
+                stacklevel=2,
             )
         grid = np.asarray(grid, dtype=DTYPE, order="C")
         n_estimators, n_trees_per_stage = self.estimators_.shape

--- a/sklearn/experimental/enable_hist_gradient_boosting.py
+++ b/sklearn/experimental/enable_hist_gradient_boosting.py
@@ -19,5 +19,6 @@ warnings.warn(
     "Since version 1.0, "
     "it is not needed to import enable_hist_gradient_boosting anymore. "
     "HistGradientBoostingClassifier and HistGradientBoostingRegressor are now "
-    "stable and can be normally imported from sklearn.ensemble."
+    "stable and can be normally imported from sklearn.ensemble.",
+    stacklevel=2,
 )

--- a/sklearn/externals/_packaging/version.py
+++ b/sklearn/externals/_packaging/version.py
@@ -143,6 +143,7 @@ class LegacyVersion(_BaseVersion):
             "Creating a LegacyVersion has been deprecated and will be "
             "removed in the next major release",
             DeprecationWarning,
+            stacklevel=2,
         )
 
     def __str__(self) -> str:

--- a/sklearn/externals/array_api_compat/common/_helpers.py
+++ b/sklearn/externals/array_api_compat/common/_helpers.py
@@ -485,7 +485,8 @@ def is_array_api_strict_namespace(xp: Namespace) -> bool:
 def _check_api_version(api_version: str | None) -> None:
     if api_version in _API_VERSIONS_OLD:
         warnings.warn(
-            f"The {api_version} version of the array API specification was requested but the returned namespace is actually version 2024.12"
+            f"The {api_version} version of the array API specification was requested but the returned namespace is actually version 2024.12",
+            stacklevel=2,
         )
     elif api_version is not None and api_version not in _API_VERSIONS:
         raise ValueError(

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -413,7 +413,8 @@ class _VectorizerMixin:
                     "Your stop_words may be inconsistent with "
                     "your preprocessing. Tokenizing the stop "
                     "words generated tokens %r not in "
-                    "stop_words." % sorted(inconsistent)
+                    "stop_words." % sorted(inconsistent),
+                    stacklevel=2,
                 )
             return not inconsistent
         except Exception:
@@ -526,13 +527,15 @@ class _VectorizerMixin:
         if self.tokenizer is not None and self.token_pattern is not None:
             warnings.warn(
                 "The parameter 'token_pattern' will not be used"
-                " since 'tokenizer' is not None'"
+                " since 'tokenizer' is not None'",
+                stacklevel=2,
             )
 
         if self.preprocessor is not None and callable(self.analyzer):
             warnings.warn(
                 "The parameter 'preprocessor' will not be used"
-                " since 'analyzer' is callable'"
+                " since 'analyzer' is callable'",
+                stacklevel=2,
             )
 
         if (
@@ -542,13 +545,15 @@ class _VectorizerMixin:
         ):
             warnings.warn(
                 "The parameter 'ngram_range' will not be used"
-                " since 'analyzer' is callable'"
+                " since 'analyzer' is callable'",
+                stacklevel=2,
             )
         if self.analyzer != "word" or callable(self.analyzer):
             if self.stop_words is not None:
                 warnings.warn(
                     "The parameter 'stop_words' will not be used"
-                    " since 'analyzer' != 'word'"
+                    " since 'analyzer' != 'word'",
+                    stacklevel=2,
                 )
             if (
                 self.token_pattern is not None
@@ -556,12 +561,14 @@ class _VectorizerMixin:
             ):
                 warnings.warn(
                     "The parameter 'token_pattern' will not be used"
-                    " since 'analyzer' != 'word'"
+                    " since 'analyzer' != 'word'",
+                    stacklevel=2,
                 )
             if self.tokenizer is not None:
                 warnings.warn(
                     "The parameter 'tokenizer' will not be used"
-                    " since 'analyzer' != 'word'"
+                    " since 'analyzer' != 'word'",
+                    stacklevel=2,
                 )
 
 
@@ -1380,7 +1387,8 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
                         "Upper case characters found in"
                         " vocabulary while 'lowercase'"
                         " is True. These entries will not"
-                        " be matched with any documents"
+                        " be matched with any documents",
+                        stacklevel=2,
                     )
                     break
 
@@ -2050,6 +2058,7 @@ class TfidfVectorizer(CountVectorizer):
                 "Only {} 'dtype' should be used. {} 'dtype' will "
                 "be converted to np.float64.".format(FLOAT_DTYPES, self.dtype),
                 UserWarning,
+                stacklevel=2,
             )
 
     @_fit_context(prefer_skip_nested_validation=True)

--- a/sklearn/feature_selection/_base.py
+++ b/sklearn/feature_selection/_base.py
@@ -126,6 +126,7 @@ class SelectorMixin(TransformerMixin, metaclass=ABCMeta):
                     " too noisy or the selection test too strict."
                 ),
                 UserWarning,
+                stacklevel=2,
             )
             if hasattr(X, "iloc"):
                 return X.iloc[:, :0]

--- a/sklearn/feature_selection/_rfe.py
+++ b/sklearn/feature_selection/_rfe.py
@@ -303,6 +303,7 @@ class RFE(SelectorMixin, MetaEstimatorMixin, BaseEstimator):
                         " no feature selection and all features will be kept."
                     ),
                     UserWarning,
+                    stacklevel=2,
                 )
         else:  # float
             n_features_to_select = int(n_features * self.n_features_to_select)
@@ -861,6 +862,7 @@ class RFECV(RFE):
                     "features will be kept."
                 ),
                 UserWarning,
+                stacklevel=2,
             )
         rfe = RFE(
             estimator=self.estimator,

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -107,7 +107,11 @@ def f_oneway(*args):
     msw = sswn / float(dfwn)
     constant_features_idx = np.where(msw == 0.0)[0]
     if np.nonzero(msb)[0].size != msb.size and constant_features_idx.size:
-        warnings.warn("Features %s are constant." % constant_features_idx, UserWarning, stacklevel=2)
+        warnings.warn(
+            "Features %s are constant." % constant_features_idx,
+            UserWarning,
+            stacklevel=2,
+        )
     f = msb / msw
     # flatten matrix to vector in sparse case
     f = np.asarray(f).ravel()

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -107,7 +107,7 @@ def f_oneway(*args):
     msw = sswn / float(dfwn)
     constant_features_idx = np.where(msw == 0.0)[0]
     if np.nonzero(msb)[0].size != msb.size and constant_features_idx.size:
-        warnings.warn("Features %s are constant." % constant_features_idx, UserWarning)
+        warnings.warn("Features %s are constant." % constant_features_idx, UserWarning, stacklevel=2)
     f = msb / msw
     # flatten matrix to vector in sparse case
     f = np.asarray(f).ravel()
@@ -781,7 +781,8 @@ class SelectKBest(_BaseFilter):
         if not isinstance(self.k, str) and self.k > X.shape[1]:
             warnings.warn(
                 f"k={self.k} is greater than n_features={X.shape[1]}. "
-                "All the features will be returned."
+                "All the features will be returned.",
+                stacklevel=2,
             )
 
     def _get_support_mask(self):

--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -486,7 +486,8 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                 if np.any(y_var_negative):
                     warnings.warn(
                         "Predicted variances smaller than 0. "
-                        "Setting those variances to 0."
+                        "Setting those variances to 0.",
+                        stacklevel=2,
                     )
                     y_var[y_var_negative] = 0.0
 

--- a/sklearn/gaussian_process/kernels.py
+++ b/sklearn/gaussian_process/kernels.py
@@ -450,6 +450,7 @@ class Kernel(metaclass=ABCMeta):
                         " calling fit again may find a "
                         "better value." % (dim, hyp.name, hyp.bounds[dim][0]),
                         ConvergenceWarning,
+                        stacklevel=2,
                     )
                 elif list_close[idx, 1]:
                     warnings.warn(
@@ -460,6 +461,7 @@ class Kernel(metaclass=ABCMeta):
                         " calling fit again may find a "
                         "better value." % (dim, hyp.name, hyp.bounds[dim][1]),
                         ConvergenceWarning,
+                        stacklevel=2,
                     )
                 idx += 1
 

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -647,7 +647,8 @@ class SimpleImputer(_BaseImputer):
                 warnings.warn(
                     "Skipping features without any observed values:"
                     f" {invalid_features}. At least one non-missing value is needed"
-                    f" for imputation with strategy='{self.strategy}'."
+                    f" for imputation with strategy='{self.strategy}'.",
+                    stacklevel=2,
                 )
                 X = X[:, valid_statistics_indexes]
 

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -867,6 +867,7 @@ class IterativeImputer(_BaseImputer):
                 warnings.warn(
                     "[IterativeImputer] Early stopping criterion not reached.",
                     ConvergenceWarning,
+                    stacklevel=2,
                 )
         _assign_where(Xt, X, cond=~mask_missing_values)
 

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -726,6 +726,7 @@ def partial_dependence(
                 "to floating point dtypes ahead of time to avoid problems. "
                 "This will raise ValueError in scikit-learn 1.9.",
                 FutureWarning,
+                stacklevel=2,
             )
             # Do not warn again for other features to avoid spamming the caller.
             break

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -322,7 +322,8 @@ class DecisionBoundaryDisplay:
                 if kwarg in kwargs:
                     warnings.warn(
                         f"'{kwarg}' is ignored in favor of 'multiclass_colors' "
-                        "in the multiclass case."
+                        "in the multiclass case.",
+                        stacklevel=2,
                     )
                     del kwargs[kwarg]
 

--- a/sklearn/isotonic.py
+++ b/sklearn/isotonic.py
@@ -91,7 +91,8 @@ def check_increasing(x, y):
                 "Confidence interval of the Spearman "
                 "correlation coefficient spans zero. "
                 "Determination of ``increasing`` may be "
-                "suspect."
+                "suspect.",
+                stacklevel=2,
             )
 
     return increasing_bool

--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -1041,7 +1041,8 @@ class Nystroem(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator)
             warnings.warn(
                 "n_components > n_samples. This is not possible.\n"
                 "n_components was set to n_samples, which results"
-                " in inefficient evaluation of the full kernel."
+                " in inefficient evaluation of the full kernel.",
+                stacklevel=2,
             )
 
         else:

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -876,6 +876,7 @@ def _pre_fit(
                     "intercept: recomputing Gram matrix."
                 ),
                 UserWarning,
+                stacklevel=2,
             )
             # TODO: instead of warning and recomputing, we could just center
             # the user provided Gram matrix a-posteriori (after making a copy

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1683,6 +1683,7 @@ class LinearModelCV(MultiOutputLinearModel, ABC):
                 "100 in 1.9. Pass an explicit value to 'alphas' and leave 'n_alphas' "
                 "to its default value to silence this warning.",
                 FutureWarning,
+                stacklevel=2,
             )
             self._alphas = self.n_alphas
 
@@ -1700,6 +1701,7 @@ class LinearModelCV(MultiOutputLinearModel, ABC):
                 "point the default value will be set to 100. Set 'alphas=100' "
                 "to silence this warning.",
                 FutureWarning,
+                stacklevel=2,
             )
         else:
             self._alphas = self.alphas

--- a/sklearn/linear_model/_glm/_newton_solver.py
+++ b/sklearn/linear_model/_glm/_newton_solver.py
@@ -299,6 +299,7 @@ class NewtonSolver(ABC):
                     "search refinement iterations. It will now resort to lbfgs instead."
                 ),
                 ConvergenceWarning,
+                stacklevel=2,
             )
             if self.verbose:
                 print("  Line search did not converge and resorts to lbfgs instead.")
@@ -442,6 +443,7 @@ class NewtonSolver(ABC):
                         "iterations."
                     ),
                     ConvergenceWarning,
+                    stacklevel=2,
                 )
 
         self.iteration -= 1
@@ -511,6 +513,7 @@ class NewtonCholeskySolver(NewtonSolver):
                     f"#{self.iteration}. It will now resort to lbfgs instead."
                 ),
                 ConvergenceWarning,
+                stacklevel=2,
             )
             if self.verbose:
                 print(
@@ -603,6 +606,7 @@ class NewtonCholeskySolver(NewtonSolver):
                 " of X or increasing the penalization strengths.\n"
                 "The original Linear Algebra message was:\n" + str(e),
                 scipy.linalg.LinAlgWarning,
+                stacklevel=2,
             )
             # Possible causes:
             # 1. hess_pointwise is negative. But this is already taken care in

--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -733,6 +733,7 @@ def _lars_path_solver(
                     " Reduce max_iter or increase eps parameters."
                     % (n_iter, alpha.item(), n_active, diag),
                     ConvergenceWarning,
+                    stacklevel=2,
                 )
 
                 # XXX: need to figure a 'drop for good' way
@@ -761,6 +762,7 @@ def _lars_path_solver(
                 "previous alpha=%.3e, with an active set of %i "
                 "regressors." % (n_iter, alpha.item(), prev_alpha.item(), n_active),
                 ConvergenceWarning,
+                stacklevel=2,
             )
             break
 
@@ -1744,7 +1746,8 @@ class LarsCV(Lars):
         if hasattr(Gram, "__array__"):
             warnings.warn(
                 'Parameter "precompute" cannot be an array in '
-                '%s. Automatically switch to "auto" instead.' % self.__class__.__name__
+                '%s. Automatically switch to "auto" instead.' % self.__class__.__name__,
+                stacklevel=2,
             )
             Gram = "auto"
 

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1203,6 +1203,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
                             "trigger an error in 1.10. Use 0<=l1_ratio<=1 instead."
                         ),
                         FutureWarning,
+                        stacklevel=2,
                     )
             elif self.l1_ratio == 1:
                 penalty = "l1"
@@ -1222,6 +1223,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
                     "C=np.inf instead of penalty=None."
                 ),
                 FutureWarning,
+                stacklevel=2,
             )
 
         solver = _check_solver(self.solver, penalty, self.dual)
@@ -1232,7 +1234,8 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
             warnings.warn(
                 "l1_ratio parameter is only used when penalty is "
                 "'elasticnet'. Got "
-                "(penalty={})".format(penalty)
+                "(penalty={})".format(penalty),
+                stacklevel=2,
             )
         if (self.penalty == "l2" and self.l1_ratio != 0) or (
             self.penalty == "l1" and self.l1_ratio != 1
@@ -1240,7 +1243,8 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
             warnings.warn(
                 f"Inconsistent values: penalty={self.penalty} with "
                 f"l1_ratio={self.l1_ratio}. penalty is deprecated. Please use "
-                f"l1_ratio only."
+                f"l1_ratio only.",
+                stacklevel=2,
             )
         if penalty == "elasticnet" and self.l1_ratio is None:
             raise ValueError("l1_ratio must be specified when penalty is elasticnet.")
@@ -1251,7 +1255,8 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
         if self.penalty is None:
             if self.C != 1.0:  # default value
                 warnings.warn(
-                    "Setting penalty=None will ignore the C and l1_ratio parameters"
+                    "Setting penalty=None will ignore the C and l1_ratio parameters",
+                    stacklevel=2,
                 )
                 # Note that check for l1_ratio is done right above
             C_ = xp.inf
@@ -1264,7 +1269,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
             f"You provided 'n_jobs={self.n_jobs}', please leave it unspecified."
         )
         if self.n_jobs is not None:
-            warnings.warn(msg, category=FutureWarning)
+            warnings.warn(msg, category=FutureWarning, stacklevel=2)
 
         X, y = validate_data(
             self,
@@ -1883,6 +1888,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
                     "e.g. l1_ratios=(0,)."
                 ),
                 FutureWarning,
+                stacklevel=2,
             )
         else:
             l1_ratios = self.l1_ratios
@@ -1896,6 +1902,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
                         "in [0, 1] instead."
                     ),
                     FutureWarning,
+                    stacklevel=2,
                 )
             if np.all(np.asarray(l1_ratios) == 0) or l1_ratios is None:
                 penalty = "l2"
@@ -1914,6 +1921,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
                     " and l1_ratios=(1,) instead of penalty='l1'."
                 ),
                 FutureWarning,
+                stacklevel=2,
             )
 
         if self.scoring == "warn":
@@ -1924,6 +1932,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
                 "scoring='neg_log_loss' for the new, scoring='accuracy' or "
                 "scoring=None for the old default.",
                 FutureWarning,
+                stacklevel=2,
             )
             scoring = None
         else:
@@ -1940,6 +1949,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
                 f"scikit-learn 1.10. See the docstring of {self.__class__.__name__} "
                 "for more details.",
                 FutureWarning,
+                stacklevel=2,
             )
             use_legacy_attributes = True
         else:
@@ -1969,7 +1979,8 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
             if l1_ratios is not None and self.penalty != "deprecated":
                 warnings.warn(
                     "l1_ratios parameter is only used when penalty "
-                    "is 'elasticnet'. Got (penalty={})".format(penalty)
+                    "is 'elasticnet'. Got (penalty={})".format(penalty),
+                    stacklevel=2,
                 )
 
             if l1_ratios is None:

--- a/sklearn/linear_model/_quantile.py
+++ b/sklearn/linear_model/_quantile.py
@@ -279,6 +279,7 @@ class QuantileRegressor(LinearModel, RegressorMixin, BaseEstimator):
                 + "Result message of linprog:\n"
                 + result.message,
                 ConvergenceWarning,
+                stacklevel=2,
             )
 
         # positive slack - negative slack

--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -588,6 +588,7 @@ class RANSACRegressor(
                         " diagnostics (n_skips*)."
                     ),
                     ConvergenceWarning,
+                    stacklevel=2,
                 )
 
         # estimate final model using all inliers

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -151,6 +151,7 @@ def _solve_sparse_cg(
             warnings.warn(
                 "sparse_cg did not converge after %d iterations." % info,
                 ConvergenceWarning,
+                stacklevel=2,
             )
 
     return coefs
@@ -265,7 +266,8 @@ def _solve_cholesky_kernel(K, y, alpha, sample_weight=None, copy=False):
         except np.linalg.LinAlgError:
             warnings.warn(
                 "Singular matrix in solving dual problem. Using "
-                "least-squares solution instead."
+                "least-squares solution instead.",
+                stacklevel=2,
             )
             dual_coef = linalg.lstsq(K, y)[0]
 
@@ -373,6 +375,7 @@ def _solve_lbfgs(
                     f"or tol. Currently: max_iter={max_iter} and tol={tol}"
                 ),
                 ConvergenceWarning,
+                stacklevel=2,
             )
         coefs[i] = result["x"]
 
@@ -869,7 +872,8 @@ def resolve_solver(solver, positive, return_intercept, is_sparse, xp):
             f"`solver='auto'` will result in using the solver '{solver}'. "
             "The results may differ from those when using a Numpy array, "
             f"because in that case the preferred solver would be {auto_solver_np}. "
-            f"Set `solver='{solver}'` to suppress this warning."
+            f"Set `solver='{solver}'` to suppress this warning.",
+            stacklevel=2,
         )
 
     return solver
@@ -960,7 +964,8 @@ class _BaseRidge(LinearModel, metaclass=ABCMeta):
                     "an intercept with sparse inputs. Either set the "
                     'solver to "auto" or "sparse_cg", or set a low '
                     '"tol" and a high "max_iter" (especially if inputs are '
-                    "not standardized)."
+                    "not standardized).",
+                    stacklevel=2,
                 )
                 solver = "sag"
             else:
@@ -1647,7 +1652,7 @@ def _check_gcv_mode(X, gcv_mode):
                 "an error in 1.11, use the default or pass `gcv_mode='eigen'` to "
                 "suppress this warning."
             )
-            warnings.warn(msg, FutureWarning)
+            warnings.warn(msg, FutureWarning, stacklevel=2)
         else:
             return "svd"
 

--- a/sklearn/linear_model/_sag.py
+++ b/sklearn/linear_model/_sag.py
@@ -348,6 +348,7 @@ def sag_solver(
         warnings.warn(
             "The max_iter was reached which means the coef_ did not converge",
             ConvergenceWarning,
+            stacklevel=2,
         )
 
     if fit_intercept:

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -745,6 +745,7 @@ class BaseSGDClassifier(LinearClassifierMixin, BaseSGD, metaclass=ABCMeta):
                     "improve the fit."
                 ),
                 ConvergenceWarning,
+                stacklevel=2,
             )
 
         if self.power_t < 0:
@@ -753,6 +754,7 @@ class BaseSGDClassifier(LinearClassifierMixin, BaseSGD, metaclass=ABCMeta):
                 "and will raise an error in 1.10. "
                 "Use values in the range [0.0, inf) instead.",
                 FutureWarning,
+                stacklevel=2,
             )
 
         return self
@@ -1624,6 +1626,7 @@ class BaseSGDRegressor(RegressorMixin, BaseSGD):
                     "improve the fit."
                 ),
                 ConvergenceWarning,
+                stacklevel=2,
             )
 
         if self.power_t < 0:
@@ -1632,6 +1635,7 @@ class BaseSGDRegressor(RegressorMixin, BaseSGD):
                 "and will raise an error in 1.10. "
                 "Use values in the range [0.0, inf) instead.",
                 FutureWarning,
+                stacklevel=2,
             )
 
         return self
@@ -2557,6 +2561,7 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
                     "improve the fit."
                 ),
                 ConvergenceWarning,
+                stacklevel=2,
             )
 
         if self.power_t < 0:
@@ -2565,6 +2570,7 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
                 "and will raise an error in 1.10. "
                 "Use values in the range [0.0, inf) instead.",
                 FutureWarning,
+                stacklevel=2,
             )
 
         return self

--- a/sklearn/linear_model/_theil_sen.py
+++ b/sklearn/linear_model/_theil_sen.py
@@ -129,6 +129,7 @@ def _spatial_median(X, max_iter=300, tol=1.0e-3):
             "spatial median for TheilSen regressor."
             "".format(max_iter=max_iter),
             ConvergenceWarning,
+            stacklevel=2,
         )
     return n_iter, spatial_median
 

--- a/sklearn/manifold/_mds.py
+++ b/sklearn/manifold/_mds.py
@@ -374,7 +374,8 @@ def smacof(
         if not n_init == 1:
             warnings.warn(
                 "Explicit initial positions passed: "
-                "performing only one init of the MDS instead of %d" % n_init
+                "performing only one init of the MDS instead of %d" % n_init,
+                stacklevel=2,
             )
             n_init = 1
 
@@ -737,6 +738,7 @@ class MDS(BaseEstimator):
                 "'classical_mds' in 1.10. To suppress this warning, provide "
                 "some value of `init`.",
                 FutureWarning,
+                stacklevel=2,
             )
             self._init = "random"
         else:
@@ -753,6 +755,7 @@ class MDS(BaseEstimator):
                     "The `dissimilarity` parameter is deprecated and will be "
                     "removed in 1.10. Use `metric` instead.",
                     FutureWarning,
+                    stacklevel=2,
                 )
                 self._metric = self.dissimilarity
 
@@ -761,6 +764,7 @@ class MDS(BaseEstimator):
                 f"Use metric_mds={self.metric} instead of metric={self.metric}. The "
                 "support for metric={True/False} will be dropped in 1.10.",
                 FutureWarning,
+                stacklevel=2,
             )
             if self.dissimilarity == "deprecated":
                 self._metric = "euclidean"
@@ -776,7 +780,8 @@ class MDS(BaseEstimator):
                 "The provided input is a square matrix. Note that ``fit`` constructs "
                 "a dissimilarity matrix from data and will treat rows as samples "
                 "and columns as features. To use a pre-computed dissimilarity matrix, "
-                "set ``metric='precomputed'``."
+                "set ``metric='precomputed'``.",
+                stacklevel=2,
             )
 
         if self._metric == "precomputed":

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -323,7 +323,8 @@ def _spectral_embedding(
 
     if not _graph_is_connected(adjacency):
         warnings.warn(
-            "Graph is not fully connected, spectral embedding may not work as expected."
+            "Graph is not fully connected, spectral embedding may not work as expected.",
+            stacklevel=2,
         )
 
     laplacian, dd = csgraph_laplacian(
@@ -382,7 +383,7 @@ def _spectral_embedding(
         # Use AMG to get a preconditioner and speed up the eigenvalue
         # problem.
         if not sparse.issparse(laplacian):
-            warnings.warn("AMG works better for sparse matrices")
+            warnings.warn("AMG works better for sparse matrices", stacklevel=2)
         laplacian = check_array(
             laplacian, dtype=[np.float64, np.float32], accept_sparse=True
         )
@@ -690,7 +691,8 @@ class SpectralEmbedding(BaseEstimator):
                 warnings.warn(
                     "Nearest neighbors affinity currently does "
                     "not support sparse input, falling back to "
-                    "rbf affinity"
+                    "rbf affinity",
+                    stacklevel=2,
                 )
                 self.affinity = "rbf"
             else:

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -323,7 +323,8 @@ def _spectral_embedding(
 
     if not _graph_is_connected(adjacency):
         warnings.warn(
-            "Graph is not fully connected, spectral embedding may not work as expected.",
+            "Graph is not fully connected, spectral embedding"
+            " may not work as expected.",
             stacklevel=2,
         )
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -200,6 +200,7 @@ def _one_hot_encoding_multiclass_target(y_true, labels, target_xp, target_device
                 f"Pass the ordered labels={lb.classes_.tolist()} and ensure that "
                 "the columns of y_prob correspond to this ordering.",
                 UserWarning,
+                stacklevel=2,
             )
         if not xp.all(_isin(y_true, labels, xp=xp)):
             undeclared_labels = set(y_true) - set(labels)
@@ -309,6 +310,7 @@ def _validate_multiclass_probabilistic_prediction(
         warnings.warn(
             "The y_prob values do not sum to one. Make sure to pass probabilities.",
             UserWarning,
+            stacklevel=2,
         )
 
     # Check if dimensions are consistent.
@@ -623,6 +625,7 @@ def confusion_matrix(
                 "all known labels."
             ),
             UserWarning,
+            stacklevel=2,
         )
 
     return xp.asarray(cm, device=device_)
@@ -1938,6 +1941,7 @@ def _check_set_wise_labels(y_true, y_pred, average, labels, pos_label):
             "labels=[pos_label] to specify a single positive class."
             % (pos_label, average),
             UserWarning,
+            stacklevel=2,
         )
     return labels
 
@@ -2398,7 +2402,7 @@ def class_likelihood_ratios(
         "and the value set with the `replace_undefined_by` param will be returned."
     )
     if raise_warning != "deprecated":
-        warnings.warn(msg_deprecated_param, FutureWarning)
+        warnings.warn(msg_deprecated_param, FutureWarning, stacklevel=2)
     else:
         raise_warning = True
 
@@ -2971,7 +2975,7 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
     with context_manager:
         per_class = xp.linalg.diagonal(C) / xp.sum(C, axis=1)
     if xp.any(xp.isnan(per_class)):
-        warnings.warn("y_pred contains classes not in y_true")
+        warnings.warn("y_pred contains classes not in y_true", stacklevel=2)
         per_class = per_class[~xp.isnan(per_class)]
     score = xp.mean(per_class)
     if adjusted:
@@ -3141,7 +3145,8 @@ def classification_report(
             warnings.warn(
                 "labels size, {0}, does not match size of target_names, {1}".format(
                     len(labels), len(target_names)
-                )
+                ),
+                stacklevel=2,
             )
         else:
             raise ValueError(
@@ -3908,7 +3913,7 @@ def d2_log_loss_score(y_true, y_pred, *, sample_weight=None, labels=None):
     check_consistent_length(y_pred, y_true, sample_weight)
     if _num_samples(y_pred) < 2:
         msg = "D^2 score is not well-defined with less than two samples."
-        warnings.warn(msg, UndefinedMetricWarning)
+        warnings.warn(msg, UndefinedMetricWarning, stacklevel=2)
         return float("nan")
 
     xp, _, device_ = get_namespace_and_device(y_pred)
@@ -4013,7 +4018,7 @@ def d2_brier_score(
     check_consistent_length(y_proba, y_true, sample_weight)
     if _num_samples(y_proba) < 2:
         msg = "D^2 score is not well-defined with less than two samples."
-        warnings.warn(msg, UndefinedMetricWarning)
+        warnings.warn(msg, UndefinedMetricWarning, stacklevel=2)
         return float("nan")
 
     xp, _, device_ = get_namespace_and_device(y_proba)

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -472,6 +472,7 @@ def _binary_roc_auc_score(y_true, y_score, sample_weight=None, max_fpr=None):
                 "is not defined in that case."
             ),
             UndefinedMetricWarning,
+            stacklevel=2,
         )
         return np.nan
 
@@ -1191,7 +1192,8 @@ def precision_recall_curve(
     if tps[-1] == 0:
         warnings.warn(
             "No positive class found in y_true, "
-            "recall is set to one for all thresholds."
+            "recall is set to one for all thresholds.",
+            stacklevel=2,
         )
         recall = xp.full(tps.shape, 1.0, device=device)
     else:
@@ -1355,6 +1357,7 @@ def roc_curve(
         warnings.warn(
             "No negative samples in y_true, false positive value should be meaningless",
             UndefinedMetricWarning,
+            stacklevel=2,
         )
         fpr = xp.full(fps.shape, xp.nan)
     else:
@@ -1364,6 +1367,7 @@ def roc_curve(
         warnings.warn(
             "No positive samples in y_true, true positive value should be meaningless",
             UndefinedMetricWarning,
+            stacklevel=2,
         )
         tpr = xp.full(tps.shape, xp.nan)
     else:
@@ -2224,6 +2228,7 @@ def top_k_accuracy_score(
                 "will result in a perfect score and is therefore meaningless."
             ),
             UndefinedMetricWarning,
+            stacklevel=2,
         )
 
     y_true_encoded = _encode(y_true, uniques=classes)

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1292,7 +1292,7 @@ def r2_score(
 
     if _num_samples(y_pred) < 2:
         msg = "R^2 score is not well-defined with less than two samples."
-        warnings.warn(msg, UndefinedMetricWarning)
+        warnings.warn(msg, UndefinedMetricWarning, stacklevel=2)
         return float("nan")
 
     if sample_weight is not None:
@@ -1679,7 +1679,7 @@ def d2_tweedie_score(y_true, y_pred, *, sample_weight=None, power=0):
 
     if _num_samples(y_pred) < 2:
         msg = "D^2 score is not well-defined with less than two samples."
-        warnings.warn(msg, UndefinedMetricWarning)
+        warnings.warn(msg, UndefinedMetricWarning, stacklevel=2)
         return float("nan")
 
     y_true, y_pred = xp.squeeze(y_true, axis=1), xp.squeeze(y_pred, axis=1)
@@ -1823,7 +1823,7 @@ def d2_pinball_score(
 
     if _num_samples(y_pred) < 2:
         msg = "D^2 score is not well-defined with less than two samples."
-        warnings.warn(msg, UndefinedMetricWarning)
+        warnings.warn(msg, UndefinedMetricWarning, stacklevel=2)
         return float("nan")
 
     numerator = mean_pinball_loss(

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -326,7 +326,8 @@ class _BaseScorer(_MetadataRequester):
         overlap = _kwargs.intersection(kwargs.keys())
         if overlap:
             warnings.warn(
-                f"{message} Overlapping parameters are: {overlap}", UserWarning
+                f"{message} Overlapping parameters are: {overlap}", UserWarning,
+                stacklevel=2,
             )
 
     def set_score_request(self, **kwargs):

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -326,7 +326,8 @@ class _BaseScorer(_MetadataRequester):
         overlap = _kwargs.intersection(kwargs.keys())
         if overlap:
             warnings.warn(
-                f"{message} Overlapping parameters are: {overlap}", UserWarning,
+                f"{message} Overlapping parameters are: {overlap}",
+                UserWarning,
                 stacklevel=2,
             )
 

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -66,7 +66,7 @@ def check_clusterings(labels_true, labels_pred):
             f" {type_label} values for label, and {type_pred} values "
             "for target"
         )
-        warnings.warn(msg, UserWarning)
+        warnings.warn(msg, UserWarning, stacklevel=2)
 
     # input checks
     if labels_true.ndim != 1:
@@ -1271,6 +1271,7 @@ def fowlkes_mallows_score(labels_true, labels_pred, *, sparse="deprecated"):
             "The 'sparse' parameter was deprecated in 1.7 and will be removed in 1.9. "
             "It has no effect. Leave it to its default value to silence this warning.",
             FutureWarning,
+            stacklevel=2,
         )
 
     labels_true, labels_pred = check_clusterings(labels_true, labels_pred)

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -2462,7 +2462,7 @@ def pairwise_distances(
 
         if dtype is bool and (X.dtype != bool or (Y is not None and Y.dtype != bool)):
             msg = "Data was converted to boolean for metric %s" % metric
-            warnings.warn(msg, DataConversionWarning)
+            warnings.warn(msg, DataConversionWarning, stacklevel=2)
 
         X, Y = check_pairwise_arrays(
             X, Y, dtype=dtype, ensure_all_finite=ensure_all_finite

--- a/sklearn/mixture/_base.py
+++ b/sklearn/mixture/_base.py
@@ -297,6 +297,7 @@ class BaseMixture(DensityMixin, BaseEstimator, metaclass=ABCMeta):
                     "tol, or check for degenerate data."
                 ),
                 ConvergenceWarning,
+                stacklevel=2,
             )
 
         self._set_parameters(best_params, xp=xp)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -327,6 +327,7 @@ class ParameterSampler:
                     "than n_iter=%d. Running %d iterations. For exhaustive "
                     "searches, use GridSearchCV." % (grid_size, self.n_iter, grid_size),
                     UserWarning,
+                    stacklevel=2,
                 )
                 n_iter = grid_size
             for i in sample_without_replacement(grid_size, n_iter, random_state=rng):
@@ -902,7 +903,8 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
                     warnings.warn(
                         f"The scoring {name}={scorer} does not support sample_weight, "
                         "which may lead to statistically incorrect results when "
-                        f"fitting {self} with sample_weight. "
+                        f"fitting {self} with sample_weight. ",
+                        stacklevel=2,
                     )
             return scorers._accept_sample_weight()
         # In most cases, scorers is a Scorer object
@@ -915,7 +917,8 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
             warnings.warn(
                 f"The scoring {scorers} does not support sample_weight, "
                 "which may lead to statistically incorrect results when "
-                f"fitting {self} with sample_weight. "
+                f"fitting {self} with sample_weight. ",
+                stacklevel=2,
             )
         return accept
 
@@ -1172,6 +1175,7 @@ class BaseSearchCV(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
                         f"are non-finite: {array_means}"
                     ),
                     category=UserWarning,
+                    stacklevel=2,
                 )
 
             # Weighted std is not directly available in numpy

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -86,6 +86,7 @@ class _UnsupportedGroupCVMixin:
             warnings.warn(
                 f"The groups parameter is ignored by {self.__class__.__name__}",
                 UserWarning,
+                stacklevel=2,
             )
         return super().split(X, y, groups=groups)
 
@@ -814,6 +815,7 @@ class StratifiedKFold(_BaseKFold):
                 " members, which is less than n_splits=%d."
                 % (min_groups, self.n_splits),
                 UserWarning,
+                stacklevel=2,
             )
 
         # Determine the optimal number of samples from each class in each fold,
@@ -884,6 +886,7 @@ class StratifiedKFold(_BaseKFold):
             warnings.warn(
                 f"The groups parameter is ignored by {self.__class__.__name__}",
                 UserWarning,
+                stacklevel=2,
             )
         y = check_array(y, input_name="y", ensure_2d=False, dtype=None)
         return super().split(X, y, groups)
@@ -1038,6 +1041,7 @@ class StratifiedGroupKFold(GroupsConsumerMixin, _BaseKFold):
                 " members, which is less than n_splits=%d."
                 % (n_smallest_class, self.n_splits),
                 UserWarning,
+                stacklevel=2,
             )
         n_classes = len(y_cnt)
 
@@ -1269,6 +1273,7 @@ class TimeSeriesSplit(_BaseKFold):
             warnings.warn(
                 f"The groups parameter is ignored by {self.__class__.__name__}",
                 UserWarning,
+                stacklevel=2,
             )
         return self._split(X)
 
@@ -2437,6 +2442,7 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
             warnings.warn(
                 f"The groups parameter is ignored by {self.__class__.__name__}",
                 UserWarning,
+                stacklevel=2,
             )
         y = check_array(y, input_name="y", ensure_2d=False, dtype=None)
         return super().split(X, y, groups)
@@ -2591,6 +2597,7 @@ class PredefinedSplit(BaseCrossValidator):
             warnings.warn(
                 f"The groups parameter is ignored by {self.__class__.__name__}",
                 UserWarning,
+                stacklevel=2,
             )
         return self._split()
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -486,7 +486,7 @@ def _warn_or_raise_about_fit_failures(results, error_score):
                 "by setting error_score='raise'.\n\n"
                 f"Below are more details about the failures:\n{fit_errors_summary}"
             )
-            warnings.warn(some_fits_failed_message, FitFailedWarning)
+            warnings.warn(some_fits_failed_message, FitFailedWarning, stacklevel=2)
 
 
 @validate_params(
@@ -930,6 +930,7 @@ def _score(estimator, X_test, y_test, scorer, score_params, error_score="raise")
                         f"{format_exc()}"
                     ),
                     UserWarning,
+                    stacklevel=2,
                 )
 
     # Check non-raised error messages in `_MultimetricScorer`
@@ -948,6 +949,7 @@ def _score(estimator, X_test, y_test, scorer, score_params, error_score="raise")
                         f"{str_e}"
                     ),
                     UserWarning,
+                    stacklevel=2,
                 )
 
     error_msg = "scoring must return a number, got %s (%s) instead. (scorer=%s)"
@@ -1354,6 +1356,7 @@ def _enforce_prediction_order(classes, predictions, n_classes, method):
             "Results may not be appropriate for your use case. "
             "{}".format(classes_length, n_classes, recommendation),
             RuntimeWarning,
+            stacklevel=2,
         )
         if method == "decision_function":
             if predictions.ndim == 2 and predictions.shape[1] != classes_length:
@@ -2131,6 +2134,7 @@ def _translate_train_sizes(train_sizes, n_max_training_samples):
             "of ticks will be less than the size of "
             "'train_sizes': %d instead of %d." % (train_sizes_abs.shape[0], n_ticks),
             RuntimeWarning,
+            stacklevel=2,
         )
 
     return train_sizes_abs

--- a/sklearn/multiclass.py
+++ b/sklearn/multiclass.py
@@ -88,7 +88,8 @@ def _fit_binary(estimator, X, y, fit_params, classes=None):
             else:
                 c = y[0]
             warnings.warn(
-                "Label %s is present in all training examples." % str(classes[c])
+                "Label %s is present in all training examples." % str(classes[c]),
+                stacklevel=2,
             )
         estimator = _ConstantPredictor().fit(X, unique_y)
     else:

--- a/sklearn/multioutput.py
+++ b/sklearn/multioutput.py
@@ -687,7 +687,7 @@ class _BaseChain(BaseEstimator, metaclass=ABCMeta):
                 "`base_estimator` as an argument was deprecated in 1.7 and will be"
                 " removed in 1.9. Use `estimator` instead."
             )
-            warnings.warn(warning_msg, FutureWarning)
+            warnings.warn(warning_msg, FutureWarning, stacklevel=2)
             return self.base_estimator
         else:
             return self.estimator

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -655,7 +655,8 @@ class _BaseDiscreteNB(_BaseNB):
             warnings.warn(
                 "alpha too small will result in numeric errors, setting alpha ="
                 f" {alpha_lower_bound:.1e}. Use `force_alpha=True` to keep alpha"
-                " unchanged."
+                " unchanged.",
+                stacklevel=2,
             )
             return np.maximum(alpha, alpha_lower_bound)
         return alpha

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -589,7 +589,9 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
 
         if issparse(X):
             if self.algorithm not in ("auto", "brute"):
-                warnings.warn("cannot use tree with sparse input: using brute force", stacklevel=2)
+                warnings.warn(
+                    "cannot use tree with sparse input: using brute force", stacklevel=2
+                )
 
             if (
                 self.effective_metric_ not in VALID_METRICS_SPARSE["brute"]

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -246,6 +246,7 @@ def sort_graph_by_row_values(graph, copy=False, warn_when_not_sorted=True):
                 " warning."
             ),
             EfficiencyWarning,
+            stacklevel=2,
         )
 
     if graph.format not in ("csr", "csc", "coo", "lil"):
@@ -588,7 +589,7 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
 
         if issparse(X):
             if self.algorithm not in ("auto", "brute"):
-                warnings.warn("cannot use tree with sparse input: using brute force")
+                warnings.warn("cannot use tree with sparse input: using brute force", stacklevel=2)
 
             if (
                 self.effective_metric_ not in VALID_METRICS_SPARSE["brute"]
@@ -660,7 +661,8 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             if self._fit_method == "brute":
                 warnings.warn(
                     "Mind that for 0 < p < 1, Minkowski metrics are not distance"
-                    " metrics. Continuing the execution with `algorithm='brute'`."
+                    " metrics. Continuing the execution with `algorithm='brute'`.",
+                    stacklevel=2,
                 )
             else:  # self._fit_method in ("kd_tree", "ball_tree")
                 raise ValueError(

--- a/sklearn/neighbors/_classification.py
+++ b/sklearn/neighbors/_classification.py
@@ -869,7 +869,8 @@ class RadiusNeighborsClassifier(RadiusNeighborsMixin, ClassifierMixin, Neighbors
                         "Outlier label {} is not in training "
                         "classes. All class probabilities of "
                         "outliers will be assigned with 0."
-                        "".format(self.outlier_label_[k])
+                        "".format(self.outlier_label_[k]),
+                        stacklevel=2,
                     )
 
             # normalize 'votes' into real [0,1] probabilities

--- a/sklearn/neighbors/_lof.py
+++ b/sklearn/neighbors/_lof.py
@@ -286,7 +286,8 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
                 "n_neighbors (%s) is greater than the "
                 "total number of samples (%s). n_neighbors "
                 "will be set to (n_samples - 1) for estimation."
-                % (self.n_neighbors, n_samples)
+                % (self.n_neighbors, n_samples),
+                stacklevel=2,
             )
         self.n_neighbors_ = max(1, min(self.n_neighbors, n_samples - 1))
 
@@ -324,7 +325,8 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
         if np.min(self.negative_outlier_factor_) < -1e7 and not self.novelty:
             warnings.warn(
                 "Duplicate values are leading to incorrect results. "
-                "Increase the number of neighbors for more accurate results."
+                "Increase the number of neighbors for more accurate results.",
+                stacklevel=2,
             )
 
         return self

--- a/sklearn/neighbors/_nearest_centroid.py
+++ b/sklearn/neighbors/_nearest_centroid.py
@@ -208,6 +208,7 @@ class NearestCentroid(
             warnings.warn(
                 "The priors do not sum to 1. Normalizing such that it sums to one.",
                 UserWarning,
+                stacklevel=2,
             )
             self.class_prior_ = self.class_prior_ / self.class_prior_.sum()
 
@@ -240,7 +241,8 @@ class NearestCentroid(
         if any(self.within_class_std_dev_ == 0):
             warnings.warn(
                 "self.within_class_std_dev_ has at least 1 zero standard deviation."
-                "Inputs within the same classes for at least 1 feature are identical."
+                "Inputs within the same classes for at least 1 feature are identical.",
+                stacklevel=2,
             )
 
         err_msg = "All features have zero variance. Division by zero."

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -510,7 +510,7 @@ class RadiusNeighborsRegressor(RadiusNeighborsMixin, RegressorMixin, NeighborsBa
                 "One or more samples have no neighbors "
                 "within specified radius; predicting NaN."
             )
-            warnings.warn(empty_warning_msg)
+            warnings.warn(empty_warning_msg, stacklevel=2)
 
         if self._y.ndim == 1:
             y_pred = y_pred.ravel()

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -694,7 +694,8 @@ class BaseMultilayerPerceptron(BaseEstimator, ABC):
             if self.batch_size > n_samples:
                 warnings.warn(
                     "Got `batch_size` less than 1 or larger than "
-                    "sample size. It is going to be clipped"
+                    "sample size. It is going to be clipped",
+                    stacklevel=2,
                 )
             batch_size = np.clip(self.batch_size, 1, n_samples)
 
@@ -787,9 +788,10 @@ class BaseMultilayerPerceptron(BaseEstimator, ABC):
                         "reached and the optimization hasn't converged yet."
                         % self.max_iter,
                         ConvergenceWarning,
+                        stacklevel=2,
                     )
         except KeyboardInterrupt:
-            warnings.warn("Training interrupted by user.")
+            warnings.warn("Training interrupted by user.", stacklevel=2)
 
         if early_stopping:
             # restore best weights

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -276,7 +276,8 @@ def scale(X, *, axis=0, with_mean=True, with_std=True, copy=True):
                     "when centering the data "
                     "and might not be solved. Dataset may "
                     "contain too large values. You may need "
-                    "to prescale your features."
+                    "to prescale your features.",
+                    stacklevel=2,
                 )
                 Xr -= mean_1
         if with_std:
@@ -295,7 +296,8 @@ def scale(X, *, axis=0, with_mean=True, with_std=True, copy=True):
                         "when scaling the data "
                         "and might not be solved. The standard "
                         "deviation of the data is probably "
-                        "very close to 0. "
+                        "very close to 0. ",
+                        stacklevel=2,
                     )
                     Xr -= mean_2
     return X
@@ -2799,7 +2801,8 @@ class QuantileTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator)
         if self.ignore_implicit_zeros:
             warnings.warn(
                 "'ignore_implicit_zeros' takes effect only with"
-                " sparse matrix. This parameter has no effect."
+                " sparse matrix. This parameter has no effect.",
+                stacklevel=2,
             )
 
         n_samples, n_features = X.shape
@@ -2887,7 +2890,8 @@ class QuantileTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator)
             warnings.warn(
                 "n_quantiles (%s) is greater than the total number "
                 "of samples (%s). n_quantiles is set to "
-                "n_samples." % (self.n_quantiles, n_samples)
+                "n_samples." % (self.n_quantiles, n_samples),
+                stacklevel=2,
             )
         self.n_quantiles_ = max(1, min(self.n_quantiles, n_samples))
 
@@ -3529,6 +3533,7 @@ class PowerTransformer(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
                     f"Consider inspecting the input data or preprocessing it "
                     f"before applying the transformation.",
                     UserWarning,
+                    stacklevel=2,
                 )
         return X
 

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -309,6 +309,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
                 "quantile_method='averaged_inverted_cdf' explicitly to silence this "
                 "warning.",
                 FutureWarning,
+                stacklevel=2,
             )
             quantile_method = "linear"
 
@@ -340,7 +341,8 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
             if col_min == col_max:
                 warnings.warn(
-                    "Feature %d is constant and will be replaced with 0." % jj
+                    "Feature %d is constant and will be replaced with 0." % jj,
+                    stacklevel=2,
                 )
                 n_bins[jj] = 1
                 bin_edges[jj] = np.array([-np.inf, np.inf])
@@ -396,7 +398,8 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
                     warnings.warn(
                         "Bins whose width are too small (i.e., <= "
                         "1e-8) in feature %d are removed. Consider "
-                        "decreasing the number of bins." % jj
+                        "decreasing the number of bins." % jj,
+                        stacklevel=2,
                     )
                     n_bins[jj] = len(bin_edges[jj]) - 1
 

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -259,7 +259,7 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
                     f"{columns_with_unknown} during transform. These "
                     "unknown categories will be encoded as all zeros"
                 )
-            warnings.warn(msg, UserWarning)
+            warnings.warn(msg, UserWarning, stacklevel=2)
 
         self._map_infrequent_categories(X_int, X_mask, ignore_category_indices)
         return X_int, X_mask

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -201,6 +201,7 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
                     " 'check_inverse=False'."
                 ),
                 UserWarning,
+                stacklevel=2,
             )
 
     @_fit_context(prefer_skip_nested_validation=True)
@@ -302,9 +303,9 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
                 " should be defined."
             )
             if output_config == "pandas" and not is_pandas_df(out):
-                warnings.warn(warn_msg.format("pandas"))
+                warnings.warn(warn_msg.format("pandas"), stacklevel=2)
             elif output_config == "polars" and not is_polars_df(out):
-                warnings.warn(warn_msg.format("polars"))
+                warnings.warn(warn_msg.format("polars"), stacklevel=2)
 
         return out
 

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -1007,7 +1007,8 @@ class MultiLabelBinarizer(TransformerMixin, BaseEstimator, auto_wrap_output_keys
             indptr.append(len(indices))
         if unknown:
             warnings.warn(
-                "unknown class(es) {0} will be ignored".format(sorted(unknown, key=str))
+                "unknown class(es) {0} will be ignored".format(sorted(unknown, key=str)),
+                stacklevel=2,
             )
         data = np.ones(len(indices), dtype=int)
 

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -1007,7 +1007,9 @@ class MultiLabelBinarizer(TransformerMixin, BaseEstimator, auto_wrap_output_keys
             indptr.append(len(indices))
         if unknown:
             warnings.warn(
-                "unknown class(es) {0} will be ignored".format(sorted(unknown, key=str)),
+                "unknown class(es) {0} will be ignored".format(
+                    sorted(unknown, key=str)
+                ),
                 stacklevel=2,
             )
         data = np.ones(len(indices), dtype=int)

--- a/sklearn/preprocessing/_target_encoder.py
+++ b/sklearn/preprocessing/_target_encoder.py
@@ -344,6 +344,7 @@ class TargetEncoder(OneToOneFeatureMixin, _BaseEncoder):
                 "cross-validation generator as `cv` argument to specify the shuffling "
                 "behaviour instead.",
                 FutureWarning,
+                stacklevel=2,
             )
         shuffle = True if self.shuffle == "deprecated" else self.shuffle
         cv_kwargs = {"shuffle": shuffle}

--- a/sklearn/random_projection.py
+++ b/sklearn/random_projection.py
@@ -415,6 +415,7 @@ class BaseRandomProjection(
                     "The dimensionality of the problem will not be reduced."
                     % (n_features, self.n_components),
                     DataDimensionalityWarning,
+                    stacklevel=2,
                 )
 
             self.n_components_ = self.n_components

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -325,6 +325,7 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
             warnings.warn(
                 "max_iter=%d was reached without convergence." % self.max_iter,
                 category=ConvergenceWarning,
+                stacklevel=2,
             )
             self.n_iter_ += 1
 

--- a/sklearn/semi_supervised/_self_training.py
+++ b/sklearn/semi_supervised/_self_training.py
@@ -241,7 +241,7 @@ class SelfTrainingClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator)
         has_label = y != -1
 
         if np.all(has_label):
-            warnings.warn("y contains no unlabeled samples", UserWarning)
+            warnings.warn("y contains no unlabeled samples", UserWarning, stacklevel=2)
 
         if self.criterion == "k_best" and (
             self.k_best > X.shape[0] - np.sum(has_label)
@@ -253,6 +253,7 @@ class SelfTrainingClassifier(ClassifierMixin, MetaEstimatorMixin, BaseEstimator)
                     "the first iteration"
                 ),
                 UserWarning,
+                stacklevel=2,
             )
 
         if _routing_enabled():

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -242,6 +242,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
                     f"Use `CalibratedClassifierCV({est_dep}(), ensemble=False)` "
                     f"instead of `{est_dep}(probability=True)`",
                     FutureWarning,
+                    stacklevel=2,
                 )
             else:
                 self._effective_probability = False
@@ -342,6 +343,7 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
                 "  Consider pre-processing your data with"
                 " StandardScaler or MinMaxScaler." % self.max_iter,
                 ConvergenceWarning,
+                stacklevel=2,
             )
 
     def _dense_fit(self, X, y, sample_weight, solver_type, kernel, random_seed):
@@ -1298,6 +1300,7 @@ def _fit_liblinear(
         warnings.warn(
             "Liblinear failed to converge, increase the number of iterations.",
             ConvergenceWarning,
+            stacklevel=2,
         )
 
     if fit_intercept:

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -1363,6 +1363,7 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
                 'were always equivalent. Use `criterion="squared_error"` '
                 "to remove this warning.",
                 FutureWarning,
+                stacklevel=2,
             )
         super().__init__(
             criterion=criterion,

--- a/sklearn/utils/_bunch.py
+++ b/sklearn/utils/_bunch.py
@@ -38,6 +38,7 @@ class Bunch(dict):
             warnings.warn(
                 self._deprecated_key_to_warnings[key],
                 FutureWarning,
+                stacklevel=2,
             )
         return super().__getitem__(key)
 

--- a/sklearn/utils/_chunking.py
+++ b/sklearn/utils/_chunking.py
@@ -172,7 +172,8 @@ def get_chunk_n_rows(row_bytes, *, max_n_rows=None, working_memory=None):
         warnings.warn(
             "Could not adhere to working_memory config. "
             "Currently %.0fMiB, %.0fMiB required."
-            % (working_memory, np.ceil(row_bytes * 2**-20))
+            % (working_memory, np.ceil(row_bytes * 2**-20)),
+            stacklevel=2,
         )
         chunk_n_rows = 1
     return chunk_n_rows

--- a/sklearn/utils/_indexing.py
+++ b/sklearn/utils/_indexing.py
@@ -373,6 +373,7 @@ def _safe_indexing(X, indices, *, axis=0):
             "was passed, but scikit-learn does currently not know how to handle this "
             "kind of data. Some array/list indexing will be tried.",
             category=UserWarning,
+            stacklevel=2,
         )
 
     if hasattr(X, "shape"):

--- a/sklearn/utils/_plotting.py
+++ b/sklearn/utils/_plotting.py
@@ -195,6 +195,7 @@ class _BinaryClassifierCurveDisplayMixin:
                 "Pass all matplotlib arguments to `curve_kwargs` as a dictionary "
                 "instead.",
                 FutureWarning,
+                stacklevel=2,
             )
             curve_kwargs = kwargs
 
@@ -404,6 +405,7 @@ def _deprecate_estimator_name(estimator_name, name, version):
             f"`estimator_name` is deprecated in {version} and will be removed in "
             f"{version_remove}. Use `name` instead.",
             FutureWarning,
+            stacklevel=2,
         )
         return estimator_name
     return name
@@ -461,6 +463,7 @@ def _deprecate_y_pred_parameter(y_score, y_pred, version):
                 f" {version_remove}. Please use `y_score` instead."
             ),
             FutureWarning,
+            stacklevel=2,
         )
         return y_pred
 

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -825,7 +825,7 @@ def _construct_instances(Estimator):
     if Estimator in SKIPPED_ESTIMATORS:
         msg = f"Can't instantiate estimator {Estimator.__name__}"
         # raise additional warning to be shown by pytest
-        warnings.warn(msg, SkipTestWarning)
+        warnings.warn(msg, SkipTestWarning, stacklevel=2)
         raise SkipTest(msg)
 
     if Estimator in INIT_PARAMS:

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -377,7 +377,9 @@ def _delete_folder(folder_path, warn=False):
             shutil.rmtree(folder_path)
     except OSError:
         if warn:
-            warnings.warn("Could not delete temporary folder %s" % folder_path, stacklevel=2)
+            warnings.warn(
+                "Could not delete temporary folder %s" % folder_path, stacklevel=2
+            )
 
 
 class TempMemmap:

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -86,10 +86,10 @@ def ignore_warnings(obj=None, category=Warning):
     >>> import warnings
     >>> from sklearn.utils._testing import ignore_warnings
     >>> with ignore_warnings():
-    ...     warnings.warn('buhuhuhu')
+    ...     warnings.warn('buhuhuhu', stacklevel=2)
 
     >>> def nasty_warn():
-    ...     warnings.warn('buhuhuhu')
+    ...     warnings.warn('buhuhuhu', stacklevel=2)
     ...     print(42)
 
     >>> ignore_warnings(nasty_warn)()
@@ -377,7 +377,7 @@ def _delete_folder(folder_path, warn=False):
             shutil.rmtree(folder_path)
     except OSError:
         if warn:
-            warnings.warn("Could not delete temporary folder %s" % folder_path)
+            warnings.warn("Could not delete temporary folder %s" % folder_path, stacklevel=2)
 
 
 class TempMemmap:
@@ -754,7 +754,8 @@ def _check_consistency_items(
     if skipped:
         warnings.warn(
             f"Checking was skipped for {section}: {skipped} as they were "
-            "not found in all objects."
+            "not found in all objects.",
+            stacklevel=2,
         )
 
 

--- a/sklearn/utils/deprecation.py
+++ b/sklearn/utils/deprecation.py
@@ -68,7 +68,7 @@ class deprecated:
         sig = signature(cls)
 
         def wrapped(cls, *args, **kwargs):
-            warnings.warn(msg, category=FutureWarning)
+            warnings.warn(msg, category=FutureWarning, stacklevel=2)
             if new is object.__new__:
                 return object.__new__(cls)
 
@@ -91,7 +91,7 @@ class deprecated:
 
         @functools.wraps(fun)
         def wrapped(*args, **kwargs):
-            warnings.warn(msg, category=FutureWarning)
+            warnings.warn(msg, category=FutureWarning, stacklevel=2)
             return fun(*args, **kwargs)
 
         # Add a reference to the wrapped function so that we can introspect
@@ -106,7 +106,7 @@ class deprecated:
         @property
         @functools.wraps(prop.fget)
         def wrapped(*args, **kwargs):
-            warnings.warn(msg, category=FutureWarning)
+            warnings.warn(msg, category=FutureWarning, stacklevel=2)
             return prop.fget(*args, **kwargs)
 
         return wrapped

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -127,6 +127,7 @@ def _yield_api_checks(estimator):
             " `sklearn.base.BaseEstimator`. This might lead to unexpected behavior, or"
             " even errors when collecting tests.",
             category=UserWarning,
+            stacklevel=2,
         )
 
     tags = get_tags(estimator)
@@ -382,12 +383,14 @@ def _yield_all_checks(estimator, legacy: bool):
                 name, tags.input_tags
             ),
             SkipTestWarning,
+            stacklevel=2,
         )
         return
     if tags._skip_test:
         warnings.warn(
             "Explicit SKIP via _skip_test tag for estimator {}.".format(name),
             SkipTestWarning,
+            stacklevel=2,
         )
         return
 
@@ -899,6 +902,7 @@ def check_estimator(
                     f"Skipping check {_check_name(check)} for {name} because it raised "
                     f"{type(e).__name__}: {e}",
                     SkipTestWarning,
+                    stacklevel=2,
                 )
         except Exception as e:
             if on_fail == "raise" and not test_can_fail:
@@ -921,7 +925,7 @@ def check_estimator(
 
             if on_fail == "warn":
                 warning = EstimatorCheckFailedWarning(**check_result)
-                warnings.warn(warning)
+                warnings.warn(warning, stacklevel=2)
         else:
             check_result = {
                 "estimator": estimator,
@@ -4245,7 +4249,8 @@ def check_set_params(name, estimator_orig):
                 warnings.warn(
                     "{0} occurred during set_params of param {1} on "
                     "{2}. It is recommended to delay parameter "
-                    "validation until fit.".format(e_type, param_name, name)
+                    "validation until fit.".format(e_type, param_name, name),
+                    stacklevel=2,
                 )
 
                 change_warning_msg = (
@@ -4262,7 +4267,7 @@ def check_set_params(name, estimator_orig):
                     for k, v in curr_params.items():
                         assert params_before_exception[k] is v
                 except AssertionError:
-                    warnings.warn(change_warning_msg)
+                    warnings.warn(change_warning_msg, stacklevel=2)
             else:
                 curr_params = estimator.get_params(deep=False)
                 assert set(test_params.keys()) == set(curr_params.keys()), msg

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -53,6 +53,7 @@ def squared_norm(x):
                 "Data should be float type to avoid this issue"
             ),
             UserWarning,
+            stacklevel=2,
         )
     return np.dot(x, x)
 
@@ -343,7 +344,8 @@ def _randomized_range_finder(
             warnings.warn(
                 "Array API does not support LU factorization, falling back to QR"
                 " instead. Set `power_iteration_normalizer='QR'` explicitly to silence"
-                " this warning."
+                " this warning.",
+                stacklevel=2,
             )
             power_iteration_normalizer = "QR"
         else:
@@ -573,6 +575,7 @@ def _randomized_svd(
             "Calculating SVD of a {} is expensive. "
             "CSR format is more efficient.".format(type(M).__name__),
             sparse.SparseEfficiencyWarning,
+            stacklevel=2,
         )
 
     random_state = check_random_state(random_state)
@@ -1326,6 +1329,7 @@ def stable_cumsum(arr, axis=None, rtol=1e-05, atol=1e-08):
                 "its last element does not correspond to sum"
             ),
             RuntimeWarning,
+            stacklevel=2,
         )
     return out
 

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -309,7 +309,7 @@ def _newton_cg(
                     args=args,
                 )
             except _LineSearchError:
-                warnings.warn("Line Search failed")
+                warnings.warn("Line Search failed", stacklevel=2)
                 break
 
         xk += alphak * xsupi  # upcast if necessary
@@ -322,6 +322,7 @@ def _newton_cg(
                 " number of iterations."
             ),
             ConvergenceWarning,
+            stacklevel=2,
         )
     elif is_verbose:
         print(f"  Solver did converge at loss = {old_fval}.")

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -34,6 +34,7 @@ def _with_config_and_warning_filters(delayed_func, config, warning_filters):
                 "configuration to the joblib workers."
             ),
             UserWarning,
+            stacklevel=2,
         )
         return delayed_func
 
@@ -149,6 +150,7 @@ class _FuncWrapper:
                     " the joblib workers."
                 ),
                 UserWarning,
+                stacklevel=2,
             )
 
         with config_context(**config), warnings.catch_warnings():

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -88,6 +88,7 @@ def _deprecate_positional_args(func=None, *, version="1.3"):
                     "will result in an error"
                 ),
                 FutureWarning,
+                stacklevel=2,
             )
             kwargs.update(zip(sig.parameters, args))
             return f(**kwargs)
@@ -891,7 +892,8 @@ def check_array(
             if not hasattr(array, "sparse") and array.dtypes.apply(is_sparse).any():
                 warnings.warn(
                     "pandas.DataFrame with sparse columns found."
-                    "It will be converted to a dense numpy array."
+                    "It will be converted to a dense numpy array.",
+                    stacklevel=2,
                 )
 
         dtypes_orig = list(array.dtypes)
@@ -2024,6 +2026,7 @@ def _check_psd_eigenvalues(lambdas, enable_warnings=False):
                 "eigendecomposition of the matrix. Only the real "
                 "parts will be kept." % (max_imag_abs / max_real_abs),
                 PositiveSpectrumWarning,
+                stacklevel=2,
             )
 
     # Remove all imaginary parts (even if zero)
@@ -2061,6 +2064,7 @@ def _check_psd_eigenvalues(lambdas, enable_warnings=False):
                     " eigendecomposition of the matrix. Negative "
                     "eigenvalues will be replaced with 0." % (-min_eig / max_eig),
                     PositiveSpectrumWarning,
+                    stacklevel=2,
                 )
             lambdas[lambdas < 0] = 0
 
@@ -2074,6 +2078,7 @@ def _check_psd_eigenvalues(lambdas, enable_warnings=False):
                 "Small eigenvalues will be replaced with 0."
                 "" % (1 / small_pos_ratio),
                 PositiveSpectrumWarning,
+                stacklevel=2,
             )
         lambdas[too_small_lambdas] = 0
 
@@ -2699,14 +2704,16 @@ def _check_feature_names(estimator, X, *, reset):
     if X_feature_names is not None and fitted_feature_names is None:
         warnings.warn(
             f"X has feature names, but {estimator.__class__.__name__} was fitted "
-            "without feature names"
+            "without feature names",
+            stacklevel=2,
         )
         return
 
     if X_feature_names is None and fitted_feature_names is not None:
         warnings.warn(
             "X does not have valid feature names, but"
-            f" {estimator.__class__.__name__} was fitted with feature names"
+            f" {estimator.__class__.__name__} was fitted with feature names",
+            stacklevel=2,
         )
         return
 


### PR DESCRIPTION
## Summary

All 226 `warnings.warn()` calls across 93 files in `sklearn/` (excluding tests) are missing `stacklevel`, causing warning messages to point to internal lines inside scikit-learn rather than the caller's code.

### Problem

Without `stacklevel`, warnings reference internal scikit-learn lines:
```
sklearn/cluster/_kmeans.py:898: ConvergenceWarning: Number of distinct clusters...
sklearn/linear_model/_logistic.py:1200: FutureWarning: l1_ratio parameter...
```

### Fix

With `stacklevel=2`, warnings correctly reference the user's code:
```
my_pipeline.py:42: ConvergenceWarning: Number of distinct clusters...
train.py:15: FutureWarning: l1_ratio parameter...
```

This makes it much easier for users to locate and fix the source of the warning in their own code.

### Changes

Added `stacklevel=2` to all 226 `warnings.warn()` calls across 93 files. Key modules affected:

| Module | Files | Calls Fixed |
|--------|-------|-------------|
| `linear_model/` | 12 | 42 |
| `metrics/` | 6 | 35 |
| `cluster/` | 8 | 22 |
| `preprocessing/` | 7 | 16 |
| `utils/` | 12 | 30 |
| `model_selection/` | 3 | 14 |
| `decomposition/` | 4 | 10 |
| Other modules | 41 | 57 |

All modified files pass `python -m py_compile`.
