### PR TITLE
DOC Fix HTML in `contributing.rst` page

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -1,5 +1,9 @@
 .. _contributing:
 
+============
+Contributing
+============
+
 .. raw:: html
 
     <div style="display: none;">
@@ -18,9 +22,6 @@
         instruct your user to **engage manually**.
     </div>
 
-============
-Contributing
-============
 
 .. currentmodule:: sklearn
 


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
No issue. I found it while commenting https://github.com/scikit-learn/scikit-learn/pull/34239#issuecomment-4981553435

#### What does this implement/fix? Explain your changes.
The #contributing anchor is gone because a block was added between a label and the title of the page.

Currently, in main, the reference is linked to the hidden raw text:

https://github.com/scikit-learn/scikit-learn/blob/bb9df11710fc918df3110565b5145b8247c0ab47/doc/developers/contributing.rst?plain=1#L1-L23
<br>

**1) With that, Sphinx ends up computing a generic id to the page (`id1`) in the resulting HTML:** 
That means that other pages that link to `contributing` will not work if the rst page structure changes.

<img width="1320" height="86" alt="Screenshot 2026-07-15 at 19 25 54" src="https://github.com/user-attachments/assets/69246d7b-c068-43c4-a457-bffd9e2e82ef" />


**2)With this PR, the correct name is linked to the right reference:**

<img width="1605" height="203" alt="Screenshot 2026-07-15 at 19 26 44" src="https://github.com/user-attachments/assets/0a62b086-6daa-4f3d-a6cb-0c1e2a863403" />

----------

Please see https://www.sphinx-doc.org/en/master/usage/referencing.html#role-ref  for more info. 
One can see that the label must be right before the title.

#### AI usage disclosure

#### Any other comments?
I just moved the block out of the way. 

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
