### PR TITLE
DOC fix parameter name typos in docstrings (5 locations)

### DIFF
--- a/sklearn/cluster/_hdbscan/hdbscan.py
+++ b/sklearn/cluster/_hdbscan/hdbscan.py
@@ -93,7 +93,7 @@ def _brute_mst(mutual_reachability, min_samples):
 
     Parameters
     ----------
-    mututal_reachability_graph: {ndarray, sparse matrix} of shape \
+    mutual_reachability : {ndarray, sparse matrix} of shape \
             (n_samples, n_samples)
         Weighted adjacency matrix of the mutual reachability graph.
 

--- a/sklearn/mixture/_bayesian_mixture.py
+++ b/sklearn/mixture/_bayesian_mixture.py
@@ -49,7 +49,7 @@ def _log_wishart_norm(degrees_of_freedom, log_det_precisions_chol, n_features):
         The number of degrees of freedom on the covariance Wishart
         distributions.
 
-    log_det_precision_chol : array-like of shape (n_components,)
+    log_det_precisions_chol : array-like of shape (n_components,)
          The determinant of the precision matrix for each component.
 
     n_features : int

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -699,7 +699,7 @@ def _check_consistency_items(
 
     Parameters
     ----------
-    items_doc : dict of dict of str
+    items_docs : dict of dict of str
         Dictionary where the key is the string type or description, value is
         a dictionary where the key is "type description" or "description"
         and the value is a list of object names with the same string type or
@@ -1084,7 +1084,7 @@ def raises(expected_exc_type, match=None, may_pass=False, err_msg=None):
 
     Parameters
     ----------
-    excepted_exc_type : Exception or list of Exception
+    expected_exc_type : Exception or list of Exception
         The exception that should be raised by the block. If a list, the block
         should raise one of the exceptions.
     match : str or list of str, default=None

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -2454,7 +2454,7 @@ def _generate_get_feature_names_out(estimator, n_features_out, input_features=No
     estimator : estimator instance
         Estimator producing output feature names.
 
-    n_feature_out : int
+    n_features_out : int
         Number of feature names out.
 
     input_features : array-like of str or None, default=None


### PR DESCRIPTION
## What does this implement/fix?

Corrects 5 parameter name typos in docstrings where the documented name does not match the actual function signature.

| File | Wrong | Correct |
|------|-------|---------|
| `sklearn/mixture/_bayesian_mixture.py` | `log_det_precision_chol` | `log_det_precisions_chol` |
| `sklearn/utils/validation.py` | `n_feature_out` | `n_features_out` |
| `sklearn/utils/_testing.py` | `excepted_exc_type` | `expected_exc_type` |
| `sklearn/utils/_testing.py` | `items_doc` | `items_docs` |
| `sklearn/cluster/_hdbscan/hdbscan.py` | `mututal_reachability_graph` | `mutual_reachability` |

All changes are docstring-only — no logic affected.

## Did you add a news fragment?

These are docstring-only fixes so I've skipped the news fragment per maintainer discretion — happy to add one if preferred.