### PR TITLE
FIX raise TypeError for sparse torch tensors in Ridge SVD solver

### DIFF
--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -136,6 +136,12 @@ For Intel GPUs, install PyTorch 2.12 or newer with XPU support following the
 <https://docs.pytorch.org/docs/stable/notes/get_start_xpu.html>`_ and use
 `device="xpu"` instead of `device="cuda"`.
 
+.. note::
+    Sparse PyTorch tensors (created with ``.to_sparse()``) are not officially
+    supported. Their behavior may be undefined or inconsistent across estimators.
+    Estimators that do not support sparse inputs (such as :class:`linear_model.Ridge`
+    with ``solver="svd"``) will raise a :exc:`TypeError`.
+
 dpnp Support
 ------------
 

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/34150.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/34150.fix.rst
@@ -1,4 +1,0 @@
-- Fixed incomplete deprecation message for the :class:`linear_model.LogisticRegression`
-  and :class:`linear_model.LogisticRegressionCV` ``penalty`` parameter, which was
-  missing the ``penalty=None`` and ``penalty='elasticnet'`` migration guidance.
-  By :user:`baynecheke <baynecheke>`.

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/34150.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/34150.fix.rst
@@ -1,0 +1,4 @@
+- Fixed incomplete deprecation message for the :class:`linear_model.LogisticRegression`
+  and :class:`linear_model.LogisticRegressionCV` ``penalty`` parameter, which was
+  missing the ``penalty=None`` and ``penalty='elasticnet'`` migration guidance.
+  By :user:`baynecheke <baynecheke>`.

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1016,9 +1016,9 @@ class LogisticRegression(
 
         .. deprecated:: 1.8
            `penalty` was deprecated in version 1.8 and will be removed in 1.10.
-           Use `l1_ratio` instead. `l1_ratio=0` for `penalty='l2'`, `l1_ratio=1` for
-           `penalty='l1'` and `l1_ratio` set to any float between 0 and 1 for
-           `'penalty='elasticnet'`.
+           Use `l1_ratio` and `C` instead. `l1_ratio=0` for `penalty='l2'`,
+           `l1_ratio=1` for `penalty='l1'`, `l1_ratio` set to any float between 0 and 1
+           for `penalty='elasticnet'`, and `C=np.inf` for `penalty=None`.
 
     C : float, default=1.0
         Inverse of regularization strength; must be a positive float.
@@ -1401,8 +1401,9 @@ class LogisticRegression(
                     " 1.10. To avoid this warning, leave 'penalty' set to its default"
                     " value and use 'l1_ratio' or 'C' instead."
                     " Use l1_ratio=0 instead of penalty='l2',"
-                    " l1_ratio=1 instead of penalty='l1', and "
-                    "C=np.inf instead of penalty=None."
+                    " l1_ratio=1 instead of penalty='l1',"
+                    " l1_ratio set to a float between 0 and 1 instead of"
+                    " penalty='elasticnet', and C=np.inf instead of penalty=None."
                 ),
                 FutureWarning,
             )
@@ -1734,9 +1735,9 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
 
         .. deprecated:: 1.8
            `penalty` was deprecated in version 1.8 and will be removed in 1.10.
-           Use `l1_ratio` instead. `l1_ratio=0` for `penalty='l2'`, `l1_ratio=1` for
-           `penalty='l1'` and `l1_ratio` set to any float between 0 and 1 for
-           `'penalty='elasticnet'`.
+           Use `l1_ratio` and `C` instead. `l1_ratio=0` for `penalty='l2'`,
+           `l1_ratio=1` for `penalty='l1'`, `l1_ratio` set to any float between 0 and 1
+           for `penalty='elasticnet'`, and `C=np.inf` for `penalty=None`.
 
     scoring : str or callable, default=None
         The scoring method to use for cross-validation. Options:
@@ -2118,9 +2119,11 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
                 (
                     "'penalty' was deprecated in version 1.8 and will be removed in"
                     " 1.10. To avoid this warning, leave 'penalty' set to its default"
-                    " value and use 'l1_ratios' instead."
-                    " Use l1_ratios=(0,) instead of penalty='l2' "
-                    " and l1_ratios=(1,) instead of penalty='l1'."
+                    " value and use 'l1_ratios' and 'Cs' instead."
+                    " Use l1_ratios=(0,) instead of penalty='l2',"
+                    " l1_ratios=(1,) instead of penalty='l1',"
+                    " l1_ratios set to floats between 0 and 1 instead of"
+                    " penalty='elasticnet', and Cs=(np.inf,) instead of penalty=None."
                 ),
                 FutureWarning,
             )

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -889,7 +889,6 @@ def resolve_solver_for_numpy(positive, return_intercept, is_sparse):
     return "sparse_cg"
 
 
-
 class _BaseRidge(LinearModel, metaclass=ABCMeta):
     _parameter_constraints: dict = {
         "alpha": [Interval(Real, 0, None, closed="left"), np.ndarray],
@@ -948,10 +947,10 @@ class _BaseRidge(LinearModel, metaclass=ABCMeta):
         elif sparse.issparse(X) and self.fit_intercept:
             if self.solver not in ["auto", "lbfgs", "lsqr", "sag", "sparse_cg"]:
                 raise ValueError(
-                    "solver='{}' does not support fitting the intercept "
+                    f"solver='{self.solver}' does not support fitting the intercept "
                     "on sparse data. Please set the solver to 'auto' or "
                     "'lsqr', 'sparse_cg', 'sag', 'lbfgs' "
-                    "or set `fit_intercept=False`".format(self.solver)
+                    "or set `fit_intercept=False`"
                 )
             if self.solver in ["lsqr", "lbfgs"]:
                 solver = self.solver

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -822,7 +822,7 @@ def _ridge_regression(
         )
 
     if solver == "svd":
-        if X_is_sparse:
+        if X_is_sparse or getattr(X, "is_sparse", False):
             raise TypeError("SVD solver does not support sparse inputs currently")
         coef = _solve_svd(X, y, alpha, xp)
 
@@ -887,6 +887,7 @@ def resolve_solver_for_numpy(positive, return_intercept, is_sparse):
         return "cholesky"
 
     return "sparse_cg"
+
 
 
 class _BaseRidge(LinearModel, metaclass=ABCMeta):

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -968,6 +968,9 @@ class _BaseRidge(LinearModel, metaclass=ABCMeta):
         else:
             solver = self.solver
 
+        if solver == "svd" and getattr(X, "is_sparse", False):
+            raise TypeError("SVD solver does not support sparse inputs currently")
+
         if sample_weight is not None:
             sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
 

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -915,6 +915,20 @@ def test_regularization_limits_ridge(
     assert_allclose(ridge.intercept_, expected_intercept, atol=1e-10)
 
 
+def test_ridge_svd_rejects_sparse_torch_tensor():
+    """Ridge with solver='svd' should raise TypeError for sparse torch tensors."""
+    torch = pytest.importorskip("torch")
+
+    X = np.array([[1.0, 2.0], [3.0, 0.0], [0.0, 4.0]])
+    y = np.array([1.0, 2.0, 3.0])
+
+    X_sparse = torch.tensor(X).to_sparse()
+    y_torch = torch.tensor(y)
+
+    with config_context(array_api_dispatch=True):
+        with pytest.raises(TypeError, match="SVD solver does not support sparse inputs"):
+            Ridge(solver="svd").fit(X_sparse, y_torch)
+
 @pytest.mark.parametrize("alpha", [1e-16, 1e16], ids=["zero_alpha", "inf_alpha"])
 @pytest.mark.parametrize("gcv_mode", ["ignored"])
 @pytest.mark.parametrize("fit_intercept", [True, False])

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -476,9 +476,12 @@ def test_ridge_regression_sample_weights(
     for z=[y, y], A' = [X', X'] (vstacked), and W[:n/2] + W[n/2:] = 1, W=diag(W)
     """
     if sparse_container is not None:
-        if fit_intercept and solver not in SPARSE_SOLVERS_WITH_INTERCEPT:
-            pytest.skip()
-        elif not fit_intercept and solver not in SPARSE_SOLVERS_WITHOUT_INTERCEPT:
+        if (
+            fit_intercept
+            and solver not in SPARSE_SOLVERS_WITH_INTERCEPT
+            or not fit_intercept
+            and solver not in SPARSE_SOLVERS_WITHOUT_INTERCEPT
+        ):
             pytest.skip()
     X, y, _, coef = ols_ridge_dataset
     n_samples, n_features = X.shape
@@ -926,8 +929,11 @@ def test_ridge_svd_rejects_sparse_torch_tensor():
     y_torch = torch.tensor(y)
 
     with config_context(array_api_dispatch=True):
-        with pytest.raises(TypeError, match="SVD solver does not support sparse inputs"):
+        with pytest.raises(
+            TypeError, match="SVD solver does not support sparse inputs"
+        ):
             Ridge(solver="svd").fit(X_sparse, y_torch)
+
 
 @pytest.mark.parametrize("alpha", [1e-16, 1e16], ids=["zero_alpha", "inf_alpha"])
 @pytest.mark.parametrize("gcv_mode", ["ignored"])
@@ -2005,7 +2011,7 @@ def test_ridge_fit_intercept_sparse_error(solver, csr_container):
     X, y = _make_sparse_offset_regression(n_features=20, random_state=0)
     X_csr = csr_container(X)
     sparse_ridge = Ridge(solver=solver)
-    err_msg = "solver='{}' does not support".format(solver)
+    err_msg = f"solver='{solver}' does not support"
     with pytest.raises(ValueError, match=err_msg):
         sparse_ridge.fit(X_csr, y)
 


### PR DESCRIPTION
Passing a sparse PyTorch tensor to Ridge with solver="svd" previously crashed 
with a confusing RuntimeError deep inside PyTorch ("Sparse division requires a 
scalar or zero-dim dense tensor divisor"). This happened because the existing 
sparse check used scipy.sparse.issparse(), which only detects SciPy sparse 
objects and returns False for torch sparse tensors.

This PR extends the SVD solver guard in _ridge_regression to also detect sparse 
torch tensors using getattr(X, "is_sparse", False), so users now get a clear 
TypeError("SVD solver does not support sparse inputs currently") instead.
See #34087

Changes:
- sklearn/linear_model/_ridge.py: extend SVD sparse check to cover torch sparse tensors
- sklearn/linear_model/tests/test_ridge.py: add test (skipped when torch not installed)
- doc/modules/array_api.rst: add note that sparse PyTorch tensors are not officially supported

I used AI assistance for:
- Code generation 
- Test/benchmark generation
- Research and understanding