### PR TITLE
Fix KMeans stale labels_ after empty cluster relocation

### DIFF
--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -601,23 +601,24 @@ def _kmeans_single_elkan(
 
         labels_old[:] = labels
 
-    if not strict_convergence:
-        # rerun E-step so that predicted labels match cluster centers
-        elkan_iter(
-            X,
-            sample_weight,
-            centers,
-            centers,
-            weight_in_clusters,
-            center_half_distances,
-            distance_next_center,
-            upper_bounds,
-            lower_bounds,
-            labels,
-            center_shift,
-            n_threads,
-            update_centers=False,
-        )
+    # Always run final E-step so that predicted labels match cluster centers.
+    # Empty cluster relocation can mutate centers without updating labels,
+    # causing stale labels_/inertia_ on strict convergence.
+    elkan_iter(
+        X,
+        sample_weight,
+        centers,
+        centers,
+        weight_in_clusters,
+        center_half_distances,
+        distance_next_center,
+        upper_bounds,
+        lower_bounds,
+        labels,
+        center_shift,
+        n_threads,
+        update_centers=False,
+    )
 
     inertia = _inertia(X, sample_weight, centers, labels, n_threads)
 
@@ -739,19 +740,20 @@ def _kmeans_single_lloyd(
 
         labels_old[:] = labels
 
-    if not strict_convergence:
-        # rerun E-step so that predicted labels match cluster centers
-        lloyd_iter(
-            X,
-            sample_weight,
-            centers,
-            centers,
-            weight_in_clusters,
-            labels,
-            center_shift,
-            n_threads,
-            update_centers=False,
-        )
+    # Always run final E-step so that predicted labels match cluster centers.
+    # Empty cluster relocation can mutate centers without updating labels,
+    # causing stale labels_/inertia_ on strict convergence.
+    lloyd_iter(
+        X,
+        sample_weight,
+        centers,
+        centers,
+        weight_in_clusters,
+        labels,
+        center_shift,
+        n_threads,
+        update_centers=False,
+    )
 
     inertia = _inertia(X, sample_weight, centers, labels, n_threads)
 

--- a/sklearn/cluster/tests/test_k_means.py
+++ b/sklearn/cluster/tests/test_k_means.py
@@ -1374,3 +1374,49 @@ def test_relocating_with_duplicates(algorithm, array_constr):
         km.fit(array_constr(X))
 
     assert km.n_iter_ == 1
+
+
+def test_kmeans_empty_cluster_relocation_labels_consistency():
+    """Check that labels_ are consistent with cluster_centers_ after empty cluster relocation.
+
+    Non-regression test for https://github.com/scikit-learn/scikit-learn/issues/34074
+    When empty cluster relocation mutates centers but labels stay the same,
+    strict convergence should not skip the final E-step.
+    """
+    import scipy.sparse as sp
+
+    X = sp.csr_matrix(np.array([[1.0], [2.0], [3.0]]))
+    init = np.array([[4.0], [0.0], [1.0]])
+
+    for algorithm in ["lloyd", "elkan"]:
+        km = KMeans(
+            n_clusters=3,
+            init=init,
+            n_init=1,
+            max_iter=10,
+            tol=0,
+            algorithm=algorithm,
+        )
+        km.fit(X)
+
+        predicted = km.predict(X)
+        assert_array_equal(
+            km.labels_,
+            predicted,
+            err_msg=(
+                f"labels_ inconsistent with predict() for {algorithm}. "
+                f"This indicates the final E-step was skipped after empty "
+                f"cluster relocation (strict convergence bug)."
+            ),
+        )
+
+        # Also verify inertia_ is consistent with labels_
+        from sklearn.cluster._kmeans import _labels_inertia
+        labels_fresh, inertia_fresh = _labels_inertia(
+            X, sample_weight=None, centers=km.cluster_centers_
+        )
+        assert_allclose(
+            km.inertia_,
+            inertia_fresh,
+            err_msg=f"inertia_ stale for {algorithm}",
+        )


### PR DESCRIPTION
## Reference Issue

Fixes #34074

## What does this implement/fix?

When empty cluster relocation mutates `centers_new` without updating `labels`, the strict convergence check (`np.array_equal(labels, labels_old)`) incorrectly declares convergence. The final E-step is skipped, causing `labels_` and `inertia_` to be inconsistent with `cluster_centers_`.

**Reproduction** (from the issue):
```python
import numpy as np
from scipy import sparse
from sklearn.cluster import KMeans

X = sparse.csr_matrix(np.array([[1.0], [2.0], [3.0]]))
init = np.array([[4.0], [0.0], [1.0]])
for algorithm in ["lloyd", "elkan"]:
    km = KMeans(n_clusters=3, init=init, n_init=1, max_iter=10, tol=0, algorithm=algorithm).fit(X)
    print(algorithm, np.array_equal(km.labels_, km.predict(X)))  # False before fix
```

## Fix

Remove the `if not strict_convergence:` guard around the final E-step in both `_kmeans_single_elkan` and `_kmeans_single_lloyd`. Always run the E-step with `update_centers=False` to ensure labels match the final centers. This is a read-only pass — no center updates, minimal overhead.

## Testing

Added `test_kmeans_empty_cluster_relocation_labels_consistency` which:
1. Creates a scenario that triggers empty cluster relocation (sparse data, specific init)
2. Verifies `labels_ == predict(X)` for both lloyd and elkan algorithms
3. Verifies `inertia_` matches a fresh computation against final centers