### PR TITLE
Don't parameterize tests using non-Collection iterables

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -740,7 +740,7 @@ def parametrize_with_checks(
 
     return pytest.mark.parametrize(
         "estimator, check",
-        _checks_generator(estimators, legacy, expected_failed_checks),
+        list(_checks_generator(estimators, legacy, expected_failed_checks)),
         ids=_get_check_estimator_ids,
     )
 


### PR DESCRIPTION
This is deprecated as of pytest 9.1; see
https://docs.pytest.org/en/stable/deprecations.html#non-collection-iterables-in-pytest-mark-parametrize.

This caused a [downstream test failure](https://bugs.debian.org/1141210).  Although Debian has a slightly out-of-date version of scikit-learn, the same problem seems to be present on `main`.

#### First time contributor introduction
I'm a Debian developer who spends a lot of time working on keeping Python ecosystem packages up to date, so as a result I send a lot of small PRs to various projects with compatibility fixes like this.