### PR TITLE
FIX LinearDiscriminantAnalysis support for mixed namespace/device array API inputs

### DIFF
--- a/doc/whats_new/upcoming_changes/array-api/34475.fix.rst
+++ b/doc/whats_new/upcoming_changes/array-api/34475.fix.rst
@@ -1,0 +1,5 @@
+- :class:`discriminant_analysis.LinearDiscriminantAnalysis` now supports array
+  API inputs where `y` are from a different namespace or
+  device than `X`, moving them to the namespace and device of `X` while keeping
+  `classes_` in the namespace and device of `y`.
+  By :user:`Kiyarash Fazeli <Fazel94>`.

--- a/doc/whats_new/upcoming_changes/array-api/34475.fix.rst
+++ b/doc/whats_new/upcoming_changes/array-api/34475.fix.rst
@@ -1,5 +1,3 @@
 - :class:`discriminant_analysis.LinearDiscriminantAnalysis` now supports array
-  API inputs where `y` are from a different namespace or
-  device than `X`, moving them to the namespace and device of `X` while keeping
-  `classes_` in the namespace and device of `y`.
+  API inputs where `y` is from a different namespace or device than `X`.
   By :user:`Kiyarash Fazeli <Fazel94>`.

--- a/doc/whats_new/upcoming_changes/array-api/34475.fix.rst
+++ b/doc/whats_new/upcoming_changes/array-api/34475.fix.rst
@@ -1,3 +1,4 @@
 - :class:`discriminant_analysis.LinearDiscriminantAnalysis` now supports array
-  API inputs where `y` is from a different namespace or device than `X`.
+  API inputs where `y` is from a different namespace or device than `X`,
+  including string labels.
   By :user:`Kiyarash Fazeli <Fazel94>`.

--- a/doc/whats_new/upcoming_changes/sklearn.discriminant_analysis/34475.efficiency.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.discriminant_analysis/34475.efficiency.rst
@@ -1,0 +1,6 @@
+- :class:`discriminant_analysis.LinearDiscriminantAnalysis` is faster to fit: the
+  target is ordinal-encoded once in `fit` and the number of classes is passed down
+  to the internal helpers, removing a redundant pass over the target to recompute
+  the unique class labels. Computing the class means is up to 1.4x faster for
+  large numbers of samples and classes.
+  By :user:`Kiyarash Fazeli <Fazel94>`.

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -674,9 +674,6 @@ class LinearDiscriminantAnalysis(
             self, X, y, ensure_min_samples=2, dtype=[xp.float64, xp.float32]
         )
         self.classes_ = unique_labels(y)
-        # `y` follows `X`: move it to `X`'s namespace/device so downstream math
-        # stays single-device. Must stay after `classes_` above, which is
-        # intentionally kept in `y`'s original namespace/device.
         y = move_to(y, xp=xp, device=device(X))
         n_samples, n_features = X.shape
         n_classes = self.classes_.shape[0]

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -28,6 +28,7 @@ from sklearn.utils._array_api import (
     move_to,
     size,
 )
+from sklearn.utils._encode import _encode
 from sklearn.utils._param_validation import HasMethods, Interval, StrOptions
 from sklearn.utils.extmath import softmax
 from sklearn.utils.multiclass import check_classification_targets, unique_labels
@@ -593,12 +594,10 @@ class LinearDiscriminantAnalysis(
             self.covariance_ = _class_cov(X, y, self.priors_)
 
         Xc = []
-        # `self.classes_` stays in `y`'s namespace/device. Use a copy of classes
-        # using the device of `X` so the mask `y == group` below does not mix
-        # devices.
-        classes = move_to(self.classes_, xp=xp, device=device(X))
-        for idx, group in enumerate(classes):
-            Xg = X[y == group]
+        # `y` holds integer class codes (see `fit`), so groups are indexed by
+        # position in `self.classes_`.
+        for idx in range(n_classes):
+            Xg = X[y == idx]
             Xc.append(Xg - self.means_[idx, :])
 
         self.xbar_ = self.priors_ @ self.means_
@@ -674,7 +673,13 @@ class LinearDiscriminantAnalysis(
             self, X, y, ensure_min_samples=2, dtype=[xp.float64, xp.float32]
         )
         self.classes_ = unique_labels(y)
-        y = move_to(y, xp=xp, device=device(X))
+        # `y` may hold strings, which no array API namespace can represent: move
+        # integer codes instead. `classes_` stays in `y`'s namespace and device.
+        y = move_to(
+            _encode(y, uniques=self.classes_, check_unknown=False),
+            xp=xp,
+            device=array_device(X),
+        )
         n_samples, n_features = X.shape
         n_classes = self.classes_.shape[0]
 

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -593,8 +593,9 @@ class LinearDiscriminantAnalysis(
             self.covariance_ = _class_cov(X, y, self.priors_)
 
         Xc = []
-        # `self.classes_` stays in `y`'s namespace/device; use an `X`-device copy
-        # so the mask `y == group` below does not mix devices.
+        # `self.classes_` stays in `y`'s namespace/device. Use a copy of classes
+        # using the device of `X` so the mask `y == group` below does not mix
+        # devices.
         classes = move_to(self.classes_, xp=xp, device=device(X))
         for idx, group in enumerate(classes):
             Xg = X[y == group]

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -97,7 +97,7 @@ def _cov(X, shrinkage=None, covariance_estimator=None):
     return s
 
 
-def _class_means(X, y):
+def _class_means(X, y_encoded, *, n_classes):
     """Compute class means.
 
     Parameters
@@ -105,8 +105,11 @@ def _class_means(X, y):
     X : array-like of shape (n_samples, n_features)
         Input data.
 
-    y : array-like of shape (n_samples,) or (n_samples, n_targets)
-        Target values.
+    y_encoded : array-like of shape (n_samples,)
+        Target values encoded as integer codes indexing `self.classes_`.
+
+    n_classes : int
+        Number of classes, i.e. `1 + max(y_encoded)`.
 
     Returns
     -------
@@ -114,24 +117,23 @@ def _class_means(X, y):
         Class means.
     """
     xp, is_array_api_compliant = get_namespace(X)
-    classes, y = xp.unique_inverse(y)
-    means = xp.zeros(
-        (classes.shape[0], X.shape[1]), device=array_device(X), dtype=X.dtype
-    )
+    means = xp.zeros((n_classes, X.shape[1]), device=array_device(X), dtype=X.dtype)
 
     if is_array_api_compliant:
-        for i in range(classes.shape[0]):
-            means[i, :] = xp.mean(X[y == i], axis=0)
+        for i in range(n_classes):
+            means[i, :] = xp.mean(X[y_encoded == i], axis=0)
     else:
         # TODO: Explore the choice of using bincount + add.at as it seems sub optimal
         # from a performance-wise
-        cnt = np.bincount(y)
-        np.add.at(means, y, X)
+        cnt = np.bincount(y_encoded, minlength=n_classes)
+        np.add.at(means, y_encoded, X)
         means /= cnt[:, None]
     return means
 
 
-def _class_cov(X, y, priors, shrinkage=None, covariance_estimator=None):
+def _class_cov(
+    X, y_encoded, priors, shrinkage=None, covariance_estimator=None, *, n_classes
+):
     """Compute weighted within-class covariance matrix.
 
     The per-class covariance are weighted by the class priors.
@@ -141,8 +143,11 @@ def _class_cov(X, y, priors, shrinkage=None, covariance_estimator=None):
     X : array-like of shape (n_samples, n_features)
         Input data.
 
-    y : array-like of shape (n_samples,) or (n_samples, n_targets)
-        Target values.
+    y_encoded : array-like of shape (n_samples,)
+        Target values encoded as integer codes indexing `self.classes_`.
+
+    n_classes : int
+        Number of classes, i.e. `1 + max(y_encoded)`.
 
     priors : array-like of shape (n_classes,)
         Class priors.
@@ -170,10 +175,9 @@ def _class_cov(X, y, priors, shrinkage=None, covariance_estimator=None):
     cov : array-like of shape (n_features, n_features)
         Weighted within-class covariance matrix
     """
-    classes = np.unique(y)
     cov = np.zeros(shape=(X.shape[1], X.shape[1]))
-    for idx, group in enumerate(classes):
-        Xg = X[y == group, :]
+    for idx in range(n_classes):
+        Xg = X[y_encoded == idx, :]
         cov += priors[idx] * np.atleast_2d(_cov(Xg, shrinkage, covariance_estimator))
     return cov
 
@@ -446,7 +450,7 @@ class LinearDiscriminantAnalysis(
         self.tol = tol  # used only in svd solver
         self.covariance_estimator = covariance_estimator
 
-    def _solve_lstsq(self, X, y, shrinkage, covariance_estimator):
+    def _solve_lstsq(self, X, y_encoded, shrinkage, covariance_estimator):
         """Least squares solver.
 
         The least squares solver computes a straightforward solution of the
@@ -461,8 +465,8 @@ class LinearDiscriminantAnalysis(
         X : array-like of shape (n_samples, n_features)
             Training data.
 
-        y : array-like of shape (n_samples,) or (n_samples, n_classes)
-            Target values.
+        y_encoded : array-like of shape (n_samples,)
+            Target values encoded as integer codes indexing `self.classes_`.
 
         shrinkage : 'auto', float or None
             Shrinkage parameter, possible values:
@@ -493,16 +497,22 @@ class LinearDiscriminantAnalysis(
            (Second Edition). John Wiley & Sons, Inc., New York, 2001. ISBN
            0-471-05669-3.
         """
-        self.means_ = _class_means(X, y)
+        n_classes = self.classes_.shape[0]
+        self.means_ = _class_means(X, y_encoded, n_classes=n_classes)
         self.covariance_ = _class_cov(
-            X, y, self.priors_, shrinkage, covariance_estimator
+            X,
+            y_encoded,
+            self.priors_,
+            shrinkage,
+            covariance_estimator,
+            n_classes=n_classes,
         )
         self.coef_ = linalg.lstsq(self.covariance_, self.means_.T)[0].T
         self.intercept_ = -0.5 * np.diag(np.dot(self.means_, self.coef_.T)) + np.log(
             self.priors_
         )
 
-    def _solve_eigen(self, X, y, shrinkage, covariance_estimator):
+    def _solve_eigen(self, X, y_encoded, shrinkage, covariance_estimator):
         """Eigenvalue solver.
 
         The eigenvalue solver computes the optimal solution of the Rayleigh
@@ -515,8 +525,8 @@ class LinearDiscriminantAnalysis(
         X : array-like of shape (n_samples, n_features)
             Training data.
 
-        y : array-like of shape (n_samples,) or (n_samples, n_targets)
-            Target values.
+        y_encoded : array-like of shape (n_samples,)
+            Target values encoded as integer codes indexing `self.classes_`.
 
         shrinkage : 'auto', float or None
             Shrinkage parameter, possible values:
@@ -547,9 +557,15 @@ class LinearDiscriminantAnalysis(
            (Second Edition). John Wiley & Sons, Inc., New York, 2001. ISBN
            0-471-05669-3.
         """
-        self.means_ = _class_means(X, y)
+        n_classes = self.classes_.shape[0]
+        self.means_ = _class_means(X, y_encoded, n_classes=n_classes)
         self.covariance_ = _class_cov(
-            X, y, self.priors_, shrinkage, covariance_estimator
+            X,
+            y_encoded,
+            self.priors_,
+            shrinkage,
+            covariance_estimator,
+            n_classes=n_classes,
         )
 
         Sw = self.covariance_  # within scatter
@@ -589,9 +605,11 @@ class LinearDiscriminantAnalysis(
         n_samples, _ = X.shape
         n_classes = self.classes_.shape[0]
 
-        self.means_ = _class_means(X, y_encoded)
+        self.means_ = _class_means(X, y_encoded, n_classes=n_classes)
         if self.store_covariance:
-            self.covariance_ = _class_cov(X, y_encoded, self.priors_)
+            self.covariance_ = _class_cov(
+                X, y_encoded, self.priors_, n_classes=n_classes
+            )
 
         Xc = []
         # `y_encoded` holds integer class codes (see `fit`), so groups are
@@ -677,7 +695,7 @@ class LinearDiscriminantAnalysis(
         # therefore convert to integer codes instead.
         # `classes_` stays in `y`'s namespace and device.
         y_encoded = move_to(
-            _encode(y, uniques=self.classes_, check_unknown=False),
+            _encode(y, uniques=self.classes_),
             xp=xp,
             device=array_device(X),
         )

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -25,6 +25,7 @@ from sklearn.utils._array_api import (
     array_device,
     check_same_namespace,
     get_namespace,
+    move_to,
     size,
 )
 from sklearn.utils._param_validation import HasMethods, Interval, StrOptions
@@ -592,7 +593,10 @@ class LinearDiscriminantAnalysis(
             self.covariance_ = _class_cov(X, y, self.priors_)
 
         Xc = []
-        for idx, group in enumerate(self.classes_):
+        # `self.classes_` stays in `y`'s namespace/device; use an `X`-device copy
+        # so the mask `y == group` below does not mix devices.
+        classes = move_to(self.classes_, xp=xp, device=device(X))
+        for idx, group in enumerate(classes):
             Xg = X[y == group]
             Xc.append(Xg - self.means_[idx, :])
 
@@ -669,6 +673,10 @@ class LinearDiscriminantAnalysis(
             self, X, y, ensure_min_samples=2, dtype=[xp.float64, xp.float32]
         )
         self.classes_ = unique_labels(y)
+        # `y` follows `X`: move it to `X`'s namespace/device so downstream math
+        # stays single-device. Must stay after `classes_` above, which is
+        # intentionally kept in `y`'s original namespace/device.
+        y = move_to(y, xp=xp, device=device(X))
         n_samples, n_features = X.shape
         n_classes = self.classes_.shape[0]
 

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -674,7 +674,7 @@ class LinearDiscriminantAnalysis(
         )
         self.classes_ = unique_labels(y)
         # `y` may hold strings, which no array API namespace can represent,
-        # therefore convert to integer codes instead. 
+        # therefore convert to integer codes instead.
         # `classes_` stays in `y`'s namespace and device.
         y = move_to(
             _encode(y, uniques=self.classes_, check_unknown=False),

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -673,8 +673,9 @@ class LinearDiscriminantAnalysis(
             self, X, y, ensure_min_samples=2, dtype=[xp.float64, xp.float32]
         )
         self.classes_ = unique_labels(y)
-        # `y` may hold strings, which no array API namespace can represent: move
-        # integer codes instead. `classes_` stays in `y`'s namespace and device.
+        # `y` may hold strings, which no array API namespace can represent,
+        # therefore convert to integer codes instead. 
+        # `classes_` stays in `y`'s namespace and device.
         y = move_to(
             _encode(y, uniques=self.classes_, check_unknown=False),
             xp=xp,

--- a/sklearn/discriminant_analysis.py
+++ b/sklearn/discriminant_analysis.py
@@ -568,7 +568,7 @@ class LinearDiscriminantAnalysis(
             self.priors_
         )
 
-    def _solve_svd(self, X, y):
+    def _solve_svd(self, X, y_encoded):
         """SVD solver.
 
         Parameters
@@ -576,8 +576,8 @@ class LinearDiscriminantAnalysis(
         X : array-like of shape (n_samples, n_features)
             Training data.
 
-        y : array-like of shape (n_samples,) or (n_samples, n_targets)
-            Target values.
+        y_encoded : array-like of shape (n_samples,)
+            Target values encoded as integer codes indexing `self.classes_`.
         """
         xp, is_array_api_compliant = get_namespace(X)
 
@@ -589,15 +589,15 @@ class LinearDiscriminantAnalysis(
         n_samples, _ = X.shape
         n_classes = self.classes_.shape[0]
 
-        self.means_ = _class_means(X, y)
+        self.means_ = _class_means(X, y_encoded)
         if self.store_covariance:
-            self.covariance_ = _class_cov(X, y, self.priors_)
+            self.covariance_ = _class_cov(X, y_encoded, self.priors_)
 
         Xc = []
-        # `y` holds integer class codes (see `fit`), so groups are indexed by
-        # position in `self.classes_`.
+        # `y_encoded` holds integer class codes (see `fit`), so groups are
+        # indexed by position in `self.classes_`.
         for idx in range(n_classes):
-            Xg = X[y == idx]
+            Xg = X[y_encoded == idx]
             Xc.append(Xg - self.means_[idx, :])
 
         self.xbar_ = self.priors_ @ self.means_
@@ -676,7 +676,7 @@ class LinearDiscriminantAnalysis(
         # `y` may hold strings, which no array API namespace can represent,
         # therefore convert to integer codes instead.
         # `classes_` stays in `y`'s namespace and device.
-        y = move_to(
+        y_encoded = move_to(
             _encode(y, uniques=self.classes_, check_unknown=False),
             xp=xp,
             device=array_device(X),
@@ -690,7 +690,7 @@ class LinearDiscriminantAnalysis(
             )
 
         if self.priors is None:  # estimate priors from sample
-            _, cnts = xp.unique_counts(y)  # non-negative ints
+            _, cnts = xp.unique_counts(y_encoded)  # non-negative ints
             self.priors_ = xp.astype(cnts, X.dtype) / float(n_samples)
         else:
             self.priors_ = xp.asarray(self.priors, dtype=X.dtype)
@@ -724,18 +724,18 @@ class LinearDiscriminantAnalysis(
                     "is not supported "
                     "with svd solver. Try another solver"
                 )
-            self._solve_svd(X, y)
+            self._solve_svd(X, y_encoded)
         elif self.solver == "lsqr":
             self._solve_lstsq(
                 X,
-                y,
+                y_encoded,
                 shrinkage=self.shrinkage,
                 covariance_estimator=self.covariance_estimator,
             )
         elif self.solver == "eigen":
             self._solve_eigen(
                 X,
-                y,
+                y_encoded,
                 shrinkage=self.shrinkage,
                 covariance_estimator=self.covariance_estimator,
             )

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -1081,7 +1081,6 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
         "check_methods_sample_order_invariance": "check is not applicable."
     },
     LinearDiscriminantAnalysis: {
-        "check_array_api_mixed_inputs": "mixed array API input support not added yet",
         "check_array_api_string_and_numeric_inputs": (
             "mixed string and numeric array API input support not added yet"
         ),

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -1080,11 +1080,6 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
     KNeighborsTransformer: {
         "check_methods_sample_order_invariance": "check is not applicable."
     },
-    LinearDiscriminantAnalysis: {
-        "check_array_api_string_and_numeric_inputs": (
-            "mixed string and numeric array API input support not added yet"
-        ),
-    },
     LabelEncoder: {
         "check_array_api_same_namespace": "check_same_namespace not yet added",
     },


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Towards #28668

#### What does this implement/fix
`LinearDiscriminantAnalysis.fit` now moves `y` to the namespace and device of `X` (the "everything follows `X`" policy), so inputs where `y` comes from a different array API device than `X` no longer raise. 

`classes_` is derived from the original `y` before the move and stays in its device except in the `svd` solver's case where it is used in-device, and is moves only on that branch.         

#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Research and understanding