### PR TITLE
DOC document Array API limitation for LogisticRegression.sparsify

### DIFF
--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -487,17 +487,17 @@ class SparseCoefMixin:
 
         The ``intercept_`` member is not converted.
 
-        Returns
-        -------
-        self
-            Fitted estimator.
-
         .. warning::
             This method is not supported for estimators fitted with Array API
             inputs (i.e. when :func:`sklearn.config_context` is used with
             ``array_api_dispatch=True``). The call may succeed but subsequent
             calls to :meth:`predict` and other methods involving passing arrays
             may raise or return unexpected results.
+
+        Returns
+        -------
+        self
+            Fitted estimator.
 
         Notes
         -----

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -488,7 +488,7 @@ class SparseCoefMixin:
         The ``intercept_`` member is not converted.
 
         .. warning::
-            This method is not supported for estimators fitted with Array API
+            This method is not supported for estimators fitted with array API
             inputs (i.e. when :func:`sklearn.config_context` is used with
             ``array_api_dispatch=True``). The call may succeed but subsequent
             calls to :meth:`predict` and other methods involving passing arrays

--- a/sklearn/linear_model/_base.py
+++ b/sklearn/linear_model/_base.py
@@ -492,6 +492,13 @@ class SparseCoefMixin:
         self
             Fitted estimator.
 
+        .. warning::
+            This method is not supported for estimators fitted with Array API
+            inputs (i.e. when :func:`sklearn.config_context` is used with
+            ``array_api_dispatch=True``). The call may succeed but subsequent
+            calls to :meth:`predict` and other methods involving passing arrays
+            may raise or return unexpected results.
+
         Notes
         -----
         For non-sparse models, i.e. when there are not many zeros in ``coef_``,


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #34114

#### What does this implement/fix?

Documents the limitation of calling `.sparsify()` on a `LogisticRegression`
estimator fitted with Array API inputs.

When `array_api_dispatch=True` is set via `config_context`, calling
`.sparsify()` on a fitted `LogisticRegression` silently succeeds but leaves
`coef_` as a `scipy.sparse` matrix. This causes subsequent `predict()` calls
to raise a `ValueError` due to a device/namespace mismatch on `coef_`.

Changes:
- `doc/modules/array_api.rst`: added a note next to the `LogisticRegression`
  entry describing this limitation
- `sklearn/linear_model/_base.py`: added a `.. warning::` block in the
  `sparsify()` docstring explaining that it is not supported for estimators
  fitted with Array API inputs

#### AI usage disclosure

I used AI assistance for:
- Research and understanding

#### Any other comments?