### PR TITLE
MNT Fix welcome comment (again)

### DIFF
--- a/.github/workflows/welcome-first-time-contributor.yml
+++ b/.github/workflows/welcome-first-time-contributor.yml
@@ -14,7 +14,10 @@ jobs:
 
   post_comment:
     name: welcome
-    if: contains('FIRST_TIME_CONTRIBUTOR FIRST_TIMER NONE', github.event.pull_request.author_association)
+    if: |
+      github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
+      github.event.pull_request.author_association == 'FIRST_TIMER' ||
+      github.event.pull_request.author_association == 'NONE'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The welcome comment appears on PRs from existing contributors.
One obvious reason is that the current condition does substring matching and so matches on "CONTRIBUTOR". Changed it to a robust condition check.

ping @AnneBeyer @virchan, I hope this time it'll work :)