### PR TITLE
FIX partial_fit is no-op when sample_weight all zeros (#33436)

### DIFF
--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -637,6 +637,12 @@ class BaseSGDClassifier(LinearClassifierMixin, BaseSGD, metaclass=ABCMeta):
             allow_all_zero_weights=self.early_stopping,
         )
 
+        # If all sample weights are zero and the model is already fitted,
+        # there is nothing to learn - return early without mutating the model.
+        # (If this is the first call, we still need to allocate parameters below.)
+        if not first_call and not np.any(sample_weight):
+            return self
+
         if getattr(self, "coef_", None) is None or coef_init is not None:
             self._allocate_parameter_mem(
                 n_classes=n_classes,
@@ -1518,6 +1524,11 @@ class BaseSGDRegressor(RegressorMixin, BaseSGD):
         n_samples, n_features = X.shape
 
         sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
+
+        # If all sample weights are zero and the model is already fitted,
+        # there is nothing to learn - return early without mutating the model.
+        if not first_call and not np.any(sample_weight):
+            return self
 
         # Allocate datastructures from input arguments
         if first_call:


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs: Closes #33436
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
When SGDClassifier/SGDRegressor.partial_fit called with all-zero
sample_weight, the model was still mutating coef_, intercept_, and t_.
this patch adds an early return guard, so the call is a true no-op
for an already-fitted model.

#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Research and understanding



<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
