### PR TITLE
Fix Pandas output path fails to reject infinite values during transform  

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.feature_selection/34513.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.feature_selection/34513.fix.rst
@@ -1,0 +1,4 @@
+- Feature selectors such as :class:`feature_selection.SelectKBest` now correctly
+  reject non-finite values (infinity, and NaN unless allowed) in ``transform``
+  when using ``set_output(transform="pandas")``.
+  By :user:`Abhimanyu Singh Shekhawat <abhimanyu-bitsgoa>`.

--- a/sklearn/feature_selection/_base.py
+++ b/sklearn/feature_selection/_base.py
@@ -19,6 +19,7 @@ from sklearn.utils._sparse import _align_api_if_sparse
 from sklearn.utils._tags import get_tags
 from sklearn.utils.validation import (
     _check_feature_names_in,
+    assert_all_finite,
     check_is_fitted,
     validate_data,
 )
@@ -108,15 +109,19 @@ class SelectorMixin(TransformerMixin, metaclass=ABCMeta):
 
         # note: we use get_tags instead of __sklearn_tags__ because this is a
         # public Mixin.
+        allow_nan = get_tags(self).input_tags.allow_nan
         X = validate_data(
             self,
             X,
             dtype=None,
             accept_sparse="csr",
-            ensure_all_finite=not get_tags(self).input_tags.allow_nan,
+            ensure_all_finite=not allow_nan,
             skip_check_array=preserve_X,
             reset=False,
         )
+        # Check if X is non-finite as check_array is skipped when preserving X
+        if preserve_X:
+            assert_all_finite(X, allow_nan=allow_nan, input_name="X")
         return self._transform(X)
 
     def _transform(self, X):

--- a/sklearn/feature_selection/tests/test_base.py
+++ b/sklearn/feature_selection/tests/test_base.py
@@ -152,3 +152,17 @@ def test_output_dataframe():
 
     assert_array_equal(output0.index, X.index)
     assert output0.shape == (X.shape[0], 0)
+
+
+@pytest.mark.parametrize("non_finite", [np.inf, np.nan])
+def test_transform_dataframe_non_finite(non_finite):
+    """transform rejects non-finite values with pandas output."""
+    pd = pytest.importorskip("pandas")
+
+    X = pd.DataFrame({"a": [1.0, 2.0, 3.0], "b": [4.0, 5.0, 6.0]})
+    sel = StepSelector().set_output(transform="pandas").fit(X)
+
+    X_bad = X.copy()
+    X_bad.loc[0, "a"] = non_finite
+    with pytest.raises(ValueError, match="Input X contains"):
+        sel.transform(X_bad)

--- a/sklearn/feature_selection/tests/test_base.py
+++ b/sklearn/feature_selection/tests/test_base.py
@@ -156,10 +156,12 @@ def test_output_dataframe():
 
 @pytest.mark.parametrize("non_finite", [np.inf, np.nan])
 def test_transform_dataframe_non_finite(non_finite):
-    """transform rejects non-finite values with pandas output."""
+    """Check that transform rejects non-finite values with pandas output.
+    Regression test for https://github.com/scikit-learn/scikit-learn/issues/34500.
+    """
     pd = pytest.importorskip("pandas")
 
-    X = pd.DataFrame({"a": [1.0, 2.0, 3.0], "b": [4.0, 5.0, 6.0]})
+    X = pd.DataFrame({"a": [1.0, 2.0, 3.0]})
     sel = StepSelector().set_output(transform="pandas").fit(X)
 
     X_bad = X.copy()

--- a/sklearn/feature_selection/tests/test_variance_threshold.py
+++ b/sklearn/feature_selection/tests/test_variance_threshold.py
@@ -70,3 +70,21 @@ def test_variance_nan(sparse_container):
     X = arr if sparse_container is None else sparse_container(arr)
     sel = VarianceThreshold().fit(X)
     assert_array_equal([0, 3, 4], sel.get_support(indices=True))
+
+
+def test_transform_dataframe_allow_nan():
+    """For pandas output, NaN passes through but infinity is still rejected."""
+    pd = pytest.importorskip("pandas")
+
+    X = pd.DataFrame({"a": [1.0, 2.0, 3.0], "b": [4.0, 5.0, 6.0]})
+    sel = VarianceThreshold().set_output(transform="pandas").fit(X)
+
+    X_inf = X.copy()
+    X_inf.loc[0, "a"] = np.inf
+    with pytest.raises(ValueError, match="Input X contains infinity"):
+        sel.transform(X_inf)
+
+    X_nan = X.copy()
+    X_nan.loc[0, "a"] = np.nan
+    output = sel.transform(X_nan)
+    assert np.isnan(output.loc[0, "a"])

--- a/sklearn/feature_selection/tests/test_variance_threshold.py
+++ b/sklearn/feature_selection/tests/test_variance_threshold.py
@@ -73,16 +73,14 @@ def test_variance_nan(sparse_container):
 
 
 def test_transform_dataframe_allow_nan():
-    """For pandas output, NaN passes through but infinity is still rejected."""
+    """Test that `VarianceThreshold` (only built-in selector with hardcoded nan
+    support) passes nan values if "pandas" is selected as an output.
+    Regression test for https://github.com/scikit-learn/scikit-learn/issues/34500.
+    """
     pd = pytest.importorskip("pandas")
 
     X = pd.DataFrame({"a": [1.0, 2.0, 3.0], "b": [4.0, 5.0, 6.0]})
     sel = VarianceThreshold().set_output(transform="pandas").fit(X)
-
-    X_inf = X.copy()
-    X_inf.loc[0, "a"] = np.inf
-    with pytest.raises(ValueError, match="Input X contains infinity"):
-        sel.transform(X_inf)
 
     X_nan = X.copy()
     X_nan.loc[0, "a"] = np.nan


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #34500 

#### What does this implement/fix? Explain your changes.
This PR fixes an edge case pointed in #34500 where  while using `set_output(transform="pandas")`, SelectKBest.transform allows the `inf` values in the the pandas `DataFrame`.

As per the changes in the PR #25102, the when the input is a Pandas DataFrame & `set_output(transform="pandas")` is set the array is not validated to contain all the finite value.

The fix involves enabling `assert_all_finite` validation for the pandas DataFrame & the corresponding tests.
Please note that `inf` will now always be rejected while `NaN` will be subjected to the `allow_nan` tag.


#### First time contributor introduction
<!-- If you are new to the scikit-learn community, please introduce yourself. How do you
 use scikit-learn, what prompted you to make this contribution? Getting to know you
 helps us build trust in your judgement and welcome you into the community.
-->
Hi! I am Abhimanyu Singh Shekhawat. I am fixing this issue as a part of EuroPython 2026 Sprint.

#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Fix implementation
- Test implementation
- Codebase understanding

Please note that, as an author I've gone through & tested the change that I am contributing.


#### Any other comments?

The getting started guide for the codebase is pretty good. I am excited to contribute more to the codebase & help the community.

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
