### PR TITLE
DOC fix inconsistent estimators_ shape in GradientBoostingRegressor

### DIFF
--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -2014,7 +2014,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         The estimator that provides the initial predictions. Set via the ``init``
         argument.
 
-    estimators_ : ndarray of DecisionTreeRegressor of shape (n_estimators, 1)
+    estimators_ : ndarray of DecisionTreeRegressor of shape (n_estimators, ``n_trees_per_iteration_``)
         The collection of fitted sub-estimators.
 
     n_features_in_ : int

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -2014,8 +2014,8 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         The estimator that provides the initial predictions. Set via the ``init``
         argument.
 
-    estimators_ : ndarray of DecisionTreeRegressor of shape (n_estimators, ``n_trees_per_iteration_``)
-        The collection of fitted sub-estimators.
+    estimators_ : ndarray of DecisionTreeRegressor of shape \
+            (n_estimators, ``n_trees_per_iteration_``)
 
     n_features_in_ : int
         Number of features seen during :term:`fit`.


### PR DESCRIPTION
Closes #34279

## What does this fix?

In `sklearn/ensemble/_gb.py`, the `estimators_` attribute shape was 
documented inconsistently between the two classes:

- `GradientBoostingClassifier` used `(n_estimators, ``n_trees_per_iteration_``)`
- `GradientBoostingRegressor` hardcoded `(n_estimators, 1)`

This PR updates `GradientBoostingRegressor` to use `n_trees_per_iteration_` 
for consistency, which also matches the existing `n_trees_per_iteration_` 
attribute that already documents regressors always have 1 tree per iteration.