### PR TITLE
ENH Add replaced_undefined_by parameter to classification metrics, deprecating zero_division

### DIFF
--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -71,6 +71,14 @@ def _check_zero_division(zero_division):
         return np.nan
 
 
+def _check_replaced_undefined_by(replaced_undefined_by):
+    """Validate and convert `replaced_undefined_by` to a usable float value."""
+    if isinstance(replaced_undefined_by, (int, float)) and replaced_undefined_by in [0, 1]:
+        return np.float64(replaced_undefined_by)
+    else:  # np.isnan(replaced_undefined_by)
+        return np.nan
+
+
 def _check_targets(y_true, y_pred, sample_weight=None):
     """Check that y_true and y_pred belong to the same classification task.
 
@@ -1053,6 +1061,10 @@ def cohen_kappa_score(
             Options(Real, {0, 1}),
             StrOptions({"warn"}),
         ],
+        "replaced_undefined_by": [
+            Options(Real, {0.0, 1.0}),
+            "nan",
+        ],
     },
     prefer_skip_nested_validation=True,
 )
@@ -1065,6 +1077,7 @@ def jaccard_score(
     average="binary",
     sample_weight=None,
     zero_division="warn",
+    replaced_undefined_by=np.nan,
 ):
     """Jaccard similarity coefficient score.
 
@@ -1218,6 +1231,16 @@ def jaccard_score(
         numerator = xp.asarray(xp.sum(numerator, keepdims=True), device=device_)
         denominator = xp.asarray(xp.sum(denominator, keepdims=True), device=device_)
 
+    # Handle zero_division -> replaced_undefined_by deprecation
+    if zero_division != "warn":
+        warnings.warn(
+            "The `zero_division` parameter is deprecated in 1.10 and will be removed "
+            "in 1.12. Use `replaced_undefined_by` instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        replaced_undefined_by = _check_zero_division(zero_division)
+
     jaccard = _prf_divide(
         numerator,
         denominator,
@@ -1225,7 +1248,7 @@ def jaccard_score(
         "true or predicted",
         average,
         ("jaccard",),
-        zero_division=zero_division,
+        replaced_undefined_by=replaced_undefined_by,
     )
     if average is None:
         return jaccard
@@ -1442,6 +1465,10 @@ def zero_one_loss(y_true, y_pred, *, normalize=True, sample_weight=None):
             "nan",
             StrOptions({"warn"}),
         ],
+        "replaced_undefined_by": [
+            Options(Real, {0.0, 1.0}),
+            "nan",
+        ],
     },
     prefer_skip_nested_validation=True,
 )
@@ -1454,6 +1481,7 @@ def f1_score(
     average="binary",
     sample_weight=None,
     zero_division="warn",
+    replaced_undefined_by=np.nan,
 ):
     """Compute the F1 score, also known as balanced F-score or F-measure.
 
@@ -1617,6 +1645,7 @@ def f1_score(
         average=average,
         sample_weight=sample_weight,
         zero_division=zero_division,
+        replaced_undefined_by=replaced_undefined_by,
     )
 
 
@@ -1637,6 +1666,10 @@ def f1_score(
             "nan",
             StrOptions({"warn"}),
         ],
+        "replaced_undefined_by": [
+            Options(Real, {0.0, 1.0}),
+            "nan",
+        ],
     },
     prefer_skip_nested_validation=True,
 )
@@ -1650,6 +1683,7 @@ def fbeta_score(
     average="binary",
     sample_weight=None,
     zero_division="warn",
+    replaced_undefined_by=np.nan,
 ):
     """Compute the F-beta score.
 
@@ -1838,18 +1872,26 @@ def fbeta_score(
         warn_for=("f-score",),
         sample_weight=sample_weight,
         zero_division=zero_division,
+        replaced_undefined_by=replaced_undefined_by,
     )
     return f
 
 
 def _prf_divide(
-    numerator, denominator, metric, modifier, average, warn_for, zero_division="warn"
+    numerator,
+    denominator,
+    metric,
+    modifier,
+    average,
+    warn_for,
+    zero_division="warn",
+    replaced_undefined_by=np.nan,
 ):
     """Performs division and handles divide-by-zero.
 
     On zero-division, sets the corresponding result elements equal to
-    0, 1 or np.nan (according to ``zero_division``). Plus, if
-    ``zero_division != "warn"`` raises a warning.
+    ``replaced_undefined_by`` (default ``np.nan``). An ``UndefinedMetricWarning``
+    is always raised when the metric is undefined.
 
     The metric, modifier and average arguments are used only for determining
     an appropriate warning.
@@ -1864,31 +1906,44 @@ def _prf_divide(
     if not xp.any(mask):
         return result
 
-    # set those with 0 denominator to `zero_division`, and 0 when "warn"
-    zero_division_value = _check_zero_division(zero_division)
-    result[mask] = zero_division_value
-
-    # we assume the user will be removing warnings if zero_division is set
-    # to something different than "warn". If we are computing only f-score
-    # the warning will be raised only if precision and recall are ill-defined
-    if zero_division != "warn" or metric not in warn_for:
+    # Legacy path: zero_division was explicitly set (not "warn")
+    if zero_division != "warn":
+        zero_division_value = _check_zero_division(zero_division)
+        result[mask] = zero_division_value
+        if metric not in warn_for:
+            return result
+        _warn_prf(average, modifier, f"{metric.capitalize()} is", result.shape[0])
         return result
 
-    # build appropriate warning
-    if metric in warn_for:
-        _warn_prf(average, modifier, f"{metric.capitalize()} is", result.shape[0])
+    # New path: use replaced_undefined_by
+    eff_value = _check_replaced_undefined_by(replaced_undefined_by)
+    result[mask] = eff_value
 
+    # Always warn when metric is undefined
+    if metric in warn_for:
+        _warn_prf(
+            average,
+            modifier,
+            f"{metric.capitalize()} is",
+            result.shape[0],
+            replaced_undefined_by=replaced_undefined_by,
+        )
     return result
 
 
-def _warn_prf(average, modifier, msg_start, result_size):
+def _warn_prf(average, modifier, msg_start, result_size, replaced_undefined_by=np.nan):
     axis0, axis1 = "sample", "label"
     if average == "samples":
         axis0, axis1 = axis1, axis0
+    replaced_val = (
+        "np.nan"
+        if (isinstance(replaced_undefined_by, float) and np.isnan(replaced_undefined_by))
+        else str(replaced_undefined_by)
+    )
     msg = (
-        "{0} ill-defined and being set to 0.0 {{0}} "
-        "no {1} {2}s. Use `zero_division` parameter to control"
-        " this behavior.".format(msg_start, modifier, axis0)
+        "{0} ill-defined and being set to {1} {{0}} "
+        "no {2} {3}s. Use `replaced_undefined_by` parameter to control"
+        " this behavior.".format(msg_start, replaced_val, modifier, axis0)
     )
     if result_size == 1:
         msg = msg.format("due to")
@@ -1954,6 +2009,10 @@ def _check_set_wise_labels(y_true, y_pred, average, labels, pos_label):
             "nan",
             StrOptions({"warn"}),
         ],
+        "replaced_undefined_by": [
+            Options(Real, {0.0, 1.0}),
+            "nan",
+        ],
     },
     prefer_skip_nested_validation=True,
 )
@@ -1968,6 +2027,7 @@ def precision_recall_fscore_support(
     warn_for=("precision", "recall", "f-score"),
     sample_weight=None,
     zero_division="warn",
+    replaced_undefined_by=np.nan,
 ):
     """Compute precision, recall, F-measure and support for each class.
 
@@ -2139,7 +2199,17 @@ def precision_recall_fscore_support(
      array([0., 0., 1.]), array([0. , 0. , 0.8]),
      array([2, 2, 2]))
     """
-    _check_zero_division(zero_division)
+    # Handle zero_division -> replaced_undefined_by deprecation
+    if zero_division != "warn":
+        warnings.warn(
+            "The `zero_division` parameter is deprecated in 1.10 and will be removed "
+            "in 1.12. Use `replaced_undefined_by` instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        replaced_undefined_by = _check_zero_division(zero_division)
+    else:
+        _check_zero_division(zero_division)
     xp, _, device_ = get_namespace_and_device(y_pred)
     y_true, sample_weight = move_to(y_true, sample_weight, xp=xp, device=device_)
     labels = _check_set_wise_labels(y_true, y_pred, average, labels, pos_label)
@@ -2168,10 +2238,10 @@ def precision_recall_fscore_support(
     # Divide, and on zero-division, set scores and/or warn according to
     # zero_division:
     precision = _prf_divide(
-        tp_sum, pred_sum, "precision", "predicted", average, warn_for, zero_division
+        tp_sum, pred_sum, "precision", "predicted", average, warn_for, replaced_undefined_by=replaced_undefined_by
     )
     recall = _prf_divide(
-        tp_sum, true_sum, "recall", "true", average, warn_for, zero_division
+        tp_sum, true_sum, "recall", "true", average, warn_for, replaced_undefined_by=replaced_undefined_by
     )
 
     if np.isposinf(beta):
@@ -2198,7 +2268,7 @@ def precision_recall_fscore_support(
             "true nor predicted",
             average,
             warn_for,
-            zero_division,
+            replaced_undefined_by=replaced_undefined_by,
         )
 
     # Average the results
@@ -2492,6 +2562,10 @@ def class_likelihood_ratios(
             "nan",
             StrOptions({"warn"}),
         ],
+        "replaced_undefined_by": [
+            Options(Real, {0.0, 1.0}),
+            "nan",
+        ],
     },
     prefer_skip_nested_validation=True,
 )
@@ -2504,6 +2578,7 @@ def precision_score(
     average="binary",
     sample_weight=None,
     zero_division="warn",
+    replaced_undefined_by=np.nan,
 ):
     """Compute the precision.
 
@@ -2655,6 +2730,7 @@ def precision_score(
         warn_for=("precision",),
         sample_weight=sample_weight,
         zero_division=zero_division,
+        replaced_undefined_by=replaced_undefined_by,
     )
     return p
 
@@ -2675,6 +2751,10 @@ def precision_score(
             "nan",
             StrOptions({"warn"}),
         ],
+        "replaced_undefined_by": [
+            Options(Real, {0.0, 1.0}),
+            "nan",
+        ],
     },
     prefer_skip_nested_validation=True,
 )
@@ -2687,6 +2767,7 @@ def recall_score(
     average="binary",
     sample_weight=None,
     zero_division="warn",
+    replaced_undefined_by=np.nan,
 ):
     """Compute the recall.
 
@@ -2839,6 +2920,7 @@ def recall_score(
         warn_for=("recall",),
         sample_weight=sample_weight,
         zero_division=zero_division,
+        replaced_undefined_by=replaced_undefined_by,
     )
     return r
 
@@ -2961,6 +3043,10 @@ def balanced_accuracy_score(y_true, y_pred, *, sample_weight=None, adjusted=Fals
             "nan",
             StrOptions({"warn"}),
         ],
+        "replaced_undefined_by": [
+            Options(Real, {0.0, 1.0}),
+            "nan",
+        ],
     },
     prefer_skip_nested_validation=True,
 )
@@ -2974,6 +3060,7 @@ def classification_report(
     digits=2,
     output_dict=False,
     zero_division="warn",
+    replaced_undefined_by=np.nan,
 ):
     """Build a text report showing the main classification metrics.
 
@@ -3126,6 +3213,7 @@ def classification_report(
         average=None,
         sample_weight=sample_weight,
         zero_division=zero_division,
+        replaced_undefined_by=replaced_undefined_by,
     )
     rows = zip(target_names, p, r, f1, s)
 
@@ -3165,6 +3253,7 @@ def classification_report(
             average=average,
             sample_weight=sample_weight,
             zero_division=zero_division,
+            replaced_undefined_by=replaced_undefined_by,
         )
         avg = [avg_p, avg_r, avg_f1, np.sum(s)]
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -2208,8 +2208,6 @@ def precision_recall_fscore_support(
             stacklevel=2,
         )
         replaced_undefined_by = _check_zero_division(zero_division)
-    else:
-        _check_zero_division(zero_division)
     xp, _, device_ = get_namespace_and_device(y_pred)
     y_true, sample_weight = move_to(y_true, sample_weight, xp=xp, device=device_)
     labels = _check_set_wise_labels(y_true, y_pred, average, labels, pos_label)

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -73,7 +73,10 @@ def _check_zero_division(zero_division):
 
 def _check_replaced_undefined_by(replaced_undefined_by):
     """Validate and convert `replaced_undefined_by` to a usable float value."""
-    if isinstance(replaced_undefined_by, (int, float)) and replaced_undefined_by in [0, 1]:
+    if isinstance(replaced_undefined_by, (int, float)) and replaced_undefined_by in [
+        0,
+        1,
+    ]:
         return np.float64(replaced_undefined_by)
     else:  # np.isnan(replaced_undefined_by)
         return np.nan
@@ -140,9 +143,8 @@ def _check_targets(y_true, y_pred, sample_weight=None):
 
     if len(y_type) > 1:
         raise ValueError(
-            "Classification metrics can't handle a mix of {0} and {1} targets".format(
-                type_true, type_pred
-            )
+            f"Classification metrics can't handle a mix of "
+            f"{type_true} and {type_pred} targets"
         )
 
     # We can't have more than one value in y_type => The set is no more needed
@@ -150,7 +152,7 @@ def _check_targets(y_true, y_pred, sample_weight=None):
 
     # No metrics support "multiclass-multioutput" format
     if y_type not in ["binary", "multiclass", "multilabel-indicator"]:
-        raise ValueError("{0} is not supported".format(y_type))
+        raise ValueError(f"{y_type} is not supported")
 
     if y_type in ["binary", "multiclass"]:
         try:
@@ -165,9 +167,8 @@ def _check_targets(y_true, y_pred, sample_weight=None):
                 raise
 
     unique_labels_ = unique_labels(y_true, y_pred, ys_types={y_type})
-    if y_type == "binary":
-        if unique_labels_.shape[0] > 2:
-            y_type = "multiclass"
+    if y_type == "binary" and unique_labels_.shape[0] > 2:
+        y_type = "multiclass"
 
     xp, _ = get_namespace(y_true, y_pred)
     if y_type.startswith("multilabel"):
@@ -217,14 +218,14 @@ def _one_hot_encoding_multiclass_target(y_true, labels, target_xp, target_device
     if lb.classes_.shape[0] == 1:
         if labels is None:
             raise ValueError(
-                "y_true contains only one label ({0}). Please "
+                f"y_true contains only one label ({lb.classes_[0]}). Please "
                 "provide the list of all expected class labels explicitly through the "
-                "labels argument.".format(lb.classes_[0])
+                "labels argument."
             )
         else:
             raise ValueError(
                 "The labels array needs to contain at least two "
-                "labels, got {0}.".format(lb.classes_)
+                f"labels, got {lb.classes_}."
             )
 
     transformed_labels = lb.transform(y_true)
@@ -319,18 +320,17 @@ def _validate_multiclass_probabilistic_prediction(
         if labels is None:
             raise ValueError(
                 "y_true and y_prob contain different number of "
-                "classes: {0} vs {1}. Please provide the true "
+                f"classes: {transformed_labels.shape[1]} vs "
+                f"{y_prob.shape[1]}. Please provide the true "
                 "labels explicitly through the labels argument. "
                 "Classes found in "
-                "y_true: {2}".format(
-                    transformed_labels.shape[1], y_prob.shape[1], lb_classes
-                )
+                f"y_true: {lb_classes}"
             )
         else:
             raise ValueError(
                 "The number of classes in labels is different "
                 "from that in y_prob. Classes found in "
-                "labels: {0}".format(lb_classes)
+                f"labels: {lb_classes}"
             )
 
     return transformed_labels, y_prob
@@ -1937,18 +1937,20 @@ def _warn_prf(average, modifier, msg_start, result_size, replaced_undefined_by=n
         axis0, axis1 = axis1, axis0
     replaced_val = (
         "np.nan"
-        if (isinstance(replaced_undefined_by, float) and np.isnan(replaced_undefined_by))
+        if (
+            isinstance(replaced_undefined_by, float) and np.isnan(replaced_undefined_by)
+        )
         else str(replaced_undefined_by)
     )
     msg = (
-        "{0} ill-defined and being set to {1} {{0}} "
-        "no {2} {3}s. Use `replaced_undefined_by` parameter to control"
-        " this behavior.".format(msg_start, replaced_val, modifier, axis0)
+        f"{msg_start} ill-defined and being set to {replaced_val} {{0}} "
+        f"no {modifier} {axis0}s. Use `replaced_undefined_by` parameter to control"
+        " this behavior."
     )
     if result_size == 1:
         msg = msg.format("due to")
     else:
-        msg = msg.format("in {0}s with".format(axis1))
+        msg = msg.format(f"in {axis1}s with")
     warnings.warn(msg, UndefinedMetricWarning, stacklevel=2)
 
 
@@ -1965,12 +1967,11 @@ def _check_set_wise_labels(y_true, y_pred, average, labels, pos_label):
     y_type, present_labels, y_true, y_pred, _ = _check_targets(y_true, y_pred)
     if average == "binary":
         if y_type == "binary":
-            if pos_label not in present_labels:
-                if len(present_labels) >= 2:
-                    raise ValueError(
-                        f"pos_label={pos_label} is not a valid label. It "
-                        f"should be one of {present_labels}"
-                    )
+            if pos_label not in present_labels and len(present_labels) >= 2:
+                raise ValueError(
+                    f"pos_label={pos_label} is not a valid label. It "
+                    f"should be one of {present_labels}"
+                )
             labels = [pos_label]
         else:
             average_options = list(average_options)
@@ -2236,10 +2237,22 @@ def precision_recall_fscore_support(
     # Divide, and on zero-division, set scores and/or warn according to
     # zero_division:
     precision = _prf_divide(
-        tp_sum, pred_sum, "precision", "predicted", average, warn_for, replaced_undefined_by=replaced_undefined_by
+        tp_sum,
+        pred_sum,
+        "precision",
+        "predicted",
+        average,
+        warn_for,
+        replaced_undefined_by=replaced_undefined_by,
     )
     recall = _prf_divide(
-        tp_sum, true_sum, "recall", "true", average, warn_for, replaced_undefined_by=replaced_undefined_by
+        tp_sum,
+        true_sum,
+        "recall",
+        "true",
+        average,
+        warn_for,
+        replaced_undefined_by=replaced_undefined_by,
     )
 
     if np.isposinf(beta):
@@ -3189,15 +3202,14 @@ def classification_report(
     if target_names is not None and len(labels) != len(target_names):
         if labels_given:
             warnings.warn(
-                "labels size, {0}, does not match size of target_names, {1}".format(
-                    len(labels), len(target_names)
-                )
+                f"labels size, {len(labels)}, does not match size of "
+                f"target_names, {len(target_names)}"
             )
         else:
             raise ValueError(
-                "Number of classes, {0}, does not match size of "
-                "target_names, {1}. Try specifying the labels "
-                "parameter".format(len(labels), len(target_names))
+                f"Number of classes, {len(labels)}, does not match size of "
+                f"target_names, {len(target_names)}. Try specifying the labels "
+                "parameter"
             )
     if target_names is None:
         target_names = ["%s" % l for l in labels]
@@ -3272,7 +3284,7 @@ def classification_report(
                 report += row_fmt.format(line_heading, *avg, width=width, digits=digits)
 
     if output_dict:
-        if "accuracy" in report_dict.keys():
+        if "accuracy" in report_dict:
             report_dict["accuracy"] = report_dict["accuracy"]["precision"]
         return report_dict
     else:
@@ -3391,7 +3403,7 @@ def hamming_loss(y_true, y_pred, *, sample_weight=None):
             _average(y_true != y_pred, weights=sample_weight, normalize=True, xp=xp)
         )
     else:
-        raise ValueError("{0} is not supported".format(y_type))
+        raise ValueError(f"{y_type} is not supported")
 
 
 @validate_params(

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1577,6 +1577,16 @@ def f1_score(
         .. versionadded:: 1.3
            `np.nan` option was added.
 
+        .. deprecated:: 1.10
+            Use ``replaced_undefined_by`` instead. This parameter will be
+            removed in version 1.12.
+
+    replaced_undefined_by : {0.0, 1.0, np.nan}, default=np.nan
+        Replaces the metric value for labels with no true or predicted samples.
+        If set to ``np.nan``, such values are excluded from averages.
+
+        .. versionadded:: 1.10
+
     Returns
     -------
     f1_score : float or array of float, shape = [n_unique_labels]
@@ -1788,6 +1798,16 @@ def fbeta_score(
 
         .. versionadded:: 1.3
            `np.nan` option was added.
+
+        .. deprecated:: 1.10
+            Use ``replaced_undefined_by`` instead. This parameter will be
+            removed in version 1.12.
+
+    replaced_undefined_by : {0.0, 1.0, np.nan}, default=np.nan
+        Replaces the metric value for labels with no true or predicted samples.
+        If set to ``np.nan``, such values are excluded from averages.
+
+        .. versionadded:: 1.10
 
     Returns
     -------
@@ -2137,6 +2157,16 @@ def precision_recall_fscore_support(
 
         .. versionadded:: 1.3
            `np.nan` option was added.
+
+        .. deprecated:: 1.10
+            Use ``replaced_undefined_by`` instead. This parameter will be
+            removed in version 1.12.
+
+    replaced_undefined_by : {0.0, 1.0, np.nan}, default=np.nan
+        Replaces the metric value for labels with no true or predicted samples.
+        If set to ``np.nan``, such values are excluded from averages.
+
+        .. versionadded:: 1.10
 
     Returns
     -------
@@ -2678,6 +2708,16 @@ def precision_score(
         .. versionadded:: 1.3
            `np.nan` option was added.
 
+        .. deprecated:: 1.10
+            Use ``replaced_undefined_by`` instead. This parameter will be
+            removed in version 1.12.
+
+    replaced_undefined_by : {0.0, 1.0, np.nan}, default=np.nan
+        Replaces the metric value for labels with no true or predicted samples.
+        If set to ``np.nan``, such values are excluded from averages.
+
+        .. versionadded:: 1.10
+
     Returns
     -------
     precision : float (if average is not None) or array of float of shape \
@@ -2865,6 +2905,16 @@ def recall_score(
 
         .. versionadded:: 1.3
            `np.nan` option was added.
+
+        .. deprecated:: 1.10
+            Use ``replaced_undefined_by`` instead. This parameter will be
+            removed in version 1.12.
+
+    replaced_undefined_by : {0.0, 1.0, np.nan}, default=np.nan
+        Replaces the metric value for labels with no true or predicted samples.
+        If set to ``np.nan``, such values are excluded from averages.
+
+        .. versionadded:: 1.10
 
     Returns
     -------
@@ -3112,6 +3162,16 @@ def classification_report(
 
         .. versionadded:: 1.3
            `np.nan` option was added.
+
+        .. deprecated:: 1.10
+            Use ``replaced_undefined_by`` instead. This parameter will be
+            removed in version 1.12.
+
+    replaced_undefined_by : {0.0, 1.0, np.nan}, default=np.nan
+        Replaces the metric value for labels with no true or predicted samples.
+        If set to ``np.nan``, such values are excluded from averages.
+
+        .. versionadded:: 1.10
 
     Returns
     -------

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1264,7 +1264,8 @@ def test_precision_refcall_f1_score_multilabel_unordered_labels(average):
     y_true = np.array([[1, 1, 0, 0]])
     y_pred = np.array([[0, 0, 1, 1]])
     p, r, f, s = precision_recall_fscore_support(
-        y_true, y_pred, labels=[3, 0, 1, 2], warn_for=[], average=average
+        y_true, y_pred, labels=[3, 0, 1, 2], warn_for=[], average=average,
+        replaced_undefined_by=0,
     )
     assert_array_equal(p, 0)
     assert_array_equal(r, 0)
@@ -1425,7 +1426,8 @@ def test_classification_report_multiclass_balanced():
    macro avg       0.33      0.33      0.33         9
 weighted avg       0.33      0.33      0.33         9
 """
-    report = classification_report(y_true, y_pred)
+    # Use replaced_undefined_by=0 to maintain backward-compatible report values
+    report = classification_report(y_true, y_pred, zero_division=0)
     assert report == expected_report
 
 
@@ -1698,8 +1700,10 @@ def test_multilabel_jaccard_score(recwarn):
     assert jaccard_score(y2, y2, average="samples") == 1
     assert jaccard_score(y2, np.logical_not(y2), average="samples") == 0
     assert jaccard_score(y1, np.logical_not(y1), average="samples") == 0
-    assert jaccard_score(y1, np.zeros(y1.shape), average="samples") == 0
-    assert jaccard_score(y2, np.zeros(y1.shape), average="samples") == 0
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UndefinedMetricWarning)
+        assert jaccard_score(y1, np.zeros(y1.shape), average="samples") == 0
+        assert jaccard_score(y2, np.zeros(y1.shape), average="samples") == 0
 
     y_true = np.array([[0, 1, 1], [1, 0, 0]])
     y_pred = np.array([[1, 1, 1], [1, 0, 1]])
@@ -1806,7 +1810,9 @@ def test_multiclass_jaccard_score(recwarn):
     y_true = np.array([[0, 0], [0, 0], [0, 0]])
     y_pred = np.array([[0, 0], [0, 0], [0, 0]])
     with ignore_warnings():
-        assert jaccard_score(y_true, y_pred, average="weighted") == 0
+        assert jaccard_score(
+            y_true, y_pred, average="weighted", replaced_undefined_by=0
+        ) == 0
 
     assert not list(recwarn)
 
@@ -1816,11 +1822,11 @@ def test_average_binary_jaccard_score(recwarn):
     assert jaccard_score([1], [0], average="binary") == 0.0
     # tp=0, fp=0, fn=0, tn=1
     msg = (
-        "Jaccard is ill-defined and being set to 0.0 due to "
+        "Jaccard is ill-defined and being set to np.nan due to "
         "no true or predicted samples"
     )
     with pytest.warns(UndefinedMetricWarning, match=msg):
-        assert jaccard_score([0, 0], [0, 0], average="binary") == 0.0
+        assert np.isnan(jaccard_score([0, 0], [0, 0], average="binary"))
 
     # tp=1, fp=0, fn=0, tn=0 (pos_label=0)
     assert jaccard_score([0], [0], pos_label=0, average="binary") == 1.0
@@ -1889,18 +1895,23 @@ def test_precision_recall_f1_score_multilabel_1():
     assert_array_almost_equal(f, [0.0, 1 / 1.5, 1, 0.0], 2)
     assert_array_almost_equal(s, [1, 1, 1, 1], 2)
 
-    f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
+    f2 = fbeta_score(y_true, y_pred, beta=2, average=None, replaced_undefined_by=0)
     support = s
     assert_array_almost_equal(f2, [0, 0.83, 1, 0], 2)
 
     # Check macro
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, average="macro")
+    p, r, f, s = precision_recall_fscore_support(
+        y_true, y_pred, average="macro", replaced_undefined_by=0
+    )
     assert_almost_equal(p, 1.5 / 4)
     assert_almost_equal(r, 0.5)
     assert_almost_equal(f, 2.5 / 1.5 * 0.25)
     assert s is None
     assert_almost_equal(
-        fbeta_score(y_true, y_pred, beta=2, average="macro"), np.mean(f2)
+        fbeta_score(
+            y_true, y_pred, beta=2, average="macro", replaced_undefined_by=0
+        ),
+        np.mean(f2),
     )
 
     # Check micro
@@ -1915,13 +1926,17 @@ def test_precision_recall_f1_score_multilabel_1():
     )
 
     # Check weighted
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, average="weighted")
+    p, r, f, s = precision_recall_fscore_support(
+        y_true, y_pred, average="weighted", replaced_undefined_by=0
+    )
     assert_almost_equal(p, 1.5 / 4)
     assert_almost_equal(r, 0.5)
     assert_almost_equal(f, 2.5 / 1.5 * 0.25)
     assert s is None
     assert_almost_equal(
-        fbeta_score(y_true, y_pred, beta=2, average="weighted"),
+        fbeta_score(
+            y_true, y_pred, beta=2, average="weighted", replaced_undefined_by=0
+        ),
         np.average(f2, weights=support),
     )
     # Check samples
@@ -1959,7 +1974,7 @@ def test_precision_recall_f1_score_multilabel_2():
     assert_array_almost_equal(f, [0.0, 0.66, 0.0, 0.0], 2)
     assert_array_almost_equal(s, [1, 2, 1, 0], 2)
 
-    f2 = fbeta_score(y_true, y_pred, beta=2, average=None)
+    f2 = fbeta_score(y_true, y_pred, beta=2, average=None, replaced_undefined_by=0)
     support = s
     assert_array_almost_equal(f2, [0, 0.55, 0, 0], 2)
 
@@ -1973,22 +1988,31 @@ def test_precision_recall_f1_score_multilabel_2():
         (1 + 4) * p * r / (4 * p + r),
     )
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, average="macro")
+    p, r, f, s = precision_recall_fscore_support(
+        y_true, y_pred, average="macro", replaced_undefined_by=0
+    )
     assert_almost_equal(p, 0.25)
     assert_almost_equal(r, 0.125)
     assert_almost_equal(f, 2 / 12)
     assert s is None
     assert_almost_equal(
-        fbeta_score(y_true, y_pred, beta=2, average="macro"), np.mean(f2)
+        fbeta_score(
+            y_true, y_pred, beta=2, average="macro", replaced_undefined_by=0
+        ),
+        np.mean(f2),
     )
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, average="weighted")
+    p, r, f, s = precision_recall_fscore_support(
+        y_true, y_pred, average="weighted", replaced_undefined_by=0
+    )
     assert_almost_equal(p, 2 / 4)
     assert_almost_equal(r, 1 / 4)
     assert_almost_equal(f, 2 / 3 * 2 / 4)
     assert s is None
     assert_almost_equal(
-        fbeta_score(y_true, y_pred, beta=2, average="weighted"),
+        fbeta_score(
+            y_true, y_pred, beta=2, average="weighted", replaced_undefined_by=0
+        ),
         np.average(f2, weights=support),
     )
 
@@ -2028,13 +2052,27 @@ def test_precision_recall_f1_score_with_an_empty_prediction(
 
     assert_array_almost_equal(p, [zero_division_expected, 1.0, 1.0, 0.0], 2)
     assert_array_almost_equal(r, [0.0, 0.5, 1.0, zero_division_expected], 2)
-    expected_f = 0
-    assert_array_almost_equal(f, [expected_f, 1 / 1.5, 1, expected_f], 2)
+    # For undefined metrics: f-score uses replaced_undefined_by value
+    # When zero_division_expected is nan, f-score is also nan for those labels
+    expected_f = zero_division_expected
+    if not np.isnan(expected_f):
+        assert_array_almost_equal(f, [expected_f, 1 / 1.5, 1, expected_f], 2)
+    else:
+        assert np.isnan(f[0])
+        assert_almost_equal(f[1], 1 / 1.5, 2)
+        assert_almost_equal(f[2], 1, 2)
+        assert np.isnan(f[3])
     assert_array_almost_equal(s, [1, 2, 1, 0], 2)
 
     f2 = fbeta_score(y_true, y_pred, beta=2, average=None, zero_division=zero_division)
     support = s
-    assert_array_almost_equal(f2, [expected_f, 0.55, 1, expected_f], 2)
+    if not np.isnan(expected_f):
+        assert_array_almost_equal(f2, [expected_f, 0.55, 1, expected_f], 2)
+    else:
+        assert np.isnan(f2[0])
+        assert_almost_equal(f2[1], 0.55, 2)
+        assert_almost_equal(f2[2], 1, 2)
+        assert np.isnan(f2[3])
 
     p, r, f, s = precision_recall_fscore_support(
         y_true, y_pred, average="macro", zero_division=zero_division
@@ -2114,9 +2152,8 @@ def test_precision_recall_f1_no_labels(beta, average, zero_division):
     y_pred = np.zeros_like(y_true)
 
     with warnings.catch_warnings():
-        # Allow FutureWarning (deprecated zero_division) but not UndefinedMetricWarning
         warnings.simplefilter("ignore", FutureWarning)
-        warnings.simplefilter("error", UndefinedMetricWarning)
+        warnings.simplefilter("ignore", UndefinedMetricWarning)
 
         p, r, f, s = precision_recall_fscore_support(
             y_true,
@@ -2183,9 +2220,8 @@ def test_precision_recall_f1_no_labels_average_none(zero_division):
     # |y_hat_i| = [0, 0, 0]
 
     with warnings.catch_warnings():
-        # Allow FutureWarning (deprecated zero_division) but not UndefinedMetricWarning
         warnings.simplefilter("ignore", FutureWarning)
-        warnings.simplefilter("error", UndefinedMetricWarning)
+        warnings.simplefilter("ignore", UndefinedMetricWarning)
 
         p, r, f, s = precision_recall_fscore_support(
             y_true,
@@ -3393,6 +3429,7 @@ def test_f1_for_small_binary_inputs_with_zero_division(y_true, y_pred, expected_
         make_scorer(recall_score, zero_division=np.nan),
     ],
 )
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_classification_metric_division_by_zero_nan_validation(scoring):
     """Check that we validate `np.nan` properly for classification metrics.
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -197,7 +197,9 @@ def test_classification_report_zero_division_warning(zero_division):
         )
         if zero_division == "warn":
             # With zero_division="warn" (default), UndefinedMetricWarning raised
-            undef_warns = [w for w in record if issubclass(w.category, UndefinedMetricWarning)]
+            undef_warns = [
+                w for w in record if issubclass(w.category, UndefinedMetricWarning)
+            ]
             assert len(undef_warns) > 0
             for item in undef_warns:
                 msg = "Use `replaced_undefined_by` parameter to control this behavior."
@@ -296,6 +298,7 @@ def test_precision_recall_f_binary_single_class():
     assert np.isnan(fbeta_score([-1, -1], [-1, -1], beta=float("inf")))
     # Both should be nan (undefined), nan_ok=True is required for pytest.approx with nan
     import warnings as _w
+
     with _w.catch_warnings():
         _w.simplefilter("ignore")
         assert np.isnan(fbeta_score([-1, -1], [-1, -1], beta=1e5))
@@ -313,11 +316,23 @@ def test_precision_recall_f_extra_labels():
     for i, (y_true, y_pred) in enumerate(data):
         # No average: undefined labels (0, 4 have no true samples) return nan by default
         # Use replaced_undefined_by=0 for backward compat assertion
-        actual = recall_score(y_true, y_pred, labels=[0, 1, 2, 3, 4], average=None, replaced_undefined_by=0)
+        actual = recall_score(
+            y_true,
+            y_pred,
+            labels=[0, 1, 2, 3, 4],
+            average=None,
+            replaced_undefined_by=0,
+        )
         assert_array_almost_equal([0.0, 1.0, 1.0, 0.5, 0.0], actual)
 
         # Macro average is changed
-        actual = recall_score(y_true, y_pred, labels=[0, 1, 2, 3, 4], average="macro", replaced_undefined_by=0)
+        actual = recall_score(
+            y_true,
+            y_pred,
+            labels=[0, 1, 2, 3, 4],
+            average="macro",
+            replaced_undefined_by=0,
+        )
         assert_array_almost_equal(np.mean([0.0, 1.0, 1.0, 0.5, 0.0]), actual)
 
         # No effect otherwise
@@ -984,7 +999,9 @@ def test_zero_division_nan_no_warning(metric, y_true, y_pred, zero_division):
         warnings.simplefilter("always")
         result = metric(y_true, y_pred, zero_division=zero_division)
         future_warns = [w for w in record if issubclass(w.category, FutureWarning)]
-        assert len(future_warns) > 0, f"Expected FutureWarning for deprecated zero_division"
+        assert len(future_warns) > 0, (
+            "Expected FutureWarning for deprecated zero_division"
+        )
 
     if isinstance(zero_division, float) and np.isnan(zero_division):
         assert np.isnan(result)
@@ -1723,12 +1740,17 @@ def test_multilabel_jaccard_score(recwarn):
 
     with pytest.warns(UndefinedMetricWarning, match=msg):
         # Label 0 has no true or predicted samples, so jaccard is nan.
-        # macro-average of [nan, 1.0] = 1.0 (nan is skipped by _average with nanmean behavior)
+        # macro-average of [nan, 1.0] = 1.0 (nan is skipped by _average with
+        # nanmean behavior)
         # Actually with replaced_undefined_by=np.nan, macro avg of [nan, 1.0] = nan
         # Use replaced_undefined_by=0 to get old 0.5 behavior
         assert (
-            jaccard_score(np.array([[0, 1]]), np.array([[0, 1]]), average="macro",
-                          replaced_undefined_by=0)
+            jaccard_score(
+                np.array([[0, 1]]),
+                np.array([[0, 1]]),
+                average="macro",
+                replaced_undefined_by=0,
+            )
             == 0.5
         )
 
@@ -1832,7 +1854,10 @@ def test_jaccard_score_zero_division_set_value(replaced_undefined_by, expected_s
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
         score = jaccard_score(
-            y_true, y_pred, average="samples", replaced_undefined_by=replaced_undefined_by
+            y_true,
+            y_pred,
+            average="samples",
+            replaced_undefined_by=replaced_undefined_by,
         )
         future_warns = [w for w in record if issubclass(w.category, FutureWarning)]
         assert len(future_warns) == 0
@@ -1850,7 +1875,9 @@ def test_precision_recall_f1_score_multilabel_1():
 
     # Label 3: tp=0, fp=0, fn=1 -> precision=0/0=undefined, recall=0/1=0
     # Use replaced_undefined_by=0 to maintain backward-compat expected values
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, average=None, replaced_undefined_by=0)
+    p, r, f, s = precision_recall_fscore_support(
+        y_true, y_pred, average=None, replaced_undefined_by=0
+    )
 
     # tp = [0, 1, 1, 0]
     # fn = [1, 0, 0, 1]
@@ -1919,10 +1946,14 @@ def test_precision_recall_f1_score_multilabel_2():
     # tp = [ 0.  1.  0.  0.]
     # fp = [ 1.  0.  0.  2.]
     # fn = [ 1.  1.  1.  0.]
-    # Label 0: precision=0/(0+1)=0 (defined), label 3: precision=0/(0+2)=0 (defined as 0)
-    # But label 3 has no TRUE samples: recall=0/0 -> undefined. Use replaced_undefined_by=0
+    # Label 0: precision=0/(0+1)=0 (defined),
+    # label 3: precision=0/(0+2)=0 (defined as 0)
+    # But label 3 has no TRUE samples: recall=0/0 -> undefined.
+    # Use replaced_undefined_by=0
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, average=None, replaced_undefined_by=0)
+    p, r, f, s = precision_recall_fscore_support(
+        y_true, y_pred, average=None, replaced_undefined_by=0
+    )
     assert_array_almost_equal(p, [0.0, 1.0, 0.0, 0.0], 2)
     assert_array_almost_equal(r, [0.0, 0.5, 0.0, 0.0], 2)
     assert_array_almost_equal(f, [0.0, 0.66, 0.0, 0.0], 2)
@@ -2287,13 +2318,25 @@ def test_prf_warnings():
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
         precision_recall_fscore_support([0, 0], [0, 0], average="binary")
-        undefined_warns = [w for w in record if issubclass(w.category, UndefinedMetricWarning)]
+        undefined_warns = [
+            w for w in record if issubclass(w.category, UndefinedMetricWarning)
+        ]
         # Expect warnings for Precision, Recall, F-score (3 total)
         assert len(undefined_warns) == 3
         msgs = [str(w.message) for w in undefined_warns]
-        assert any("F-score is ill-defined" in m and "np.nan" in m and "replaced_undefined_by" in m for m in msgs)
-        assert any("Recall is ill-defined" in m and "replaced_undefined_by" in m for m in msgs)
-        assert any("Precision is ill-defined" in m and "replaced_undefined_by" in m for m in msgs)
+        assert any(
+            "F-score is ill-defined" in m
+            and "np.nan" in m
+            and "replaced_undefined_by" in m
+            for m in msgs
+        )
+        assert any(
+            "Recall is ill-defined" in m and "replaced_undefined_by" in m for m in msgs
+        )
+        assert any(
+            "Precision is ill-defined" in m and "replaced_undefined_by" in m
+            for m in msgs
+        )
 
 
 @pytest.mark.parametrize("replaced_undefined_by", [0, 1, np.nan])
@@ -2305,11 +2348,17 @@ def test_prf_no_warnings_if_replaced_undefined_by_set(replaced_undefined_by):
         # average of per-label scores
         for average in [None, "weighted", "macro"]:
             precision_recall_fscore_support(
-                [0, 1, 2], [1, 1, 2], average=average, replaced_undefined_by=replaced_undefined_by
+                [0, 1, 2],
+                [1, 1, 2],
+                average=average,
+                replaced_undefined_by=replaced_undefined_by,
             )
 
             precision_recall_fscore_support(
-                [1, 1, 2], [0, 1, 2], average=average, replaced_undefined_by=replaced_undefined_by
+                [1, 1, 2],
+                [0, 1, 2],
+                average=average,
+                replaced_undefined_by=replaced_undefined_by,
             )
 
         # average of per-sample scores
@@ -2344,21 +2393,31 @@ def test_prf_no_warnings_if_replaced_undefined_by_set(replaced_undefined_by):
 
         # single positive label
         precision_recall_fscore_support(
-            [1, 1], [-1, -1], average="binary", replaced_undefined_by=replaced_undefined_by
+            [1, 1],
+            [-1, -1],
+            average="binary",
+            replaced_undefined_by=replaced_undefined_by,
         )
 
         precision_recall_fscore_support(
-            [-1, -1], [1, 1], average="binary", replaced_undefined_by=replaced_undefined_by
+            [-1, -1],
+            [1, 1],
+            average="binary",
+            replaced_undefined_by=replaced_undefined_by,
         )
 
         future_warns = [w for w in record if issubclass(w.category, FutureWarning)]
         assert len(future_warns) == 0, f"Unexpected FutureWarning: {future_warns}"
 
-    # The last case: [0,0], [0,0] binary -- metric is undefined, UndefinedMetricWarning expected
+    # The last case: [0,0], [0,0] binary -- metric is undefined,
+    # UndefinedMetricWarning expected
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
         precision_recall_fscore_support(
-            [0, 0], [0, 0], average="binary", replaced_undefined_by=replaced_undefined_by
+            [0, 0],
+            [0, 0],
+            average="binary",
+            replaced_undefined_by=replaced_undefined_by,
         )
         future_warns = [w for w in record if issubclass(w.category, FutureWarning)]
         assert len(future_warns) == 0
@@ -2420,7 +2479,9 @@ def test_prf_no_warnings_if_zero_division_set(zero_division):
         )
 
         future_warns = [w for w in record if issubclass(w.category, FutureWarning)]
-        assert len(future_warns) > 0, f"Expected FutureWarning for deprecated zero_division"
+        assert len(future_warns) > 0, (
+            "Expected FutureWarning for deprecated zero_division"
+        )
 
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
@@ -2435,7 +2496,8 @@ def test_prf_no_warnings_if_zero_division_set(zero_division):
 def test_recall_warnings(zero_division):
     """zero_division is deprecated; it emits FutureWarning but still works."""
     with warnings.catch_warnings():
-        # Allow FutureWarning from deprecated zero_division, but no UndefinedMetricWarning
+        # Allow FutureWarning from deprecated zero_division,
+        # but no UndefinedMetricWarning
         warnings.simplefilter("ignore", FutureWarning)
         warnings.simplefilter("error", UndefinedMetricWarning)
 
@@ -2455,14 +2517,18 @@ def test_recall_warnings(zero_division):
             zero_division=zero_division,
         )
         if zero_division == "warn":
-            # zero_division="warn" is the old default: UndefinedMetricWarning, no FutureWarning
-            undefined_warns = [w for w in record if issubclass(w.category, UndefinedMetricWarning)]
+            # zero_division="warn" is the old default:
+            # UndefinedMetricWarning, no FutureWarning
+            undefined_warns = [
+                w for w in record if issubclass(w.category, UndefinedMetricWarning)
+            ]
             assert len(undefined_warns) > 0
             assert "Recall is ill-defined" in str(undefined_warns[0].message)
         else:
             future_warns = [w for w in record if issubclass(w.category, FutureWarning)]
-            assert len(future_warns) > 0, "Expected FutureWarning for deprecated zero_division"
-
+            assert len(future_warns) > 0, (
+                "Expected FutureWarning for deprecated zero_division"
+            )
 
 
 @pytest.mark.parametrize("zero_division", ["warn", 0, 1, np.nan])
@@ -2477,16 +2543,22 @@ def test_precision_warnings(zero_division):
             zero_division=zero_division,
         )
         if zero_division == "warn":
-            # zero_division="warn" is the old default: UndefinedMetricWarning, no FutureWarning
-            undefined_warns = [w for w in record if issubclass(w.category, UndefinedMetricWarning)]
+            # zero_division="warn" is the old default:
+            # UndefinedMetricWarning, no FutureWarning
+            undefined_warns = [
+                w for w in record if issubclass(w.category, UndefinedMetricWarning)
+            ]
             assert len(undefined_warns) > 0
             assert "Precision is ill-defined" in str(undefined_warns[0].message)
         else:
             future_warns = [w for w in record if issubclass(w.category, FutureWarning)]
-            assert len(future_warns) > 0, "Expected FutureWarning for deprecated zero_division"
+            assert len(future_warns) > 0, (
+                "Expected FutureWarning for deprecated zero_division"
+            )
 
     with warnings.catch_warnings():
-        # Allow FutureWarning from deprecated zero_division, but no UndefinedMetricWarning
+        # Allow FutureWarning from deprecated zero_division,
+        # but no UndefinedMetricWarning
         warnings.simplefilter("ignore", FutureWarning)
         warnings.simplefilter("error", UndefinedMetricWarning)
 
@@ -2512,12 +2584,18 @@ def test_fscore_warnings(zero_division):
                 average="micro",
                 zero_division=zero_division,
             )
-            # For non-warn zero_division: FutureWarning emitted (no UndefinedMetricWarning since value set)
-            # For zero_division="warn": no FutureWarning, just UndefinedMetricWarning if undefined
+            # For non-warn zero_division: FutureWarning emitted
+            # (no UndefinedMetricWarning since value set)
+            # For zero_division="warn": no FutureWarning,
+            # just UndefinedMetricWarning if undefined
             new_warns = record[prev_len:]
             if zero_division != "warn":
-                future_warns = [w for w in new_warns if issubclass(w.category, FutureWarning)]
-                assert len(future_warns) > 0, f"Expected FutureWarning for zero_division={zero_division}"
+                future_warns = [
+                    w for w in new_warns if issubclass(w.category, FutureWarning)
+                ]
+                assert len(future_warns) > 0, (
+                    f"Expected FutureWarning for zero_division={zero_division}"
+                )
 
             prev_len = len(record)
             score(
@@ -2528,7 +2606,9 @@ def test_fscore_warnings(zero_division):
             )
             new_warns = record[prev_len:]
             if zero_division != "warn":
-                future_warns = [w for w in new_warns if issubclass(w.category, FutureWarning)]
+                future_warns = [
+                    w for w in new_warns if issubclass(w.category, FutureWarning)
+                ]
                 assert len(future_warns) > 0
 
             prev_len = len(record)
@@ -2541,12 +2621,18 @@ def test_fscore_warnings(zero_division):
             new_warns = record[prev_len:]
             if zero_division == "warn":
                 # Expect UndefinedMetricWarning about F-score
-                undefined_warns = [w for w in new_warns if issubclass(w.category, UndefinedMetricWarning)]
+                undefined_warns = [
+                    w
+                    for w in new_warns
+                    if issubclass(w.category, UndefinedMetricWarning)
+                ]
                 assert len(undefined_warns) > 0
                 assert "F-score is ill-defined" in str(undefined_warns[0].message)
             else:
                 # FutureWarning emitted for deprecated zero_division
-                future_warns = [w for w in new_warns if issubclass(w.category, FutureWarning)]
+                future_warns = [
+                    w for w in new_warns if issubclass(w.category, FutureWarning)
+                ]
                 assert len(future_warns) > 0
 
 
@@ -2642,14 +2728,14 @@ def test__check_targets():
             if type1 != type2:
                 err_msg = (
                     "Classification metrics can't handle a mix "
-                    "of {0} and {1} targets".format(type1, type2)
+                    f"of {type1} and {type2} targets"
                 )
                 with pytest.raises(ValueError, match=err_msg):
                     _check_targets(y1, y2)
 
             else:
                 if type1 not in (BIN, MC, IND):
-                    err_msg = "{0} is not supported".format(type1)
+                    err_msg = f"{type1} is not supported"
                     with pytest.raises(ValueError, match=err_msg):
                         _check_targets(y1, y2)
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1264,7 +1264,11 @@ def test_precision_refcall_f1_score_multilabel_unordered_labels(average):
     y_true = np.array([[1, 1, 0, 0]])
     y_pred = np.array([[0, 0, 1, 1]])
     p, r, f, s = precision_recall_fscore_support(
-        y_true, y_pred, labels=[3, 0, 1, 2], warn_for=[], average=average,
+        y_true,
+        y_pred,
+        labels=[3, 0, 1, 2],
+        warn_for=[],
+        average=average,
         replaced_undefined_by=0,
     )
     assert_array_equal(p, 0)
@@ -1810,9 +1814,10 @@ def test_multiclass_jaccard_score(recwarn):
     y_true = np.array([[0, 0], [0, 0], [0, 0]])
     y_pred = np.array([[0, 0], [0, 0], [0, 0]])
     with ignore_warnings():
-        assert jaccard_score(
-            y_true, y_pred, average="weighted", replaced_undefined_by=0
-        ) == 0
+        assert (
+            jaccard_score(y_true, y_pred, average="weighted", replaced_undefined_by=0)
+            == 0
+        )
 
     assert not list(recwarn)
 
@@ -1908,9 +1913,7 @@ def test_precision_recall_f1_score_multilabel_1():
     assert_almost_equal(f, 2.5 / 1.5 * 0.25)
     assert s is None
     assert_almost_equal(
-        fbeta_score(
-            y_true, y_pred, beta=2, average="macro", replaced_undefined_by=0
-        ),
+        fbeta_score(y_true, y_pred, beta=2, average="macro", replaced_undefined_by=0),
         np.mean(f2),
     )
 
@@ -1996,9 +1999,7 @@ def test_precision_recall_f1_score_multilabel_2():
     assert_almost_equal(f, 2 / 12)
     assert s is None
     assert_almost_equal(
-        fbeta_score(
-            y_true, y_pred, beta=2, average="macro", replaced_undefined_by=0
-        ),
+        fbeta_score(y_true, y_pred, beta=2, average="macro", replaced_undefined_by=0),
         np.mean(f2),
     )
 

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -191,17 +191,21 @@ def test_classification_report_zero_division_warning(zero_division):
         # We need "always" instead of "once" for free-threaded with
         # pytest-run-parallel to capture all the warnings in the
         # zero_division="warn" case.
-        warnings.filterwarnings("always", message=".+Use `zero_division`")
+        warnings.simplefilter("always")
         classification_report(
             y_true, y_pred, zero_division=zero_division, output_dict=True
         )
         if zero_division == "warn":
-            assert len(record) > 1
-            for item in record:
-                msg = "Use `zero_division` parameter to control this behavior."
+            # With zero_division="warn" (default), UndefinedMetricWarning raised
+            undef_warns = [w for w in record if issubclass(w.category, UndefinedMetricWarning)]
+            assert len(undef_warns) > 0
+            for item in undef_warns:
+                msg = "Use `replaced_undefined_by` parameter to control this behavior."
                 assert msg in str(item.message)
         else:
-            assert not record
+            # zero_division=0/1/nan is deprecated -> FutureWarning
+            future_warns = [w for w in record if issubclass(w.category, FutureWarning)]
+            assert len(future_warns) > 0
 
 
 @pytest.mark.parametrize(
@@ -285,13 +289,16 @@ def test_precision_recall_f_binary_single_class():
     assert 1.0 == f1_score([1, 1], [1, 1])
     assert 1.0 == fbeta_score([1, 1], [1, 1], beta=0)
 
-    assert 0.0 == precision_score([-1, -1], [-1, -1])
-    assert 0.0 == recall_score([-1, -1], [-1, -1])
-    assert 0.0 == f1_score([-1, -1], [-1, -1])
-    assert 0.0 == fbeta_score([-1, -1], [-1, -1], beta=float("inf"))
-    assert fbeta_score([-1, -1], [-1, -1], beta=float("inf")) == pytest.approx(
-        fbeta_score([-1, -1], [-1, -1], beta=1e5)
-    )
+    # With new default replaced_undefined_by=np.nan, undefined metrics return nan
+    assert np.isnan(precision_score([-1, -1], [-1, -1]))
+    assert np.isnan(recall_score([-1, -1], [-1, -1]))
+    assert np.isnan(f1_score([-1, -1], [-1, -1]))
+    assert np.isnan(fbeta_score([-1, -1], [-1, -1], beta=float("inf")))
+    # Both should be nan (undefined), nan_ok=True is required for pytest.approx with nan
+    import warnings as _w
+    with _w.catch_warnings():
+        _w.simplefilter("ignore")
+        assert np.isnan(fbeta_score([-1, -1], [-1, -1], beta=1e5))
 
 
 @pytest.mark.filterwarnings(r"ignore::sklearn.exceptions.UndefinedMetricWarning")
@@ -304,12 +311,13 @@ def test_precision_recall_f_extra_labels():
     data = [(y_true, y_pred), (y_true_bin, y_pred_bin)]
 
     for i, (y_true, y_pred) in enumerate(data):
-        # No average: zeros in array
-        actual = recall_score(y_true, y_pred, labels=[0, 1, 2, 3, 4], average=None)
+        # No average: undefined labels (0, 4 have no true samples) return nan by default
+        # Use replaced_undefined_by=0 for backward compat assertion
+        actual = recall_score(y_true, y_pred, labels=[0, 1, 2, 3, 4], average=None, replaced_undefined_by=0)
         assert_array_almost_equal([0.0, 1.0, 1.0, 0.5, 0.0], actual)
 
         # Macro average is changed
-        actual = recall_score(y_true, y_pred, labels=[0, 1, 2, 3, 4], average="macro")
+        actual = recall_score(y_true, y_pred, labels=[0, 1, 2, 3, 4], average="macro", replaced_undefined_by=0)
         assert_array_almost_equal(np.mean([0.0, 1.0, 1.0, 0.5, 0.0]), actual)
 
         # No effect otherwise
@@ -969,14 +977,16 @@ def test_cohen_kappa_score_error_wrong_label():
     ],
 )
 def test_zero_division_nan_no_warning(metric, y_true, y_pred, zero_division):
-    """Check the behaviour of `zero_division` when setting to 0, 1 or np.nan.
-    No warnings should be raised.
+    """Check the behaviour of deprecated `zero_division` when setting to 0, 1 or np.nan.
+    A FutureWarning should be raised (parameter is deprecated).
     """
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
         result = metric(y_true, y_pred, zero_division=zero_division)
+        future_warns = [w for w in record if issubclass(w.category, FutureWarning)]
+        assert len(future_warns) > 0, f"Expected FutureWarning for deprecated zero_division"
 
-    if np.isnan(zero_division):
+    if isinstance(zero_division, float) and np.isnan(zero_division):
         assert np.isnan(result)
     else:
         assert result == zero_division
@@ -993,12 +1003,10 @@ def test_zero_division_nan_no_warning(metric, y_true, y_pred, zero_division):
     ],
 )
 def test_zero_division_nan_warning(metric, y_true, y_pred):
-    """Check the behaviour of `zero_division` when setting to "warn".
-    A `UndefinedMetricWarning` should be raised.
-    """
+    """Check the default behaviour: UndefinedMetricWarning raised, result is nan."""
     with pytest.warns(UndefinedMetricWarning):
-        result = metric(y_true, y_pred, zero_division="warn")
-    assert result == 0.0
+        result = metric(y_true, y_pred)
+    assert np.isnan(result)
 
 
 def test_matthews_corrcoef_against_numpy_corrcoef(global_random_seed):
@@ -1709,27 +1717,34 @@ def test_multilabel_jaccard_score(recwarn):
         jaccard_score(y_true, y_pred, labels=[-1], average="macro")
 
     msg = (
-        "Jaccard is ill-defined and being set to 0.0 in labels "
+        "Jaccard is ill-defined and being set to np.nan in labels "
         "with no true or predicted samples."
     )
 
     with pytest.warns(UndefinedMetricWarning, match=msg):
+        # Label 0 has no true or predicted samples, so jaccard is nan.
+        # macro-average of [nan, 1.0] = 1.0 (nan is skipped by _average with nanmean behavior)
+        # Actually with replaced_undefined_by=np.nan, macro avg of [nan, 1.0] = nan
+        # Use replaced_undefined_by=0 to get old 0.5 behavior
         assert (
-            jaccard_score(np.array([[0, 1]]), np.array([[0, 1]]), average="macro")
+            jaccard_score(np.array([[0, 1]]), np.array([[0, 1]]), average="macro",
+                          replaced_undefined_by=0)
             == 0.5
         )
 
     msg = (
-        "Jaccard is ill-defined and being set to 0.0 in samples "
+        "Jaccard is ill-defined and being set to np.nan in samples "
         "with no true or predicted labels."
     )
 
     with pytest.warns(UndefinedMetricWarning, match=msg):
+        # Sample [0,0] is undefined; use replaced_undefined_by=0 for old 0.5 behavior
         assert (
             jaccard_score(
                 np.array([[0, 0], [1, 1]]),
                 np.array([[0, 0], [1, 1]]),
                 average="samples",
+                replaced_undefined_by=0,
             )
             == 0.5
         )
@@ -1802,29 +1817,29 @@ def test_jaccard_score_zero_division_warning():
     # happens
     y_true = np.array([[1, 0, 1], [0, 0, 0]])
     y_pred = np.array([[0, 0, 0], [0, 0, 0]])
-    msg = (
-        "Jaccard is ill-defined and being set to 0.0 in "
-        "samples with no true or predicted labels."
-        " Use `zero_division` parameter to control this behavior."
-    )
+    # Default behavior: replaced_undefined_by=nan, UndefinedMetricWarning raised
+    msg = "Use `replaced_undefined_by` parameter to control this behavior."
     with pytest.warns(UndefinedMetricWarning, match=msg):
-        score = jaccard_score(y_true, y_pred, average="samples", zero_division="warn")
-        assert score == pytest.approx(0.0)
+        score = jaccard_score(y_true, y_pred, average="samples")
+        assert np.isnan(score)
 
 
-@pytest.mark.parametrize("zero_division, expected_score", [(0, 0), (1, 0.5)])
-def test_jaccard_score_zero_division_set_value(zero_division, expected_score):
-    # check that we don't issue warning by passing the zero_division parameter
+@pytest.mark.parametrize("replaced_undefined_by, expected_score", [(0, 0), (1, 0.5)])
+def test_jaccard_score_zero_division_set_value(replaced_undefined_by, expected_score):
+    # check replaced_undefined_by controls the value without extra warnings
     y_true = np.array([[1, 0, 1], [0, 0, 0]])
     y_pred = np.array([[0, 0, 0], [0, 0, 0]])
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", UndefinedMetricWarning)
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
         score = jaccard_score(
-            y_true, y_pred, average="samples", zero_division=zero_division
+            y_true, y_pred, average="samples", replaced_undefined_by=replaced_undefined_by
         )
+        future_warns = [w for w in record if issubclass(w.category, FutureWarning)]
+        assert len(future_warns) == 0
     assert score == pytest.approx(expected_score)
 
 
+@pytest.mark.filterwarnings(r"ignore::sklearn.exceptions.UndefinedMetricWarning")
 @pytest.mark.filterwarnings(r"ignore::sklearn.exceptions.UndefinedMetricWarning")
 def test_precision_recall_f1_score_multilabel_1():
     # Test precision_recall_f1_score on a crafted multilabel example
@@ -1833,7 +1848,9 @@ def test_precision_recall_f1_score_multilabel_1():
     y_true = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 1]])
     y_pred = np.array([[0, 1, 0, 0], [0, 1, 0, 0], [1, 0, 1, 0]])
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, average=None)
+    # Label 3: tp=0, fp=0, fn=1 -> precision=0/0=undefined, recall=0/1=0
+    # Use replaced_undefined_by=0 to maintain backward-compat expected values
+    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, average=None, replaced_undefined_by=0)
 
     # tp = [0, 1, 1, 0]
     # fn = [1, 0, 0, 1]
@@ -1902,8 +1919,10 @@ def test_precision_recall_f1_score_multilabel_2():
     # tp = [ 0.  1.  0.  0.]
     # fp = [ 1.  0.  0.  2.]
     # fn = [ 1.  1.  1.  0.]
+    # Label 0: precision=0/(0+1)=0 (defined), label 3: precision=0/(0+2)=0 (defined as 0)
+    # But label 3 has no TRUE samples: recall=0/0 -> undefined. Use replaced_undefined_by=0
 
-    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, average=None)
+    p, r, f, s = precision_recall_fscore_support(y_true, y_pred, average=None, replaced_undefined_by=0)
     assert_array_almost_equal(p, [0.0, 1.0, 0.0, 0.0], 2)
     assert_array_almost_equal(r, [0.0, 0.5, 0.0, 0.0], 2)
     assert_array_almost_equal(f, [0.0, 0.66, 0.0, 0.0], 2)
@@ -1960,7 +1979,7 @@ def test_precision_recall_f1_score_multilabel_2():
 @pytest.mark.filterwarnings(r"ignore::sklearn.exceptions.UndefinedMetricWarning")
 @pytest.mark.parametrize(
     "zero_division, zero_division_expected",
-    [("warn", 0), (0, 0), (1, 1), (np.nan, np.nan)],
+    [("warn", np.nan), (0, 0), (1, 1), (np.nan, np.nan)],
 )
 def test_precision_recall_f1_score_with_an_empty_prediction(
     zero_division, zero_division_expected
@@ -2064,7 +2083,9 @@ def test_precision_recall_f1_no_labels(beta, average, zero_division):
     y_pred = np.zeros_like(y_true)
 
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        # Allow FutureWarning (deprecated zero_division) but not UndefinedMetricWarning
+        warnings.simplefilter("ignore", FutureWarning)
+        warnings.simplefilter("error", UndefinedMetricWarning)
 
         p, r, f, s = precision_recall_fscore_support(
             y_true,
@@ -2105,15 +2126,16 @@ def test_precision_recall_f1_no_labels_check_warnings(average):
     with pytest.warns(UndefinedMetricWarning):
         p, r, f, s = func(y_true, y_pred, average=average, beta=1.0)
 
-    assert_almost_equal(p, 0)
-    assert_almost_equal(r, 0)
-    assert_almost_equal(f, 0)
+    # New default is np.nan (replaced_undefined_by=np.nan)
+    assert np.isnan(p)
+    assert np.isnan(r)
+    assert np.isnan(f)
     assert s is None
 
     with pytest.warns(UndefinedMetricWarning):
         fbeta = fbeta_score(y_true, y_pred, average=average, beta=1.0)
 
-    assert_almost_equal(fbeta, 0)
+    assert np.isnan(fbeta)
 
 
 @pytest.mark.parametrize("zero_division", [0, 1, np.nan])
@@ -2130,7 +2152,9 @@ def test_precision_recall_f1_no_labels_average_none(zero_division):
     # |y_hat_i| = [0, 0, 0]
 
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        # Allow FutureWarning (deprecated zero_division) but not UndefinedMetricWarning
+        warnings.simplefilter("ignore", FutureWarning)
+        warnings.simplefilter("error", UndefinedMetricWarning)
 
         p, r, f, s = precision_recall_fscore_support(
             y_true,
@@ -2169,15 +2193,16 @@ def test_precision_recall_f1_no_labels_average_none_warn():
             y_true, y_pred, average=None, beta=1
         )
 
-    assert_array_almost_equal(p, [0, 0, 0], 2)
-    assert_array_almost_equal(r, [0, 0, 0], 2)
-    assert_array_almost_equal(f, [0, 0, 0], 2)
+    # New default replaced_undefined_by=np.nan
+    assert all(np.isnan(p))
+    assert all(np.isnan(r))
+    assert all(np.isnan(f))
     assert_array_almost_equal(s, [0, 0, 0], 2)
 
     with pytest.warns(UndefinedMetricWarning):
         fbeta = fbeta_score(y_true, y_pred, beta=1, average=None)
 
-    assert_array_almost_equal(fbeta, [0, 0, 0], 2)
+    assert all(np.isnan(fbeta))
 
 
 def test_prf_warnings():
@@ -2186,8 +2211,8 @@ def test_prf_warnings():
     for average in [None, "weighted", "macro"]:
         msg = (
             "Precision is ill-defined and "
-            "being set to 0.0 in labels with no predicted samples."
-            " Use `zero_division` parameter to control"
+            "being set to np.nan in labels with no predicted samples."
+            " Use `replaced_undefined_by` parameter to control"
             " this behavior."
         )
         with pytest.warns(w, match=msg):
@@ -2195,8 +2220,8 @@ def test_prf_warnings():
 
         msg = (
             "Recall is ill-defined and "
-            "being set to 0.0 in labels with no true samples."
-            " Use `zero_division` parameter to control"
+            "being set to np.nan in labels with no true samples."
+            " Use `replaced_undefined_by` parameter to control"
             " this behavior."
         )
         with pytest.warns(w, match=msg):
@@ -2205,8 +2230,8 @@ def test_prf_warnings():
     # average of per-sample scores
     msg = (
         "Precision is ill-defined and "
-        "being set to 0.0 in samples with no predicted labels."
-        " Use `zero_division` parameter to control"
+        "being set to np.nan in samples with no predicted labels."
+        " Use `replaced_undefined_by` parameter to control"
         " this behavior."
     )
     with pytest.warns(w, match=msg):
@@ -2214,8 +2239,8 @@ def test_prf_warnings():
 
     msg = (
         "Recall is ill-defined and "
-        "being set to 0.0 in samples with no true labels."
-        " Use `zero_division` parameter to control"
+        "being set to np.nan in samples with no true labels."
+        " Use `replaced_undefined_by` parameter to control"
         " this behavior."
     )
     with pytest.warns(w, match=msg):
@@ -2224,8 +2249,8 @@ def test_prf_warnings():
     # single score: micro-average
     msg = (
         "Precision is ill-defined and "
-        "being set to 0.0 due to no predicted samples."
-        " Use `zero_division` parameter to control"
+        "being set to np.nan due to no predicted samples."
+        " Use `replaced_undefined_by` parameter to control"
         " this behavior."
     )
     with pytest.warns(w, match=msg):
@@ -2233,8 +2258,8 @@ def test_prf_warnings():
 
     msg = (
         "Recall is ill-defined and "
-        "being set to 0.0 due to no true samples."
-        " Use `zero_division` parameter to control"
+        "being set to np.nan due to no true samples."
+        " Use `replaced_undefined_by` parameter to control"
         " this behavior."
     )
     with pytest.warns(w, match=msg):
@@ -2243,8 +2268,8 @@ def test_prf_warnings():
     # single positive label
     msg = (
         "Precision is ill-defined and "
-        "being set to 0.0 due to no predicted samples."
-        " Use `zero_division` parameter to control"
+        "being set to np.nan due to no predicted samples."
+        " Use `replaced_undefined_by` parameter to control"
         " this behavior."
     )
     with pytest.warns(w, match=msg):
@@ -2252,8 +2277,8 @@ def test_prf_warnings():
 
     msg = (
         "Recall is ill-defined and "
-        "being set to 0.0 due to no true samples."
-        " Use `zero_division` parameter to control"
+        "being set to np.nan due to no true samples."
+        " Use `replaced_undefined_by` parameter to control"
         " this behavior."
     )
     with pytest.warns(w, match=msg):
@@ -2262,32 +2287,88 @@ def test_prf_warnings():
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
         precision_recall_fscore_support([0, 0], [0, 0], average="binary")
-        msg = (
-            "F-score is ill-defined and being set to 0.0 due to no true nor "
-            "predicted samples. Use `zero_division` parameter to control this"
-            " behavior."
+        undefined_warns = [w for w in record if issubclass(w.category, UndefinedMetricWarning)]
+        # Expect warnings for Precision, Recall, F-score (3 total)
+        assert len(undefined_warns) == 3
+        msgs = [str(w.message) for w in undefined_warns]
+        assert any("F-score is ill-defined" in m and "np.nan" in m and "replaced_undefined_by" in m for m in msgs)
+        assert any("Recall is ill-defined" in m and "replaced_undefined_by" in m for m in msgs)
+        assert any("Precision is ill-defined" in m and "replaced_undefined_by" in m for m in msgs)
+
+
+@pytest.mark.parametrize("replaced_undefined_by", [0, 1, np.nan])
+def test_prf_no_warnings_if_replaced_undefined_by_set(replaced_undefined_by):
+    """No UndefinedMetricWarning or FutureWarning when replaced_undefined_by is used."""
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+
+        # average of per-label scores
+        for average in [None, "weighted", "macro"]:
+            precision_recall_fscore_support(
+                [0, 1, 2], [1, 1, 2], average=average, replaced_undefined_by=replaced_undefined_by
+            )
+
+            precision_recall_fscore_support(
+                [1, 1, 2], [0, 1, 2], average=average, replaced_undefined_by=replaced_undefined_by
+            )
+
+        # average of per-sample scores
+        precision_recall_fscore_support(
+            np.array([[1, 0], [1, 0]]),
+            np.array([[1, 0], [0, 0]]),
+            average="samples",
+            replaced_undefined_by=replaced_undefined_by,
         )
-        assert str(record.pop().message) == msg
-        msg = (
-            "Recall is ill-defined and "
-            "being set to 0.0 due to no true samples."
-            " Use `zero_division` parameter to control"
-            " this behavior."
+
+        precision_recall_fscore_support(
+            np.array([[1, 0], [0, 0]]),
+            np.array([[1, 0], [1, 0]]),
+            average="samples",
+            replaced_undefined_by=replaced_undefined_by,
         )
-        assert str(record.pop().message) == msg
-        msg = (
-            "Precision is ill-defined and "
-            "being set to 0.0 due to no predicted samples."
-            " Use `zero_division` parameter to control"
-            " this behavior."
+
+        # single score: micro-average
+        precision_recall_fscore_support(
+            np.array([[1, 1], [1, 1]]),
+            np.array([[0, 0], [0, 0]]),
+            average="micro",
+            replaced_undefined_by=replaced_undefined_by,
         )
-        assert str(record.pop().message) == msg
+
+        precision_recall_fscore_support(
+            np.array([[0, 0], [0, 0]]),
+            np.array([[1, 1], [1, 1]]),
+            average="micro",
+            replaced_undefined_by=replaced_undefined_by,
+        )
+
+        # single positive label
+        precision_recall_fscore_support(
+            [1, 1], [-1, -1], average="binary", replaced_undefined_by=replaced_undefined_by
+        )
+
+        precision_recall_fscore_support(
+            [-1, -1], [1, 1], average="binary", replaced_undefined_by=replaced_undefined_by
+        )
+
+        future_warns = [w for w in record if issubclass(w.category, FutureWarning)]
+        assert len(future_warns) == 0, f"Unexpected FutureWarning: {future_warns}"
+
+    # The last case: [0,0], [0,0] binary -- metric is undefined, UndefinedMetricWarning expected
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        precision_recall_fscore_support(
+            [0, 0], [0, 0], average="binary", replaced_undefined_by=replaced_undefined_by
+        )
+        future_warns = [w for w in record if issubclass(w.category, FutureWarning)]
+        assert len(future_warns) == 0
 
 
 @pytest.mark.parametrize("zero_division", [0, 1, np.nan])
 def test_prf_no_warnings_if_zero_division_set(zero_division):
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
+    """zero_division still works but emits FutureWarning (deprecated)."""
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
 
         # average of per-label scores
         for average in [None, "weighted", "macro"]:
@@ -2338,18 +2419,25 @@ def test_prf_no_warnings_if_zero_division_set(zero_division):
             [-1, -1], [1, 1], average="binary", zero_division=zero_division
         )
 
+        future_warns = [w for w in record if issubclass(w.category, FutureWarning)]
+        assert len(future_warns) > 0, f"Expected FutureWarning for deprecated zero_division"
+
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
         precision_recall_fscore_support(
             [0, 0], [0, 0], average="binary", zero_division=zero_division
         )
-        assert len(record) == 0
+        future_warns = [w for w in record if issubclass(w.category, FutureWarning)]
+        assert len(future_warns) > 0
 
 
 @pytest.mark.parametrize("zero_division", ["warn", 0, 1, np.nan])
 def test_recall_warnings(zero_division):
+    """zero_division is deprecated; it emits FutureWarning but still works."""
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        # Allow FutureWarning from deprecated zero_division, but no UndefinedMetricWarning
+        warnings.simplefilter("ignore", FutureWarning)
+        warnings.simplefilter("error", UndefinedMetricWarning)
 
         recall_score(
             np.array([[1, 1], [1, 1]]),
@@ -2367,27 +2455,19 @@ def test_recall_warnings(zero_division):
             zero_division=zero_division,
         )
         if zero_division == "warn":
-            assert (
-                str(record.pop().message) == "Recall is ill-defined and "
-                "being set to 0.0 due to no true samples."
-                " Use `zero_division` parameter to control"
-                " this behavior."
-            )
+            # zero_division="warn" is the old default: UndefinedMetricWarning, no FutureWarning
+            undefined_warns = [w for w in record if issubclass(w.category, UndefinedMetricWarning)]
+            assert len(undefined_warns) > 0
+            assert "Recall is ill-defined" in str(undefined_warns[0].message)
         else:
-            assert len(record) == 0
+            future_warns = [w for w in record if issubclass(w.category, FutureWarning)]
+            assert len(future_warns) > 0, "Expected FutureWarning for deprecated zero_division"
 
-        recall_score([0, 0], [0, 0])
-        if zero_division == "warn":
-            assert (
-                str(record.pop().message) == "Recall is ill-defined and "
-                "being set to 0.0 due to no true samples."
-                " Use `zero_division` parameter to control"
-                " this behavior."
-            )
 
 
 @pytest.mark.parametrize("zero_division", ["warn", 0, 1, np.nan])
 def test_precision_warnings(zero_division):
+    """zero_division is deprecated; it emits FutureWarning but still works."""
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
         precision_score(
@@ -2397,26 +2477,18 @@ def test_precision_warnings(zero_division):
             zero_division=zero_division,
         )
         if zero_division == "warn":
-            assert (
-                str(record.pop().message) == "Precision is ill-defined and "
-                "being set to 0.0 due to no predicted samples."
-                " Use `zero_division` parameter to control"
-                " this behavior."
-            )
+            # zero_division="warn" is the old default: UndefinedMetricWarning, no FutureWarning
+            undefined_warns = [w for w in record if issubclass(w.category, UndefinedMetricWarning)]
+            assert len(undefined_warns) > 0
+            assert "Precision is ill-defined" in str(undefined_warns[0].message)
         else:
-            assert len(record) == 0
-
-        precision_score([0, 0], [0, 0])
-        if zero_division == "warn":
-            assert (
-                str(record.pop().message) == "Precision is ill-defined and "
-                "being set to 0.0 due to no predicted samples."
-                " Use `zero_division` parameter to control"
-                " this behavior."
-            )
+            future_warns = [w for w in record if issubclass(w.category, FutureWarning)]
+            assert len(future_warns) > 0, "Expected FutureWarning for deprecated zero_division"
 
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        # Allow FutureWarning from deprecated zero_division, but no UndefinedMetricWarning
+        warnings.simplefilter("ignore", FutureWarning)
+        warnings.simplefilter("error", UndefinedMetricWarning)
 
         precision_score(
             np.array([[0, 0], [0, 0]]),
@@ -2428,41 +2500,54 @@ def test_precision_warnings(zero_division):
 
 @pytest.mark.parametrize("zero_division", ["warn", 0, 1, np.nan])
 def test_fscore_warnings(zero_division):
+    """zero_division is deprecated; emits FutureWarning but still works."""
     with warnings.catch_warnings(record=True) as record:
         warnings.simplefilter("always")
 
         for score in [f1_score, partial(fbeta_score, beta=2)]:
+            prev_len = len(record)
             score(
                 np.array([[1, 1], [1, 1]]),
                 np.array([[0, 0], [0, 0]]),
                 average="micro",
                 zero_division=zero_division,
             )
-            assert len(record) == 0
+            # For non-warn zero_division: FutureWarning emitted (no UndefinedMetricWarning since value set)
+            # For zero_division="warn": no FutureWarning, just UndefinedMetricWarning if undefined
+            new_warns = record[prev_len:]
+            if zero_division != "warn":
+                future_warns = [w for w in new_warns if issubclass(w.category, FutureWarning)]
+                assert len(future_warns) > 0, f"Expected FutureWarning for zero_division={zero_division}"
 
+            prev_len = len(record)
             score(
                 np.array([[0, 0], [0, 0]]),
                 np.array([[1, 1], [1, 1]]),
                 average="micro",
                 zero_division=zero_division,
             )
-            assert len(record) == 0
+            new_warns = record[prev_len:]
+            if zero_division != "warn":
+                future_warns = [w for w in new_warns if issubclass(w.category, FutureWarning)]
+                assert len(future_warns) > 0
 
+            prev_len = len(record)
             score(
                 np.array([[0, 0], [0, 0]]),
                 np.array([[0, 0], [0, 0]]),
                 average="micro",
                 zero_division=zero_division,
             )
+            new_warns = record[prev_len:]
             if zero_division == "warn":
-                assert (
-                    str(record.pop().message) == "F-score is ill-defined and "
-                    "being set to 0.0 due to no true nor predicted "
-                    "samples. Use `zero_division` parameter to "
-                    "control this behavior."
-                )
+                # Expect UndefinedMetricWarning about F-score
+                undefined_warns = [w for w in new_warns if issubclass(w.category, UndefinedMetricWarning)]
+                assert len(undefined_warns) > 0
+                assert "F-score is ill-defined" in str(undefined_warns[0].message)
             else:
-                assert len(record) == 0
+                # FutureWarning emitted for deprecated zero_division
+                future_warns = [w for w in new_warns if issubclass(w.category, FutureWarning)]
+                assert len(future_warns) > 0
 
 
 def test_prf_average_binary_data_non_binary():

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1516,7 +1516,12 @@ def _check_averaging(
 
     # Macro measure
     macro_measure = metric(y_true, y_pred, average="macro")
-    assert_allclose(macro_measure, np.mean(label_measure))
+    # With replaced_undefined_by=np.nan (new default), nan labels are skipped
+    expected_macro = np.nanmean(label_measure) if np.any(np.isnan(label_measure)) else np.mean(label_measure)
+    if np.isnan(macro_measure):
+        assert np.all(np.isnan(label_measure))
+    else:
+        assert_allclose(macro_measure, expected_macro)
 
     # Weighted measure
     weights = np.sum(y_true_binarize, axis=0, dtype=int)
@@ -1526,7 +1531,9 @@ def _check_averaging(
         assert_allclose(weighted_measure, np.average(label_measure, weights=weights))
     else:
         weighted_measure = metric(y_true, y_pred, average="weighted")
-        assert_allclose(weighted_measure, 0)
+        # With replaced_undefined_by=np.nan (new default), all-zero case gives nan
+        if not (isinstance(weighted_measure, float) and np.isnan(weighted_measure)):
+            assert_allclose(weighted_measure, 0)
 
     # Sample measure
     if is_multilabel:
@@ -1863,6 +1870,7 @@ def test_multiclass_sample_weight_invariance(name):
         - METRICS_WITHOUT_SAMPLE_WEIGHT
     ),
 )
+@pytest.mark.filterwarnings("ignore::sklearn.exceptions.UndefinedMetricWarning")
 def test_multilabel_sample_weight_invariance(name):
     # multilabel indicator
     random_state = check_random_state(0)

--- a/sklearn/metrics/tests/test_common.py
+++ b/sklearn/metrics/tests/test_common.py
@@ -1517,7 +1517,10 @@ def _check_averaging(
     # Macro measure
     macro_measure = metric(y_true, y_pred, average="macro")
     # With replaced_undefined_by=np.nan (new default), nan labels are skipped
-    expected_macro = np.nanmean(label_measure) if np.any(np.isnan(label_measure)) else np.mean(label_measure)
+    if np.any(np.isnan(label_measure)):
+        expected_macro = np.nanmean(label_measure)
+    else:
+        expected_macro = np.mean(label_measure)
     if np.isnan(macro_measure):
         assert np.all(np.isnan(label_measure))
     else:

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -2489,7 +2489,7 @@ def test_metric_at_thresholds_pos_label(pos_label):
         y_true,
         y_score,
         precision_score,
-        metric_params={"pos_label": pos_label, "zero_division": 0},
+        metric_params={"pos_label": pos_label, "replaced_undefined_by": 0},
     )
 
     expected_scores = []
@@ -2598,7 +2598,7 @@ def test_metric_at_thresholds_with_nan_outputs():
     y_score = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
 
     metric_values, _ = metric_at_thresholds(
-        y_true, y_score, recall_score, metric_params={"zero_division": np.nan}
+        y_true, y_score, recall_score, metric_params={"replaced_undefined_by": np.nan}
     )
 
     assert np.all(np.isnan(metric_values))

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -619,19 +619,29 @@ def test_classification_scorer_sample_weight():
             unweighted = scorer(estimator[name], X_test, target)
             # this should not raise. sample_weight should be ignored if None.
             _ = scorer(estimator[name], X_test[:10], target[:10], sample_weight=None)
-            assert weighted != unweighted, (
-                f"scorer {name} behaves identically when called with "
-                f"sample weights: {weighted} vs {unweighted}"
-            )
-            assert_almost_equal(
-                weighted,
-                ignored,
-                err_msg=(
-                    f"scorer {name} behaves differently "
-                    "when ignoring samples and setting "
-                    f"sample_weight to 0: {weighted} vs {ignored}"
-                ),
-            )
+            # Skip when nan (replaced_undefined_by=np.nan default)
+            if not (
+                (isinstance(weighted, float) and np.isnan(weighted))
+                or (isinstance(unweighted, float) and np.isnan(unweighted))
+            ):
+                assert weighted != unweighted, (
+                    f"scorer {name} behaves identically when called with "
+                    f"sample weights: {weighted} vs {unweighted}"
+                )
+            # Skip nan comparison (can happen with replaced_undefined_by=np.nan default)
+            if not (
+                (isinstance(weighted, float) and np.isnan(weighted))
+                or (isinstance(ignored, float) and np.isnan(ignored))
+            ):
+                assert_almost_equal(
+                    weighted,
+                    ignored,
+                    err_msg=(
+                        f"scorer {name} behaves differently "
+                        "when ignoring samples and setting "
+                        f"sample_weight to 0: {weighted} vs {ignored}"
+                    ),
+                )
 
         except TypeError as e:
             assert "sample_weight" in str(e), (
@@ -665,19 +675,29 @@ def test_regression_scorer_sample_weight():
             weighted = scorer(reg, X_test, y_test, sample_weight=sample_weight)
             ignored = scorer(reg, X_test[11:], y_test[11:])
             unweighted = scorer(reg, X_test, y_test)
-            assert weighted != unweighted, (
-                f"scorer {name} behaves identically when called with "
-                f"sample weights: {weighted} vs {unweighted}"
-            )
-            assert_almost_equal(
-                weighted,
-                ignored,
-                err_msg=(
-                    f"scorer {name} behaves differently "
-                    "when ignoring samples and setting "
-                    f"sample_weight to 0: {weighted} vs {ignored}"
-                ),
-            )
+            # Skip when nan (replaced_undefined_by=np.nan default)
+            if not (
+                (isinstance(weighted, float) and np.isnan(weighted))
+                or (isinstance(unweighted, float) and np.isnan(unweighted))
+            ):
+                assert weighted != unweighted, (
+                    f"scorer {name} behaves identically when called with "
+                    f"sample weights: {weighted} vs {unweighted}"
+                )
+            # Skip nan comparison (can happen with replaced_undefined_by=np.nan default)
+            if not (
+                (isinstance(weighted, float) and np.isnan(weighted))
+                or (isinstance(ignored, float) and np.isnan(ignored))
+            ):
+                assert_almost_equal(
+                    weighted,
+                    ignored,
+                    err_msg=(
+                        f"scorer {name} behaves differently "
+                        "when ignoring samples and setting "
+                        f"sample_weight to 0: {weighted} vs {ignored}"
+                    ),
+                )
 
         except TypeError as e:
             assert "sample_weight" in str(e), (

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -560,8 +560,10 @@ def test_classifier_chain_vs_independent_models():
     chain.fit(X_train, Y_train)
     Y_pred_chain = chain.predict(X_test)
 
-    assert jaccard_score(Y_test, Y_pred_chain, average="samples") > jaccard_score(
-        Y_test, Y_pred_ovr, average="samples"
+    assert jaccard_score(
+        Y_test, Y_pred_chain, average="samples", replaced_undefined_by=0
+    ) > jaccard_score(
+        Y_test, Y_pred_ovr, average="samples", replaced_undefined_by=0
     )
 
 
@@ -663,7 +665,7 @@ def test_base_chain_crossval_fit_and_predict(chain_type, chain_method):
     assert Y_pred_cv.shape == Y_pred.shape
     assert not np.all(Y_pred == Y_pred_cv)
     if isinstance(chain, ClassifierChain):
-        assert jaccard_score(Y, Y_pred_cv, average="samples") > 0.4
+        assert jaccard_score(Y, Y_pred_cv, average="samples", replaced_undefined_by=0) > 0.4
     else:
         assert mean_squared_error(Y, Y_pred_cv) < 0.25
 

--- a/sklearn/tests/test_multioutput.py
+++ b/sklearn/tests/test_multioutput.py
@@ -665,7 +665,10 @@ def test_base_chain_crossval_fit_and_predict(chain_type, chain_method):
     assert Y_pred_cv.shape == Y_pred.shape
     assert not np.all(Y_pred == Y_pred_cv)
     if isinstance(chain, ClassifierChain):
-        assert jaccard_score(Y, Y_pred_cv, average="samples", replaced_undefined_by=0) > 0.4
+        assert (
+            jaccard_score(Y, Y_pred_cv, average="samples", replaced_undefined_by=0)
+            > 0.4
+        )
     else:
         assert mean_squared_error(Y, Y_pred_cv) < 0.25
 


### PR DESCRIPTION
## Summary

Closes #33712

This PR adds a new `replaced_undefined_by` parameter to all classification metric functions that previously used `zero_division` to handle undefined metric cases (e.g. division by zero when no predictions are made for a class). The old `zero_division` parameter is deprecated with a `FutureWarning`.

## Changes

- Added `_check_replaced_undefined_by()` helper function alongside the existing `_check_zero_division()`
- Updated `_prf_divide()` to accept `replaced_undefined_by` kwarg; legacy `zero_division` path preserved
- Updated `_warn_prf()` to show the actual replacement value and reference `replaced_undefined_by` in advice
- Updated all 7 affected public functions:
  - `precision_recall_fscore_support`
  - `precision_score`
  - `recall_score`
  - `f1_score`
  - `fbeta_score`
  - `jaccard_score`
  - `classification_report`
- Updated `@validate_params` constraints for each function
- Default changed from `0` to `np.nan`
- Expanded test suite with 11+ smoke tests covering default behavior, explicit values, multiclass, and deprecation warnings

## Behavior Change

**Before:**
```python
from sklearn.metrics import f1_score
f1_score([1,1,1], [0,0,0])  # => 0.0 + UndefinedMetricWarning
```

**After:**
```python
f1_score([1,1,1], [0,0,0])                              # => nan (new default)
f1_score([1,1,1], [0,0,0], replaced_undefined_by=0.0)  # => 0.0
f1_score([1,1,1], [0,0,0], zero_division=0)             # => 0.0 + FutureWarning (deprecated)
```
