### PR TITLE
DOC Add numerical stability note to CCA when n_features > n_samples

### DIFF
--- a/sklearn/cross_decomposition/_pls.py
+++ b/sklearn/cross_decomposition/_pls.py
@@ -870,6 +870,21 @@ class CCA(_PLS):
     PLSCanonical : Partial Least Squares transformer and regressor.
     PLSSVD : Partial Least Square SVD.
 
+    Notes
+    -----
+    CCA (mode B) internally uses pseudo-inverse computations which become
+    numerically unstable when ``n_features > n_samples`` or
+    ``n_targets > n_samples``. In such cases the fitted weights may depend on
+    the order of the columns in ``X`` or ``y`` and should not be interpreted.
+    Consider reducing the number of features or using :class:`PLSCanonical`
+    instead. See the Wegelin review [1]_ for a theoretical discussion.
+
+    References
+    ----------
+    .. [1] Wegelin, J. A. (2000). A Survey of Partial Least Squares (PLS)
+       Methods, with Emphasis on the Two-Block Case. Technical Report 371,
+       University of Washington Statistics Department.
+
     Examples
     --------
     >>> from sklearn.cross_decomposition import CCA


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #19042

#### What does this implement/fix? Explain your changes.

CCA (Canonical Correlation Analysis, mode B) uses pseudo-inverse computations internally. These become numerically unstable when `n_features > n_samples` or `n_targets > n_samples` — the fitted weights may depend on the order of columns in `X` or `y` and cannot be interpreted reliably.

This instability was already documented as a code comment at line 73–74 of `_pls.py`:

```python
# As a result, and as detailed in the Wegelin's review, CCA (i.e. mode
# B) will be unstable if n_features > n_samples or n_targets > n_samples
```

But it was absent from the public docstring, so users calling `CCA` directly had no way to discover this limitation without reading the source.

This PR adds a `Notes` section to the `CCA` class docstring documenting:
- The instability condition
- The recommendation to use `PLSCanonical` as an alternative
- A reference to the Wegelin review already cited in the source code

#### Did you add any tests? Why or why not?

No — this is a documentation-only change (a `Notes` section added to a docstring). No behavior changes.

---

> **AI Assistance Disclosure** (required per [AGENTS.md](https://github.com/scikit-learn/scikit-learn/blob/main/AGENTS.md))
> This pull request includes code written with the assistance of AI (Claude Code).
> All changes have been read, understood, and verified by the human contributor (Rudrendu Paul).