### PR TITLE
FIX raise NotImplementedError for recursion PDP with categorical target features

### DIFF
--- a/doc/whats_new/upcoming_changes/many-modules/34554.fix.rst
+++ b/doc/whats_new/upcoming_changes/many-modules/34554.fix.rst
@@ -1,0 +1,6 @@
+- :func:`inspection.partial_dependence` with ``method="recursion"`` now raises
+  `NotImplementedError` for categorical target features on
+  :class:`tree.DecisionTreeRegressor`, :class:`ensemble.HistGradientBoostingRegressor`
+  and :class:`ensemble.HistGradientBoostingClassifier`, instead of silently
+  returning incorrect values. Use ``method="brute"`` instead.
+  By :user:`Arthur Lacote <cakedev0>`.

--- a/doc/whats_new/upcoming_changes/sklearn.tree/34554.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.tree/34554.fix.rst
@@ -1,5 +1,0 @@
-- :meth:`tree.DecisionTreeRegressor._compute_partial_dependence_recursion` (used by
-  :func:`inspection.partial_dependence` with ``method="recursion"``) now raises
-  `NotImplementedError` for categorical target features instead of silently
-  returning incorrect values. Use ``method="brute"`` instead.
-  By :user:`Arthur Lacote <cakedev0>`.

--- a/doc/whats_new/upcoming_changes/sklearn.tree/34554.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.tree/34554.fix.rst
@@ -1,0 +1,5 @@
+- :meth:`tree.DecisionTreeRegressor._compute_partial_dependence_recursion` (used by
+  :func:`inspection.partial_dependence` with ``method="recursion"``) now raises
+  `NotImplementedError` for categorical target features instead of silently
+  returning incorrect values. Use ``method="brute"`` instead.
+  By :user:`Arthur Lacote <cakedev0>`.

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1316,11 +1316,21 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                 "time.".format(self.__class__.__name__)
             )
 
+        target_features = np.asarray(target_features, dtype=np.intp, order="C")
+
+        if self.is_categorical_ is not None and np.any(
+            self.is_categorical_[target_features]
+        ):
+            raise NotImplementedError(
+                "The 'recursion' method for partial dependence is not "
+                "supported for categorical target features. Use "
+                "method='brute' instead."
+            )
+
         grid = np.asarray(grid, dtype=X_DTYPE, order="C")
         averaged_predictions = np.zeros(
             (self.n_trees_per_iteration_, grid.shape[0]), dtype=Y_DTYPE
         )
-        target_features = np.asarray(target_features, dtype=np.intp, order="C")
 
         for predictors_of_ith_iteration in self._predictors:
             for k, predictor in enumerate(predictors_of_ith_iteration):

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -523,12 +523,20 @@ def test_partial_dependence_easy_target(est, power):
     assert r2 > 0.99
 
 
-def test_partial_dependence_recursion_decision_tree_categorical_target_feature():
+@pytest.mark.parametrize(
+    "Estimator",
+    (
+        DecisionTreeRegressor,
+        HistGradientBoostingRegressor,
+        HistGradientBoostingClassifier,
+    ),
+)
+def test_partial_dependence_recursion_categorical_target_feature(Estimator):
     # Recursion is not supported as the re-encoding of the grid is not implemented
     X = np.array(["a", "b", "b", "a", "a"]).reshape(-1, 1)
     y = np.array([0, 1, 1, 0, 1])
 
-    est = DecisionTreeRegressor(categorical_features=[0]).fit(X, y)
+    est = Estimator(categorical_features=[0]).fit(X, y)
 
     with pytest.raises(
         NotImplementedError, match="not supported for categorical target features"

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -524,18 +524,11 @@ def test_partial_dependence_easy_target(est, power):
 
 
 def test_partial_dependence_recursion_decision_tree_categorical_target_feature():
-    # The 'recursion' method computes partial dependence by traversing the
-    # tree with the raw (unencoded) grid values, but categorical splits are
-    # expressed in terms of the encoding learned by `_categorical_encoder`
-    # at fit time. Since the two are not guaranteed to match, recursion must
-    # raise NotImplementedError for categorical target features.
-    category_values = np.arange(6, dtype=np.float64)
-    X = np.repeat(category_values, 4).reshape(-1, 1)
-    y = np.isin(X.ravel(), [1, 2, 5]).astype(np.float64)
+    # Recursion is not supported as the re-encoding of the grid is not implemented
+    X = np.array(["a", "b", "b", "a", "a"]).reshape(-1, 1)
+    y = np.array([0, 1, 1, 0, 1])
 
-    est = DecisionTreeRegressor(
-        categorical_features=[0], max_depth=1, random_state=0
-    ).fit(X, y)
+    est = DecisionTreeRegressor(categorical_features=[0]).fit(X, y)
 
     with pytest.raises(
         NotImplementedError, match="not supported for categorical target features"
@@ -543,31 +536,6 @@ def test_partial_dependence_recursion_decision_tree_categorical_target_feature()
         partial_dependence(
             est, X, features=[0], method="recursion", categorical_features=[0]
         )
-
-
-def test_partial_dependence_brute_decision_tree_categorical_target_feature():
-    # Unlike 'recursion' (see the test above), 'brute' does not traverse the
-    # tree with raw grid values: it calls `predict`, which re-encodes
-    # categories through `_categorical_encoder`. It must therefore stay
-    # correct even when raw categories don't coincide with their internal
-    # ordinal encoding, e.g. string categories.
-    category_values = np.array(["a", "b", "c", "d", "e", "f"], dtype=object)
-    X = np.repeat(category_values, 4).reshape(-1, 1)
-    y = np.isin(X.ravel(), ["b", "c", "f"]).astype(np.float64)
-
-    est = DecisionTreeRegressor(
-        categorical_features=[0], max_depth=1, random_state=0
-    ).fit(X, y)
-
-    brute = partial_dependence(
-        est, X, features=[0], method="brute", categorical_features=[0]
-    )
-
-    grid = brute["grid_values"][0].reshape(-1, 1)
-    expected = est.predict(grid)
-
-    assert_array_equal(np.sort(brute["grid_values"][0]), category_values)
-    assert_allclose(brute["average"][0], expected)
 
 
 def test_partial_dependence_recursion_decision_tree_missing_target_feature():

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -545,6 +545,31 @@ def test_partial_dependence_recursion_decision_tree_categorical_target_feature()
         )
 
 
+def test_partial_dependence_brute_decision_tree_categorical_target_feature():
+    # Unlike 'recursion' (see the test above), 'brute' does not traverse the
+    # tree with raw grid values: it calls `predict`, which re-encodes
+    # categories through `_categorical_encoder`. It must therefore stay
+    # correct even when raw categories don't coincide with their internal
+    # ordinal encoding, e.g. string categories.
+    category_values = np.array(["a", "b", "c", "d", "e", "f"], dtype=object)
+    X = np.repeat(category_values, 4).reshape(-1, 1)
+    y = np.isin(X.ravel(), ["b", "c", "f"]).astype(np.float64)
+
+    est = DecisionTreeRegressor(
+        categorical_features=[0], max_depth=1, random_state=0
+    ).fit(X, y)
+
+    brute = partial_dependence(
+        est, X, features=[0], method="brute", categorical_features=[0]
+    )
+
+    grid = brute["grid_values"][0].reshape(-1, 1)
+    expected = est.predict(grid)
+
+    assert_array_equal(np.sort(brute["grid_values"][0]), category_values)
+    assert_allclose(brute["average"][0], expected)
+
+
 def test_partial_dependence_recursion_decision_tree_missing_target_feature():
     # Missing values are isolated by the split. Recursion must route np.nan
     # according to the fitted node's missing_go_to_left flag.

--- a/sklearn/inspection/tests/test_partial_dependence.py
+++ b/sklearn/inspection/tests/test_partial_dependence.py
@@ -524,8 +524,11 @@ def test_partial_dependence_easy_target(est, power):
 
 
 def test_partial_dependence_recursion_decision_tree_categorical_target_feature():
-    # Non-ordinal categorical signal: categories {1, 2, 5} -> 1 and
-    # {0, 3, 4} -> 0. Recursion must route with the categorical bitset.
+    # The 'recursion' method computes partial dependence by traversing the
+    # tree with the raw (unencoded) grid values, but categorical splits are
+    # expressed in terms of the encoding learned by `_categorical_encoder`
+    # at fit time. Since the two are not guaranteed to match, recursion must
+    # raise NotImplementedError for categorical target features.
     category_values = np.arange(6, dtype=np.float64)
     X = np.repeat(category_values, 4).reshape(-1, 1)
     y = np.isin(X.ravel(), [1, 2, 5]).astype(np.float64)
@@ -534,19 +537,12 @@ def test_partial_dependence_recursion_decision_tree_categorical_target_feature()
         categorical_features=[0], max_depth=1, random_state=0
     ).fit(X, y)
 
-    recursion = partial_dependence(
-        est, X, features=[0], method="recursion", categorical_features=[0]
-    )
-    brute = partial_dependence(
-        est, X, features=[0], method="brute", categorical_features=[0]
-    )
-
-    grid = recursion["grid_values"][0].reshape(-1, 1)
-    expected = est.predict(grid)
-
-    assert_array_equal(recursion["grid_values"][0], category_values)
-    assert_allclose(recursion["average"][0], brute["average"][0])
-    assert_allclose(recursion["average"][0], expected)
+    with pytest.raises(
+        NotImplementedError, match="not supported for categorical target features"
+    ):
+        partial_dependence(
+            est, X, features=[0], method="recursion", categorical_features=[0]
+        )
 
 
 def test_partial_dependence_recursion_decision_tree_missing_target_feature():

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -1656,10 +1656,7 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
             self.is_categorical_[target_features]
         ):
             # `grid` holds raw (unencoded) feature values, but the tree splits
-            # on the categories as encoded by `self._categorical_encoder` at
-            # fit time. The two only coincide by coincidence, so we cannot
-            # route `grid` through the tree without re-implementing that
-            # encoding here.
+            # on the categories as encoded by `self._categorical_encoder`.
             raise NotImplementedError(
                 "The 'recursion' method for partial dependence is not "
                 "supported for categorical target features. Use "

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -1650,11 +1650,26 @@ class DecisionTreeRegressor(RegressorMixin, BaseDecisionTree):
         averaged_predictions : ndarray of shape (n_samples,), dtype=np.float64
             The value of the partial dependence function on each grid point.
         """
+        target_features = np.asarray(target_features, dtype=np.intp, order="C")
+
+        if self.is_categorical_ is not None and np.any(
+            self.is_categorical_[target_features]
+        ):
+            # `grid` holds raw (unencoded) feature values, but the tree splits
+            # on the categories as encoded by `self._categorical_encoder` at
+            # fit time. The two only coincide by coincidence, so we cannot
+            # route `grid` through the tree without re-implementing that
+            # encoding here.
+            raise NotImplementedError(
+                "The 'recursion' method for partial dependence is not "
+                "supported for categorical target features. Use "
+                "method='brute' instead."
+            )
+
         grid = np.asarray(grid, dtype=np.float32, order="C")
         averaged_predictions = np.zeros(
             shape=grid.shape[0], dtype=np.float64, order="C"
         )
-        target_features = np.asarray(target_features, dtype=np.intp, order="C")
 
         self.tree_.compute_partial_dependence(
             grid, target_features, averaged_predictions


### PR DESCRIPTION
#### Reference Issues/PRs

Follow-up from #33354, addresses https://github.com/scikit-learn/scikit-learn/pull/33354#discussion_r3530561195

#### What does this implement/fix? Explain your changes.

`BaseDecisionTree._compute_partial_dependence_recursion` passed grid values straight to `tree_.compute_partial_dependence`, which routes categorical splits by casting the raw feature value to a bitset index. But categorical values are ordinal-encoded by `_categorical_encoder` at fit time, and `predict`/`apply` re-encode through `_transform_categorical_features` before reaching the tree — the recursion path never did. It silently returned wrong values whenever the raw categories didn't already coincide with their `0..n_categories-1` encoding.

As discussed in review, supporting this properly isn't trivial (the grid would need to go through the fitted encoder), so for now let's just raise a `NotImplementedError` for categorical target features.

While looking into this, found that `HistGradientBoosting*` has a related but distinct bug: `_predictor.pyx::_compute_partial_dependence` (the recursion tree walker) has no categorical branch at all, and `grower.py` never sets `num_threshold` for categorical splits, so recursion silently used a `<= 0.0` split for any categorical target feature (not "correct by coincidence" like trees could be, just wrong). Applied the same fix there and parametrized the regression test over `DecisionTreeRegressor`, `HistGradientBoostingRegressor` and `HistGradientBoostingClassifier`.

#### AI usage disclosure

I used AI assistance for:
- Code generation
- Test update
- Investigating the HGB bug
- Writing this