### PR TITLE
DOC add scalability warning for LabelSpreading/LabelPropagation RBF kernel

### DIFF
--- a/doc/modules/semi_supervised.rst
+++ b/doc/modules/semi_supervised.rst
@@ -138,6 +138,15 @@ algorithm can lead to prohibitively long running times. On the other hand,
 the KNN kernel will produce a much more memory-friendly sparse matrix
 which can drastically reduce running times.
 
+.. note::
+
+   The ``rbf`` kernel (default) constructs a dense :math:`n \times n`
+   affinity matrix in memory, where :math:`n` is the total number of samples.
+   This becomes infeasible above roughly 20,000-30,000 samples. For larger
+   datasets, use ``kernel='knn'`` to construct a sparse graph, or use
+   :class:`~sklearn.semi_supervised.SelfTrainingClassifier` which avoids the
+   full graph entirely.
+
 .. rubric:: Examples
 
 * :ref:`sphx_glr_auto_examples_semi_supervised_plot_semi_supervised_versus_svm_iris.py`

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -407,6 +407,24 @@ class LabelPropagation(BaseLabelPropagation):
     --------
     LabelSpreading : Alternate label propagation strategy more robust to noise.
 
+    Notes
+    -----
+    **Memory and scalability (RBF kernel):** When ``kernel='rbf'`` (the
+    default), this estimator builds a dense ``n x n`` affinity matrix, where
+    ``n`` is the total number of samples (labeled + unlabeled combined).
+    Memory scales as ``O(n ** 2)``: approximately 200 MB at ``n = 5,000``
+    and 8 GB at ``n = 32,000``. For datasets larger than roughly 20,000
+    samples, the RBF kernel will be prohibitively slow and may exhaust
+    available memory.
+
+    For large datasets prefer ``kernel='knn'``, which builds a sparse
+    k-nearest-neighbor graph with ``O(n * n_neighbors)`` memory::
+
+        LabelPropagation(kernel='knn', n_neighbors=7)
+
+    :class:`LabelSpreading` with ``alpha > 0`` is generally more robust to
+    label noise than :class:`LabelPropagation`, which uses hard clamping.
+
     References
     ----------
     Xiaojin Zhu and Zoubin Ghahramani. Learning from labeled and unlabeled data
@@ -571,6 +589,27 @@ class LabelSpreading(BaseLabelPropagation):
     See Also
     --------
     LabelPropagation : Unregularized graph based semi-supervised learning.
+
+    Notes
+    -----
+    **Memory and scalability (RBF kernel):** When ``kernel='rbf'`` (the
+    default), this estimator builds a dense ``n x n`` affinity matrix, where
+    ``n`` is the total number of samples (labeled + unlabeled combined).
+    Memory scales as ``O(n ** 2)``: approximately 200 MB at ``n = 5,000``,
+    8 GB at ``n = 32,000``, and 200 GB at ``n = 160,000``. For datasets
+    larger than roughly 20,000 samples, the RBF kernel will be prohibitively
+    slow and may exhaust available memory.
+
+    **Recommended approach for large datasets:** Switch to ``kernel='knn'``,
+    which builds a sparse k-nearest-neighbor graph with
+    ``O(n * n_neighbors)`` memory::
+
+        LabelSpreading(kernel='knn', n_neighbors=7, alpha=0.2)
+
+    For datasets larger than ~50,000 samples, consider subsampling the
+    unlabeled pool, or use :class:`SelfTrainingClassifier` instead, which
+    avoids the full graph construction entirely and scales to arbitrarily
+    large unlabeled sets.
 
     References
     ----------


### PR DESCRIPTION
The current User Guide and docstrings note that kernel choice "affects
both scalability and performance" but give no quantitative guidance.
Users running semi-supervised learning on large unlabeled datasets —
the scenario these algorithms are designed for — have no way to know
when the RBF kernel becomes infeasible or what to use instead.

This PR adds a Notes section to both LabelSpreading and LabelPropagation
documenting:
- The O(n²) memory cost of kernel='rbf' with concrete estimates
  (200 MB at n=5,000; 8 GB at n=32,000)
- A recommendation to use kernel='knn' for datasets above ~20,000 samples
- A pointer to SelfTrainingClassifier for very large datasets

Also updates the semi_supervised User Guide RST with a matching note block.

This came from direct experience: while running LabelSpreading on a
~235k-row phishing URL dataset, the RBF kernel was infeasible and the
existing docs gave no guidance on the knn workaround.