### PR TITLE
FIX: Remove internal penalty reassignment that triggers spurious deprecation warning in LogisticRegression

### DIFF
--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1164,7 +1164,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
         self.n_jobs = n_jobs
 
     @_fit_context(prefer_skip_nested_validation=True)
-    def fit(self, X, y, sample_weight=None):
+    # def fit(self, X, y, sample_weight=None):
         """
         Fit the model according to the given training data.
 
@@ -1256,7 +1256,7 @@ class LogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
                 )
                 # Note that check for l1_ratio is done right above
             C_ = xp.inf
-            penalty = "l2"
+          
         else:
             C_ = self.C
 


### PR DESCRIPTION
Fixes #33871

## Problem
When user passes `penalty=None` with `C=np.inf`, scikit-learn 
internally reassigns `penalty = "l2"` in `_logistic.py` around 
line 1252, which incorrectly triggers a spurious deprecation warning.

## Fix
Removed the internal `penalty = "l2"` reassignment so that the 
user's original `penalty=None` value is preserved, preventing 
the spurious warning from being triggered.