### PR TITLE
fix(utils): show output features in HTML repr for estimators without n_features_in_

### DIFF
--- a/sklearn/utils/_repr_html/estimator.py
+++ b/sklearn/utils/_repr_html/estimator.py
@@ -431,7 +431,6 @@ def _write_estimator_html(
             has_feature_names_out
             and is_not_pipeline_step
             and is_fitted_css_class
-            and hasattr(estimator, "n_features_in_")
         ):
             output_features = estimator.get_feature_names_out()
         else:


### PR DESCRIPTION
## Description

CountVectorizer and other text transformers expose `get_feature_names_out()` but do not set `n_features_in_` since they consume raw text rather than tabular input. The HTML repr path for single estimators incorrectly required `n_features_in_()`, causing output features to be hidden for these estimators.

The serial/parallel estimator branches already handle this correctly (they only check `is_fitted_css_class`, `has_feature_names_out`, and `is_not_pipeline_step`). This fix aligns the single estimator branch with that behavior by removing the unnecessary `n_features_in_` check.

**Before:** CountVectorizer shows no output feature count after fitting
**After:** Correctly shows e.g. "9 features"

## Changes
- Remove `hasattr(estimator, "n_features_in_")` condition in `_write_estimator_html` for single estimators (1 line removed)

Fixes #33772