### PR TITLE
MNT: remove redundant `_check_initialized` method and refactor `_check_is_fitted` calling(only once)

### DIFF
--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -597,10 +597,6 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
     def _is_fitted(self):
         return len(getattr(self, "estimators_", [])) > 0
 
-    def _check_initialized(self):
-        """Check that the estimator is initialized, raising an error if not."""
-        check_is_fitted(self)
-
     @_fit_context(
         # GradientBoosting*.init is not validated yet
         prefer_skip_nested_validation=False
@@ -948,7 +944,6 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
 
     def _raw_predict_init(self, X):
         """Check input and compute raw predictions of the init estimator."""
-        self._check_initialized()
         X = self.estimators_[0, 0]._validate_X_predict(X, check_input=True)
         if self.init_ == "zero":
             raw_predictions = np.zeros(
@@ -991,6 +986,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             Regression and binary classification are special cases with
             ``k == 1``, otherwise ``k==n_classes``.
         """
+        check_is_fitted(self)
         if check_input:
             X = validate_data(
                 self, X, dtype=np.float32, order="C", accept_sparse="csr", reset=False
@@ -1020,7 +1016,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             trees consisting of only the root node, in which case it will be an
             array of zeros.
         """
-        self._check_initialized()
+        check_is_fitted(self)
 
         relevant_trees = [
             tree
@@ -1103,7 +1099,7 @@ class BaseGradientBoosting(BaseEnsemble, metaclass=ABCMeta):
             In the case of binary classification n_classes is 1.
         """
 
-        self._check_initialized()
+        check_is_fitted(self)
         X = self.estimators_[0, 0]._validate_X_predict(X, check_input=True)
 
         # n_classes will be equal to 1 in the binary classification or the


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #34511

#### What does this implement/fix? Explain your changes.

Removes the redundant `_check_initialized` wrapper method, which is a historical leftover that only calls `check_is_fitted(self)`.

Also refactors [`_raw_predict_init`, `_raw_predict` and `_staged_raw_predict`](https://github.com/scikit-learn/scikit-learn/pull/34519/changes#diff-b42a8fe90542c69dbcd2fbbd57283dcc795db42a93d691206ae1db80056c4dceL949-L1002): the fitted check previously lived in `_raw_predict_init`, which meant it ran twice on the `_staged_raw_predict` path. It is now called once in `_staged_raw_predict` instead.

#### First time contributor introduction

I recently fell down the ML rabbit hole and use scikit-learn to train models for a range of tasks.

#### AI usage disclosure

I used AI assistance for:

- Researching the codebase and understanding how these methods call into each other.
- Analysing test failures while refactoring (identifying why tests broke and what the underlying cause was).

#### Any other comments?

The aim here is consistency: `check_is_fitted` is the convention everywhere else in the codebase, so the wrapper adds indirection without adding behaviour. Happy to split this into two PRs if maintainers would prefer the removal and the refactor reviewed separately.