### PR TITLE
FIX preserve pandas dataframes in SequentialFeatureSelector

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.feature_selection/34457.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.feature_selection/34457.fix.rst
@@ -1,0 +1,6 @@
+- :class:`feature_selection.SequentialFeatureSelector` now passes pandas dataframes
+  to the underlying estimator with their original column names and dtypes instead of
+  converting them to NumPy arrays. This allows using estimators that rely on column
+  names or dtypes, e.g. a :class:`~sklearn.pipeline.Pipeline` containing a
+  :class:`~sklearn.compose.ColumnTransformer` with callable column selectors.
+  By :user:`Shahrier Islam Arham <arham766>`.

--- a/sklearn/feature_selection/_sequential.py
+++ b/sklearn/feature_selection/_sequential.py
@@ -7,6 +7,7 @@ Sequential feature selection
 
 from numbers import Integral, Real
 
+import narwhals.stable.v2 as nw
 import numpy as np
 
 from sklearn.base import (
@@ -19,6 +20,7 @@ from sklearn.base import (
 from sklearn.feature_selection._base import SelectorMixin
 from sklearn.metrics import check_scoring, get_scorer_names
 from sklearn.model_selection import check_cv, cross_val_score
+from sklearn.utils import _safe_indexing
 from sklearn.utils._metadata_requests import (
     MetadataRouter,
     MethodMapping,
@@ -212,6 +214,13 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
             Training vectors, where `n_samples` is the number of samples and
             `n_features` is the number of predictors.
 
+            .. versionchanged:: 1.10
+                Pandas dataframes are now passed to the underlying estimator with
+                their original column names and dtypes, so that estimators relying
+                on them (e.g. a pipeline containing a
+                :class:`~sklearn.compose.ColumnTransformer` with a callable column
+                selector) can be used for the selection.
+
         y : array-like of shape (n_samples,), default=None
             Target values. This parameter may be ignored for
             unsupervised learning.
@@ -235,14 +244,26 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
         """
         _raise_for_params(params, self, "fit")
         tags = self.__sklearn_tags__()
+        # Preserve X when it is a pandas dataframe so that the underlying estimator
+        # sees the selected columns with their original names and dtypes. This
+        # allows estimators relying on column names or dtypes (e.g. a pipeline
+        # containing a `ColumnTransformer` with a callable column selector) to be
+        # used for the selection.
+        preserve_X = nw.dependencies.is_pandas_dataframe(X)
         X = validate_data(
             self,
             X,
             accept_sparse="csc",
             ensure_min_features=2,
             ensure_all_finite=not tags.input_tags.allow_nan,
+            skip_check_array=preserve_X,
         )
         n_features = X.shape[1]
+        if preserve_X and n_features < 2:
+            raise ValueError(
+                f"Found array with {n_features} feature(s) (shape={X.shape}) while"
+                " a minimum of 2 is required by SequentialFeatureSelector."
+            )
 
         if self.n_features_to_select == "auto":
             if self.tol is not None:
@@ -316,7 +337,7 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
             candidate_mask[feature_idx] = True
             if self.direction == "backward":
                 candidate_mask = ~candidate_mask
-            X_new = X[:, candidate_mask]
+            X_new = _safe_indexing(X, candidate_mask, axis=1)
             scores[feature_idx] = cross_val_score(
                 estimator,
                 X_new,

--- a/sklearn/feature_selection/tests/test_sequential.py
+++ b/sklearn/feature_selection/tests/test_sequential.py
@@ -2,15 +2,17 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
+from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.cluster import KMeans
+from sklearn.compose import make_column_selector, make_column_transformer
 from sklearn.datasets import make_blobs, make_classification, make_regression
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.feature_selection import SequentialFeatureSelector
-from sklearn.linear_model import LinearRegression
+from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.model_selection import LeaveOneGroupOut, cross_val_score
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.pipeline import make_pipeline
-from sklearn.preprocessing import StandardScaler
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
 from sklearn.utils.fixes import CSR_CONTAINERS
 
 
@@ -330,3 +332,76 @@ def test_fit_rejects_params_with_no_routing_enabled():
 
     with pytest.raises(ValueError, match="is only supported if"):
         sfs.fit(X, y, sample_weight=np.ones_like(y))
+
+
+@pytest.mark.parametrize("direction", ["forward", "backward"])
+def test_dataframe_column_transformer_support(direction):
+    """Check that a pipeline containing a `ColumnTransformer` with callable column
+    selectors can be used as the estimator when fitting on a pandas dataframe.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/25711
+    """
+    pd = pytest.importorskip("pandas")
+    rng = np.random.RandomState(0)
+    n_samples = 50
+    X = pd.DataFrame(
+        {
+            "num_1": rng.randn(n_samples),
+            "num_2": rng.randn(n_samples),
+            "cat_1": rng.choice(["a", "b"], size=n_samples),
+            "cat_2": rng.choice(["c", "d"], size=n_samples),
+        }
+    )
+    y = rng.randint(0, 2, size=n_samples)
+
+    ct = make_column_transformer(
+        (StandardScaler(), make_column_selector(dtype_include=np.number)),
+        (OneHotEncoder(), make_column_selector(dtype_exclude=np.number)),
+    )
+    pipeline = make_pipeline(ct, LogisticRegression())
+    sfs = SequentialFeatureSelector(
+        pipeline, n_features_to_select=2, direction=direction
+    )
+    sfs.fit(X, y)
+
+    assert_array_equal(sfs.feature_names_in_, X.columns)
+    assert sfs.get_support().sum() == 2
+    assert sfs.transform(X).shape == (n_samples, 2)
+
+
+def test_dataframe_passed_through_to_estimator():
+    """Check that pandas dataframes are passed to the underlying estimator with
+    their original column names.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/25711
+    """
+    pd = pytest.importorskip("pandas")
+    rng = np.random.RandomState(0)
+    n_samples = 50
+    X = pd.DataFrame(
+        {
+            "num_1": rng.randn(n_samples),
+            "num_2": rng.randn(n_samples),
+            "cat_1": rng.choice(["a", "b"], size=n_samples),
+        }
+    )
+    y = rng.randint(0, 2, size=n_samples)
+    seen_columns = []
+
+    class ColumnRecordingClassifier(ClassifierMixin, BaseEstimator):
+        def fit(self, X, y):
+            assert isinstance(X, pd.DataFrame)
+            seen_columns.append(tuple(X.columns))
+            self.classes_ = np.unique(y)
+            return self
+
+        def predict(self, X):
+            return np.full(shape=len(X), fill_value=self.classes_[0])
+
+    sfs = SequentialFeatureSelector(ColumnRecordingClassifier(), n_features_to_select=1)
+    sfs.fit(X, y)
+
+    # Each candidate subset is a single column, evaluated with its original name.
+    assert set(seen_columns) == {("num_1",), ("num_2",), ("cat_1",)}


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #25711

#### What does this implement/fix? Explain your changes.

`SequentialFeatureSelector.fit` converted `X` to a numpy array before slicing candidate feature subsets, so the underlying estimator never saw column names or dtypes. This made it impossible to use estimators that rely on them — notably a `Pipeline` containing a `ColumnTransformer` with callable column selectors, the pattern suggested in https://github.com/scikit-learn/scikit-learn/issues/25711#issuecomment-1534646795.

This PR preserves pandas dataframes in `fit` via `validate_data(..., skip_check_array=True)` and slices candidate subsets with `_safe_indexing(X, candidate_mask, axis=1)`, mirroring what `SelectorMixin.transform` already does to preserve dataframes. With this change the following works:

```python
ct = make_column_transformer(
    (StandardScaler(), make_column_selector(dtype_include=np.number)),
    (OneHotEncoder(), make_column_selector(dtype_exclude=np.number)),
)
selector_pipe = make_pipeline(ct, LogisticRegression())
SequentialFeatureSelector(selector_pipe, n_features_to_select=2).fit(X, y)
```

`ColumnTransformer`s configured with hard-coded positional indices still fail, as discussed in the issue — once features are subset, positional specs against the original `X` are inherently ambiguous; callable selectors (or refitting semantics) are the supported route.

An explicit check keeps the previous `ensure_min_features=2` error message for dataframes. Numpy, sparse, and other inputs go through the exact same validation as before.

#### Any other comments?

Behaviour change for pandas input: the inner estimator is now fitted on dataframe slices (original dtypes, no forced float conversion, no upfront NaN check — the estimator's own validation applies, consistent with the general meta-estimator delegation direction). Happy to adjust if full validation should be retained for the non-`ColumnTransformer` case.
