### PR TITLE
Add replace_undefined_by parameter to ndcg_score

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1895,7 +1895,9 @@ def dcg_score(
     )
 
 
-def _ndcg_sample_scores(y_true, y_score, k=None, ignore_ties=False):
+def _ndcg_sample_scores(
+    y_true, y_score, k=None, ignore_ties=False, replace_undefined_by=np.nan
+):
     """Compute Normalized Discounted Cumulative Gain.
 
     Sum the true scores ranked in the order induced by the predicted scores,
@@ -1925,6 +1927,10 @@ def _ndcg_sample_scores(y_true, y_score, k=None, ignore_ties=False):
         Assume that there are no ties in y_score (which is likely to be the
         case if y_score is continuous) for efficiency gains.
 
+    replace_undefined_by : np.nan or float in [0.0, 1.0], default=np.nan
+        Sets the return value for samples where NDCG is undefined (i.e., when
+        all true relevance values are zero, making IDCG = 0).
+
     Returns
     -------
     normalized_discounted_cumulative_gain : ndarray of shape (n_samples,)
@@ -1941,7 +1947,15 @@ def _ndcg_sample_scores(y_true, y_score, k=None, ignore_ties=False):
     # change the value of the re-ordered y_true)
     normalizing_gain = _dcg_sample_scores(y_true, y_true, k, ignore_ties=True)
     all_irrelevant = normalizing_gain == 0
-    gain[all_irrelevant] = 0
+    if all_irrelevant.any():
+        msg = (
+            "NDCG is undefined for samples where all true relevance values "
+            "are zero (IDCG = 0). The score for those samples is set to the "
+            "value defined by the `replace_undefined_by` param, which is set "
+            f"to {replace_undefined_by}."
+        )
+        warnings.warn(msg, UndefinedMetricWarning, stacklevel=3)
+    gain[all_irrelevant] = replace_undefined_by
     gain[~all_irrelevant] /= normalizing_gain[~all_irrelevant]
     return gain
 
@@ -1953,10 +1967,22 @@ def _ndcg_sample_scores(y_true, y_score, k=None, ignore_ties=False):
         "k": [Interval(Integral, 1, None, closed="left"), None],
         "sample_weight": ["array-like", None],
         "ignore_ties": ["boolean"],
+        "replace_undefined_by": [
+            Interval(Real, 0.0, 1.0, closed="both"),
+            np.nan,
+        ],
     },
     prefer_skip_nested_validation=True,
 )
-def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False):
+def ndcg_score(
+    y_true,
+    y_score,
+    *,
+    k=None,
+    sample_weight=None,
+    ignore_ties=False,
+    replace_undefined_by=np.nan,
+):
     """Compute Normalized Discounted Cumulative Gain.
 
     Sum the true scores ranked in the order induced by the predicted scores,
@@ -1989,6 +2015,18 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
     ignore_ties : bool, default=False
         Assume that there are no ties in y_score (which is likely to be the
         case if y_score is continuous) for efficiency gains.
+
+    replace_undefined_by : np.nan or float in [0.0, 1.0], default=np.nan
+        Sets the return value for samples where NDCG is undefined (i.e., when
+        all true relevance values are zero, making IDCG = 0). In these cases,
+        an :class:`~sklearn.exceptions.UndefinedMetricWarning` is raised. Can
+        take the following values:
+
+        - ``np.nan`` to return ``np.nan`` (default)
+        - a floating point value in the range of [0.0, 1.0] to return a
+          specific value
+
+        .. versionadded:: 1.9
 
     Returns
     -------
@@ -2062,7 +2100,22 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
             f"Got {y_true.shape[1]} instead."
         )
     _check_dcg_target_type(y_true)
-    gain = _ndcg_sample_scores(y_true, y_score, k=k, ignore_ties=ignore_ties)
+    gain = _ndcg_sample_scores(
+        y_true,
+        y_score,
+        k=k,
+        ignore_ties=ignore_ties,
+        replace_undefined_by=replace_undefined_by,
+    )
+    if np.isnan(replace_undefined_by):
+        # Exclude undefined samples from averaging
+        mask = ~np.isnan(gain)
+        if not mask.any():
+            return replace_undefined_by
+        if sample_weight is not None:
+            sample_weight = np.asarray(sample_weight)
+            return float(np.average(gain[mask], weights=sample_weight[mask]))
+        return float(np.nanmean(gain))
     return float(np.average(gain, weights=sample_weight))
 
 

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1,5 +1,6 @@
 import math
 import re
+import warnings
 
 import numpy as np
 import pytest
@@ -2076,8 +2077,8 @@ def test_ndcg_score():
 
 
 def _test_ndcg_score_for(y_true, y_score):
-    ideal = _ndcg_sample_scores(y_true, y_true)
-    score = _ndcg_sample_scores(y_true, y_score)
+    ideal = _ndcg_sample_scores(y_true, y_true, replace_undefined_by=0.0)
+    score = _ndcg_sample_scores(y_true, y_score, replace_undefined_by=0.0)
     assert (score <= ideal).all()
     all_zero = (y_true == 0).all(axis=1)
     assert ideal[~all_zero] == pytest.approx(np.ones((~all_zero).sum()))
@@ -2089,6 +2090,66 @@ def _test_ndcg_score_for(y_true, y_score):
     assert score[all_zero] == pytest.approx(np.zeros(all_zero.sum()))
     assert ideal.shape == (y_true.shape[0],)
     assert score.shape == (y_true.shape[0],)
+
+
+def test_ndcg_replace_undefined_by_default_nan():
+    """NDCG with default replace_undefined_by=np.nan excludes undefined samples."""
+    y_true = np.array([[1, 0, 1], [0, 0, 0]])
+    y_score = np.array([[1, 0, 1], [0, 0, 0]])
+    with pytest.warns(UndefinedMetricWarning):
+        result = ndcg_score(y_true, y_score)
+    # Only the first sample contributes; it's a perfect prediction so NDCG=1
+    assert result == pytest.approx(1.0)
+
+
+def test_ndcg_replace_undefined_by_zero():
+    """NDCG with replace_undefined_by=0.0 includes undefined samples as 0."""
+    y_true = np.array([[1, 0, 1], [0, 0, 0]])
+    y_score = np.array([[1, 0, 1], [0, 0, 0]])
+    with pytest.warns(UndefinedMetricWarning):
+        result = ndcg_score(y_true, y_score, replace_undefined_by=0.0)
+    # First sample: NDCG=1, second: 0 -> average = 0.5
+    assert result == pytest.approx(0.5)
+
+
+def test_ndcg_replace_undefined_by_one():
+    """NDCG with replace_undefined_by=1.0 treats undefined as perfect."""
+    y_true = np.array([[1, 0, 1], [0, 0, 0]])
+    y_score = np.array([[1, 0, 1], [0, 0, 0]])
+    with pytest.warns(UndefinedMetricWarning):
+        result = ndcg_score(y_true, y_score, replace_undefined_by=1.0)
+    # Both samples: 1.0 -> average = 1.0
+    assert result == pytest.approx(1.0)
+
+
+def test_ndcg_all_zero_relevance_warns():
+    """NDCG raises UndefinedMetricWarning when all samples have zero relevance."""
+    y_true = np.array([[0, 0], [0, 0]])
+    y_score = np.array([[1, 2], [3, 4]])
+    with pytest.warns(UndefinedMetricWarning, match="NDCG is undefined"):
+        ndcg_score(y_true, y_score)
+
+
+def test_ndcg_no_warning_when_all_relevant():
+    """No warning when no samples have all-zero relevance."""
+    y_true = np.array([[1, 0, 1], [0, 1, 0]])
+    y_score = np.array([[1, 0, 1], [0, 1, 0]])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        result = ndcg_score(y_true, y_score)
+    assert result == pytest.approx(1.0)
+
+
+def test_ndcg_sample_scores_replace_undefined_by():
+    """_ndcg_sample_scores returns replace_undefined_by for undefined samples."""
+    y_true = np.array([[1, 0], [0, 0]])
+    y_score = np.array([[1, 0], [1, 0]])
+    with pytest.warns(UndefinedMetricWarning):
+        scores = _ndcg_sample_scores(
+            y_true, y_score, replace_undefined_by=0.5
+        )
+    assert scores[0] == pytest.approx(1.0)  # defined sample
+    assert scores[1] == pytest.approx(0.5)  # undefined -> replaced
 
 
 def test_partial_roc_auc_score():

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -2145,9 +2145,7 @@ def test_ndcg_sample_scores_replace_undefined_by():
     y_true = np.array([[1, 0], [0, 0]])
     y_score = np.array([[1, 0], [1, 0]])
     with pytest.warns(UndefinedMetricWarning):
-        scores = _ndcg_sample_scores(
-            y_true, y_score, replace_undefined_by=0.5
-        )
+        scores = _ndcg_sample_scores(y_true, y_score, replace_undefined_by=0.5)
     assert scores[0] == pytest.approx(1.0)  # defined sample
     assert scores[1] == pytest.approx(0.5)  # undefined -> replaced
 


### PR DESCRIPTION
Fixes #29521
Reference: #33712

## What

When all true relevance values are zero for a sample, IDCG = 0 and NDCG is undefined. Previously this returned 0 silently and included it in averaging, causing `ndcg_score(y, y) != 1` when any sample has all-zero relevances.

This adds a `replace_undefined_by` parameter following the pattern from `cohen_kappa_score` (#29210) and `class_likelihood_ratios` (#29288) per the direction set in #33712.

## Changes

- `_ndcg_sample_scores`: returns `replace_undefined_by` for undefined samples, raises `UndefinedMetricWarning`
- `ndcg_score`: passes parameter through, excludes NaN from averaging when using default
- `@validate_params` updated to accept the new parameter
- 7 new tests covering default nan behavior, explicit replacement values, warning behavior, and sample-level scores

## Behavior

```python
>>> ndcg_score([[1,0,1],[0,0,0]], [[1,0,1],[0,0,0]])
# Before: 0.5 (undefined sample counted as 0)
# After (default): 1.0 (undefined sample excluded, with warning)

>>> ndcg_score([[1,0,1],[0,0,0]], [[1,0,1],[0,0,0]], replace_undefined_by=0.0)
# 0.5 (explicit: treat undefined as 0, same as old behavior)
```