### PR TITLE
FIX avoid polars deprecation warning in `PolarsAdapter.hstack`

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.utils/34447.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/34447.fix.rst
@@ -1,0 +1,5 @@
+- ``set_output(transform="polars")`` no longer emits a
+  ``DeprecationWarning`` with ``polars>=1.42.1`` by using
+  ``how="horizontal_extend"`` instead of the deprecated
+  ``how="horizontal"`` when concatenating polars dataframes.
+  By :user:`Felix Hoehle <fhoehle>`.

--- a/sklearn/utils/_set_output.py
+++ b/sklearn/utils/_set_output.py
@@ -10,6 +10,7 @@ from scipy.sparse import issparse
 
 from sklearn._config import get_config
 from sklearn.utils._available_if import available_if
+from sklearn.utils.fixes import parse_version
 
 
 def check_library_installed(library):
@@ -169,7 +170,14 @@ class PolarsAdapter:
 
     def hstack(self, Xs):
         pl = check_library_installed("polars")
-        return pl.concat(Xs, how="horizontal")
+
+        # "horizontal" is deprecated in favor of "horizontal_extend" ahead of
+        # polars 2.0, see https://github.com/pola-rs/polars/issues/27927
+        how = "horizontal"
+        if parse_version(pl.__version__) >= parse_version("1.42.1"):
+            how = "horizontal_extend"
+
+        return pl.concat(Xs, how=how)
 
 
 class ContainerAdaptersManager:


### PR DESCRIPTION
`polars >= 1.42.1` deprecates `pl.concat(..., how="horizontal")` in favor of `how="horizontal_extend"` ahead of removal in polars 2.0 (pola-rs/polars#27927). Use the new variant when available so `set_output(transform="polars")` doesn't emit a DeprecationWarning.

<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
None, since it is a minimal change and `polars=1.42.1` emitting the deprecation warnings was released June 30th.
Related to pola-rs/polars#27927 (upstream deprecation that this PR guards against).

#### What does this implement/fix? Explain your changes.
`PolarsAdapter.hstack` used by `set_output(transform="polars")` executes `pl.concat(..., how="horizontal")`. Polars is deprecating the implicit non-strict behavior of how="horizontal" starting in 1.42.1, and plans to remove it in `polars=2.0`. The new `how="horizontal_extend"` variant is the successor of the `polars<=1.42.0` variant `how="horizontal"`. Currently every polars-output pipeline will start emitting a DeprecationWarning once users upgrade `polars`. Since `polars<=1.42.0` does not provide `how="horizontal_extend"` switching of the key word argument value is necessary. 

#### First time contributor introduction
<!-- If you are new to the scikit-learn community, please introduce yourself. How do you
 use scikit-learn, what prompted you to make this contribution? Getting to know you
 helps us build trust in your judgement and welcome you into the community.
-->
I used `scikit-learn` for years as part of my day-to-day work and switched recently to using `polars`. Afterwards my tests  flooded me with above deprecation warnings originating from the`hstack` function of the `PolarsAdapter`.

#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Research and understanding


#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
