### PR TITLE
FIX SimpleImputer: fix inverse_transform for all-NaN columns with add_indicator=True

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.impute/34008.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.impute/34008.fix.rst
@@ -1,0 +1,4 @@
+- :class:`impute.SimpleImputer` now correctly handles :meth:`inverse_transform` 
+  when ``add_indicator=True`` and some columns were entirely empty (all-NaN) 
+  during :meth:`fit`.
+  By :user:`max12G`

--- a/doc/whats_new/upcoming_changes/sklearn.impute/34008.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.impute/34008.fix.rst
@@ -1,4 +1,3 @@
 - :class:`impute.SimpleImputer` now correctly handles :meth:`inverse_transform` 
   when ``add_indicator=True`` and some columns were entirely empty (all-NaN) 
-  during :meth:`fit`.
-  By :user:`max12G`
+  during :meth:`fit`. Fixes :issue:`27012`. By :user:`max12G`.

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -1,8 +1,6 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
-# type: ignore
-
 import numbers
 import warnings
 from collections import Counter
@@ -733,15 +731,16 @@ class SimpleImputer(_BaseImputer):
         array_imputed = X[:, :non_empty_feature_count].copy()
 
         missing_mask = X[:, non_empty_feature_count:].astype(bool)
-        
+
         if isinstance(self.fill_value, (int, float)) and np.isnan(self.fill_value):
             fullnan_indices = np.where(np.isnan(self.statistics_))
         else:
             fullnan_indices = []
 
         mask_indices_nan = np.where(np.isin(self.indicator_.features_, fullnan_indices))[0]
-        missing_mask[:, mask_indices_nan] = True # that small fix for add_indicator = True and problem with full row of nan(or other fill_values)
+        missing_mask[:, mask_indices_nan] = True
 
+        # Fix for add_indicator=True when columns are entirely NaN
         n_features_original = len(self.statistics_)
         shape_original = (X.shape[0], n_features_original)
 

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -734,9 +734,9 @@ class SimpleImputer(_BaseImputer):
 
         fullnan_indices = np.where(_get_mask(self.statistics_, np.nan))[0]
 
-        mask_indices_nan = np.where(np.isin(
-            self.indicator_.features_, fullnan_indices
-        ))[0]
+        mask_indices_nan = np.where(
+            np.isin(self.indicator_.features_, fullnan_indices)
+        )[0]
         missing_mask[:, mask_indices_nan] = True
 
         # Fix for add_indicator=True when columns are entirely NaN

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -1,6 +1,8 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+# type: ignore
+
 import numbers
 import warnings
 from collections import Counter
@@ -729,10 +731,20 @@ class SimpleImputer(_BaseImputer):
         n_features_missing = len(self.indicator_.features_)
         non_empty_feature_count = X.shape[1] - n_features_missing
         array_imputed = X[:, :non_empty_feature_count].copy()
+
         missing_mask = X[:, non_empty_feature_count:].astype(bool)
+        
+        if isinstance(self.fill_value, (int, float)) and np.isnan(self.fill_value):
+            fullnan_indices = np.where(np.isnan(self.statistics_))
+        else:
+            fullnan_indices = []
+
+        mask_indices_nan = np.where(np.isin(self.indicator_.features_, fullnan_indices))[0]
+        missing_mask[:, mask_indices_nan] = True # that small fix for add_indicator = True and problem with full row of nan(or other fill_values)
 
         n_features_original = len(self.statistics_)
         shape_original = (X.shape[0], n_features_original)
+
         X_original = np.zeros(shape_original)
         X_original[:, self.indicator_.features_] = missing_mask
         full_mask = X_original.astype(bool)

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -732,12 +732,11 @@ class SimpleImputer(_BaseImputer):
 
         missing_mask = X[:, non_empty_feature_count:].astype(bool)
 
-        if isinstance(self.fill_value, (int, float)) and np.isnan(self.fill_value):
-            fullnan_indices = np.where(np.isnan(self.statistics_))
-        else:
-            fullnan_indices = []
+        fullnan_indices = np.where(_get_mask(self.statistics_, np.nan))[0]
 
-        mask_indices_nan = np.where(np.isin(self.indicator_.features_, fullnan_indices))[0]
+        mask_indices_nan = np.where(np.isin(
+            self.indicator_.features_, fullnan_indices
+        ))[0]
         missing_mask[:, mask_indices_nan] = True
 
         # Fix for add_indicator=True when columns are entirely NaN

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1942,30 +1942,32 @@ def test_iterative_imputer_with_empty_features(strategy, X_test):
 @pytest.mark.parametrize("missing_value", [np.nan])
 def test_simple_imputer_column_shift(missing_value):
     """Test for bug #27012: columns shift with indicator and fill_value = np.nan"""
-    X1 = np.array([[missing_value, 2.0, 3.0],
-                   [missing_value, 2.0, 3.0]])
-    X2 = np.array([[1.0, 2.0, 3.0],
-                   [1.0, 2.0, 3.0]])
+    X1 = np.array([[missing_value, 2.0, 3.0], [missing_value, 2.0, 3.0]])
+    X2 = np.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
 
     imputer = SimpleImputer(add_indicator=True, fill_value=missing_value)
     imputer.fit(X1)
     X_inv = imputer.inverse_transform(imputer.transform(X2))
 
-    expected = np.array([[missing_value, 2.0, 3.0],
-                         [missing_value, 2.0, 3.0]])
+    expected = np.array([[missing_value, 2.0, 3.0], [missing_value, 2.0, 3.0]])
     assert_allclose(X_inv, expected)
 
-    X1 = np.array([[missing_value, 2.0, missing_value, 3.0],
-                   [missing_value, 2.0, missing_value, 3.0]])
-    X2 = np.array([[1.0, 2.0, 3.0, 4.0],
-                   [1.0, 2.0, 3.0, 4.0]])
+    X1 = np.array(
+        [
+            [missing_value, 2.0, missing_value, 3.0],
+            [missing_value, 2.0, missing_value, 3.0],
+        ]
+    )
+    X2 = np.array([[1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0]])
 
     imputer = SimpleImputer(add_indicator=True)
     imputer.fit(X1)
     X_inv = imputer.inverse_transform(imputer.transform(X2))
 
-    expected = np.array([[missing_value, 2.0, missing_value, 4.0],
-                         [missing_value, 2.0, missing_value, 4.0]])
+    expected = np.array(
+        [
+            [missing_value, 2.0, missing_value, 4.0],
+            [missing_value, 2.0, missing_value, 4.0],
+        ]
+    )
     assert_allclose(X_inv, expected)
-
-

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1947,7 +1947,7 @@ def test_simple_imputer_column_shift(missing_value):
     X2 = np.array([[1.0, 2.0, 3.0],
                    [1.0, 2.0, 3.0]])
 
-    imputer = SimpleImputer(add_indicator=True)
+    imputer = SimpleImputer(add_indicator=True, fill_value=missing_value)
     imputer.fit(X1)
     X_inv = imputer.inverse_transform(imputer.transform(X2))
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1944,24 +1944,30 @@ def test_iterative_imputer_with_empty_features(strategy, X_test):
 @pytest.mark.parametrize("missing_value", [np.nan])
 def test_simple_imputer_column_shift(missing_value):
     """Test for bug #27012: columns shift with indicator and fill_value = np.nan"""
-    X1 = np.array([[missing_value, 2.0, 3.0], [missing_value, 2.0, 3.0]])
-    X2 = np.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
+    X1 = np.array([[missing_value, 2.0, 3.0], 
+                   [missing_value, 2.0, 3.0]])
+    X2 = np.array([[1.0, 2.0, 3.0], 
+                   [1.0, 2.0, 3.0]])
     
     imputer = SimpleImputer(add_indicator=True, fill_value=missing_value)
     imputer.fit(X1)
     X_inv = imputer.inverse_transform(imputer.transform(X2))
     
-    expected = np.array([[missing_value, 2.0, 3.0], [missing_value, 2.0, 3.0]])
+    expected = np.array([[missing_value, 2.0, 3.0], 
+                         [missing_value, 2.0, 3.0]])
     assert_allclose(X_inv, expected)
 
-    X1 = np.array([[missing_value, 2.0, missing_value, 3.0], [missing_value, 2.0, missing_value, 3.0]])
-    X2 = np.array([[1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0]])
+    X1 = np.array([[missing_value, 2.0, missing_value, 3.0], 
+                   [missing_value, 2.0, missing_value, 3.0]])
+    X2 = np.array([[1.0, 2.0, 3.0, 4.0], 
+                   [1.0, 2.0, 3.0, 4.0]])
     
     imputer = SimpleImputer(add_indicator=True, fill_value=missing_value)
     imputer.fit(X1)
     X_inv = imputer.inverse_transform(imputer.transform(X2))
     
-    expected = np.array([[missing_value, 2.0, missing_value, 4.0], [missing_value, 2.0, missing_value, 4.0]])
+    expected = np.array([[missing_value, 2.0, missing_value, 4.0], 
+                         [missing_value, 2.0, missing_value, 4.0]])
     assert_allclose(X_inv, expected)
 
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1945,7 +1945,7 @@ def test_simple_imputer_column_shift(missing_value):
     X1 = np.array([[missing_value, 2.0, 3.0], [missing_value, 2.0, 3.0]])
     X2 = np.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
 
-    imputer = SimpleImputer(add_indicator=True, fill_value=missing_value)
+    imputer = SimpleImputer(add_indicator=True)
     imputer.fit(X1)
     X_inv = imputer.inverse_transform(imputer.transform(X2))
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1,5 +1,3 @@
-#type: ignore
-
 import io
 import re
 import warnings
@@ -1944,29 +1942,29 @@ def test_iterative_imputer_with_empty_features(strategy, X_test):
 @pytest.mark.parametrize("missing_value", [np.nan])
 def test_simple_imputer_column_shift(missing_value):
     """Test for bug #27012: columns shift with indicator and fill_value = np.nan"""
-    X1 = np.array([[missing_value, 2.0, 3.0], 
+    X1 = np.array([[missing_value, 2.0, 3.0],
                    [missing_value, 2.0, 3.0]])
-    X2 = np.array([[1.0, 2.0, 3.0], 
+    X2 = np.array([[1.0, 2.0, 3.0],
                    [1.0, 2.0, 3.0]])
-    
-    imputer = SimpleImputer(add_indicator=True, fill_value=missing_value)
+
+    imputer = SimpleImputer(add_indicator=True)
     imputer.fit(X1)
     X_inv = imputer.inverse_transform(imputer.transform(X2))
-    
-    expected = np.array([[missing_value, 2.0, 3.0], 
+
+    expected = np.array([[missing_value, 2.0, 3.0],
                          [missing_value, 2.0, 3.0]])
     assert_allclose(X_inv, expected)
 
-    X1 = np.array([[missing_value, 2.0, missing_value, 3.0], 
+    X1 = np.array([[missing_value, 2.0, missing_value, 3.0],
                    [missing_value, 2.0, missing_value, 3.0]])
-    X2 = np.array([[1.0, 2.0, 3.0, 4.0], 
+    X2 = np.array([[1.0, 2.0, 3.0, 4.0],
                    [1.0, 2.0, 3.0, 4.0]])
-    
-    imputer = SimpleImputer(add_indicator=True, fill_value=missing_value)
+
+    imputer = SimpleImputer(add_indicator=True)
     imputer.fit(X1)
     X_inv = imputer.inverse_transform(imputer.transform(X2))
-    
-    expected = np.array([[missing_value, 2.0, missing_value, 4.0], 
+
+    expected = np.array([[missing_value, 2.0, missing_value, 4.0],
                          [missing_value, 2.0, missing_value, 4.0]])
     assert_allclose(X_inv, expected)
 

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1,3 +1,5 @@
+#type: ignore
+
 import io
 import re
 import warnings
@@ -1937,3 +1939,29 @@ def test_iterative_imputer_with_empty_features(strategy, X_test):
 
     assert X_train_drop_empty_features.shape[1] == X_test_drop_empty_features.shape[1]
     assert X_train_keep_empty_features.shape[1] == X_test_keep_empty_features.shape[1]
+
+
+@pytest.mark.parametrize("missing_value", [np.nan])
+def test_simple_imputer_column_shift(missing_value):
+    """Test for bug #27012: columns shift with indicator and fill_value = np.nan"""
+    X1 = np.array([[missing_value, 2.0, 3.0], [missing_value, 2.0, 3.0]])
+    X2 = np.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
+    
+    imputer = SimpleImputer(add_indicator=True, fill_value=missing_value)
+    imputer.fit(X1)
+    X_inv = imputer.inverse_transform(imputer.transform(X2))
+    
+    expected = np.array([[missing_value, 2.0, 3.0], [missing_value, 2.0, 3.0]])
+    assert_allclose(X_inv, expected)
+
+    X1 = np.array([[missing_value, 2.0, missing_value, 3.0], [missing_value, 2.0, missing_value, 3.0]])
+    X2 = np.array([[1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0]])
+    
+    imputer = SimpleImputer(add_indicator=True, fill_value=missing_value)
+    imputer.fit(X1)
+    X_inv = imputer.inverse_transform(imputer.transform(X2))
+    
+    expected = np.array([[missing_value, 2.0, missing_value, 4.0], [missing_value, 2.0, missing_value, 4.0]])
+    assert_allclose(X_inv, expected)
+
+


### PR DESCRIPTION
### Description
This PR fixes a bug in `SimpleImputer.inverse_transform` where columns that were entirely missing (`NaN`) during `fit` were not correctly identified as missing during the inverse transformation when `add_indicator=True`.

### Why this happens
`MissingIndicator` might not track columns with zero variance (all-NaN) during training. This caused a misalignment in the mask during `inverse_transform`, leading to a column shift or incorrect data restoration.

### Changes
- Added logic to synchronize `statistics_` with the `missing_mask` using `self.indicator_.features_`.
- Implemented a check specifically for `np.nan` to ensure robust handling without side effects for other types.
- Added regression tests in sklearn/impute/tests/test_impute.py to ensure correct data restoration for all-NaN columns.

### Fixes
Fixes #27012

### Limitations & Design Choices
- **Targeted at `np.nan`**: This fix explicitly handles `np.nan` as the missing value. 
- **Non-NaN Collisions**: For integer-based missing values (like `-1`), if a column is entirely filled with that value, it remains outside `indicator_.features_` by design of the `MissingIndicator`. Since distinguishing a "naturally occurring" `-1` from a "missing" `-1` without variance is mathematically ambiguous during `inverse_transform`, this PR focuses on the most common case (`np.nan`) to avoid breaking existing statistical behavior for other types.