### PR TITLE
ENH add array API support for _newton_cg

### DIFF
--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -34,6 +34,8 @@ class _LineSearchError(RuntimeError):
 # Copied from scipy
 # https://github.com/scipy/scipy/blob/7a7fbca0b9baa1b709e4a5e0afaf9f94bd34941c/scipy/optimize/_linesearch.py#L37
 # Modified for array API compliance: np.dot(a, b) -> a @ b
+# TODO: use the `line_search_wolfe1` from `scipy` when it is array API compliant.
+# Reference: https://github.com/scipy/scipy/pull/25022
 def line_search_wolfe1(
     f,
     fprime,
@@ -50,38 +52,7 @@ def line_search_wolfe1(
     xtol=1e-14,
 ):
     """
-    As `scalar_search_wolfe1` but do a line search to direction `pk`
-
-    Parameters
-    ----------
-    f : callable
-        Function `f(x)`
-    fprime : callable
-        Gradient of `f`
-    xk : array_like
-        Current point
-    pk : array_like
-        Search direction
-    gfk : array_like, optional
-        Gradient of `f` at point `xk`
-    old_fval : float, optional
-        Value of `f` at point `xk`
-    old_old_fval : float, optional
-        Value of `f` at point preceding `xk`
-
-    The rest of the parameters are the same as for `scalar_search_wolfe1`.
-
-    Returns
-    -------
-    stp, f_count, g_count, fval, old_fval
-        As in `line_search_wolfe1`
-    gval : array
-        Gradient of `f` at the final point
-
-    Notes
-    -----
-    Parameters `c1` and `c2` must satisfy ``0 < c1 < c2 < 1``.
-
+    Same as `scalar_search_wolfe1` but do a line search to direction `pk`
     """
     if gfk is None:
         gfk = fprime(xk, *args)

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -36,7 +36,7 @@ class _LineSearchError(RuntimeError):
 # Modified for array API compliance: np.dot(a, b) -> a @ b
 # TODO: use the `line_search_wolfe1` from `scipy` when it is array API compliant.
 # Reference: https://github.com/scipy/scipy/pull/25022
-def line_search_wolfe1(
+def _line_search_wolfe1(
     f,
     fprime,
     xk,
@@ -109,7 +109,7 @@ def _line_search_wolfe12(
         print(f"    eps=16 * finfo.eps={eps}")
         print("    try line search wolfe1")
 
-    ret = line_search_wolfe1(f, fprime, xk, pk, gfk, old_fval, old_old_fval, **kwargs)
+    ret = _line_search_wolfe1(f, fprime, xk, pk, gfk, old_fval, old_old_fval, **kwargs)
 
     if is_verbose:
         _not_ = "not " if ret[0] is None else ""

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -18,14 +18,103 @@ significant speedups.
 import warnings
 
 import scipy
-from scipy.optimize._linesearch import line_search_wolfe1, line_search_wolfe2
+from scipy.optimize._linesearch import (
+    line_search_wolfe2,
+    scalar_search_wolfe1,
+)
 
 from sklearn.exceptions import ConvergenceWarning
-from sklearn.utils._array_api import get_namespace_and_device
+from sklearn.utils._array_api import get_namespace_and_device, size
 
 
 class _LineSearchError(RuntimeError):
     pass
+
+
+# Copied from scipy
+# https://github.com/scipy/scipy/blob/7a7fbca0b9baa1b709e4a5e0afaf9f94bd34941c/scipy/optimize/_linesearch.py#L37
+# Modified for array API compliance: np.dot(a, b) -> a @ b
+def line_search_wolfe1(
+    f,
+    fprime,
+    xk,
+    pk,
+    gfk=None,
+    old_fval=None,
+    old_old_fval=None,
+    args=(),
+    c1=1e-4,
+    c2=0.9,
+    amax=50,
+    amin=1e-8,
+    xtol=1e-14,
+):
+    """
+    As `scalar_search_wolfe1` but do a line search to direction `pk`
+
+    Parameters
+    ----------
+    f : callable
+        Function `f(x)`
+    fprime : callable
+        Gradient of `f`
+    xk : array_like
+        Current point
+    pk : array_like
+        Search direction
+    gfk : array_like, optional
+        Gradient of `f` at point `xk`
+    old_fval : float, optional
+        Value of `f` at point `xk`
+    old_old_fval : float, optional
+        Value of `f` at point preceding `xk`
+
+    The rest of the parameters are the same as for `scalar_search_wolfe1`.
+
+    Returns
+    -------
+    stp, f_count, g_count, fval, old_fval
+        As in `line_search_wolfe1`
+    gval : array
+        Gradient of `f` at the final point
+
+    Notes
+    -----
+    Parameters `c1` and `c2` must satisfy ``0 < c1 < c2 < 1``.
+
+    """
+    if gfk is None:
+        gfk = fprime(xk, *args)
+
+    gval = [gfk]
+    gc = [0]
+    fc = [0]
+
+    def phi(s):
+        fc[0] += 1
+        return f(xk + s * pk, *args)
+
+    def derphi(s):
+        gval[0] = fprime(xk + s * pk, *args)
+        gc[0] += 1
+        return gval[0] @ pk
+
+    derphi0 = gfk @ pk
+
+    stp, fval, old_fval = scalar_search_wolfe1(
+        phi,
+        derphi,
+        old_fval,
+        old_old_fval,
+        derphi0,
+        c1=c1,
+        c2=c2,
+        amax=amax,
+        amin=amin,
+        xtol=xtol,
+    )
+
+    return stp, fc[0], gc[0], fval, old_fval, gval[0]
 
 
 def _line_search_wolfe12(
@@ -136,7 +225,7 @@ def _cg(fhess_p, fgrad, maxiter, tol, xp, device, verbose=0):
         Estimated solution.
     """
     eps = 16 * xp.finfo(fgrad.dtype).eps
-    xsupi = xp.zeros(len(fgrad), dtype=fgrad.dtype, device=device)
+    xsupi = xp.zeros(size(fgrad), dtype=fgrad.dtype, device=device)
     ri = xp.asarray(fgrad, copy=True)  # residual = fgrad - fhess_p @ xsupi
     psupi = -ri
     i = 0

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -258,7 +258,10 @@ def _newton_cg(
         Estimated minimum.
     """
     xp, _, device = get_namespace_and_device(x0)
-    x0 = xp.asarray(x0, device=device).flatten()
+    x0 = xp.asarray(x0, device=device)
+    if x0.ndim != 1:
+        msg = f"x0 must be 1-dimensional; got {x0.ndim=}"
+        raise ValueError(msg)
     xk = xp.asarray(x0, copy=True)  # np.copy(x0)
     k = 0
 

--- a/sklearn/utils/optimize.py
+++ b/sklearn/utils/optimize.py
@@ -17,11 +17,11 @@ significant speedups.
 
 import warnings
 
-import numpy as np
 import scipy
 from scipy.optimize._linesearch import line_search_wolfe1, line_search_wolfe2
 
 from sklearn.exceptions import ConvergenceWarning
+from sklearn.utils._array_api import get_namespace_and_device
 
 
 class _LineSearchError(RuntimeError):
@@ -29,7 +29,7 @@ class _LineSearchError(RuntimeError):
 
 
 def _line_search_wolfe12(
-    f, fprime, xk, pk, gfk, old_fval, old_old_fval, verbose=0, **kwargs
+    f, fprime, xk, pk, gfk, old_fval, old_old_fval, xp, device, verbose=0, **kwargs
 ):
     """
     Same as line_search_wolfe1, but fall back to line_search_wolfe2 if
@@ -43,7 +43,7 @@ def _line_search_wolfe12(
 
     """
     is_verbose = verbose >= 2
-    eps = 16 * np.finfo(np.asarray(old_fval).dtype).eps
+    eps = 16 * xp.finfo(xk.dtype).eps
     if is_verbose:
         print("  Line Search")
         print(f"    eps=16 * finfo.eps={eps}")
@@ -61,13 +61,13 @@ def _line_search_wolfe12(
         # Deal with relative loss differences around machine precision.
         args = kwargs.get("args", tuple())
         fval = f(xk + pk, *args)
-        tiny_loss = np.abs(old_fval * eps)
+        tiny_loss = xp.abs(old_fval * eps)
         loss_improvement = fval - old_fval
-        check = np.abs(loss_improvement) <= tiny_loss
+        check = xp.abs(loss_improvement) <= tiny_loss
         if is_verbose:
             print(
                 "    check loss |improvement| <= eps * |loss_old|:"
-                f" {np.abs(loss_improvement)} <= {tiny_loss} {check}"
+                f" {xp.abs(loss_improvement)} <= {tiny_loss} {check}"
             )
         if check:
             # 2.1 Check sum of absolute gradients as alternative condition.
@@ -110,7 +110,7 @@ def _line_search_wolfe12(
     return ret
 
 
-def _cg(fhess_p, fgrad, maxiter, tol, verbose=0):
+def _cg(fhess_p, fgrad, maxiter, tol, xp, device, verbose=0):
     """
     Solve iteratively the linear system 'fhess_p . xsupi = fgrad'
     with a conjugate gradient descent.
@@ -135,28 +135,28 @@ def _cg(fhess_p, fgrad, maxiter, tol, verbose=0):
     xsupi : ndarray of shape (n_features,) or (n_features + 1,)
         Estimated solution.
     """
-    eps = 16 * np.finfo(np.float64).eps
-    xsupi = np.zeros(len(fgrad), dtype=fgrad.dtype)
-    ri = np.copy(fgrad)  # residual = fgrad - fhess_p @ xsupi
+    eps = 16 * xp.finfo(fgrad.dtype).eps
+    xsupi = xp.zeros(len(fgrad), dtype=fgrad.dtype, device=device)
+    ri = xp.asarray(fgrad, copy=True)  # residual = fgrad - fhess_p @ xsupi
     psupi = -ri
     i = 0
-    dri0 = np.dot(ri, ri)
+    dri0 = ri @ ri
     # We also keep track of |p_i|^2.
     psupi_norm2 = dri0
     is_verbose = verbose >= 2
 
     while i <= maxiter:
-        if np.sum(np.abs(ri)) <= tol:
+        if (norm1_re := xp.sum(xp.abs(ri))) <= tol:
             if is_verbose:
                 print(
                     f"  Inner CG solver iteration {i} stopped with\n"
-                    f"    sum(|residuals|) <= tol: {np.sum(np.abs(ri))} <= {tol}"
+                    f"    sum(|residuals|) <= tol: {norm1_re} <= {tol}"
                 )
             break
 
         Ap = fhess_p(psupi)
         # check curvature
-        curv = np.dot(psupi, Ap)
+        curv = psupi @ Ap
         if 0 <= curv <= eps * psupi_norm2:
             # See https://arxiv.org/abs/1803.02924, Algo 1 Capped Conjugate Gradient.
             if is_verbose:
@@ -184,17 +184,17 @@ def _cg(fhess_p, fgrad, maxiter, tol, verbose=0):
         alphai = dri0 / curv
         xsupi += alphai * psupi
         ri += alphai * Ap
-        dri1 = np.dot(ri, ri)
+        dri1 = ri @ ri
         betai = dri1 / dri0
         psupi = -ri + betai * psupi
         # We use  |p_i|^2 = |r_i|^2 + beta_i^2 |p_{i-1}|^2
         psupi_norm2 = dri1 + betai**2 * psupi_norm2
         i = i + 1
-        dri0 = dri1  # update np.dot(ri,ri) for next time.
+        dri0 = dri1  # update ri @ri for next time.
     if is_verbose and i > maxiter:
         print(
             f"  Inner CG solver stopped reaching maxiter={i - 1} with "
-            f"sum(|residuals|) = {np.sum(np.abs(ri))}"
+            f"sum(|residuals|) = {xp.sum(xp.abs(ri))}"
         )
     return xsupi
 
@@ -229,7 +229,7 @@ def _newton_cg(
         Should return the function value and the gradient. This is used
         by the linesearch functions.
 
-    x0 : array of float
+    x0 : array-like of float
         Initial guess.
 
     args : tuple, default=()
@@ -254,11 +254,12 @@ def _newton_cg(
 
     Returns
     -------
-    xk : ndarray of float
+    xk : array-like of float
         Estimated minimum.
     """
-    x0 = np.asarray(x0).flatten()
-    xk = np.copy(x0)
+    xp, _, device = get_namespace_and_device(x0)
+    x0 = xp.asarray(x0, device=device).flatten()
+    xk = xp.asarray(x0, copy=True)  # np.copy(x0)
     k = 0
 
     if line_search:
@@ -275,8 +276,8 @@ def _newton_cg(
         #  del2 f(xk) p = - fgrad f(xk) starting from 0.
         fgrad, fhess_p = grad_hess(xk, *args)
 
-        absgrad = np.abs(fgrad)
-        max_absgrad = np.max(absgrad)
+        absgrad = xp.abs(fgrad)
+        max_absgrad = xp.max(absgrad)
         check = max_absgrad <= tol
         if is_verbose:
             print(f"Newton-CG iter = {k}")
@@ -285,13 +286,21 @@ def _newton_cg(
         if check:
             break
 
-        maggrad = np.sum(absgrad)
-        eta = min([0.5, np.sqrt(maggrad)])
+        maggrad = xp.sum(absgrad)
+        eta = min([0.5, xp.sqrt(maggrad)])
         termcond = eta * maggrad
 
         # Inner loop: solve the Newton update by conjugate gradient, to
         # avoid inverting the Hessian
-        xsupi = _cg(fhess_p, fgrad, maxiter=maxinner, tol=termcond, verbose=verbose)
+        xsupi = _cg(
+            fhess_p,
+            fgrad,
+            maxiter=maxinner,
+            tol=termcond,
+            xp=xp,
+            device=device,
+            verbose=verbose,
+        )
 
         alphak = 1.0
 
@@ -305,6 +314,8 @@ def _newton_cg(
                     fgrad,
                     old_fval,
                     old_old_fval,
+                    xp=xp,
+                    device=device,
                     verbose=verbose,
                     args=args,
                 )

--- a/sklearn/utils/tests/test_optimize.py
+++ b/sklearn/utils/tests/test_optimize.py
@@ -4,9 +4,11 @@ import numpy as np
 import pytest
 from scipy.optimize import fmin_ncg
 
+from sklearn import config_context
 from sklearn.exceptions import ConvergenceWarning
+from sklearn.utils._array_api import move_to, yield_namespace_device_dtype_combinations
 from sklearn.utils._bunch import Bunch
-from sklearn.utils._testing import assert_allclose
+from sklearn.utils._testing import _array_api_for_tests, assert_allclose
 from sklearn.utils.optimize import _check_optimize_result, _newton_cg
 
 
@@ -40,6 +42,41 @@ def test_newton_cg(global_random_seed):
     )
 
 
+@pytest.mark.parametrize(
+    "array_namespace, device_name, dtype_name",
+    yield_namespace_device_dtype_combinations(),
+)
+def test_newton_cg_array_api_compliance(array_namespace, device_name, dtype_name):
+    """Test that newton_cg works with Array API input."""
+    xp, device = _array_api_for_tests(array_namespace, device_name)
+    A = xp.asarray(np.array([[3, -1], [-1, 1]]).astype(dtype_name), device=device)
+    y = xp.asarray(np.arange(2).astype(dtype_name), device=device)
+    x0 = xp.asarray(np.ones(2).astype(dtype_name), device=device)
+    print(f"{xp=}")
+
+    def func(x):
+        return 0.5 * (y - A @ x) @ (y - A @ x)
+
+    def grad(x):
+        return A.T @ (A @ x - y)
+
+    def hess(x, p):
+        return A.T @ (A @ p)
+
+    def grad_hess(x):
+        return grad(x), lambda p: hess(x, p)
+
+    with config_context(array_api_dispatch=True):
+        res = _newton_cg(grad_hess, func, grad, x0, tol=1e-10)
+
+    assert_allclose(
+        move_to(res[0], xp=np, device="cpu"),
+        [1 / 2, 3 / 2],
+        atol=1e-10,
+    )
+
+
+# @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("verbose", [0, 1, 2])
 def test_newton_cg_verbosity(capsys, verbose):
     """Test the std output of verbose newton_cg solver."""
@@ -85,7 +122,7 @@ def test_newton_cg_verbosity(capsys, verbose):
         b = np.array([1.0, 2.0])
         # Note that scipy.optimize._linesearch LineSearchWarning inherits from
         # RuntimeWarning, but we do not want to import from non public APIs.
-        with pytest.warns(RuntimeWarning):
+        with pytest.warns((RuntimeWarning, UserWarning)):
             _newton_cg(
                 grad_hess=lambda x: (A @ x - b, lambda z: A @ z),
                 func=lambda x: 0.5 * x @ A @ x - b @ x,
@@ -128,7 +165,7 @@ def test_newton_cg_verbosity(capsys, verbose):
         # curvature", but that is very hard to trigger.
         A = np.eye(2)
         b = np.array([-2.0, 1])
-        with pytest.warns(RuntimeWarning):
+        with pytest.warns((RuntimeWarning, UserWarning)):
             _newton_cg(
                 # Note the wrong sign in the hessian product.
                 grad_hess=lambda x: (A @ x - b, lambda z: -A @ z),

--- a/sklearn/utils/tests/test_optimize.py
+++ b/sklearn/utils/tests/test_optimize.py
@@ -52,7 +52,6 @@ def test_newton_cg_array_api_compliance(array_namespace, device_name, dtype_name
     A = xp.asarray(np.array([[3, -1], [-1, 1]]).astype(dtype_name), device=device)
     y = xp.asarray(np.arange(2).astype(dtype_name), device=device)
     x0 = xp.asarray(np.ones(2).astype(dtype_name), device=device)
-    print(f"{xp=}")
 
     def func(x):
         return 0.5 * (y - A @ x) @ (y - A @ x)
@@ -76,7 +75,6 @@ def test_newton_cg_array_api_compliance(array_namespace, device_name, dtype_name
     )
 
 
-# @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("verbose", [0, 1, 2])
 def test_newton_cg_verbosity(capsys, verbose):
     """Test the std output of verbose newton_cg solver."""


### PR DESCRIPTION
#### Reference Issues/PRs
This contributes to #26024.


#### What does this implement/fix? Explain your changes.
Make the private `sklearn.optimize._newton_cg` array API compatible. 

#### AI usage disclosure
None


#### Any other comments?
This enables to make `LogisticRegression(solver="newton-cg")` array API compatible. It would be the first solver of LR to 100% support array API compat because lbfgs still needs to convert some arrays to numpy (and the CPU), because lbfgs (from scipy) is implemented in C.