### PR TITLE
DOC Clarify that best_params_, best_score_, best_estimator_ reflect last halving iteration

### DIFF
--- a/sklearn/model_selection/_search_successive_halving.py
+++ b/sklearn/model_selection/_search_successive_halving.py
@@ -603,17 +603,23 @@ class HalvingGridSearchCV(BaseSuccessiveHalving):
         for details.
         For an example of analysing ``cv_results_``,
         see :ref:`sphx_glr_auto_examples_model_selection_plot_grid_search_stats.py`.
-
-    best_estimator_ : estimator or dict
+    968best_estimator_ : estimator or dict
         Estimator that was chosen by the search, i.e. estimator
         which gave highest score (or smallest loss if specified)
-        on the left out data. Not available if ``refit=False``.
+        on the left out data **in the last halving iteration**.
+        Not available if ``refit=False``.
 
     best_score_ : float
-        Mean cross-validated score of the best_estimator.
+        Mean cross-validated score of the best_estimator, corresponding
+        to the last halving iteration. Note that this may differ from
+        the highest score in ``cv_results_``, which includes results
+        from all iterations.
 
     best_params_ : dict
-        Parameter setting that gave the best results on the hold out data.
+        Parameter setting that gave the best results on the hold out
+        data in the last halving iteration. Note that earlier iterations
+        may show higher scores in ``cv_results_`` due to evaluating
+        candidates on fewer resources.
 
     best_index_ : int
         The index (of the ``cv_results_`` arrays) which corresponds to the best
@@ -968,13 +974,20 @@ class HalvingRandomSearchCV(BaseSuccessiveHalving):
     best_estimator_ : estimator or dict
         Estimator that was chosen by the search, i.e. estimator
         which gave highest score (or smallest loss if specified)
-        on the left out data. Not available if ``refit=False``.
+        on the left out data **in the last halving iteration**.
+        Not available if ``refit=False``.
 
     best_score_ : float
-        Mean cross-validated score of the best_estimator.
+        Mean cross-validated score of the best_estimator, corresponding
+        to the last halving iteration. Note that this may differ from
+        the highest score in ``cv_results_``, which includes results
+        from all iterations.
 
     best_params_ : dict
-        Parameter setting that gave the best results on the hold out data.
+        Parameter setting that gave the best results on the hold out
+        data in the last halving iteration. Note that earlier iterations
+        may show higher scores in ``cv_results_`` due to evaluating
+        candidates on fewer resources.
 
     best_index_ : int
         The index (of the ``cv_results_`` arrays) which corresponds to the best


### PR DESCRIPTION
Fixes #24901

The docstrings for `best_estimator_`, `best_score_`, and `best_params_` 
in both `HalvingGridSearchCV` and `HalvingRandomSearchCV` did not mention 
that these attributes reflect results from the last halving iteration only,
not the globally highest score across all iterations.

This causes confusion because `cv_results_` contains scores from all 
iterations, and users expect the best score to match the top ranked entry 
in `cv_results_`. 

Changes:
- Updated `best_estimator_` docstring to mention "last halving iteration"
- Updated `best_score_` to clarify it may differ from highest score in `cv_results_`
- Updated `best_params_` to explain why earlier iterations may show higher scores
- Applied same changes to both `HalvingGridSearchCV` and `HalvingRandomSearchCV`