### PR TITLE
MNT: Fix CI for cython-lint 0.21

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         files: sklearn/
         additional_dependencies: [pytest==6.2.4]
 -   repo: https://github.com/MarcoGorelli/cython-lint
-    rev: v0.20.0
+    rev: v0.21.0
     hooks:
     # TODO: add the double-quote-cython-strings hook when it's usability has improved:
     # possibility to pass a directory and use it as a check instead of auto-formatter.

--- a/sklearn/cluster/_k_means_common.pyx
+++ b/sklearn/cluster/_k_means_common.pyx
@@ -27,7 +27,7 @@ cdef floating _euclidean_dense_dense(
         floating result = 0
 
     # We manually unroll the loop for better cache optimization.
-    for i in range(n):
+    for _ in range(n):
         result += (
             (a[0] - b[0]) * (a[0] - b[0]) +
             (a[1] - b[1]) * (a[1] - b[1]) +

--- a/sklearn/manifold/_utils.pyx
+++ b/sklearn/manifold/_utils.pyx
@@ -58,7 +58,7 @@ def _binary_search_perplexity(
     cdef double entropy
     cdef double sum_Pi
     cdef double sum_disti_Pi
-    cdef long i, j, l
+    cdef long i, j
 
     # This array is later used as a 32bit array. It has multiple intermediate
     # floating point additions that benefit from the extra precision
@@ -71,7 +71,7 @@ def _binary_search_perplexity(
         beta = 1.0
 
         # Binary search of precision for i-th conditional distribution
-        for l in range(n_steps):
+        for _ in range(n_steps):
             # Compute current entropy and corresponding probabilities
             # computed just over the nearest neighbors or over all data
             # if we're not using neighbors


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #34356 

Very similar to #34331

#### What does this implement/fix? Explain your changes.

- Bump cython lint rev to 0.21 in precommit.yaml
- Fixes the new linting errors (I discovered Cython nicely support `for _ in range(...)` syntax).
