### PR TITLE
Proof of concept: Thread oversaturation mitigation

### DIFF
--- a/examples/model_selection/plot_grid_search_refit_callable.py
+++ b/examples/model_selection/plot_grid_search_refit_callable.py
@@ -139,7 +139,7 @@ grid = GridSearchCV(
     # Use a non-stratified CV strategy to make sure that the inter-fold
     # standard deviation of the test scores is informative.
     cv=ShuffleSplit(n_splits=30, random_state=0),
-    n_jobs=1,  # increase this on your machine to use more physical cores
+    n_jobs=-1,  # increase this on your machine to use more physical cores
     param_grid=param_grid,
     scoring="accuracy",
     refit=best_low_complexity,

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -21,10 +21,11 @@ import logging
 import os
 import random
 
+import joblib
+
 from sklearn._config import config_context, get_config, set_config
 
 logger = logging.getLogger(__name__)
-
 
 # PEP0440 compatible formatted version, see:
 # https://www.python.org/dev/peps/pep-0440/
@@ -149,3 +150,16 @@ def setup_module(module):
     print("I: Seeding RNGs with %r" % _random_seed)
     np.random.seed(_random_seed)
     random.seed(_random_seed)
+
+
+def _enable_threading():
+    threading_mode = os.getenv("SKLEARN_THREADING")
+    if threading_mode is None:
+        return
+
+    # TODO figuer out if parallel_config()'s public API guarantees
+    # non-contextmanager usage works.
+    joblib.parallel_config(backend="threading").__enter__()
+
+
+_enable_threading()

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -160,6 +160,10 @@ def _enable_threading():
     # TODO figuer out if parallel_config()'s public API guarantees
     # non-contextmanager usage works.
     joblib.parallel_config(backend="threading").__enter__()
+    if threading_mode == "tod":
+        import openblas_tod
+
+        openblas_tod.install()
 
 
 _enable_threading()

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -899,7 +899,8 @@ def test_estimators_samples_deterministic():
     X, y = iris.data, iris.target
 
     base_pipeline = make_pipeline(
-        SparseRandomProjection(n_components=2), LogisticRegression()
+        SparseRandomProjection(n_components=2, random_state=0),
+        LogisticRegression(random_state=0),
     )
     clf = BaggingClassifier(estimator=base_pipeline, max_samples=0.5, random_state=0)
     clf.fit(X, y)

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -899,8 +899,7 @@ def test_estimators_samples_deterministic():
     X, y = iris.data, iris.target
 
     base_pipeline = make_pipeline(
-        SparseRandomProjection(n_components=2, random_state=0),
-        LogisticRegression(random_state=0),
+        SparseRandomProjection(n_components=2), LogisticRegression()
     )
     clf = BaggingClassifier(estimator=base_pipeline, max_samples=0.5, random_state=0)
     clf.fit(X, y)

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -35,7 +35,7 @@ class ConstrainedThreadingBackend(ThreadingBackend):
 
     def _limit_nested_thread_pools(self):
         # OpenMP thread limits are per-thread:
-        _get_threadpool_controller().limit(
+        ThreadpoolController().limit(
             limits=max(joblib.cpu_count() // self._n_jobs, 1), user_api="openmp"
         )
 

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -36,7 +36,7 @@ class ConstrainedThreadingBackend(ThreadingBackend):
     def _limit_nested_thread_pools(self):
         # OpenMP thread limits are per-thread:
         _get_threadpool_controller().limit(
-            limits=joblib.cpu_count() // self._n_jobs, user_api="openmp"
+            limits=max(joblib.cpu_count() // self._n_jobs, 1), user_api="openmp"
         )
 
     # TODO: this is a private joblib API

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -138,6 +138,7 @@ class Parallel(joblib.Parallel):
         # Given this limitation, algorithms that cannot saturate all cores
         # should having documentation suggesting either sticking to process
         # pools, or choosing a better BLAS library.
+        # TODO don't do this on process pools:
         with _get_threadpool_controller().limit(
             limits=max(joblib.cpu_count() // self.n_jobs, 1)
         ):

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -8,8 +8,10 @@ usage.
 import functools
 import warnings
 from functools import update_wrapper
+from multiprocessing.pool import ThreadPool
 
 import joblib
+from joblib.parallel import ThreadingBackend
 from threadpoolctl import ThreadpoolController
 
 from sklearn._config import config_context, get_config
@@ -19,6 +21,37 @@ from sklearn._config import config_context, get_config
 # It should not be accessed directly and _get_threadpool_controller should be used
 # instead.
 _threadpool_controller = None
+
+
+class ConstrainedThreadingBackend(ThreadingBackend):
+    """
+    Prevent oversaturation by limiting OpenMP pool sizes.
+
+    OpenMP pool size limits are thread-local, which is why we need to do this
+    for every thread in the pool.
+
+    This should eventually be the default in joblib.
+    """
+
+    def _limit_nested_thread_pools(self):
+        # OpenMP thread limits are per-thread:
+        _get_threadpool_controller().limit(
+            limits=joblib.cpu_count() // self._n_jobs, user_api="openmp"
+        )
+
+    # TODO: this is a private joblib API
+    def _get_pool(self):
+        if self._pool is None:
+            self._pool = ThreadPool(
+                self._n_jobs, initializer=self._limit_nested_thread_pools
+            )
+        return self._pool
+
+
+# TODO it's unclear if joblib intended for pre-existing backends to be
+#      overridable.
+# Override default threading backend with one that limits oversaturation:
+joblib.register_parallel_backend("threading", ConstrainedThreadingBackend)
 
 
 def _with_config_and_warning_filters(delayed_func, config, warning_filters):
@@ -88,7 +121,27 @@ class Parallel(joblib.Parallel):
             )
             for delayed_func, args, kwargs in iterable
         )
-        return super().__call__(iterable_with_config_and_warning_filters)
+
+        # For processes this is redundant, matching the default logic in
+        # joblib. For threads, the OpenMP limit will be only for this thread,
+        # so we need to do it for other threads too; see
+        # ConstrainedThreadingBackend.
+        #
+        # Note that for BLAS libraries that don't know about OpenMP (e.g.
+        # OpenBLAS with pthreads) this limit may be too low if n_jobs is
+        # smaller than the number of available cores. The result is that BLAS
+        # calculations will be limited to only n_job cores instead of all
+        # cores. The alternative is having the number be too high, and given
+        # oversaturation can make OpenBLAS orders of magnitude slower, this is
+        # the better choice.
+        #
+        # Given this limitation, algorithms that cannot saturate all cores
+        # should having documentation suggesting either sticking to process
+        # pools, or choosing a better BLAS library.
+        with _get_threadpool_controller().limit(
+            limits=max(joblib.cpu_count() // self.n_jobs, 1)
+        ):
+            return super().__call__(iterable_with_config_and_warning_filters)
 
 
 # remove when https://github.com/joblib/joblib/issues/1071 is fixed


### PR DESCRIPTION
This is a sketch of what a fix for #34070 might look like.

You can enable thread pools globally by setting an environment variable `SKLEARN_THREADING=1` (this was added just for experimentation purposes, it's not intended to be merged.)

The changes in `parallel.py` then prevent oversaturation (tested with OpenBLAS pthreads and OpenBLAS OpenMP variants). Plausibly these changes should be done upstream in `joblib`, rather than here.