### PR TITLE
FIX Handle scorer pos_label in LogisticRegressionCV

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/34540.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/34540.fix.rst
@@ -1,0 +1,3 @@
+- Fix a regression in :class:`linear_model.LogisticRegressionCV` that caused
+  binary classification with a string scorer such as ``"f1_macro"`` to raise a
+  ``TypeError``. By :user:`msaule`.

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -962,13 +962,16 @@ def _log_reg_scoring_path(
             if is_binary and "pos_label" in sig:
                 # see _logistic_regression_path
                 pos_label_kwarg["pos_label"] = n_classes - 1  # classes[-1]
+            scorer_kwargs = {
+                **getattr(scoring, "_kwargs", {}),
+                **pos_label_kwarg,
+            }
             scoring = make_scorer(
                 scoring._score_func,
                 greater_is_better=True if scoring._sign == 1 else False,
                 response_method=scoring._response_method,
                 labels=log_reg.classes_,
-                **pos_label_kwarg,
-                **getattr(scoring, "_kwargs", {}),
+                **scorer_kwargs,
             )
 
         def calc_score(log_reg):

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -675,6 +675,22 @@ def test_logistic_cv_multinomial_score(scoring, multiclass_agg_list):
         )
 
 
+def test_logistic_cv_string_scorer_with_pos_label():
+    """Check that a binary scorer with ``pos_label`` can be reconstructed."""
+    X, y = make_classification(
+        n_samples=50, n_features=5, n_informative=3, random_state=0
+    )
+    logistic_regression_cv = LogisticRegressionCV(
+        Cs=[1.0],
+        cv=2,
+        l1_ratios=(0.0,),
+        scoring="f1_macro",
+        use_legacy_attributes=False,
+    ).fit(X, y)
+
+    assert_array_equal(logistic_regression_cv.C_, [1.0])
+
+
 def test_multinomial_logistic_regression_string_inputs():
     """Test internally encode labels"""
     n_samples, n_features, n_classes = 50, 5, 3


### PR DESCRIPTION
Fixes #34531.

## Summary

`LogisticRegressionCV` rebuilds scorers that accept `labels` so every cross-validation fold retains the complete class set. For binary string scorers such as `f1_macro`, the stored scorer kwargs already contain `pos_label`; passing that mapping separately from the internally encoded positive class raises `TypeError`.

Merge the mappings before rebuilding the scorer, with the internally encoded class taking precedence. This preserves all other scorer kwargs and avoids mutating the original scorer.

## Validation

- `sklearn/linear_model/tests/test_logistic.py -k string_scorer_with_pos_label -q`
- `sklearn/linear_model/tests/test_logistic.py -q` — 324 passed, 753 skipped
- `pre-commit run --files sklearn/linear_model/_logistic.py sklearn/linear_model/tests/test_logistic.py`

## Changelog

Added `doc/whats_new/upcoming_changes/sklearn.linear_model/34540.fix.rst`.

This pull request includes code written with the assistance of AI.
