### PR TITLE
DOC fix broken external links on homepage and governance page

### DIFF
--- a/doc/governance.rst
+++ b/doc/governance.rst
@@ -43,7 +43,7 @@ as being an organization member on the scikit-learn `GitHub organization
 <https://github.com/orgs/scikit-learn/people>`_.
 
 They are also welcome to join our `monthly core contributor meetings
-<https://github.com/scikit-learn/administrative/tree/master/meeting_notes>`_.
+<https://github.com/scikit-learn/administrative/tree/master/biweekly_meetings>`_.
 
 New members can be nominated by any existing member. Once they have been
 nominated, there will be a vote by the current core contributors. Voting on new

--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -209,7 +209,7 @@
     </div>
     <div class="row">
       <div class="col-md-4">
-        <a class="sk-funding-link" href="https://probabl.ai/lp/scikit-learn">
+        <a class="sk-funding-link" href="https://probabl.ai/">
           <div class="text-center">
             <div class="sk-funding-logos">
               <img src="_static/probabl.png" title="Probabl">


### PR DESCRIPTION
Fixes two broken external links identified in #34319:

- **probabl.ai sponsor link** on the homepage (`doc/templates/index.html`): was linking to a 404 page, updated to the root URL
- **Meeting notes path** in `doc/governance.rst`: was pointing to a non-existent path, corrected to `biweekly_meetings`

Closes #34319

Signed-off-by: Md Mushfiqur Rahim <20mahin2020@gmail.com>