### PR TITLE
DOC Clarify where n_jobs parallelization applies in glossary

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1664,6 +1664,12 @@ functions or non-estimator constructors.
         threads should be used for routines that are parallelized with
         :term:`joblib`.
 
+        Where (and if) parallelization happens in a fit or prediction routine
+        is implementation-dependent and is described in the estimator's own
+        documentation. For instance, in
+        :class:`~sklearn.ensemble.RandomForestClassifier`, fitting the trees
+        in the forest is parallelized over the trees.
+
         ``n_jobs`` is an integer, specifying the maximum number of concurrently
         running workers. If 1 is given, no joblib parallelism is used at all,
         which is useful for debugging. If set to -1, all CPUs are used. For


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #14228.

#### What does this implement/fix? Explain your changes.

This PR improves the n_jobs glossary entry in doc/glossary.rst to make its behavior more actionable for users.

Changes made:

- Clarified that where parallelization happens is implementation-dependent and estimator-specific.
- Added a concrete example for RandomForestClassifier: fitting is parallelized over trees.

Goal:

- Help users understand what n_jobs is expected to speed up in practice, instead of only describing it as “number of jobs”.

#### AI usage disclosure

I used AI assistance for:

- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [x] Documentation (including examples)
- [x] Research and understanding

#### Any other comments?

This is a documentation-only change. No code behavior is modified and no changelog entry is needed.