### PR TITLE
DOC Clarify n_jobs in voting estimators

### DIFF
--- a/sklearn/ensemble/_voting.py
+++ b/sklearn/ensemble/_voting.py
@@ -222,7 +222,8 @@ class VotingClassifier(ClassifierMixin, _BaseVoting):
         before averaging (`soft` voting). Uses uniform weights if `None`.
 
     n_jobs : int, default=None
-        The number of jobs to run in parallel for ``fit``.
+        The number of jobs to run in parallel when fitting the member
+        estimators.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -574,7 +575,8 @@ class VotingRegressor(RegressorMixin, _BaseVoting):
         predicted values before averaging. Uses uniform weights if `None`.
 
     n_jobs : int, default=None
-        The number of jobs to run in parallel for ``fit``.
+        The number of jobs to run in parallel when fitting the member
+        estimators.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.


### PR DESCRIPTION
#### Reference Issues/PRs

Refs #14228

#### What does this implement/fix? Explain your changes.

Clarifies the `n_jobs` parameter text for `VotingClassifier` and `VotingRegressor` by saying that fitting the member estimators is parallelized.

#### Any other comments?

Validation:
- `git diff --check`
- Checked the updated docstring text locally.
