### PR TITLE
DOC improve safe_sparse_dot docstring and remove stale ignore entry

### DIFF
--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -55,7 +55,6 @@ _DOCSTRING_IGNORES = [
     "sklearn.utils.deprecation.load_mlcomp",
     "sklearn.pipeline.make_pipeline",
     "sklearn.pipeline.make_union",
-    "sklearn.utils.extmath.safe_sparse_dot",
     "HalfBinomialLoss",
 ]
 

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -169,7 +169,9 @@ def safe_sparse_dot(a, b, *, dense_output=False):
     Parameters
     ----------
     a : {ndarray, sparse matrix}
+        First operand of the dot product.
     b : {ndarray, sparse matrix}
+        Second operand of the dot product.
     dense_output : bool, default=False
         When False, ``a`` and ``b`` both being sparse will yield sparse output.
         When True, output will always be a dense array.


### PR DESCRIPTION
This supersedes #33836, which was closed due to an incorrectly included changelog entry. Per maintainer feedback on that PR, documentation-only improvements do not need changelog entries. The code changes are unchanged.

## Changes

- `sklearn/utils/extmath.py`: Added one-line descriptions to the `a` and `b`
  parameters of `safe_sparse_dot`, which previously had type annotations but no description text.

- `sklearn/tests/test_docstring_parameters.py`: Removed the stale `"sklearn.utils.extmath.safe_sparse_dot"` entry from `_DOCSTRING_IGNORES`. This entry was added in 2017 when the test was first introduced. PR #24567 (merged Oct 2022) already removed `safe_sparse_dot` from the ignore list in `test_docstrings.py`; the corresponding entry in `test_docstring_parameters.py` was never cleaned up. The function's three parameters (`a`, `b`, `dense_output`) are now fully documented and match the signature exactly, so no ignore entry is needed.

🤖 Research for this contribution was done with AI assistance.