### PR TITLE
DOC Fix det_curve fnr docstring threshold direction

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -371,7 +371,7 @@ def det_curve(
         referred to as false rejection or miss rate.
 
     thresholds : ndarray of shape (n_thresholds,)
-        Decreasing thresholds on the decision function (either `predict_proba`
+        Increasing thresholds on the decision function (either `predict_proba`
         or `decision_function`) used to compute FPR and FNR.
 
         .. versionchanged:: 1.7

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -367,7 +367,7 @@ def det_curve(
 
     fnr : ndarray of shape (n_thresholds,)
         False negative rate (FNR) such that element i is the false negative
-        rate of predictions with score >= thresholds[i]. This is occasionally
+        rate of predictions with score < thresholds[i]. This is occasionally
         referred to as false rejection or miss rate.
 
     thresholds : ndarray of shape (n_thresholds,)

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -1383,10 +1383,11 @@ def test_score_scale_invariance():
 )
 def test_det_curve_toydata(y_true, y_score, expected_fpr, expected_fnr):
     # Check on a batch of small examples.
-    fpr, fnr, _ = det_curve(y_true, y_score)
+    fpr, fnr, thresholds = det_curve(y_true, y_score)
 
     assert_allclose(fpr, expected_fpr)
     assert_allclose(fnr, expected_fnr)
+    assert np.all(np.diff(thresholds) >= 0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Reference Issues/PRs

Issue #34310 and PR #34325 concern the adjacent `thresholds` increasing/decreasing wording; this PR fixes the separate `fnr` threshold-direction sentence.

What does this implement/fix? Explain your changes.

The `Returns` section of `sklearn.metrics.det_curve` describes `fnr` as "the false negative rate of predictions with score >= thresholds[i]." That text is copied from the `fpr` entry and is wrong for the false negative rate: a false negative is a positive sample predicted negative, i.e. one scoring below the threshold, so FNR at element `i` is the rate of positives with `score < thresholds[i]`. The function's own example confirms this: with `thresholds=[0.35, 0.4, 0.8]` and `fnr=[0., 0.5, 0.5]`, the positive scoring `0.35` becomes a false negative at threshold `0.4` (`0.35 < 0.4`). This is a one-token docstring fix (`>=` to `<`) on the `fnr` line only; the `fpr` line is left unchanged (its `>=` is correct), there is no behavior change, and the existing doctest still passes.

First time contributor introduction

Hi, I'm Christian, and I'm a rising sophomore studying CS at Johns Hopkins. I used scikit-learn for binary classification for a project where a false negative (a missed positive) can potentially be dangerous for the user/client. I ran into this while using `det_curve` to choose an operating threshold on the miss-rate vs false-alarm tradeoff, and the inverted `fnr` threshold direction in the docs pointed me the wrong way until the worked example set me straight.

AI usage disclosure

I used AI assistance for:
- Documentation (including examples)
- Research and understanding

Any other comments?

The correctness proof is already encoded in the function's own doctest (the `fnr=[0., 0.5, 0.5]` example), so no new test is needed.