### PR TITLE
Fix TypeError in LogisticRegressionCV with refit, use_legacy_attribute False

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/33902.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/33902.fix.rst
@@ -1,5 +1,5 @@
 - :class:`linear_model.LogisticRegressionCV` no longer raises a ``TypeError``
   when `refit=False` and `use_legacy_attributes=False` are set together with a
-  non-elasticnet penalty. Previously, `None` was stored in `l1_ratio_` instead
+  non-elasticnet penalty like `l1_ratios=[0.0]`. Previously, `None` was stored in `l1_ratio_` instead
   of `0.0`, which caused `float()` to fail during post-processing.
   By :user:`Mohamad Fazeli <Fazel94>`.

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/33902.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/33902.fix.rst
@@ -1,0 +1,5 @@
+- :class:`linear_model.LogisticRegressionCV` no longer raises a ``TypeError``
+  when `refit=False` and `use_legacy_attributes=False` are set together with a
+  non-elasticnet penalty. Previously, `None` was stored in `l1_ratio_` instead
+  of `0.0`, which caused `float()` to fail during post-processing.
+  By :user:`Mohamad Fazeli <Fazel94>`.

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -2195,7 +2195,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
                 best_indices_l1 = best_indices[:, 1]
                 self.l1_ratio_.append(np.mean(l1_ratios_[best_indices_l1]))
             else:
-                self.l1_ratio_.append(None)
+                self.l1_ratio_.append(0.0)
 
         if is_binary:
             self.coef_ = w[:, :n_features] if w.ndim == 2 else w[:n_features][None, :]

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -476,8 +476,8 @@ def test_logistic_cv(global_random_seed, use_legacy_attributes):
 # TODO(1.11): remove filterwarnings with change of default scoring
 @pytest.mark.filterwarnings("ignore:The default value.*scoring.*:FutureWarning")
 def test_logistic_cv_refit_false_non_elasticnet(global_random_seed):
-    """Non-regression test for non-elasticnet penalties with refit=False and
-    use_legacy_attributes=False.
+    """Test that non-elasticnet penalty with refit=False and
+    use_legacy_attributes=False works without error.
 
     For non-elasticnet penalties, l1_ratio=0.0 (equivalent to pure L2).
     Previously, None was stored, which caused float() to raise a

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -473,6 +473,27 @@ def test_logistic_cv(global_random_seed, use_legacy_attributes):
         assert lr_cv.scores_.shape == (n_cv, n_l1_ratios, n_Cs)
 
 
+# TODO(1.11): remove filterwarnings with change of default scoring
+@pytest.mark.filterwarnings("ignore:The default value.*scoring.*:FutureWarning")
+def test_logistic_cv_refit_false_non_elasticnet(global_random_seed):
+    """Non-regression test for non-elasticnet penalties with refit=False and
+    use_legacy_attributes=False.
+
+    For non-elasticnet penalties, l1_ratio=0.0 (equivalent to pure L2).
+    Previously, None was stored, which caused float() to raise a
+    TypeError when use_legacy_attributes=False converted the value to a scalar.
+    """
+    X, y = make_classification(random_state=global_random_seed)
+    lr_cv = LogisticRegressionCV(
+        l1_ratios=[0.0],
+        refit=False,
+        use_legacy_attributes=False,
+        random_state=global_random_seed,
+    )
+    lr_cv.fit(X, y)
+    assert lr_cv.l1_ratio_ == 0.0
+
+
 def test_logistic_cv_mock_scorer():
     """Test that LogisticRegressionCV calls the scorer."""
 


### PR DESCRIPTION


<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
Fixes #33885  

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
`LogisticRegressionCV` crashed with a `TypeError` when both `refit=False` and     
 `use_legacy_attributes=False` were set, as long as the penalty was not `elasticnet`.  

In the `refit=False` branch, the code stored `None` into `self.l1_ratio_` for          
 non-elasticnet penalties, using it as a "not applicable" sentinel.
 Later, the               
 `use_legacy_attributes=False` block unconditionally called `float(self.l1_ratio_[0])`, which     
 fails on `None`.


#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding


#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
