### PR TITLE
MNT: moving sorting functions from `tree/` to `utils/_sorting.pyx`

### DIFF
--- a/sklearn/tree/_criterion.pyx
+++ b/sklearn/tree/_criterion.pyx
@@ -13,7 +13,7 @@ from scipy.special.cython_special cimport xlogy
 
 from sklearn.tree._utils cimport log
 from sklearn.tree._utils cimport WeightedFenwickTree
-from sklearn.tree._partitioner cimport sort
+from sklearn.utils._sorting cimport sort
 
 # EPSILON is used in the Poisson criterion
 cdef float64_t EPSILON = 10 * np.finfo('double').eps

--- a/sklearn/tree/_partitioner.pxd
+++ b/sklearn/tree/_partitioner.pxd
@@ -3,8 +3,6 @@
 
 # See _partitioner.pyx for details.
 
-from cython cimport floating
-
 from sklearn.utils._typedefs cimport (
     float32_t, float64_t, int32_t, intp_t, uint8_t
 )
@@ -169,9 +167,6 @@ cdef class SparsePartitioner:
         self,
         float64_t threshold
     ) noexcept nogil
-
-
-cdef void sort(floating* feature_values, intp_t* samples, intp_t n) noexcept nogil
 
 
 ctypedef fused array_data_type:

--- a/sklearn/tree/_partitioner.pyx
+++ b/sklearn/tree/_partitioner.pyx
@@ -21,6 +21,7 @@ cnp.import_array()
 from scipy.sparse import issparse
 
 from sklearn.tree._splitter cimport SplitRecord
+from sklearn.utils._sorting cimport sort
 
 # Constant to switch between algorithm non zero value extract algorithm
 # in SparsePartitioner
@@ -699,118 +700,10 @@ def _py_sort(float32_t[::1] feature_values, intp_t[::1] samples, intp_t n):
     sort(&feature_values[0], &samples[0], n)
 
 
-# Sort n-element arrays pointed to by feature_values and samples, simultaneously,
-# by the values in feature_values. Algorithm: Introsort (Musser, SP&E, 1997).
-cdef void sort(floating* feature_values, intp_t* samples, intp_t n) noexcept nogil:
-    if n == 0:
-        return
-    cdef intp_t maxd = 2 * <intp_t>log2(n)
-    introsort(feature_values, samples, n, maxd)
-
-
-cdef inline void swap(floating* feature_values, intp_t* samples,
+cdef inline void swap(float32_t* feature_values, intp_t* samples,
                       intp_t i, intp_t j) noexcept nogil:
-    # Helper for sort
     feature_values[i], feature_values[j] = feature_values[j], feature_values[i]
     samples[i], samples[j] = samples[j], samples[i]
-
-
-cdef inline floating median3(floating* feature_values, intp_t n) noexcept nogil:
-    # Median of three pivot selection, after Bentley and McIlroy (1993).
-    # Engineering a sort function. SP&E. Requires 8/3 comparisons on average.
-    cdef floating a = feature_values[0], b = feature_values[n / 2], c = feature_values[n - 1]
-    if a < b:
-        if b < c:
-            return b
-        elif a < c:
-            return c
-        else:
-            return a
-    elif b < c:
-        if a < c:
-            return a
-        else:
-            return c
-    else:
-        return b
-
-
-# Introsort with median of 3 pivot selection and 3-way partition function
-# (robust to repeated elements, e.g. lots of zero features).
-cdef void introsort(floating* feature_values, intp_t *samples,
-                    intp_t n, intp_t maxd) noexcept nogil:
-    cdef floating pivot
-    cdef intp_t i, l, r
-
-    while n > 1:
-        if maxd <= 0:   # max depth limit exceeded ("gone quadratic")
-            heapsort(feature_values, samples, n)
-            return
-        maxd -= 1
-
-        pivot = median3(feature_values, n)
-
-        # Three-way partition.
-        i = l = 0
-        r = n
-        while i < r:
-            if feature_values[i] < pivot:
-                swap(feature_values, samples, i, l)
-                i += 1
-                l += 1
-            elif feature_values[i] > pivot:
-                r -= 1
-                swap(feature_values, samples, i, r)
-            else:
-                i += 1
-
-        introsort(feature_values, samples, l, maxd)
-        feature_values += r
-        samples += r
-        n -= r
-
-
-cdef inline void sift_down(floating* feature_values, intp_t* samples,
-                           intp_t start, intp_t end) noexcept nogil:
-    # Restore heap order in feature_values[start:end] by moving the max element to start.
-    cdef intp_t child, maxind, root
-
-    root = start
-    while True:
-        child = root * 2 + 1
-
-        # find max of root, left child, right child
-        maxind = root
-        if child < end and feature_values[maxind] < feature_values[child]:
-            maxind = child
-        if child + 1 < end and feature_values[maxind] < feature_values[child + 1]:
-            maxind = child + 1
-
-        if maxind == root:
-            break
-        else:
-            swap(feature_values, samples, root, maxind)
-            root = maxind
-
-
-cdef void heapsort(floating* feature_values, intp_t* samples, intp_t n) noexcept nogil:
-    cdef intp_t start, end
-
-    # heapify
-    start = (n - 2) / 2
-    end = n
-    while True:
-        sift_down(feature_values, samples, start, end)
-        if start == 0:
-            break
-        start -= 1
-
-    # sort by shrinking the heap, putting the max element immediately after it
-    end = n - 1
-    while end > 0:
-        swap(feature_values, samples, 0, end)
-        sift_down(feature_values, samples, 0, end)
-        end = end - 1
 
 
 cdef void swap_array_slices(

--- a/sklearn/tree/_partitioner.pyx
+++ b/sklearn/tree/_partitioner.pyx
@@ -695,11 +695,6 @@ cdef inline void sparse_swap(intp_t[::1] index_to_samples, intp_t[::1] samples,
     index_to_samples[samples[pos_2]] = pos_2
 
 
-def _py_sort(float32_t[::1] feature_values, intp_t[::1] samples, intp_t n):
-    """Used for testing sort."""
-    sort(&feature_values[0], &samples[0], n)
-
-
 cdef inline void swap(float32_t* feature_values, intp_t* samples,
                       intp_t i, intp_t j) noexcept nogil:
     feature_values[i], feature_values[j] = feature_values[j], feature_values[i]

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -54,7 +54,6 @@ from sklearn.tree._tree import (
 from sklearn.tree._tree import Tree as CythonTree
 from sklearn.utils import compute_sample_weight
 from sklearn.utils._array_api import xpx
-from sklearn.utils._sorting import _py_sort
 from sklearn.utils._testing import (
     assert_almost_equal,
     assert_array_almost_equal,
@@ -2907,28 +2906,6 @@ def test_build_pruned_tree_infinite_loop():
         ValueError, match="Node has reached a leaf in the original tree"
     ):
         _build_pruned_tree_py(pruned_tree, tree.tree_, leave_in_subtree)
-
-
-def test_sort_log2_build():
-    """Non-regression test for gh-30554.
-
-    Using log2 and log in sort correctly sorts feature_values, but the tie breaking is
-    different which can results in placing samples in a different order.
-    """
-    rng = np.random.default_rng(75)
-    some = rng.normal(loc=0.0, scale=10.0, size=10).astype(np.float32)
-    feature_values = np.concatenate([some] * 5)
-    samples = np.arange(50, dtype=np.intp)
-    _py_sort(feature_values, samples, 50)
-    # fmt: off
-    # no black reformatting for this specific array
-    expected_samples = [
-        0, 40, 30, 20, 10, 29, 39, 19, 49,  9, 45, 15, 35,  5, 25, 11, 31,
-        41,  1, 21, 22, 12,  2, 42, 32, 23, 13, 43,  3, 33,  6, 36, 46, 16,
-        26,  4, 14, 24, 34, 44, 27, 47,  7, 37, 17,  8, 38, 48, 28, 18
-    ]
-    # fmt: on
-    assert_array_equal(samples, expected_samples)
 
 
 def test_absolute_errors_precomputation_function(global_random_seed):

--- a/sklearn/tree/tests/test_tree.py
+++ b/sklearn/tree/tests/test_tree.py
@@ -42,7 +42,6 @@ from sklearn.tree._classes import (
     SPARSE_SPLITTERS,
 )
 from sklearn.tree._criterion import _py_precompute_absolute_errors
-from sklearn.tree._partitioner import _py_sort
 from sklearn.tree._tree import (
     NODE_DTYPE,
     TREE_LEAF,
@@ -55,6 +54,7 @@ from sklearn.tree._tree import (
 from sklearn.tree._tree import Tree as CythonTree
 from sklearn.utils import compute_sample_weight
 from sklearn.utils._array_api import xpx
+from sklearn.utils._sorting import _py_sort
 from sklearn.utils._testing import (
     assert_almost_equal,
     assert_array_almost_equal,

--- a/sklearn/utils/_sorting.pxd
+++ b/sklearn/utils/_sorting.pxd
@@ -7,3 +7,9 @@ cdef int simultaneous_sort(
     intp_t *idx,
     intp_t size,
 ) noexcept nogil
+
+cdef void sort(
+    floating* feature_values,
+    intp_t* samples,
+    intp_t n,
+) noexcept nogil

--- a/sklearn/utils/_sorting.pyx
+++ b/sklearn/utils/_sorting.pyx
@@ -1,4 +1,9 @@
+from libc.math cimport log2
+
 from cython cimport floating
+
+from sklearn.utils._typedefs cimport float32_t, intp_t
+
 
 cdef inline void dual_swap(
     floating* darr,
@@ -91,3 +96,115 @@ cdef int simultaneous_sort(
                               indices + pivot_idx + 1,
                               size - pivot_idx - 1)
     return 0
+
+
+def _py_sort(float32_t[::1] feature_values, intp_t[::1] samples, intp_t n):
+    """Used for testing sort."""
+    sort(&feature_values[0], &samples[0], n)
+
+
+# Sort n-element arrays pointed to by feature_values and samples, simultaneously,
+# by the values in feature_values. Algorithm: Introsort (Musser, SP&E, 1997).
+cdef void sort(floating* feature_values, intp_t* samples, intp_t n) noexcept nogil:
+    if n == 0:
+        return
+    cdef intp_t maxd = 2 * <intp_t>log2(n)
+    introsort(feature_values, samples, n, maxd)
+
+
+cdef inline floating median3(floating* feature_values, intp_t n) noexcept nogil:
+    # Median of three pivot selection, after Bentley and McIlroy (1993).
+    # Engineering a sort function. SP&E. Requires 8/3 comparisons on average.
+    cdef floating a = feature_values[0], b = feature_values[n / 2], c = feature_values[n - 1]
+    if a < b:
+        if b < c:
+            return b
+        elif a < c:
+            return c
+        else:
+            return a
+    elif b < c:
+        if a < c:
+            return a
+        else:
+            return c
+    else:
+        return b
+
+
+# Introsort with median of 3 pivot selection and 3-way partition function
+# (robust to repeated elements, e.g. lots of zero features).
+cdef void introsort(floating* feature_values, intp_t *samples,
+                    intp_t n, intp_t maxd) noexcept nogil:
+    cdef floating pivot
+    cdef intp_t i, l, r
+
+    while n > 1:
+        if maxd <= 0:   # max depth limit exceeded ("gone quadratic")
+            heapsort(feature_values, samples, n)
+            return
+        maxd -= 1
+
+        pivot = median3(feature_values, n)
+
+        # Three-way partition.
+        i = l = 0
+        r = n
+        while i < r:
+            if feature_values[i] < pivot:
+                dual_swap(feature_values, samples, i, l)
+                i += 1
+                l += 1
+            elif feature_values[i] > pivot:
+                r -= 1
+                dual_swap(feature_values, samples, i, r)
+            else:
+                i += 1
+
+        introsort(feature_values, samples, l, maxd)
+        feature_values += r
+        samples += r
+        n -= r
+
+
+cdef inline void sift_down(floating* feature_values, intp_t* samples,
+                           intp_t start, intp_t end) noexcept nogil:
+    # Restore heap order in feature_values[start:end] by moving the max element to start.
+    cdef intp_t child, maxind, root
+
+    root = start
+    while True:
+        child = root * 2 + 1
+
+        # find max of root, left child, right child
+        maxind = root
+        if child < end and feature_values[maxind] < feature_values[child]:
+            maxind = child
+        if child + 1 < end and feature_values[maxind] < feature_values[child + 1]:
+            maxind = child + 1
+
+        if maxind == root:
+            break
+        else:
+            dual_swap(feature_values, samples, root, maxind)
+            root = maxind
+
+
+cdef void heapsort(floating* feature_values, intp_t* samples, intp_t n) noexcept nogil:
+    cdef intp_t start, end
+
+    # heapify
+    start = (n - 2) / 2
+    end = n
+    while True:
+        sift_down(feature_values, samples, start, end)
+        if start == 0:
+            break
+        start -= 1
+
+    # sort by shrinking the heap, putting the max element immediately after it
+    end = n - 1
+    while end > 0:
+        dual_swap(feature_values, samples, 0, end)
+        sift_down(feature_values, samples, 0, end)
+        end = end - 1

--- a/sklearn/utils/_sorting.pyx
+++ b/sklearn/utils/_sorting.pyx
@@ -12,13 +12,8 @@ cdef inline void dual_swap(
     intp_t b,
 ) noexcept nogil:
     """Swap the values at index a and b of both darr and iarr"""
-    cdef floating dtmp = darr[a]
-    darr[a] = darr[b]
-    darr[b] = dtmp
-
-    cdef intp_t itmp = iarr[a]
-    iarr[a] = iarr[b]
-    iarr[b] = itmp
+    darr[a], darr[b] = darr[b], darr[a]
+    iarr[a], iarr[b] = iarr[b], iarr[a]
 
 
 cdef int simultaneous_sort(

--- a/sklearn/utils/tests/test_sorting.py
+++ b/sklearn/utils/tests/test_sorting.py
@@ -1,0 +1,28 @@
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from sklearn.utils._sorting import _py_sort
+
+
+def test_sort_log2_build():
+    """Non-regression test for gh-30554.
+
+    Using log2 and log in sort correctly sorts feature_values, but the tie breaking is
+    different which can results in placing samples in a different order.
+    """
+    rng = np.random.default_rng(75)
+    some = rng.normal(loc=0.0, scale=10.0, size=10).astype(np.float32)
+    feature_values = np.concatenate([some] * 5)
+    samples = np.arange(50, dtype=np.intp)
+
+    _py_sort(feature_values, samples, 50)
+
+    # fmt: off
+    # no black reformatting for this specific array
+    expected_samples = [
+        0, 40, 30, 20, 10, 29, 39, 19, 49,  9, 45, 15, 35,  5, 25, 11, 31,
+        41,  1, 21, 22, 12,  2, 42, 32, 23, 13, 43,  3, 33,  6, 36, 46, 16,
+        26,  4, 14, 24, 34, 44, 27, 47,  7, 37, 17,  8, 38, 48, 28, 18
+    ]
+    # fmt: on
+    assert_array_equal(samples, expected_samples)


### PR DESCRIPTION
#### Reference Issues/PRs

Prepare the ground for #33252, towards fixing #33167.

#### What does this implement/fix? Explain your changes.

Move sorting functions from `tree/` to `utils/_sorting.pyx` as suggested by @jeremiedbb here https://github.com/scikit-learn/scikit-learn/pull/33252#issuecomment-4419539851 

#### AI usage

AI made most of the changes, I reviewed them.

