### PR TITLE
DOC Use a list instead of a checklist for AI disclosure

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,15 +27,16 @@ is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
 
 #### AI usage disclosure
 <!--
-If AI tools were involved in creating this PR, please check all boxes that apply
-below and make sure that you adhere to our Automated Contributions Policy:
+Edit the list below to show when/how you used AI tools to create this PR.
+Keep the ones that apply, delete the rest.
+Make sure that you adhere to our Automated Contributions Policy:
 https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
 -->
 I used AI assistance for:
-- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
-- [ ] Test/benchmark generation
-- [ ] Documentation (including examples)
-- [ ] Research and understanding
+- Code generation (e.g., when writing an implementation or fixing a bug)
+- Test/benchmark generation
+- Documentation (including examples)
+- Research and understanding
 
 
 #### Any other comments?


### PR DESCRIPTION
Using a checklist makes it appear as if there are (open) todo items for the PR. This switches the template to use a list and asks the user to delete the items that don't apply.

This is an attempt to have the best of both worlds. Easy to use by PR authors (mostly just deleting stuff) and not have the spurious "there are open todo items" impression for PRs.

What do you think @AnneBeyer and others?