### PR TITLE
DOC document rich dependency in ProgressBar docstring

### DIFF
--- a/sklearn/callback/_progressbar.py
+++ b/sklearn/callback/_progressbar.py
@@ -20,6 +20,9 @@ _run_monitors = {}
 class ProgressBar:
     """Callback that displays progress bars for each iterative step of an estimator.
 
+    This callback requires `rich <https://rich.readthedocs.io>`_ to be installed.
+    It can be installed with ``pip install rich``.
+
     Parameters
     ----------
     max_propagation_depth : int, default=1


### PR DESCRIPTION
Closes #34166

Documents that the `ProgressBar` callback requires `rich` to be installed.

Added a note to the class docstring following the same pattern used elsewhere in the codebase (e.g. `SpectralClustering` with `pyamg`).