### PR TITLE
FIX linear.cpp: avoid out-of-bound read in n_iter for crammer_singer

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.svm/34273.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.svm/34273.fix.rst
@@ -1,0 +1,2 @@
+- Fixed an out-of-bound write in the ``fit`` method of :class:`svm.LinearSVC` memory
+  when using ``multi_class="crammer_singer"``.  By :user:`Jake VanderPlas <jakevdp>`.

--- a/sklearn/svm/src/liblinear/linear.cpp
+++ b/sklearn/svm/src/liblinear/linear.cpp
@@ -32,6 +32,8 @@
    Modified 2026:
    - Fixed a memory leak due to conditional deallocation of `newprob` attributes;
      see <https://github.com/scikit-learn/scikit-learn/pull/34256>
+   - Fixed an out-of-bound read when solver_type=MCSVM_CS;
+     see <https://github.com/scikit-learn/scikit-learn/pull/34273>
  */
 
 #include <math.h>

--- a/sklearn/svm/src/liblinear/linear.cpp
+++ b/sklearn/svm/src/liblinear/linear.cpp
@@ -2941,7 +2941,7 @@ void get_n_iter(const model *model_, int* n_iter)
 {
     int labels;
     labels = model_->nr_class;
-    if (labels == 2)
+    if (labels == 2 || model_->param.solver_type == MCSVM_CS)
         labels = 1;
 
     if (model_->n_iter != NULL)


### PR DESCRIPTION
Following up on #34256, I ran some of the SVM tests in ASAN mode and discovered an out-of-bound read in `linear.cpp`. Here's a Python script that hits this (run in sklearn v1.9.0, but the issue predates this):
```python
import numpy as np
from sklearn import svm

# Toy dataset with 3 classes
X = np.array([[0, 0], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5]], dtype=np.float64)
y = np.array([0, 0, 1, 1, 2, 2])

n_iter_values = set()

for i in range(100):
  clf = svm.LinearSVC(multi_class="crammer_singer", random_state=42)
  clf.fit(X, y)
  n_iter_values.add(clf.n_iter_)

print(n_iter_values)
```
The expectation is that `clf.n_iter_` would be deterministic, such that `n_iter_values` would always contain a single entry. But this non-deterministically returns 2 or more entries:
```
$ python repro.py
{446}
$ python repro.py
{251081824, 446}
```
ASAN shows that the culprit is an out-of-bound read at line 2949 here: https://github.com/scikit-learn/scikit-learn/blob/88080a5ac13e4c69264bd234731352406e54d3ed/sklearn/svm/src/liblinear/linear.cpp#L2940-L2950

The issue is the condition in lines 2943-2955: it assumes that the length of `n_iter` is `nr_class`, except in the case that `nr_class == 2`. Looking through the file for where `n_iter` is allocated, this logic is correct *except* in the case that `solver_type == MCSVM_CS` here: https://github.com/scikit-learn/scikit-learn/blob/88080a5ac13e4c69264bd234731352406e54d3ed/sklearn/svm/src/liblinear/linear.cpp#L2531-L2534
Here the length of `n_iter` is 1, while the associated `nr_class` is an arbitrary non-negative integer representing the number of classes: https://github.com/scikit-learn/scikit-learn/blob/88080a5ac13e4c69264bd234731352406e54d3ed/sklearn/svm/src/liblinear/linear.cpp#L2493

The net result of this is that line 2949 is an out-of-bound-read under the following conditions:

- `LinearSVC` with `multi_class="crammer_singer"`
- The number of classes is 3 or more

The fix here is to specifically check the `solver_type` to use the correct length for `n_iter` in this read.

## AI usage disclosure

I used AI to execute tests in ASAN mode and to locate the root cause of this issue. I made the code changes and wrote the PR description manually.