### PR TITLE
DOC clarify optimal SGD learning rate

### DIFF
--- a/doc/modules/sgd.rst
+++ b/doc/modules/sgd.rst
@@ -500,14 +500,29 @@ is given by
 
 .. math::
 
-    \eta^{(t)} = \frac {1}{\alpha  (t_0 + t)}
+    \eta^{(t)} = \frac {1}{\alpha  (t_0 + t - 1)}
 
-where :math:`t` is the time step (there are a total of `n_samples * n_iter`
-time steps), :math:`t_0` is determined based on a heuristic proposed by Léon Bottou
-such that the expected initial updates are comparable with the expected
-size of the weights (this assumes that the norm of the training samples is
-approximately 1). The exact definition can be found in ``_init_t`` in `BaseSGD`.
+where :math:`t` is the time step starting at 1 (there are a total of
+``n_samples * n_iter`` time steps). The offset :math:`t_0` is determined
+by the heuristic proposed by Léon Bottou in section 5.2 of [#1]_, such that
+the expected initial updates are comparable with the expected size of the
+weights (this assumes that the norm of the training samples is approximately
+1). In the implementation, this is computed as:
 
+.. math::
+
+    \begin{aligned}
+    \textrm{typw} &= \sqrt{\frac{1}{\sqrt{\alpha}}},\\
+    \eta^{(1)} &=
+        \frac{\textrm{typw}}
+             {\max(1, \partial L(y, p) / \partial p \mid_{y=1, p=-\textrm{typw}})},\\
+    t_0 &= \frac{1}{\eta^{(1)} \alpha}.
+    \end{aligned}
+
+Thus the first update uses :math:`\eta^{(1)}` and later updates follow the
+decreasing schedule above. The value of :math:`t_0` depends on the
+regularization strength ``alpha`` and on the selected loss through its
+gradient.
 
 For regression the default learning rate schedule is inverse scaling
 (``learning_rate='invscaling'``), given by


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #24172.

#### What does this implement/fix? Explain your changes.

This clarifies the user guide description of `learning_rate="optimal"` for SGD estimators. The previous text described the decreasing schedule but did not document how the initial learning-rate offset is chosen, and it pointed readers to a stale `_init_t` implementation detail.

The updated text keeps the formula in one place, in the SGD user guide, and documents the implementation-owned Bottou heuristic for `typw`, `eta^(1)`, and `t0`. Estimator docstrings continue to point to the user guide instead of duplicating the formula.

#### First time contributor introduction

I have contributed to scikit-learn before and opened this PR after checking that #24172 is still open and that there is no active duplicate PR for this documentation issue.

#### AI usage disclosure

I used AI assistance for research and documentation drafting support. I manually reviewed the issue discussion, the current implementation, and the final diff, and I ran the validation commands listed below before submitting.

#### Any other comments?

Validation:

- `python -m py_compile sklearn/linear_model/_stochastic_gradient.py`
- `git diff --check`
- content smoke check for the one-based schedule, `typw`, `eta^(1)`, `t0`, and the Bottou section 5.2 reference

I could not build the docs locally because Sphinx is not installed in this environment (`No module named sphinx`). I am relying on CI for the rendered documentation check.

No changelog entry: this is a documentation clarification for an existing user guide section and does not change runtime behavior.