### PR TITLE
CI Update `actions/checkout` to v7

### DIFF
--- a/.github/workflows/autoclose-schedule.yml
+++ b/.github/workflows/autoclose-schedule.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'scikit-learn/scikit-learn'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
@@ -28,7 +28,7 @@ jobs:
         run: pip install -Uq PyGithub
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Close PRs labeled more than 14 days ago
         run: |

--- a/.github/workflows/bot-lint-comment.yml
+++ b/.github/workflows/bot-lint-comment.yml
@@ -48,7 +48,7 @@ jobs:
             --jq '"PR_NUMBER=\(.number)"' \
             >> $GITHUB_ENV
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           sparse-checkout: build_tools/get_comment.py
 

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -14,7 +14,7 @@ jobs:
     name: A reviewer will let you know if it is required or can be bypassed
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: '0'
       - name: Check if tests have changed

--- a/.github/workflows/check-sdist.yml
+++ b/.github/workflows/check-sdist.yml
@@ -13,7 +13,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Annotate locations with typos
         uses: codespell-project/codespell-problem-matcher@v1
       - name: Codespell

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: "ubuntu-latest"
     name: Build wheel for Pull Request
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Build wheels
         uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
@@ -51,7 +51,7 @@ jobs:
           # https://github.com/actions/setup-python/issues/886
           python-version: '3.12.3'
       - name: Checkout main repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install miniforge
         run: bash build_tools/github/create_gpu_environment.sh
       - name: Install scikit-learn

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -35,7 +35,7 @@ jobs:
       build: ${{ steps.check_build_trigger.outputs.build }}
     steps:
       - name: Checkout scikit-learn
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
@@ -63,7 +63,7 @@ jobs:
     if: needs.check_build_trigger.outputs.build
     steps:
       - name: Checkout scikit-learn
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/labeler-title-regex.yml
+++ b/.github/workflows/labeler-title-regex.yml
@@ -15,7 +15,7 @@ jobs:
   labeler:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         persist-credentials: false
     - uses: actions/setup-python@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/not-ready-for-pr-warning.yml
+++ b/.github/workflows/not-ready-for-pr-warning.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install PyGithub
         run: pip install -Uq PyGithub
       - name: Checkout workflow script
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           sparse-checkout: .github/scripts/add_or_remove_no_pr_warning.py
           sparse-checkout-cone-mode: false # false for files/ true for directories
@@ -49,7 +49,7 @@ jobs:
       - name: Install PyGithub
         run: pip install -Uq PyGithub
       - name: Checkout workflow script
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           sparse-checkout: .github/scripts/add_or_remove_no_pr_warning.py
           sparse-checkout-cone-mode: false # false for files/ true for directories

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -18,7 +18,7 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: actions/setup-python@v6
       with:
         python-version: '3.8'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
@@ -54,7 +54,7 @@ jobs:
     outputs:
       message: ${{ steps.git-log.outputs.message }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - id: git-log
@@ -225,7 +225,7 @@ jobs:
 
     steps: &unit-tests-steps
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # This step is necessary to access the job name the same way in both matrix and
       # non-matrix jobs (like free-threaded or scipy-dev builds).
@@ -364,7 +364,7 @@ jobs:
       JOB_NAME: *debian-32bit-job-name
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Create cache for ccache
         uses: actions/cache@v5

--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -31,7 +31,7 @@ jobs:
             update_script_args: "--select-tag cuda"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Generate lock files
         run: |
           source build_tools/shared.sh

--- a/.github/workflows/update_tracking_issue.yml
+++ b/.github/workflows/update_tracking_issue.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'scikit-learn/scikit-learn' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: '3.9'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout scikit-learn
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -173,7 +173,7 @@ jobs:
 
     steps:
       - name: Checkout scikit-learn
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -236,7 +236,7 @@ jobs:
 
     steps:
       - name: Checkout scikit-learn
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -268,7 +268,7 @@ jobs:
 
     steps:
       - name: Checkout scikit-learn
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION


#### What does this implement/fix? Explain your changes.

Update the `actions/checkout` action to v7 from v6. This makes it harder to checkout code from a fork instead of the main repo when running with `pull_request_target` trigger. See https://github.com/actions/checkout#checkout-v7

We aren't effected by this restriction, but it seems like an easy thing to do in order to prevent accidents.


#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)


xref https://github.com/scikit-learn/scikit-learn/issues/34006
