### PR TITLE
FIX avoid spurious DataConversionWarning in pairwise_distances_argmin

### DIFF
--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -657,6 +657,44 @@ def _argmin_reduce(dist, start):
     return xp.argmin(dist, axis=1)
 
 
+def _ensure_boolean_dtype_for_metric(X, Y, metric, *, ensure_all_finite=True):
+    """Ensure X and Y have the correct dtype for the given metric.
+
+    For boolean distance metrics (e.g., Jaccard, Dice), this function checks if
+    X and Y need to be converted to bool dtype and emits a DataConversionWarning
+    if conversion is necessary. For non-boolean metrics, it delegates to
+    :func:`check_pairwise_arrays` with the default float dtype.
+
+    Parameters
+    ----------
+    X : array-like of shape (n_samples_X, n_features)
+        Input array.
+
+    Y : array-like of shape (n_samples_Y, n_features)
+        Input array.
+
+    metric : str
+        The metric to be used.
+
+    ensure_all_finite : bool or 'allow-nan', default=True
+        Whether to raise an error on np.inf, np.nan, pd.NA in array.
+
+    Returns
+    -------
+    X : ndarray of shape (n_samples_X, n_features)
+        Converted array.
+
+    Y : ndarray of shape (n_samples_Y, n_features)
+        Converted array.
+    """
+    if metric in PAIRWISE_BOOLEAN_FUNCTIONS:
+        if getattr(X, "dtype", None) != bool or getattr(Y, "dtype", None) != bool:
+            msg = "Data was converted to boolean for metric %s" % metric
+            warnings.warn(msg, DataConversionWarning)
+        return check_pairwise_arrays(X, Y, dtype=bool, ensure_all_finite=ensure_all_finite)
+    return check_pairwise_arrays(X, Y, ensure_all_finite=ensure_all_finite)
+
+
 _VALID_METRICS = [
     "euclidean",
     "l2",
@@ -799,7 +837,7 @@ def pairwise_distances_argmin_min(
     array([1., 1.])
     """
     ensure_all_finite = "allow-nan" if metric == "nan_euclidean" else True
-    X, Y = check_pairwise_arrays(X, Y, ensure_all_finite=ensure_all_finite)
+    X, Y = _ensure_boolean_dtype_for_metric(X, Y, metric, ensure_all_finite=ensure_all_finite)
 
     if axis == 0:
         X, Y = Y, X
@@ -940,7 +978,7 @@ def pairwise_distances_argmin(X, Y, *, axis=1, metric="euclidean", metric_kwargs
     array([0, 1])
     """
     ensure_all_finite = "allow-nan" if metric == "nan_euclidean" else True
-    X, Y = check_pairwise_arrays(X, Y, ensure_all_finite=ensure_all_finite)
+    X, Y = _ensure_boolean_dtype_for_metric(X, Y, metric, ensure_all_finite=ensure_all_finite)
     xp, _ = get_namespace(X, Y)
 
     if axis == 0:

--- a/sklearn/metrics/tests/test_pairwise.py
+++ b/sklearn/metrics/tests/test_pairwise.py
@@ -312,6 +312,34 @@ def test_pairwise_boolean_distance(metric):
         pairwise_distances(X.astype(bool), metric=metric)
 
 
+@pytest.mark.parametrize(
+    "func",
+    [pairwise_distances_argmin, pairwise_distances_argmin_min],
+)
+@pytest.mark.parametrize("metric", PAIRWISE_BOOLEAN_FUNCTIONS)
+def test_pairwise_distances_argmin_boolean_no_warning(func, metric):
+    """Non-regression test for #32495.
+
+    pairwise_distances_argmin and pairwise_distances_argmin_min should not
+    emit a DataConversionWarning when the input data is already boolean and
+    the metric is a boolean distance metric. Each metric is tested in
+    isolation to make failures easier to diagnose.
+    """
+    X = np.array([[True, False], [False, True]], dtype=bool)
+    Y = np.array([[True, True], [False, False]], dtype=bool)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DataConversionWarning)
+        func(X, Y, metric=metric)
+
+    # When data is NOT boolean, the warning should still be raised
+    Xf = np.array([[1.0, 0.0], [0.0, 1.0]])
+    Yf = np.array([[1.0, 1.0], [0.0, 0.0]])
+    msg = "Data was converted to boolean for metric %s" % metric
+    with pytest.warns(DataConversionWarning, match=msg):
+        func(Xf, Yf, metric=metric)
+
+
 def test_no_data_conversion_warning():
     # No warnings issued if metric is not a boolean distance function
     rng = np.random.RandomState(0)


### PR DESCRIPTION
pairwise_distances_argmin and pairwise_distances_argmin_min now determine
the correct dtype (bool for boolean metrics) before calling
check_pairwise_arrays, matching the behavior of pairwise_distances.

Fixes #32495
