### PR TITLE
FIX avoid infinite recursion when cloning estimators with MagicMock params

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.base/34512.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.base/34512.fix.rst
@@ -1,0 +1,6 @@
+- :func:`base.clone` no longer enters infinite recursion when an estimator
+  parameter is a :class:`unittest.mock.MagicMock` (or similar auto-attribute
+  object). Access to ``_metadata_request`` now uses
+  ``object.__getattribute__`` so missing attributes are not invented during
+  cloning.
+  :pr:`34512` by :user:`Fstarnb <Fstarnb>`.

--- a/sklearn/base.py
+++ b/sklearn/base.py
@@ -129,10 +129,15 @@ def _clone_parametrized(estimator, *, safe=True):
         new_object_params[name] = clone(param, safe=False)
 
     new_object = klass(**new_object_params)
+    # Use object.__getattribute__ so MagicMock / other auto-attr objects do not
+    # invent a nested `_metadata_request` (which would recurse forever when
+    # cloned). See issue #34477.
     try:
-        new_object._metadata_request = clone(estimator._metadata_request)
+        metadata_request = object.__getattribute__(estimator, "_metadata_request")
     except AttributeError:
         pass
+    else:
+        new_object._metadata_request = clone(metadata_request)
 
     params_set = new_object.get_params(deep=False)
 

--- a/sklearn/tests/test_base.py
+++ b/sklearn/tests/test_base.py
@@ -203,6 +203,24 @@ def test_clone_nan():
     assert clf.empty is clf2.empty
 
 
+def test_clone_estimator_with_magicmock_param():
+    # MagicMock auto-creates missing attributes. Accessing `_metadata_request`
+    # via getattr must not recurse when cloning (issue #34477).
+    from unittest.mock import MagicMock
+
+    from sklearn.base import ClassifierMixin
+
+    class FastMockClassifier(BaseEstimator, ClassifierMixin):
+        def __init__(self, learning_rate=0.1):
+            self.learning_rate = learning_rate
+
+    mock_lr = MagicMock()
+    cloned = clone(FastMockClassifier(learning_rate=mock_lr))
+    assert isinstance(cloned, FastMockClassifier)
+    # Parameter itself is still cloned via safe=False deepcopy path for non-estimators
+    assert cloned.learning_rate is not None
+
+
 def test_clone_dict():
     # test that clone creates a clone of a dict
     orig = {"a": MyEstimator()}


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #34477.

#### What does this implement/fix? Explain your changes.
`clone()` copies `estimator._metadata_request` with a bare attribute access:

```python
new_object._metadata_request = clone(estimator._metadata_request)
```

For `unittest.mock.MagicMock` (and similar auto-attribute objects), missing attributes are created on access. That invents a nested `MagicMock` for `_metadata_request`, which is then cloned again, producing infinite recursion / memory blow-up when an estimator parameter is a `MagicMock` (regression vs 1.8).

This uses `object.__getattribute__(estimator, "_metadata_request")` so only a real instance attribute is copied; absence raises `AttributeError` and is ignored as before.

#### First time contributor introduction
I use scikit-learn in simulation/control ML pipelines. Hit this while cloning test doubles that inject MagicMock hyperparameters.

#### AI usage disclosure
I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation

I reproduced the recursion on scikit-learn 1.9.0, verified the `object.__getattribute__` approach stops the recursion while still cloning ordinary estimators (e.g. `LogisticRegression`), and reviewed the change manually.

#### Any other comments.
Added `test_clone_estimator_with_magicmock_param` in `sklearn/tests/test_base.py`.