### PR TITLE
FIX Clamp variance to zero in f_regression for constant columns

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.feature_selection/34197.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.feature_selection/34197.fix.rst
@@ -1,0 +1,4 @@
+- :func:`feature_selection.r_regression` and :func:`feature_selection.f_regression`
+  no longer emit a spurious ``RuntimeWarning`` for constant features when floating
+  point cancellation makes the computed variance slightly negative.
+  By :user:`Eden Rochman <EdenRochmanSharabi>`.

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -377,7 +377,9 @@ def r_regression(X, y, *, center=True, force_finite=True):
         X_means = X.mean(axis=0)
         X_means = X_means.getA1() if isinstance(X_means, np.matrix) else X_means
         # Compute the scaled standard deviations via moments
-        X_norms = np.sqrt(row_norms(X.T, squared=True) - n_samples * X_means**2)
+        X_norms = row_norms(X.T, squared=True) - n_samples * X_means**2
+        np.maximum(X_norms, 0, out=X_norms)
+        np.sqrt(X_norms, out=X_norms)
     else:
         X_norms = row_norms(X.T)
 

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -303,6 +303,26 @@ def test_f_regression_corner_case(
     np.testing.assert_array_almost_equal(p_values, expected_p_values)
 
 
+def test_f_regression_constant_column():
+    """Check f_regression does not raise on constant columns.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/11395
+    """
+    rng = np.random.RandomState(0)
+    X = rng.randn(100, 5)
+    X[:, 2] = 1.0  # constant column
+    y = rng.randn(100)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        F, pv = f_regression(X, y)
+
+    assert np.isfinite(F).all()
+    assert np.isfinite(pv).all()
+    assert F[2] == 0.0
+
+
 def test_f_classif_multi_class():
     # Test whether the F test yields meaningful results
     # on a simple simulated classification problem


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #11395.

#### What does this implement/fix? Explain your changes.

In `r_regression`, which `f_regression` calls, the per-column scale is computed as
`sqrt(row_norms(X.T, squared=True) - n_samples * X_means**2)`. For a constant column
the variance is mathematically zero, but catastrophic cancellation makes the
subtraction land on a small negative value, so `np.sqrt` emits a `RuntimeWarning` and
returns `NaN`. The `NaN` propagates into the correlation coefficient, where
`force_finite=True` collapses it back to 0.0, so the visible symptom is the spurious
warning.

This clamps the intermediate result to zero with `np.maximum` before the square root.

Added `test_f_regression_constant_column`, which fails on `main` with a
`RuntimeWarning` and passes here.

#### AI usage disclosure

I used AI assistance for:
- Documentation (including examples)
- Research and understanding

The fix itself was written by hand. AI was used to double check the diagnosis and to
review the change, not to generate it.

#### Any other comments?

The diagnosis in #11395 is @Lawson-Darrow's and they had offered to open a PR with a
regression test, so apologies for getting ahead of that. They also asked whether
`mean_variance_axis` would be preferable to a clamp, following @agramfort's earlier
suggestion. I went with the clamp because it keeps the dense and sparse paths
identical and adds no second pass over the data, but I am happy to switch, or to close
this in favour of their PR.