### PR TITLE
Don't share regression data across tests and test runs

### DIFF
--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -9,7 +9,6 @@ import os
 import pkgutil
 import re
 import warnings
-from copy import deepcopy
 from functools import partial
 from itertools import chain
 
@@ -119,11 +118,6 @@ def test_get_check_estimator_ids(val, expected):
     list(_tested_estimators()), expected_failed_checks=_get_expected_failed_checks
 )
 def test_estimators(estimator, check, request):
-    # Make sure the shared estimator created by @parametrize_with_checks
-    # remains unchanged, especially important for --parallel-threads tests.
-    # clone() will often only do a safe=True copy, thus deepcopy just to be
-    # certain no sharing happens.
-    estimator = deepcopy(estimator)
     # Common tests for estimator instances
     with ignore_warnings(
         category=(FutureWarning, ConvergenceWarning, UserWarning, LinAlgWarning)

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -9,6 +9,7 @@ import os
 import pkgutil
 import re
 import warnings
+from copy import deepcopy
 from functools import partial
 from itertools import chain
 
@@ -118,6 +119,11 @@ def test_get_check_estimator_ids(val, expected):
     list(_tested_estimators()), expected_failed_checks=_get_expected_failed_checks
 )
 def test_estimators(estimator, check, request):
+    # Make sure the shared estimator created by @parametrize_with_checks
+    # remains unchanged, especially important for --parallel-threads tests.
+    # clone() will often only do a safe=True copy, thus deepcopy just to be
+    # certain no sharing happens.
+    estimator = deepcopy(estimator)
     # Common tests for estimator instances
     with ignore_warnings(
         category=(FutureWarning, ConvergenceWarning, UserWarning, LinAlgWarning)

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -973,7 +973,9 @@ def _regression_dataset():
         )
         X = StandardScaler().fit_transform(X)
         REGRESSION_DATASET = X, y
-    return REGRESSION_DATASET
+    X, y = REGRESSION_DATASET
+    # Make a copy, in case tests mutate this data:
+    return X.copy(), y.copy()
 
 
 class _NotAnArray:

--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -974,7 +974,7 @@ def _regression_dataset():
         X = StandardScaler().fit_transform(X)
         REGRESSION_DATASET = X, y
     X, y = REGRESSION_DATASET
-    # Make a copy, in case tests mutate this data:
+    # Make a copy, in case the caller wants to mutate this data:
     return X.copy(), y.copy()
 
 


### PR DESCRIPTION
[free-threaded]

For now the goal is to do a series of CI runs and see if the failures recur or if this fixes them; I can't reproduce CI failures locally, unfortunately.

#### Reference Issues/PRs
Fixes #33470 

Or that's the hope. 

#### What does this implement/fix? Explain your changes.

Prevent the same regression data being used by multiple tests (sequentially across tests, or in the case of `free-threading` CI run, in parallel of the same test), since some tests may mutate it.

(Originally, as referred to in some commits below, this was trying to ensure _estimators_ weren't being shared, but that was a dead end.)

#### AI usage disclosure
No AI.
