### PR TITLE
DOC demonstrate partial_fit batching in IncrementalPCA example

### DIFF
--- a/examples/decomposition/plot_incremental_pca.py
+++ b/examples/decomposition/plot_incremental_pca.py
@@ -33,8 +33,17 @@ X = iris.data
 y = iris.target
 
 n_components = 2
-ipca = IncrementalPCA(n_components=n_components, batch_size=10)
-X_ipca = ipca.fit_transform(X)
+batch_size = 10
+
+# `IncrementalPCA` can be fit incrementally on batches of samples with
+# `partial_fit`. Here the batches are obtained by slicing an in-memory array,
+# but in a real out-of-core setting each batch could be loaded progressively
+# from a disk-based storage, allowing to decompose datasets too large to fit
+# in memory. Calling `fit(X)` with `batch_size=10` would be equivalent.
+ipca = IncrementalPCA(n_components=n_components)
+for idx in range(0, len(X), batch_size):
+    ipca.partial_fit(X[idx : idx + batch_size])
+X_ipca = ipca.transform(X)
 
 pca = PCA(n_components=n_components)
 X_pca = pca.fit_transform(X)


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #25379 (stalled).

#### What does this implement/fix? Explain your changes.

Takes over stalled PR #25379 by @dsblank (inactive since 2023), picked up at the EuroPython 2026 sprint.

The `IncrementalPCA` example called `fit_transform` on the full dataset at once, so it never demonstrated the incremental usage the class exists for. The example now fits the model with `partial_fit` on batches of samples, following the approach suggested in the review of the original PR (batches obtained by slicing, estimator variable name kept as `ipca`), with a comment noting that in a real out-of-core setting each batch could be loaded progressively from disk-based storage, and that `fit(X)` with `batch_size=10` is equivalent.

The transformed output is numerically identical to the previous version of the example (checked with `np.allclose`).

The original author is credited as co-author on the commit.

#### First time contributor introduction

Hi! This is my first scikit-learn contribution — (Hi! I am Amine, PhD in mathematics turned ML Scientist -- I live between London, Paris and Barcelona). I'm at the EuroPython 2026 sprint and the maintainers here suggested looking at stalled PRs that had been abandoned by their authors.

#### AI usage disclosure

I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Documentation (including examples)
- Research and understanding

(Pair-programmed with Claude Code: it helped find and triage stalled PRs, drafted the change following the existing review feedback on #25379, and verified the output is unchanged. I reviewed and take responsibility for the change.)

#### Any other comments?

cc @ogrisel @jeremiedbb who reviewed the original PR.