### PR TITLE
ENH Handle categorical param_range in ValidationCurveDisplay

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.model_selection/34204.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.model_selection/34204.enhancement.rst
@@ -1,0 +1,4 @@
+- :class:`model_selection.ValidationCurveDisplay` now handles categorical
+  (non-numeric) ``param_range`` values by using integer indices for plotting
+  and setting the original values as tick labels.
+  By :user:`Eden Rochman <EdenRochmanSharabi>`.

--- a/sklearn/model_selection/_plot.py
+++ b/sklearn/model_selection/_plot.py
@@ -663,8 +663,15 @@ class ValidationCurveDisplay(_BaseCurveDisplay):
         display : :class:`~sklearn.model_selection.ValidationCurveDisplay`
             Object that stores computed values.
         """
+        param_range = np.asarray(self.param_range)
+        is_categorical = not np.issubdtype(param_range.dtype, np.number)
+        if is_categorical:
+            x_data = np.arange(len(param_range))
+        else:
+            x_data = param_range
+
         self._plot_curve(
-            self.param_range,
+            x_data,
             ax=ax,
             negate_score=negate_score,
             score_name=score_name,
@@ -674,6 +681,9 @@ class ValidationCurveDisplay(_BaseCurveDisplay):
             fill_between_kw=fill_between_kw,
             errorbar_kw=errorbar_kw,
         )
+        if is_categorical:
+            self.ax_.set_xticks(x_data)
+            self.ax_.set_xticklabels(param_range)
         self.ax_.set_xlabel(f"{self.param_name}")
         return self
 

--- a/sklearn/model_selection/tests/test_plot.py
+++ b/sklearn/model_selection/tests/test_plot.py
@@ -570,3 +570,23 @@ def test_subclassing_displays(pyplot, data, Display, params):
 
     display = SubclassOfDisplay.from_estimator(estimator, X, y, **params)
     assert isinstance(display, SubclassOfDisplay)
+
+
+def test_validation_curve_display_categorical_param(pyplot, data):
+    """Check ValidationCurveDisplay handles string/categorical param_range.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/28536
+    """
+    X, y = data
+    param_range = ["gini", "entropy"]
+    display = ValidationCurveDisplay.from_estimator(
+        DecisionTreeClassifier(random_state=0),
+        X,
+        y,
+        param_name="criterion",
+        param_range=param_range,
+    )
+    tick_labels = [t.get_text() for t in display.ax_.get_xticklabels()]
+    assert tick_labels == param_range
+    assert display.ax_.get_xlabel() == "criterion"


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #28536.

#### What does this implement/fix? Explain your changes.

`ValidationCurveDisplay.plot()` failed with categorical (string)
`param_range` values because matplotlib cannot use strings as x
coordinates for line plots.

This detects non-numeric `param_range`, uses integer indices for
plotting, and sets the tick labels to the original parameter values.

```python
ValidationCurveDisplay.from_estimator(
    DecisionTreeClassifier(),
    X, y,
    param_name="criterion",
    param_range=["gini", "entropy"],
)
```

Previously raised `TypeError`. Now plots correctly with categorical
tick labels on the x-axis.

#### AI usage disclosure

No AI tools were used for this contribution.

#### Any other comments?