### PR TITLE
FIX off-by-one in OrdinalEncoder infrequent-category collision check

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.preprocessing/34461.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.preprocessing/34461.fix.rst
@@ -1,0 +1,5 @@
+- :class:`preprocessing.OrdinalEncoder` now correctly rejects an `unknown_value`
+  or `encoded_missing_value` that collides with the shared code of grouped
+  infrequent categories. Previously an off-by-one in the used-code count let such
+  a value silently alias with the infrequent categories.
+  By :user:`Madankumar <winklemad>`.

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -1525,10 +1525,11 @@ class OrdinalEncoder(OneToOneFeatureMixin, _BaseEncoder):
         cardinalities = [len(categories) for categories in self.categories_]
         if self._infrequent_enabled:
             # Cardinality decreases because the infrequent categories are grouped
-            # together
+            # together into a single code, so `len(infrequent)` categories are
+            # replaced by one, reducing the count by `len(infrequent) - 1`.
             for feature_idx, infrequent in enumerate(self.infrequent_categories_):
                 if infrequent is not None:
-                    cardinalities[feature_idx] -= len(infrequent)
+                    cardinalities[feature_idx] -= len(infrequent) - 1
 
         # missing values are not considered part of the cardinality
         # when considering unknown categories or encoded_missing_value

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -2296,42 +2296,61 @@ def test_ordinal_encoder_infrequent_custom_mapping():
     assert_allclose(X_trans, expected_trans)
 
 
-def test_ordinal_encoder_infrequent_group_code_collision():
+@pytest.mark.parametrize(
+    ("data", "kwargs", "group_code", "infrequent"),
+    [
+        # A group of several infrequent categories collapses to one shared code:
+        # "b" (count 20) is the only frequent category -> code 0; {a, c, d} share
+        # code 1.
+        (
+            ["a"] * 5 + ["b"] * 20 + ["c"] * 10 + ["d"] * 3,
+            {"max_categories": 2},
+            1,
+            ["a", "c", "d"],
+        ),
+        # A single infrequent category (len(infrequent) == 1): {b, c} are frequent
+        # -> codes 0, 1 and "a" alone is grouped -> code 2. This is the boundary
+        # where the old ``- len(infrequent)`` (remove 1) diverges most from the
+        # correct ``- (len - 1)`` (remove 0).
+        (["a"] * 1 + ["b"] * 20 + ["c"] * 10, {"min_frequency": 5}, 2, ["a"]),
+    ],
+)
+def test_ordinal_encoder_infrequent_group_code_collision(
+    data, kwargs, group_code, infrequent
+):
     """Check that `unknown_value` / `encoded_missing_value` are rejected when they
     collide with the shared code of the grouped infrequent categories.
 
-    Non-regression test: the infrequent categories are grouped into a single code,
-    so the number of codes used by the known categories decreases by
-    ``len(infrequent) - 1``, not ``len(infrequent)``. The off-by-one made the
-    cardinality one too small, so a value equal to the infrequent-group code
-    passed the collision checks and silently aliased with it.
+    Non-regression test: grouping collapses the ``len(infrequent)`` infrequent
+    categories into a single shared code, so the number of codes used by the known
+    categories drops by ``len(infrequent) - 1``, not ``len(infrequent)``. The
+    off-by-one made the cardinality one too small, so a value equal to the
+    infrequent-group code passed the collision checks and silently aliased with it.
+    Covers both a multi-category group and the single-category boundary.
     """
-    # "b" (count 20) is the only frequent category -> code 0; {a, c, d} are grouped
-    # as infrequent and share code 1.
-    X = np.array([["a"] * 5 + ["b"] * 20 + ["c"] * 10 + ["d"] * 3], dtype=object).T
+    X = np.array([data], dtype=object).T
 
-    # unknown_value == infrequent group code (1) collides and must raise.
+    # unknown_value == infrequent-group code collides and must raise.
     with pytest.raises(
-        ValueError, match="unknown_value 1 is one of the values already used"
+        ValueError,
+        match=f"unknown_value {group_code} is one of the values already used",
     ):
         OrdinalEncoder(
-            handle_unknown="use_encoded_value", unknown_value=1, max_categories=2
+            handle_unknown="use_encoded_value", unknown_value=group_code, **kwargs
         ).fit(X)
 
-    # The first safe code above the group is still accepted.
+    # The first code above the group is still accepted.
     encoder = OrdinalEncoder(
-        handle_unknown="use_encoded_value", unknown_value=2, max_categories=2
+        handle_unknown="use_encoded_value", unknown_value=group_code + 1, **kwargs
     ).fit(X)
-    assert_array_equal(encoder.infrequent_categories_, [["a", "c", "d"]])
+    assert_array_equal(encoder.infrequent_categories_, [infrequent])
 
-    # encoded_missing_value == infrequent group code (1) collides and must raise.
-    X_missing = np.array(
-        [["a"] * 5 + ["b"] * 20 + ["c"] * 10 + ["d"] * 3 + [np.nan]], dtype=object
-    ).T
+    # encoded_missing_value == infrequent-group code collides and must raise.
+    X_missing = np.array([data + [np.nan]], dtype=object).T
     with pytest.raises(
-        ValueError, match=r"encoded_missing_value \(1\) is already used"
+        ValueError, match=rf"encoded_missing_value \({group_code}\) is already used"
     ):
-        OrdinalEncoder(max_categories=2, encoded_missing_value=1).fit(X_missing)
+        OrdinalEncoder(encoded_missing_value=group_code, **kwargs).fit(X_missing)
 
 
 @pytest.mark.parametrize(

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -2296,6 +2296,44 @@ def test_ordinal_encoder_infrequent_custom_mapping():
     assert_allclose(X_trans, expected_trans)
 
 
+def test_ordinal_encoder_infrequent_group_code_collision():
+    """Check that `unknown_value` / `encoded_missing_value` are rejected when they
+    collide with the shared code of the grouped infrequent categories.
+
+    Non-regression test: the infrequent categories are grouped into a single code,
+    so the number of codes used by the known categories decreases by
+    ``len(infrequent) - 1``, not ``len(infrequent)``. The off-by-one made the
+    cardinality one too small, so a value equal to the infrequent-group code
+    passed the collision checks and silently aliased with it.
+    """
+    # "b" (count 20) is the only frequent category -> code 0; {a, c, d} are grouped
+    # as infrequent and share code 1.
+    X = np.array([["a"] * 5 + ["b"] * 20 + ["c"] * 10 + ["d"] * 3], dtype=object).T
+
+    # unknown_value == infrequent group code (1) collides and must raise.
+    with pytest.raises(
+        ValueError, match="unknown_value 1 is one of the values already used"
+    ):
+        OrdinalEncoder(
+            handle_unknown="use_encoded_value", unknown_value=1, max_categories=2
+        ).fit(X)
+
+    # The first safe code above the group is still accepted.
+    encoder = OrdinalEncoder(
+        handle_unknown="use_encoded_value", unknown_value=2, max_categories=2
+    ).fit(X)
+    assert_array_equal(encoder.infrequent_categories_, [["a", "c", "d"]])
+
+    # encoded_missing_value == infrequent group code (1) collides and must raise.
+    X_missing = np.array(
+        [["a"] * 5 + ["b"] * 20 + ["c"] * 10 + ["d"] * 3 + [np.nan]], dtype=object
+    ).T
+    with pytest.raises(
+        ValueError, match=r"encoded_missing_value \(1\) is already used"
+    ):
+        OrdinalEncoder(max_categories=2, encoded_missing_value=1).fit(X_missing)
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [


### PR DESCRIPTION
#### Reference Issues/PRs

No linked issue — found by reading the code. The affected logic was introduced in #25677 (infrequent-category support for `OrdinalEncoder`).

#### What does this implement/fix? Explain your changes.

When infrequent-category grouping is enabled, `OrdinalEncoder` maps all infrequent categories of a feature to a **single** shared code. In `fit`, the guard that checks `unknown_value` / `encoded_missing_value` don't collide with a code used by a known category computes the number of used codes by subtracting `len(infrequent)` from the category count:

```python
cardinalities = [len(categories) for categories in self.categories_]
if self._infrequent_enabled:
    for feature_idx, infrequent in enumerate(self.infrequent_categories_):
        if infrequent is not None:
            cardinalities[feature_idx] -= len(infrequent)   # off by one
```

But grouping replaces the `N` infrequent categories with **one** code, so it only removes `N - 1` codes, not `N`. The cardinality ends up one too small, and a value equal to the infrequent-group code (`n_frequent`) passes the collision checks that should reject it.

**Reproducer** (`b` is the only frequent category → code `0`; `{a, c, d}` are grouped as infrequent → code `1`):

```python
import numpy as np
from sklearn.preprocessing import OrdinalEncoder

X = np.array([["a"]*5 + ["b"]*20 + ["c"]*10 + ["d"]*3], dtype=object).T

enc = OrdinalEncoder(handle_unknown="use_encoded_value", unknown_value=1, max_categories=2).fit(X)
# fit succeeds, but unknown_value=1 collides with the infrequent-group code:
enc.transform(np.array([["b"], ["a"], ["zzz"]], dtype=object)).ravel()
# array([0., 1., 1.])  -> 'a' (infrequent) and 'zzz' (unknown) both map to 1
enc.inverse_transform([[1]]).ravel()
# array(['infrequent_sklearn'], dtype=object)  -> an unknown code decodes as infrequent
```

`fit` should raise (`unknown_value 1 is one of the values already used for encoding the seen categories`), matching the behavior for non-infrequent categories. The same off-by-one affects the symmetric `encoded_missing_value` check.

The fix subtracts `len(infrequent) - 1` so the cardinality reflects the code actually occupied by the grouped infrequent categories.

#### Any other comments?

Added `test_ordinal_encoder_infrequent_group_code_collision` covering both the `unknown_value` and `encoded_missing_value` collision paths. It fails before the change (`fit` does not raise) and passes after; the existing `sklearn/preprocessing/tests/test_encoders.py` suite passes with no regressions (230 passed, 32 skipped). Verified against a working install since the affected code is identical on the current release.