### PR TITLE
FIX correct _resize_state ValueError format string (estimators_[0] → estimators_.shape[0])

### DIFF
--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -572,7 +572,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
         if total_n_estimators < self.estimators_.shape[0]:
             raise ValueError(
                 "resize with smaller n_estimators %d < %d"
-                % (total_n_estimators, self.estimators_[0])
+                % (total_n_estimators, self.estimators_.shape[0])
             )
 
         self.estimators_ = np.resize(

--- a/sklearn/ensemble/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/tests/test_gradient_boosting.py
@@ -1675,3 +1675,21 @@ def test_criterion_param_deprecation(GradientBoosting):
     with pytest.warns(FutureWarning, match="criterion"):
         reg = GradientBoosting(criterion="friedman_mse")
         reg.fit(X, y)
+
+
+@pytest.mark.parametrize("GradientBoostingEstimator", GRADIENT_BOOSTING_ESTIMATORS)
+def test_resize_state_smaller_n_estimators_typeerror(GradientBoostingEstimator):
+    """Test that _resize_state raises ValueError, not TypeError.
+
+    Non-regression test for _resize_state using self.estimators_[0] instead
+    of self.estimators_.shape[0] in the error message format string,
+    which caused a misleading TypeError.
+    """
+    import numpy as np
+
+    est = GradientBoostingEstimator(n_estimators=5)
+    # populate estimators_ directly to bypass the fit-time check so the
+    # _resize_state path is actually exercised
+    est.estimators_ = np.empty((10, 1), dtype=object)
+    with pytest.raises(ValueError, match="resize with smaller n_estimators"):
+        est._resize_state()


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #34497

#### What does this implement/fix? Explain your changes.

`BaseGradientBoosting._resize_state()` has a bug in its error message format: it uses `self.estimators_[0]` (the first fitted estimator object, an ndarray) instead of `self.estimators_.shape[0]` (the current estimator count). When the `%d` format string tries to print the ndarray, it raises a confusing `TypeError` instead of the intended `ValueError`.

This is a one-character fix in `_gb.py` plus a non-regression test.

The bug is latent because normal `fit()` checks the same condition earlier and raises its own `ValueError` before `_resize_state` ever runs. However, users calling `_resize_state` directly (or future refactoring that removes the fit-time guard) would hit this.

#### Any other comments?

Minimal, single-line fix. Test added to verify the correct exception type.