### PR TITLE
DOC: fix double word 'be be' in example comments

### DIFF
--- a/examples/applications/plot_time_series_lagged_features.py
+++ b/examples/applications/plot_time_series_lagged_features.py
@@ -379,7 +379,7 @@ _ = ax.legend()
 # - Finally, it is expected that 10% of the time, the actual demand does not lie
 #   between the 5% and 95% percentile estimates. On this test span, the actual
 #   demand seems to be higher, especially during the rush hours. It might reveal that
-#   our 95% percentile estimator underestimates the demand peaks. This could be be
+#   our 95% percentile estimator underestimates the demand peaks. This could be
 #   quantitatively confirmed by computing empirical coverage numbers as done in
 #   the :ref:`calibration of confidence intervals <calibration-section>`.
 #

--- a/examples/ensemble/plot_hgbt_regression.py
+++ b/examples/ensemble/plot_hgbt_regression.py
@@ -309,7 +309,7 @@ ax.set(
 _ = ax.legend(loc="lower right")
 
 # %%
-# We observe a tendency to over-estimate the energy transfer. This could be be
+# We observe a tendency to over-estimate the energy transfer. This could be
 # quantitatively confirmed by computing empirical coverage numbers as done in
 # the :ref:`calibration of confidence intervals section <calibration-section>`.
 # Keep in mind that those predicted percentiles are just estimations from a


### PR DESCRIPTION
Fixes a double word typo in example comments: 'be be' → 'be'.