### PR TITLE
API Move IterativeImputer outside from experimental

### DIFF
--- a/doc/api_reference.py
+++ b/doc/api_reference.py
@@ -417,7 +417,7 @@ API_REFERENCE = {
         "sections": [
             {
                 "title": None,
-                "autosummary": ["enable_halving_search_cv", "enable_iterative_imputer"],
+                "autosummary": ["enable_halving_search_cv"],
             },
         ],
     },

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -785,10 +785,7 @@ carousel_thumbs = {"sphx_glr_plot_classifier_comparison_001.png": 600}
 
 # enable experimental module so that experimental estimators can be
 # discovered properly by sphinx
-from sklearn.experimental import (  # noqa: F401
-    enable_halving_search_cv,
-    enable_iterative_imputer,
-)
+from sklearn.experimental import enable_halving_search_cv  # noqa: F401
 
 
 def make_carousel_thumbs(app, exception):

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -130,42 +130,21 @@ Convergence and diminishing returns
 
 :class:`IterativeImputer` repeats the round-robin imputation for ``max_iter``
 rounds and stops early when the change between two consecutive rounds falls
-below ``tol`` (when ``sample_posterior=False``). In practice, this stopping
-criterion is often not met: the difference between rounds does not necessarily
-decrease monotonically and the imputed values may not converge, even as
-``max_iter`` grows (:issue:`14338`). This is expected rather than a defect of
-the implementation: the round-robin scheme is a Gibbs-sampler-like procedure
-that is not guaranteed to converge to a fixed point, and the optimization
-target is the conditional model of each feature, not the agreement between
-successive rounds.
+below ``tol`` (when ``sample_posterior=False``). In practice, the imputed
+values often do not converge: the round-robin scheme is not guaranteed to
+reach a fixed point, so the number of iterations is best seen as a trade-off
+against the available time budget rather than a target to be met.
 
-More importantly, chasing convergence is usually not worthwhile when the goal
-is prediction. Le Morvan and Varoquaux [3]_ quantify, across 19 datasets and a
-range of imputation and predictive models, how gains in *imputation accuracy*
-translate into gains in *predictive performance*, and report strongly
-diminishing returns: large improvements in imputation accuracy yield only small
-improvements in downstream prediction. The effect of better imputation is
-further reduced when
+This is rarely a problem when the goal is prediction. Le Morvan and Varoquaux
+[3]_ report strongly diminishing returns: better imputation accuracy yields
+only small gains in downstream predictive performance, especially with an
+expressive model and a missingness indicator (see ``add_indicator``).
 
-- the downstream model is expressive (e.g. gradient-boosted trees), as a
-  flexible model can compensate for a crude imputation;
-- a missingness indicator is appended to the data (see ``add_indicator`` in
-  :class:`IterativeImputer` and :class:`SimpleImputer`, and the
-  :class:`MissingIndicator` transformer), which is beneficial for prediction
-  even when values are Missing Completely At Random;
-- the relationship between features and target is non-linear, as is typical of
-  real-world data.
-
-These results were obtained in a favorable Missing-Completely-At-Random
-setting; with the Missing-Not-At-Random patterns common in real data, the
-benefit of advanced imputation is expected to be even smaller. The practical
-takeaway is that running :class:`IterativeImputer` for more iterations to reach
-convergence, or investing in more elaborate imputation in general, rarely
-improves prediction. A small, fixed number of rounds combined with a
-missingness indicator and an expressive downstream model is usually a better
-use of compute. When the goal is to *reconstruct* the data accurately rather
-than to predict, the convergence behavior and the choice of imputer remain
-relevant and should be assessed on the task at hand.
+In practice, prefer a small, fixed ``max_iter`` together with a missingness
+indicator and an expressive downstream model over investing in convergence.
+When the goal is to *reconstruct* the data rather than predict, the number of
+iterations and the choice of imputer matter more and should be assessed on the
+task at hand.
 
 Flexibility of IterativeImputer
 -------------------------------

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -138,13 +138,13 @@ against the available time budget rather than a target to be met.
 This is rarely a problem when the goal is prediction. Le Morvan and Varoquaux
 [3]_ report strongly diminishing returns: better imputation accuracy yields
 only small gains in downstream predictive performance, especially with an
-expressive model and a missingness indicator (see ``add_indicator``).
+expressive model and a missingness indicator (``add_indicator``).
 
-In practice, prefer a small, fixed ``max_iter`` together with a missingness
-indicator and an expressive downstream model over investing in convergence.
-When the goal is to *reconstruct* the data rather than predict, the number of
-iterations and the choice of imputer matter more and should be assessed on the
-task at hand.
+In practice, prefer a small, fixed ``max_iter`` (i.e. `max_iter=10`) together with 
+a missingness indicator and an expressive downstream model over investing 
+in convergence. When imputation itself is the goal (e.i. for *reconstructing data*) 
+rather than predicting, the number of iterations (i.e. `max_iter>50`) and the 
+choice of imputer matter more and should be assessed on the task at hand.
 
 Flexibility of IterativeImputer
 -------------------------------

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -105,19 +105,9 @@ of ``y``.  This is done for each feature in an iterative fashion, and then is
 repeated for ``max_iter`` imputation rounds. The results of the final
 imputation round are returned.
 
-.. note::
-
-   This estimator is still **experimental** for now: default parameters or
-   details of behaviour might change without any deprecation cycle. Resolving
-   the following issues would help stabilize :class:`IterativeImputer`:
-   convergence criteria (:issue:`14338`) and default estimators
-   (:issue:`13286`). To use it, you need to explicitly import
-   ``enable_iterative_imputer``.
-
 ::
 
     >>> import numpy as np
-    >>> from sklearn.experimental import enable_iterative_imputer
     >>> from sklearn.impute import IterativeImputer
     >>> imp = IterativeImputer(max_iter=10, random_state=0)
     >>> imp.fit([[1, 2], [3, 6], [4, 8], [np.nan, 3], [7, np.nan]])
@@ -132,6 +122,50 @@ imputation round are returned.
 Both :class:`SimpleImputer` and :class:`IterativeImputer` can be used in a
 Pipeline as a way to build a composite estimator that supports imputation.
 See :ref:`sphx_glr_auto_examples_impute_plot_missing_values.py`.
+
+.. _iterative_imputer_convergence:
+
+Convergence and diminishing returns
+-----------------------------------
+
+:class:`IterativeImputer` repeats the round-robin imputation for ``max_iter``
+rounds and stops early when the change between two consecutive rounds falls
+below ``tol`` (when ``sample_posterior=False``). In practice, this stopping
+criterion is often not met: the difference between rounds does not necessarily
+decrease monotonically and the imputed values may not converge, even as
+``max_iter`` grows (:issue:`14338`). This is expected rather than a defect of
+the implementation: the round-robin scheme is a Gibbs-sampler-like procedure
+that is not guaranteed to converge to a fixed point, and the optimization
+target is the conditional model of each feature, not the agreement between
+successive rounds.
+
+More importantly, chasing convergence is usually not worthwhile when the goal
+is prediction. Le Morvan and Varoquaux [3]_ quantify, across 19 datasets and a
+range of imputation and predictive models, how gains in *imputation accuracy*
+translate into gains in *predictive performance*, and report strongly
+diminishing returns: large improvements in imputation accuracy yield only small
+improvements in downstream prediction. The effect of better imputation is
+further reduced when
+
+- the downstream model is expressive (e.g. gradient-boosted trees), as a
+  flexible model can compensate for a crude imputation;
+- a missingness indicator is appended to the data (see ``add_indicator`` in
+  :class:`IterativeImputer` and :class:`SimpleImputer`, and the
+  :class:`MissingIndicator` transformer), which is beneficial for prediction
+  even when values are Missing Completely At Random;
+- the relationship between features and target is non-linear, as is typical of
+  real-world data.
+
+These results were obtained in a favorable Missing-Completely-At-Random
+setting; with the Missing-Not-At-Random patterns common in real data, the
+benefit of advanced imputation is expected to be even smaller. The practical
+takeaway is that running :class:`IterativeImputer` for more iterations to reach
+convergence, or investing in more elaborate imputation in general, rarely
+improves prediction. A small, fixed number of rounds combined with a
+missingness indicator and an expressive downstream model is usually a better
+use of compute. When the goal is to *reconstruct* the data accurately rather
+than to predict, the convergence behavior and the choice of imputer remain
+relevant and should be assessed on the task at hand.
 
 Flexibility of IterativeImputer
 -------------------------------
@@ -183,6 +217,11 @@ cannot be achieved by a single call to ``transform``.
 
 .. [2] Roderick J A Little and Donald B Rubin (1986). "Statistical Analysis
    with Missing Data". John Wiley & Sons, Inc., New York, NY, USA.
+
+.. [3] `Marine Le Morvan, Gaël Varoquaux (2025). "Imputation for prediction:
+   beware of diminishing returns". International Conference on Learning
+   Representations (ICLR).
+   <https://arxiv.org/abs/2407.19804>`_
 
 .. _knnimpute:
 

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -6,6 +6,17 @@ Imputation of missing values
 
 .. currentmodule:: sklearn.impute
 
+
+.. topic:: Key points for machine-learning with missing values
+
+   * Avoid dropping rows with missing values; it risks creating bias.
+
+   * Tree-based learners can natively predict on data with missing values
+     and work fairly well with no additional cost.
+
+  * Imputation can be very computationaly costly, and quickly hits
+    diminishing returns to improve subsequent prediction performance [3]_.
+
 For various reasons, many real-world datasets contain missing values, often
 encoded as blanks, NaNs or other placeholders. They arise from faulty
 measurements, unanswered questionnaire items, or information that was simply
@@ -40,11 +51,13 @@ high-level guidelines help choose among these tools [3]_:
 - Flag missing entries: adding a missingness indicator (the ``add_indicator``
   option of the imputers, or :class:`MissingIndicator`) tends to help
   prediction, even when values are missing completely at random.
-- Prefer expressive models: flexible estimators benefit even less from
-  sophisticated imputation, and some handle missing values natively without
-  any imputation (see :ref:`estimators_that_handle_nan`).
-- Invest in imputation quality mainly when reconstructing the data itself, not
-  prediction, is the objective.
+- Prefer expressive models for the supervised-learner step: flexible estimators
+  benefit even less from sophisticated imputation, and some handle missing
+  values natively without any imputation (see :ref:`estimators_that_handle_nan`).
+- Sophisticated imputation can help prediction, but it can be very
+  computationally cost (it scales poorly with data size).
+- Invest heavily in imputation quality mainly when reconstructing the data
+  itself, not prediction, is the objective.
 
 
 Univariate vs. Multivariate Imputation

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -44,6 +44,8 @@ them from the known part of the data (see the glossary entry on
 :class:`SimpleImputer`, as well as the model-based :class:`IterativeImputer`
 and :class:`KNNImputer`.
 
+Invest in imputation quality mainly when reconstructing the data itself, not
+prediction, is the objective.
 When the goal is prediction rather than reconstructing the data, a few
 high-level guidelines help choose among these tools [3]_:
 

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -6,15 +6,45 @@ Imputation of missing values
 
 .. currentmodule:: sklearn.impute
 
-For various reasons, many real world datasets contain missing values, often
-encoded as blanks, NaNs or other placeholders. Such datasets however are
-incompatible with scikit-learn estimators which assume that all values in an
-array are numerical, and that all have and hold meaning. A basic strategy to
-use incomplete datasets is to discard entire rows and/or columns containing
-missing values. However, this comes at the price of losing data which may be
-valuable (even though incomplete). A better strategy is to impute the missing
-values, i.e., to infer them from the known part of the data. See the
-glossary entry on :term:`imputation`.
+For various reasons, many real-world datasets contain missing values, often
+encoded as blanks, NaNs or other placeholders. They arise from faulty
+measurements, unanswered questionnaire items, or information that was simply
+never recorded, and can affect both the data ``X`` and the target ``y``. Most
+scikit-learn estimators assume that every entry of an array is numerical and
+holds meaning, and therefore cannot be trained directly on incomplete data.
+
+A naive way to meet that requirement is to discard every row or column that
+contains a missing value. This is detrimental on two counts: it throws away
+potentially valuable information, and it generally introduces bias, since the
+remaining samples are rarely representative of the original population (unless
+values are missing completely at random). The same caution applies to the
+target: silently dropping samples whose outcome ``y`` is unknown biases the
+analysis. In particular, when an outcome has not been observed yet, the problem
+is one of censoring and should be handled with dedicated methods from `survival
+analysis <https://en.wikipedia.org/wiki/Survival_analysis>`_ rather than by
+discarding data.
+
+The tools described on this page address missing values in ``X``. A better
+strategy than discarding data is to impute the missing values, i.e. to infer
+them from the known part of the data (see the glossary entry on
+:term:`imputation`). scikit-learn provides simple column statistics with
+:class:`SimpleImputer`, as well as the model-based :class:`IterativeImputer`
+and :class:`KNNImputer`.
+
+When the goal is prediction rather than reconstructing the data, a few
+high-level guidelines help choose among these tools [3]_:
+
+- Start simple: constant or mean / most-frequent imputation with
+  :class:`SimpleImputer` is a strong and cheap baseline, and more elaborate
+  imputation often brings only marginal gains in predictive performance.
+- Flag missing entries: adding a missingness indicator (the ``add_indicator``
+  option of the imputers, or :class:`MissingIndicator`) tends to help
+  prediction, even when values are missing completely at random.
+- Prefer expressive models: flexible estimators benefit even less from
+  sophisticated imputation, and some handle missing values natively without
+  any imputation (see :ref:`estimators_that_handle_nan`).
+- Invest in imputation quality mainly when reconstructing the data itself, not
+  prediction, is the objective.
 
 
 Univariate vs. Multivariate Imputation
@@ -367,6 +397,8 @@ wrap this in a :class:`~sklearn.pipeline.Pipeline` with a classifier (e.g., a
   >>> results = clf.predict(X_test)
   >>> results.shape
   (100,)
+
+.. _estimators_that_handle_nan:
 
 Estimators that handle NaN values
 =================================

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -10,13 +10,11 @@ Imputation of missing values
 .. topic:: Key points for machine-learning with missing values
 
    * Avoid dropping rows with missing values; it risks creating bias.
-
    * :ref:`Some supervised learning methods <estimators_that_handle_nan>` (typically
      tree-based learners) can natively predict on data with missing values
      and work fairly well with no additional cost.
-
-  * Imputation can be very computationaly costly, and quickly hits
-    diminishing returns to improve subsequent prediction performance [3]_.
+   * Imputation can be very computationaly costly, and quickly hits
+     diminishing returns to improve subsequent prediction performance [3]_.
 
 For various reasons, many real-world datasets contain missing values, often
 encoded as blanks, NaNs or other placeholders. They arise from faulty
@@ -26,7 +24,7 @@ scikit-learn estimators assume that every entry of an array is numerical and
 holds meaning, and therefore cannot be trained directly on incomplete data.
 
 A naive way to meet that requirement is to discard every row or column that
-contains a missing value. This is detrimental on two counts: valuable 
+contains a missing value. This is detrimental on two counts: valuable
 information from those cases is lost, and it generally introduces bias, since the
 remaining samples are rarely representative of the original population (unless
 values are missing completely at random). The same caution applies to the

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -128,23 +128,23 @@ See :ref:`sphx_glr_auto_examples_impute_plot_missing_values.py`.
 Convergence and diminishing returns
 -----------------------------------
 
-:class:`IterativeImputer` repeats the round-robin imputation for ``max_iter``
-rounds and stops early when the change between two consecutive rounds falls
-below ``tol`` (when ``sample_posterior=False``). In practice, the imputed
-values often do not converge: the round-robin scheme is not guaranteed to
-reach a fixed point, so the number of iterations is best seen as a trade-off
-against the available time budget rather than a target to be met.
+:class:`IterativeImputer` repeats the round-robin imputation for ``max_iter`` rounds and
+stops early when the change between two consecutive rounds falls below ``tol`` (when
+``sample_posterior=False``). In practice, the imputed values often do not converge: the
+round-robin scheme is not guaranteed to reach a fixed point, so the number of iterations
+is best seen as a trade-off against the available time budget rather than a target to be
+met.
 
-This is rarely a problem when the goal is prediction. Le Morvan and Varoquaux
-[3]_ report strongly diminishing returns: better imputation accuracy yields
-only small gains in downstream predictive performance, especially with an
-expressive model and a missingness indicator (``add_indicator``).
+This is rarely a problem when the goal is prediction. Le Morvan and Varoquaux [3]_
+report strongly diminishing returns: better imputation accuracy yields only small gains
+in downstream predictive performance, especially with an expressive model and a
+missingness indicator (``add_indicator``).
 
-In practice, prefer a small, fixed ``max_iter`` (i.e. `max_iter=10`) together with 
-a missingness indicator and an expressive downstream model over investing 
-in convergence. When imputation itself is the goal (e.i. for *reconstructing data*) 
-rather than predicting, the number of iterations (i.e. `max_iter>50`) and the 
-choice of imputer matter more and should be assessed on the task at hand.
+In practice, prefer a small, fixed ``max_iter`` (i.e. `max_iter=10`) together with a
+missingness indicator and an expressive downstream model over investing in convergence.
+When imputation itself is the goal (e.i. for *reconstructing data*) rather than
+predicting, the number of iterations (i.e. `max_iter>50`) and the choice of imputer
+matter more and should be assessed on the task at hand.
 
 Flexibility of IterativeImputer
 -------------------------------

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -31,7 +31,9 @@ remaining samples are rarely representative of the original population (unless
 values are missing completely at random). The same caution applies to the
 target: silently dropping samples whose outcome ``y`` is unknown biases the
 analysis. In particular, when an outcome has not been observed yet, it is a
-censoring problem and should be handled with dedicated methods from `survival
+`censoring
+problem <https://en.wikipedia.org/wiki/Survival_analysis#Censoring>`_
+and should be handled with dedicated methods from `survival
 analysis <https://en.wikipedia.org/wiki/Survival_analysis>`_ rather than by
 discarding data.
 

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -25,13 +25,13 @@ scikit-learn estimators assume that every entry of an array is numerical and
 holds meaning, and therefore cannot be trained directly on incomplete data.
 
 A naive way to meet that requirement is to discard every row or column that
-contains a missing value. This is detrimental on two counts: it throws away
-potentially valuable information, and it generally introduces bias, since the
+contains a missing value. This is detrimental on two counts: valuable 
+information from those cases is lost, and it generally introduces bias, since the
 remaining samples are rarely representative of the original population (unless
 values are missing completely at random). The same caution applies to the
 target: silently dropping samples whose outcome ``y`` is unknown biases the
-analysis. In particular, when an outcome has not been observed yet, the problem
-is one of censoring and should be handled with dedicated methods from `survival
+analysis. In particular, when an outcome has not been observed yet, it is a
+censoring problem and should be handled with dedicated methods from `survival
 analysis <https://en.wikipedia.org/wiki/Survival_analysis>`_ rather than by
 discarding data.
 

--- a/doc/modules/impute.rst
+++ b/doc/modules/impute.rst
@@ -11,7 +11,8 @@ Imputation of missing values
 
    * Avoid dropping rows with missing values; it risks creating bias.
 
-   * Tree-based learners can natively predict on data with missing values
+   * :ref:`Some supervised learning methods <estimators_that_handle_nan>` (typically
+     tree-based learners) can natively predict on data with missing values
      and work fairly well with no additional cost.
 
   * Imputation can be very computationaly costly, and quickly hits

--- a/doc/whats_new/upcoming_changes/sklearn.impute/34214.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.impute/34214.api.rst
@@ -1,0 +1,8 @@
+- :class:`impute.IterativeImputer` is no longer experimental. It can now be
+  imported directly with ``from sklearn.impute import IterativeImputer``, and
+  importing ``sklearn.experimental.enable_iterative_imputer`` is no longer
+  required (doing so now raises a warning and is a no-op). The :ref:`User Guide
+  <iterative_imputer_convergence>` now documents why the imputed values are not
+  guaranteed to converge and why investing in better imputation often yields
+  diminishing returns for prediction.
+  By :user:`Guillaume Lemaitre <glemaitre>`.

--- a/doc/whats_new/upcoming_changes/sklearn.impute/34214.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.impute/34214.api.rst
@@ -1,7 +1,10 @@
 - :class:`impute.IterativeImputer` is no longer experimental. It can now be
   imported directly with ``from sklearn.impute import IterativeImputer``, and
   importing ``sklearn.experimental.enable_iterative_imputer`` is no longer
-  required (doing so now raises a warning and is a no-op). The :ref:`User Guide
+  required (doing so now raises a warning and is a no-op). It also no longer
+  raises a :class:`exceptions.ConvergenceWarning` when ``max_iter`` is reached
+  without meeting the ``tol`` stopping criterion, as non-convergence of the
+  round-robin imputation is expected. The :ref:`User Guide
   <iterative_imputer_convergence>` now documents why the imputed values are not
   guaranteed to converge and why investing in better imputation often yields
   diminishing returns for prediction.

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -578,11 +578,6 @@ Support for Python 3.4 and below has been officially dropped.
     >>> # now you can import normally from sklearn.impute
     >>> from sklearn.impute import IterativeImputer
 
-  .. note::
-      Update: since version 1.10, :class:`impute.IterativeImputer` is not
-      experimental anymore and you don't need to use `from sklearn.experimental
-      import enable_iterative_imputer`.
-
 
 - |Feature| The :class:`impute.SimpleImputer` and
   :class:`impute.IterativeImputer` have a new parameter ``'add_indicator'``,

--- a/doc/whats_new/v0.21.rst
+++ b/doc/whats_new/v0.21.rst
@@ -578,6 +578,11 @@ Support for Python 3.4 and below has been officially dropped.
     >>> # now you can import normally from sklearn.impute
     >>> from sklearn.impute import IterativeImputer
 
+  .. note::
+      Update: since version 1.10, :class:`impute.IterativeImputer` is not
+      experimental anymore and you don't need to use `from sklearn.experimental
+      import enable_iterative_imputer`.
+
 
 - |Feature| The :class:`impute.SimpleImputer` and
   :class:`impute.IterativeImputer` have a new parameter ``'add_indicator'``,

--- a/examples/impute/plot_iterative_imputer_variants_comparison.py
+++ b/examples/impute/plot_iterative_imputer_variants_comparison.py
@@ -53,9 +53,6 @@ import pandas as pd
 
 from sklearn.datasets import fetch_california_housing
 from sklearn.ensemble import RandomForestRegressor
-
-# To use this experimental feature, we need to explicitly ask for it:
-from sklearn.experimental import enable_iterative_imputer  # noqa: F401
 from sklearn.impute import IterativeImputer, SimpleImputer
 from sklearn.kernel_approximation import Nystroem
 from sklearn.linear_model import BayesianRidge, Ridge

--- a/examples/impute/plot_missing_values.py
+++ b/examples/impute/plot_missing_values.py
@@ -92,9 +92,6 @@ X_miss_california, y_miss_california = add_missing_values(
 #
 
 from sklearn.ensemble import RandomForestRegressor
-
-# To use the experimental IterativeImputer, we need to explicitly ask for it:
-from sklearn.experimental import enable_iterative_imputer  # noqa: F401
 from sklearn.impute import IterativeImputer, KNNImputer, SimpleImputer
 from sklearn.model_selection import cross_val_score
 from sklearn.pipeline import make_pipeline

--- a/sklearn/experimental/enable_iterative_imputer.py
+++ b/sklearn/experimental/enable_iterative_imputer.py
@@ -11,6 +11,8 @@ imported normally from ``sklearn.impute``.
 # Don't remove this file, we don't want to break users code just because the
 # feature isn't experimental anymore.
 
+# TODO(1.14): is it long enough to start a full deprecation cycle?
+
 import warnings
 
 warnings.warn(

--- a/sklearn/experimental/enable_iterative_imputer.py
+++ b/sklearn/experimental/enable_iterative_imputer.py
@@ -1,23 +1,21 @@
-"""Enables IterativeImputer
+"""This is now a no-op and can be safely removed from your code.
 
-The API and results of this estimator might change without any deprecation
-cycle.
-
-Importing this file dynamically sets :class:`~sklearn.impute.IterativeImputer`
-as an attribute of the impute module::
-
-    >>> # explicitly require this experimental feature
-    >>> from sklearn.experimental import enable_iterative_imputer  # noqa
-    >>> # now you can import normally from impute
-    >>> from sklearn.impute import IterativeImputer
+It used to enable the use of :class:`~sklearn.impute.IterativeImputer` when it
+was still :term:`experimental`, but this estimator is now stable and can be
+imported normally from ``sklearn.impute``.
 """
 
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
-from sklearn import impute
-from sklearn.impute._iterative import IterativeImputer
+# Don't remove this file, we don't want to break users code just because the
+# feature isn't experimental anymore.
 
-# use settattr to avoid mypy errors when monkeypatching
-setattr(impute, "IterativeImputer", IterativeImputer)
-impute.__all__ += ["IterativeImputer"]
+import warnings
+
+warnings.warn(
+    "Since version 1.10, "
+    "it is not needed to import enable_iterative_imputer anymore. "
+    "IterativeImputer is now stable and can be normally imported from "
+    "sklearn.impute."
+)

--- a/sklearn/experimental/tests/test_enable_iterative_imputer.py
+++ b/sklearn/experimental/tests/test_enable_iterative_imputer.py
@@ -9,43 +9,11 @@ from sklearn.utils.fixes import _IS_WASM
 
 
 @pytest.mark.xfail(_IS_WASM, reason="cannot start subprocess")
-def test_imports_strategies():
-    # Make sure different import strategies work or fail as expected.
-
-    # Since Python caches the imported modules, we need to run a child process
-    # for every test case. Else, the tests would not be independent
-    # (manually removing the imports from the cache (sys.modules) is not
-    # recommended and can lead to many complications).
-    pattern = "IterativeImputer is experimental"
-    good_import = """
-    from sklearn.experimental import enable_iterative_imputer
-    from sklearn.impute import IterativeImputer
-    """
-    assert_run_python_script_without_output(
-        textwrap.dedent(good_import), pattern=pattern
-    )
-
-    good_import_with_ensemble_first = """
-    import sklearn.ensemble
-    from sklearn.experimental import enable_iterative_imputer
-    from sklearn.impute import IterativeImputer
-    """
-    assert_run_python_script_without_output(
-        textwrap.dedent(good_import_with_ensemble_first),
-        pattern=pattern,
-    )
-
-    bad_imports = f"""
+def test_import_raises_warning():
+    code = """
     import pytest
-
-    with pytest.raises(ImportError, match={pattern!r}):
-        from sklearn.impute import IterativeImputer
-
-    import sklearn.experimental
-    with pytest.raises(ImportError, match={pattern!r}):
-        from sklearn.impute import IterativeImputer
+    with pytest.warns(UserWarning, match="it is not needed to import"):
+        from sklearn.experimental import enable_iterative_imputer  # noqa
     """
-    assert_run_python_script_without_output(
-        textwrap.dedent(bad_imports),
-        pattern=pattern,
-    )
+    pattern = "it is not needed to import enable_iterative_imputer anymore"
+    assert_run_python_script_without_output(textwrap.dedent(code), pattern=pattern)

--- a/sklearn/impute/__init__.py
+++ b/sklearn/impute/__init__.py
@@ -3,26 +3,8 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
-import typing
-
 from sklearn.impute._base import MissingIndicator, SimpleImputer
+from sklearn.impute._iterative import IterativeImputer
 from sklearn.impute._knn import KNNImputer
 
-if typing.TYPE_CHECKING:
-    # Avoid errors in type checkers (e.g. mypy) for experimental estimators.
-    # TODO: remove this check once the estimator is no longer experimental.
-    from sklearn.impute._iterative import IterativeImputer  # noqa: F401
-
-__all__ = ["KNNImputer", "MissingIndicator", "SimpleImputer"]
-
-
-# TODO: remove this check once the estimator is no longer experimental.
-def __getattr__(name):
-    if name == "IterativeImputer":
-        raise ImportError(
-            f"{name} is experimental and the API might change without any "
-            "deprecation cycle. To use it, you need to explicitly import "
-            "enable_iterative_imputer:\n"
-            "from sklearn.experimental import enable_iterative_imputer"
-        )
-    raise AttributeError(f"module {__name__} has no attribute {name}")
+__all__ = ["IterativeImputer", "KNNImputer", "MissingIndicator", "SimpleImputer"]

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -1,7 +1,6 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
-import warnings
 from collections import namedtuple
 from numbers import Integral, Real
 from time import time
@@ -10,7 +9,6 @@ import numpy as np
 from scipy import stats
 
 from sklearn.base import _fit_context, clone
-from sklearn.exceptions import ConvergenceWarning
 from sklearn.impute._base import SimpleImputer, _BaseImputer, _check_inputs_dtype
 from sklearn.preprocessing import normalize
 from sklearn.utils import _safe_indexing, check_array, check_random_state
@@ -863,12 +861,6 @@ class IterativeImputer(_BaseImputer):
                         print("[IterativeImputer] Early stopping criterion reached.")
                     break
                 Xt_previous = Xt.copy()
-        else:
-            if not self.sample_posterior:
-                warnings.warn(
-                    "[IterativeImputer] Early stopping criterion not reached.",
-                    ConvergenceWarning,
-                )
         _assign_where(Xt, X, cond=~mask_missing_values)
 
         return super()._concatenate_indicator(Xt, X_indicator)

--- a/sklearn/impute/_iterative.py
+++ b/sklearn/impute/_iterative.py
@@ -67,16 +67,18 @@ class IterativeImputer(_BaseImputer):
 
     .. versionadded:: 0.21
 
+    .. versionchanged:: 1.10
+        :class:`IterativeImputer` is no longer experimental and can be imported
+        directly from :mod:`sklearn.impute` without enabling it through
+        ``sklearn.experimental``.
+
     .. note::
 
-      This estimator is still **experimental** for now: the predictions
-      and the API might change without any deprecation cycle. To use it,
-      you need to explicitly import `enable_iterative_imputer`::
-
-        >>> # explicitly require this experimental feature
-        >>> from sklearn.experimental import enable_iterative_imputer  # noqa
-        >>> # now you can import normally from sklearn.impute
-        >>> from sklearn.impute import IterativeImputer
+        The stopping criterion of this imputer rarely improves the downstream
+        predictive performance, and the imputed values are not guaranteed to
+        converge with the number of iterations. See the
+        :ref:`User Guide <iterative_imputer_convergence>` for details on why
+        chasing convergence is usually not worthwhile.
 
     Parameters
     ----------
@@ -274,7 +276,6 @@ class IterativeImputer(_BaseImputer):
     Examples
     --------
     >>> import numpy as np
-    >>> from sklearn.experimental import enable_iterative_imputer
     >>> from sklearn.impute import IterativeImputer
     >>> imp_mean = IterativeImputer(random_state=0)
     >>> imp_mean.fit([[7, 2, 3], [4, np.nan, 6], [10, 5, 9]])

--- a/sklearn/impute/tests/test_common.py
+++ b/sklearn/impute/tests/test_common.py
@@ -19,8 +19,6 @@ def sparse_imputers():
     return [SimpleImputer()]
 
 
-# ConvergenceWarning will be raised by the IterativeImputer
-@pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
 @pytest.mark.parametrize("imputer", imputers(), ids=lambda x: x.__class__.__name__)
 def test_imputation_missing_value_in_test_array(imputer):
     # [Non Regression Test for issue #13968] Missing value in test set should
@@ -32,8 +30,6 @@ def test_imputation_missing_value_in_test_array(imputer):
     imputer.fit(train).transform(test)
 
 
-# ConvergenceWarning will be raised by the IterativeImputer
-@pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
 @pytest.mark.parametrize("marker", [np.nan, -1, 0])
 @pytest.mark.parametrize("imputer", imputers(), ids=lambda x: x.__class__.__name__)
 def test_imputers_add_indicator(marker, imputer):
@@ -65,8 +61,6 @@ def test_imputers_add_indicator(marker, imputer):
     assert_allclose(X_trans[:, :-4], X_trans_no_indicator)
 
 
-# ConvergenceWarning will be raised by the IterativeImputer
-@pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
 @pytest.mark.parametrize("marker", [np.nan, -1])
 @pytest.mark.parametrize(
     "imputer", sparse_imputers(), ids=lambda x: x.__class__.__name__
@@ -101,8 +95,6 @@ def test_imputers_add_indicator_sparse(imputer, marker, csr_container):
     assert_allclose_dense_sparse(X_trans[:, :-4], X_trans_no_indicator)
 
 
-# ConvergenceWarning will be raised by the IterativeImputer
-@pytest.mark.filterwarnings("ignore::sklearn.exceptions.ConvergenceWarning")
 @pytest.mark.parametrize("imputer", imputers(), ids=lambda x: x.__class__.__name__)
 @pytest.mark.parametrize("add_indicator", [True, False])
 def test_imputers_pandas_na_integer_array_support(imputer, add_indicator):

--- a/sklearn/impute/tests/test_common.py
+++ b/sklearn/impute/tests/test_common.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from sklearn.base import clone
-from sklearn.experimental import enable_iterative_imputer  # noqa: F401
 from sklearn.impute import IterativeImputer, KNNImputer, SimpleImputer
 from sklearn.utils._testing import (
     assert_allclose,

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -11,7 +11,6 @@ from scipy.stats import kstest
 from sklearn import tree
 from sklearn.datasets import load_diabetes
 from sklearn.dummy import DummyRegressor
-from sklearn.exceptions import ConvergenceWarning
 from sklearn.impute import IterativeImputer, KNNImputer, MissingIndicator, SimpleImputer
 from sklearn.impute._base import _most_frequent
 from sklearn.linear_model import ARDRegression, BayesianRidge, RidgeCV
@@ -1424,12 +1423,9 @@ def test_imputation_order(order, idx_order):
     X[:20, 2] = np.nan
     X[:10, 4] = np.nan
 
-    with pytest.warns(ConvergenceWarning):
-        trs = IterativeImputer(max_iter=1, imputation_order=order, random_state=0).fit(
-            X
-        )
-        idx = [x.feat_idx for x in trs.imputation_sequence_]
-        assert idx == idx_order
+    trs = IterativeImputer(max_iter=1, imputation_order=order, random_state=0).fit(X)
+    idx = [x.feat_idx for x in trs.imputation_sequence_]
+    assert idx == idx_order
 
 
 @pytest.mark.parametrize("missing_value", [-1, np.nan])

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -12,9 +12,6 @@ from sklearn import tree
 from sklearn.datasets import load_diabetes
 from sklearn.dummy import DummyRegressor
 from sklearn.exceptions import ConvergenceWarning
-
-# make IterativeImputer available
-from sklearn.experimental import enable_iterative_imputer  # noqa: F401
 from sklearn.impute import IterativeImputer, KNNImputer, MissingIndicator, SimpleImputer
 from sklearn.impute._base import _most_frequent
 from sklearn.linear_model import ARDRegression, BayesianRidge, RidgeCV

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -21,10 +21,7 @@ from sklearn.compose import ColumnTransformer
 from sklearn.exceptions import ConvergenceWarning
 
 # make it possible to discover experimental estimators when calling `all_estimators`
-from sklearn.experimental import (
-    enable_halving_search_cv,  # noqa: F401
-    enable_iterative_imputer,  # noqa: F401
-)
+from sklearn.experimental import enable_halving_search_cv  # noqa: F401
 from sklearn.linear_model import LogisticRegression
 from sklearn.pipeline import FeatureUnion, make_pipeline
 from sklearn.preprocessing import (
@@ -128,6 +125,10 @@ def test_estimators(estimator, check, request):
 @pytest.mark.filterwarnings(
     "ignore:Since version 1.0, it is not needed to import "
     "enable_hist_gradient_boosting anymore"
+)
+@pytest.mark.filterwarnings(
+    "ignore:Since version 1.10, it is not needed to import "
+    "enable_iterative_imputer anymore"
 )
 @pytest.mark.thread_unsafe  # import side-effects
 def test_import_all_consistency():

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -16,10 +16,7 @@ from sklearn.callback._base import _BaseCallback
 from sklearn.datasets import make_classification
 
 # make it possible to discover experimental estimators when calling `all_estimators`
-from sklearn.experimental import (
-    enable_halving_search_cv,  # noqa: F401
-    enable_iterative_imputer,  # noqa: F401
-)
+from sklearn.experimental import enable_halving_search_cv  # noqa: F401
 from sklearn.linear_model import LogisticRegression
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.utils import all_estimators

--- a/sklearn/tests/test_docstrings.py
+++ b/sklearn/tests/test_docstrings.py
@@ -7,10 +7,7 @@ import pytest
 from sklearn.callback._base import _BaseCallback
 
 # make it possible to discover experimental estimators when calling `all_estimators`
-from sklearn.experimental import (
-    enable_halving_search_cv,  # noqa: F401
-    enable_iterative_imputer,  # noqa: F401
-)
+from sklearn.experimental import enable_halving_search_cv  # noqa: F401
 from sklearn.utils.discovery import all_displays, all_estimators, all_functions
 
 numpydoc_validation = pytest.importorskip("numpydoc.validate")

--- a/sklearn/tests/test_metaestimators_metadata_routing.py
+++ b/sklearn/tests/test_metaestimators_metadata_routing.py
@@ -16,10 +16,7 @@ from sklearn.ensemble import (
     BaggingRegressor,
 )
 from sklearn.exceptions import UnsetMetadataPassedError
-from sklearn.experimental import (
-    enable_halving_search_cv,  # noqa: F401
-    enable_iterative_imputer,  # noqa: F401
-)
+from sklearn.experimental import enable_halving_search_cv  # noqa: F401
 from sklearn.feature_selection import (
     RFE,
     RFECV,


### PR DESCRIPTION
closes #14338

We never moved out of experimental `IterativeImputer` notably because of the reason that we get convergence warning.

However, the work in https://arxiv.org/abs/2407.19804 will tell us that we should not expect the iterative imputation to converge and that it can even be counter productive to spend too many imputation with a diminishing return.

Based on this research, we should make the `IterativeImputer` out of experimental, stop to warn when it does not converge and instead make it such that we run it with a certain budget and document this positioning by recalling the literature.