### PR TITLE
Fix Ridge parameter validation and scalar detection for Array API

### DIFF
--- a/doc/whats_new/upcoming_changes/pr_34098_ridge_array_api.rst
+++ b/doc/whats_new/upcoming_changes/pr_34098_ridge_array_api.rst
@@ -1,0 +1,7 @@
+:mod:`sklearn.linear_model`
+...........................
+
+- Fixes a bug where :class:`linear_model.Ridge` and :func:`linear_model.ridge_regression` 
+  failed parameter validation or scalar detection when using alternative Array API backends 
+  (such as PyTorch or CuPy) with array-valued ``alpha`` hyperparameters.
+  by :user:`prem-479`

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -62,6 +62,7 @@ from sklearn.utils.metadata_routing import (
 )
 from sklearn.utils.validation import (
     _check_sample_weight,
+    _is_arraylike_not_scalar,
     check_is_fitted,
     validate_data,
 )
@@ -702,7 +703,7 @@ def _ridge_regression(
 
     # Some callers of this method might pass alpha as single
     # element array which already has been validated.
-    if alpha is not None and not isinstance(alpha, type(xp.asarray([0.0]))):
+    if alpha is not None and not _is_arraylike_not_scalar(alpha):
         alpha = check_scalar(
             alpha,
             "alpha",
@@ -891,7 +892,7 @@ def resolve_solver_for_numpy(positive, return_intercept, is_sparse):
 
 class _BaseRidge(LinearModel, metaclass=ABCMeta):
     _parameter_constraints: dict = {
-        "alpha": [Interval(Real, 0, None, closed="left"), np.ndarray],
+        "alpha": [Interval(Real, 0, None, closed="left"), "array-like"],
         "fit_intercept": ["boolean"],
         "copy_X": ["boolean"],
         "max_iter": [Interval(Integral, 1, None, closed="left"), None],

--- a/sklearn/linear_model/tests/test_ridge_array_api_alpha.py
+++ b/sklearn/linear_model/tests/test_ridge_array_api_alpha.py
@@ -1,12 +1,13 @@
 """
-Regression tests for Issue #34003:
-  Array API: Ridge with alpha as an array fails due to misconfigured checks
+Regression tests for Issue #34003: Array API: Ridge with alpha as an array
+fails due to misconfigured checks.
 
 Two root causes:
   1. _BaseRidge._parameter_constraints uses np.ndarray instead of "array-like",
      rejecting non-NumPy array-like objects (e.g. torch.Tensor) at _validate_params.
-  2. _ridge_regression's scalar detection uses isinstance(alpha, type(xp.asarray([0.0]))),
-     which is broken when xp is derived from X (e.g. torch) but alpha is np.ndarray.
+  2. _ridge_regression's scalar detection uses
+     isinstance(alpha, type(xp.asarray([0.0]))), which is broken when xp is
+     derived from X (e.g. torch) but alpha is np.ndarray.
 """
 
 import numpy as np

--- a/sklearn/linear_model/tests/test_ridge_array_api_alpha.py
+++ b/sklearn/linear_model/tests/test_ridge_array_api_alpha.py
@@ -1,4 +1,4 @@
-
+"""
 Regression tests for Issue #34003:
   Array API: Ridge with alpha as an array fails due to misconfigured checks
 

--- a/sklearn/linear_model/tests/test_ridge_array_api_alpha.py
+++ b/sklearn/linear_model/tests/test_ridge_array_api_alpha.py
@@ -1,0 +1,252 @@
+
+Regression tests for Issue #34003:
+  Array API: Ridge with alpha as an array fails due to misconfigured checks
+
+Two root causes:
+  1. _BaseRidge._parameter_constraints uses np.ndarray instead of "array-like",
+     rejecting non-NumPy array-like objects (e.g. torch.Tensor) at _validate_params.
+  2. _ridge_regression's scalar detection uses isinstance(alpha, type(xp.asarray([0.0]))),
+     which is broken when xp is derived from X (e.g. torch) but alpha is np.ndarray.
+"""
+
+import numpy as np
+import pytest
+
+from sklearn import config_context
+from sklearn.datasets import make_regression
+from sklearn.linear_model import Ridge
+from sklearn.utils._array_api import yield_namespace_device_dtype_combinations
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_multi_target_data(n_samples=200, n_targets=5, random_state=0):
+    X, y = make_regression(
+        n_samples=n_samples,
+        n_features=10,
+        n_targets=n_targets,
+        noise=0.1,
+        random_state=random_state,
+    )
+    return X, y
+
+
+# ---------------------------------------------------------------------------
+# Tests for numpy-only (no array_api_dispatch) - should be unaffected
+# ---------------------------------------------------------------------------
+
+
+def test_ridge_alpha_scalar_numpy():
+    """Scalar float alpha works with numpy (baseline, must not regress)."""
+    X, y = _make_multi_target_data()
+    reg = Ridge(alpha=1.0, solver="svd")
+    reg.fit(X, y)
+    assert reg.coef_.shape == (5, 10)
+
+
+def test_ridge_alpha_numpy_array_numpy_dispatch():
+    """np.ndarray alpha works in pure numpy mode (baseline, must not regress)."""
+    X, y = _make_multi_target_data(n_targets=5)
+    reg = Ridge(alpha=np.array([0.1, 0.5, 1.0, 2.0, 5.0]), solver="svd")
+    reg.fit(X, y)
+    assert reg.coef_.shape == (5, 10)
+
+
+def test_ridge_alpha_list_numpy_dispatch():
+    """List alpha is accepted (converted internally)."""
+    X, y = _make_multi_target_data(n_targets=3)
+    reg = Ridge(alpha=[0.1, 1.0, 5.0], solver="svd")
+    reg.fit(X, y)
+    assert reg.coef_.shape == (3, 10)
+
+
+# ---------------------------------------------------------------------------
+# Tests for Array API dispatch with numpy.array alpha (Bug 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "array_namespace, device, dtype_name",
+    yield_namespace_device_dtype_combinations(),
+)
+def test_ridge_array_api_numpy_array_alpha(array_namespace, device, dtype_name):
+    """
+    Regression test for Bug 1:
+      Ridge(alpha=np.ndarray).fit(xp_tensor, xp_tensor) must succeed.
+
+    Previously failed at _ridge_regression line 703:
+      isinstance(np.array([...]), type(xp.asarray([0.0])))
+      = isinstance(np.ndarray, torch.Tensor)  [with torch namespace]
+      = False  ->  check_scalar was wrongly called -> TypeError
+    """
+    from sklearn.utils._array_api import _array_api_for_tests
+
+    xp = _array_api_for_tests(array_namespace, device)
+    n_targets = 4
+
+    X_np, y_np = _make_multi_target_data(n_targets=n_targets)
+    X_np = X_np.astype(dtype_name)
+    y_np = y_np.astype(dtype_name)
+
+    X_xp = xp.asarray(X_np, device=device)
+    y_xp = xp.asarray(y_np, device=device)
+
+    # alpha is np.ndarray, X and y are backend tensors
+    alpha = np.array([0.1, 0.5, 1.0, 2.0], dtype=np.float64)
+
+    reg = Ridge(alpha=alpha, solver="svd")
+    with config_context(array_api_dispatch=True):
+        reg.fit(X_xp, y_xp)
+
+    assert reg.coef_.shape == (n_targets, X_np.shape[1])
+
+
+@pytest.mark.parametrize(
+    "array_namespace, device, dtype_name",
+    yield_namespace_device_dtype_combinations(),
+)
+def test_ridge_array_api_xp_array_alpha(array_namespace, device, dtype_name):
+    """
+    Regression test for Bug 2:
+      Ridge(alpha=xp.tensor([...])).fit(xp_tensor, xp_tensor) must succeed.
+
+    Previously failed at _validate_params:
+      _parameter_constraints has np.ndarray as the only array type;
+      torch.Tensor is not np.ndarray -> InvalidParameterError.
+    """
+    from sklearn.utils._array_api import _array_api_for_tests
+
+    xp = _array_api_for_tests(array_namespace, device)
+    n_targets = 4
+
+    X_np, y_np = _make_multi_target_data(n_targets=n_targets)
+    X_np = X_np.astype(dtype_name)
+    y_np = y_np.astype(dtype_name)
+
+    X_xp = xp.asarray(X_np, device=device)
+    y_xp = xp.asarray(y_np, device=device)
+
+    # alpha is an xp-native tensor
+    alpha_np = np.array([0.1, 0.5, 1.0, 2.0], dtype=np.float64)
+    alpha_xp = xp.asarray(alpha_np, device=device)
+
+    reg = Ridge(alpha=alpha_xp, solver="svd")
+    with config_context(array_api_dispatch=True):
+        reg.fit(X_xp, y_xp)
+
+    assert reg.coef_.shape == (n_targets, X_np.shape[1])
+
+
+@pytest.mark.parametrize(
+    "array_namespace, device, dtype_name",
+    yield_namespace_device_dtype_combinations(),
+)
+def test_ridge_array_api_scalar_alpha(array_namespace, device, dtype_name):
+    """
+    Scalar alpha must continue to work with Array API dispatch (no regression).
+    """
+    from sklearn.utils._array_api import _array_api_for_tests
+
+    xp = _array_api_for_tests(array_namespace, device)
+    n_targets = 3
+
+    X_np, y_np = _make_multi_target_data(n_targets=n_targets)
+    X_np = X_np.astype(dtype_name)
+    y_np = y_np.astype(dtype_name)
+
+    X_xp = xp.asarray(X_np, device=device)
+    y_xp = xp.asarray(y_np, device=device)
+
+    reg = Ridge(alpha=1.0, solver="svd")
+    with config_context(array_api_dispatch=True):
+        reg.fit(X_xp, y_xp)
+
+    assert reg.coef_.shape == (n_targets, X_np.shape[1])
+
+
+# ---------------------------------------------------------------------------
+# Tests for coefficient correctness (array alpha must match scalar-alpha results)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "array_namespace, device, dtype_name",
+    yield_namespace_device_dtype_combinations(),
+)
+def test_ridge_array_api_alpha_array_coef_correctness(
+    array_namespace, device, dtype_name
+):
+    """
+    Uniform array alpha (all same value) must produce the same coefficients
+    as the equivalent scalar alpha.
+    """
+    from sklearn.utils._array_api import _array_api_for_tests, _convert_to_numpy
+    from sklearn.utils._testing import assert_allclose
+
+    xp = _array_api_for_tests(array_namespace, device)
+    n_targets = 3
+    alpha_val = 1.0
+
+    X_np, y_np = _make_multi_target_data(n_targets=n_targets)
+    X_np = X_np.astype(dtype_name)
+    y_np = y_np.astype(dtype_name)
+
+    X_xp = xp.asarray(X_np, device=device)
+    y_xp = xp.asarray(y_np, device=device)
+
+    # Scalar alpha reference
+    reg_scalar = Ridge(alpha=alpha_val, solver="svd")
+    with config_context(array_api_dispatch=True):
+        reg_scalar.fit(X_xp, y_xp)
+
+    # np.ndarray alpha (all same value)
+    reg_arr_np = Ridge(alpha=np.full(n_targets, alpha_val), solver="svd")
+    with config_context(array_api_dispatch=True):
+        reg_arr_np.fit(X_xp, y_xp)
+
+    # xp-native array alpha
+    reg_arr_xp = Ridge(
+        alpha=xp.asarray(np.full(n_targets, alpha_val), device=device), solver="svd"
+    )
+    with config_context(array_api_dispatch=True):
+        reg_arr_xp.fit(X_xp, y_xp)
+
+    coef_scalar = _convert_to_numpy(reg_scalar.coef_, xp=xp)
+    coef_arr_np = _convert_to_numpy(reg_arr_np.coef_, xp=xp)
+    coef_arr_xp = _convert_to_numpy(reg_arr_xp.coef_, xp=xp)
+
+    atol = 1e-4 if dtype_name == "float32" else 1e-8
+    assert_allclose(coef_arr_np, coef_scalar, atol=atol)
+    assert_allclose(coef_arr_xp, coef_scalar, atol=atol)
+
+
+# ---------------------------------------------------------------------------
+# Parameter validation edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_ridge_invalid_alpha_rejected():
+    """Negative scalar alpha must still be rejected."""
+    from sklearn.utils._param_validation import InvalidParameterError
+
+    with pytest.raises((InvalidParameterError, ValueError)):
+        Ridge(alpha=-1.0).fit(*_make_multi_target_data())
+
+
+def test_ridge_wrong_shape_alpha_rejected():
+    """Array alpha with wrong number of elements must raise ValueError."""
+    X, y = _make_multi_target_data(n_targets=5)
+    # alpha has 3 values but y has 5 targets
+    reg = Ridge(alpha=np.array([1.0, 2.0, 3.0]), solver="svd")
+    with pytest.raises(ValueError, match="Number of targets"):
+        reg.fit(X, y)
+
+
+def test_ridge_single_element_array_alpha():
+    """Single-element array alpha broadcasts to all targets."""
+    X, y = _make_multi_target_data(n_targets=5)
+    reg = Ridge(alpha=np.array([1.0]), solver="svd")
+    reg.fit(X, y)
+    assert reg.coef_.shape == (5, 10)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #34003

#### What does this implement/fix? Explain your changes.

This PR addresses an architectural limitation where alternative array backends (e.g., PyTorch, CuPy) fail during parameter validation or execution when passing array-valued `alpha` hyperparameters to the `Ridge` estimator or the `_ridge_regression` function.

##### Root Causes
1. **Validation Layer Failure:** `_BaseRidge._parameter_constraints` explicitly expected `np.ndarray` for `alpha`, triggering an `InvalidParameterError` during `_validate_params` when native non-NumPy tensors were passed. Meanwhile, the standalone `ridge_regression` function correctly accepted `"array-like"`.
2. **Runtime Execution Layer Failure:** In `_ridge_regression`, scalar detection relied on checking `isinstance(alpha, type(xp.asarray([0.0])))`. When `xp` was resolved from an alternative backend tensor `X` but `alpha` remained a standard NumPy array, this check evaluated to `False`. This incorrectly routed array-valued alphas into `check_scalar`, causing a `TypeError`.

##### Solutions Implemented
* **`sklearn/linear_model/_ridge.py`**:
  * Updated `_BaseRidge._parameter_constraints` to accept `"array-like"` for `alpha` instead of strictly `np.ndarray`.
  * Replaced the backend-coupled `isinstance` runtime branching logic inside `_ridge_regression` with `not _is_arraylike_not_scalar(alpha)` to reliably isolate true scalars across multiple array namespaces.
* **`sklearn/linear_model/tests/test_ridge_array_api_alpha.py`**:
  * Added a dedicated regression test file leveraging `yield_namespace_device_dtype_combinations()` to fully validate uniform coefficient correctness, pure NumPy baselines, mixed/native backend array scenarios, and proper constraint rejection behavior.

---

##### Hyperparameter Routing Matrix (Verification Summary)

| `alpha` value type | Before fix | After fix | Expected Routing / Outcome |
| :--- | :--- | :--- | :--- |
| `float(1.0)` | ✓ | ✓ | `check_scalar` validates bounds $\ge 0$ |
| `np.float64(1.0)` | ✓ | ✓ | Treated as scalar $\rightarrow$ bounds check |
| `np.array(1.0)` (0-d array) | ✓ | ✓ | Skips `check_scalar`, converted by `xp.asarray` |
| `np.array([1.] * N)` with NumPy `X` | ✓ | ✓ | Validated array execution |
| `np.array([1.] * N)` with PyTorch `X` | ✗ `TypeError` | ✓ | Validated array execution |
| `torch.tensor([1.] * N)` | ✗ `InvalidParameterError` | ✓ | Validated array execution |
| `[1., 2., 3.]` (Python list) | ✗ `InvalidParameterError` | ✓ | Accepted via `"array-like"` |
| `float(-1.0)` | ✓ (Rejected) | ✓ (Rejected) | Caught correctly by bounds check |
| Shape mismatch array | ✓ (Rejected) | ✓ (Rejected) | Caught correctly by subsequent logic |

#### AI usage disclosure
I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Documentation (including examples)

#### Any other comments?
All 770+ local tests in the `linear_model` suite pass successfully, alongside the new comprehensive multi-backend regression tests. Ready for maintainer review!