### PR TITLE
Fix color conversion to rgb hexstring

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.tree/33845.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.tree/33845.fix.rst
@@ -1,0 +1,4 @@
+- Fixed color conversion in tree export so RGB values with zero channels are
+  correctly converted to two-digit hexadecimal components (for example,
+  ``(0, 255, 0)`` now yields ``#00ff00``).
+  By :user:`Simon-Martin Schröder <moi90>`.

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -28,6 +28,11 @@ from sklearn.utils._param_validation import (
 from sklearn.utils.validation import check_array, check_is_fitted
 
 
+def _rgb_to_hexstring(rgb):
+    """Convert 8bit integer rgb color to html hexstring"""
+    return "#%02x%02x%02x" % tuple(rgb)
+
+
 def _color_brew(n):
     """Generate n colors with equally spaced hues.
 
@@ -261,7 +266,7 @@ class _BaseTreeExporter:
         # compute the color as alpha against white
         color = [int(round(alpha * c + (1 - alpha) * 255, 0)) for c in color]
         # Return html color code in #RRGGBB format
-        return "#%2x%2x%2x" % tuple(color)
+        return _rgb_to_hexstring(color)
 
     def get_fill_color(self, tree, node_id):
         # Fetch appropriate color for node

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -19,6 +19,7 @@ from sklearn.tree import (
     export_text,
     plot_tree,
 )
+from sklearn.tree._export import _rgb_to_hexstring
 
 CLF_CRITERIONS = ("gini", "log_loss")
 REG_CRITERIONS = ("squared_error", "absolute_error", "poisson")
@@ -32,8 +33,12 @@ y_degraded = [1, 1, 1, 1, 1, 1]
 
 
 def test_rgb_to_hexstring():
-    pytest.importorskip("matplotlib")
-    from sklearn.tree._export import _rgb_to_hexstring
+    """
+    Test that _rgb_to_hexstring correctly converts an RGB tuple to a hex color string.
+
+    A previous bug caused incorrect hex color string generation for zero values
+    in the RGB tuple.
+    """
 
     assert _rgb_to_hexstring((0, 255, 0)) == "#00ff00"
 

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -31,6 +31,13 @@ w = [1, 1, 1, 0.5, 0.5, 0.5]
 y_degraded = [1, 1, 1, 1, 1, 1]
 
 
+def test_rgb_to_hexstring():
+    pytest.importorskip("matplotlib")
+    from sklearn.tree._export import _rgb_to_hexstring
+
+    assert _rgb_to_hexstring((0, 255, 0)) == "#00ff00"
+
+
 def test_graphviz_toy():
     # Check correctness of export_graphviz
     clf = DecisionTreeClassifier(


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #33844.
Spin-off of #33810.

#### What does this implement/fix? 
This PR fixes the HTML hex color formatting used by tree export utilities.

Previously, node colors were formatted with `%2x`, which can produce space-padded hex values for channels below `0x10` (for example, `" a"` instead of `"0a"`). That can lead to invalid or inconsistent color strings.

#### AI usage disclosure
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [x] Research and understanding

#### Any other comments?
None.