### PR TITLE
fix(utils): handle NotFittedError in nested meta-estimator HTML repr

### DIFF
--- a/sklearn/utils/_repr_html/estimator.py
+++ b/sklearn/utils/_repr_html/estimator.py
@@ -417,8 +417,12 @@ def _write_estimator_html(
             and is_not_pipeline_step
             and not (is_column_transformer and has_single_estimator)
         ):
+            try:
+                output_features = estimator.get_feature_names_out()
+            except Exception:
+                output_features = ""
             features_div = _features_html(
-                estimator.get_feature_names_out(), is_fitted_css_class
+                output_features, is_fitted_css_class
             )
             total_output_features_item = (
                 f"<div class='total_features'>{features_div}</div>"

--- a/sklearn/utils/_repr_html/tests/test_estimator.py
+++ b/sklearn/utils/_repr_html/tests/test_estimator.py
@@ -402,6 +402,33 @@ def test_estimator_get_params_return_cls():
     assert "MyEstimator" in estimator_html_repr(est)
 
 
+def test_nested_meta_estimator_html_unfitted_feature_names_out():
+    """Check that nested meta-estimator HTML repr does not fail when
+    an inner unfitted estimator defines get_feature_names_out."""
+    from sklearn.exceptions import NotFittedError
+    from sklearn.pipeline import Pipeline
+    from sklearn.multiclass import OneVsRestClassifier
+
+    class UnfittedFeatureNamesTransformer(BaseEstimator):
+        """A transformer that has get_feature_names_out but raises when unfitted."""
+
+        def get_feature_names_out(self, input_features=None):
+            raise NotFittedError("Not fitted.")
+
+    estimator = OneVsRestClassifier(
+        estimator=Pipeline(
+            [
+                ("transform", UnfittedFeatureNamesTransformer()),
+                ("classifier", LogisticRegression()),
+            ]
+        )
+    )
+    # Should not raise
+    html_output = estimator_html_repr(estimator)
+    assert "OneVsRestClassifier" in html_output
+    assert "Pipeline" in html_output
+
+
 def test_estimator_html_repr_unfitted_vs_fitted():
     """Check that we have the information that the estimator is fitted or not in the
     HTML representation.


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #33887

#### What does this implement/fix? Explain your changes.
When a nested meta-estimator (e.g., `OneVsRestClassifier` wrapping a `Pipeline`) contains an unfitted transformer that defines `get_feature_names_out` but raises `NotFittedError`, the HTML representation previously failed because `get_feature_names_out()` was called without a `try/except` in the `serial`/`parallel` estimator block.

This PR adds a `try/except` around `get_feature_names_out()` in that block, consistent with the existing handling in the `single` estimator block (which already catches exceptions and sets `output_features = ""`).

A regression test is added to verify that `estimator_html_repr` no longer raises for such nested meta-estimators.

#### AI usage disclosure
I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding

#### Any other comments?
The fix is minimal and follows the existing pattern already present for `single` estimator blocks. This should make the HTML representation more robust for complex estimator compositions.
