### PR TITLE
MAINT bump pyodide to 0.29.4 in jupyterlite config

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -67,9 +67,12 @@ jobs:
         with:
           persist-credentials: false
 
+      # Build the wheel for the Pyodide version used in the jupyterlite deployment configured
+      # in doc/jupyter-lite.json (the two Pyodide versions need to be manually aligned).
       - uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3.1
         env:
           CIBW_PLATFORM: pyodide
+          CIBW_PYODIDE_VERSION: "0.29.0"
           SKLEARN_SKIP_OPENMP_TEST: "true"
           SKLEARN_SKIP_NETWORK_TESTS: 1
           CIBW_TEST_REQUIRES: "pytest pandas"

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -67,12 +67,9 @@ jobs:
         with:
           persist-credentials: false
 
-      # Build the wheel for the Pyodide version used in the jupyterlite deployment configured
-      # in doc/jupyter-lite.json (the two Pyodide versions need to be manually aligned).
       - uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3.1
         env:
           CIBW_PLATFORM: pyodide
-          CIBW_PYODIDE_VERSION: "0.29.0"
           SKLEARN_SKIP_OPENMP_TEST: "true"
           SKLEARN_SKIP_NETWORK_TESTS: 1
           CIBW_TEST_REQUIRES: "pytest pandas"

--- a/doc/jupyter-lite.json
+++ b/doc/jupyter-lite.json
@@ -3,7 +3,7 @@
   "jupyter-config-data": {
     "litePluginSettings": {
       "@jupyterlite/pyodide-kernel-extension:kernel": {
-        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.29.0/full/pyodide.js"
+        "pyodideUrl": "https://cdn.jsdelivr.net/pyodide/v0.29.4/full/pyodide.js"
       }
     }
   }


### PR DESCRIPTION
This is an attempt to fix a version mismatch for the nightly build of the scikit-learn pypodide wheel that is deployed on our dev website.

See: https://github.com/scikit-learn/scikit-learn/issues/34017#issuecomment-4476052371

If this works, then we should be able to `piplite.install` the scikit-learn wheel with correct dependency resolution for narwhals. Since a fixed narwhals version is shipped with pyodide we need a recent enough version of Pyodide to use the nightly build of scikit-learn on this platform.


For the record, here is the output of executing the top cell of example notebooks in jupyterlite on our dev website:

<details>

```python
%pip install pyodide-http
import pyodide_http
pyodide_http.patch_all()
import matplotlib
import pandas
import piplite
import joblib
import threadpoolctl
import scipy
await piplite.install(
  'scikit-learn==1.9.dev0',
   index_urls='https://pypi.anaconda.org/scientific-python-nightly-wheels/simple',
)
```

```python-traceback
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[1], line 11
      9 import threadpoolctl
     10 import scipy
---> 11 await piplite.install(
     12   'scikit-learn==1.9.dev0',
     13    index_urls='https://pypi.anaconda.org/scientific-python-nightly-wheels/simple',
     14 )

File /lib/python3.13/site-packages/piplite/piplite.py:135, in _install(requirements, keep_going, deps, credentials, pre, index_urls, verbose, constraints, reinstall)
    133 """Invoke micropip.install with a patch to get data from local indexes"""
    134 with patch("micropip.package_index.query_package", _query_package):
--> 135     return await micropip.install(
    136         requirements=requirements,
    137         keep_going=keep_going,
    138         deps=deps,
    139         credentials=credentials,
    140         pre=pre,
    141         constraints=constraints,
    142         index_urls=index_urls,
    143         verbose=verbose,
    144         reinstall=reinstall,
    145     )

File /lib/python3.13/site-packages/micropip/package_manager.py:205, in PackageManager.install(self, requirements, keep_going, deps, credentials, pre, index_urls, constraints, reinstall, verbose)
    190 wheel_base = Path(getsitepackages()[0])
    192 transaction = Transaction(
    193     _compat_layer=self.compat_layer,
    194     ctx=ctx,  # type: ignore[arg-type]
   (...)    203     reinstall=reinstall,
    204 )
--> 205 await transaction.gather_requirements(requirements)
    207 if transaction.failed:
    208     failed_requirements = ", ".join(
    209         [f"'{req}'" for req in transaction.failed]
    210     )

File /lib/python3.13/site-packages/micropip/transaction.py:74, in Transaction.gather_requirements(self, requirements)
     66 async def gather_requirements(
     67     self,
     68     requirements: list[str] | list[Requirement],
     69 ) -> None:
     70     requirement_promises = [
     71         self.add_requirement(requirement) for requirement in requirements
     72     ]
---> 74     await asyncio.gather(*requirement_promises)

File /lib/python3.13/site-packages/micropip/transaction.py:90, in Transaction.add_requirement(self, req)
     83     if as_req.name.endswith(".whl"):
     84         # This happens when the requirement is passed as a relative URL:
     85         # For instance, micropip.install("pkg-1.0.0-py3-none-any.whl")
     86         # packaging cannot distinguish this is a relative URL or a very weird wheel name ... sigh ...
     87         # But we want to treat it as a custom download location.
     88         return await self.add_requirement_from_url(req)
---> 90     return await self.add_requirement_inner(as_req)
     91 except InvalidRequirement:
     92     if not urlparse(req).path.endswith(".whl"):

File /lib/python3.13/site-packages/micropip/transaction.py:224, in Transaction.add_requirement_inner(self, req)
    222 else:
    223     try:
--> 224         await self._add_requirement_from_package_index(req)
    225     except ValueError:
    226         logger.debug(
    227             "Transaction: package %r not found in index, will search lock file",
    228             req,
    229         )

File /lib/python3.13/site-packages/micropip/transaction.py:299, in Transaction._add_requirement_from_package_index(self, req)
    296 if satisfied:
    297     logger.info("Requirement already satisfied: %s (%s)", req, ver)
--> 299 await self.add_wheel(wheel, req.extras, specifier=str(req.specifier))

File /lib/python3.13/site-packages/micropip/transaction.py:356, in Transaction.add_wheel(self, wheel, extras, specifier)
    352     # Case 2) If metadata file is not available,
    353     #         we have to wait for the wheel to be downloaded.
    354     else:
    355         await wheel_download_task
--> 356         await self.gather_requirements(wheel.requires(extras))
    357 else:
    358     await wheel_download_task

File /lib/python3.13/site-packages/micropip/transaction.py:74, in Transaction.gather_requirements(self, requirements)
     66 async def gather_requirements(
     67     self,
     68     requirements: list[str] | list[Requirement],
     69 ) -> None:
     70     requirement_promises = [
     71         self.add_requirement(requirement) for requirement in requirements
     72     ]
---> 74     await asyncio.gather(*requirement_promises)

File /lib/python3.13/site-packages/micropip/transaction.py:78, in Transaction.add_requirement(self, req)
     76 async def add_requirement(self, req: str | Requirement) -> None:
     77     if isinstance(req, Requirement):
---> 78         return await self.add_requirement_inner(req)
     80     try:
     81         as_req = constrain_requirement(Requirement(req), self.constrained_reqs)

File /lib/python3.13/site-packages/micropip/transaction.py:224, in Transaction.add_requirement_inner(self, req)
    222 else:
    223     try:
--> 224         await self._add_requirement_from_package_index(req)
    225     except ValueError:
    226         logger.debug(
    227             "Transaction: package %r not found in index, will search lock file",
    228             req,
    229         )

File /lib/python3.13/site-packages/micropip/transaction.py:268, in Transaction._add_requirement_from_package_index(self, req)
    263 async def _add_requirement_from_package_index(self, req: Requirement):
    264     """Find requirement from package index.
    265 
    266     If the requirement is found, add it to the package list.
    267     """
--> 268     metadata = await package_index.query_package(
    269         req.name,
    270         self.index_urls,
    271         compat_layer=self._compat_layer,
    272         fetch_kwargs=self.fetch_kwargs,
    273     )
    275     logger.debug("Transaction: got metadata %r for requirement %r", metadata, req)
    277     wheel = find_wheel(metadata, req)

File /lib/python3.13/site-packages/piplite/piplite.py:113, in _query_package(name, index_urls, compat_layer, fetch_kwargs)
    108 if _PIPLITE_DISABLE_PYPI:
    109     raise PiplitePyPIDisabled(
    110         f"{name} could not be installed: PyPI fallback is disabled"
    111     )
--> 113 return await _MP_QUERY_PACKAGE(
    114     name=name,
    115     index_urls=index_urls,
    116     compat_layer=compat_layer,
    117     fetch_kwargs=fetch_kwargs,
    118 )

File /lib/python3.13/site-packages/micropip/package_index.py:338, in query_package(name, index_urls, compat_layer, fetch_kwargs)
    336     return parser(metadata)
    337 else:
--> 338     raise ValueError(
    339         f"Can't fetch metadata for '{name}'. "
    340         "Please make sure you have entered a correct package name "
    341         "and correctly specified index_urls (if you changed them)."
    342     )

ValueError: Can't fetch metadata for 'narwhals'. Please make sure you have entered a correct package name and correctly specified index_urls (if you changed them).
```

</details>