### PR TITLE
Fix tracking of nightly wheel failure

### DIFF
--- a/.github/workflows/update_tracking_issue.yml
+++ b/.github/workflows/update_tracking_issue.yml
@@ -6,6 +6,8 @@
 #   needs: [JOB_NAME]
 #   with:
 #     job_status: ${{ needs.JOB_NAME.result }}
+#     # Optional, defaults to false
+#     auto_close: true
 #   secrets:
 #     BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
 # Where JOB_NAME is contains the status of the job you are interested in
@@ -20,6 +22,13 @@ on:
       job_status:
         required: true
         type: string
+      auto_close:
+        description: >-
+          Close the tracking issue once the job succeeds again. Off by default
+          so that a maintainer has to confirm intermittent failures are gone.
+        required: false
+        type: boolean
+        default: false
     secrets:
       BOT_GITHUB_TOKEN:
         required: true
@@ -49,4 +58,4 @@ jobs:
             "$GITHUB_REPOSITORY" \
             https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID \
             --tests-passed $TESTS_PASSED \
-            --auto-close false
+            --auto-close ${{ inputs.auto_close }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -218,15 +218,6 @@ jobs:
           name: cibw-wheels-cp${{ matrix.python }}-${{ matrix.platform_id }}
           path: wheelhouse/*.whl
 
-  update-tracker:
-    uses: ./.github/workflows/update_tracking_issue.yml
-    if: ${{ always() }}
-    needs: [build_wheels]
-    with:
-      job_status: ${{ needs.build_wheels.result }}
-    secrets:
-      BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
-
   # Build the source distribution under Linux
   build_sdist:
     name: Source distribution
@@ -288,3 +279,23 @@ jobs:
           ARTIFACTS_PATH: dist
         # Force a replacement if the remote file already exists
         run: bash build_tools/github/upload_anaconda.sh
+
+  # Track nightly failures in a single GitHub issue. The nightly build is only
+  # useful if the wheels and the sdist actually land on
+  # scientific-python-nightly-wheels, so the upload job is tracked as well and
+  # not just the build ones.
+  update-tracker:
+    uses: ./.github/workflows/update_tracking_issue.yml
+    if: ${{ always() }}
+    needs: [build_wheels, build_sdist, upload_anaconda]
+    with:
+      job_status: >-
+        ${{ (needs.build_wheels.result == 'success'
+        && needs.build_sdist.result == 'success'
+        && needs.upload_anaconda.result == 'success')
+        && 'success' || 'failure' }}
+      # A nightly upload either works or it does not, so there is no need for a
+      # maintainer to manually confirm that the failure is gone.
+      auto_close: true
+    secrets:
+      BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Make the automatic issue track more jobs so that `scientific-python-nightly-wheels` failures are noted in https://github.com/scikit-learn/scikit-learn/issues/34458.

#### AI usage disclosure

I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)

Used Claude Fable 5, but I understand and vouch for the code
