### PR TITLE
DOC: replace raw arxiv URL with :arxiv: directive in _oas covariance docstring

### DIFF
--- a/sklearn/covariance/_shrunk_covariance.py
+++ b/sklearn/covariance/_shrunk_covariance.py
@@ -56,10 +56,13 @@ def _oas(X, *, assume_centered=False):
     """Estimate covariance with the Oracle Approximating Shrinkage algorithm.
 
     The formulation is based on [1]_.
-    [1] "Shrinkage algorithms for MMSE covariance estimation.",
-        Chen, Y., Wiesel, A., Eldar, Y. C., & Hero, A. O.
-        IEEE Transactions on Signal Processing, 58(10), 5016-5029, 2010.
-        https://arxiv.org/pdf/0907.4698.pdf
+
+    References
+    ----------
+    .. [1] :arxiv:`"Shrinkage algorithms for MMSE covariance estimation.",
+           Chen, Y., Wiesel, A., Eldar, Y. C., & Hero, A. O.
+           IEEE Transactions on Signal Processing, 58(10), 5016-5029, 2010.
+           <0907.4698>`
     """
     if len(X.shape) == 2 and X.shape[1] == 1:
         # for only one feature, the result is the same whatever the shrinkage


### PR DESCRIPTION
#### Reference Issues/PRs

No related issue. This is a leftover from the broader cleanup effort in #21088.

#### What does this implement/fix? Explain your changes.

The `_oas` function in `sklearn/covariance/_shrunk_covariance.py` had a
raw `https://arxiv.org/pdf/0907.4698.pdf` URL in its docstring reference.
This PR replaces it with the proper `:arxiv:` Sphinx directive and adds
a `References` section, consistent with the style already used in the
rest of the same file (lines 688 and 787).

#### First time contributor introduction

I am a BE student of Electronics, Communication and Technology at Thapathali
Campus, Institute of Engineering (Tribhuvan University), Nepal. I use
scikit-learn for ML projects including a non-invasive anemia detection
system using Random Forest. I wanted to contribute back to the library
I use and started with documentation improvements.

#### AI usage disclosure

I used AI assistance for:
- Research and understanding (used AI to help identify the inconsistency
  in the docstring and understand the correct `:arxiv:` directive format
  used in scikit-learn documentation)
- Documentation (AI helped me understand the correct format to apply the fix)

The actual code change was made manually by me after understanding the issue.

#### Any other comments?

This is my first contribution to scikit-learn. Happy to make any
changes requested during review.