### PR TITLE
DOC update coef_ docstring for models with sparsify()

### DIFF
--- a/sklearn/linear_model/_passive_aggressive.py
+++ b/sklearn/linear_model/_passive_aggressive.py
@@ -141,9 +141,10 @@ class PassiveAggressiveClassifier(BaseSGDClassifier):
 
     Attributes
     ----------
-    coef_ : ndarray of shape (1, n_features) if n_classes == 2 else \
-            (n_classes, n_features)
-        Weights assigned to the features.
+    coef_ : ndarray or sparse matrix of shape (1, n_features) if n_classes == 2 \
+                else (n_classes, n_features)
+            Weights assigned to the features. ``coef_`` is a dense ndarray by
+            default. It becomes a sparse matrix after calling ``sparsify()``.
 
     intercept_ : ndarray of shape (1,) if n_classes == 2 else (n_classes,)
         Constants in decision function.
@@ -452,9 +453,9 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
 
     Attributes
     ----------
-    coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes,\
-            n_features]
-        Weights assigned to the features.
+    coef_ : ndarray or sparse matrix of shape (n_features,)
+            Weights assigned to the features. ``coef_`` is a dense ndarray by
+            default. It becomes a sparse matrix after calling ``sparsify()``.
 
     intercept_ : array, shape = [1] if n_classes == 2 else [n_classes]
         Constants in decision function.

--- a/sklearn/linear_model/_perceptron.py
+++ b/sklearn/linear_model/_perceptron.py
@@ -117,9 +117,10 @@ class Perceptron(BaseSGDClassifier):
     classes_ : ndarray of shape (n_classes,)
         The unique classes labels.
 
-    coef_ : ndarray of shape (1, n_features) if n_classes == 2 else \
-            (n_classes, n_features)
-        Weights assigned to the features.
+    coef_ : ndarray or sparse matrix of shape (1, n_features) if n_classes == 2 \
+                else (n_classes, n_features)
+            Weights assigned to the features. ``coef_`` is a dense ndarray by
+            default. It becomes a sparse matrix after calling ``sparsify()``.
 
     intercept_ : ndarray of shape (1,) if n_classes == 2 else (n_classes,)
         Constants in decision function.

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -1192,9 +1192,10 @@ class SGDClassifier(BaseSGDClassifier):
 
     Attributes
     ----------
-    coef_ : ndarray of shape (1, n_features) if n_classes == 2 else \
-            (n_classes, n_features)
-        Weights assigned to the features.
+    coef_ : ndarray or sparse matrix of shape (1, n_features) if n_classes == 2 \
+                else (n_classes, n_features)
+            Weights assigned to the features. ``coef_`` is a dense ndarray by
+            default. It becomes a sparse matrix after calling ``sparsify()``.
 
     intercept_ : ndarray of shape (1,) if n_classes == 2 else (n_classes,)
         Constants in decision function.
@@ -2006,8 +2007,9 @@ class SGDRegressor(BaseSGDRegressor):
 
     Attributes
     ----------
-    coef_ : ndarray of shape (n_features,)
-        Weights assigned to the features.
+    coef_ : ndarray or sparse matrix of shape (n_features,)
+            Weights assigned to the features. ``coef_`` is a dense ndarray by
+            default. It becomes a sparse matrix after calling ``sparsify()``.
 
     intercept_ : ndarray of shape (1,)
         The intercept term.
@@ -2219,8 +2221,9 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
 
     Attributes
     ----------
-    coef_ : ndarray of shape (1, n_features)
-        Weights assigned to the features.
+    coef_ : ndarray or sparse matrix of shape (1, n_features)
+            Weights assigned to the features. ``coef_`` is a dense ndarray by
+            default. It becomes a sparse matrix after calling ``sparsify()``.
 
     offset_ : ndarray of shape (1,)
         Offset used to define the decision function from the raw scores.

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -156,8 +156,8 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
     coef_ : ndarray or sparse matrix of shape (1, n_features) if n_classes == 2 \
             else (n_classes, n_features)
         Weights assigned to the features (coefficients in the primal
-        problem). 
-        
+        problem).
+
         ``coef_`` is a dense ndarray by default. It becomes a
         sparse matrix after calling ``sparsify()``.
 

--- a/sklearn/svm/_classes.py
+++ b/sklearn/svm/_classes.py
@@ -153,10 +153,13 @@ class LinearSVC(LinearClassifierMixin, SparseCoefMixin, BaseEstimator):
 
     Attributes
     ----------
-    coef_ : ndarray of shape (1, n_features) if n_classes == 2 \
+    coef_ : ndarray or sparse matrix of shape (1, n_features) if n_classes == 2 \
             else (n_classes, n_features)
         Weights assigned to the features (coefficients in the primal
-        problem).
+        problem). 
+        
+        ``coef_`` is a dense ndarray by default. It becomes a
+        sparse matrix after calling ``sparsify()``.
 
         ``coef_`` is a readonly property derived from ``raw_coef_`` that
         follows the internal memory layout of liblinear.


### PR DESCRIPTION
Fixes #34117

#### Reference Issues/PRs
Fixes #34117

#### What does this implement/fix? Explain your changes.
Several linear model classes that implement `.sparsify()` had `coef_`
documented as always being an `ndarray`, which is inaccurate — after
calling `sparsify()`, `coef_` becomes a sparse CSR matrix.

This PR updates the `coef_` attribute docstring for all affected classes
to match the fix already done for `LogisticRegression` in #34093.

Classes updated:
- SGDClassifier
- SGDRegressor
- SGDOneClassSVM
- Perceptron
- PassiveAggressiveClassifier
- PassiveAggressiveRegressor
- LinearSVC

#### AI usage disclosure
I used AI assistance for:
- Research and understanding

#### Any other comments?
This is a documentation-only fix with no behavior changes, so no
changelog entry has been added.