### PR TITLE
DOC: Clarify that coefficients in `LogisticRegression` can be sparse

### DIFF
--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1178,10 +1178,16 @@ class LogisticRegression(
     classes_ : ndarray of shape (n_classes, )
         A list of class labels known to the classifier.
 
-    coef_ : ndarray of shape (1, n_features) or (n_classes, n_features)
-        Coefficient of the features in the decision function.
+    coef_ : ndarray or CSR array/matrix of shape \
+            (1, n_features) or (n_classes, n_features)
+        Coefficients of the features in the decision function.
 
         `coef_` is of shape (1, n_features) when the given problem is binary.
+
+        By default, it will be created as a dense array, but can be turned to
+        sparse (CSR format) through :meth:`sparsify` (which can be beneficial
+        under L1 regularization when many coefficients are zero), and back to
+        dense through :meth:`densify`.
 
     intercept_ : ndarray of shape (1,) or (n_classes,)
         Intercept (a.k.a. bias) added to the decision function.

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1178,8 +1178,7 @@ class LogisticRegression(
     classes_ : ndarray of shape (n_classes, )
         A list of class labels known to the classifier.
 
-    coef_ : ndarray or CSR array/matrix of shape \
-            (1, n_features) or (n_classes, n_features)
+    coef_ : ndarray or CSR matrix of shape (1, n_features) or (n_classes, n_features)
         Coefficients of the features in the decision function.
 
         `coef_` is of shape (1, n_features) when the given problem is binary.


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Documentation (including examples)
- Research and understanding


#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

Fitted coefficients in logistic regression can be sparsified, but the docs state that they are `ndarray`.