### PR TITLE
FIX Set default transform_input of Pipeline to ["X_val"]

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.pipeline/34263.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.pipeline/34263.fix.rst
@@ -1,0 +1,3 @@
+- The default value for the `transform_input parameter of :class:`Pipeline` was changed
+  from `None` to `["X_val"]` to prevent easy to miss mistakes.
+  By :user:`Jérémie du Boisberranger <jeremiedbb>`.

--- a/doc/whats_new/upcoming_changes/sklearn.pipeline/34263.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.pipeline/34263.fix.rst
@@ -1,3 +1,4 @@
-- The default value for the `transform_input parameter of :class:`Pipeline` was changed
-  from `None` to `["X_val"]` to prevent easy to miss mistakes.
+- The default value for the `transform_input` parameter of :class:`Pipeline` was changed
+  from `None` to `("X_val",)` so that the validation set, when passed to `fit`, is
+  always transformed alongside `X`, to prevent easy to miss mistakes.
   By :user:`Jérémie du Boisberranger <jeremiedbb>`.

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -129,7 +129,7 @@ class Pipeline(CallbackSupportMixin, _BaseComposition):
         must define `fit`. All non-last steps must also define `transform`. See
         :ref:`Combining Estimators <combining_estimators>` for more details.
 
-    transform_input : list of str, default=None
+    transform_input : list of str, default=["X_val"]
         The names of the :term:`metadata` parameters that should be transformed by the
         pipeline before passing it to the step consuming it.
 
@@ -138,10 +138,13 @@ class Pipeline(CallbackSupportMixin, _BaseComposition):
         them. Requirement is defined via :ref:`metadata routing <metadata_routing>`.
         For instance, this can be used to pass a validation set through the pipeline.
 
-        You can only set this if metadata routing is enabled, which you
+        You can only use this if metadata routing is enabled, which you
         can enable using ``sklearn.set_config(enable_metadata_routing=True)``.
 
         .. versionadded:: 1.6
+
+        .. versionchanged:: 1.10
+            The default changed from ``None`` to ``["X_val"]``.
 
     memory : str or object with the joblib.Memory interface, default=None
         Used to cache the fitted transformers of the pipeline. The last step
@@ -215,7 +218,7 @@ class Pipeline(CallbackSupportMixin, _BaseComposition):
         "verbose": ["boolean"],
     }
 
-    def __init__(self, steps, *, transform_input=None, memory=None, verbose=False):
+    def __init__(self, steps, *, transform_input=["X_val"], memory=None, verbose=False):
         self.steps = steps
         self.transform_input = transform_input
         self.memory = memory
@@ -621,9 +624,13 @@ class Pipeline(CallbackSupportMixin, _BaseComposition):
         callback_ctx = self._init_callback_context(max_subtasks=len(self.steps))
         callback_ctx.call_on_fit_task_begin(estimator=self, X=X, y=y)
 
-        if not _routing_enabled() and self.transform_input is not None:
+        if (
+            not _routing_enabled()
+            and self.transform_input  # don't raise for None or []
+            and self.transform_input != ["X_val"]
+        ):
             raise ValueError(
-                "The `transform_input` parameter can only be set if metadata "
+                "The `transform_input` parameter can only be used if metadata "
                 "routing is enabled. You can enable metadata routing using "
                 "`sklearn.set_config(enable_metadata_routing=True)`."
             )
@@ -1457,7 +1464,7 @@ def _name_estimators(estimators):
     return list(zip(names, estimators))
 
 
-def make_pipeline(*steps, memory=None, transform_input=None, verbose=False):
+def make_pipeline(*steps, memory=None, transform_input=["X_val"], verbose=False):
     """Construct a :class:`Pipeline` from the given estimators.
 
     This is a shorthand for the :class:`Pipeline` constructor; it does not
@@ -1479,16 +1486,19 @@ def make_pipeline(*steps, memory=None, transform_input=None, verbose=False):
         or ``steps`` to inspect estimators within the pipeline. Caching the
         transformers is advantageous when fitting is time consuming.
 
-    transform_input : list of str, default=None
+    transform_input : list of str, default=["X_val"]
         This enables transforming some input arguments to ``fit`` (other than ``X``)
         to be transformed by the steps of the pipeline up to the step which requires
         them. Requirement is defined via :ref:`metadata routing <metadata_routing>`.
         This can be used to pass a validation set through the pipeline for instance.
 
-        You can only set this if metadata routing is enabled, which you
+        You can only use this if metadata routing is enabled, which you
         can enable using ``sklearn.set_config(enable_metadata_routing=True)``.
 
         .. versionadded:: 1.6
+
+        .. versionchanged:: 1.10
+            The default changed from ``None`` to ``["X_val"]``.
 
     verbose : bool, default=False
         If True, the time elapsed while fitting each step will be printed as it

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -129,7 +129,7 @@ class Pipeline(CallbackSupportMixin, _BaseComposition):
         must define `fit`. All non-last steps must also define `transform`. See
         :ref:`Combining Estimators <combining_estimators>` for more details.
 
-    transform_input : list of str, default=["X_val"]
+    transform_input : tuple or list of str, default=("X_val",)
         The names of the :term:`metadata` parameters that should be transformed by the
         pipeline before passing it to the step consuming it.
 
@@ -144,7 +144,7 @@ class Pipeline(CallbackSupportMixin, _BaseComposition):
         .. versionadded:: 1.6
 
         .. versionchanged:: 1.10
-            The default changed from ``None`` to ``["X_val"]``.
+            The default changed from `None` to `("X_val",)`.
 
     memory : str or object with the joblib.Memory interface, default=None
         Used to cache the fitted transformers of the pipeline. The last step
@@ -213,12 +213,14 @@ class Pipeline(CallbackSupportMixin, _BaseComposition):
     # BaseEstimator interface
     _parameter_constraints: dict = {
         "steps": [list, Hidden(tuple)],
-        "transform_input": [list, None],
+        "transform_input": [list, tuple, None],
         "memory": [None, str, HasMethods(["cache"])],
         "verbose": ["boolean"],
     }
 
-    def __init__(self, steps, *, transform_input=["X_val"], memory=None, verbose=False):
+    def __init__(
+        self, steps, *, transform_input=("X_val",), memory=None, verbose=False
+    ):
         self.steps = steps
         self.transform_input = transform_input
         self.memory = memory
@@ -626,8 +628,8 @@ class Pipeline(CallbackSupportMixin, _BaseComposition):
 
         if (
             not _routing_enabled()
-            and self.transform_input  # don't raise for None or []
-            and self.transform_input != ["X_val"]
+            and self.transform_input  # don't raise for None or ()
+            and self.transform_input != ("X_val",)
         ):
             raise ValueError(
                 "The `transform_input` parameter can only be used if metadata "
@@ -1464,7 +1466,7 @@ def _name_estimators(estimators):
     return list(zip(names, estimators))
 
 
-def make_pipeline(*steps, memory=None, transform_input=["X_val"], verbose=False):
+def make_pipeline(*steps, memory=None, transform_input=("X_val",), verbose=False):
     """Construct a :class:`Pipeline` from the given estimators.
 
     This is a shorthand for the :class:`Pipeline` constructor; it does not
@@ -1486,7 +1488,7 @@ def make_pipeline(*steps, memory=None, transform_input=["X_val"], verbose=False)
         or ``steps`` to inspect estimators within the pipeline. Caching the
         transformers is advantageous when fitting is time consuming.
 
-    transform_input : list of str, default=["X_val"]
+    transform_input : tuple or list of str, default=("X_val",)
         This enables transforming some input arguments to ``fit`` (other than ``X``)
         to be transformed by the steps of the pipeline up to the step which requires
         them. Requirement is defined via :ref:`metadata routing <metadata_routing>`.
@@ -1498,7 +1500,7 @@ def make_pipeline(*steps, memory=None, transform_input=["X_val"], verbose=False)
         .. versionadded:: 1.6
 
         .. versionchanged:: 1.10
-            The default changed from ``None`` to ``["X_val"]``.
+            The default changed from `None` to `("X_val",)`.
 
     verbose : bool, default=False
         If True, the time elapsed while fitting each step will be printed as it

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -138,6 +138,8 @@ class Pipeline(CallbackSupportMixin, _BaseComposition):
         them. Requirement is defined via :ref:`metadata routing <metadata_routing>`.
         For instance, this can be used to pass a validation set through the pipeline.
 
+        By default, the validation set `X_val` is always transformed.
+
         You can only use this if metadata routing is enabled, which you
         can enable using ``sklearn.set_config(enable_metadata_routing=True)``.
 
@@ -1493,6 +1495,8 @@ def make_pipeline(*steps, memory=None, transform_input=("X_val",), verbose=False
         to be transformed by the steps of the pipeline up to the step which requires
         them. Requirement is defined via :ref:`metadata routing <metadata_routing>`.
         This can be used to pass a validation set through the pipeline for instance.
+
+        By default, the validation set `X_val` is always transformed.
 
         You can only use this if metadata routing is enabled, which you
         can enable using ``sklearn.set_config(enable_metadata_routing=True)``.

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -882,7 +882,7 @@ def test_set_pipeline_step_passthrough(passthrough):
         "memory": None,
         "m2__mult": 2,
         "last__mult": 5,
-        "transform_input": None,
+        "transform_input": ["X_val"],
         "verbose": False,
     }
 
@@ -2221,9 +2221,18 @@ def test_transform_input_no_slep6():
     """Make sure the right error is raised if slep6 is not enabled."""
     X = np.array([[1, 2], [3, 4]])
     y = np.array([0, 1])
-    msg = "The `transform_input` parameter can only be set if metadata"
+
+    # non-default / non-empty transform_input raises
+    msg = "The `transform_input` parameter can only be used if metadata"
     with pytest.raises(ValueError, match=msg):
         make_pipeline(DummyTransf(), transform_input=["blah"]).fit(X, y)
+
+    # default ["X_val"] doesn't raise even if X_val is not passed
+    make_pipeline(DummyTransf()).fit(X, y)
+
+    # the usual metadata-routing error is raised if X_val is passed
+    with pytest.raises(ValueError, match="Pipeline.fit does not accept"):
+        make_pipeline(DummyTransf()).fit(X, y, X_val=X)
 
 
 @config_context(enable_metadata_routing=True)

--- a/sklearn/tests/test_pipeline.py
+++ b/sklearn/tests/test_pipeline.py
@@ -882,7 +882,7 @@ def test_set_pipeline_step_passthrough(passthrough):
         "memory": None,
         "m2__mult": 2,
         "last__mult": 5,
-        "transform_input": ["X_val"],
+        "transform_input": ("X_val",),
         "verbose": False,
     }
 
@@ -2227,7 +2227,7 @@ def test_transform_input_no_slep6():
     with pytest.raises(ValueError, match=msg):
         make_pipeline(DummyTransf(), transform_input=["blah"]).fit(X, y)
 
-    # default ["X_val"] doesn't raise even if X_val is not passed
+    # default ("X_val",) doesn't raise even when X_val is not passed
     make_pipeline(DummyTransf()).fit(X, y)
 
     # the usual metadata-routing error is raised if X_val is passed

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -304,7 +304,7 @@ Pipeline(memory=None,
                                     multi_class='warn', n_jobs=None,
                                     random_state=None, solver='warn',
                                     tol=0.0001, verbose=0, warm_start=False))],
-         transform_input=("X_val",), verbose=False)"""
+         transform_input=('X_val',), verbose=False)"""
 
     expected = expected[1:]  # remove first \n
     assert pipeline.__repr__() == expected

--- a/sklearn/utils/tests/test_pprint.py
+++ b/sklearn/utils/tests/test_pprint.py
@@ -304,7 +304,7 @@ Pipeline(memory=None,
                                     multi_class='warn', n_jobs=None,
                                     random_state=None, solver='warn',
                                     tol=0.0001, verbose=0, warm_start=False))],
-         transform_input=None, verbose=False)"""
+         transform_input=("X_val",), verbose=False)"""
 
     expected = expected[1:]  # remove first \n
     assert pipeline.__repr__() == expected


### PR DESCRIPTION
It's very easy to forget to set `transform_input=["X_val"]`, because Pipeline is one of a kind in this regard. This leads to surprising behaviors that can be hard to identify. This PR changes the default to `(X_val,)`. The behavior is:
- when routing is not enabled, it doesn't break. Only when you pass X_val to fit, then it's the usual metadata-routing error
- when routing is enabled, no error if X_val is not passed to fit to not break user code. (same behavior as for any other metadata)

ping @adrinjalali @ogrisel @StefanieSenger @FrancoisPgm 