### PR TITLE
PERF Fast path in `multilabel_confusion_matrix` for integer inputs

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/34073.efficiency.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/34073.efficiency.rst
@@ -1,0 +1,7 @@
+- :func:`metrics.multilabel_confusion_matrix` now uses a fast path for integer or
+  bool inputs whose present labels form the dense range `[0, K-1]`, avoiding
+  the redundant unique and searchsorted scans inside `LabelEncoder.transform`.
+  This also speeds up :func:`metrics.f1_score`, :func:`metrics.jaccard_score`,
+  :func:`metrics.precision_score`, :func:`metrics.recall_score`, and
+  :func:`metrics.precision_recall_fscore_support` for the same inputs.
+  By :user:`Muhammad Taha Mukhtar <tahamukhtar20>`.

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -768,12 +768,8 @@ def multilabel_confusion_matrix(
         if (
             _is_numpy_namespace(xp)
             and K > 0
-            and xp.isdtype(
-                y_true.dtype, ("bool", "signed integer", "unsigned integer")
-            )
-            and xp.isdtype(
-                y_pred.dtype, ("bool", "signed integer", "unsigned integer")
-            )
+            and xp.isdtype(y_true.dtype, ("bool", "signed integer", "unsigned integer"))
+            and xp.isdtype(y_pred.dtype, ("bool", "signed integer", "unsigned integer"))
             and int(present_labels[0]) == 0
             and int(present_labels[-1]) == K - 1
             and int(xp.min(labels)) >= 0

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -764,11 +764,29 @@ def multilabel_confusion_matrix(
                 "multilabel classification."
             )
 
-        le = LabelEncoder()
-        le.fit(labels)
-        y_true = le.transform(y_true)
-        y_pred = le.transform(y_pred)
-        sorted_labels = le.classes_
+        K = int(present_labels.shape[0])
+        if (
+            _is_numpy_namespace(xp)
+            and K > 0
+            and xp.isdtype(
+                y_true.dtype, ("bool", "signed integer", "unsigned integer")
+            )
+            and xp.isdtype(
+                y_pred.dtype, ("bool", "signed integer", "unsigned integer")
+            )
+            and int(present_labels[0]) == 0
+            and int(present_labels[-1]) == K - 1
+            and int(xp.min(labels)) >= 0
+        ):
+            y_true = y_true.astype(np.int64)
+            y_pred = y_pred.astype(np.int64)
+            sorted_labels = present_labels
+        else:
+            le = LabelEncoder()
+            le.fit(labels)
+            y_true = le.transform(y_true)
+            y_pred = le.transform(y_pred)
+            sorted_labels = le.classes_
 
         # labels are now from 0 to len(labels) - 1 -> use bincount
         tp = y_true == y_pred

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -609,6 +609,116 @@ def test_multilabel_confusion_matrix_errors():
         multilabel_confusion_matrix([[0, 1, 2], [2, 1, 0]], [[1, 2, 0], [1, 0, 2]])
 
 
+@pytest.mark.parametrize("dtype", [np.uint8, np.int32, np.int64, bool])
+def test_multilabel_confusion_matrix_fastpath_binary(dtype):
+    rng = np.random.RandomState(0)
+    y_true = rng.randint(0, 2, size=1000).astype(dtype)
+    y_pred = rng.randint(0, 2, size=1000).astype(dtype)
+    result_int = multilabel_confusion_matrix(y_true, y_pred)
+    result_float = multilabel_confusion_matrix(
+        y_true.astype(np.float64), y_pred.astype(np.float64)
+    )
+    np.testing.assert_array_equal(result_int, result_float)
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.int32, np.int64])
+@pytest.mark.parametrize("K", [3, 5, 20])
+def test_multilabel_confusion_matrix_fastpath_multiclass(dtype, K):
+    rng = np.random.RandomState(0)
+    y_true = rng.randint(0, K, size=2000).astype(dtype)
+    y_pred = rng.randint(0, K, size=2000).astype(dtype)
+    result_int = multilabel_confusion_matrix(y_true, y_pred)
+    result_float = multilabel_confusion_matrix(
+        y_true.astype(np.float64), y_pred.astype(np.float64)
+    )
+    np.testing.assert_array_equal(result_int, result_float)
+
+
+def test_multilabel_confusion_matrix_fastpath_single_class():
+    y_true = np.zeros(100, dtype=np.uint8)
+    y_pred = np.zeros(100, dtype=np.uint8)
+    result_int = multilabel_confusion_matrix(y_true, y_pred)
+    result_float = multilabel_confusion_matrix(
+        y_true.astype(np.float64), y_pred.astype(np.float64)
+    )
+    np.testing.assert_array_equal(result_int, result_float)
+    assert result_int.shape == (1, 2, 2)
+    np.testing.assert_array_equal(result_int[0], np.array([[0, 0], [0, 100]]))
+
+
+def test_multilabel_confusion_matrix_fastpath_f1_jaccard():
+    rng = np.random.RandomState(0)
+    y_true = rng.randint(0, 2, size=1000).astype(np.uint8)
+    y_pred = rng.randint(0, 2, size=1000).astype(np.uint8)
+    y_true_float = y_true.astype(np.float64)
+    y_pred_float = y_pred.astype(np.float64)
+
+    assert f1_score(y_true, y_pred, average="binary") == f1_score(
+        y_true_float, y_pred_float, average="binary"
+    )
+    assert jaccard_score(y_true, y_pred, average="binary") == jaccard_score(
+        y_true_float, y_pred_float, average="binary"
+    )
+
+
+@pytest.mark.parametrize("labels", [[1, 0], [0], [1]])
+def test_multilabel_confusion_matrix_fastpath_labels_subset_or_reorder(labels):
+    rng = np.random.RandomState(0)
+    y_true = rng.randint(0, 2, size=1000).astype(np.uint8)
+    y_pred = rng.randint(0, 2, size=1000).astype(np.uint8)
+    result_int = multilabel_confusion_matrix(y_true, y_pred, labels=labels)
+    result_float = multilabel_confusion_matrix(
+        y_true.astype(np.float64), y_pred.astype(np.float64), labels=labels
+    )
+    np.testing.assert_array_equal(result_int, result_float)
+
+
+def test_multilabel_confusion_matrix_fastpath_labels_force_include():
+    rng = np.random.RandomState(0)
+    y_true = rng.randint(0, 2, size=1000).astype(np.uint8)
+    y_pred = rng.randint(0, 2, size=1000).astype(np.uint8)
+    result = multilabel_confusion_matrix(y_true, y_pred, labels=[0, 1, 99])
+    baseline = multilabel_confusion_matrix(y_true, y_pred, labels=[0, 1])
+    assert result.shape == (3, 2, 2)
+    np.testing.assert_array_equal(result[:2], baseline)
+    # class 99 absent from data: TN=n_samples, FP=FN=TP=0
+    np.testing.assert_array_equal(result[2], np.array([[1000, 0], [0, 0]]))
+
+
+def test_multilabel_confusion_matrix_fastpath_sample_weight():
+    rng = np.random.RandomState(0)
+    y_true = rng.randint(0, 2, size=1000).astype(np.uint8)
+    y_pred = rng.randint(0, 2, size=1000).astype(np.uint8)
+    sample_weight = rng.uniform(0.5, 2.0, size=1000)
+    result_int = multilabel_confusion_matrix(
+        y_true, y_pred, sample_weight=sample_weight
+    )
+    result_float = multilabel_confusion_matrix(
+        y_true.astype(np.float64),
+        y_pred.astype(np.float64),
+        sample_weight=sample_weight,
+    )
+    np.testing.assert_array_equal(result_int, result_float)
+
+
+def test_multilabel_confusion_matrix_fastpath_fallthrough_negative_labels():
+    rng = np.random.RandomState(0)
+    y_true = rng.randint(0, 2, size=100).astype(np.int64)
+    y_pred = rng.randint(0, 2, size=100).astype(np.int64)
+    result = multilabel_confusion_matrix(y_true, y_pred, labels=[-1, 0, 1])
+    assert result.shape == (3, 2, 2)
+    # class -1 absent from data: TN=n_samples, FP=FN=TP=0
+    np.testing.assert_array_equal(result[0], np.array([[100, 0], [0, 0]]))
+
+
+def test_multilabel_confusion_matrix_fastpath_fallthrough_nonconsecutive():
+    y_true = np.array([3, 7, 3, 7, 3], dtype=np.int64)
+    y_pred = np.array([3, 7, 7, 3, 3], dtype=np.int64)
+    result = multilabel_confusion_matrix(y_true, y_pred)
+    assert result.shape == (2, 2, 2)
+    np.testing.assert_array_equal(result[0], np.array([[1, 1], [1, 2]]))
+
+
 @pytest.mark.parametrize(
     "normalize, cm_dtype, expected_results",
     [


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #31554 

#### What does this implement/fix? Explain your changes.
Adds a fast path in `multilabel_confusion_matrix` for the common case of integer or bool inputs whose present labels form the dense range `[0, K-1]`. In that case `LabelEncoder.transform` can be skipped.

Single `multilabel_confusion_matrix` call at n=10M elements:

| K  | slow path | fast path | speedup |
|----|----------:|----------:|--------:|
| 2  |    769 ms |    358 ms |   2.1x  |
| 5  |    878 ms |    305 ms |   2.9x  |
| 20 |   1162 ms |    275 ms |   4.2x  |

#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Research and understanding

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->