### PR TITLE
MNT Disable pytest cacheprovider in Pyodide wheel builds

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -73,8 +73,9 @@ jobs:
           SKLEARN_SKIP_OPENMP_TEST: "true"
           SKLEARN_SKIP_NETWORK_TESTS: 1
           CIBW_TEST_REQUIRES: "pytest pandas"
-          # -s pytest argument is needed to avoid an issue in pytest output capturing with Pyodide
-          CIBW_TEST_COMMAND: "python -m pytest -sra --pyargs sklearn --durations 20 --showlocals"
+          # pytest -s argument is needed to avoid an issue in pytest output capturing with Pyodide
+          # -p no:cacheprovider is needed to avoid cleaning up pytest cache failing with PermissionError
+          CIBW_TEST_COMMAND: "python -m pytest -sra -p no:cacheprovider --pyargs sklearn --durations 20 --showlocals"
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
#### Reference Issues/PRs
https://github.com/scikit-learn/scikit-learn/pull/34555#issuecomment-5058105543

#### What does this implement/fix? Explain your changes.
This disables a pytest feature (`cacheprovider`) that fails with `PermissionError` when building pyodide wheels.
Solution suggested in https://github.com/pypa/cibuildwheel/issues/1966#issuecomment-2289312224.

If the CI passes on this, any maintainer can merge, see https://github.com/scikit-learn/scikit-learn/pull/34555#issuecomment-5058203597.

#### AI usage disclosure
- Research and understanding

