### PR TITLE
DOC Recommend cleaning the doc repo only for major final releases

### DIFF
--- a/doc/developers/maintainer.rst.template
+++ b/doc/developers/maintainer.rst.template
@@ -120,7 +120,6 @@ Reference Steps
         {% if key == "rc" -%}
         * [ ] Update the sklearn dev0 version in main branch
         {%- endif %}
-        * [ ] Cleanup the doc repo to free up space
         * [ ] Set the version number in the release branch
         * [ ] Set an upper bound on build dependencies in the release branch
         * [ ] Generate the changelog in the release branch
@@ -136,6 +135,7 @@ Reference Steps
         * [ ] Backport news and what's new date in release branch
         {%- endif %}
         {%- if key == "final" %}
+        * [ ] Cleanup the doc repo to free up space
         * [ ] Update symlink for stable in https://github.com/scikit-learn/scikit-learn.github.io
         {%- endif %}
         {%- if key != "rc" %}
@@ -160,27 +160,6 @@ Reference Steps
       - Change the what's new file to the newly created one in the `filename` field of
         the `tool.towncrier` section in `pyproject.toml`.
     {% endif %}
-
-    - The `scikit-learn/scikit-learn.github.io` needs to be cleaned up so that ideally
-      it stays <5GB in size. Before doing this, create a new fresh fork of the existing
-      repo in your own user, to have a place with the history of the repo in case it's
-      needed. These commands will purge the history from the repo.
-
-      .. prompt:: bash
-
-        # need a non-shallow copy, and using https is much faster than ssh here
-        # note that this will be a large download size, up to 100GB (repo size limit)
-        git clone https://github.com/scikit-learn/scikit-learn.github.io.git
-        cd scikit-learn.github.io
-        git remote add write git@github.com:scikit-learn/scikit-learn.github.io.git
-        # checkout an orphan branch w/o history
-        git checkout --orphan temp_branch
-        git add -A
-        git commit -m "Initial commit after purging history"
-        git branch -D main
-        # rename current branch to main to replace it
-        git branch -m main
-        git push --force write main
 
     - In the release branch, change the version number `__version__` in
       `sklearn/__init__.py` to `{{ version_full }}`.
@@ -346,6 +325,27 @@ Reference Steps
     {% endif %}
 
     {% if key == "final" %}
+    - The `scikit-learn/scikit-learn.github.io` needs to be cleaned up so that ideally
+      it stays <5GB in size. Before doing this, create a new fresh fork of the existing
+      repo in your own user, to have a place with the history of the repo in case it's
+      needed. These commands will purge the history from the repo.
+
+      .. prompt:: bash
+
+        # need a non-shallow copy, and using https is much faster than ssh here
+        # note that this will be a large download size, up to 100GB (repo size limit)
+        git clone https://github.com/scikit-learn/scikit-learn.github.io.git
+        cd scikit-learn.github.io
+        git remote add write git@github.com:scikit-learn/scikit-learn.github.io.git
+        # checkout an orphan branch w/o history
+        git checkout --orphan temp_branch
+        git add -A
+        git commit -m "Initial commit after purging history"
+        git branch -D main
+        # rename current branch to main to replace it
+        git branch -m main
+        git push --force write main
+
     - Update the symlink for `stable` and the `latestStable` variable in
       `versionwarning.js` in https://github.com/scikit-learn/scikit-learn.github.io.
 


### PR DESCRIPTION
Follow-up of #32620.

The last clean up was done 5 month ago, around the 1.8 release and the repo has now a size of 15GB which is way below the 100GB limit. So I believe we're safe doing it only twice a year, say for each minor/major final release. This PR just changes the tab in which this item appears in https://scikit-learn.org/dev/developers/maintainer.html#reference-steps