### PR TITLE
Raise ValueError instead of FutureWarning for integer dtype in partial_dependence

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.inspection/33762.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.inspection/33762.api.rst
@@ -1,3 +1,0 @@
-- :func:`inspection.partial_dependence` now raises a ``ValueError`` instead of
-  a ``FutureWarning`` when a feature column contains integer data.
-  By :user:`Ashutosh Devpura <AshutoshDevpura>`.

--- a/doc/whats_new/upcoming_changes/sklearn.inspection/33762.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.inspection/33762.api.rst
@@ -1,0 +1,3 @@
+- :func:`inspection.partial_dependence` now raises a ``ValueError`` instead of
+  a ``FutureWarning`` when a feature column contains integer data.
+  By :user:`Ashutosh Devpura <AshutoshDevpura>`.

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -611,7 +611,9 @@ def partial_dependence(
     if method == "auto":
         if sample_weight is not None:
             method = "brute"
-        elif isinstance(estimator, BaseGradientBoosting) and estimator.init is None or isinstance(
+        elif isinstance(estimator, BaseGradientBoosting) and estimator.init is None:
+            method = "recursion"
+        elif isinstance(
             estimator,
             (BaseHistGradientBoosting, DecisionTreeRegressor, RandomForestRegressor),
         ):

--- a/sklearn/inspection/_partial_dependence.py
+++ b/sklearn/inspection/_partial_dependence.py
@@ -3,7 +3,6 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
-import warnings
 from collections.abc import Iterable
 
 import numpy as np
@@ -612,9 +611,7 @@ def partial_dependence(
     if method == "auto":
         if sample_weight is not None:
             method = "brute"
-        elif isinstance(estimator, BaseGradientBoosting) and estimator.init is None:
-            method = "recursion"
-        elif isinstance(
+        elif isinstance(estimator, BaseGradientBoosting) and estimator.init is None or isinstance(
             estimator,
             (BaseHistGradientBoosting, DecisionTreeRegressor, RandomForestRegressor),
         ):
@@ -653,7 +650,7 @@ def partial_dependence(
         if response_method != "decision_function":
             raise ValueError(
                 "With the 'recursion' method, the response_method must be "
-                "'decision_function'. Got {}.".format(response_method)
+                f"'decision_function'. Got {response_method}."
             )
 
     if sample_weight is not None:
@@ -664,7 +661,7 @@ def partial_dependence(
         # the indexing to be positive. The upper bound will be checked
         # by _get_column_indices()
         if np.any(np.less(features, 0)):
-            raise ValueError("all features must be in [0, {}]".format(X.shape[1] - 1))
+            raise ValueError(f"all features must be in [0, {X.shape[1] - 1}]")
 
     features_indices = np.asarray(
         _get_column_indices(X, features), dtype=np.intp, order="C"
@@ -717,18 +714,13 @@ def partial_dependence(
             continue
 
         if _safe_indexing(X, feature_idx, axis=1).dtype.kind in "iu":
-            # TODO(1.9): raise a ValueError instead.
-            warnings.warn(
+            raise ValueError(
                 f"The column {feature!r} contains integer data. Partial "
                 "dependence plots are not supported for integer data: this "
                 "can lead to implicit rounding with NumPy arrays or even errors "
-                "with newer pandas versions. Please convert numerical features"
-                "to floating point dtypes ahead of time to avoid problems. "
-                "This will raise ValueError in scikit-learn 1.9.",
-                FutureWarning,
+                "with newer pandas versions. Please convert numerical features "
+                "to floating point dtypes ahead of time to avoid problems."
             )
-            # Do not warn again for other features to avoid spamming the caller.
-            break
 
     X_subset = _safe_indexing(X, features_indices, axis=1)
 

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -3,7 +3,6 @@ Testing for the partial dependence module.
 """
 
 import re
-import warnings
 
 import numpy as np
 import pytest
@@ -1144,26 +1143,21 @@ def test_reject_array_with_integer_dtype():
     y = np.array([0, 1, 0, 1])
     clf = DummyClassifier()
     clf.fit(X, y)
-    with pytest.warns(
-        FutureWarning, match=re.escape("The column 0 contains integer data.")
+    with pytest.raises(
+        ValueError, match=re.escape("The column 0 contains integer data.")
     ):
         partial_dependence(clf, X, features=0)
-
-    with pytest.warns(
-        FutureWarning, match=re.escape("The column 1 contains integer data.")
+    with pytest.raises(
+        ValueError, match=re.escape("The column 1 contains integer data.")
     ):
         partial_dependence(clf, X, features=[1], categorical_features=[0])
-
-    with pytest.warns(
-        FutureWarning, match=re.escape("The column 0 contains integer data.")
+    with pytest.raises(
+        ValueError, match=re.escape("The column 0 contains integer data.")
     ):
         partial_dependence(clf, X, features=[0, 1])
-
     # The following should not raise as we do not compute numerical partial
     # dependence on integer columns.
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        partial_dependence(clf, X, features=1, categorical_features=[1])
+    partial_dependence(clf, X, features=1, categorical_features=[1])
 
 
 def test_reject_pandas_with_integer_dtype():
@@ -1179,22 +1173,18 @@ def test_reject_pandas_with_integer_dtype():
     clf = DummyClassifier()
     clf.fit(X, y)
 
-    with pytest.warns(
-        FutureWarning, match=re.escape("The column 'c' contains integer data.")
+    with pytest.raises(
+        ValueError, match=re.escape("The column 'c' contains integer data.")
     ):
         partial_dependence(clf, X, features="c")
-
-    with pytest.warns(
-        FutureWarning, match=re.escape("The column 'c' contains integer data.")
+    with pytest.raises(
+        ValueError, match=re.escape("The column 'c' contains integer data.")
     ):
         partial_dependence(clf, X, features=["a", "c"])
-
     # The following should not raise as we do not compute numerical partial
     # dependence on integer columns.
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        partial_dependence(clf, X, features=["a"])
-        partial_dependence(clf, X, features=["c"], categorical_features=["c"])
+    partial_dependence(clf, X, features=["a"])
+    partial_dependence(clf, X, features=["c"], categorical_features=["c"])
 
 
 def test_partial_dependence_empty_categorical_features():


### PR DESCRIPTION
The `partial_dependence` function was issuing a `FutureWarning` for integer 
dtype features since v1.7, with a TODO(1.9) to raise a `ValueError` instead. 
Now at v1.9.dev0, this PR implements that change.

Changes:
- Replace `warnings.warn(FutureWarning)` with `raise ValueError` in 
  `_partial_dependence.py`
- Remove unused `warnings` import
- Update `test_reject_array_with_integer_dtype` and 
  `test_reject_pandas_with_integer_dtype` to expect `ValueError`
- Add changelog entry