### PR TITLE
[DOC] update docstring for orthogonal_mp

### DIFF
--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -320,14 +320,14 @@ def orthogonal_mp(
     (i.e. the :math:`\\ell_0` pseudo-norm) using `n_nonzero_coefs`:
 
     .. math::
-        \\underset{w}{\\operatorname{arg\\,min\\,}} ||y - Xw||^2_2
-            \\text{subject to} ||w||_0 <= n_{nonzero coefs}
+        \underset{w}{\operatorname{arg\,min\,}} ||y - Xw||^2_2
+            \text{subject to} ||w||_0 <= n_{nonzero_coefs}
 
     When parametrized by error using the parameter `tol`:
 
     .. math::
-        \\underset{w}{\\operatorname{arg\\,min\\,}} ||w||_0
-            \\text{subject to} ||y - Xw||^2_2 <= tol
+        \underset{w}{\operatorname{arg\,min\,}} ||w||_0
+            \text{subject to} ||y - Xw||^2_2 <= tol
 
     Read more in the :ref:`User Guide <omp>`.
 
@@ -663,7 +663,7 @@ class OrthogonalMatchingPursuit(RegressorMixin, MultiOutputLinearModel):
 
     .. math::
         \\underset{w}{\\operatorname{arg\\,min\\,}} ||y - Xw||^2_2
-            \\text{subject to} ||w||_0 <= n_{nonzero coefs}
+            \\text{subject to} ||w||_0 <= n_{nonzero_coefs}
 
     When parametrized by error using the parameter `tol`:
 

--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -314,15 +314,7 @@ def orthogonal_mp(
 ):
     r"""Orthogonal Matching Pursuit (OMP).
 
-    Solves n_targets Orthogonal Matching Pursuit problems.
-    An instance of the problem has the form:
-
-    When parametrized by the number of non-zero coefficients using
-    `n_nonzero_coefs`:
-    argmin ||y - X\gamma||^2 subject to ||\gamma||_0 <= n_{nonzero coefs}
-
-    When parametrized by error using the parameter `tol`:
-    argmin ||\gamma||_0 subject to ||y - X\gamma||^2 <= tol
+    Solves `n_targets` Orthogonal Matching Pursuit problems.
 
     Read more in the :ref:`User Guide <omp>`.
 

--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -315,6 +315,19 @@ def orthogonal_mp(
     r"""Orthogonal Matching Pursuit (OMP).
 
     Solves `n_targets` Orthogonal Matching Pursuit problems.
+    Each instance of the problem fits a linear model with constraints
+    imposed on the number of non-zero coefficients
+    (i.e. the :math:`\\ell_0` pseudo-norm) using `n_nonzero_coefs`:
+
+    .. math::
+        \\underset{w}{\\operatorname{arg\\,min\\,}} ||y - Xw||^2_2
+            \\text{subject to} ||w||_0 <= n_{nonzero coefs}
+
+    When parametrized by error using the parameter `tol`:
+
+    .. math::
+        \\underset{w}{\\operatorname{arg\\,min\\,}} ||w||_0
+            \\text{subject to} ||y - Xw||^2_2 <= tol
 
     Read more in the :ref:`User Guide <omp>`.
 
@@ -485,8 +498,15 @@ def orthogonal_mp_gram(
 ):
     """Gram Orthogonal Matching Pursuit (OMP).
 
-    Solves n_targets Orthogonal Matching Pursuit problems using only
-    the Gram matrix X.T * X and the product X.T * y.
+    Solves `n_targets` Orthogonal Matching Pursuit problems using only
+    the precomputed Gram matrix ``X.T * X`` and the product ``X.T * y``.
+    This implementation efficiently computes the solution using the
+    Cholesky decomposition.
+
+    Each instance of the problem fits a linear model with constraints
+    imposed on the number of non-zero coefficients (i.e. the
+    :math:`\\ell_0` pseudo-norm) using `n_nonzero_coefs` or
+    on the error using the parameter `tol`.
 
     Read more in the :ref:`User Guide <omp>`.
 
@@ -637,6 +657,19 @@ def orthogonal_mp_gram(
 
 class OrthogonalMatchingPursuit(RegressorMixin, MultiOutputLinearModel):
     """Orthogonal Matching Pursuit model (OMP).
+
+    Fits a linear model with constraints imposed on the number of non-zero coefficients
+    (i.e. the :math:`\\ell_0` pseudo-norm) using `n_nonzero_coefs`:
+
+    .. math::
+        \\underset{w}{\\operatorname{arg\\,min\\,}} ||y - Xw||^2_2
+            \\text{subject to} ||w||_0 <= n_{nonzero coefs}
+
+    When parametrized by error using the parameter `tol`:
+
+    .. math::
+        \\underset{w}{\\operatorname{arg\\,min\\,}} ||w||_0
+            \\text{subject to} ||y - Xw||^2_2 <= tol
 
     Read more in the :ref:`User Guide <omp>`.
 

--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -321,13 +321,13 @@ def orthogonal_mp(
 
     .. math::
         \underset{w}{\operatorname{arg\,min\,}} ||y - Xw||^2_2
-            \text{subject to} ||w||_0 <= n_{nonzero_coefs}
+            \text{ subject to } ||w||_0 \leq n_{\text{nonzero_coefs}}
 
     When parametrized by error using the parameter `tol`:
 
     .. math::
         \underset{w}{\operatorname{arg\,min\,}} ||w||_0
-            \text{subject to} ||y - Xw||^2_2 <= tol
+            \text{ subject to } ||y - Xw||^2_2 \leq tol
 
     Read more in the :ref:`User Guide <omp>`.
 
@@ -340,7 +340,7 @@ def orthogonal_mp(
         Input targets.
 
     n_nonzero_coefs : int, default=None
-        Desired number of non-zero entries in the solution. If None (by
+        Maximum number of non-zero entries in the solution. If None (by
         default) this value is set to 10% of n_features.
 
     tol : float, default=None
@@ -519,7 +519,7 @@ def orthogonal_mp_gram(
         Input targets multiplied by `X`: `X.T * y`.
 
     n_nonzero_coefs : int, default=None
-        Desired number of non-zero entries in the solution. If `None` (by
+        Maximum number of non-zero entries in the solution. If `None` (by
         default) this value is set to 10% of n_features.
 
     tol : float, default=None
@@ -663,20 +663,20 @@ class OrthogonalMatchingPursuit(RegressorMixin, MultiOutputLinearModel):
 
     .. math::
         \\underset{w}{\\operatorname{arg\\,min\\,}} ||y - Xw||^2_2
-            \\text{subject to} ||w||_0 <= n_{nonzero_coefs}
+            \\text{ subject to } ||w||_0 \\leq n_{\\text{nonzero_coefs}}
 
     When parametrized by error using the parameter `tol`:
 
     .. math::
         \\underset{w}{\\operatorname{arg\\,min\\,}} ||w||_0
-            \\text{subject to} ||y - Xw||^2_2 <= tol
+            \\text{ subject to } ||y - Xw||^2_2 \\leq tol
 
     Read more in the :ref:`User Guide <omp>`.
 
     Parameters
     ----------
     n_nonzero_coefs : int, default=None
-        Desired number of non-zero entries in the solution. Ignored if `tol` is set.
+        Maximum number of non-zero entries in the solution. Ignored if `tol` is set.
         When `None` and `tol` is also `None`, this value is either set to 10% of
         `n_features` or 1, whichever is greater.
 


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes #34454 

#### What does this implement/fix? Explain your changes.

Improves the docstring for `linear_model.orthogonal_mp`. Removes notation that does not align with the Linear Model [User Guide](https://scikit-learn.org/stable/modules/linear_model.html#orthogonal-matching-pursuit-omp), and aligns the docstring with other Orthogonal Matching Pursuit estimators (e.g., [`OrthogonalMatchingPursuit`](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.OrthogonalMatchingPursuit.html)).

#### First time contributor introduction
<!-- If you are new to the scikit-learn community, please introduce yourself. How do you
 use scikit-learn, what prompted you to make this contribution? Getting to know you
 helps us build trust in your judgement and welcome you into the community.
-->

👋 Hi, I'm Elizabeth ! I'm a postdoctoral researcher at the University of Montreal and a core developer of the [nilearn](https://nilearn.github.io) software library (which extends scikit-learn for neuroimaging data).


#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->

I did not use AI assistance.


#### Any other comments?

Thanks for your work in maintaining scikit-learn !

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
