### PR TITLE
MNT Remove unused extra_requires from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,60 +43,6 @@ download = "https://pypi.org/project/scikit-learn/#files"
 tracker = "https://github.com/scikit-learn/scikit-learn/issues"
 "release notes" = "https://scikit-learn.org/stable/whats_new"
 
-[project.optional-dependencies]
-# TODO: once https://github.com/cython/cython/issues/7846 is fixed and in a Cython release
-# change to "cython>[fixed-version]" or "cython>=3.1.2,!=3.2.6,!=3.2.7,..."
-build = ["numpy>=1.24.1", "scipy>=1.10.0", "cython>=3.1.2,<3.2.6", "meson-python>=0.17.1"]
-install = ["numpy>=1.24.1", "scipy>=1.10.0", "joblib>=1.4.0", "narwhals>=2.0.1", "threadpoolctl>=3.5.0"]
-benchmark = ["matplotlib>=3.6.1", "pandas>=1.5.0", "memory_profiler>=0.57.0"]
-docs = [
-    "matplotlib>=3.6.1",
-    "scikit-image>=0.22.0",
-    "pandas>=1.5.0",
-    "rich>=14.1.0",
-    "seaborn>=0.13.0",
-    "memory_profiler>=0.57.0",
-    "sphinx>=7.3.7",
-    "sphinx-copybutton>=0.5.2",
-    "sphinx-gallery>=0.17.1",
-    "numpydoc>=1.2.0",
-    "Pillow>=12.1.1",
-    "pooch>=1.8.0",
-    "sphinx-prompt>=1.4.0",
-    "sphinxext-opengraph>=0.9.1",
-    "plotly>=5.22.0",
-    "polars>=0.20.30",
-    "sphinx-design>=0.6.0",
-    "pydata-sphinx-theme>=0.15.3",
-    "sphinx-remove-toctrees>=1.0.0.post1",
-    "towncrier>=24.8.0",
-]
-examples = [
-    "matplotlib>=3.6.1",
-    "scikit-image>=0.22.0",
-    "pandas>=1.5.0",
-    "rich>=14.1.0",
-    "seaborn>=0.13.0",
-    "pooch>=1.8.0",
-    "plotly>=5.22.0",
-]
-tests = [
-    "matplotlib>=3.6.1",
-    "pandas>=1.5.0",
-    "rich>=14.1.0",
-    "pytest>=7.1.2",
-    "pytest-cov>=2.9.0",
-    "ruff>=0.12.2",
-    "mypy>=1.15",
-    "cython-lint>=0.21",
-    "pyamg>=5.0.0",
-    "polars>=0.20.30",
-    "pyarrow>=13.0.0",
-    "numpydoc>=1.2.0",
-    "pooch>=1.8.0",
-]
-maintenance = ["conda-lock==3.0.1"]
-
 [build-system]
 build-backend = "mesonpy"
 # Minimum requirements for the build system to execute.

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import argparse
-from collections import defaultdict
 
 # scipy and cython should by in sync with pyproject.toml
 NUMPY_MIN_VERSION = "1.24.1"
@@ -16,9 +15,10 @@ PYTEST_MIN_VERSION = "7.1.2"
 CYTHON_MIN_VERSION = "3.1.2"
 
 
-# 'build' and 'install' is included to have structured metadata for CI.
-# It will NOT be included in setup's extras_require
-# The values are (version_spec, comma separated tags)
+# The values are (version_spec, comma separated tags). The tags are used to
+# generate the minimum dependency table in the docs and to cross-check
+# pyproject.toml's build and install dependencies in
+# sklearn/tests/test_min_dependencies_readme.py.
 dependent_packages = {
     "numpy": (NUMPY_MIN_VERSION, "build, install"),
     "scipy": (SCIPY_MIN_VERSION, "build, install"),
@@ -60,13 +60,6 @@ dependent_packages = {
     # from time to time)
     "conda-lock": ("3.0.1", "maintenance"),
 }
-
-
-# create inverse mapping for setuptools
-tag_to_packages: dict = defaultdict(list)
-for package, (min_version, extras) in dependent_packages.items():
-    for extra in extras.split(", "):
-        tag_to_packages[extra].append("{}>={}".format(package, min_version))
 
 
 # Used by CI to get the min dependencies

--- a/sklearn/tests/test_min_dependencies_consistency.py
+++ b/sklearn/tests/test_min_dependencies_consistency.py
@@ -17,16 +17,11 @@ from sklearn.utils.fixes import parse_version
 TOY_MIN_DEPENDENCIES_PY_INFO = {
     "joblib": ("1.3.0", "install"),
     "scipy": ("1.10.0", "build, install"),
-    "conda-lock": ("3.0.1", "maintenance"),
 }
 
 TOY_MATCHING_PYPROJECT_SECTIONS = """
 [project]
 dependencies = ["joblib>=1.3.0", "scipy>=1.10.0"]
-[project.optional-dependencies]
-build = ["scipy>=1.10.0"]
-install = ["joblib>=1.3.0", "scipy>=1.10.0"]
-maintenance = ["conda-lock==3.0.1"]
 [build-system]
 requires = ["scipy>=1.10.0"]
 """
@@ -34,10 +29,6 @@ requires = ["scipy>=1.10.0"]
 TOY_MATCHING_PYPROJECT_SECTIONS_WITH_UPPER_BOUND = """
 [project]
 dependencies = ["joblib>=1.3.0,<2.0", "scipy>=1.10.0"]
-[project.optional-dependencies]
-build = ["scipy>=1.10.0,<1.19.0"]
-install = ["joblib>=1.3.0,<2.0", "scipy>=1.10.0"]
-maintenance = ["conda-lock==3.0.1"]
 [build-system]
 requires = ["scipy>=1.10.0,<1.19.0"]
 """
@@ -45,10 +36,6 @@ requires = ["scipy>=1.10.0,<1.19.0"]
 TOY_WRONG_SYMBOL_PYPROJECT_SECTIONS = """
 [project]
 dependencies = ["scipy<1.10.0"]
-[project.optional-dependencies]
-build = ["scipy>=1.10.0"]
-install = ["scipy>=1.10.0"]
-maintenance = ["conda-lock==3.0.1"]
 [build-system]
 requires = ["scipy>=1.10.0"]
 """
@@ -56,10 +43,6 @@ requires = ["scipy>=1.10.0"]
 TOY_MISSING_PACKAGE_PYPROJECT_SECTIONS = """
 [project]
 dependencies = ["scipy>=1.10.0"]
-[project.optional-dependencies]
-build = ["scipy>=1.10.0"]
-install = ["scipy>=1.10.0"]
-maintenance = ["conda-lock==3.0.1"]
 [build-system]
 requires = ["scipy>=1.10.0"]
 """
@@ -67,21 +50,13 @@ requires = ["scipy>=1.10.0"]
 TOY_ADDITIONAL_PACKAGE_PYPROJECT_SECTIONS = """
 [project]
 dependencies = ["joblib>=1.3.0", "scipy>=1.10.0"]
-[project.optional-dependencies]
-build = ["scipy>=1.10.0", "package_not_in_min_dependencies_py_file>=4.2"]
-install = ["joblib>=1.3.0", "scipy>=1.10.0"]
-maintenance = ["conda-lock==3.0.1"]
 [build-system]
-requires = ["scipy>=1.10.0"]
+requires = ["scipy>=1.10.0", "package_not_in_min_dependencies_py_file>=4.2"]
 """
 
 TOY_NON_MATCHING_VERSION_PYPROJECT_SECTIONS = """
 [project]
 dependencies = ["joblib>=1.42.0", "scipy>=1.10.0"]
-[project.optional-dependencies]
-build = ["scipy>=1.10.0"]
-install = ["joblib>=1.3.0", "scipy>=1.10.0"]
-maintenance = ["conda-lock==3.0.1"]
 [build-system]
 requires = ["scipy>=1.10.0"]
 """
@@ -129,18 +104,16 @@ def test_min_dependencies_readme():
 
 
 def extract_packages_and_pyproject_tags(dependencies):
-    min_dependencies_tag_to_packages_without_version = defaultdict(list)
-    for package, (min_version, tags) in dependencies.items():
-        for t in tags.split(", "):
-            min_dependencies_tag_to_packages_without_version[t].append(package)
-
     pyproject_section_to_min_dependencies_tag = {
         "build-system.requires": "build",
         "project.dependencies": "install",
     }
-    for tag in min_dependencies_tag_to_packages_without_version:
-        section = f"project.optional-dependencies.{tag}"
-        pyproject_section_to_min_dependencies_tag[section] = tag
+
+    min_dependencies_tag_to_packages_without_version = defaultdict(list)
+    for package, (min_version, tags) in dependencies.items():
+        for t in tags.split(", "):
+            if t in pyproject_section_to_min_dependencies_tag.values():
+                min_dependencies_tag_to_packages_without_version[t].append(package)
 
     return (
         min_dependencies_tag_to_packages_without_version,


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #34537

#### What does this implement/fix? Explain your changes.

Removes the `[project.optional-dependencies]` extras (`build`, `install`, `benchmark`, `docs`, `examples`, `tests`, `maintenance`) from `pyproject.toml`. See why in the issue.

Also:
- Removed the `tag_to_packages` inverse mapping in `sklearn/_min_dependencies.py`. It was already dead code since `setup.py`'s `extras_require` (its only consumer) was removed in #29400.
- Renamed `sklearn/tests/test_min_dependencies_readme.py` -> `test_min_dependencies_consistency.py` because it tests consistency of `sklearn/_min_dependencies.py` against the doc **and** the `pyproject.toml`.
- Updated it to drop checks on the now-removed `project.optional-dependencies.*` sections


#### AI usage disclosure

I used AI assistance for:
- Code generation
- Test generation
- Research and understanding

#### Follow-up question

Tags in `dependent_packages` are now used this way:
- build & install tags to cross-check `pyproject.toml`
- others tags are only used to render the minimum-dependency table in the docs. For me the table it generates s a bit confusing for end-users. It's more contributor oriented but it's in the [installing-the-latest-release](https://scikit-learn.org/stable/install.html#installing-the-latest-release) section... Maybe we could revisit that? 
