### PR TITLE
DOC: Fix brackets in the RANSACRegressor.score docstring in the file

### DIFF
--- a/sklearn/linear_model/_ransac.py
+++ b/sklearn/linear_model/_ransac.py
@@ -654,7 +654,7 @@ class RANSACRegressor(
 
         Parameters
         ----------
-        X : (array-like or sparse matrix} of shape (n_samples, n_features)
+        X : {array-like or sparse matrix} of shape (n_samples, n_features)
             Training data.
 
         y : array-like of shape (n_samples,) or (n_samples, n_targets)


### PR DESCRIPTION
While reading through the RANSACRegressor code, I noticed a bracket typo in the 
`score()` method docstring. The parameter does not follow numpy convention

Fixed it from: `X : (array-like or sparse matrix}`
To: `X : {array-like or sparse matrix}`

Fixed the docstring

Regards
Jai Bhairav
TheHashiramaSenju