### PR TITLE
DOC clarify interventional vs conditional difference between brute and recursion methods in partial_dependence

### DIFF
--- a/doc/modules/partial_dependence.rst
+++ b/doc/modules/partial_dependence.rst
@@ -252,15 +252,24 @@ estimators that support it, and 'brute' is used for the rest.
 
 .. note::
 
-    While both methods should be close in general, they might differ in some
-    specific settings. The `'brute'` method assumes the existence of the
-    data points :math:`(x_S, x_C^{(i)})`. When the features are correlated,
-    such artificial samples may have a very low probability mass. The `'brute'`
-    and `'recursion'` methods will likely disagree regarding the value of the
-    partial dependence, because they will treat these unlikely
-    samples differently. Remember, however, that the primary assumption for
-    interpreting PDPs is that the features should be independent.
+    The `'brute'` and `'recursion'` methods compute conceptually different
+    quantities when features are correlated:
 
+    - `'brute'` computes the **interventional** partial dependence,
+      :math:`E_{X_C}[f(x_S, X_C)]`, by marginalizing over the empirical
+      distribution of the complement features :math:`X_C` independently of
+      :math:`X_S`. This matches the original PDP definition.
+
+    - `'recursion'` computes the **conditional** partial dependence,
+      :math:`E[f(x_S, X_C) | X_S = x_s]`, by exploiting the tree structure.
+      When features are correlated, this conditions on :math:`X_S = x_s`
+      and therefore produces different results than `'brute'`.
+
+    When features are independent, both methods give the same result. When
+    features are correlated, `'brute'` is more faithful to the original PDP
+    definition, while `'recursion'` is faster but reflects conditional rather
+    than marginal effects. The primary assumption for interpreting PDPs is
+    that the features should be independent.
 
 .. rubric:: Examples
 


### PR DESCRIPTION
## What does this PR do?

Improves the documentation note about differences between `method='brute'` 
and `method='recursion'` in `partial_dependence()`.

## Motivation

Fixes #27441

The existing note vaguely states the two methods "might differ" without 
explaining **why** they differ conceptually. This is confusing for users 
who expect both methods to compute the same quantity.

## Changes

Rewrites the `pdp_method_differences` note in 
`doc/modules/partial_dependence.rst` to clearly explain:

- `'brute'` computes the **interventional** partial dependence 
  E[f(x_S, X_C)] — marginalizing over X_C independently of X_S
- `'recursion'` computes the **conditional** partial dependence 
  E[f(x_S, X_C) | X_S = x_s] — conditioning on X_S when traversing the tree

These are fundamentally different quantities when features are correlated, 
which explains why they can give very different results (as shown in #27441).

## Related issues

- Closes #27441
- Related to stale PR #28771 (open since April 2024, no review activity)

cc @glemaitre @lorentzenchr @mayer79