### PR TITLE
fix(adaBoost): replace dead error-handling with check_is_fitted

### DIFF
--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -290,10 +290,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         feature_importances_ : ndarray of shape (n_features,)
             The feature importances.
         """
-        if self.estimators_ is None or len(self.estimators_) == 0:
-            raise ValueError(
-                "Estimator not fitted, call `fit` before `feature_importances_`."
-            )
+        check_is_fitted(self)
 
         try:
             norm = self.estimator_weights_.sum()


### PR DESCRIPTION
## Description

Replaces unreachable error-handling code in  with .

## Problem

The  property had a guard:


This condition is never reachable:
- Before , accessing  raises  (the attribute doesn't exist)
- After ,  is never empty

## Fix

Replace with , which:
1. Gives a clear, standard error message ()
2. Follows the pattern used by other ensemble classes (e.g.,  at )
3.  is already imported in this module (line 48)

## Testing

The existing test suite covers  behavior. The change only affects the error path, which was previously unreachable.

Closes #34472