### PR TITLE
FIX improve empty vocabulary error when ngram_range filters all tokens

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -382,6 +382,29 @@ def test_countvectorizer_empty_vocabulary():
         # fit on stopwords only
         v.fit(["to be or not to be", "and me too", "and so do you"])
 
+def test_countvectorizer_empty_vocabulary_ngram_range():
+    """Check that an informative error is raised when the vocabulary is empty
+    because all documents are shorter than the minimum n-gram length.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/33981
+    """
+    # char analyzer with single-character documents and ngram_range=(2, 4)
+    with pytest.raises(ValueError, match=r"ngram_range\[0\]=2"):
+        CountVectorizer(analyzer="char", ngram_range=(2, 4)).fit_transform(
+            list("abcdefghij")
+        )
+
+    # word analyzer with single-word documents and ngram_range=(3, 3)
+    with pytest.raises(ValueError, match=r"ngram_range\[0\]=3"):
+        CountVectorizer(ngram_range=(3, 3)).fit_transform(
+            ["hello", "world", "foo"]
+        )
+
+    # ngram_range=(1, 1) should NOT mention ngram_range
+    with pytest.raises(ValueError, match="^(?!.*ngram_range).*empty vocabulary"):
+        CountVectorizer(stop_words="english").fit(["the", "a", "an"])
+
 
 def test_fit_countvectorizer_twice():
     cv = CountVectorizer()

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -382,6 +382,7 @@ def test_countvectorizer_empty_vocabulary():
         # fit on stopwords only
         v.fit(["to be or not to be", "and me too", "and so do you"])
 
+
 def test_countvectorizer_empty_vocabulary_ngram_range():
     """Check that an informative error is raised when the vocabulary is empty
     because all documents are shorter than the minimum n-gram length.

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -397,9 +397,7 @@ def test_countvectorizer_empty_vocabulary_ngram_range():
 
     # word analyzer with single-word documents and ngram_range=(3, 3)
     with pytest.raises(ValueError, match=r"ngram_range\[0\]=3"):
-        CountVectorizer(ngram_range=(3, 3)).fit_transform(
-            ["hello", "world", "foo"]
-        )
+        CountVectorizer(ngram_range=(3, 3)).fit_transform(["hello", "world", "foo"])
 
     # ngram_range=(1, 1) should NOT mention ngram_range
     with pytest.raises(ValueError, match="^(?!.*ngram_range).*empty vocabulary"):

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -1290,10 +1290,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
             # disable defaultdict behaviour
             vocabulary = dict(vocabulary)
             if not vocabulary:
-                msg = (
-                    "empty vocabulary; perhaps the documents only"
-                    " contain stop words"
-                )
+                msg = "empty vocabulary; perhaps the documents only contain stop words"
                 min_n = self.ngram_range[0]
                 if min_n > 1:
                     msg += (

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from collections.abc import Mapping
 from functools import partial
 from numbers import Integral
-from operator import itemgetterh
+from operator import itemgetter
 
 import numpy as np
 import scipy.sparse as sp

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from collections.abc import Mapping
 from functools import partial
 from numbers import Integral
-from operator import itemgetter
+from operator import itemgetterh
 
 import numpy as np
 import scipy.sparse as sp
@@ -1290,9 +1290,18 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
             # disable defaultdict behaviour
             vocabulary = dict(vocabulary)
             if not vocabulary:
-                raise ValueError(
-                    "empty vocabulary; perhaps the documents only contain stop words"
+                msg = (
+                    "empty vocabulary; perhaps the documents only"
+                    " contain stop words"
                 )
+                min_n = self.ngram_range[0]
+                if min_n > 1:
+                    msg += (
+                        ", or the documents contain only tokens shorter"
+                        " than the minimum n-gram size"
+                        f" (ngram_range[0]={min_n})"
+                    )
+                raise ValueError(msg)
 
         if indptr[-1] > np.iinfo(np.int32).max:  # = 2**31 - 1
             if _IS_32BIT:


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #33981

#### What does this implement/fix? Explain your changes.

When `CountVectorizer` is configured with `ngram_range` where `min_n > 1`, and the input documents contain only tokens shorter than `min_n`, the resulting vocabulary is empty. The current error message says:

> empty vocabulary; perhaps the documents only contain stop words

This is misleading because the real cause is the n-gram length constraint, not stop words. This PR appends a hint to the error message when `ngram_range[0] > 1`:

> empty vocabulary; perhaps the documents only contain stop words, or the documents contain only tokens shorter than the minimum n-gram size (ngram_range[0]=N)

The fix is in `CountVectorizer._count_vocab` and only activates when `min_n > 1`, so the default `ngram_range=(1, 1)` behavior is unchanged.

A non-regression test is included covering:
- char analyzer with single-character documents and `ngram_range=(2, 4)`
- word analyzer with single-word documents and `ngram_range=(3, 3)`
- default `ngram_range=(1, 1)` confirming the original message is preserved