### PR TITLE
FIX Avoid recursion when pickling Birch

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.cluster/34476.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.cluster/34476.fix.rst
@@ -1,0 +1,3 @@
+- Fixes a :class:`cluster.Birch` persistence failure caused by deep recursion
+  when fitted trees contain many leaf nodes.
+  By :user:`snoopuppy582`.

--- a/sklearn/cluster/_birch.py
+++ b/sklearn/cluster/_birch.py
@@ -169,6 +169,13 @@ class _CFNode:
         self.prev_leaf_ = None
         self.next_leaf_ = None
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # Birch serializes and restores the leaf links without recursing through them.
+        state["prev_leaf_"] = None
+        state["next_leaf_"] = None
+        return state
+
     def append_subcluster(self, subcluster):
         n_samples = len(self.subclusters_)
         self.subclusters_.append(subcluster)
@@ -499,6 +506,24 @@ class Birch(
         self.branching_factor = branching_factor
         self.n_clusters = n_clusters
         self.compute_labels = compute_labels
+
+    def __getstate__(self):
+        state = super().__getstate__()
+        if hasattr(self, "dummy_leaf_"):
+            state["_serialized_leaves"] = self._get_leaves()
+        return state
+
+    def __setstate__(self, state):
+        leaves = state.pop("_serialized_leaves", None)
+        super().__setstate__(state)
+
+        if leaves is not None:
+            previous_leaf = self.dummy_leaf_
+            for leaf in leaves:
+                previous_leaf.next_leaf_ = leaf
+                leaf.prev_leaf_ = previous_leaf
+                previous_leaf = leaf
+            previous_leaf.next_leaf_ = None
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X, y=None):

--- a/sklearn/cluster/tests/test_birch.py
+++ b/sklearn/cluster/tests/test_birch.py
@@ -2,6 +2,10 @@
 Tests for the birch clustering algorithm.
 """
 
+import io
+from itertools import pairwise
+
+import joblib
 import numpy as np
 import pytest
 
@@ -44,6 +48,35 @@ def test_partial_fit(global_random_seed, global_dtype):
     brc_partial.set_params(n_clusters=3)
     brc_partial.partial_fit(None)
     assert_array_equal(brc_partial.subcluster_labels_, brc.subcluster_labels_)
+
+
+def test_pickle_many_leaves():
+    """Check that fitted trees with many linked leaves can be persisted."""
+    n_samples = 200
+    X = np.arange(n_samples * 2, dtype=np.float64).reshape(n_samples, 2)
+    brc = Birch(
+        threshold=1e-12, branching_factor=2, n_clusters=None, compute_labels=False
+    ).fit(X)
+
+    buffer = io.BytesIO()
+    joblib.dump(brc, buffer)
+    buffer.seek(0)
+    loaded_brc = joblib.load(buffer)
+
+    assert_allclose(loaded_brc.subcluster_centers_, brc.subcluster_centers_)
+
+    leaves = loaded_brc._get_leaves()
+    assert len(leaves) == len(brc._get_leaves())
+    assert leaves[0].prev_leaf_ is loaded_brc.dummy_leaf_
+    for previous_leaf, next_leaf in pairwise(leaves):
+        assert previous_leaf.next_leaf_ is next_leaf
+        assert next_leaf.prev_leaf_ is previous_leaf
+    assert leaves[-1].next_leaf_ is None
+
+    X_next = np.array([[n_samples * 2.0, n_samples * 2.0 + 1]])
+    brc.partial_fit(X_next)
+    loaded_brc.partial_fit(X_next)
+    assert_allclose(loaded_brc.subcluster_centers_, brc.subcluster_centers_)
 
 
 def test_birch_predict(global_random_seed, global_dtype):


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #8806.

#### What does this implement/fix? Explain your changes.

Fitted `Birch` trees keep their leaves in a doubly linked list in addition to
the hierarchical CF tree. Pickle follows those leaf links recursively, so a
model with many leaves can raise `RecursionError` even when the CF tree itself
is shallow.

This change omits `prev_leaf_` and `next_leaf_` from each `_CFNode` pickle
state, stores the leaves once in their existing order, and rebuilds the links
when the estimator is loaded. State produced by older versions does not have
the flat leaf list and continues to use its existing links.

The regression test creates a deterministic tree with enough leaves to fail
with `joblib` before the fix. It checks the round-trip model state, every
restored leaf link, and continued `partial_fit` behavior.

The main area for careful review is the identity and order of leaf objects
after unpickling. Pickle memoization keeps the nodes in the flat list identical
to those reachable from `root_`, while the explicit list preserves the
original leaf traversal order.

#### First time contributor introduction

I am a first-time scikit-learn contributor. I picked up this long-standing
issue after reproducing it on the current `main` branch and focused the change
on the persistence path without altering BIRCH fitting behavior.

#### AI usage disclosure

I used OpenAI Codex for:
- Research and understanding
- Code generation for the serialization change
- Regression test generation
- Drafting this pull request description

#### Any other comments?

Validation performed locally:

- `python -m pytest sklearn/cluster/tests/test_birch.py -q` (`15 passed`,
  `9 skipped`)
- `python -m pytest sklearn/tests/test_common.py -k Birch -q` (`57 passed`,
  `4 skipped`)
- `ruff check` and `ruff format --check` on both changed Python files
- Standard `pickle` and `joblib` round trips for a model with 1,199 leaves

This pull request includes code written with the assistance of AI.
I reviewed the implementation and regression coverage and remain responsible
for the submitted change. An independent contributor also reproduced the bug
and verified the serialization behavior on scikit-learn 1.8.0 / Python 3.14.
