### PR TITLE
Improve error message in _get_column_indices to list missing columns

### DIFF
--- a/sklearn/utils/_indexing.py
+++ b/sklearn/utils/_indexing.py
@@ -474,7 +474,10 @@ def _get_column_indices(X, key):
                 column_indices.append(col_idx)
 
         except KeyError as e:
-            raise ValueError("A given column is not a column of the dataframe") from e
+            missing = set(columns) - set(all_columns)
+            raise ValueError(
+                f"A given column is not a column of the dataframe: {missing}"
+            ) from e
 
         return column_indices
 
@@ -510,7 +513,10 @@ def _get_column_indices_interchange(X_interchange, key, key_dtype):
         try:
             return [column_names.index(col) for col in selected_columns]
         except ValueError as e:
-            raise ValueError("A given column is not a column of the dataframe") from e
+            missing = set(selected_columns) - set(column_names)
+            raise ValueError(
+                f"A given column is not a column of the dataframe: {missing}"
+            ) from e
 
 
 @validate_params(


### PR DESCRIPTION
Description:

Problem: The current error message doesn't show which columns are missing, making debugging hard.

Solution: Modified _get_column_indices to catch KeyError and list the specific missing columns.

Result: The error changes from a generic message to:
ValueError: A given column is not a column of the dataframe: {'column_name'}

Testing:
Verified manually with a pandas DataFrame and confirmed the missing columns appear correctly in the message.