### PR TITLE
DOC fix SVM citation: add full paper title for Fan et al. JMLR 2005

### DIFF
--- a/sklearn/svm/src/libsvm/svm.cpp
+++ b/sklearn/svm/src/libsvm/svm.cpp
@@ -527,7 +527,8 @@ double Kernel::k_function(const PREFIX(node) *x, const PREFIX(node) *y,
 			return 0;  // Unreachable
 	}
 }
-// An SMO algorithm in Fan et al., JMLR 6(2005), p. 1889--1918
+// An SMO algorithm in Fan et al., "Working set selection using second order
+// information for training support vector machines", JMLR 6(2005), p. 1889--1918
 // Solves:
 //
 //	min 0.5(\alpha^T Q \alpha) + p^T \alpha


### PR DESCRIPTION
Fixes #34086

## What

The comment at line 530 of `svm.cpp` cited the Fan et al. 2005 paper 
without its title, making it difficult to locate the specific publication.

**Before:**
// An SMO algorithm in Fan et al., JMLR 6(2005), p. 1889--1918


// An SMO algorithm in Fan et al., "Working set selection using second order
// information for training support vector machines", JMLR 6(2005), p. 1889--1918

The full citation is:
Fan RE, Chen PH, Lin CJ. "Working set selection using second order information 
for training support vector machines." JMLR. 2005;6(12):1889-1918.
