### PR TITLE
FIX guard zero normalizer in LabelPropagation/LabelSpreading.predict_proba

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.semi_supervised/34350.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.semi_supervised/34350.fix.rst
@@ -1,0 +1,5 @@
+- :class:`semi_supervised.LabelPropagation` and
+  :class:`semi_supervised.LabelSpreading` now guard against a zero row
+  normalizer in `predict_proba`, returning finite probabilities instead of
+  `nan` for query points far from all training samples.
+  By :user:`Syed Osama Ali Shah <Osamaali313>`.

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -229,6 +229,7 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
             weight_matrices = weight_matrices.T
             probabilities = safe_sparse_dot(weight_matrices, self.label_distributions_)
         normalizer = np.atleast_2d(np.sum(probabilities, axis=1)).T
+        normalizer[normalizer == 0] = 1
         probabilities /= normalizer
         return probabilities
 

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -79,6 +79,19 @@ def test_predict_proba(global_dtype, Estimator, parameters):
     assert_allclose(clf.predict_proba([[1.0, 1.0]]), np.array([[0.5, 0.5]]))
 
 
+@pytest.mark.parametrize("Estimator, parameters", ESTIMATORS)
+def test_predict_proba_finite_for_far_query(global_dtype, Estimator, parameters):
+    # Non-regression: a query point far from all training samples can drive the
+    # RBF affinity (and hence the row normalizer) to zero. predict_proba must
+    # apply the same zero-normalizer guard that fit uses, returning finite
+    # values instead of nan (which would silently corrupt predict).
+    samples = np.asarray([[1.0, 0.0], [0.0, 1.0], [1.0, 2.5]], dtype=global_dtype)
+    labels = [0, 1, -1]
+    clf = Estimator(**parameters).fit(samples, labels)
+    proba = clf.predict_proba(np.asarray([[1e6, 1e6]], dtype=global_dtype))
+    assert np.all(np.isfinite(proba))
+
+
 @pytest.mark.parametrize("alpha", [0.1, 0.3, 0.5, 0.7, 0.9])
 @pytest.mark.parametrize("Estimator, parameters", ESTIMATORS)
 def test_label_spreading_closed_form(global_dtype, Estimator, parameters, alpha):


### PR DESCRIPTION
#### Reference Issues/PRs
None found (searched open PRs/issues for `label_propagation predict_proba nan normalizer`).

#### What does this implement/fix? Explain your changes.

`BaseLabelPropagation.predict_proba` (shared by `LabelPropagation` and `LabelSpreading`) normalizes the per-sample class probabilities by their row sum **without** guarding a zero sum:

```python
normalizer = np.atleast_2d(np.sum(probabilities, axis=1)).T
probabilities /= normalizer
```

…even though `fit` guards the **identical** normalization in two places:

```python
normalizer = np.sum(self.label_distributions_, axis=1)[:, np.newaxis]
normalizer[normalizer == 0] = 1
self.label_distributions_ /= normalizer
```

For a query point far from all training samples, the RBF affinity underflows to 0, so the probability row is all-zero, its sum is 0, and `predict_proba` computes `0 / 0` — emitting `RuntimeWarning: invalid value encountered in divide` and returning `nan`. `predict` then `argmax`es over `nan` and silently returns class 0.

Reproduction (against released **1.8.0**):

```python
import numpy as np
from sklearn.semi_supervised import LabelPropagation
X = np.array([[1., 0.], [0., 1.], [1., 2.5]]); y = [0, 1, -1]
clf = LabelPropagation(kernel="rbf").fit(X, y)
clf.predict_proba([[1e6, 1e6]])
# RuntimeWarning: invalid value encountered in divide
# array([[nan, nan]])
```

`LabelSpreading` behaves identically (shared base method).

#### Fix

Apply the same zero-normalizer guard `fit` already uses, so `predict_proba` returns finite values (a zero row, consistent with what `fit` produces for zero-affinity rows) instead of `nan`:

```diff
 normalizer = np.atleast_2d(np.sum(probabilities, axis=1)).T
+normalizer[normalizer == 0] = 1
 probabilities /= normalizer
```

After the fix the call above returns `array([[0., 0.]])` with no warning. Normal (non-zero-affinity) queries are unchanged.

#### Any other comments?

Adds a non-regression test (`test_predict_proba_finite_for_far_query`) that asserts `predict_proba` is finite for an out-of-distribution query across the existing `ESTIMATORS` parametrization. The pre-existing `predict_proba` test only covered an in-distribution point, which is why the zero-normalizer path was overlooked. I'll add a changelog fragment referencing this PR number.
