### PR TITLE
FIX raise ValueError in compute_class_weight for all-zero class weigh…

### DIFF
--- a/doc/whats_new/upcoming_changes/34199.fix.rst
+++ b/doc/whats_new/upcoming_changes/34199.fix.rst
@@ -1,0 +1,1 @@
+:func:`utils.class_weight.compute_class_weight` now raises a :class:`ValueError` when a class has all-zero sample weights instead of silently returning ``inf`` or ``nan``. :pr:`34199` by :user:`Shahaborakzai`. 

--- a/doc/whats_new/upcoming_changes/sklearn.utils/34199.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/34199.fix.rst
@@ -1,0 +1,1 @@
+- :func:`utils.class_weight.compute_class_weight` now raises a :class:`ValueError` when a class has all-zero sample weights instead of silently returning ``inf`` or ``nan``. :pr:`34199` by :user:`Shahaborakzai`. 

--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -93,6 +93,18 @@ def compute_class_weight(class_weight, *, classes, y, sample_weight=None):
 
         sample_weight = _check_sample_weight(sample_weight, y)
         weighted_class_counts = _bincount(y_ind, weights=sample_weight, xp=xp)
+        # Check for classes with all-zero sample weights (causes division by zero)
+        zero_weight_classes = np.where(
+            move_to(weighted_class_counts, xp=np, device="cpu") == 0
+        )[0]
+        if len(zero_weight_classes) > 0:
+            zero_class_labels = le.classes_[zero_weight_classes].tolist()
+            raise ValueError(
+                f"Classes {zero_class_labels} have all-zero sample weights. "
+                "The 'balanced' class_weight mode cannot be used when all "
+                "samples of a class have zero weight, as this would result "
+                "in a division by zero."
+            )
         recip_freq = xp.sum(weighted_class_counts) / (
             size(le.classes_) * weighted_class_counts
         )

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -332,3 +332,17 @@ def test_compute_sample_weight_sparse(csc_container):
     y = csc_container(np.asarray([[0], [1], [1]]))
     sample_weight = compute_sample_weight("balanced", y)
     assert_allclose(sample_weight, [1.5, 0.75, 0.75])
+def test_compute_class_weight_all_zero_sample_weight():
+    """Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/34139
+    When a class has all-zero sample weights, a clear ValueError
+    should be raised instead of returning inf or nan.
+    """
+    y = np.array([0, 0, 1, 1, 2, 2])
+    classes = np.unique(y)
+    sample_weight = np.array([1.0, 1.0, 1.0, 1.0, 0.0, 0.0])
+
+    with pytest.raises(ValueError, match="all-zero sample weights"):
+        compute_class_weight(
+            "balanced", classes=classes, y=y, sample_weight=sample_weight
+        )

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -332,6 +332,8 @@ def test_compute_sample_weight_sparse(csc_container):
     y = csc_container(np.asarray([[0], [1], [1]]))
     sample_weight = compute_sample_weight("balanced", y)
     assert_allclose(sample_weight, [1.5, 0.75, 0.75])
+
+
 def test_compute_class_weight_all_zero_sample_weight():
     """Non-regression test for:
     https://github.com/scikit-learn/scikit-learn/issues/34139


### PR DESCRIPTION
…ts - Closes #34139

<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Documentation (including examples)
- Research and understanding


#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
## Description
Closes #34139

## What was the bug?
When compute_class_weight("balanced", ..., sample_weight=...) is called
and all sample weights for a given class are zero, the function performs
a division by zero, silently returning inf or nan instead of raising
a clear error.

## What changed?
Added a check after computing weighted_class_counts to detect any class
with a total weight of zero and raise a clear ValueError with the
affected class labels listed.

## How to reproduce the original bug
import numpy as np
from sklearn.utils.class_weight import compute_class_weight
y = np.array([0, 0, 1, 1, 2, 2])
classes = np.unique(y)
sample_weight = np.array([1.0, 1.0, 1.0, 1.0, 0.0, 0.0])
compute_class_weight("balanced", classes=classes, y=y, sample_weight=sample_weight)
# Before fix: returns inf/nan silently
# After fix: raises clear ValueError

## Test
Verified fix works locally - ValueError is correctly raised with message:
"Classes [2] have all-zero sample weights..."