### PR TITLE
fix(datasets): retry corrupted OpenML downloads and report the cached path

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.datasets/34262.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.datasets/34262.fix.rst
@@ -1,0 +1,3 @@
+- :func:`datasets.fetch_openml` now correctly recovers from a corrupted
+  download by re-downloading it, instead of raising an error.
+  By :user:`Roman Yurchak <rth>`.

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -53,6 +53,7 @@ def _openml_path_from_url(url: str) -> str:
     This is the path component of the URL, used both to download the resource
     and to mirror it as sub-folders of the local cache folder.
 
+    >>> from sklearn.datasets._openml import _openml_path_from_url
     >>> _openml_path_from_url("https://www.openml.org/data/v1/download/42/iris.arff")
     'data/v1/download/42/iris.arff'
     """

--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -10,6 +10,7 @@ import time
 from contextlib import closing
 from functools import wraps
 from os.path import join
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.error import HTTPError, URLError
@@ -46,22 +47,34 @@ def _get_local_path(openml_path: str, data_home: str) -> str:
     return os.path.join(data_home, "openml.org", openml_path + ".gz")
 
 
+def _openml_path_from_url(url: str) -> str:
+    """Return the OpenML cache-relative path encoded in a download/API ``url``.
+
+    This is the path component of the URL, used both to download the resource
+    and to mirror it as sub-folders of the local cache folder.
+
+    >>> _openml_path_from_url("https://www.openml.org/data/v1/download/42/iris.arff")
+    'data/v1/download/42/iris.arff'
+    """
+    return urlparse(url).path.lstrip("/")
+
+
 def _retry_with_clean_cache(
     openml_path: str,
     data_home: Optional[str],
     no_retry_exception: Optional[Exception] = None,
 ) -> Callable:
-    """If the first call to the decorated function fails, the local cached
-    file is removed, and the function is called again. If ``data_home`` is
-    ``None``, then the function is called once. We can provide a specific
-    exception to not retry on using `no_retry_exception` parameter.
+    """If the first call to the decorated function fails, the local cached file
+    (if any) is removed and the function is called again. The retry happens
+    whether or not ``data_home`` is set: when caching is disabled there is no
+    file to remove and the function is simply called a second time. We can
+    provide a specific exception to not retry on using `no_retry_exception`
+    parameter.
     """
 
     def decorator(f):
         @wraps(f)
         def wrapper(*args, **kw):
-            if data_home is None:
-                return f(*args, **kw)
             try:
                 return f(*args, **kw)
             except URLError:
@@ -71,10 +84,18 @@ def _retry_with_clean_cache(
                     exc, no_retry_exception
                 ):
                     raise
-                warn("Invalid cache, redownloading file", RuntimeWarning)
-                local_path = _get_local_path(openml_path, data_home)
-                if os.path.exists(local_path):
-                    os.unlink(local_path)
+                if data_home is None:
+                    warn(
+                        "Downloaded file could have been corrupted, redownloading.",
+                        RuntimeWarning,
+                    )
+                else:
+                    local_path = _get_local_path(openml_path, data_home)
+                    warn(
+                        f"Invalid cache, redownloading file to {local_path}",
+                        RuntimeWarning,
+                    )
+                    Path(local_path).unlink(missing_ok=True)
                 return f(*args, **kw)
 
         return wrapper
@@ -163,7 +184,7 @@ def _open_openml_url(
             return gzip.GzipFile(fileobj=fsrc, mode="rb")
         return fsrc
 
-    openml_path = urlparse(url).path.lstrip("/")
+    openml_path = _openml_path_from_url(url)
     local_path = _get_local_path(openml_path, data_home)
     dir_name, file_name = os.path.split(local_path)
     if not os.path.exists(local_path):
@@ -240,7 +261,7 @@ def _get_json_content_from_openml_api(
         An exception otherwise.
     """
 
-    @_retry_with_clean_cache(url, data_home=data_home)
+    @_retry_with_clean_cache(_openml_path_from_url(url), data_home=data_home)
     def _load_json():
         with closing(
             _open_openml_url(url, data_home, n_retries=n_retries, delay=delay)
@@ -529,11 +550,15 @@ def _load_arff_response(
         actual_md5_checksum = md5.hexdigest()
 
     if actual_md5_checksum != md5_checksum:
+        location = f"downloaded from {url}"
+        if data_home is not None:
+            local_path = _get_local_path(_openml_path_from_url(url), data_home)
+            location += f" and cached at {local_path}"
         raise ValueError(
-            f"md5 checksum of local file for {url} does not match description: "
-            f"expected: {md5_checksum} but got {actual_md5_checksum}. "
-            "Downloaded file could have been modified / corrupted, clean cache "
-            "and retry..."
+            f"The md5 checksum of the file {location} does not match the expected "
+            f"checksum from the dataset description: expected {md5_checksum} but "
+            f"got {actual_md5_checksum}. The downloaded file could have been "
+            "modified or corrupted; clean the cache and retry."
         )
 
     def _open_url_and_load_gzip_file(url, data_home, n_retries, delay, arff_params):
@@ -687,7 +712,7 @@ def _download_data_to_bunch(
         no_retry_exception = ParserError
 
     X, y, frame, categories = _retry_with_clean_cache(
-        url, data_home, no_retry_exception
+        _openml_path_from_url(url), data_home, no_retry_exception
     )(_load_arff_response)(
         url,
         data_home,

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -1466,6 +1466,8 @@ def test_fetch_openml_cache(monkeypatch, gzip_response, tmpdir):
     np.testing.assert_array_equal(y_fetched, y_cached)
 
 
+@pytest.mark.parametrize("cache", [False, True])
+@pytest.mark.parametrize("recoverable", [True, False])
 @pytest.mark.parametrize(
     "as_frame, parser",
     [
@@ -1475,15 +1477,24 @@ def test_fetch_openml_cache(monkeypatch, gzip_response, tmpdir):
         (False, "pandas"),
     ],
 )
-def test_fetch_openml_verify_checksum(monkeypatch, as_frame, tmpdir, parser):
-    """Check that the checksum is working as expected."""
+def test_fetch_openml_verify_checksum(
+    monkeypatch, as_frame, tmpdir, parser, cache, recoverable
+):
+    """Check that the md5 checksum is enforced and a corrupted download retried.
+
+    The mock serves corrupted bytes on the first download. When ``recoverable``,
+    a valid copy is served on the retry, so the fetch succeeds; otherwise every
+    download is corrupted and a ``ValueError`` is raised once the retry is
+    exhausted. The retry happens whether or not caching is enabled.
+    """
     if as_frame or parser == "pandas":
         pytest.importorskip("pandas")
 
     data_id = 2
     _monkey_patch_webbased_functions(monkeypatch, data_id, True)
 
-    # create a temporary modified arff file
+    # Create a corrupted copy of the arff file (flip the last byte so that its
+    # md5 checksum does not match the description).
     original_data_module = OPENML_TEST_DATA_MODULE + "." + f"id_{data_id}"
     original_data_file_name = "data-v1-dl-1666876.arff.gz"
     original_data_path = resources.files(original_data_module) / original_data_file_name
@@ -1496,29 +1507,69 @@ def test_fetch_openml_verify_checksum(monkeypatch, as_frame, tmpdir, parser):
     with gzip.GzipFile(corrupt_copy_path, "wb") as modified_gzip:
         modified_gzip.write(data)
 
-    # Requests are already mocked by monkey_patch_webbased_functions.
-    # We want to reuse that mock for all requests except file download,
-    # hence creating a thin mock over the original mock
+    # Requests are already mocked by monkey_patch_webbased_functions. We reuse
+    # that mock for all requests except the data download, hence creating a thin
+    # mock over the original mock. Corrupted bytes are served on the first
+    # download; on subsequent downloads, valid bytes are served only when the
+    # failure is ``recoverable``.
     mocked_openml_url = sklearn.datasets._openml.urlopen
+    download_url = "https://www.openml.org/data/v1/download/1666876/anneal.arff"
+    download_calls = []
 
     def swap_file_mock(request, *args, **kwargs):
         url = request.get_full_url()
         if url.endswith("data/v1/download/1666876/anneal.arff"):
-            with open(corrupt_copy_path, "rb") as f:
-                corrupted_data = f.read()
-            return _MockHTTPResponse(BytesIO(corrupted_data), is_gzip=True)
-        else:
-            return mocked_openml_url(request)
+            download_calls.append(url)
+            if len(download_calls) == 1 or not recoverable:
+                with open(corrupt_copy_path, "rb") as f:
+                    corrupted_data = f.read()
+                return _MockHTTPResponse(BytesIO(corrupted_data), is_gzip=True)
+        return mocked_openml_url(request)
 
     monkeypatch.setattr(sklearn.datasets._openml, "urlopen", swap_file_mock)
 
-    # validate failed checksum
-    with pytest.raises(ValueError) as exc:
-        sklearn.datasets.fetch_openml(
-            data_id=data_id, cache=False, as_frame=as_frame, parser=parser
+    if cache:
+        data_home = str(tmpdir.mkdir("scikit_learn_data"))
+    else:
+        data_home = None
+    fetch = partial(
+        fetch_openml_orig,
+        data_id=data_id,
+        data_home=data_home,
+        cache=cache,
+        as_frame=as_frame,
+        parser=parser,
+    )
+
+    # Both the redownload warning and the checksum error report the download
+    # URL, plus the local cache path (rooted at ``data_home``) when caching is on.
+    if cache:
+        cache_path = re.escape(data_home) + r".*openml\.org/.*/anneal\.arff\.gz"
+        warn_match = f"Invalid cache, redownloading file to {cache_path}"
+        error_match = (
+            f"md5 checksum of the file downloaded from {re.escape(download_url)} "
+            f"and cached at {cache_path} does not match"
         )
-    # exception message should have file-path
-    assert exc.match("1666876")
+    else:
+        warn_match = r"Downloaded file could have been corrupted, redownloading\."
+        error_match = (
+            f"md5 checksum of the file downloaded from {re.escape(download_url)} "
+            "does not match"
+        )
+
+    if recoverable:
+        # The corrupted (cache) file is removed and a valid copy redownloaded.
+        with pytest.warns(RuntimeWarning, match=warn_match):
+            bunch = fetch()
+        assert bunch.data.shape[0] > 0
+    else:
+        # Every download is corrupted: the retry is exhausted and we raise.
+        with pytest.raises(ValueError, match=error_match):
+            fetch()
+
+    # The download was retried: it was attempted at least twice (the initial
+    # try plus one retry; without caching the file is also reopened to parse it).
+    assert len(download_calls) >= 2
 
 
 def test_open_openml_url_retry_on_network_error(monkeypatch):

--- a/sklearn/datasets/tests/test_openml.py
+++ b/sklearn/datasets/tests/test_openml.py
@@ -1544,7 +1544,7 @@ def test_fetch_openml_verify_checksum(
     # Both the redownload warning and the checksum error report the download
     # URL, plus the local cache path (rooted at ``data_home``) when caching is on.
     if cache:
-        cache_path = re.escape(data_home) + r".*openml\.org/.*/anneal\.arff\.gz"
+        cache_path = re.escape(data_home) + r".*1666876/anneal\.arff\.gz"
         warn_match = f"Invalid cache, redownloading file to {cache_path}"
         error_match = (
             f"md5 checksum of the file downloaded from {re.escape(download_url)} "


### PR DESCRIPTION
Closes https://github.com/scikit-learn/scikit-learn/issues/34260

`fetch_openml` checks the md5 checksum of downloaded files, but the  retry on failure was passed the full URL instead of the URL path. It therefore tried to delete a non-existing path, leaving the corrupted file in the cache and skipping the redownload. The retry was also skipped entirely when caching was disabled (which is strange)

This:

- Add a `_openml_path_from_url` helper and pass the URL path component to `_retry_with_clean_cache` so the corrupted cache file is actually removed and redownloaded.
- Retry md5/integrity failures whether or not caching is enabled to be more symmetric there.
- Include the download URL and the local cache path in the error message.

I updated the unit test to test this more extensively. I have also manually checked that is you download an actual openml dataset, then corrupt the cache, and try reloading it that dataset,
 - this fails on main with the md5sum failure (so redownload is not working)
 - works with this fix
 
 cc @GaelVaroquaux  @glemaitre 
