### PR TITLE
DOC: Fix penalty deprecation docs for LogisticRegression and LogisticRegressionCV

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/34150.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/34150.fix.rst
@@ -1,4 +1,0 @@
-- Fixed incomplete deprecation message for the :class:`linear_model.LogisticRegression`
-  and :class:`linear_model.LogisticRegressionCV` ``penalty`` parameter, which was
-  missing the ``penalty=None`` and ``penalty='elasticnet'`` migration guidance.
-  By :user:`baynecheke <baynecheke>`.

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/34150.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/34150.fix.rst
@@ -1,0 +1,4 @@
+- Fixed incomplete deprecation message for the :class:`linear_model.LogisticRegression`
+  and :class:`linear_model.LogisticRegressionCV` ``penalty`` parameter, which was
+  missing the ``penalty=None`` and ``penalty='elasticnet'`` migration guidance.
+  By :user:`baynecheke <baynecheke>`.

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1016,9 +1016,9 @@ class LogisticRegression(
 
         .. deprecated:: 1.8
            `penalty` was deprecated in version 1.8 and will be removed in 1.10.
-           Use `l1_ratio` instead. `l1_ratio=0` for `penalty='l2'`, `l1_ratio=1` for
-           `penalty='l1'` and `l1_ratio` set to any float between 0 and 1 for
-           `'penalty='elasticnet'`.
+           Use `l1_ratio` and `C` instead. `l1_ratio=0` for `penalty='l2'`,
+           `l1_ratio=1` for `penalty='l1'`, `l1_ratio` set to any float between 0 and 1
+           for `penalty='elasticnet'`, and `C=np.inf` for `penalty=None`.
 
     C : float, default=1.0
         Inverse of regularization strength; must be a positive float.
@@ -1401,8 +1401,9 @@ class LogisticRegression(
                     " 1.10. To avoid this warning, leave 'penalty' set to its default"
                     " value and use 'l1_ratio' or 'C' instead."
                     " Use l1_ratio=0 instead of penalty='l2',"
-                    " l1_ratio=1 instead of penalty='l1', and "
-                    "C=np.inf instead of penalty=None."
+                    " l1_ratio=1 instead of penalty='l1',"
+                    " l1_ratio set to a float between 0 and 1 instead of"
+                    " penalty='elasticnet', and C=np.inf instead of penalty=None."
                 ),
                 FutureWarning,
             )
@@ -1734,9 +1735,9 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
 
         .. deprecated:: 1.8
            `penalty` was deprecated in version 1.8 and will be removed in 1.10.
-           Use `l1_ratio` instead. `l1_ratio=0` for `penalty='l2'`, `l1_ratio=1` for
-           `penalty='l1'` and `l1_ratio` set to any float between 0 and 1 for
-           `'penalty='elasticnet'`.
+           Use `l1_ratio` and `C` instead. `l1_ratio=0` for `penalty='l2'`,
+           `l1_ratio=1` for `penalty='l1'`, `l1_ratio` set to any float between 0 and 1
+           for `penalty='elasticnet'`, and `C=np.inf` for `penalty=None`.
 
     scoring : str or callable, default=None
         The scoring method to use for cross-validation. Options:
@@ -2118,9 +2119,11 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
                 (
                     "'penalty' was deprecated in version 1.8 and will be removed in"
                     " 1.10. To avoid this warning, leave 'penalty' set to its default"
-                    " value and use 'l1_ratios' instead."
-                    " Use l1_ratios=(0,) instead of penalty='l2' "
-                    " and l1_ratios=(1,) instead of penalty='l1'."
+                    " value and use 'l1_ratios' and 'Cs' instead."
+                    " Use l1_ratios=(0,) instead of penalty='l2',"
+                    " l1_ratios=(1,) instead of penalty='l1',"
+                    " l1_ratios set to floats between 0 and 1 instead of"
+                    " penalty='elasticnet', and Cs=(np.inf,) instead of penalty=None."
                 ),
                 FutureWarning,
             )


### PR DESCRIPTION
DOC Fix penalty deprecation docs for LogisticRegression and LogisticRegressionCV

#### Reference Issues/PRs
Fixes #34090

#### What does this implement/fix? Explain your changes.
The deprecation notice for the `penalty` parameter in `LogisticRegression`
and `LogisticRegressionCV` was missing the `penalty=None` case. Users who
relied on `penalty=None` had no guidance on the equivalent new API (`C=np.inf`).

The FutureWarning raised at runtime was also missing the `penalty='elasticnet'`
case for `LogisticRegression`, and missing both elasticnet and None cases for
`LogisticRegressionCV`.

This PR adds the missing cases and fixes a typo in both docstrings
(`'penalty='elasticnet'` → `penalty='elasticnet'`).

#### AI usage disclosure
I used AI assistance for:
- Documentation (including examples)