### PR TITLE
DOC fix the docstring for the load_descr()

### DIFF
--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -466,15 +466,13 @@ def load_descr(descr_file_name, *, descr_module=DESCR_MODULE, encoding="utf-8"):
 
     Parameters
     ----------
-    descr_file_name : str, default=None
+    descr_file_name : str
         Name of rst file to be loaded from `descr_module/descr_file_name`.
-        For example `'wine_data.rst'`. See also :func:`load_descr`.
-        If not None, also returns the corresponding description of
-        the dataset.
+        For example `'wine_data.rst'`.
 
     descr_module : str or module, default='sklearn.datasets.descr'
-        Module where `descr_file_name` lives. See also :func:`load_descr`.
-        The default  is `'sklearn.datasets.descr'`.
+        Module where `descr_file_name` lives.
+        The default is `'sklearn.datasets.descr'`.
 
     encoding : str, default="utf-8"
         Name of the encoding that `descr_file_name` will be decoded with.


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The `descr_file_name` parameter of the `load_descr()` does not have a default value while the related docstring says opposite. Remove the default value for this parameter and in addition remove the reference of the `load_descr()` to itself from the docstring.
