### PR TITLE
CI Do not store credentials in a file (labler workflow)

### DIFF
--- a/.github/workflows/labeler-title-regex.yml
+++ b/.github/workflows/labeler-title-regex.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - uses: actions/setup-python@v6
       with:
         python-version: '3.9'


### PR DESCRIPTION
#### Reference Issues/PRs
https://github.com/scikit-learn/scikit-learn/issues/34006

#### What does this implement/fix? Explain your changes.

This makes a small tweak to the labeler workflow. It makes sure the github credentials/token is not added to a `.git` config file.

This makes it a little harder to accidentally have the token stored in a cache or otherwise exported. The token value itself is available in the environment, so this doesn't make it harder to get the token. It does remove one way that you might accidentally leak the token. As far as I can tell there is no downside to this "defense in depth".

Implementing this was a recommendation from using zizmor on our workflows and asking AI for best practices in addressing the findings. There are a few issues on the checkout action repo about changing the default value of this option, so I feel like it isn't just AI tools and security scanners that want this.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Research and understanding
