### PR TITLE
Change default quantile_method to averaged_inverted_cdf in KBinsDiscretizer

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.preprocessing/33763.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.preprocessing/33763.api.rst
@@ -1,0 +1,5 @@
+- :class:`preprocessing.KBinsDiscretizer` now defaults to
+  ``quantile_method="averaged_inverted_cdf"`` instead of ``"linear"`` when
+  ``strategy="quantile"``. This naturally supports sample weight equivalence
+  properties by default.
+  By :user:`Ashutosh Devpura <AshutoshDevpura>`.

--- a/doc/whats_new/upcoming_changes/sklearn.preprocessing/33763.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.preprocessing/33763.api.rst
@@ -1,5 +1,0 @@
-- :class:`preprocessing.KBinsDiscretizer` now defaults to
-  ``quantile_method="averaged_inverted_cdf"`` instead of ``"linear"`` when
-  ``strategy="quantile"``. This naturally supports sample weight equivalence
-  properties by default.
-  By :user:`Ashutosh Devpura <AshutoshDevpura>`.

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -59,7 +59,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
     quantile_method : {"inverted_cdf", "averaged_inverted_cdf",
             "closest_observation", "interpolated_inverted_cdf", "hazen",
             "weibull", "linear", "median_unbiased", "normal_unbiased"},
-            default="linear"
+            default="averaged_inverted_cdf"
             Method to pass on to np.percentile calculation when using
             strategy="quantile". Only `averaged_inverted_cdf` and `inverted_cdf`
             support the use of `sample_weight != None` when subsampling is not
@@ -196,7 +196,6 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         "quantile_method": [
             StrOptions(
                 {
-                    "warn",
                     "inverted_cdf",
                     "averaged_inverted_cdf",
                     "closest_observation",
@@ -220,7 +219,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
         *,
         encode="onehot",
         strategy="quantile",
-        quantile_method="warn",
+        quantile_method="averaged_inverted_cdf",
         dtype=None,
         subsample=200_000,
         random_state=None,
@@ -297,20 +296,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
         bin_edges = np.zeros(n_features, dtype=object)
 
-        # TODO(1.9): remove and switch to quantile_method="averaged_inverted_cdf"
-        # by default.
         quantile_method = self.quantile_method
-        if self.strategy == "quantile" and quantile_method == "warn":
-            warnings.warn(
-                "The current default behavior, quantile_method='linear', will be "
-                "changed to quantile_method='averaged_inverted_cdf' in "
-                "scikit-learn version 1.9 to naturally support sample weight "
-                "equivalence properties by default. Pass "
-                "quantile_method='averaged_inverted_cdf' explicitly to silence this "
-                "warning.",
-                FutureWarning,
-            )
-            quantile_method = "linear"
 
         if (
             self.strategy == "quantile"

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -68,8 +68,7 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
             .. versionadded:: 1.7
 
             .. versionchanged:: 1.9
-                The default value changed from ``"linear"`` to
-                ``"averaged_inverted_cdf"``.
+                The default value changed from `"linear"` to `"averaged_inverted_cdf"`.
 
     dtype : {np.float32, np.float64}, default=None
         The desired data-type for the output. If None, output dtype is

--- a/sklearn/preprocessing/_discretization.py
+++ b/sklearn/preprocessing/_discretization.py
@@ -67,6 +67,10 @@ class KBinsDiscretizer(TransformerMixin, BaseEstimator):
 
             .. versionadded:: 1.7
 
+            .. versionchanged:: 1.9
+                The default value changed from ``"linear"`` to
+                ``"averaged_inverted_cdf"``.
+
     dtype : {np.float32, np.float64}, default=None
         The desired data-type for the output. If None, output dtype is
         consistent with input dtype. Only np.float32 and np.float64 are

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -328,8 +328,20 @@ def test_encode_options():
 @pytest.mark.parametrize(
     "strategy, quantile_method, expected_2bins, expected_3bins, expected_5bins",
     [
-        ("uniform", "averaged_inverted_cdf", [0, 0, 0, 0, 1, 1], [0, 0, 0, 0, 2, 2], [0, 0, 1, 1, 4, 4]),
-        ("kmeans", "averaged_inverted_cdf", [0, 0, 0, 0, 1, 1], [0, 0, 1, 1, 2, 2], [0, 0, 1, 2, 3, 4]),
+        (
+            "uniform",
+            "averaged_inverted_cdf",
+            [0, 0, 0, 0, 1, 1],
+            [0, 0, 0, 0, 2, 2],
+            [0, 0, 1, 1, 4, 4],
+        ),
+        (
+            "kmeans",
+            "averaged_inverted_cdf",
+            [0, 0, 0, 0, 1, 1],
+            [0, 0, 1, 1, 2, 2],
+            [0, 0, 1, 2, 3, 4],
+        ),
         (
             "quantile",
             "averaged_inverted_cdf",

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -634,8 +634,6 @@ def test_kbinsdiscretizer_subsample(strategy, global_random_seed):
     )
 
 
-
-
 def test_invalid_quantile_method_with_sample_weight():
     X = [[-2, 1, -4], [-1, 2, -3], [0, 3, -2], [1, 4, -1]]
     expected_msg = (

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -634,18 +634,6 @@ def test_kbinsdiscretizer_subsample(strategy, global_random_seed):
     )
 
 
-def test_quantile_method_future_warnings():
-    X = [[-2, 1, -4], [-1, 2, -3], [0, 3, -2], [1, 4, -1]]
-    with pytest.warns(
-        FutureWarning,
-        match="The current default behavior, quantile_method='linear', will be "
-        "changed to quantile_method='averaged_inverted_cdf' in "
-        "scikit-learn version 1.9 to naturally support sample weight "
-        "equivalence properties by default. Pass "
-        "quantile_method='averaged_inverted_cdf' explicitly to silence this "
-        "warning.",
-    ):
-        KBinsDiscretizer(strategy="quantile").fit(X)
 
 
 def test_invalid_quantile_method_with_sample_weight():

--- a/sklearn/preprocessing/tests/test_discretization.py
+++ b/sklearn/preprocessing/tests/test_discretization.py
@@ -22,13 +22,13 @@ X = [[-2, 1.5, -4, -1], [-1, 2.5, -3, -0.5], [0, 3.5, -2, 0.5], [1, 4.5, -1, 2]]
     [
         (
             "uniform",
-            "warn",  # default, will not warn when strategy != "quantile"
+            "averaged_inverted_cdf",  # default
             [[0, 0, 0, 0], [1, 1, 1, 0], [2, 2, 2, 1], [2, 2, 2, 2]],
             None,
         ),
         (
             "kmeans",
-            "warn",  # default, will not warn when strategy != "quantile"
+            "averaged_inverted_cdf",  # default
             [[0, 0, 0, 0], [0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]],
             None,
         ),
@@ -40,13 +40,13 @@ X = [[-2, 1.5, -4, -1], [-1, 2.5, -3, -0.5], [0, 3.5, -2, 0.5], [1, 4.5, -1, 2]]
         ),
         (
             "uniform",
-            "warn",  # default, will not warn when strategy != "quantile"
+            "averaged_inverted_cdf",  # default
             [[0, 0, 0, 0], [1, 1, 1, 0], [2, 2, 2, 1], [2, 2, 2, 2]],
             [1, 1, 2, 1],
         ),
         (
             "uniform",
-            "warn",  # default, will not warn when strategy != "quantile"
+            "averaged_inverted_cdf",  # default
             [[0, 0, 0, 0], [1, 1, 1, 0], [2, 2, 2, 1], [2, 2, 2, 2]],
             [1, 1, 1, 1],
         ),
@@ -70,13 +70,13 @@ X = [[-2, 1.5, -4, -1], [-1, 2.5, -3, -0.5], [0, 3.5, -2, 0.5], [1, 4.5, -1, 2]]
         ),
         (
             "kmeans",
-            "warn",  # default, will not warn when strategy != "quantile"
+            "averaged_inverted_cdf",  # default
             [[0, 0, 0, 0], [1, 1, 1, 0], [1, 1, 1, 1], [2, 2, 2, 2]],
             [1, 0, 3, 1],
         ),
         (
             "kmeans",
-            "warn",  # default, will not warn when strategy != "quantile"
+            "averaged_inverted_cdf",  # default
             [[0, 0, 0, 0], [0, 0, 0, 0], [1, 1, 1, 1], [2, 2, 2, 2]],
             [1, 1, 1, 1],
         ),
@@ -145,13 +145,13 @@ def test_invalid_n_bins_array():
     [
         (
             "uniform",
-            "warn",  # default, will not warn when strategy != "quantile"
+            "averaged_inverted_cdf",  # default
             [[0, 0, 0, 0], [0, 1, 1, 0], [1, 2, 2, 1], [1, 2, 2, 2]],
             None,
         ),
         (
             "kmeans",
-            "warn",  # default, will not warn when strategy != "quantile"
+            "averaged_inverted_cdf",  # default
             [[0, 0, 0, 0], [0, 0, 0, 0], [1, 1, 1, 1], [1, 2, 2, 2]],
             None,
         ),
@@ -187,7 +187,7 @@ def test_invalid_n_bins_array():
         ),
         (
             "kmeans",
-            "warn",  # default, will not warn when strategy != "quantile"
+            "averaged_inverted_cdf",  # default
             [[0, 0, 0, 0], [0, 1, 1, 0], [1, 1, 1, 1], [1, 2, 2, 2]],
             [1, 0, 3, 1],
         ),
@@ -328,8 +328,8 @@ def test_encode_options():
 @pytest.mark.parametrize(
     "strategy, quantile_method, expected_2bins, expected_3bins, expected_5bins",
     [
-        ("uniform", "warn", [0, 0, 0, 0, 1, 1], [0, 0, 0, 0, 2, 2], [0, 0, 1, 1, 4, 4]),
-        ("kmeans", "warn", [0, 0, 0, 0, 1, 1], [0, 0, 1, 1, 2, 2], [0, 0, 1, 2, 3, 4]),
+        ("uniform", "averaged_inverted_cdf", [0, 0, 0, 0, 1, 1], [0, 0, 0, 0, 2, 2], [0, 0, 1, 1, 4, 4]),
+        ("kmeans", "averaged_inverted_cdf", [0, 0, 0, 0, 1, 1], [0, 0, 1, 1, 2, 2], [0, 0, 1, 2, 3, 4]),
         (
             "quantile",
             "averaged_inverted_cdf",
@@ -377,7 +377,7 @@ def test_nonuniform_strategies(
                 [0.5, 4.0, -1.5, 0.5],
                 [0.5, 4.0, -1.5, 1.5],
             ],
-            "warn",  # default, will not warn when strategy != "quantile"
+            "averaged_inverted_cdf",  # default
         ),
         (
             "kmeans",
@@ -387,7 +387,7 @@ def test_nonuniform_strategies(
                 [-0.125, 3.375, -2.125, 0.5625],
                 [0.75, 4.25, -1.25, 1.625],
             ],
-            "warn",  # default, will not warn when strategy != "quantile"
+            "averaged_inverted_cdf",  # default
         ),
         (
             "quantile",
@@ -452,7 +452,7 @@ def test_overwrite():
     "strategy, expected_bin_edges, quantile_method",
     [
         ("quantile", [0, 1.5, 3], "averaged_inverted_cdf"),
-        ("kmeans", [0, 1.5, 3], "warn"),
+        ("kmeans", [0, 1.5, 3], "averaged_inverted_cdf"),
     ],
 )
 def test_redundant_bins(strategy, expected_bin_edges, quantile_method):


### PR DESCRIPTION
The `quantile_method` parameter in `KBinsDiscretizer` had a `TODO(1.9)` to 
switch the default from `"linear"` to `"averaged_inverted_cdf"`. Now at 
v1.9.dev0, this PR implements that change.

Changes:
- Change default `quantile_method` from `"warn"` to `"averaged_inverted_cdf"` 
  in `__init__`
- Remove `"warn"` from `_parameter_constraints`
- Remove the `FutureWarning` block
- Update docstring to reflect new default and add `versionchanged` note
- Remove `test_quantile_method_future_warnings` test
- Add changelog entry