### PR TITLE
PERF Cache inspect.signature for callback hook evaluation

### DIFF
--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -15,7 +15,7 @@ from sklearn.callback._base import AutoPropagatedCallback
 VALID_HOOK_PARAMS_OUT = ["X", "y", "metadata", "fitted_estimator"]
 
 
-_cached_signature = functools.lru_cache(maxsize=None)(inspect.signature)
+_cached_signature = functools.lru_cache()(inspect.signature)
 
 
 class CallbackContext:

--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import copy
+import functools
 import inspect
 import uuid
 import warnings
@@ -12,6 +13,9 @@ from sklearn.callback._base import AutoPropagatedCallback
 
 # List of the parameters expected to be in the hooks signatures
 VALID_HOOK_PARAMS_OUT = ["X", "y", "metadata", "fitted_estimator"]
+
+
+_cached_signature = functools.lru_cache(maxsize=None)(inspect.signature)
 
 
 class CallbackContext:
@@ -317,7 +321,7 @@ class CallbackContext:
                 # sub-estimator's root context (both represent the same task).
                 continue
 
-            signature = inspect.signature(getattr(callback, hook_name))
+            signature = _cached_signature(getattr(callback, hook_name))
             params_names = {
                 p.name
                 for p in signature.parameters.values()


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/33587

inspect.signature is not free. It's the first source of overhead from the hook call.
The overhead from the hook call is not a lot in itself (a few micro seconds), compared to the computations happening during fit it's usually very small, but maybe it's not negligible for estimators with very fast iterations. Also this optimization is pretty easy and divides the overhead by 4 so why not. 

benchmark script:
```py
import time
import numpy as np
import sklearn.callback.tests._utils as _cb_utils
from sklearn.callback.tests._utils import MaxIterEstimator, RecordingCallback

# to avoid the overhead of calling sleep (even for 0s)
_cb_utils.time.sleep = lambda _: None

times = []
for _ in range(20):
    est = MaxIterEstimator(max_iter=1000).set_callbacks(RecordingCallback())
    t0 = time.perf_counter()
    est.fit()
    times.append(time.perf_counter() - t0)

times = np.array(times) * 1000
print(f"{times.mean():.2f} ± {times.std():.2f} ms")
```
Results:
- main: 39.54 ± 11.10 ms
- this PR: 13.10 ± 10.66 ms

I removed any form of stuff happening if fit so it's just the callback overhead + evaluation: ~10ms for 1000 iterations
(it's very noisy, probably due to the listener, but not sure, the speed-up is there and visible anyway)
