### PR TITLE
Fix: Array-API - avoid failing for numpy fit + predict with sparse or array-like X

### DIFF
--- a/doc/whats_new/upcoming_changes/array-api/34144.fix.rst
+++ b/doc/whats_new/upcoming_changes/array-api/34144.fix.rst
@@ -1,0 +1,5 @@
+- Fixed a bug where NumPy-fitted estimators could raise an error with
+  ``config_context(array_api_dispatch=True)`` when making predictions with
+  array-like or SciPy sparse inputs, or when a fitted attribute was sparse,
+  such as after calling :meth:`linear_model.LogisticRegression.sparsify`.
+  By :user:`Arthur Lacote <cakedev0>`.

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -1146,9 +1146,9 @@ def check_same_namespace(X, estimator, *, attribute, method):
     if X_device is None:
         type_name = "sparse array" if sp.issparse(X) else "array-like"
         msg = (
-            f"Array namespaces used during fit ({a_xp.__name__}) "
+            f"Array namespace used during fit ({a_xp.__name__}) "
             f"is not compatible with the {type_name} input passed to {method}. "
-            f"Only NumPy namespaces might be compatible with {type_name} inputs."
+            f"Only the NumPy namespace is compatible with {type_name} inputs."
         )
     elif X_xp != a_xp:
         msg = (

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -1132,13 +1132,15 @@ def check_same_namespace(X, estimator, *, attribute, method):
 
     X_xp, _, X_device = get_namespace_and_device(X)
 
-    if X_xp == a_xp and (
-        # device matches
-        X_device == a_device
-        # or: X is a list/dataframe/sparse matrix/etc.
-        # and the estimator was fitted on Numpy/CPU
-        or (X_device is None and _is_numpy_namespace(a_xp))
-    ):
+    if X_xp == a_xp and X_device == a_device:
+        return
+
+    if _is_numpy_namespace(a_xp) and _is_numpy_namespace(X_xp):
+        # this condition is reached when either:
+        # - `X` is array-like or sparse-matrix and the estimator was fitted with numpy
+        # - `attr` is a sparse matrix and `X` is a numpy array
+        # in which case devices are different (None vs "cpu") but
+        # `check_same_namespace` should not raise
         return
 
     if X_device is None:

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -1144,7 +1144,7 @@ def check_same_namespace(X, estimator, *, attribute, method):
         return
 
     if X_device is None:
-        type_name = "sparse matrix" if sp.issparse(X) else "array-like"
+        type_name = "sparse array" if sp.issparse(X) else "array-like"
         msg = (
             f"Array namespaces used during fit ({a_xp.__name__}) "
             f"is not compatible with the {type_name} input passed to {method}. "

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -1163,7 +1163,7 @@ def check_same_namespace(X, estimator, *, attribute, method):
         "must use the same namespace and the same device as those passed to fit(). "
         f"{msg} "
         "You can move the estimator to the same namespace and device as X with: "
-        "'from sklearn.utils._array_api import move_estimator_to; "
+        "'from sklearn.utils._array_api import get_namespace_and_device, move_estimator_to; "
         "xp, _, device = get_namespace_and_device(X); "
         "estimator = move_estimator_to(estimator, xp, device)'"
     )

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -1132,8 +1132,22 @@ def check_same_namespace(X, estimator, *, attribute, method):
 
     X_xp, _, X_device = get_namespace_and_device(X)
 
-    if X_xp == a_xp and X_device == a_device:
+    if X_xp == a_xp and (
+        # device matches
+        X_device == a_device
+        # or: X is a list/dataframe/sparse matrix/etc.
+        # and the estimator was fitted on Numpy/CPU
+        or (X_device is None and _is_numpy_namespace(a_xp))
+    ):
         return
+
+    if X_device is None:
+        type_name = "sparse matrix" if sp.issparse(X) else "array-like"
+        msg = (
+            f"Array namespaces used during fit ({a_xp.__name__}) "
+            f"is not compatible with the {type_name} input passed to {method}. "
+            f"Only NumPy namespaces might compatible with {type_name} inputs."
+        )
 
     if X_xp != a_xp:
         msg = (

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -1146,7 +1146,7 @@ def check_same_namespace(X, estimator, *, attribute, method):
         msg = (
             f"Array namespaces used during fit ({a_xp.__name__}) "
             f"is not compatible with the {type_name} input passed to {method}. "
-            f"Only NumPy namespaces might compatible with {type_name} inputs."
+            f"Only NumPy namespaces might be compatible with {type_name} inputs."
         )
 
     if X_xp != a_xp:

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -1148,8 +1148,7 @@ def check_same_namespace(X, estimator, *, attribute, method):
             f"is not compatible with the {type_name} input passed to {method}. "
             f"Only NumPy namespaces might be compatible with {type_name} inputs."
         )
-
-    if X_xp != a_xp:
+    elif X_xp != a_xp:
         msg = (
             f"Array namespaces used during fit ({a_xp.__name__}) "
             f"and {method} ({X_xp.__name__}) differ."

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -1163,7 +1163,8 @@ def check_same_namespace(X, estimator, *, attribute, method):
         "must use the same namespace and the same device as those passed to fit(). "
         f"{msg} "
         "You can move the estimator to the same namespace and device as X with: "
-        "'from sklearn.utils._array_api import get_namespace_and_device, move_estimator_to; "
+        "'from sklearn.utils._array_api import get_namespace_and_device, "
+        "move_estimator_to; "
         "xp, _, device = get_namespace_and_device(X); "
         "estimator = move_estimator_to(estimator, xp, device)'"
     )

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -503,6 +503,9 @@ class SimpleEstimator(BaseEstimator):
         check_same_namespace(X, self, attribute="X_", method="predict")
         return X
 
+    def sparsify(self):
+        self.X_ = sp.csr_matrix(self.X_)
+
 
 class SimpleEstimatorCustomLogic(BaseEstimator):
     def fit(self, X, y=None):
@@ -616,6 +619,11 @@ def test_check_fitted_attribute_with_non_array_input(X):
         est = SimpleEstimator().fit(numpy.asarray([[1.3, 4.5]]))
         # shouldn't raise:
         est.predict(X)
+
+        est.sparsify()
+        # shouldn't raise either:
+        est.predict(X)
+        est.predict(numpy.asarray([[1.3, 4.5]]))
 
         est = SimpleEstimator().fit(xp.asarray([[1.3, 4.5]]))
         with pytest.raises(ValueError, match="Array namespaces.*not compatible"):

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -613,6 +613,11 @@ def test_check_fitted_attribute():
 @skip_if_array_api_compat_not_configured
 @pytest.mark.parametrize("X", [[[1.3, 4.5]], sp.csr_array([[1.3, 4.5]])])
 def test_check_fitted_attribute_with_non_array_input(X):
+    """Check validation of non-array input against fitted attribute ``X_``.
+
+    ``SimpleEstimator.predict`` calls ``check_same_namespace`` with
+    ``attribute="X_"`` to compare the input with the fitted data.
+    """
     xp = pytest.importorskip("array_api_strict")
 
     with config_context(array_api_dispatch=True):

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -607,6 +607,21 @@ def test_check_fitted_attribute():
             est.predict(numpy.asarray([0]))
 
 
+@skip_if_array_api_compat_not_configured
+@pytest.mark.parametrize("X", [[[1.3, 4.5]], sp.csr_array([[1.3, 4.5]])])
+def test_check_fitted_attribute_with_non_array_input(X):
+    xp = pytest.importorskip("array_api_strict")
+
+    with config_context(array_api_dispatch=True):
+        est = SimpleEstimator().fit(numpy.asarray([[1.3, 4.5]]))
+        # shouldn't raise:
+        est.predict(X)
+
+        est = SimpleEstimator().fit(xp.asarray([[1.3, 4.5]]))
+        with pytest.raises(ValueError, match=".*Array namespaces.*not compatible"):
+            est.predict(X)
+
+
 @pytest.mark.parametrize(
     "namespace, device_name, dtype_name",
     yield_namespace_device_dtype_combinations(),

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -631,7 +631,7 @@ def test_check_fitted_attribute_with_non_array_input(X):
         est.predict(numpy.asarray([[1.3, 4.5]]))
 
         est = SimpleEstimator().fit(xp.asarray([[1.3, 4.5]]))
-        with pytest.raises(ValueError, match="Array namespaces.*not compatible"):
+        with pytest.raises(ValueError, match="Array namespace.*not compatible"):
             est.predict(X)
 
 

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -618,7 +618,7 @@ def test_check_fitted_attribute_with_non_array_input(X):
         est.predict(X)
 
         est = SimpleEstimator().fit(xp.asarray([[1.3, 4.5]]))
-        with pytest.raises(ValueError, match=".*Array namespaces.*not compatible"):
+        with pytest.raises(ValueError, match="Array namespaces.*not compatible"):
             est.predict(X)
 
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #34132 

#### What does this implement/fix? Explain your changes.

- Add a condition in `check_same_namespace` to allow the cases:
  - [estimator `xp` is numpy, X is not an array]
  - [estimator is sparsified, X is a numpy array]
- Add a (hopefully) helpful error message for the case [estimator's `xp` is NOT numpy, X is not an array], for which the current message might be quite hard to understand.
- Add tests

#### AI usage disclosure

I used AI assistance for:
- Test/benchmark generation
- Research and understanding

