### PR TITLE
FIX `Pipeline` to use metadata passed to `transform_input` in intermediate steps

### DIFF
--- a/doc/whats_new/upcoming_changes/metadata-routing/34201.fix.rst
+++ b/doc/whats_new/upcoming_changes/metadata-routing/34201.fix.rst
@@ -1,0 +1,4 @@
+- :class:`pipeline.Pipeline`'s :meth:`~pipeline.Pipeline.fit_transform` and
+  :meth:`~pipeline.Pipeline.fit_predict` now correctly apply ``transform_input`` to
+  metadata routed to intermediate steps, matching :meth:`~pipeline.Pipeline.fit`.
+  By :user:`Stefanie Senger <StefanieSenger>`.

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -713,7 +713,9 @@ class Pipeline(CallbackSupportMixin, _BaseComposition):
         callback_ctx.call_on_fit_task_begin(estimator=self, X=X, y=y)
 
         routed_params = self._check_method_params(method="fit_transform", props=params)
-        Xt = self._fit(X, y, routed_params, callback_ctx=callback_ctx)
+        Xt = self._fit(
+            X, y, routed_params, raw_params=params, callback_ctx=callback_ctx
+        )
 
         last_step = self._final_estimator
         with _print_elapsed_time("Pipeline", self._log_message(len(self.steps) - 1)):
@@ -859,7 +861,9 @@ class Pipeline(CallbackSupportMixin, _BaseComposition):
         callback_ctx.call_on_fit_task_begin(estimator=self, X=X, y=y)
 
         routed_params = self._check_method_params(method="fit_predict", props=params)
-        Xt = self._fit(X, y, routed_params, callback_ctx=callback_ctx)
+        Xt = self._fit(
+            X, y, routed_params, raw_params=params, callback_ctx=callback_ctx
+        )
 
         subcontext = callback_ctx.subcontext(task_name="fit-predict-final-estimator")
         with subcontext.propagate_callback_context(self._final_estimator):


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
found while working on #34179,

#### What does this implement/fix? Explain your changes.
After fixing the tests in #34179, `sklearn/tests/test_pipeline.py::test_transform_input_pipeline[fit_transform]` legitimately failed.

With `transform_input=["sample_weight"]` and metadata routing enabled, Pipeline did not transform inputs in intermediate steps. These use the user-passed sample_weight instead. It works for `fit` though.

This fixes the bug (and makes the tests in #34179 pass).

#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Research and understanding

CC @adrinjalali @OmarManzoor 