### PR TITLE
FIX handling nan during scoring of early-stopping in MLPClassifier

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.neural_network/33774.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.neural_network/33774.fix.rst
@@ -1,4 +1,5 @@
 - :class:`neural_network.MLPClassifier` with ``early_stopping=True`` no longer
-  raises when ``y`` contains non-numeric class labels (e.g. strings): validation
-  scoring now checks finiteness only for floating predictions.
+  raises a `TypeError` when ``y`` contains non-numeric class labels (e.g.
+  strings): validation scoring now checks finiteness only for floating
+  predictions.
   By :user:`Guillaume Lemaitre <glemaitre>`.

--- a/doc/whats_new/upcoming_changes/sklearn.neural_network/33774.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.neural_network/33774.fix.rst
@@ -1,0 +1,4 @@
+- :class:`neural_network.MLPClassifier` with ``early_stopping=True`` no longer
+  raises when ``y`` contains non-numeric class labels (e.g. strings): validation
+  scoring now checks finiteness only for floating predictions.
+  By :user:`Guillaume Lemaitre <glemaitre>`.

--- a/sklearn/neural_network/_multilayer_perceptron.py
+++ b/sklearn/neural_network/_multilayer_perceptron.py
@@ -865,7 +865,7 @@ class BaseMultilayerPerceptron(BaseEstimator, ABC):
         # Input validation would remove feature names, so we disable it
         y_pred = self._predict(X, check_input=False)
 
-        if np.isnan(y_pred).any() or np.isinf(y_pred).any():
+        if np.issubdtype(y_pred.dtype, np.floating) and not np.isfinite(y_pred).all():
             return np.nan
 
         return score_function(y, y_pred, sample_weight=sample_weight)

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -833,20 +833,23 @@ def test_early_stopping_stratified():
 
 
 def test_mlp_early_stopping_string_labels():
-    # Non-regression: early stopping calls _score_with_function, which must not
-    # use np.isnan on string predictions from LabelBinarizer.inverse_transform.
-    X, y_numeric = make_classification(
+    """Check that labels can be strings when `early_stopping=True`.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/33760
+    """
+    X, y = make_classification(
         n_samples=200,
         n_features=10,
         n_classes=3,
         n_informative=5,
         random_state=42,
     )
-    label_map = {0: "Class_A", 1: "Class_B", 2: "Class_C"}
-    y_string = np.array([label_map[i] for i in y_numeric])
+    labels = np.array(["class_a", "class_b", "class_c"], dtype=object)
+    y = labels[y]
 
     mlp = MLPClassifier(early_stopping=True, max_iter=50, random_state=42)
-    mlp.fit(X, y_string)
+    mlp.fit(X, y)
 
     assert mlp.validation_scores_ is not None
     assert len(mlp.validation_scores_) == mlp.n_iter_

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -15,6 +15,7 @@ import pytest
 from sklearn.datasets import (
     load_digits,
     load_iris,
+    make_classification,
     make_multilabel_classification,
     make_regression,
 )
@@ -829,6 +830,27 @@ def test_early_stopping_stratified():
         ),
     ):
         mlp.fit(X, y)
+
+
+def test_mlp_early_stopping_string_labels():
+    # Non-regression: early stopping calls _score_with_function, which must not
+    # use np.isnan on string predictions from LabelBinarizer.inverse_transform.
+    X, y_numeric = make_classification(
+        n_samples=200,
+        n_features=10,
+        n_classes=3,
+        n_informative=5,
+        random_state=42,
+    )
+    label_map = {0: "Class_A", 1: "Class_B", 2: "Class_C"}
+    y_string = np.array([label_map[i] for i in y_numeric])
+
+    mlp = MLPClassifier(early_stopping=True, max_iter=50, random_state=42)
+    mlp.fit(X, y_string)
+
+    assert mlp.validation_scores_ is not None
+    assert len(mlp.validation_scores_) == mlp.n_iter_
+    assert np.isfinite(mlp.validation_scores_).all()
 
 
 def test_mlp_classifier_dtypes_casting():


### PR DESCRIPTION
closes #33760 

This PR is fixing the issue related to passing `early_stopping=True` with some string labels.