### PR TITLE
DOC fix incorrect default for n_iter_max in cluster.discretize

### DIFF
--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -70,7 +70,7 @@ def discretize(
     max_svd_restarts : int, default=30
         Maximum number of attempts to restart SVD if convergence fails
 
-    n_iter_max : int, default=30
+    n_iter_max : int, default=20
         Maximum number of iterations to attempt in rotation and partition
         matrix search if machine precision convergence is not reached
 


### PR DESCRIPTION
The `discretize` docstring documents `n_iter_max` as `default=30`, but the function signature sets `n_iter_max=20`. The 30 appears to have been copied from the adjacent `max_svd_restarts` parameter, which does default to 30. This is a docstring-only fix so the documented default matches the signature.