### PR TITLE
DOC fix grammer and RST citation in AdaBoost docstring

### DIFF
--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -3,7 +3,7 @@
 This module contains weight boosting estimators for both classification and
 regression.
 
-The module structure is the following:
+The module structure is as follows:
 
 - The `BaseWeightBoosting` base class implements a common ``fit`` method
   for all the estimators in the module. Regression and classification
@@ -641,7 +641,7 @@ class AdaBoostClassifier(
         score : ndarray of shape of (n_samples, k)
             The decision function of the input samples. The order of
             outputs is the same as that of the :term:`classes_` attribute.
-            Binary classification is a special cases with ``k == 1``,
+            Binary classification is a special case with ``k == 1``,
             otherwise ``k==n_classes``. For binary classification,
             values closer to -1 or 1 mean more like the first or second
             class in ``classes_``, respectively.
@@ -686,8 +686,8 @@ class AdaBoostClassifier(
         ------
         score : generator of ndarray of shape (n_samples, k)
             The decision function of the input samples. The order of
-            outputs is the same of that of the :term:`classes_` attribute.
-            Binary classification is a special cases with ``k == 1``,
+            outputs is the same as that of the :term:`classes_` attribute.
+            Binary classification is a special case with ``k == 1``,
             otherwise ``k==n_classes``. For binary classification,
             values closer to -1 or 1 mean more like the first or second
             class in ``classes_``, respectively.
@@ -757,7 +757,7 @@ class AdaBoostClassifier(
         -------
         p : ndarray of shape (n_samples, n_classes)
             The class probabilities of the input samples. The order of
-            outputs is the same of that of the :term:`classes_` attribute.
+            outputs is the same as that of the :term:`classes_` attribute.
         """
         check_is_fitted(self)
         n_classes = self.n_classes_
@@ -790,7 +790,7 @@ class AdaBoostClassifier(
         ------
         p : generator of ndarray of shape (n_samples,)
             The class probabilities of the input samples. The order of
-            outputs is the same of that of the :term:`classes_` attribute.
+            outputs is the same as that of the :term:`classes_` attribute.
         """
 
         n_classes = self.n_classes_
@@ -815,7 +815,7 @@ class AdaBoostClassifier(
         -------
         p : ndarray of shape (n_samples, n_classes)
             The class probabilities of the input samples. The order of
-            outputs is the same of that of the :term:`classes_` attribute.
+            outputs is the same as that of the :term:`classes_` attribute.
         """
         return np.log(self.predict_proba(X))
 
@@ -823,7 +823,7 @@ class AdaBoostClassifier(
 class AdaBoostRegressor(_RoutingNotSupportedMixin, RegressorMixin, BaseWeightBoosting):
     """An AdaBoost regressor.
 
-    An AdaBoost [1] regressor is a meta-estimator that begins by fitting a
+    An AdaBoost [1]_ regressor is a meta-estimator that begins by fitting a
     regressor on the original dataset and then fits additional copies of the
     regressor on the same dataset but where the weights of instances are
     adjusted according to the error of the current prediction. As such,


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #34354

---

#### What does this implement/fix? Explain your changes.

This PR fixes several grammatical errors and an RST citation inconsistency in the docstrings of `AdaBoostClassifier` and `AdaBoostRegressor` in `sklearn/ensemble/_weight_boosting.py`.

The changes include:

* Changed "The module structure is the following" to "The module structure is as follows".
* Corrected "special cases" to "special case" in the AdaBoost classifier docstrings.
* Corrected "same of that of" to "same as that of" in multiple docstrings.
* Fixed the RST citation by changing `[1]` to `[1]_` in the `AdaBoostRegressor` docstring.

No functional code was modified.

---

#### First time contributor introduction

Hello! This is my first contribution to scikit-learn.

I'm a Computer Science student currently learning machine learning and open source. I've used scikit-learn while studying ML, and I wanted to start contributing to the project by working on a documentation issue to become familiar with the contribution workflow.

---

#### AI usage disclosure

I used AI assistance for:

* Research and understanding

---

#### Any other comments?

No additional comments.
