### PR TITLE
FIX Raise NotFittedError for AdaBoost importances

### DIFF
--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -290,10 +290,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         feature_importances_ : ndarray of shape (n_features,)
             The feature importances.
         """
-        if self.estimators_ is None or len(self.estimators_) == 0:
-            raise ValueError(
-                "Estimator not fitted, call `fit` before `feature_importances_`."
-            )
+        check_is_fitted(self)
 
         try:
             norm = self.estimator_weights_.sum()

--- a/sklearn/ensemble/tests/test_weight_boosting.py
+++ b/sklearn/ensemble/tests/test_weight_boosting.py
@@ -9,6 +9,7 @@ from sklearn import datasets
 from sklearn.base import BaseEstimator, clone
 from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.ensemble import AdaBoostClassifier, AdaBoostRegressor
+from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.model_selection import GridSearchCV, train_test_split
 from sklearn.svm import SVC, SVR
@@ -222,6 +223,12 @@ def test_importances():
 
     assert importances.shape[0] == 10
     assert (importances[:3, np.newaxis] >= importances[3:]).all()
+
+
+@pytest.mark.parametrize("estimator", [AdaBoostClassifier(), AdaBoostRegressor()])
+def test_feature_importances_not_fitted(estimator):
+    with pytest.raises(NotFittedError):
+        _ = estimator.feature_importances_
 
 
 def test_adaboost_classifier_sample_weight_error():


### PR DESCRIPTION
## Summary

- raise `NotFittedError` when feature importances are requested before fitting either AdaBoost estimator
- preserve the fitted-estimator error path for base estimators without `feature_importances_`
- add classifier and regressor regression coverage

Fixes #34472.

## Validation

- `python -m pytest sklearn/ensemble/tests/test_weight_boosting.py -q`
- `git diff --check`

This pull request includes code written with the assistance of AI.
The code has not yet been reviewed by a human.
