### PR TITLE
ENH Support precomputed kernel in Nystroem

### DIFF
--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -1049,18 +1049,25 @@ class Nystroem(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator)
         n_components = min(n_samples, n_components)
         inds = rnd.permutation(n_samples)
         basis_inds = xp.asarray(inds[:n_components], dtype=xp.int64, device=device)
-        if sp.issparse(X):
-            basis = X[basis_inds]
-        else:
-            basis = _safe_indexing(X, basis_inds, axis=0)
 
-        basis_kernel = pairwise_kernels(
-            basis,
-            metric=self.kernel,
-            filter_params=True,
-            n_jobs=self.n_jobs,
-            **self._get_kernel_params(),
-        )
+        kernel_params = self._get_kernel_params()
+
+        if self.kernel == "precomputed":
+            basis_kernel = X[np.ix_(basis_inds, basis_inds)]
+            basis = None
+        else:
+            if sp.issparse(X):
+                basis = X[basis_inds]
+            else:
+                basis = _safe_indexing(X, basis_inds, axis=0)
+
+            basis_kernel = pairwise_kernels(
+                basis,
+                metric=self.kernel,
+                filter_params=True,
+                n_jobs=self.n_jobs,
+                **kernel_params,
+            )
 
         # sqrt of kernel matrix on basis vectors
         _, _, dtype = _find_floating_dtype_allow_sparse(basis_kernel, Y=None, xp=xp)
@@ -1094,15 +1101,18 @@ class Nystroem(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator)
         xp, _, device = get_namespace_and_device(X)
         X = validate_data(self, X, accept_sparse="csr", reset=False)
 
-        kernel_params = self._get_kernel_params()
-        embedded = pairwise_kernels(
-            X,
-            self.components_,
-            metric=self.kernel,
-            filter_params=True,
-            n_jobs=self.n_jobs,
-            **kernel_params,
-        )
+        if self.kernel == "precomputed":
+            embedded = X[:, self.component_indices_]
+        else:
+            kernel_params = self._get_kernel_params()
+            embedded = pairwise_kernels(
+                X,
+                self.components_,
+                metric=self.kernel,
+                filter_params=True,
+                n_jobs=self.n_jobs,
+                **kernel_params,
+            )
         dtype = _find_matching_floating_dtype(embedded, xp=xp)
         embedded = xp.asarray(embedded, dtype=dtype, device=device)
         return embedded @ self.normalization_.T

--- a/sklearn/tests/test_kernel_approximation.py
+++ b/sklearn/tests/test_kernel_approximation.py
@@ -488,6 +488,27 @@ def test_nystroem_precomputed_kernel():
             ny.fit(K)
 
 
+def test_nystroem_precomputed_kernel_subsample():
+    """Check Nystroem with precomputed kernel and n_components < n_samples.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/29353
+    """
+    rnd = np.random.RandomState(0)
+    X = rnd.randn(50, 5)
+    K = polynomial_kernel(X, degree=2, coef0=0.1)
+
+    n_components = 20
+    nystroem = Nystroem(kernel="precomputed", n_components=n_components, random_state=0)
+    X_transformed = nystroem.fit_transform(K)
+    assert X_transformed.shape == (50, n_components)
+
+    X_transformed2 = nystroem.transform(K)
+    assert_array_almost_equal(X_transformed, X_transformed2)
+
+    assert nystroem.components_ is None
+
+
 def test_nystroem_component_indices():
     """Check that `component_indices_` corresponds to the subset of
     training points used to construct the feature map.


### PR DESCRIPTION
Closes #29353.

`Nystroem` accepts `kernel="precomputed"` but fails when
`n_components < n_samples` because it tries to call `pairwise_kernels`
on rows of a precomputed kernel matrix as if they were feature vectors.

This PR adds a precomputed path in both `fit` and `transform`:

- `fit`: extracts the basis submatrix directly from the precomputed
  kernel matrix using `np.ix_` instead of calling `pairwise_kernels`.
  `components_` is set to `None` since there are no raw feature vectors
  to store.
- `transform`: selects the relevant columns via
  `component_indices_` instead of calling `pairwise_kernels`.

Validation of `gamma`/`coef0`/`degree` through `_get_kernel_params()`
is preserved for all kernel types.