### PR TITLE
BLD Pin cython<3.2.6 to avoid Cython __annotate__  pickling bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,8 @@ build-backend = "mesonpy"
 # Minimum requirements for the build system to execute.
 requires = [
     "meson-python>=0.17.1",
+    # TODO: once https://github.com/cython/cython/issues/7846 is fixed,
+    # change to "cython>[fixed-version]" or "cython>=3.1.2,!=3.2.6,!=3.2.7,..."
     "cython>=3.1.2,<3.2.6",
     "numpy>=2",
     "scipy>=1.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ tracker = "https://github.com/scikit-learn/scikit-learn/issues"
 "release notes" = "https://scikit-learn.org/stable/whats_new"
 
 [project.optional-dependencies]
-build = ["numpy>=1.24.1", "scipy>=1.10.0", "cython>=3.1.2", "meson-python>=0.17.1"]
+build = ["numpy>=1.24.1", "scipy>=1.10.0", "cython>=3.1.2,<3.2.6", "meson-python>=0.17.1"]
 install = ["numpy>=1.24.1", "scipy>=1.10.0", "joblib>=1.4.0", "narwhals>=2.0.1", "threadpoolctl>=3.5.0"]
 benchmark = ["matplotlib>=3.6.1", "pandas>=1.5.0", "memory_profiler>=0.57.0"]
 docs = [
@@ -100,7 +100,7 @@ build-backend = "mesonpy"
 # Minimum requirements for the build system to execute.
 requires = [
     "meson-python>=0.17.1",
-    "cython>=3.1.2",
+    "cython>=3.1.2,<3.2.6",
     "numpy>=2",
     "scipy>=1.10.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ tracker = "https://github.com/scikit-learn/scikit-learn/issues"
 "release notes" = "https://scikit-learn.org/stable/whats_new"
 
 [project.optional-dependencies]
+# TODO: once https://github.com/cython/cython/issues/7846 is fixed and in a Cython release
+# change to "cython>[fixed-version]" or "cython>=3.1.2,!=3.2.6,!=3.2.7,..."
 build = ["numpy>=1.24.1", "scipy>=1.10.0", "cython>=3.1.2,<3.2.6", "meson-python>=0.17.1"]
 install = ["numpy>=1.24.1", "scipy>=1.10.0", "joblib>=1.4.0", "narwhals>=2.0.1", "threadpoolctl>=3.5.0"]
 benchmark = ["matplotlib>=3.6.1", "pandas>=1.5.0", "memory_profiler>=0.57.0"]
@@ -100,7 +102,7 @@ build-backend = "mesonpy"
 # Minimum requirements for the build system to execute.
 requires = [
     "meson-python>=0.17.1",
-    # TODO: once https://github.com/cython/cython/issues/7846 is fixed,
+    # TODO: once https://github.com/cython/cython/issues/7846 is fixed and in a Cython release
     # change to "cython>[fixed-version]" or "cython>=3.1.2,!=3.2.6,!=3.2.7,..."
     "cython>=3.1.2,<3.2.6",
     "numpy>=2",


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #34525

#### What does this implement/fix? Explain your changes.

Pins `cython<3.2.6` in `pyproject.toml`, in both `[build-system] requires` and the `build` optional-dependencies extra. These two lists are kept in sync historically, and only `[build-system] requires` is actually read by pip's isolated build backend, so both need updating together for the fix to be complete and consistent.

(The `build` extra isn't invoked anywhere in our own docs/CI — `development_setup.rst` installs build deps by literal package name instead — but it's still valid PEP 508 metadata: anyone can `pip install -e ".[build]"` to pull in the pinned build deps before `pip install --no-build-isolation --editable .`, and it's also what tools that introspect `pyproject.toml` extras without doing a build, e.g. PyPI's own project page, will see.)

#### AI usage disclosure

- research and understanding
- writing this PR desc.