### PR TITLE
FIX OrdinalEncoder crash on numeric transform data with object dtype categories

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.preprocessing/34464.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.preprocessing/34464.fix.rst
@@ -1,0 +1,4 @@
+- :class:`preprocessing.OrdinalEncoder` and :class:`preprocessing.OneHotEncoder` no
+  longer raise ``TypeError`` when transforming numeric data after being fitted on
+  object dtype data containing missing values.
+  By :user:`Dechante Chang <chang-pro>`.

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -233,10 +233,10 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
                         and self.categories_[i].itemsize > Xi.itemsize
                     ):
                         Xi = Xi.astype(self.categories_[i].dtype)
-                    elif self.categories_[i].dtype.kind == "O" and Xi.dtype.kind == "U":
-                        # categories are objects and Xi are numpy strings.
-                        # Cast Xi to an object dtype to prevent truncation
-                        # when setting invalid values.
+                    elif self.categories_[i].dtype.kind == "O" and Xi.dtype.kind != "O":
+                        # categories are objects and Xi is a numpy string or
+                        # numeric array. Cast Xi to an object dtype to prevent
+                        # truncation or rounding when setting invalid values.
                         Xi = Xi.astype("O")
                     else:
                         Xi = Xi.copy()

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -1819,6 +1819,31 @@ def test_ordinal_encoder_handle_missing_and_unknown(X, expected_X_trans, X_test)
     assert_allclose(oe.transform(X_test), [[-1.0]])
 
 
+def test_ordinal_encoder_missing_value_object_categories_numeric_transform():
+    """Check that transforming numeric data works when the encoder was fitted
+    on object dtype data containing missing values.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/34387
+    """
+    # np.nan is a known category from fit
+    oe = OrdinalEncoder(encoded_missing_value=np.nan)
+    oe.fit(np.array([[0], [1], [np.nan]], dtype=object))
+    X_trans = oe.transform([[np.nan]])
+    assert np.isnan(X_trans[0, 0])
+    assert_allclose(oe.transform([[1], [0]]), [[1.0], [0.0]])
+
+    # np.nan is unknown at transform time and encoded with `unknown_value`
+    oe = OrdinalEncoder(
+        encoded_missing_value=np.nan,
+        handle_unknown="use_encoded_value",
+        unknown_value=np.nan,
+    )
+    oe.fit(np.array([[0], [1]], dtype=object))
+    X_trans = oe.transform(np.array([[np.nan]]))
+    assert np.isnan(X_trans[0, 0])
+
+
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 def test_ordinal_encoder_sparse(csr_container):
     """Check that we raise proper error with sparse input in OrdinalEncoder.

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -1844,6 +1844,29 @@ def test_ordinal_encoder_missing_value_object_categories_numeric_transform():
     assert np.isnan(X_trans[0, 0])
 
 
+@pytest.mark.parametrize(
+    "encoder",
+    [
+        OrdinalEncoder(handle_unknown="use_encoded_value", unknown_value=-1),
+        OneHotEncoder(handle_unknown="ignore"),
+    ],
+)
+def test_encoders_object_categories_unknown_numeric_transform(encoder):
+    """Check unknown numeric values are handled when the encoder was fitted on
+    object dtype data whose categories cannot round-trip through float64.
+
+    Non-regression test for:
+    https://github.com/scikit-learn/scikit-learn/issues/34387
+    """
+    big0, big1 = 2**60 + 1, 2**60 + 3
+    X = np.array([[big0], [big1], [np.nan]], dtype=object)
+    X_trans = encoder.fit(X).transform(np.array([[42.0]]))
+    if isinstance(encoder, OrdinalEncoder):
+        assert_allclose(X_trans, [[-1.0]])
+    else:
+        assert X_trans.sum() == 0
+
+
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 def test_ordinal_encoder_sparse(csr_container):
     """Check that we raise proper error with sparse input in OrdinalEncoder.

--- a/sklearn/utils/_encode.py
+++ b/sklearn/utils/_encode.py
@@ -206,8 +206,8 @@ def _unique_python(values, *, return_inverse, return_counts):
 def _encode(values, *, uniques, check_unknown=True):
     """Helper function to encode values into [0, n_uniques - 1].
 
-    Uses pure python method when `values` or `uniques` has an object
-    dtype, and numpy method for all other dtypes.
+    Uses pure python method when `values` or `uniques` has a non-numeric
+    dtype, and numpy method when both have a numeric dtype.
     The numpy method has the limitation that the `uniques` need to
     be sorted. Importantly, this is not checked but assumed to already be
     the case. The calling method needs to ensure this for all non-object

--- a/sklearn/utils/_encode.py
+++ b/sklearn/utils/_encode.py
@@ -206,8 +206,8 @@ def _unique_python(values, *, return_inverse, return_counts):
 def _encode(values, *, uniques, check_unknown=True):
     """Helper function to encode values into [0, n_uniques - 1].
 
-    Uses pure python method for object dtype, and numpy method for
-    all other dtypes.
+    Uses pure python method when `values` or `uniques` has an object
+    dtype, and numpy method for all other dtypes.
     The numpy method has the limitation that the `uniques` need to
     be sorted. Importantly, this is not checked but assumed to already be
     the case. The calling method needs to ensure this for all non-object
@@ -233,7 +233,9 @@ def _encode(values, *, uniques, check_unknown=True):
         Encoded values
     """
     xp, _ = get_namespace(values, uniques)
-    if not xp.isdtype(values.dtype, "numeric"):
+    if not xp.isdtype(values.dtype, "numeric") or not xp.isdtype(
+        uniques.dtype, "numeric"
+    ):
         try:
             return _map_to_integer(values, uniques)
         except KeyError as e:
@@ -250,8 +252,8 @@ def _check_unknown(values, known_values, return_mask=False):
     """
     Helper function to check for unknowns in values to be encoded.
 
-    Uses pure python method for object dtype, and numpy method for
-    all other dtypes.
+    Uses pure python method when `values` or `known_values` has an object
+    dtype, and numpy method for all other dtypes.
 
     Parameters
     ----------
@@ -274,7 +276,9 @@ def _check_unknown(values, known_values, return_mask=False):
     xp, _ = get_namespace(values, known_values)
     valid_mask = None
 
-    if not xp.isdtype(values.dtype, "numeric"):
+    if not xp.isdtype(values.dtype, "numeric") or not xp.isdtype(
+        known_values.dtype, "numeric"
+    ):
         values_set = set(values)
         values_set, missing_in_values = _extract_missing(values_set)
 

--- a/sklearn/utils/tests/test_encode.py
+++ b/sklearn/utils/tests/test_encode.py
@@ -233,6 +233,20 @@ def test_check_unknown_with_both_missing_values():
     assert_array_equal(valid_mask, [False, True, True, True, False, False, False])
 
 
+def test_check_unknown_and_encode_object_uniques_numeric_values():
+    # numeric values against object dtype known values take the python path
+    # non-regression test for
+    # https://github.com/scikit-learn/scikit-learn/issues/34387
+    values = np.array([np.nan, 1.0])
+    known_values = np.array([0, 1, np.nan], dtype=object)
+
+    diff, valid_mask = _check_unknown(values, known_values, return_mask=True)
+    assert diff == []
+    assert_array_equal(valid_mask, [True, True])
+
+    assert_array_equal(_encode(values, uniques=known_values), [2, 1])
+
+
 NAN1 = float("nan")
 NAN2 = float("nan")
 


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes the crashing cases of #34387 (the `TypeError: ufunc 'isnan' not supported` ones). The broader missing-value semantics discussion in that issue is left untouched.

#### What does this implement/fix? Explain your changes.

`_check_unknown` and `_encode` in `sklearn/utils/_encode.py` choose between the numpy path and the pure python path based only on the dtype of the values being encoded. When an encoder is fitted on object dtype data (so `categories_` is an object array) and `transform` receives numeric data, the numeric path runs `xp.isnan(known_values)` on the object array and raises `TypeError`. That happens for something as simple as:

```python
enc = OrdinalEncoder(encoded_missing_value=np.nan)
enc.fit(np.array([[0], [1], [np.nan]], dtype=object)).transform([[np.nan]])  # raised TypeError
```

Both helpers now take the python path when either array is non-numeric. The python path already handles nan matching through `is_scalar_nan`/`_nandict`, so known missing values encode correctly and unknown values still raise the proper `ValueError` / follow `handle_unknown`.

Regression tests added at the encoder level (`test_encoders.py`) and the helper level (`test_encode.py`); both fail without the fix. The preprocessing encoder/label and utils encode suites pass.

I understand this issue is still labeled Needs Triage; happy to adjust scope based on the triage outcome.

#### Any other comments?

Note: I used AI assistance for this contribution and have reviewed and understood all of the changes.