### PR TITLE
FIX use pseudo-inverse for singular PCA precision

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.decomposition/34395.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.decomposition/34395.fix.rst
@@ -1,0 +1,3 @@
+- |Fix| :meth:`decomposition.PCA.get_precision` now uses a pseudo-inverse
+  when the estimated covariance is singular.
+  By :user:`dannyward630`.

--- a/sklearn/decomposition/_base.py
+++ b/sklearn/decomposition/_base.py
@@ -75,11 +75,13 @@ class _BasePCA(
 
         if is_array_api_compliant:
             linalg_inv = xp.linalg.inv
+            linalg_pinv = xp.linalg.pinv
         else:
             linalg_inv = linalg.inv
+            linalg_pinv = linalg.pinv
 
         if self.noise_variance_ == 0.0:
-            return linalg_inv(self.get_covariance())
+            return linalg_pinv(self.get_covariance())
 
         # Get precision using matrix inversion lemma
         components_ = self.components_

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -718,6 +718,15 @@ def test_pca_zero_noise_variance_edge_cases(svd_solver):
     pca.score(X.T)
 
 
+def test_pca_get_precision_singular_covariance():
+    """Check get_precision uses the pseudo-inverse for rank-deficient covariance."""
+    X = np.arange(50, dtype=np.float64).reshape(5, 10)
+    pca = PCA().fit(X)
+
+    assert pca.noise_variance_ == 0
+    assert_allclose(pca.get_precision(), np.linalg.pinv(pca.get_covariance()))
+
+
 @pytest.mark.parametrize(
     "n_samples, n_features, n_components, expected_solver",
     [


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #33205

#### What does this implement/fix? Explain your changes.

`PCA.get_precision()` currently uses a direct inverse when `noise_variance_ == 0`. If the fitted covariance is rank deficient, that asks the backend to invert a singular matrix. This is the failure mode reported for Array API backends, and it can also be reproduced with deterministic rank-deficient inputs.

This changes the zero-noise covariance path to use the pseudo-inverse and adds a regression test that fits PCA on a rank-deficient matrix and checks `get_precision()` against `scipy.linalg.pinv(get_covariance())`. The matrix inversion lemma path for positive noise variance is unchanged.

#### First time contributor introduction



#### AI usage disclosure

I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Research and understanding

#### Any other comments?

Validation run locally:

- `python3 -m py_compile sklearn/decomposition/_base.py sklearn/decomposition/tests/test_pca.py`
- `git diff --check`

I could not run the targeted pytest in this checkout because the available system Python is 3.9.6, while current scikit-learn requires Python >= 3.11 for editable builds.