### PR TITLE
FIX ParameterSampler samples each sub-grid uniformly (#18057)

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.model_selection/34494.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.model_selection/34494.fix.rst
@@ -1,0 +1,5 @@
+- :class:`model_selection.RandomizedSearchCV` and
+  :class:`model_selection.ParameterSampler` now sample each sub-grid uniformly
+  when ``param_distributions`` is a list of dicts whose values are all lists,
+  instead of over-sampling the sub-grids that contain more combinations.
+  By :user:`Pranav Achar <PranavAchar01>`.

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -318,21 +318,31 @@ class ParameterSampler:
         # if all distributions are given as lists, we want to sample without
         # replacement
         if self._is_all_lists():
-            # look up sampled parameter settings in parameter grid
-            param_grid = ParameterGrid(self.param_distributions)
-            grid_size = len(param_grid)
+            # Sample each sub-grid (dict) uniformly rather than flattening all
+            # sub-grids into a single grid. Flattening biases sampling towards
+            # the sub-grids that happen to hold more combinations, which
+            # contradicts the documented behaviour of first sampling a dict
+            # uniformly and then a parameter within it. See #18057.
+            grids = [ParameterGrid(dist) for dist in self.param_distributions]
+            grid_sizes = [len(grid) for grid in grids]
+            total_size = sum(grid_sizes)
             n_iter = self.n_iter
 
-            if grid_size < n_iter:
+            if total_size < n_iter:
                 warnings.warn(
-                    "The total space of parameters %d is smaller "
-                    "than n_iter=%d. Running %d iterations. For exhaustive "
-                    "searches, use GridSearchCV." % (grid_size, self.n_iter, grid_size),
+                    f"The total space of parameters {total_size} is smaller "
+                    f"than n_iter={self.n_iter}. Running {total_size} iterations. "
+                    f"For exhaustive searches, use GridSearchCV.",
                     UserWarning,
                 )
-                n_iter = grid_size
-            for i in sample_without_replacement(grid_size, n_iter, random_state=rng):
-                yield param_grid[i]
+                n_iter = total_size
+
+            # Distribute the draws across the sub-grids as evenly as possible
+            # and sample without replacement within each sub-grid.
+            n_samples = self._distribute_n_samples(grid_sizes, n_iter)
+            for grid, grid_size, n in zip(grids, grid_sizes, n_samples):
+                for i in sample_without_replacement(grid_size, n, random_state=rng):
+                    yield grid[i]
 
         else:
             for _ in range(self.n_iter):
@@ -346,6 +356,27 @@ class ParameterSampler:
                     else:
                         params[k] = v[rng.randint(len(v))]
                 yield params
+
+    @staticmethod
+    def _distribute_n_samples(grid_sizes, n_iter):
+        """Split ``n_iter`` draws across sub-grids as evenly as possible.
+
+        Each sub-grid receives an equal share of the remaining draws, capped
+        at its own number of candidates, with any leftover flowing to the
+        larger sub-grids. This keeps sampling uniform across sub-grids while
+        never requesting more unique samples than a sub-grid can provide.
+        """
+        n_samples = [0] * len(grid_sizes)
+        remaining = n_iter
+        # Fill the smallest sub-grids first so their unused capacity is
+        # redistributed to the larger ones.
+        for position, i in enumerate(
+            sorted(range(len(grid_sizes)), key=lambda idx: grid_sizes[idx])
+        ):
+            n_left = len(grid_sizes) - position
+            n_samples[i] = min(grid_sizes[i], remaining // n_left)
+            remaining -= n_samples[i]
+        return n_samples
 
     def __len__(self):
         """Number of points that will be sampled."""

--- a/sklearn/model_selection/tests/test_search.py
+++ b/sklearn/model_selection/tests/test_search.py
@@ -1880,6 +1880,41 @@ def test_parameters_sampler_replacement():
     assert len(samples) == 7
 
 
+def test_parameter_sampler_lists_of_dicts_uniform_sampling():
+    # Non-regression test for #18057: with a list of all-list dicts, each dict
+    # must be sampled about uniformly rather than in proportion to the number
+    # of candidate combinations it holds.
+    small = {"a": [1, 2, 3, 4, 5], "b": [1, 2, 3, 4, 5, 6]}  # 30 combinations
+    large = {  # 120 combinations
+        "a": [6, 7, 8],
+        "b": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "c": [True, False],
+        "d": [True, False],
+    }
+    n_iter = 50
+    samples = list(ParameterSampler([small, large], n_iter=n_iter, random_state=1))
+    assert len(samples) == n_iter
+    # sampling without replacement is preserved: every draw is unique
+    assert len({tuple(sorted(s.items())) for s in samples}) == n_iter
+    from_small = sum(1 for s in samples if s["a"] in {1, 2, 3, 4, 5})
+    # both sub-grids get an equal share (was 9 / 41 before the fix)
+    assert from_small == 25
+    assert n_iter - from_small == 25
+
+
+def test_parameter_sampler_distribute_n_samples():
+    # Draws are spread across sub-grids as evenly as possible, capped by each
+    # sub-grid's size, with the remainder flowing to the larger sub-grids.
+    distribute = ParameterSampler._distribute_n_samples
+    assert distribute([30, 120], 50) == [25, 25]
+    assert distribute([10, 50, 100], 100) == [10, 45, 45]
+    assert sum(distribute([3, 3, 3], 7)) == 7
+    # a sub-grid is never asked for more unique samples than it can provide
+    alloc = distribute([2, 100], 50)
+    assert alloc[0] <= 2
+    assert sum(alloc) == 50
+
+
 def test_stochastic_gradient_loss_param():
     # Make sure the predict_proba works when loss is specified
     # as one of the parameters in the param_grid.


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #18057.

#### What does this implement/fix? Explain your changes.
When `param_distributions` is a **list of dicts** whose values are all lists,
`ParameterSampler` built a single `ParameterGrid` over every sub-grid and sampled
uniformly across the flattened space. Sub-grids that hold more combinations were
therefore over-sampled, which contradicts the documented behaviour:

> If a list of dicts is given, first a dict is sampled uniformly, and then a
> parameter is sampled using that dict as above.

Reproducer from the issue (two all-list dicts of size 30 and 120, `n_iter=50`):
the size-120 dict was chosen 41/50 times instead of ~25/25.

This is confirmed as a bug by @jnothman, @NicolasHug and @amueller in the issue
thread. This PR implements the fix along the lines @amueller sketched there:

- Build one `ParameterGrid` per sub-grid instead of flattening them together.
- Distribute `n_iter` across the sub-grids **as evenly as possible**, capping each
  allocation at the sub-grid's size and letting the remainder flow to the larger
  sub-grids (`_distribute_n_samples`). For the reporter's case this yields 25/25;
  for grids of size 10/50/100 with `n_iter=100` it yields 10/45/45, matching
  @amueller's worked example.
- Sample **without replacement** within each sub-grid, preserving the existing
  "all lists ⇒ without replacement" guarantee.

Single-dict behaviour is unchanged (the allocation degenerates to the previous
single `sample_without_replacement` call), so existing results for the common
single-dict case are byte-for-byte identical.

#### Any other comments?
This changes the sampling results for the multi-dict all-lists case, so it is a
behaviour change (a changelog entry is included). `test_parameters_sampler_replacement`
still passes; two focused non-regression tests are added.
