### PR TITLE
test: speed up two slow tests

### DIFF
--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -2481,7 +2481,8 @@ def test_groups_with_routing_validation(func, extra_args):
         (cross_val_score, {}),
         (cross_val_predict, {}),
         (learning_curve, {}),
-        (permutation_test_score, {}),
+        # Few permutations: this test only checks the params=None code path.
+        (permutation_test_score, {"n_permutations": 5}),
         (validation_curve, {"param_name": "alpha", "param_range": np.array([1])}),
     ],
 )

--- a/sklearn/tests/test_calibration.py
+++ b/sklearn/tests/test_calibration.py
@@ -1097,7 +1097,7 @@ def test_calibrated_classifier_cv_works_with_large_confidence_scores(
     Non-regression test for issue #26766.
     """
     prob = 0.67
-    n = 1000
+    n = 200
     random_noise = np.random.default_rng(global_random_seed).normal(size=n)
 
     y = np.array([1] * int(n * prob) + [0] * (n - int(n * prob)))


### PR DESCRIPTION
A tiny fix to speed up the 2 slowest tests in CI:

before
```
  17.46s call     sklearn/tests/test_calibration.py::test_calibrated_classifier_cv_works_with_large_confidence_scores[3]
  1.72s call     sklearn/model_selection/tests/test_validation.py::test_cross_validate_params_none[permutation_test_score-extra_args4]
```
after
```
  0.62s call     sklearn/tests/test_calibration.py::test_calibrated_classifier_cv_works_with_large_confidence_scores[3]
  0.13s call     sklearn/model_selection/tests/test_validation.py::test_cross_validate_params_none[learning_curve-extra_args3]
```

So gains 18s on a 11min test suite run (maybe a bit more in CI). Small but non negligible.