### PR TITLE
ENH Speed up histogram gradient categorical data prediction (and perhaps other code) by ensuring C/Cython inlining actually happens

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.ensemble/34486.efficiency.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.ensemble/34486.efficiency.rst
@@ -1,0 +1,2 @@
+- Prediction in :class:`sklearn.ensemble.HistGradientBoostingClassifier` and :class:`sklearn.ensemble.HistGradientBoostingRegressor` is faster when using categoricals.
+  By :user:`Itamar Turner-Trauring <itamarst>`.

--- a/sklearn/utils/_bitset.pxd
+++ b/sklearn/utils/_bitset.pxd
@@ -19,16 +19,39 @@ cdef enum:
 
 ctypedef BITSET_INNER_DTYPE_C[BITSET_LENGTH] BITSET_DTYPE_C
 
-cdef void init_bitset(BITSET_DTYPE_C bitset) noexcept nogil
+cdef inline void init_bitset(BITSET_DTYPE_C bitset) noexcept nogil:
+    cdef:
+        unsigned int i
 
-cdef void set_bitset(BITSET_DTYPE_C bitset, uint8_t val) noexcept nogil
+    for i in range(BITSET_LENGTH):
+        bitset[i] = 0
 
-cdef uint8_t in_bitset(const BITSET_INNER_DTYPE_C* bitset, uint8_t val) noexcept nogil
 
-cpdef uint8_t in_bitset_memoryview(
+cdef inline void set_bitset(BITSET_DTYPE_C bitset, uint8_t val) noexcept nogil:
+    bitset[val // BITSET_INNER_BITS] |= (1 << (val % BITSET_INNER_BITS))
+
+
+cdef inline uint8_t in_bitset(
+    const BITSET_INNER_DTYPE_C* bitset, uint8_t val
+) noexcept nogil:
+    return (bitset[val // BITSET_INNER_BITS] >> (val % BITSET_INNER_BITS)) & 1
+
+
+cpdef inline uint8_t in_bitset_memoryview(
     const BITSET_INNER_DTYPE_C[:] bitset, uint8_t val
-) noexcept nogil
+) noexcept nogil:
+    return (bitset[val // BITSET_INNER_BITS] >> (val % BITSET_INNER_BITS)) & 1
 
-cdef uint8_t in_bitset_2d_memoryview(
+
+cdef inline uint8_t in_bitset_2d_memoryview(
     const BITSET_INNER_DTYPE_C[:, :] bitset, uint8_t val, unsigned int row
-) noexcept nogil
+) noexcept nogil:
+    # Same as above but works on 2d memory views to avoid the creation of 1d
+    # memory views. See https://github.com/scikit-learn/scikit-learn/issues/17299
+    return (
+        bitset[row, val // BITSET_INNER_BITS] >> (val % BITSET_INNER_BITS)
+    ) & 1
+
+
+cpdef inline void set_bitset_memoryview(BITSET_INNER_DTYPE_C[:] bitset, uint8_t val):
+    bitset[val // BITSET_INNER_BITS] |= (1 << (val % BITSET_INNER_BITS))

--- a/sklearn/utils/_bitset.pyx
+++ b/sklearn/utils/_bitset.pyx
@@ -11,44 +11,6 @@ https://en.wikipedia.org/wiki/Bitwise_operation
 # SPDX-License-Identifier: BSD-3-Clause
 
 
-cdef inline void init_bitset(BITSET_DTYPE_C bitset) noexcept nogil:
-    cdef:
-        unsigned int i
-
-    for i in range(BITSET_LENGTH):
-        bitset[i] = 0
-
-
-cdef inline void set_bitset(BITSET_DTYPE_C bitset, uint8_t val) noexcept nogil:
-    bitset[val // BITSET_INNER_BITS] |= (1 << (val % BITSET_INNER_BITS))
-
-
-cdef inline uint8_t in_bitset(
-    const BITSET_INNER_DTYPE_C* bitset, uint8_t val
-) noexcept nogil:
-    return (bitset[val // BITSET_INNER_BITS] >> (val % BITSET_INNER_BITS)) & 1
-
-
-cpdef inline uint8_t in_bitset_memoryview(
-    const BITSET_INNER_DTYPE_C[:] bitset, uint8_t val
-) noexcept nogil:
-    return (bitset[val // BITSET_INNER_BITS] >> (val % BITSET_INNER_BITS)) & 1
-
-
-cdef inline uint8_t in_bitset_2d_memoryview(
-    const BITSET_INNER_DTYPE_C[:, :] bitset, uint8_t val, unsigned int row
-) noexcept nogil:
-    # Same as above but works on 2d memory views to avoid the creation of 1d
-    # memory views. See https://github.com/scikit-learn/scikit-learn/issues/17299
-    return (
-        bitset[row, val // BITSET_INNER_BITS] >> (val % BITSET_INNER_BITS)
-    ) & 1
-
-
-cpdef inline void set_bitset_memoryview(BITSET_INNER_DTYPE_C[:] bitset, uint8_t val):
-    bitset[val // BITSET_INNER_BITS] |= (1 << (val % BITSET_INNER_BITS))
-
-
 def set_raw_bitset_from_binned_bitset(
     BITSET_INNER_DTYPE_C[:] raw_bitset,
     BITSET_INNER_DTYPE_C[:] binned_bitset,


### PR DESCRIPTION
Because of the structure of the `.pyx`/`.pxd`, inlining wasn't actually happening for bitview functions; I will file an issue against `cython-lint` to catch this problem. Here are [the relevant Cython docs](https://cython.readthedocs.io/en/latest/src/tutorial/pxd_files.html); they mention including the whole function in the `.pxd` in order to ensure inlining.

As a result, the usage of bitviews in `_predictor.pyx` was a lot slower.

There are probably other codepaths using bitviews that will also be sped up by this change, but this is the one I tried.

Running `OMP_NUM_THREADS=1 python benchmarks/bench_hist_gradient_boosting_adult.py`:

`upstream/main`:

```
fitted in 0.449s
predicted in 0.121s, ROC AUC: 0.9172, ACC: 0.8629
```

This branch:

```
fitted in 0.423s
predicted in 0.078s, ROC AUC: 0.9172, ACC: 0.8629
```
