### PR TITLE
DOC Remove redundant array API SciPy note

### DIFF
--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -230,7 +230,7 @@ Metrics
 - :func:`sklearn.metrics.mean_absolute_percentage_error`
 - :func:`sklearn.metrics.mean_gamma_deviance`
 - :func:`sklearn.metrics.mean_pinball_loss`
-- :func:`sklearn.metrics.mean_poisson_deviance` (requires `enabling array API support for SciPy <https://docs.scipy.org/doc/scipy/dev/api-dev/array_api.html#using-array-api-standard-support>`_)
+- :func:`sklearn.metrics.mean_poisson_deviance`
 - :func:`sklearn.metrics.mean_squared_error`
 - :func:`sklearn.metrics.mean_squared_log_error`
 - :func:`sklearn.metrics.mean_tweedie_deviance`


### PR DESCRIPTION
#### Reference Issues/PRs

I noticed a small things to correct while reviewing #34054

#### What does this implement/fix? Explain your changes.

Removes a redundant note from the array API supported metrics list. The SciPy `SCIPY_ARRAY_API=1` requirement is already documented in the setup section and applies globally.
