### PR TITLE
DOC clarify n_iter_ can be 0 when warm_start=True in LogisticRegression

### DIFF
--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1159,9 +1159,13 @@ class LogisticRegression(
         number for verbosity.
 
     warm_start : bool, default=False
-        When set to True, reuse the solution of the previous call to fit as
-        initialization, otherwise, just erase the previous solution.
-        Useless for liblinear solver. See :term:`the Glossary <warm_start>`.
+    When set to ``True``, reuse the solution of the previous call to
+    fit as initialization, otherwise, just erase the previous solution.
+    Useless for liblinear solver. See :term:`the Glossary <warm_start>`.
+
+    .. note::
+        When ``warm_start=True``, ``n_iter_`` may be 0 on subsequent
+        fits if the model has already converged from a previous fit.
 
         .. versionadded:: 0.17
            *warm_start* to support *lbfgs*, *newton-cg*, *sag*, *saga* solvers.
@@ -1207,11 +1211,6 @@ class LogisticRegression(
 
     n_iter_ : ndarray of shape (1, )
     Actual number of iterations for all classes.
-
-    .. note::
-        When ``warm_start=True``, this reports the number of iterations
-        in the last call to fit. It may be 0 if the model has already
-        converged from a previous fit.
 
         .. versionchanged:: 0.20
 

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1208,9 +1208,10 @@ class LogisticRegression(
     n_iter_ : ndarray of shape (1, )
     Actual number of iterations for all classes.
 
-    When ``warm_start=True``, this reports the number of iterations in
-    the last call to fit. It may be 0 if the model has already converged
-    from a previous fit.
+    .. note::
+        When ``warm_start=True``, this reports the number of iterations
+        in the last call to fit. It may be 0 if the model has already
+        converged from a previous fit.
 
         .. versionchanged:: 0.20
 

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1162,10 +1162,9 @@ class LogisticRegression(
     When set to ``True``, reuse the solution of the previous call to
     fit as initialization, otherwise, just erase the previous solution.
     Useless for liblinear solver. See :term:`the Glossary <warm_start>`.
+    Note that ``n_iter_`` may be 0 on subsequent fits when
+    ``warm_start=True`` if the model has already converged.
 
-    .. note::
-        When ``warm_start=True``, ``n_iter_`` may be 0 on subsequent
-        fits if the model has already converged from a previous fit.
 
         .. versionadded:: 0.17
            *warm_start* to support *lbfgs*, *newton-cg*, *sag*, *saga* solvers.

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1206,9 +1206,11 @@ class LogisticRegression(
         .. versionadded:: 1.0
 
     n_iter_ : ndarray of shape (1, )
-    Actual number of iterations for all classes. When ``warm_start=True``,
-    this reports the number of iterations in the last call to fit. It may
-    be 0 if the model has already converged from a previous fit.
+    Actual number of iterations for all classes.
+
+    When ``warm_start=True``, this reports the number of iterations in
+    the last call to fit. It may be 0 if the model has already converged
+    from a previous fit.
 
         .. versionchanged:: 0.20
 

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1206,7 +1206,9 @@ class LogisticRegression(
         .. versionadded:: 1.0
 
     n_iter_ : ndarray of shape (1, )
-        Actual number of iterations for all classes.
+    Actual number of iterations for all classes. When ``warm_start=True``,
+    this reports the number of iterations in the last call to fit. It may
+    be 0 if the model has already converged from a previous fit.
 
         .. versionchanged:: 0.20
 


### PR DESCRIPTION
Closes #34459

## What does this fix?

Adds a note to the `n_iter_` attribute docstring in `LogisticRegression`
clarifying that it can be 0 when `warm_start=True` and the model has
already converged from a previous fit. This is technically correct
behavior from scipy's lbfgs solver but was undocumented and surprising
to users.