### PR TITLE
CI Fix `TransformTargetRegressor` metadata routing test

### DIFF
--- a/sklearn/compose/tests/test_target.py
+++ b/sklearn/compose/tests/test_target.py
@@ -445,4 +445,4 @@ def test_transform_target_regressor_metadata_routing_default_estimator():
     """Test that metadata request is set on the default regressor"""
     X, y = make_regression()
     ttr = TransformedTargetRegressor()
-    ttr.fit(X, y, sample_weight=np.empty(shape=(X.shape[0],)))
+    ttr.fit(X, y, sample_weight=np.ones(shape=(X.shape[0],)))


### PR DESCRIPTION
#### Reference Issues/PRs

Fix for the latest failure in https://github.com/scikit-learn/scikit-learn/issues/32393 (That is a mega issue that keeps running. So I am not sure if we should close it when merging this PR?)

#### What does this implement/fix? Explain your changes.

Instead of using `np.empty()` the test now uses `np.ones()`. On macos `np.empty()` seems to reliably return an array that contains only zeros, this fails a check that not all weights are zero. I think we don't care about the values of the weights, at least I hope we don't care given that we used `np.empty`. So using `np.ones` should be fine as well.

For some reason `np.empty` returns something that contains at least one element that isn't zero when we run the test in the normal PR CI. I guess that is "expected" because `np.empty` says it will return a new array without initialising the entries. Uninitialised memory -> no one knows what is/isn't in that memory. I'm not sure if free-threaded vs not free-threaded has anything to do with it?

My conclusion, if we look at the contents of an array we should probably not use `np.empty`.

#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Research and understanding

My AI researcher thinks that #32212 and #34224 "conspired" to cause this. 

cc @lucyleeow 