### PR TITLE
ENH Newton-CD part 6: add l1_ratio to GLMs and expose newton-cd-gram as solver

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/34523.major-feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/34523.major-feature.rst
@@ -1,0 +1,9 @@
+- The generalized linear models (GLM) :class:`linear_model.GammaRegressor`,
+  :class:`linear_model.PoissonRegressor` and :class:`linear_model.TweedieRegressor`
+  are now able to fit L1 and Elastic-Net penalties with the new parameter `l1_ratio`
+  together with the new solver `"newton-cd-gram"`.
+  This new solver is also available for :class:`linear_model.LogisticRegression`.
+  It is based on the Newton solver infrastructure introduced for `"newton-cholesky"`
+  and takes advantage of the already available and fast (e.g. via gap safe screening
+  rules) coordinate descent solver of `ElasticNet(precompute=True)`.
+  By :user:`Christian Lorentzen <lorentzenchr>`. :pr:`34377`.

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -81,8 +81,8 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
 
     l1_ratio : float, default=0.0
         The Elastic-Net mixing parameter, with `0 <= l1_ratio <= 1`. Setting
-        `l1_ratio=1` gives a pure L1-penalty, setting `l1_ratio=0` a pure L2-penalty.
-        Any value between 0 and 1 gives an Elastic-Net penalty of the form
+        `l1_ratio=1` gives a pure L1-penalty, setting `l1_ratio=0` gives a pure
+        L2-penalty. Any value between 0 and 1 gives an Elastic-Net penalty of the form
         `l1_ratio * L1 + (1 - l1_ratio) * L2`.
 
         .. warning::
@@ -591,8 +591,8 @@ class PoissonRegressor(_GeneralizedLinearRegressor):
 
     l1_ratio : float, default=0.0
         The Elastic-Net mixing parameter, with `0 <= l1_ratio <= 1`. Setting
-        `l1_ratio=1` gives a pure L1-penalty, setting `l1_ratio=0` a pure L2-penalty.
-        Any value between 0 and 1 gives an Elastic-Net penalty of the form
+        `l1_ratio=1` gives a pure L1-penalty, setting `l1_ratio=0` gives a pure
+        L2-penalty. Any value between 0 and 1 gives an Elastic-Net penalty of the form
         `l1_ratio * L1 + (1 - l1_ratio) * L2`.
 
         .. warning::
@@ -779,8 +779,8 @@ class GammaRegressor(_GeneralizedLinearRegressor):
 
     l1_ratio : float, default=0.0
         The Elastic-Net mixing parameter, with `0 <= l1_ratio <= 1`. Setting
-        `l1_ratio=1` gives a pure L1-penalty, setting `l1_ratio=0` a pure L2-penalty.
-        Any value between 0 and 1 gives an Elastic-Net penalty of the form
+        `l1_ratio=1` gives a pure L1-penalty, setting `l1_ratio=0` gives a pure
+        L2-penalty. Any value between 0 and 1 gives an Elastic-Net penalty of the form
         `l1_ratio * L1 + (1 - l1_ratio) * L2`.
 
         .. warning::
@@ -981,8 +981,8 @@ class TweedieRegressor(_GeneralizedLinearRegressor):
 
     l1_ratio : float, default=0.0
         The Elastic-Net mixing parameter, with `0 <= l1_ratio <= 1`. Setting
-        `l1_ratio=1` gives a pure L1-penalty, setting `l1_ratio=0` a pure L2-penalty.
-        Any value between 0 and 1 gives an Elastic-Net penalty of the form
+        `l1_ratio=1` gives a pure L1-penalty, setting `l1_ratio=0` gives a pure
+        L2-penalty. Any value between 0 and 1 gives an Elastic-Net penalty of the form
         `l1_ratio * L1 + (1 - l1_ratio) * L2`.
 
         .. warning::

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -380,15 +380,16 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
                 verbose=self.verbose,
             )
         elif self.solver in ("newton-cd-gram", "newton-cholesky"):
-            sol = (
-                NewtonCDGramSolver
-                if self.solver == "newton-cd-gram"
-                else NewtonCholeskySolver
-            )
+            if self.solver == "newton-cholesky":
+                sol = NewtonCholeskySolver
+                params = dict()
+            else:
+                sol = NewtonCDGramSolver
+                params = dict(l1_reg_strength=l1_reg_strength)
             sol = sol(
                 coef=coef,
                 linear_loss=linear_loss,
-                l1_reg_strength=l1_reg_strength,
+                **params,
                 l2_reg_strength=l2_reg_strength,
                 tol=self.tol,
                 max_iter=self.max_iter,

--- a/sklearn/linear_model/_glm/glm.py
+++ b/sklearn/linear_model/_glm/glm.py
@@ -53,7 +53,8 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
     Therefore, the fit minimizes the following objective function with L2 priors as
     regularizer::
 
-        1/(2*sum(s_i)) * sum(s_i * deviance(y_i, h(x_i*w)) + 1/2 * alpha * ||w||_2^2
+        1/(2*sum(s_i)) * sum(s_i * deviance(y_i, h(x_i*w))
+        + alpha * l1_ratio ||w||_1 + 1/2 * alpha * (1 - l1_ratio) * ||w||_2^2
 
     with inverse link function h, s=sample_weight and per observation (unit) deviance
     deviance(y_i, h(x_i*w)). Note that for an EDM, 1/2 * deviance is the negative
@@ -72,11 +73,24 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
     Parameters
     ----------
     alpha : float, default=1
-        Constant that multiplies the penalty term and thus determines the
+        Constant that multiplies the penalty terms and determines the
         regularization strength. ``alpha = 0`` is equivalent to unpenalized
         GLMs. In this case, the design matrix `X` must have full column rank
         (no collinearities).
-        Values must be in the range `[0.0, inf)`.
+        Values of `alpha` must be in the range `[0.0, inf)`.
+
+    l1_ratio : float, default=0.0
+        The Elastic-Net mixing parameter, with `0 <= l1_ratio <= 1`. Setting
+        `l1_ratio=1` gives a pure L1-penalty, setting `l1_ratio=0` a pure L2-penalty.
+        Any value between 0 and 1 gives an Elastic-Net penalty of the form
+        `l1_ratio * L1 + (1 - l1_ratio) * L2`.
+
+        .. warning::
+           Certain values of `l1_ratio`, i.e. some penalties, do not work with some
+           solvers. See the parameter `solver` below, to know the compatibility between
+           the penalty and solver.
+
+        .. versionadded:: 1.10
 
     fit_intercept : bool, default=True
         Specifies if a constant (a.k.a. bias or intercept) should be
@@ -87,6 +101,17 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
 
         'lbfgs'
             Calls scipy's L-BFGS-B optimizer.
+
+        'newton-cd-gram'
+            Uses Newton-Raphson steps (in arbitrary precision arithmetic equivalent to
+            iterated reweighted least squares) with an inner coordinate descent based
+            solver that uses the full Hessian/Gram matrix. It can solve for all
+            values of `l1_ratio`.
+            This solver is a good choice for `n_samples` >> `n_features`. Be aware
+            that the memory usage of this solver has a quadratic dependency on
+            `n_features` because it explicitly computes the Hessian matrix.
+
+            .. versionadded:: 1.10
 
         'newton-cg'
             Uses a slightly adapted version of scipy's Newton-CG optimizer. This is
@@ -106,6 +131,20 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
             `n_features` because it explicitly computes the Hessian matrix.
 
             .. versionadded:: 1.2
+
+        .. warning::
+           The choice of the algorithm depends on the penalty chosen (`l1_ratio=0`
+           for L2-penalty, `l1_ratio=1` for L1-penalty and `0 < l1_ratio < 1` for
+           Elastic-Net):
+
+           ================= ========================
+           solver            l1_ratio
+           ================= ========================
+           'lbfgs'           l1_ratio=0
+           'newton-cd-gram'  0<=l1_ratio<=1
+           'newton-cg'       l1_ratio=0
+           'newton-cholesky' l1_ratio=0
+           ================= ========================
 
     max_iter : int, default=100
         The maximal number of iterations for the solver.
@@ -164,10 +203,10 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
     # benchmarking.
     _parameter_constraints: dict = {
         "alpha": [Interval(Real, 0.0, None, closed="left")],
+        "l1_ratio": [Interval(Real, 0, 1, closed="both")],
         "fit_intercept": ["boolean"],
         "solver": [
-            StrOptions({"lbfgs", "newton-cg", "newton-cholesky"}),
-            Hidden(StrOptions({"newton-cd-gram"})),
+            StrOptions({"lbfgs", "newton-cd-gram", "newton-cg", "newton-cholesky"}),
             Hidden(type),
         ],
         "max_iter": [Interval(Integral, 1, None, closed="left")],
@@ -180,6 +219,7 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
         self,
         *,
         alpha=1.0,
+        l1_ratio=0.0,
         fit_intercept=True,
         solver="lbfgs",
         max_iter=100,
@@ -188,6 +228,7 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
         verbose=0,
     ):
         self.alpha = alpha
+        self.l1_ratio = l1_ratio
         self.fit_intercept = fit_intercept
         self.solver = solver
         self.max_iter = max_iter
@@ -215,6 +256,12 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
         self : object
             Fitted model.
         """
+        if self.l1_ratio > 0 and self.solver != "newton-cd-gram":
+            msg = (
+                f"The solver '{self.solver}' does not support l1_ratio > 0; got "
+                f"l1_ratio={self.l1_ratio}."
+            )
+            raise ValueError(msg)
         xp, _, device_ = get_namespace_and_device(X)
         X, y = validate_data(
             self,
@@ -254,13 +301,13 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
         # NOTE: Rescaling of sample_weight:
         # We want to minimize
         #     obj = 1/(2 * sum(sample_weight)) * sum(sample_weight * deviance)
-        #         + 1/2 * alpha * L2,
+        #         + a * L1 + 1/2 * b * L2
         # with
-        #     deviance = 2 * loss.
+        #     deviance = 2 * loss, a = alpha * l1_ratio, b = alpha * (1 - l1_ratio).
         # The objective is invariant to multiplying sample_weight by a constant. We
         # could choose this constant such that sum(sample_weight) = 1 in order to end
         # up with
-        #     obj = sum(sample_weight * loss) + 1/2 * alpha * L2.
+        #     obj = sum(sample_weight * loss) + a * L1 + 1/2 * b * L2.
         # But LinearModelLoss.loss() already computes
         #     average(loss, weights=sample_weight)
         # Thus, without rescaling, we have
@@ -282,7 +329,8 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
                     _average(y, weights=sample_weight)
                 )
 
-        l2_reg_strength = self.alpha
+        l1_reg_strength = self.l1_ratio * self.alpha
+        l2_reg_strength = (1 - self.l1_ratio) * self.alpha
         n_threads = _openmp_effective_n_threads()
 
         # Algorithms for optimization:
@@ -340,7 +388,7 @@ class _GeneralizedLinearRegressor(RegressorMixin, BaseEstimator):
             sol = sol(
                 coef=coef,
                 linear_loss=linear_loss,
-                # l1_reg_strength=0.0 is the default value for NewtonCDGramSolver
+                l1_reg_strength=l1_reg_strength,
                 l2_reg_strength=l2_reg_strength,
                 tol=self.tol,
                 max_iter=self.max_iter,
@@ -534,11 +582,24 @@ class PoissonRegressor(_GeneralizedLinearRegressor):
     Parameters
     ----------
     alpha : float, default=1
-        Constant that multiplies the L2 penalty term and determines the
+        Constant that multiplies the penalty terms and determines the
         regularization strength. ``alpha = 0`` is equivalent to unpenalized
         GLMs. In this case, the design matrix `X` must have full column rank
         (no collinearities).
         Values of `alpha` must be in the range `[0.0, inf)`.
+
+    l1_ratio : float, default=0.0
+        The Elastic-Net mixing parameter, with `0 <= l1_ratio <= 1`. Setting
+        `l1_ratio=1` gives a pure L1-penalty, setting `l1_ratio=0` a pure L2-penalty.
+        Any value between 0 and 1 gives an Elastic-Net penalty of the form
+        `l1_ratio * L1 + (1 - l1_ratio) * L2`.
+
+        .. warning::
+           Certain values of `l1_ratio`, i.e. some penalties, do not work with some
+           solvers. See the parameter `solver` below, to know the compatibility between
+           the penalty and solver.
+
+        .. versionadded:: 1.10
 
     fit_intercept : bool, default=True
         Specifies if a constant (a.k.a. bias or intercept) should be
@@ -549,6 +610,17 @@ class PoissonRegressor(_GeneralizedLinearRegressor):
 
         'lbfgs'
             Calls scipy's L-BFGS-B optimizer.
+
+        'newton-cd-gram'
+            Uses Newton-Raphson steps (in arbitrary precision arithmetic equivalent to
+            iterated reweighted least squares) with an inner coordinate descent based
+            solver that uses the full Hessian/Gram matrix. It can solve for all
+            values of `l1_ratio`.
+            This solver is a good choice for `n_samples` >> `n_features`. Be aware
+            that the memory usage of this solver has a quadratic dependency on
+            `n_features` because it explicitly computes the Hessian matrix.
+
+            .. versionadded:: 1.10
 
         'newton-cg'
             Uses a slightly adapted version of scipy's Newton-CG optimizer. This is
@@ -568,6 +640,20 @@ class PoissonRegressor(_GeneralizedLinearRegressor):
             `n_features` because it explicitly computes the Hessian matrix.
 
             .. versionadded:: 1.2
+
+        .. warning::
+           The choice of the algorithm depends on the penalty chosen (`l1_ratio=0`
+           for L2-penalty, `l1_ratio=1` for L1-penalty and `0 < l1_ratio < 1` for
+           Elastic-Net):
+
+           ================= ========================
+           solver            l1_ratio
+           ================= ========================
+           'lbfgs'           l1_ratio=0
+           'newton-cd-gram'  0<=l1_ratio<=1
+           'newton-cg'       l1_ratio=0
+           'newton-cholesky' l1_ratio=0
+           ================= ========================
 
     max_iter : int, default=100
         The maximal number of iterations for the solver.
@@ -641,6 +727,7 @@ class PoissonRegressor(_GeneralizedLinearRegressor):
         self,
         *,
         alpha=1.0,
+        l1_ratio=0.0,
         fit_intercept=True,
         solver="lbfgs",
         max_iter=100,
@@ -650,6 +737,7 @@ class PoissonRegressor(_GeneralizedLinearRegressor):
     ):
         super().__init__(
             alpha=alpha,
+            l1_ratio=l1_ratio,
             fit_intercept=fit_intercept,
             solver=solver,
             max_iter=max_iter,
@@ -682,21 +770,45 @@ class GammaRegressor(_GeneralizedLinearRegressor):
     Parameters
     ----------
     alpha : float, default=1
-        Constant that multiplies the L2 penalty term and determines the
+        Constant that multiplies the penalty terms and determines the
         regularization strength. ``alpha = 0`` is equivalent to unpenalized
         GLMs. In this case, the design matrix `X` must have full column rank
         (no collinearities).
         Values of `alpha` must be in the range `[0.0, inf)`.
 
+    l1_ratio : float, default=0.0
+        The Elastic-Net mixing parameter, with `0 <= l1_ratio <= 1`. Setting
+        `l1_ratio=1` gives a pure L1-penalty, setting `l1_ratio=0` a pure L2-penalty.
+        Any value between 0 and 1 gives an Elastic-Net penalty of the form
+        `l1_ratio * L1 + (1 - l1_ratio) * L2`.
+
+        .. warning::
+           Certain values of `l1_ratio`, i.e. some penalties, do not work with some
+           solvers. See the parameter `solver` below, to know the compatibility between
+           the penalty and solver.
+
+        .. versionadded:: 1.10
+
     fit_intercept : bool, default=True
         Specifies if a constant (a.k.a. bias or intercept) should be
-        added to the linear predictor (`X @ coef_ + intercept_`).
+        added to the linear predictor (`X @ coef + intercept`).
 
     solver : {'lbfgs', 'newton-cg', 'newton-cholesky'}, default='lbfgs'
         Algorithm to use in the optimization problem:
 
         'lbfgs'
             Calls scipy's L-BFGS-B optimizer.
+
+        'newton-cd-gram'
+            Uses Newton-Raphson steps (in arbitrary precision arithmetic equivalent to
+            iterated reweighted least squares) with an inner coordinate descent based
+            solver that uses the full Hessian/Gram matrix. It can solve for all
+            values of `l1_ratio`.
+            This solver is a good choice for `n_samples` >> `n_features`. Be aware
+            that the memory usage of this solver has a quadratic dependency on
+            `n_features` because it explicitly computes the Hessian matrix.
+
+            .. versionadded:: 1.10
 
         'newton-cg'
             Uses a slightly adapted version of scipy's Newton-CG optimizer. This is
@@ -716,6 +828,20 @@ class GammaRegressor(_GeneralizedLinearRegressor):
             `n_features` because it explicitly computes the Hessian matrix.
 
             .. versionadded:: 1.2
+
+        .. warning::
+           The choice of the algorithm depends on the penalty chosen (`l1_ratio=0`
+           for L2-penalty, `l1_ratio=1` for L1-penalty and `0 < l1_ratio < 1` for
+           Elastic-Net):
+
+           ================= ========================
+           solver            l1_ratio
+           ================= ========================
+           'lbfgs'           l1_ratio=0
+           'newton-cd-gram'  0<=l1_ratio<=1
+           'newton-cg'       l1_ratio=0
+           'newton-cholesky' l1_ratio=0
+           ================= ========================
 
     max_iter : int, default=100
         The maximal number of iterations for the solver.
@@ -790,6 +916,7 @@ class GammaRegressor(_GeneralizedLinearRegressor):
         self,
         *,
         alpha=1.0,
+        l1_ratio=0.0,
         fit_intercept=True,
         solver="lbfgs",
         max_iter=100,
@@ -799,6 +926,7 @@ class GammaRegressor(_GeneralizedLinearRegressor):
     ):
         super().__init__(
             alpha=alpha,
+            l1_ratio=l1_ratio,
             fit_intercept=fit_intercept,
             solver=solver,
             max_iter=max_iter,
@@ -844,11 +972,24 @@ class TweedieRegressor(_GeneralizedLinearRegressor):
             For ``0 < power < 1``, no distribution exists.
 
     alpha : float, default=1
-        Constant that multiplies the L2 penalty term and determines the
+        Constant that multiplies the penalty terms and determines the
         regularization strength. ``alpha = 0`` is equivalent to unpenalized
         GLMs. In this case, the design matrix `X` must have full column rank
         (no collinearities).
         Values of `alpha` must be in the range `[0.0, inf)`.
+
+    l1_ratio : float, default=0.0
+        The Elastic-Net mixing parameter, with `0 <= l1_ratio <= 1`. Setting
+        `l1_ratio=1` gives a pure L1-penalty, setting `l1_ratio=0` a pure L2-penalty.
+        Any value between 0 and 1 gives an Elastic-Net penalty of the form
+        `l1_ratio * L1 + (1 - l1_ratio) * L2`.
+
+        .. warning::
+           Certain values of `l1_ratio`, i.e. some penalties, do not work with some
+           solvers. See the parameter `solver` below, to know the compatibility between
+           the penalty and solver.
+
+        .. versionadded:: 1.10
 
     fit_intercept : bool, default=True
         Specifies if a constant (a.k.a. bias or intercept) should be
@@ -869,6 +1010,17 @@ class TweedieRegressor(_GeneralizedLinearRegressor):
         'lbfgs'
             Calls scipy's L-BFGS-B optimizer.
 
+        'newton-cd-gram'
+            Uses Newton-Raphson steps (in arbitrary precision arithmetic equivalent to
+            iterated reweighted least squares) with an inner coordinate descent based
+            solver that uses the full Hessian/Gram matrix. It can solve for all
+            values of `l1_ratio`.
+            This solver is a good choice for `n_samples` >> `n_features`. Be aware
+            that the memory usage of this solver has a quadratic dependency on
+            `n_features` because it explicitly computes the Hessian matrix.
+
+            .. versionadded:: 1.10
+
         'newton-cg'
             Uses a slightly adapted version of scipy's Newton-CG optimizer. This is
             sometimes called the truncated Newton method. Due to the fact that it
@@ -887,6 +1039,20 @@ class TweedieRegressor(_GeneralizedLinearRegressor):
             `n_features` because it explicitly computes the Hessian matrix.
 
             .. versionadded:: 1.2
+
+        .. warning::
+           The choice of the algorithm depends on the penalty chosen (`l1_ratio=0`
+           for L2-penalty, `l1_ratio=1` for L1-penalty and `0 < l1_ratio < 1` for
+           Elastic-Net):
+
+           ================= ========================
+           solver            l1_ratio
+           ================= ========================
+           'lbfgs'           l1_ratio=0
+           'newton-cd-gram'  0<=l1_ratio<=1
+           'newton-cg'       l1_ratio=0
+           'newton-cholesky' l1_ratio=0
+           ================= ========================
 
     max_iter : int, default=100
         The maximal number of iterations for the solver.
@@ -964,6 +1130,7 @@ class TweedieRegressor(_GeneralizedLinearRegressor):
         *,
         power=0.0,
         alpha=1.0,
+        l1_ratio=0.0,
         fit_intercept=True,
         link="auto",
         solver="lbfgs",
@@ -974,6 +1141,7 @@ class TweedieRegressor(_GeneralizedLinearRegressor):
     ):
         super().__init__(
             alpha=alpha,
+            l1_ratio=l1_ratio,
             fit_intercept=fit_intercept,
             solver=solver,
             max_iter=max_iter,

--- a/sklearn/linear_model/_glm/tests/test_glm.py
+++ b/sklearn/linear_model/_glm/tests/test_glm.py
@@ -680,6 +680,17 @@ def test_glm_wrong_y_range(glm):
         glm.fit(X, y)
 
 
+@pytest.mark.parametrize("GLM", (TweedieRegressor, PoissonRegressor, GammaRegressor))
+@pytest.mark.parametrize("solver", ("lbfgs", "newton-cg", "newton-cholesky"))
+def test_glm_l1_ratio_solver_raises(GLM, solver):
+    """Test that GLM raises if solver does not support l1_ratio > 0."""
+    X = np.array([[1, 1, 1, 1, 1], [0, 1, 2, 3, 4]]).T
+    y = np.linspace(1, 5, 4)
+    msg = f"The solver '{solver}' does not support l1_ratio > 0; got l1_ratio=0.1"
+    with pytest.raises(ValueError, match=msg):
+        GLM(l1_ratio=0.1, solver=solver).fit(X, y)
+
+
 @pytest.mark.parametrize("fit_intercept", [False, True])
 def test_glm_identity_regression(fit_intercept):
     """Test GLM regression with identity link on a simple dataset."""
@@ -913,7 +924,7 @@ def test_normal_ridge_comparison(
 
 
 @pytest.mark.parametrize("solver", SOLVERS)
-def test_poisson_glmnet(solver):
+def test_poisson_glmnet_L2(solver):
     """Compare Poisson regression with L2 regularization and LogLink to glmnet"""
     # library("glmnet")
     # options(digits=10)
@@ -938,6 +949,35 @@ def test_poisson_glmnet(solver):
     glm.fit(X, y)
     assert_allclose(glm.intercept_, -0.12889386979, rtol=1e-5)
     assert_allclose(glm.coef_, [0.29019207995, 0.03741173122], rtol=1e-5)
+
+
+@pytest.mark.parametrize("solver", ["newton-cd-gram"])
+def test_poisson_glmnet_enet(solver):
+    """Compare Poisson regression with Elastic-Net penaltiy and LogLink to glmnet"""
+    # library("glmnet")
+    # options(digits=10)
+    # df <- data.frame(a=c(-2,-1,1,2), b=c(0,0,1,1), y=c(0,1,1,2))
+    # x <- data.matrix(df[,c("a", "b")])
+    # y <- df$y
+    # fit <- glmnet(x=x, y=y, alpha=0.5, lambda=1, intercept=T, family="poisson",
+    #               standardize=F, thresh=1e-12)
+    # coef(fit)  # s=1 because lambda=1
+    # (Intercept) -0.03550976074
+    # a            0.16936420181
+    # b            .
+    X = np.array([[-2, -1, 1, 2], [0, 0, 1, 1]]).T
+    y = np.array([0, 1, 1, 2])
+    glm = PoissonRegressor(
+        alpha=1,
+        l1_ratio=0.5,
+        fit_intercept=True,
+        tol=1e-12,
+        solver=solver,
+    )
+    glm.fit(X, y)
+    print(glm.coef_)
+    assert_allclose(glm.intercept_, -0.03550976074, rtol=1e-6)
+    assert_allclose(glm.coef_, [0.16936420181, 0], rtol=1e-6)
 
 
 def test_convergence_warning(regression_data):

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1047,8 +1047,8 @@ class LogisticRegression(
 
     l1_ratio : float, default=0.0
         The Elastic-Net mixing parameter, with `0 <= l1_ratio <= 1`. Setting
-        `l1_ratio=1` gives a pure L1-penalty, setting `l1_ratio=0` a pure L2-penalty.
-        Any value between 0 and 1 gives an Elastic-Net penalty of the form
+        `l1_ratio=1` gives a pure L1-penalty, setting `l1_ratio=0` gives a pure
+        L2-penalty. Any value between 0 and 1 gives an Elastic-Net penalty of the form
         `l1_ratio * L1 + (1 - l1_ratio) * L2`.
 
         .. warning::
@@ -1714,8 +1714,8 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
     l1_ratios : array-like of shape (n_l1_ratios), default=None
         Floats between 0 and 1 passed as Elastic-Net mixing parameter (scaling between
         L1 and L2 penalties). For `l1_ratio = 0` the penalty is an L2 penalty. For
-        `l1_ratio = 1` it is an L1 penalty. For `0 < l1_ratio < 1`, the penalty is a
-        combination of L1 and L2.
+        `l1_ratio = 1` it is an L1 penalty. Any value between 0 and 1 gives
+        an Elastic-Net penalty of the form `l1_ratio * L1 + (1 - l1_ratio) * L2`.
         All the values of the given array-like are tested by cross-validation and the
         one giving the best prediction score is used.
 

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1110,8 +1110,8 @@ class LogisticRegression(
         data. It has no effect on the other solvers.
         See :term:`Glossary <random_state>` for details.
 
-    solver : {'lbfgs', 'liblinear', 'newton-cg', 'newton-cholesky', 'sag', 'saga'}, \
-            default='lbfgs'
+    solver : {'lbfgs', 'liblinear', 'newton-cd-gram', 'newton-cg', 'newton-cholesky', \
+            'sag', 'saga'}, default='lbfgs'
 
         Algorithm to use in the optimization problem. Default is 'lbfgs'.
         To choose a solver, you might want to consider the following aspects:
@@ -1778,8 +1778,8 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
            The default will change from None, i.e. accuracy, to 'neg_log_loss' in
            version 1.11.
 
-    solver : {'lbfgs', 'liblinear', 'newton-cg', 'newton-cholesky', 'sag', 'saga'}, \
-            default='lbfgs'
+    solver : {'lbfgs', 'liblinear', 'newton-cd-gram', 'newton-cg', 'newton-cholesky', \
+            'sag', 'saga'}, default='lbfgs'
 
         Algorithm to use in the optimization problem. Default is 'lbfgs'.
         To choose a solver, you might want to consider the following aspects:


### PR DESCRIPTION
#### Reference Issues/PRs
Part 6 of #33160, follow-up of #34377.

#### What does this implement/fix? Explain your changes.
This PR:
- adds `l1_ratio` to `PoissonRegressor`, `GammaRegressor` and `TweedieRegressor`
- changelog entry for newton-cd-gram

#### AI usage disclosure
None

#### Any other comments?
