### PR TITLE
FIX: Prevent OOB read in get_n_iter() for MCSVM_CS solver

### DIFF
--- a/sklearn/svm/src/liblinear/linear.cpp
+++ b/sklearn/svm/src/liblinear/linear.cpp
@@ -2941,6 +2941,12 @@ void get_n_iter(const model *model_, int* n_iter)
     if (labels == 2)
         labels = 1;
 
+    // MCSVM_CS solver stores only a single n_iter value (the total iterations
+    // of the multi-class solver), not one per class. Reading beyond slot 0
+    // would be an out-of-bounds access on the allocated buffer.
+    if (model_->param.solver_type == MCSVM_CS)
+        labels = 1;
+
     if (model_->n_iter != NULL)
         for(int i=0;i<labels;i++)
             n_iter[i] = model_->n_iter[i];


### PR DESCRIPTION
## Problem

For  with K>=3 classes,  reports garbage values from out-of-bounds reads of the LIBLINEAR heap. This causes false  on every fit.

**Root cause:** The MCSVM_CS solver allocates exactly 1 int for , but  reads  slots — for K>=3, slots [1..K-1] are OOB reads of uninitialized heap memory.

## Fix

Add a special case in  to limit reads to 1 slot when , matching the allocation in .

## Reproducer



Fixes #34029