### PR TITLE
perf: defer scipy.stats, pandas and scipy.special imports 

### DIFF
--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -632,7 +632,7 @@ def _expit(x, out=None, xp=None):
     # but not in the Array API specification.
     xp, _ = get_namespace(x, xp=xp)
     if _is_numpy_namespace(xp):
-        from scipy.special import expit
+        from scipy.special import expit  # lazy import, speeds up `import sklearn`
 
         return expit(x, out=out)
 
@@ -644,7 +644,7 @@ def _logit(x, out=None, xp=None):
     # but not in the Array API specification.
     xp, _ = get_namespace(x, xp=xp)
     if _is_numpy_namespace(xp):
-        from scipy.special import logit
+        from scipy.special import logit  # lazy import, speeds up `import sklearn`
 
         return logit(x, out=out)
 

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -13,7 +13,6 @@ from functools import partial
 import numpy
 import scipy
 import scipy.sparse as sp
-import scipy.special as special
 
 from sklearn._config import get_config
 from sklearn.externals import array_api_compat
@@ -633,7 +632,9 @@ def _expit(x, out=None, xp=None):
     # but not in the Array API specification.
     xp, _ = get_namespace(x, xp=xp)
     if _is_numpy_namespace(xp):
-        return special.expit(x, out=out)
+        from scipy.special import expit
+
+        return expit(x, out=out)
 
     return 1.0 / (1.0 + xp.exp(-x))
 
@@ -643,7 +644,9 @@ def _logit(x, out=None, xp=None):
     # but not in the Array API specification.
     xp, _ = get_namespace(x, xp=xp)
     if _is_numpy_namespace(xp):
-        return special.logit(x, out=out)
+        from scipy.special import logit
+
+        return logit(x, out=out)
 
     # See https://github.com/scipy/xsf/blob/e0c4d22d6ae768b39efc69586f1e8d5560a32fc5/include/xsf/log_exp.h#L30
     def logit_v2(x):

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -13,12 +13,6 @@ import struct
 import numpy as np
 import scipy
 import scipy.sparse.linalg
-import scipy.stats
-
-try:
-    import pandas as pd
-except ImportError:
-    pd = None
 
 from sklearn.externals._packaging.version import parse as parse_version
 from sklearn.utils.parallel import _get_threadpool_controller
@@ -56,6 +50,8 @@ def _object_dtype_isnan(X):
 
 # TODO: Remove when SciPy 1.11 is the minimum supported version
 def _mode(a, axis=0):
+    import scipy.stats
+
     mode = scipy.stats.mode(a, axis=axis, keepdims=True)
     if sp_version >= parse_version("1.10.999"):
         # scipy.stats.mode has changed returned array shape with axis=None

--- a/sklearn/utils/fixes.py
+++ b/sklearn/utils/fixes.py
@@ -50,7 +50,7 @@ def _object_dtype_isnan(X):
 
 # TODO: Remove when SciPy 1.11 is the minimum supported version
 def _mode(a, axis=0):
-    import scipy.stats
+    import scipy.stats  # lazy import, speeds up `import sklearn`
 
     mode = scipy.stats.mode(a, axis=axis, keepdims=True)
     if sp_version >= parse_version("1.10.999"):


### PR DESCRIPTION
It's small micro-optimisation to reduce the import time both for `import sklearn` and also when running inference of some of the most propular models. The use case is typically training a model somewhere and then runnning the inference in some resource constrained environement where cold start matters (lambda like, wasm etc)

Relates to #25590

This defers  scipy.stats, pandas and scipy.special imports .
These modules sit on the default `import sklearn` path (via `sklearn.base` -> `sklearn.utils`) but none of them are needed at import time:

- `sklearn/utils/fixes.py` imported `scipy.stats` (used only by `_mode`) and `pandas` (imported but never used in the module nor re-exported).
- `sklearn/utils/_array_api.py` imported `scipy.special` (used only by `_expit` / `_logit`).


I did quick benchmarks here for typical inference scenarios [import_time.zip](https://github.com/user-attachments/files/28878588/import_time.zip) and the results below are import times for these cases (on M4 CPU, it will be more noticable on a slower system)

| scenario | before | after | Δ | speedup |
|---|---:|---:|---:|---:|
| hist_gradient_boosting | 1067 ms | 879 ms | 182 ms | 1.21x |
| kmeans | 1066 ms | 891 ms | 167 ms | 1.20x |
| random_forest | 1058 ms | 880 ms | 185 ms | 1.20x |
| knn_classifier | 977 ms | 785 ms | 191 ms | 1.25x |
| pca | 951 ms | 777 ms | 171 ms | 1.22x |
| svc | 941 ms | 740 ms | 199 ms | 1.27x |
| pipeline_scaler_logreg | 936 ms | 739 ms | 195 ms | 1.27x |
| linear_regression | 931 ms | 735 ms | 193 ms | 1.27x |
| logistic_regression | 928 ms | 733 ms | 191 ms | 1.27x |
| standard_scaler | 771 ms | 587 ms | 180 ms | 1.31x |
| **bare_import** | **731 ms** | **264 ms** | **467 ms** | **2.77x** |


cc @ogrisel @jeremiedbb 
