### PR TITLE
Fix metadata routed to correct consumer in `BaggingClassifier.predict_proba`

### DIFF
--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -199,7 +199,7 @@ def _parallel_predict_proba(
     for estimator, features in zip(estimators, estimators_features):
         if hasattr(estimator, "predict_proba"):
             proba_estimator = estimator.predict_proba(
-                X[:, features], **(predict_params or {})
+                X[:, features], **(predict_proba_params or {})
             )
 
             if n_classes == len(estimator.classes_):
@@ -212,9 +212,7 @@ def _parallel_predict_proba(
 
         else:
             # Resort to voting
-            predictions = estimator.predict(
-                X[:, features], **(predict_proba_params or {})
-            )
+            predictions = estimator.predict(X[:, features], **(predict_params or {}))
 
             for i in range(n_samples):
                 proba[i, predictions[i]] += 1


### PR DESCRIPTION
#### Reference Issues/PRs
discovered while working on #34179

#### What does this implement/fix? Explain your changes.
This fixes a bug where metadata was not routed to the correct underlying consuming function when consuming function is dynamically selected. This makes the repaired tests in #34179 pass.

#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Research and understanding

CC @adrinjalali :)