### PR TITLE
[Callbacks] Rework progressbar and fix performance issues

### DIFF
--- a/sklearn/callback/_progressbar.py
+++ b/sklearn/callback/_progressbar.py
@@ -65,10 +65,31 @@ class ProgressBar:
         self._run_monitors[context.root_uuid] = progress_monitor
 
     def on_fit_task_begin(self, estimator, context):
-        pass
+        # Don't pass the context to the queue to avoid pickling the whole context tree.
+        # Instead we pass the minimal information needed to create a progress bar.
+        if context.max_subtasks != 0:
+            path = [ctx.task_id for ctx in get_context_path(context)]
+            self._run_queues[context.root_uuid].put(
+                {
+                    "event": "begin",
+                    "path": path,
+                    "task_name": context.task_name,
+                    "task_id": context.task_id,
+                    "max_subtasks": context.max_subtasks,
+                    "estimator_name": context.estimator_name,
+                    "source_estimator_name": context.source_estimator_name,
+                    "source_task_name": context.source_task_name,
+                }
+            )
 
     def on_fit_task_end(self, estimator, context):
-        self._run_queues[context.root_uuid].put(context)
+        # The path is enough to update the progress of the task and its ancestors.
+        self._run_queues[context.root_uuid].put(
+            {
+                "event": "end",
+                "path": [ctx.task_id for ctx in get_context_path(context)],
+            }
+        )
 
     def teardown(self, estimator, context):
         # Signal that the queue won't receive any more tasks.
@@ -93,8 +114,15 @@ try:
         # setting the _ordered_tasks attribute). In particular it allows to dynamically
         # create and insert tasks between existing tasks.
         def get_renderables(self):
-            table = self.make_tasks_table(getattr(self, "_ordered_tasks", []))
-            yield table
+            yield self.make_tasks_table(getattr(self, "_ordered_tasks", []))
+
+    class _StyledTimeRemainingColumn(TimeRemainingColumn):
+        """Time column with per-state color styling."""
+
+        def render(self, task):
+            text = super().render(task)
+            text.style = "#29ABE2" if task.finished else "#F7931E"
+            return text
 
 except ImportError:
     pass
@@ -120,12 +148,11 @@ class RichProgressMonitor(Thread):
         self.progress_ctx = _Progress(
             TextColumn("[progress.description]{task.description}"),
             BarColumn(
-                complete_style=Style(color="dark_orange"),
-                finished_style=Style(color="cyan"),
+                complete_style=Style(color="#F7931E"),
+                finished_style=Style(color="#29ABE2"),
             ),
             TextColumn("[bright_magenta]{task.percentage:>3.0f}%"),
-            TimeRemainingColumn(elapsed_when_finished=True),
-            auto_refresh=False,
+            _StyledTimeRemainingColumn(elapsed_when_finished=True),
         )
 
         # Holds the root of the tree of rich tasks (i.e. progress bars) that will be
@@ -133,89 +160,82 @@ class RichProgressMonitor(Thread):
         self.root_rich_task = None
 
         with self.progress_ctx:
-            while context := self.queue.get():
-                context_path = get_context_path(context)
-                self._update_task_tree(context_path)
-                self._update_tasks()
-                self.progress_ctx.refresh()
-
-    def _update_task_tree(self, context_path):
-        """Update the tree of rich tasks from the path of a new task.
-
-        A new rich task is created for the task and all its ancestors if needed.
-        """
-        curr_rich_task, parent_rich_task = None, None
-
-        for context in context_path:
-            if context.parent is None:  # root node
-                if self.root_rich_task is None:
-                    self.root_rich_task = RichTask(
-                        context, progress_ctx=self.progress_ctx
-                    )
-                curr_rich_task = self.root_rich_task
-            elif context.task_id not in parent_rich_task.children:
-                curr_rich_task = RichTask(
-                    context,
-                    progress_ctx=self.progress_ctx,
-                    parent=parent_rich_task,
-                )
-                parent_rich_task.children[context.task_id] = curr_rich_task
-            else:  # task already exists
-                curr_rich_task = parent_rich_task.children[context.task_id]
-            parent_rich_task = curr_rich_task
-
-        # Mark the deepest task as finished (this is the one corresponding to the
-        # task that we just get from the queue).
-        curr_rich_task.finished = True
-
-    def _update_tasks(self):
-        """Loop through the tasks in their display order and update their progress."""
-        self.progress_ctx._ordered_tasks = []
-
-        for rich_task_node in self.root_rich_task:
-            task = self.progress_ctx.tasks[rich_task_node.task_id]
-
-            total = task.total
-
-            if rich_task_node.finished:
-                # It's possible that a task finishes without reaching its total
-                # (e.g. early stopping). We mark it as 100% completed.
-
-                if task.total is None:
-                    # Indeterminate task is finished. Set total to an arbitrary
-                    # value to render its completion as 100%.
-                    completed = total = 1
+            while task_info := self.queue.get():
+                if task_info.pop("event") == "begin":
+                    self._on_task_begin(task_info)
                 else:
-                    completed = total
-            else:
-                completed = sum(t.finished for t in rich_task_node.children.values())
+                    self._on_task_end(task_info)
 
-            self.progress_ctx.update(
-                rich_task_node.task_id, completed=completed, total=total, refresh=False
-            )
-            self.progress_ctx._ordered_tasks.append(task)
+    def _on_task_begin(self, task_info):
+        """Create a progress bar the task and update the list of ordered tasks."""
+        path = task_info.pop("path")
+
+        rich_task = RichTask(
+            progress_ctx=self.progress_ctx, task_info=task_info, depth=len(path) - 1
+        )
+        if rich_task.depth == 0:
+            self.root_rich_task = rich_task
+        else:
+            parent = self.root_rich_task.get_descendants(path)[-2]
+            parent.children[path[-1]] = rich_task
+
+        self.progress_ctx._ordered_tasks = [
+            self.progress_ctx.tasks[task.id] for task in self.root_rich_task
+        ]
+
+    def _on_task_end(self, task_info):
+        """Update the progress of the task and its ancestors recursively."""
+        *ancestors, task = self.root_rich_task.get_descendants(task_info["path"])
+
+        if task is not None:
+            task.completed = task.total
+            if task.total is None:
+                # Indeterminate task is finished. Set total to an arbitrary
+                # value to render its completion as 100%.
+                self.progress_ctx.update(task.id, completed=1, total=1)
+            else:
+                self.progress_ctx.update(task.id, completed=task.total)
+
+        for ancestor in reversed(ancestors):
+            if ancestor.total is None:
+                continue
+
+            if not ancestor.children:
+                ancestor.completed += 1
+                self.progress_ctx.update(ancestor.id, advance=1)
+            else:
+                completed = ancestor.progress * ancestor.total
+                self.progress_ctx.update(ancestor.id, completed=completed)
 
 
 class RichTask:
     """A task, i.e. progressbar, in the tree of rich tasks.
 
+    There is a rich task for each non-leaf task in the context tree of the estimator.
+
     Parameters
     ----------
-    context : `sklearn.callback.CallbackContext` instance
-        Context of the estimator task for which this rich task is created.
-
     progress_ctx : `rich.Progress` instance
         The progress context to which this task belongs.
 
-    parent : `RichTask` instance
-        The parent of this task.
+    task_info : dict
+        Information about the task for which this rich task is created.
+
+    depth : int
+        The depth of the task in the tree of rich tasks.
 
     Attributes
     ----------
-    finished : bool
-        Whether the task is finished.
+    completed : int
+        The number of completed subtasks.
 
-    task_id : int
+    total : int or None
+        The total number of subtasks. None if the total number of subtasks is not known.
+
+    progress : float
+        The fraction, between 0 and 1, of the task that is completed.
+
+    id : int
         The ID of the task in the Progress context.
 
     children : dict
@@ -223,38 +243,53 @@ class RichTask:
         For a leaf, it's an empty dictionary.
     """
 
-    def __init__(self, context, progress_ctx, parent=None):
-        self.parent = parent
+    def __init__(self, *, progress_ctx, task_info, depth):
         self.children = {}
-        self.finished = False
-        self.depth = 0 if parent is None else parent.depth + 1
+        self.depth = depth
+        self.completed = 0
+        self.total = task_info.pop("max_subtasks")
 
-        if context.max_subtasks != 0:
-            description = self._format_task_description(context)
-            self.task_id = progress_ctx.add_task(
-                description, total=context.max_subtasks
-            )
+        description = self._format_task_description(task_info)
+        self.id = progress_ctx.add_task(description, total=self.total)
 
-    def _format_task_description(self, context):
+    @property
+    def progress(self):
+        """Return the fraction of the task that is completed."""
+        if self.completed == self.total:
+            return 1.0
+        if self.total is None:
+            return 0.0
+        if not self.children:
+            return self.completed / self.total
+        return sum(child.progress for child in self.children.values()) / self.total
+
+    def _format_task_description(self, task_info):
         """Return a formatted description for the task."""
         colors = ["bright_magenta", "cyan", "dark_orange"]
 
         indent = f"{'  ' * self.depth}"
         style = f"[{colors[(self.depth) % len(colors)]}]"
 
-        task_desc = f"{context.estimator_name} - {context.task_name}"
-        id_mark = f" #{context.task_id}" if context.parent is not None else ""
+        task_desc = f"{task_info['estimator_name']} - {task_info['task_name']}"
+        id_mark = f" #{task_info['task_id']}" if self.depth > 0 else ""
         source_task_desc = (
-            f"{context.source_estimator_name} - {context.source_task_name} | "
-            if context.source_estimator_name is not None
+            f"{task_info['source_estimator_name']} - {task_info['source_task_name']} | "
+            if task_info["source_estimator_name"] is not None
             else ""
         )
 
         return f"{style}{indent}{source_task_desc}{task_desc}{id_mark}"
 
+    def get_descendants(self, path):
+        """Return the descendants from this task along the given path."""
+        if len(path) == 1:
+            return [self]
+        if path[1] not in self.children:
+            return [self, None]
+        return [self] + self.children[path[1]].get_descendants(path[1:])
+
     def __iter__(self):
-        """Pre-order depth-first traversal, excluding leaves."""
-        if self.children:
-            yield self
-            for child in self.children.values():
-                yield from child
+        """Pre-order depth-first traversal."""
+        yield self
+        for child in self.children.values():
+            yield from child

--- a/sklearn/callback/_progressbar.py
+++ b/sklearn/callback/_progressbar.py
@@ -116,24 +116,19 @@ try:
         def get_renderables(self):
             yield self.make_tasks_table(getattr(self, "_ordered_tasks", []))
 
-    class _StyledTimeRemainingColumn(TimeRemainingColumn):
-        """Time column with per-state color styling."""
+    class _StyledColumnMixin:
+        """Apply finished/in-progress color style to rendered text."""
 
         def render(self, task):
             text = super().render(task)
             text.style = "#29ABE2" if task.finished else "#F7931E"
             return text
 
-    class _StyledPercentageColumn(TextColumn):
-        """Percentage column with per-state color styling."""
+    class _StyledTimeRemainingColumn(_StyledColumnMixin, TimeRemainingColumn):
+        """Time column with color styling."""
 
-        def __init__(self):
-            super().__init__("{task.percentage:>3.0f}%")
-
-        def render(self, task):
-            text = super().render(task)
-            text.style = "#29ABE2" if task.percentage >= 100 else "#F7931E"
-            return text
+    class _StyledPercentageColumn(_StyledColumnMixin, TextColumn):
+        """Percentage column with color styling."""
 
 except ImportError:
     pass
@@ -163,7 +158,7 @@ class RichProgressMonitor(Thread):
                 finished_style=Style(color="#29ABE2"),
                 pulse_style=Style(color="#F7931E"),
             ),
-            _StyledPercentageColumn(),
+            _StyledPercentageColumn("{task.percentage:>3.0f}%"),
             _StyledTimeRemainingColumn(elapsed_when_finished=True),
         )
 

--- a/sklearn/callback/_progressbar.py
+++ b/sklearn/callback/_progressbar.py
@@ -176,7 +176,7 @@ class RichProgressMonitor(Thread):
             self.progress_ctx.refresh()
 
     def _on_task_begin(self, task_info):
-        """Create a progress bar the task and update the list of ordered tasks."""
+        """Create a progress bar for the task and update the list of ordered tasks."""
         path = task_info.pop("path")
 
         rich_task = RichTask(

--- a/sklearn/callback/_progressbar.py
+++ b/sklearn/callback/_progressbar.py
@@ -124,6 +124,17 @@ try:
             text.style = "#29ABE2" if task.finished else "#F7931E"
             return text
 
+    class _StyledPercentageColumn(TextColumn):
+        """Percentage column with per-state color styling."""
+
+        def __init__(self):
+            super().__init__("{task.percentage:>3.0f}%")
+
+        def render(self, task):
+            text = super().render(task)
+            text.style = "#29ABE2" if task.percentage >= 100 else "#F7931E"
+            return text
+
 except ImportError:
     pass
 
@@ -151,7 +162,7 @@ class RichProgressMonitor(Thread):
                 complete_style=Style(color="#F7931E"),
                 finished_style=Style(color="#29ABE2"),
             ),
-            TextColumn("[bright_magenta]{task.percentage:>3.0f}%"),
+            _StyledPercentageColumn(),
             _StyledTimeRemainingColumn(elapsed_when_finished=True),
         )
 
@@ -165,6 +176,8 @@ class RichProgressMonitor(Thread):
                     self._on_task_begin(task_info)
                 else:
                     self._on_task_end(task_info)
+
+            self.progress_ctx.refresh()
 
     def _on_task_begin(self, task_info):
         """Create a progress bar the task and update the list of ordered tasks."""
@@ -265,11 +278,7 @@ class RichTask:
 
     def _format_task_description(self, task_info):
         """Return a formatted description for the task."""
-        colors = ["bright_magenta", "cyan", "dark_orange"]
-
         indent = f"{'  ' * self.depth}"
-        style = f"[{colors[(self.depth) % len(colors)]}]"
-
         task_desc = f"{task_info['estimator_name']} - {task_info['task_name']}"
         id_mark = f" #{task_info['task_id']}" if self.depth > 0 else ""
         source_task_desc = (
@@ -277,8 +286,7 @@ class RichTask:
             if task_info["source_estimator_name"] is not None
             else ""
         )
-
-        return f"{style}{indent}{source_task_desc}{task_desc}{id_mark}"
+        return f"{indent}{source_task_desc}{task_desc}{id_mark}"
 
     def get_descendants(self, path):
         """Return the descendants from this task along the given path."""

--- a/sklearn/callback/_progressbar.py
+++ b/sklearn/callback/_progressbar.py
@@ -161,6 +161,7 @@ class RichProgressMonitor(Thread):
             BarColumn(
                 complete_style=Style(color="#F7931E"),
                 finished_style=Style(color="#29ABE2"),
+                pulse_style=Style(color="#F7931E"),
             ),
             _StyledPercentageColumn(),
             _StyledTimeRemainingColumn(elapsed_when_finished=True),


### PR DESCRIPTION
I noticed that currently ProgressBar terribly slows down the estimator. It's not that bad for a single estimator with not many iterations but gets unusable for big compositions. The reason is that the context tree grows dynamically and we pickle it entirely at the end of each task so we pickle a bigger object at every new task.

(The reason that we pickle the whole tree is because a context has a reference to its parent and to all it's children)

I changed it so that we pickle an object of constant size: the necessary attributes of the context to create a progress bar + the path of task ids to uniquely identify the task.

With this change, the example below runs in 11s, vs 1m27s previously ! (without progress bars it runs in 3s)
Roughly, the progress bar now adds a constant ~2ms overhead per task.

--------------

I took the opportunity to rework the logic and use the fact that we now have a hook at the beginning of tasks. It makes the implementation a lot more intuitive as well.
- at the beginning of a task, a progress bar is created for the task and the rich display is updated to include the new bar
- at the end of a task, the task is marked as finished and the progress bars for the task and all its ancestors are updated accordingly.

--------------

I also to the opportunity to make some visual improvements:
- the bar, percentage and ellapsed time columns are now orange while progressing and blue when finished (I used the official sklearn colors).
- the task descriptions are left to default rich foreground color (black on light theme and white on dark theme). I found that there was too much color. But open to suggestions :)
- the progress of a bar is computed based on the progress of its children recursively for a way smoother progression. For instance, previously if the root task had only 4 children, it would progress only by increments of 25%. Now it progresses smoothly. It also has the advantage that now the estimated remaining time starts right away even for the top level bars so you have an idea of the total time.

Here's how it looks like on dark theme
<img width="1193" height="217" alt="bars_dark" src="https://github.com/user-attachments/assets/311cc5ef-6c16-427a-9217-7191e39a1bf3" />

and on light theme
<img width="1083" height="215" alt="image" src="https://github.com/user-attachments/assets/03cb3e52-361b-48ca-b18c-793af6f303ea" />

You can test it as follows:
```py
from sklearn.callback.tests._utils import MaxIterEstimator, MetaEstimator
from sklearn.callback import ProgressBar

m = (
    MetaEstimator(MaxIterEstimator(max_iter=500), n_outer=4, n_inner=3, n_jobs=2)
    .set_callbacks(ProgressBar())
    .fit()
)
```
---------------

Note that the changes of this PR are only performance and style so I didn't have to add or modify tests. The fact the existing tests pass hints that it didn't change the behavior.

---------------

Possible future improvements that I didn't add here:
- remove that small white artifact that appear between the completed part and the background of the bar on light theme (see picture). Maybe ?
- make the color of the bar and percent and ellapsed time columns change progressively from orange to blue.
  I tested it and it looks nice to me. It adds a little bit of complexity but not very much. But there's no urgency at all
- add an option to only show the top progressbar.
  I big compositions, there can be a large number of bars that quickly fill the whole screen. Of course you can set `max_propagation_depth=0` but it still shows all the nested levels of the top level estimator. Maybe some user would prefer to have a single bar.
- alternatively add a "transient" option to remove finished bars from the display. I tested it a bit but so far I'm not satisfied because there are jumps when removing a bar changes the size of the descriptions columns and all bars move to the left.

None of these are urgent so I left them for a different PR.

-------------

ping @FrancoisPgm @StefanieSenger @ogrisel 