### PR TITLE
fix: handle PyTorch's from_dlpack not supporting device kwarg in move_to (closes #34046)

### DIFF
--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -588,7 +588,16 @@ def move_to(*arrays, xp, device):
                     # only used as fallback in case of failure.
                     # Note: copy=None is the default since array-api 2023.12. Namespace
                     # libraries should only trigger a copy automatically if needed.
-                    array_converted = xp.from_dlpack(array, device=device)
+                    try:
+                array_converted = xp.from_dlpack(array, device=device)
+            except (TypeError, AssertionError):
+                # Some namespaces (e.g. PyTorch) do not support the `device`
+                # keyword argument in `from_dlpack` when the input is already
+                # a DLPack capsule. In that case, we convert first and then
+                # move to the target device.
+                array_converted = xp.from_dlpack(array)
+                if device is not None:
+                    array_converted = xp.to_device(array_converted, device)
                     # `AttributeError` occurs when `__dlpack__` and `__dlpack_device__`
                     # methods are not present on the input array
                     # `TypeError` and `NotImplementedError` for packages that do not

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -589,15 +589,15 @@ def move_to(*arrays, xp, device):
                     # Note: copy=None is the default since array-api 2023.12. Namespace
                     # libraries should only trigger a copy automatically if needed.
                     try:
-                array_converted = xp.from_dlpack(array, device=device)
-            except (TypeError, AssertionError):
-                # Some namespaces (e.g. PyTorch) do not support the `device`
-                # keyword argument in `from_dlpack` when the input is already
-                # a DLPack capsule. In that case, we convert first and then
-                # move to the target device.
-                array_converted = xp.from_dlpack(array)
-                if device is not None:
-                    array_converted = xp.to_device(array_converted, device)
+                        array_converted = xp.from_dlpack(array, device=device)
+                    except (TypeError, AssertionError):
+                        # Some namespaces (e.g. PyTorch) do not support the `device`
+                        # keyword argument in `from_dlpack` when the input is already
+                        # a DLPack capsule. In that case, we convert first and then
+                        # move to the target device.
+                        array_converted = xp.from_dlpack(array)
+                        if device is not None:
+                            array_converted = xp.to_device(array_converted, device)
                     # `AttributeError` occurs when `__dlpack__` and `__dlpack_device__`
                     # methods are not present on the input array
                     # `TypeError` and `NotImplementedError` for packages that do not


### PR DESCRIPTION
## What

The `move_to` utility function fails when using a torch namespace and converting a pandas Series (or similar object) to a torch tensor. The error occurs because `torch.from_dlpack` does not support the `device` keyword argument when the input is already a DLPack capsule.

```
AssertionError: device and copy kwargs not supported when ext_tensor is already a DLPack capsule.
```

## Fix

Wrap the `xp.from_dlpack(array, device=device)` call in a try/except that catches `TypeError` and `AssertionError`. When the call fails, fall back to calling `from_dlpack` without the `device` argument and then explicitly move the resulting array to the target device using `xp.to_device`.

Closes #34046