### PR TITLE
DOC: Note alpha_per_target incompatibility with cv in RidgeCV

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -2751,6 +2751,10 @@ class RidgeCV(MultiOutputMixin, RegressorMixin, _BaseRidgeCV):
         fitting, the `alpha_` attribute will contain a value for each target.
         When set to `False`, a single alpha is used for all targets.
 
+        .. note::
+            This parameter is incompatible with ``cv``. If ``cv`` is not
+            ``None``, ``alpha_per_target`` must be ``False``.
+
         .. versionadded:: 0.24
 
     Attributes


### PR DESCRIPTION
## What does this PR do?

Adds a note in the RidgeCV docstring for the `alpha_per_target` parameter explaining that it is incompatible with the `cv` parameter.

Fixes scikit-learn#33819