### PR TITLE
DOC clarify weighted percentile averaging with floating weights

### DIFF
--- a/sklearn/utils/stats.py
+++ b/sklearn/utils/stats.py
@@ -73,7 +73,9 @@ def _weighted_percentile(
         unit `sample_weight`, such that the total of `sample_weight` below or equal to
         `_weighted_percentile(percentile_rank)` is the same as the total of
         `sample_weight` above or equal to `_weighted_percentile(100-percentile_rank)`.
-        This symmetry is not guaranteed with non-unit weights.
+        This symmetry is not guaranteed with non-unit weights. With floating-point
+        `sample_weight`, numerical roundoff can also affect whether the requested
+        percentile is treated as falling exactly on a cumulative weight boundary.
 
     xp : array_namespace, default=None
         The standard-compatible namespace for `array`. Default: infer.


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #32289

#### What does this implement/fix? Explain your changes.

This clarifies the `_weighted_percentile(..., average=True)` documentation for
floating-point `sample_weight`.

The existing docstring already notes that the symmetry property is not guaranteed
with non-unit weights. This PR adds that floating-point roundoff can also affect
whether the requested percentile is treated as falling exactly on a cumulative
weight boundary.

This is a documentation-only change and does not change the percentile
implementation.

#### AI usage disclosure

I used AI assistance for:
- Documentation (including examples)

#### Any other comments?

Checks run:

- `python -m ruff check sklearn/utils/stats.py`
- `python -m ruff format --check sklearn/utils/stats.py`
- `git diff --check`