### PR TITLE
DOC Fix coef_ shape in RidgeClassifier and RidgeClassifierCV

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1500,10 +1500,10 @@ class RidgeClassifier(_RidgeClassifierMixin, _BaseRidge):
 
     Attributes
     ----------
-    coef_ : ndarray of shape (1, n_features) or (n_classes, n_features)
+    coef_ : ndarray of shape (n_features,) or (n_classes, n_features)
         Coefficient of the features in the decision function.
 
-        ``coef_`` is of shape (1, n_features) when the given problem is binary.
+        ``coef_`` is of shape (n_features,) when the given problem is binary.
 
     intercept_ : float or ndarray of shape (n_targets,)
         Independent term in decision function. Set to 0.0 if
@@ -2943,10 +2943,10 @@ class RidgeClassifierCV(_RidgeClassifierMixin, _BaseRidgeCV):
         .. versionchanged:: 1.5
             `cv_values_` changed to `cv_results_`.
 
-    coef_ : ndarray of shape (1, n_features) or (n_targets, n_features)
+    coef_ : ndarray of shape (n_features,) or (n_classes, n_features)
         Coefficient of the features in the decision function.
 
-        ``coef_`` is of shape (1, n_features) when the given problem is binary.
+        ``coef_`` is of shape (n_features,) when the given problem is binary.
 
     intercept_ : float or ndarray of shape (n_targets,)
         Independent term in decision function. Set to 0.0 if


### PR DESCRIPTION
## Description

Fix the documented shape of `coef_` for `RidgeClassifier` and `RidgeClassifierCV` in binary classification.

The documentation stated that `coef_` has shape `(1, n_features)` for binary problems, while the actual shape is `(n_features,)`.

Fixes #34170.