### PR TITLE
Fix libsvm SMO paper reference

### DIFF
--- a/sklearn/svm/src/libsvm/svm.cpp
+++ b/sklearn/svm/src/libsvm/svm.cpp
@@ -527,7 +527,10 @@ double Kernel::k_function(const PREFIX(node) *x, const PREFIX(node) *y,
 			return 0;  // Unreachable
 	}
 }
-// An SMO algorithm in Fan et al., JMLR 6(2005), p. 1889--1918
+// An SMO algorithm based on:
+// R.-E. Fan, P.-H. Chen, and C.-J. Lin. Working set selection using second
+// order information for training support vector machines. Journal of Machine
+// Learning Research 6(2005), p. 1889--1918.
 // Solves:
 //
 //	min 0.5(\alpha^T Q \alpha) + p^T \alpha


### PR DESCRIPTION
## Summary
- Replaces the ambiguous libsvm SMO reference with the full Fan, Chen, and Lin JMLR citation.
- Leaves the solver implementation untouched.

## Root cause
The existing comment cited `Fan et al.` with page numbers but omitted the actual paper title and full author context, which made the reference hard to verify.

## Code shape
One comment-only change in `svm.cpp`. No C/C++ logic, generated files, tests, dependencies, or public Python API behavior changed.

## Security assessment
Low risk: documentation/comment-only update. No executable path, input handling, memory ownership, dependency, or build configuration changed.

## Verification
- `rg -n "An SMO algorithm|Working set selection|Journal of Machine|Fan" sklearn\svm\src\libsvm\svm.cpp`
- `git diff --check`

Fixes #34086
