### PR TITLE
MNT remove get_columns/callable in set_output

### DIFF
--- a/sklearn/utils/_set_output.py
+++ b/sklearn/utils/_set_output.py
@@ -23,18 +23,6 @@ def check_library_installed(library):
         ) from exc
 
 
-def get_columns(columns):
-    if callable(columns):
-        try:
-            return columns()
-        except AttributeError as e:
-            if "does not provide get_feature_names_out" in str(e):
-                return None
-            else:
-                raise
-    return columns
-
-
 @runtime_checkable
 class ContainerAdapterProtocol(Protocol):
     container_lib: str
@@ -51,9 +39,8 @@ class ContainerAdapterProtocol(Protocol):
             Original input dataframe. This is used to extract the metadata that should
             be passed to `X_output`, e.g. pandas row index.
 
-        columns : callable, ndarray, or None
-            The column names or a callable that returns the column names. The
-            callable is useful if the column names require some computation. If `None`,
+        columns : ndarray or None
+            The column names, e.g. as returned by get_feature_names_out. If `None`,
             then no columns are passed to the container's constructor.
 
         inplace : bool, default=False
@@ -118,7 +105,6 @@ class PandasAdapter:
 
     def create_container(self, X_output, X_original, columns, inplace=True):
         pd = check_library_installed("pandas")
-        columns = get_columns(columns)
 
         if not inplace or not isinstance(X_output, pd.DataFrame):
             # In all these cases, we need to create a new DataFrame
@@ -160,7 +146,6 @@ class PolarsAdapter:
 
     def create_container(self, X_output, X_original, columns, inplace=True):
         pl = check_library_installed("polars")
-        columns = get_columns(columns)
         columns = columns.tolist() if isinstance(columns, np.ndarray) else columns
 
         if not inplace or not isinstance(X_output, pl.DataFrame):
@@ -178,6 +163,7 @@ class PolarsAdapter:
     def rename_columns(self, X, columns):
         # we cannot use `rename` since it takes a dictionary and at this stage we have
         # potentially duplicate column names in `X`
+        # Anyway, polars will raise a DuplicateError in that case.
         X.columns = columns
         return X
 
@@ -304,10 +290,18 @@ def _wrap_data_with_container(method, data_to_wrap, original_input, estimator):
         )
 
     adapter = ADAPTERS_MANAGER.adapters[dense_config]
+
+    try:
+        columns = estimator.get_feature_names_out()
+    except AttributeError as e:
+        if "does not provide get_feature_names_out" in str(e):
+            columns = None
+        else:
+            raise
     return adapter.create_container(
         data_to_wrap,
         original_input,
-        columns=estimator.get_feature_names_out,
+        columns=columns,
     )
 
 

--- a/sklearn/utils/tests/test_set_output.py
+++ b/sklearn/utils/tests/test_set_output.py
@@ -30,13 +30,13 @@ def test_pandas_adapter():
     X_ser_orig = pd.Series([2, 3], index=index)
 
     adapter = ADAPTERS_MANAGER.adapters["pandas"]
-    X_container = adapter.create_container(X_np, X_df_orig, columns=lambda: columns)
+    X_container = adapter.create_container(X_np, X_df_orig, columns=columns)
     assert isinstance(X_container, pd.DataFrame)
     assert_array_equal(X_container.columns, columns)
     assert_array_equal(X_container.index, index)
 
     # use original index when the original is a series
-    X_container = adapter.create_container(X_np, X_ser_orig, columns=lambda: columns)
+    X_container = adapter.create_container(X_np, X_ser_orig, columns=columns)
     assert isinstance(X_container, pd.DataFrame)
     assert_array_equal(X_container.columns, columns)
     assert_array_equal(X_container.index, index)
@@ -98,7 +98,7 @@ def test_polars_adapter():
     X_df_orig = pl.DataFrame(X_np, schema=columns, orient="row")
 
     adapter = ADAPTERS_MANAGER.adapters["polars"]
-    X_container = adapter.create_container(X_np, X_df_orig, columns=lambda: columns)
+    X_container = adapter.create_container(X_np, X_df_orig, columns=columns)
 
     assert isinstance(X_container, pl.DataFrame)
     assert_array_equal(X_container.columns, columns)


### PR DESCRIPTION
#### Reference Issues/PRs
None


#### What does this implement/fix? Explain your changes.
Small maintenance in `sklearn.utils._set_output`.

#### AI usage disclosure
None


#### Any other comments?
At first sight, set_output seemed like a good place to use narwhals. After a closer look, I would leave it as is.