### PR TITLE
TST use global_random_seed in sklearn/utils/tests/test_arrayfuncs.py

### DIFF
--- a/sklearn/utils/tests/test_arrayfuncs.py
+++ b/sklearn/utils/tests/test_arrayfuncs.py
@@ -5,10 +5,10 @@ from sklearn.utils._testing import assert_allclose
 from sklearn.utils.arrayfuncs import _all_with_any_reduction_axis_1, min_pos
 
 
-def test_min_pos():
+def test_min_pos(global_random_seed):
     # Check that min_pos returns a positive value and that it's consistent
     # between float and double
-    X = np.random.RandomState(0).randn(100)
+    X = np.random.RandomState(global_random_seed).randn(100)
 
     min_double = min_pos(X)
     min_float = min_pos(X.astype(np.float32))


### PR DESCRIPTION
Reference: #22827.

Convert `test_min_pos` to use the `global_random_seed` fixture instead of a hardcoded `RandomState(0)`. The test asserts that `min_pos` agrees between float32 and float64 on a random input, so it is genuinely independent of the seed and benefits from being exercised across the full seed range.

```diff
-def test_min_pos():
+def test_min_pos(global_random_seed):
     # Check that min_pos returns a positive value and that it's consistent
     # between float and double
-    X = np.random.RandomState(0).randn(100)
+    X = np.random.RandomState(global_random_seed).randn(100)
```

The other two tests in the file (`test_min_pos_no_positive`, `test_all_with_any_reduction_axis_1`) use deterministic inputs and don't need a fixture.

### Verification

`SKLEARN_TESTS_GLOBAL_RANDOM_SEED="all" pytest sklearn/utils/tests/test_arrayfuncs.py` — 100 / 100 seeds pass for `test_min_pos`; 117 / 117 tests pass for the whole file.