### PR TITLE
DOC Fix colors in decision tree example

### DIFF
--- a/examples/tree/plot_iris_dtc.py
+++ b/examples/tree/plot_iris_dtc.py
@@ -28,16 +28,10 @@ iris = load_iris()
 # %%
 # Display the decision functions of trees trained on all pairs of features.
 import matplotlib.pyplot as plt
-import numpy as np
+from matplotlib.colors import ListedColormap
 
 from sklearn.inspection import DecisionBoundaryDisplay
 from sklearn.tree import DecisionTreeClassifier
-
-# Parameters
-n_classes = 3
-plot_colors = "ryb"
-plot_step = 0.02
-
 
 for pairidx, pair in enumerate([[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]]):
     # We only take the two corresponding features
@@ -50,30 +44,33 @@ for pairidx, pair in enumerate([[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]])
     # Plot the decision boundary
     ax = plt.subplot(2, 3, pairidx + 1)
     plt.tight_layout(h_pad=0.5, w_pad=0.5, pad=2.5)
-    DecisionBoundaryDisplay.from_estimator(
+    disp = DecisionBoundaryDisplay.from_estimator(
         clf,
         X,
-        cmap=plt.cm.RdYlBu,
         response_method="predict",
         ax=ax,
         xlabel=iris.feature_names[pair[0]],
         ylabel=iris.feature_names[pair[1]],
+        alpha=0.5,
     )
 
     # Plot the training points
-    for i, color in zip(range(n_classes), plot_colors):
-        idx = np.asarray(y == i).nonzero()
-        plt.scatter(
-            X[idx, 0],
-            X[idx, 1],
-            c=color,
-            label=iris.target_names[i],
-            edgecolor="black",
-            s=15,
-        )
+    scatter = disp.ax_.scatter(
+        X[:, 0],
+        X[:, 1],
+        c=y,
+        cmap=ListedColormap(disp.multiclass_colors_),
+        edgecolor="black",
+        s=15,
+    )
 
 plt.suptitle("Decision surface of decision trees trained on pairs of features")
-plt.legend(loc="lower right", borderpad=0, handletextpad=0)
+plt.figlegend(
+    scatter.legend_elements()[0],
+    iris.target_names,
+    loc="lower center",
+    ncols=len(iris.target_names),
+)
 _ = plt.axis("tight")
 
 # %%


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #33557 

#### What does this implement/fix? Explain your changes.
DecisionBoundaryDisplay and scatter plot now use the default colors.
I also cleaned up some unused parameters, refactored the scatter plot and moved the legend to the bottom.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding


#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
