### PR TITLE
FIX ColumnTransformer with callable selectors and integer column names

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.compose/33748.bugfix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.compose/33748.bugfix.rst
@@ -1,1 +1,6 @@
-- :class:`compose.ColumnTransformer` now correctly handles pandas DataFrames with integer column names when using callable column selectors such as :func:`compose.make_column_selector`. :pr:`33748` by :user:`showard04`.
+- :class:`compose.ColumnTransformer` now correctly handles pandas DataFrames
+  with integer column names when using callable column selectors such as
+  :func:`compose.make_column_selector`. Previously, integer column names
+  returned by the callable were misinterpreted as positional indices, causing
+  an ``IndexError`` or ``ValueError``.
+  By :user:`showard04`

--- a/doc/whats_new/upcoming_changes/sklearn.compose/33748.bugfix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.compose/33748.bugfix.rst
@@ -1,0 +1,1 @@
+- :class:`compose.ColumnTransformer` now correctly handles pandas DataFrames with integer column names when using callable column selectors such as :func:`compose.make_column_selector`. :pr:`33748` by :user:`showard04`.

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -542,6 +542,17 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         for name, _, columns in self.transformers:
             if callable(columns):
                 columns = columns(X)
+                # If X is a DataFrame with integer column names, a callable
+                # (e.g. make_column_selector) returns column names as integers.
+                # Convert them to positional indices to avoid them being
+                # misinterpreted as positions downstream (see gh-30983).
+                if (
+                    hasattr(X, "columns")
+                    and X.columns.dtype.kind in ("i", "u")
+                    and isinstance(columns, list)
+                    and all(isinstance(c, (int, np.integer)) for c in columns)
+                ):
+                    columns = [X.columns.get_loc(c) for c in columns]
             all_columns.append(columns)
             transformer_to_input_indices[name] = _get_column_indices(X, columns)
 

--- a/sklearn/compose/tests/test_column_transformer.py
+++ b/sklearn/compose/tests/test_column_transformer.py
@@ -2889,3 +2889,28 @@ def test_unused_transformer_request_present():
 
 # End of Metadata Routing Tests
 # =============================
+def test_column_transformer_int_column_names():
+    """Non-regression test for gh-30983.
+    ColumnTransformer should handle DataFrames with integer column names
+    without treating them as positional indices.
+    """
+    pd = pytest.importorskip("pandas")
+    import numpy as np
+    from sklearn.impute import SimpleImputer
+
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame(rng.random((10, 3)))
+    X = X.iloc[:, [0, -1]]  # integer column names: 0 and 2
+
+    # This should not raise an IndexError/ValueError
+    ct = ColumnTransformer(
+        transformers=[
+            (
+                "continuous",
+                SimpleImputer(),
+                make_column_selector(dtype_include="number"),
+            )
+        ]
+    )
+    X_out = ct.fit_transform(X)
+    assert X_out.shape == (10, 2)


### PR DESCRIPTION
Fixes #30983

## What the problem is

When a pandas DataFrame has integer column names (after slicing
with `iloc`), using `make_column_selector` with `ColumnTransformer`
raises an `IndexError`/`ValueError`. This happens because
`make_column_selector` returns the integer column *names*, which are
then misinterpreted as positional indices.

## What this PR does

In `_validate_column_callables`, after a callable (e.g.
`make_column_selector`) resolves its columns, we check whether X is a
DataFrame with integer-dtype column names. If so, we immediately
convert the returned integer names to positional indices using
`get_loc()`. This scopes the fix narrowly to the callable case only,
which preserves the existing behavior where integer column specs passed
directly by the user are treated positionally.

## How to reproduce

```python
import numpy as np
import pandas as pd
from sklearn.compose import ColumnTransformer, make_column_selector
from sklearn.impute import SimpleImputer

rng = np.random.default_rng(0)
X = pd.DataFrame(rng.random((10, 3)))
X = X.iloc[:, [0, -1]]  # integer column names: 0 and 2

ct = ColumnTransformer(
    transformers=[
        ("continuous", SimpleImputer(),
         make_column_selector(dtype_include="number"))
    ]
)
ct.fit(X)  # previously raised ValueError
```

## Tests

Added a non-regression test
`test_column_transformer_int_column_names` in
`test_column_transformer.py`. All 235 existing tests continue to pass.