### PR TITLE
DOC FIX coef0 type in PolynomialCountSketch class docstring

### DIFF
--- a/sklearn/kernel_approximation.py
+++ b/sklearn/kernel_approximation.py
@@ -63,7 +63,7 @@ class PolynomialCountSketch(
         Degree of the polynomial kernel whose feature map
         will be approximated.
 
-    coef0 : int, default=0
+    coef0 : float, default=0.0
         Constant term of the polynomial kernel whose feature map
         will be approximated.
 
@@ -136,7 +136,7 @@ class PolynomialCountSketch(
     }
 
     def __init__(
-        self, *, gamma=1.0, degree=2, coef0=0, n_components=100, random_state=None
+        self, *, gamma=1.0, degree=2, coef0=0.0, n_components=100, random_state=None
     ):
         self.gamma = gamma
         self.degree = degree


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

In the class docstring of `PolynomialCountSketch`, the type of the `coef0` parameter is incorrect: it is stated as being an `int` while the `_parameter_constraints` ensure it is a `float`. 

This PR corrects this.

#### AI usage disclosure
I used AI assistance for:
Nothing

#### Any other comments?

Found while working with @ogrisel.
