### PR TITLE
DOC Document var_smoothing and epsilon_ in GaussianNB (#14054)

### DIFF
--- a/doc/modules/naive_bayes.rst
+++ b/doc/modules/naive_bayes.rst
@@ -101,6 +101,28 @@ are estimated using maximum likelihood.
    ...       % (X_test.shape[0], (y_test != y_pred).sum()))
    Number of mislabeled points out of a total 75 points : 4
 
+.. _gaussian_naive_bayes_var_smoothing:
+
+Variance smoothing
+~~~~~~~~~~~~~~~~~~
+
+When one or more features have a variance close to zero, the Gaussian
+likelihood :math:`P(x_i \mid y)` degenerates and the resulting
+log-probabilities can be ``inf`` or ``nan``. To keep the model
+numerically stable, :class:`GaussianNB` adds a small constant to every
+feature variance before computing the likelihood. The constant is stored
+in the :attr:`~GaussianNB.epsilon_` attribute after :meth:`~GaussianNB.fit`
+and is derived from the ``var_smoothing`` parameter as
+
+.. math::
+
+   \varepsilon = \text{var\_smoothing} \times \max_i \operatorname{Var}(X_i)
+
+so it always scales with the spread of the most-variable feature in the
+training data. The default ``var_smoothing=1e-9`` is sufficient for
+nearly all datasets; increase it only if you observe ``inf`` or ``nan``
+predictions from features whose values are almost constant.
+
 .. _multinomial_naive_bayes:
 
 Multinomial Naive Bayes

--- a/doc/whats_new/upcoming_changes/sklearn.naive_bayes/33994.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.naive_bayes/33994.enhancement.rst
@@ -1,0 +1,5 @@
+- Documented the role of ``var_smoothing`` and the derived ``epsilon_`` attribute
+  in :class:`naive_bayes.GaussianNB`, added a *Variance smoothing* subsection
+  to the user guide, and added regression tests covering the ``epsilon_``
+  formula and stability on near-constant features.
+  By :user:`Woo-Je Jung <wjddnwp29>`.

--- a/sklearn/naive_bayes.py
+++ b/sklearn/naive_bayes.py
@@ -178,8 +178,15 @@ class GaussianNB(_BaseNB):
         adjusted according to the data.
 
     var_smoothing : float, default=1e-9
-        Portion of the largest variance of all features that is added to
-        variances for calculation stability.
+        A small constant added to every feature variance to keep the
+        Gaussian likelihood numerically stable when one or more features
+        have near-zero variance. The actual additive value used at fit
+        time is stored in :attr:`epsilon_` and equals
+        ``var_smoothing * np.var(X, axis=0).max()``. The default is
+        sufficient for almost all use cases; increase it only if you
+        observe ``inf`` or ``nan`` predictions due to extremely
+        low-variance features. See the :ref:`User Guide
+        <gaussian_naive_bayes_var_smoothing>` for details.
 
         .. versionadded:: 0.20
 
@@ -195,7 +202,10 @@ class GaussianNB(_BaseNB):
         class labels known to the classifier.
 
     epsilon_ : float
-        absolute additive value to variances.
+        Absolute additive value applied to every feature variance,
+        computed as ``var_smoothing * np.var(X, axis=0).max()`` at fit
+        time. Stored so that :meth:`partial_fit` can subtract and re-add
+        it consistently across incremental updates.
 
     n_features_in_ : int
         Number of features seen during :term:`fit`.

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -159,7 +159,11 @@ def test_gnb_var_smoothing_increases_stored_variance(global_random_seed):
 
 
 def test_gnb_var_smoothing_stabilizes_constant_feature():
-    """A near-constant feature should not produce ``inf``/``nan`` predictions thanks to ``var_smoothing``."""
+    """A constant feature should not yield ``inf``/``nan`` predictions.
+
+    Without ``var_smoothing`` the zero variance of the first column would
+    make the Gaussian likelihood diverge.
+    """
     X_const = np.array([[1.0, 0.0], [1.0, 1.0], [1.0, 2.0], [1.0, 3.0]])
     y_const = np.array([0, 0, 1, 1])
     proba = GaussianNB().fit(X_const, y_const).predict_proba(X_const)

--- a/sklearn/tests/test_naive_bayes.py
+++ b/sklearn/tests/test_naive_bayes.py
@@ -136,6 +136,36 @@ def test_gnb_neg_priors():
         clf.fit(X, y)
 
 
+@pytest.mark.parametrize("var_smoothing", [0.0, 1e-9, 1e-3])
+def test_gnb_epsilon_matches_var_smoothing_formula(var_smoothing):
+    """``epsilon_`` should equal ``var_smoothing * max(np.var(X, axis=0))``."""
+    rng = np.random.RandomState(0)
+    X_rand = rng.randn(50, 3)
+    y_rand = rng.randint(0, 2, size=50)
+    clf = GaussianNB(var_smoothing=var_smoothing).fit(X_rand, y_rand)
+    expected = var_smoothing * np.var(X_rand, axis=0).max()
+    assert clf.epsilon_ == pytest.approx(expected)
+
+
+def test_gnb_var_smoothing_increases_stored_variance(global_random_seed):
+    """Larger ``var_smoothing`` should raise ``epsilon_`` and the stored variances."""
+    rng = np.random.RandomState(global_random_seed)
+    X_rand = rng.randn(60, 4)
+    y_rand = rng.randint(0, 3, size=60)
+    small = GaussianNB(var_smoothing=1e-9).fit(X_rand, y_rand)
+    large = GaussianNB(var_smoothing=1e-2).fit(X_rand, y_rand)
+    assert large.epsilon_ > small.epsilon_
+    assert np.all(large.var_ >= small.var_)
+
+
+def test_gnb_var_smoothing_stabilizes_constant_feature():
+    """A near-constant feature should not produce ``inf``/``nan`` predictions thanks to ``var_smoothing``."""
+    X_const = np.array([[1.0, 0.0], [1.0, 1.0], [1.0, 2.0], [1.0, 3.0]])
+    y_const = np.array([0, 0, 1, 1])
+    proba = GaussianNB().fit(X_const, y_const).predict_proba(X_const)
+    assert np.all(np.isfinite(proba))
+
+
 def test_gnb_priors():
     """Test whether the class prior override is properly used"""
     clf = GaussianNB(priors=np.array([0.3, 0.7])).fit(X, y)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #14054.

#### What does this implement/fix? Explain your changes.
`var_smoothing` was historically under-documented (a one-liner saying "Portion of the largest variance ... added to variances for calculation stability") and the linked `epsilon_` attribute had a single short sentence with no reference back to `var_smoothing`. Issue #14054 also notes there was no dedicated test for the parameter. The validation part of that issue was already addressed by the `_parameter_constraints` framework that landed afterward (`Interval(Real, 0, None, closed="left")`), so this PR focuses on the remaining gaps:

- **`GaussianNB.var_smoothing` docstring** — expanded to explain why the parameter exists (numerical stability when features have near-zero variance), how the effective epsilon is derived (`var_smoothing * np.var(X, axis=0).max()`), when to tune it, and a cross-reference to the new user guide section.
- **`GaussianNB.epsilon_` attribute docstring** — now states the formula and notes that the stored value is used by `partial_fit` to subtract/re-add the smoothing term across incremental updates.
- **User guide (`doc/modules/naive_bayes.rst`)** — added a short `Variance smoothing` subsection inside the existing `gaussian_naive_bayes` block, with the math formula and guidance on when to increase the default.
- **Tests (`sklearn/tests/test_naive_bayes.py`)** — three new tests next to the existing `test_gnb_*` family:
  - `test_gnb_epsilon_matches_var_smoothing_formula` parametrized over `var_smoothing in {0.0, 1e-9, 1e-3}`, asserts `epsilon_ == var_smoothing * np.var(X, axis=0).max()`.
  - `test_gnb_var_smoothing_increases_stored_variance` (uses `global_random_seed`) asserts that a larger `var_smoothing` raises both `epsilon_` and the stored `var_`.
  - `test_gnb_var_smoothing_stabilizes_constant_feature` regression-tests that a near-constant feature does not produce `inf`/`nan` predictions.

No behavior change; this is a docs + tests PR.

#### AI usage disclosure
I used AI assistance for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug) — the new test functions were drafted with AI assistance after I read the existing `test_gnb_*` style and the `epsilon_` derivation in `_partial_fit`.
- [x] Test/benchmark generation
- [x] Documentation (including examples) — both the docstring expansions and the new user-guide subsection
- [x] Research and understanding — locating the relevant code paths (`_partial_fit` epsilon computation, the `_parameter_constraints` already validating non-negative `var_smoothing`)

I self-reviewed the final diff, ran the new tests locally against an installed scikit-learn 1.8.0 (after copying the edited `naive_bayes.py` into site-packages, since building from source is heavy on Windows), and verified the new docstring is loaded and the assertions hold. `ruff format --check` passes; the existing UP031 lint findings in `naive_bayes.py` are untouched and pre-date this PR.

#### Any other comments?
Happy to add a `whats_new/upcoming_changes/<PR>.other.rst` (or `.fix.rst`) news fragment once a PR number is assigned and you confirm the preferred type — this PR has no user-facing API change, so I left it out of the initial diff. The reference label I added (`_gaussian_naive_bayes_var_smoothing:`) is namespaced under the existing `_gaussian_naive_bayes:` block so it shouldn't clash with anything elsewhere.
