### PR TITLE
Fix memory leak in liblinear

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.svm/34256.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.svm/34256.fix.rst
@@ -1,0 +1,2 @@
+- Fixed a memory leak when calling the `fit` method of :class:`svm.LinearSVR`.
+  By :user:`Jake VanderPlas <jakevdp>`.

--- a/sklearn/svm/src/liblinear/linear.cpp
+++ b/sklearn/svm/src/liblinear/linear.cpp
@@ -29,6 +29,9 @@
      Sylvain Marie, Schneider Electric
      See <https://github.com/scikit-learn/scikit-learn/pull/13511#issuecomment-481729756>
 
+   Modified 2026:
+   - Fixed a memory leak due to conditional deallocation of `newprob` attributes;
+     see <https://github.com/scikit-learn/scikit-learn/pull/34256>
  */
 
 #include <math.h>

--- a/sklearn/svm/src/liblinear/linear.cpp
+++ b/sklearn/svm/src/liblinear/linear.cpp
@@ -2453,7 +2453,7 @@ static void remove_zero_weight(problem *newprob, const problem *prob)
 model* train(const problem *prob, const parameter *param, BlasFunctions *blas_functions)
 {
 	problem newprob;
-	remove_zero_weight(&newprob, prob);
+	remove_zero_weight(&newprob, prob);  // This allocates memory for newprob
 	prob = &newprob;
 	int i,j;
 	int l = prob->l;
@@ -2587,10 +2587,10 @@ model* train(const problem *prob, const parameter *param, BlasFunctions *blas_fu
 		free(sub_prob.y);
 		free(sub_prob.W);
 		free(weighted_C);
-		free(newprob.x);
-		free(newprob.y);
-		free(newprob.W);
 	}
+	free(newprob.x);
+	free(newprob.y);
+	free(newprob.W);
 	return model_;
 }
 


### PR DESCRIPTION
There is a memory leak in `LinearSVR`, as demonstrated by this snippet (run on sklearn v1.9.0, but the issue predates this):
```python
import os
import psutil
import numpy as np
from sklearn.svm import LinearSVR

def get_memory_usage():
    process = psutil.Process(os.getpid())
    return process.memory_info().rss / (1024 * 1024)

X = np.random.randn(1000, 10)
y = X.sum(axis=1)

for i in range(10001):
    if i % 2000 == 0:
        print(f"Iteration {i:5d}: Memory = {get_memory_usage():6.2f} MB")
    LinearSVR(max_iter=10).fit(X, y)
```
Output:
```
Iteration     0: Memory = 244.92 MB
Iteration  2000: Memory = 291.26 MB
Iteration  4000: Memory = 337.13 MB
Iteration  6000: Memory = 383.00 MB
Iteration  8000: Memory = 428.87 MB
Iteration 10000: Memory = 474.74 MB
```
Running under MSAN identified that the problem comes from memory allocated here: https://github.com/scikit-learn/scikit-learn/blob/87fb943911bd81a3f679a3f86e367730a7bb997f/sklearn/svm/src/liblinear/linear.cpp#L2433-L2437

via this line: https://github.com/scikit-learn/scikit-learn/blob/87fb943911bd81a3f679a3f86e367730a7bb997f/sklearn/svm/src/liblinear/linear.cpp#L2456

but the memory is only freed in the `else` branch later in the function: https://github.com/scikit-learn/scikit-learn/blob/87fb943911bd81a3f679a3f86e367730a7bb997f/sklearn/svm/src/liblinear/linear.cpp#L2590-L2592

The fix is straightforward: move these `free` lines outside the `else` branch, so that they're executed unconditionally.

## AI usage disclosure

I used AI to research and understand the issue, but wrote the code in this PR manually.