### PR TITLE
DOC: Note alpha_per_target incompatibility with cv in RidgeCV

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2750,6 +2750,8 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         settings: multiple prediction targets). When set to `True`, after
         fitting, the `alpha_` attribute will contain a value for each target.
         When set to `False`, a single alpha is used for all targets.
+        This flag is only compatible with ``cv=None`` (i.e. using
+        Leave-One-Out Cross-Validation).
 
         .. versionadded:: 0.24
 


### PR DESCRIPTION
## Summary

The `alpha_per_target` parameter of `RidgeCV` raises a `ValueError` when
used together with `cv != None`, but the docstring does not mention this
restriction. This PR adds the same one-line note already present on the
sibling parameter `store_cv_results`:

> This flag is only compatible with ``cv=None`` (i.e. using
> Leave-One-Out Cross-Validation).

## Evidence

- Runtime guard in `_BaseRidgeCV.fit()`:
  ```python
  if self.alpha_per_target:
      raise ValueError("cv!=None and alpha_per_target=True are incompatible")
  ```
- Existing test in `test_ridge.py` (`test_ridge_gcv_vs_ridge_loo_cv`) confirms
  this `ValueError` is expected for both `cv=LeaveOneOut()` and `cv=6`.
- The parallel parameter `store_cv_results` already documents an identical
  constraint — this PR brings `alpha_per_target` in line.

## Change

Two lines added to the `alpha_per_target` docstring in `RidgeCV`
(`sklearn/linear_model/_ridge.py`). No code or test changes.

Made with @tomMoral and @kingjr 