### PR TITLE
DOC Improve ProgressBar rich dependency note with link and install command

### DIFF
--- a/sklearn/callback/_progressbar.py
+++ b/sklearn/callback/_progressbar.py
@@ -29,7 +29,8 @@ class ProgressBar:
 
     Notes
     -----
-    This callback requires rich to be installed.
+    This callback requires `rich <https://rich.readthedocs.io>`_ to be installed.
+    It can be installed with ``pip install rich``.
     """
 
     @validate_params(

--- a/sklearn/callback/_progressbar.py
+++ b/sklearn/callback/_progressbar.py
@@ -30,7 +30,6 @@ class ProgressBar:
     Notes
     -----
     This callback requires `rich <https://rich.readthedocs.io>`_ to be installed.
-    It can be installed with ``pip install rich``.
     """
 
     @validate_params(


### PR DESCRIPTION
#### Reference Issues/PRs

Follow-up to #34168 (fixes #34166).

#### What does this implement/fix? Explain your changes.

Improves the `ProgressBar` docstring note added in #34168 by:

- Adding a link to the [rich documentation](https://rich.readthedocs.io) using standard RST syntax
- Adding the `pip install rich` command so users know how to install it

#### Any other comments?

Documentation-only change. As suggested in #34184, contributing the improvement here instead.