### PR TITLE
Skip kernel computation when nu is infeasible in NuSVC

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.svm/34177.efficiency.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.svm/34177.efficiency.rst
@@ -1,0 +1,4 @@
+- :class:`svm.NuSVC` now checks the feasibility of `nu` before computing the
+  kernel, so an infeasible `nu` raises early instead of first materializing a
+  potentially expensive precomputed or callable kernel.
+  By :user:`Lawson Darrow <Lawson-Darrow>`.

--- a/sklearn/svm/_base.py
+++ b/sklearn/svm/_base.py
@@ -83,6 +83,49 @@ def _one_vs_one_coef(dual_coef, n_support, support_vectors):
     return coef
 
 
+def _check_nu_feasibility(y, nu, sample_weight):
+    """Check the feasibility of `nu` for nu-SVC the same way libsvm does.
+
+    For each pair of classes ``(i, j)``, ``nu`` is feasible only if
+    ``nu * (n_i + n_j) / 2 <= min(n_i, n_j)``, where ``n_i`` is the (possibly
+    sample-weighted) number of samples of class ``i``. This mirrors the check
+    in ``svm_check_parameter`` in ``sklearn/svm/src/libsvm/svm.cpp`` and lets
+    us fail fast with the same error before computing a potentially expensive
+    callable kernel.
+
+    Parameters
+    ----------
+    y : ndarray of shape (n_samples,)
+        Encoded target values (one integer-valued float per class).
+
+    nu : float
+        The ``nu`` parameter of the nu-SVC model.
+
+    sample_weight : ndarray of shape (n_samples,) or shape (0,)
+        Per-sample weights. An empty array means uniform weights, matching the
+        libsvm default where ``W[i] == 1``.
+
+    Raises
+    ------
+    ValueError
+        If ``nu`` is infeasible, with the same message libsvm would raise.
+    """
+    classes, y_indices = np.unique(y, return_inverse=True)
+    if sample_weight.shape[0] == 0:
+        counts = np.bincount(y_indices, minlength=classes.shape[0]).astype(np.float64)
+    else:
+        counts = np.bincount(
+            y_indices, weights=sample_weight, minlength=classes.shape[0]
+        )
+
+    for i in range(counts.shape[0]):
+        n1 = counts[i]
+        for j in range(i + 1, counts.shape[0]):
+            n2 = counts[j]
+            if nu * (n1 + n2) / 2 > min(n1, n2):
+                raise ValueError("specified nu is infeasible")
+
+
 class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
     """Base class for estimators that use libsvm as backing library.
 
@@ -284,6 +327,15 @@ class BaseLibSVM(BaseEstimator, metaclass=ABCMeta):
                 self._gamma = 1.0 / X.shape[1]
         elif isinstance(self.gamma, Real):
             self._gamma = self.gamma
+
+        # For nu-SVC, the feasibility of `nu` only depends on the (possibly
+        # sample-weighted) class counts, not on the kernel. Check it here, before
+        # a potentially expensive callable kernel is computed in `_dense_fit`, so
+        # that an infeasible `nu` fails fast with the same error libsvm raises.
+        # libsvm performs the same check internally, but only after the kernel
+        # has been computed; this extra O(n) check has negligible overhead.
+        if self._impl == "nu_svc":
+            _check_nu_feasibility(y, self.nu, sample_weight)
 
         fit = self._sparse_fit if self._sparse else self._dense_fit
         if self.verbose:

--- a/sklearn/svm/tests/test_svm.py
+++ b/sklearn/svm/tests/test_svm.py
@@ -643,6 +643,76 @@ def test_negative_weights_svc_leave_just_one_label(Classifier, err_msg, sample_w
         clf.fit(X, Y, sample_weight=sample_weight)
 
 
+def test_nusvc_infeasible_nu_skips_callable_kernel():
+    """nu feasibility must be checked before computing a callable kernel.
+
+    Non-regression test for
+    https://github.com/scikit-learn/scikit-learn/issues/33478: with an
+    infeasible `nu`, `NuSVC` should raise "specified nu is infeasible" without
+    ever evaluating a (potentially expensive) callable kernel.
+    """
+    n_calls = {"count": 0}
+
+    def counting_kernel(X, Y):
+        n_calls["count"] += 1
+        return np.dot(X, Y.T)
+
+    # Imbalanced binary problem: 2 vs 8 samples. nu is feasible iff
+    # nu * (n_i + n_j) / 2 <= min(n_i, n_j), i.e. nu * 10 / 2 <= 2 -> nu <= 0.4.
+    rng = np.random.RandomState(0)
+    X_unbalanced = rng.randn(10, 3)
+    y_unbalanced = np.array([0, 0, 1, 1, 1, 1, 1, 1, 1, 1])
+
+    # Infeasible nu: error is raised and the kernel is never computed.
+    with pytest.raises(ValueError, match="specified nu is infeasible"):
+        svm.NuSVC(kernel=counting_kernel, nu=0.9).fit(X_unbalanced, y_unbalanced)
+    assert n_calls["count"] == 0
+
+    # Feasible nu: model fits normally and the kernel is computed as before.
+    svm.NuSVC(kernel=counting_kernel, nu=0.3).fit(X_unbalanced, y_unbalanced)
+    assert n_calls["count"] > 0
+
+
+def test_nusvc_early_nu_feasibility_matches_libsvm():
+    """The early nu-feasibility check must match libsvm's exact boundary.
+
+    Non-regression test for
+    https://github.com/scikit-learn/scikit-learn/issues/33478. For each `nu`,
+    the result of the callable-kernel path (which is checked early, in Python)
+    must agree with the built-in-kernel path (checked inside libsvm), including
+    the effect of ``sample_weight`` on the per-class counts.
+    """
+    rng = np.random.RandomState(0)
+    X_unbalanced = rng.randn(10, 3)
+    y_unbalanced = np.array([0, 0, 1, 1, 1, 1, 1, 1, 1, 1])
+
+    def callable_linear(X, Y):
+        return np.dot(X, Y.T)
+
+    for nu in [0.1, 0.39, 0.4, 0.41, 0.8, 1.0]:
+        early_infeasible = False
+        try:
+            svm.NuSVC(kernel=callable_linear, nu=nu).fit(X_unbalanced, y_unbalanced)
+        except ValueError:
+            early_infeasible = True
+
+        libsvm_infeasible = False
+        try:
+            svm.NuSVC(kernel="linear", nu=nu).fit(X_unbalanced, y_unbalanced)
+        except ValueError:
+            libsvm_infeasible = True
+
+        assert early_infeasible == libsvm_infeasible
+
+    # sample_weight rescales the class counts: weighting the two minority-class
+    # samples by 4 balances the problem (weighted counts 8 vs 8), making nu=0.9
+    # feasible where it was infeasible with uniform weights.
+    sample_weight = np.array([4.0, 4.0, 1, 1, 1, 1, 1, 1, 1, 1])
+    svm.NuSVC(kernel=callable_linear, nu=0.9).fit(
+        X_unbalanced, y_unbalanced, sample_weight=sample_weight
+    )
+
+
 @pytest.mark.parametrize(
     "Classifier, model",
     [


### PR DESCRIPTION
Fixes #33478

When `NuSVC` is fit with a callable kernel, the full kernel matrix is computed before libsvm checks whether `nu` is feasible. For expensive custom kernels this wastes a lot of work, since an infeasible `nu` then fails immediately with "specified nu is infeasible".

The feasibility check only depends on the per class counts and `nu`, not on the kernel. This moves an equivalent check to the Python side in `BaseLibSVM.fit`, before the kernel is computed.

The condition mirrors libsvm's check in `svm_check_parameter` (`svm.cpp`). For every pair of classes it requires `nu * (n_i + n_j) / 2 <= min(n_i, n_j)`, where the counts are sample weighted to match libsvm's `W[i]`. The check is gated to NuSVC only, since NuSVR and OneClassSVM are not subject to it in libsvm.

An infeasible `nu` now raises before any kernel call. A feasible `nu` is unaffected apart from an O(n) count over the labels.

Added two regression tests in `test_svm.py`: one asserts the callable kernel is never invoked when `nu` is infeasible, the other checks the early verdict matches the libsvm built in kernel path across a range of `nu` values and under sample weights.
