### PR TITLE
FIX use the correct base URL for openml.org API calls

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.datasets/33868.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.datasets/33868.fix.rst
@@ -1,0 +1,5 @@
+- Fixed :func:`datasets.fetch_openml` to issue OpenML API calls to
+  ``https://www.openml.org/api/v1/`` instead of
+  ``https://api.openml.org/api/v1/``, which no longer resolves or redirects
+  correctly.
+  By :user:`Olivier Grisel <ogrisel>`.

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -33,10 +33,10 @@ from sklearn.utils._param_validation import (
 
 __all__ = ["fetch_openml"]
 
-_SEARCH_NAME = "https://api.openml.org/api/v1/json/data/list/data_name/{}/limit/2"
-_DATA_INFO = "https://api.openml.org/api/v1/json/data/{}"
-_DATA_FEATURES = "https://api.openml.org/api/v1/json/data/features/{}"
-_DATA_QUALITIES = "https://api.openml.org/api/v1/json/data/qualities/{}"
+_SEARCH_NAME = "https://www.openml.org/api/v1/json/data/list/data_name/{}/limit/2"
+_DATA_INFO = "https://www.openml.org/api/v1/json/data/{}"
+_DATA_FEATURES = "https://www.openml.org/api/v1/json/data/features/{}"
+_DATA_QUALITIES = "https://www.openml.org/api/v1/json/data/qualities/{}"
 
 OpenmlQualitiesType = List[Dict[str, str]]
 OpenmlFeaturesType = List[Dict[str, str]]

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -72,10 +72,10 @@ def _monkey_patch_webbased_functions(context, data_id, gzip_response):
     # monkey patches the urlopen function. Important note: Do NOT use this
     # in combination with a regular cache directory, as the files that are
     # stored as cache should not be mixed up with real openml datasets
-    url_prefix_data_description = "https://api.openml.org/api/v1/json/data/"
-    url_prefix_data_features = "https://api.openml.org/api/v1/json/data/features/"
+    url_prefix_data_description = "https://www.openml.org/api/v1/json/data/"
+    url_prefix_data_features = "https://www.openml.org/api/v1/json/data/features/"
     url_prefix_download_data = "https://www.openml.org/data/v1/download"
-    url_prefix_data_list = "https://api.openml.org/api/v1/json/data/list/"
+    url_prefix_data_list = "https://www.openml.org/api/v1/json/data/list/"
 
     path_suffix = ".gz"
     read_fn = gzip.open


### PR DESCRIPTION
Fixes #33867.

Let's see if this fixes our doc build among other things.