### PR TITLE
DOC add missing precompute incompatibility note to Lasso sample_weight

### DIFF
--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -1107,8 +1107,8 @@ class ElasticNet(RegressorMixin, MultiOutputLinearModel):
             Target. Will be cast to X's dtype if necessary.
 
         sample_weight : float or array-like of shape (n_samples,), default=None
-            Sample weights. Internally, the `sample_weight` vector will be
-            rescaled to sum to `n_samples`.
+            Sample weights. Internally, the `sample_weight` vector is rescaled to
+            sum to `n_samples`. This argument is incompatible with ``precompute``.
 
             .. versionadded:: 0.23
 
@@ -2730,8 +2730,8 @@ class MultiTaskElasticNet(ElasticNet):
             Target. Will be cast to X's dtype if necessary.
 
         sample_weight : float or array-like of shape (n_samples,), default=None
-            Sample weights. Internally, the `sample_weight` vector will be
-            rescaled to sum to `n_samples`.
+            Sample weights. Internally, the `sample_weight` vector is rescaled to
+            sum to `n_samples`. This argument is incompatible with ``precompute``.
 
             .. versionadded:: 1.9
 


### PR DESCRIPTION
Closes #XXXXX

## What does this fix?

Adds the missing "This argument is incompatible with ``precompute``."
sentence to the `sample_weight` parameter in `Lasso.fit` to match
the existing documentation in `ElasticNet.fit`.