### PR TITLE
DOC: added document constructor parameters for ScoringMonitorLog

### DIFF
--- a/sklearn/callback/_scoring_monitor.py
+++ b/sklearn/callback/_scoring_monitor.py
@@ -33,6 +33,20 @@ class ScoringMonitorLog:
     - `sequential_subtasks`: whether the task has sequential subtasks.
     - A column for each score name that was passed as `scoring` parameter.
 
+    Parameters
+    ----------
+    run_id : uuid.UUID
+        The unique identifier for the run.
+
+    estimator_name : str
+        The name of the estimator for the run.
+
+    timestamp : datetime.datetime
+        The timestamp of the start of the run.
+
+    data : list[dict]
+        The recorded scores for the run.
+
     Attributes
     ----------
     run_id : uuid.UUID
@@ -49,6 +63,24 @@ class ScoringMonitorLog:
 
     data_as_pandas : pandas.DataFrame
         The recorded scores for the run as a Pandas DataFrame.
+
+    See Also
+    --------
+    ScoringMonitor : Callback that monitors a score.
+
+    Examples
+    --------
+    >>> import uuid
+    >>> from datetime import datetime
+    >>> from sklearn.callback import ScoringMonitorLog
+    >>> log = ScoringMonitorLog(
+    ...     run_id=uuid.UUID('12345678-1234-5678-1234-567812345678'),
+    ...     estimator_name="LogisticRegression",
+    ...     timestamp=datetime(2026, 6, 30),
+    ...     data=[{"accuracy": 0.9}]
+    ... )
+    >>> log.estimator_name
+    'LogisticRegression'
     """
 
     run_id: uuid.UUID

--- a/sklearn/tests/test_docstring_parameters.py
+++ b/sklearn/tests/test_docstring_parameters.py
@@ -54,7 +54,6 @@ _DOCSTRING_IGNORES = [
     "sklearn.pipeline.make_pipeline",
     "sklearn.pipeline.make_union",
     "HalfBinomialLoss",
-    "ScoringMonitorLog",  # dataclass
 ]
 
 # Methods where y param should be ignored if y=None by default


### PR DESCRIPTION
Small docstring fix for `sklearn.callback.ScoringMonitorLog`.

It's a dataclass with four constructor fields (`run_id`, `estimator_name`, `timestamp`, `data`), but the docstring only documented them under `Attributes`, not `Parameters` — so the project's own numpydoc validator flagged it (`PR01: Parameters not documented`), along with a couple of missing standard sections (`SA01`, `EX01`). It was sitting in `_DOCSTRING_IGNORES` in `test_docstring_parameters.py` as a known-failing case.

This adds the missing `Parameters` section, a `See Also` pointing to `ScoringMonitor` (which is what actually produces a `ScoringMonitorLog`), and a runnable example — then removes it from the ignore list now that it passes.

```python
$ python sklearn/tests/test_docstrings.py sklearn.callback.ScoringMonitorLog
#All docstring checks passed for sklearn.callback.ScoringMonitorLog!

$ python -m pytest sklearn/tests/test_docstring_parameters.py -k test_docstring_parameters
#212 passed
```

Also ran the new example directly to confirm it's not just well-formatted but actually correct:

```python
>>> import uuid
>>> from datetime import datetime
>>> from sklearn.callback import ScoringMonitorLog
>>> log = ScoringMonitorLog(
...     run_id=uuid.UUID('12345678-1234-5678-1234-567812345678'),
...     estimator_name="LogisticRegression",
...     timestamp=datetime(2026, 6, 30),
...     data=[{"accuracy": 0.9}]
... )
>>> log.estimator_name
'LogisticRegression'
```

### AI Disclosure

Used an AI assistant to run scikit-learn's own docstring validator across the codebase to find a currently-ignored/failing case, and to draft the missing docstring sections. I independently ran the validator, the test suite, and the new example myself to confirm everything actually passes and works before opening this.