### PR TITLE
fix: center test data in BayesianRidge.predict when return_std=True

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/33757.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/33757.fix.rst
@@ -1,0 +1,5 @@
+- :class:`linear_model.BayesianRidge` now correctly centers test data when
+  computing the predictive standard deviation with ``return_std=True``,
+  so that the variance is minimized near the training data rather than near
+  the origin.
+  By :user:`NIK-TIGER-BILL <NIK-TIGER-BILL>`.

--- a/sklearn/linear_model/_bayes.py
+++ b/sklearn/linear_model/_bayes.py
@@ -397,6 +397,8 @@ class BayesianRidge(RegressorMixin, LinearModel):
         if not return_std:
             return y_mean
         else:
+            if self.fit_intercept:
+                X = X - self.X_offset_
             sigmas_squared_data = (np.dot(X, self.sigma_) * X).sum(axis=1)
             y_std = np.sqrt(sigmas_squared_data + (1.0 / self.alpha_))
             return y_mean, y_std

--- a/sklearn/linear_model/tests/test_bayes.py
+++ b/sklearn/linear_model/tests/test_bayes.py
@@ -305,6 +305,25 @@ def test_dtype_match(dtype, Estimator):
 
 
 @pytest.mark.parametrize("Estimator", [BayesianRidge, ARDRegression])
+def test_bayesian_ridge_std_centered_data():
+    """Check that predictive std is centered around the training data.
+
+    Non-regression test for https://github.com/scikit-learn/scikit-learn/issues/33757
+    """
+    x_train = np.linspace(80, 100, 4).reshape(-1, 1)
+    y_train = x_train.ravel() + np.array([2.0, -1.0, 1.0, -2.0])
+    model = BayesianRidge().fit(x_train, y_train)
+    x_test = np.linspace(-100, 100, 101).reshape(-1, 1)
+    y_mean, y_std = model.predict(x_test, return_std=True)
+    # The predictive variance should be minimal near the training data
+    # (around 80-100) rather than near the origin.
+    assert y_std[x_test.ravel().argmin()] > y_std[x_test.ravel().argmax()]
+    assert_array_less(
+        y_std[(x_test >= 80).ravel() & (x_test <= 100).ravel()],
+        y_std[(x_test <= 0).ravel()],
+    )
+
+
 def test_dtype_correctness(Estimator):
     X = np.array([[1, 1], [3, 4], [5, 7], [4, 1], [2, 6], [3, 10], [3, 2]])
     y = np.array([1, 2, 3, 2, 0, 4, 5]).T


### PR DESCRIPTION
Fixes #33757

#### What does this implement/fix? Explain your changes.
`BayesianRidge.predict` with `return_std=True` and `fit_intercept=True` was computing the predictive variance on the raw test features `X` instead of centering them by the training mean `X_offset_`. This caused the model to incorrectly report its lowest uncertainty near the origin rather than near the region where it had seen the most training data.

The fix subtracts `X_offset_` from `X` before the variance computation when `fit_intercept=True`, aligning the variance calculation with the centered training data.

#### AI usage disclosure
I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Any other comments
A regression test has been added in `sklearn/linear_model/tests/test_bayes.py` to ensure that the predictive standard deviation is minimal near the training data for non-centered data. A changelog entry has been added in `doc/whats_new/upcoming_changes/sklearn.linear_model/33757.fix.rst`.
