### PR TITLE
MNT: Fix CI for cython-lint 0.20

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         files: sklearn/
         additional_dependencies: [pytest==6.2.4]
 -   repo: https://github.com/MarcoGorelli/cython-lint
-    rev: v0.18.0
+    rev: v0.20.0
     hooks:
     # TODO: add the double-quote-cython-strings hook when it's usability has improved:
     # possibility to pass a directory and use it as a check instead of auto-formatter.

--- a/sklearn/cluster/_dbscan_inner.pyx
+++ b/sklearn/cluster/_dbscan_inner.pyx
@@ -28,8 +28,8 @@ def dbscan_inner(const uint8_t[::1] is_core,
                 labels[i] = label_num
                 if is_core[i]:
                     neighb = neighborhoods[i]
-                    for i in range(neighb.shape[0]):
-                        v = neighb[i]
+                    for j in range(neighb.shape[0]):
+                        v = neighb[j]
                         if labels[v] == -1:
                             stack.push_back(v)
 


### PR DESCRIPTION
```
sklearn/cluster/_dbscan_inner.pyx:31:25: Outer for loop variable 'i' overwritten by inner for-loop target
```

<img width="958" height="544" alt="image" src="https://github.com/user-attachments/assets/ee803e66-03a5-403d-af14-652f051a92e2" />
