### PR TITLE
TST use global_random_seed in sklearn/metrics/tests/test_ranking.py

### DIFF
--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1951,11 +1951,15 @@ def test_ranking_loss_ties_handling():
     assert_almost_equal(label_ranking_loss([[1, 1, 0]], [[0.25, 0.5, 0.5]]), 1)
 
 
-def test_dcg_score():
-    _, y_true = make_multilabel_classification(random_state=0, n_classes=10)
+def test_dcg_score(global_random_seed):
+    _, y_true = make_multilabel_classification(
+        random_state=global_random_seed, n_classes=10
+    )
     y_score = -y_true + 1
     _test_dcg_score_for(y_true, y_score)
-    y_true, y_score = np.random.RandomState(0).random_sample((2, 100, 10))
+    y_true, y_score = np.random.RandomState(global_random_seed).random_sample(
+        (2, 100, 10)
+    )
     _test_dcg_score_for(y_true, y_score)
 
 
@@ -2006,9 +2010,11 @@ def test_ndcg_negative_ndarray_error():
         ndcg_score(y_true, y_score)
 
 
-def test_ndcg_invariant():
+def test_ndcg_invariant(global_random_seed):
     y_true = np.arange(70).reshape(7, 10)
-    y_score = y_true + np.random.RandomState(0).uniform(-0.2, 0.2, size=y_true.shape)
+    y_score = y_true + np.random.RandomState(global_random_seed).uniform(
+        -0.2, 0.2, size=y_true.shape
+    )
     ndcg = ndcg_score(y_true, y_score)
     ndcg_no_ties = ndcg_score(y_true, y_score, ignore_ties=True)
     assert ndcg == pytest.approx(ndcg_no_ties)
@@ -2018,10 +2024,10 @@ def test_ndcg_invariant():
 
 
 @pytest.mark.parametrize("ignore_ties", [True, False])
-def test_ndcg_toy_examples(ignore_ties):
+def test_ndcg_toy_examples(ignore_ties, global_random_seed):
     y_true = 3 * np.eye(7)[:5]
     y_score = np.tile(np.arange(6, -1, -1), (5, 1))
-    y_score_noisy = y_score + np.random.RandomState(0).uniform(
+    y_score_noisy = y_score + np.random.RandomState(global_random_seed).uniform(
         -0.2, 0.2, size=y_score.shape
     )
     assert _dcg_sample_scores(
@@ -2190,15 +2196,20 @@ def test_top_k_accuracy_score_multiclass_with_labels(
     assert score == pytest.approx(true_score)
 
 
-def test_top_k_accuracy_score_increasing():
-    # Make sure increasing k leads to a higher score
+def test_top_k_accuracy_score_increasing(global_random_seed):
+    # Make sure increasing k does not lower the score.
     X, y = datasets.make_classification(
-        n_classes=10, n_samples=1000, n_informative=10, random_state=0
+        n_classes=10,
+        n_samples=1000,
+        n_informative=10,
+        random_state=global_random_seed,
     )
 
-    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, random_state=global_random_seed
+    )
 
-    clf = LogisticRegression()
+    clf = LogisticRegression(random_state=global_random_seed)
     clf.fit(X_train, y_train)
 
     for X, y in zip((X_train, X_test), (y_train, y_test)):
@@ -2206,7 +2217,8 @@ def test_top_k_accuracy_score_increasing():
             top_k_accuracy_score(y, clf.predict_proba(X), k=k) for k in range(2, 10)
         ]
 
-        assert np.all(np.diff(scores) > 0)
+        assert np.all(np.diff(scores) >= 0)
+        assert scores[-1] > scores[0]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference Issues/PRs

Related to #22827.

#### What does this implement/fix? Explain your changes.

This updates selected ranking metric tests in `sklearn/metrics/tests/test_ranking.py` to use the `global_random_seed` fixture:

- `test_dcg_score`
- `test_ndcg_invariant`
- `test_ndcg_toy_examples`
- `test_top_k_accuracy_score_increasing`

While checking seed-insensitivity, `test_top_k_accuracy_score_increasing` exposed a brittle strict-increase assertion. `top_k_accuracy_score` is guaranteed to be non-decreasing as `k` increases, but it is not guaranteed to strictly increase at every step. The test now checks the mathematical invariant (`np.diff(scores) >= 0`) while still requiring the final score to improve over the first checked `k`.

#### AI usage disclosure

I used AI assistance for:

- Code generation (updating test code and assertions)
- Test/benchmark generation (selecting and running local validation commands)
- Research and understanding (triaging the issue, reviewing the metric invariant, and checking CI behavior)

#### Any other comments?

Validation run locally:

- `PATH="$PWD/.venv/bin:$PATH" SKLEARN_TESTS_GLOBAL_RANDOM_SEED=all .venv/bin/python -m pytest sklearn/metrics/tests/test_ranking.py -k "test_dcg_score or test_ndcg_invariant or test_ndcg_toy_examples or test_top_k_accuracy_score_increasing" -q`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest sklearn/metrics/tests/test_ranking.py -q`
- `.venv/bin/python -m ruff check sklearn/metrics/tests/test_ranking.py`
- `.venv/bin/python -m ruff format --check sklearn/metrics/tests/test_ranking.py`
- `git diff --check`