### PR TITLE
DOC add set_output custom transformer example

### DIFF
--- a/doc/developers/develop.rst
+++ b/doc/developers/develop.rst
@@ -562,6 +562,35 @@ features, such as :class:`~preprocessing.StandardScaler`.
 :class:`base.ClassNamePrefixFeaturesOutMixin` is useful when the transformer
 needs to generate its own feature names out, such as :class:`~decomposition.PCA`.
 
+For example, a custom transformer with a one-to-one correspondence between input
+and output features can inherit from :class:`base.OneToOneFeatureMixin` to reuse
+the input feature names when `set_output(transform="pandas")` is configured:
+
+.. code-block:: python
+
+    import pandas as pd
+
+    from sklearn.base import BaseEstimator, OneToOneFeatureMixin, TransformerMixin
+    from sklearn.utils.validation import validate_data
+
+
+    class ScaleByFactor(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
+        def __init__(self, factor=2):
+            self.factor = factor
+
+        def fit(self, X, y=None):
+            validate_data(self, X, reset=True)
+            return self
+
+        def transform(self, X):
+            X = validate_data(self, X, reset=False)
+            return X * self.factor
+
+
+    X = pd.DataFrame({"height": [1.5, 1.8], "weight": [60, 80]})
+    transformer = ScaleByFactor().set_output(transform="pandas")
+    transformer.fit_transform(X)
+
 You can opt-out of the `set_output` API by setting `auto_wrap_output_keys=None`
 when defining a custom subclass::
 


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #26460.

#### What does this implement/fix? Explain your changes.

Adds a small custom transformer example to the developer `set_output` API docs. The example shows how a transformer with one-to-one input/output features can inherit from `OneToOneFeatureMixin`, `TransformerMixin`, and `BaseEstimator` so that `set_output(transform="pandas")` preserves the input feature names in the pandas output.

#### AI usage disclosure

I used AI assistance for:
- Documentation (including examples)
- Research and understanding

#### Any other comments?

Local checks run:

- `git diff --check`
- `codespell doc/developers/develop.rst`
- Ran the added example as a standalone Python snippet against the released `scikit-learn` package and confirmed it returns a pandas `DataFrame` with `['height', 'weight']` columns.

I did not run a full local documentation build because the cloned source tree is not built in this environment and the Sphinx documentation dependencies were not installed.
