### PR TITLE
Testing functionality to catch thread-safety issues, and a fix for one problem it finds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,6 @@ tests = [
     "pyarrow>=13.0.0",
     "numpydoc>=1.2.0",
     "pooch>=1.8.0",
-    "deepdiff>9.1.0",
 ]
 maintenance = ["conda-lock==3.0.1"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ tests = [
     "pyarrow>=13.0.0",
     "numpydoc>=1.2.0",
     "pooch>=1.8.0",
+    "deepdiff>9.1.0",
 ]
 maintenance = ["conda-lock==3.0.1"]
 

--- a/sklearn/callback/_callback_support.py
+++ b/sklearn/callback/_callback_support.py
@@ -15,6 +15,15 @@ class CallbackSupportMixin:
     .. automethod:: _init_callback_context
     """
 
+    __sklearn_thread_safe_attributes__ = {
+        "_skl_callbacks": "OK if set_callbacks() is called before dispatch to Parallel",
+    }
+
+    __sklearn_thread_buggy_attributes__ = {
+        "_callback_fit_ctx": "Doesn't appear thread-safe, should file bug.",
+        "_skl_callbacks_to_teardown": "Doesn't appear thread-safe, should file bug.",
+    }
+
     def set_callbacks(self, *callbacks):
         """Set callbacks for the estimator.
 

--- a/sklearn/conftest.py
+++ b/sklearn/conftest.py
@@ -36,6 +36,7 @@ from sklearn.utils.fixes import (
     parse_version,
     sp_version,
 )
+from sklearn.utils.parallel import Parallel
 
 try:
     import pytest_run_parallel  # noqa:F401
@@ -430,6 +431,12 @@ def pytest_addoption(parser, pluginmanager):
         default=False,
         help="raise for spmatrix usage that breaks sparray",
     )
+    parser.addoption(
+        "--thread-safety-testing",
+        action="store_true",
+        default=False,
+        help="run Parallel code in threads, and try to catch thread-safety issues",
+    )
 
 
 def pytest_runtest_setup(item):
@@ -468,6 +475,9 @@ def pytest_configure(config):
         # - uses the sparray interface for manipulating the sparse object
         # - uses align_api_if_sparse(X) just before returning a sparse object
         munge_scipy_to_check_spmatrix_usage()
+
+    if config.option.thread_safety_testing:
+        Parallel._thread_safety_testing = True
 
     if not PARALLEL_RUN_AVAILABLE:
         config.addinivalue_line(

--- a/sklearn/decomposition/_lda.py
+++ b/sklearn/decomposition/_lda.py
@@ -30,6 +30,7 @@ from sklearn.decomposition._online_lda_fast import (
 from sklearn.decomposition._online_lda_fast import _dirichlet_expectation_2d
 from sklearn.decomposition._online_lda_fast import mean_change as cy_mean_change
 from sklearn.utils import check_random_state, gen_batches, gen_even_slices
+from sklearn.utils._parallel_testing import mark_thread_buggy
 from sklearn.utils._param_validation import Interval, StrOptions
 from sklearn.utils.parallel import Parallel, delayed
 from sklearn.utils.validation import check_is_fitted, check_non_negative, validate_data
@@ -468,7 +469,7 @@ class LatentDirichletAllocation(
                 self.max_doc_update_iter,
                 self.mean_change_tol,
                 cal_sstats,
-                random_state,
+                mark_thread_buggy(random_state, "TODO this should probably be cloned?"),
             )
             for idx_slice in gen_even_slices(X.shape[0], n_jobs)
         )

--- a/sklearn/neighbors/_binary_tree.pxi.tp
+++ b/sklearn/neighbors/_binary_tree.pxi.tp
@@ -813,12 +813,6 @@ cdef class BinaryTree{{name_suffix}}:
     cdef DistanceMetric{{name_suffix}} dist_metric
     cdef int euclidean
 
-    # variables to keep track of building & querying stats
-    cdef int n_trims
-    cdef int n_leaves
-    cdef int n_splits
-    cdef int n_calls
-
     valid_metrics = VALID_METRIC_IDS{{name_suffix}}
 
     # Use cinit to initialize all arrays to empty: this will prevent memory
@@ -838,11 +832,6 @@ cdef class BinaryTree{{name_suffix}}:
         self.n_nodes = 0
 
         self.euclidean = False
-
-        self.n_trims = 0
-        self.n_leaves = 0
-        self.n_splits = 0
-        self.n_calls = 0
 
     def __init__(self, data,
                  leaf_size=40, metric='minkowski', sample_weight=None, **kwargs):
@@ -924,10 +913,6 @@ cdef class BinaryTree{{name_suffix}}:
                 int(self.leaf_size),
                 int(self.n_levels),
                 int(self.n_nodes),
-                int(self.n_trims),
-                int(self.n_leaves),
-                int(self.n_splits),
-                int(self.n_calls),
                 self.dist_metric,
                 sample_weight)
 
@@ -942,51 +927,13 @@ cdef class BinaryTree{{name_suffix}}:
         self.leaf_size = state[4]
         self.n_levels = state[5]
         self.n_nodes = state[6]
-        self.n_trims = state[7]
-        self.n_leaves = state[8]
-        self.n_splits = state[9]
-        self.n_calls = state[10]
-        self.dist_metric = state[11]
-        sample_weight = state[12]
+        self.dist_metric = state[7]
+        sample_weight = state[8]
 
         self.euclidean = (self.dist_metric.__class__.__name__
                           == 'EuclideanDistance64')
         n_samples = self.data.shape[0]
         self._update_sample_weight(n_samples, sample_weight)
-
-    def get_tree_stats(self):
-        """
-        get_tree_stats()
-
-        Get tree status.
-
-        Returns
-        -------
-        tree_stats: tuple of int
-            (number of trims, number of leaves, number of splits)
-        """
-        return (self.n_trims, self.n_leaves, self.n_splits)
-
-    def reset_n_calls(self):
-        """
-        reset_n_calls()
-
-        Reset number of calls to 0.
-        """
-        self.n_calls = 0
-
-    def get_n_calls(self):
-        """
-        get_n_calls()
-
-        Get number of calls.
-
-        Returns
-        -------
-        n_calls: int
-            number of distance computation calls
-        """
-        return self.n_calls
 
     def get_arrays(self):
         """
@@ -1009,7 +956,6 @@ cdef class BinaryTree{{name_suffix}}:
     cdef inline float64_t dist(self, const {{INPUT_DTYPE_t}}* x1, const {{INPUT_DTYPE_t}}* x2,
                              intp_t size) except -1 nogil:
         """Compute the distance between arrays x1 and x2"""
-        self.n_calls += 1
         if self.euclidean:
             return euclidean_dist{{name_suffix}}(x1, x2, size)
         else:
@@ -1024,7 +970,6 @@ cdef class BinaryTree{{name_suffix}}:
         relative rankings of the true distance.  For example, the reduced
         distance for the Euclidean metric is the squared-euclidean distance.
         """
-        self.n_calls += 1
         if self.euclidean:
             return euclidean_rdist{{name_suffix}}(x1, x2, size)
         else:
@@ -1154,10 +1099,6 @@ cdef class BinaryTree{{name_suffix}}:
 
         # bounds is needed for the dual tree algorithm
         cdef float64_t[::1] bounds
-
-        self.n_trims = 0
-        self.n_leaves = 0
-        self.n_splits = 0
 
         if dualtree:
             other = self.__class__(np_Xarr, metric=self.dist_metric,
@@ -1620,12 +1561,11 @@ cdef class BinaryTree{{name_suffix}}:
         # Case 1: query point is outside node radius:
         #         trim it from the query
         if reduced_dist_LB > heap.largest(i_pt):
-            self.n_trims += 1
+            pass
 
         # ------------------------------------------------------------
         # Case 2: this is a leaf node.  Update set of nearby points
         elif node_info.is_leaf:
-            self.n_leaves += 1
             for i in range(node_info.idx_start, node_info.idx_end):
                 dist_pt = self.rdist(pt,
                                      &self.data[self.idx_array[i], 0],
@@ -1636,7 +1576,6 @@ cdef class BinaryTree{{name_suffix}}:
         # Case 3: Node is not a leaf.  Recursively query subnodes
         #         starting with the closest
         else:
-            self.n_splits += 1
             i1 = 2 * i_node + 1
             i2 = i1 + 1
             reduced_dist_LB_1 = min_rdist{{name_suffix}}(self, i1, pt)
@@ -1684,12 +1623,11 @@ cdef class BinaryTree{{name_suffix}}:
             # Case 1: query point is outside node radius:
             #         trim it from the query
             if reduced_dist_LB > heap.largest(i_pt):
-                self.n_trims += 1
+                pass
 
             # ------------------------------------------------------------
             # Case 2: this is a leaf node.  Update set of nearby points
             elif node_data[i_node].is_leaf:
-                self.n_leaves += 1
                 for i in range(node_data[i_node].idx_start,
                                node_data[i_node].idx_end):
                     dist_pt = self.rdist(pt,
@@ -1700,7 +1638,6 @@ cdef class BinaryTree{{name_suffix}}:
             # ------------------------------------------------------------
             # Case 3: Node is not a leaf.  Add subnodes to the node heap
             else:
-                self.n_splits += 1
                 for i in range(2 * i_node + 1, 2 * i_node + 3):
                     nodeheap_item.i1 = i
                     nodeheap_item.val = min_rdist{{name_suffix}}(self, i, pt)

--- a/sklearn/utils/_parallel_testing.py
+++ b/sklearn/utils/_parallel_testing.py
@@ -44,7 +44,8 @@ class DetectChanges:
         self.hashes[obj_id] = obj_hash
         self.objects[obj_id] = obj
         self.old_attributes[obj_id] = {
-            attr: object_hash(getattr(obj, attr)) for attr in _get_immutable_attrs(obj)
+            attr: object_hash(getattr(obj, attr))
+            for attr in _get_hopefully_immutable_attrs(obj)
         }
 
     def store_parallel_calls(
@@ -95,7 +96,7 @@ class DetectChanges:
                 )
 
 
-def get_thread_mutable_attributes(obj: Any) -> set[str]:
+def _get_thread_mutable_attributes(obj: Any) -> set[str]:
     """
     Return attributes that are known to be mutated from multiple threads.
 
@@ -126,54 +127,70 @@ class _ThreadSafe:
 _T = TypeVar("_T")
 
 
-def mark_thread_safe(obj: _T, reason: str = "") -> _T:
+def mark_thread_safe(obj: _T, reason: str) -> _T:
     """Mark object passed to ``delayed()`` as thread-safe."""
+    # If we import at top-level it's circular import.
     from sklearn.utils.parallel import Parallel
+
+    del reason  # Only passed in for documentation purposes
 
     if Parallel._thread_safety_testing:
         # The return type doesn't match the signature, but this is only used in
-        # debug mode, which has special handling for it in
-        # DelayedChanges.store_parallel_calls().
+        # free-threading debug mode, which hands it off for special handling
+        # and unwrapping in DelayedChanges.store_parallel_calls().
         return _ThreadSafe(obj)  # type: ignore[return-value]
 
     return obj
 
 
-def mark_thread_buggy(obj: _T, reason: str = "") -> _T:
+def mark_thread_buggy(obj: _T, reason: str) -> _T:
     """
     Mark object passed to ``delayed()`` as thread-buggy.
 
     This is a separate function in order to aid in grepping.
     """
-    return mark_thread_safe(obj)
+    return mark_thread_safe(obj, reason)
 
 
-def _get_immutable_attrs(obj: Any) -> set[str]:
+def _get_hopefully_immutable_attrs(obj: Any) -> set[str]:
     """Return attributes that shouldn't change."""
     return {
         attr
         for attr in (
             (getattr(obj, "__dict__", {}).keys() | getattr(obj, "__slots__", set()))
-            - get_thread_mutable_attributes(obj)
+            - _get_thread_mutable_attributes(obj)
         )
         if not attr.startswith("__")
     }
 
 
-def _noop(obj):
+def _noop(_):
     """Meaningless placeholder for the pickler."""
 
 
 class _HashingPickler(Pickler):
     """Write-only pickler designed for hashing."""
 
+    # TODO Semantically identical but different objects might be hiding
+    # thread-safety, should add id(obj) to the result, perhaps via
+    # persistent_id().
+
     def reducer_override(self, obj: Any) -> Any:
-        changing_attrs = get_thread_mutable_attributes(obj)
+        # Check if there are any attributes to omit from the hash:
+        changing_attrs = _get_thread_mutable_attributes(obj)
         if not changing_attrs:
             # Fall back to normal pickling:
+
+            # TODO Attributes that don't get pickled might be hiding
+            # thread-safety!
             return NotImplemented
 
-        return _noop, ({attr: getattr(obj, attr) for attr in _get_immutable_attrs(obj)})
+        # TODO If you have a subclass of a built-in type that also has
+        # __sklearn_thread_buggy/safe_attributes__, then this will give the
+        # wrong result.
+        return _noop, (
+            {attr: getattr(obj, attr) for attr in _get_hopefully_immutable_attrs(obj)}
+        )
 
 
 def object_hash(obj: Any) -> bytes:

--- a/sklearn/utils/_parallel_testing.py
+++ b/sklearn/utils/_parallel_testing.py
@@ -6,12 +6,13 @@
 from collections import Counter
 from collections.abc import Iterable
 from copy import deepcopy
-from hashlib import md5
-from pickle import PicklingError, dumps
+from dataclasses import dataclass
+from inspect import getmro
+from pickle import dumps, loads
 from types import MethodType
-from typing import Any
+from typing import Any, TypeVar
 
-import numpy as np
+from deepdiff import DeepHash
 
 from sklearn.utils.parallel import _FuncWrapper
 
@@ -33,6 +34,8 @@ class DetectChanges:
 
     def store_object(self, obj: Any) -> None:
         """Record an object's hash, if possible."""
+        if isinstance(obj, _ThreadSafe):
+            return
         obj_id = id(obj)
         try:
             obj_hash = object_hash(obj)
@@ -41,22 +44,38 @@ class DetectChanges:
         self.counts[obj_id] += 1
         self.hashes[obj_id] = obj_hash
         self.objects[obj_id] = obj
-        self.old_objects[obj_id] = deepcopy(obj)
+        if hasattr(obj, "__deepcopy__"):
+            # Fallback to pickle:
+            copied = loads(dumps(obj))
+        else:
+            copied = deepcopy(obj)
+        self.old_objects[obj_id] = obj
 
     def store_parallel_calls(
         self, iterable: Iterable[tuple[_FuncWrapper, tuple[Any], dict[str, Any]]]
     ) -> Iterable[tuple[_FuncWrapper, tuple[Any], dict[str, Any]]]:
         """
-        Record hashes for inputs to ``Parallel.__call__``
+        Record hashes for inputs to ``Parallel.__call__``.
+
+        Skip objects wrapped in ``_ThreadSafe``.
         """
         for f, args, kwargs in iterable:
             if isinstance(f.function, MethodType):
                 self.store_object(f.function.__self__)
+            new_args = []
             for obj in args:
-                self.store_object(obj)
-            for obj in kwargs.values():
-                self.store_object(obj)
-            yield (f, args, kwargs)
+                if isinstance(obj, _ThreadSafe):
+                    obj = obj.unwrap()
+                else:
+                    self.store_object(obj)
+                new_args.append(obj)
+            new_kwargs = kwargs.copy()
+            for key, obj in kwargs.items():
+                if isinstance(obj, _ThreadSafe):
+                    new_kwargs[key] = obj.unwrap()
+                else:
+                    self.store_object(obj)
+            yield (f, tuple(new_args), new_kwargs)
 
     def assert_objects_unchanged(self, min_count=1) -> None:
         """
@@ -69,30 +88,96 @@ class DetectChanges:
             old_hash = self.hashes[obj_id]
             orig_obj = self.old_objects[obj_id]
             if object_hash(obj) != old_hash:
-                changed = []
+                changed = set()
                 if hasattr(orig_obj, "__dict__"):
                     attrs = orig_obj.__dict__.keys()
                 else:
-                    attrs = getattr(orig_obj, "__slots__", ())
+                    attrs = set()
+                attrs |= set(getattr(orig_obj, "__slots__", ()))
                 for attr in attrs:
-                    if not attr.startswith("__") and not np.array_equal(
-                        getattr(orig_obj, attr), getattr(obj, attr)
-                    ):
-                        changed.append(attr)
+                    if not attr.startswith("__") and object_hash(
+                        getattr(orig_obj, attr)
+                    ) != object_hash(getattr(obj, attr)):
+                        changed.add(attr)
+
+                expected_changed = get_thread_mutable_attributes(obj)
+                if expected_changed and changed <= expected_changed:
+                    continue
+
                 raise AssertionError(
                     f"Hash for object of type {type(obj)} has changed, "
-                    "suggesting potential thread unsafety. "
-                    f"Start by checking attributes: {changed}"
+                    "suggesting potential thread unsafety. Attrs that "
+                    f"changed unexpectedly: {changed - expected_changed}. "
+                    f"Attrs whose change was expected: {changed & expected_changed}."
                 )
 
 
-def object_hash(obj: Any) -> bytes:
+def get_thread_mutable_attributes(obj: Any) -> set[str]:
+    """
+    Return attributes that are known to be mutated from multiple threads.
+
+    These may be known thread-unsafe code that needs to be fixed, or known
+    thread-safe code.
+    """
+
+    def _get(klass):
+        return (
+            getattr(klass, "__sklearn_thread_safe_attributes__", {})
+            | getattr(klass, "__sklearn_thread_buggy_attributes__", {})
+        ).keys()
+
+    result = set()
+    for klass in getmro(type(obj)):
+        result |= _get(klass)
+    return result
+
+
+@dataclass
+class _ThreadSafe:
+    wrapped: object
+
+    def unwrap(self):
+        return self.wrapped
+
+
+_T = TypeVar("_T")
+
+
+def mark_thread_safe(obj: _T, reason: str = "") -> _T:
+    """Mark object passed to ``delayed()`` as thread-safe."""
+    from sklearn.utils.parallel import Parallel
+
+    if Parallel._thread_safety_testing:
+        # The return type doesn't match the signature, but this is only used in
+        # debug mode, which has special handling for it in
+        # DelayedChanges.store_parallel_calls().
+        return _ThreadSafe(obj)  # type: ignore[return-value]
+
+    return obj
+
+
+def mark_thread_buggy(obj: _T, reason: str = "") -> _T:
+    """
+    Mark object passed to ``delayed()`` as thread-buggy.
+
+    This is a separate function in order to aid in grepping.
+    """
+    return mark_thread_safe(obj)
+
+
+def object_hash(obj: Any) -> str:
     """
     Hash a Python object; mutating the object should change the result.
 
     Raises ``TypeError`` in some rare cases.
     """
-    try:
-        return md5(dumps(obj), usedforsecurity=False).digest()
-    except PicklingError:
-        raise TypeError
+    return DeepHash(
+        obj,
+        exclude_paths=get_thread_mutable_attributes(obj),
+        ignore_repetition=False,
+        ignore_string_type_changes=False,
+        ignore_iterable_order=False,
+        # Apparently bytes are encoded into strings... this suggests long term
+        # might want to recreate this library, or submit fixes.
+        encodings=["utf-8", "latin-1"],
+    )[obj]

--- a/sklearn/utils/_parallel_testing.py
+++ b/sklearn/utils/_parallel_testing.py
@@ -5,10 +5,13 @@
 
 from collections import Counter
 from collections.abc import Iterable
+from copy import deepcopy
 from hashlib import md5
 from pickle import PicklingError, dumps
 from types import MethodType
 from typing import Any
+
+import numpy as np
 
 from sklearn.utils.parallel import _FuncWrapper
 
@@ -25,6 +28,7 @@ class DetectChanges:
     def __init__(self):
         self.counts = Counter()
         self.hashes = {}
+        self.old_objects = {}
         self.objects = {}
 
     def store_object(self, obj: Any) -> None:
@@ -32,11 +36,12 @@ class DetectChanges:
         obj_id = id(obj)
         try:
             obj_hash = object_hash(obj)
-        except (TypeError, PicklingError):
+        except TypeError:
             return
         self.counts[obj_id] += 1
         self.hashes[obj_id] = obj_hash
         self.objects[obj_id] = obj
+        self.old_objects[obj_id] = deepcopy(obj)
 
     def store_parallel_calls(
         self, iterable: Iterable[tuple[_FuncWrapper, tuple[Any], dict[str, Any]]]
@@ -62,10 +67,22 @@ class DetectChanges:
                 continue
             obj = self.objects[obj_id]
             old_hash = self.hashes[obj_id]
+            orig_obj = self.old_objects[obj_id]
             if object_hash(obj) != old_hash:
+                changed = []
+                if hasattr(orig_obj, "__dict__"):
+                    attrs = orig_obj.__dict__.keys()
+                else:
+                    attrs = getattr(orig_obj, "__slots__", ())
+                for attr in attrs:
+                    if not attr.startswith("__") and not np.array_equal(
+                        getattr(orig_obj, attr), getattr(obj, attr)
+                    ):
+                        changed.append(attr)
                 raise AssertionError(
                     f"Hash for object of type {type(obj)} has changed, "
-                    "suggesting potential thread unsafety"
+                    "suggesting potential thread unsafety. "
+                    f"Start by checking attributes: {changed}"
                 )
 
 
@@ -75,4 +92,7 @@ def object_hash(obj: Any) -> bytes:
 
     Raises ``TypeError`` in some rare cases.
     """
-    return md5(dumps(obj), usedforsecurity=False).digest()
+    try:
+        return md5(dumps(obj), usedforsecurity=False).digest()
+    except PicklingError:
+        raise TypeError

--- a/sklearn/utils/_parallel_testing.py
+++ b/sklearn/utils/_parallel_testing.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from hashlib import md5
 from inspect import getmro
 from io import BytesIO
-from pickle import Pickler, PicklingError
+from pickle import Pickler, PicklingError, dumps
 from types import MethodType
 from typing import Any, TypeVar
 
@@ -43,10 +43,12 @@ class DetectChanges:
         self.counts[obj_id] += 1
         self.hashes[obj_id] = obj_hash
         self.objects[obj_id] = obj
-        self.old_attributes[obj_id] = {
-            attr: object_hash(getattr(obj, attr))
-            for attr in _get_hopefully_immutable_attrs(obj)
-        }
+        self.old_attributes[obj_id] = attrs = {}
+        for attr in _get_hopefully_immutable_attrs(obj):
+            try:
+                attrs[attr] = object_hash(getattr(obj, attr))
+            except TypeError:
+                continue
 
     def store_parallel_calls(
         self, iterable: Iterable[tuple[_FuncWrapper, tuple[Any], dict[str, Any]]]
@@ -177,6 +179,12 @@ class _HashingPickler(Pickler):
     # persistent_id().
 
     def reducer_override(self, obj: Any) -> Any:
+        # If the object isn't pickleable, just hash a repr.
+        try:
+            _ = dumps(obj)
+        except (PicklingError, TypeError):
+            return _noop, (repr(obj),)
+
         # Check if there are any attributes to omit from the hash:
         changing_attrs = _get_thread_mutable_attributes(obj)
         if not changing_attrs:

--- a/sklearn/utils/_parallel_testing.py
+++ b/sklearn/utils/_parallel_testing.py
@@ -5,14 +5,13 @@
 
 from collections import Counter
 from collections.abc import Iterable
-from copy import deepcopy
 from dataclasses import dataclass
+from hashlib import md5
 from inspect import getmro
-from pickle import dumps, loads
+from io import BytesIO
+from pickle import Pickler, PicklingError
 from types import MethodType
 from typing import Any, TypeVar
-
-from deepdiff import DeepHash
 
 from sklearn.utils.parallel import _FuncWrapper
 
@@ -29,7 +28,7 @@ class DetectChanges:
     def __init__(self):
         self.counts = Counter()
         self.hashes = {}
-        self.old_objects = {}
+        self.old_attributes = {}
         self.objects = {}
 
     def store_object(self, obj: Any) -> None:
@@ -44,12 +43,9 @@ class DetectChanges:
         self.counts[obj_id] += 1
         self.hashes[obj_id] = obj_hash
         self.objects[obj_id] = obj
-        if hasattr(obj, "__deepcopy__"):
-            # Fallback to pickle:
-            copied = loads(dumps(obj))
-        else:
-            copied = deepcopy(obj)
-        self.old_objects[obj_id] = obj
+        self.old_attributes[obj_id] = {
+            attr: object_hash(getattr(obj, attr)) for attr in _get_immutable_attrs(obj)
+        }
 
     def store_parallel_calls(
         self, iterable: Iterable[tuple[_FuncWrapper, tuple[Any], dict[str, Any]]]
@@ -86,29 +82,16 @@ class DetectChanges:
                 continue
             obj = self.objects[obj_id]
             old_hash = self.hashes[obj_id]
-            orig_obj = self.old_objects[obj_id]
             if object_hash(obj) != old_hash:
                 changed = set()
-                if hasattr(orig_obj, "__dict__"):
-                    attrs = orig_obj.__dict__.keys()
-                else:
-                    attrs = set()
-                attrs |= set(getattr(orig_obj, "__slots__", ()))
-                for attr in attrs:
-                    if not attr.startswith("__") and object_hash(
-                        getattr(orig_obj, attr)
-                    ) != object_hash(getattr(obj, attr)):
+                for attr, old_attr_hash in self.old_attributes[obj_id].items():
+                    if old_attr_hash != object_hash(getattr(obj, attr)):
                         changed.add(attr)
-
-                expected_changed = get_thread_mutable_attributes(obj)
-                if expected_changed and changed <= expected_changed:
-                    continue
 
                 raise AssertionError(
                     f"Hash for object of type {type(obj)} has changed, "
                     "suggesting potential thread unsafety. Attrs that "
-                    f"changed unexpectedly: {changed - expected_changed}. "
-                    f"Attrs whose change was expected: {changed & expected_changed}."
+                    f"changed unexpectedly: {changed}"
                 )
 
 
@@ -165,19 +148,44 @@ def mark_thread_buggy(obj: _T, reason: str = "") -> _T:
     return mark_thread_safe(obj)
 
 
-def object_hash(obj: Any) -> str:
+def _get_immutable_attrs(obj: Any) -> set[str]:
+    """Return attributes that shouldn't change."""
+    return {
+        attr
+        for attr in (
+            (getattr(obj, "__dict__", {}).keys() | getattr(obj, "__slots__", set()))
+            - get_thread_mutable_attributes(obj)
+        )
+        if not attr.startswith("__")
+    }
+
+
+def _noop(obj):
+    """Meaningless placeholder for the pickler."""
+
+
+class _HashingPickler(Pickler):
+    """Write-only pickler designed for hashing."""
+
+    def reducer_override(self, obj: Any) -> Any:
+        changing_attrs = get_thread_mutable_attributes(obj)
+        if not changing_attrs:
+            # Fall back to normal pickling:
+            return NotImplemented
+
+        return _noop, ({attr: getattr(obj, attr) for attr in _get_immutable_attrs(obj)})
+
+
+def object_hash(obj: Any) -> bytes:
     """
     Hash a Python object; mutating the object should change the result.
 
     Raises ``TypeError`` in some rare cases.
     """
-    return DeepHash(
-        obj,
-        exclude_paths=get_thread_mutable_attributes(obj),
-        ignore_repetition=False,
-        ignore_string_type_changes=False,
-        ignore_iterable_order=False,
-        # Apparently bytes are encoded into strings... this suggests long term
-        # might want to recreate this library, or submit fixes.
-        encodings=["utf-8", "latin-1"],
-    )[obj]
+    f = BytesIO()
+    hasher = _HashingPickler(f)
+    try:
+        hasher.dump(obj)
+    except PicklingError:
+        raise TypeError
+    return md5(f.getvalue()).digest()

--- a/sklearn/utils/_parallel_testing.py
+++ b/sklearn/utils/_parallel_testing.py
@@ -153,14 +153,15 @@ def mark_thread_buggy(obj: _T, reason: str) -> _T:
 
 
 def _get_hopefully_immutable_attrs(obj: Any) -> set[str]:
-    """Return attributes that shouldn't change."""
+    """
+    Return attributes that shouldn't change.
+    """
     return {
         attr
         for attr in (
             (getattr(obj, "__dict__", {}).keys() | getattr(obj, "__slots__", set()))
             - _get_thread_mutable_attributes(obj)
         )
-        if not attr.startswith("__")
     }
 
 

--- a/sklearn/utils/_parallel_testing.py
+++ b/sklearn/utils/_parallel_testing.py
@@ -1,0 +1,78 @@
+# Authors: The scikit-learn developers
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Infrastructure for testing thread-safety."""
+
+from collections import Counter
+from collections.abc import Iterable
+from hashlib import md5
+from pickle import PicklingError, dumps
+from types import MethodType
+from typing import Any
+
+from sklearn.utils.parallel import _FuncWrapper
+
+
+class DetectChanges:
+    """
+    Heuristically detect if a set of objects have changed.
+
+    This can be used to detect potential thread-safety issues.  If the
+    arguments to tasks running in a thread pool have changed while running in
+    the thread pool, that suggests unsafe mutation.
+    """
+
+    def __init__(self):
+        self.counts = Counter()
+        self.hashes = {}
+        self.objects = {}
+
+    def store_object(self, obj: Any) -> None:
+        """Record an object's hash, if possible."""
+        obj_id = id(obj)
+        try:
+            obj_hash = object_hash(obj)
+        except (TypeError, PicklingError):
+            return
+        self.counts[obj_id] += 1
+        self.hashes[obj_id] = obj_hash
+        self.objects[obj_id] = obj
+
+    def store_parallel_calls(
+        self, iterable: Iterable[tuple[_FuncWrapper, tuple[Any], dict[str, Any]]]
+    ) -> Iterable[tuple[_FuncWrapper, tuple[Any], dict[str, Any]]]:
+        """
+        Record hashes for inputs to ``Parallel.__call__``
+        """
+        for f, args, kwargs in iterable:
+            if isinstance(f.function, MethodType):
+                self.store_object(f.function.__self__)
+            for obj in args:
+                self.store_object(obj)
+            for obj in kwargs.values():
+                self.store_object(obj)
+            yield (f, args, kwargs)
+
+    def assert_objects_unchanged(self, min_count=1) -> None:
+        """
+        Raise an ``AssertionError`` if stored objects have changed.
+        """
+        for obj_id, count in self.counts.items():
+            if count < min_count:
+                continue
+            obj = self.objects[obj_id]
+            old_hash = self.hashes[obj_id]
+            if object_hash(obj) != old_hash:
+                raise AssertionError(
+                    f"Hash for object of type {type(obj)} has changed, "
+                    "suggesting potential thread unsafety"
+                )
+
+
+def object_hash(obj: Any) -> bytes:
+    """
+    Hash a Python object; mutating the object should change the result.
+
+    Raises ``TypeError`` in some rare cases.
+    """
+    return md5(dumps(obj), usedforsecurity=False).digest()

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -60,22 +60,11 @@ class Parallel(joblib.Parallel):
         if self._thread_safety_testing:
             # Try to force the threading backend for joblib:
             bound = Signature.from_callable(super().__init__).bind(*args, **kwargs)
-            if (
-                bound.arguments.get("require") == "sharedmem"
-                or bound.arguments.get("prefer") == "threads"
-            ):
-                # If the API is explicitly using thread pools, for now don't
-                # bother with testing it, for now at least:
-                #
-                # 1. Hopefully it was already designed to be thread-safe.
-                # 2. It has edge cases the test infrastructure can't handle yet.
-                self._thread_safety_testing = False
-            else:
-                # Force threading:
-                bound.arguments["backend"] = "threading"
-                # Force result to a be list:
-                bound.arguments["return_as"] = "list"
-                args, kwargs = bound.args, bound.kwargs
+            # Force threading:
+            bound.arguments["backend"] = "threading"
+            # Force result to a be list:
+            bound.arguments["return_as"] = "list"
+            args, kwargs = bound.args, bound.kwargs
 
         super().__init__(*args, **kwargs)
 

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -8,6 +8,7 @@ usage.
 import functools
 import warnings
 from functools import update_wrapper
+from inspect import Signature
 
 import joblib
 from threadpoolctl import ThreadpoolController
@@ -51,6 +52,33 @@ class Parallel(joblib.Parallel):
     .. versionadded:: 1.3
     """
 
+    # If True, enable additional testing infrastructure: parallelization will
+    # always happen with thread pools, and thread safety will be tested.
+    _thread_safety_testing = False
+
+    def __init__(self, *args, **kwargs):
+        if self._thread_safety_testing:
+            # Try to force the threading backend for joblib:
+            bound = Signature.from_callable(super().__init__).bind(*args, **kwargs)
+            if (
+                bound.arguments.get("require") == "sharedmem"
+                or bound.arguments.get("prefer") == "threads"
+            ):
+                # If the API is explicitly using thread pools, for now don't
+                # bother with testing it, for now at least:
+                #
+                # 1. Hopefully it was already designed to be thread-safe.
+                # 2. It has edge cases the test infrastructure can't handle yet.
+                self._thread_safety_testing = False
+            else:
+                # Force threading:
+                bound.arguments["backend"] = "threading"
+                # Force result to a be list:
+                bound.arguments["return_as"] = "list"
+                args, kwargs = bound.args, bound.kwargs
+
+        super().__init__(*args, **kwargs)
+
     def __call__(self, iterable):
         """Dispatch the tasks and return the results.
 
@@ -80,6 +108,12 @@ class Parallel(joblib.Parallel):
             filters_func() if filters_func is not None else warnings.filters
         )
 
+        if self._thread_safety_testing:
+            from sklearn.utils._parallel_testing import DetectChanges
+
+            detect_changes = DetectChanges()
+            iterable = detect_changes.store_parallel_calls(iterable)
+
         iterable_with_config_and_warning_filters = (
             (
                 _with_config_and_warning_filters(delayed_func, config, warning_filters),
@@ -88,7 +122,18 @@ class Parallel(joblib.Parallel):
             )
             for delayed_func, args, kwargs in iterable
         )
-        return super().__call__(iterable_with_config_and_warning_filters)
+
+        result = super().__call__(iterable_with_config_and_warning_filters)
+
+        if self._thread_safety_testing:
+            # We forced result to be a list so we're guaranteed to have
+            # finished running all threaded code.
+            assert isinstance(result, list)
+            # For now only check objects that appear at least twice, meaning
+            # they were likely passed to multiple tasks in the thread pool:
+            detect_changes.assert_objects_unchanged(min_count=2)
+
+        return result
 
 
 # remove when https://github.com/joblib/joblib/issues/1071 is fixed


### PR DESCRIPTION
#### Background

I am working for Quansight on a contract to improve free-threading/threading support in Scikit-Learn.

To ensure thread-safety, it's useful to have test infrastructure that will provide:

* A way to identify thread-safety issues in code that has previously mostly been run in process pools. Free-threading's lack of GIL makes thread safety issues more likely than in the past.
* A way to prevent _future changes_ to the code introducing new thread-safety problems.

A good starting point here is focusing on operations that are _already_ parallel, where users might reasonably expect to be able to turn threading on as a `joblib` backend and have it Just Work. These operations also work in a very particular way: create some tasks, run them in a worker pool, get back the results of the tasks.

What can go wrong in this particular idiom? Switching from a process pool to a thread pool introduces thread-safety issues with the _inputs_ to a `Parallel()` operation: whereas mutating in a process is fine, mutating in a thread can affect other threads, or future interactions with the object in the main thread.

This suggests a starting point for a invariant to be using in testing: **the inputs to a `Parallel()` operation that can correctly run with both process and thread pools should not change when the function is run.**

> **Note:** `pytest-run-parallel` won't catch these sort of problems, as the problem here is not with shared global state, but with shared temporary and/or internal state.

#### What this PR does

When `pytest` is run with a new `--thread-safety-testing` flag:

1. `Parallel()` switches to running using a thread pool.
2. Arguments passed to functions called in parallel are tracked to see if they changed as part of execution. "Change" is calculated heuristically, with a hash.

This testing mechanism causes many tests to fail, suggesting objects are being mutated in the thread pool. At least in some cases this would suggest data races.

To demonstrate one of the (potential) problems it identifies, I fixed a real problem it identified: in `BinaryTree`/`KDTree`, certain C-level attributes were being modified in a non-thread-safe way. In normal Python with a GIL this was _maybe_ safe, depending where the GIL was released. In free-threaded code this is definitely not safe.

In practice these attributes weren't actually used by sklearn, so this wouldn't have impacted users, and removing them altogether seemed the easiest way to solve the problem.

In the short term I will keep going through the identified problems to see if there are any that impact real-world usage. But even if most of the currently found issues are minor, the real value will be having this run in CI in the future, because it will catch many thread-safety regressions _before_ they get merged, as thread pools become more common.

#### Next steps

I am opening this PR as a draft for discussion purposes. If this approach is acceptable, future steps (in this PR, or more likely spread across multiple PRs) would likely include:

* Add tests for `_parallel_testing.py`.
* Add a CI job that runs with these tests, likely configured with a ratchet so you get green checkmarks so long as changes haven't made the situation worse.
* Fixing the other (likely) problems this testing approach identifies.
* Add more edge cases to the hash change detection to catch more problems.

#### Reference Issues/PRs
None for now.

#### AI usage disclosure

I did not use "AI" assistance.

#### Any other comments?

