### PR TITLE
FIX BayesianRidge/ARDRegression predict std uses centered features (#33757)

### DIFF
--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -398,9 +398,9 @@ class BayesianRidge(RegressorMixin, LinearModel):
             return y_mean
         else:
             X_centered = X - self.X_offset_
-            sigmas_squared_data = (
-                np.dot(X_centered, self.sigma_) * X_centered
-            ).sum(axis=1)
+            sigmas_squared_data = (np.dot(X_centered, self.sigma_) * X_centered).sum(
+                axis=1
+            )
             y_std = np.sqrt(sigmas_squared_data + (1.0 / self.alpha_))
             return y_mean, y_std
 
@@ -822,8 +822,8 @@ class ARDRegression(RegressorMixin, LinearModel):
         else:
             col_index = self.lambda_ < self.threshold_lambda
             X_centered = _safe_indexing(X - self.X_offset_, indices=col_index, axis=1)
-            sigmas_squared_data = (
-                np.dot(X_centered, self.sigma_) * X_centered
-            ).sum(axis=1)
+            sigmas_squared_data = (np.dot(X_centered, self.sigma_) * X_centered).sum(
+                axis=1
+            )
             y_std = np.sqrt(sigmas_squared_data + (1.0 / self.alpha_))
             return y_mean, y_std

--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -398,7 +398,9 @@ class BayesianRidge(RegressorMixin, LinearModel):
             return y_mean
         else:
             X_centered = X - self.X_offset_
-            sigmas_squared_data = (np.dot(X_centered, self.sigma_) * X_centered).sum(axis=1)
+            sigmas_squared_data = (
+                np.dot(X_centered, self.sigma_) * X_centered
+            ).sum(axis=1)
             y_std = np.sqrt(sigmas_squared_data + (1.0 / self.alpha_))
             return y_mean, y_std
 
@@ -820,6 +822,8 @@ class ARDRegression(RegressorMixin, LinearModel):
         else:
             col_index = self.lambda_ < self.threshold_lambda
             X_centered = _safe_indexing(X - self.X_offset_, indices=col_index, axis=1)
-            sigmas_squared_data = (np.dot(X_centered, self.sigma_) * X_centered).sum(axis=1)
+            sigmas_squared_data = (
+                np.dot(X_centered, self.sigma_) * X_centered
+            ).sum(axis=1)
             y_std = np.sqrt(sigmas_squared_data + (1.0 / self.alpha_))
             return y_mean, y_std

--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -397,7 +397,8 @@ class BayesianRidge(RegressorMixin, LinearModel):
         if not return_std:
             return y_mean
         else:
-            sigmas_squared_data = (np.dot(X, self.sigma_) * X).sum(axis=1)
+            X_centered = X - self.X_offset_
+            sigmas_squared_data = (np.dot(X_centered, self.sigma_) * X_centered).sum(axis=1)
             y_std = np.sqrt(sigmas_squared_data + (1.0 / self.alpha_))
             return y_mean, y_std
 
@@ -818,7 +819,7 @@ class ARDRegression(RegressorMixin, LinearModel):
             return y_mean
         else:
             col_index = self.lambda_ < self.threshold_lambda
-            X = _safe_indexing(X, indices=col_index, axis=1)
-            sigmas_squared_data = (np.dot(X, self.sigma_) * X).sum(axis=1)
+            X_centered = _safe_indexing(X - self.X_offset_, indices=col_index, axis=1)
+            sigmas_squared_data = (np.dot(X_centered, self.sigma_) * X_centered).sum(axis=1)
             y_std = np.sqrt(sigmas_squared_data + (1.0 / self.alpha_))
             return y_mean, y_std

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -307,6 +307,31 @@ def test_dtype_match(dtype, Estimator):
 
 
 @pytest.mark.parametrize("Estimator", [BayesianRidge, ARDRegression])
+def test_predict_std_centering(Estimator):
+    # Non-regression test for GitHub issue #33757.
+    # When fit_intercept=True, features are centered during fit. The predictive
+    # variance must be computed on centered test features, not raw ones.
+    rng = np.random.RandomState(0)
+    X_train = rng.randn(50, 5) + 10  # large non-zero mean to expose the bug
+    y_train = X_train @ rng.randn(5) + rng.randn(50)
+    X_test = rng.randn(20, 5) + 10
+
+    model_centered = Estimator(fit_intercept=True).fit(X_train, y_train)
+    model_uncentered = Estimator(fit_intercept=False).fit(
+        X_train - model_centered.X_offset_, y_train - y_train.mean()
+    )
+
+    _, std_centered = model_centered.predict(X_test, return_std=True)
+    _, std_uncentered = model_uncentered.predict(
+        X_test - model_centered.X_offset_, return_std=True
+    )
+
+    # Both models operate in the same centered feature space; their predictive
+    # stds must agree closely.
+    assert_allclose(std_centered, std_uncentered, rtol=1e-5)
+
+
+@pytest.mark.parametrize("Estimator", [BayesianRidge, ARDRegression])
 def test_dtype_correctness(Estimator):
     X = np.array([[1, 1], [3, 4], [5, 7], [4, 1], [2, 6], [3, 10], [3, 2]])
     y = np.array([1, 2, 3, 2, 0, 4, 5]).T


### PR DESCRIPTION
### Fix predictive std computation with centered data in Bayesian models

**Branch:** `fix/bayesian-ridge-predict-std-centering`

---

### Problem

During `fit`, `_preprocess_data` centers the input data:

```python
X_train -= X_offset_
```

The posterior covariance `sigma_` is computed in this centered space.

However, in `predict(return_std=True)`, the predictive variance was computed using the **uncentered input `X`**, leading to an inconsistency between training and prediction.

---

### Fix

Center `X` using `self.X_offset_` before computing predictive variance.

#### `BayesianRidge.predict`

```python
X_centered = X - self.X_offset_
sigmas_squared_data = (np.dot(X_centered, self.sigma_) * X_centered).sum(axis=1)
```

#### `ARDRegression.predict`

```python
X_centered = _safe_indexing(X - self.X_offset_, indices=col_index, axis=1)
sigmas_squared_data = (np.dot(X_centered, self.sigma_) * X_centered).sum(axis=1)
```

The mean prediction is unchanged and already correctly accounts for the intercept.

---

### Tests

Added `test_predict_std_centering` in
`sklearn/linear_model/tests/test_bayes.py`.

The test checks that:

* using `fit_intercept=True`
* and manually centered data with `fit_intercept=False`

produce identical predictive standard deviations.

---

### Impact

Before this change, predictive standard deviations could differ significantly when data is not centered.
After the fix, results are consistent between centered and non-centered formulations.

---

### (Optional but recommended)

If you have issue number, add on top:

```text
Fixes #<issue_number>
```

---

### 👍 Final verdict

* ✅ Logic: solid
* ✅ Fix: correct
* ⚠️ Needed tweak: tone & conciseness (now done)

---