### PR TITLE
FIX metadata routing in `learning_curve` and related module tests

### DIFF
--- a/doc/whats_new/upcoming_changes/metadata-routing/34039.fix.rst
+++ b/doc/whats_new/upcoming_changes/metadata-routing/34039.fix.rst
@@ -1,0 +1,3 @@
+- :func:`~model_selection.learning_curve` now correctly routes `sample_weight` to the
+  sub-estimator's partial_fit method if `exploit_incremental_learning` is set to `True`.
+  By :user:`Stefanie Senger <StefanieSenger>`.

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -2153,8 +2153,8 @@ def _incremental_fit_estimator(
     """Train estimator on training subsets incrementally and compute scores."""
     train_scores, test_scores, fit_times, score_times = [], [], [], []
     partitions = zip(train_sizes, np.split(train, train_sizes)[:-1])
-    fit_params = fit_params if fit_params is not None else {}
-    score_params = score_params if score_params is not None else {}
+    fit_params = fit_params or {}
+    score_params = score_params or {}
     if classes is None:
         partial_fit_func = partial(estimator.partial_fit)
     else:

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -2153,10 +2153,8 @@ def _incremental_fit_estimator(
     """Train estimator on training subsets incrementally and compute scores."""
     train_scores, test_scores, fit_times, score_times = [], [], [], []
     partitions = zip(train_sizes, np.split(train, train_sizes)[:-1])
-    if fit_params is None:
-        fit_params = {}
-    if score_params is None:
-        score_params = {}
+    fit_params = fit_params if fit_params is not None else {}
+    score_params = score_params if score_params is not None else {}
     if classes is None:
         partial_fit_func = partial(estimator.partial_fit)
     else:

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -2155,13 +2155,12 @@ def _incremental_fit_estimator(
     partitions = zip(train_sizes, np.split(train, train_sizes)[:-1])
     if fit_params is None:
         fit_params = {}
+    if score_params is None:
+        score_params = {}
     if classes is None:
-        partial_fit_func = partial(estimator.partial_fit, **fit_params)
+        partial_fit_func = partial(estimator.partial_fit)
     else:
-        partial_fit_func = partial(estimator.partial_fit, classes=classes, **fit_params)
-    score_params = score_params if score_params is not None else {}
-    score_params_train = _check_method_params(X, params=score_params, indices=train)
-    score_params_test = _check_method_params(X, params=score_params, indices=test)
+        partial_fit_func = partial(estimator.partial_fit, classes=classes)
 
     for n_train_samples, partial_train in partitions:
         train_subset = train[:n_train_samples]
@@ -2169,14 +2168,26 @@ def _incremental_fit_estimator(
         X_partial_train, y_partial_train = _safe_split(estimator, X, y, partial_train)
         X_test, y_test = _safe_split(estimator, X, y, test, train_subset)
         start_fit = time.time()
+
+        fit_params_iter = _check_method_params(
+            X, params=fit_params, indices=partial_train
+        )
+
         if y_partial_train is None:
-            partial_fit_func(X_partial_train)
+            partial_fit_func(X_partial_train, **fit_params_iter)
         else:
-            partial_fit_func(X_partial_train, y_partial_train)
+            partial_fit_func(X_partial_train, y_partial_train, **fit_params_iter)
         fit_time = time.time() - start_fit
         fit_times.append(fit_time)
 
         start_score = time.time()
+
+        score_params_test_iter = _check_method_params(
+            X, params=score_params, indices=test
+        )
+        score_params_train_iter = _check_method_params(
+            X, params=score_params, indices=train_subset
+        )
 
         test_scores.append(
             _score(
@@ -2184,7 +2195,7 @@ def _incremental_fit_estimator(
                 X_test,
                 y_test,
                 scorer,
-                score_params=score_params_test,
+                score_params=score_params_test_iter,
                 error_score=error_score,
             )
         )
@@ -2194,7 +2205,7 @@ def _incremental_fit_estimator(
                 X_train,
                 y_train,
                 scorer,
-                score_params=score_params_train,
+                score_params=score_params_train_iter,
                 error_score=error_score,
             )
         )

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -2620,18 +2620,11 @@ def test_validation_functions_routing(func, extra_args):
     if func is not cross_val_predict:
         # cross_val_predict doesn't need a scorer
         assert len(scorer_registry)
-    func_names = {
-        "cross_validate": ("_score", "__call__"),
-        "cross_val_score": ("_score", "__call__"),
-        "learning_curve": ("_score", "__call__"),
-        "permutation_test_score": ("_score", "__call__"),
-        "validation_curve": ("_score", "__call__"),
-    }
     for _scorer in scorer_registry:
         check_recorded_metadata(
             obj=_scorer,
-            method=func_names[func.__name__][0],
-            parent=func_names[func.__name__][1],
+            method="_score",
+            parent="__call__",
             split_params=("sample_weight", "metadata"),
             sample_weight=score_weights,
             metadata=score_metadata,
@@ -2639,36 +2632,31 @@ def test_validation_functions_routing(func, extra_args):
 
     assert len(splitter_registry)
     func_names = {
-        "cross_validate": ("split", "<genexpr>"),
-        "cross_val_score": ("split", "<genexpr>"),
-        "cross_val_predict": ("split", "cross_val_predict"),
-        "learning_curve": ("split", "learning_curve"),
-        "permutation_test_score": ("split", "_permutation_test_score"),
-        "validation_curve": ("split", "<genexpr>"),
+        "cross_validate": {"split": "<genexpr>", "fit": "_fit_and_score"},
+        "cross_val_score": {"split": "<genexpr>", "fit": "_fit_and_score"},
+        "cross_val_predict": {"split": "cross_val_predict", "fit": "_fit_and_predict"},
+        "learning_curve": {"split": "learning_curve", "fit": "_fit_and_score"},
+        "permutation_test_score": {
+            "split": "_permutation_test_score",
+            "fit": "_permutation_test_score",
+        },
+        "validation_curve": {"split": "<genexpr>", "fit": "_fit_and_score"},
     }
     for _splitter in splitter_registry:
         check_recorded_metadata(
             obj=_splitter,
-            method=func_names[func.__name__][0],
-            parent=func_names[func.__name__][1],
+            method="split",
+            parent=func_names[func.__name__]["split"],
             groups=split_groups,
             metadata=split_metadata,
         )
 
     assert len(estimator_registry)
-    func_names = {
-        "cross_validate": ("fit", "_fit_and_score"),
-        "cross_val_score": ("fit", "_fit_and_score"),
-        "cross_val_predict": ("fit", "_fit_and_predict"),
-        "learning_curve": ("fit", "_fit_and_score"),
-        "permutation_test_score": ("fit", "_permutation_test_score"),
-        "validation_curve": ("fit", "_fit_and_score"),
-    }
     for _estimator in estimator_registry:
         check_recorded_metadata(
             obj=_estimator,
-            method=func_names[func.__name__][0],
-            parent=func_names[func.__name__][1],
+            method="fit",
+            parent=func_names[func.__name__]["fit"],
             split_params=("sample_weight", "metadata"),
             sample_weight=fit_sample_weight,
             metadata=fit_metadata,

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1568,30 +1568,6 @@ def test_learning_curve_incremental_learning_params():
             error_score="raise",
         )
 
-    err_msg = "Fit parameter sample_weight has length 3; expected"
-    with pytest.raises(AssertionError, match=err_msg):
-        learning_curve(
-            estimator,
-            X,
-            y,
-            cv=3,
-            exploit_incremental_learning=True,
-            train_sizes=np.linspace(0.1, 1.0, 10),
-            error_score="raise",
-            params={"sample_weight": np.ones(3)},
-        )
-
-    learning_curve(
-        estimator,
-        X,
-        y,
-        cv=3,
-        exploit_incremental_learning=True,
-        train_sizes=np.linspace(0.1, 1.0, 10),
-        error_score="raise",
-        params={"sample_weight": np.ones(2)},
-    )
-
 
 def test_validation_curve():
     X, y = make_classification(
@@ -2575,7 +2551,7 @@ def test_passed_unrequested_metadata(func, extra_args):
         (cross_val_score, {}),
         (cross_val_predict, {}),
         (learning_curve, {}),
-        (permutation_test_score, {}),
+        (permutation_test_score, {"n_permutations": 20}),
         (validation_curve, {"param_name": "alpha", "param_range": np.array([1])}),
     ],
 )
@@ -2592,8 +2568,12 @@ def test_validation_functions_routing(func, extra_args):
         groups="split_groups", metadata="split_metadata"
     )
     estimator_registry = _Registry()
-    estimator = ConsumingClassifier(registry=estimator_registry).set_fit_request(
-        sample_weight="fit_sample_weight", metadata="fit_metadata"
+    estimator = (
+        ConsumingClassifier(registry=estimator_registry)
+        .set_fit_request(sample_weight="fit_sample_weight", metadata="fit_metadata")
+        .set_partial_fit_request(
+            sample_weight="fit_sample_weight", metadata="fit_metadata"
+        )
     )
 
     n_samples = _num_samples(X)
@@ -2640,32 +2620,55 @@ def test_validation_functions_routing(func, extra_args):
     if func is not cross_val_predict:
         # cross_val_predict doesn't need a scorer
         assert len(scorer_registry)
+    func_names = {
+        "cross_validate": ("_score", "__call__"),
+        "cross_val_score": ("_score", "__call__"),
+        "learning_curve": ("_score", "__call__"),
+        "permutation_test_score": ("_score", "__call__"),
+        "validation_curve": ("_score", "__call__"),
+    }
     for _scorer in scorer_registry:
         check_recorded_metadata(
             obj=_scorer,
-            method="score",
-            parent=func.__name__,
+            method=func_names[func.__name__][0],
+            parent=func_names[func.__name__][1],
             split_params=("sample_weight", "metadata"),
             sample_weight=score_weights,
             metadata=score_metadata,
         )
 
     assert len(splitter_registry)
+    func_names = {
+        "cross_validate": ("split", "<genexpr>"),
+        "cross_val_score": ("split", "<genexpr>"),
+        "cross_val_predict": ("split", "cross_val_predict"),
+        "learning_curve": ("split", "learning_curve"),
+        "permutation_test_score": ("split", "_permutation_test_score"),
+        "validation_curve": ("split", "<genexpr>"),
+    }
     for _splitter in splitter_registry:
         check_recorded_metadata(
             obj=_splitter,
-            method="split",
-            parent=func.__name__,
+            method=func_names[func.__name__][0],
+            parent=func_names[func.__name__][1],
             groups=split_groups,
             metadata=split_metadata,
         )
 
     assert len(estimator_registry)
+    func_names = {
+        "cross_validate": ("fit", "_fit_and_score"),
+        "cross_val_score": ("fit", "_fit_and_score"),
+        "cross_val_predict": ("fit", "_fit_and_predict"),
+        "learning_curve": ("fit", "_fit_and_score"),
+        "permutation_test_score": ("fit", "_permutation_test_score"),
+        "validation_curve": ("fit", "_fit_and_score"),
+    }
     for _estimator in estimator_registry:
         check_recorded_metadata(
             obj=_estimator,
-            method="fit",
-            parent=func.__name__,
+            method=func_names[func.__name__][0],
+            parent=func_names[func.__name__][1],
             split_params=("sample_weight", "metadata"),
             sample_weight=fit_sample_weight,
             metadata=fit_metadata,
@@ -2703,7 +2706,7 @@ def test_learning_curve_exploit_incremental_learning_routing():
         check_recorded_metadata(
             obj=_estimator,
             method="partial_fit",
-            parent="learning_curve",
+            parent="_incremental_fit_estimator",
             split_params=("sample_weight", "metadata"),
             sample_weight=fit_sample_weight,
             metadata=fit_metadata,


### PR DESCRIPTION
#### Reference Issues/PRs
closes https://github.com/scikit-learn/scikit-learn/issues/33283
also related to https://github.com/scikit-learn/scikit-learn/pull/28975
This PR is a split-off part of #33285 (which I have divided into two). 

#### What does this implement/fix? Explain your changes.
With `exploit_incremental_learning=True` we call the estimator's `partial_fit` method via `_incremental_fit_estimator`. In this process, `sample_weight` in both `fit_params` and `score_params` needs to get split following the same rules as `X` and `y`. Both was not done correctly before.

I've also fixed the related module test that did not detect this bug.

#### AI usage disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding
