### PR TITLE
DEP Remove the experimental module for the HGBT model

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.ensemble/34236.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.ensemble/34236.api.rst
@@ -1,0 +1,6 @@
+- The :mod:`sklearn.experimental.enable_hist_gradient_boosting` module is
+  deprecated and will be removed in 1.12. It is no longer needed since
+  :class:`ensemble.HistGradientBoostingClassifier` and
+  :class:`ensemble.HistGradientBoostingRegressor` are stable and can be
+  imported normally from :mod:`sklearn.ensemble`.
+  By :user:`Guillaume Lemaitre <glemaitre>`.

--- a/sklearn/experimental/enable_hist_gradient_boosting.py
+++ b/sklearn/experimental/enable_hist_gradient_boosting.py
@@ -10,14 +10,15 @@ normally from `sklearn.ensemble`.
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
-# Don't remove this file, we don't want to break users code just because the
-# feature isn't experimental anymore.
+# TODO(1.12): remove this file
 
 import warnings
 
 warnings.warn(
-    "Since version 1.0, "
-    "it is not needed to import enable_hist_gradient_boosting anymore. "
-    "HistGradientBoostingClassifier and HistGradientBoostingRegressor are now "
-    "stable and can be normally imported from sklearn.ensemble."
+    "The sklearn.experimental.enable_hist_gradient_boosting module is "
+    "deprecated since version 1.10 and will be removed in 1.12. It is no "
+    "longer needed: HistGradientBoostingClassifier and "
+    "HistGradientBoostingRegressor are stable and can be imported normally "
+    "from sklearn.ensemble.",
+    FutureWarning,
 )

--- a/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py
+++ b/sklearn/experimental/tests/test_enable_hist_gradient_boosting.py
@@ -8,12 +8,16 @@ from sklearn.utils._testing import assert_run_python_script_without_output
 from sklearn.utils.fixes import _IS_WASM
 
 
+# TODO(1.12): remove this test
 @pytest.mark.xfail(_IS_WASM, reason="cannot start subprocess")
 def test_import_raises_warning():
     code = """
     import pytest
-    with pytest.warns(UserWarning, match="it is not needed to import"):
+    with pytest.warns(
+        FutureWarning,
+        match="deprecated since version 1.10 and will be removed in 1.12",
+    ):
         from sklearn.experimental import enable_hist_gradient_boosting  # noqa
     """
-    pattern = "it is not needed to import enable_hist_gradient_boosting anymore"
+    pattern = "deprecated since version 1.10 and will be removed in 1.12"
     assert_run_python_script_without_output(textwrap.dedent(code), pattern=pattern)

--- a/sklearn/tests/test_build.py
+++ b/sklearn/tests/test_build.py
@@ -11,6 +11,11 @@ from sklearn import __version__
 from sklearn.utils._openmp_helpers import _openmp_parallelism_enabled
 
 
+# TODO(1.12): remove filter
+@pytest.mark.filterwarnings(
+    "ignore:The sklearn.experimental.enable_hist_gradient_boosting module is "
+    "deprecated:FutureWarning"
+)
 @pytest.mark.thread_unsafe  # import side-effects
 def test_extension_type_module():
     """Check that Cython extension types have a correct ``__module__``.

--- a/sklearn/tests/test_common.py
+++ b/sklearn/tests/test_common.py
@@ -125,9 +125,10 @@ def test_estimators(estimator, check, request):
         check(estimator)
 
 
+# TODO(1.12): remove filter
 @pytest.mark.filterwarnings(
-    "ignore:Since version 1.0, it is not needed to import "
-    "enable_hist_gradient_boosting anymore"
+    "ignore:The sklearn.experimental.enable_hist_gradient_boosting module is "
+    "deprecated:FutureWarning"
 )
 @pytest.mark.thread_unsafe  # import side-effects
 def test_import_all_consistency():

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -71,6 +71,11 @@ _METHODS_IGNORE_NONE_Y = [
 ]
 
 
+# TODO(1.12): remove filter
+@pytest.mark.filterwarnings(
+    "ignore:The sklearn.experimental.enable_hist_gradient_boosting module is "
+    "deprecated:FutureWarning"
+)
 def test_docstring_parameters():
     # Test module docstring formatting
 


### PR DESCRIPTION
We put HGBDT out of experimental from 1.0 but we kept the experimental import work up to today.
I think it is time to clean up by announcing a final complete removal with the usual deprecation cycle.