### PR TITLE
FIX ridge validation of alphas with array api

### DIFF
--- a/doc/whats_new/upcoming_changes/array-api/34004.fix.rst
+++ b/doc/whats_new/upcoming_changes/array-api/34004.fix.rst
@@ -1,0 +1,3 @@
+- Fix passing an array as ``alpha`` in :class:`linear_model.Ridge` when using
+  the array API.
+  By :user:`Thomas Moreau <tommoral>`.

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -703,7 +703,7 @@ def _ridge_regression(
     # Some callers of this method might pass alpha as single
     # element array which already has been validated.
     if alpha is not None and not isinstance(
-            alpha, (type(xp.asarray([0.0])), np.ndarray)
+        alpha, (type(xp.asarray([0.0])), np.ndarray)
     ):
         alpha = check_scalar(
             alpha,

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1403,7 +1403,7 @@ class RidgeClassifier(_RidgeClassifierMixin, _BaseRidge):
 
     Parameters
     ----------
-    alpha : float or array-like of shape (n_targets,), default=1.0
+    alpha : float, default=1.0
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
         the estimates. Larger values specify stronger regularization.

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -891,7 +891,7 @@ def resolve_solver_for_numpy(positive, return_intercept, is_sparse):
 
 class _BaseRidge(LinearModel, metaclass=ABCMeta):
     _parameter_constraints: dict = {
-        "alpha": [Interval(Real, 0, None, closed="left"), np.ndarray],
+        "alpha": [Interval(Real, 0, None, closed="left"), "array-like"],
         "fit_intercept": ["boolean"],
         "copy_X": ["boolean"],
         "max_iter": [Interval(Integral, 1, None, closed="left"), None],

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -700,19 +700,6 @@ def _ridge_regression(
             # we implement sample_weight via a simple rescaling.
             X, y, sample_weight_sqrt = _rescale_data(X, y, sample_weight)
 
-    # Some callers of this method might pass alpha as single
-    # element array which already has been validated.
-    if alpha is not None and not isinstance(
-        alpha, (type(xp.asarray([0.0])), np.ndarray)
-    ):
-        alpha = check_scalar(
-            alpha,
-            "alpha",
-            target_type=numbers.Real,
-            min_val=0.0,
-            include_boundaries="left",
-        )
-
     # There should be either 1 or n_targets penalties
     alpha = _ravel(xp.asarray(alpha, device=device_, dtype=X.dtype), xp=xp)
     if alpha.shape[0] not in [1, n_targets]:
@@ -1049,7 +1036,7 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
 
     Parameters
     ----------
-    alpha : {float, ndarray of shape (n_targets,)}, default=1.0
+    alpha : float or array-like of shape (n_targets,), default=1.0
         Constant that multiplies the L2 term, controlling regularization
         strength. `alpha` must be a non-negative float i.e. in `[0, inf)`.
 
@@ -1416,7 +1403,7 @@ class RidgeClassifier(_RidgeClassifierMixin, _BaseRidge):
 
     Parameters
     ----------
-    alpha : float, default=1.0
+    alpha : float or array-like of shape (n_targets,), default=1.0
         Regularization strength; must be a positive float. Regularization
         improves the conditioning of the problem and reduces the variance of
         the estimates. Larger values specify stronger regularization.

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -702,7 +702,9 @@ def _ridge_regression(
 
     # Some callers of this method might pass alpha as single
     # element array which already has been validated.
-    if alpha is not None and not isinstance(alpha, type(xp.asarray([0.0]))):
+    if alpha is not None and not isinstance(
+            alpha, (type(xp.asarray([0.0])), np.ndarray)
+    ):
         alpha = check_scalar(
             alpha,
             "alpha",

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1507,13 +1507,9 @@ def test_ridge_classifier_multilabel_array_api(
     "array_namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),
 )
-def test_ridge_per_target_alpha_array_api(
-    array_namespace, device_name, dtype_name
-):
+def test_ridge_per_target_alpha_array_api(array_namespace, device_name, dtype_name):
     xp, device = _array_api_for_tests(array_namespace, device_name, dtype_name)
-    X, y = make_regression(
-        n_targets=3, n_features=10, random_state=0
-    )
+    X, y = make_regression(n_targets=3, n_features=10, random_state=0)
     X_np = X.astype(dtype_name)
     y_np = y.astype(dtype_name)
     alphas = np.asarray([1e-2, 0.1, 1.0], dtype=dtype_name)

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1504,6 +1504,31 @@ def test_ridge_classifier_multilabel_array_api(
 
 
 @pytest.mark.parametrize(
+    "array_namespace, device_name, dtype_name",
+    yield_namespace_device_dtype_combinations(),
+)
+def test_ridge_per_target_alpha_array_api(
+    array_namespace, device_name, dtype_name
+):
+    xp, device = _array_api_for_tests(array_namespace, device_name, dtype_name)
+    X, y = make_regression(n_targets=2, random_state=0)
+    X_np = X.astype(dtype_name)
+    y_np = y.astype(dtype_name)
+    alphas = np.asarray([0.1, 1.0], dtype=dtype_name)
+    estimator = Ridge(alpha=alphas)
+
+    ridge_np = estimator.fit(X_np, y_np)
+    pred_np = ridge_np.predict(X_np)
+    with config_context(array_api_dispatch=True):
+        estimator = Ridge(alpha=xp.asarray(alphas))
+        X_xp, y_xp = xp.asarray(X_np, device=device), xp.asarray(y_np, device=device)
+        ridge_xp = estimator.fit(X_xp, y_xp)
+        pred_xp = ridge_xp.predict(X_xp)
+        assert pred_xp.shape == pred_np.shape == y.shape
+        assert_allclose(move_to(pred_xp, xp=np, device="cpu"), pred_np)
+
+
+@pytest.mark.parametrize(
     "array_namespace", yield_namespaces(include_numpy_namespaces=False)
 )
 def test_array_api_error_and_warnings_for_solver_parameter(array_namespace):

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1508,33 +1508,32 @@ def test_ridge_classifier_multilabel_array_api(
     yield_namespace_device_dtype_combinations(),
 )
 def test_ridge_per_target_alpha_array_api(array_namespace, device_name, dtype_name):
-    # non-regression test for #34003, where passing a array-like for alpha was
-    # not working with array API dispatch
+    """Check that passing an array for alpha works with array API dispatch.
+
+    Non-regression test for issue #34003.
+    """
     xp, device = _array_api_for_tests(array_namespace, device_name, dtype_name)
     X, y = make_regression(n_targets=3, n_features=10, random_state=0)
     X_np = X.astype(dtype_name)
     y_np = y.astype(dtype_name)
     alphas = np.asarray([1e-2, 0.1, 1.0], dtype=dtype_name)
-    estimator = Ridge(alpha=alphas, solver="svd")
 
-    ridge_np = estimator.fit(X_np, y_np)
+    ridge_np = Ridge(alpha=alphas, solver="svd").fit(X_np, y_np)
     pred_np = ridge_np.predict(X_np)
+
     with config_context(array_api_dispatch=True):
         X_xp, y_xp = xp.asarray(X_np, device=device), xp.asarray(y_np, device=device)
 
-        # check that passing a numpy array for alpha works as expected
-        estimator = Ridge(alpha=alphas, solver="svd")
-        ridge_xp = estimator.fit(X_xp, y_xp)
-        pred_xp = ridge_xp.predict(X_xp)
-        assert pred_xp.shape == pred_np.shape == y.shape
-        assert_allclose(move_to(pred_xp, xp=np, device="cpu"), pred_np)
-
-        # check that passing the same array type for alpha also works as expected
-        estimator = Ridge(alpha=xp.asarray(alphas), solver="svd")
-        ridge_xp = estimator.fit(X_xp, y_xp)
-        pred_xp = ridge_xp.predict(X_xp)
-        assert pred_xp.shape == pred_np.shape == y.shape
-        assert_allclose(move_to(pred_xp, xp=np, device="cpu"), pred_np)
+        # alpha can be a numpy array or an array on the same device
+        for alpha in (alphas, xp.asarray(alphas, device=device)):
+            ridge_xp = Ridge(alpha=alpha, solver="svd").fit(X_xp, y_xp)
+            pred_xp = ridge_xp.predict(X_xp)
+            assert pred_xp.shape == pred_np.shape == y.shape
+            assert_allclose(
+                move_to(pred_xp, xp=np, device="cpu"),
+                pred_np,
+                atol=_atol_for_type(dtype_name),
+            )
 
 
 @pytest.mark.parametrize(

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1511,17 +1511,28 @@ def test_ridge_per_target_alpha_array_api(
     array_namespace, device_name, dtype_name
 ):
     xp, device = _array_api_for_tests(array_namespace, device_name, dtype_name)
-    X, y = make_regression(n_targets=2, random_state=0)
+    X, y = make_regression(
+        n_targets=3, n_features=10, random_state=0
+    )
     X_np = X.astype(dtype_name)
     y_np = y.astype(dtype_name)
-    alphas = np.asarray([0.1, 1.0], dtype=dtype_name)
+    alphas = np.asarray([1e-2, 0.1, 1.0], dtype=dtype_name)
     estimator = Ridge(alpha=alphas)
 
     ridge_np = estimator.fit(X_np, y_np)
     pred_np = ridge_np.predict(X_np)
     with config_context(array_api_dispatch=True):
-        estimator = Ridge(alpha=xp.asarray(alphas))
         X_xp, y_xp = xp.asarray(X_np, device=device), xp.asarray(y_np, device=device)
+
+        # check that passing a numpy array for alpha works as expected
+        estimator = Ridge(alpha=alphas)
+        ridge_xp = estimator.fit(X_xp, y_xp)
+        pred_xp = ridge_xp.predict(X_xp)
+        assert pred_xp.shape == pred_np.shape == y.shape
+        assert_allclose(move_to(pred_xp, xp=np, device="cpu"), pred_np)
+
+        # check that passing the same array type for alpha also works as expected
+        estimator = Ridge(alpha=xp.asarray(alphas))
         ridge_xp = estimator.fit(X_xp, y_xp)
         pred_xp = ridge_xp.predict(X_xp)
         assert pred_xp.shape == pred_np.shape == y.shape

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1508,12 +1508,14 @@ def test_ridge_classifier_multilabel_array_api(
     yield_namespace_device_dtype_combinations(),
 )
 def test_ridge_per_target_alpha_array_api(array_namespace, device_name, dtype_name):
+    # non-regression test for #34003, where passing a array-like for alpha was
+    # not working with array API dispatch
     xp, device = _array_api_for_tests(array_namespace, device_name, dtype_name)
     X, y = make_regression(n_targets=3, n_features=10, random_state=0)
     X_np = X.astype(dtype_name)
     y_np = y.astype(dtype_name)
     alphas = np.asarray([1e-2, 0.1, 1.0], dtype=dtype_name)
-    estimator = Ridge(alpha=alphas)
+    estimator = Ridge(alpha=alphas, solver="svd")
 
     ridge_np = estimator.fit(X_np, y_np)
     pred_np = ridge_np.predict(X_np)
@@ -1521,14 +1523,14 @@ def test_ridge_per_target_alpha_array_api(array_namespace, device_name, dtype_na
         X_xp, y_xp = xp.asarray(X_np, device=device), xp.asarray(y_np, device=device)
 
         # check that passing a numpy array for alpha works as expected
-        estimator = Ridge(alpha=alphas)
+        estimator = Ridge(alpha=alphas, solver="svd")
         ridge_xp = estimator.fit(X_xp, y_xp)
         pred_xp = ridge_xp.predict(X_xp)
         assert pred_xp.shape == pred_np.shape == y.shape
         assert_allclose(move_to(pred_xp, xp=np, device="cpu"), pred_np)
 
         # check that passing the same array type for alpha also works as expected
-        estimator = Ridge(alpha=xp.asarray(alphas))
+        estimator = Ridge(alpha=xp.asarray(alphas), solver="svd")
         ridge_xp = estimator.fit(X_xp, y_xp)
         pred_xp = ridge_xp.predict(X_xp)
         assert pred_xp.shape == pred_np.shape == y.shape


### PR DESCRIPTION
Fix for #34003 

Allows to pass both `np.array` and an array of the same type as fit data as `alphas`.
Add non regression tests.

~~Need to add non-regression tests~~