### PR TITLE
docs: Correct det_curve thresholds docstring to say increasing not decreasing

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -370,7 +370,7 @@ def det_curve(
         referred to as false rejection or miss rate.
 
     thresholds : ndarray of shape (n_thresholds,)
-        Decreasing thresholds on the decision function (either `predict_proba`
+        Increasing thresholds on the decision function (either `predict_proba`
         or `decision_function`) used to compute FPR and FNR.
 
         .. versionchanged:: 1.7

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1383,10 +1383,11 @@ def test_score_scale_invariance():
 )
 def test_det_curve_toydata(y_true, y_score, expected_fpr, expected_fnr):
     # Check on a batch of small examples.
-    fpr, fnr, _ = det_curve(y_true, y_score)
+    fpr, fnr, thresholds = det_curve(y_true, y_score)
 
     assert_allclose(fpr, expected_fpr)
     assert_allclose(fnr, expected_fnr)
+    assert np.all(np.diff(thresholds) >= 0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
The `det_curve` function in sklearn/metrics/_ranking.py documents its returned `thresholds` array as 'Decreasing thresholds on the decision function', but the function actually returns thresholds in strictly increasing order (e.g. [0.1, 0.35, 0.4, 0.8, inf]).

Fixes #34310
