### PR TITLE
DOC Fix Matern nu=5/2 formula typo and paired_manhattan_distances off-by-one docstring

### DIFF
--- a/doc/modules/gaussian_process.rst
+++ b/doc/modules/gaussian_process.rst
@@ -414,7 +414,7 @@ the smoothness of the resulting function. It is parameterized by a length-scale 
    and :math:`\nu = 5/2`:
 
    .. math::
-      k(x_i, x_j) = \Bigg(1 + \frac{\sqrt{5}}{l} d(x_i , x_j ) +\frac{5}{3l} d(x_i , x_j )^2 \Bigg) \exp \Bigg(-\frac{\sqrt{5}}{l} d(x_i , x_j ) \Bigg) \quad \quad \nu= \tfrac{5}{2}
+      k(x_i, x_j) = \Bigg(1 + \frac{\sqrt{5}}{l} d(x_i , x_j ) +\frac{5}{3l^2} d(x_i , x_j )^2 \Bigg) \exp \Bigg(-\frac{\sqrt{5}}{l} d(x_i , x_j ) \Bigg) \quad \quad \nu= \tfrac{5}{2}
 
    are popular choices for learning functions that are not infinitely
    differentiable (as assumed by the RBF kernel) but at least once (:math:`\nu =

--- a/doc/whats_new/upcoming_changes/sklearn.gaussian_process/34283.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.gaussian_process/34283.fix.rst
@@ -1,0 +1,5 @@
+- Fixed a typo in the Matérn kernel formula for :math:`\nu=5/2` in the user guide.
+  The quadratic term's denominator was incorrectly written as :math:`3l` instead of
+  :math:`3l^2`, which is inconsistent with the reference [RW2006]_ and the actual
+  implementation.
+  By :user:`AYUSH PALLAV <AYUSHPALLAV1>`.

--- a/doc/whats_new/upcoming_changes/sklearn.metrics/34315.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/34315.fix.rst
@@ -1,0 +1,7 @@
+- Fixed an off-by-one indexing error in the docstring of
+  :func:`sklearn.metrics.pairwise.paired_manhattan_distances`. The description
+  stated that distances are computed up to ``(X[n_samples], Y[n_samples])``,
+  which would cause an :class:`IndexError` in Python since valid indices for an
+  array of ``n_samples`` elements range from ``0`` to ``n_samples - 1``. The
+  docstring now correctly reads ``(X[n_samples - 1], Y[n_samples - 1])``.
+  By :user:`AYUSH PALLAV <AYUSHPALLAV1>`.

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1226,7 +1226,7 @@ def paired_manhattan_distances(X, Y):
     """Compute the paired L1 distances between X and Y.
 
     Distances are calculated between (X[0], Y[0]), (X[1], Y[1]), ...,
-    (X[n_samples], Y[n_samples]).
+    (X[n_samples - 1], Y[n_samples - 1]).
 
     Read more in the :ref:`User Guide <metrics>`.
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #34315
Fixes #34283

#### What does this implement/fix?

**Fix 1 â€” Off-by-one in `paired_manhattan_distances` docstring (#34315)**

The docstring described the last computed pair as `(X[n_samples], Y[n_samples])`, which would raise `IndexError` in Python. Valid indices for an array of `n_samples` elements are `0` to `n_samples - 1`. Updated to `(X[n_samples - 1], Y[n_samples - 1])`.

**Fix 2 â€” Missing exponent in Matern kernel nu=5/2 formula (#34283)**

The closed-form Matern nu=5/2 formula in `doc/modules/gaussian_process.rst` had a typo in the quadratic term:
- **Incorrect:** `5 / (3l) * d^2`
- **Correct:** `5 / (3l^2) * d^2`

This is consistent with:
- Rasmussen & Williams (2006), p. 84 (the referenced source)
- The `kernels.py` implementation: `K = dists * sqrt(5)` (already divided by `l`), then `K**2 / 3.0`, which expands to `5/(3l^2) * d^2`

#### First time contributor introduction

I am an ML student who uses scikit-learn extensively for research in Gaussian Processes and metric learning. I found these issues while studying the source code and documentation.

#### AI usage disclosure

I used AI-assisted tooling to verify the mathematical correctness against the reference implementation and the Rasmussen & Williams textbook.