### PR TITLE
DOC added link to user guide for local outlier factor

### DIFF
--- a/sklearn/neighbors/_lof.py
+++ b/sklearn/neighbors/_lof.py
@@ -30,6 +30,8 @@ class LocalOutlierFactor(KNeighborsMixin, OutlierMixin, NeighborsBase):
     neighbors, one can identify samples that have a substantially lower density
     than their neighbors. These are considered outliers.
 
+    Read more in the :ref:`User Guide <local_outlier_factor>`.
+
     .. versionadded:: 0.19
 
     Parameters


### PR DESCRIPTION
There was a missing link to the user guide in the LocalOutlierFactor API page, and I added one.  

Part of EPFL hackathon ping @glemaitre 