### PR TITLE
FIX: address integer overflow in label_binarize for uint64 dtypes

### DIFF
--- a/doc/whats_new/upcoming_changes/binarize_overflow.rst
+++ b/doc/whats_new/upcoming_changes/binarize_overflow.rst
@@ -1,5 +1,5 @@
 .. item_description
-.. Fix integer overflow in :func:`preprocessing.label_binarize` and
-.. :func:`preprocessing._inverse_binarize_thresholding` when using
-.. unsigned integer labels (e.g., uint64).
-.. By :user:`Mariam`
+Fix integer overflow in :func:`preprocessing.label_binarize` and
+:func:`preprocessing._inverse_binarize_thresholding` when using
+unsigned integer labels (e.g., uint64).
+By :user:`Mariam mariam851`

--- a/doc/whats_new/upcoming_changes/binarize_overflow.rst
+++ b/doc/whats_new/upcoming_changes/binarize_overflow.rst
@@ -1,5 +1,5 @@
 .. item_description
-Fix integer overflow in :func:`preprocessing.label_binarize` and
-:func:`preprocessing._inverse_binarize_thresholding` when using
-unsigned integer labels (e.g., uint64).
-By :user:`Mariam mariam851`
+    Fix integer overflow in :func:`preprocessing.label_binarize` and
+    :func:`preprocessing._inverse_binarize_thresholding` when using
+    unsigned integer labels (e.g., uint64).
+    By :user:`Mariam <mariam851>`

--- a/doc/whats_new/upcoming_changes/binarize_overflow.rst
+++ b/doc/whats_new/upcoming_changes/binarize_overflow.rst
@@ -1,0 +1,5 @@
+.. item_description
+.. Fix integer overflow in :func:`preprocessing.label_binarize` and
+.. :func:`preprocessing._inverse_binarize_thresholding` when using
+.. unsigned integer labels (e.g., uint64).
+.. By :user:`Mariam`

--- a/doc/whats_new/upcoming_changes/binarize_overflow.rst
+++ b/doc/whats_new/upcoming_changes/binarize_overflow.rst
@@ -3,3 +3,4 @@
     :func:`preprocessing._inverse_binarize_thresholding` when using
     unsigned integer labels (e.g., uint64).
     By :user:`Mariam <mariam851>`
+

--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -590,7 +590,7 @@ def label_binarize(y, *, classes, neg_label=0, pos_label=1, sparse_output=False)
 
     n_samples = y.shape[0] if hasattr(y, "shape") else len(y)
     n_classes = classes.shape[0]
-    if hasattr(y, "dtype") and xp.isdtype(y.dtype, "integral"):
+    if hasattr(y, "dtype") and xp.isdtype(y.dtype, "signed integer"):
         int_dtype_ = y.dtype
     else:
         int_dtype_ = indexing_dtype(xp)
@@ -752,7 +752,7 @@ def _inverse_binarize_thresholding(y, output_type, classes, threshold, xp=None):
         )
 
     dtype_ = _find_matching_floating_dtype(y, xp=xp)
-    if hasattr(y, "dtype") and xp.isdtype(y.dtype, "integral"):
+    if hasattr(y, "dtype") and xp.isdtype(y.dtype, "signed integer"):
         int_dtype_ = y.dtype
     else:
         int_dtype_ = indexing_dtype(xp)

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -887,3 +887,24 @@ def test_label_encoder_array_api_compliance(
         assert_array_equal(
             move_to(xp_label.classes_, xp=np, device="cpu"), np_label.classes_
         )
+
+
+def test_label_binarize_uint64_overflow():
+    """Check that label_binarize does not overflow with uint64 labels.
+
+    This ensures that unsigned integers are handled by converting them
+    to signed integers to prevent issues in estimators like RidgeClassifier.
+    Reference: Fixes Issue #30177
+    """
+    import numpy as np
+
+    from sklearn.preprocessing import label_binarize
+
+    y = np.array([0, 1], dtype=np.uint64)
+    classes = np.array([0, 1], dtype=np.uint64)
+
+    Y = label_binarize(y, classes=classes)
+
+    assert np.all(np.logical_or(Y == 0, Y == 1))
+
+    assert Y.dtype.kind in "bi"


### PR DESCRIPTION
### Description
This PR addresses an integer overflow issue in `label_binarize` when input labels are of unsigned integer types (e.g., `uint64`). This overflow previously led to astronomical values in estimators like `RidgeClassifier`.

### Changes
- Modified `label_binarize` to ensure it uses a signed integer dtype when dealing with unsigned inputs.
- Applied the same logic to `_inverse_binarize_thresholding` for consistency.
- Added a regression test in `test_label.py` to prevent future regressions.

### Verification
- Verified manually using the user-provided snippet.
- Added and passed a new unit test: `test_label_binarize_uint64_overflow`.
- Cleaned and formatted using `ruff`.

Fixes #30177