### PR TITLE
FIX - documentation link in HTML displays for parameters that include special character `

### DIFF
--- a/sklearn/utils/_repr_html/common.py
+++ b/sklearn/utils/_repr_html/common.py
@@ -16,9 +16,8 @@ def generate_link_to_param_doc(estimator_class, param_name, doc_link):
     https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments
     """
     docstring = estimator_class.__doc__
-
-    m = re.search(f"{param_name} : (.+)\\n", docstring or "")
-
+    clean_param_name = param_name.replace("`", "")
+    m = re.search(f"{clean_param_name} : (.+)\\n", docstring or "")
     if m is None:
         # No match found in the docstring, return None to indicate that we
         # cannot link.
@@ -26,9 +25,8 @@ def generate_link_to_param_doc(estimator_class, param_name, doc_link):
 
     # Extract the whole line of the type information, up to the line break as
     # disambiguation suffix to build the fragment
-    param_type = m.group(1)
-    text_fragment = f"{quote(param_name)},-{quote(param_type)}"
-
+    param_type = m.group(1).replace("`", "")
+    text_fragment = f"{quote(clean_param_name)},-{quote(param_type)}"
     return f"{doc_link}#:~:text={text_fragment}"
 
 

--- a/sklearn/utils/_repr_html/common.py
+++ b/sklearn/utils/_repr_html/common.py
@@ -17,8 +17,7 @@ def generate_link_to_param_doc(estimator_class, param_name, doc_link):
     """
     docstring = estimator_class.__doc__
 
-    clean_param_name = param_name.replace("`", "")
-    m = re.search(f"{clean_param_name} : (.+)\\n", docstring or "")
+    m = re.search(f"{param_name} : (.+)\\n", docstring or "")
 
     if m is None:
         # No match found in the docstring, return None to indicate that we
@@ -28,7 +27,7 @@ def generate_link_to_param_doc(estimator_class, param_name, doc_link):
     # Extract the whole line of the type information, up to the line break as
     # disambiguation suffix to build the fragment
     param_type = m.group(1).replace("`", "")
-    text_fragment = f"{quote(clean_param_name)},-{quote(param_type)}"
+    text_fragment = f"{quote(param_name)},-{quote(param_type)}"
 
     return f"{doc_link}#:~:text={text_fragment}"
 

--- a/sklearn/utils/_repr_html/common.py
+++ b/sklearn/utils/_repr_html/common.py
@@ -16,8 +16,10 @@ def generate_link_to_param_doc(estimator_class, param_name, doc_link):
     https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments
     """
     docstring = estimator_class.__doc__
+
     clean_param_name = param_name.replace("`", "")
     m = re.search(f"{clean_param_name} : (.+)\\n", docstring or "")
+
     if m is None:
         # No match found in the docstring, return None to indicate that we
         # cannot link.
@@ -27,6 +29,7 @@ def generate_link_to_param_doc(estimator_class, param_name, doc_link):
     # disambiguation suffix to build the fragment
     param_type = m.group(1).replace("`", "")
     text_fragment = f"{quote(clean_param_name)},-{quote(param_type)}"
+
     return f"{doc_link}#:~:text={text_fragment}"
 
 

--- a/sklearn/utils/_repr_html/tests/test_params.py
+++ b/sklearn/utils/_repr_html/tests/test_params.py
@@ -179,7 +179,7 @@ def test_generate_link_to_param_doc_basic():
 
     doc_link = "mock_module.MockEstimator.html"
     url = generate_link_to_param_doc(MockEstimator, "alpha", doc_link)
-    assert url == "mock_module.MockEstimator.html#:~:text=alpha,-float "
+    assert url == "mock_module.MockEstimator.html#:~:text=alpha,-float"
 
     url = generate_link_to_param_doc(MockEstimator, "beta", doc_link)
     assert url == "mock_module.MockEstimator.html#:~:text=beta,-int"

--- a/sklearn/utils/_repr_html/tests/test_params.py
+++ b/sklearn/utils/_repr_html/tests/test_params.py
@@ -179,7 +179,7 @@ def test_generate_link_to_param_doc_basic():
 
     doc_link = "mock_module.MockEstimator.html"
     url = generate_link_to_param_doc(MockEstimator, "alpha", doc_link)
-    assert url == "mock_module.MockEstimator.html#:~:text=alpha,-float"
+    assert url == "mock_module.MockEstimator.html#:~:text=alpha,-float "
 
     url = generate_link_to_param_doc(MockEstimator, "beta", doc_link)
     assert url == "mock_module.MockEstimator.html#:~:text=beta,-int"
@@ -212,3 +212,25 @@ def test_generate_link_to_param_doc_empty_docstring():
     doc_link = "mock_module.MockEstimator.html"
     url = generate_link_to_param_doc(MockEstimator, "alpha", doc_link)
     assert url is None
+
+
+def test_generate_link_to_param_doc_special_char():
+    """Non-regression test for
+    https://github.com/scikit-learn/scikit-learn/issues/33830
+    """
+
+    class MockEstimator:
+        """Mock class.
+
+        Attributes
+        ----------
+        weird_attr_ : ndarray of shape (`n_features_in_`,)
+        """
+
+    doc_link = "mock_module.MockEstimator.html"
+    url = generate_link_to_param_doc(MockEstimator, "weird_attr_", doc_link)
+    expected_url = (
+        "mock_module.MockEstimator.html#:~:text=weird_attr_,"
+        "-ndarray%20of%20shape%20%28n_features_in_%2C%29"
+    )
+    assert url == expected_url


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#33830

#### What does this implement/fix? Explain your changes.
When the character ` is included in the docstring, its doc link is not correct. 
This PR removes that character when the documentation link is constructed.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
