### PR TITLE
CI Fix uninitialised memory at exactly x=0.35

### DIFF
--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -36,7 +36,7 @@ X = np.atleast_2d(np.linspace(0, 10, 30)).T
 X2 = np.atleast_2d([2.0, 4.0, 5.5, 6.5, 7.5]).T
 y = np.array(f(X).ravel() > 0, dtype=int)
 fX = f(X).ravel()
-y_mc = np.empty(y.shape, dtype=int)  # multi-class
+y_mc = np.zeros(y.shape, dtype=int)  # multi-class
 y_mc[fX < -0.35] = 0
 y_mc[(fX >= -0.35) & (fX < 0.35)] = 1
 y_mc[fX > 0.35] = 2

--- a/sklearn/gaussian_process/tests/test_gpc.py
+++ b/sklearn/gaussian_process/tests/test_gpc.py
@@ -39,7 +39,7 @@ fX = f(X).ravel()
 y_mc = np.zeros(y.shape, dtype=int)  # multi-class
 y_mc[fX < -0.35] = 0
 y_mc[(fX >= -0.35) & (fX < 0.35)] = 1
-y_mc[fX > 0.35] = 2
+y_mc[fX >= 0.35] = 2
 
 
 fixed_kernel = RBF(length_scale=1.0, length_scale_bounds="fixed")


### PR DESCRIPTION
This is a very unlikely case but cheap to fix. The point `fX == 0.35` isn't covered by any of the assignments. So theoretically you could end up with uninitialised memory.

This is a follow up to https://github.com/scikit-learn/scikit-learn/pull/34371. I asked AI to look at all the tests in the project to see if there are any other occurrences of `np.empty` that should be fixed. It found several uses of `np.empty`/`np.empty_like` (about 40) but thinks that this is the only case where the array isn't immediately filled with values.

I didn't check all of the ones it did not change to see if it got all of them right.  Given that we don't suffer more flakyness in our tests I think that would be too much effort.

(Could have also changed the condition in the assignments to make a `<` into a `<=`)

#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Research and understanding
