### PR TITLE
FIX #34531: prevent duplicate pos_label in scorer metadata routing

### DIFF
--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -966,7 +966,11 @@ def _log_reg_scoring_path(
 
         if "labels" in sig:
             pos_label_kwarg = {}
-            if is_binary and "pos_label" in sig:
+            if (
+                is_binary
+                and "pos_label" in sig
+                and "pos_label" not in getattr(scoring, "_kwargs", {})
+            ):
                 # see _logistic_regression_path
                 pos_label_kwarg["pos_label"] = n_classes - 1  # classes[-1]
             scoring = make_scorer(
@@ -1435,7 +1439,7 @@ class LogisticRegression(
             warnings.warn(
                 "l1_ratio parameter is only used when penalty is "
                 "'elasticnet'. Got "
-                "(penalty={})".format(penalty)
+                f"(penalty={penalty})"
             )
         if (self.penalty == "l2" and self.l1_ratio != 0) or (
             self.penalty == "l1" and self.l1_ratio != 1
@@ -2220,7 +2224,7 @@ class LogisticRegressionCV(LogisticRegression, LinearClassifierMixin, BaseEstima
             if l1_ratios is not None and self.penalty != "deprecated":
                 warnings.warn(
                     "l1_ratios parameter is only used when penalty "
-                    "is 'elasticnet'. Got (penalty={})".format(penalty)
+                    f"is 'elasticnet'. Got (penalty={penalty})"
                 )
 
             if l1_ratios is None:

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -1063,7 +1063,7 @@ def test_logistic_regression_solvers_multiclass_unpenalized(
         ).fit(X, y)
         for solver in set(SOLVERS) - set(["liblinear"])
     }
-    for solver in regressors.keys():
+    for solver in regressors:
         # See the docstring of test_multinomial_identifiability_on_iris for reference.
         assert_allclose(
             regressors[solver].coef_.sum(axis=0), 0, atol=1e-10, err_msg=solver
@@ -3229,3 +3229,12 @@ def test_logistic_regression_callback_support_warning():
         match="Callbacks are only supported in LogisticRegression for solver='lbfgs'",
     ):
         LogisticRegression(solver="liblinear").set_callbacks(cb)
+
+
+def test_logistic_regression_cv_f1_macro():
+    """Non-regression test for issue #34531"""
+    X, y = make_classification(
+        n_samples=100, n_features=20, n_classes=2, random_state=0
+    )
+    clf = LogisticRegressionCV(cv=3, random_state=0, scoring="f1_macro")
+    clf.fit(X, y)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #34531

#### What does this implement/fix?
LogisticRegressionCV with a string scoring like "f1_macro" raised
`TypeError: make_scorer() got multiple values for keyword argument 'pos_label'`
on binary classification (a 1.9 regression). The scorer already carried
pos_label in its _kwargs and the CV path injected it again.

This only injects pos_label when the scorer doesn't already define it, and
adds a non-regression test reproducing the issue.

#### Any other comments?
The diff also has a couple of trivial f-string tidy-ups in the files touched —
happy to drop those if you'd prefer a strictly minimal diff.
