### PR TITLE
FIX add `atol` to `test_enet_ridge_consistency`

### DIFF
--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1661,7 +1661,7 @@ def test_enet_ridge_consistency(ridge_alpha, precompute, n_targets, global_rando
     # by working with the squares of matrices like Q=X'X (=gram) and
     # R^2 = y^2 + wQw - 2yQw (=square of residuals).
     rtol = 1e-5 if precompute else 5e-7
-    atol = 1e-11
+    atol = 3e-11
     assert_allclose(enet.coef_, ridge.coef_, rtol=rtol, atol=atol)
     assert_allclose(enet.intercept_, ridge.intercept_, atol=atol)
 

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -1624,11 +1624,11 @@ def test_enet_sample_weight_does_not_overwrite_sample_weight(check_input):
 @pytest.mark.parametrize(
     ["precompute", "n_targets"], [(False, 1), (True, 1), (False, 3)]
 )
-def test_enet_ridge_consistency(ridge_alpha, precompute, n_targets):
+def test_enet_ridge_consistency(ridge_alpha, precompute, n_targets, global_random_seed):
     # Check that ElasticNet(l1_ratio=0) converges to the same solution as Ridge
     # provided that the value of alpha is adapted.
 
-    rng = np.random.RandomState(42)
+    rng = np.random.RandomState(global_random_seed)
     n_samples = 300
     X, y = make_regression(
         n_samples=n_samples,
@@ -1660,9 +1660,10 @@ def test_enet_ridge_consistency(ridge_alpha, precompute, n_targets):
     # The CD solver using the gram matrix (precompute = True) loses numerical precision
     # by working with the squares of matrices like Q=X'X (=gram) and
     # R^2 = y^2 + wQw - 2yQw (=square of residuals).
-    rtol = 1e-5 if precompute else 1e-7
-    assert_allclose(enet.coef_, ridge.coef_, rtol=rtol)
-    assert_allclose(enet.intercept_, ridge.intercept_)
+    rtol = 1e-5 if precompute else 5e-7
+    atol = 1e-11
+    assert_allclose(enet.coef_, ridge.coef_, rtol=rtol, atol=atol)
+    assert_allclose(enet.intercept_, ridge.intercept_, atol=atol)
 
 
 @pytest.mark.filterwarnings("ignore:With alpha=0, this algorithm:UserWarning")


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #33939.


#### What does this implement/fix? Explain your changes.

This PR adds a small `atol` to the `test_enet_ridge_consistency` to avoid random-seed-dependent test failures.


#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding


#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

N / A