### PR TITLE
MNT remove tree DOUBLE and DTYPE

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -64,7 +64,6 @@ from sklearn.tree import (
     ExtraTreeClassifier,
     ExtraTreeRegressor,
 )
-from sklearn.tree._tree import DOUBLE, DTYPE
 from sklearn.utils import (
     check_random_state,
     compute_class_weight,
@@ -338,7 +337,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
             y,
             multi_output=True,
             accept_sparse="csc",
-            dtype=DTYPE,
+            dtype=np.float32,
             ensure_all_finite=False,
         )
         # _compute_missing_values_in_feature_mask checks if X has missing values and
@@ -393,8 +392,8 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
 
         y, expanded_class_weight = self._validate_y_class_weight(y, sample_weight)
 
-        if getattr(y, "dtype", None) != DOUBLE or not y.flags.contiguous:
-            y = np.ascontiguousarray(y, dtype=DOUBLE)
+        if getattr(y, "dtype", None) != np.float64 or not y.flags.contiguous:
+            y = np.ascontiguousarray(y, dtype=np.float64)
 
         # Combined _sample_weight = sample_weight * expanded_class_weight
         # (when provided) used in _parallel_build_trees to draw indices
@@ -616,7 +615,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         X = validate_data(
             self,
             X,
-            dtype=DTYPE,
+            dtype=np.float32,
             accept_sparse="csr",
             reset=False,
             ensure_all_finite=ensure_all_finite,
@@ -1137,7 +1136,7 @@ class ForestRegressor(RegressorMixin, BaseForest, metaclass=ABCMeta):
 
         Parameters
         ----------
-        grid : ndarray of shape (n_samples, n_target_features), dtype=DTYPE
+        grid : ndarray of shape (n_samples, n_target_features), dtype=np.float32
             The grid points on which the partial dependence should be
             evaluated.
         target_features : ndarray of shape (n_target_features), dtype=np.intp
@@ -1149,7 +1148,7 @@ class ForestRegressor(RegressorMixin, BaseForest, metaclass=ABCMeta):
         averaged_predictions : ndarray of shape (n_samples,)
             The value of the partial dependence function on each grid point.
         """
-        grid = np.asarray(grid, dtype=DTYPE, order="C")
+        grid = np.asarray(grid, dtype=np.float32, order="C")
         target_features = np.asarray(target_features, dtype=np.intp, order="C")
         averaged_predictions = np.zeros(
             shape=grid.shape[0], dtype=np.float64, order="C"

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -50,7 +50,7 @@ from sklearn.exceptions import NotFittedError
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder
 from sklearn.tree import DecisionTreeRegressor
-from sklearn.tree._tree import DOUBLE, DTYPE, TREE_LEAF
+from sklearn.tree._tree import TREE_LEAF
 from sklearn.utils import check_array, check_random_state, column_or_1d
 from sklearn.utils._param_validation import HasMethods, Hidden, Interval, StrOptions
 from sklearn.utils.multiclass import check_classification_targets
@@ -679,7 +679,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             X,
             y,
             accept_sparse=["csr", "csc", "coo"],
-            dtype=DTYPE,
+            dtype=np.float32,
             multi_output=True,
         )
         sample_weight_is_none = sample_weight is None
@@ -794,7 +794,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             # matrices. Finite values have already been checked in _validate_data.
             X_train = check_array(
                 X_train,
-                dtype=DTYPE,
+                dtype=np.float32,
                 order="C",
                 accept_sparse="csr",
                 ensure_all_finite=False,
@@ -1011,7 +1011,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         """
         if check_input:
             X = validate_data(
-                self, X, dtype=DTYPE, order="C", accept_sparse="csr", reset=False
+                self, X, dtype=np.float32, order="C", accept_sparse="csr", reset=False
             )
         raw_predictions = self._raw_predict_init(X)
         for i in range(self.estimators_.shape[0]):
@@ -1084,7 +1084,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
                 "Got init=%s." % self.init,
                 UserWarning,
             )
-        grid = np.asarray(grid, dtype=DTYPE, order="C")
+        grid = np.asarray(grid, dtype=np.float32, order="C")
         n_estimators, n_trees_per_stage = self.estimators_.shape
         averaged_predictions = np.zeros(
             (n_trees_per_stage, grid.shape[0]), dtype=np.float64, order="C"
@@ -1596,7 +1596,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
             array of shape (n_samples,).
         """
         X = validate_data(
-            self, X, dtype=DTYPE, order="C", accept_sparse="csr", reset=False
+            self, X, dtype=np.float32, order="C", accept_sparse="csr", reset=False
         )
         raw_predictions = self._raw_predict(X)
         if raw_predictions.shape[1] == 1:
@@ -2138,7 +2138,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
     def _encode_y(self, y=None, sample_weight=None):
         # Just convert y to the expected dtype
         self.n_trees_per_iteration_ = 1
-        y = y.astype(DOUBLE, copy=False)
+        y = y.astype(np.float64, copy=False)
         return y
 
     def _get_loss(self, sample_weight):
@@ -2163,7 +2163,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
             The predicted values.
         """
         X = validate_data(
-            self, X, dtype=DTYPE, order="C", accept_sparse="csr", reset=False
+            self, X, dtype=np.float32, order="C", accept_sparse="csr", reset=False
         )
         # In regression we can directly return the raw value from the trees.
         return self._raw_predict(X).ravel()

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -12,7 +12,6 @@ from scipy.sparse import issparse
 from sklearn.base import OutlierMixin, _fit_context
 from sklearn.ensemble._bagging import BaseBagging
 from sklearn.tree import ExtraTreeRegressor
-from sklearn.tree._tree import DTYPE as tree_dtype
 from sklearn.utils import check_array, check_random_state, gen_batches
 from sklearn.utils._chunking import get_chunk_n_rows
 from sklearn.utils._param_validation import Interval, RealNotInt, StrOptions
@@ -319,7 +318,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
             Fitted estimator.
         """
         X = validate_data(
-            self, X, accept_sparse=["csc"], dtype=tree_dtype, ensure_all_finite=False
+            self, X, accept_sparse=["csc"], dtype=np.float32, ensure_all_finite=False
         )
 
         if sample_weight is not None:
@@ -528,7 +527,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
             self,
             X,
             accept_sparse="csr",
-            dtype=tree_dtype,
+            dtype=np.float32,
             reset=False,
             ensure_all_finite=False,
         )

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -25,7 +25,7 @@ from sklearn.base import (
     clone,
     is_classifier,
 )
-from sklearn.tree import _criterion, _splitter, _tree
+from sklearn.tree import _criterion, _splitter
 from sklearn.tree._criterion import Criterion
 from sklearn.tree._splitter import Splitter
 from sklearn.tree._tree import (
@@ -63,9 +63,6 @@ __all__ = [
 # =============================================================================
 # Types and constants
 # =============================================================================
-
-DTYPE = _tree.DTYPE
-DOUBLE = _tree.DOUBLE
 
 CRITERIA_CLF = {
     "gini": _criterion.Gini,
@@ -197,7 +194,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
 
         Parameter
         ---------
-        X : array-like of shape (n_samples, n_features), dtype=DOUBLE
+        X : array-like of shape (n_samples, n_features)
             Input data.
 
         estimator_name : str or None, default=None
@@ -248,7 +245,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             # _compute_missing_values_in_feature_mask will check for finite values and
             # compute the missing mask if the tree supports missing values
             check_X_params = dict(
-                dtype=DTYPE, accept_sparse="csc", ensure_all_finite=False
+                dtype=np.float32, accept_sparse="csc", ensure_all_finite=False
             )
             check_y_params = dict(ensure_2d=False, dtype=None)
             X, y = validate_data(
@@ -316,8 +313,8 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
 
             self.n_classes_ = np.array(self.n_classes_, dtype=np.intp)
 
-        if getattr(y, "dtype", None) != DOUBLE or not y.flags.contiguous:
-            y = np.ascontiguousarray(y, dtype=DOUBLE)
+        if getattr(y, "dtype", None) != np.float64 or not y.flags.contiguous:
+            y = np.ascontiguousarray(y, dtype=np.float64)
 
         max_depth = np.iinfo(np.int32).max if self.max_depth is None else self.max_depth
 
@@ -360,7 +357,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             )
 
         if sample_weight is not None:
-            sample_weight = _check_sample_weight(sample_weight, X, dtype=DOUBLE)
+            sample_weight = _check_sample_weight(sample_weight, X, dtype=np.float64)
 
         if expanded_class_weight is not None:
             if sample_weight is not None:
@@ -491,7 +488,7 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             X = validate_data(
                 self,
                 X,
-                dtype=DTYPE,
+                dtype=np.float32,
                 accept_sparse="csr",
                 reset=False,
                 ensure_all_finite=ensure_all_finite,
@@ -1434,7 +1431,7 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
         averaged_predictions : ndarray of shape (n_samples,), dtype=np.float64
             The value of the partial dependence function on each grid point.
         """
-        grid = np.asarray(grid, dtype=DTYPE, order="C")
+        grid = np.asarray(grid, dtype=np.float32, order="C")
         averaged_predictions = np.zeros(
             shape=grid.shape[0], dtype=np.float64, order="C"
         )

--- a/sklearn/tree/_tree.pyx
+++ b/sklearn/tree/_tree.pyx
@@ -39,9 +39,6 @@ cdef extern from "numpy/arrayobject.h":
 # Types and constants
 # =============================================================================
 
-from numpy import float32 as DTYPE
-from numpy import float64 as DOUBLE
-
 cdef float64_t INFINITY = np.inf
 cdef float64_t EPSILON = np.finfo('double').eps
 
@@ -98,19 +95,19 @@ cdef class TreeBuilder:
             X = X.tocsc()
             X.sort_indices()
 
-            if X.data.dtype != DTYPE:
-                X.data = np.ascontiguousarray(X.data, dtype=DTYPE)
+            if X.data.dtype != np.float32:
+                X.data = np.ascontiguousarray(X.data, dtype=np.float32)
 
             if X.indices.dtype != np.int32 or X.indptr.dtype != np.int32:
                 raise ValueError("No support for np.int64 index based "
                                  "sparse matrices")
 
-        elif X.dtype != DTYPE:
+        elif X.dtype != np.float32:
             # since we have to copy we will make it fortran for efficiency
-            X = np.asfortranarray(X, dtype=DTYPE)
+            X = np.asfortranarray(X, dtype=np.float32)
 
         if sample_weight is not None and not sample_weight.base.flags.contiguous:
-            sample_weight = np.asarray(sample_weight, dtype=DOUBLE, order="C")
+            sample_weight = np.asarray(sample_weight, dtype=np.float64, order="C")
 
         return X, y, sample_weight
 
@@ -963,7 +960,7 @@ cdef class Tree:
             raise ValueError("X should be in np.ndarray format, got %s"
                              % type(X))
 
-        if X.dtype != DTYPE:
+        if X.dtype != np.float32:
             raise ValueError("X.dtype should be np.float32, got %s" % X.dtype)
 
         # Extract input
@@ -1007,7 +1004,7 @@ cdef class Tree:
             raise ValueError("X should be in CSR sparse format, got %s"
                              % type(X))
 
-        if X.dtype != DTYPE:
+        if X.dtype != np.float32:
             raise ValueError("X.dtype should be np.float32, got %s" % X.dtype)
 
         # Extract input
@@ -1083,7 +1080,7 @@ cdef class Tree:
             raise ValueError("X should be in np.ndarray format, got %s"
                              % type(X))
 
-        if X.dtype != DTYPE:
+        if X.dtype != np.float32:
             raise ValueError("X.dtype should be np.float32, got %s" % X.dtype)
 
         # Extract input
@@ -1142,7 +1139,7 @@ cdef class Tree:
             raise ValueError("X should be in CSR sparse format, got %s"
                              % type(X))
 
-        if X.dtype != DTYPE:
+        if X.dtype != np.float32:
             raise ValueError("X.dtype should be np.float32, got %s" % X.dtype)
 
         # Extract input

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -621,7 +621,7 @@ def test_error():
 
 def test_min_samples_split():
     """Test min_samples_split parameter"""
-    X = np.asfortranarray(iris.data, dtype=tree._tree.DTYPE)
+    X = np.asfortranarray(iris.data, dtype=np.float32)
     y = iris.target
 
     # test both DepthFirstTreeBuilder and BestFirstTreeBuilder
@@ -652,7 +652,7 @@ def test_min_samples_split():
 
 def test_min_samples_leaf():
     # Test if leaves contain more than leaf_count training examples
-    X = np.asfortranarray(iris.data, dtype=tree._tree.DTYPE)
+    X = np.asfortranarray(iris.data, dtype=np.float32)
     y = iris.target
 
     # test both DepthFirstTreeBuilder and BestFirstTreeBuilder
@@ -1622,7 +1622,7 @@ def test_min_weight_leaf_split_level(name, sparse_container):
 
 @pytest.mark.parametrize("name", ALL_TREES)
 def test_public_apply_all_trees(name):
-    X_small32 = X_small.astype(tree._tree.DTYPE, copy=False)
+    X_small32 = X_small.astype(np.float32, copy=False)
 
     est = ALL_TREES[name]()
     est.fit(X_small, y_small)
@@ -1632,7 +1632,7 @@ def test_public_apply_all_trees(name):
 @pytest.mark.parametrize("name", SPARSE_TREES)
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 def test_public_apply_sparse_trees(name, csr_container):
-    X_small32 = csr_container(X_small.astype(tree._tree.DTYPE, copy=False))
+    X_small32 = csr_container(X_small.astype(np.float32, copy=False))
 
     est = ALL_TREES[name]()
     est.fit(X_small, y_small)
@@ -1993,13 +1993,13 @@ def assert_is_subtree(tree, subtree):
 @pytest.mark.parametrize("sparse_container", [None] + CSC_CONTAINERS + CSR_CONTAINERS)
 def test_apply_path_readonly_all_trees(name, splitter, sparse_container):
     dataset = DATASETS["clf_small"]
-    X_small = dataset["X"].astype(tree._tree.DTYPE, copy=False)
+    X_small = dataset["X"].astype(np.float32, copy=False)
     if sparse_container is None:
         X_readonly = create_memmap_backed_data(X_small)
     else:
         X_readonly = sparse_container(dataset["X"])
 
-        X_readonly.data = np.array(X_readonly.data, dtype=tree._tree.DTYPE)
+        X_readonly.data = np.array(X_readonly.data, dtype=np.float32)
         (
             X_readonly.data,
             X_readonly.indices,
@@ -2008,7 +2008,7 @@ def test_apply_path_readonly_all_trees(name, splitter, sparse_container):
             (X_readonly.data, X_readonly.indices, X_readonly.indptr)
         )
 
-    y_readonly = create_memmap_backed_data(np.array(y_small, dtype=tree._tree.DTYPE))
+    y_readonly = create_memmap_backed_data(np.array(y_small, dtype=np.float32))
     est = ALL_TREES[name](splitter=splitter)
     est.fit(X_readonly, y_readonly)
     assert_array_equal(est.predict(X_readonly), est.predict(X_small))


### PR DESCRIPTION
#### Reference Issues/PRs
Much smaller alternative to #33944.


#### What does this implement/fix? Explain your changes.
Remove `DOUBLE` and `DTYPE` from `sklearn.tree._tree`.

#### AI usage disclosure
None

#### Any other comments?
