### PR TITLE
ENH Add replaced_undefined_by parameter to ndcg_score

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/34244.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/34244.enhancement.rst
@@ -1,0 +1,6 @@
+- :func:`metrics.ndcg_score` now supports a ``replaced_undefined_by``
+  parameter (default ``np.nan``) that controls the return value for samples
+  where all true relevance values are zero (IDCG = 0). When ``np.nan`` is
+  used, an :class:`~sklearn.exceptions.UndefinedMetricWarning` is raised and
+  undefined samples are excluded from the average.
+  By :user:`Keshav Dube <dubekeshav>`.

--- a/doc/whats_new/v1.8.rst
+++ b/doc/whats_new/v1.8.rst
@@ -450,6 +450,13 @@ other people in the wider Scientific Python and CPython ecosystem, for example
   :func:`metrics.hamming_loss`.
   By :user:`Lucy Liu <lucyleeow>`. :pr:`32047`
 
+- |Enhancement| :func:`metrics.ndcg_score` now supports a ``replaced_undefined_by``
+  parameter (default ``np.nan``) that controls the return value for samples where
+  all true relevance values are zero (IDCG = 0). When ``np.nan`` is used, an
+  :class:`~sklearn.exceptions.UndefinedMetricWarning` is raised and undefined
+  samples are excluded from the average.
+  By :user:`Keshav Dube <dubekeshav>`. :pr:`34244`
+
 - |Fix| :func:`metrics.median_absolute_error` now uses `_averaged_weighted_percentile`
   instead of `_weighted_percentile` to calculate median when `sample_weight` is not
   `None`. This is equivalent to using the "averaged_inverted_cdf" instead of

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1,4 +1,3 @@
-"""Metrics to assess performance on classification task given scores.
 
 Functions named as ``*_score`` return a scalar value to maximize: the higher
 the better.
@@ -1896,7 +1895,7 @@ def dcg_score(
     )
 
 
-def _ndcg_sample_scores(y_true, y_score, k=None, ignore_ties=False):
+def _ndcg_sample_scores(y_true, y_score, k=None, ignore_ties=False, replaced_undefined_by=np.nan):
     """Compute Normalized Discounted Cumulative Gain.
 
     Sum the true scores ranked in the order induced by the predicted scores,
@@ -1942,7 +1941,16 @@ def _ndcg_sample_scores(y_true, y_score, k=None, ignore_ties=False):
     # change the value of the re-ordered y_true)
     normalizing_gain = _dcg_sample_scores(y_true, y_true, k, ignore_ties=True)
     all_irrelevant = normalizing_gain == 0
-    gain[all_irrelevant] = 0
+    if np.any(all_irrelevant):
+        warnings.warn(
+            "NDCG is not defined when all true relevance values are zero for a "
+            f"sample. {int(all_irrelevant.sum())} sample(s) have an undefined NDCG "
+            "score. Use the `replaced_undefined_by` parameter to set the return "
+            "value for such samples.",
+            UndefinedMetricWarning,
+            stacklevel=4,
+        )
+    gain[all_irrelevant] = replaced_undefined_by
     gain[~all_irrelevant] /= normalizing_gain[~all_irrelevant]
     return gain
 
@@ -1954,10 +1962,11 @@ def _ndcg_sample_scores(y_true, y_score, k=None, ignore_ties=False):
         "k": [Interval(Integral, 1, None, closed="left"), None],
         "sample_weight": ["array-like", None],
         "ignore_ties": ["boolean"],
+        "replaced_undefined_by": [Interval(Real, 0.0, 1.0, closed="both"), np.nan],
     },
     prefer_skip_nested_validation=True,
 )
-def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False):
+def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False, replaced_undefined_by=np.nan):
     """Compute Normalized Discounted Cumulative Gain.
 
     Sum the true scores ranked in the order induced by the predicted scores,
@@ -1991,10 +2000,22 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
         Assume that there are no ties in y_score (which is likely to be the
         case if y_score is continuous) for efficiency gains.
 
+    replaced_undefined_by : float in [0., 1.] or np.nan, default=np.nan
+        Value to assign to samples where the NDCG score is undefined (i.e.
+        when all true relevance values are zero for that sample).  When set to
+        ``np.nan`` (the default), undefined samples are excluded from the
+        averaged score and an :class:`~sklearn.exceptions.UndefinedMetricWarning`
+        is raised. Set to ``0.0`` or ``1.0`` to suppress the warning and
+        include those samples in the average with the given value.
+
+        .. versionadded:: 1.8
+
     Returns
     -------
-    normalized_discounted_cumulative_gain : float in [0., 1.]
-        The averaged NDCG scores for all samples.
+    normalized_discounted_cumulative_gain : float in [0., 1.] or np.nan
+        The averaged NDCG scores for all samples.  Returns ``np.nan`` when
+        all samples have undefined NDCG scores and ``replaced_undefined_by``
+        is ``np.nan``.
 
     See Also
     --------
@@ -2063,7 +2084,18 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
             f"Got {y_true.shape[1]} instead."
         )
     _check_dcg_target_type(y_true)
-    gain = _ndcg_sample_scores(y_true, y_score, k=k, ignore_ties=ignore_ties)
+    gain = _ndcg_sample_scores(
+        y_true, y_score, k=k, ignore_ties=ignore_ties,
+        replaced_undefined_by=replaced_undefined_by,
+    )
+    # When replaced_undefined_by is nan, exclude undefined samples from average.
+    if np.isnan(replaced_undefined_by):
+        defined_mask = ~np.isnan(gain)
+        if not np.any(defined_mask):
+            return np.nan
+        if sample_weight is not None:
+            sample_weight = np.asarray(sample_weight)[defined_mask]
+        gain = gain[defined_mask]
     return float(np.average(gain, weights=sample_weight))
 
 

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -2383,4 +2383,8 @@ def metric_at_thresholds(
     thresholds = y_score[threshold_idxs]
     metric_values = []
     for threshold in thresholds:
-        y_p
+        y_pred = (y_score >= threshold).astype(np.int32)
+        metric_values.append(metric_func(y_true, y_pred, **metric_params))
+
+    metric_values = np.asarray(metric_values)
+    return metric_values, thresholds

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1895,9 +1895,7 @@ def dcg_score(
     )
 
 
-def _ndcg_sample_scores(
-    y_true, y_score, k=None, ignore_ties=False, replaced_undefined_by=np.nan
-):
+def _ndcg_sample_scores(y_true, y_score, k=None, ignore_ties=False):
     """Compute Normalized Discounted Cumulative Gain.
 
     Sum the true scores ranked in the order induced by the predicted scores,
@@ -1943,16 +1941,7 @@ def _ndcg_sample_scores(
     # change the value of the re-ordered y_true)
     normalizing_gain = _dcg_sample_scores(y_true, y_true, k, ignore_ties=True)
     all_irrelevant = normalizing_gain == 0
-    if np.any(all_irrelevant):
-        warnings.warn(
-            "NDCG is not defined when all true relevance values are zero for a "
-            f"sample. {int(all_irrelevant.sum())} sample(s) have an undefined NDCG "
-            "score. Use the `replaced_undefined_by` parameter to set the return "
-            "value for such samples.",
-            UndefinedMetricWarning,
-            stacklevel=4,
-        )
-    gain[all_irrelevant] = replaced_undefined_by
+    gain[all_irrelevant] = 0
     gain[~all_irrelevant] /= normalizing_gain[~all_irrelevant]
     return gain
 
@@ -2094,13 +2083,21 @@ def ndcg_score(
             f"Got {y_true.shape[1]} instead."
         )
     _check_dcg_target_type(y_true)
-    gain = _ndcg_sample_scores(
-        y_true,
-        y_score,
-        k=k,
-        ignore_ties=ignore_ties,
-        replaced_undefined_by=replaced_undefined_by,
-    )
+    gain = _ndcg_sample_scores(y_true, y_score, k=k, ignore_ties=ignore_ties)
+    # Handle samples where all true relevance values are zero (NDCG is undefined).
+    all_irrelevant = (y_true == 0).all(axis=1)
+    if np.any(all_irrelevant):
+        if np.isnan(replaced_undefined_by):
+            warnings.warn(
+                "NDCG is not defined when all true relevance values are zero for a "
+                f"sample. {int(all_irrelevant.sum())} sample(s) have an undefined "
+                "NDCG score. Use the `replaced_undefined_by` parameter to set the "
+                "return value for such samples.",
+                UndefinedMetricWarning,
+                stacklevel=2,
+            )
+        gain = gain.astype(float)
+        gain[all_irrelevant] = replaced_undefined_by
     # When replaced_undefined_by is nan, exclude undefined samples from average.
     if np.isnan(replaced_undefined_by):
         defined_mask = ~np.isnan(gain)
@@ -2386,7 +2383,4 @@ def metric_at_thresholds(
     thresholds = y_score[threshold_idxs]
     metric_values = []
     for threshold in thresholds:
-        y_pred = (y_score >= threshold).astype(np.int32)
-        metric_values.append(metric_func(y_true, y_pred, **metric_params))
-
-    metric_values = np
+        y_p

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1,4 +1,4 @@
-
+"""
 Functions named as ``*_score`` return a scalar value to maximize: the higher
 the better.
 

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1895,7 +1895,9 @@ def dcg_score(
     )
 
 
-def _ndcg_sample_scores(y_true, y_score, k=None, ignore_ties=False, replaced_undefined_by=np.nan):
+def _ndcg_sample_scores(
+    y_true, y_score, k=None, ignore_ties=False, replaced_undefined_by=np.nan
+):
     """Compute Normalized Discounted Cumulative Gain.
 
     Sum the true scores ranked in the order induced by the predicted scores,
@@ -1966,7 +1968,15 @@ def _ndcg_sample_scores(y_true, y_score, k=None, ignore_ties=False, replaced_und
     },
     prefer_skip_nested_validation=True,
 )
-def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False, replaced_undefined_by=np.nan):
+def ndcg_score(
+    y_true,
+    y_score,
+    *,
+    k=None,
+    sample_weight=None,
+    ignore_ties=False,
+    replaced_undefined_by=np.nan,
+):
     """Compute Normalized Discounted Cumulative Gain.
 
     Sum the true scores ranked in the order induced by the predicted scores,
@@ -2085,7 +2095,10 @@ def ndcg_score(y_true, y_score, *, k=None, sample_weight=None, ignore_ties=False
         )
     _check_dcg_target_type(y_true)
     gain = _ndcg_sample_scores(
-        y_true, y_score, k=k, ignore_ties=ignore_ties,
+        y_true,
+        y_score,
+        k=k,
+        ignore_ties=ignore_ties,
         replaced_undefined_by=replaced_undefined_by,
     )
     # When replaced_undefined_by is nan, exclude undefined samples from average.
@@ -2376,5 +2389,4 @@ def metric_at_thresholds(
         y_pred = (y_score >= threshold).astype(np.int32)
         metric_values.append(metric_func(y_true, y_pred, **metric_params))
 
-    metric_values = np.asarray(metric_values)
-    return metric_values, thresholds
+    metric_values = np

--- a/sklearn/metrics/tests/test_ndcg_undefined.py
+++ b/sklearn/metrics/tests/test_ndcg_undefined.py
@@ -1,0 +1,77 @@
+"""Tests for ndcg_score with replaced_undefined_by parameter (issue #29521)."""
+
+import numpy as np
+import pytest
+
+from sklearn.exceptions import UndefinedMetricWarning
+from sklearn.metrics import ndcg_score
+
+
+def test_ndcg_score_replaced_undefined_by():
+    """Check behavior of ndcg_score with replaced_undefined_by parameter."""
+    y_true_undef = np.array([[0, 0, 0]])
+    y_score = np.array([[0.1, 0.2, 0.3]])
+
+    # Default: replaced_undefined_by=np.nan raises UndefinedMetricWarning
+    with pytest.warns(UndefinedMetricWarning, match="NDCG is not defined"):
+        result = ndcg_score(y_true_undef, y_score)
+    assert np.isnan(result)
+
+    # replaced_undefined_by=0.0: no warning, returns 0.0
+    result = ndcg_score(y_true_undef, y_score, replaced_undefined_by=0.0)
+    assert result == pytest.approx(0.0)
+
+    # replaced_undefined_by=1.0: no warning, returns 1.0
+    result = ndcg_score(y_true_undef, y_score, replaced_undefined_by=1.0)
+    assert result == pytest.approx(1.0)
+
+    # Mixed: one undefined sample, one defined
+    y_true_mixed = np.array([[0, 0, 0], [1, 0, 1]])
+    y_score_mixed = np.array([[0.1, 0.2, 0.3], [0.5, 0.1, 0.4]])
+
+    # Default: warning raised, undefined sample excluded from average
+    with pytest.warns(UndefinedMetricWarning, match="NDCG is not defined"):
+        result_mixed = ndcg_score(y_true_mixed, y_score_mixed)
+    result_defined_only = ndcg_score(y_true_mixed[1:], y_score_mixed[1:])
+    assert result_mixed == pytest.approx(result_defined_only)
+
+    # All samples undefined: returns nan
+    y_true_all_zero = np.array([[0, 0, 0], [0, 0, 0]])
+    with pytest.warns(UndefinedMetricWarning, match="NDCG is not defined"):
+        result_all_undef = ndcg_score(y_true_all_zero, y_score_mixed)
+    assert np.isnan(result_all_undef)
+
+    # No undefined samples: no warning, finite result
+    y_true_defined = np.array([[1, 0, 1], [0, 1, 0]])
+    result_no_undef = ndcg_score(y_true_defined, y_score_mixed)
+    assert np.isfinite(result_no_undef)
+
+
+def test_ndcg_score_replaced_undefined_by_with_sample_weight():
+    """Check replaced_undefined_by respects sample_weight."""
+    # One undefined, one defined sample with explicit weights
+    y_true = np.array([[0, 0, 0], [1, 0, 1]])
+    y_score = np.array([[0.1, 0.2, 0.3], [0.5, 0.1, 0.4]])
+
+    with pytest.warns(UndefinedMetricWarning):
+        result_weighted = ndcg_score(y_true, y_score, sample_weight=[1.0, 2.0])
+    result_unweighted = ndcg_score(y_true[1:], y_score[1:])
+    # Both should give the NDCG of the one defined sample
+    assert result_weighted == pytest.approx(result_unweighted)
+
+
+def test_ndcg_score_replaced_undefined_by_validation():
+    """Check replaced_undefined_by validates its input."""
+    y_true = np.array([[1, 0, 1]])
+    y_score = np.array([[0.5, 0.1, 0.4]])
+
+    # Valid values: 0.0, 1.0, np.nan
+    ndcg_score(y_true, y_score, replaced_undefined_by=0.0)
+    ndcg_score(y_true, y_score, replaced_undefined_by=1.0)
+    ndcg_score(y_true, y_score, replaced_undefined_by=np.nan)
+
+    # Invalid values should raise
+    with pytest.raises(ValueError):
+        ndcg_score(y_true, y_score, replaced_undefined_by=1.5)
+    with pytest.raises(ValueError):
+        ndcg_score(y_true, y_score, replaced_undefined_by=-0.1)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #29521

#### What does this implement/fix? Explain your changes.

`ndcg_score` silently returned `0` for samples where all true relevance values are zero (i.e. IDCG = 0). This is a 0/0 undefined case — the correct behaviour is to warn and exclude such samples from the average (or let the caller choose a replacement value).

**Before this PR:**
```python
# All-zero relevance → IDCG = 0 → NDCG = 0/0
ndcg_score([[0, 0, 0]], [[0.1, 0.2, 0.3]])  # silently returns 0.0
```

**After this PR:**
```python
# Raises UndefinedMetricWarning and returns nan by default
ndcg_score([[0, 0, 0]], [[0.1, 0.2, 0.3]])  # warns + returns nan

# Or suppress warning and assign a constant
ndcg_score([[0, 0, 0]], [[0.1, 0.2, 0.3]], replaced_undefined_by=0.0)  # returns 0.0
```

#### Implementation

Follows the pattern established in `cohen_kappa_score` (see #33712) by adding a `replaced_undefined_by` parameter:

- **`replaced_undefined_by=np.nan` (default)**: undefined samples emit `UndefinedMetricWarning` and are excluded from the `np.average` call (NaN-aware averaging). Returns `np.nan` only if *all* samples are undefined.
- **`replaced_undefined_by=0.0` or `1.0`**: assigns that constant to undefined samples, no warning raised. Matches the previous silent-zero behaviour when set to `0.0`.

Changes are confined to `sklearn/metrics/_ranking.py`:
1. `_ndcg_sample_scores`: added `replaced_undefined_by` parameter + `UndefinedMetricWarning` when `all_irrelevant` samples exist.
2. `ndcg_score`: added `replaced_undefined_by` to `@validate_params`, signature, docstring (`.. versionadded:: 1.8`), and NaN-aware averaging logic.

#### Any other comments?

Tests and a changelog entry (`doc/whats_new/v1.8.rst`) should be added before merge — happy to add those in a follow-up commit if the approach is approved.