### PR TITLE
DOC Fix description of the load_diabetes() return value

### DIFF
--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1112,9 +1112,11 @@ def load_diabetes(*, return_X_y=False, as_frame=False, scaled=True):
             The path to the location of the target.
 
     (data, target) : tuple if ``return_X_y`` is True
-        Returns a tuple of two ndarray of shape (n_samples, n_features)
-        A 2D array with each row representing one sample and each column
-        representing the features and/or target of a given sample.
+        A tuple of two ndarrays by default. The first contains a 2D ndarray of
+        shape (442, 100) with each row representing one sample and each column
+        representing the features. The second ndarray of shape (442,) contains
+        the target samples. If `as_frame=True`, both arrays are pandas objects,
+        i.e. `X` a dataframe and `y` a series.
 
         .. versionadded:: 0.18
 

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -357,11 +357,11 @@ def load_csv_data(
         A 2D array with each row representing one sample and the columns
         representing the features of a given sample.
 
-    target : ndarry of shape (n_samples,)
+    target : ndarray of shape (n_samples,)
         A 1D array holding target variables for all the samples in `data`.
         For example target[0] is the target variable for data[0].
 
-    target_names : ndarry of shape (n_samples,)
+    target_names : ndarray of shape (n_samples,)
         A 1D array containing the names of the classifications. For example
         target_names[0] is the name of the target[0] class.
 

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -355,7 +355,7 @@ def load_csv_data(
     -------
     data : ndarray of shape (n_samples, n_features)
         A 2D array with each row representing one sample and the columns
-        representing one feature of a given sample.
+        representing the features of a given sample.
 
     target : ndarry of shape (n_samples,)
         A 1D array holding target variables for all the samples in `data`.

--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -354,8 +354,8 @@ def load_csv_data(
     Returns
     -------
     data : ndarray of shape (n_samples, n_features)
-        A 2D array with each row representing one sample and each column
-        representing the features of a given sample.
+        A 2D array with each row representing one sample and the columns
+        representing one feature of a given sample.
 
     target : ndarry of shape (n_samples,)
         A 1D array holding target variables for all the samples in `data`.
@@ -441,7 +441,7 @@ def load_gzip_compressed_csv_data(
     Returns
     -------
     data : ndarray of shape (n_samples, n_features)
-        A 2D array with each row representing one sample and each column
+        A 2D array with each row representing one sample and the columns
         representing the features and/or target of a given sample.
 
     descr : str, optional
@@ -559,9 +559,11 @@ def load_wine(*, return_X_y=False, as_frame=False):
             The full description of the dataset.
 
     (data, target) : tuple if ``return_X_y`` is True
-        A tuple of two ndarrays by default. The first contains a 2D array of shape
-        (178, 13) with each row representing one sample and each column representing
-        the features. The second array of shape (178,) contains the target samples.
+        A tuple of two ndarrays. The first contains a 2D array of
+        shape (178, 13) with each row representing one sample and the columns
+        representing the features. The second array of shape (178,) contains
+        the target samples. If `as_frame=True`, both arrays are pandas objects,
+        i.e. `X` a dataframe and `y` a series.
 
     Examples
     --------
@@ -625,8 +627,7 @@ def load_wine(*, return_X_y=False, as_frame=False):
 def load_iris(*, return_X_y=False, as_frame=False):
     """Load and return the iris dataset (classification).
 
-    The iris dataset is a classic and very easy multi-class classification
-    dataset.
+    The iris dataset is a classic and very easy multi-class classification dataset.
 
     =================   ==============
     Classes                          3
@@ -688,10 +689,11 @@ def load_iris(*, return_X_y=False, as_frame=False):
             .. versionadded:: 0.20
 
     (data, target) : tuple if ``return_X_y`` is True
-        A tuple of two ndarray. The first containing a 2D array of shape
-        (n_samples, n_features) with each row representing one sample and
-        each column representing the features. The second ndarray of shape
-        (n_samples,) containing the target samples.
+        A tuple of two ndarrays. The first contains a 2D array of
+        shape (150, 4) with each row representing one sample and the columns
+        representing the features. The second ndarray of shape (150,) contains
+        the target samples. If `as_frame=True`, both arrays are pandas objects,
+        i.e. `X` a dataframe and `y` a series.
 
         .. versionadded:: 0.18
 
@@ -816,10 +818,10 @@ def load_breast_cancer(*, return_X_y=False, as_frame=False):
             .. versionadded:: 0.20
 
     (data, target) : tuple if ``return_X_y`` is True
-        A tuple of two ndarrays by default. The first contains a 2D ndarray of
-        shape (569, 30) with each row representing one sample and each column
+        A tuple of two ndarrays. The first contains a 2D ndarray of
+        shape (569, 30) with each row representing one sample and the columns
         representing the features. The second ndarray of shape (569,) contains
-        the target samples.  If `as_frame=True`, both arrays are pandas objects,
+        the target samples. If `as_frame=True`, both arrays are pandas objects,
         i.e. `X` a dataframe and `y` a series.
 
         .. versionadded:: 0.18
@@ -975,10 +977,10 @@ def load_digits(*, n_class=10, return_X_y=False, as_frame=False):
             The full description of the dataset.
 
     (data, target) : tuple if ``return_X_y`` is True
-        A tuple of two ndarrays by default. The first contains a 2D ndarray of
-        shape (1797, 64) with each row representing one sample and each column
-        representing the features. The second ndarray of shape (1797) contains
-        the target samples.  If `as_frame=True`, both arrays are pandas objects,
+        A tuple of two ndarrays. The first contains a 2D ndarray of
+        shape (1797, 64) with each row representing one sample and the columns
+        representing the features. The second ndarray of shape (1797,) contains
+        the target samples. If `as_frame=True`, both arrays are pandas objects,
         i.e. `X` a dataframe and `y` a series.
 
         .. versionadded:: 0.18
@@ -1112,8 +1114,8 @@ def load_diabetes(*, return_X_y=False, as_frame=False, scaled=True):
             The path to the location of the target.
 
     (data, target) : tuple if ``return_X_y`` is True
-        A tuple of two ndarrays by default. The first contains a 2D ndarray of
-        shape (442, 100) with each row representing one sample and each column
+        A tuple of two ndarrays. The first contains a 2D ndarray of
+        shape (442, 10) with each row representing one sample and the columns
         representing the features. The second ndarray of shape (442,) contains
         the target samples. If `as_frame=True`, both arrays are pandas objects,
         i.e. `X` a dataframe and `y` a series.
@@ -1234,9 +1236,10 @@ def load_linnerud(*, return_X_y=False, as_frame=False):
             .. versionadded:: 0.20
 
     (data, target) : tuple if ``return_X_y`` is True
-        Returns a tuple of two ndarrays or dataframe of shape
-        `(20, 3)`. Each row represents one sample and each column represents the
-        features in `X` and a target in `y` of a given sample.
+        A tuple of two ndarrays. The first contains a 2D ndarray of
+        shape `(20, 3)` with each row representing one sample and the columns
+        representing the features. The second ndarray of shape `(20, 3)` contains
+        the multi target samples. If `as_frame=True`, both arrays are pandas dataframes.
 
         .. versionadded:: 0.18
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The description of the return value of the `load_diabetes()` function when the `return_X_y` parameter is passed seems was derived from `load_csv_data()` or `load_gzip_compressed_csv_data()`. This is wrong, because `load_diabetes()` returns one 2D array for `data` and 1D array for `target`, but not two 2D arrays.

The new description is unified with other dataset loader APIs and specifies the values of the array shapes related to the `load_diabetes()` function.