### PR TITLE
FIX Improve tree export node_id error message

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.tree/33995.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.tree/33995.fix.rst
@@ -1,0 +1,4 @@
+- Improved the error message raised by :func:`tree.export_graphviz` when an invalid
+  ``node_id`` is passed to internal tree export routines by including the valid
+  range and clarifying that ``TREE_LEAF`` is not a valid root node.
+  By :user:`Krish Patel <KrishPatel1905>`.

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -522,7 +522,11 @@ class _DOTTreeExporter(_BaseTreeExporter):
 
     def recurse(self, tree, node_id, criterion, parent=None, depth=0):
         if node_id == _tree.TREE_LEAF:
-            raise ValueError("Invalid node_id %s" % _tree.TREE_LEAF)
+            raise ValueError(
+                f"node_id must be in [0, {tree.node_count}). "
+                f"Got node_id={node_id}. "
+                "TREE_LEAF (-2) is used internally and is not a valid output node."
+            )
 
         left_child = tree.children_left[node_id]
         right_child = tree.children_right[node_id]

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -15,12 +15,12 @@ from sklearn.exceptions import NotFittedError
 from sklearn.tree import (
     DecisionTreeClassifier,
     DecisionTreeRegressor,
+    _tree,
     export_graphviz,
     export_text,
     plot_tree,
 )
-from sklearn.tree._export import _rgb_to_hexstring, _DOTTreeExporter
-from sklearn.tree import _tree
+from sklearn.tree._export import _DOTTreeExporter, _rgb_to_hexstring
 
 CLF_CRITERIONS = ("gini", "log_loss")
 REG_CRITERIONS = ("squared_error", "absolute_error", "poisson")

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -19,7 +19,8 @@ from sklearn.tree import (
     export_text,
     plot_tree,
 )
-from sklearn.tree._export import _rgb_to_hexstring
+from sklearn.tree._export import _rgb_to_hexstring, _DOTTreeExporter
+from sklearn.tree import _tree
 
 CLF_CRITERIONS = ("gini", "log_loss")
 REG_CRITERIONS = ("squared_error", "absolute_error", "poisson")
@@ -401,6 +402,13 @@ def test_graphviz_errors():
     out = StringIO()
     with pytest.raises(IndexError):
         export_graphviz(clf, out, class_names=[])
+
+    # Check invalid node_id error with improved error message
+    exporter = _DOTTreeExporter(out_file=StringIO())
+    tree = clf.tree_
+    # Test with TREE_LEAF (-2) as node_id
+    with pytest.raises(ValueError, match="node_id must be in"):
+        exporter.recurse(tree, _tree.TREE_LEAF, criterion="gini")
 
 
 @pytest.mark.parametrize("criterion", CLF_CRITERIONS + REG_CRITERIONS)


### PR DESCRIPTION
## Description

Improved the error message raised for invalid `node_id` values in `sklearn/tree/_export.py`.

The previous error message:
`Invalid node_id`

did not provide enough debugging information.

The updated message now:

* shows the valid range
* includes the received invalid value
* explains the meaning of `TREE_LEAF (-2)`

## Changes

* Updated ValueError message
* Updated test assertion for improved clarity

## Motivation

Improve debugging experience and usability for users working with tree export utilities.
