### PR TITLE
Fix typo in api.scss: 'the the' → 'to the'

### DIFF
--- a/doc/scss/api.scss
+++ b/doc/scss/api.scss
@@ -27,7 +27,7 @@ dd {
   }
 }
 
-// The first method is too close the the docstring above
+// The first method is too close to the docstring above
 dl.py.method:first-of-type {
   margin-top: 2rem;
 }


### PR DESCRIPTION
Fixes a typo in `doc/scss/api.scss` (missing preposition 'to').