### PR TITLE
Silence deprecation warnings in `_repr_mimebundle_`

### DIFF
--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -357,7 +357,13 @@ class BaseEstimator(ReprHTMLMixin, _HTMLDocumentationLinkMixin, _MetadataRequest
         """Get fitted attributes of the estimator."""
 
         fitted_attr = {}
-        for name, value in inspect.getmembers(self):
+        # Ignore deprecation warnings for deprecated fitted attributes when
+        # generating the repr.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            members = inspect.getmembers(self)
+
+        for name, value in members:
             # We display up to 100 fitted attributes
             if len(fitted_attr) > 100:
                 fitted_attr["..."] = {

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -30,6 +30,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import LabelEncoder, StandardScaler
 from sklearn.svm import SVC, SVR
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
+from sklearn.utils import deprecated
 from sklearn.utils._mocking import MockDataFrame
 from sklearn.utils._set_output import _get_output_config
 from sklearn.utils._testing import (
@@ -1024,6 +1025,28 @@ def test_get_fitted_attr_html():
     assert fitted_attr_html["components_"]["type_name"] == ("ndarray")
     assert fitted_attr_html["components_"]["shape"] == (2, 2)
     assert_allclose(fitted_attr_html["components_"]["value"], pca.components_)
+
+
+def test_get_fitted_attr_html_no_warnings():
+    """Check that deprecated fitted attrs don't generate a warning in the repr.
+
+    Non-regression test for
+    https://github.com/scikit-learn/scikit-learn/issues/34056
+    """
+
+    class Estimator(BaseEstimator):
+        @deprecated("Attribute `foo` is deprecated")
+        @property
+        def foo_(self):
+            return 1
+
+    model = Estimator()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        html = model._get_fitted_attr_html()
+
+    assert html["foo_"] == {"type_name": "int", "value": 1}
 
 
 def make_estimator_with_param(default_value):


### PR DESCRIPTION
This silences deprecation warnings raised when accessing fitted attributes while generating the rich html repr. The deprecated attributes are still included in the repr (but will warn when accessed by the user), but no warning is generated.

Fixes #34056

#### AI usage disclosure

I did not use AI for anything.