### PR TITLE
FIX avoid torch dlpack crash for negative strides

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.utils/34380.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/34380.fix.rst
@@ -1,4 +1,5 @@
-- ``utils._array_api.move_to`` now makes negative-stride NumPy arrays
-  contiguous before transferring them to PyTorch through DLPack, avoiding a
-  Python process abort in ``torch.from_dlpack``.
+- Array API supporting functions and estimators that handle mixed input
+  namespaces now make negative-stride NumPy arrays contiguous before
+  transferring them to PyTorch through DLPack, avoiding a Python process
+  abort in ``torch.from_dlpack``.
   By :user:`Yin Li <Kevin-Li-2025>`.

--- a/doc/whats_new/upcoming_changes/sklearn.utils/34380.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/34380.fix.rst
@@ -1,0 +1,4 @@
+- ``utils._array_api.move_to`` now makes negative-stride NumPy arrays
+  contiguous before transferring them to PyTorch through DLPack, avoiding a
+  Python process abort in ``torch.from_dlpack``.
+  By :user:`Yin Li <Kevin-Li-2025>`.

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -580,18 +580,13 @@ def move_to(*arrays, xp, device):
             if xp == xp_array and device == device_array:
                 converted_arrays.append(array)
             else:
-                strides = getattr(array, "strides", None)
-                if (
-                    _is_xp_namespace(xp, "torch")
-                    and _is_numpy_namespace(xp_array)
-                    and strides is not None
-                    and any(stride < 0 for stride in strides)
-                ):
-                    # Work around PyTorch aborting the process when importing
-                    # negative-strided NumPy arrays with DLPack. Remove this once
-                    # https://github.com/pytorch/pytorch/issues/188023 is fixed.
-                    # See also https://github.com/scikit-learn/scikit-learn/issues/34307
-                    array = numpy.ascontiguousarray(array)
+                if _is_xp_namespace(xp, "torch") and _is_numpy_namespace(xp_array):
+                    if any(stride < 0 for stride in array.strides):
+                        # Work around PyTorch aborting the process when importing
+                        # negative-strided NumPy arrays with DLPack. Remove this once
+                        # https://github.com/pytorch/pytorch/issues/188023 is fixed.
+                        # See also https://github.com/scikit-learn/scikit-learn/issues/34307
+                        array = numpy.ascontiguousarray(array)
                 try:
                     # The dlpack protocol is the future proof and library agnostic
                     # method to transfer arrays across namespace and device boundaries

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -580,6 +580,18 @@ def move_to(*arrays, xp, device):
             if xp == xp_array and device == device_array:
                 converted_arrays.append(array)
             else:
+                strides = getattr(array, "strides", None)
+                if (
+                    _is_xp_namespace(xp, "torch")
+                    and _is_numpy_namespace(xp_array)
+                    and strides is not None
+                    and any(stride < 0 for stride in strides)
+                ):
+                    # Work around PyTorch aborting the process when importing
+                    # negative-strided NumPy arrays with DLPack. Remove this once
+                    # https://github.com/pytorch/pytorch/issues/188023 is fixed.
+                    # See also https://github.com/scikit-learn/scikit-learn/issues/34307
+                    array = numpy.ascontiguousarray(array)
                 try:
                     # The dlpack protocol is the future proof and library agnostic
                     # method to transfer arrays across namespace and device boundaries

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -53,6 +53,7 @@ from sklearn.utils._testing import (
     _array_api_for_tests,
     _convert_container,
     assert_array_equal,
+    assert_run_python_script_without_output,
     skip_if_array_api_compat_not_configured,
 )
 from sklearn.utils.fixes import _IS_32BIT, CSR_CONTAINERS, np_version, parse_version
@@ -190,6 +191,34 @@ def test_move_to_sparse():
             move_to(sparse1, numpy_array, xp=xp_torch, device=device_cpu)
         with pytest.raises(TypeError, match=msg):
             move_to(sparse1, None, xp=xp_torch, device=device_cpu)
+
+
+def test_move_to_numpy_negative_strides_to_torch():
+    """Check NumPy arrays with negative strides can be moved to torch."""
+    pytest.importorskip("torch")
+
+    code = """
+import os
+
+os.environ["SCIPY_ARRAY_API"] = "1"
+
+import numpy
+from numpy.testing import assert_allclose
+
+from sklearn._config import config_context
+from sklearn.utils._array_api import get_namespace_and_device, move_to
+
+import torch
+
+a = numpy.arange(12.0).reshape(3, 4)[:, ::-1]
+with config_context(array_api_dispatch=True):
+    xp, _, device = get_namespace_and_device(torch.asarray([1.0]))
+    result = move_to(a, xp=xp, device=device)
+    assert_allclose(result.cpu().numpy(), a)
+"""
+    # This must run in a subprocess because old PyTorch versions abort the
+    # Python process before a Python exception can be raised.
+    assert_run_python_script_without_output(code)
 
 
 @pytest.mark.parametrize("array_api", ["numpy", "array_api_strict"])


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #34307.
Related to pytorch/pytorch#188023.

#### What does this implement/fix? Explain your changes.

`move_to` currently transfers NumPy arrays to torch through DLPack when possible. PyTorch aborts the Python process when importing a NumPy array with negative strides through DLPack, before scikit-learn can fall back to a safer conversion path.

This adds a narrow workaround for the affected path: when the source array is NumPy, the target namespace is torch, and any stride is negative, `move_to` first makes the array contiguous with `numpy.ascontiguousarray` before calling `xp.from_dlpack`. Other namespaces and non-negative-strided NumPy arrays continue to use the existing path.

The regression test runs in a subprocess because the previous failure mode aborts the Python process instead of raising a Python exception.

#### Any other comments?

Validation run locally:

```bash
MPLCONFIGDIR=/private/tmp/mplconfig LOKY_MAX_CPU_COUNT=8 PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest sklearn/utils/tests/test_array_api.py::test_move_to_numpy_negative_strides_to_torch sklearn/utils/tests/test_array_api.py::test_move_to_array_api_conversions sklearn/utils/tests/test_array_api.py::test_move_to_sparse -q
```

Result: `1 passed, 6 skipped`.
