### PR TITLE
MNT X_DTYPE and Y_DTYPE in tree module

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -64,7 +64,7 @@ from sklearn.tree import (
     ExtraTreeClassifier,
     ExtraTreeRegressor,
 )
-from sklearn.tree._tree import DOUBLE, DTYPE
+from sklearn.tree._common import X_DTYPE, Y_DTYPE
 from sklearn.utils import (
     check_random_state,
     compute_class_weight,
@@ -338,7 +338,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
             y,
             multi_output=True,
             accept_sparse="csc",
-            dtype=DTYPE,
+            dtype=X_DTYPE,
             ensure_all_finite=False,
         )
         # _compute_missing_values_in_feature_mask checks if X has missing values and
@@ -393,8 +393,8 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
 
         y, expanded_class_weight = self._validate_y_class_weight(y, sample_weight)
 
-        if getattr(y, "dtype", None) != DOUBLE or not y.flags.contiguous:
-            y = np.ascontiguousarray(y, dtype=DOUBLE)
+        if getattr(y, "dtype", None) != Y_DTYPE or not y.flags.contiguous:
+            y = np.ascontiguousarray(y, dtype=Y_DTYPE)
 
         # Combined _sample_weight = sample_weight * expanded_class_weight
         # (when provided) used in _parallel_build_trees to draw indices
@@ -616,7 +616,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         X = validate_data(
             self,
             X,
-            dtype=DTYPE,
+            dtype=X_DTYPE,
             accept_sparse="csr",
             reset=False,
             ensure_all_finite=ensure_all_finite,
@@ -1137,7 +1137,7 @@ class ForestRegressor(RegressorMixin, BaseForest, metaclass=ABCMeta):
 
         Parameters
         ----------
-        grid : ndarray of shape (n_samples, n_target_features), dtype=DTYPE
+        grid : ndarray of shape (n_samples, n_target_features), dtype=float32
             The grid points on which the partial dependence should be
             evaluated.
         target_features : ndarray of shape (n_target_features), dtype=np.intp
@@ -1149,7 +1149,7 @@ class ForestRegressor(RegressorMixin, BaseForest, metaclass=ABCMeta):
         averaged_predictions : ndarray of shape (n_samples,)
             The value of the partial dependence function on each grid point.
         """
-        grid = np.asarray(grid, dtype=DTYPE, order="C")
+        grid = np.asarray(grid, dtype=X_DTYPE, order="C")
         target_features = np.asarray(target_features, dtype=np.intp, order="C")
         averaged_predictions = np.zeros(
             shape=grid.shape[0], dtype=np.float64, order="C"

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -50,7 +50,8 @@ from sklearn.exceptions import NotFittedError
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder
 from sklearn.tree import DecisionTreeRegressor
-from sklearn.tree._tree import DOUBLE, DTYPE, TREE_LEAF
+from sklearn.tree._common import X_DTYPE, Y_DTYPE
+from sklearn.tree._tree import TREE_LEAF
 from sklearn.utils import check_array, check_random_state, column_or_1d
 from sklearn.utils._param_validation import HasMethods, Hidden, Interval, StrOptions
 from sklearn.utils.multiclass import check_classification_targets
@@ -679,7 +680,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             X,
             y,
             accept_sparse=["csr", "csc", "coo"],
-            dtype=DTYPE,
+            dtype=X_DTYPE,
             multi_output=True,
         )
         sample_weight_is_none = sample_weight is None
@@ -794,7 +795,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             # matrices. Finite values have already been checked in _validate_data.
             X_train = check_array(
                 X_train,
-                dtype=DTYPE,
+                dtype=X_DTYPE,
                 order="C",
                 accept_sparse="csr",
                 ensure_all_finite=False,
@@ -1011,7 +1012,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         """
         if check_input:
             X = validate_data(
-                self, X, dtype=DTYPE, order="C", accept_sparse="csr", reset=False
+                self, X, dtype=X_DTYPE, order="C", accept_sparse="csr", reset=False
             )
         raw_predictions = self._raw_predict_init(X)
         for i in range(self.estimators_.shape[0]):
@@ -1084,7 +1085,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                 "Got init=%s." % self.init,
                 UserWarning,
             )
-        grid = np.asarray(grid, dtype=DTYPE, order="C")
+        grid = np.asarray(grid, dtype=X_DTYPE, order="C")
         n_estimators, n_trees_per_stage = self.estimators_.shape
         averaged_predictions = np.zeros(
             (n_trees_per_stage, grid.shape[0]), dtype=np.float64, order="C"
@@ -1596,7 +1597,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
             array of shape (n_samples,).
         """
         X = validate_data(
-            self, X, dtype=DTYPE, order="C", accept_sparse="csr", reset=False
+            self, X, dtype=X_DTYPE, order="C", accept_sparse="csr", reset=False
         )
         raw_predictions = self._raw_predict(X)
         if raw_predictions.shape[1] == 1:
@@ -2138,7 +2139,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
     def _encode_y(self, y=None, sample_weight=None):
         # Just convert y to the expected dtype
         self.n_trees_per_iteration_ = 1
-        y = y.astype(DOUBLE, copy=False)
+        y = y.astype(Y_DTYPE, copy=False)
         return y
 
     def _get_loss(self, sample_weight):
@@ -2163,7 +2164,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
             The predicted values.
         """
         X = validate_data(
-            self, X, dtype=DTYPE, order="C", accept_sparse="csr", reset=False
+            self, X, dtype=X_DTYPE, order="C", accept_sparse="csr", reset=False
         )
         # In regression we can directly return the raw value from the trees.
         return self._raw_predict(X).ravel()

--- a/sklearn/ensemble/_gradient_boosting.pyx
+++ b/sklearn/ensemble/_gradient_boosting.pyx
@@ -7,10 +7,10 @@ from libc.string cimport memset
 import numpy as np
 from scipy.sparse import issparse
 
-from sklearn.utils._typedefs cimport float32_t, float64_t, intp_t, int32_t, uint8_t
+from sklearn.utils._typedefs cimport float64_t, intp_t, int32_t, uint8_t
+from sklearn.tree._common cimport node_struct, X_DTYPE_C
 # Note: _tree uses cimport numpy, cnp.import_array, so we need to include
 # numpy headers in the build configuration of this extension
-from sklearn.tree._tree cimport Node
 from sklearn.tree._tree cimport Tree
 from sklearn.tree._utils cimport safe_realloc
 
@@ -23,11 +23,11 @@ from numpy import zeros as np_zeros
 cdef intp_t TREE_LEAF = -1
 
 cdef void _predict_regression_tree_inplace_fast_dense(
-    const float32_t[:, ::1] X,
-    Node* root_node,
+    const X_DTYPE_C[:, ::1] X,
+    node_struct* root_node,
     double *value,
     double scale,
-    Py_ssize_t k,
+    intp_t k,
     float64_t[:, :] out
 ) noexcept nogil:
     """Predicts output for regression tree and stores it in ``out[i, k]``.
@@ -44,7 +44,7 @@ cdef void _predict_regression_tree_inplace_fast_dense(
     X : float32_t 2d memory view
         The memory view on the data ndarray of the input ``X``.
         Assumes that the array is c-continuous.
-    root_node : tree Node pointer
+    root_node : tree node_struct pointer
         Pointer to the main node array of the :class:``sklearn.tree.Tree``.
     value : np.float64_t pointer
         The pointer to the data array of the ``value`` array attribute
@@ -60,8 +60,8 @@ cdef void _predict_regression_tree_inplace_fast_dense(
         shape ``(n_samples, K)``.
     """
     cdef intp_t n_samples = X.shape[0]
-    cdef Py_ssize_t i
-    cdef Node *node
+    cdef intp_t i
+    cdef node_struct *node
     for i in range(n_samples):
         node = root_node
         # While node not a leaf
@@ -83,7 +83,7 @@ def _predict_regression_tree_stages_sparse(
 
     The function assumes that the ndarray that wraps ``X`` is csr_matrix.
     """
-    cdef const float32_t[::1] X_data = X.data
+    cdef const X_DTYPE_C[::1] X_data = X.data
     cdef const int32_t[::1] X_indices = X.indices
     cdef const int32_t[::1] X_indptr = X.indptr
 
@@ -97,12 +97,12 @@ def _predict_regression_tree_stages_sparse(
     cdef intp_t feature_i
     cdef intp_t stage_i
     cdef intp_t output_i
-    cdef Node *root_node = NULL
-    cdef Node *node = NULL
+    cdef node_struct *root_node = NULL
+    cdef node_struct *node = NULL
     cdef double *value = NULL
 
     cdef Tree tree
-    cdef Node** nodes = NULL
+    cdef node_struct** nodes = NULL
     cdef double** values = NULL
     safe_realloc(&nodes, n_stages * n_outputs)
     safe_realloc(&values, n_stages * n_outputs)
@@ -113,8 +113,8 @@ def _predict_regression_tree_stages_sparse(
             values[stage_i * n_outputs + output_i] = tree.value
 
     # Initialize auxiliary data-structure
-    cdef float32_t feature_value = 0.
-    cdef float32_t* X_sample = NULL
+    cdef X_DTYPE_C feature_value = 0.
+    cdef X_DTYPE_C* X_sample = NULL
 
     # feature_to_sample as a data structure records the last seen sample
     # for each feature; functionally, it is an efficient way to identify
@@ -172,10 +172,10 @@ def predict_stages(
     Each estimator is scaled by ``scale`` before its prediction
     is added to ``out``.
     """
-    cdef Py_ssize_t i
-    cdef Py_ssize_t k
-    cdef Py_ssize_t n_estimators = estimators.shape[0]
-    cdef Py_ssize_t K = estimators.shape[1]
+    cdef intp_t i
+    cdef intp_t k
+    cdef intp_t n_estimators = estimators.shape[0]
+    cdef intp_t K = estimators.shape[1]
     cdef Tree tree
 
     if issparse(X):

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -12,7 +12,7 @@ from scipy.sparse import issparse
 from sklearn.base import OutlierMixin, _fit_context
 from sklearn.ensemble._bagging import BaseBagging
 from sklearn.tree import ExtraTreeRegressor
-from sklearn.tree._tree import DTYPE as tree_dtype
+from sklearn.tree._common import X_DTYPE
 from sklearn.utils import check_array, check_random_state, gen_batches
 from sklearn.utils._chunking import get_chunk_n_rows
 from sklearn.utils._param_validation import Interval, RealNotInt, StrOptions
@@ -319,7 +319,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
             Fitted estimator.
         """
         X = validate_data(
-            self, X, accept_sparse=["csc"], dtype=tree_dtype, ensure_all_finite=False
+            self, X, accept_sparse=["csc"], dtype=X_DTYPE, ensure_all_finite=False
         )
 
         if sample_weight is not None:
@@ -528,7 +528,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
             self,
             X,
             accept_sparse="csr",
-            dtype=tree_dtype,
+            dtype=X_DTYPE,
             reset=False,
             ensure_all_finite=False,
         )

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -25,7 +25,8 @@ from sklearn.base import (
     clone,
     is_classifier,
 )
-from sklearn.tree import _criterion, _splitter, _tree
+from sklearn.tree import _criterion, _splitter
+from sklearn.tree._common import X_DTYPE, Y_DTYPE
 from sklearn.tree._criterion import Criterion
 from sklearn.tree._splitter import Splitter
 from sklearn.tree._tree import (
@@ -63,9 +64,6 @@ __all__ = [
 # =============================================================================
 # Types and constants
 # =============================================================================
-
-DTYPE = _tree.DTYPE
-DOUBLE = _tree.DOUBLE
 
 CRITERIA_CLF = {
     "gini": _criterion.Gini,
@@ -197,7 +195,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
 
         Parameter
         ---------
-        X : array-like of shape (n_samples, n_features), dtype=DOUBLE
+        X : array-like of shape (n_samples, n_features), dtype=X_DTYPE
             Input data.
 
         estimator_name : str or None, default=None
@@ -248,7 +246,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             # _compute_missing_values_in_feature_mask will check for finite values and
             # compute the missing mask if the tree supports missing values
             check_X_params = dict(
-                dtype=DTYPE, accept_sparse="csc", ensure_all_finite=False
+                dtype=X_DTYPE, accept_sparse="csc", ensure_all_finite=False
             )
             check_y_params = dict(ensure_2d=False, dtype=None)
             X, y = validate_data(
@@ -316,8 +314,8 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
 
             self.n_classes_ = np.array(self.n_classes_, dtype=np.intp)
 
-        if getattr(y, "dtype", None) != DOUBLE or not y.flags.contiguous:
-            y = np.ascontiguousarray(y, dtype=DOUBLE)
+        if getattr(y, "dtype", None) != Y_DTYPE or not y.flags.contiguous:
+            y = np.ascontiguousarray(y, dtype=Y_DTYPE)
 
         max_depth = np.iinfo(np.int32).max if self.max_depth is None else self.max_depth
 
@@ -360,7 +358,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             )
 
         if sample_weight is not None:
-            sample_weight = _check_sample_weight(sample_weight, X, dtype=DOUBLE)
+            sample_weight = _check_sample_weight(sample_weight, X, dtype=Y_DTYPE)
 
         if expanded_class_weight is not None:
             if sample_weight is not None:
@@ -491,7 +489,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             X = validate_data(
                 self,
                 X,
-                dtype=DTYPE,
+                dtype=X_DTYPE,
                 accept_sparse="csr",
                 reset=False,
                 ensure_all_finite=ensure_all_finite,
@@ -1434,7 +1432,7 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
         averaged_predictions : ndarray of shape (n_samples,), dtype=np.float64
             The value of the partial dependence function on each grid point.
         """
-        grid = np.asarray(grid, dtype=DTYPE, order="C")
+        grid = np.asarray(grid, dtype=X_DTYPE, order="C")
         averaged_predictions = np.zeros(
             shape=grid.shape[0], dtype=np.float64, order="C"
         )

--- a/sklearn/tree/_common.pxd
+++ b/sklearn/tree/_common.pxd
@@ -1,0 +1,16 @@
+from sklearn.utils._typedefs cimport float32_t, float64_t, intp_t, uint8_t
+
+
+ctypedef float32_t X_DTYPE_C  # C version of X_DTYPE
+ctypedef float64_t Y_DTYPE_C  # C version of Y_DTYPE
+
+cdef struct node_struct:
+    # Base storage structure for the nodes in a Tree object
+    intp_t left_child                    # id of the left child of the node
+    intp_t right_child                   # id of the right child of the node
+    intp_t feature                       # Feature used for splitting the node
+    float64_t threshold                  # Threshold value at the node
+    Y_DTYPE_C impurity                   # Impurity of the node (i.e., the value of the criterion)
+    intp_t n_node_samples                # Number of samples at the node
+    Y_DTYPE_C weighted_n_node_samples    # Weighted number of samples at the node
+    uint8_t missing_go_to_left           # Whether features have missing values

--- a/sklearn/tree/_common.pyx
+++ b/sklearn/tree/_common.pyx
@@ -1,0 +1,5 @@
+import numpy as np
+
+
+X_DTYPE = np.float32
+Y_DTYPE = np.float64

--- a/sklearn/tree/_criterion.pxd
+++ b/sklearn/tree/_criterion.pxd
@@ -3,6 +3,7 @@
 
 # See _criterion.pyx for implementation details.
 from sklearn.utils._typedefs cimport float64_t, int8_t, intp_t
+from sklearn.tree._common cimport X_DTYPE_C, Y_DTYPE_C
 
 
 cdef class Criterion:
@@ -11,21 +12,21 @@ cdef class Criterion:
     # such as the mean in regression and class probabilities in classification.
 
     # Internal structures
-    cdef const float64_t[:, ::1] y         # Values of y
-    cdef const float64_t[:] sample_weight  # Sample weights
+    cdef const Y_DTYPE_C[:, ::1] y         # Values of y
+    cdef const Y_DTYPE_C[:] sample_weight  # Sample weights
 
     cdef const intp_t[:] sample_indices    # Sample indices in X, y
     cdef intp_t start                      # samples[start:pos] are the samples in the left node
     cdef intp_t pos                        # samples[pos:end] are the samples in the right node
     cdef intp_t end
 
-    cdef intp_t n_outputs                  # Number of outputs
-    cdef intp_t n_samples                  # Number of samples
-    cdef intp_t n_node_samples             # Number of samples in the node (end-start)
-    cdef float64_t weighted_n_samples         # Weighted number of samples (in total)
-    cdef float64_t weighted_n_node_samples    # Weighted number of samples in the node
-    cdef float64_t weighted_n_left            # Weighted number of samples in the left node
-    cdef float64_t weighted_n_right           # Weighted number of samples in the right node
+    cdef intp_t n_outputs                   # Number of outputs
+    cdef intp_t n_samples                   # Number of samples
+    cdef intp_t n_node_samples              # Number of samples in the node (end-start)
+    cdef Y_DTYPE_C weighted_n_samples       # Weighted number of samples (in total)
+    cdef Y_DTYPE_C weighted_n_node_samples  # Weighted number of samples in the node
+    cdef Y_DTYPE_C weighted_n_left          # Weighted number of samples in the left node
+    cdef Y_DTYPE_C weighted_n_right         # Weighted number of samples in the right node
 
     # The criterion object is maintained such that left and right collected
     # statistics correspond to samples[start:pos] and samples[pos:end].
@@ -33,9 +34,9 @@ cdef class Criterion:
     # Methods
     cdef int init(
         self,
-        const float64_t[:, ::1] y,
-        const float64_t[:] sample_weight,
-        float64_t weighted_n_samples,
+        const Y_DTYPE_C[:, ::1] y,
+        const Y_DTYPE_C[:] sample_weight,
+        Y_DTYPE_C weighted_n_samples,
         const intp_t[:] sample_indices,
         intp_t start,
         intp_t end

--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -15,8 +15,10 @@ from sklearn.tree._utils cimport log
 from sklearn.tree._utils cimport WeightedFenwickTree
 from sklearn.tree._partitioner cimport sort
 
+from sklearn.tree._common import Y_DTYPE
+
 # EPSILON is used in the Poisson criterion
-cdef float64_t EPSILON = 10 * np.finfo('double').eps
+cdef Y_DTYPE_C EPSILON = 10 * np.finfo('double').eps
 
 cdef class Criterion:
     """Interface for impurity criteria.
@@ -32,9 +34,9 @@ cdef class Criterion:
 
     cdef int init(
         self,
-        const float64_t[:, ::1] y,
-        const float64_t[:] sample_weight,
-        float64_t weighted_n_samples,
+        const Y_DTYPE_C[:, ::1] y,
+        const Y_DTYPE_C[:] sample_weight,
+        Y_DTYPE_C weighted_n_samples,
         const intp_t[:] sample_indices,
         intp_t start,
         intp_t end,
@@ -92,7 +94,7 @@ cdef class Criterion:
         """
         pass
 
-    cdef float64_t node_impurity(self) noexcept nogil:
+    cdef Y_DTYPE_C node_impurity(self) noexcept nogil:
         """Placeholder for calculating the impurity of the node.
 
         Placeholder for a method which will evaluate the impurity of
@@ -102,8 +104,8 @@ cdef class Criterion:
         """
         pass
 
-    cdef void children_impurity(self, float64_t* impurity_left,
-                                float64_t* impurity_right) noexcept nogil:
+    cdef void children_impurity(self, Y_DTYPE_C* impurity_left,
+                                Y_DTYPE_C* impurity_right) noexcept nogil:
         """Placeholder for calculating the impurity of children.
 
         Placeholder for a method which evaluates the impurity in
@@ -121,7 +123,7 @@ cdef class Criterion:
         """
         pass
 
-    cdef void node_value(self, float64_t* dest) noexcept nogil:
+    cdef void node_value(self, Y_DTYPE_C* dest) noexcept nogil:
         """Placeholder for storing the node value.
 
         Placeholder for a method which will compute the node value
@@ -134,17 +136,17 @@ cdef class Criterion:
         """
         pass
 
-    cdef void clip_node_value(self, float64_t* dest, float64_t lower_bound, float64_t upper_bound) noexcept nogil:
+    cdef void clip_node_value(self, Y_DTYPE_C* dest, Y_DTYPE_C lower_bound, Y_DTYPE_C upper_bound) noexcept nogil:
         pass
 
-    cdef float64_t middle_value(self) noexcept nogil:
+    cdef Y_DTYPE_C middle_value(self) noexcept nogil:
         """Compute the middle value of a split for monotonicity constraints
 
         This method is implemented in ClassificationCriterion and RegressionCriterion.
         """
         pass
 
-    cdef float64_t proxy_impurity_improvement(self) noexcept nogil:
+    cdef Y_DTYPE_C proxy_impurity_improvement(self) noexcept nogil:
         """Compute a proxy of the impurity reduction.
 
         This method is used to speed up the search for the best split.
@@ -155,16 +157,16 @@ cdef class Criterion:
         The absolute impurity improvement is only computed by the
         impurity_improvement method once the best split has been found.
         """
-        cdef float64_t impurity_left
-        cdef float64_t impurity_right
+        cdef Y_DTYPE_C impurity_left
+        cdef Y_DTYPE_C impurity_right
         self.children_impurity(&impurity_left, &impurity_right)
 
         return (- self.weighted_n_right * impurity_right
                 - self.weighted_n_left * impurity_left)
 
-    cdef float64_t impurity_improvement(self, float64_t impurity_parent,
-                                        float64_t impurity_left,
-                                        float64_t impurity_right) noexcept nogil:
+    cdef Y_DTYPE_C impurity_improvement(self, Y_DTYPE_C impurity_parent,
+                                        Y_DTYPE_C impurity_left,
+                                        Y_DTYPE_C impurity_right) noexcept nogil:
         """Compute the improvement in impurity.
 
         This method computes the improvement in impurity when a split occurs.
@@ -201,18 +203,18 @@ cdef class Criterion:
     cdef bint check_monotonicity(
         self,
         cnp.int8_t monotonic_cst,
-        float64_t lower_bound,
-        float64_t upper_bound,
+        Y_DTYPE_C lower_bound,
+        Y_DTYPE_C upper_bound,
     ) noexcept nogil:
         pass
 
     cdef inline bint _check_monotonicity(
         self,
         cnp.int8_t monotonic_cst,
-        float64_t lower_bound,
-        float64_t upper_bound,
-        float64_t value_left,
-        float64_t value_right,
+        Y_DTYPE_C lower_bound,
+        Y_DTYPE_C upper_bound,
+        Y_DTYPE_C value_left,
+        Y_DTYPE_C value_right,
     ) noexcept nogil:
         cdef:
             bint check_lower_bound = (
@@ -231,10 +233,10 @@ cdef class Criterion:
 
 cdef inline void _move_sums_classification(
     ClassificationCriterion criterion,
-    float64_t[:, ::1] sum_1,
-    float64_t[:, ::1] sum_2,
-    float64_t* weighted_n_1,
-    float64_t* weighted_n_2,
+    Y_DTYPE_C[:, ::1] sum_1,
+    Y_DTYPE_C[:, ::1] sum_2,
+    Y_DTYPE_C* weighted_n_1,
+    Y_DTYPE_C* weighted_n_2,
 ) noexcept nogil:
     """Distribute sum_total into sum_1 and sum_2.
     """
@@ -242,7 +244,7 @@ cdef inline void _move_sums_classification(
 
     # Assigning sum_2 = sum_total for all outputs.
     for k in range(criterion.n_outputs):
-        n_bytes = criterion.n_classes[k] * sizeof(float64_t)
+        n_bytes = criterion.n_classes[k] * sizeof(Y_DTYPE_C)
         memset(&sum_1[k, 0], 0, n_bytes)
         memcpy(&sum_2[k, 0], &criterion.sum_total[k, 0], n_bytes)
 
@@ -301,9 +303,9 @@ cdef class ClassificationCriterion(Criterion):
 
     cdef int init(
         self,
-        const float64_t[:, ::1] y,
-        const float64_t[:] sample_weight,
-        float64_t weighted_n_samples,
+        const Y_DTYPE_C[:, ::1] y,
+        const Y_DTYPE_C[:] sample_weight,
+        Y_DTYPE_C weighted_n_samples,
         const intp_t[:] sample_indices,
         intp_t start,
         intp_t end
@@ -345,10 +347,10 @@ cdef class ClassificationCriterion(Criterion):
         cdef intp_t p
         cdef intp_t k
         cdef intp_t c
-        cdef float64_t w = 1.0
+        cdef Y_DTYPE_C w = 1.0
 
         for k in range(self.n_outputs):
-            memset(&self.sum_total[k, 0], 0, self.n_classes[k] * sizeof(float64_t))
+            memset(&self.sum_total[k, 0], 0, self.n_classes[k] * sizeof(Y_DTYPE_C))
 
         for p in range(start, end):
             i = sample_indices[p]
@@ -419,7 +421,7 @@ cdef class ClassificationCriterion(Criterion):
         cdef intp_t p
         cdef intp_t k
         cdef intp_t c
-        cdef float64_t w = 1.0
+        cdef Y_DTYPE_C w = 1.0
 
         # Update statistics up to new_pos
         #
@@ -463,14 +465,14 @@ cdef class ClassificationCriterion(Criterion):
         self.pos = new_pos
         return 0
 
-    cdef float64_t node_impurity(self) noexcept nogil:
+    cdef Y_DTYPE_C node_impurity(self) noexcept nogil:
         pass
 
-    cdef void children_impurity(self, float64_t* impurity_left,
-                                float64_t* impurity_right) noexcept nogil:
+    cdef void children_impurity(self, Y_DTYPE_C* impurity_left,
+                                Y_DTYPE_C* impurity_right) noexcept nogil:
         pass
 
-    cdef void node_value(self, float64_t* dest) noexcept nogil:
+    cdef void node_value(self, Y_DTYPE_C* dest) noexcept nogil:
         """Compute the node value of sample_indices[start:end] and save it into dest.
 
         Parameters
@@ -486,7 +488,7 @@ cdef class ClassificationCriterion(Criterion):
             dest += self.max_n_classes
 
     cdef inline void clip_node_value(
-        self, float64_t * dest, float64_t lower_bound, float64_t upper_bound
+        self, Y_DTYPE_C * dest, Y_DTYPE_C lower_bound, Y_DTYPE_C upper_bound
     ) noexcept nogil:
         """Clip the values in dest such that predicted probabilities stay between
         `lower_bound` and `upper_bound` when monotonic constraints are enforced.
@@ -502,7 +504,7 @@ cdef class ClassificationCriterion(Criterion):
         # Values for binary classification must sum to 1.
         dest[1] = 1 - dest[0]
 
-    cdef inline float64_t middle_value(self) noexcept nogil:
+    cdef inline Y_DTYPE_C middle_value(self) noexcept nogil:
         """Compute the middle value of a split for monotonicity constraints as the simple average
         of the left and right children values.
 
@@ -518,13 +520,13 @@ cdef class ClassificationCriterion(Criterion):
     cdef inline bint check_monotonicity(
         self,
         cnp.int8_t monotonic_cst,
-        float64_t lower_bound,
-        float64_t upper_bound,
+        Y_DTYPE_C lower_bound,
+        Y_DTYPE_C upper_bound,
     ) noexcept nogil:
         """Check monotonicity constraint is satisfied at the current classification split"""
         cdef:
-            float64_t value_left = self.sum_left[0][0] / self.weighted_n_left
-            float64_t value_right = self.sum_right[0][0] / self.weighted_n_right
+            Y_DTYPE_C value_left = self.sum_left[0][0] / self.weighted_n_left
+            Y_DTYPE_C value_right = self.sum_right[0][0] / self.weighted_n_right
 
         return self._check_monotonicity(monotonic_cst, lower_bound, upper_bound, value_left, value_right)
 
@@ -545,15 +547,15 @@ cdef class Entropy(ClassificationCriterion):
         cross-entropy = -\sum_{k=0}^{K-1} count_k log(count_k)
     """
 
-    cdef float64_t node_impurity(self) noexcept nogil:
+    cdef Y_DTYPE_C node_impurity(self) noexcept nogil:
         """Evaluate the impurity of the current node.
 
         Evaluate the cross-entropy criterion as impurity of the current node,
         i.e. the impurity of sample_indices[start:end]. The smaller the impurity the
         better.
         """
-        cdef float64_t entropy = 0.0
-        cdef float64_t count_k
+        cdef Y_DTYPE_C entropy = 0.0
+        cdef Y_DTYPE_C count_k
         cdef intp_t k
         cdef intp_t c
 
@@ -566,8 +568,8 @@ cdef class Entropy(ClassificationCriterion):
 
         return entropy / self.n_outputs
 
-    cdef void children_impurity(self, float64_t* impurity_left,
-                                float64_t* impurity_right) noexcept nogil:
+    cdef void children_impurity(self, Y_DTYPE_C* impurity_left,
+                                Y_DTYPE_C* impurity_right) noexcept nogil:
         """Evaluate the impurity in children nodes.
 
         i.e. the impurity of the left child (sample_indices[start:pos]) and the
@@ -580,9 +582,9 @@ cdef class Entropy(ClassificationCriterion):
         impurity_right : float64_t pointer
             The memory address to save the impurity of the right node
         """
-        cdef float64_t entropy_left = 0.0
-        cdef float64_t entropy_right = 0.0
-        cdef float64_t count_k
+        cdef Y_DTYPE_C entropy_left = 0.0
+        cdef Y_DTYPE_C entropy_right = 0.0
+        cdef Y_DTYPE_C count_k
         cdef intp_t k
         cdef intp_t c
 
@@ -619,16 +621,16 @@ cdef class Gini(ClassificationCriterion):
               = 1 - \sum_{k=0}^{K-1} count_k ** 2
     """
 
-    cdef float64_t node_impurity(self) noexcept nogil:
+    cdef Y_DTYPE_C node_impurity(self) noexcept nogil:
         """Evaluate the impurity of the current node.
 
         Evaluate the Gini criterion as impurity of the current node,
         i.e. the impurity of sample_indices[start:end]. The smaller the impurity the
         better.
         """
-        cdef float64_t gini = 0.0
-        cdef float64_t sq_count
-        cdef float64_t count_k
+        cdef Y_DTYPE_C gini = 0.0
+        cdef Y_DTYPE_C sq_count
+        cdef Y_DTYPE_C count_k
         cdef intp_t k
         cdef intp_t c
 
@@ -644,8 +646,8 @@ cdef class Gini(ClassificationCriterion):
 
         return gini / self.n_outputs
 
-    cdef void children_impurity(self, float64_t* impurity_left,
-                                float64_t* impurity_right) noexcept nogil:
+    cdef void children_impurity(self, Y_DTYPE_C* impurity_left,
+                                Y_DTYPE_C* impurity_right) noexcept nogil:
         """Evaluate the impurity in children nodes.
 
         i.e. the impurity of the left child (sample_indices[start:pos]) and the
@@ -658,11 +660,11 @@ cdef class Gini(ClassificationCriterion):
         impurity_right : float64_t pointer
             The memory address to save the impurity of the right node to
         """
-        cdef float64_t gini_left = 0.0
-        cdef float64_t gini_right = 0.0
-        cdef float64_t sq_count_left
-        cdef float64_t sq_count_right
-        cdef float64_t count_k
+        cdef Y_DTYPE_C gini_left = 0.0
+        cdef Y_DTYPE_C gini_right = 0.0
+        cdef Y_DTYPE_C sq_count_left
+        cdef Y_DTYPE_C sq_count_right
+        cdef Y_DTYPE_C count_k
         cdef intp_t k
         cdef intp_t c
 
@@ -689,13 +691,13 @@ cdef class Gini(ClassificationCriterion):
 
 cdef inline void _move_sums_regression(
     RegressionCriterion criterion,
-    float64_t[::1] sum_1,
-    float64_t[::1] sum_2,
-    float64_t* weighted_n_1,
-    float64_t* weighted_n_2,
+    Y_DTYPE_C[::1] sum_1,
+    Y_DTYPE_C[::1] sum_2,
+    Y_DTYPE_C* weighted_n_1,
+    Y_DTYPE_C* weighted_n_2,
 ) noexcept nogil:
     """Distribute sum_total into sum_1 and sum_2."""
-    cdef intp_t n_bytes = criterion.n_outputs * sizeof(float64_t)
+    cdef intp_t n_bytes = criterion.n_outputs * sizeof(Y_DTYPE_C)
 
     memset(&sum_1[0], 0, n_bytes)
     # Assigning sum_2 = sum_total for all outputs.
@@ -750,9 +752,9 @@ cdef class RegressionCriterion(Criterion):
 
     cdef int init(
         self,
-        const float64_t[:, ::1] y,
-        const float64_t[:] sample_weight,
-        float64_t weighted_n_samples,
+        const Y_DTYPE_C[:, ::1] y,
+        const Y_DTYPE_C[:] sample_weight,
+        Y_DTYPE_C weighted_n_samples,
         const intp_t[:] sample_indices,
         intp_t start,
         intp_t end,
@@ -775,11 +777,11 @@ cdef class RegressionCriterion(Criterion):
         cdef intp_t i
         cdef intp_t p
         cdef intp_t k
-        cdef float64_t y_ik
-        cdef float64_t w_y_ik
-        cdef float64_t w = 1.0
+        cdef Y_DTYPE_C y_ik
+        cdef Y_DTYPE_C w_y_ik
+        cdef Y_DTYPE_C w = 1.0
         self.sq_sum_total = 0.0
-        memset(&self.sum_total[0], 0, self.n_outputs * sizeof(float64_t))
+        memset(&self.sum_total[0], 0, self.n_outputs * sizeof(Y_DTYPE_C))
 
         for p in range(start, end):
             i = sample_indices[p]
@@ -830,7 +832,7 @@ cdef class RegressionCriterion(Criterion):
         cdef intp_t i
         cdef intp_t p
         cdef intp_t k
-        cdef float64_t w = 1.0
+        cdef Y_DTYPE_C w = 1.0
 
         # Update statistics up to new_pos
         #
@@ -872,28 +874,28 @@ cdef class RegressionCriterion(Criterion):
         self.pos = new_pos
         return 0
 
-    cdef float64_t node_impurity(self) noexcept nogil:
+    cdef Y_DTYPE_C node_impurity(self) noexcept nogil:
         pass
 
-    cdef void children_impurity(self, float64_t* impurity_left,
-                                float64_t* impurity_right) noexcept nogil:
+    cdef void children_impurity(self, Y_DTYPE_C* impurity_left,
+                                Y_DTYPE_C* impurity_right) noexcept nogil:
         pass
 
-    cdef void node_value(self, float64_t* dest) noexcept nogil:
+    cdef void node_value(self, Y_DTYPE_C* dest) noexcept nogil:
         """Compute the node value of sample_indices[start:end] into dest."""
         cdef intp_t k
 
         for k in range(self.n_outputs):
             dest[k] = self.sum_total[k] / self.weighted_n_node_samples
 
-    cdef inline void clip_node_value(self, float64_t* dest, float64_t lower_bound, float64_t upper_bound) noexcept nogil:
+    cdef inline void clip_node_value(self, Y_DTYPE_C* dest, Y_DTYPE_C lower_bound, Y_DTYPE_C upper_bound) noexcept nogil:
         """Clip the value in dest between lower_bound and upper_bound for monotonic constraints."""
         if dest[0] < lower_bound:
             dest[0] = lower_bound
         elif dest[0] > upper_bound:
             dest[0] = upper_bound
 
-    cdef float64_t middle_value(self) noexcept nogil:
+    cdef Y_DTYPE_C middle_value(self) noexcept nogil:
         """Compute the middle value of a split for monotonicity constraints as the simple average
         of the left and right children values.
 
@@ -908,13 +910,13 @@ cdef class RegressionCriterion(Criterion):
     cdef bint check_monotonicity(
         self,
         cnp.int8_t monotonic_cst,
-        float64_t lower_bound,
-        float64_t upper_bound,
+        Y_DTYPE_C lower_bound,
+        Y_DTYPE_C upper_bound,
     ) noexcept nogil:
         """Check monotonicity constraint is satisfied at the current regression split"""
         cdef:
-            float64_t value_left = self.sum_left[0] / self.weighted_n_left
-            float64_t value_right = self.sum_right[0] / self.weighted_n_right
+            Y_DTYPE_C value_left = self.sum_left[0] / self.weighted_n_left
+            Y_DTYPE_C value_right = self.sum_right[0] / self.weighted_n_right
 
         return self._check_monotonicity(monotonic_cst, lower_bound, upper_bound, value_left, value_right)
 
@@ -925,14 +927,14 @@ cdef class MSE(RegressionCriterion):
         MSE = var_left + var_right
     """
 
-    cdef float64_t node_impurity(self) noexcept nogil:
+    cdef Y_DTYPE_C node_impurity(self) noexcept nogil:
         """Evaluate the impurity of the current node.
 
         Evaluate the MSE criterion as impurity of the current node,
         i.e. the impurity of sample_indices[start:end]. The smaller the impurity the
         better.
         """
-        cdef float64_t impurity
+        cdef Y_DTYPE_C impurity
         cdef intp_t k
 
         impurity = self.sq_sum_total / self.weighted_n_node_samples
@@ -941,7 +943,7 @@ cdef class MSE(RegressionCriterion):
 
         return impurity / self.n_outputs
 
-    cdef float64_t proxy_impurity_improvement(self) noexcept nogil:
+    cdef Y_DTYPE_C proxy_impurity_improvement(self) noexcept nogil:
         """Compute a proxy of the impurity reduction.
 
         This method is used to speed up the search for the best split.
@@ -962,8 +964,8 @@ cdef class MSE(RegressionCriterion):
             - 1/n_L * sum_{i left}(y_i)^2 - 1/n_R * sum_{i right}(y_i)^2
         """
         cdef intp_t k
-        cdef float64_t proxy_impurity_left = 0.0
-        cdef float64_t proxy_impurity_right = 0.0
+        cdef Y_DTYPE_C proxy_impurity_left = 0.0
+        cdef Y_DTYPE_C proxy_impurity_right = 0.0
 
         for k in range(self.n_outputs):
             proxy_impurity_left += self.sum_left[k] * self.sum_left[k]
@@ -972,27 +974,27 @@ cdef class MSE(RegressionCriterion):
         return (proxy_impurity_left / self.weighted_n_left +
                 proxy_impurity_right / self.weighted_n_right)
 
-    cdef void children_impurity(self, float64_t* impurity_left,
-                                float64_t* impurity_right) noexcept nogil:
+    cdef void children_impurity(self, Y_DTYPE_C* impurity_left,
+                                Y_DTYPE_C* impurity_right) noexcept nogil:
         """Evaluate the impurity in children nodes.
 
         i.e. the impurity of the left child (sample_indices[start:pos]) and the
         impurity the right child (sample_indices[pos:end]).
         """
-        cdef const float64_t[:] sample_weight = self.sample_weight
+        cdef const Y_DTYPE_C[:] sample_weight = self.sample_weight
         cdef const intp_t[:] sample_indices = self.sample_indices
         cdef intp_t pos = self.pos
         cdef intp_t start = self.start
 
-        cdef float64_t y_ik
+        cdef Y_DTYPE_C y_ik
 
-        cdef float64_t sq_sum_left = 0.0
-        cdef float64_t sq_sum_right
+        cdef Y_DTYPE_C sq_sum_left = 0.0
+        cdef Y_DTYPE_C sq_sum_right
 
         cdef intp_t i
         cdef intp_t p
         cdef intp_t k
-        cdef float64_t w = 1.0
+        cdef Y_DTYPE_C w = 1.0
 
         for p in range(start, pos):
             i = sample_indices[p]
@@ -1020,15 +1022,15 @@ cdef class MSE(RegressionCriterion):
 # Helper for MAE criterion:
 
 cdef void precompute_absolute_errors(
-    const float64_t[::1] sorted_y,
+    const Y_DTYPE_C[::1] sorted_y,
     const intp_t[::1] ranks,
-    const float64_t[:] sample_weight,
+    const Y_DTYPE_C[:] sample_weight,
     const intp_t[:] sample_indices,
     WeightedFenwickTree tree,
     intp_t start,
     intp_t end,
-    float64_t[::1] abs_errors,
-    float64_t[::1] medians,
+    Y_DTYPE_C[::1] abs_errors,
+    Y_DTYPE_C[::1] medians,
 ) noexcept nogil:
     """
     Fill `abs_errors` and `medians`.
@@ -1069,9 +1071,9 @@ cdef void precompute_absolute_errors(
     """
     cdef:
         intp_t p, i, step, n, rank, median_rank, median_prev_rank
-        float64_t w = 1.
-        float64_t half_weight, median
-        float64_t w_right, w_left, wy_left, wy_right
+        Y_DTYPE_C w = 1.
+        Y_DTYPE_C half_weight, median
+        Y_DTYPE_C w_right, w_left, wy_left, wy_right
 
     if start < end:
         step = 1
@@ -1129,7 +1131,7 @@ cdef void precompute_absolute_errors(
 
 
 cdef inline void compute_ranks(
-    float64_t* sorted_y,
+    Y_DTYPE_C* sorted_y,
     intp_t* sorted_indices,
     intp_t* ranks,
     intp_t n
@@ -1144,8 +1146,8 @@ cdef inline void compute_ranks(
 
 
 def _py_precompute_absolute_errors(
-    const float64_t[:, ::1] ys,
-    const float64_t[:] sample_weight,
+    const Y_DTYPE_C[:, ::1] ys,
+    const Y_DTYPE_C[:] sample_weight,
     const intp_t[:] sample_indices,
     const intp_t start,
     const intp_t end,
@@ -1157,11 +1159,11 @@ def _py_precompute_absolute_errors(
         intp_t s = start
         intp_t e = end
         WeightedFenwickTree tree = WeightedFenwickTree(n)
-        float64_t[::1] sorted_y = np.empty(n, dtype=np.float64)
+        Y_DTYPE_C[::1] sorted_y = np.empty(n, dtype=Y_DTYPE)
         intp_t[::1] sorted_indices = np.empty(n, dtype=np.intp)
         intp_t[::1] ranks = np.empty(n, dtype=np.intp)
-        float64_t[::1] abs_errors = np.zeros(n, dtype=np.float64)
-        float64_t[::1] medians = np.empty(n, dtype=np.float64)
+        Y_DTYPE_C[::1] abs_errors = np.zeros(n, dtype=np.float64)
+        Y_DTYPE_C[::1] medians = np.empty(n, dtype=np.float64)
 
     if start > end:
         s = end + 1
@@ -1243,12 +1245,12 @@ cdef class MAE(Criterion):
     choices, see the external report:
     https://github.com/cakedev0/fast-mae-split/blob/main/report.ipynb
     """
-    cdef float64_t[::1] node_medians
-    cdef float64_t[::1] left_abs_errors
-    cdef float64_t[::1] right_abs_errors
-    cdef float64_t[::1] left_medians
-    cdef float64_t[::1] right_medians
-    cdef float64_t[::1] sorted_y
+    cdef Y_DTYPE_C[::1] node_medians
+    cdef Y_DTYPE_C[::1] left_abs_errors
+    cdef Y_DTYPE_C[::1] right_abs_errors
+    cdef Y_DTYPE_C[::1] left_medians
+    cdef Y_DTYPE_C[::1] right_medians
+    cdef Y_DTYPE_C[::1] sorted_y
     cdef intp_t [::1] sorted_indices
     cdef intp_t[::1] ranks
     cdef WeightedFenwickTree prefix_sum_tree
@@ -1303,9 +1305,9 @@ cdef class MAE(Criterion):
 
     cdef int init(
         self,
-        const float64_t[:, ::1] y,
-        const float64_t[:] sample_weight,
-        float64_t weighted_n_samples,
+        const Y_DTYPE_C[:, ::1] y,
+        const Y_DTYPE_C[:] sample_weight,
+        Y_DTYPE_C weighted_n_samples,
         const intp_t[:] sample_indices,
         intp_t start,
         intp_t end,
@@ -1321,7 +1323,7 @@ cdef class MAE(Criterion):
         cdef:
             intp_t i, p
             intp_t n = end - start
-            float64_t w = 1.0
+            Y_DTYPE_C w = 1.0
 
         # Initialize fields
         self.y = y
@@ -1359,7 +1361,7 @@ cdef class MAE(Criterion):
         self.weighted_n_right = self.weighted_n_node_samples
         self.pos = self.start
 
-        n_bytes = self.n_node_samples * sizeof(float64_t)
+        n_bytes = self.n_node_samples * sizeof(Y_DTYPE_C)
         memset(&self.left_abs_errors[self.start],  0, n_bytes)
         memset(&self.right_abs_errors[self.start], 0, n_bytes)
 
@@ -1429,7 +1431,7 @@ cdef class MAE(Criterion):
         """
         cdef intp_t pos = self.pos
         cdef intp_t i, p
-        cdef float64_t w = 1.0
+        cdef Y_DTYPE_C w = 1.0
 
         # Update statistics up to new_pos
         for p in range(pos, new_pos):
@@ -1443,13 +1445,13 @@ cdef class MAE(Criterion):
         self.pos = new_pos
         return 0
 
-    cdef void node_value(self, float64_t* dest) noexcept nogil:
+    cdef void node_value(self, Y_DTYPE_C* dest) noexcept nogil:
         """Computes the node value of sample_indices[start:end] into dest."""
         cdef intp_t k
         for k in range(self.n_outputs):
-            dest[k] = <float64_t> self.node_medians[k]
+            dest[k] = <Y_DTYPE_C> self.node_medians[k]
 
-    cdef inline float64_t middle_value(self) noexcept nogil:
+    cdef inline Y_DTYPE_C middle_value(self) noexcept nogil:
         """Compute the middle value of a split for monotonicity constraints as the simple average
         of the left and right children values.
 
@@ -1464,15 +1466,15 @@ cdef class MAE(Criterion):
     cdef inline bint check_monotonicity(
         self,
         cnp.int8_t monotonic_cst,
-        float64_t lower_bound,
-        float64_t upper_bound,
+        Y_DTYPE_C lower_bound,
+        Y_DTYPE_C upper_bound,
     ) noexcept nogil:
         """Check monotonicity constraint is satisfied at the current regression split"""
         return self._check_monotonicity(
             monotonic_cst, lower_bound, upper_bound,
             self.left_medians[self.pos - 1], self.right_medians[self.pos])
 
-    cdef float64_t node_impurity(self) noexcept nogil:
+    cdef Y_DTYPE_C node_impurity(self) noexcept nogil:
         """Evaluate the impurity of the current node.
 
         Evaluate the MAE criterion as impurity of the current node,
@@ -1486,8 +1488,8 @@ cdef class MAE(Criterion):
             / (self.weighted_n_node_samples * self.n_outputs)
         )
 
-    cdef void children_impurity(self, float64_t* p_impurity_left,
-                                float64_t* p_impurity_right) noexcept nogil:
+    cdef void children_impurity(self, Y_DTYPE_C* p_impurity_left,
+                                Y_DTYPE_C* p_impurity_right) noexcept nogil:
         """Evaluate the impurity in children nodes.
 
         i.e. the impurity of the left child (sample_indices[start:pos]) and the
@@ -1495,8 +1497,8 @@ cdef class MAE(Criterion):
 
         Time complexity: O(1) (precomputed in `.reset()`)
         """
-        cdef float64_t impurity_left = 0.0
-        cdef float64_t impurity_right = 0.0
+        cdef Y_DTYPE_C impurity_left = 0.0
+        cdef Y_DTYPE_C impurity_right = 0.0
 
         # if pos == start, left child is empty, hence impurity is 0
         if self.pos > self.start:
@@ -1514,7 +1516,7 @@ cdef class MAE(Criterion):
     def __reduce__(self):
         return (type(self), (self.n_outputs, self.n_samples), self.__getstate__())
 
-    cdef inline void clip_node_value(self, float64_t* dest, float64_t lower_bound, float64_t upper_bound) noexcept nogil:
+    cdef inline void clip_node_value(self, Y_DTYPE_C* dest, Y_DTYPE_C lower_bound, Y_DTYPE_C upper_bound) noexcept nogil:
         """Clip the value in dest between lower_bound and upper_bound for monotonic constraints."""
         if dest[0] < lower_bound:
             dest[0] = lower_bound
@@ -1543,7 +1545,7 @@ cdef class Poisson(RegressionCriterion):
     # children_impurity would only need to go over left xor right split, not
     # both. This could be faster.
 
-    cdef float64_t node_impurity(self) noexcept nogil:
+    cdef Y_DTYPE_C node_impurity(self) noexcept nogil:
         """Evaluate the impurity of the current node.
 
         Evaluate the Poisson criterion as impurity of the current node,
@@ -1553,7 +1555,7 @@ cdef class Poisson(RegressionCriterion):
         return self.poisson_loss(self.start, self.end, self.sum_total,
                                  self.weighted_n_node_samples)
 
-    cdef float64_t proxy_impurity_improvement(self) noexcept nogil:
+    cdef Y_DTYPE_C proxy_impurity_improvement(self) noexcept nogil:
         """Compute a proxy of the impurity reduction.
 
         This method is used to speed up the search for the best split.
@@ -1577,10 +1579,10 @@ cdef class Poisson(RegressionCriterion):
             - sum{i right}(y_i) * log(mean{i right}(y_i))
         """
         cdef intp_t k
-        cdef float64_t proxy_impurity_left = 0.0
-        cdef float64_t proxy_impurity_right = 0.0
-        cdef float64_t y_mean_left = 0.
-        cdef float64_t y_mean_right = 0.
+        cdef Y_DTYPE_C proxy_impurity_left = 0.0
+        cdef Y_DTYPE_C proxy_impurity_right = 0.0
+        cdef Y_DTYPE_C y_mean_left = 0.
+        cdef Y_DTYPE_C y_mean_right = 0.
 
         for k in range(self.n_outputs):
             if (self.sum_left[k] <= EPSILON) or (self.sum_right[k] <= EPSILON):
@@ -1599,8 +1601,8 @@ cdef class Poisson(RegressionCriterion):
 
         return - proxy_impurity_left - proxy_impurity_right
 
-    cdef void children_impurity(self, float64_t* impurity_left,
-                                float64_t* impurity_right) noexcept nogil:
+    cdef void children_impurity(self, Y_DTYPE_C* impurity_left,
+                                Y_DTYPE_C* impurity_right) noexcept nogil:
         """Evaluate the impurity in children nodes.
 
         i.e. the impurity of the left child (sample_indices[start:pos]) and the
@@ -1616,22 +1618,22 @@ cdef class Poisson(RegressionCriterion):
         impurity_right[0] = self.poisson_loss(pos, end, self.sum_right,
                                               self.weighted_n_right)
 
-    cdef inline float64_t poisson_loss(
+    cdef inline Y_DTYPE_C poisson_loss(
         self,
         intp_t start,
         intp_t end,
-        const float64_t[::1] y_sum,
-        float64_t weight_sum
+        const Y_DTYPE_C[::1] y_sum,
+        Y_DTYPE_C weight_sum
     ) noexcept nogil:
         """Helper function to compute Poisson loss (~deviance) of a given node.
         """
-        cdef const float64_t[:, ::1] y = self.y
-        cdef const float64_t[:] sample_weight = self.sample_weight
+        cdef const Y_DTYPE_C[:, ::1] y = self.y
+        cdef const Y_DTYPE_C[:] sample_weight = self.sample_weight
         cdef const intp_t[:] sample_indices = self.sample_indices
 
-        cdef float64_t y_mean = 0.
-        cdef float64_t poisson_loss = 0.
-        cdef float64_t w = 1.0
+        cdef Y_DTYPE_C y_mean = 0.
+        cdef Y_DTYPE_C poisson_loss = 0.
+        cdef Y_DTYPE_C w = 1.0
         cdef intp_t i, k, p
         cdef intp_t n_outputs = self.n_outputs
 

--- a/sklearn/tree/_partitioner.pxd
+++ b/sklearn/tree/_partitioner.pxd
@@ -6,13 +6,14 @@
 from cython cimport floating
 
 from sklearn.utils._typedefs cimport (
-    float32_t, float64_t, int8_t, int32_t, intp_t, uint8_t, uint32_t
+    float32_t, float64_t, int32_t, intp_t, uint8_t
 )
+from sklearn.tree._common cimport X_DTYPE_C, Y_DTYPE_C
 from sklearn.tree._splitter cimport SplitRecord
 
 
 # Mitigate precision differences between 32 bit and 64 bit
-cdef const float32_t FEATURE_THRESHOLD = 1e-7
+cdef const X_DTYPE_C FEATURE_THRESHOLD = 1e-7
 
 
 # We provide here the abstract interface for a Partitioner that would be
@@ -26,7 +27,7 @@ cdef const float32_t FEATURE_THRESHOLD = 1e-7
 #
 # cdef class BasePartitioner:
 #     cdef intp_t[::1] samples
-#     cdef float32_t[::1] feature_values
+#     cdef X_DTYPE_C[::1] feature_values
 #     cdef intp_t start
 #     cdef intp_t end
 #     cdef intp_t n_missing
@@ -43,8 +44,8 @@ cdef const float32_t FEATURE_THRESHOLD = 1e-7
 #     cdef void find_min_max(
 #         self,
 #         intp_t current_feature,
-#         float32_t* min_feature_value_out,
-#         float32_t* max_feature_value_out,
+#         X_DTYPE_C* min_feature_value_out,
+#         X_DTYPE_C* max_feature_value_out,
 #     ) noexcept nogil
 #     cdef void next_p(
 #         self,
@@ -67,9 +68,9 @@ cdef class DensePartitioner:
 
     Note that this partitioner is agnostic to the splitting strategy (best vs. random).
     """
-    cdef const float32_t[:, :] X
+    cdef const X_DTYPE_C[:, :] X
     cdef intp_t[::1] samples
-    cdef float32_t[::1] feature_values
+    cdef X_DTYPE_C[::1] feature_values
     cdef intp_t start
     cdef intp_t end
     cdef intp_t n_missing
@@ -88,8 +89,8 @@ cdef class DensePartitioner:
     cdef void find_min_max(
         self,
         intp_t current_feature,
-        float32_t* min_feature_value_out,
-        float32_t* max_feature_value_out,
+        X_DTYPE_C* min_feature_value_out,
+        X_DTYPE_C* max_feature_value_out,
     ) noexcept nogil
     cdef void next_p(
         self,
@@ -113,7 +114,7 @@ cdef class SparsePartitioner:
 
     Note that this partitioner is agnostic to the splitting strategy (best vs. random).
     """
-    cdef const float32_t[::1] X_data
+    cdef const X_DTYPE_C[::1] X_data
     cdef const int32_t[::1] X_indices
     cdef const int32_t[::1] X_indptr
     cdef intp_t n_total_samples
@@ -124,7 +125,7 @@ cdef class SparsePartitioner:
     cdef bint is_samples_sorted
 
     cdef intp_t[::1] samples
-    cdef float32_t[::1] feature_values
+    cdef X_DTYPE_C[::1] feature_values
     cdef intp_t start
     cdef intp_t end
     cdef intp_t n_missing
@@ -142,8 +143,8 @@ cdef class SparsePartitioner:
     cdef void find_min_max(
         self,
         intp_t current_feature,
-        float32_t* min_feature_value_out,
-        float32_t* max_feature_value_out,
+        X_DTYPE_C* min_feature_value_out,
+        X_DTYPE_C* max_feature_value_out,
     ) noexcept nogil
     cdef void next_p(
         self,
@@ -176,4 +177,4 @@ cdef void sort(floating* feature_values, intp_t* samples, intp_t n) noexcept nog
 
 ctypedef fused array_data_type:
     intp_t
-    float32_t
+    X_DTYPE_C

--- a/sklearn/tree/_partitioner.pyx
+++ b/sklearn/tree/_partitioner.pyx
@@ -27,7 +27,7 @@ from sklearn.tree._splitter cimport SplitRecord
 cdef float32_t EXTRACT_NNZ_SWITCH = 0.1
 
 # Allow for 32 bit float comparisons
-cdef float32_t INFINITY_32t = np.inf
+cdef X_DTYPE_C INFINITY_32t = np.inf
 
 
 @final
@@ -38,9 +38,9 @@ cdef class DensePartitioner:
     """
     def __init__(
         self,
-        const float32_t[:, :] X,
+        const X_DTYPE_C[:, :] X,
         intp_t[::1] samples,
-        float32_t[::1] feature_values,
+        X_DTYPE_C[::1] feature_values,
         const uint8_t[::1] missing_values_in_feature_mask,
     ):
         self.X = X
@@ -69,8 +69,8 @@ cdef class DensePartitioner:
         """
         cdef:
             intp_t i, current_end
-            float32_t[::1] feature_values = self.feature_values
-            const float32_t[:, :] X = self.X
+            X_DTYPE_C[::1] feature_values = self.feature_values
+            const X_DTYPE_C[:, :] X = self.X
             intp_t[::1] samples = self.samples
             intp_t n_missing = 0
             const uint8_t[::1] missing_values_in_feature_mask = self.missing_values_in_feature_mask
@@ -126,8 +126,8 @@ cdef class DensePartitioner:
     cdef inline void find_min_max(
         self,
         intp_t current_feature,
-        float32_t* min_feature_value_out,
-        float32_t* max_feature_value_out,
+        X_DTYPE_C* min_feature_value_out,
+        X_DTYPE_C* max_feature_value_out,
     ) noexcept nogil:
         """Find the minimum and maximum value for current_feature.
 
@@ -136,11 +136,11 @@ cdef class DensePartitioner:
         """
         cdef:
             intp_t p
-            float32_t current_feature_value
+            X_DTYPE_C current_feature_value
             intp_t[::1] samples = self.samples
-            float32_t min_feature_value = INFINITY_32t
-            float32_t max_feature_value = -INFINITY_32t
-            float32_t[::1] feature_values = self.feature_values
+            X_DTYPE_C min_feature_value = INFINITY_32t
+            X_DTYPE_C max_feature_value = -INFINITY_32t
+            X_DTYPE_C[::1] feature_values = self.feature_values
             intp_t n_missing = 0
             bint seen_non_missing = False
 
@@ -226,7 +226,7 @@ cdef class DensePartitioner:
             intp_t partition_start = self.start
             intp_t partition_end = self.end
             intp_t* samples = &self.samples[0]
-            float32_t* feature_values = &self.feature_values[0]
+            X_DTYPE_C* feature_values = &self.feature_values[0]
             bint go_to_left
 
         while partition_start < partition_end:
@@ -259,7 +259,7 @@ cdef class DensePartitioner:
             float64_t best_threshold = best_split[0].threshold
             intp_t best_feature = best_split[0].feature
             bint best_missing_go_to_left = best_split[0].missing_go_to_left
-            float32_t current_value
+            X_DTYPE_C current_value
             bint go_to_left
 
         while partition_start < partition_end:
@@ -287,7 +287,7 @@ cdef class SparsePartitioner:
         object X,
         intp_t[::1] samples,
         intp_t n_samples,
-        float32_t[::1] feature_values,
+        X_DTYPE_C[::1] feature_values,
         const uint8_t[::1] missing_values_in_feature_mask,
     ):
         if not (issparse(X) and X.format == "csc"):
@@ -327,7 +327,7 @@ cdef class SparsePartitioner:
     ) noexcept nogil:
         """Simultaneously sort based on the feature_values."""
         cdef:
-            float32_t[::1] feature_values = self.feature_values
+            X_DTYPE_C[::1] feature_values = self.feature_values
             intp_t[::1] index_to_samples = self.index_to_samples
             intp_t[::1] samples = self.samples
 
@@ -366,14 +366,14 @@ cdef class SparsePartitioner:
     cdef inline void find_min_max(
         self,
         intp_t current_feature,
-        float32_t* min_feature_value_out,
-        float32_t* max_feature_value_out,
+        X_DTYPE_C* min_feature_value_out,
+        X_DTYPE_C* max_feature_value_out,
     ) noexcept nogil:
         """Find the minimum and maximum value for current_feature."""
         cdef:
             intp_t p
-            float32_t current_feature_value, min_feature_value, max_feature_value
-            float32_t[::1] feature_values = self.feature_values
+            X_DTYPE_C current_feature_value, min_feature_value, max_feature_value
+            X_DTYPE_C[::1] feature_values = self.feature_values
 
         self.extract_nnz(current_feature)
 
@@ -462,7 +462,7 @@ cdef class SparsePartitioner:
         cdef:
             intp_t p, partition_end
             intp_t[::1] index_to_samples = self.index_to_samples
-            float32_t[::1] feature_values = self.feature_values
+            X_DTYPE_C[::1] feature_values = self.feature_values
             intp_t[::1] samples = self.samples
 
         if threshold < 0.:
@@ -509,7 +509,7 @@ cdef class SparsePartitioner:
             Index of the feature we want to extract non zero value.
         """
         cdef intp_t[::1] samples = self.samples
-        cdef float32_t[::1] feature_values = self.feature_values
+        cdef X_DTYPE_C[::1] feature_values = self.feature_values
         cdef intp_t indptr_start = self.X_indptr[feature]
         cdef intp_t indptr_end = self.X_indptr[feature + 1]
         cdef intp_t n_indices = <intp_t>(indptr_end - indptr_start)
@@ -517,7 +517,7 @@ cdef class SparsePartitioner:
         cdef intp_t[::1] index_to_samples = self.index_to_samples
         cdef intp_t[::1] sorted_samples = self.sorted_samples
         cdef const int32_t[::1] X_indices = self.X_indices
-        cdef const float32_t[::1] X_data = self.X_data
+        cdef const X_DTYPE_C[::1] X_data = self.X_data
 
         # Use binary search if n_samples * log(n_indices) <
         # n_indices and index_to_samples approach otherwise.
@@ -580,14 +580,14 @@ cdef inline void binary_search(const int32_t[::1] sorted_array,
 
 
 cdef inline void extract_nnz_index_to_samples(const int32_t[::1] X_indices,
-                                              const float32_t[::1] X_data,
+                                              const X_DTYPE_C[::1] X_data,
                                               int32_t indptr_start,
                                               int32_t indptr_end,
                                               intp_t[::1] samples,
                                               intp_t start,
                                               intp_t end,
                                               intp_t[::1] index_to_samples,
-                                              float32_t[::1] feature_values,
+                                              X_DTYPE_C[::1] feature_values,
                                               intp_t* end_negative,
                                               intp_t* start_positive) noexcept nogil:
     """Extract and partition values for a feature using index_to_samples.
@@ -619,14 +619,14 @@ cdef inline void extract_nnz_index_to_samples(const int32_t[::1] X_indices,
 
 
 cdef inline void extract_nnz_binary_search(const int32_t[::1] X_indices,
-                                           const float32_t[::1] X_data,
+                                           const X_DTYPE_C[::1] X_data,
                                            int32_t indptr_start,
                                            int32_t indptr_end,
                                            intp_t[::1] samples,
                                            intp_t start,
                                            intp_t end,
                                            intp_t[::1] index_to_samples,
-                                           float32_t[::1] feature_values,
+                                           X_DTYPE_C[::1] feature_values,
                                            intp_t* end_negative,
                                            intp_t* start_positive,
                                            intp_t[::1] sorted_samples,
@@ -697,7 +697,7 @@ cdef inline void sparse_swap(intp_t[::1] index_to_samples, intp_t[::1] samples,
     index_to_samples[samples[pos_2]] = pos_2
 
 
-def _py_sort(float32_t[::1] feature_values, intp_t[::1] samples, intp_t n):
+def _py_sort(X_DTYPE_C[::1] feature_values, intp_t[::1] samples, intp_t n):
     """Used for testing sort."""
     sort(&feature_values[0], &samples[0], n)
 

--- a/sklearn/tree/_splitter.pxd
+++ b/sklearn/tree/_splitter.pxd
@@ -4,8 +4,9 @@
 # See _splitter.pyx for details.
 
 from sklearn.utils._typedefs cimport (
-    float32_t, float64_t, int8_t, int32_t, intp_t, uint8_t, uint32_t
+    float64_t, int8_t, intp_t, uint8_t, uint32_t
 )
+from sklearn.tree._common cimport X_DTYPE_C, Y_DTYPE_C
 from sklearn.tree._criterion cimport Criterion
 from sklearn.tree._tree cimport ParentInfo
 
@@ -17,11 +18,11 @@ cdef struct SplitRecord:
     #                      # i.e. count of samples below threshold for feature.
     #                      # pos is >= end if the node is a leaf.
     float64_t threshold       # Threshold to split at.
-    float64_t improvement     # Impurity improvement given parent node.
-    float64_t impurity_left   # Impurity of the left split.
-    float64_t impurity_right  # Impurity of the right split.
-    float64_t lower_bound     # Lower bound on value of both children for monotonicity
-    float64_t upper_bound     # Upper bound on value of both children for monotonicity
+    Y_DTYPE_C improvement     # Impurity improvement given parent node.
+    Y_DTYPE_C impurity_left   # Impurity of the left split.
+    Y_DTYPE_C impurity_right  # Impurity of the right split.
+    Y_DTYPE_C lower_bound     # Lower bound on value of both children for monotonicity
+    Y_DTYPE_C upper_bound     # Upper bound on value of both children for monotonicity
     uint8_t missing_go_to_left  # Controls if missing values go to the left node.
 
 
@@ -35,23 +36,23 @@ cdef class Splitter:
     cdef public Criterion criterion      # Impurity criterion
     cdef public intp_t max_features      # Number of features to test
     cdef public intp_t min_samples_leaf  # Min samples in a leaf
-    cdef public float64_t min_weight_leaf   # Minimum weight in a leaf
+    cdef public Y_DTYPE_C min_weight_leaf   # Minimum weight in a leaf
 
     cdef object random_state             # Random state
     cdef uint32_t rand_r_state           # sklearn_rand_r random number state
 
     cdef intp_t[::1] samples             # Sample indices in X, y
     cdef intp_t n_samples                # X.shape[0]
-    cdef float64_t weighted_n_samples       # Weighted number of samples
+    cdef Y_DTYPE_C weighted_n_samples       # Weighted number of samples
     cdef intp_t[::1] features            # Feature indices in X
     cdef intp_t[::1] constant_features   # Constant features indices
     cdef intp_t n_features               # X.shape[1]
-    cdef float32_t[::1] feature_values   # temp. array holding feature values
+    cdef X_DTYPE_C[::1] feature_values   # temp. array holding feature values
 
     cdef intp_t start                    # Start position for the current node
     cdef intp_t end                      # End position for the current node
 
-    cdef const float64_t[:, ::1] y
+    cdef const Y_DTYPE_C[:, ::1] y
     # Monotonicity constraints for each feature.
     # The encoding is as follows:
     #   -1: monotonic decrease
@@ -59,7 +60,7 @@ cdef class Splitter:
     #   +1: monotonic increase
     cdef const int8_t[:] monotonic_cst
     cdef bint with_monotonic_cst
-    cdef const float64_t[:] sample_weight
+    cdef const Y_DTYPE_C[:] sample_weight
 
     # The samples vector `samples` is maintained by the Splitter object such
     # that the samples contained in a node are contiguous. With this setting,
@@ -81,8 +82,8 @@ cdef class Splitter:
     cdef int init(
         self,
         object X,
-        const float64_t[:, ::1] y,
-        const float64_t[:] sample_weight,
+        const Y_DTYPE_C[:, ::1] y,
+        const Y_DTYPE_C[:] sample_weight,
         const uint8_t[::1] missing_values_in_feature_mask,
     ) except -1
 
@@ -90,7 +91,7 @@ cdef class Splitter:
         self,
         intp_t start,
         intp_t end,
-        float64_t* weighted_n_node_samples
+        Y_DTYPE_C* weighted_n_node_samples
     ) except -1 nogil
 
     cdef int node_split(
@@ -99,8 +100,8 @@ cdef class Splitter:
         SplitRecord* split,
     ) except -1 nogil
 
-    cdef void node_value(self, float64_t* dest) noexcept nogil
+    cdef void node_value(self, Y_DTYPE_C* dest) noexcept nogil
 
-    cdef void clip_node_value(self, float64_t* dest, float64_t lower_bound, float64_t upper_bound) noexcept nogil
+    cdef void clip_node_value(self, Y_DTYPE_C* dest, Y_DTYPE_C lower_bound, Y_DTYPE_C upper_bound) noexcept nogil
 
-    cdef float64_t node_impurity(self) noexcept nogil
+    cdef Y_DTYPE_C node_impurity(self) noexcept nogil

--- a/sklearn/tree/_splitter.pyx
+++ b/sklearn/tree/_splitter.pyx
@@ -31,6 +31,8 @@ from sklearn.tree._utils cimport RAND_R_MAX, rand_int, rand_uniform
 
 import numpy as np
 
+from sklearn.tree._common import X_DTYPE
+
 # Introduce a fused-class to make it possible to share the split implementation
 # between the dense and sparse cases in the node_split_best and node_split_random
 # functions. The alternative would have been to use inheritance-based polymorphism
@@ -41,7 +43,7 @@ ctypedef fused Partitioner:
     SparsePartitioner
 
 
-cdef float64_t INFINITY = np.inf
+cdef Y_DTYPE_C INFINITY = np.inf
 
 
 cdef inline void _init_split(SplitRecord* self, intp_t start_pos) noexcept nogil:
@@ -65,7 +67,7 @@ cdef class Splitter:
         Criterion criterion,
         intp_t max_features,
         intp_t min_samples_leaf,
-        float64_t min_weight_leaf,
+        Y_DTYPE_C min_weight_leaf,
         object random_state,
         const int8_t[:] monotonic_cst,
     ):
@@ -125,8 +127,8 @@ cdef class Splitter:
     cdef int init(
         self,
         object X,
-        const float64_t[:, ::1] y,
-        const float64_t[:] sample_weight,
+        const Y_DTYPE_C[:, ::1] y,
+        const Y_DTYPE_C[:] sample_weight,
         const uint8_t[::1] missing_values_in_feature_mask,
     ) except -1:
         """Initialize the splitter.
@@ -164,7 +166,7 @@ cdef class Splitter:
         cdef intp_t[::1] samples = self.samples
 
         cdef intp_t i, j
-        cdef float64_t weighted_n_samples = 0.0
+        cdef Y_DTYPE_C weighted_n_samples = 0.0
         j = 0
 
         for i in range(n_samples):
@@ -186,7 +188,7 @@ cdef class Splitter:
         self.features = np.arange(n_features, dtype=np.intp)
         self.n_features = n_features
 
-        self.feature_values = np.empty(n_samples, dtype=np.float32)
+        self.feature_values = np.empty(n_samples, dtype=X_DTYPE)
         self.constant_features = np.empty(n_features, dtype=np.intp)
 
         self.y = y
@@ -198,7 +200,7 @@ cdef class Splitter:
         self,
         intp_t start,
         intp_t end,
-        float64_t* weighted_n_node_samples
+        Y_DTYPE_C* weighted_n_node_samples
     ) except -1 nogil:
         """Reset splitter on node samples[start:end].
 
@@ -246,17 +248,17 @@ cdef class Splitter:
 
         pass
 
-    cdef void node_value(self, float64_t* dest) noexcept nogil:
+    cdef void node_value(self, Y_DTYPE_C* dest) noexcept nogil:
         """Copy the value of node samples[start:end] into dest."""
 
         self.criterion.node_value(dest)
 
-    cdef inline void clip_node_value(self, float64_t* dest, float64_t lower_bound, float64_t upper_bound) noexcept nogil:
+    cdef inline void clip_node_value(self, Y_DTYPE_C* dest, Y_DTYPE_C lower_bound, Y_DTYPE_C upper_bound) noexcept nogil:
         """Clip the value in dest between lower_bound and upper_bound for monotonic constraints."""
 
         self.criterion.clip_node_value(dest, lower_bound, upper_bound)
 
-    cdef float64_t node_impurity(self) noexcept nogil:
+    cdef Y_DTYPE_C node_impurity(self) noexcept nogil:
         """Return the impurity of the current node."""
 
         return self.criterion.node_impurity()
@@ -291,19 +293,19 @@ cdef inline int node_split_best(
     cdef intp_t[::1] constant_features = splitter.constant_features
     cdef intp_t n_features = splitter.n_features
 
-    cdef float32_t[::1] feature_values = splitter.feature_values
+    cdef X_DTYPE_C[::1] feature_values = splitter.feature_values
     cdef intp_t max_features = splitter.max_features
     cdef intp_t min_samples_leaf = splitter.min_samples_leaf
-    cdef float64_t min_weight_leaf = splitter.min_weight_leaf
+    cdef Y_DTYPE_C min_weight_leaf = splitter.min_weight_leaf
     cdef uint32_t* random_state = &splitter.rand_r_state
 
     cdef SplitRecord best_split, current_split
-    cdef float64_t current_proxy_improvement = -INFINITY
-    cdef float64_t best_proxy_improvement = -INFINITY
+    cdef Y_DTYPE_C current_proxy_improvement = -INFINITY
+    cdef Y_DTYPE_C best_proxy_improvement = -INFINITY
 
-    cdef float64_t impurity = parent_record.impurity
-    cdef float64_t lower_bound = parent_record.lower_bound
-    cdef float64_t upper_bound = parent_record.upper_bound
+    cdef Y_DTYPE_C impurity = parent_record.impurity
+    cdef Y_DTYPE_C lower_bound = parent_record.lower_bound
+    cdef Y_DTYPE_C upper_bound = parent_record.upper_bound
 
     cdef intp_t f_i = n_features
     cdef intp_t f_j
@@ -536,16 +538,16 @@ cdef inline int node_split_random(
 
     cdef intp_t max_features = splitter.max_features
     cdef intp_t min_samples_leaf = splitter.min_samples_leaf
-    cdef float64_t min_weight_leaf = splitter.min_weight_leaf
+    cdef Y_DTYPE_C min_weight_leaf = splitter.min_weight_leaf
     cdef uint32_t* random_state = &splitter.rand_r_state
 
     cdef SplitRecord best_split, current_split
-    cdef float64_t current_proxy_improvement = - INFINITY
-    cdef float64_t best_proxy_improvement = - INFINITY
+    cdef Y_DTYPE_C current_proxy_improvement = - INFINITY
+    cdef Y_DTYPE_C best_proxy_improvement = - INFINITY
 
-    cdef float64_t impurity = parent_record.impurity
-    cdef float64_t lower_bound = parent_record.lower_bound
-    cdef float64_t upper_bound = parent_record.upper_bound
+    cdef Y_DTYPE_C impurity = parent_record.impurity
+    cdef Y_DTYPE_C lower_bound = parent_record.lower_bound
+    cdef Y_DTYPE_C upper_bound = parent_record.upper_bound
 
     cdef intp_t f_i = n_features
     cdef intp_t f_j
@@ -557,8 +559,8 @@ cdef inline int node_split_random(
     # n_total_constants = n_known_constants + n_found_constants
     cdef intp_t n_total_constants = n_known_constants
     cdef intp_t n_visited_features = 0
-    cdef float32_t min_feature_value
-    cdef float32_t max_feature_value
+    cdef X_DTYPE_C min_feature_value
+    cdef X_DTYPE_C max_feature_value
 
     _init_split(&best_split, end)
 
@@ -745,8 +747,8 @@ cdef class BestSplitter(Splitter):
     cdef int init(
         self,
         object X,
-        const float64_t[:, ::1] y,
-        const float64_t[:] sample_weight,
+        const Y_DTYPE_C[:, ::1] y,
+        const Y_DTYPE_C[:] sample_weight,
         const uint8_t[::1] missing_values_in_feature_mask,
     ) except -1:
         Splitter.init(self, X, y, sample_weight, missing_values_in_feature_mask)
@@ -773,8 +775,8 @@ cdef class BestSparseSplitter(Splitter):
     cdef int init(
         self,
         object X,
-        const float64_t[:, ::1] y,
-        const float64_t[:] sample_weight,
+        const Y_DTYPE_C[:, ::1] y,
+        const Y_DTYPE_C[:] sample_weight,
         const uint8_t[::1] missing_values_in_feature_mask,
     ) except -1:
         Splitter.init(self, X, y, sample_weight, missing_values_in_feature_mask)
@@ -801,8 +803,8 @@ cdef class RandomSplitter(Splitter):
     cdef int init(
         self,
         object X,
-        const float64_t[:, ::1] y,
-        const float64_t[:] sample_weight,
+        const Y_DTYPE_C[:, ::1] y,
+        const Y_DTYPE_C[:] sample_weight,
         const uint8_t[::1] missing_values_in_feature_mask,
     ) except -1:
         Splitter.init(self, X, y, sample_weight, missing_values_in_feature_mask)
@@ -829,8 +831,8 @@ cdef class RandomSparseSplitter(Splitter):
     cdef int init(
         self,
         object X,
-        const float64_t[:, ::1] y,
-        const float64_t[:] sample_weight,
+        const Y_DTYPE_C[:, ::1] y,
+        const Y_DTYPE_C[:] sample_weight,
         const uint8_t[::1] missing_values_in_feature_mask,
     ) except -1:
         Splitter.init(self, X, y, sample_weight, missing_values_in_feature_mask)

--- a/sklearn/tree/_tree.pxd
+++ b/sklearn/tree/_tree.pxd
@@ -6,31 +6,20 @@
 import numpy as np
 cimport numpy as cnp
 
-from sklearn.utils._typedefs cimport float32_t, float64_t, intp_t, int32_t, uint8_t, uint32_t
+from sklearn.utils._typedefs cimport float64_t, intp_t, int32_t, uint8_t, uint32_t
 
+from sklearn.tree._common cimport node_struct, Y_DTYPE_C
 from sklearn.tree._splitter cimport Splitter
 from sklearn.tree._splitter cimport SplitRecord
-
-cdef struct Node:
-    # Base storage structure for the nodes in a Tree object
-
-    intp_t left_child                    # id of the left child of the node
-    intp_t right_child                   # id of the right child of the node
-    intp_t feature                       # Feature used for splitting the node
-    float64_t threshold                  # Threshold value at the node
-    float64_t impurity                   # Impurity of the node (i.e., the value of the criterion)
-    intp_t n_node_samples                # Number of samples at the node
-    float64_t weighted_n_node_samples    # Weighted number of samples at the node
-    uint8_t missing_go_to_left     # Whether features have missing values
 
 
 cdef struct ParentInfo:
     # Structure to store information about the parent of a node
     # This is passed to the splitter, to provide information about the previous split
 
-    float64_t lower_bound           # the lower bound of the parent's impurity
-    float64_t upper_bound           # the upper bound of the parent's impurity
-    float64_t impurity              # the impurity of the parent
+    Y_DTYPE_C lower_bound           # the lower bound of the parent's impurity
+    Y_DTYPE_C upper_bound           # the upper bound of the parent's impurity
+    Y_DTYPE_C impurity              # the impurity of the parent
     intp_t n_constant_features      # the number of constant features found in parent
 
 cdef class Tree:
@@ -49,15 +38,15 @@ cdef class Tree:
     cdef public intp_t max_depth         # Max depth of the tree
     cdef public intp_t node_count        # Counter for node IDs
     cdef public intp_t capacity          # Capacity of tree, in terms of nodes
-    cdef Node* nodes                     # Array of nodes
-    cdef float64_t* value                # (capacity, n_outputs, max_n_classes) array of values
+    cdef node_struct* nodes              # Array of nodes
+    cdef Y_DTYPE_C* value                # (capacity, n_outputs, max_n_classes) array of values
     cdef intp_t value_stride             # = n_outputs * max_n_classes
 
     # Methods
     cdef intp_t _add_node(self, intp_t parent, bint is_left, bint is_leaf,
-                          intp_t feature, float64_t threshold, float64_t impurity,
+                          intp_t feature, float64_t threshold, Y_DTYPE_C impurity,
                           intp_t n_node_samples,
-                          float64_t weighted_n_node_samples,
+                          Y_DTYPE_C weighted_n_node_samples,
                           uint8_t missing_go_to_left) except -1 nogil
     cdef int _resize(self, intp_t capacity) except -1 nogil
     cdef int _resize_c(self, intp_t capacity=*) except -1 nogil
@@ -91,28 +80,27 @@ cdef class TreeBuilder:
     # This class controls the various stopping criteria and the node splitting
     # evaluation order, e.g. depth-first or best-first.
 
-    cdef Splitter splitter              # Splitting algorithm
-
-    cdef intp_t min_samples_split       # Minimum number of samples in an internal node
-    cdef intp_t min_samples_leaf        # Minimum number of samples in a leaf
-    cdef float64_t min_weight_leaf         # Minimum weight in a leaf
-    cdef intp_t max_depth               # Maximal tree depth
-    cdef float64_t min_impurity_decrease   # Impurity threshold for early stopping
+    cdef Splitter splitter                # Splitting algorithm
+    cdef intp_t min_samples_split         # Minimum number of samples in an internal node
+    cdef intp_t min_samples_leaf          # Minimum number of samples in a leaf
+    cdef Y_DTYPE_C min_weight_leaf        # Minimum weight in a leaf
+    cdef intp_t max_depth                 # Maximal tree depth
+    cdef Y_DTYPE_C min_impurity_decrease  # Impurity threshold for early stopping
 
     cpdef build(
         self,
         Tree tree,
         object X,
-        const float64_t[:, ::1] y,
-        const float64_t[:] sample_weight=*,
+        const Y_DTYPE_C[:, ::1] y,
+        const Y_DTYPE_C[:] sample_weight=*,
         const uint8_t[::1] missing_values_in_feature_mask=*,
     )
 
     cdef _check_input(
         self,
         object X,
-        const float64_t[:, ::1] y,
-        const float64_t[:] sample_weight,
+        const Y_DTYPE_C[:, ::1] y,
+        const Y_DTYPE_C[:] sample_weight,
     )
 
 

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -23,8 +23,10 @@ cnp.import_array()
 from scipy.sparse import issparse
 from scipy.sparse import csr_array
 
+from sklearn.tree._common import X_DTYPE, Y_DTYPE
 from sklearn.utils import _align_api_if_sparse
 
+from sklearn.tree._common cimport node_struct, X_DTYPE_C, Y_DTYPE_C
 from sklearn.tree._utils cimport safe_realloc
 from sklearn.tree._utils cimport sizet_ptr_to_ndarray
 
@@ -39,11 +41,8 @@ cdef extern from "numpy/arrayobject.h":
 # Types and constants
 # =============================================================================
 
-from numpy import float32 as DTYPE
-from numpy import float64 as DOUBLE
-
-cdef float64_t INFINITY = np.inf
-cdef float64_t EPSILON = np.finfo('double').eps
+cdef Y_DTYPE_C INFINITY = np.inf
+cdef Y_DTYPE_C EPSILON = np.finfo('double').eps
 
 # Some handy constants (BestFirstTreeBuilder)
 cdef bint IS_FIRST = 1
@@ -56,12 +55,13 @@ TREE_UNDEFINED = -2
 cdef intp_t _TREE_LEAF = TREE_LEAF
 cdef intp_t _TREE_UNDEFINED = TREE_UNDEFINED
 
-# Build the corresponding numpy dtype for Node.
-# This works by casting `dummy` to an array of Node of length 1, which numpy
+# Build the corresponding numpy dtype for node_struct.
+# This works by casting `dummy` to an array of node_struct of length 1, which numpy
 # can construct a `dtype`-object for. See https://stackoverflow.com/q/62448946
 # for a more detailed explanation.
-cdef Node dummy
-NODE_DTYPE = np.asarray(<Node[:1]>(&dummy)).dtype
+# TODO: should be np.intp, corresponding to Py_ssize_t
+cdef node_struct dummy
+NODE_DTYPE = np.asarray(<node_struct[:1]>(&dummy)).dtype
 
 cdef inline void _init_parent_record(ParentInfo* record) noexcept nogil:
     record.n_constant_features = 0
@@ -80,8 +80,8 @@ cdef class TreeBuilder:
         self,
         Tree tree,
         object X,
-        const float64_t[:, ::1] y,
-        const float64_t[:] sample_weight=None,
+        const Y_DTYPE_C[:, ::1] y,
+        const Y_DTYPE_C[:] sample_weight=None,
         const uint8_t[::1] missing_values_in_feature_mask=None,
     ):
         """Build a decision tree from the training set (X, y)."""
@@ -90,27 +90,27 @@ cdef class TreeBuilder:
     cdef inline _check_input(
         self,
         object X,
-        const float64_t[:, ::1] y,
-        const float64_t[:] sample_weight,
+        const Y_DTYPE_C[:, ::1] y,
+        const Y_DTYPE_C[:] sample_weight,
     ):
         """Check input dtype, layout and format"""
         if issparse(X):
             X = X.tocsc()
             X.sort_indices()
 
-            if X.data.dtype != DTYPE:
-                X.data = np.ascontiguousarray(X.data, dtype=DTYPE)
+            if X.data.dtype != X_DTYPE:
+                X.data = np.ascontiguousarray(X.data, dtype=X_DTYPE)
 
             if X.indices.dtype != np.int32 or X.indptr.dtype != np.int32:
                 raise ValueError("No support for np.int64 index based "
                                  "sparse matrices")
 
-        elif X.dtype != DTYPE:
+        elif X.dtype != X_DTYPE:
             # since we have to copy we will make it fortran for efficiency
-            X = np.asfortranarray(X, dtype=DTYPE)
+            X = np.asfortranarray(X, dtype=X_DTYPE)
 
         if sample_weight is not None and not sample_weight.base.flags.contiguous:
-            sample_weight = np.asarray(sample_weight, dtype=DOUBLE, order="C")
+            sample_weight = np.asarray(sample_weight, dtype=Y_DTYPE, order="C")
 
         return X, y, sample_weight
 
@@ -122,17 +122,17 @@ cdef struct StackRecord:
     intp_t depth
     intp_t parent
     bint is_left
-    float64_t impurity
+    Y_DTYPE_C impurity
     intp_t n_constant_features
-    float64_t lower_bound
-    float64_t upper_bound
+    Y_DTYPE_C lower_bound
+    Y_DTYPE_C upper_bound
 
 cdef class DepthFirstTreeBuilder(TreeBuilder):
     """Build a decision tree in depth-first fashion."""
 
     def __cinit__(self, Splitter splitter, intp_t min_samples_split,
-                  intp_t min_samples_leaf, float64_t min_weight_leaf,
-                  intp_t max_depth, float64_t min_impurity_decrease):
+                  intp_t min_samples_leaf, Y_DTYPE_C min_weight_leaf,
+                  intp_t max_depth, Y_DTYPE_C min_impurity_decrease):
         self.splitter = splitter
         self.min_samples_split = min_samples_split
         self.min_samples_leaf = min_samples_leaf
@@ -144,8 +144,8 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
         self,
         Tree tree,
         object X,
-        const float64_t[:, ::1] y,
-        const float64_t[:] sample_weight=None,
+        const Y_DTYPE_C[:, ::1] y,
+        const Y_DTYPE_C[:] sample_weight=None,
         const uint8_t[::1] missing_values_in_feature_mask=None,
     ):
         """Build a decision tree from the training set (X, y)."""
@@ -167,9 +167,9 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
         cdef Splitter splitter = self.splitter
         cdef intp_t max_depth = self.max_depth
         cdef intp_t min_samples_leaf = self.min_samples_leaf
-        cdef float64_t min_weight_leaf = self.min_weight_leaf
+        cdef Y_DTYPE_C min_weight_leaf = self.min_weight_leaf
         cdef intp_t min_samples_split = self.min_samples_split
-        cdef float64_t min_impurity_decrease = self.min_impurity_decrease
+        cdef Y_DTYPE_C min_impurity_decrease = self.min_impurity_decrease
 
         # Recursive partition (without actual recursion)
         splitter.init(X, y, sample_weight, missing_values_in_feature_mask)
@@ -180,15 +180,15 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
         cdef intp_t parent
         cdef bint is_left
         cdef intp_t n_node_samples = splitter.n_samples
-        cdef float64_t weighted_n_node_samples
+        cdef Y_DTYPE_C weighted_n_node_samples
         cdef SplitRecord split
         cdef intp_t node_id
 
-        cdef float64_t middle_value
-        cdef float64_t left_child_min
-        cdef float64_t left_child_max
-        cdef float64_t right_child_min
-        cdef float64_t right_child_max
+        cdef Y_DTYPE_C middle_value
+        cdef Y_DTYPE_C left_child_min
+        cdef Y_DTYPE_C left_child_max
+        cdef Y_DTYPE_C right_child_min
+        cdef Y_DTYPE_C right_child_max
         cdef bint is_leaf
         cdef bint first = 1
         cdef intp_t max_depth_seen = -1
@@ -352,13 +352,13 @@ cdef struct FrontierRecord:
     intp_t pos
     intp_t depth
     bint is_leaf
-    float64_t impurity
-    float64_t impurity_left
-    float64_t impurity_right
-    float64_t improvement
-    float64_t lower_bound
-    float64_t upper_bound
-    float64_t middle_value
+    Y_DTYPE_C impurity
+    Y_DTYPE_C impurity_left
+    Y_DTYPE_C impurity_right
+    Y_DTYPE_C improvement
+    Y_DTYPE_C lower_bound
+    Y_DTYPE_C upper_bound
+    Y_DTYPE_C middle_value
 
 cdef inline bool _compare_records(
     const FrontierRecord& left,
@@ -386,7 +386,7 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
     def __cinit__(self, Splitter splitter, intp_t min_samples_split,
                   intp_t min_samples_leaf,  min_weight_leaf,
                   intp_t max_depth, intp_t max_leaf_nodes,
-                  float64_t min_impurity_decrease):
+                  Y_DTYPE_C min_impurity_decrease):
         self.splitter = splitter
         self.min_samples_split = min_samples_split
         self.min_samples_leaf = min_samples_leaf
@@ -399,8 +399,8 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
         self,
         Tree tree,
         object X,
-        const float64_t[:, ::1] y,
-        const float64_t[:] sample_weight=None,
+        const Y_DTYPE_C[:, ::1] y,
+        const Y_DTYPE_C[:] sample_weight=None,
         const uint8_t[::1] missing_values_in_feature_mask=None,
     ):
         """Build a decision tree from the training set (X, y)."""
@@ -419,17 +419,17 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
         cdef FrontierRecord record
         cdef FrontierRecord split_node_left
         cdef FrontierRecord split_node_right
-        cdef float64_t left_child_min
-        cdef float64_t left_child_max
-        cdef float64_t right_child_min
-        cdef float64_t right_child_max
+        cdef Y_DTYPE_C left_child_min
+        cdef Y_DTYPE_C left_child_max
+        cdef Y_DTYPE_C right_child_min
+        cdef Y_DTYPE_C right_child_max
 
         cdef intp_t n_node_samples = splitter.n_samples
         cdef intp_t max_split_nodes = max_leaf_nodes - 1
         cdef bint is_leaf
         cdef intp_t max_depth_seen = -1
         cdef int rc = 0
-        cdef Node* node
+        cdef node_struct* node
 
         cdef ParentInfo parent_record
         _init_parent_record(&parent_record)
@@ -571,7 +571,7 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
         intp_t end,
         bint is_first,
         bint is_left,
-        Node* parent,
+        node_struct* parent,
         intp_t depth,
         ParentInfo* parent_record,
         FrontierRecord* res
@@ -580,8 +580,8 @@ cdef class BestFirstTreeBuilder(TreeBuilder):
         cdef SplitRecord split
         cdef intp_t node_id
         cdef intp_t n_node_samples
-        cdef float64_t min_impurity_decrease = self.min_impurity_decrease
-        cdef float64_t weighted_n_node_samples
+        cdef Y_DTYPE_C min_impurity_decrease = self.min_impurity_decrease
+        cdef Y_DTYPE_C weighted_n_node_samples
         cdef bint is_leaf
 
         splitter.node_reset(start, end, &weighted_n_node_samples)
@@ -838,7 +838,7 @@ cdef class Tree:
         node_ndarray = _check_node_ndarray(node_ndarray, expected_dtype=NODE_DTYPE)
         value_ndarray = _check_value_ndarray(
             value_ndarray,
-            expected_dtype=np.dtype(np.float64),
+            expected_dtype=np.dtype(Y_DTYPE),
             expected_shape=value_shape
         )
 
@@ -847,9 +847,9 @@ cdef class Tree:
             raise MemoryError("resizing tree to %d" % self.capacity)
 
         memcpy(self.nodes, cnp.PyArray_DATA(node_ndarray),
-               self.capacity * sizeof(Node))
+               self.capacity * sizeof(node_struct))
         memcpy(self.value, cnp.PyArray_DATA(value_ndarray),
-               self.capacity * self.value_stride * sizeof(float64_t))
+               self.capacity * self.value_stride * sizeof(Y_DTYPE_C))
 
     cdef int _resize(self, intp_t capacity) except -1 nogil:
         """Resize all inner arrays to `capacity`, if `capacity` == -1, then
@@ -885,9 +885,9 @@ cdef class Tree:
             # value memory is initialised to 0 to enable classifier argmax
             memset(<void*>(self.value + self.capacity * self.value_stride), 0,
                    (capacity - self.capacity) * self.value_stride *
-                   sizeof(float64_t))
-            # node memory is initialised to 0 to ensure deterministic pickle (padding in Node struct)
-            memset(<void*>(self.nodes + self.capacity), 0, (capacity - self.capacity) * sizeof(Node))
+                   sizeof(Y_DTYPE_C))
+            # node memory is initialised to 0 to ensure deterministic pickle (padding in node_struct)
+            memset(<void*>(self.nodes + self.capacity), 0, (capacity - self.capacity) * sizeof(node_struct))
 
         # if capacity smaller than node_count, adjust the counter
         if capacity < self.node_count:
@@ -897,9 +897,9 @@ cdef class Tree:
         return 0
 
     cdef intp_t _add_node(self, intp_t parent, bint is_left, bint is_leaf,
-                          intp_t feature, float64_t threshold, float64_t impurity,
+                          intp_t feature, float64_t threshold, Y_DTYPE_C impurity,
                           intp_t n_node_samples,
-                          float64_t weighted_n_node_samples,
+                          Y_DTYPE_C weighted_n_node_samples,
                           uint8_t missing_go_to_left) except -1 nogil:
         """Add a node to the tree.
 
@@ -913,7 +913,7 @@ cdef class Tree:
             if self._resize_c() != 0:
                 return INTPTR_MAX
 
-        cdef Node* node = &self.nodes[node_id]
+        cdef node_struct* node = &self.nodes[node_id]
         node.impurity = impurity
         node.n_node_samples = n_node_samples
         node.weighted_n_node_samples = weighted_n_node_samples
@@ -963,19 +963,19 @@ cdef class Tree:
             raise ValueError("X should be in np.ndarray format, got %s"
                              % type(X))
 
-        if X.dtype != DTYPE:
+        if X.dtype != X_DTYPE:
             raise ValueError("X.dtype should be np.float32, got %s" % X.dtype)
 
         # Extract input
-        cdef const float32_t[:, :] X_ndarray = X
+        cdef const X_DTYPE_C[:, :] X_ndarray = X
         cdef intp_t n_samples = X.shape[0]
-        cdef float32_t X_i_node_feature
+        cdef X_DTYPE_C X_i_node_feature
 
         # Initialize output
         cdef intp_t[:] out = np.zeros(n_samples, dtype=np.intp)
 
         # Initialize auxiliary data-structure
-        cdef Node* node = NULL
+        cdef node_struct* node = NULL
         cdef intp_t i = 0
 
         with nogil:
@@ -1007,11 +1007,11 @@ cdef class Tree:
             raise ValueError("X should be in CSR sparse format, got %s"
                              % type(X))
 
-        if X.dtype != DTYPE:
+        if X.dtype != X_DTYPE:
             raise ValueError("X.dtype should be np.float32, got %s" % X.dtype)
 
         # Extract input
-        cdef const float32_t[:] X_data = X.data
+        cdef const X_DTYPE_C[:] X_data = X.data
         cdef const int32_t[:] X_indices = X.indices
         cdef const int32_t[:] X_indptr = X.indptr
 
@@ -1022,9 +1022,9 @@ cdef class Tree:
         cdef intp_t[:] out = np.zeros(n_samples, dtype=np.intp)
 
         # Initialize auxiliary data-structure
-        cdef float32_t feature_value = 0.
-        cdef Node* node = NULL
-        cdef float32_t* X_sample = NULL
+        cdef X_DTYPE_C feature_value = 0.
+        cdef node_struct* node = NULL
+        cdef X_DTYPE_C* X_sample = NULL
         cdef intp_t i = 0
         cdef int32_t k = 0
 
@@ -1083,13 +1083,13 @@ cdef class Tree:
             raise ValueError("X should be in np.ndarray format, got %s"
                              % type(X))
 
-        if X.dtype != DTYPE:
+        if X.dtype != X_DTYPE:
             raise ValueError("X.dtype should be np.float32, got %s" % X.dtype)
 
         # Extract input
-        cdef const float32_t[:, :] X_ndarray = X
+        cdef const X_DTYPE_C[:, :] X_ndarray = X
         cdef intp_t n_samples = X.shape[0]
-        cdef float32_t X_i_node_feature
+        cdef X_DTYPE_C X_i_node_feature
 
         # Initialize output
         cdef intp_t[:] indptr = np.zeros(n_samples + 1, dtype=np.intp)
@@ -1098,7 +1098,7 @@ cdef class Tree:
         )
 
         # Initialize auxiliary data-structure
-        cdef Node* node = NULL
+        cdef node_struct* node = NULL
         cdef intp_t i = 0
 
         with nogil:
@@ -1142,11 +1142,11 @@ cdef class Tree:
             raise ValueError("X should be in CSR sparse format, got %s"
                              % type(X))
 
-        if X.dtype != DTYPE:
+        if X.dtype != X_DTYPE:
             raise ValueError("X.dtype should be np.float32, got %s" % X.dtype)
 
         # Extract input
-        cdef const float32_t[:] X_data = X.data
+        cdef const X_DTYPE_C[:] X_data = X.data
         cdef const int32_t[:] X_indices = X.indices
         cdef const int32_t[:] X_indptr = X.indptr
 
@@ -1160,9 +1160,9 @@ cdef class Tree:
         )
 
         # Initialize auxiliary data-structure
-        cdef float32_t feature_value = 0.
-        cdef Node* node = NULL
-        cdef float32_t* X_sample = NULL
+        cdef X_DTYPE_C feature_value = 0.
+        cdef node_struct* node = NULL
+        cdef X_DTYPE_C* X_sample = NULL
         cdef intp_t i = 0
         cdef int32_t k = 0
 
@@ -1247,15 +1247,15 @@ cdef class Tree:
 
     cpdef compute_feature_importances(self, normalize=True):
         """Computes the importance of each feature (aka variable)."""
-        cdef Node* left
-        cdef Node* right
-        cdef Node* nodes = self.nodes
-        cdef Node* node = nodes
-        cdef Node* end_node = node + self.node_count
+        cdef node_struct* left
+        cdef node_struct* right
+        cdef node_struct* nodes = self.nodes
+        cdef node_struct* node = nodes
+        cdef node_struct* end_node = node + self.node_count
 
         cdef float64_t normalizer = 0.
 
-        cdef cnp.float64_t[:] importances = np.zeros(self.n_features)
+        cdef float64_t[:] importances = np.zeros(self.n_features)
 
         with nogil:
             while node != end_node:
@@ -1289,7 +1289,7 @@ cdef class Tree:
         The array keeps a reference to this Tree, which manages the underlying
         memory.
         """
-        cdef cnp.npy_intp shape[3]
+        cdef cnp.npy_intp[3] shape
         shape[0] = <cnp.npy_intp> self.node_count
         shape[1] = <cnp.npy_intp> self.n_outputs
         shape[2] = <cnp.npy_intp> self.max_n_classes
@@ -1310,7 +1310,7 @@ cdef class Tree:
         cdef cnp.npy_intp shape[1]
         shape[0] = <cnp.npy_intp> self.node_count
         cdef cnp.npy_intp strides[1]
-        strides[0] = sizeof(Node)
+        strides[0] = sizeof(node_struct)
         cdef cnp.ndarray arr
         Py_INCREF(NODE_DTYPE)
         arr = PyArray_NewFromDescr(<PyTypeObject *> cnp.ndarray,
@@ -1322,7 +1322,7 @@ cdef class Tree:
             raise ValueError("Can't initialize array.")
         return arr
 
-    def compute_partial_dependence(self, float32_t[:, ::1] X,
+    def compute_partial_dependence(self, X_DTYPE_C[:, ::1] X,
                                    const intp_t[::1] target_features,
                                    float64_t[::1] out):
         """Partial dependence of the response on the ``target_feature`` set.
@@ -1363,7 +1363,7 @@ cdef class Tree:
             float64_t left_sample_frac
             float64_t current_weight
             float64_t total_weight  # used for sanity check only
-            Node *current_node  # use a pointer to avoid copying attributes
+            node_struct *current_node  # use a pointer to avoid copying attributes
             intp_t current_node_idx
             bint is_target_feature
             intp_t _TREE_LEAF = TREE_LEAF  # to avoid python interactions
@@ -1481,7 +1481,7 @@ def _dtype_to_dict(dtype):
 
 
 def _dtype_dict_with_modified_bitness(dtype_dict):
-    # field names in Node struct with intp_t types (see sklearn/tree/_tree.pxd)
+    # field names in node_struct with intp_t types (see sklearn/tree/_common.pxd)
     indexing_field_names = ["left_child", "right_child", "feature", "n_node_samples"]
 
     expected_dtype_size = str(struct.calcsize("P"))
@@ -1571,7 +1571,7 @@ cdef class _CCPPruneController:
         return 0
 
     cdef void save_metrics(self, float64_t effective_alpha,
-                           float64_t subtree_impurities) noexcept nogil:
+                           Y_DTYPE_C subtree_impurities) noexcept nogil:
         """Save metrics when pruning"""
         pass
 
@@ -1604,17 +1604,17 @@ cdef class _AlphaPruner(_CCPPruneController):
 cdef class _PathFinder(_CCPPruneController):
     """Record metrics used to return the cost complexity path."""
     cdef float64_t[:] ccp_alphas
-    cdef float64_t[:] impurities
+    cdef Y_DTYPE_C[:] impurities
     cdef uint32_t count
 
     def __cinit__(self,  intp_t node_count):
         self.ccp_alphas = np.zeros(shape=(node_count), dtype=np.float64)
-        self.impurities = np.zeros(shape=(node_count), dtype=np.float64)
+        self.impurities = np.zeros(shape=(node_count), dtype=Y_DTYPE)
         self.count = 0
 
     cdef void save_metrics(self,
                            float64_t effective_alpha,
-                           float64_t subtree_impurities) noexcept nogil:
+                           Y_DTYPE_C subtree_impurities) noexcept nogil:
         self.ccp_alphas[self.count] = effective_alpha
         self.impurities[self.count] = subtree_impurities
         self.count += 1
@@ -1649,11 +1649,11 @@ cdef _cost_complexity_prune(uint8_t[:] leaves_in_subtree,  # OUT
         intp_t i
         intp_t n_nodes = orig_tree.node_count
         # prior probability using weighted samples
-        float64_t[:] weighted_n_node_samples = orig_tree.weighted_n_node_samples
-        float64_t total_sum_weights = weighted_n_node_samples[0]
-        float64_t[:] impurity = orig_tree.impurity
+        Y_DTYPE_C[:] weighted_n_node_samples = orig_tree.weighted_n_node_samples
+        Y_DTYPE_C total_sum_weights = weighted_n_node_samples[0]
+        Y_DTYPE_C[:] impurity = orig_tree.impurity
         # weighted impurity of each node
-        float64_t[:] r_node = np.empty(shape=n_nodes, dtype=np.float64)
+        Y_DTYPE_C[:] r_node = np.empty(shape=n_nodes, dtype=Y_DTYPE)
 
         intp_t[:] child_l = orig_tree.children_left
         intp_t[:] child_r = orig_tree.children_right
@@ -1665,8 +1665,8 @@ cdef _cost_complexity_prune(uint8_t[:] leaves_in_subtree,  # OUT
         stack[intp_t] node_indices_stack
 
         intp_t[:] n_leaves = np.zeros(shape=n_nodes, dtype=np.intp)
-        float64_t[:] r_branch = np.zeros(shape=n_nodes, dtype=np.float64)
-        float64_t current_r
+        Y_DTYPE_C[:] r_branch = np.zeros(shape=n_nodes, dtype=Y_DTYPE)
+        Y_DTYPE_C current_r
         intp_t leaf_idx
         intp_t parent_idx
 
@@ -1678,7 +1678,7 @@ cdef _cost_complexity_prune(uint8_t[:] leaves_in_subtree,  # OUT
         float64_t subtree_alpha
         float64_t effective_alpha
         intp_t n_pruned_leaves
-        float64_t r_diff
+        Y_DTYPE_C r_diff
         float64_t max_float64 = np.finfo(np.float64).max
 
     # find parent node ids and leaves
@@ -1849,7 +1849,7 @@ def ccp_pruning_path(Tree orig_tree):
     cdef:
         uint32_t total_items = path_finder.count
         float64_t[:] ccp_alphas = np.empty(shape=total_items, dtype=np.float64)
-        float64_t[:] impurities = np.empty(shape=total_items, dtype=np.float64)
+        Y_DTYPE_C[:] impurities = np.empty(shape=total_items, dtype=Y_DTYPE)
         uint32_t count = 0
 
     while count < total_items:
@@ -1905,9 +1905,9 @@ cdef void _build_pruned_tree(
         intp_t value_stride = orig_tree.value_stride
         intp_t max_depth_seen = -1
         int rc = 0
-        Node* node
-        float64_t* orig_value_ptr
-        float64_t* new_value_ptr
+        node_struct* node
+        Y_DTYPE_C* orig_value_ptr
+        Y_DTYPE_C* new_value_ptr
 
         stack[BuildPrunedRecord] prune_stack
         BuildPrunedRecord stack_record
@@ -1949,7 +1949,7 @@ cdef void _build_pruned_tree(
             # copy value from original tree to new tree
             orig_value_ptr = orig_tree.value + value_stride * orig_node_id
             new_value_ptr = tree.value + value_stride * new_node_id
-            memcpy(new_value_ptr, orig_value_ptr, sizeof(float64_t) * value_stride)
+            memcpy(new_value_ptr, orig_value_ptr, sizeof(Y_DTYPE_C) * value_stride)
 
             if not is_leaf:
                 # Push right child on stack

--- a/sklearn/tree/_utils.pxd
+++ b/sklearn/tree/_utils.pxd
@@ -4,7 +4,7 @@
 # See _utils.pyx for details.
 
 cimport numpy as cnp
-from sklearn.tree._tree cimport Node
+from sklearn.tree._common cimport node_struct, Y_DTYPE_C
 from sklearn.neighbors._quad_tree cimport Cell
 from sklearn.utils._typedefs cimport float32_t, float64_t, intp_t, uint8_t, int32_t, uint32_t
 
@@ -30,9 +30,9 @@ ctypedef fused realloc_ptr:
     (uint8_t*)
     (float64_t*)
     (float64_t**)
-    (Node*)
+    (node_struct*)
     (Cell*)
-    (Node**)
+    (node_struct**)
 
 cdef int safe_realloc(realloc_ptr* p, size_t nelems) except -1 nogil
 
@@ -53,18 +53,18 @@ cdef float64_t log(float64_t x) noexcept nogil
 
 cdef class WeightedFenwickTree:
     cdef intp_t size         # number of leaves (ranks)
-    cdef float64_t* tree_w   # BIT for weights
-    cdef float64_t* tree_wy  # BIT for weighted targets
+    cdef Y_DTYPE_C* tree_w   # BIT for weights
+    cdef Y_DTYPE_C* tree_wy  # BIT for weighted targets
     cdef intp_t max_pow2     # highest power of two <= n
-    cdef float64_t total_w   # running total weight
-    cdef float64_t total_wy  # running total weighted target
+    cdef Y_DTYPE_C total_w   # running total weight
+    cdef Y_DTYPE_C total_wy  # running total weighted target
 
     cdef void reset(self, intp_t size) noexcept nogil
-    cdef void add(self, intp_t idx, float64_t y, float64_t w) noexcept nogil
+    cdef void add(self, intp_t idx, Y_DTYPE_C y, Y_DTYPE_C w) noexcept nogil
     cdef intp_t search(
         self,
-        float64_t t,
-        float64_t* cw_out,
-        float64_t* cwy_out,
+        Y_DTYPE_C t,
+        Y_DTYPE_C* cw_out,
+        Y_DTYPE_C* cwy_out,
         intp_t* prev_idx_out,
     ) noexcept nogil

--- a/sklearn/tree/_utils.pyx
+++ b/sklearn/tree/_utils.pyx
@@ -96,7 +96,7 @@ cdef class WeightedFenwickTree:
         Reset the tree to hold 'size' elements and clear all aggregates.
         """
         cdef intp_t p
-        cdef intp_t n_bytes = (size + 1) * sizeof(float64_t)  # +1 for 1-based storage
+        cdef intp_t n_bytes = (size + 1) * sizeof(Y_DTYPE_C)  # +1 for 1-based storage
 
         # Public size and zeroed aggregates.
         self.size = size
@@ -117,7 +117,7 @@ cdef class WeightedFenwickTree:
         if self.tree_wy != NULL:
             free(self.tree_wy)
 
-    cdef void add(self, intp_t idx, float64_t y_value, float64_t weight) noexcept nogil:
+    cdef void add(self, intp_t idx, Y_DTYPE_C y_value, Y_DTYPE_C weight) noexcept nogil:
         """
         Add a weighted observation to the Fenwick tree.
 
@@ -134,7 +134,7 @@ cdef class WeightedFenwickTree:
         -----
         Updates both weight sums and weighted target sums in O(log n) time.
         """
-        cdef float64_t weighted_y = weight * y_value
+        cdef Y_DTYPE_C weighted_y = weight * y_value
         cdef intp_t fenwick_idx = idx + 1  # Convert to 1-based indexing
 
         # Update Fenwick tree nodes by traversing up the tree
@@ -150,9 +150,9 @@ cdef class WeightedFenwickTree:
 
     cdef intp_t search(
         self,
-        float64_t target_weight,
-        float64_t* cumul_weight_out,
-        float64_t* cumul_weighted_y_out,
+        Y_DTYPE_C target_weight,
+        Y_DTYPE_C* cumul_weight_out,
+        Y_DTYPE_C* cumul_weighted_y_out,
         intp_t* prev_idx_out,
     ) noexcept nogil:
         """
@@ -188,10 +188,10 @@ cdef class WeightedFenwickTree:
         cdef:
             intp_t current_idx = 0
             intp_t next_idx, prev_idx, equal_bit
-            float64_t cumul_weight = 0.0
-            float64_t cumul_weighted_y = 0.0
+            Y_DTYPE_C cumul_weight = 0.0
+            Y_DTYPE_C cumul_weighted_y = 0.0
             intp_t search_bit = self.max_pow2  # Start from highest power of 2
-            float64_t node_weight, equal_target
+            Y_DTYPE_C node_weight, equal_target
 
         # Phase 1: Standard Fenwick binary search with prefix accumulation
         # Traverse down the tree, moving right when we can consume more weight
@@ -260,11 +260,11 @@ cdef class PytestWeightedFenwickTree(WeightedFenwickTree):
     def py_reset(self, intp_t n):
         self.reset(n)
 
-    def py_add(self, intp_t idx, float64_t y, float64_t w):
+    def py_add(self, intp_t idx, Y_DTYPE_C y, Y_DTYPE_C w):
         self.add(idx, y, w)
 
-    def py_search(self, float64_t t):
-        cdef float64_t w, wy
+    def py_search(self, Y_DTYPE_C t):
+        cdef Y_DTYPE_C w, wy
         cdef intp_t prev_idx
         idx = self.search(t, &w, &wy, &prev_idx)
         return prev_idx, idx, w, wy

--- a/sklearn/tree/meson.build
+++ b/sklearn/tree/meson.build
@@ -14,6 +14,9 @@ tree_extension_metadata = {
   '_utils':
     {'sources': [cython_gen.process('_utils.pyx')],
      'override_options': ['optimization=3']},
+  '_common':
+    {'sources': [cython_gen.process('_common.pyx')],
+     'override_options': ['optimization=3']},
 }
 
 foreach ext_name, ext_dict : tree_extension_metadata

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -621,7 +621,7 @@ def test_error():
 
 def test_min_samples_split():
     """Test min_samples_split parameter"""
-    X = np.asfortranarray(iris.data, dtype=tree._tree.DTYPE)
+    X = np.asfortranarray(iris.data, dtype=tree._tree.X_DTYPE)
     y = iris.target
 
     # test both DepthFirstTreeBuilder and BestFirstTreeBuilder
@@ -652,7 +652,7 @@ def test_min_samples_split():
 
 def test_min_samples_leaf():
     # Test if leaves contain more than leaf_count training examples
-    X = np.asfortranarray(iris.data, dtype=tree._tree.DTYPE)
+    X = np.asfortranarray(iris.data, dtype=tree._tree.X_DTYPE)
     y = iris.target
 
     # test both DepthFirstTreeBuilder and BestFirstTreeBuilder
@@ -1622,7 +1622,7 @@ def test_min_weight_leaf_split_level(name, sparse_container):
 
 @pytest.mark.parametrize("name", ALL_TREES)
 def test_public_apply_all_trees(name):
-    X_small32 = X_small.astype(tree._tree.DTYPE, copy=False)
+    X_small32 = X_small.astype(tree._tree.X_DTYPE, copy=False)
 
     est = ALL_TREES[name]()
     est.fit(X_small, y_small)
@@ -1632,7 +1632,7 @@ def test_public_apply_all_trees(name):
 @pytest.mark.parametrize("name", SPARSE_TREES)
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 def test_public_apply_sparse_trees(name, csr_container):
-    X_small32 = csr_container(X_small.astype(tree._tree.DTYPE, copy=False))
+    X_small32 = csr_container(X_small.astype(tree._tree.X_DTYPE, copy=False))
 
     est = ALL_TREES[name]()
     est.fit(X_small, y_small)
@@ -1993,13 +1993,13 @@ def assert_is_subtree(tree, subtree):
 @pytest.mark.parametrize("sparse_container", [None] + CSC_CONTAINERS + CSR_CONTAINERS)
 def test_apply_path_readonly_all_trees(name, splitter, sparse_container):
     dataset = DATASETS["clf_small"]
-    X_small = dataset["X"].astype(tree._tree.DTYPE, copy=False)
+    X_small = dataset["X"].astype(tree._tree.X_DTYPE, copy=False)
     if sparse_container is None:
         X_readonly = create_memmap_backed_data(X_small)
     else:
         X_readonly = sparse_container(dataset["X"])
 
-        X_readonly.data = np.array(X_readonly.data, dtype=tree._tree.DTYPE)
+        X_readonly.data = np.array(X_readonly.data, dtype=tree._tree.X_DTYPE)
         (
             X_readonly.data,
             X_readonly.indices,
@@ -2008,7 +2008,7 @@ def test_apply_path_readonly_all_trees(name, splitter, sparse_container):
             (X_readonly.data, X_readonly.indices, X_readonly.indptr)
         )
 
-    y_readonly = create_memmap_backed_data(np.array(y_small, dtype=tree._tree.DTYPE))
+    y_readonly = create_memmap_backed_data(np.array(y_small, dtype=tree._tree.Y_DTYPE))
     est = ALL_TREES[name](splitter=splitter)
     est.fit(X_readonly, y_readonly)
     assert_array_equal(est.predict(X_readonly), est.predict(X_small))
@@ -2187,7 +2187,8 @@ def test_different_endianness_joblib_pickle():
 def get_different_bitness_node_ndarray(node_ndarray):
     new_dtype_for_indexing_fields = np.int64 if _IS_32BIT else np.int32
 
-    # field names in Node struct with SIZE_t types (see sklearn/tree/_tree.pxd)
+    # field names in node_struct with intp_t (Py_ssize_t) types (see
+    # sklearn/tree/_common.pxd)
     indexing_field_names = ["left_child", "right_child", "feature", "n_node_samples"]
 
     new_dtype_dict = {


### PR DESCRIPTION
#### Reference Issues/PRs
Makes #27535 easier.

#### What does this implement/fix? Explain your changes.
This is a pure maintenance PR that consequentially uses the new `X_DTYPE_C` and `Y_DTYPE_C`. This makes the code more aligned with HGBT.
This PR should contain ZERO actual change, just change of dtype names.

#### AI usage disclosure
None

#### Any other comments?
#33948 is a much smaller alternative.
