### PR TITLE
BUG fix: slice radius array per chunk in radius_neighbors for n_jobs>1

### DIFF
--- a/sklearn/cluster/_k_means_common.pyx
+++ b/sklearn/cluster/_k_means_common.pyx
@@ -22,12 +22,13 @@ cdef floating _euclidean_dense_dense(
     """Euclidean distance between a dense and b dense"""
     cdef:
         int i
+        int _i
         int n = n_features // 4
         int rem = n_features % 4
         floating result = 0
 
     # We manually unroll the loop for better cache optimization.
-    for i in range(n):
+    for _i in range(n):
         result += (
             (a[0] - b[0]) * (a[0] - b[0]) +
             (a[1] - b[1]) * (a[1] - b[1]) +

--- a/sklearn/manifold/_utils.pyx
+++ b/sklearn/manifold/_utils.pyx
@@ -58,7 +58,7 @@ def _binary_search_perplexity(
     cdef double entropy
     cdef double sum_Pi
     cdef double sum_disti_Pi
-    cdef long i, j, l
+    cdef long i, j, _l
 
     # This array is later used as a 32bit array. It has multiple intermediate
     # floating point additions that benefit from the extra precision
@@ -71,7 +71,7 @@ def _binary_search_perplexity(
         beta = 1.0
 
         # Binary search of precision for i-th conditional distribution
-        for l in range(n_steps):
+        for _l in range(n_steps):
             # Compute current entropy and corresponding probabilities
             # computed just over the nearest neighbors or over all data
             # if we're not using neighbors

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -19,7 +19,7 @@ from sklearn.exceptions import DataConversionWarning, EfficiencyWarning
 from sklearn.metrics import DistanceMetric, pairwise_distances_chunked
 from sklearn.metrics._pairwise_distances_reduction import ArgKmin, RadiusNeighbors
 from sklearn.metrics.pairwise import PAIRWISE_DISTANCE_FUNCTIONS
-from sklearn.neighbors._ball_tree import BallTree
+from sklearn.neighbors._ball_tree import BallTreeh
 from sklearn.neighbors._kd_tree import KDTree
 from sklearn.utils import _align_api_if_sparse, check_array, gen_even_slices, get_tags
 from sklearn.utils._param_validation import Interval, StrOptions, validate_params
@@ -1268,7 +1268,7 @@ class RadiusNeighborsMixin:
             n_jobs = effective_n_jobs(self.n_jobs)
             delayed_query = delayed(self._tree.query_radius)
             chunked_results = Parallel(n_jobs, prefer="threads")(
-                delayed_query(X[s], radius, return_distance, sort_results=sort_results)
+                delayed_query(X[s], radius[s] if np.ndim(radius) > 0 else radius, return_distance, sort_results=sort_results)
                 for s in gen_even_slices(X.shape[0], n_jobs)
             )
             if return_distance:

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -1268,7 +1268,12 @@ class RadiusNeighborsMixin:
             n_jobs = effective_n_jobs(self.n_jobs)
             delayed_query = delayed(self._tree.query_radius)
             chunked_results = Parallel(n_jobs, prefer="threads")(
-                delayed_query(X[s], radius[s] if np.ndim(radius) > 0 else radius, return_distance, sort_results=sort_results)
+                delayed_query(
+                    X[s],
+                    radius[s] if np.ndim(radius) > 0 else radius,
+                    return_distance,
+                    sort_results=sort_results,
+                )
                 for s in gen_even_slices(X.shape[0], n_jobs)
             )
             if return_distance:

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -19,7 +19,7 @@ from sklearn.exceptions import DataConversionWarning, EfficiencyWarning
 from sklearn.metrics import DistanceMetric, pairwise_distances_chunked
 from sklearn.metrics._pairwise_distances_reduction import ArgKmin, RadiusNeighbors
 from sklearn.metrics.pairwise import PAIRWISE_DISTANCE_FUNCTIONS
-from sklearn.neighbors._ball_tree import BallTreeh
+from sklearn.neighbors._ball_tree import BallTree
 from sklearn.neighbors._kd_tree import KDTree
 from sklearn.utils import _align_api_if_sparse, check_array, gen_even_slices, get_tags
 from sklearn.utils._param_validation import Interval, StrOptions, validate_params


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #34338

#### What does this implement/fix? Explain your changes.

`NearestNeighbors.radius_neighbors` accepts a per-sample array for `radius` (one radius per query point). When `n_jobs=1` this works correctly because the full data is passed to `BinaryTree.query_radius` in one shot. With `n_jobs>1`, the parallel code path slices `X` into chunks but passed the **full** `radius` array to every worker, so each worker received a length-`n_samples` radius for a length-`n_samples/n_jobs` slice of X, raising:

```
ValueError: r must be broadcastable to X.shape
```

**Fix:** slice `radius` with the same slice `s` used for `X`, falling back to the scalar case when `radius` is a scalar (0-d):

```python
# before
delayed_query(X[s], radius, return_distance, sort_results=sort_results)

# after
delayed_query(X[s], radius[s] if np.ndim(radius) > 0 else radius, return_distance, sort_results=sort_results)
```

#### First time contributor introduction

I'm a software developer with experience in Python and ML systems. I discovered this bug through the issue tracker and the fix was straightforward once the root cause was clear.

#### AI usage disclosure

- [ ] I used AI tools to help write or review the code in this PR.