### PR TITLE
FIX SimpleImputer.inverse_transform shifts columns when keep_empty_fe…

### DIFF
--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -732,20 +732,28 @@ class SimpleImputer(_BaseImputer):
         missing_mask = X[:, non_empty_feature_count:].astype(bool)
 
         n_features_original = len(self.statistics_)
-        shape_original = (X.shape[0], n_features_original)
-        X_original = np.zeros(shape_original)
-        X_original[:, self.indicator_.features_] = missing_mask
-        full_mask = X_original.astype(bool)
 
-        imputed_idx, original_idx = 0, 0
-        while imputed_idx < len(array_imputed.T):
-            if not np.all(X_original[:, original_idx]):
-                X_original[:, original_idx] = array_imputed.T[imputed_idx]
-                imputed_idx += 1
-                original_idx += 1
-            else:
-                original_idx += 1
+        # Full-width missing mask: True where the indicator marks a value as
+        # missing in the input that was passed to ``transform``.
+        full_mask = np.zeros((X.shape[0], n_features_original), dtype=bool)
+        full_mask[:, self.indicator_.features_] = missing_mask
 
+        # Determine which original columns survived ``transform``. When
+        # ``keep_empty_features=False`` columns that were entirely missing at
+        # ``fit`` time are dropped (their entry in ``self.statistics_`` is
+        # ``np.nan``), so ``array_imputed`` has fewer columns than the
+        # original data. Place the imputed columns back at their original
+        # positions rather than inferring them from the indicator mask, which
+        # produced off-by-one column shifts when an empty-at-fit column had
+        # values at ``transform`` time (see issue #27012).
+        if self.keep_empty_features:
+            valid_indexes = np.arange(n_features_original)
+        else:
+            invalid_mask = _get_mask(self.statistics_, np.nan)
+            valid_indexes = np.flatnonzero(np.logical_not(invalid_mask))
+
+        X_original = np.zeros((X.shape[0], n_features_original))
+        X_original[:, valid_indexes] = array_imputed
         X_original[full_mask] = self.missing_values
         return X_original
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1494,6 +1494,49 @@ def test_simple_imputation_inverse_transform(missing_value):
 
 
 @pytest.mark.parametrize("missing_value", [-1, np.nan])
+def test_simple_imputation_inverse_transform_empty_feature_at_fit():
+    """Non-regression test for #27012.
+
+    When ``keep_empty_features=False`` and ``add_indicator=True``, columns
+    that are entirely missing at ``fit`` time are dropped during ``transform``.
+    ``inverse_transform`` must place the imputed columns back at their
+    original positions rather than relying on the indicator mask, which would
+    produce an off-by-one column shift when a previously-empty column has
+    values at ``transform`` time.
+    """
+    X_fit = np.array(
+        [
+            [np.nan, 2.0, 3.0],
+            [np.nan, 2.0, 3.0],
+        ]
+    )
+    X_transform = np.array(
+        [
+            [1.0, 2.0, 3.0],
+            [1.0, 2.0, 3.0],
+        ]
+    )
+
+    imputer = SimpleImputer(
+        strategy="mean",
+        keep_empty_features=False,
+        add_indicator=True,
+    )
+    imputer.fit(X_fit)
+    X_t = imputer.transform(X_transform)
+    X_inv = imputer.inverse_transform(X_t)
+
+    # Column 0 was dropped at transform (all-missing at fit). The imputed
+    # values for columns 1 and 2 must land in those columns, not be shifted.
+    expected = np.array(
+        [
+            [0.0, 2.0, 3.0],
+            [0.0, 2.0, 3.0],
+        ]
+    )
+    assert_array_equal(X_inv, expected)
+
+
 def test_simple_imputation_inverse_transform_exceptions(missing_value):
     X_1 = np.array(
         [


### PR DESCRIPTION
…atures=False

Closes #27012

When SimpleImputer is fit with keep_empty_features=False and add_indicator=True, columns that were entirely missing at fit time are dropped during transform (their entry in statistics_ is set to np.nan). The previous inverse_transform implementation tried to skip those dropped positions by checking np.all(X_original[:, original_idx]) on the indicator mask, which mistakenly treated a column with no missing values at transform time as a present-and- imputed column. The result was an off-by-one shift of every imputed column to the right of the empty-at-fit one.

Replace the heuristic with the explicit list of surviving column indices derived from statistics_, mirroring how transform itself decides which columns to drop. Add a non-regression test.

<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
