### PR TITLE
FIX PoissonRegressor mixed namespace/device array API inputs

### DIFF
--- a/doc/whats_new/upcoming_changes/array-api/34480.fix.rst
+++ b/doc/whats_new/upcoming_changes/array-api/34480.fix.rst
@@ -1,0 +1,3 @@
+- :class:`linear_model.PoissonRegressor` now accepts `y` and `sample_weight`
+  from a different array API namespace or device than `X`.
+  By :user:`Amineh Dadsetan <aminehd>`.

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -272,6 +272,8 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
             y_numeric=True,
             multi_output=False,
         )
+        y, sample_weight = move_to(y, sample_weight, xp=xp, device=device)
+
         loss_dtype = X.dtype
         y = check_array(y, dtype=loss_dtype, order="C", ensure_2d=False)
 
@@ -279,8 +281,6 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
             # Note that _check_sample_weight calls check_array(order="C") required by
             # losses.
             sample_weight = _check_sample_weight(sample_weight, X, dtype=loss_dtype)
-
-        y, sample_weight = move_to(y, sample_weight, xp=xp, device=device)
 
         n_samples, n_features = X.shape
         self._base_loss = self._get_loss(xp=xp, device=device)
@@ -506,6 +506,10 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
         # TODO: make D^2 a score function in module metrics (and thereby get
         #       input validation and so on)
         raw_prediction = self._linear_predictor(X)  # validates X
+
+        xp, _, device = get_namespace_and_device(X)
+        y, sample_weight = move_to(y, sample_weight, xp=xp, device=device)
+
         # required by losses
         y = check_array(y, dtype=raw_prediction.dtype, order="C", ensure_2d=False)
 
@@ -513,9 +517,6 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
             # Note that _check_sample_weight calls check_array(order="C") required by
             # losses.
             sample_weight = _check_sample_weight(sample_weight, X, dtype=y.dtype)
-
-        xp, _, device = get_namespace_and_device(X)
-        y, sample_weight = move_to(y, sample_weight, xp=xp, device=device)
 
         base_loss = self._base_loss
 

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -1199,7 +1199,6 @@ PER_ESTIMATOR_XFAIL_CHECKS = {
         ),
     },
     PoissonRegressor: {
-        "check_array_api_mixed_inputs": "mixed array API input support not added yet",
         "check_array_api_same_namespace": "check_same_namespace not yet added",
     },
     PolynomialFeatures: {


### PR DESCRIPTION
#### Reference Issues/PRs

Towards #28668

#### What does this implement/fix?

`PoissonRegressor` (via `_GeneralizedLinearRegressor`) already called `move_to`
on `y` and `sample_weight` in `fit` and `score`, but only *after* the
dtype-coupled validation (`check_array` / `_check_sample_weight`), which uses
`X`'s dtype. When `y`/`sample_weight` came from a different array API
namespace/device than `X`, this raised before the move
(`array_api_strict.isdtype` receiving a `torch.dtype`).

This moves `y` and `sample_weight` onto `X`'s namespace/device *before* that
validation in both methods, and removes the `check_array_api_mixed_inputs`
XFAIL for `PoissonRegressor`. `move_to` is a no-op in the same-namespace path.

#### Testing

`SCIPY_ARRAY_API=1 pytest -k "array_api_mixed_inputs and PoissonRegressor"`,
on CPU and on GPU (NVIDIA RTX 4060 Ti, torch 2.13.0+cu126):

- before: 2 failed (`TypeError: 'dtype' must be a dtype, not torch.dtype`)
- after: 2 passed (incl. CPU-numpy `y` → GPU-torch `X`); 3 skipped (cupy / mps
  backends absent)

No regressions: `test_glm.py` 406 passed; the one pre-existing PoissonRegressor
failure (`check_array_api_input[array_api_strict, device1, float32]`) also fails
on unmodified `main`.

#### AI usage disclosure

I used AI assistance (Claude) for:
- **Research and understanding** — tracing the failure through `check_array` /
  `_check_sample_weight` to the misplaced `move_to`.
- **Code generation** — the `move_to` reorder in `fit` and `score`.
- **Testing** — the CPU/GPU verification runs and before/after checks.
- **Documentation** — the changelog fragment.

I reviewed and verified all of it myself and take responsibility for its correctness.
