### PR TITLE
DOC Document approximate stratification in StratifiedShuffleSplit

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.model_selection/33728.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.model_selection/33728.enhancement.rst
@@ -1,0 +1,5 @@
+- :class:`model_selection.StratifiedShuffleSplit` now documents that
+  per-class sample allocation uses an approximation of the multivariate
+  hypergeometric distribution, which can be off by one sample per class.
+  Heavily underrepresented classes may receive zero samples in a split.
+  By :user:`Rudrendu Paul <RudrenduPaul>`.

--- a/doc/whats_new/upcoming_changes/sklearn.model_selection/33728.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.model_selection/33728.enhancement.rst
@@ -1,5 +1,0 @@
-- :class:`model_selection.StratifiedShuffleSplit` now documents that
-  per-class sample allocation uses an approximation of the multivariate
-  hypergeometric distribution, which can be off by one sample per class.
-  Heavily underrepresented classes may receive zero samples in a split.
-  By :user:`Rudrendu Paul <RudrenduPaul>`.

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2256,6 +2256,18 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
         Stratification on the class label solves an engineering problem rather
         than a statistical one. See :ref:`stratification` for more details.
 
+    .. note::
+
+        The per-class allocation of samples to train and test splits is based
+        on an approximation of the multivariate hypergeometric distribution.
+        This approximation can be off by one sample per class. As a result,
+        when a class is heavily underrepresented relative to the total dataset
+        size, it may receive zero samples in either the train or test split
+        even though both ``n_train`` and ``n_test`` are greater than or equal
+        to the number of classes. In such cases, consider using
+        :class:`StratifiedKFold` instead, or ensure that the least populated
+        class has sufficiently many members relative to the split sizes.
+
     Parameters
     ----------
     n_splits : int, default=10

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2240,6 +2240,10 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     are made by preserving the percentage of samples for each class in `y` in a
     binary or multiclass classification setting.
 
+    The per-class sample count between train and test splits can differ by one,
+    which for heavily underrepresented classes may result in no samples of that
+    class in the test set.
+
     Note: like the :class:`ShuffleSplit` strategy, stratified random splits
     do not guarantee that test sets across all folds will be mutually exclusive,
     and might include overlapping samples. However, this is still very likely for
@@ -2255,18 +2259,6 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
 
         Stratification on the class label solves an engineering problem rather
         than a statistical one. See :ref:`stratification` for more details.
-
-    .. note::
-
-        The per-class allocation of samples to train and test splits is based
-        on an approximation of the multivariate hypergeometric distribution.
-        This approximation can be off by one sample per class. As a result,
-        when a class is heavily underrepresented relative to the total dataset
-        size, it may receive zero samples in either the train or test split
-        even though both ``n_train`` and ``n_test`` are greater than or equal
-        to the number of classes. In such cases, consider using
-        :class:`StratifiedKFold` instead, or ensure that the least populated
-        class has sufficiently many members relative to the split sizes.
 
     Parameters
     ----------

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -2240,9 +2240,14 @@ class StratifiedShuffleSplit(BaseShuffleSplit):
     are made by preserving the percentage of samples for each class in `y` in a
     binary or multiclass classification setting.
 
-    The per-class sample count between train and test splits can differ by one,
-    which for heavily underrepresented classes may result in no samples of that
-    class in the test set.
+    Each split's per-class sample count can differ by at most one from
+    that class's own proportional allocation for that split (not from
+    the other split's count for the same class). For classes with very
+    few samples this can mean zero samples in the test set: this happens
+    exactly when the class's sample count multiplied by ``test_size`` is
+    less than 0.5. For example, with 2 samples in a class and
+    ``test_size=0.2``, ``2 * 0.2 = 0.4 < 0.5``, so both samples always
+    go to train and the class never appears in the test set.
 
     Note: like the :class:`ShuffleSplit` strategy, stratified random splits
     do not guarantee that test sets across all folds will be mutually exclusive,


### PR DESCRIPTION
## What does this PR do?

Fixes #28994.

Adds a `.. note::` to the `StratifiedShuffleSplit` class docstring explaining that per-class sample allocation uses an approximation of the multivariate hypergeometric distribution (via `_approximate_mode`). This approximation can be off by one sample per class.

### Context

As reported in #28994 and confirmed by @glemaitre, when a class is heavily underrepresented relative to the total dataset size (e.g., 2 minority samples out of 50,000), `StratifiedShuffleSplit` may allocate zero samples from that class to either the train or test split. This happens even though both `n_train` and `n_test` satisfy the existing `>= n_classes` validation check.

Concretely, with 2 minority samples out of 50,000 total:
- `_approximate_mode([2, 49998], n_train, rng)` assigns 1 to train
- `_approximate_mode([1, 49999], n_test, rng)` where `1/50000 * n_test < 0.5`, so the minority class gets 0 in test

This behavior is surprising to users who expect the stratification guarantee to hold.

### What changed

Added a `.. note::` block to the `StratifiedShuffleSplit` class docstring explaining:
- The per-class allocation is approximate (can be off by ±1)
- Heavily underrepresented classes may receive 0 samples in a split
- Users should consider `StratifiedKFold` for such cases, or ensure sufficient minority class membership

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md)
- [x] The change is a documentation-only addition to an existing class
- [x] No code logic was modified

---

> **AI Assistance Disclosure** (required per [AGENTS.md](https://github.com/scikit-learn/scikit-learn/blob/main/AGENTS.md))
> This pull request includes code written with the assistance of AI (Claude Code).
> All changes have been read, understood, and verified by the human contributor (Rudrendu Paul).