### PR TITLE
TST Remove non-functional test_ridge_loo_cv_asym_scoring (#16041)

### DIFF
--- a/sklearn/linear_model/tests/test_ridge.py
+++ b/sklearn/linear_model/tests/test_ridge.py
@@ -1010,38 +1010,6 @@ def test_regularization_limits_ridge_gcv(
     assert_allclose(gcv_ridge.intercept_, expected_intercept, atol=atol)
 
 
-def test_ridge_loo_cv_asym_scoring():
-    # checking on asymmetric scoring
-    scoring = "explained_variance"
-    n_samples, n_features = 10, 5
-    n_targets = 1
-    X, y = _make_sparse_offset_regression(
-        n_samples=n_samples,
-        n_features=n_features,
-        n_targets=n_targets,
-        random_state=0,
-        shuffle=False,
-        noise=1,
-        n_informative=5,
-    )
-
-    alphas = [1e-3, 0.1, 1.0, 10.0, 1e3]
-    loo_ridge = RidgeCV(
-        cv=n_samples, fit_intercept=True, alphas=alphas, scoring=scoring
-    )
-
-    gcv_ridge = RidgeCV(fit_intercept=True, alphas=alphas, scoring=scoring)
-
-    loo_ridge.fit(X, y)
-    gcv_ridge.fit(X, y)
-
-    assert gcv_ridge.alpha_ == pytest.approx(loo_ridge.alpha_), (
-        f"{gcv_ridge.alpha_=}, {loo_ridge.alpha_=}"
-    )
-    assert_allclose(gcv_ridge.coef_, loo_ridge.coef_, rtol=1e-3)
-    assert_allclose(gcv_ridge.intercept_, loo_ridge.intercept_, rtol=1e-3)
-
-
 @pytest.mark.parametrize("gcv_mode", ["svd", "eigen"])
 @pytest.mark.parametrize("X_container", [np.asarray] + CSR_CONTAINERS)
 @pytest.mark.parametrize("n_features", [8, 20])


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #16041.

#### What does this implement/fix?

Removes `test_ridge_loo_cv_asym_scoring`. As reported in #16041, it did not test anything meaningful: it compared `RidgeCV(cv=n_samples, scoring="explained_variance")` against the GCV path, but with leave-one-out each fold has a single sample and `explained_variance` on one sample is degenerate, so every alpha tied and the test passed by chance. Per maintainer suggestion, removing it rather than rewriting.