### PR TITLE
ENH Newton-CD part 3: Add compute_d2 to NewtonSolver

### DIFF
--- a/sklearn/linear_model/_glm/_newton_solver.py
+++ b/sklearn/linear_model/_glm/_newton_solver.py
@@ -54,6 +54,10 @@ class NewtonSolver(ABC):
       Cambridge University Press, 2004.
       https://web.stanford.edu/~boyd/cvxbook/bv_cvxbook.pdf
 
+    - Yuan, G., Ho, C., & Lin, C. (2011). "An improved GLMNET for l1-regularized
+      logistic regression." Journal of machine learning research.
+      https://doi.org/10.1145/2020408.2020421
+
     Parameters
     ----------
     coef : ndarray of shape (n_dof,), (n_classes, n_dof) or (n_classes * n_dof,)
@@ -169,6 +173,10 @@ class NewtonSolver(ABC):
             - self.coef_newton
             - self.gradient_times_newton
         """
+
+    @abstractmethod
+    def compute_d2(self, X, sample_weight):
+        """Compute square of Newton decrement."""
 
     def fallback_lbfgs_solve(self, X, y, sample_weight):
         """Fallback solver in case of emergency.
@@ -401,8 +409,9 @@ class NewtonSolver(ABC):
         # 2. Criterion: For Newton decrement d, check 1/2 * d^2 <= tol
         #       d = sqrt(grad @ hessian^-1 @ grad)
         #         = sqrt(coef_newton @ hessian @ coef_newton)
-        #    See Boyd, Vanderberghe (2009) "Convex Optimization" Chapter 9.5.1.
-        d2 = self.coef_newton @ self.hessian @ self.coef_newton
+        #    See Boyd, Vandenberghe (2009) "Convex Optimization" Chapter 9.5.1. and
+        #    Eq. 20 of Yuan, Ho, Lin (2011).
+        d2 = self.compute_d2(X, sample_weight=sample_weight)
         check = 0.5 * d2 <= self.tol
         if self.verbose:
             print(f"    2. Newton decrement {0.5 * d2} <= {self.tol} {check}")
@@ -684,6 +693,10 @@ class NewtonCholeskySolver(NewtonSolver):
                 )
             self.use_fallback_lbfgs_solve = True
             return
+
+    def compute_d2(self, X, sample_weight):
+        """Compute square of Newton decrement."""
+        return self.coef_newton @ self.hessian @ self.coef_newton
 
     def finalize(self, X, y, sample_weight):
         if self.is_multinomial_no_penalty:


### PR DESCRIPTION
#### Reference Issues/PRs
Part 3 of #33160.

#### What does this implement/fix? Explain your changes.
This adds the method `compute_d2` to `NewtonSolver` such that future solvers (the ones in #33160) can deviate in the way they compute the Newton decrement `d2`.

#### AI usage disclosure
None

#### Any other comments?
