### PR TITLE
MNT Deprecate paired_*_distances and paired_distances public functions

### DIFF
--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -218,9 +218,6 @@ Metrics
 - :func:`sklearn.metrics.pairwise.laplacian_kernel`
 - :func:`sklearn.metrics.pairwise.linear_kernel`
 - :func:`sklearn.metrics.pairwise.manhattan_distances`
-- :func:`sklearn.metrics.pairwise.paired_cosine_distances`
-- :func:`sklearn.metrics.pairwise.paired_euclidean_distances`
-- :func:`sklearn.metrics.pairwise.paired_manhattan_distances`
 - :func:`sklearn.metrics.pairwise.pairwise_kernels`
 - :func:`sklearn.metrics.pairwise.polynomial_kernel`
 - :func:`sklearn.metrics.pairwise.rbf_kernel` (see :ref:`device_support_for_float64`)

--- a/doc/whats_new/upcoming_changes/sklearn.metrics/30537.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/30537.api.rst
@@ -1,0 +1,7 @@
+- :func:`metrics.pairwise.paired_distances`,
+  :func:`metrics.pairwise.paired_euclidean_distances`,
+  :func:`metrics.pairwise.paired_manhattan_distances` and
+  :func:`metrics.pairwise.paired_cosine_distances` are deprecated in 1.10 and
+  will be removed in 1.12.
+  By :user:`Success Moses <SuccessMoses>` and
+  :user:`Shreesha Kumar Bhat <Shreesha3112>`.

--- a/sklearn/cluster/_agglomerative.py
+++ b/sklearn/cluster/_agglomerative.py
@@ -29,7 +29,7 @@ from sklearn.cluster import (  # type: ignore[attr-defined]
 from sklearn.cluster._feature_agglomeration import AgglomerationTransform
 from sklearn.metrics import DistanceMetric
 from sklearn.metrics._dist_metrics import METRIC_MAPPING64
-from sklearn.metrics.pairwise import _VALID_METRICS, paired_distances
+from sklearn.metrics.pairwise import _VALID_METRICS, _paired_distances
 from sklearn.utils import check_array
 from sklearn.utils._fast_dict import IntFloatDict
 from sklearn.utils._param_validation import (
@@ -608,7 +608,7 @@ def linkage_tree(
     else:
         # FIXME We compute all the distances, while we could have only computed
         # the "interesting" distances
-        distances = paired_distances(
+        distances = _paired_distances(
             X[connectivity.row], X[connectivity.col], metric=affinity
         )
     connectivity.data = distances

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1222,7 +1222,7 @@ def paired_euclidean_distances(X, Y):
     >>> from sklearn.metrics.pairwise import paired_euclidean_distances
     >>> X = [[0, 0, 0], [1, 1, 1]]
     >>> Y = [[1, 0, 0], [1, 1, 0]]
-    >>> paired_euclidean_distances(X, Y)
+    >>> paired_euclidean_distances(X, Y)  # doctest: +SKIP
     array([1., 1.])
     """
     return _paired_euclidean_distances(X, Y)
@@ -1276,7 +1276,7 @@ def paired_manhattan_distances(X, Y):
     >>> import numpy as np
     >>> X = np.array([[1, 1, 0], [0, 1, 0], [0, 0, 1]])
     >>> Y = np.array([[0, 1, 0], [0, 0, 1], [0, 0, 0]])
-    >>> paired_manhattan_distances(X, Y)
+    >>> paired_manhattan_distances(X, Y)  # doctest: +SKIP
     array([1., 2., 1.])
     """
     return _paired_manhattan_distances(X, Y)
@@ -1327,7 +1327,7 @@ def paired_cosine_distances(X, Y):
     >>> from sklearn.metrics.pairwise import paired_cosine_distances
     >>> X = [[0, 0, 0], [1, 1, 1]]
     >>> Y = [[1, 0, 0], [1, 1, 0]]
-    >>> paired_cosine_distances(X, Y)
+    >>> paired_cosine_distances(X, Y)  # doctest: +SKIP
     array([0.5       , 0.184])
     """
     return _paired_cosine_distances(X, Y)
@@ -1416,7 +1416,7 @@ def paired_distances(X, Y, *, metric="euclidean", **kwds):
     >>> from sklearn.metrics.pairwise import paired_distances
     >>> X = [[0, 1], [1, 1]]
     >>> Y = [[0, 1], [2, 1]]
-    >>> paired_distances(X, Y)
+    >>> paired_distances(X, Y)  # doctest: +SKIP
     array([0., 1.])
     """
     return _paired_distances(X, Y, metric=metric, **kwds)

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -41,6 +41,7 @@ from sklearn.utils._param_validation import (
     validate_params,
 )
 from sklearn.utils._sparse import _align_api_if_sparse
+from sklearn.utils.deprecation import deprecated
 from sklearn.utils.extmath import row_norms, safe_sparse_dot
 from sklearn.utils.fixes import parse_version, sp_base_version
 from sklearn.utils.parallel import Parallel, delayed
@@ -1183,6 +1184,16 @@ def cosine_distances(X, Y=None):
 
 
 # Paired distances
+def _paired_euclidean_distances(X, Y):
+    X, Y = check_paired_arrays(X, Y)
+    return row_norms(X - Y)
+
+
+# TODO(1.12): Remove
+@deprecated(
+    "The public function `sklearn.metrics.pairwise.paired_euclidean_distances` "
+    "is deprecated in 1.10 and will be removed in 1.12."
+)
 @validate_params(
     {"X": ["array-like", "sparse matrix"], "Y": ["array-like", "sparse matrix"]},
     prefer_skip_nested_validation=True,
@@ -1214,10 +1225,25 @@ def paired_euclidean_distances(X, Y):
     >>> paired_euclidean_distances(X, Y)
     array([1., 1.])
     """
+    return _paired_euclidean_distances(X, Y)
+
+
+def _paired_manhattan_distances(X, Y):
     X, Y = check_paired_arrays(X, Y)
-    return row_norms(X - Y)
+    xp, _ = get_namespace(X, Y)
+    diff = X - Y
+    if issparse(diff):
+        diff.data = np.abs(diff.data)
+        return np.squeeze(np.array(diff.sum(axis=1)))
+    else:
+        return xp.sum(xp.abs(diff), axis=-1)
 
 
+# TODO(1.12): Remove
+@deprecated(
+    "The public function `sklearn.metrics.pairwise.paired_manhattan_distances` "
+    "is deprecated in 1.10 and will be removed in 1.12."
+)
 @validate_params(
     {"X": ["array-like", "sparse matrix"], "Y": ["array-like", "sparse matrix"]},
     prefer_skip_nested_validation=True,
@@ -1253,16 +1279,19 @@ def paired_manhattan_distances(X, Y):
     >>> paired_manhattan_distances(X, Y)
     array([1., 2., 1.])
     """
+    return _paired_manhattan_distances(X, Y)
+
+
+def _paired_cosine_distances(X, Y):
     X, Y = check_paired_arrays(X, Y)
-    xp, _ = get_namespace(X, Y)
-    diff = X - Y
-    if issparse(diff):
-        diff.data = np.abs(diff.data)
-        return np.squeeze(np.array(diff.sum(axis=1)))
-    else:
-        return xp.sum(xp.abs(diff), axis=-1)
+    return 0.5 * row_norms(normalize(X) - normalize(Y), squared=True)
 
 
+# TODO(1.12): Remove
+@deprecated(
+    "The public function `sklearn.metrics.pairwise.paired_cosine_distances` "
+    "is deprecated in 1.10 and will be removed in 1.12."
+)
 @validate_params(
     {"X": ["array-like", "sparse matrix"], "Y": ["array-like", "sparse matrix"]},
     prefer_skip_nested_validation=True,
@@ -1301,20 +1330,39 @@ def paired_cosine_distances(X, Y):
     >>> paired_cosine_distances(X, Y)
     array([0.5       , 0.184])
     """
-    X, Y = check_paired_arrays(X, Y)
-    return 0.5 * row_norms(normalize(X) - normalize(Y), squared=True)
+    return _paired_cosine_distances(X, Y)
 
 
+# TODO(1.12): Remove `PAIRED_DISTANCES` when the public `paired_*_distances`
+# functions are removed.
 PAIRED_DISTANCES = {
-    "cosine": paired_cosine_distances,
-    "euclidean": paired_euclidean_distances,
-    "l2": paired_euclidean_distances,
-    "l1": paired_manhattan_distances,
-    "manhattan": paired_manhattan_distances,
-    "cityblock": paired_manhattan_distances,
+    "cosine": _paired_cosine_distances,
+    "euclidean": _paired_euclidean_distances,
+    "l2": _paired_euclidean_distances,
+    "l1": _paired_manhattan_distances,
+    "manhattan": _paired_manhattan_distances,
+    "cityblock": _paired_manhattan_distances,
 }
 
 
+def _paired_distances(X, Y, *, metric="euclidean", **kwds):
+    if metric in PAIRED_DISTANCES:
+        func = PAIRED_DISTANCES[metric]
+        return func(X, Y)
+    elif callable(metric):
+        # Check the matrix first (it is usually done by the metric)
+        X, Y = check_paired_arrays(X, Y)
+        distances = np.zeros(len(X))
+        for i in range(len(X)):
+            distances[i] = metric(X[i], Y[i])
+        return distances
+
+
+# TODO(1.12): Remove
+@deprecated(
+    "The public function `sklearn.metrics.pairwise.paired_distances` "
+    "is deprecated in 1.10 and will be removed in 1.12."
+)
 @validate_params(
     {
         "X": ["array-like"],
@@ -1371,17 +1419,7 @@ def paired_distances(X, Y, *, metric="euclidean", **kwds):
     >>> paired_distances(X, Y)
     array([0., 1.])
     """
-
-    if metric in PAIRED_DISTANCES:
-        func = PAIRED_DISTANCES[metric]
-        return func(X, Y)
-    elif callable(metric):
-        # Check the matrix first (it is usually done by the metric)
-        X, Y = check_paired_arrays(X, Y)
-        distances = np.zeros(len(X))
-        for i in range(len(X)):
-            distances[i] = metric(X[i], Y[i])
-        return distances
+    return _paired_distances(X, Y, metric=metric, **kwds)
 
 
 # Kernels

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -63,6 +63,9 @@ from sklearn.metrics import (
 )
 from sklearn.metrics._base import _average_binary_score
 from sklearn.metrics.pairwise import (
+    _paired_cosine_distances,
+    _paired_euclidean_distances,
+    _paired_manhattan_distances,
     additive_chi2_kernel,
     chi2_kernel,
     cosine_distances,
@@ -71,9 +74,6 @@ from sklearn.metrics.pairwise import (
     laplacian_kernel,
     linear_kernel,
     manhattan_distances,
-    paired_cosine_distances,
-    paired_euclidean_distances,
-    paired_manhattan_distances,
     pairwise_distances,
     pairwise_distances_argmin,
     pairwise_kernels,
@@ -2468,7 +2468,7 @@ array_api_metric_checkers = {
     d2_tweedie_score: [
         check_array_api_regression_metric,
     ],
-    paired_cosine_distances: [check_array_api_metric_pairwise],
+    _paired_cosine_distances: [check_array_api_metric_pairwise],
     mean_poisson_deviance: [check_array_api_regression_metric],
     additive_chi2_kernel: [check_array_api_metric_pairwise],
     mean_gamma_deviance: [check_array_api_regression_metric],
@@ -2478,8 +2478,8 @@ array_api_metric_checkers = {
         check_array_api_regression_metric_multioutput,
     ],
     chi2_kernel: [check_array_api_metric_pairwise],
-    paired_euclidean_distances: [check_array_api_metric_pairwise],
-    paired_manhattan_distances: [check_array_api_metric_pairwise],
+    _paired_euclidean_distances: [check_array_api_metric_pairwise],
+    _paired_manhattan_distances: [check_array_api_metric_pairwise],
     cosine_distances: [check_array_api_metric_pairwise],
     euclidean_distances: [check_array_api_metric_pairwise],
     manhattan_distances: [check_array_api_metric_pairwise],

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -1,3 +1,4 @@
+import re
 import warnings
 from types import GeneratorType
 
@@ -22,6 +23,10 @@ from sklearn.metrics.pairwise import (
     PAIRWISE_DISTANCE_FUNCTIONS,
     PAIRWISE_KERNEL_FUNCTIONS,
     _euclidean_distances_upcast,
+    _paired_cosine_distances,
+    _paired_distances,
+    _paired_euclidean_distances,
+    _paired_manhattan_distances,
     additive_chi2_kernel,
     check_paired_arrays,
     check_pairwise_arrays,
@@ -34,6 +39,8 @@ from sklearn.metrics.pairwise import (
     linear_kernel,
     manhattan_distances,
     nan_euclidean_distances,
+    # TODO(1.12): Remove public paired_* imports when deprecated functions are
+    # removed; they are imported here to test their deprecation warnings.
     paired_cosine_distances,
     paired_distances,
     paired_euclidean_distances,
@@ -562,7 +569,7 @@ def test_paired_distances(metric, func, csr_container):
     # Euclidean distance, with Y != X.
     Y = rng.random_sample((5, 4))
 
-    S = paired_distances(X, Y, metric=metric)
+    S = _paired_distances(X, Y, metric=metric)
     S2 = func(X, Y)
     assert_allclose(S, S2)
     S3 = func(csr_container(X), csr_container(Y))
@@ -584,15 +591,15 @@ def test_paired_distances_callable(global_dtype):
     # Euclidean distance, with Y != X.
     Y = rng.random_sample((5, 4)).astype(global_dtype, copy=False)
 
-    S = paired_distances(X, Y, metric="manhattan")
-    S2 = paired_distances(X, Y, metric=lambda x, y: np.abs(x - y).sum(axis=0))
+    S = _paired_distances(X, Y, metric="manhattan")
+    S2 = _paired_distances(X, Y, metric=lambda x, y: np.abs(x - y).sum(axis=0))
     assert_allclose(S, S2)
 
     # Test that a value error is raised when the lengths of X and Y should not
     # differ
     Y = rng.random_sample((3, 4))
     with pytest.raises(ValueError):
-        paired_distances(X, Y)
+        _paired_distances(X, Y)
 
 
 # XXX: thread-safety bug tracked at:
@@ -1335,7 +1342,7 @@ def test_paired_euclidean_distances():
     # Check the paired Euclidean distances computation
     X = [[0], [0]]
     Y = [[1], [2]]
-    D = paired_euclidean_distances(X, Y)
+    D = _paired_euclidean_distances(X, Y)
     assert_allclose(D, [1.0, 2.0])
 
 
@@ -1343,7 +1350,7 @@ def test_paired_manhattan_distances():
     # Check the paired manhattan distances computation
     X = [[0], [0]]
     Y = [[1], [2]]
-    D = paired_manhattan_distances(X, Y)
+    D = _paired_manhattan_distances(X, Y)
     assert_allclose(D, [1.0, 2.0])
 
 
@@ -1351,8 +1358,33 @@ def test_paired_cosine_distances():
     # Check the paired manhattan distances computation
     X = [[0], [0]]
     Y = [[1], [2]]
-    D = paired_cosine_distances(X, Y)
+    D = _paired_cosine_distances(X, Y)
     assert_allclose(D, [0.5, 0.5])
+
+
+# TODO(1.12): Remove
+@pytest.mark.parametrize(
+    "func, func_name",
+    [
+        (paired_distances, "paired_distances"),
+        (paired_cosine_distances, "paired_cosine_distances"),
+        (paired_euclidean_distances, "paired_euclidean_distances"),
+        (paired_manhattan_distances, "paired_manhattan_distances"),
+    ],
+)
+def test_paired_distances_deprecation(func, func_name):
+    # Check that the public paired_* functions emit a FutureWarning
+    # pointing users to the upcoming removal.
+    rng = np.random.RandomState(0)
+    X = rng.random_sample((5, 4))
+    Y = rng.random_sample((5, 4))
+
+    warn_msg = (
+        f"The public function `sklearn.metrics.pairwise.{func_name}` "
+        "is deprecated in 1.10 and will be removed in 1.12."
+    )
+    with pytest.warns(FutureWarning, match=re.escape(warn_msg)):
+        func(X, Y)
 
 
 def test_chi_square_kernel():

--- a/sklearn/tests/test_public_functions.py
+++ b/sklearn/tests/test_public_functions.py
@@ -11,6 +11,7 @@ from sklearn.utils._param_validation import (
     generate_valid_param,
     make_constraint,
 )
+from sklearn.utils._testing import ignore_warnings
 
 
 def _get_func_info(func_module):
@@ -280,10 +281,6 @@ PARAM_VALIDATION_FUNCTION_LIST = [
     "sklearn.metrics.pairwise.linear_kernel",
     "sklearn.metrics.pairwise.manhattan_distances",
     "sklearn.metrics.pairwise.nan_euclidean_distances",
-    "sklearn.metrics.pairwise.paired_cosine_distances",
-    "sklearn.metrics.pairwise.paired_distances",
-    "sklearn.metrics.pairwise.paired_euclidean_distances",
-    "sklearn.metrics.pairwise.paired_manhattan_distances",
     "sklearn.metrics.pairwise.pairwise_distances_argmin_min",
     "sklearn.metrics.pairwise.pairwise_kernels",
     "sklearn.metrics.pairwise.polynomial_kernel",
@@ -340,6 +337,31 @@ PARAM_VALIDATION_FUNCTION_LIST = [
 def test_function_param_validation(func_module):
     """Check param validation for public functions that are not wrappers around
     estimators.
+    """
+    func, func_name, func_params, required_params = _get_func_info(func_module)
+
+    parameter_constraints = getattr(func, "_skl_parameter_constraints")
+
+    _check_function_param_validation(
+        func, func_name, func_params, required_params, parameter_constraints
+    )
+
+
+# TODO(1.12): Remove when paired_distances and paired_*_distances are removed.
+DEPRECATED_PARAM_VALIDATION_FUNCTION_LIST = [
+    "sklearn.metrics.pairwise.paired_cosine_distances",
+    "sklearn.metrics.pairwise.paired_distances",
+    "sklearn.metrics.pairwise.paired_euclidean_distances",
+    "sklearn.metrics.pairwise.paired_manhattan_distances",
+]
+
+
+# TODO(1.12): Remove when paired_distances and paired_*_distances are removed.
+@pytest.mark.parametrize("func_module", DEPRECATED_PARAM_VALIDATION_FUNCTION_LIST)
+@ignore_warnings(category=FutureWarning)
+def test_deprecated_function_param_validation(func_module):
+    """Check param validation for deprecated public functions that are not
+    wrappers around estimators.
     """
     func, func_name, func_params, required_params = _get_func_info(func_module)
 


### PR DESCRIPTION
#### Reference Issues/PRs

Continues the stalled #30537 (which in turn continued #27129). Fixes #26982.

The original author (@SuccessMoses) was last active on the branch in December 2024 and did not respond to the maintainer re-ping in July 2025. Work has been picked up with full credit preserved (see commit trailers and changelog).

#### What does this implement/fix?

Deprecates the four public `metrics.pairwise` functions
`paired_distances`, `paired_euclidean_distances`,
`paired_manhattan_distances` and `paired_cosine_distances` via the
`@deprecated` decorator. Deprecation targets 1.10; removal scheduled
for 1.12.

Internal callers (only `sklearn.cluster._agglomerative.linkage_tree`)
now go through module-private `_paired_*` helpers so they do not
trigger the deprecation warnings on their own use. The
`PAIRED_DISTANCES` dict is kept under the same name (per review
feedback in #30537) but its values are repointed to the private
implementations.

#### Changes relative to #30537

Addresses all outstanding review comments from @StefanieSenger:

- Bumped versions to reflect the current release window: deprecate in
  1.10, remove in 1.12 (was 1.7/1.9 and then 1.8/1.10).
- Kept the original public-facing docstrings/examples on the
  deprecated functions (the prior iteration had changed them to
  reference the private `_paired_*` counterparts, which we do not want
  to expose in API docs).
- Kept the name `PAIRED_DISTANCES` (no rename to `_PAIRED_DISTANCES`)
  so no other import sites need to change.
- Used `@ignore_warnings(category=FutureWarning)` as a decorator for
  the new parametrized `test_deprecated_function_param_validation`,
  per the suggestion to use the context manager / decorator form.
- Added @Shreesha3112 to the changelog alongside @SuccessMoses.

#### Test plan

- [ ] `pytest sklearn/metrics/tests/test_pairwise.py -k paired`
- [ ] `pytest sklearn/tests/test_public_functions.py -k paired`
- [ ] `pytest sklearn/cluster/tests/test_hierarchical.py` (sanity
      check for internal `_paired_distances` call site)
- [ ] `pytest sklearn/metrics/tests/test_common.py -k array_api`

Notes:
- The new `test_paired_distances_deprecation` asserts the
  `FutureWarning` is raised for each of the four deprecated public
  functions.
- `test_deprecated_function_param_validation` keeps param-validation
  coverage while silencing the expected `FutureWarning`.