### PR TITLE
MAINT remove unnecessary `XFAIL` cases for `check_array_api_string_and_numeric_inputs`

### DIFF
--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -1015,9 +1015,6 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
     },
     HalvingGridSearchCV: {
         "check_array_api_mixed_inputs": "mixed array API input support not added yet",
-        "check_array_api_string_and_numeric_inputs": (
-            "mixed string and numeric array API input support not added yet"
-        ),
         "check_fit2d_1sample": (
             "Fail during parameter check since min/max resources requires more samples"
         ),
@@ -1029,9 +1026,6 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
     },
     HalvingRandomSearchCV: {
         "check_array_api_mixed_inputs": "mixed array API input support not added yet",
-        "check_array_api_string_and_numeric_inputs": (
-            "mixed string and numeric array API input support not added yet"
-        ),
         "check_fit2d_1sample": (
             "Fail during parameter check since min/max resources requires more samples"
         ),
@@ -1183,9 +1177,6 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
     },
     PCA: {
         "check_array_api_mixed_inputs": "mixed array API input support not added yet",
-        "check_array_api_string_and_numeric_inputs": (
-            "mixed string and numeric array API input support not added yet"
-        ),
         # TODO: see gh-33205 for details
         "check_array_api_input": "`linalg.inv` fails because input is singular",
         "check_array_api_same_namespace": "check_same_namespace not yet added",
@@ -1211,9 +1202,6 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
     },
     PoissonRegressor: {
         "check_array_api_mixed_inputs": "mixed array API input support not added yet",
-        "check_array_api_string_and_numeric_inputs": (
-            "mixed string and numeric array API input support not added yet"
-        ),
         "check_array_api_same_namespace": "check_same_namespace not yet added",
     },
     PolynomialFeatures: {

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -1014,7 +1014,6 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
         "check_requires_y_none": "Doesn't fail gracefully",
     },
     HalvingGridSearchCV: {
-        "check_array_api_mixed_inputs": "mixed array API input support not added yet",
         "check_fit2d_1sample": (
             "Fail during parameter check since min/max resources requires more samples"
         ),
@@ -1025,7 +1024,6 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
         "check_requires_y_none": "Doesn't fail gracefully",
     },
     HalvingRandomSearchCV: {
-        "check_array_api_mixed_inputs": "mixed array API input support not added yet",
         "check_fit2d_1sample": (
             "Fail during parameter check since min/max resources requires more samples"
         ),


### PR DESCRIPTION
Follow-up on #34142.

Some estimators were not classifiers.

Others should pass (`HalvingGridSearchCV` and `HalvingRandomSearchCV` when they are parametrized with a base classifier). However, those cases are not generated (while the `GridSearchCV` case is generated and does pass when typing:


```
export SCIPY_ARRAY_API=1
pytest -vlk "check_array_api_string_and_numeric_inputs and array_api_strict"
```

We need to investigate why but we could also merge this PR as is and investigate in a later PR.

cc @betatim @virchan @lucyleeow.