### PR TITLE
Doc: fix typos in scoring parameter description

### DIFF
--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -187,7 +187,7 @@ def permutation_importance(
         - a list or tuple of unique strings;
         - a callable returning a dictionary where the keys are the metric
           names and the values are the metric scores;
-        - a dictionary with metric names as keys and callables a values.
+        - a dictionary with metric names as keys and callables as values.
 
         Passing multiple scores to `scoring` is more efficient than calling
         `permutation_importance` for each of the scores as it reuses

--- a/sklearn/metrics/_scorer.py
+++ b/sklearn/metrics/_scorer.py
@@ -584,7 +584,7 @@ def _check_multimetric_scoring(estimator, scoring):
         - a list or tuple of unique strings;
         - a callable returning a dictionary where they keys are the metric
           names and the values are the metric scores;
-        - a dictionary with metric names as keys and callables a values.
+        - a dictionary with metric names as keys and callables as values.
 
         See :ref:`multimetric_grid_search` for an example.
 
@@ -968,7 +968,7 @@ def check_scoring(estimator=None, scoring=None, *, allow_none=False, raise_exc=T
         - a list, tuple or set of unique strings;
         - a callable returning a dictionary where the keys are the metric names and the
           values are the metric scorers;
-        - a dictionary with metric names as keys and callables a values. The callables
+        - a dictionary with metric names as keys and callables as values. The callables
           need to have the signature `callable(estimator, X, y)`.
 
     allow_none : bool, default=False

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -159,7 +159,7 @@ def cross_validate(
         - a list or tuple of unique strings;
         - a callable returning a dictionary where the keys are the metric
           names and the values are the metric scores;
-        - a dictionary with metric names as keys and callables a values.
+        - a dictionary with metric names as keys and callables as values.
 
         See :ref:`multimetric_grid_search` for an example.
 


### PR DESCRIPTION
Hi there. I'm Al, and this is my first time contributing to scikit-learn. I was using the cross_validate function for a project in my 'AI for Medicine' course, and I took a look at the documentation on the website and noticed a small typo, so I fixed it, which happened 4 time in other places too. That's all. Thank you for your attention.