### PR TITLE
[Callbacks] Repr for CallbackContext

### DIFF
--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -178,6 +178,14 @@ class CallbackContext:
         for context in self._children_map.values():
             yield from context
 
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}("
+            f"estimator_name={self.estimator_name!r}, "
+            f"task_name={self.task_name!r}, "
+            f"task_id={self.task_id})"
+        )
+
     def _add_child(self, child_context):
         """Add `child_context` as a child of this context."""
         if child_context.task_id in self._children_map:

--- a/sklearn/callback/tests/test_callback_context.py
+++ b/sklearn/callback/tests/test_callback_context.py
@@ -522,3 +522,14 @@ def test_locally_defined_estimator():
     assert callback.count_hooks("on_fit_task_begin") == 1
     assert callback.count_hooks("on_fit_task_end") == 1
     assert callback.count_hooks("teardown") == 1
+
+
+def test_callback_context_repr():
+    """Smoke test for the repr of the callback context."""
+    estimator = MaxIterEstimator()
+    context = _make_callback_ctx(estimator, task_name="mytask", task_id=42)
+    expected_repr = (
+        "CallbackContext(estimator_name='MaxIterEstimator', task_name='mytask', "
+        "task_id=42)"
+    )
+    assert repr(context) == expected_repr


### PR DESCRIPTION
Extracted from #33591. Only implements the oneliner ``repr`` here. It will already help debugging when implementing callback support in estimators: having the task name and task id from the traceback allows to directly identify the context that causes an issue in the code.

It would have been helpful for the implementation of callback support in pipeline, gridsearch, ... Let's have it before starting to implement callback support in more estimators

Note: These 3 attributes are enough imo. They allow to uniquely identify the problematic context in the code. Then the other attributes can be read from the construction if needed.

ping @FrancoisPgm @StefanieSenger 