### PR TITLE
DOC clarify cluster metric label inputs

### DIFF
--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -972,11 +972,11 @@ def adjusted_mutual_info_score(
 
     Parameters
     ----------
-    labels_true : int array-like of shape (n_samples,)
+    labels_true : array-like of shape (n_samples,)
         A clustering of the data into disjoint subsets, called :math:`U` in
         the above formula.
 
-    labels_pred : int array-like of shape (n_samples,)
+    labels_pred : array-like of shape (n_samples,)
         A clustering of the data into disjoint subsets, called :math:`V` in
         the above formula.
 
@@ -1108,10 +1108,10 @@ def normalized_mutual_info_score(
 
     Parameters
     ----------
-    labels_true : int array-like of shape (n_samples,)
+    labels_true : array-like of shape (n_samples,)
         A clustering of the data into disjoint subsets.
 
-    labels_pred : int array-like of shape (n_samples,)
+    labels_pred : array-like of shape (n_samples,)
         A clustering of the data into disjoint subsets.
 
     average_method : {'min', 'geometric', 'arithmetic', 'max'}, default='arithmetic'


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #32930.

#### What does this implement/fix? Explain your changes.

This updates the parameter documentation for adjusted_mutual_info_score and normalized_mutual_info_score so labels_true and labels_pred are documented as array like inputs instead of integer only inputs.

This matches the current implementation, which accepts arbitrary discrete labels, and aligns these docstrings with the rest of the supervised clustering metrics documentation.

#### Any other comments?

The existing clustering metric common tests already cover string label inputs through test_format_invariance.
