### PR TITLE
DOC data interoperability and pandas/polars output for transformers

### DIFF
--- a/doc/data_interoperability.rst
+++ b/doc/data_interoperability.rst
@@ -4,20 +4,31 @@ Data Interoperability
 
 .. currentmodule:: sklearn
 
-Scikit-learn handles four kinds of data for :term:`X` as in `fit(X)` and
-`fit(X, y)` as well as :term:`Xt` as returned by `transform(X)`:
+Scikit-learn handles four kinds of data for :term:`X` as in `fit(X)`, `fit(X, y)`
+and `transform(X)` as well as :term:`Xt` as returned by `transform(X)`:
 
 - :term:`array-like` objects
 
-  They are converted to a numpy ndarray by calling `numpy.asarray` upon them.
-  The returned `Xt` of `transform` and `fit_transform` is also a numpy ndarray.
+  In `fit(X)` and `transform(X)`, array-like `X` is converted to a numpy ndarray by
+  calling `numpy.asarray` upon them.
+  The returned `Xt` of `transform` and `fit_transform` is also a numpy ndarray or it
+  is a sparse matrix or sparse array, see next bullet.
 - sparse matrices and sparse arrays
 
-  To control whether `transform` returns a sparse matrix or a sparse array, use
-  `sparse_interface` in :func:`config_context` or :func:`set_config`. This also
-  controls whether sparse attributes are sparse matrices or sparse arrays.
-  Note that it is estimator specific if a sparse object is returned. Most often, it
-  can be controlled by `sparse_output` as in :class:`preprocessing.SplineTransformer`.
+  - `X` as in `fit(X)` and `transform(X)`
+
+    Many estimators can deal with sparse `X`, some can not and will raise an error.
+    For instance, :class:`linear_model.LogisticRegression` can be fit on sparse `X`,
+    :class:`isotonic.IsotonicRegression` can not.
+  - `Xt` as returned by `transform` and `fit_transform`
+
+    Some transformers return sparse `Xt` from `transform` and `fit_transform`.
+    Most often, it can be controlled by `sparse_output` as in
+    :class:`preprocessing.SplineTransformer`.
+
+    To control whether it returns a sparse matrix or a sparse array, use
+    `sparse_interface` in :func:`config_context` or :func:`set_config`.
+    This also controls whether sparse attributes are sparse matrices or sparse arrays.
 - tabular data: pandas and polars dataframes
 
   See :ref:`df_output_transform`.

--- a/doc/data_interoperability.rst
+++ b/doc/data_interoperability.rst
@@ -4,8 +4,9 @@ Data Interoperability
 
 .. currentmodule:: sklearn
 
-Scikit-learn handles four kinds of data for :term:`X` as in `fit(X)`, `fit(X, y)`
-and `transform(X)` as well as :term:`Xt` as returned by `transform(X)`:
+Scikit-learn handles four kinds of data for :term:`X` as in `fit(X, y)`, `fit(X)`,
+`fit_transform(X)` and `transform(X)` as well as :term:`Xt` as returned by
+`transform(X)` and `fit_transform(X)`:
 
 - :term:`array-like` objects
 
@@ -13,22 +14,18 @@ and `transform(X)` as well as :term:`Xt` as returned by `transform(X)`:
   calling `numpy.asarray` upon them.
   The returned `Xt` of `transform` and `fit_transform` is also a numpy ndarray or it
   is a sparse matrix or sparse array, see next bullet.
-- sparse matrices and sparse arrays
+- :term:`sparse matrix` and sparse array
+  Many estimators can deal with sparse `X`, some cannot and will raise an error.
+  For instance, :class:`linear_model.LogisticRegression` can be fit on sparse `X`,
+  :class:`isotonic.IsotonicRegression` can not.
 
-  - `X` as in `fit(X)` and `transform(X)`
+  Some transformers return sparse `Xt` from `transform` and `fit_transform`.
+  Most often, it can be controlled by `sparse_output` as in
+  :class:`preprocessing.SplineTransformer`.
 
-    Many estimators can deal with sparse `X`, some can not and will raise an error.
-    For instance, :class:`linear_model.LogisticRegression` can be fit on sparse `X`,
-    :class:`isotonic.IsotonicRegression` can not.
-  - `Xt` as returned by `transform` and `fit_transform`
-
-    Some transformers return sparse `Xt` from `transform` and `fit_transform`.
-    Most often, it can be controlled by `sparse_output` as in
-    :class:`preprocessing.SplineTransformer`.
-
-    To control whether it returns a sparse matrix or a sparse array, use
-    `sparse_interface` in :func:`config_context` or :func:`set_config`.
-    This also controls whether sparse attributes are sparse matrices or sparse arrays.
+  To control whether it returns a sparse matrix or a sparse array, use
+  `sparse_interface` in :func:`config_context` or :func:`set_config`.
+  This also controls whether sparse attributes are sparse matrices or sparse arrays.
 - tabular data: pandas and polars dataframes
 
   See :ref:`df_output_transform`.

--- a/doc/data_interoperability.rst
+++ b/doc/data_interoperability.rst
@@ -15,6 +15,7 @@ Scikit-learn handles four kinds of data for :term:`X` as in `fit(X, y)`, `fit(X)
   The returned `Xt` of `transform` and `fit_transform` is also a numpy ndarray or it
   is a sparse matrix or sparse array, see next bullet.
 - :term:`sparse matrices <sparse matrix>` and sparse arrays
+
   Many estimators can deal with sparse `X`, some cannot and will raise an error.
   For instance, :class:`linear_model.LogisticRegression` can be fit on sparse `X`,
   :class:`isotonic.IsotonicRegression` can not.

--- a/doc/data_interoperability.rst
+++ b/doc/data_interoperability.rst
@@ -14,7 +14,7 @@ Scikit-learn handles four kinds of data for :term:`X` as in `fit(X, y)`, `fit(X)
   calling `numpy.asarray` upon them.
   The returned `Xt` of `transform` and `fit_transform` is also a numpy ndarray or it
   is a sparse matrix or sparse array, see next bullet.
-- :term:`sparse matrix` and sparse array
+- :term:`sparse matrices <sparse matrix>` and sparse arrays
   Many estimators can deal with sparse `X`, some cannot and will raise an error.
   For instance, :class:`linear_model.LogisticRegression` can be fit on sparse `X`,
   :class:`isotonic.IsotonicRegression` can not.

--- a/doc/data_interoperability.rst
+++ b/doc/data_interoperability.rst
@@ -2,6 +2,30 @@
 Data Interoperability
 =====================
 
+.. currentmodule:: sklearn
+
+Scikit-learn handles four kinds of data for :term:`X` as in `fit(X)` and
+`fit(X, y)` as well as :term:`Xt` as returned by `transform(X)`:
+
+- :term:`array-like` objects
+
+  They are converted to a numpy ndarray by calling `numpy.asarray` upon them.
+  The returned `Xt` of `transform` and `fit_transform` is also a numpy ndarray.
+- sparse matrices and sparse arrays
+
+  To control whether `transform` returns a sparse matrix or a sparse array, use
+  `sparse_interface` in :func:`config_context` or :func:`set_config`. This also
+  controls whether sparse attributes are sparse matrices or sparse arrays.
+  Note that it is estimator specific if a sparse object is returned. Most often, it
+  can be controlled by `sparse_output` as in :class:`preprocessing.SplineTransformer`.
+- tabular data: pandas and polars dataframes
+
+  See :ref:`df_output_transform`.
+- Array API compliant arrays
+
+  Very importantly, this includes arrays on the GPU, see :ref:`array_api`.
+
+
 .. toctree::
     :maxdepth: 2
 

--- a/doc/data_interoperability.rst
+++ b/doc/data_interoperability.rst
@@ -4,7 +4,7 @@ Data Interoperability
 
 .. currentmodule:: sklearn
 
-Scikit-learn handles four kinds of data for :term:`X` as in `fit(X, y)`, `fit(X)`,
+Scikit-learn handles four kinds of data for :term:`X` as used in `fit(X, y)`, `fit(X)`,
 `fit_transform(X)` and `transform(X)` as well as :term:`Xt` as returned by
 `transform(X)` and `fit_transform(X)`:
 
@@ -21,7 +21,7 @@ Scikit-learn handles four kinds of data for :term:`X` as in `fit(X, y)`, `fit(X)
   :class:`isotonic.IsotonicRegression` can not.
 
   Some transformers return sparse `Xt` from `transform` and `fit_transform`.
-  Most often, it can be controlled by `sparse_output` as in
+  Most often, it can be controlled by a `sparse_output` parameter as in
   :class:`preprocessing.SplineTransformer`.
 
   To control whether it returns a sparse matrix or a sparse array, use

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -583,7 +583,9 @@ keyword arguments to its super class. Super classes' `__init_subclass__` should
 For transformers that return multiple arrays in `transform`, auto wrapping will
 only wrap the first array and not alter the other arrays.
 
-See :ref:`modules/df_output_transform` for an example on how to use the API.
+Refer to the :ref:`user guide <df_output_transform>` for more details
+and :ref:`sphx_glr_auto_examples_miscellaneous_plot_set_output.py` for an
+example on how to use the API.
 
 .. _developer_api_check_is_fitted:
 

--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -583,8 +583,7 @@ keyword arguments to its super class. Super classes' `__init_subclass__` should
 For transformers that return multiple arrays in `transform`, auto wrapping will
 only wrap the first array and not alter the other arrays.
 
-See :ref:`sphx_glr_auto_examples_miscellaneous_plot_set_output.py`
-for an example on how to use the API.
+See :ref:`modules/df_output_transform` for an example on how to use the API.
 
 .. _developer_api_check_is_fitted:
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -196,8 +196,7 @@ Does scikit-learn work natively with various types of dataframes?
 Scikit-learn has limited support for :class:`pandas.DataFrame` and
 :class:`polars.DataFrame`. Scikit-learn estimators can accept both these dataframe types
 as input, and scikit-learn transformers can output dataframes using the `set_output`
-API. For more details, refer to
-:ref:`sphx_glr_auto_examples_miscellaneous_plot_set_output.py`.
+API. For more details, refer to :ref:`df_output_transform`.
 
 However, the internal computations in scikit-learn estimators rely on numerical
 operations that are more efficiently performed on homogeneous data structures such as

--- a/doc/modules/df_output_transform.rst
+++ b/doc/modules/df_output_transform.rst
@@ -92,7 +92,7 @@ Now the same, but with pandas set as output::
     >>> from sklearn import set_config
     >>> set_config(transform_output="pandas")
     >>> model[0].transform(X)
-    ...
+           c...
 
 .. raw:: html
 

--- a/doc/modules/df_output_transform.rst
+++ b/doc/modules/df_output_transform.rst
@@ -12,18 +12,18 @@ This part of the user guide explains how scikit-learn supports tabular data.
 Propagation of Feature Names
 ============================
 
-By default, scikit-learn transformers (estimators with a :meth:`transform` method)
-return numpy arrays (sometimes also sparse arrays). Because numpy arrays do not provide
-names for the indices of axes/dimensions, prior to version 1.0
+By default, scikit-learn :term:`transformers` (estimators with a :meth:`transform`
+method) return numpy arrays (sometimes also sparse arrays). Because numpy arrays do
+not provide names for the indices of axes/dimensions, prior to version 1.0
 the :class:`pipeline.Pipeline` did not know how to propagate feature names:
 
-- The single step estimators did not know how to handle incoming features names.
-- The pipeline did not know how to pass features names from step to step.
+- The single step estimators did not know how to handle incoming feature names.
+- The pipeline did not know how to pass feature names from step to step.
 
 In practice, a lot of use cases start with tabular data like a `pandas dataframe
 <https://pandas.pydata.org/docs/user_guide/dsintro.html#dataframe>`_ or a
 `polars dataframe <https://docs.pola.rs/api/python/stable/reference/dataframe/index.html>`__
-which have column/features names.
+which have column/feature names.
 
 A first step to support this important use case was made by the addition of the
 :class:`compose.ColumnTransformer` in :ref:`version 0.20 <changes_0_20>`.
@@ -53,7 +53,7 @@ implemented for pandas dataframes in :ref:`version 1.2 <release_notes_1_2>` and 
 polars dataframes in :ref:`version 1.4 <release_notes_1_4>`. It introduced the
 `set_output` API to configure transformers to output pandas or polars DataFrames.
 The output of transformers can be configured per estimator by calling
-the :meth:`set_output` method or globally by setting `set_config(transform_output="pandas")`.
+the :meth:`set_output` method or globally, by setting `set_config(transform_output="pandas")`.
 Set it to `"polars"` instead of `"pandas"` if you want the same thing to happen but with
 polars DataFrames.
 

--- a/doc/modules/df_output_transform.rst
+++ b/doc/modules/df_output_transform.rst
@@ -34,8 +34,7 @@ It was then properly solved by `SLEP007: Feature names, their generation and the
 <https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep007/proposal.html>`__
 and fully implemented in :ref:`version 1.1 <release_notes_1_1>`, see
 the :ref:`release highlights 1.0 <feature_names_in_release_highlights_1_0_0>` and
-:ref:`get_feature_names_out in the release highlights 1.1
-<get_feature_names_out_release_highlights_1_1_0>`.
+:ref:`release highlights 1.1 <get_feature_names_out_release_highlights_1_1_0>`.
 When an estimator is passed a dataframe during :term:`fit`, the estimator will
 set a `feature_names_in_` attribute containing the feature names. It understands pandas
 dataframes as well as dataframes with the `Python dataframe interchange protocol

--- a/doc/modules/df_output_transform.rst
+++ b/doc/modules/df_output_transform.rst
@@ -6,16 +6,16 @@ Pandas/Polars Output for Transformers with `set_output` API
 
 .. currentmodule:: sklearn
 
-This part of the use guide explains how scikit-learn supports tabular data.
+This part of the user guide explains how scikit-learn supports tabular data.
 
 
-Feature Names
-=============
+Propagation of Feature Names
+============================
 
 By default, scikit-learn transformers (estimators with a :meth:`transform` method)
 return numpy arrays (sometimes also sparse arrays). Because numpy arrays do not provide
 names for the indices of axes/dimensions, prior to version 1.0
-the :class:`pipeline.Pipeline` did not know how to propagate features names:
+the :class:`pipeline.Pipeline` did not know how to propagate feature names:
 
 - The single step estimators did not know how to handle incoming features names.
 - The pipeline did not know how to pass features names from step to step.

--- a/doc/modules/df_output_transform.rst
+++ b/doc/modules/df_output_transform.rst
@@ -1,8 +1,136 @@
 .. _df_output_transform:
 
-=====================================================
-Pandas/Polars Output for Transformers with set_output
-=====================================================
+===========================================================
+Pandas/Polars Output for Transformers with `set_output` API
+===========================================================
 
-See `SLEP018 <https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep018/proposal.html>`__
-and :ref:`sphx_glr_auto_examples_miscellaneous_plot_set_output.py`.
+.. currentmodule:: sklearn
+
+This part of the use guide explains how scikit-learn supports tabular data.
+
+
+Feature Names
+=============
+
+By default, scikit-learn transformers (estimators with a :meth:`transform` method)
+return numpy arrays (sometimes also sparse arrays). Because numpy arrays do not provide
+names for the indices of axes/dimensions, prior to version 1.0
+the :class:`pipeline.Pipeline` did not know how to propagate features names:
+
+- The single step estimators did not know how to handle incoming features names.
+- The pipeline did not know how to pass features names from step to step.
+
+In practice, a lot of use cases start with tabular data like a `pandas dataframe
+<https://pandas.pydata.org/docs/user_guide/dsintro.html#dataframe>`_ or a
+`polars dataframe <https://docs.pola.rs/api/python/stable/reference/dataframe/index.html>`__
+which have column/features names.
+
+A first step to support this important use case was made by the addition of the
+:class:`compose.ColumnTransformer` in :ref:`version 0.20 <changes_0_20>`.
+It acts as a gateway to apply different estimators on the different features. Most
+notably it understands incoming feature names.
+
+It was then properly solved by `SLEP007: Feature names, their generation and the API
+<https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep007/proposal.html>`__
+and fully implemented in :ref:`version 1.1 <release_notes_1_1>`, see
+the :ref:`release highlights 1.0 <feature_names_in_release_highlights_1_0_0>` and
+:ref:`get_feature_names_out in the release highlights 1.1
+<get_feature_names_out_release_highlights_1_1_0>`.
+When an estimator is passed a dataframe during :term:`fit`, the estimator will
+set a `feature_names_in_` attribute containing the feature names. It understands pandas
+dataframes as well as dataframes with the `Python dataframe interchange protocol
+<https://data-apis.org/dataframe-protocol/latest/index.html>`__ `__dataframe__`.
+Furthermore, fitted estimators have the method :meth:`get_feature_names_out`. The
+`get_feature_names_out` of a transformer returns⸺you guessed it⸺the feature names of
+what `transform` returns.
+
+
+Introducing the `set_output` API
+================================
+
+A further major step to support dataframes in a "dataframe in, dataframe out" fashion was
+`SLEP018 <https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep018/proposal.html>`__,
+implemented for pandas dataframes in :ref:`version 1.2 <release_notes_1_2>` and for
+polars dataframes in :ref:`version 1.4 <release_notes_1_4>`. It introduced the
+`set_output` API to configure transformers to output pandas or polars DataFrames.
+The output of transformers can be configured per estimator by calling
+the :meth:`set_output` method or globally by setting `set_config(transform_output="pandas")`.
+Set it to `"polars"` instead of `"pandas"` if you want the same thing to happen but with
+polars DataFrames.
+
+The usage is basically as follows::
+
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> from sklearn.compose import ColumnTransformer
+    >>> from sklearn.pipeline import make_pipeline
+    >>> from sklearn.preprocessing import OneHotEncoder
+    >>> from sklearn.linear_model import LinearRegression
+
+    >>> X = pd.DataFrame(
+    ...     {"animals": ["cat", "cat", "dog", "dog"], "numeric": np.linspace(-1, 1, 4)}
+    ... )
+    >>> y = np.array([-1.5, 0, 0.1, 1.0])
+    >>> ct = ColumnTransformer(
+    ...     [("categorical", OneHotEncoder(sparse_output=False), ["animals"])],
+    ...     remainder="passthrough",
+    ... )
+    >>> model = make_pipeline(ct, LinearRegression()).fit(X, y)
+    >>> model.feature_names_in_
+    array(['animals', 'numeric'], dtype=object)
+    >>> model[0].get_feature_names_out()
+    array(['categorical__animals_cat', 'categorical__animals_dog',
+       'remainder__numeric'], dtype=object)
+    >>> model[0].transform(X)
+    array([[ 1.        ,  0.        , -1.        ],
+           [ 1.        ,  0.        , -0.33333333],
+           [ 0.        ,  1.        ,  0.33333333],
+           [ 0.        ,  1.        ,  1.        ]])
+
+Now the same, but with pandas set as output::
+
+    >>> from sklearn import set_config
+    >>> set_config(transform_output="pandas")
+    >>> model[0].transform(X)
+
+.. raw:: html
+
+    <table border="1" class="dataframe">
+        <thead>
+            <tr style="text-align: right;">
+                <th></th>
+                <th>categorical__animals_cat</th>
+                <th>categorical__animals_dog</th>
+                <th>remainder__numeric</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <th>0</th>
+                <td>1.0</td>
+                <td>0.0</td>
+                <td>-1.000000</td>
+            </tr>
+            <tr>
+                <th>1</th>
+                <td>1.0</td>
+                <td>0.0</td>
+                <td>-0.333333</td>
+            </tr>
+            <tr>
+                <th>2</th>
+                <td>0.0</td>
+                <td>1.0</td>
+                <td>0.333333</td>
+            </tr>
+            <tr>
+                <th>3</th>
+                <td>0.0</td>
+                <td>1.0</td>
+                <td>1.000000</td>
+            </tr>
+        </tbody>
+    </table>
+
+A more detailed example can be found in
+:ref:`sphx_glr_auto_examples_miscellaneous_plot_set_output.py`.

--- a/doc/modules/df_output_transform.rst
+++ b/doc/modules/df_output_transform.rst
@@ -92,7 +92,7 @@ Now the same, but with pandas set as output::
     >>> from sklearn import set_config
     >>> set_config(transform_output="pandas")
     >>> model[0].transform(X)
-    <...>
+    ...
 
 .. raw:: html
 

--- a/doc/modules/df_output_transform.rst
+++ b/doc/modules/df_output_transform.rst
@@ -92,6 +92,7 @@ Now the same, but with pandas set as output::
     >>> from sklearn import set_config
     >>> set_config(transform_output="pandas")
     >>> model[0].transform(X)
+    <...>
 
 .. raw:: html
 
@@ -131,6 +132,10 @@ Now the same, but with pandas set as output::
             </tr>
         </tbody>
     </table>
+
+To return to the default, simply run::
+
+    >>> set_config(transform_output="default")
 
 A more detailed example can be found in
 :ref:`sphx_glr_auto_examples_miscellaneous_plot_set_output.py`.

--- a/examples/release_highlights/plot_release_highlights_1_0_0.py
+++ b/examples/release_highlights/plot_release_highlights_1_0_0.py
@@ -136,6 +136,8 @@ spline.fit_transform(X)
 #    :scale: 50%
 
 ##############################################################################
+# .. _feature_names_in_release_highlights_1_0_0:
+#
 # Feature Names Support
 # --------------------------------------------------------------------------
 # When an estimator is passed a `pandas' dataframe

--- a/examples/release_highlights/plot_release_highlights_1_1_0.py
+++ b/examples/release_highlights/plot_release_highlights_1_1_0.py
@@ -59,6 +59,8 @@ _ = ax.legend(loc="lower left")
 # :ref:`sphx_glr_auto_examples_ensemble_plot_hgbt_regression.py`
 
 # %%
+# .. _get_feature_names_out_release_highlights_1_1_0:
+#
 # `get_feature_names_out` Available in all Transformers
 # -----------------------------------------------------
 # :term:`get_feature_names_out` is now available in all transformers, thereby

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -155,7 +155,9 @@ def set_config(
     transform_output : str, default=None
         Configure output of `transform` and `fit_transform`.
 
-        See :ref:`modules/df_output_transform` for an example on how to use the API.
+        Refer to the :ref:`user guide <df_output_transform>` for more details
+        and :ref:`sphx_glr_auto_examples_miscellaneous_plot_set_output.py` for an
+        example on how to use the API.
 
         - `"default"`: Default output format of a transformer
         - `"pandas"`: DataFrame output
@@ -334,7 +336,9 @@ def config_context(
     transform_output : str, default=None
         Configure output of `transform` and `fit_transform`.
 
-        See :ref:`modules/df_output_transform` for an example on how to use the API.
+        Refer to the :ref:`user guide <df_output_transform>` for more details
+        and :ref:`sphx_glr_auto_examples_miscellaneous_plot_set_output.py` for an
+        example on how to use the API.
 
         - `"default"`: Default output format of a transformer
         - `"pandas"`: DataFrame output

--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -155,8 +155,7 @@ def set_config(
     transform_output : str, default=None
         Configure output of `transform` and `fit_transform`.
 
-        See :ref:`sphx_glr_auto_examples_miscellaneous_plot_set_output.py`
-        for an example on how to use the API.
+        See :ref:`modules/df_output_transform` for an example on how to use the API.
 
         - `"default"`: Default output format of a transformer
         - `"pandas"`: DataFrame output
@@ -335,8 +334,7 @@ def config_context(
     transform_output : str, default=None
         Configure output of `transform` and `fit_transform`.
 
-        See :ref:`sphx_glr_auto_examples_miscellaneous_plot_set_output.py`
-        for an example on how to use the API.
+        See :ref:`modules/df_output_transform` for an example on how to use the API.
 
         - `"default"`: Default output format of a transformer
         - `"pandas"`: DataFrame output

--- a/sklearn/preprocessing/_function_transformer.py
+++ b/sklearn/preprocessing/_function_transformer.py
@@ -394,8 +394,9 @@ class FunctionTransformer(TransformerMixin, BaseEstimator):
     def set_output(self, *, transform=None):
         """Set output container.
 
-        See :ref:`sphx_glr_auto_examples_miscellaneous_plot_set_output.py`
-        for an example on how to use the API.
+        Refer to the :ref:`user guide <df_output_transform>` for more details
+        and :ref:`sphx_glr_auto_examples_miscellaneous_plot_set_output.py` for an
+        example on how to use the API.
 
         Parameters
         ----------

--- a/sklearn/utils/_set_output.py
+++ b/sklearn/utils/_set_output.py
@@ -408,8 +408,9 @@ class _SetOutputMixin:
     def set_output(self, *, transform=None):
         """Set output container.
 
-        See :ref:`sphx_glr_auto_examples_miscellaneous_plot_set_output.py`
-        for an example on how to use the API.
+        Refer to the :ref:`user guide <df_output_transform>` for more details
+        and :ref:`sphx_glr_auto_examples_miscellaneous_plot_set_output.py` for an
+        example on how to use the API.
 
         Parameters
         ----------


### PR DESCRIPTION
#### Reference Issues/PRs
Follow-up of #33466.

#### What does this implement/fix? Explain your changes.
As it stands, the documentation is quite sparse (if not poor) on data interoperability. A lot what we know is not written down or accessible. This is an attempt to change that in a concise way.

#### AI usage disclosure
None

#### Any other comments?