### PR TITLE
fix: TunedThresholdClassifierCV reuses cv.split() iterator when refit=False

### DIFF
--- a/sklearn/model_selection/_classification_threshold.py
+++ b/sklearn/model_selection/_classification_threshold.py
@@ -759,8 +759,10 @@ class TunedThresholdClassifierCV(BaseThresholdClassifier):
                 # train on the whole dataset
                 X_train, y_train, fit_params_train = X, y, routed_params.estimator.fit
             else:
-                # single split cross-validation
-                train_idx, _ = next(cv.split(X, y, **routed_params.splitter.split))
+                # single split cross-validation; consume the one split from the
+                # iterator so estimator_ and threshold tuning use the same partition
+                train_idx, val_idx = next(splits)
+                splits = [(train_idx, val_idx)]  # re-wrap for the Parallel loop below
                 X_train = _safe_indexing(X, train_idx)
                 y_train = _safe_indexing(y, train_idx)
                 fit_params_train = _check_method_params(

--- a/sklearn/model_selection/tests/test_classification_threshold.py
+++ b/sklearn/model_selection/tests/test_classification_threshold.py
@@ -500,6 +500,29 @@ def test_tuned_threshold_classifier_cv_float():
     assert_allclose(tuned_model.estimator_.coef_, cloned_estimator.coef_)
 
 
+def test_tuned_threshold_classifier_refit_false_consistent_split():
+    """Non-regression test for gh-33540.
+
+    When refit=False and cv is a float, estimator_ must be trained on the same
+    partition used for threshold tuning. Previously a second cv.split() call was made
+    which produced a different random partition when random_state was not a fixed seed.
+    """
+    from unittest.mock import patch
+
+    X, y = make_classification(random_state=0)
+
+    cv = StratifiedShuffleSplit(n_splits=1, test_size=0.2, random_state=0)
+    with patch.object(cv, "split", wraps=cv.split) as mock_split:
+        TunedThresholdClassifierCV(
+            LogisticRegression(), cv=cv, refit=False
+        ).fit(X, y)
+        assert mock_split.call_count == 1, (
+            f"cv.split() was called {mock_split.call_count} times; expected 1. "
+            "The second call produces a different split and makes estimator_ "
+            "inconsistent with the tuned threshold."
+        )
+
+
 def test_tuned_threshold_classifier_error_constant_predictor():
     """Check that we raise a ValueError if the underlying classifier returns constant
     probabilities such that we cannot find any threshold.

--- a/sklearn/model_selection/tests/test_classification_threshold.py
+++ b/sklearn/model_selection/tests/test_classification_threshold.py
@@ -513,9 +513,7 @@ def test_tuned_threshold_classifier_refit_false_consistent_split():
 
     cv = StratifiedShuffleSplit(n_splits=1, test_size=0.2, random_state=0)
     with patch.object(cv, "split", wraps=cv.split) as mock_split:
-        TunedThresholdClassifierCV(
-            LogisticRegression(), cv=cv, refit=False
-        ).fit(X, y)
+        TunedThresholdClassifierCV(LogisticRegression(), cv=cv, refit=False).fit(X, y)
         assert mock_split.call_count == 1, (
             f"cv.split() was called {mock_split.call_count} times; expected 1. "
             "The second call produces a different split and makes estimator_ "


### PR DESCRIPTION
## What
When `refit=False` and `cv` is a float, `TunedThresholdClassifierCV.fit()` called `cv.split()` twice — once to create the `splits` iterator and a second time inside the `else` branch to get `train_idx` for `estimator_`. The two calls produce **different random partitions** whenever `random_state` is not a fixed integer seed (e.g. `None` or a `numpy.random.RandomState` instance), so `estimator_` ends up trained on data that is inconsistent with the partition used for threshold tuning.

## Why
Users who rely on `TunedThresholdClassifierCV(cv=0.3, refit=False)` without a fixed `random_state` get an estimator whose decision threshold is calibrated against a split it was never trained on — silently producing a suboptimal or incorrect threshold.

## Reproduce
```python
import numpy as np
from sklearn.datasets import make_classification
from sklearn.linear_model import LogisticRegression
from sklearn.model_selection import TunedThresholdClassifierCV, StratifiedShuffleSplit

X, y = make_classification(random_state=0)

# Track how many times split() is called
cv = StratifiedShuffleSplit(n_splits=1, test_size=0.2, random_state=0)
original_split = cv.split
call_count = [0]
def counted_split(*args, **kwargs):
    call_count[0] += 1
    return original_split(*args, **kwargs)
cv.split = counted_split

TunedThresholdClassifierCV(LogisticRegression(), cv=cv, refit=False).fit(X, y)
print(call_count[0])  # prints 2 (bug) — should be 1
```

## Fix
Consume the single split from the already-created `splits` iterator (instead of calling `cv.split()` again), then re-wrap the values in a list so the `Parallel` loop below can still iterate them. The change is 3 lines in `_classification_threshold.py` and adds one regression test.

## Testing
```python
# After fix:
print(call_count[0])  # prints 1 ✓
```
The new test `test_tuned_threshold_classifier_refit_false_consistent_split` asserts `cv.split()` is called exactly once when `refit=False`.

Fixes #33540