### PR TITLE
Improve clarity of NaN error message in validation utilities

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -115,7 +115,10 @@ def _assert_all_finite(
     # for object dtype data, we only check for NaNs (GH-13254)
     if not is_array_api and X.dtype == np.dtype("object") and not allow_nan:
         if _object_dtype_isnan(X).any():
-            raise ValueError("Input contains NaN")
+            raise ValueError(
+                "Input contains NaN values. Please handle missing values "
+                "(e.g., imputation or removal) before passing data."
+            )
 
     # We need only consider float arrays, hence can early return for all else.
     if not xp.isdtype(X.dtype, ("real floating", "complex floating")):


### PR DESCRIPTION
Fixes #33904
This PR improves the clarity of error messages related to NaN values in
validation utilities.

Specifically:
- Extends existing "Input contains NaN" messages to include guidance on
  handling missing values (e.g., imputation or removal)
- Preserves the original message prefix ("Input ... contains NaN") to
  maintain backward compatibility with existing tests and user expectations

This change does not affect functionality and is limited to improving
usability and error message clarity.
I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding