### PR TITLE
Limit HGBT threads on small datasets

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.ensemble/30662.efficiency.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.ensemble/30662.efficiency.rst
@@ -1,0 +1,4 @@
+- |Efficiency| :class:`ensemble.HistGradientBoostingClassifier` and
+  :class:`ensemble.HistGradientBoostingRegressor` now limit the number of OpenMP
+  threads used during fitting on small datasets to avoid thread scheduling overhead.
+  By :user:`hanhan761 <hanhan761>`.

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -65,6 +65,16 @@ _LOSSES.update(
 )
 
 
+def _adjust_n_threads_for_small_hgb(n_samples, n_features, max_threads):
+    """Limit OpenMP overhead when fitting HGBT on small datasets."""
+    if max_threads <= 1:
+        return max_threads
+
+    n_threads = max(n_samples * n_features // int(1e5), 1)
+    n_threads = min(n_threads, max(n_features // 2, 1))
+    return min(n_threads, max_threads)
+
+
 def _update_leaves_values(loss, grower, y_true, raw_prediction, sample_weight):
     """Update the leaf values to be predicted by the tree.
 
@@ -523,7 +533,11 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
 
         # `_openmp_effective_n_threads` is used to take cgroups CPU quotes
         # into account when determine the maximum number of threads to use.
-        n_threads = _openmp_effective_n_threads()
+        n_threads = _adjust_n_threads_for_small_hgb(
+            n_samples=n_samples,
+            n_features=self._n_features,
+            max_threads=_openmp_effective_n_threads(),
+        )
 
         if isinstance(self.loss, str):
             self._loss = self._get_loss(sample_weight=sample_weight)

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -51,6 +51,44 @@ X_multi_classification, y_multi_classification = make_classification(
 )
 
 
+@pytest.mark.parametrize(
+    "n_samples, n_features, max_threads, expected_n_threads",
+    [
+        (100, 10, 8, 1),
+        (1_000, 100, 8, 1),
+        (10_000, 100, 8, 8),
+        (10_000, 100, 4, 4),
+        (10_000, 1, 8, 1),
+    ],
+)
+def test_adjust_n_threads_for_small_hgb(
+    n_samples, n_features, max_threads, expected_n_threads
+):
+    assert (
+        hgb_module._adjust_n_threads_for_small_hgb(
+            n_samples=n_samples,
+            n_features=n_features,
+            max_threads=max_threads,
+        )
+        == expected_n_threads
+    )
+
+
+def test_fit_adjusts_n_threads_for_small_hgb(monkeypatch):
+    X = X_regression[:50]
+    y = y_regression[:50]
+    adjust_n_threads = Mock(return_value=1)
+
+    monkeypatch.setattr(hgb_module, "_openmp_effective_n_threads", Mock(return_value=8))
+    monkeypatch.setattr(hgb_module, "_adjust_n_threads_for_small_hgb", adjust_n_threads)
+
+    HistGradientBoostingRegressor(max_iter=1, random_state=0).fit(X, y)
+
+    adjust_n_threads.assert_called_once_with(
+        n_samples=X.shape[0], n_features=X.shape[1], max_threads=8
+    )
+
+
 def _make_dumb_dataset(n_samples):
     """Make a dumb dataset to test early stopping."""
     rng = np.random.RandomState(42)


### PR DESCRIPTION
## Summary
- Limit OpenMP threads used by HistGradientBoosting* during fitting on small datasets.
- Add regression coverage for the thread-count heuristic and its fit-time integration.
- Add a whats_new efficiency entry for the ensemble module.

## Related issues
- Part of #34128
- Helps address #30662

## Test plan
- python -m pytest sklearn\ensemble\_hist_gradient_boosting\tests -q