### PR TITLE
FIX radius_neighbors with array-like radius and n_jobs > 1 for tree-based algorithms

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.neighbors/34341.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.neighbors/34341.fix.rst
@@ -1,0 +1,4 @@
+- :meth:`neighbors.NearestNeighbors.radius_neighbors` now correctly handles an
+  array-like ``radius`` when ``n_jobs > 1`` with the ``ball_tree`` and
+  ``kd_tree`` algorithms.
+  By :user:`Nicolas Salvy <nicolassalvy>`.

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -1268,7 +1268,12 @@ class RadiusNeighborsMixin:
             n_jobs = effective_n_jobs(self.n_jobs)
             delayed_query = delayed(self._tree.query_radius)
             chunked_results = Parallel(n_jobs, prefer="threads")(
-                delayed_query(X[s], radius, return_distance, sort_results=sort_results)
+                delayed_query(
+                    X[s],
+                    radius[s] if np.ndim(radius) > 0 else radius,
+                    return_distance,
+                    sort_results=sort_results,
+                )
                 for s in gen_even_slices(X.shape[0], n_jobs)
             )
             if return_distance:

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -2099,6 +2099,22 @@ def test_same_radius_neighbors_parallel(algorithm):
     assert_allclose(graph, graph_parallel)
 
 
+@pytest.mark.parametrize("algorithm", ["ball_tree", "kd_tree"])
+def test_radius_neighbors_parallel_array_radius(algorithm):
+    rng = np.random.RandomState(0)
+    X = rng.rand(10, 3)
+    radius = np.full(len(X), 0.4)
+
+    nn = neighbors.NearestNeighbors(algorithm=algorithm).fit(X)
+    ind = nn.radius_neighbors(X, radius=radius, return_distance=False)
+
+    nn_parallel = neighbors.NearestNeighbors(algorithm=algorithm, n_jobs=2).fit(X)
+    ind_parallel = nn_parallel.radius_neighbors(X, radius=radius, return_distance=False)
+
+    for i in range(len(ind)):
+        assert_array_equal(np.sort(ind[i]), np.sort(ind_parallel[i]))
+
+
 # TODO: remove mark once loky bug is fixed:
 # https://github.com/joblib/loky/issues/458
 @pytest.mark.thread_unsafe


### PR DESCRIPTION


<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #34338
Towards #25970 

#### What does this implement/fix? Explain your changes.

When `radius` is passed as a per-sample array, `NearestNeighbors.radius_neighbors` returns a correct result with `n_jobs=1` but used to raise a `ValueError` with `n_jobs>1` on identical input for both `ball_tree` and `kd_tree`. This PR fixes that by slicing `radius` together with the already sliced data `X` when `radius` is not a scalar.


