### PR TITLE
DOC: fix estimators_ shape doc in GradientBoostingRegressor

### DIFF
--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1996,7 +1996,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         The estimator that provides the initial predictions. Set via the ``init``
         argument.
 
-    estimators_ : ndarray of DecisionTreeRegressor of shape (n_estimators, 1)
+    estimators_ : ndarray of DecisionTreeRegressor of shape (n_estimators, ``n_trees_per_iteration_``)
         The collection of fitted sub-estimators.
 
     n_features_in_ : int


### PR DESCRIPTION
Closes #34279.

The estimators_ shape in GradientBoostingRegressor was documented as `(n_estimators, 1)` instead of `(n_estimators, n_trees_per_iteration_)`, making it inconsistent with the GradientBoostingClassifier documentation.