### PR TITLE
FIX make that exhaust option in successive halving consume properly resource

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.model_selection/34226.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.model_selection/34226.fix.rst
@@ -1,0 +1,7 @@
+- :class:`model_selection.HalvingGridSearchCV` and
+  :class:`model_selection.HalvingRandomSearchCV` now set `min_resources_` based on
+  the actual number of iterations that will be run when `min_resources="exhaust"`,
+  instead of the number of iterations required to reduce the candidates below
+  `factor`. This ensures the last iteration uses as many resources as possible
+  when the resource budget is the binding constraint.
+  By :user:`Guillaume Lemaitre <glemaitre>`.

--- a/sklearn/model_selection/_search_successive_halving.py
+++ b/sklearn/model_selection/_search_successive_halving.py
@@ -264,16 +264,6 @@ class BaseSuccessiveHalving(BaseSearchCV):
         # last iterations evaluates less than `factor` candidates.
         n_required_iterations = 1 + floor(log(len(candidate_params), self.factor))
 
-        if self.min_resources == "exhaust":
-            # To exhaust the resources, we want to start with the biggest
-            # min_resources possible so that the last (required) iteration
-            # uses as many resources as possible
-            last_iteration = n_required_iterations - 1
-            self.min_resources_ = max(
-                self.min_resources_,
-                self.max_resources_ // self.factor**last_iteration,
-            )
-
         # n_possible_iterations is the number of iterations that we can
         # actually do starting from min_resources and without exceeding
         # max_resources. Depending on max_resources and the number of
@@ -287,6 +277,19 @@ class BaseSuccessiveHalving(BaseSearchCV):
             n_iterations = n_required_iterations
         else:
             n_iterations = min(n_possible_iterations, n_required_iterations)
+
+        if self.min_resources == "exhaust":
+            # To exhaust the resources, we want to start with the biggest
+            # min_resources possible so that the last (actual) iteration
+            # uses as many resources as possible
+            last_iteration = n_iterations - 1
+            self.min_resources_ = max(
+                self.min_resources_,
+                self.max_resources_ // self.factor**last_iteration,
+            )
+            n_possible_iterations = 1 + floor(
+                log(self.max_resources_ // self.min_resources_, self.factor)
+            )
 
         if self.verbose:
             print(f"n_iterations: {n_iterations}")

--- a/sklearn/model_selection/tests/test_successive_halving.py
+++ b/sklearn/model_selection/tests/test_successive_halving.py
@@ -201,6 +201,32 @@ def test_aggressive_elimination(
 
 
 @pytest.mark.parametrize("Est", (HalvingGridSearchCV, HalvingRandomSearchCV))
+def test_exhaust_min_resources_uses_actual_iterations(GridSearchCV):
+    # Non-regression test for gh-27422: min_resources='exhaust' must size r0
+    # from the actual number of iterations, not n_required_iterations.
+    X, y = make_classification(
+        n_samples=1050, n_classes=2, n_informative=4, random_state=0
+    )
+    param_grid = {"a": range(8), "b": range(10), "c": range(2)}  # 160 candidates
+    base_estimator = FastClassifier()
+
+    sh = GridSearchCV(
+        base_estimator,
+        param_grid,
+        cv=5,
+        factor=2,
+        min_resources="exhaust",
+    )
+    if GridSearchCV is HalvingRandomSearchCV:
+        sh.set_params(n_candidates=160)
+
+    sh.fit(X, y)
+
+    assert sh.min_resources_ == 32
+    assert sh.n_resources_[-1] == 1024
+
+
+@pytest.mark.parametrize("Est", (HalvingGridSearchCV, HalvingRandomSearchCV))
 @pytest.mark.parametrize(
     (
         "min_resources,"
@@ -224,7 +250,7 @@ def test_aggressive_elimination(
         ("exhaust", 599, 2, 2, [199, 597]),
         ("exhaust", 300, 2, 2, [100, 300]),
         ("exhaust", 60, 2, 2, [20, 60]),
-        ("exhaust", 50, 1, 1, [20]),
+        ("exhaust", 50, 1, 1, [50]),
         ("exhaust", 20, 1, 1, [20]),
     ],
 )

--- a/sklearn/model_selection/tests/test_successive_halving.py
+++ b/sklearn/model_selection/tests/test_successive_halving.py
@@ -200,30 +200,34 @@ def test_aggressive_elimination(
     assert ceil(sh.n_candidates_[-1] / sh.factor) == sh.n_remaining_candidates_
 
 
-@pytest.mark.parametrize("Est", (HalvingGridSearchCV, HalvingRandomSearchCV))
-def test_exhaust_min_resources_uses_actual_iterations(GridSearchCV):
-    # Non-regression test for gh-27422: min_resources='exhaust' must size r0
-    # from the actual number of iterations, not n_required_iterations.
+@pytest.mark.parametrize("SearchCV", (HalvingGridSearchCV, HalvingRandomSearchCV))
+def test_exhaust_min_resources_uses_actual_iterations(SearchCV):
+    """Check thatmin_resources='exhaust' must size r0 from the actual number of
+    iterations, not n_required_iterations
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/27422
+    """
     X, y = make_classification(
         n_samples=1050, n_classes=2, n_informative=4, random_state=0
     )
     param_grid = {"a": range(8), "b": range(10), "c": range(2)}  # 160 candidates
     base_estimator = FastClassifier()
 
-    sh = GridSearchCV(
+    search_cv = SearchCV(
         base_estimator,
         param_grid,
         cv=5,
         factor=2,
         min_resources="exhaust",
     )
-    if GridSearchCV is HalvingRandomSearchCV:
-        sh.set_params(n_candidates=160)
+    if SearchCV is HalvingRandomSearchCV:
+        search_cv.set_params(n_candidates=160)
 
-    sh.fit(X, y)
+    search_cv.fit(X, y)
 
-    assert sh.min_resources_ == 32
-    assert sh.n_resources_[-1] == 1024
+    assert search_cv.min_resources_ == 32
+    assert search_cv.n_resources_[-1] == 1024
 
 
 @pytest.mark.parametrize("Est", (HalvingGridSearchCV, HalvingRandomSearchCV))


### PR DESCRIPTION
closes #27422 

This PR fixes the the successive halving cross-validation `exhaust` option that should be consuming optimally.