### PR TITLE
Fix KMeans strict convergence check after empty cluster relocation

### DIFF
--- a/sklearn/cluster/_k_means_common.pyx
+++ b/sklearn/cluster/_k_means_common.pyx
@@ -164,7 +164,7 @@ cpdef floating _inertia_sparse(
     return inertia
 
 
-cpdef void _relocate_empty_clusters_dense(
+cpdef bint _relocate_empty_clusters_dense(
         const floating[:, ::1] X,            # IN
         const floating[::1] sample_weight,   # IN
         const floating[:, ::1] centers_old,  # IN
@@ -172,13 +172,19 @@ cpdef void _relocate_empty_clusters_dense(
         floating[::1] weight_in_clusters,    # INOUT
         const int[::1] labels                # IN
 ):
-    """Relocate centers which have no sample assigned to them."""
+    """Relocate centers which have no sample assigned to them.
+
+    Returns
+    -------
+    relocated : bool
+        True if any empty clusters were relocated, False otherwise.
+    """
     cdef:
         int[::1] empty_clusters = np.where(np.equal(weight_in_clusters, 0))[0].astype(np.int32)
         int n_empty = empty_clusters.shape[0]
 
     if n_empty == 0:
-        return
+        return False
 
     cdef:
         int n_features = X.shape[1]
@@ -192,7 +198,7 @@ cpdef void _relocate_empty_clusters_dense(
     if np.max(distances) == 0:
         # Happens when there are more clusters than non-duplicate samples. Relocating
         # is pointless in this case.
-        return
+        return False
 
     for idx in range(n_empty):
 
@@ -210,8 +216,10 @@ cpdef void _relocate_empty_clusters_dense(
         weight_in_clusters[new_cluster_id] = weight
         weight_in_clusters[old_cluster_id] -= weight
 
+    return True
 
-cpdef void _relocate_empty_clusters_sparse(
+
+cpdef bint _relocate_empty_clusters_sparse(
         const floating[::1] X_data,          # IN
         const int[::1] X_indices,            # IN
         const int[::1] X_indptr,             # IN
@@ -221,13 +229,19 @@ cpdef void _relocate_empty_clusters_sparse(
         floating[::1] weight_in_clusters,    # INOUT
         const int[::1] labels                # IN
 ):
-    """Relocate centers which have no sample assigned to them."""
+    """Relocate centers which have no sample assigned to them.
+
+    Returns
+    -------
+    relocated : bool
+        True if any empty clusters were relocated, False otherwise.
+    """
     cdef:
         int[::1] empty_clusters = np.where(np.equal(weight_in_clusters, 0))[0].astype(np.int32)
         int n_empty = empty_clusters.shape[0]
 
     if n_empty == 0:
-        return
+        return False
 
     cdef:
         int n_samples = X_indptr.shape[0] - 1
@@ -246,7 +260,7 @@ cpdef void _relocate_empty_clusters_sparse(
     if np.max(distances) == 0:
         # Happens when there are more clusters than non-duplicate samples. Relocating
         # is pointless in this case.
-        return
+        return False
 
     cdef:
         int[::1] far_from_centers = np.argpartition(distances, -n_empty)[:-n_empty-1:-1].astype(np.int32)
@@ -269,6 +283,8 @@ cpdef void _relocate_empty_clusters_sparse(
 
         weight_in_clusters[new_cluster_id] = weight
         weight_in_clusters[old_cluster_id] -= weight
+
+    return True
 
 
 cdef void _average_centers(

--- a/sklearn/cluster/_k_means_elkan.pyx
+++ b/sklearn/cluster/_k_means_elkan.pyx
@@ -252,6 +252,12 @@ def elkan_iter_chunked_dense(
         - If False, only the labels will be computed, i.e runs the E-step of
           the algorithm. This is useful especially when calling predict on a
           fitted model.
+
+    Returns
+    -------
+    relocated_empty_clusters : bool
+        True if any empty clusters were relocated during this iteration,
+        False otherwise. Only meaningful when update_centers is True.
     """
     cdef:
         int n_samples = X.shape[0]
@@ -331,10 +337,13 @@ def elkan_iter_chunked_dense(
         free(centers_new_chunk)
         free(weight_in_clusters_chunk)
 
+    cdef bint relocated_empty_clusters = False
+
     if update_centers:
         omp_destroy_lock(&lock)
-        _relocate_empty_clusters_dense(X, sample_weight, centers_old,
-                                       centers_new, weight_in_clusters, labels)
+        relocated_empty_clusters = _relocate_empty_clusters_dense(
+            X, sample_weight, centers_old,
+            centers_new, weight_in_clusters, labels)
 
         _average_centers(centers_new, weight_in_clusters)
         _center_shift(centers_old, centers_new, center_shift)
@@ -347,6 +356,8 @@ def elkan_iter_chunked_dense(
                 lower_bounds[i, j] -= center_shift[j]
                 if lower_bounds[i, j] < 0:
                     lower_bounds[i, j] = 0
+
+    return relocated_empty_clusters
 
 
 cdef void _update_chunk_dense(
@@ -495,6 +506,12 @@ def elkan_iter_chunked_sparse(
         - If False, only the labels will be computed, i.e runs the E-step of
           the algorithm. This is useful especially when calling predict on a
           fitted model.
+
+    Returns
+    -------
+    relocated_empty_clusters : bool
+        True if any empty clusters were relocated during this iteration,
+        False otherwise. Only meaningful when update_centers is True.
     """
     cdef:
         int n_samples = X.shape[0]
@@ -506,7 +523,7 @@ def elkan_iter_chunked_sparse(
         # attempting to compute n_chunks). This can typically happen when
         # calling the prediction function of a bisecting k-means model with a
         # large fraction of outliers.
-        return
+        return False
 
     cdef:
         floating[::1] X_data = X.data
@@ -583,9 +600,11 @@ def elkan_iter_chunked_sparse(
         free(centers_new_chunk)
         free(weight_in_clusters_chunk)
 
+    cdef bint relocated_empty_clusters = False
+
     if update_centers:
         omp_destroy_lock(&lock)
-        _relocate_empty_clusters_sparse(
+        relocated_empty_clusters = _relocate_empty_clusters_sparse(
             X_data, X_indices, X_indptr, sample_weight,
             centers_old, centers_new, weight_in_clusters, labels)
 
@@ -600,6 +619,8 @@ def elkan_iter_chunked_sparse(
                 lower_bounds[i, j] -= center_shift[j]
                 if lower_bounds[i, j] < 0:
                     lower_bounds[i, j] = 0
+
+    return relocated_empty_clusters
 
 
 cdef void _update_chunk_sparse(

--- a/sklearn/cluster/_k_means_lloyd.pyx
+++ b/sklearn/cluster/_k_means_lloyd.pyx
@@ -72,6 +72,12 @@ def lloyd_iter_chunked_dense(
         - If False, only the labels will be computed, i.e runs the E-step of
           the algorithm. This is useful especially when calling predict on a
           fitted model.
+
+    Returns
+    -------
+    relocated_empty_clusters : bool
+        True if any empty clusters were relocated during this iteration,
+        False otherwise. Only meaningful when update_centers is True.
     """
     cdef:
         int n_samples = X.shape[0]
@@ -155,14 +161,18 @@ def lloyd_iter_chunked_dense(
         free(weight_in_clusters_chunk)
         free(pairwise_distances_chunk)
 
+    cdef bint relocated_empty_clusters = False
+
     if update_centers:
         omp_destroy_lock(&lock)
-        _relocate_empty_clusters_dense(
+        relocated_empty_clusters = _relocate_empty_clusters_dense(
             X, sample_weight, centers_old, centers_new, weight_in_clusters, labels
         )
 
         _average_centers(centers_new, weight_in_clusters)
         _center_shift(centers_old, centers_new, center_shift)
+
+    return relocated_empty_clusters
 
 
 cdef void _update_chunk_dense(
@@ -270,6 +280,12 @@ def lloyd_iter_chunked_sparse(
         - If False, only the labels will be computed, i.e runs the E-step of
           the algorithm. This is useful especially when calling predict on a
           fitted model.
+
+    Returns
+    -------
+    relocated_empty_clusters : bool
+        True if any empty clusters were relocated during this iteration,
+        False otherwise. Only meaningful when update_centers is True.
     """
     cdef:
         int n_samples = X.shape[0]
@@ -281,7 +297,7 @@ def lloyd_iter_chunked_sparse(
         # attempting to compute n_chunks). This can typically happen when
         # calling the prediction function of a bisecting k-means model with a
         # large fraction of outliers.
-        return
+        return False
 
     cdef:
         # Choose same as for dense. Does not have the same impact since with
@@ -355,14 +371,18 @@ def lloyd_iter_chunked_sparse(
         free(centers_new_chunk)
         free(weight_in_clusters_chunk)
 
+    cdef bint relocated_empty_clusters = False
+
     if update_centers:
         omp_destroy_lock(&lock)
-        _relocate_empty_clusters_sparse(
+        relocated_empty_clusters = _relocate_empty_clusters_sparse(
             X_data, X_indices, X_indptr, sample_weight,
             centers_old, centers_new, weight_in_clusters, labels)
 
         _average_centers(centers_new, weight_in_clusters)
         _center_shift(centers_old, centers_new, center_shift)
+
+    return relocated_empty_clusters
 
 
 cdef void _update_chunk_sparse(

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -554,7 +554,7 @@ def _kmeans_single_elkan(
     strict_convergence = False
 
     for i in range(max_iter):
-        elkan_iter(
+        relocated_empty_clusters = elkan_iter(
             X,
             sample_weight,
             centers,
@@ -582,8 +582,10 @@ def _kmeans_single_elkan(
 
         centers, centers_new = centers_new, centers
 
-        if np.array_equal(labels, labels_old):
+        if np.array_equal(labels, labels_old) and not relocated_empty_clusters:
             # First check the labels for strict convergence.
+            # Only declare strict convergence if no empty clusters were relocated,
+            # because relocation can change centers without changing labels.
             if verbose:
                 print(f"Converged at iteration {i}: strict convergence.")
             strict_convergence = True
@@ -703,7 +705,7 @@ def _kmeans_single_lloyd(
     strict_convergence = False
 
     for i in range(max_iter):
-        lloyd_iter(
+        relocated_empty_clusters = lloyd_iter(
             X,
             sample_weight,
             centers,
@@ -720,8 +722,10 @@ def _kmeans_single_lloyd(
 
         centers, centers_new = centers_new, centers
 
-        if np.array_equal(labels, labels_old):
+        if np.array_equal(labels, labels_old) and not relocated_empty_clusters:
             # First check the labels for strict convergence.
+            # Only declare strict convergence if no empty clusters were relocated,
+            # because relocation can change centers without changing labels.
             if verbose:
                 print(f"Converged at iteration {i}: strict convergence.")
             strict_convergence = True


### PR DESCRIPTION
## Description

This PR fixes a bug in KMeans where the strict convergence check could incorrectly declare convergence when empty cluster relocation occurred, leading to inconsistent `labels_` and `inertia_` values.

### Problem

When empty clusters are relocated during KMeans iteration, the cluster centers can change even when the sample labels remain the same. Previously, the strict convergence check only verified if labels were unchanged:

```python
if np.array_equal(labels, labels_old):
    strict_convergence = True
    break
```

This could lead to:
- `labels_` not matching `predict(X)`
- `inertia_` not matching `-score(X)`
- Inconsistent state after fitting

### Solution

This fix modifies the empty cluster relocation functions to return a boolean indicating whether any relocation occurred, and updates the convergence check to consider both conditions:

```python
if np.array_equal(labels, labels_old) and not relocated_empty_clusters:
    strict_convergence = True
    break
```

### Changes

1. **`sklearn/cluster/_k_means_common.pyx`**:
   - Modified `_relocate_empty_clusters_dense` to return `bint` (boolean)
   - Modified `_relocate_empty_clusters_sparse` to return `bint` (boolean)

2. **`sklearn/cluster/_k_means_lloyd.pyx`**:
   - Modified `lloyd_iter_chunked_dense` to return `bool` indicating relocation status
   - Modified `lloyd_iter_chunked_sparse` to return `bool` indicating relocation status

3. **`sklearn/cluster/_k_means_elkan.pyx`**:
   - Modified `elkan_iter_chunked_dense` to return `bool` indicating relocation status
   - Modified `elkan_iter_chunked_sparse` to return `bool` indicating relocation status

4. **`sklearn/cluster/_kmeans.py`**:
   - Updated `_kmeans_single_lloyd` to check relocation status
   - Updated `_kmeans_single_elkan` to check relocation status

### Testing

The fix can be verified with the reproduction script from issue #34074:

```python
import numpy as np
from scipy import sparse
from sklearn.cluster import KMeans

X = sparse.csr_matrix(np.array([[1.0], [2.0], [3.0]]))
init = np.array([[4.0], [0.0], [1.0]])

for algorithm in ["lloyd", "elkan"]:
    km = KMeans(
        n_clusters=3,
        init=init,
        n_init=1,
        max_iter=10,
        tol=0,
        algorithm=algorithm,
        verbose=1,
    ).fit(X)

    print(f"\n{algorithm}")
    print("centers: ", km.cluster_centers_.ravel())
    print("labels_: ", km.labels_)
    print("predict: ", km.predict(X))
    print("inertia_:", km.inertia_)
    print("score:   ", km.score(X))
    
    # These should now pass
    np.testing.assert_array_equal(km.labels_, km.predict(X))
    np.testing.assert_allclose(km.inertia_, -km.score(X))
```

### References

- Fixes #34074
- Related discussion in issue comments

Co-Authored-By: Claude <noreply@anthropic.com>