### PR TITLE
contain openml cache path against traversal

### DIFF
--- a/doc/whats_new/upcoming_changes/security/34220.fix.rst
+++ b/doc/whats_new/upcoming_changes/security/34220.fix.rst
@@ -1,0 +1,5 @@
+- :func:`datasets.fetch_openml` now validates the cache file path derived from
+  the server-provided download URL and rejects paths that escape the local
+  scikit-learn data cache directory. This prevents a malicious or compromised
+  OpenML server from writing to or deleting files outside of the cache.
+  By :user:`jmestwa-coder`.

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -49,10 +49,9 @@ def _get_local_path(openml_path: str, data_home: str) -> str:
     # ``openml_path`` is derived from a server-provided URL. Reject paths that
     # escape the cache directory so a malicious response cannot read, overwrite
     # or delete files outside of ``data_home``.
-    if (
-        os.path.commonpath([os.path.abspath(cache_dir), os.path.abspath(local_path)])
-        != os.path.abspath(cache_dir)
-    ):
+    if os.path.commonpath(
+        [os.path.abspath(cache_dir), os.path.abspath(local_path)]
+    ) != os.path.abspath(cache_dir):
         raise ValueError(
             f"Invalid OpenML path escaping the cache directory: {openml_path!r}"
         )

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -45,12 +45,14 @@ OpenmlFeaturesType = List[Dict[str, str]]
 
 def _get_local_path(openml_path: str, data_home: str) -> str:
     cache_dir = os.path.join(data_home, "openml.org")
-    local_path = os.path.normpath(os.path.join(cache_dir, openml_path + ".gz"))
+    local_path = os.path.join(cache_dir, openml_path + ".gz")
     # ``openml_path`` is derived from a server-provided URL. Reject paths that
     # escape the cache directory so a malicious response cannot read, overwrite
-    # or delete files outside of ``data_home``.
+    # or delete files outside of ``data_home``. The containment check runs on a
+    # normalized copy while ``local_path`` is returned unchanged.
+    normalized = os.path.normpath(local_path)
     if os.path.commonpath(
-        [os.path.abspath(cache_dir), os.path.abspath(local_path)]
+        [os.path.abspath(cache_dir), os.path.abspath(normalized)]
     ) != os.path.abspath(cache_dir):
         raise ValueError(
             f"Invalid OpenML path escaping the cache directory: {openml_path!r}"

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -44,7 +44,19 @@ OpenmlFeaturesType = List[Dict[str, str]]
 
 
 def _get_local_path(openml_path: str, data_home: str) -> str:
-    return os.path.join(data_home, "openml.org", openml_path + ".gz")
+    cache_dir = os.path.join(data_home, "openml.org")
+    local_path = os.path.normpath(os.path.join(cache_dir, openml_path + ".gz"))
+    # ``openml_path`` is derived from a server-provided URL. Reject paths that
+    # escape the cache directory so a malicious response cannot read, overwrite
+    # or delete files outside of ``data_home``.
+    if (
+        os.path.commonpath([os.path.abspath(cache_dir), os.path.abspath(local_path)])
+        != os.path.abspath(cache_dir)
+    ):
+        raise ValueError(
+            f"Invalid OpenML path escaping the cache directory: {openml_path!r}"
+        )
+    return local_path
 
 
 def _openml_path_from_url(url: str) -> str:

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -1415,6 +1415,20 @@ def test_retry_with_clean_cache(tmpdir):
     assert result == 1
 
 
+def test_get_local_path_rejects_path_traversal(tmpdir):
+    cache_directory = str(tmpdir.mkdir("scikit_learn_data"))
+
+    # A regular OpenML path stays inside the cache directory.
+    safe = _get_local_path("data/v1/download/61/iris.arff", cache_directory)
+    cache_dir = os.path.join(cache_directory, "openml.org")
+    assert os.path.abspath(safe).startswith(os.path.abspath(cache_dir))
+
+    # A path crafted from a malicious server URL must be rejected instead of
+    # escaping the cache directory.
+    with pytest.raises(ValueError, match="escaping the cache directory"):
+        _get_local_path("../../../../../../tmp/pwned", cache_directory)
+
+
 def test_retry_with_clean_cache_http_error(tmpdir):
     data_id = 61
     openml_path = _MONKEY_PATCH_LOCAL_OPENML_PATH.format(data_id)


### PR DESCRIPTION
`_get_local_path` builds the cache file path from the path component of `data_description["url"]`, which the OpenML JSON API returns and the client does not control:

- the path is joined under `data_home/openml.org` with no containment, so a server url like `https://host/../../../../tmp/x` resolves outside `data_home`
- `_open_openml_url` then writes the downloaded body to that location, and `_retry_with_clean_cache` unlinks it, giving a hostile/compromised server an arbitrary `.gz` write and delete

Normalize the joined path and reject anything that escapes the cache directory.
