### PR TITLE
DOC clarify that KNNImputer needs informative multi-feature input

### DIFF
--- a/sklearn/impute/_knn.py
+++ b/sklearn/impute/_knn.py
@@ -28,6 +28,12 @@ class KNNImputer(_BaseImputer):
     `n_neighbors` nearest neighbors found in the training set. Two samples are
     close if the features that neither is missing are close.
 
+    Note that meaningful neighbor-based imputation relies on having other
+    informative features to compute distances between samples: if only a
+    single feature is provided, all samples are equidistant and the
+    imputed value reduces to the column mean (equivalent to
+    :class:`~sklearn.impute.SimpleImputer`).
+
     Read more in the :ref:`User Guide <knnimpute>`.
 
     .. versionadded:: 0.22


### PR DESCRIPTION
Adds a docstring note explaining that KNNImputer requires multiple informative features to produce meaningful neighbor-based imputations; a single-column input degenerates to the column mean. Addresses #17140.

#### What does this implement/fix? Explain your changes.
Adds a short paragraph to the `KNNImputer` class docstring clarifying that neighbor-based imputation needs multiple informative features to compute meaningful distances between samples. With a single feature, all samples are equidistant and the result reduces to `SimpleImputer`'s mean strategy. This was the root cause of the confusion reported in #17140, as explained by @jnothman in that thread.

#### First time contributor introduction
I'm new to contributing to scikit-learn. I have a data analysis background (SQL/Python) and I'm building up a track record of small, focused documentation contributions.

#### AI usage disclosure
- Documentation (including examples): I used Claude (Anthropic) to help draft the docstring wording for this PR.
#### Any other comments?
This PR is opened as a draft because I already have one open PR (#34450) and non-write contributors are limited to 1 open PR at a time on this repo. Happy to convert to ready-for-review once that one is merged/closed, or sooner if a maintainer prefers.