### PR TITLE
DOC Clarify GPR multi-output behavior

### DIFF
--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -48,6 +48,10 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
     Bayesian modelling approach, refer to the example entitled
     :ref:`sphx_glr_auto_examples_gaussian_process_plot_compare_gpr_krr.py`.
 
+    Multi-output targets are handled by fitting one Gaussian process per target
+    while sharing the same kernel hyperparameters. This estimator does not model
+    correlations between different target dimensions.
+
     Read more in the :ref:`User Guide <gaussian_process>`.
 
     .. versionadded:: 0.18


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #13989.

#### What does this implement/fix? Explain your changes.

This PR adds a short note to the `GaussianProcessRegressor` docstring clarifying how multi-output targets are handled.

The implementation computes the log marginal likelihood independently for each output and sums across outputs. The new wording explains that the estimator fits one Gaussian process per target while sharing the same kernel hyperparameters, and does not model correlations between target dimensions.

#### AI usage disclosure

I used AI assistance for:

- Documentation wording
- Research and understanding

#### Any other comments?

I kept the change intentionally small and documentation-only, following the scope discussed in the issue.