### PR TITLE
CI Add hint about optional CI to lockfile update bot message

### DIFF
--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -68,6 +68,7 @@ jobs:
             ### Note
             If the CI tasks fail, create a new branch based on this PR and add the required fixes to that branch.
             Prefer re-running the same command above (with the matching `--select-tag`) rather than updating all lock files.
+            ${{ matrix.additional_commit_message && format('Remember to include `{0}` in your commit message so that the optional CI build runs.', matrix.additional_commit_message) || '' }}
 
       # The CUDA workflow needs to be triggered explicitly as it uses an expensive runner
       - name: Trigger additional tests


### PR DESCRIPTION
Follow up to https://github.com/scikit-learn/scikit-learn/pull/34546#issuecomment-5053625489

The goal is to make it easier for the human who looks at the lockfile update PR to know what they need to include in their commit message to get the right kinds of CI to run.

cc @lesteve 