### PR TITLE
MAINT Fix cython-lint unused loop control variable warnings

### DIFF
--- a/sklearn/cluster/_k_means_common.pyx
+++ b/sklearn/cluster/_k_means_common.pyx
@@ -21,13 +21,13 @@ cdef floating _euclidean_dense_dense(
 ) noexcept nogil:
     """Euclidean distance between a dense and b dense"""
     cdef:
-        int i
+        int i, _i
         int n = n_features // 4
         int rem = n_features % 4
         floating result = 0
 
     # We manually unroll the loop for better cache optimization.
-    for i in range(n):
+    for _i in range(n):
         result += (
             (a[0] - b[0]) * (a[0] - b[0]) +
             (a[1] - b[1]) * (a[1] - b[1]) +

--- a/sklearn/manifold/_utils.pyx
+++ b/sklearn/manifold/_utils.pyx
@@ -58,7 +58,7 @@ def _binary_search_perplexity(
     cdef double entropy
     cdef double sum_Pi
     cdef double sum_disti_Pi
-    cdef long i, j, l
+    cdef long i, j, _l
 
     # This array is later used as a 32bit array. It has multiple intermediate
     # floating point additions that benefit from the extra precision
@@ -71,7 +71,7 @@ def _binary_search_perplexity(
         beta = 1.0
 
         # Binary search of precision for i-th conditional distribution
-        for l in range(n_steps):
+        for _l in range(n_steps):
             # Compute current entropy and corresponding probabilities
             # computed just over the nearest neighbors or over all data
             # if we're not using neighbors


### PR DESCRIPTION
A recent cython-lint release flags loop control variables that are not used within the loop body, which started failing the lint CI job on all pull requests. Two pre-existing loops trip this check:

- `_euclidean_dense_dense` in cluster/_k_means_common.pyx manually unrolls the loop, so its index is unused; rename it to `_i`.
- `_binary_search_perplexity` in manifold/_utils.pyx uses `l` only as a binary search step counter; rename it to `_l`.

Prefixing the variables with an underscore is the resolution suggested by cython-lint itself.

<!--
Thanks for contributing a pull request!

Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### First time contributor introduction
<!-- If you are new to the scikit-learn community, please introduce yourself. How do you
 use scikit-learn, what prompted you to make this contribution? Getting to know you
 helps us build trust in your judgement and welcome you into the community.
-->


#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->



#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
