### PR TITLE
FIX label_binarize returns pos_label for matching labels with single class

### DIFF
--- a/sklearn/preprocessing/_label.py
+++ b/sklearn/preprocessing/_label.py
@@ -604,12 +604,16 @@ def label_binarize(y, *, classes, neg_label=0, pos_label=1, sparse_output=False)
 
     if y_type == "binary":
         if n_classes == 1:
+            y = column_or_1d(y)
+            y_in_class = xp.reshape(
+                xp.astype(xp.asarray(y == classes[0]), int_dtype_), (n_samples, 1)
+            )
             if sparse_output:
-                return _align_api_if_sparse(sp.csr_array((n_samples, 1), dtype=int))
+                return _align_api_if_sparse(
+                    sp.csr_array(y_in_class * pos_label + (1 - y_in_class) * neg_label)
+                )
             else:
-                Y = xp.zeros((n_samples, 1), dtype=int_dtype_)
-                Y += neg_label
-                return Y
+                return y_in_class * pos_label + (1 - y_in_class) * neg_label
         elif n_classes >= 3:
             y_type = "multiclass"
 

--- a/sklearn/preprocessing/tests/test_label.py
+++ b/sklearn/preprocessing/tests/test_label.py
@@ -48,11 +48,11 @@ def toarray(a):
 
 
 def test_label_binarizer():
-    # one-class case defaults to negative label
+    # one-class case: matching labels get pos_label
     # For dense case:
     inp = ["pos", "pos", "pos", "pos"]
     lb = LabelBinarizer(sparse_output=False)
-    expected = np.array([[0, 0, 0, 0]]).T
+    expected = np.array([[1, 1, 1, 1]]).T
     got = lb.fit_transform(inp)
     assert_array_equal(lb.classes_, ["pos"])
     assert_array_equal(expected, got)
@@ -708,6 +708,26 @@ def test_label_binarize_binary():
     expected = np.array([[3, 0], [0, 3], [3, 0]])[:, 1].reshape((-1, 1))
 
     check_binarized_results(y, classes, pos_label, neg_label, expected)
+
+
+def test_label_binarize_single_class():
+    """Check label_binarize with a single class marks matching labels correctly.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/13674
+    """
+    y = [1, 1, 0, 1]
+    classes = [1]
+    result = label_binarize(y, classes=classes)
+    expected = np.array([[1], [1], [0], [1]])
+    assert_array_equal(result, expected)
+
+    result_sparse = label_binarize(y, classes=classes, sparse_output=True)
+    assert_array_equal(result_sparse.toarray(), expected)
+
+    result_custom = label_binarize(y, classes=classes, pos_label=5, neg_label=-1)
+    expected_custom = np.array([[5], [5], [-1], [5]])
+    assert_array_equal(result_custom, expected_custom)
 
 
 def test_label_binarize_multiclass():


### PR DESCRIPTION
Fixes #13674.

`label_binarize` with a single class returned `neg_label` for all samples,
regardless of whether they matched the class. Now samples that match the
class receive `pos_label` and non-matching samples receive `neg_label`.

Before:
```python
>>> label_binarize([1, 1, 0, 1], classes=[1])
array([[0], [0], [0], [0]])
```

After:
```python
>>> label_binarize([1, 1, 0, 1], classes=[1])
array([[1], [1], [0], [1]])
```

Also works with `sparse_output=True` and custom `pos_label`/`neg_label`.