### PR TITLE
ENH Add title to Decision Boundary Display

### DIFF
--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -569,9 +569,7 @@ class DecisionBoundaryDisplay:
 
         if title is None:
             if self.name is not None and self.response_method_used is not None:
-                title = (
-                    f'{self.name} using "{self.response_method_used}" method'
-                )
+                title = f'{self.name} using "{self.response_method_used}" method'
         if title is not None:
             ax.set_title(title)
 

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -224,6 +224,12 @@ class DecisionBoundaryDisplay:
     ylabel : str, default=None
         Default label to place on y axis.
 
+    name : str, default=None
+        Name of the estimator used to create the display.
+
+    response_method_used : str, default=None
+        Response method used to compute `response`.
+
     multiclass_colors : str or list of matplotlib colors, default=None
         Specifies how to color each class when plotting all classes of
         :term:`multiclass` problems.
@@ -275,6 +281,12 @@ class DecisionBoundaryDisplay:
 
         .. versionadded:: 1.10
             `multiclass_colors_` was renamed to `target_colors_`
+
+    name : str or None
+        Name of the estimator used to create the display.
+
+    response_method_used : str or None
+        Response method used to compute `response`.
 
     ax_ : matplotlib Axes
         Axes with decision boundary.
@@ -350,6 +362,8 @@ class DecisionBoundaryDisplay:
         xlabel=None,
         ylabel=None,
         multiclass_colors="deprecated",  # TODO(1.12): remove
+        response_method_used=None,
+        name=None,
     ):
         self.xx0 = xx0
         self.xx1 = xx1
@@ -361,6 +375,8 @@ class DecisionBoundaryDisplay:
         )
         self.xlabel = xlabel
         self.ylabel = ylabel
+        self.response_method_used = response_method_used
+        self.name = name
 
     # TODO(1.12): remove
     @deprecated(  # type: ignore[prop-decorator]
@@ -371,7 +387,15 @@ class DecisionBoundaryDisplay:
     def multiclass_colors_(self):
         return self.target_colors_
 
-    def plot(self, plot_method="contourf", ax=None, xlabel=None, ylabel=None, **kwargs):
+    def plot(
+        self,
+        plot_method="contourf",
+        ax=None,
+        xlabel=None,
+        ylabel=None,
+        title=None,
+        **kwargs,
+    ):
         """Plot visualization.
 
         Parameters
@@ -392,6 +416,11 @@ class DecisionBoundaryDisplay:
 
         ylabel : str, default=None
             Overwrite the y-axis label.
+
+        title : str, default=None
+            Title to set on the axes. If ``None`` and the display was created by
+            :meth:`DecisionBoundaryDisplay.from_estimator`, a default title is set
+            using the estimator name and the response method that was used.
 
         **kwargs : dict
             Additional keyword arguments to be passed to the `plot_method`. For
@@ -538,6 +567,14 @@ class DecisionBoundaryDisplay:
             ylabel = self.ylabel if ylabel is None else ylabel
             ax.set_ylabel(ylabel)
 
+        if title is None:
+            if self.name is not None and self.response_method_used is not None:
+                title = (
+                    f'{self.name} using "{self.response_method_used}" method'
+                )
+        if title is not None:
+            ax.set_title(title)
+
         self.ax_ = ax
         self.figure_ = ax.figure
         return self
@@ -556,6 +593,7 @@ class DecisionBoundaryDisplay:
         target_colors=None,
         xlabel=None,
         ylabel=None,
+        name=None,
         ax=None,
         multiclass_colors="deprecated",  # TODO(1.12): remove
         **kwargs,
@@ -647,6 +685,13 @@ class DecisionBoundaryDisplay:
             The label used for the y-axis. If `None`, an attempt is made to
             extract a label from `X` if it is a dataframe, otherwise an empty
             string is used.
+
+        name : str, default=None
+            Name to use for the display. If ``None``, the estimator class name
+            is used.
+
+            If provided, it is displayed in the default plot title when
+            ``plot(title=None)`` is called.
 
         ax : Matplotlib axes, default=None
             Axes object to plot on. If `None`, a new figure and axes is
@@ -840,6 +885,9 @@ class DecisionBoundaryDisplay:
         if ylabel is None:
             ylabel = X.columns[1] if hasattr(X, "columns") else ""
 
+        if name is None:
+            name = type(estimator).__name__
+
         # TODO(1.12): remove and replace with direct use of `target_colors`
         target_colors = _deprecate_multiclass_colors(multiclass_colors, target_colors)
         display = cls(
@@ -850,5 +898,7 @@ class DecisionBoundaryDisplay:
             target_colors=target_colors,
             xlabel=xlabel,
             ylabel=ylabel,
+            response_method_used=response_method_used,
+            name=name,
         )
         return display.plot(ax=ax, plot_method=plot_method, **kwargs)

--- a/sklearn/inspection/_plot/decision_boundary.py
+++ b/sklearn/inspection/_plot/decision_boundary.py
@@ -224,12 +224,6 @@ class DecisionBoundaryDisplay:
     ylabel : str, default=None
         Default label to place on y axis.
 
-    name : str, default=None
-        Name of the estimator used to create the display.
-
-    response_method_used : str, default=None
-        Response method used to compute `response`.
-
     multiclass_colors : str or list of matplotlib colors, default=None
         Specifies how to color each class when plotting all classes of
         :term:`multiclass` problems.
@@ -266,6 +260,12 @@ class DecisionBoundaryDisplay:
         .. deprecated:: 1.10
             `multiclass_colors` was renamed to `target_colors` in 1.10 and will be
             removed in 1.12.
+
+    response_method_used : str, default=None
+        Response method used to compute `response`.
+
+    name : str, default=None
+        Name of the estimator used to create the display.
 
     Attributes
     ----------

--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -249,7 +249,7 @@ def test_decision_boundary_display_classifier(
     )
     assert ax.get_title() == expected_title
 
-    # custom name override in from_estimator should be reflected in the title
+    # custom name override to be reflected in the title
     fig_custom, ax_custom = pyplot.subplots()
     disp_custom = DecisionBoundaryDisplay.from_estimator(
         fitted_clf,

--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -245,7 +245,7 @@ def test_decision_boundary_display_classifier(
     assert disp.xx1.max() == pytest.approx(x1_max)
 
     expected_title = (
-        f'{type(fitted_clf).__name__} using "{response_method}" method'
+        f'{type(fitted_clf).__name__} using "{disp.response_method_used}" method'
     )
     assert ax.get_title() == expected_title
 
@@ -261,8 +261,9 @@ def test_decision_boundary_display_classifier(
         name="CustomName",
         ax=ax_custom,
     )
-    assert ax_custom.get_title() == (
-        f'CustomName using "{response_method}" method'
+    assert (
+        ax_custom.get_title()
+        == f'CustomName using "{disp_custom.response_method_used}" method'
     )
 
     fig2, ax2 = pyplot.subplots()

--- a/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
+++ b/sklearn/inspection/_plot/tests/test_boundary_decision_display.py
@@ -244,6 +244,27 @@ def test_decision_boundary_display_classifier(
     assert disp.xx1.min() == pytest.approx(x1_min)
     assert disp.xx1.max() == pytest.approx(x1_max)
 
+    expected_title = (
+        f'{type(fitted_clf).__name__} using "{response_method}" method'
+    )
+    assert ax.get_title() == expected_title
+
+    # custom name override in from_estimator should be reflected in the title
+    fig_custom, ax_custom = pyplot.subplots()
+    disp_custom = DecisionBoundaryDisplay.from_estimator(
+        fitted_clf,
+        X,
+        grid_resolution=5,
+        response_method=response_method,
+        plot_method=plot_method,
+        eps=eps,
+        name="CustomName",
+        ax=ax_custom,
+    )
+    assert ax_custom.get_title() == (
+        f'CustomName using "{response_method}" method'
+    )
+
     fig2, ax2 = pyplot.subplots()
     # change plotting method for second plot
     disp.plot(plot_method="pcolormesh", ax=ax2, shading="auto")


### PR DESCRIPTION
Caters to enhancement discussed in #27462 by @StefanieSenger 
> Based on that I would suggest further improvements:
>    1. add a title to the plot that clearly states which response_method from which estimator was used in the plot

