### PR TITLE
FIX reuse the single CV split in TunedThresholdClassifierCV when refit=False

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.model_selection/34426.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.model_selection/34426.fix.rst
@@ -1,0 +1,7 @@
+- :class:`model_selection.TunedThresholdClassifierCV` with ``refit=False`` and a
+  float ``cv`` now computes the train/validation split once and reuses it, so the
+  fitted ``estimator_`` and the tuned decision threshold are calibrated on the same
+  data. Previously the split was drawn twice, which with the default
+  ``random_state=None`` could fit ``estimator_`` on a different split than the one
+  used to tune the threshold.
+  By :user:`Gunjan Jaswal <gunjanjaswal>`.

--- a/sklearn/model_selection/_classification_threshold.py
+++ b/sklearn/model_selection/_classification_threshold.py
@@ -754,14 +754,17 @@ class TunedThresholdClassifierCV(BaseThresholdClassifier):
         else:
             self.estimator_ = clone(self.estimator)
             classifier = clone(self.estimator)
-            splits = cv.split(X, y, **routed_params.splitter.split)
+            splits = list(cv.split(X, y, **routed_params.splitter.split))
 
             if self.refit:
                 # train on the whole dataset
                 X_train, y_train, fit_params_train = X, y, routed_params.estimator.fit
             else:
-                # single split cross-validation
-                train_idx, _ = next(cv.split(X, y, **routed_params.splitter.split))
+                # single split cross-validation; reuse the split that threshold
+                # tuning consumes so `estimator_` and the tuned threshold are
+                # calibrated on the same data (refit=False is constrained to a
+                # single fold above)
+                train_idx, _ = splits[0]
                 X_train = _safe_indexing(X, train_idx)
                 y_train = _safe_indexing(y, train_idx)
                 fit_params_train = _check_method_params(

--- a/sklearn/model_selection/tests/test_classification_threshold.py
+++ b/sklearn/model_selection/tests/test_classification_threshold.py
@@ -517,6 +517,32 @@ def test_tuned_threshold_classifier_cv_float():
     assert_allclose(tuned_model.estimator_.coef_, cloned_estimator.coef_)
 
 
+def test_tuned_threshold_classifier_cv_float_single_split(monkeypatch):
+    """Non-regression test for the split-reuse bug with `cv` a float.
+
+    With `cv` a float and `refit=False`, the cross-validation split must be
+    computed once and reused, so that `estimator_` is fit on the same training
+    split that the decision threshold is tuned on. Previously the split was
+    drawn a second time, which with the default `random_state=None` could fit
+    `estimator_` and tune the threshold on different splits.
+    Non-regression test for gh-33540.
+    """
+    X, y = make_classification(random_state=0)
+
+    n_calls = {"split": 0}
+    original_split = StratifiedShuffleSplit.split
+
+    def counting_split(self, X, y=None, groups=None):
+        n_calls["split"] += 1
+        return original_split(self, X, y, groups)
+
+    monkeypatch.setattr(StratifiedShuffleSplit, "split", counting_split)
+
+    TunedThresholdClassifierCV(LogisticRegression(), cv=0.3, refit=False).fit(X, y)
+
+    assert n_calls["split"] == 1
+
+
 def test_tuned_threshold_classifier_error_constant_predictor():
     """Check that we raise a ValueError if the underlying classifier returns constant
     probabilities such that we cannot find any threshold.


### PR DESCRIPTION
## Summary

Fixes #33540.

`TunedThresholdClassifierCV._fit` builds the CV split generator once (`splits = cv.split(...)`), but the `refit=False` branch calls `cv.split(...)` a second time to get the training indices for `estimator_`. With `cv` a float, `cv` is a `StratifiedShuffleSplit(n_splits=1, ..., random_state=self.random_state)` and `random_state` defaults to `None`, so the two `cv.split()` calls draw different splits. `estimator_` then ends up trained on one split while the threshold is tuned on another, so the returned `best_threshold_` is not calibrated for the returned `estimator_`.

`refit=False` is already constrained to a single fold (the code raises when `cv.get_n_splits() > 1`), so materializing the split list and reusing `splits[0]` is safe and gives both `estimator_` and threshold tuning the same split.

## Changes

- `sklearn/model_selection/_classification_threshold.py`: materialize the split once and reuse `splits[0]` for the `refit=False` training fit.
- `sklearn/model_selection/tests/test_classification_threshold.py`: add a non-regression test asserting `cv.split()` is called exactly once.

## Testing

`pytest sklearn/model_selection/tests/test_classification_threshold.py`
