### PR TITLE
FIX move multioutput weights to correct array namespace/device

### DIFF
--- a/doc/whats_new/upcoming_changes/array-api/33519.bugfix.rst
+++ b/doc/whats_new/upcoming_changes/array-api/33519.bugfix.rst
@@ -1,0 +1,6 @@
+- :func:`metrics.explained_variance_score` and other regression metrics now
+  correctly handle array-like ``multioutput`` weights (list or numpy array)
+  when ``array_api_dispatch=True`` and ``y_pred`` is a non-NumPy array
+  (e.g. a PyTorch tensor). Previously this raised a confusing
+  ``ValueError: Input arrays use different devices: cpu, cpu``.
+  By :user:`Sachin Mahajan <Mahajan-Sachin>`

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -142,6 +142,13 @@ def _check_reg_targets(
             )
     elif multioutput is not None:
         multioutput = check_array(multioutput, ensure_2d=False)
+        # Move multioutput to the same namespace/device as y_pred so that
+        # array API weighted-average operations work correctly when y_pred is
+        # a non-NumPy array (e.g. a PyTorch tensor). Without this, _average()
+        # sees mismatched namespaces and raises a confusing
+        # "Input arrays use different devices: cpu, cpu" error.
+        _, _, device = get_namespace_and_device(y_pred)
+        multioutput = move_to(multioutput, xp=xp, device=device)
         if n_outputs == 1:
             raise ValueError("Custom weights are useful only in multi-output cases.")
         elif n_outputs != multioutput.shape[0]:

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -656,9 +656,7 @@ def test_regression_metrics_array_api_multioutput_weights():
 
     with config_context(array_api_dispatch=True):
         # Reference: compute with numpy y_pred and list weights (always worked)
-        ref = explained_variance_score(
-            y_true, y_pred_np, multioutput=weights_list
-        )
+        ref = explained_variance_score(y_true, y_pred_np, multioutput=weights_list)
 
         # list weights with torch y_pred — was broken before the fix
         result_list = explained_variance_score(
@@ -676,4 +674,3 @@ def test_regression_metrics_array_api_multioutput_weights():
     assert result_array == pytest.approx(ref, rel=1e-6), (
         "multioutput=np.array should give the same result as with numpy y_pred"
     )
-

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -634,3 +634,46 @@ def test_pinball_loss_relation_with_mae(global_random_seed):
         mean_absolute_error(y_true, y_pred)
         == mean_pinball_loss(y_true, y_pred, alpha=0.5) * 2
     )
+
+
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+def test_regression_metrics_array_api_multioutput_weights():
+    """Non-regression test for #33519.
+
+    When array_api_dispatch=True and y_pred is a non-NumPy array (e.g. a
+    PyTorch tensor), passing multioutput weights as a list or numpy array
+    should work without raising a confusing
+    "Input arrays use different devices: cpu, cpu" error.
+    """
+    torch = pytest.importorskip("torch")
+    from sklearn import config_context
+
+    y_true = np.array([[0.5, 1], [-1, 1], [7, -6]])
+    y_pred_np = np.array([[0, 2], [-1, 2], [8, -5]], dtype=np.float64)
+    y_pred_torch = torch.asarray(y_pred_np, dtype=torch.float64)
+    weights_list = [0.3, 0.7]
+    weights_array = np.array(weights_list)
+
+    with config_context(array_api_dispatch=True):
+        # Reference: compute with numpy y_pred and list weights (always worked)
+        ref = explained_variance_score(
+            y_true, y_pred_np, multioutput=weights_list
+        )
+
+        # list weights with torch y_pred — was broken before the fix
+        result_list = explained_variance_score(
+            y_true, y_pred_torch, multioutput=weights_list
+        )
+
+        # numpy array weights with torch y_pred — was broken before the fix
+        result_array = explained_variance_score(
+            y_true, y_pred_torch, multioutput=weights_array
+        )
+
+    assert result_list == pytest.approx(ref, rel=1e-6), (
+        "multioutput=list should give the same result as with numpy y_pred"
+    )
+    assert result_array == pytest.approx(ref, rel=1e-6), (
+        "multioutput=np.array should give the same result as with numpy y_pred"
+    )
+


### PR DESCRIPTION
Fixes #33519

When array_api_dispatch=True and y_pred is a torch tensor, multioutput weights passed as a list or numpy array raised a confusing "Input arrays use different devices: cpu, cpu" error.

Root cause: check_array(multioutput) converts weights to NumPy but y_pred is in torch namespace. _average() then sees mismatched namespaces.

Fix: in _check_reg_targets, after check_array, call move_to(multioutput, xp=xp, device=device).

Added non-regression test: test_regression_metrics_array_api_multioutput_weights.

> This pull request includes code written with the assistance of AI. The code has not yet been reviewed by a human.
## before
<img width="940" height="377" alt="image" src="https://github.com/user-attachments/assets/353a9c0e-769c-4be1-b6af-0e7dfeafb10c" />

## after

<img width="940" height="400" alt="image" src="https://github.com/user-attachments/assets/3a7e0806-f41f-4ed1-9580-06f956605e2e" />
