### PR TITLE
DOC Improve documentation of `safe_mask`

### DIFF
--- a/sklearn/utils/_mask.py
+++ b/sklearn/utils/_mask.py
@@ -76,7 +76,7 @@ def _get_mask(X, value_to_mask):
     prefer_skip_nested_validation=True,
 )
 def safe_mask(X, mask):
-    """Return a mask which is safe to use on X.
+    """Return an indexing mask compatible with X.
 
     Parameters
     ----------


### PR DESCRIPTION
Fixes #34505 

Clarify the `safe_mask` docstring by improving the function summary from:
```
Return a mask which is safe to use on X.
```
to:
```
Return an indexing mask compatible with X.
```