### PR TITLE
[Callbacks] ENH Make optional kwargs keyword only in the FitCallback's hooks

### DIFF
--- a/sklearn/callback/_base.py
+++ b/sklearn/callback/_base.py
@@ -48,7 +48,14 @@ class FitCallback(_BaseCallback, Protocol):
     """Protocol for the callbacks evaluated on tasks during the fit of an estimator."""
 
     def on_fit_task_begin(
-        self, estimator, context, X=None, y=None, metadata=None, fitted_estimator=None
+        self,
+        estimator,
+        context,
+        *,
+        X=None,
+        y=None,
+        metadata=None,
+        fitted_estimator=None,
     ):
         """Method called at the beginning of each fit task of the estimator.
 
@@ -75,7 +82,14 @@ class FitCallback(_BaseCallback, Protocol):
         """
 
     def on_fit_task_end(
-        self, estimator, context, X=None, y=None, metadata=None, fitted_estimator=None
+        self,
+        estimator,
+        context,
+        *,
+        X=None,
+        y=None,
+        metadata=None,
+        fitted_estimator=None,
     ):
         """Method called at the end of each fit task of the estimator.
 


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Addresses the issue raised in [this comment](https://github.com/scikit-learn/scikit-learn/pull/33322#discussion_r3153639381)

#### What does this implement/fix? Explain your changes.
Make the optional arguments in the `FitCallback` protocol's methods keyword only.
The motivation is that these optional arguments must be keyword only to receive non default values in `CallbackContext`'s `_call_hook`, so it makes easier to develop a custom callback from copy-pasting the protocol.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?
ping @jeremiedbb 

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
