### PR TITLE
Remove deprecated sparse parameter from fowlkes_mallows_score

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/33761.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/33761.api.rst
@@ -1,0 +1,4 @@
+- Remove the deprecated `sparse` parameter from
+  :func:`metrics.cluster.fowlkes_mallows_score`. It was deprecated in v1.7 and
+  had no effect.
+  By :user:`Ashutosh Devpura <AshutoshDevpura>`.

--- a/doc/whats_new/upcoming_changes/sklearn.metrics/33761.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/33761.api.rst
@@ -1,4 +1,0 @@
-- Remove the deprecated `sparse` parameter from
-  :func:`metrics.cluster.fowlkes_mallows_score`. It was deprecated in v1.7 and
-  had no effect.
-  By :user:`Ashutosh Devpura <AshutoshDevpura>`.

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -1190,11 +1190,10 @@ def normalized_mutual_info_score(
     {
         "labels_true": ["array-like"],
         "labels_pred": ["array-like"],
-        "sparse": ["boolean", Hidden(StrOptions({"deprecated"}))],
     },
     prefer_skip_nested_validation=True,
 )
-def fowlkes_mallows_score(labels_true, labels_pred, *, sparse="deprecated"):
+def fowlkes_mallows_score(labels_true, labels_pred):
     """Measure the similarity of two clusterings of a set of points.
 
     .. versionadded:: 0.18
@@ -1224,13 +1223,6 @@ def fowlkes_mallows_score(labels_true, labels_pred, *, sparse="deprecated"):
 
     labels_pred : array-like of shape (n_samples,), dtype=int
         A clustering of the data into disjoint subsets.
-
-    sparse : bool, default=False
-        Compute contingency matrix internally with sparse matrix.
-
-        .. deprecated:: 1.7
-            The ``sparse`` parameter is deprecated and will be removed in 1.9. It has
-            no effect.
 
     Returns
     -------
@@ -1265,13 +1257,6 @@ def fowlkes_mallows_score(labels_true, labels_pred, *, sparse="deprecated"):
       >>> fowlkes_mallows_score([0, 0, 0, 0], [0, 1, 2, 3])
       0.0
     """
-    # TODO(1.9): remove the sparse parameter
-    if sparse != "deprecated":
-        warnings.warn(
-            "The 'sparse' parameter was deprecated in 1.7 and will be removed in 1.9. "
-            "It has no effect. Leave it to its default value to silence this warning.",
-            FutureWarning,
-        )
 
     labels_true, labels_pred = check_clusterings(labels_true, labels_pred)
     (n_samples,) = labels_true.shape

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -23,7 +23,6 @@ from sklearn.utils._array_api import (
     get_namespace_and_device,
 )
 from sklearn.utils._param_validation import (
-    Hidden,
     Interval,
     StrOptions,
     validate_params,

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -518,13 +518,3 @@ def test_normalized_mutual_info_score_bounded(average_method):
     # non constant, non perfect matching labels
     nmi = normalized_mutual_info_score(labels2, labels3, average_method=average_method)
     assert 0 <= nmi < 1
-
-
-# TODO(1.9): remove
-@pytest.mark.parametrize("sparse", [True, False])
-def test_fowlkes_mallows_sparse_deprecated(sparse):
-    """Check deprecation warning for 'sparse' parameter of fowlkes_mallows_score."""
-    with pytest.warns(
-        FutureWarning, match="The 'sparse' parameter was deprecated in 1.7"
-    ):
-        fowlkes_mallows_score([0, 1], [1, 1], sparse=sparse)


### PR DESCRIPTION
The `sparse` parameter in `fowlkes_mallows_score` was deprecated in v1.7 
and scheduled for removal in v1.9. Now at v1.9.dev0, this PR removes it.

Changes:
- Remove `sparse` parameter from function signature
- Remove `sparse` from `@validate_params` decorator
- Remove deprecated docstring section
- Remove deprecation warning block
- Remove `test_fowlkes_mallows_sparse_deprecated` test