### PR TITLE
fix(linear_model): center test features in BayesianRidge/ARDRegression predict variance

### DIFF
--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -397,6 +397,8 @@ class BayesianRidge(RegressorMixin, LinearModel):
         if not return_std:
             return y_mean
         else:
+            if self.fit_intercept:
+                X = X - self.X_offset_
             sigmas_squared_data = (np.dot(X, self.sigma_) * X).sum(axis=1)
             y_std = np.sqrt(sigmas_squared_data + (1.0 / self.alpha_))
             return y_mean, y_std
@@ -817,6 +819,8 @@ class ARDRegression(RegressorMixin, LinearModel):
         if return_std is False:
             return y_mean
         else:
+            if self.fit_intercept:
+                X = X - self.X_offset_
             col_index = self.lambda_ < self.threshold_lambda
             X = _safe_indexing(X, indices=col_index, axis=1)
             sigmas_squared_data = (np.dot(X, self.sigma_) * X).sum(axis=1)


### PR DESCRIPTION
## Summary

When `fit_intercept=True` (the default), `fit()` centers features (`X - X_offset_`) before computing the posterior covariance `sigma_`. However, `predict(return_std=True)` was using raw (uncentered) `X` for the variance calculation `(X @ sigma_ * X).sum()`.

This causes incorrect uncertainty estimation: the model reports lowest variance at the coordinate origin instead of near the center of the training data. For datasets far from the origin, the error is significant.

## Fix

Center `X` by `X_offset_` before computing the variance term in both:
- `BayesianRidge.predict()` (line ~400)
- `ARDRegression.predict()` (line ~822)

The change is 4 lines total (2 per method). The mean prediction (`y_mean`) was already correct via `_decision_function()` which properly handles intercepts.

Fixes #33757