### PR TITLE
CI Fix clone global estimator instance before fit in tests

### DIFF
--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -306,6 +306,7 @@ def test_pipeline_invalid_parameters():
 )
 def test_meta_estimator_raises_class_not_instance_error(meta_estimators, class_name):
     # non-regression tests for https://github.com/scikit-learn/scikit-learn/issues/32719
+    meta_estimators = clone(meta_estimators)
     msg = re.escape(
         f"Expected an estimator instance ({class_name}()), "
         f"got estimator class instead ({class_name})."

--- a/sklearn/utils/_repr_html/tests/test_features.py
+++ b/sklearn/utils/_repr_html/tests/test_features.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from sklearn.base import clone
 from sklearn.compose import ColumnTransformer
 from sklearn.decomposition import PCA, TruncatedSVD
 from sklearn.feature_extraction.text import CountVectorizer
@@ -51,8 +52,8 @@ def test_estimator_html_repr_col_names(pandas, feature_cols):
     else:
         X = np.array([[0, 2], [1, 1]])
 
-    ct.fit(X)
-    out = estimator_html_repr(ct)
+    ct_cloned = clone(ct).fit(X)
+    out = estimator_html_repr(ct_cloned)
     assert feature_cols[0] in out
     assert feature_cols[1] in out
 
@@ -72,8 +73,8 @@ def test_estimator_html_repr_total_feature_names(pandas, total_output_features):
     else:
         X = np.array([[0, 2, 3], [1, 1, 3], [3, 5, 4]])
 
-    ct.fit(X)
-    out = estimator_html_repr(ct)
+    ct_cloned = clone(ct).fit(X)
+    out = estimator_html_repr(ct_cloned)
 
     assert "<div class='total_features'>" in out
     assert "3 features</div>" in out
@@ -83,8 +84,8 @@ def test_estimator_html_repr_total_feature_names(pandas, total_output_features):
 
 def test_estimator_html_col_names_featureunion():
     X = [[0.0, 1.0, 3], [2.0, 2.0, 5]]
-    ct2.fit_transform(X)
-    out = estimator_html_repr(ct2)
+    ct2_cloned = clone(ct2).fit_transform(X)
+    out = estimator_html_repr(ct2_cloned)
 
     assert "pca__pca0" in out
     assert "svd__truncatedsvd0" in out

--- a/sklearn/utils/_repr_html/tests/test_features.py
+++ b/sklearn/utils/_repr_html/tests/test_features.py
@@ -84,7 +84,8 @@ def test_estimator_html_repr_total_feature_names(pandas, total_output_features):
 
 def test_estimator_html_col_names_featureunion():
     X = [[0.0, 1.0, 3], [2.0, 2.0, 5]]
-    ct2_cloned = clone(ct2).fit_transform(X)
+    ct2_cloned = clone(ct2)
+    ct2_cloned.fit_transform(X)
     out = estimator_html_repr(ct2_cloned)
 
     assert "pca__pca0" in out


### PR DESCRIPTION
free-threaded job fails from time to time. see https://github.com/scikit-learn/scikit-learn/actions/runs/25869479082/attempts/1

The failing test is `test_estimator_html_col_names_featureunion`. It's most likely due to the estimator fitted in the test not being cloned before (it's an instance defined globally).

I don't know why some other tests in this file don't fail. They fit a globally defined estimator as well. Maybe they don't make the same kind of assertions. I cloned all of them to be safe