### PR TITLE
FIX avoid spurious EfficiencyWarning in DBSCAN for sorted precomputed graphs

### DIFF
--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -14,7 +14,7 @@ from scipy import sparse
 from sklearn.base import BaseEstimator, ClusterMixin, _fit_context
 from sklearn.cluster._dbscan_inner import dbscan_inner
 from sklearn.metrics.pairwise import _VALID_METRICS
-from sklearn.neighbors import NearestNeighbors
+from sklearn.neighbors import NearestNeighbors,sort_graph_by_row_values
 from sklearn.utils._param_validation import Interval, StrOptions, validate_params
 from sklearn.utils.validation import _check_sample_weight, validate_data
 
@@ -434,6 +434,14 @@ class DBSCAN(ClusterMixin, BaseEstimator):
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", sparse.SparseEfficiencyWarning)
                 X.setdiag(X.diagonal())
+                
+            X = sort_graph_by_row_values(
+             X,
+             copy=False,
+                   warn_when_not_sorted=False,
+)
+
+        
 
         neighbors_model = NearestNeighbors(
             radius=self.eps,

--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -14,7 +14,7 @@ from scipy import sparse
 from sklearn.base import BaseEstimator, ClusterMixin, _fit_context
 from sklearn.cluster._dbscan_inner import dbscan_inner
 from sklearn.metrics.pairwise import _VALID_METRICS
-from sklearn.neighbors import NearestNeighbors,sort_graph_by_row_values
+from sklearn.neighbors import NearestNeighbors, sort_graph_by_row_values
 from sklearn.utils._param_validation import Interval, StrOptions, validate_params
 from sklearn.utils.validation import _check_sample_weight, validate_data
 
@@ -434,14 +434,12 @@ class DBSCAN(ClusterMixin, BaseEstimator):
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", sparse.SparseEfficiencyWarning)
                 X.setdiag(X.diagonal())
-                
-            X = sort_graph_by_row_values(
-             X,
-             copy=False,
-                   warn_when_not_sorted=False,
-)
 
-        
+            X = sort_graph_by_row_values(
+                X,
+                copy=False,
+                warn_when_not_sorted=False,
+            )
 
         neighbors_model = NearestNeighbors(
             radius=self.eps,

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -144,8 +144,6 @@ def test_dbscan_input_not_modified_precomputed_sparse_nodiag(csr_container):
     assert_array_equal(X.toarray(), X_copy.toarray())
 
 
-
-
 def test_dbscan_precomputed_sorted_graph_no_efficiency_warning():
     rng = np.random.RandomState(0)
     X = rng.randn(200, 10)
@@ -170,12 +168,12 @@ def test_dbscan_precomputed_sorted_graph_no_efficiency_warning():
     efficiency_warnings = [
         w
         for w in recorded_warnings
-        if "Precomputed sparse input was not sorted by row values"
-        in str(w.message)
+        if "Precomputed sparse input was not sorted by row values" in str(w.message)
     ]
 
     assert len(efficiency_warnings) == 0
-    
+
+
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 def test_dbscan_no_core_samples(csr_container):
     rng = np.random.RandomState(0)

--- a/sklearn/cluster/tests/test_dbscan.py
+++ b/sklearn/cluster/tests/test_dbscan.py
@@ -144,6 +144,38 @@ def test_dbscan_input_not_modified_precomputed_sparse_nodiag(csr_container):
     assert_array_equal(X.toarray(), X_copy.toarray())
 
 
+
+
+def test_dbscan_precomputed_sorted_graph_no_efficiency_warning():
+    rng = np.random.RandomState(0)
+    X = rng.randn(200, 10)
+
+    from sklearn.neighbors import (
+        kneighbors_graph,
+        sort_graph_by_row_values,
+    )
+
+    graph = kneighbors_graph(
+        X,
+        n_neighbors=20,
+        mode="distance",
+    )
+
+    graph = sort_graph_by_row_values(graph)
+
+    with warnings.catch_warnings(record=True) as recorded_warnings:
+        warnings.simplefilter("always")
+        DBSCAN(metric="precomputed", eps=0.5).fit(graph)
+
+    efficiency_warnings = [
+        w
+        for w in recorded_warnings
+        if "Precomputed sparse input was not sorted by row values"
+        in str(w.message)
+    ]
+
+    assert len(efficiency_warnings) == 0
+    
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 def test_dbscan_no_core_samples(csr_container):
     rng = np.random.RandomState(0)


### PR DESCRIPTION
## Summary

Fix a spurious `EfficiencyWarning` emitted by DBSCAN when using sorted sparse precomputed distance graphs.

## Root cause

When `metric="precomputed"` and the input is a sparse matrix, DBSCAN calls:

```python
X.setdiag(X.diagonal())
```

to ensure that each sample is its own neighbor.

This operation disrupts the row-value ordering of an already sorted sparse graph. As a result, `_check_precomputed()` later detects the graph as unsorted and emits an `EfficiencyWarning`, even when the graph was previously sorted with `sort_graph_by_row_values()`.

## Fix

Re-sort the graph after `setdiag()`:

```python
X = sort_graph_by_row_values(
    X,
    copy=False,
    warn_when_not_sorted=False,
)
```

## Tests

Added a regression test ensuring that DBSCAN does not emit the warning when given a sorted sparse precomputed graph.

Fixes #31030
