### PR TITLE
DOC Clarify fixed vocabulary with n-grams

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -342,6 +342,19 @@ def test_countvectorizer_custom_vocabulary_pipeline():
     assert X.shape[1] == len(what_we_like)
 
 
+@pytest.mark.parametrize("Vectorizer", (CountVectorizer, TfidfVectorizer))
+def test_vectorizer_fixed_vocabulary_with_ngrams(Vectorizer):
+    vocabulary = ["ab", "bc", "cd", "de"]
+    vectorizer = Vectorizer(analyzer="char", ngram_range=(2, 2), vocabulary=vocabulary)
+
+    X = vectorizer.fit_transform(["abc", "bcd", "cde"])
+
+    assert vectorizer.get_feature_names_out().tolist() == vocabulary
+    assert_array_equal(
+        X.toarray() > 0, [[1, 1, 0, 0], [0, 1, 1, 0], [0, 0, 1, 1]]
+    )
+
+
 def test_countvectorizer_custom_vocabulary_repeated_indices():
     vocab = {"pizza": 0, "beer": 0}
     msg = "Vocabulary contains repeated indices"

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1072,7 +1072,8 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         indices in the feature matrix, or an iterable over terms. If not
         given, a vocabulary is determined from the input documents. Indices
         in the mapping should not be repeated and should not have any gap
-        between 0 and the largest index.
+        between 0 and the largest index. When `ngram_range` is used, the
+        vocabulary terms are expected to be n-grams, not the original tokens.
 
     binary : bool, default=False
         If True, all non zero counts are set to 1. This is useful for discrete
@@ -1874,7 +1875,9 @@ class TfidfVectorizer(CountVectorizer):
     vocabulary : Mapping or iterable, default=None
         Either a Mapping (e.g., a dict) where keys are terms and values are
         indices in the feature matrix, or an iterable over terms. If not
-        given, a vocabulary is determined from the input documents.
+        given, a vocabulary is determined from the input documents. When
+        `ngram_range` is used, the vocabulary terms are expected to be
+        n-grams, not the original tokens.
 
     binary : bool, default=False
         If True, all non-zero term counts are set to 1. This does not mean


### PR DESCRIPTION
#### Reference Issues/PRs

Addresses #16017.

#### What does this implement/fix? Explain your changes.

Clarifies the `vocabulary` parameter documentation for `CountVectorizer` and `TfidfVectorizer` when `ngram_range` is used. A fixed vocabulary is interpreted as the final feature vocabulary, so when n-grams are requested the vocabulary entries are expected to be n-grams rather than the original tokens.

Adds a regression test covering fixed vocabularies with character bigrams for both vectorizers.

#### Any other comments?

Validation run in an isolated Docker container:

- `pytest sklearn/feature_extraction/tests/test_text.py -k fixed_vocabulary_with_ngrams -q`
- `pytest sklearn/feature_extraction/tests/test_text.py -k 'custom_vocabulary or fixed_vocabulary_with_ngrams or ngram_analyzer' -q`
- `pytest sklearn/feature_extraction/tests/test_text.py -q`