### PR TITLE
MAINT Remove deprecations scheduled for 1.10

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/34342.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/34342.api.rst
@@ -1,0 +1,2 @@
+- The ``metrics.cluster.entropy`` function, deprecated in 1.8, is now removed.
+  By :user:`mkusiappiah`.

--- a/doc/whats_new/upcoming_changes/sklearn.utils/34342.api.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/34342.api.rst
@@ -1,0 +1,3 @@
+- The ``utils.extmath.stable_cumsum`` function, deprecated in 1.8, is now
+  removed. Use ``numpy.cumulative_sum`` with the desired dtype instead.
+  By :user:`mkusiappiah`.

--- a/sklearn/metrics/cluster/__init__.py
+++ b/sklearn/metrics/cluster/__init__.py
@@ -14,7 +14,6 @@ from sklearn.metrics.cluster._supervised import (
     adjusted_rand_score,
     completeness_score,
     contingency_matrix,
-    entropy,
     expected_mutual_information,
     fowlkes_mallows_score,
     homogeneity_completeness_v_measure,
@@ -40,8 +39,6 @@ __all__ = [
     "consensus_score",
     "contingency_matrix",
     "davies_bouldin_score",
-    # TODO(1.10): Remove
-    "entropy",
     "expected_mutual_information",
     "fowlkes_mallows_score",
     "homogeneity_completeness_v_measure",

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -17,7 +17,7 @@ from scipy import sparse as sp
 from sklearn.metrics.cluster._expected_mutual_info_fast import (
     expected_mutual_information,
 )
-from sklearn.utils import _align_api_if_sparse, deprecated
+from sklearn.utils import _align_api_if_sparse
 from sklearn.utils._array_api import (
     _max_precision_float_dtype,
     get_namespace_and_device,
@@ -1302,25 +1302,3 @@ def _entropy(labels):
     # Always convert the result as a Python scalar (on CPU) instead of a device
     # specific scalar array.
     return float(-xp.sum((pi / pi_sum) * (xp.log(pi) - log(pi_sum))))
-
-
-# TODO(1.10): Remove
-@deprecated("`entropy` is deprecated in 1.8 and will be removed in 1.10.")
-def entropy(labels):
-    """Calculate the entropy for a labeling.
-
-    Parameters
-    ----------
-    labels : array-like of shape (n_samples,)
-        The labels.
-
-    Returns
-    -------
-    entropy : float
-       The entropy for a labeling.
-
-    Notes
-    -----
-    The logarithm used is the natural logarithm (base-e).
-    """
-    return _entropy(labels)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -24,7 +24,6 @@ from sklearn.metrics.cluster._supervised import (
     _entropy,
     _generalized_average,
     check_clusterings,
-    entropy,
 )
 from sklearn.utils import assert_all_finite
 from sklearn.utils._array_api import (
@@ -268,12 +267,6 @@ def test_int_overflow_mutual_info_fowlkes_mallows_score():
 
     assert_all_finite(mutual_info_score(x, y))
     assert_all_finite(fowlkes_mallows_score(x, y))
-
-
-# TODO(1.10): Remove
-def test_public_entropy_deprecation():
-    with pytest.warns(FutureWarning, match="Function entropy is deprecated"):
-        entropy([0, 0, 42.0])
 
 
 def test_entropy():

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -23,7 +23,6 @@ from sklearn.utils._array_api import (
     get_namespace_and_device,
 )
 from sklearn.utils._param_validation import Interval, StrOptions, validate_params
-from sklearn.utils.deprecation import deprecated
 from sklearn.utils.sparsefuncs import sparse_matmul_to_dense
 from sklearn.utils.sparsefuncs_fast import csr_row_norms
 from sklearn.utils.validation import check_array, check_random_state
@@ -1284,54 +1283,6 @@ def _deterministic_vector_sign_flip(u):
     signs = np.sign(u[range(u.shape[0]), max_abs_rows])
     u *= signs[:, np.newaxis]
     return u
-
-
-# TODO(1.10): Remove
-@deprecated(
-    "`sklearn.utils.extmath.stable_cumsum` is deprecated in version 1.8 and "
-    "will be removed in 1.10. Use `np.cumulative_sum` with the desired dtype "
-    "directly instead."
-)
-def stable_cumsum(arr, axis=None, rtol=1e-05, atol=1e-08):
-    """Use high precision for cumsum and check that final value matches sum.
-
-    .. deprecated:: 1.8
-        This function is deprecated in version 1.8 and will be removed in 1.10.
-        Use `np.cumulative_sum` with the desired dtype directly instead.
-
-    Warns if the final cumulative sum does not match the sum (up to the chosen
-    tolerance).
-
-    Parameters
-    ----------
-    arr : array-like
-        To be cumulatively summed as flat.
-    axis : int, default=None
-        Axis along which the cumulative sum is computed.
-        The default (None) is to compute the cumsum over the flattened array.
-    rtol : float, default=1e-05
-        Relative tolerance, see ``np.allclose``.
-    atol : float, default=1e-08
-        Absolute tolerance, see ``np.allclose``.
-
-    Returns
-    -------
-    out : ndarray
-        Array with the cumulative sums along the chosen axis.
-    """
-    out = np.cumsum(arr, axis=axis, dtype=np.float64)
-    expected = np.sum(arr, axis=axis, dtype=np.float64)
-    if not np.allclose(
-        out.take(-1, axis=axis), expected, rtol=rtol, atol=atol, equal_nan=True
-    ):
-        warnings.warn(
-            (
-                "cumsum was found to be unstable: "
-                "its last element does not correspond to sum"
-            ),
-            RuntimeWarning,
-        )
-    return out
 
 
 def _nanaverage(a, weights=None):

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -44,7 +44,6 @@ from sklearn.utils.extmath import (
     row_norms,
     safe_sparse_dot,
     softmax,
-    stable_cumsum,
     svd_flip,
     weighted_mode,
 )
@@ -993,11 +992,6 @@ def test_softmax():
     exp_X = np.exp(X)
     sum_exp_X = np.sum(exp_X, axis=1).reshape((-1, 1))
     assert_array_almost_equal(softmax(X), exp_X / sum_exp_X)
-
-
-def test_stable_cumsum_deprecation():
-    with pytest.warns(FutureWarning, match="stable_cumsum.+is deprecated"):
-        stable_cumsum([1, 2, 3])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference Issues/PRs

None. Follow-up to deprecations introduced in 1.8 — both removed symbols
carry `# TODO(1.10): Remove` markers in the code.

#### What does this implement/fix? Explain your changes.

Removes two functions that were deprecated in 1.8 and scheduled for removal
in 1.10 (the tree is now `1.10.dev0`):

- `metrics.cluster.entropy` — a thin deprecated wrapper around the private
  `_entropy`, which every internal caller already uses. Also removed from
  `metrics.cluster.__all__` and the module imports.
- `utils.extmath.stable_cumsum` — no internal callers remain; users should
  use `numpy.cumulative_sum` with the desired dtype directly instead.

The now-unused `deprecated` imports and the two associated deprecation tests
are dropped as well. I checked the rest of the repo: the only remaining
references are the historical 1.6/1.8 changelog entries (kept) and the
`entropy` *concept* in the docs math (unrelated).

#### Any other comments?

Changelog fragments are added in a follow-up commit now that the PR number
is known.
