### PR TITLE
FIX Propagate feature_names_in_ to sub-estimators in forest models

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -141,11 +141,15 @@ def _parallel_build_trees(
     class_weight=None,
     n_samples_bootstrap=None,
     missing_values_in_feature_mask=None,
+    feature_names_in_=None,
 ):
     """
     Private function used to fit a single tree in parallel."""
     if verbose > 1:
         print("building tree %d of %d" % (tree_idx + 1, n_trees))
+
+    if feature_names_in_ is not None:
+        tree.feature_names_in_ = feature_names_in_
 
     if bootstrap:
         n_samples = X.shape[0]
@@ -482,6 +486,7 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
                     class_weight=self.class_weight,
                     n_samples_bootstrap=n_samples_bootstrap,
                     missing_values_in_feature_mask=missing_values_in_feature_mask,
+                    feature_names_in_=getattr(self, "feature_names_in_", None),
                 )
                 for i, t in enumerate(trees)
             )

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1955,9 +1955,10 @@ def test_forest_feature_names_in_on_estimators(ForestClass):
     for tree in est.estimators_:
         assert hasattr(tree, "feature_names_in_")
         assert_array_equal(tree.feature_names_in_, ["a", "b"])
-        # predict or predict_proba on individual trees shouldn't raise user warning
-        # about feature names
-        with pytest.warns(None) as record:
+        import warnings
+
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
             if hasattr(tree, "predict_proba"):
                 tree.predict_proba(X)
             else:

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1933,3 +1933,36 @@ def test_missing_value_is_predictive(Forest, criterion, global_random_seed):
 def test_friedman_mse_deprecation(Forest):
     with pytest.warns(FutureWarning, match="friedman_mse"):
         _ = Forest(criterion="friedman_mse")
+
+
+@pytest.mark.parametrize("ForestClass", FOREST_CLASSIFIERS_REGRESSORS.values())
+def test_forest_feature_names_in_on_estimators(ForestClass):
+    # Check that feature_names_in_ is correctly passed down to all trees
+    # in the forest. Non-regression test for #26140.
+    pd = pytest.importorskip("pandas")
+    X = pd.DataFrame([[1, 2], [3, 4]], columns=["a", "b"])
+    if ForestClass.__name__.endswith("Classifier"):
+        y = [0, 1]
+    else:
+        y = [0.1, 0.2]
+
+    est = ForestClass(n_estimators=2, random_state=0)
+    est.fit(X, y)
+
+    assert hasattr(est, "feature_names_in_")
+    assert_array_equal(est.feature_names_in_, ["a", "b"])
+
+    for tree in est.estimators_:
+        assert hasattr(tree, "feature_names_in_")
+        assert_array_equal(tree.feature_names_in_, ["a", "b"])
+        # predict or predict_proba on individual trees shouldn't raise user warning
+        # about feature names
+        with pytest.warns(None) as record:
+            if hasattr(tree, "predict_proba"):
+                tree.predict_proba(X)
+            else:
+                tree.predict(X)
+
+        # Check that no UserWarning related to feature names was raised
+        for warning in record:
+            assert "feature names" not in str(warning.message)


### PR DESCRIPTION
FIX Propagate feature_names_in_ to sub-estimators in forest models

This PR propagates the feature_names_in_ attribute to individual decision trees (estimators_) during forest fitting. This resolves #26140, preventing UserWarning messages when calling prediction methods directly on individual sub-estimators.

Propagated feature_names_in_ through _parallel_build_trees.
Added unit test test_forest_feature_names_in_on_estimators.FIX Propagate feature_names_in_ to sub-estimators in forest models

This PR propagates the feature_names_in_ attribute to individual decision trees (estimators_) during forest fitting. This resolves #26140, preventing UserWarning messages when calling prediction methods directly on individual sub-estimators.

Propagated feature_names_in_ through _parallel_build_trees.
Added unit test test_forest_feature_names_in_on_estimators.