### PR TITLE
DOC Update coef_ type for sparse linear models

### DIFF
--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -481,7 +481,7 @@ class SparseCoefMixin:
         """
         Convert coefficient matrix to sparse format.
 
-        Converts the ``coef_`` member to a scipy.sparse matrix, which for
+        Converts the ``coef_`` member to a scipy.sparse array/matrix, which for
         L1-regularized models can be much more memory- and storage-efficient
         than the usual numpy.ndarray representation.
 

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1178,7 +1178,8 @@ class LogisticRegression(
     classes_ : ndarray of shape (n_classes, )
         A list of class labels known to the classifier.
 
-    coef_ : ndarray or CSR matrix of shape (1, n_features) or (n_classes, n_features)
+    coef_ : ndarray or CSR array/matrix of shape (1, n_features) or (n_classes, \
+        n_features)
         Coefficients of the features in the decision function.
 
         `coef_` is of shape (1, n_features) when the given problem is binary.
@@ -1896,12 +1897,11 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
     classes_ : ndarray of shape (n_classes, )
         A list of class labels known to the classifier.
 
-    coef_ : ndarray or CSR array/matrix of shape \
-        (1, n_features) or (n_classes, n_features)
+    coef_ : ndarray or CSR array/matrix of shape (1, n_features) or (n_classes, \
+        n_features)
         Coefficient of the features in the decision function.
 
-        `coef_` is of shape (1, n_features) when the given problem
-        is binary.
+        `coef_` is of shape (1, n_features) when the given problem is binary.
 
         By default, it will be created as a dense array, but can be turned to
         sparse (CSR format) through :meth:`sparsify` (which can be beneficial

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1896,11 +1896,16 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
     classes_ : ndarray of shape (n_classes, )
         A list of class labels known to the classifier.
 
-    coef_ : ndarray or sparse matrix of shape (1, n_features) or (n_classes, n_features)
+    coef_ : ndarray or CSR array/matrix of shape (1, n_features) or (n_classes, n_features)
         Coefficient of the features in the decision function.
 
         `coef_` is of shape (1, n_features) when the given problem
         is binary.
+
+        By default, it will be created as a dense array, but can be turned to
+        sparse (CSR format) through :meth:`sparsify` (which can be beneficial
+        under L1 regularization when many coefficients are zero), and back to
+        dense through :meth:`densify`.
 
     intercept_ : ndarray of shape (1,) or (n_classes,)
         Intercept (a.k.a. bias) added to the decision function.

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1896,7 +1896,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
     classes_ : ndarray of shape (n_classes, )
         A list of class labels known to the classifier.
 
-    coef_ : ndarray of shape (1, n_features) or (n_classes, n_features)
+    coef_ : ndarray or sparse matrix of shape (1, n_features) or (n_classes, n_features)
         Coefficient of the features in the decision function.
 
         `coef_` is of shape (1, n_features) when the given problem

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1896,7 +1896,8 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
     classes_ : ndarray of shape (n_classes, )
         A list of class labels known to the classifier.
 
-    coef_ : ndarray or CSR array/matrix of shape (1, n_features) or (n_classes, n_features)
+    coef_ : ndarray or CSR array/matrix of shape \
+        (1, n_features) or (n_classes, n_features)
         Coefficient of the features in the decision function.
 
         `coef_` is of shape (1, n_features) when the given problem

--- a/sklearn/linear_model/_passive_aggressive.py
+++ b/sklearn/linear_model/_passive_aggressive.py
@@ -146,8 +146,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
         Weights assigned to the features.
 
         By default, it will be created as a dense array, but can be turned to
-        sparse (CSR format) through :meth:`sparsify` (which can be beneficial
-        under L1 regularization when many coefficients are zero), and back to
+        sparse (CSR format) through :meth:`sparsify`, and back to
         dense through :meth:`densify`.
 
     intercept_ : ndarray of shape (1,) if n_classes == 2 else (n_classes,)

--- a/sklearn/linear_model/_passive_aggressive.py
+++ b/sklearn/linear_model/_passive_aggressive.py
@@ -145,6 +145,11 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
         else (n_classes, n_features)
         Weights assigned to the features.
 
+        By default, it will be created as a dense array, but can be turned to
+        sparse (CSR format) through :meth:`sparsify` (which can be beneficial
+        under L1 regularization when many coefficients are zero), and back to
+        dense through :meth:`densify`.
+
     intercept_ : ndarray of shape (1,) if n_classes == 2 else (n_classes,)
         Constants in decision function.
 

--- a/sklearn/linear_model/_passive_aggressive.py
+++ b/sklearn/linear_model/_passive_aggressive.py
@@ -141,9 +141,8 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
 
     Attributes
     ----------
-    coef_ : ndarray or CSR array/matrix of shape \
-            (1, n_features) if n_classes == 2 else \
-            (n_classes, n_features)
+    coef_ : ndarray or CSR array/matrix of shape (1, n_features) if n_classes == 2 \
+        else (n_classes, n_features)
         Weights assigned to the features.
 
     intercept_ : ndarray of shape (1,) if n_classes == 2 else (n_classes,)

--- a/sklearn/linear_model/_passive_aggressive.py
+++ b/sklearn/linear_model/_passive_aggressive.py
@@ -141,7 +141,8 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
 
     Attributes
     ----------
-    coef_ : ndarray or CSR array/matrix of shape (1, n_features) if n_classes == 2 else \
+    coef_ : ndarray or CSR array/matrix of shape \
+            (1, n_features) if n_classes == 2 else \
             (n_classes, n_features)
         Weights assigned to the features.
 

--- a/sklearn/linear_model/_passive_aggressive.py
+++ b/sklearn/linear_model/_passive_aggressive.py
@@ -141,7 +141,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
 
     Attributes
     ----------
-    coef_ : ndarray of shape (1, n_features) if n_classes == 2 else \
+    coef_ : ndarray or sparse matrix of shape (1, n_features) if n_classes == 2 else \
             (n_classes, n_features)
         Weights assigned to the features.
 

--- a/sklearn/linear_model/_passive_aggressive.py
+++ b/sklearn/linear_model/_passive_aggressive.py
@@ -141,7 +141,7 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
 
     Attributes
     ----------
-    coef_ : ndarray or sparse matrix of shape (1, n_features) if n_classes == 2 else \
+    coef_ : ndarray or CSR array/matrix of shape (1, n_features) if n_classes == 2 else \
             (n_classes, n_features)
         Weights assigned to the features.
 

--- a/sklearn/linear_model/_perceptron.py
+++ b/sklearn/linear_model/_perceptron.py
@@ -117,7 +117,7 @@ class Perceptron(BaseSGDClassifier):
     classes_ : ndarray of shape (n_classes,)
         The unique classes labels.
 
-    coef_ : ndarray or sparse matrix of shape (1, n_features) if n_classes == 2 else \
+    coef_ : ndarray or CSR array/matrix of shape (1, n_features) if n_classes == 2 else \
             (n_classes, n_features)
         Weights assigned to the features.
 

--- a/sklearn/linear_model/_perceptron.py
+++ b/sklearn/linear_model/_perceptron.py
@@ -117,7 +117,7 @@ class Perceptron(BaseSGDClassifier):
     classes_ : ndarray of shape (n_classes,)
         The unique classes labels.
 
-    coef_ : ndarray of shape (1, n_features) if n_classes == 2 else \
+    coef_ : ndarray or sparse matrix of shape (1, n_features) if n_classes == 2 else \
             (n_classes, n_features)
         Weights assigned to the features.
 

--- a/sklearn/linear_model/_perceptron.py
+++ b/sklearn/linear_model/_perceptron.py
@@ -117,7 +117,8 @@ class Perceptron(BaseSGDClassifier):
     classes_ : ndarray of shape (n_classes,)
         The unique classes labels.
 
-    coef_ : ndarray or CSR array/matrix of shape (1, n_features) if n_classes == 2 else \
+    coef_ : ndarray or CSR array/matrix of shape \
+            (1, n_features) if n_classes == 2 else \
             (n_classes, n_features)
         Weights assigned to the features.
 

--- a/sklearn/linear_model/_perceptron.py
+++ b/sklearn/linear_model/_perceptron.py
@@ -117,9 +117,8 @@ class Perceptron(BaseSGDClassifier):
     classes_ : ndarray of shape (n_classes,)
         The unique classes labels.
 
-    coef_ : ndarray or CSR array/matrix of shape \
-            (1, n_features) if n_classes == 2 else \
-            (n_classes, n_features)
+    coef_ : ndarray or CSR array/matrix of shape (1, n_features) if n_classes == 2 \
+        else (n_classes, n_features)
         Weights assigned to the features.
 
     intercept_ : ndarray of shape (1,) if n_classes == 2 else (n_classes,)

--- a/sklearn/linear_model/_perceptron.py
+++ b/sklearn/linear_model/_perceptron.py
@@ -121,6 +121,11 @@ class Perceptron(BaseSGDClassifier):
         else (n_classes, n_features)
         Weights assigned to the features.
 
+        By default, it will be created as a dense array, but can be turned to
+        sparse (CSR format) through :meth:`sparsify` (which can be beneficial
+        under L1 regularization when many coefficients are zero), and back to
+        dense through :meth:`densify`.
+
     intercept_ : ndarray of shape (1,) if n_classes == 2 else (n_classes,)
         Constants in decision function.
 

--- a/sklearn/linear_model/_perceptron.py
+++ b/sklearn/linear_model/_perceptron.py
@@ -122,8 +122,7 @@ class Perceptron(BaseSGDClassifier):
         Weights assigned to the features.
 
         By default, it will be created as a dense array, but can be turned to
-        sparse (CSR format) through :meth:`sparsify` (which can be beneficial
-        under L1 regularization when many coefficients are zero), and back to
+        sparse (CSR format) through :meth:`sparsify`, and back to
         dense through :meth:`densify`.
 
     intercept_ : ndarray of shape (1,) if n_classes == 2 else (n_classes,)

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -1192,7 +1192,8 @@ class SGDClassifier(BaseSGDClassifier):
 
     Attributes
     ----------
-    coef_ : ndarray or CSR array/matrix of shape (1, n_features) if n_classes == 2 else \
+    coef_ : ndarray or CSR array/matrix of shape \
+            (1, n_features) if n_classes == 2 else \
             (n_classes, n_features)
         Weights assigned to the features.
 
@@ -2006,7 +2007,8 @@ class SGDRegressor(BaseSGDRegressor):
 
     Attributes
     ----------
-    coef_ : ndarray or CSR array/matrix of shape (n_features,)
+    coef_ : ndarray or CSR array/matrix of shape \
+        (n_features,)
         Weights assigned to the features.
 
     intercept_ : ndarray of shape (1,)
@@ -2219,7 +2221,8 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
 
     Attributes
     ----------
-    coef_ : ndarray or CSR array/matrix of shape (1, n_features)
+    coef_ : ndarray or CSR array/matrix of shape \
+        (1, n_features)
         Weights assigned to the features.
 
     offset_ : ndarray of shape (1,)

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -2221,8 +2221,7 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
 
     Attributes
     ----------
-    coef_ : ndarray or CSR array/matrix of shape \
-        (1, n_features)
+    coef_ : ndarray or CSR array/matrix of shape (1, n_features)
         Weights assigned to the features.
 
     offset_ : ndarray of shape (1,)

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -1192,7 +1192,7 @@ class SGDClassifier(BaseSGDClassifier):
 
     Attributes
     ----------
-    coef_ : ndarray of shape (1, n_features) if n_classes == 2 else \
+    coef_ : ndarray or sparse matrix of shape (1, n_features) if n_classes == 2 else \
             (n_classes, n_features)
         Weights assigned to the features.
 
@@ -2006,7 +2006,7 @@ class SGDRegressor(BaseSGDRegressor):
 
     Attributes
     ----------
-    coef_ : ndarray of shape (n_features,)
+    coef_ : ndarray or sparse matrix of shape (n_features,)
         Weights assigned to the features.
 
     intercept_ : ndarray of shape (1,)
@@ -2219,7 +2219,7 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
 
     Attributes
     ----------
-    coef_ : ndarray of shape (1, n_features)
+    coef_ : ndarray or sparse matrix of shape (1, n_features)
         Weights assigned to the features.
 
     offset_ : ndarray of shape (1,)

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -1192,7 +1192,7 @@ class SGDClassifier(BaseSGDClassifier):
 
     Attributes
     ----------
-    coef_ : ndarray or sparse matrix of shape (1, n_features) if n_classes == 2 else \
+    coef_ : ndarray or CSR array/matrix of shape (1, n_features) if n_classes == 2 else \
             (n_classes, n_features)
         Weights assigned to the features.
 
@@ -2006,7 +2006,7 @@ class SGDRegressor(BaseSGDRegressor):
 
     Attributes
     ----------
-    coef_ : ndarray or sparse matrix of shape (n_features,)
+    coef_ : ndarray or CSR array/matrix of shape (n_features,)
         Weights assigned to the features.
 
     intercept_ : ndarray of shape (1,)
@@ -2219,7 +2219,7 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
 
     Attributes
     ----------
-    coef_ : ndarray or sparse matrix of shape (1, n_features)
+    coef_ : ndarray or CSR array/matrix of shape (1, n_features)
         Weights assigned to the features.
 
     offset_ : ndarray of shape (1,)

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -1192,9 +1192,8 @@ class SGDClassifier(BaseSGDClassifier):
 
     Attributes
     ----------
-    coef_ : ndarray or CSR array/matrix of shape \
-            (1, n_features) if n_classes == 2 else \
-            (n_classes, n_features)
+    coef_ : ndarray or CSR array/matrix of shape (1, n_features) if n_classes == 2 \
+            else (n_classes, n_features)
         Weights assigned to the features.
 
     intercept_ : ndarray of shape (1,) if n_classes == 2 else (n_classes,)
@@ -2007,8 +2006,7 @@ class SGDRegressor(BaseSGDRegressor):
 
     Attributes
     ----------
-    coef_ : ndarray or CSR array/matrix of shape \
-        (n_features,)
+    coef_ : ndarray or CSR array/matrix of shape (n_features,)
         Weights assigned to the features.
 
     intercept_ : ndarray of shape (1,)

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -1196,6 +1196,11 @@ class SGDClassifier(BaseSGDClassifier):
             else (n_classes, n_features)
         Weights assigned to the features.
 
+        By default, it will be created as a dense array, but can be turned to
+        sparse (CSR format) through :meth:`sparsify` (which can be beneficial
+        under L1 regularization when many coefficients are zero), and back to
+        dense through :meth:`densify`.
+
     intercept_ : ndarray of shape (1,) if n_classes == 2 else (n_classes,)
         Constants in decision function.
 
@@ -2009,6 +2014,11 @@ class SGDRegressor(BaseSGDRegressor):
     coef_ : ndarray or CSR array/matrix of shape (n_features,)
         Weights assigned to the features.
 
+        By default, it will be created as a dense array, but can be turned to
+        sparse (CSR format) through :meth:`sparsify` (which can be beneficial
+        under L1 regularization when many coefficients are zero), and back to
+        dense through :meth:`densify`.
+
     intercept_ : ndarray of shape (1,)
         The intercept term.
 
@@ -2221,6 +2231,11 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
     ----------
     coef_ : ndarray or CSR array/matrix of shape (1, n_features)
         Weights assigned to the features.
+
+        By default, it will be created as a dense array, but can be turned to
+        sparse (CSR format) through :meth:`sparsify` (which can be beneficial
+        under L1 regularization when many coefficients are zero), and back to
+        dense through :meth:`densify`.
 
     offset_ : ndarray of shape (1,)
         Offset used to define the decision function from the raw scores.

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -1197,8 +1197,7 @@ class SGDClassifier(BaseSGDClassifier):
         Weights assigned to the features.
 
         By default, it will be created as a dense array, but can be turned to
-        sparse (CSR format) through :meth:`sparsify` (which can be beneficial
-        under L1 regularization when many coefficients are zero), and back to
+        sparse (CSR format) through :meth:`sparsify`, and back to
         dense through :meth:`densify`.
 
     intercept_ : ndarray of shape (1,) if n_classes == 2 else (n_classes,)
@@ -2015,8 +2014,7 @@ class SGDRegressor(BaseSGDRegressor):
         Weights assigned to the features.
 
         By default, it will be created as a dense array, but can be turned to
-        sparse (CSR format) through :meth:`sparsify` (which can be beneficial
-        under L1 regularization when many coefficients are zero), and back to
+        sparse (CSR format) through :meth:`sparsify`, and back to
         dense through :meth:`densify`.
 
     intercept_ : ndarray of shape (1,)
@@ -2233,8 +2231,7 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
         Weights assigned to the features.
 
         By default, it will be created as a dense array, but can be turned to
-        sparse (CSR format) through :meth:`sparsify` (which can be beneficial
-        under L1 regularization when many coefficients are zero), and back to
+        sparse (CSR format) through :meth:`sparsify`, and back to
         dense through :meth:`densify`.
 
     offset_ : ndarray of shape (1,)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #34117

#### What does this implement/fix? Explain your changes.

Updates the `coef_` attribute documentation for linear models supporting
sparse coefficients through `sparsify()`.

The documentation now mentions that `coef_` can be either an `ndarray`
or a sparse matrix for affected estimators such as SGD-based models,
Perceptron, PassiveAggressiveClassifier, and LogisticRegressionCV.

#### AI usage disclosure

I used AI assistance for:
- Research and understanding

#### Any other comments?