### PR TITLE
ENH Add support for sparse `importance_getter` in `RFE` and `SelectFromModel`

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.feature_selection/33786.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.feature_selection/33786.enhancement.rst
@@ -4,5 +4,5 @@
   the internal ``_get_feature_importances()`` function only handled dense
   NumPy arrays, causing errors when a sparse ``coef_`` was passed via
   ``importance_getter``.
-  By :user:`andymucyo-ops <andymucyo-ops>` andymucyo-ops
+  By :user:`andymucyo-ops <andymucyo-ops>` and
   :user:`isaacambrogetti <isaacambrogetti>`.

--- a/doc/whats_new/upcoming_changes/sklearn.feature_selection/33786.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.feature_selection/33786.enhancement.rst
@@ -1,7 +1,5 @@
 - :class:`feature_selection.SelectFromModel` and :class:`feature_selection.RFE`
-  now support estimators whose feature importance is a sparse matrix or array
-  (e.g., as produced by linear models' ``sparsify()`` method). Previously,
-  they would only handle dense NumPy arrays, causing errors when a sparse
-  ``coef_`` was passed via ``importance_getter``.
+  now support estimators whose feature importance is a sparse matrix or array, notably
+  by passing a user-defined callable to the parameter `importance_getter`.
   By :user:`andymucyo-ops <andymucyo-ops>` and
   :user:`isaacambrogetti <isaacambrogetti>`.

--- a/doc/whats_new/upcoming_changes/sklearn.feature_selection/33786.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.feature_selection/33786.enhancement.rst
@@ -1,8 +1,7 @@
 - :class:`feature_selection.SelectFromModel` and :class:`feature_selection.RFE`
   now support estimators whose feature importance is a sparse matrix or array
   (e.g., as produced by linear models' ``sparsify()`` method). Previously,
-  the internal ``_get_feature_importances()`` function only handled dense
-  NumPy arrays, causing errors when a sparse ``coef_`` was passed via
-  ``importance_getter``.
+  they would only handle dense NumPy arrays, causing errors when a sparse
+  ``coef_`` was passed via ``importance_getter``.
   By :user:`andymucyo-ops <andymucyo-ops>` and
   :user:`isaacambrogetti <isaacambrogetti>`.

--- a/doc/whats_new/upcoming_changes/sklearn.feature_selection/33786.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.feature_selection/33786.enhancement.rst
@@ -1,0 +1,8 @@
+- :class:`feature_selection.SelectFromModel` and :class:`feature_selection.RFE`
+  now support estimators whose ``coef_`` attribute is a sparse matrix or array
+  (e.g., as produced by linear models' ``sparsify()`` method). Previously,
+  the internal ``_get_feature_importances()`` function only handled dense
+  NumPy arrays, causing errors when a sparse ``coef_`` was passed via
+  ``importance_getter``.
+  By :user:`andymucyo-ops <andymucyo-ops>` andymucyo-ops
+  :user:`isaacambrogetti <isaacambrogetti>`.

--- a/doc/whats_new/upcoming_changes/sklearn.feature_selection/33786.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.feature_selection/33786.enhancement.rst
@@ -1,5 +1,5 @@
 - :class:`feature_selection.SelectFromModel` and :class:`feature_selection.RFE`
-  now support estimators whose ``coef_`` attribute is a sparse matrix or array
+  now support estimators whose feature importance is a sparse matrix or array
   (e.g., as produced by linear models' ``sparsify()`` method). Previously,
   the internal ``_get_feature_importances()`` function only handled dense
   NumPy arrays, causing errors when a sparse ``coef_`` was passed via

--- a/sklearn/feature_selection/_base.py
+++ b/sklearn/feature_selection/_base.py
@@ -8,7 +8,7 @@ from abc import ABCMeta, abstractmethod
 from operator import attrgetter
 
 import numpy as np
-from scipy.sparse import csc_array, issparse
+from scipy.sparse import csc_array, csr_array, issparse, linalg
 
 from sklearn.base import TransformerMixin
 from sklearn.utils import _safe_indexing, check_array, safe_sqr
@@ -246,13 +246,19 @@ def _get_feature_importances(estimator, getter, transform_func=None, norm_order=
 
     importances = getter(estimator)
 
+    if issparse(importances):
+        importances = _align_api_if_sparse(csr_array(importances))
+
     if transform_func is None:
         return importances
     elif transform_func == "norm":
         if importances.ndim == 1:
             importances = np.abs(importances)
         else:
-            importances = np.linalg.norm(importances, axis=0, ord=norm_order)
+            if issparse(importances):
+                importances = linalg.norm(importances, axis=0, ord=norm_order)
+            else:
+                importances = np.linalg.norm(importances, axis=0, ord=norm_order)
     elif transform_func == "square":
         if importances.ndim == 1:
             importances = safe_sqr(importances)

--- a/sklearn/feature_selection/_base.py
+++ b/sklearn/feature_selection/_base.py
@@ -255,18 +255,13 @@ def _get_feature_importances(estimator, getter, transform_func=None, norm_order=
         if importances.ndim == 1:
             importances = np.abs(importances)
         else:
-            if issparse(importances):
-                importances = linalg.norm(importances, axis=0, ord=norm_order)
-            else:
-                importances = np.linalg.norm(importances, axis=0, ord=norm_order)
+            norm = linalg.norm if issparse(importances) else np.linalg.norm
+            importances = norm(importances, axis=0, ord=norm_order)
     elif transform_func == "square":
         if importances.ndim == 1:
             importances = safe_sqr(importances)
         else:
-            if issparse(importances):
-                importances = safe_sqr(importances).sum(axis=0)
-            else:
-                importances = safe_sqr(importances).sum(axis=0)
+            importances = safe_sqr(importances).sum(axis=0)
     else:
         raise ValueError(
             "Valid values for `transform_func` are "

--- a/sklearn/feature_selection/_base.py
+++ b/sklearn/feature_selection/_base.py
@@ -254,14 +254,15 @@ def _get_feature_importances(estimator, getter, transform_func=None, norm_order=
     elif transform_func == "norm":
         if importances.ndim == 1:
             importances = np.abs(importances)
+        elif issparse(importances):
+            importances = linalg.norm(importances, axis=0, ord=norm_order)
         else:
-            if issparse(importances):
-                importances = linalg.norm(importances, axis=0, ord=norm_order)
-            else:
-                importances = np.linalg.norm(importances, axis=0, ord=norm_order)
+            importances = np.linalg.norm(importances, axis=0, ord=norm_order)
     elif transform_func == "square":
         if importances.ndim == 1:
             importances = safe_sqr(importances)
+        elif issparse(importances):
+            importances = linalg.norm(importances, axis=0, ord=norm_order)
         else:
             importances = safe_sqr(importances).sum(axis=0)
     else:

--- a/sklearn/feature_selection/_base.py
+++ b/sklearn/feature_selection/_base.py
@@ -254,17 +254,19 @@ def _get_feature_importances(estimator, getter, transform_func=None, norm_order=
     elif transform_func == "norm":
         if importances.ndim == 1:
             importances = np.abs(importances)
-        elif issparse(importances):
-            importances = linalg.norm(importances, axis=0, ord=norm_order)
         else:
-            importances = np.linalg.norm(importances, axis=0, ord=norm_order)
+            if issparse(importances):
+                importances = linalg.norm(importances, axis=0, ord=norm_order)
+            else:
+                importances = np.linalg.norm(importances, axis=0, ord=norm_order)
     elif transform_func == "square":
         if importances.ndim == 1:
             importances = safe_sqr(importances)
-        elif issparse(importances):
-            importances = linalg.norm(importances, axis=0, ord=norm_order)
         else:
-            importances = safe_sqr(importances).sum(axis=0)
+            if issparse(importances):
+                importances = safe_sqr(importances).sum(axis=0)
+            else:
+                importances = safe_sqr(importances).sum(axis=0)
     else:
         raise ValueError(
             "Valid values for `transform_func` are "

--- a/sklearn/feature_selection/_base.py
+++ b/sklearn/feature_selection/_base.py
@@ -8,7 +8,8 @@ from abc import ABCMeta, abstractmethod
 from operator import attrgetter
 
 import numpy as np
-from scipy.sparse import csc_array, csr_array, issparse, linalg
+import scipy.sparse
+from scipy.sparse import csc_array, csr_array, issparse
 
 from sklearn.base import TransformerMixin
 from sklearn.utils import _safe_indexing, check_array, safe_sqr
@@ -255,7 +256,7 @@ def _get_feature_importances(estimator, getter, transform_func=None, norm_order=
         if importances.ndim == 1:
             importances = np.abs(importances)
         else:
-            norm = linalg.norm if issparse(importances) else np.linalg.norm
+            norm = scipy.sparse.linalg.norm if issparse(importances) else np.linalg.norm
             importances = norm(importances, axis=0, ord=norm_order)
     elif transform_func == "square":
         if importances.ndim == 1:

--- a/sklearn/feature_selection/tests/test_from_model.py
+++ b/sklearn/feature_selection/tests/test_from_model.py
@@ -670,3 +670,23 @@ def test_from_model_estimator_attribute_error():
         from_model.fit(data, y).partial_fit(data)
     assert isinstance(exec_info.value.__cause__, AttributeError)
     assert inner_msg in str(exec_info.value.__cause__)
+
+
+@pytest.mark.parametrize(
+    "feature_importance",
+    [
+        lambda estimator: estimator.sparsify().coef_,
+        lambda estimator: estimator.sparsify().coef_.tocsc(),
+    ],
+)
+def test_feature_importance_sparse(feature_importance):
+    from_model_sparse = SelectFromModel(
+        estimator=LogisticRegression(), importance_getter=feature_importance
+    )
+    from_model_dense = SelectFromModel(estimator=LogisticRegression())
+
+    from_model_sparse.fit(data, y)
+    from_model_dense.fit(data, y)
+
+    assert_array_equal(from_model_sparse.get_support(), from_model_dense.get_support())
+    assert_allclose(from_model_sparse.transform(data), from_model_dense.transform(data))

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -753,3 +753,22 @@ def test_results_per_cv_in_rfecv(global_random_seed):
     assert len(rfecv.cv_results_["split1_ranking"]) == len(
         rfecv.cv_results_["split2_ranking"]
     )
+
+
+@pytest.mark.parametrize("feature_importance", [
+    lambda estimator: estimator.sparsify().coef_,
+    lambda estimator: estimator.sparsify().coef_.tocsc(),
+])
+def test_rfe_sparse_coef(feature_importance):
+
+    X = [[0, 1, 3], [1, 0, 0], [2, 0, 4], [0, 2, 4]]
+    y = [0, 1, 2, 3]
+
+    estimator = LogisticRegression()
+    selector_sparse = RFE(estimator, n_features_to_select=1, importance_getter=feature_importance)
+    selector_dense = RFE(estimator, n_features_to_select=1)
+    selector_sparse.fit(X, y)
+    selector_dense.fit(X, y)
+
+    assert_array_equal(selector_sparse.support_, selector_dense.support_)
+    assert_array_equal(selector_sparse.ranking_, selector_dense.ranking_)

--- a/sklearn/feature_selection/tests/test_rfe.py
+++ b/sklearn/feature_selection/tests/test_rfe.py
@@ -755,17 +755,21 @@ def test_results_per_cv_in_rfecv(global_random_seed):
     )
 
 
-@pytest.mark.parametrize("feature_importance", [
-    lambda estimator: estimator.sparsify().coef_,
-    lambda estimator: estimator.sparsify().coef_.tocsc(),
-])
+@pytest.mark.parametrize(
+    "feature_importance",
+    [
+        lambda estimator: estimator.sparsify().coef_,
+        lambda estimator: estimator.sparsify().coef_.tocsc(),
+    ],
+)
 def test_rfe_sparse_coef(feature_importance):
-
     X = [[0, 1, 3], [1, 0, 0], [2, 0, 4], [0, 2, 4]]
     y = [0, 1, 2, 3]
 
     estimator = LogisticRegression()
-    selector_sparse = RFE(estimator, n_features_to_select=1, importance_getter=feature_importance)
+    selector_sparse = RFE(
+        estimator, n_features_to_select=1, importance_getter=feature_importance
+    )
     selector_dense = RFE(estimator, n_features_to_select=1)
     selector_sparse.fit(X, y)
     selector_dense.fit(X, y)


### PR DESCRIPTION
Closes #7479 

Added support to pass estimator's coef_ as scipy.sparse.arrays and matrices for the _get_feature_importances used in SelectFromModel and RFE classes, together with relevant tests for those implementations. 

Acknowledgment:
- @glemaitre for the supervision
- @isaacambrogetti whom I've collaborated with for this fix
- @jnothman, @kgilliam125, @amueller and @nelson-liu for their past contributions to the correlated issue #7675 

Part of the EPFL hackathon, ping @glemaitre