### PR TITLE
FIX SimpleImputer to support bool dtype for most_frequent/constant st…

### DIFF
--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -379,7 +379,7 @@ class SimpleImputer(_BaseImputer):
             self._fit_dtype = X.dtype
 
         _check_inputs_dtype(X, self.missing_values)
-        if X.dtype.kind =='b' and self.strategy not in ("most_frequent", "constant"):
+        if X.dtype.kind == 'b' and self.strategy not in ("most_frequent", "constant"):
             raise ValueError(
                 "SimpleImputer does not support bool dtype with"
                 "strategy={!r}. Use 'most_frequent' or " 

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -379,16 +379,21 @@ class SimpleImputer(_BaseImputer):
             self._fit_dtype = X.dtype
 
         _check_inputs_dtype(X, self.missing_values)
-        if X.dtype.kind not in ("i", "u", "f", "O"):
+        if X.dtype.kind =='b' and self.strategy not in ("most_frequent", "constant"):
             raise ValueError(
-                "SimpleImputer does not support data with dtype "
-                "{0}. Please provide either a numeric array (with"
-                " a floating point or integer dtype) or "
-                "categorical data represented either as an array "
-                "with integer dtype or an array of string values "
+                "SimpleImputer does not support bool dtype with"
+                "strategy={!r}. Use 'most_frequent' or " 
+                "'constant' instead.".format(self.strategy)
+            )
+        elif X.dtype.kind not in ("i", "u", "f", "O","b"):
+            raise ValueError(
+                "SimpleImputer does not support data with dtype"
+                "{0}. Please provide either a numeric array( with"
+                " a floating poit or integer dtype) or"
+                "categorical data represented either as an array"
+                "with integer dtype or an array of string values"
                 "with an object dtype.".format(X.dtype)
             )
-
         if sp.issparse(X) and self.missing_values == 0:
             # missing_values = 0 not allowed with sparse data as it would
             # force densification


### PR DESCRIPTION
 Fixes #26292

**What this PR does:**
Adds support for bool dtype arrays in SimpleImputer for 
`most_frequent` and `constant` strategies.

**Why it was failing:**
The dtype check in `_validate_input` only allowed kinds 
"i", "u", "f", "O". Bool dtype kind "b" was excluded, 
causing a ValueError even when the strategy makes sense 
for boolean data.

**Changes:**
- `sklearn/impute/_base.py`: updated dtype check to allow 
  bool for compatible strategies, with a clear error message 
  for incompatible ones (mean/median)