### PR TITLE
TST Add numerical gradient check for RBF kernel (#26502)

### DIFF
--- a/doc/whats_new/upcoming_changes/34034.maintenance.rst
+++ b/doc/whats_new/upcoming_changes/34034.maintenance.rst
@@ -1,4 +1,0 @@
-Verify RBF Kernel Gradient
-==========================
-
-- **Maintenance**: Added a numerical gradient test for the `RBF` kernel to definitively verify its analytical gradient and resolve a long-standing mathematical discrepancy in issue #26502. By Adi

--- a/doc/whats_new/upcoming_changes/34034.maintenance.rst
+++ b/doc/whats_new/upcoming_changes/34034.maintenance.rst
@@ -1,0 +1,4 @@
+Verify RBF Kernel Gradient
+==========================
+
+- **Maintenance**: Added a numerical gradient test for the `RBF` kernel to definitively verify its analytical gradient and resolve a long-standing mathematical discrepancy in issue #26502. By Adi

--- a/doc/whats_new/upcoming_changes/sklearn.gaussian_process/34034.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.gaussian_process/34034.fix.rst
@@ -1,0 +1,1 @@
+- Added a numerical gradient test for the `RBF` kernel to definitively verify its analytical gradient and resolve a long-standing mathematical discrepancy in issue #26502. By Adii

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -8,7 +8,6 @@ from inspect import signature
 import numpy as np
 import pytest
 from scipy.optimize import approx_fprime
-from numpy.testing import assert_allclose
 
 from sklearn.base import clone
 from sklearn.gaussian_process.kernels import (
@@ -404,6 +403,7 @@ def test_rational_quadratic_kernel():
     with pytest.raises(AttributeError, match=message):
         kernel(X)
 
+
 @pytest.mark.parametrize("length_scale", [2.0, np.array([1.0, 2.0, 3.0])])
 def test_rbf_gradient_numerical_check(length_scale):
     """
@@ -415,32 +415,34 @@ def test_rbf_gradient_numerical_check(length_scale):
     # Generate mock data (3 dimensions if isotropic, matching dims if anisotropic)
     n_features = 3 if np.isscalar(length_scale) else len(length_scale)
     X = rng.randn(5, n_features)
-    
+
     from sklearn.gaussian_process.kernels import RBF
+
     kernel = RBF(length_scale=length_scale)
-    
+
     # 1. Analytical Gradient (computed w.r.t log-transformed length_scale)
     K, K_gradient_analytical = kernel(X, eval_gradient=True)
-    
+
     # 2. Numerical Gradient setup
     theta = kernel.theta
     K_gradient_numerical = np.zeros_like(K_gradient_analytical)
-    
+
     # We must flatten K to calculate the gradient for each element independently
     for i in range(K.size):
+
         def f_i(t):
             # Clone kernel with perturbed theta (log-parameters)
             k_clone = kernel.clone_with_theta(t)
             # Return the i-th element of the flattened kernel matrix
             return k_clone(X).ravel()[i]
-            
+
         # Calculate numerical gradient for the i-th element
         grad_num_i = approx_fprime(theta, f_i, 1e-6)
-        
+
         # Map the 1D index back to the 3D gradient array
         idx_row = i // K.shape[1]
         idx_col = i % K.shape[1]
         K_gradient_numerical[idx_row, idx_col, :] = grad_num_i
-        
+
     # 3. The Truth Protocol: Do the analytical and numerical gradients match?
     assert_allclose(K_gradient_analytical, K_gradient_numerical, rtol=1e-4, atol=1e-4)

--- a/sklearn/gaussian_process/tests/test_kernels.py
+++ b/sklearn/gaussian_process/tests/test_kernels.py
@@ -7,6 +7,8 @@ from inspect import signature
 
 import numpy as np
 import pytest
+from scipy.optimize import approx_fprime
+from numpy.testing import assert_allclose
 
 from sklearn.base import clone
 from sklearn.gaussian_process.kernels import (
@@ -401,3 +403,44 @@ def test_rational_quadratic_kernel():
     )
     with pytest.raises(AttributeError, match=message):
         kernel(X)
+
+@pytest.mark.parametrize("length_scale", [2.0, np.array([1.0, 2.0, 3.0])])
+def test_rbf_gradient_numerical_check(length_scale):
+    """
+    Non-regression test to verify the analytical gradient of the RBF kernel.
+    Addresses Issue #26502 by comparing analytical gradients to numerical approximations
+    using scipy.optimize.approx_fprime.
+    """
+    rng = np.random.RandomState(42)
+    # Generate mock data (3 dimensions if isotropic, matching dims if anisotropic)
+    n_features = 3 if np.isscalar(length_scale) else len(length_scale)
+    X = rng.randn(5, n_features)
+    
+    from sklearn.gaussian_process.kernels import RBF
+    kernel = RBF(length_scale=length_scale)
+    
+    # 1. Analytical Gradient (computed w.r.t log-transformed length_scale)
+    K, K_gradient_analytical = kernel(X, eval_gradient=True)
+    
+    # 2. Numerical Gradient setup
+    theta = kernel.theta
+    K_gradient_numerical = np.zeros_like(K_gradient_analytical)
+    
+    # We must flatten K to calculate the gradient for each element independently
+    for i in range(K.size):
+        def f_i(t):
+            # Clone kernel with perturbed theta (log-parameters)
+            k_clone = kernel.clone_with_theta(t)
+            # Return the i-th element of the flattened kernel matrix
+            return k_clone(X).ravel()[i]
+            
+        # Calculate numerical gradient for the i-th element
+        grad_num_i = approx_fprime(theta, f_i, 1e-6)
+        
+        # Map the 1D index back to the 3D gradient array
+        idx_row = i // K.shape[1]
+        idx_col = i % K.shape[1]
+        K_gradient_numerical[idx_row, idx_col, :] = grad_num_i
+        
+    # 3. The Truth Protocol: Do the analytical and numerical gradients match?
+    assert_allclose(K_gradient_analytical, K_gradient_numerical, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
Resolves #26502.

This PR implements the numerical gradient check requested by @ogrisel to definitively verify the analytical gradient computation of the `RBF` kernel.

Using `scipy.optimize.approx_fprime`, this test confirms that the analytical gradient returned by `kernel(X, eval_gradient=True)` matches the numerical derivative with respect to the **log-transformed** `length_scale` (i.e., `kernel.theta`). 

This mathematically proves that the current implementation (with the `-2` power) is perfectly correct due to the chain rule applied to the log-transform, confirming @Charlie-XIAO's derivation. The bug report is a false alarm, and this non-regression test ensures the math remains untouched in the future.

**ADDED CODE IN test_kernels.py**
@pytest.mark.parametrize("length_scale", [2.0, np.array([1.0, 2.0, 3.0])])
def test_rbf_gradient_numerical_check(length_scale):
    """
    Non-regression test to verify the analytical gradient of the RBF kernel.
    Addresses Issue #26502 by comparing analytical gradients to numerical approximations
    using scipy.optimize.approx_fprime.
    """
    rng = np.random.RandomState(42)
    # Generate mock data (3 dimensions if isotropic, matching dims if anisotropic)
    n_features = 3 if np.isscalar(length_scale) else len(length_scale)
    X = rng.randn(5, n_features)
    
    from sklearn.gaussian_process.kernels import RBF
    kernel = RBF(length_scale=length_scale)
    
    # 1. Analytical Gradient (computed w.r.t log-transformed length_scale)
    K, K_gradient_analytical = kernel(X, eval_gradient=True)
    
    # 2. Numerical Gradient setup
    theta = kernel.theta
    K_gradient_numerical = np.zeros_like(K_gradient_analytical)
    
    # We must flatten K to calculate the gradient for each element independently
    for i in range(K.size):
        def f_i(t):
            # Clone kernel with perturbed theta (log-parameters)
            k_clone = kernel.clone_with_theta(t)
            # Return the i-th element of the flattened kernel matrix
            return k_clone(X).ravel()[i]
            
        # Calculate numerical gradient for the i-th element
        grad_num_i = approx_fprime(theta, f_i, 1e-6)
        
        # Map the 1D index back to the 3D gradient array
        idx_row = i // K.shape[1]
        idx_col = i % K.shape[1]
        K_gradient_numerical[idx_row, idx_col, :] = grad_num_i
        
    # 3. The Truth Protocol: Do the analytical and numerical gradients match?
    assert_allclose(K_gradient_analytical, K_gradient_numerical, rtol=1e-4, atol=1e-4)

**RESULT**
python -m pytest sklearn/gaussian_process/tests/test_kernels.py::test_rbf_gradient_numerical_check -v
================================ test session starts =================================
platform linux -- Python 3.13.11, pytest-9.0.3, pluggy-1.6.0 -- /home/******/scikit-learn/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/*****/scikit-learn
configfile: pyproject.toml
collected 2 items                                                                    

sklearn/gaussian_process/tests/test_kernels.py::test_rbf_gradient_numerical_check[2.0] PASSED [ 50%]
sklearn/gaussian_process/tests/test_kernels.py::test_rbf_gradient_numerical_check[length_scale1] PASSED [100%]

================================= 2 passed in 0.31s ==================================