### PR TITLE
MNT move test on pandas sparse dataframe to validation - where it belongs

### DIFF
--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -1,8 +1,6 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
-import warnings
-
 import numpy as np
 import pytest
 from scipy import linalg, sparse
@@ -369,34 +367,6 @@ def test_inplace_data_preprocessing(sparse_container, use_sw, global_random_seed
     if use_sw:
         # Sample weights have no reason to ever be modified inplace.
         assert_allclose(sample_weight, original_sw_data)
-
-
-def test_linear_regression_pd_sparse_dataframe_warning():
-    pd = pytest.importorskip("pandas")
-
-    # Warning is raised only when some of the columns is sparse
-    df = pd.DataFrame({"0": np.random.randn(10)})
-    for col in range(1, 4):
-        arr = np.random.randn(10)
-        arr[:8] = 0
-        # all columns but the first column is sparse
-        if col != 0:
-            arr = pd.arrays.SparseArray(arr, fill_value=0)
-        df[str(col)] = arr
-
-    msg = "pandas.DataFrame with sparse columns found."
-
-    reg = LinearRegression()
-    with pytest.warns(UserWarning, match=msg):
-        reg.fit(df.iloc[:, 0:2], df.iloc[:, 3])
-
-    # does not warn when the whole dataframe is sparse
-    df["0"] = pd.arrays.SparseArray(df["0"], fill_value=0)
-    assert hasattr(df, "sparse")
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", UserWarning)
-        reg.fit(df.iloc[:, 0:2], df.iloc[:, 3])
 
 
 def test_preprocess_data(global_random_seed):

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1125,8 +1125,6 @@ def test_check_array_series():
     res = check_array(s, dtype=None, ensure_2d=False)
     assert_array_equal(res, np.array(["a", "b", "c"], dtype=object))
 
-    # TODO: pandas sparse array
-
 
 @pytest.mark.parametrize(
     "dtype", ((np.float64, np.float32), np.float64, None, "numeric")

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -1125,6 +1125,8 @@ def test_check_array_series():
     res = check_array(s, dtype=None, ensure_2d=False)
     assert_array_equal(res, np.array(["a", "b", "c"], dtype=object))
 
+    # TODO: pandas sparse array
+
 
 @pytest.mark.parametrize(
     "dtype", ((np.float64, np.float32), np.float64, None, "numeric")
@@ -1920,6 +1922,32 @@ def test_check_sparse_pandas_sp_format(sp_format):
     assert sp.issparse(result)
     assert result.format == sp_format
     assert_allclose_dense_sparse(sp_mat, result)
+
+
+def test_check_array_pd_sparse_dataframe_warning():
+    """Test that check_array warns on pandas dataframe with sparse columns."""
+    pd = pytest.importorskip("pandas")
+
+    # Warning is raised only when some of the columns are sparse, not all of them.
+    # Construct a pandas.DataFrame with first column dense, all others sparse.
+    df = pd.DataFrame({"col_0": np.linspace(0, 1, 10)})
+    for i in range(1, 4):
+        arr = np.zeros(10)
+        arr[:4] = np.arange(4)
+        arr = pd.arrays.SparseArray(arr, fill_value=0)
+        df[f"col_{i}"] = arr
+
+    msg = "pandas.DataFrame with sparse columns found."
+    with pytest.warns(UserWarning, match=msg):
+        check_array(df, accept_sparse=True)
+
+    # No warning when the whole dataframe is sparse
+    df = df.drop(columns="col_0")
+    assert hasattr(df, "sparse")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        check_array(df, accept_sparse=True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference Issues/PRs
None


#### What does this implement/fix? Explain your changes.
`check_array` is part of `sklearn.utils.validation`. Currently, the only test for the warning `"pandas.DataFrame with sparse columns found."` is in linear models.

This PR moves the test where it belongs: to validation.

#### AI usage disclosure
None

#### Any other comments?
