### PR TITLE
Fix zero-padded hex color formatting in _MPLTreeExporter

### DIFF
--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -261,7 +261,7 @@ class _BaseTreeExporter:
         # compute the color as alpha against white
         color = [int(round(alpha * c + (1 - alpha) * 255, 0)) for c in color]
         # Return html color code in #RRGGBB format
-        return "#%2x%2x%2x" % tuple(color)
+        return "#%02x%02x%02x" % tuple(color)
 
     def get_fill_color(self, tree, node_id):
         # Fetch appropriate color for node


### PR DESCRIPTION
Fixes #33844

## Problem
When RGB color components contain 0, the hex string was formatted 
with spaces instead of zeros e.g. `# 0ffff` instead of `#00ffff`.

## Fix
Changed `%2x` to `%02x` in the `get_color` method of `_MPLTreeExporter`.