### PR TITLE
[Callbacks] ENH Avoid repeating the no callback support warning

### DIFF
--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -495,11 +495,26 @@ class CallbackContext:
             )
         ]
         if callbacks_to_propagate and not hasattr(sub_estimator, "set_callbacks"):
-            warnings.warn(
-                f"The estimator {sub_estimator.__class__.__name__} does not support "
+            warning_message = (
+                f"{sub_estimator.__class__.__name__} estimators do not support "
                 f"callbacks. The callbacks attached to {self.estimator_name} will not "
-                f"be propagated to this estimator."
+                f"be propagated to its {sub_estimator.__class__.__name__} "
+                "sub-estimators."
             )
+            # Check on the root context not to repeat the same warning.
+            root_context = get_context_path(self)[0]
+            if not hasattr(
+                root_context, "_raised_no_callback_support_subestimator_warnings"
+            ):
+                root_context._raised_no_callback_support_subestimator_warnings = set()
+            if (
+                warning_message
+                not in root_context._raised_no_callback_support_subestimator_warnings
+            ):
+                warnings.warn(warning_message)
+                root_context._raised_no_callback_support_subestimator_warnings.add(
+                    warning_message
+                )
             callbacks_to_propagate = []
 
         if callbacks_to_propagate:

--- a/sklearn/callback/tests/test_callback_context.py
+++ b/sklearn/callback/tests/test_callback_context.py
@@ -253,23 +253,6 @@ def test_callback_ctx_removed_after_fit(estimator_class):
     assert not hasattr(estimator, "_callback_fit_ctx")
 
 
-def test_inner_estimator_no_callback_support():
-    """Check that meta estimators can have sub estimators without callback support.
-
-    No error is raised when the sub-estimator does not support callbacks. If callbacks
-    would be propagated, a warning is raised instead.
-    """
-    estimator = NoCallbackEstimator()
-    meta_estimator = MetaEstimator(estimator)
-    meta_estimator.set_callbacks(RecordingAutoPropagatedCallback())
-
-    with pytest.warns(
-        UserWarning,
-        match="The estimator NoCallbackEstimator does not support callbacks.",
-    ):
-        meta_estimator.fit()
-
-
 def test_estimator_without_subtask():
     """Check that callback support works for an estimator without subtasks.
 
@@ -351,7 +334,8 @@ def test_autopropagation_to_callback_agnostic_subestimator():
     """Check the number of hook calls when the sub-estimator doesn't support callbacks.
 
     The number of task begins and ends is just the number of nodes in the context tree
-    of the meta-estimator.
+    of the meta-estimator. Also check that the warning for no callback support in
+    sub-estimator is raised and only once.
     """
     n_outer, n_inner = 2, 3
     callback = RecordingAutoPropagatedCallback()
@@ -361,9 +345,11 @@ def test_autopropagation_to_callback_agnostic_subestimator():
 
     with pytest.warns(
         UserWarning,
-        match="The estimator NoCallbackEstimator does not support callbacks.",
-    ):
+        match="NoCallbackEstimator estimators do not support callbacks.",
+    ) as caught_warnings:
         meta_estimator.fit()
+
+    assert len(caught_warnings) == 1
 
     assert callback.count_hooks("setup") == 1
     expected_n_tasks = np.sum(np.cumprod([1, n_outer, n_inner]))


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #33328
This a rework of https://github.com/jeremiedbb/scikit-learn/pull/33

#### What does this implement/fix? Explain your changes.

Lazily create an attribute on the root context recording the messages of raised warnings for no callback support in a sub-estimator, so that if the warning is raised only once. This fix does not work when parallelizing the meta-estimator, but I don't see how to tackle that case without introducing some inter threads or processes communication and I don't think it would be worth it.

Add a check in the tests that the warning is only raised once.

Remove `test_inner_estimator_no_callback_support` which was testing the warning, as it is redundant with `test_autopropagation_to_callback_agnostic_subestimator`.

Update the warning message to make it slightly clearer.



#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [x] Research and understanding


#### Any other comments?
ping @jeremiedbb, @StefanieSenger 

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
