### PR TITLE
Fix how PCA determines which solver is available for array API inputs

### DIFF
--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -15,11 +15,17 @@ from sklearn.base import _fit_context
 from sklearn.decomposition._base import _BasePCA
 from sklearn.utils import check_random_state
 from sklearn.utils._arpack import _init_arpack_v0
-from sklearn.utils._array_api import _cov, device, get_namespace
+from sklearn.utils._array_api import (
+    _cov,
+    _is_numpy_namespace,
+    _is_xp_namespace,
+    device,
+    get_namespace,
+)
 from sklearn.utils._param_validation import Interval, RealNotInt, StrOptions
 from sklearn.utils.extmath import _randomized_svd, fast_logdet, svd_flip
 from sklearn.utils.sparsefuncs import _implicit_column_offset, mean_variance_axis
-from sklearn.utils.validation import check_is_fitted, validate_data
+from sklearn.utils.validation import _is_arraylike, check_is_fitted, validate_data
 
 
 def _assess_dimension(spectrum, rank, n_samples):
@@ -478,6 +484,55 @@ class PCA(_BasePCA):
         else:  # solver="covariance_eigh" does not compute U at fit time.
             return self._transform(X, xp, x_is_centered=x_is_centered)
 
+    def _solver_requires_numpy(self):
+        """Whether the configured solver has no Array API implementation.
+
+        These solvers are backed by SciPy (``scipy.sparse.linalg.svds`` for
+        arpack, ``scipy.linalg.lu`` for the "LU" power iteration normalizer) and
+        therefore require NumPy inputs.
+        """
+        return self.svd_solver == "arpack" or (
+            self.svd_solver == "randomized" and self.power_iteration_normalizer == "LU"
+        )
+
+    def _fit_with_numpy_fallback(self, X, xp):
+        """Fit a SciPy-backed solver on NumPy, then move results to ``xp``.
+
+        ``X`` is coerced to a NumPy array (mirroring the conversion performed
+        when ``array_api_dispatch`` is disabled), the regular NumPy code path is
+        run, and the fitted array attributes as well as the values returned for
+        ``fit_transform`` are moved back to the ``xp`` namespace and to the
+        device of the original input.
+        """
+        input_device = device(X)
+        # np.asarray mirrors the coercion used when array_api_dispatch is off:
+        # it succeeds for host array-likes (e.g. CPU tensors) and raises for
+        # inputs whose data lives on another device (e.g. GPU tensors).
+        X_np = np.asarray(X)
+
+        # Recurses into the NumPy code path: get_namespace(X_np) reports the
+        # NumPy namespace, so this branch is not taken again.
+        U, S, Vt, X_fitted, x_is_centered, _ = self._fit(X_np)
+
+        def to_xp(array):
+            if array is None:
+                return None
+            # np.ascontiguousarray avoids negative/0 strides (e.g. from the
+            # arpack output reversals) that some namespaces cannot consume.
+            return xp.asarray(np.ascontiguousarray(array), device=input_device)
+
+        for name in (
+            "components_",
+            "explained_variance_",
+            "explained_variance_ratio_",
+            "singular_values_",
+            "mean_",
+            "noise_variance_",
+        ):
+            setattr(self, name, to_xp(getattr(self, name)))
+
+        return to_xp(U), to_xp(S), to_xp(Vt), to_xp(X_fitted), x_is_centered, xp
+
     def _fit(self, X):
         """Dispatch to the right submethod depending on the chosen solver."""
         xp, is_array_api_compliant = get_namespace(X)
@@ -489,7 +544,30 @@ class PCA(_BasePCA):
                 f' "covariance_eigh" solvers, while "{self.svd_solver}" was passed. See'
                 " TruncatedSVD for a possible alternative."
             )
-        if self.svd_solver == "arpack" and is_array_api_compliant:
+        # The arpack solver (scipy.sparse.linalg.svds) and the randomized solver
+        # with the "LU" power iteration normalizer (scipy.linalg.lu) are backed
+        # by SciPy and have no Array API implementation. Enabling
+        # array_api_dispatch must not change which inputs work: an array-like
+        # that NumPy can consume (e.g. a CPU tensor) works with dispatch
+        # disabled because it is coerced to NumPy, so it must keep working with
+        # dispatch enabled. We therefore transparently compute on NumPy and move
+        # the fitted attributes back to the input namespace and device.
+        #
+        # array_api_strict is intentionally excluded: it is a conformance
+        # testing namespace meant to exercise the pure Array API code paths and
+        # is never passed by end users, so unsupported solvers keep raising for
+        # it. Inputs whose data is not on the host (e.g. GPU tensors) cannot be
+        # consumed by NumPy and raise during the coercion below, exactly as they
+        # already do with array_api_dispatch disabled.
+        if (
+            not _is_numpy_namespace(xp)
+            and self._solver_requires_numpy()
+            and _is_arraylike(X)
+            and not _is_xp_namespace(xp, "array_api_strict")
+        ):
+            return self._fit_with_numpy_fallback(X, xp)
+
+        if self.svd_solver == "arpack" and not _is_numpy_namespace(xp):
             raise ValueError(
                 "PCA with svd_solver='arpack' is not supported for Array API inputs."
             )

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -1086,14 +1086,22 @@ def test_pca_mle_array_api_compliance(
         atol=atol,
     )
 
-    # If the number of components differ, check that the explained variance of
-    # the trimmed components is very small.
+    # The MLE dimensionality selection can keep a different number of
+    # components across namespaces/devices. The explained variance spectrum of
+    # this dataset has a cliff between the signal components (variance >> atol)
+    # and a few numerically zero noise directions (variance ~1e-14, e.g. from
+    # the redundant features of `make_classification`); float32 rounding can tip
+    # the likelihood comparison so that one backend keeps one extra noise
+    # direction. This is only acceptable when the trimmed components are indeed
+    # at the noise floor, i.e. their explained variance is negligible. Note that
+    # we cannot compare them to the smallest *retained* variance
+    # (`explained_variance_np[-1]`), as the latter can be a genuine signal
+    # component when the trimming happens exactly at the cliff.
     if components_xp_np.shape[0] != components_np.shape[0]:
-        reference_variance = explained_variance_np[-1]
         extra_variance_np = explained_variance_np[min_components:]
         extra_variance_xp_np = explained_variance_xp_np[min_components:]
-        assert all(np.abs(extra_variance_np - reference_variance) < atol)
-        assert all(np.abs(extra_variance_xp_np - reference_variance) < atol)
+        assert all(np.abs(extra_variance_np) < atol)
+        assert all(np.abs(extra_variance_xp_np) < atol)
 
 
 @pytest.mark.skipif(
@@ -1128,3 +1136,80 @@ def test_array_api_error_and_warnings_on_unsupported_params():
     with pytest.warns(UserWarning, match=expected_msg):
         with config_context(array_api_dispatch=True):
             pca.fit(iris_xp)
+
+
+@pytest.mark.skipif(
+    os.environ.get("SCIPY_ARRAY_API") != "1", reason="SCIPY_ARRAY_API not set to 1."
+)
+@pytest.mark.parametrize("array_namespace", ["numpy", "torch"])
+@pytest.mark.parametrize("svd_solver", PCA_SOLVERS)
+@pytest.mark.parametrize("power_iteration_normalizer", ["auto", "QR", "LU", "none"])
+def test_array_api_dispatch_array_like_invariants(
+    array_namespace, svd_solver, power_iteration_normalizer
+):
+    """Enabling ``array_api_dispatch`` only changes the output namespace.
+
+    For any array-like that NumPy can consume (NumPy arrays, torch CPU tensors),
+    the set of working ``(input, solver)`` combinations must not depend on
+    whether ``array_api_dispatch`` is enabled. The only difference is the
+    namespace of the fitted attributes:
+
+    * With dispatch disabled (the default), the input is coerced to NumPy and
+      fitting always succeeds with NumPy fitted attributes, for every solver.
+    * With dispatch enabled, fitting still always succeeds, and the fitted
+      attributes live in the input's namespace. For solvers that have no Array
+      API implementation (``arpack`` and ``randomized``/``"LU"``, both backed by
+      SciPy) PCA transparently computes on NumPy and moves the result back to
+      the input namespace. For NumPy input this is additionally a strict no-op:
+      no Array API-specific warning and the same fitted attributes as with
+      dispatch disabled (in particular ``arpack`` and ``randomized``/``"LU"``
+      must not raise -- they used to, because the guards keyed off
+      ``is_array_api_compliant``, which is ``True`` for NumPy under dispatch).
+
+    ``array_api_strict`` is deliberately not covered here: it is a conformance
+    testing namespace (not a user-facing array-like) for which unsupported
+    solvers keep raising, see
+    ``test_array_api_error_and_warnings_on_unsupported_params``.
+    """
+    X_np = iris.data
+    if array_namespace == "numpy":
+        X = X_np
+        expected_dispatch_type = np.ndarray
+    else:
+        torch = pytest.importorskip("torch")
+        X = torch.asarray(X_np, dtype=torch.float64)
+        expected_dispatch_type = torch.Tensor
+
+    params = dict(
+        n_components=2,
+        svd_solver=svd_solver,
+        power_iteration_normalizer=power_iteration_normalizer,
+        random_state=0,
+    )
+
+    # Dispatch disabled: any array-like is coerced to NumPy and always works.
+    # Force the config explicitly so the test is robust to the ambient config
+    # (e.g. when the whole suite is run with array_api_dispatch enabled).
+    with config_context(array_api_dispatch=False):
+        pca_off = PCA(**params).fit(X)
+    assert isinstance(pca_off.components_, np.ndarray)
+
+    # Dispatch enabled: fitting still always works, and the fitted attributes
+    # live in the input's namespace.
+    with config_context(array_api_dispatch=True):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            pca_on = PCA(**params).fit(X)
+        assert isinstance(pca_on.components_, expected_dispatch_type)
+
+    if array_namespace == "numpy":
+        # Strict no-op for NumPy: no Array API-specific warning and the same
+        # fitted attributes as with dispatch disabled. The randomized solver
+        # uses numpy.linalg.svd under dispatch and scipy.linalg.svd otherwise
+        # (an intentional, documented difference), hence the looser tolerance.
+        array_api_warnings = [w for w in caught if "Array API" in str(w.message)]
+        assert not array_api_warnings, (
+            "Enabling array_api_dispatch emitted an Array API-specific warning "
+            f"for NumPy input: {[str(w.message) for w in array_api_warnings]}"
+        )
+        _check_fitted_pca_close(pca_off, pca_on, rtol=1e-5, atol=1e-8)

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -317,13 +317,19 @@ def _randomized_range_finder(
     xp, is_array_api_compliant = get_namespace(A)
     random_state = check_random_state(random_state)
 
+    # Plain NumPy arrays are reported as array API compliant when
+    # array_api_dispatch is enabled. Gate the Array-API-specific code paths
+    # (which fall back to QR because the Array API has no LU factorization,
+    # and which avoid SciPy) on the namespace actually being a non-NumPy one,
+    # so that enabling array_api_dispatch is a no-op for NumPy inputs.
+    use_array_api = is_array_api_compliant and not _is_numpy_namespace(xp)
+
     # Generating normal random vectors with shape: (A.shape[1], size)
     # XXX: generate random number directly from xp if it's possible
     # one day.
     Q = random_state.normal(size=(A.shape[1], size))
     if A.dtype == xp.float32 or (
-        is_array_api_compliant
-        and _max_precision_float_dtype(xp, device=device(A)) == xp.float32
+        use_array_api and _max_precision_float_dtype(xp, device=device(A)) == xp.float32
     ):
         # Use float32 computation and components if A has a float32 dtype
         # or if A has integer dtype and device doesn't not support float64.
@@ -333,7 +339,7 @@ def _randomized_range_finder(
         # xp.asarray(..., dtype=..., device=device) to accept such a downcast.
         Q = Q.astype(np.float32, copy=False)
 
-    if is_array_api_compliant:
+    if use_array_api:
         Q = xp.asarray(Q, device=device(A))
     else:
         Q = xp.asarray(Q)
@@ -342,7 +348,7 @@ def _randomized_range_finder(
     if power_iteration_normalizer == "auto":
         if n_iter <= 2:
             power_iteration_normalizer = "none"
-        elif is_array_api_compliant:
+        elif use_array_api:
             # XXX: https://github.com/data-apis/array-api/issues/627
             warnings.warn(
                 "Array API does not support LU factorization, falling back to QR"
@@ -352,13 +358,13 @@ def _randomized_range_finder(
             power_iteration_normalizer = "QR"
         else:
             power_iteration_normalizer = "LU"
-    elif power_iteration_normalizer == "LU" and is_array_api_compliant:
+    elif power_iteration_normalizer == "LU" and use_array_api:
         raise ValueError(
             "Array API does not support LU factorization. Set "
             "`power_iteration_normalizer='QR'` instead."
         )
 
-    if is_array_api_compliant:
+    if use_array_api:
         qr_normalizer = partial(xp.linalg.qr, mode="reduced")
     else:
         # Use scipy.linalg instead of numpy.linalg when not explicitly


### PR DESCRIPTION
PCA was checking for array API enabled or not to gate access to solvers in PCA. Instead we should check if the input is not array-like, which is a more precise way to gate this.

The invariants that should be true are:
- numpy input with array API dispatching turned off and on should result in the same behaviour
- torch-cpu input with array API dispatching turned off and on should result in the same features being available (e.g. the same solvers should be available)
- torch-cpu input with array API dispatching disabled should have fitted attributes that are numpy.
- torch-cpu input with array API dispatching enabled should have fitted attributes that are torch-cpu.

The change in the `test_pca_mle_array_api_compliance` test is a fix for `float32`. The check now makes sure that the "left over" components are all compatible with being noise. Even if the two runs can't agree on how many components there are.

I think we can clean up the code a bit more, but I'm starting the PR now to see if we can agree on the invariants and the behaviour. This is already the third iteration of this fix, each time thinking that "this time I got it right". This is why I now opened the PR to see if others agree on the invariants

#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
