### PR TITLE
FIX SimpleImputer with missing_values=None

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.impute/34030.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.impute/34030.fix.rst
@@ -1,0 +1,4 @@
+- |Fix| :class:`impute.SimpleImputer` now supports `missing_values=None` with
+  `strategy="mean"` and `strategy="median"` for object arrays containing numeric
+  values and `None`.
+  By :user:`Rohan Patnaik <rohan-patnaik>`.

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -31,6 +31,8 @@ def _check_inputs_dtype(X, missing_values):
     if is_pandas_na(missing_values):
         # Allow using `pd.NA` as missing values to impute numerical arrays.
         return
+    if missing_values is None:
+        return
     if X.dtype.kind in ("f", "i", "u") and not isinstance(missing_values, numbers.Real):
         raise ValueError(
             "'X' and 'missing_values' types are expected to be"
@@ -341,13 +343,24 @@ class SimpleImputer(_BaseImputer):
             else:
                 dtype = None
         else:
-            dtype = FLOAT_DTYPES
+            if (
+                self.strategy in ("mean", "median")
+                and isinstance(X, np.ndarray)
+                and X.dtype.kind == "O"
+            ):
+                dtype = object
+            else:
+                dtype = FLOAT_DTYPES
 
         if not in_fit and self._fit_dtype.kind == "O":
             # Use object dtype if fitted on object dtypes
             dtype = self._fit_dtype
 
-        if is_pandas_na(self.missing_values) or is_scalar_nan(self.missing_values):
+        if (
+            is_pandas_na(self.missing_values)
+            or is_scalar_nan(self.missing_values)
+            or (self.missing_values is None and dtype is FLOAT_DTYPES)
+        ):
             ensure_all_finite = "allow-nan"
         else:
             ensure_all_finite = True
@@ -532,6 +545,21 @@ class SimpleImputer(_BaseImputer):
         masked_X = ma.masked_array(X, mask=missing_mask)
 
         super()._fit_indicator(missing_mask)
+
+        if strategy in ("mean", "median") and X.dtype.kind == "O":
+            masked_X = masked_X.copy()
+            masked_X.data[missing_mask] = np.nan
+            try:
+                masked_X = masked_X.astype(np.float64)
+            except ValueError as ve:
+                raise ValueError(
+                    f"Cannot use {strategy} strategy with non-numeric data:\n{ve}"
+                ) from None
+            if np.isnan(masked_X.data[~missing_mask]).any():
+                raise ValueError(
+                    f"Cannot use {strategy} strategy with non-numeric values "
+                    "that are not marked as missing."
+                )
 
         # Mean
         if strategy == "mean":

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -298,6 +298,40 @@ def test_imputation_mean_median_error_invalid_type_list_pandas(
         imputer.fit_transform(X)
 
 
+@pytest.mark.parametrize("strategy", ["mean", "median"])
+@pytest.mark.parametrize(
+    "X",
+    [
+        np.array([[0], [1], [2], [None]], dtype=object),
+        [[0], [1], [2], [None]],
+    ],
+)
+def test_imputation_mean_median_missing_values_none(strategy, X):
+    imputer = SimpleImputer(missing_values=None, strategy=strategy)
+    assert_array_equal(imputer.fit_transform(X), [[0], [1], [2], [1]])
+
+
+@pytest.mark.parametrize(
+    "missing_values, err_msg",
+    [
+        (None, "Input contains NaN"),
+        (np.nan, "non-numeric values that are not marked as missing"),
+    ],
+)
+def test_imputation_object_none_nan_distinct(missing_values, err_msg):
+    X = np.array([[0], [1], [2], [None], [np.nan]], dtype=object)
+    imputer = SimpleImputer(missing_values=missing_values)
+    with pytest.raises(ValueError, match=err_msg):
+        imputer.fit_transform(X)
+
+
+def test_imputation_list_none_missing_values_nan():
+    imputer = SimpleImputer(missing_values=np.nan)
+    assert_allclose(
+        imputer.fit_transform([[0], [1], [2], [None]]), [[0], [1], [2], [1]]
+    )
+
+
 @pytest.mark.parametrize("strategy", ["constant", "most_frequent"])
 @pytest.mark.parametrize("dtype", [str, np.dtype("U"), np.dtype("S")])
 def test_imputation_const_mostf_error_invalid_types(strategy, dtype):

--- a/sklearn/utils/_mask.py
+++ b/sklearn/utils/_mask.py
@@ -21,7 +21,9 @@ def _get_dense_mask(X, value_to_mask):
         if value_to_mask is pandas.NA:
             return pandas.isna(X)
 
-    if is_scalar_nan(value_to_mask):
+    if value_to_mask is None and X.dtype.kind == "f":
+        Xt = np.isnan(X)
+    elif is_scalar_nan(value_to_mask):
         if X.dtype.kind == "f":
             Xt = np.isnan(X)
         elif X.dtype.kind in ("i", "u"):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #19071.
This also takes over the stalled direction from #19079 with a smaller scoped patch.

#### What does this implement/fix? 
`SimpleImputer` documents `missing_values=None` as supported, but numeric strategies such as `mean` and `median` failed for object arrays containing `None`. Validation converted the data before the imputer could build a mask for `None`, so users got a NaN validation error instead of imputation.

This PR keeps object ndarray inputs as object long enough to compute the missing-value mask, then converts the masked numeric data to `float64` for the existing mean/median computation. It also keeps `None` and `np.nan` distinct for object arrays, while ppreserving the existing list-input behavior where `None` is treated as `np.nan` when `missing_values=np.nan`.

Tests added for:
- `missing_values=None` with `mean` and `median`
- object arrays containing both `None` and `np.nan`
- the existing list input behavior with `missing_values=np.nan`

Validation run locally:
- `pytest sklearn/impute/tests/test_impute.py -q`
- `pytest sklearn/impute/tests/test_common.py -q`
- `ruff format --check sklearn/impute/_base.py sklearn/utils/_mask.py sklearn/impute/tests/test_impute.py`
- `ruff check --select E501,F401,F821 sklearn/impute/_base.py sklearn/utils/_mask.py sklearn/impute/tests/test_impute.py`
