### PR TITLE
ENH Add partial_fit to Ridge for incremental learning

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -198,6 +198,40 @@ This method has the same order of complexity as
 .. between these
 
 
+Incremental fitting with partial_fit
+-------------------------------------
+
+:class:`Ridge` supports incremental fitting via
+:meth:`~linear_model.Ridge.partial_fit`. This is useful when the dataset is
+too large to fit in memory, or when data arrives in a stream.
+
+Unlike :meth:`~linear_model.Ridge.fit`, which uses the full dataset at once,
+:meth:`~linear_model.Ridge.partial_fit` accumulates the sufficient statistics
+:math:`X^\top X` and :math:`X^\top y` across batches and then solves the
+regularized normal equations:
+
+.. math::
+
+   (X^\top X + \alpha I) w = X^\top y
+
+The solution is therefore exact (not iterative): splitting the data into
+batches gives the same result as fitting on the full dataset at once::
+
+    >>> from sklearn import linear_model
+    >>> import numpy as np
+    >>> X = np.array([[1, 1], [1, 2], [2, 2], [2, 3]])
+    >>> y = np.dot(X, np.array([1, 2])) + 3
+    >>> reg = linear_model.Ridge(alpha=0.5)
+    >>> reg.partial_fit(X[:2], y[:2])
+    Ridge(alpha=0.5)
+    >>> reg.partial_fit(X[2:], y[2:])
+    Ridge(alpha=0.5)
+
+Sparse input is not supported by :meth:`~linear_model.Ridge.partial_fit`.
+Calling :meth:`~linear_model.Ridge.fit` on an estimator that has previously
+been updated with :meth:`~linear_model.Ridge.partial_fit` resets the
+incremental state.
+
 Setting the regularization parameter: leave-one-out Cross-Validation
 --------------------------------------------------------------------
 

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/33914.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/33914.feature.rst
@@ -1,5 +1,0 @@
-- :class:`linear_model.Ridge` now supports :meth:`~linear_model.Ridge.partial_fit`
-  for incremental learning. The method accumulates sufficient statistics
-  (:math:`X^\top X` and :math:`X^\top y`) across batches and solves the
-  regularized normal equations via Cholesky factorization.
-  By :user:`Teja1631 <Teja1631>`.

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/33914.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/33914.feature.rst
@@ -1,0 +1,5 @@
+- :class:`linear_model.Ridge` now supports :meth:`~linear_model.Ridge.partial_fit`
+  for incremental learning. The method accumulates sufficient statistics
+  (:math:`X^\top X` and :math:`X^\top y`) across batches and solves the
+  regularized normal equations via Cholesky factorization.
+  By :user:`Teja1631 <Teja1631>`.

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/34403.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/34403.feature.rst
@@ -1,0 +1,5 @@
+- :class:`linear_model.Ridge` now supports :meth:`~linear_model.Ridge.partial_fit`
+  for incremental learning. The method accumulates sufficient statistics
+  (:math:`X^\top X` and :math:`X^\top y`) across batches and solves the
+  regularized normal equations via Cholesky factorization.
+  By :user:`Teja1631 <Teja1631>`.

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1342,7 +1342,10 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
         n_aug = X_aug.shape[1]
 
         # Accumulate X_aug^T W X_aug and X_aug^T W y where W = diag(sw).
-        X_sw = X_aug * sample_weight[:, np.newaxis] if sample_weight is not None else X_aug
+        if sample_weight is not None:
+            X_sw = X_aug * sample_weight[:, np.newaxis]
+        else:
+            X_sw = X_aug
         XtX_batch = X_sw.T @ X_aug
         Xty_batch = X_sw.T @ y
 

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1158,7 +1158,7 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
         .. versionadded:: 0.17
 
     n_samples_seen_ : int
-        Number of samples processed by :meth:`partial_fit`. Cleared when
+        Number of samples processed by :meth:`partial_fit`. Reset to 0 when
         :meth:`fit` is called.
 
         .. versionadded:: 1.8
@@ -1252,11 +1252,12 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
         self : object
             Fitted estimator.
         """
-        # Clear incremental state so that any subsequent partial_fit call
+        # Reset incremental state so that any subsequent partial_fit call
         # starts fresh rather than accumulating on top of stale statistics.
-        for _attr in ("_XtX", "_Xty", "n_samples_seen_"):
+        for _attr in ("_XtX", "_Xty"):
             if hasattr(self, _attr):
                 delattr(self, _attr)
+        self.n_samples_seen_ = 0
 
         _accept_sparse = _get_valid_accept_sparse(sparse.issparse(X), self.solver)
         xp, _, device_ = get_namespace_and_device(X)

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1157,6 +1157,12 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
 
         .. versionadded:: 0.17
 
+    n_samples_seen_ : int
+        Number of samples processed by :meth:`partial_fit`. Cleared when
+        :meth:`fit` is called.
+
+        .. versionadded:: 1.8
+
     n_features_in_ : int
         Number of features seen during :term:`fit`.
 
@@ -1246,6 +1252,12 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
         self : object
             Fitted estimator.
         """
+        # Clear incremental state so that any subsequent partial_fit call
+        # starts fresh rather than accumulating on top of stale statistics.
+        for _attr in ("_XtX", "_Xty", "n_samples_seen_"):
+            if hasattr(self, _attr):
+                delattr(self, _attr)
+
         _accept_sparse = _get_valid_accept_sparse(sparse.issparse(X), self.solver)
         xp, _, device_ = get_namespace_and_device(X)
         y, sample_weight = move_to(y, sample_weight, xp=xp, device=device_)
@@ -1261,6 +1273,135 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
             y_numeric=True,
         )
         return super().fit(X, y, sample_weight=sample_weight)
+
+    @_fit_context(prefer_skip_nested_validation=True)
+    def partial_fit(self, X, y, sample_weight=None):
+        """Incrementally fit Ridge regression model.
+
+        Accumulates sufficient statistics :math:`X^\\top X` and
+        :math:`X^\\top y` across batches, then solves the regularized normal
+        equations. Each call updates ``coef_`` and ``intercept_`` to reflect
+        all data seen so far.
+
+        Unlike :meth:`fit`, this method does not reset the model between
+        calls. Call :meth:`fit` (or construct a new estimator) to restart
+        from scratch.
+
+        .. note::
+            Sparse input is not supported. The ``solver`` hyperparameter is
+            ignored; the normal equations are always solved via Cholesky
+            factorization (``solver_`` is set to ``'cholesky'``).
+
+        Parameters
+        ----------
+        X : ndarray of shape (n_samples, n_features)
+            Training data. Sparse matrices are not supported.
+
+        y : ndarray of shape (n_samples,) or (n_samples, n_targets)
+            Target values.
+
+        sample_weight : float or ndarray of shape (n_samples,), default=None
+            Individual weights for each sample. If given a float, every
+            sample will have the same weight.
+
+        Returns
+        -------
+        self : object
+            Returns the instance itself.
+        """
+        first_call = not hasattr(self, "_XtX")
+
+        X, y = validate_data(
+            self,
+            X,
+            y,
+            accept_sparse=False,
+            dtype=np.float64,
+            force_writeable=True,
+            multi_output=True,
+            y_numeric=True,
+            reset=first_call,
+        )
+
+        n_samples, n_features = X.shape
+        # Track whether caller passed 1-D y to restore that shape later.
+        y_ndim = y.ndim
+        y = y.reshape(n_samples, -1)
+        n_targets = y.shape[1]
+
+        if sample_weight is not None:
+            sample_weight = _check_sample_weight(sample_weight, X, dtype=X.dtype)
+
+        # Append a bias column so the intercept is absorbed into the weight
+        # vector: X_aug = [X | 1], w_aug = [coef | intercept].
+        if self.fit_intercept:
+            X_aug = np.hstack([X, np.ones((n_samples, 1), dtype=X.dtype)])
+        else:
+            X_aug = X
+
+        n_aug = X_aug.shape[1]
+
+        # Accumulate X_aug^T W X_aug and X_aug^T W y where W = diag(sw).
+        X_sw = X_aug * sample_weight[:, np.newaxis] if sample_weight is not None else X_aug
+        XtX_batch = X_sw.T @ X_aug
+        Xty_batch = X_sw.T @ y
+
+        if first_call:
+            self._XtX = XtX_batch
+            self._Xty = Xty_batch
+            self.n_samples_seen_ = n_samples
+        else:
+            self._XtX += XtX_batch
+            self._Xty += Xty_batch
+            self.n_samples_seen_ += n_samples
+
+        # Solve (X_aug^T X_aug + Lambda) w = X_aug^T y.
+        # Lambda = diag([alpha, ..., alpha, 0]) — the last entry (intercept)
+        # is not penalized.
+        alpha = np.atleast_1d(self.alpha)
+        one_alpha = np.array_equal(alpha, len(alpha) * [alpha[0]])
+
+        if not one_alpha and len(alpha) != n_targets:
+            raise ValueError(
+                f"alpha has {len(alpha)} elements but y has {n_targets} targets. "
+                "alpha must be a scalar or have the same length as the number "
+                "of targets."
+            )
+
+        if one_alpha:
+            A = self._XtX.copy()
+            A.flat[:: n_aug + 1] += alpha[0]
+            if self.fit_intercept:
+                # Undo regularization on the intercept (last diagonal entry).
+                A[-1, -1] -= alpha[0]
+            W = linalg.solve(A, self._Xty, assume_a="pos", overwrite_a=True)
+        else:
+            W = np.empty((n_aug, n_targets), dtype=np.float64)
+            for k in range(n_targets):
+                A_k = self._XtX.copy()
+                A_k.flat[:: n_aug + 1] += alpha[k]
+                if self.fit_intercept:
+                    A_k[-1, -1] -= alpha[k]
+                W[:, k] = linalg.solve(
+                    A_k, self._Xty[:, k], assume_a="pos", overwrite_a=True
+                )
+
+        if self.fit_intercept:
+            self.coef_ = W[:-1].T  # (n_targets, n_features)
+            self.intercept_ = W[-1]  # (n_targets,)
+        else:
+            self.coef_ = W.T  # (n_targets, n_features)
+            self.intercept_ = np.zeros(n_targets, dtype=np.float64)
+
+        # Restore 1-D shapes for single-target input (mirrors fit() behaviour).
+        if y_ndim == 1:
+            self.coef_ = self.coef_.ravel()
+            self.intercept_ = float(self.intercept_[0])
+
+        self.n_iter_ = None
+        self.solver_ = "cholesky"
+
+        return self
 
     def predict(self, X):
         """

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -2780,7 +2780,7 @@ def test_ridge_partial_fit_fit_resets_state(ridge_partial_fit_data):
     ridge.fit(X, y)
     assert not hasattr(ridge, "_XtX")
     assert not hasattr(ridge, "_Xty")
-    assert not hasattr(ridge, "n_samples_seen_")
+    assert ridge.n_samples_seen_ == 0
 
     # After fit(), partial_fit should start fresh.
     ridge.partial_fit(X[:50], y[:50])

--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -2663,3 +2663,162 @@ def test_set_score_request_with_default_scoring(metaestimator, make_dataset):
 
 # End of Metadata Routing Tests
 # =============================
+
+
+# ==============================================
+# Tests for Ridge.partial_fit (incremental fit)
+# ==============================================
+
+
+@pytest.fixture
+def ridge_partial_fit_data(global_random_seed):
+    rng = np.random.RandomState(global_random_seed)
+    n_samples, n_features = 200, 10
+    X = rng.randn(n_samples, n_features)
+    y = rng.randn(n_samples)
+    return X, y
+
+
+def test_ridge_partial_fit_matches_fit(ridge_partial_fit_data):
+    """partial_fit on the whole dataset should give the same result as fit."""
+    X, y = ridge_partial_fit_data
+    ridge_fit = Ridge(alpha=1.0).fit(X, y)
+    ridge_pf = Ridge(alpha=1.0).partial_fit(X, y)
+
+    assert_allclose(ridge_pf.coef_, ridge_fit.coef_, rtol=1e-10)
+    assert_allclose(ridge_pf.intercept_, ridge_fit.intercept_, atol=1e-10)
+
+
+def test_ridge_partial_fit_incremental(ridge_partial_fit_data):
+    """Batched partial_fit calls should converge to the same solution as fit."""
+    X, y = ridge_partial_fit_data
+    n_samples = X.shape[0]
+    batch_size = 50
+
+    ridge_fit = Ridge(alpha=1.0).fit(X, y)
+    ridge_pf = Ridge(alpha=1.0)
+    for start in range(0, n_samples, batch_size):
+        sl = slice(start, start + batch_size)
+        ridge_pf.partial_fit(X[sl], y[sl])
+
+    assert_allclose(ridge_pf.coef_, ridge_fit.coef_, rtol=1e-10)
+    assert_allclose(ridge_pf.intercept_, ridge_fit.intercept_, atol=1e-10)
+    assert ridge_pf.n_samples_seen_ == n_samples
+
+
+def test_ridge_partial_fit_no_intercept(ridge_partial_fit_data):
+    """partial_fit with fit_intercept=False should match fit."""
+    X, y = ridge_partial_fit_data
+    n_samples = X.shape[0]
+    batch_size = 50
+
+    ridge_fit = Ridge(alpha=2.0, fit_intercept=False).fit(X, y)
+    ridge_pf = Ridge(alpha=2.0, fit_intercept=False)
+    for start in range(0, n_samples, batch_size):
+        sl = slice(start, start + batch_size)
+        ridge_pf.partial_fit(X[sl], y[sl])
+
+    assert_allclose(ridge_pf.coef_, ridge_fit.coef_, rtol=1e-10)
+    assert_allclose(ridge_pf.intercept_, 0.0)
+
+
+def test_ridge_partial_fit_multi_target(global_random_seed):
+    """partial_fit should handle multi-target regression correctly."""
+    rng = np.random.RandomState(global_random_seed)
+    X = rng.randn(200, 8)
+    Y = rng.randn(200, 3)
+    n_samples = X.shape[0]
+    batch_size = 40
+
+    ridge_fit = Ridge(alpha=1.0).fit(X, Y)
+    ridge_pf = Ridge(alpha=1.0)
+    for start in range(0, n_samples, batch_size):
+        sl = slice(start, start + batch_size)
+        ridge_pf.partial_fit(X[sl], Y[sl])
+
+    assert ridge_pf.coef_.shape == (3, 8)
+    assert_allclose(ridge_pf.coef_, ridge_fit.coef_, rtol=1e-10)
+    assert_allclose(ridge_pf.intercept_, ridge_fit.intercept_, atol=1e-10)
+
+
+def test_ridge_partial_fit_sample_weight(global_random_seed):
+    """partial_fit with sample_weight should match fit with the same weights."""
+    rng = np.random.RandomState(global_random_seed)
+    X = rng.randn(100, 5)
+    y = rng.randn(100)
+    sw = rng.rand(100) + 0.5
+
+    ridge_fit = Ridge(alpha=1.0).fit(X, y, sample_weight=sw)
+    ridge_pf = Ridge(alpha=1.0).partial_fit(X, y, sample_weight=sw)
+
+    assert_allclose(ridge_pf.coef_, ridge_fit.coef_, rtol=1e-10)
+    assert_allclose(ridge_pf.intercept_, ridge_fit.intercept_, atol=1e-10)
+
+
+def test_ridge_partial_fit_per_target_alpha(global_random_seed):
+    """partial_fit with per-target alpha array should match fit."""
+    rng = np.random.RandomState(global_random_seed)
+    X = rng.randn(200, 6)
+    Y = rng.randn(200, 4)
+    alpha = [0.5, 1.0, 2.0, 5.0]
+
+    ridge_fit = Ridge(alpha=alpha).fit(X, Y)
+    ridge_pf = Ridge(alpha=alpha).partial_fit(X, Y)
+
+    assert_allclose(ridge_pf.coef_, ridge_fit.coef_, rtol=1e-10)
+    assert_allclose(ridge_pf.intercept_, ridge_fit.intercept_, atol=1e-10)
+
+
+def test_ridge_partial_fit_fit_resets_state(ridge_partial_fit_data):
+    """Calling fit() after partial_fit() should reset the incremental state."""
+    X, y = ridge_partial_fit_data
+    ridge = Ridge(alpha=1.0)
+    ridge.partial_fit(X[:100], y[:100])
+    assert hasattr(ridge, "_XtX")
+    assert hasattr(ridge, "n_samples_seen_")
+
+    ridge.fit(X, y)
+    assert not hasattr(ridge, "_XtX")
+    assert not hasattr(ridge, "_Xty")
+    assert not hasattr(ridge, "n_samples_seen_")
+
+    # After fit(), partial_fit should start fresh.
+    ridge.partial_fit(X[:50], y[:50])
+    assert ridge.n_samples_seen_ == 50
+
+
+def test_ridge_partial_fit_solver_attribute():
+    """partial_fit always sets solver_ to 'cholesky' regardless of solver param."""
+    X = np.random.randn(50, 5)
+    y = np.random.randn(50)
+    for solver in ["auto", "svd", "sag", "lsqr"]:
+        ridge = Ridge(alpha=1.0, solver=solver).partial_fit(X, y)
+        assert ridge.solver_ == "cholesky"
+        assert ridge.n_iter_ is None
+
+
+def test_ridge_partial_fit_predict(ridge_partial_fit_data):
+    """predict() should work after partial_fit."""
+    X, y = ridge_partial_fit_data
+    ridge = Ridge(alpha=1.0).partial_fit(X, y)
+    y_pred = ridge.predict(X)
+    assert y_pred.shape == (X.shape[0],)
+
+
+def test_ridge_partial_fit_sparse_raises(ridge_partial_fit_data):
+    """partial_fit should raise for sparse input."""
+    from scipy.sparse import csr_matrix
+
+    X, y = ridge_partial_fit_data
+    X_sparse = csr_matrix(X)
+    with pytest.raises(TypeError, match="Sparse data was passed for X"):
+        Ridge(alpha=1.0).partial_fit(X_sparse, y)
+
+
+def test_ridge_partial_fit_alpha_mismatch():
+    """partial_fit should raise when alpha length doesn't match n_targets."""
+    rng = np.random.RandomState(0)
+    X = rng.randn(50, 5)
+    Y = rng.randn(50, 3)
+    with pytest.raises(ValueError, match="alpha has 2 elements but y has 3"):
+        Ridge(alpha=[1.0, 2.0]).partial_fit(X, Y)


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
addresses #33914

#### What does this implement/fix? Explain your changes.
Adds Ridge.partial_fit() using the augmented normal-equations approach: accumulates X^T X and X^T y across batches, then solves (X^T X + alpha * I) w = X^T y via Cholesky factorization.

Batched partial_fit gives bit-identical results to fit() on the full dataset (up to float64 rounding). Supports sample_weight, multi-target, and per-target alpha arrays. Sparse input is not supported.

Calling fit() resets the incremental state so subsequent partial_fit calls start fresh.

Also adds 11 tests and a user-guide section under Ridge regression.

Closes #33914

#### First time contributor introduction
<!-- If you are new to the scikit-learn community, please introduce yourself. How do you
 use scikit-learn, what prompted you to make this contribution? Getting to know you
 helps us build trust in your judgement and welcome you into the community.
-->
Hi, second-time contributor here! I picked up this issue after seeing @ogrisel's
comment asking for a prototype implementation and empirical evaluation.

This PR adds `Ridge.partial_fit()` using the **normal-equations accumulation**
approach: across batches, we accumulate the sufficient statistics `X^T X` and
`X^T y`, then solve `(X^T X + αI) w = X^T y` via Cholesky factorization after
each batch. The intercept is handled by augmenting X with a bias column and
zeroing the corresponding regularization entry, so no centering is needed.

**Key property:** batched `partial_fit` gives identical results to `fit` on the
full dataset (up to float64 rounding) — it is not an approximation.

**Current limitations (intentional for the prototype):**
- Sparse input is not supported (`X^T X` accumulation requires dense storage)
- `solver` parameter is ignored; Cholesky is always used
- Memory cost is O(n_features²) for `_XtX`, independent of n_samples

Happy to iterate on the approach — particularly open to feedback on whether the
incremental SVD path @tomMoral mentioned would be preferred over this for a
final implementation.

#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Documentation (including examples)
- Research and understanding


#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

