### PR TITLE
ENH Newton-CD part 2: add early_stopping to CD solvers

### DIFF
--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -431,7 +431,7 @@ def enet_coordinate_descent(
         tol *= _dot(n_samples, &y[0], 1, &y[0], 1)
 
         # Check convergence before entering the main loop.
-        # We want to avoid to stop too early and set gap_smaller_eps=False.
+        # We want to avoid stopping too early and set gap_smaller_eps=False.
         gap, dual_norm_XtA = gap_enet(
             n_samples, n_features, w, alpha, beta, X, y, R, XtA, positive,
             gap_smaller_eps=False,
@@ -506,8 +506,9 @@ def enet_coordinate_descent(
             ):
                 # The biggest coordinate update of this iteration was smaller than the
                 # tolerance: check the duality gap as ultimate stopping criterion.
-                # We want to stop in case gap != 0 only because of floating point
-                # arithmetic, and set gap_smaller_eps=True.
+                # We want to stop in case the gap is small enough but not exactly 0
+                # only because of floating point arithmetic, and therefore set
+                # gap_smaller_eps=True.
                 gap, dual_norm_XtA = gap_enet(
                     n_samples, n_features, w, alpha, beta, X, y, R, XtA, positive,
                     gap_smaller_eps=True,
@@ -871,7 +872,7 @@ def sparse_enet_coordinate_descent(
         tol *= _dot(n_samples, &y[0], 1, &yw[0], 1)
 
         # Check convergence before entering the main loop.
-        # We want to avoid to stop too early and set gap_smaller_eps=False.
+        # We want to avoid stopping too early and set gap_smaller_eps=False.
         gap, dual_norm_XtA = gap_enet_sparse(
             n_samples,
             n_features,
@@ -996,8 +997,9 @@ def sparse_enet_coordinate_descent(
             ):
                 # The biggest coordinate update of this iteration was smaller than the
                 # tolerance: check the duality gap as ultimate stopping criterion.
-                # We want to stop in case gap != 0 only because of floating point
-                # arithmetic, and set gap_smaller_eps=True.
+                # We want to stop in case the gap is small enough but not exactly 0
+                # only because of floating point arithmetic, and therefore set
+                # gap_smaller_eps=True.
                 gap, dual_norm_XtA = gap_enet_sparse(
                     n_samples,
                     n_features,
@@ -1248,7 +1250,7 @@ def enet_coordinate_descent_gram(
         tol *= y_norm2
 
         # Check convergence before entering the main loop.
-        # We want to avoid to stop too early and set gap_smaller_eps=False.
+        # We want to avoid stopping too early and set gap_smaller_eps=False.
         gap, dual_norm_XtA = gap_enet_gram(
             n_features, w, alpha, beta, Qw, q, y_norm2, XtA, positive,
             gap_smaller_eps=False,
@@ -1328,8 +1330,9 @@ def enet_coordinate_descent_gram(
             ):
                 # The biggest coordinate update of this iteration was smaller than the
                 # tolerance: check the duality gap as ultimate stopping criterion.
-                # We want to stop in case gap != 0 only because of floating point
-                # arithmetic, and set gap_smaller_eps=True.
+                # We want to stop in case the gap is small enough but not exactly 0
+                # only because of floating point arithmetic, and therefore set
+                # gap_smaller_eps=True.
                 gap, dual_norm_XtA = gap_enet_gram(
                     n_features, w, alpha, beta, Qw, q, y_norm2, XtA, positive,
                     gap_smaller_eps=True,
@@ -1696,7 +1699,7 @@ def enet_coordinate_descent_multi_task(
         tol *= _dot(n_samples * n_tasks, &Y[0, 0], 1, &Yw[0, 0], 1)
 
         # Check convergence before entering the main loop.
-        # We want to avoid to stop too early and set gap_smaller_eps=False.
+        # We want to avoid stopping too early and set gap_smaller_eps=False.
         gap, dual_norm_XtA = gap_enet_multi_task(
             n_samples=n_samples,
             n_features=n_features,
@@ -1855,8 +1858,9 @@ def enet_coordinate_descent_multi_task(
             ):
                 # The biggest coordinate update of this iteration was smaller than the
                 # tolerance: check the duality gap as ultimate stopping criterion.
-                # We want to stop in case gap != 0 only because of floating point
-                # arithmetic, and set gap_smaller_eps=True.
+                # We want to stop in case the gap is small enough but not exactly 0
+                # only because of floating point arithmetic, and therefore set
+                # gap_smaller_eps=True.
                 gap, dual_norm_XtA = gap_enet_multi_task(
                     n_samples=n_samples,
                     n_features=n_features,

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -274,6 +274,7 @@ def enet_coordinate_descent(
     bint random=0,
     bint positive=0,
     bint do_screening=1,
+    bint early_stopping=1,
 ):
     """
     Cython version of the coordinate descent algorithm for Elastic-Net regression.
@@ -418,7 +419,7 @@ def enet_coordinate_descent(
             n_samples, n_features, w, alpha, beta, X, y, R, XtA, positive,
             gap_smaller_eps=False,
         )
-        if gap <= tol:
+        if early_stopping and gap <= tol:
             with gil:
                 return np.asarray(w), gap, tol, 0
 
@@ -701,6 +702,7 @@ def sparse_enet_coordinate_descent(
     bint random=0,
     bint positive=0,
     bint do_screening=1,
+    bint early_stopping=1,
 ):
     """Cython version of the coordinate descent algorithm for Elastic-Net
 
@@ -871,7 +873,7 @@ def sparse_enet_coordinate_descent(
             positive,
             gap_smaller_eps=False,
         )
-        if gap <= tol:
+        if early_stopping and gap <= tol:
             with gil:
                 return np.asarray(w), gap, tol, 0
 
@@ -1154,6 +1156,7 @@ def enet_coordinate_descent_gram(
     bint random=0,
     bint positive=0,
     bint do_screening=1,
+    bint early_stopping=1,
 ):
     """Cython version of the coordinate descent algorithm
         for Elastic-Net regression
@@ -1229,7 +1232,7 @@ def enet_coordinate_descent_gram(
             n_features, w, alpha, beta, Qw, q, y_norm2, XtA, positive,
             gap_smaller_eps=False,
         )
-        if 0 <= gap <= tol:
+        if early_stopping and 0 <= gap <= tol:
             # Only if gap >=0 as singular Q may cause dubious values of gap.
             with gil:
                 return np.asarray(w), gap, tol, 0
@@ -1501,6 +1504,7 @@ def enet_coordinate_descent_multi_task(
     object rng,
     bint random=0,
     bint do_screening=1,
+    bint early_stopping=1,
 ):
     """Cython version of the coordinate descent algorithm
         for Elastic-Net multi-task regression
@@ -1693,7 +1697,7 @@ def enet_coordinate_descent_multi_task(
             XtA_row_norms=XtA_row_norms,
             gap_smaller_eps=False,
         )
-        if gap <= tol:
+        if early_stopping and gap <= tol:
             with gil:
                 return np.asarray(W), gap, tol, 0
 

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -189,6 +189,11 @@ cdef (floating, floating) gap_enet(
     alpha > 0:            formulation A of the duality gap
     alpha = 0 & beta > 0: formulation B of the duality gap
     alpha = beta = 0:     OLS first order condition (=gradient)
+
+    gap_smaller_eps: If 1 (True), set the dual gap to zero when the gap is around
+        machine precision compared to primal. As gap = primal - dual, we might get
+        gap != 0 in floating point arithmetic, while exact arithmetic would yield
+        gap = 0.
     """
     cdef floating gap, primal, dual
     cdef floating dual_norm_XtA
@@ -329,6 +334,17 @@ def enet_coordinate_descent(
     The dual feasible set is v element real numbers. It requires beta > 0, but
     alpha = 0 is allowed. Strong duality holds and at optimum, v* = y - X w*.
 
+    Further Parameters
+    ------------------
+    positive : bint, default=0 (False)
+        If set to True, forces coefficients w to be positive.
+    do_screening : bint, default=1 (True)
+        If set to True, use gap safe screening rules to screen coefficients
+        (exclude early based on dual gap).
+    early_stopping : bint, default=1 (True)
+        If set to True, check for convergence (with the dual gap) before entering the
+        main iteration loop.
+
     Returns
     -------
     w : ndarray of shape (n_features,)
@@ -415,6 +431,7 @@ def enet_coordinate_descent(
         tol *= _dot(n_samples, &y[0], 1, &y[0], 1)
 
         # Check convergence before entering the main loop.
+        # We want to avoid to stop too early and set gap_smaller_eps=False.
         gap, dual_norm_XtA = gap_enet(
             n_samples, n_features, w, alpha, beta, X, y, R, XtA, positive,
             gap_smaller_eps=False,
@@ -487,9 +504,10 @@ def enet_coordinate_descent(
                 or n_iter == max_iter - 1
                 or n_active <= 1  # We have an analytical exact solution.
             ):
-                # the biggest coordinate update of this iteration was smaller
-                # than the tolerance: check the duality gap as ultimate
-                # stopping criterion
+                # The biggest coordinate update of this iteration was smaller than the
+                # tolerance: check the duality gap as ultimate stopping criterion.
+                # We want to stop in case gap != 0 only because of floating point
+                # arithmetic, and set gap_smaller_eps=True.
                 gap, dual_norm_XtA = gap_enet(
                     n_samples, n_features, w, alpha, beta, X, y, R, XtA, positive,
                     gap_smaller_eps=True,
@@ -853,6 +871,7 @@ def sparse_enet_coordinate_descent(
         tol *= _dot(n_samples, &y[0], 1, &yw[0], 1)
 
         # Check convergence before entering the main loop.
+        # We want to avoid to stop too early and set gap_smaller_eps=False.
         gap, dual_norm_XtA = gap_enet_sparse(
             n_samples,
             n_features,
@@ -975,9 +994,10 @@ def sparse_enet_coordinate_descent(
                 or n_iter == max_iter - 1
                 or n_active <= 1  # We have an analytical exact solution.
             ):
-                # the biggest coordinate update of this iteration was smaller than
-                # the tolerance: check the duality gap as ultimate stopping
-                # criterion
+                # The biggest coordinate update of this iteration was smaller than the
+                # tolerance: check the duality gap as ultimate stopping criterion.
+                # We want to stop in case gap != 0 only because of floating point
+                # arithmetic, and set gap_smaller_eps=True.
                 gap, dual_norm_XtA = gap_enet_sparse(
                     n_samples,
                     n_features,
@@ -1228,6 +1248,7 @@ def enet_coordinate_descent_gram(
         tol *= y_norm2
 
         # Check convergence before entering the main loop.
+        # We want to avoid to stop too early and set gap_smaller_eps=False.
         gap, dual_norm_XtA = gap_enet_gram(
             n_features, w, alpha, beta, Qw, q, y_norm2, XtA, positive,
             gap_smaller_eps=False,
@@ -1305,9 +1326,10 @@ def enet_coordinate_descent_gram(
                 or n_iter == max_iter - 1
                 or n_active <= 1  # We have an analytical exact solution.
             ):
-                # the biggest coordinate update of this iteration was smaller than
-                # the tolerance: check the duality gap as ultimate stopping
-                # criterion
+                # The biggest coordinate update of this iteration was smaller than the
+                # tolerance: check the duality gap as ultimate stopping criterion.
+                # We want to stop in case gap != 0 only because of floating point
+                # arithmetic, and set gap_smaller_eps=True.
                 gap, dual_norm_XtA = gap_enet_gram(
                     n_features, w, alpha, beta, Qw, q, y_norm2, XtA, positive,
                     gap_smaller_eps=True,
@@ -1674,6 +1696,7 @@ def enet_coordinate_descent_multi_task(
         tol *= _dot(n_samples * n_tasks, &Y[0, 0], 1, &Yw[0, 0], 1)
 
         # Check convergence before entering the main loop.
+        # We want to avoid to stop too early and set gap_smaller_eps=False.
         gap, dual_norm_XtA = gap_enet_multi_task(
             n_samples=n_samples,
             n_features=n_features,
@@ -1830,9 +1853,10 @@ def enet_coordinate_descent_multi_task(
                 or n_iter == max_iter - 1
                 or n_active <= 1  # We have an analytical exact solution.
             ):
-                # the biggest coordinate update of this iteration was smaller than
-                # the tolerance: check the duality gap as ultimate stopping
-                # criterion
+                # The biggest coordinate update of this iteration was smaller than the
+                # tolerance: check the duality gap as ultimate stopping criterion.
+                # We want to stop in case gap != 0 only because of floating point
+                # arithmetic, and set gap_smaller_eps=True.
                 gap, dual_norm_XtA = gap_enet_multi_task(
                     n_samples=n_samples,
                     n_features=n_features,

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -674,6 +674,7 @@ def enet_path(
     random_state = params.pop("random_state", None)
     selection = params.pop("selection", "cyclic")
     do_screening = params.pop("do_screening", True)
+    early_stopping = params.pop("early_stopping", True)
 
     if len(params) > 0:
         raise ValueError("Unexpected parameters in params", params.keys())
@@ -801,6 +802,7 @@ def enet_path(
                 random=random,
                 positive=positive,
                 do_screening=do_screening,
+                early_stopping=early_stopping,
             )
         elif multi_output:
             model = cd_fast.enet_coordinate_descent_multi_task(
@@ -820,6 +822,7 @@ def enet_path(
                 rng=rng,
                 random=random,
                 do_screening=do_screening,
+                early_stopping=early_stopping,
             )
         elif isinstance(precompute, np.ndarray):
             # We expect precompute to be already Fortran ordered when bypassing
@@ -839,6 +842,7 @@ def enet_path(
                 random,
                 positive,
                 do_screening,
+                early_stopping,
             )
         elif precompute is False:
             model = cd_fast.enet_coordinate_descent(
@@ -853,6 +857,7 @@ def enet_path(
                 random,
                 positive,
                 do_screening,
+                early_stopping,
             )
         else:
             raise ValueError(

--- a/sklearn/linear_model/tests/test_coordinate_descent.py
+++ b/sklearn/linear_model/tests/test_coordinate_descent.py
@@ -3,6 +3,7 @@
 
 import warnings
 from copy import deepcopy
+from functools import partial
 
 import joblib
 import numpy as np
@@ -101,6 +102,7 @@ def test_cython_solver_equivalence(sparse_csc_type):
         "rng": np.random.RandomState(0),  # not used, but needed as argument
         "random": False,
         "positive": False,
+        "early_stopping": True,
     }
 
     def zc():
@@ -166,6 +168,87 @@ def test_cython_solver_equivalence(sparse_csc_type):
             do_screening=do_screening,
         )
         assert_allclose(coef_4, coef_1)
+
+
+@pytest.mark.parametrize("cd", ["enet", "sparse_enet", "enet_gram", "enet_multi"])
+def test_cython_solver_early_stopping(cd):
+    """Test that early_stopping works correctly."""
+    X, y = make_regression()
+    X_mean = X.mean(axis=0)
+    X_centered = np.asfortranarray(X - X_mean)
+    y -= y.mean()
+    alpha_max = np.linalg.norm(X.T @ y, ord=np.inf)
+    params = {
+        "alpha": alpha_max / 100,
+        "beta": 0,
+        "max_iter": 100,
+        "tol": 1e-1,  # Set a high value on purpose.
+        "rng": np.random.RandomState(0),  # not used, but needed as argument
+        "random": False,
+    }
+    if cd == "enet":
+        cd_solve = partial(
+            cd_fast.enet_coordinate_descent,
+            X=X_centered,
+            y=y,
+            **params,
+        )
+    elif cd == "sparse_enet":
+        Xs = sparse.csc_matrix(X)
+        cd_solve = partial(
+            cd_fast.sparse_enet_coordinate_descent,
+            X_data=Xs.data,
+            X_indices=Xs.indices,
+            X_indptr=Xs.indptr,
+            y=y,
+            sample_weight=None,
+            X_mean=X_mean,
+            **params,
+        )
+    elif cd == "enet_gram":
+        cd_solve = partial(
+            cd_fast.enet_coordinate_descent_gram,
+            Q=X_centered.T @ X_centered,
+            q=X_centered.T @ y,
+            y=y,
+            **params,
+        )
+    elif cd == "enet_multi":
+
+        def cd_solve(w, early_stopping=True):
+            return cd_fast.enet_coordinate_descent_multi_task(
+                W=w,
+                X=X_centered,
+                X_is_sparse=False,
+                X_data=None,
+                X_indices=None,
+                X_indptr=None,
+                Y=np.asfortranarray(np.c_[y, y]),
+                sample_weight=None,
+                X_mean=None,
+                **params,
+                early_stopping=early_stopping,
+            )
+
+    if cd == "enet_multi":
+        coef_1 = np.zeros((2, X.shape[1]), order="F")
+    else:
+        coef_1 = np.zeros(X.shape[1])
+    _, gap_1, _, _ = cd_solve(w=coef_1)
+    assert np.sum(coef_1 != 0) > X.shape[1] / 4  # avoid all zeros
+
+    # With early stopping, the coefficients should stay unchanged.
+    coef_2 = coef_1.copy(order="F")
+    _, _, _, n_iter = cd_solve(w=coef_2, early_stopping=True)
+    assert n_iter == 0
+    assert_array_equal(coef_2, coef_1)
+
+    # Without early stopping, the coefficients should change.
+    coef_3 = coef_1.copy(order="F")
+    _, gap_3, _, n_iter = cd_solve(w=coef_3, early_stopping=False)
+    assert n_iter == 1
+    assert gap_3 < gap_1
+    assert not np.all(coef_3 == coef_1)
 
 
 def test_lasso_zero():


### PR DESCRIPTION
#### Reference Issues/PRs
Part 2 of #33160.

#### What does this implement/fix? Explain your changes.
This PR adds `early_stopping` to the private (Cython) coordinate descent solvers. If set to True, the CD checks convergence with the dual gap before entering the main iteration loop.

This has no user impact, the current behavior is kept (functionality only for future purposes).


#### AI usage disclosure
None

#### Any other comments?
