### PR TITLE
DOC Fix PassiveAggressiveRegressor attributes

### DIFF
--- a/sklearn/linear_model/_passive_aggressive.py
+++ b/sklearn/linear_model/_passive_aggressive.py
@@ -452,11 +452,10 @@ class PassiveAggressiveRegressor(BaseSGDRegressor):
 
     Attributes
     ----------
-    coef_ : array, shape = [1, n_features] if n_classes == 2 else [n_classes,\
-            n_features]
+    coef_ : ndarray of shape (n_features,)
         Weights assigned to the features.
 
-    intercept_ : array, shape = [1] if n_classes == 2 else [n_classes]
+    intercept_ : ndarray of shape (1,)
         Constants in decision function.
 
     n_features_in_ : int


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Fixes a copy-paste error in `PassiveAggressiveRegressor` where `coef_` and `intercept_` shapes are documented using classification logic (`n_classes`). 

Since this is a regression model, `n_classes` is invalid. Under the hood, `BaseSGDRegressor._partial_fit` enforces `n_classes=1`, initializing `coef_` as a 1D array of shape `(n_features,)` and `intercept_` as shape `(1,)`. This PR updates the docstring to reflect the true 1D shapes, matching `SGDRegressor` and the file's own code examples.

#### First time contributor Introduction
Have contributed by reviewing PRs here before, but this is my first pull request to the repository.

#### AI usage disclosure
Used a local LLM to run a quick static text comparison across classifier and regressor docstrings.