### PR TITLE
FIX Slices array-like radius concurrently with X in radius_neighbors when n_jobs > 1

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.neighbors/34375.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.neighbors/34375.fix.rst
@@ -1,0 +1,2 @@
+- :func:`neighbors.RadiusNeighborsMixin.radius_neighbors` now correctly supports array-like radii when running in parallel with ``n_jobs > 1``.
+  By :user:`ArjunPakhan`.

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -170,8 +170,8 @@ def _check_precomputed(X):
 
     if graph.format not in ("csr", "csc", "coo", "lil"):
         raise TypeError(
-            "Sparse matrix in {!r} format is not supported due to "
-            "its handling of explicit zeros".format(graph.format)
+            f"Sparse matrix in {graph.format!r} format is not supported due to "
+            "its handling of explicit zeros"
         )
     copied = graph.format != "csr"
     graph = check_array(
@@ -578,7 +578,7 @@ class NeighborsBase(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
             if X.shape[0] != X.shape[1]:
                 raise ValueError(
                     "Precomputed matrix must be square."
-                    " Input is a {}x{} matrix.".format(X.shape[0], X.shape[1])
+                    f" Input is a {X.shape[0]}x{X.shape[1]} matrix."
                 )
             self.n_features_in_ = X.shape[1]
 
@@ -1269,12 +1269,16 @@ class RadiusNeighborsMixin:
             delayed_query = delayed(self._tree.query_radius)
             if hasattr(radius, "__len__") and len(radius) == X.shape[0]:
                 chunked_results = Parallel(n_jobs, prefer="threads")(
-                    delayed_query(X[s], radius[s], return_distance, sort_results=sort_results)
+                    delayed_query(
+                        X[s], radius[s], return_distance, sort_results=sort_results
+                    )
                     for s in gen_even_slices(X.shape[0], n_jobs)
                 )
             else:
                 chunked_results = Parallel(n_jobs, prefer="threads")(
-                    delayed_query(X[s], radius, return_distance, sort_results=sort_results)
+                    delayed_query(
+                        X[s], radius, return_distance, sort_results=sort_results
+                    )
                     for s in gen_even_slices(X.shape[0], n_jobs)
                 )
             if return_distance:

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -1267,10 +1267,16 @@ class RadiusNeighborsMixin:
 
             n_jobs = effective_n_jobs(self.n_jobs)
             delayed_query = delayed(self._tree.query_radius)
-            chunked_results = Parallel(n_jobs, prefer="threads")(
-                delayed_query(X[s], radius, return_distance, sort_results=sort_results)
-                for s in gen_even_slices(X.shape[0], n_jobs)
-            )
+            if hasattr(radius, "__len__") and len(radius) == X.shape[0]:
+                chunked_results = Parallel(n_jobs, prefer="threads")(
+                    delayed_query(X[s], radius[s], return_distance, sort_results=sort_results)
+                    for s in gen_even_slices(X.shape[0], n_jobs)
+                )
+            else:
+                chunked_results = Parallel(n_jobs, prefer="threads")(
+                    delayed_query(X[s], radius, return_distance, sort_results=sort_results)
+                    for s in gen_even_slices(X.shape[0], n_jobs)
+                )
             if return_distance:
                 neigh_ind, neigh_dist = tuple(zip(*chunked_results))
                 results = np.hstack(neigh_dist), np.hstack(neigh_ind)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -2530,9 +2530,11 @@ def test_neighbors_classifier_with_string_labels(metric, Estimator):
     assert y_pred.shape == (5,)
     assert all(label in y for label in y_pred)
 
+
 def test_radius_neighbors_array_radius_parallel():
     # Test that radius_neighbors accepts an array of radii with n_jobs > 1
     import numpy as np
+
     from sklearn.neighbors import NearestNeighbors
 
     X = np.array([[0, 0], [1, 1], [2, 2], [3, 3]])
@@ -2547,7 +2549,9 @@ def test_radius_neighbors_array_radius_parallel():
         # n_jobs=2 (was breaking with ValueError)
         nn_parallel = NearestNeighbors(radius=1.0, algorithm=algo, n_jobs=2)
         nn_parallel.fit(X)
-        res_parallel = nn_parallel.radius_neighbors(X, radius=radii, return_distance=False)
+        res_parallel = nn_parallel.radius_neighbors(
+            X, radius=radii, return_distance=False
+        )
 
         for r1, r2 in zip(res_single, res_parallel):
             np.testing.assert_array_equal(r1, r2)

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -2529,3 +2529,25 @@ def test_neighbors_classifier_with_string_labels(metric, Estimator):
 
     assert y_pred.shape == (5,)
     assert all(label in y for label in y_pred)
+
+def test_radius_neighbors_array_radius_parallel():
+    # Test that radius_neighbors accepts an array of radii with n_jobs > 1
+    import numpy as np
+    from sklearn.neighbors import NearestNeighbors
+
+    X = np.array([[0, 0], [1, 1], [2, 2], [3, 3]])
+    radii = np.array([1.5, 1.5, 1.5, 1.5])
+
+    for algo in ["kd_tree", "ball_tree"]:
+        # n_jobs=1 (was working)
+        nn_single = NearestNeighbors(radius=1.0, algorithm=algo, n_jobs=1)
+        nn_single.fit(X)
+        res_single = nn_single.radius_neighbors(X, radius=radii, return_distance=False)
+
+        # n_jobs=2 (was breaking with ValueError)
+        nn_parallel = NearestNeighbors(radius=1.0, algorithm=algo, n_jobs=2)
+        nn_parallel.fit(X)
+        res_parallel = nn_parallel.radius_neighbors(X, radius=radii, return_distance=False)
+
+        for r1, r2 in zip(res_single, res_parallel):
+            np.testing.assert_array_equal(r1, r2)


### PR DESCRIPTION
### Description
This PR fixes a `ValueError` crash when calling `radius_neighbors` with an array-like `radius` parameter while running multi-processing (`n_jobs > 1`). 

### Why the Bug Happens
When `n_jobs > 1`, `gen_even_slices` correctly splits the input samples matrix `X` into miniature chunks `X[s]`. However, the full-length array-like `radius` was being passed completely un-sliced to every parallel worker chunk. This created a shape mismatch between the dataset chunk and the radius sequence inside `_tree.query_radius`, throwing a dimension `ValueError`.

### Changes Proposed
- Added a check in `sklearn/neighbors/_base.py` to see if `radius` is an array-like/sequence matching the length of `X`.
- If true, slice `radius[s]` concurrently alongside `X[s]` within the `Parallel` generator expression.
- Added a dedicated regression test `test_radius_neighbors_array_radius_parallel` to `sklearn/neighbors/tests/test_neighbors.py` covering both `kd_tree` and `ball_tree` multi-core execution paths.

### PR Checklist
- [x] Code follows scikit-learn formatting guidelines
- [x] All existing neighbors tests pass successfully
- [x] New regression unit test added and passes cleanly