### PR TITLE
Drop duplicate 'the the' in plot_stack_predictors example comment

### DIFF
--- a/examples/ensemble/plot_stack_predictors.py
+++ b/examples/ensemble/plot_stack_predictors.py
@@ -199,7 +199,7 @@ plt.show()
 #
 # Once fitted, we can inspect the coefficients (or meta-weights) of the trained
 # `final_estimator_` (as long as it is a linear model). They reveal how much the
-# individual estimators contribute to the the stacked regressor:
+# individual estimators contribute to the stacked regressor:
 
 stacking_regressor.fit(X, y)
 stacking_regressor.final_estimator_.coef_


### PR DESCRIPTION
Comment in `examples/ensemble/plot_stack_predictors.py` reads "contribute to the the stacked regressor". One-word fix to remove the stray `the`.