### PR TITLE
fix: center X in BayesianRidge/ARDRegression predict before variance computation

### DIFF
--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -397,6 +397,12 @@ class BayesianRidge(RegressorMixin, LinearModel):
         if not return_std:
             return y_mean
         else:
+            # Center X using the training mean so that the predictive variance
+            # is smallest near the training data, not near the origin.
+            # Internally, fit() centers X before computing sigma_, so predict()
+            # must apply the same centering. See gh-33757.
+            X = validate_data(self, X, reset=False)
+            X = X - self.X_offset_
             sigmas_squared_data = (np.dot(X, self.sigma_) * X).sum(axis=1)
             y_std = np.sqrt(sigmas_squared_data + (1.0 / self.alpha_))
             return y_mean, y_std
@@ -818,6 +824,10 @@ class ARDRegression(RegressorMixin, LinearModel):
             return y_mean
         else:
             col_index = self.lambda_ < self.threshold_lambda
+            # Center X before indexing so that variance is evaluated in the
+            # same space as sigma_ (which was computed on centered data). See gh-33757.
+            X = validate_data(self, X, reset=False)
+            X = X - self.X_offset_
             X = _safe_indexing(X, indices=col_index, axis=1)
             sigmas_squared_data = (np.dot(X, self.sigma_) * X).sum(axis=1)
             y_std = np.sqrt(sigmas_squared_data + (1.0 / self.alpha_))

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -314,3 +314,43 @@ def test_dtype_correctness(Estimator):
     coef_32 = model.fit(X.astype(np.float32), y).coef_
     coef_64 = model.fit(X.astype(np.float64), y).coef_
     np.testing.assert_allclose(coef_32, coef_64, rtol=1e-4)
+
+
+@pytest.mark.parametrize("Estimator", [BayesianRidge, ARDRegression])
+def test_predict_std_centered_at_training_data(Estimator):
+    # gh-33757: predictive std must be smallest near the training data, not
+    # near the origin.  fit() centers X before computing sigma_, so predict()
+    # must apply the same centering before evaluating the variance form.
+    rng = np.random.RandomState(0)
+    X_train = np.linspace(80, 100, 50).reshape(-1, 1)
+    y_train = X_train.ravel() + rng.randn(50)
+    model = Estimator().fit(X_train, y_train)
+
+    X_near_training = np.array([[90.0]])
+    X_near_origin = np.array([[0.0]])
+
+    _, std_near_training = model.predict(X_near_training, return_std=True)
+    _, std_near_origin = model.predict(X_near_origin, return_std=True)
+
+    assert std_near_training < std_near_origin, (
+        f"{Estimator.__name__}.predict(return_std=True) should yield lower uncertainty "
+        "near training data than near the origin when training data is far from origin."
+    )
+
+
+def test_bayesian_ridge_predict_std_matches_formula():
+    # gh-33757: verify predict(return_std=True) matches the analytical formula
+    # sigma^2 = 1/alpha + (x - x_offset)^T @ Sigma @ (x - x_offset).
+    rng = np.random.RandomState(42)
+    X_train = np.linspace(50, 70, 40).reshape(-1, 1)
+    y_train = 2 * X_train.ravel() + rng.randn(40)
+    model = BayesianRidge().fit(X_train, y_train)
+
+    X_test = np.linspace(40, 80, 15).reshape(-1, 1)
+    _, y_std = model.predict(X_test, return_std=True)
+
+    X_centered = X_test - model.X_offset_
+    sigmas_sq = (X_centered @ model.sigma_ * X_centered).sum(axis=1)
+    y_std_expected = np.sqrt(sigmas_sq + 1.0 / model.alpha_)
+
+    np.testing.assert_allclose(y_std, y_std_expected, rtol=1e-10)


### PR DESCRIPTION
## What

`BayesianRidge.predict(return_std=True)` and `ARDRegression.predict(return_std=True)` were computing predictive variance using raw test features `X` instead of centered features `X - X_offset_`.

## Why it is wrong

During `fit()`, features are centered (`X -= X_offset_`) before `sigma_` is computed. The posterior predictive variance is:

```
σ² = 1/α + (x - μ_x)ᵀ Σ (x - μ_x)
```

where `μ_x = X_offset_` is the training feature mean. The current code uses raw `x` instead of `(x - μ_x)`, so uncertainty is minimized at the **origin** rather than at the **center of the training data**. For datasets far from the origin this produces significantly wrong uncertainty estimates.

## Fix

Subtract `X_offset_` from `X` before the variance computation in both `BayesianRidge.predict` and `ARDRegression.predict` (for `ARDRegression`, centering must happen before column selection via `lambda_` threshold).

## Reproduction

```python
import numpy as np
from sklearn.linear_model import BayesianRidge

rng = np.random.RandomState(0)
X_train = np.linspace(80, 100, 50).reshape(-1, 1)
y_train = X_train.ravel() + rng.randn(50)
model = BayesianRidge().fit(X_train, y_train)

_, std_center = model.predict([[90.0]], return_std=True)   # near training
_, std_origin = model.predict([[0.0]], return_std=True)    # far from training

# Before fix: std_center > std_origin  (wrong!)
# After fix:  std_center < std_origin  (correct)
print(std_center, std_origin)
```

## Tests

Added:
- `test_predict_std_centered_at_training_data` — parametrized over both `BayesianRidge` and `ARDRegression`, asserts uncertainty is lower near training data than at origin.
- `test_bayesian_ridge_predict_std_matches_formula` — verifies the returned std matches the analytic formula with the correct centering.

Closes #33757

@ogrisel @jnothman @glemaitre