### PR TITLE
MNT Remove deprecated public `entropy` function (1.10 cleanup)

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics.cluster/34411.removal.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics.cluster/34411.removal.rst
@@ -1,0 +1,7 @@
+Remove deprecated public :func:`sklearn.metrics.cluster.entropy`
+----------------------------------------------------------------
+The public :func:`sklearn.metrics.cluster.entropy` function, deprecated
+in version 1.8, has been removed. It was a thin wrapper around the
+internal ``_entropy`` function, which remains unchanged.
+
+:pr:`34411` by :user:`Naman Agrawal <itsmehotpants>`.

--- a/sklearn/metrics/cluster/__init__.py
+++ b/sklearn/metrics/cluster/__init__.py
@@ -14,7 +14,6 @@ from sklearn.metrics.cluster._supervised import (
     adjusted_rand_score,
     completeness_score,
     contingency_matrix,
-    entropy,
     expected_mutual_information,
     fowlkes_mallows_score,
     homogeneity_completeness_v_measure,
@@ -40,8 +39,6 @@ __all__ = [
     "consensus_score",
     "contingency_matrix",
     "davies_bouldin_score",
-    # TODO(1.10): Remove
-    "entropy",
     "expected_mutual_information",
     "fowlkes_mallows_score",
     "homogeneity_completeness_v_measure",

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -1303,24 +1303,3 @@ def _entropy(labels):
     # specific scalar array.
     return float(-xp.sum((pi / pi_sum) * (xp.log(pi) - log(pi_sum))))
 
-
-# TODO(1.10): Remove
-@deprecated("`entropy` is deprecated in 1.8 and will be removed in 1.10.")
-def entropy(labels):
-    """Calculate the entropy for a labeling.
-
-    Parameters
-    ----------
-    labels : array-like of shape (n_samples,)
-        The labels.
-
-    Returns
-    -------
-    entropy : float
-       The entropy for a labeling.
-
-    Notes
-    -----
-    The logarithm used is the natural logarithm (base-e).
-    """
-    return _entropy(labels)

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -17,7 +17,7 @@ from scipy import sparse as sp
 from sklearn.metrics.cluster._expected_mutual_info_fast import (
     expected_mutual_information,
 )
-from sklearn.utils import _align_api_if_sparse, deprecated
+from sklearn.utils import _align_api_if_sparse
 from sklearn.utils._array_api import (
     _max_precision_float_dtype,
     get_namespace_and_device,

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -69,9 +69,9 @@ def check_clusterings(labels_true, labels_pred):
 
     # input checks
     if labels_true.ndim != 1:
-        raise ValueError("labels_true must be 1D: shape is %r" % (labels_true.shape,))
+        raise ValueError(f"labels_true must be 1D: shape is {labels_true.shape!r}")
     if labels_pred.ndim != 1:
-        raise ValueError("labels_pred must be 1D: shape is %r" % (labels_pred.shape,))
+        raise ValueError(f"labels_pred must be 1D: shape is {labels_pred.shape!r}")
     check_consistent_length(labels_true, labels_pred)
 
     return labels_true, labels_pred
@@ -1302,4 +1302,3 @@ def _entropy(labels):
     # Always convert the result as a Python scalar (on CPU) instead of a device
     # specific scalar array.
     return float(-xp.sum((pi / pi_sum) * (xp.log(pi) - log(pi_sum))))
-

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -269,7 +269,6 @@ def test_int_overflow_mutual_info_fowlkes_mallows_score():
     assert_all_finite(fowlkes_mallows_score(x, y))
 
 
-
 def test_entropy():
     assert_almost_equal(_entropy([0, 0, 42.0]), 0.6365141, 5)
     assert_almost_equal(_entropy([]), 1)

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -24,7 +24,6 @@ from sklearn.metrics.cluster._supervised import (
     _entropy,
     _generalized_average,
     check_clusterings,
-    entropy,
 )
 from sklearn.utils import assert_all_finite
 from sklearn.utils._array_api import (
@@ -269,11 +268,6 @@ def test_int_overflow_mutual_info_fowlkes_mallows_score():
     assert_all_finite(mutual_info_score(x, y))
     assert_all_finite(fowlkes_mallows_score(x, y))
 
-
-# TODO(1.10): Remove
-def test_public_entropy_deprecation():
-    with pytest.warns(FutureWarning, match="Function entropy is deprecated"):
-        entropy([0, 0, 42.0])
 
 
 def test_entropy():


### PR DESCRIPTION
Closes #34411

## Reference issues / PRs

Completes the deprecation cycle started in 1.8.

## What does this implement / fix?

`sklearn.metrics.cluster.entropy` was deprecated in 1.8 with a `FutureWarning` stating removal in 1.10. This PR performs that removal now that `1.10.dev0` development has started.

## Changes

| File | Change |
|---|---|
| `sklearn/metrics/cluster/_supervised.py` | Remove `@deprecated entropy()` wrapper; remove now-unused `deprecated` import |
| `sklearn/metrics/cluster/__init__.py` | Remove `entropy` from import list and `__all__` |
| `sklearn/metrics/cluster/tests/test_supervised.py` | Remove `test_public_entropy_deprecation` and the `entropy` import |

The private `_entropy()` implementation is **untouched** and continues to be used internally.

## Checklist

- [x] Maintenance/cleanup only — no new features
- [x] No behaviour change to any public API
- [x] All `TODO(1.10): Remove` markers for this deprecation addressed
- [x] Private `_entropy` (internal use) preserved