### PR TITLE
FIX: resize_state error message crashes with TypeError instead of raising ValueError

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.ensemble/34496.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.ensemble/34496.fix.rst
@@ -1,0 +1,6 @@
+- :class:`ensemble.GradientBoostingClassifier` and
+  :class:`ensemble.GradientBoostingRegressor` now produce a correct
+  ``ValueError`` message in ``_resize_state`` when ``n_estimators`` is
+  reduced with ``warm_start=True``, instead of crashing with a ``TypeError``
+  due to formatting a tree object as an integer.
+  By :user:`shipitdev <shipitdev>`.

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -572,7 +572,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         if total_n_estimators < self.estimators_.shape[0]:
             raise ValueError(
                 "resize with smaller n_estimators %d < %d"
-                % (total_n_estimators, self.estimators_[0])
+                % (total_n_estimators, self.estimators_.shape[0])
             )
 
         self.estimators_ = np.resize(

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -869,7 +869,7 @@ def test_warm_start_smaller_n_estimators(Cls):
 
 @pytest.mark.parametrize("Cls", GRADIENT_BOOSTING_ESTIMATORS)
 def test_resize_state_smaller_n_estimators_error_message(Cls):
-    #Check that _resize_state raises a clear ValueError, not a TypeError 
+    # Check that _resize_state raises a clear ValueError, not a TypeError
     gb = Cls(n_estimators=5)
     gb.estimators_ = np.empty((10, 1), dtype=object)
     with pytest.raises(

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -868,6 +868,18 @@ def test_warm_start_smaller_n_estimators(Cls):
 
 
 @pytest.mark.parametrize("Cls", GRADIENT_BOOSTING_ESTIMATORS)
+def test_resize_state_smaller_n_estimators_error_message(Cls):
+    #Check that _resize_state raises a clear ValueError, not a TypeError 
+    gb = Cls(n_estimators=5)
+    gb.estimators_ = np.empty((10, 1), dtype=object)
+    with pytest.raises(
+        ValueError,
+        match=r"resize with smaller n_estimators 5 < 10",
+    ):
+        gb._resize_state()
+
+
+@pytest.mark.parametrize("Cls", GRADIENT_BOOSTING_ESTIMATORS)
 def test_warm_start_equal_n_estimators(Cls):
     # Test if warm start with equal n_estimators does nothing
     X, y = datasets.make_hastie_10_2(n_samples=100, random_state=1)


### PR DESCRIPTION
_resize_state in _gb.py has a guard that's supposed to raise a clear ValueError when someone tries to shrink n_estimators:

```python
    if total_n_estimators < self.estimators_.shape[0]:
        raise ValueError(
            "resize with smaller n_estimators %d < %d"
            % (total_n_estimators, self.estimators_[0])
        )
``` 

self.estimators_[0] is wrong here, it grabs the first fitted estimator object instead of self.estimators_.shape[0] (the count). Since %d can't format a non-numeric object, this crashes with a confusing TypeError instead of raising the intended ValueError. Confirmed directly:

```python
>>> gb = GradientBoostingClassifier(n_estimators=5)
>>> gb.estimators_ = np.empty((10, 1), dtype=object)
>>> gb._resize_state()
TypeError: %d format: a real number is required, not numpy.ndarray
``` 

This branch is currently unreachable through the public fit() API, since BaseGradientBoosting.fit() already checks the identical condition and raises its own ValueError first, before _resize_state() is ever called. That's also why the existing test (test_warm_start_smaller_n_estimators) passes today, it's asserting on the outer check's ValueError, not this one, so this bug has been silently hiding behind it.

Fixed the variable, and added a parametrized test that calls _resize_state directly (bypassing the outer guard) to actually exercise and pin this specific line for both GradientBoostingClassifier and GradientBoostingRegressor. Verified locally that the buggy version crashes with TypeError and the fixed version raises the intended clean ValueError for both classes.

### AI Disclosure
An LLM was used to format this draft. 