### PR TITLE
FIX CountVectorizer feature display by supporting vocabulary_

### DIFF
--- a/sklearn/utils/_repr_html/estimator.py
+++ b/sklearn/utils/_repr_html/estimator.py
@@ -431,7 +431,10 @@ def _write_estimator_html(
             has_feature_names_out
             and is_not_pipeline_step
             and is_fitted_css_class
-            and hasattr(estimator, "n_features_in_")
+            and (
+                hasattr(estimator, "n_features_in_")
+                or hasattr(estimator, "vocabulary_")
+            )
         ):
             output_features = estimator.get_feature_names_out()
         else:


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #

#### What does this implement/fix? Explain your changes.

The HTML representation currently checks for `n_features_in_` to determine whether to display output features. However, `CountVectorizer` does not define this attribute since it operates on text data and builds a `vocabulary_` instead.

As a result, feature information is not displayed for `CountVectorizer`.

This PR extends the condition to also check for `vocabulary_`, allowing `CountVectorizer` to correctly display its output features via `get_feature_names_out()`.

#### AI usage disclosure

I used AI assistance for:

* Research and understanding

#### Any other comments?

This is a minimal change that preserves existing behavior for estimators using `n_features_in_` while adding support for text vectorizers like `CountVectorizer`.

