### PR TITLE
DOC Document open_listener thread-safety requirement

### DIFF
--- a/sklearn/callback/_transport.py
+++ b/sklearn/callback/_transport.py
@@ -73,8 +73,10 @@ def open_listener(message_consumer, *, owner=None):
     Parameters
     ----------
     message_consumer : callable
-        A one-argument function, `message_consumer(message)`, that processes incoming
-        message to update the callback's state.
+        A one-argument function, `message_consumer(message)`, that processes
+        incoming messages to update the callback's state.
+        It must be thread-safe because it can be called concurrently by multiple
+        listener threads when workers use threads instead of processes.
 
     owner : callback instance, default=None
         Optional owner callback. When provided, the listener is automatically closed


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #34145.

#### What does this implement/fix? Explain your changes.
This updates the `open_listener` docstring to state that `message_consumer` must be thread-safe because it may be called concurrently by listener threads when workers use threads instead of processes.

#### Any other comments?
Checks run locally:
- `git diff --check`
- `python -m py_compile sklearn/callback/_transport.py`
- `/tmp/sklearn-lint-venv/bin/python -m ruff check sklearn/callback/_transport.py`