### PR TITLE
Update DOI badge in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@
 .. |PyPI| image:: https://img.shields.io/pypi/v/scikit-learn
    :target: https://pypi.org/project/scikit-learn
 
-.. |DOI| image:: https://zenodo.org/badge/21369/scikit-learn/scikit-learn.svg
+.. |DOI| image:: https://img.shields.io/badge/DOI-10.5281%2Fzenodo-blue.svg
    :target: https://zenodo.org/badge/latestdoi/21369/scikit-learn/scikit-learn
 
 .. |Benchmark| image:: https://img.shields.io/badge/Benchmarked%20by-asv-blue

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@
 .. |PyPI| image:: https://img.shields.io/pypi/v/scikit-learn
    :target: https://pypi.org/project/scikit-learn
 
-.. |DOI| image:: https://img.shields.io/badge/DOI-10.5281%2Fzenodo-blue.svg
+.. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.17880109.svg
    :target: https://zenodo.org/badge/latestdoi/21369/scikit-learn/scikit-learn
 
 .. |Benchmark| image:: https://img.shields.io/badge/Benchmarked%20by-asv-blue


### PR DESCRIPTION
Fixes  #33840
Replaced the Zenodo SVG badge URL with a 
shields.io badge which renders consistently.

#### What does this implement/fix? Explain your changes.
The DOI badge in README.rst was intermittently not 
rendering on GitHub because Zenodo SVG badges are no 
longer rendering consistently on GitHub as of 2026.
Replaced it with a shields.io badge which renders 
consistently.

#### AI usage disclosure
I used AI assistance for:
- [ ] Code generation
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Any other comments?
This is my first contribution to scikit-learn.