### PR TITLE
[Callbacks] ENH Make propagate_callback_context a context manager

### DIFF
--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -505,7 +505,7 @@ class CallbackContext:
         # whole tree.
         sub_estimator._parent_callback_ctx = self
 
-        callbacks_to_propagate = {
+        callbacks_to_propagate = [
             callback
             for callback in self._callbacks
             if isinstance(callback, AutoPropagatedCallback)
@@ -513,25 +513,30 @@ class CallbackContext:
                 callback.max_propagation_depth is None
                 or self._propagation_depth < callback.max_propagation_depth
             )
-        }
+        ]
+        if callbacks_to_propagate and not hasattr(sub_estimator, "set_callbacks"):
+            warnings.warn(
+                f"The estimator {sub_estimator.__class__.__name__} does not support "
+                f"callbacks. The callbacks attached to {self.estimator_name} will not "
+                f"be propagated to this estimator."
+            )
+            callbacks_to_propagate = []
+
         if callbacks_to_propagate:
-            if not hasattr(sub_estimator, "set_callbacks"):
-                warnings.warn(
-                    f"The estimator {sub_estimator.__class__.__name__} does not support"
-                    f" callbacks. The callbacks attached to {self.estimator_name} will "
-                    f"not be propagated to this estimator."
-                )
-            else:
-                self._propagated_callbacks = callbacks_to_propagate
-                curr_callbacks = getattr(sub_estimator, "_skl_callbacks", set())
-                sub_estimator.set_callbacks(*(curr_callbacks | callbacks_to_propagate))
+            self._propagated_callbacks = callbacks_to_propagate
+            curr_callbacks = getattr(sub_estimator, "_skl_callbacks", [])
+            sub_estimator.set_callbacks(*(curr_callbacks + callbacks_to_propagate))
 
         try:
             yield
         finally:
-            if callbacks := getattr(self, "_propagated_callbacks", set()):
-                sub_estimator.set_callbacks(*(sub_estimator._skl_callbacks - callbacks))
-                del self._propagated_callbacks
+            if callbacks_to_propagate:
+                kept_callbacks = [
+                    cb
+                    for cb in sub_estimator._skl_callbacks
+                    if cb not in callbacks_to_propagate
+                ]
+                sub_estimator.set_callbacks(*kept_callbacks)
             del sub_estimator._parent_callback_ctx
 
 

--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -5,6 +5,7 @@ import copy
 import inspect
 import uuid
 import warnings
+from contextlib import contextmanager
 
 from sklearn.callback._base import AutoPropagatedCallback
 
@@ -466,8 +467,11 @@ class CallbackContext:
         """
         return self._call_hooks(estimator, hook_name="on_fit_task_end", **kwargs)
 
+    @contextmanager
     def propagate_callback_context(self, sub_estimator):
         """Propagate the context and callbacks to a sub-estimator.
+
+        Clear the propagated callbacks from the sub-estimator on exit.
 
         Only auto-propagated callbacks are propagated to the sub-estimator. An error is
         raised if the sub-estimator already holds auto-propagated callbacks.
@@ -501,7 +505,7 @@ class CallbackContext:
         # whole tree.
         sub_estimator._parent_callback_ctx = self
 
-        callbacks_to_propagate = [
+        callbacks_to_propagate = {
             callback
             for callback in self._callbacks
             if isinstance(callback, AutoPropagatedCallback)
@@ -509,25 +513,26 @@ class CallbackContext:
                 callback.max_propagation_depth is None
                 or self._propagation_depth < callback.max_propagation_depth
             )
-        ]
-        if not callbacks_to_propagate:
-            return self
+        }
+        if callbacks_to_propagate:
+            if not hasattr(sub_estimator, "set_callbacks"):
+                warnings.warn(
+                    f"The estimator {sub_estimator.__class__.__name__} does not support"
+                    f" callbacks. The callbacks attached to {self.estimator_name} will "
+                    f"not be propagated to this estimator."
+                )
+            else:
+                self._propagated_callbacks = callbacks_to_propagate
+                curr_callbacks = getattr(sub_estimator, "_skl_callbacks", set())
+                sub_estimator.set_callbacks(*(curr_callbacks | callbacks_to_propagate))
 
-        if not hasattr(sub_estimator, "set_callbacks"):
-            warnings.warn(
-                f"The estimator {sub_estimator.__class__.__name__} does not support "
-                f"callbacks. The callbacks attached to {self.estimator_name} will not "
-                f"be propagated to this estimator."
-            )
-            return self
-
-        self._propagated_callbacks = callbacks_to_propagate
-
-        sub_estimator.set_callbacks(
-            getattr(sub_estimator, "_skl_callbacks", []) + self._propagated_callbacks
-        )
-
-        return self
+        try:
+            yield
+        finally:
+            if callbacks := getattr(self, "_propagated_callbacks", set()):
+                sub_estimator.set_callbacks(*(sub_estimator._skl_callbacks - callbacks))
+                del self._propagated_callbacks
+            del sub_estimator._parent_callback_ctx
 
 
 def _from_reconstruction_attributes(estimator, reconstruction_attributes):

--- a/sklearn/callback/_callback_support.py
+++ b/sklearn/callback/_callback_support.py
@@ -32,12 +32,12 @@ def get_callback_manager():
 class CallbackSupportMixin:
     """Mixin class to add callback support to an estimator."""
 
-    def set_callbacks(self, callbacks):
+    def set_callbacks(self, *callbacks):
         """Set callbacks for the estimator.
 
         Parameters
         ----------
-        callbacks : callback or list of callbacks
+        *callbacks : callback instances
             The callbacks to set.
 
         Returns
@@ -45,8 +45,7 @@ class CallbackSupportMixin:
         self : estimator instance
             The estimator instance itself.
         """
-        if not isinstance(callbacks, list):
-            callbacks = [callbacks]
+        callbacks = set(callbacks)
 
         if not all(
             # isinstance for a Protocol returns True for classes too (not only
@@ -58,7 +57,10 @@ class CallbackSupportMixin:
                 "callbacks must be instances following the FitCallback protocol."
             )
 
-        self._skl_callbacks = callbacks
+        if callbacks:
+            self._skl_callbacks = callbacks
+        else:
+            del self._skl_callbacks
 
         return self
 
@@ -148,8 +150,6 @@ def callback_management_context(estimator):
                     )
 
             del estimator._callback_fit_ctx
-            if hasattr(estimator, "_parent_callback_ctx"):
-                del estimator._parent_callback_ctx
 
 
 def with_callbacks(method):

--- a/sklearn/callback/_callback_support.py
+++ b/sklearn/callback/_callback_support.py
@@ -45,8 +45,6 @@ class CallbackSupportMixin:
         self : estimator instance
             The estimator instance itself.
         """
-        callbacks = set(callbacks)
-
         if not all(
             # isinstance for a Protocol returns True for classes too (not only
             # instances). Hence the additional check for classes.
@@ -58,7 +56,7 @@ class CallbackSupportMixin:
             )
 
         if callbacks:
-            self._skl_callbacks = callbacks
+            self._skl_callbacks = list(callbacks)
         else:
             del self._skl_callbacks
 

--- a/sklearn/callback/tests/_utils.py
+++ b/sklearn/callback/tests/_utils.py
@@ -328,12 +328,12 @@ def _fit_subestimator(meta_estimator, inner_estimator, X, y, *, outer_callback_c
         est = clone(inner_estimator)
 
         inner_ctx = outer_callback_ctx.subcontext(task_name="inner")
-        inner_ctx.propagate_callback_context(sub_estimator=est)
-        inner_ctx.call_on_fit_task_begin(estimator=meta_estimator, X=X, y=y)
+        with inner_ctx.propagate_callback_context(est):
+            inner_ctx.call_on_fit_task_begin(estimator=meta_estimator, X=X, y=y)
 
-        est.fit(X, y)
+            est.fit(X, y)
 
-        inner_ctx.call_on_fit_task_end(estimator=meta_estimator, X=X, y=y)
+            inner_ctx.call_on_fit_task_end(estimator=meta_estimator, X=X, y=y)
 
     outer_callback_ctx.call_on_fit_task_end(estimator=meta_estimator, X=X, y=y)
 

--- a/sklearn/callback/tests/test_callback_context.py
+++ b/sklearn/callback/tests/test_callback_context.py
@@ -59,6 +59,7 @@ def test_propagate_callback_context_autopropagated():
         assert propagated_callback in estimator._skl_callbacks
 
     assert not hasattr(estimator, "_skl_callbacks")
+    assert not hasattr(estimator, "_parent_callback_ctx")
 
 
 def test_propagate_callback_context_clean_up():
@@ -79,6 +80,7 @@ def test_propagate_callback_context_clean_up():
         assert meta_est_callback in estimator._skl_callbacks
 
     assert estimator._skl_callbacks == [est_callback]
+    assert not hasattr(estimator, "_parent_callback_ctx")
 
 
 def test_propagate_callback_context_no_callback():
@@ -94,7 +96,10 @@ def test_propagate_callback_context_no_callback():
         assert not hasattr(metaestimator, "_skl_callbacks")
         assert not hasattr(estimator, "_skl_callbacks")
 
+    assert not hasattr(estimator, "_skl_callbacks")
     assert not hasattr(estimator, "_parent_callback_ctx")
+    assert not hasattr(metaestimator, "_skl_callbacks")
+    assert not hasattr(metaestimator, "_parent_callback_ctx")
 
 
 def test_auto_propagated_callbacks():

--- a/sklearn/callback/tests/test_callback_context.py
+++ b/sklearn/callback/tests/test_callback_context.py
@@ -41,21 +41,44 @@ def _make_callback_ctx(
     )
 
 
-def test_propagate_callback_context():
-    """Sanity check for the `propagate_callback_context` method."""
+def test_propagate_callback_context_autopropagated():
+    """Check that only auto-propagated callbacks are propagated."""
     not_propagated_callback = RecordingCallback()
     propagated_callback = RecordingAutoPropagatedCallback()
 
     estimator = MaxIterEstimator()
     metaestimator = MetaEstimator(estimator)
-    metaestimator.set_callbacks([not_propagated_callback, propagated_callback])
+    metaestimator.set_callbacks(not_propagated_callback, propagated_callback)
+
+    assert not hasattr(estimator, "_skl_callbacks")
 
     callback_ctx = _make_callback_ctx(metaestimator)
-    callback_ctx.propagate_callback_context(estimator)
+    with callback_ctx.propagate_callback_context(estimator):
+        assert hasattr(estimator, "_parent_callback_ctx")
+        assert not_propagated_callback not in estimator._skl_callbacks
+        assert propagated_callback in estimator._skl_callbacks
 
-    assert hasattr(estimator, "_parent_callback_ctx")
-    assert not_propagated_callback not in estimator._skl_callbacks
-    assert propagated_callback in estimator._skl_callbacks
+    assert not hasattr(estimator, "_skl_callbacks")
+
+
+def test_propagate_callback_context_clean_up():
+    """Check that only propagated callbacks are removed on exit."""
+    est_callback = RecordingCallback()
+    estimator = MaxIterEstimator().set_callbacks(est_callback)
+
+    meta_est_callback = RecordingAutoPropagatedCallback()
+    metaestimator = MetaEstimator(estimator)
+    metaestimator.set_callbacks(est_callback, meta_est_callback)
+
+    assert estimator._skl_callbacks == {est_callback}
+
+    callback_ctx = _make_callback_ctx(metaestimator)
+    with callback_ctx.propagate_callback_context(estimator):
+        assert hasattr(estimator, "_parent_callback_ctx")
+        assert est_callback in estimator._skl_callbacks
+        assert meta_est_callback in estimator._skl_callbacks
+
+    assert estimator._skl_callbacks == {est_callback}
 
 
 def test_propagate_callback_context_no_callback():
@@ -66,10 +89,12 @@ def test_propagate_callback_context_no_callback():
     callback_ctx = _make_callback_ctx(metaestimator)
     assert len(callback_ctx._callbacks) == 0
 
-    callback_ctx.propagate_callback_context(estimator)
+    with callback_ctx.propagate_callback_context(estimator):
+        assert hasattr(estimator, "_parent_callback_ctx")
+        assert not hasattr(metaestimator, "_skl_callbacks")
+        assert not hasattr(estimator, "_skl_callbacks")
 
-    assert not hasattr(metaestimator, "_skl_callbacks")
-    assert not hasattr(estimator, "_skl_callbacks")
+    assert not hasattr(estimator, "_parent_callback_ctx")
 
 
 def test_auto_propagated_callbacks():
@@ -248,7 +273,7 @@ def test_estimator_without_subtask():
     context's `call_on_fit_task_end` does not cause a problem.
     """
     estimator = NoSubtaskEstimator()
-    estimator.set_callbacks([RecordingCallback()])
+    estimator.set_callbacks(RecordingCallback())
     estimator.fit()
 
 
@@ -392,7 +417,7 @@ def test_hook_calling_return_value():
     # RecordingCallback.on_fit_task_end does not return a value (interpreted as False)
     assert result is False
 
-    estimator.set_callbacks([RecordingCallback(), StopFitCallback()])
+    estimator.set_callbacks(RecordingCallback(), StopFitCallback())
     result = estimator._init_callback_context().call_on_fit_task_end(
         estimator=estimator
     )
@@ -426,7 +451,7 @@ def test_hook_calling_lazy_evaluation():
 
     # kwarg used twice is evaluated only once
     eval_counts = {"X": 0}
-    estimator.set_callbacks([RecordingCallback(), RecordingCallback()])
+    estimator.set_callbacks(RecordingCallback(), RecordingCallback())
     context = estimator._init_callback_context()
     context.call_on_fit_task_begin(estimator=estimator, X=partial(eval_kwarg, "X"))
     assert eval_counts["X"] == 1

--- a/sklearn/callback/tests/test_callback_context.py
+++ b/sklearn/callback/tests/test_callback_context.py
@@ -68,9 +68,9 @@ def test_propagate_callback_context_clean_up():
 
     meta_est_callback = RecordingAutoPropagatedCallback()
     metaestimator = MetaEstimator(estimator)
-    metaestimator.set_callbacks(est_callback, meta_est_callback)
+    metaestimator.set_callbacks(meta_est_callback)
 
-    assert estimator._skl_callbacks == {est_callback}
+    assert estimator._skl_callbacks == [est_callback]
 
     callback_ctx = _make_callback_ctx(metaestimator)
     with callback_ctx.propagate_callback_context(estimator):
@@ -78,7 +78,7 @@ def test_propagate_callback_context_clean_up():
         assert est_callback in estimator._skl_callbacks
         assert meta_est_callback in estimator._skl_callbacks
 
-    assert estimator._skl_callbacks == {est_callback}
+    assert estimator._skl_callbacks == [est_callback]
 
 
 def test_propagate_callback_context_no_callback():

--- a/sklearn/callback/tests/test_callback_support.py
+++ b/sklearn/callback/tests/test_callback_support.py
@@ -31,8 +31,7 @@ def test_set_callbacks(callbacks):
     set_callbacks_return = estimator.set_callbacks(*callbacks)
     assert hasattr(estimator, "_skl_callbacks")
 
-    expected_callbacks = set(callbacks)
-    assert estimator._skl_callbacks == expected_callbacks
+    assert estimator._skl_callbacks == callbacks
 
     assert set_callbacks_return is estimator
 

--- a/sklearn/callback/tests/test_callback_support.py
+++ b/sklearn/callback/tests/test_callback_support.py
@@ -20,7 +20,6 @@ from sklearn.utils.parallel import Parallel, delayed
 @pytest.mark.parametrize(
     "callbacks",
     [
-        RecordingCallback(),
         [RecordingCallback()],
         [RecordingCallback(), RecordingAutoPropagatedCallback()],
     ],
@@ -29,17 +28,17 @@ def test_set_callbacks(callbacks):
     """Sanity check for the `set_callbacks` method."""
     estimator = MaxIterEstimator()
 
-    set_callbacks_return = estimator.set_callbacks(callbacks)
+    set_callbacks_return = estimator.set_callbacks(*callbacks)
     assert hasattr(estimator, "_skl_callbacks")
 
-    expected_callbacks = [callbacks] if not isinstance(callbacks, list) else callbacks
+    expected_callbacks = set(callbacks)
     assert estimator._skl_callbacks == expected_callbacks
 
     assert set_callbacks_return is estimator
 
 
-@pytest.mark.parametrize("callbacks", [None, NotValidCallback(), RecordingCallback])
-def test_set_callbacks_error(callbacks):
+@pytest.mark.parametrize("callback", [None, NotValidCallback(), RecordingCallback])
+def test_set_callbacks_error(callback):
     """Check the error message when not passing a valid callback to `set_callbacks`."""
     estimator = MaxIterEstimator()
 
@@ -47,7 +46,7 @@ def test_set_callbacks_error(callbacks):
         TypeError,
         match="callbacks must be instances following the FitCallback protocol.",
     ):
-        estimator.set_callbacks(callbacks)
+        estimator.set_callbacks(callback)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Extracted from https://github.com/scikit-learn/scikit-learn/pull/33787

I realized when implementing callback support in Pipeline that when callbacks are propagated from a meta-estimator to a sub-estimator, we should clear the propagated callbacks after fitting the sub-estimator.

Most of the time we propagate to a clone of the sub-estimator that doesn't outlive the fit of the meta-estimator, so it's irrelevant. But sometimes, the sub-estimator is not cloned (can happen in Pipeline), or there's a caching mechanism (e.g. Pipeline), or a fitted sub-estimator is kept as fitted attribute of the meta-estimator (e.g. GridSearchCV.best_estimator_).

I all these cases the result is that the fitted sub-estimator is available outside of the meta-estimator after fit and still has the callbacks propagated from meta-estimator. Besides being surprising, it can be the source of future issues, like not hitting the cache, being fitted in another meta-estimator and causing error, ...

I propose the make `propagate_callback_context` a context manager that cleans up the propagated callbacks on exit. This way propagation is local to fit and has no side effect: the sub-estimator is the same after fit than it was before (except that it's fitted ofc).

This PR adds a small change in `set_callbacks` to improve usability and make the clean up of the propagated callbacks cleaner: It now stores callbacks as a set. There's no point on running the exact same callback instance twice on an estimator anyway.