### PR TITLE
DOC Pluralize "object" in dataset loaders

### DIFF
--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -524,7 +524,7 @@ def load_wine(*, return_X_y=False, as_frame=False):
     ----------
     return_X_y : bool, default=False
         If True, returns ``(data, target)`` instead of a Bunch object.
-        See below for more information about the `data` and `target` object.
+        See below for more information about the `data` and `target` objects.
 
     as_frame : bool, default=False
         If True, the data is a pandas DataFrame including columns with
@@ -647,7 +647,7 @@ def load_iris(*, return_X_y=False, as_frame=False):
     ----------
     return_X_y : bool, default=False
         If True, returns ``(data, target)`` instead of a Bunch object. See
-        below for more information about the `data` and `target` object.
+        below for more information about the `data` and `target` objects.
 
         .. versionadded:: 0.18
 
@@ -775,7 +775,7 @@ def load_breast_cancer(*, return_X_y=False, as_frame=False):
     ----------
     return_X_y : bool, default=False
         If True, returns ``(data, target)`` instead of a Bunch object.
-        See below for more information about the `data` and `target` object.
+        See below for more information about the `data` and `target` objects.
 
         .. versionadded:: 0.18
 
@@ -933,7 +933,7 @@ def load_digits(*, n_class=10, return_X_y=False, as_frame=False):
 
     return_X_y : bool, default=False
         If True, returns ``(data, target)`` instead of a Bunch object.
-        See below for more information about the `data` and `target` object.
+        See below for more information about the `data` and `target` objects.
 
         .. versionadded:: 0.18
 
@@ -1066,7 +1066,7 @@ def load_diabetes(*, return_X_y=False, as_frame=False, scaled=True):
     ----------
     return_X_y : bool, default=False
         If True, returns ``(data, target)`` instead of a Bunch object.
-        See below for more information about the `data` and `target` object.
+        See below for more information about the `data` and `target` objects.
 
         .. versionadded:: 0.18
 
@@ -1189,7 +1189,7 @@ def load_linnerud(*, return_X_y=False, as_frame=False):
     ----------
     return_X_y : bool, default=False
         If True, returns ``(data, target)`` instead of a Bunch object.
-        See below for more information about the `data` and `target` object.
+        See below for more information about the `data` and `target` objects.
 
         .. versionadded:: 0.18
 

--- a/sklearn/datasets/_kddcup99.py
+++ b/sklearn/datasets/_kddcup99.py
@@ -124,7 +124,7 @@ def fetch_kddcup99(
 
     return_X_y : bool, default=False
         If True, returns ``(data, target)`` instead of a Bunch object. See
-        below for more information about the `data` and `target` object.
+        below for more information about the `data` and `target` objects.
 
         .. versionadded:: 0.20
 

--- a/sklearn/datasets/_olivetti_faces.py
+++ b/sklearn/datasets/_olivetti_faces.py
@@ -96,7 +96,7 @@ def fetch_olivetti_faces(
 
     return_X_y : bool, default=False
         If True, returns `(data, target)` instead of a `Bunch` object. See
-        below for more information about the `data` and `target` object.
+        below for more information about the `data` and `target` objects.
 
         .. versionadded:: 0.22
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Make 'object' plural in the description of the `return_X_y` argument of the dataset loaders, since the original doc-string mentions two objects - `data` and `target`.