### PR TITLE
FIX KDTree/BallTree deserialization from read-only loky memory-mapped buffers

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.neighbors/34408.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.neighbors/34408.fix.rst
@@ -1,4 +1,4 @@
 - :class:`neighbors.KDTree` and :class:`neighbors.BallTree` can now be used
   with joblib parallelism (``n_jobs > 1``) when the loky backend memory-maps
-  internal arrays as read-only buffers. :issue:`34344` :pr:`XXXXX`
+  internal arrays as read-only buffers. :issue:`34344` :pr:`34408`
   by :user:`imann_128`.

--- a/doc/whats_new/upcoming_changes/sklearn.neighbors/XXXXX.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.neighbors/XXXXX.fix.rst
@@ -1,0 +1,4 @@
+- :class:`neighbors.KDTree` and :class:`neighbors.BallTree` can now be used
+  with joblib parallelism (``n_jobs > 1``) when the loky backend memory-maps
+  internal arrays as read-only buffers. :issue:`34344` :pr:`XXXXX`
+  by :user:`imann_128`.

--- a/sklearn/neighbors/_binary_tree.pxi.tp
+++ b/sklearn/neighbors/_binary_tree.pxi.tp
@@ -961,10 +961,21 @@ cdef class BinaryTree{{name_suffix}}:
         """
         set state for pickling
         """
-        self.data = state[0]
-        self.idx_array = state[1]
-        self.node_data = state[2]
-        self.node_bounds = state[3]
+        # joblib's loky backend memory-maps arrays shared between processes as
+        # read-only buffers. Cython typed memoryview attributes (even those
+        # declared const) require writable buffers for assignment via their
+        # Python-level setter descriptors (see cython/cython#5639). We copy
+        # any read-only array before assignment so that deserialization works
+        # regardless of how the buffer was produced.
+        def _ensure_writable(arr):
+            if arr is not None and hasattr(arr, 'flags') and not arr.flags.writeable:
+                return np.array(arr)
+            return arr
+
+        self.data = _ensure_writable(state[0])
+        self.idx_array = _ensure_writable(state[1])
+        self.node_data = _ensure_writable(state[2])
+        self.node_bounds = _ensure_writable(state[3])
         self.leaf_size = state[4]
         self.n_levels = state[5]
         self.n_nodes = state[6]


### PR DESCRIPTION
Fixes #34344 

## What the problem is

When joblib's loky backend parallelises a query like `n_jobs > 1`, it memory-maps large arrays as read-only buffers before sending them to worker processes. On deserialization, `BinaryTree.__setstate__` assigns these arrays to `cdef public const` Cython memview attributes. The Python-level setter descriptors generated for `public` attributes reject read-only buffers even when the attribute is declared `const` which is a known upstream Cython issue (cython/cython#5639). This causes a `ValueError: buffer source array is read-only` which surfaces as a `BrokenProcessPool` error.

## Fix

In `BinaryTree.__setstate__`, copy any read-only array before assigning it to a memview attribute. This is a minimal-cost operation (one copy per unpickle per tree) and requires no changes to construction logic or the Cython attribute declarations.

## Tests

The existing tests `test_kdtree_picklable_with_joblib` and `test_knn_forcing_backend[*-loky]` cover this regression. They fail on
`main` and pass with this fix.


**AI tools were used for drafting. All changes have been personally reviewed, understood, and tested.**
