### PR TITLE
Improved error message when a polars LazyFrame is passed to check_array

### DIFF
--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -356,6 +356,19 @@ def test_check_array_series_err_msg():
         check_array(ser, ensure_2d=True)
 
 
+def test_check_array_polars_lazyframe():
+    """check_array raises a clear TypeError for Polars LazyFrame."""
+    pytest.importorskip("polars")
+    import polars as pl
+
+    X_lazy = pl.LazyFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+    with pytest.raises(
+        TypeError,
+        match="A polars LazyFrame was passed.*Use '.collect\\(\\)' to convert",
+    ):
+        check_array(X_lazy)
+
+
 @pytest.mark.filterwarnings("ignore:Can't check dok sparse matrix for nan or inf")
 def test_check_array():
     # accept_sparse == False

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -864,6 +864,12 @@ def check_array(
             "https://numpy.org/doc/stable/reference/generated/numpy.matrix.html"
         )
 
+    if nw.dependencies.is_polars_lazyframe(array):
+        raise TypeError(
+            "A polars LazyFrame was passed, but lazy dataframes are not supported. "
+            "Use '.collect()' to convert it to a polars DataFrame."
+        )
+
     xp, is_array_api_compliant = get_namespace(array)
 
     # store reference to original array to check if copy is needed when


### PR DESCRIPTION
Fixes #34258 

### Fix

- Added a single early check inside check_array (in sklearn/utils/validation.py) that detects a Polars LazyFrame before it reaches the array validation logic, and raises a clear, actionable error instead:
- `TypeError: A polars LazyFrame was passed, but lazy dataframes are not supported.
Use '.collect()' to convert it to a polars DataFrame.`

- This follows the same pattern already used in check_array for other unsupported types like np.matrix and sparse inputs.