### PR TITLE
FIX Clip n_nonzero_coefs in OMP instead of raising

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/34193.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/34193.fix.rst
@@ -1,0 +1,4 @@
+- :func:`linear_model.orthogonal_mp` and :func:`linear_model.orthogonal_mp_gram`
+  now clip ``n_nonzero_coefs`` to ``n_features`` with a warning instead of
+  raising a ``ValueError``, consistent with the behavior of LARS.
+  By :user:`Eden Rochman <EdenRochmanSharabi>`.

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -681,6 +681,23 @@ def test_sparse_coder_n_features_in():
     assert sc.n_features_in_ == d.shape[1]
 
 
+def test_sparse_encode_omp_clips_n_nonzero_coefs():
+    n_components = 8
+    rng = np.random.RandomState(0)
+    X_small = rng.randn(10, n_features)
+    V = rng.randn(n_components, n_features)
+    V /= np.linalg.norm(V, axis=1)[:, np.newaxis]
+
+    with pytest.warns(UserWarning, match="was clipped to"):
+        code_omp = sparse_encode(
+            X_small, V, algorithm="omp", n_nonzero_coefs=n_components + 5
+        )
+    code_lars = sparse_encode(
+        X_small, V, algorithm="lars", n_nonzero_coefs=n_components + 5
+    )
+    assert code_omp.shape == code_lars.shape == (10, n_components)
+
+
 def test_sparse_encoder_feature_number_error():
     n_components = 10
     rng = np.random.RandomState(0)

--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -411,9 +411,13 @@ def orthogonal_mp(
         # but at least one.
         n_nonzero_coefs = max(int(0.1 * X.shape[1]), 1)
     if tol is None and n_nonzero_coefs > X.shape[1]:
-        raise ValueError(
-            "The number of atoms cannot be more than the number of features"
+        warnings.warn(
+            "The number of atoms cannot be more than the number of features. "
+            f"n_nonzero_coefs={n_nonzero_coefs} was clipped to "
+            f"n_features={X.shape[1]}.",
+            UserWarning,
         )
+        n_nonzero_coefs = X.shape[1]
     if precompute == "auto":
         precompute = X.shape[0] > X.shape[1]
     if precompute:
@@ -602,9 +606,13 @@ def orthogonal_mp_gram(
     if tol is None and n_nonzero_coefs <= 0:
         raise ValueError("The number of atoms must be positive")
     if tol is None and n_nonzero_coefs > len(Gram):
-        raise ValueError(
-            "The number of atoms cannot be more than the number of features"
+        warnings.warn(
+            "The number of atoms cannot be more than the number of features. "
+            f"n_nonzero_coefs={n_nonzero_coefs} was clipped to "
+            f"n_features={len(Gram)}.",
+            UserWarning,
         )
+        n_nonzero_coefs = len(Gram)
 
     if return_path:
         coef = np.zeros((len(Gram), Xy.shape[1], len(Gram)), dtype=Gram.dtype)

--- a/sklearn/linear_model/tests/test_omp.py
+++ b/sklearn/linear_model/tests/test_omp.py
@@ -98,8 +98,8 @@ def test_unreachable_accuracy():
     "keyword_params",
     [{"n_nonzero_coefs": n_features + 1}],
 )
-def test_bad_input(positional_params, keyword_params):
-    with pytest.raises(ValueError):
+def test_n_nonzero_coefs_clipping(positional_params, keyword_params):
+    with pytest.warns(UserWarning, match="was clipped to"):
         orthogonal_mp(*positional_params, **keyword_params)
 
 


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #33454.

#### What does this implement/fix? Explain your changes.

`OrthogonalMatchingPursuit` raises a `ValueError` when
`n_nonzero_coefs > n_features`, but LARS silently clips to `n_features`.
This means `DictionaryLearning(transform_algorithm="omp")` crashes while
`transform_algorithm="lars"` works fine for the same input.

This PR changes OMP to emit a `UserWarning` and clip `n_nonzero_coefs`
to `n_features`, matching the LARS behavior. The change applies to both
`orthogonal_mp` and `orthogonal_mp_gram`.

The clipping approach is consistent with how LARS handles this
internally (see `max_features = min(max_iter, n_features)` in
`_lars_path_solver`), where the cap was introduced as a memory
pre-allocation guard rather than parameter validation.

#### AI usage disclosure

No AI tools were used for this contribution.

#### Any other comments?