### PR TITLE
MNT polars 1.40 deprecated dataframe interchange protocol __dataframe__

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.utils/33789.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/33789.fix.rst
@@ -1,0 +1,4 @@
+- The code path for polars dataframes in :func:`validate_data` was made independent of
+  the dataframe interchange protocol `__dataframe__`. This change was necessary to
+  adapt to the recent deprecation of the interchange protocol in polars version 1.40.
+  By :user:`Christian Lorentzen <lorentzenchr>`.

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -19,7 +19,7 @@ from sklearn.base import TransformerMixin, _fit_context, clone
 from sklearn.pipeline import _fit_transform_one, _name_estimators, _transform_one
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.utils import Bunch
-from sklearn.utils._dataframe import is_pandas_df
+from sklearn.utils._dataframe import is_pandas_df, is_polars_df
 from sklearn.utils._indexing import (
     _determine_key_type,
     _get_column_indices,
@@ -746,10 +746,14 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
             )
         ]
         for Xs, name in zip(result, names):
-            if not getattr(Xs, "ndim", 0) == 2 and not hasattr(Xs, "__dataframe__"):
+            if not (
+                getattr(Xs, "ndim", 0) == 2
+                or hasattr(Xs, "__dataframe__")
+                or is_polars_df(Xs)
+            ):
                 raise ValueError(
-                    "The output of the '{0}' transformer should be 2D (numpy array, "
-                    "scipy sparse array, dataframe).".format(name)
+                    f"The output of the '{name}' transformer should be 2D (numpy "
+                    "array, scipy sparse array, dataframe)."
                 )
         if _get_output_config("transform", self)["dense"] == "pandas":
             return
@@ -1041,7 +1045,7 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         # were not present in fit time, and the order of the columns doesn't
         # matter.
         fit_dataframe_and_transform_dataframe = hasattr(self, "feature_names_in_") and (
-            is_pandas_df(X) or hasattr(X, "__dataframe__")
+            is_pandas_df(X) or is_polars_df(X) or hasattr(X, "__dataframe__")
         )
 
         n_samples = _num_samples(X)
@@ -1290,6 +1294,7 @@ def _check_X(X):
     if (
         (hasattr(X, "__array__") and hasattr(X, "shape"))
         or hasattr(X, "__dataframe__")
+        or is_polars_df(X)
         or sparse.issparse(X)
     ):
         return X

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools
+import sys
 from abc import ABC, abstractmethod
 from contextlib import contextmanager, nullcontext, suppress
 from functools import partial
@@ -40,7 +41,7 @@ from sklearn.metrics._scorer import _SCORERS
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import FunctionTransformer, LabelEncoder, OrdinalEncoder
 from sklearn.utils import check_random_state, compute_sample_weight, resample
-from sklearn.utils._dataframe import is_pandas_df
+from sklearn.utils._dataframe import is_pandas_df, is_polars_df
 from sklearn.utils._missing import is_scalar_nan
 from sklearn.utils._openmp_helpers import _openmp_effective_n_threads
 from sklearn.utils._param_validation import Interval, RealNotInt, StrOptions
@@ -374,6 +375,14 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
         if is_pandas_df(X):
             X_is_dataframe = True
             categorical_columns_mask = np.asarray(X.dtypes == "category")
+        elif is_polars_df(X):
+            # Special code for polars because polars 1.40 deprecates the __dataframe__
+            # protocol.
+            X_is_dataframe = True
+            pl = sys.modules["polars"]
+            categorical_columns_mask = np.asarray(
+                [d in (pl.Categorical, pl.Enum) for d in X.dtypes]
+            )
         elif hasattr(X, "__dataframe__"):
             X_is_dataframe = True
             categorical_columns_mask = np.asarray(
@@ -1573,7 +1582,8 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         - `"from_dtype"`: dataframe columns with dtype "category" are
           considered to be categorical features. The input must be an object
           exposing a ``__dataframe__`` method such as pandas or polars
-          DataFrames to use this feature.
+          DataFrames to use this feature. For polars dataframes, dtypes
+          pl.Categorical and pl.Enum are detected.
 
         For each categorical feature, there must be at most `max_bins` unique
         categories. Negative values for categorical features encoded as numeric
@@ -1966,7 +1976,8 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
         - `"from_dtype"`: dataframe columns with dtype "category" are
           considered to be categorical features. The input must be an object
           exposing a ``__dataframe__`` method such as pandas or polars
-          DataFrames to use this feature.
+          DataFrames to use this feature. For polars dataframes, dtypes
+          pl.Categorical and pl.Enum are detected.
 
         For each categorical feature, there must be at most `max_bins` unique
         categories. Negative values for categorical features encoded as numeric

--- a/sklearn/utils/_indexing.py
+++ b/sklearn/utils/_indexing.py
@@ -18,6 +18,7 @@ from sklearn.utils._array_api import (
 )
 from sklearn.utils._dataframe import (
     is_pandas_df,
+    is_polars_df,
     is_polars_df_or_series,
     is_pyarrow_data,
 )
@@ -347,7 +348,7 @@ def _safe_indexing(X, indices, *, axis=0):
     if (
         axis == 1
         and indices_dtype == "str"
-        and not (is_pandas_df(X) or _use_interchange_protocol(X))
+        and not (is_pandas_df(X) or is_polars_df(X) or _use_interchange_protocol(X))
     ):
         raise ValueError(
             "Specifying the columns using strings is only supported for dataframes."
@@ -436,8 +437,19 @@ def _get_column_indices(X, key):
     :func:`_safe_indexing`.
     """
     key_dtype = _determine_key_type(key)
-    if _use_interchange_protocol(X):
-        return _get_column_indices_interchange(X.__dataframe__(), key, key_dtype)
+    if is_polars_df(X):
+        n_columns = X.shape[1]
+        column_names = X.columns
+        return _get_column_indices_interchange_and_polars(
+            n_columns, column_names, key, key_dtype
+        )
+    elif _use_interchange_protocol(X):
+        X_interchange = X.__dataframe__()
+        n_columns = X_interchange.num_columns()
+        column_names = list(X_interchange.column_names())
+        return _get_column_indices_interchange_and_polars(
+            n_columns, column_names, key, key_dtype
+        )
 
     n_columns = X.shape[1]
     if isinstance(key, (list, tuple)) and not key:
@@ -483,10 +495,8 @@ def _get_column_indices(X, key):
         return column_indices
 
 
-def _get_column_indices_interchange(X_interchange, key, key_dtype):
-    """Same as _get_column_indices but for X with __dataframe__ protocol."""
-
-    n_columns = X_interchange.num_columns()
+def _get_column_indices_interchange_and_polars(n_columns, column_names, key, key_dtype):
+    """Same as _get_column_indices but for X with __dataframe__ protocol or polars."""
 
     if isinstance(key, (list, tuple)) and not key:
         # we get an empty list
@@ -494,8 +504,6 @@ def _get_column_indices_interchange(X_interchange, key, key_dtype):
     elif key_dtype in ("bool", "int"):
         return _get_column_indices_for_bool_or_int(key, n_columns)
     else:
-        column_names = list(X_interchange.column_names())
-
         if isinstance(key, slice):
             if key.step not in [1, None]:
                 raise NotImplementedError("key.step must be 1 or None")

--- a/sklearn/utils/tests/test_indexing.py
+++ b/sklearn/utils/tests/test_indexing.py
@@ -504,12 +504,16 @@ def test_get_column_indices_pandas_nonunique_columns_error(key):
     assert str(exc_info.value) == err_msg
 
 
-def test_get_column_indices_interchange():
-    """Check _get_column_indices for edge cases with the interchange"""
-    pl = pytest.importorskip("polars")
-
-    # Polars dataframes go down the interchange path.
-    df = pl.DataFrame([[1, 2, 3], [4, 5, 6]], schema=["a", "b", "c"])
+@pytest.mark.parametrize("df_type", ["interchange", "polars"])
+def test_get_column_indices_interchange_and_polars(df_type):
+    """Check _get_column_indices for edge cases with the interchange and polars"""
+    if df_type == "polars":
+        pl = pytest.importorskip("polars")
+        df = pl.DataFrame([[1, 2, 3], [4, 5, 6]], schema=["a", "b", "c"])
+    else:
+        # Pyarrow tables go down the interchange path.
+        pa = pytest.importorskip("pyarrow")
+        df = pa.table([[1, 4], [2, 5], [3, 6]], names=["a", "b", "c"])
 
     key_results = [
         (slice(1, None), [1, 2]),

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -2221,10 +2221,19 @@ def test_check_array_multiple_extensions(
 
 
 def test_num_samples_dataframe_protocol():
-    """Use the DataFrame interchange protocol to get n_samples from polars."""
-    pl = pytest.importorskip("polars")
+    """Use the DataFrame interchange protocol to get n_samples."""
+    pa = pytest.importorskip("pyarrow")
 
-    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    class MockDFInterchange:
+        """A dataframe class without .shape attr but with __dataframe__ protocol"""
+
+        def __init__(self, *args, **kwargs):
+            self.df = pa.table(*args, **kwargs)
+
+        def __dataframe__(self):
+            return self.df.__dataframe__()
+
+    df = MockDFInterchange({"a": [1, 2, 3], "b": [4, 5, 6]})
     assert _num_samples(df) == 3
 
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -306,13 +306,16 @@ def _is_arraylike_not_scalar(array):
 
 
 def _use_interchange_protocol(X):
-    """Use interchange protocol for non-pandas dataframes that follow the protocol.
+    """Use interchange protocol for non-pandas/polars dataframes that follow the
+    protocol.
 
-    Note: at this point we chose not to use the interchange API on pandas dataframe
+    Note: At this point we chose not to use the interchange API on pandas dataframe
     to ensure strict behavioral backward compatibility with older versions of
     scikit-learn.
+    We also exclude the interchange protocol for polars because it was deprecated
+    in polars 1.40.
     """
-    return not is_pandas_df(X) and not is_polars_df(X) and hasattr(X, "__dataframe__")
+    return hasattr(X, "__dataframe__") and not is_pandas_df(X) and not is_polars_df(X)
 
 
 def _num_features(X):
@@ -386,15 +389,15 @@ def _num_samples(x):
         if isinstance(x.shape[0], numbers.Integral):
             return x.shape[0]
 
+    if _use_interchange_protocol(x):
+        return x.__dataframe__().num_rows()
+
     if not hasattr(x, "__len__") and not hasattr(x, "shape"):
         if hasattr(x, "__array__"):
             xp, _ = get_namespace(x)
             x = xp.asarray(x)
         else:
             raise TypeError(message)
-
-    if _use_interchange_protocol(x):
-        return x.__dataframe__().num_rows()
 
     try:
         return len(x)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -29,7 +29,7 @@ from sklearn.utils._array_api import (
     get_namespace_and_device,
     move_to,
 )
-from sklearn.utils._dataframe import is_pandas_df, is_pandas_df_or_series
+from sklearn.utils._dataframe import is_pandas_df, is_pandas_df_or_series, is_polars_df
 from sklearn.utils._isfinite import FiniteStatus, cy_isfinite
 from sklearn.utils._tags import get_tags
 from sklearn.utils.fixes import (
@@ -312,7 +312,7 @@ def _use_interchange_protocol(X):
     to ensure strict behavioral backward compatibility with older versions of
     scikit-learn.
     """
-    return not is_pandas_df(X) and hasattr(X, "__dataframe__")
+    return not is_pandas_df(X) and not is_polars_df(X) and hasattr(X, "__dataframe__")
 
 
 def _num_features(X):
@@ -375,16 +375,6 @@ def _num_samples(x):
         # Don't get num_samples from an ensembles length!
         raise TypeError(message)
 
-    if _use_interchange_protocol(x):
-        return x.__dataframe__().num_rows()
-
-    if not hasattr(x, "__len__") and not hasattr(x, "shape"):
-        if hasattr(x, "__array__"):
-            xp, _ = get_namespace(x)
-            x = xp.asarray(x)
-        else:
-            raise TypeError(message)
-
     if hasattr(x, "shape") and x.shape is not None:
         if len(x.shape) == 0:
             raise TypeError(
@@ -395,6 +385,16 @@ def _num_samples(x):
         # Dask dataframes may not return numeric shape[0] value
         if isinstance(x.shape[0], numbers.Integral):
             return x.shape[0]
+
+    if not hasattr(x, "__len__") and not hasattr(x, "shape"):
+        if hasattr(x, "__array__"):
+            xp, _ = get_namespace(x)
+            x = xp.asarray(x)
+        else:
+            raise TypeError(message)
+
+    if _use_interchange_protocol(x):
+        return x.__dataframe__().num_rows()
 
     try:
         return len(x)
@@ -2346,13 +2346,13 @@ def _get_feature_names(X):
     feature_names = None
 
     # extract feature names for support array containers
-    if is_pandas_df(X):
+    if is_pandas_df(X) or is_polars_df(X):
         # Make sure we can inspect columns names from pandas, even with
         # versions too old to expose a working implementation of
         # __dataframe__.column_names() and avoid introducing any
         # additional copy.
-        # TODO: remove the pandas-specific branch once the minimum supported
-        # version of pandas has a working implementation of
+        # TODO: remove the pandas-specific branch (but keep polars) once the minimum
+        # supported version of pandas has a working implementation of
         # __dataframe__.column_names() that is guaranteed to not introduce any
         # additional copy of the data without having to impose allow_copy=False
         # that could fail with other libraries. Note: in the longer term, we


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
Polars version 1.40 deprecated the dataframe interchange protocol `__dataframe__`, see https://github.com/pola-rs/polars/releases/tag/py-1.40.0.
This PR makes polars code path not relying on it.

#### AI usage disclosure
None

#### Any other comments?
We could treat string columns in `HistGradientBoosting*` as categorical....