### PR TITLE
[Callbacks] Some last minute fixes

### DIFF
--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -529,7 +529,7 @@ def _from_reconstruction_attributes(estimator, reconstruction_attributes):
     fitted_estimator : estimator instance
         The fitted copy of this estimator.
     """
-    new_estimator = copy.copy(estimator)  # TODO(callbacks) copy / deepcopy / clone ?
+    new_estimator = copy.copy(estimator)
     for key, val in reconstruction_attributes.items():
         setattr(new_estimator, key, val)
     return new_estimator

--- a/sklearn/callback/_callback_support.py
+++ b/sklearn/callback/_callback_support.py
@@ -85,7 +85,9 @@ class CallbackSupportMixin:
             sequential_subtasks=sequential_subtasks,
         )
 
-        # setup callbacks
+        # Setup callbacks. We store callbacks for which setup has started in order to
+        # only tear those down after fit.
+        self._skl_callbacks_to_teardown = []
         for callback in getattr(self, "_skl_callbacks", []):
             # Only call the setup hook of callbacks that are not propagated from a
             # meta-estimator.
@@ -93,6 +95,7 @@ class CallbackSupportMixin:
                 isinstance(callback, AutoPropagatedCallback)
                 and hasattr(self, "_parent_callback_ctx")
             ):
+                self._skl_callbacks_to_teardown.append(callback)
                 callback.setup(estimator=self, context=self._callback_fit_ctx)
 
         return self._callback_fit_ctx
@@ -119,18 +122,24 @@ def callback_management_context(estimator):
         yield
     finally:
         if hasattr(estimator, "_callback_fit_ctx"):
-            for callback in getattr(estimator, "_skl_callbacks", []):
-                # Only call the teardown hook of callbacks that are not propagated from
-                # a meta-estimator.
-                if not (
-                    isinstance(callback, AutoPropagatedCallback)
-                    and hasattr(estimator, "_parent_callback_ctx")
-                ):
+            teardown_errors = []
+            for callback in estimator._skl_callbacks_to_teardown:
+                try:
                     callback.teardown(
                         estimator=estimator, context=estimator._callback_fit_ctx
                     )
+                except Exception as exc:
+                    teardown_errors.append(exc)
 
+            del estimator._skl_callbacks_to_teardown
             del estimator._callback_fit_ctx
+            if len(teardown_errors) == 1:
+                raise teardown_errors[0]
+            if teardown_errors:
+                raise ExceptionGroup(
+                    "The following callback teardown errors occurred",
+                    teardown_errors,
+                )
 
 
 def with_callbacks(method):

--- a/sklearn/callback/_callback_support.py
+++ b/sklearn/callback/_callback_support.py
@@ -41,7 +41,7 @@ class CallbackSupportMixin:
         if callbacks:
             self._skl_callbacks = list(callbacks)
         else:
-            del self._skl_callbacks
+            self.__dict__.pop("_skl_callbacks", None)
 
         return self
 

--- a/sklearn/callback/_progressbar.py
+++ b/sklearn/callback/_progressbar.py
@@ -1,12 +1,14 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+from numbers import Integral
 from queue import Queue
 from threading import Thread
 
 from sklearn.callback._callback_context import get_context_path
 from sklearn.callback._transport import close_listener, open_listener, send
 from sklearn.utils._optional_dependencies import check_rich_support
+from sklearn.utils._param_validation import Interval, validate_params
 
 # Per-fit local queues and monitors, keyed by the run's `root_uuid`. Both are not
 # picklable so they live here rather than on the callback instance. Entries are added in
@@ -26,6 +28,10 @@ class ProgressBar:
         If set to None, all levels are displayed.
     """
 
+    @validate_params(
+        {"max_propagation_depth": [Interval(Integral, 0, None, closed="left"), None]},
+        prefer_skip_nested_validation=True,
+    )
     def __init__(self, max_propagation_depth=1):
         check_rich_support("Progressbar")
 

--- a/sklearn/callback/tests/test_callback_support.py
+++ b/sklearn/callback/tests/test_callback_support.py
@@ -93,3 +93,18 @@ def test_function_no_callback_support(n_jobs, prefer, Callback):
     assert callback.count_hooks("on_fit_task_begin") == n_fits * (1 + max_iter)
     assert callback.count_hooks("on_fit_task_end") == n_fits * (1 + max_iter)
     assert callback.count_hooks("teardown") == n_fits
+
+
+def test_set_callback_empty():
+    """Check that setting no callbacks removes the `_skl_callbacks` attribute."""
+    estimator = MaxIterEstimator()
+
+    estimator.set_callbacks(RecordingCallback())
+    assert hasattr(estimator, "_skl_callbacks")
+
+    estimator.set_callbacks()
+    assert not hasattr(estimator, "_skl_callbacks")
+
+    # calling again doesn't raise
+    estimator.set_callbacks()
+    assert not hasattr(estimator, "_skl_callbacks")

--- a/sklearn/callback/tests/test_callback_support.py
+++ b/sklearn/callback/tests/test_callback_support.py
@@ -59,6 +59,42 @@ def test_callback_error(fail_at):
     assert callback.count_hooks("teardown") == 1
 
 
+def test_teardown_matches_setup_calls_on_partial_setup_failure():
+    """Check that teardown only runs for callbacks that entered setup."""
+    callback_1 = FailingCallback(fail_at="setup")
+    callback_2 = RecordingCallback()
+
+    estimator = MaxIterEstimator().set_callbacks(callback_1, callback_2)
+    with pytest.raises(ValueError, match="Failing callback failed at setup"):
+        estimator.fit()
+
+    assert callback_1.count_hooks("setup") == 1
+    assert callback_1.count_hooks("teardown") == 1
+
+    # setup was never entered for this callback, so teardown should not be called.
+    assert callback_2.count_hooks("setup") == 0
+    assert callback_2.count_hooks("teardown") == 0
+
+
+def test_multiple_teardown_errors_are_grouped():
+    """Check that all teardown are called even if some fail.
+
+    All errors are raised together in one ExceptionGroup.
+    """
+    callback_1 = FailingCallback(fail_at="teardown")
+    callback_2 = FailingCallback(fail_at="teardown")
+    estimator = MaxIterEstimator().set_callbacks(callback_1, callback_2)
+
+    with pytest.raises(
+        ExceptionGroup, match="The following callback teardown errors occurred"
+    ) as exc_info:
+        estimator.fit()
+
+    assert len(exc_info.value.exceptions) == 2
+    assert callback_1.count_hooks("teardown") == 1
+    assert callback_2.count_hooks("teardown") == 1
+
+
 @pytest.mark.parametrize("n_jobs", [1, 2])
 @pytest.mark.parametrize("prefer", ["threads", "processes"])
 @pytest.mark.parametrize(

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1459,7 +1459,7 @@ class LogisticRegression(
         max_subtasks = max(self.max_iter, 1) + 1
         callback_ctx = self._init_callback_context(max_subtasks=max_subtasks)
         callback_metadata = (
-            {"sample_weght": sample_weight} if sample_weight is not None else None
+            {"sample_weight": sample_weight} if sample_weight is not None else None
         )
         callback_ctx.call_on_fit_task_begin(
             estimator=self, X=X, y=y, metadata=callback_metadata

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -998,7 +998,10 @@ class BaseSearchCV(
         params = _check_method_params(X, params=params)
         routed_params = self._get_routed_params_for_fit(params)
 
-        metadata_callbacks = {"sample_weight": params.get("sample_weight", {})}
+        if (sample_weight := params.get("sample_weight")) is not None:
+            metadata_callbacks = {"sample_weight": sample_weight}
+        else:
+            metadata_callbacks = None
         root_callback_ctx = self._init_callback_context(
             max_subtasks=1 + (self.refit is not False)  # refit can be str or callable
         ).call_on_fit_task_begin(estimator=self, X=X, y=y, metadata=metadata_callbacks)

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -813,11 +813,6 @@ def _fit_and_score(
         start_msg = f"[CV{progress_msg}] START {params_msg}"
         print(f"{start_msg}{(80 - len(start_msg)) * '.'}")
 
-    if fit_params:
-        metadata_callbacks = {"sample_weight": fit_params.get("sample_weight", {})}
-    else:
-        metadata_callbacks = {}
-
     # Adjust length of sample weights
     fit_params = fit_params if fit_params is not None else {}
     fit_params = _check_method_params(X, params=fit_params, indices=train)
@@ -836,6 +831,11 @@ def _fit_and_score(
 
     X_train, y_train = _safe_split(estimator, X, y, train)
     X_test, y_test = _safe_split(estimator, X, y, test, train)
+
+    if (sample_weight := fit_params.get("sample_weight")) is not None:
+        metadata_callbacks = {"sample_weight": sample_weight}
+    else:
+        metadata_callbacks = None
 
     result = {}
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -849,7 +849,7 @@ def _fit_and_score(
                     estimator.fit(X_train, **fit_params)
                 else:
                     estimator.fit(X_train, y_train, **fit_params)
-        else:  # custom search class does not support callbacks
+        else:  # custom search class that does not support callbacks
             if y_train is None:
                 estimator.fit(X_train, **fit_params)
             else:
@@ -882,6 +882,11 @@ def _fit_and_score(
         if return_train_score:
             train_scores = _score(
                 estimator, X_train, y_train, scorer, score_params_train, error_score
+            )
+    finally:
+        if callback_ctx is not None:
+            callback_ctx.call_on_fit_task_end(
+                estimator=caller, X=X_train, y=y_train, metadata=metadata_callbacks
             )
 
     if verbose > 1:
@@ -921,11 +926,6 @@ def _fit_and_score(
         result["parameters"] = parameters
     if return_estimator:
         result["estimator"] = estimator
-
-    if callback_ctx is not None:
-        callback_ctx.call_on_fit_task_end(
-            estimator=caller, X=X_train, y=y_train, metadata=metadata_callbacks
-        )
 
     return result
 

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -3132,3 +3132,40 @@ def test_search_callbacks_receive_search_instance(search):
 
     for entry in callback.record:
         assert entry["estimator"] is search
+
+
+def test_search_callbacks_with_partial_fit_failures():
+    """Check callbacks hooks are called when some candidate fits fail.
+
+    When error_score != "raise" and not all fit fail, the whole search doesn't raise so
+    all callback invocations are expected.
+    """
+
+    class MayFailClassifier(ClassifierMixin, BaseEstimator):
+        def __init__(self, fail=False):
+            self.fail = fail
+
+        def fit(self, X, y):
+            self.classes_ = np.unique(y)
+            if self.fail:
+                raise RuntimeError("MayFailClassifier.fit failed")
+            return self
+
+        def predict(self, X):
+            return np.zeros(len(X), dtype=int)
+
+    callback = RecordingCallback()
+    search = GridSearchCV(
+        MayFailClassifier(),
+        {"fail": [False, True]},
+        cv=2,
+        refit=False,
+        error_score=0.0,
+    ).set_callbacks(callback)
+
+    with pytest.warns(FitFailedWarning, match="2 fits failed out of a total of 4."):
+        search.fit(X, y)
+
+    expected_n_tasks = 1 + 1 + 4  # root + search + 4 candidate-split evaluations
+    assert callback.count_hooks("on_fit_task_begin") == expected_n_tasks
+    assert callback.count_hooks("on_fit_task_end") == expected_n_tasks

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -3112,7 +3112,10 @@ def test_search_callbacks_receive_sample_weight():
     ]
     assert refit_records
 
-    for entry in evaluation_records + refit_records:
+    for entry in evaluation_records:
+        assert "sample_weight" in entry["kwargs"]["metadata"]
+
+    for entry in refit_records:
         assert "sample_weight" in entry["kwargs"]["metadata"]
         passed_weights = entry["kwargs"]["metadata"]["sample_weight"]
         assert_array_equal(passed_weights, sample_weight)


### PR DESCRIPTION
- fixes some inconsistencies and typos w.r.t sample_weight.
  I wouldn't bother too much in making sure that everything's tested for that. It's very limited support that we aim to replace with proper metadata-routing handling right after the release
- make sure that set_callbacks doesn't error on empty list. Test added
- make sure that `on_fit_task_end` is called for the `candidate-split-evaluation` task in grid search since fit failures are accepted there. -> move it in a finally block. Test added
- make sure that all teardown run, even if some of them errors. While we don't care that other are always called when there's an exception during fit, the teardowns must run because they need to free allocated resources. Test added
- use validate_params in progressbar as well. That's just for consistency with scoring monitor

ping @FrancoisPgm @StefanieSenger 