### PR TITLE
FIX locally_linear_embedding incorrectly handles duplicate points (#16512)

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.manifold/34275.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.manifold/34275.fix.rst
@@ -1,0 +1,1 @@
+- :func:`manifold.locally_linear_embedding` and :class:`manifold.LocallyLinearEmbedding` now correctly exclude the point itself from its nearest neighbors when duplicate points are present. By :user:`Saiteja Bandaru <saitejabandaru-in>`.

--- a/sklearn/manifold/_locally_linear.py
+++ b/sklearn/manifold/_locally_linear.py
@@ -113,10 +113,10 @@ def barycenter_kneighbors_graph(X, n_neighbors, reg=1e-3, n_jobs=None):
     sklearn.neighbors.kneighbors_graph
     sklearn.neighbors.radius_neighbors_graph
     """
-    knn = NearestNeighbors(n_neighbors=n_neighbors + 1, n_jobs=n_jobs).fit(X)
+    knn = NearestNeighbors(n_neighbors=n_neighbors, n_jobs=n_jobs).fit(X)
     X = knn._fit_X
     n_samples = knn.n_samples_fit_
-    ind = knn.kneighbors(X, return_distance=False)[:, 1:]
+    ind = knn.kneighbors(None, return_distance=False)
     data = barycenter_weights(X, X, ind, reg=reg)
     indptr = np.arange(0, n_samples * n_neighbors + 1, n_neighbors)
     csr = csr_array((data.ravel(), ind.ravel(), indptr), shape=(n_samples, n_samples))

--- a/sklearn/manifold/tests/test_locally_linear.py
+++ b/sklearn/manifold/tests/test_locally_linear.py
@@ -37,6 +37,15 @@ def test_barycenter_kneighbors_graph(global_dtype):
     assert linalg.norm(pred - X) / X.shape[0] < 1
 
 
+def test_barycenter_kneighbors_graph_duplicates(global_dtype):
+    # Regression test for #16512
+    X = np.array([[0, 1], [1.01, 1.0], [2, 0]], dtype=global_dtype)
+    X = np.concatenate((X, X))
+
+    graph = barycenter_kneighbors_graph(X, 1).toarray()
+    assert_array_equal(np.diag(graph), np.zeros(len(X), dtype=global_dtype))
+
+
 # ----------------------------------------------------------------------
 # Test LLE by computing the reconstruction error on some manifolds.
 


### PR DESCRIPTION
Fixes #16512.

The function `barycenter_kneighbors_graph` previously used `knn.kneighbors(X, return_distance=False)[:, 1:]` which fails to exclude the point itself when there are duplicates, since a duplicate point might occupy the 0th index. 

By leveraging `knn.kneighbors(None)`, `NearestNeighbors` handles the masking of the exact self-point automatically (even with duplicates).