### PR TITLE
ENH precompute residual and column norm of X in coordinate descent

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/34572.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/34572.enhancement.rst
@@ -1,0 +1,6 @@
+- :class:`linear_model.ElasticNetCV`, :class:`linear_model.LassoCV` and
+  :class:`linear_model.MultiTaskElasticNetCV` as well as :func:`enet_path` and
+  :func:`lasso_path` are now faster. The (relative) speed-up is larger for lower
+  tolerance (larger values of `tol`) and achieved by avoiding to re-calculate the
+  residuals and the column norms of `X` for each penalty `alpha` along the path.
+  By :user:`Christian Lorentzen <lorentzenchr>`.

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -139,6 +139,40 @@ message_ridge = (
 )
 
 
+def R_and_X_colnorm2(
+    const floating[::1] w,
+    const floating[::1, :] X,
+    const floating[::1] y,
+):
+    """Compute residuals and squared column norms of X.
+
+    Returns
+    -------
+    R : memoryview of shape (n_samples,)
+        Residuals: R = y - X @ w
+
+    norm2_cols_X : memoryview of shape (n_samples,)
+        Column norms of X: norm2_cols_X = np.sum(X**2, axis=0)
+    """
+    if floating is float:
+        dtype = np.float32
+    else:
+        dtype = np.float64
+    cdef unsigned int n_samples = y.shape[0]
+    cdef unsigned int n_features = w.shape[0]
+
+    cdef floating[::1] R = np.empty_like(y)
+    cdef floating[::1] norm2_cols_X = np.einsum(
+        "ij,ij->j", X, X, dtype=dtype, order="C"
+    )
+    # R = y - np.dot(X, w)
+    _copy(n_samples, &y[0], 1, &R[0], 1)
+    _gemv(ColMajor, NoTrans, n_samples, n_features, -1.0, &X[0, 0],
+          n_samples, &w[0], 1, 1.0, &R[0], 1)
+
+    return R, norm2_cols_X
+
+
 cdef inline floating dual_gap_formulation_A(
     floating alpha,  # L1 penalty
     floating beta,  # L1 penalty
@@ -280,6 +314,8 @@ def enet_coordinate_descent(
     bint positive=0,
     bint do_screening=1,
     bint early_stopping=1,
+    floating[::1] R=None,
+    floating[::1] norm2_cols_X=None,
 ):
     """
     Cython version of the coordinate descent algorithm for Elastic-Net regression.
@@ -383,14 +419,6 @@ def enet_coordinate_descent(
     cdef unsigned int n_samples = X.shape[0]
     cdef unsigned int n_features = X.shape[1]
 
-    # compute squared norms of the columns of X
-    # same as norm2_cols_X = np.square(X).sum(axis=0)
-    cdef floating[::1] norm2_cols_X = np.einsum(
-        "ij,ij->j", X, X, dtype=dtype, order="C"
-    )
-
-    # initial value of the residuals
-    cdef floating[::1] R = np.empty(n_samples, dtype=dtype)
     cdef floating[::1] XtA = np.empty(n_features, dtype=dtype)
 
     cdef floating d_j
@@ -421,11 +449,10 @@ def enet_coordinate_descent(
         active_set = np.empty(n_features, dtype=np.uint32)  # map [:n_active] -> j
         excluded_set = np.empty(n_features, dtype=np.uint8)
 
+    if R is None:
+        R, norm2_cols_X = R_and_X_colnorm2(w=w, X=X, y=y)
+
     with nogil:
-        # R = y - np.dot(X, w)
-        _copy(n_samples, &y[0], 1, &R[0], 1)
-        _gemv(ColMajor, NoTrans, n_samples, n_features, -1.0, &X[0, 0],
-              n_samples, &w[0], 1, 1.0, &R[0], 1)
 
         # tol *= np.dot(y, y)
         tol *= _dot(n_samples, &y[0], 1, &y[0], 1)
@@ -1240,6 +1267,7 @@ def enet_coordinate_descent_gram(
     bint positive=0,
     bint do_screening=1,
     bint early_stopping=1,
+    floating[::1] Qw=None,
 ):
     """Cython version of the coordinate descent algorithm
         for Elastic-Net regression
@@ -1273,8 +1301,6 @@ def enet_coordinate_descent_gram(
     # get the data information into easy vars
     cdef unsigned int n_features = Q.shape[0]
 
-    # initial value "Q w" which will be kept of up to date in the iterations
-    cdef floating[::1] Qw = np.dot(Q, w)
     cdef floating[::1] XtA = np.zeros(n_features, dtype=dtype)
     cdef floating y_norm2 = np.dot(y, y)
 
@@ -1306,6 +1332,10 @@ def enet_coordinate_descent_gram(
     if do_screening:
         active_set = np.empty(n_features, dtype=np.uint32)  # map [:n_active] -> j
         excluded_set = np.empty(n_features, dtype=np.uint8)
+
+    if Qw is None:
+        # initial value "Q w" which will be kept of up to date in the iterations
+        Qw = np.dot(Q, w)
 
     with nogil:
         tol *= y_norm2
@@ -1437,6 +1467,121 @@ def enet_coordinate_descent_gram(
                 warnings.warn(message, ConvergenceWarning)
 
     return np.asarray(w), gap, tol, n_iter + 1
+
+
+def R_and_X_colnorm2_multi_task(
+    const floating[::1, :] W,
+    const floating[::1, :] X,
+    bint X_is_sparse,
+    const floating[::1] X_data,
+    const int32_t[::1] X_indices,
+    const int32_t[::1] X_indptr,
+    const floating[::1, :] Y,
+    const floating[::1] sample_weight,
+    const floating[::1] X_mean,
+):
+    """Compute residuals and squared column norms of X.
+
+    Z = X - X_mean
+    sw = sample_weight
+
+    Returns
+    -------
+    R : memoryview of shape (n_samples, n_tasks)
+        Residuals:
+        - unweighted: R = Y - Z @ W
+        - weighted:   R = sw * (Y - Z @ W)
+
+    norm2_cols_X : memoryview of shape (n_samples,)
+        Column norms of X:
+        - unweighted: norm2_cols_X = np.sum((X - X_mean)**2, axis=0)
+        - weighted:   norm2_cols_X = np.sum(sw * (X - X_mean)**2, axis=0)
+    """
+    if floating is float:
+        dtype = np.float32
+    else:
+        dtype = np.float64
+    cdef unsigned int n_samples = Y.shape[0]
+    cdef unsigned int n_features = W.shape[1]
+    cdef unsigned int n_tasks = Y.shape[1]
+    cdef floating X_mean_j
+    cdef floating normalize_sum
+    cdef int32_t i, i_ind
+    cdef unsigned int j
+    cdef int32_t startptr = X_indptr[0]
+    cdef int32_t endptr
+    cdef bint center = False
+    cdef bint no_sample_weights = sample_weight is None
+
+    cdef floating[::1, :] R = np.empty_like(Y, order="F")  # shape (n_samples, n_tasks)
+    norm2_cols_X_array = np.empty(shape=n_features, dtype=dtype)
+    cdef floating[::1] norm2_cols_X = norm2_cols_X_array
+
+    if X_is_sparse and X_mean is not None:
+        # center = (X_mean != 0).any()
+        for j in range(n_features):
+            if X_mean[j]:
+                center = True
+                break
+
+    if not X_is_sparse:
+        np.einsum("ij,ij->j", X, X, dtype=dtype, out=norm2_cols_X_array)
+    else:
+        for j in range(n_features):
+            startptr = X_indptr[j]
+            endptr = X_indptr[j + 1]
+            normalize_sum = 0.0
+            X_mean_j = X_mean[j]
+
+            if no_sample_weights:
+                for i_ind in range(startptr, endptr):
+                    normalize_sum += (X_data[i_ind] - X_mean_j) ** 2
+                if center:
+                    normalize_sum += (n_samples - endptr + startptr) * X_mean_j ** 2
+            else:
+                for i_ind in range(startptr, endptr):
+                    i = X_indices[i_ind]
+                    normalize_sum += sample_weight[i] * (
+                        (X_data[i_ind] - X_mean_j) ** 2 - X_mean_j ** 2
+                    )
+                if center:
+                    for i in range(n_samples):
+                        normalize_sum += sample_weight[i] * X_mean_j ** 2
+            norm2_cols_X[j] = normalize_sum
+
+    _copy(n_samples * n_tasks, &Y[0, 0], 1, &R[0, 0], 1)
+    if not no_sample_weights and X_is_sparse:
+        for t in range(n_tasks):
+            for i in range(n_samples):
+                R[i, t] *= sample_weight[i]
+    for j in range(n_features):
+        for t in range(n_tasks):
+            if W[t, j] != 0:
+                if not X_is_sparse:
+                    _axpy(n_samples, -W[t, j], &X[0, j], 1, &R[0, t], 1)
+                else:
+                    if no_sample_weights:
+                        sparse_axpy(j, -W[t, j], X_data, X_indices, X_indptr, R[:, t])
+                    else:
+                        startptr = X_indptr[j]
+                        endptr = X_indptr[j + 1]
+                        for i_ind in range(startptr, endptr):
+                            i = X_indices[i_ind]
+                            R[i, t] -= sample_weight[i] * X_data[i_ind] * W[t, j]
+
+        if X_is_sparse and center:
+            # R = Y - (X - X_mean) @ W.T
+            X_mean_j = X_mean[j]
+            if no_sample_weights:
+                for i in range(n_samples):
+                    for t in range(n_tasks):
+                        R[i, t] += X_mean_j * W[t, j]
+            else:
+                for i in range(n_samples):
+                    for t in range(n_tasks):
+                        R[i, t] += sample_weight[i] * X_mean_j * W[t, j]
+
+    return R, norm2_cols_X
 
 
 cdef (floating, floating) gap_enet_multi_task(
@@ -1591,6 +1736,8 @@ def enet_coordinate_descent_multi_task(
     bint random=0,
     bint do_screening=1,
     bint early_stopping=1,
+    floating[::1, :] R=None,
+    floating[::1] norm2_cols_X=None,
 ):
     """Cython version of the coordinate descent algorithm
         for Elastic-Net multi-task regression
@@ -1636,12 +1783,6 @@ def enet_coordinate_descent_multi_task(
     cdef unsigned int n_features = W.shape[1]
     cdef unsigned int n_tasks = Y.shape[1]
 
-    # compute squared norms of the columns of X
-    norm2_cols_X_array = np.empty(shape=n_features, dtype=dtype)
-    cdef floating[::1] norm2_cols_X = norm2_cols_X_array
-
-    # initial value of the residuals
-    cdef floating[::1, :] R  # shape (n_samples, n_tasks)
     cdef floating[:, ::1] XtA = np.empty((n_features, n_tasks), dtype=dtype)
     cdef floating[::1] XtA_row_norms = np.empty(n_features, dtype=dtype)
     cdef const floating[::1, :] Yw
@@ -1665,7 +1806,6 @@ def enet_coordinate_descent_multi_task(
     cdef uint8_t[::1] excluded_set
     cdef unsigned int j
     cdef unsigned int t
-    cdef int32_t i, i_ind, startptr, endptr
     cdef unsigned int n_iter = 0
     cdef unsigned int f_iter
     cdef uint32_t rand_r_state_seed = rng.randint(0, RAND_R_MAX)
@@ -1683,77 +1823,35 @@ def enet_coordinate_descent_multi_task(
 
     if no_sample_weights or not X_is_sparse:
         Yw = Y
-        R = np.copy(Y, order="F")
     else:
         Yw = np.multiply(sample_weight[:, None], Y)
-        R = np.copy(Yw, order="F")
 
-    if X_is_sparse:
-        R_sum = np.zeros(n_tasks, dtype=dtype)
+    if R is None:
+        R, norm2_cols_X = R_and_X_colnorm2_multi_task(
+            W=W,
+            X=X,
+            X_is_sparse=X_is_sparse,
+            X_data=X_data,
+            X_indices=X_indices,
+            X_indptr=X_indptr,
+            Y=Y,
+            sample_weight=sample_weight,
+            X_mean=X_mean,
+        )
+
+    if X_is_sparse and X_mean is not None:
         # center = (X_mean != 0).any()
         for j in range(n_features):
             if X_mean[j]:
                 center = True
                 break
 
-    # compute squared norms of the columns of X
-    # same as norm2_cols_X = np.square(X).sum(axis=0)
-    if not X_is_sparse:
-        np.einsum("ij,ij->j", X, X, dtype=dtype, out=norm2_cols_X_array)
-    else:
-        for j in range(n_features):
-            norm2_cols_X[j] = 0
-            startptr = X_indptr[j]
-            endptr = X_indptr[j + 1]
-            if no_sample_weights:
-                for i_ind in range(startptr, endptr):
-                    norm2_cols_X[j] += (X_data[i_ind] - X_mean[j]) ** 2
-                if center:
-                    norm2_cols_X[j] += (n_samples - endptr + startptr) * X_mean[j] ** 2
-            else:
-                for i_ind in range(startptr, endptr):
-                    i = X_indices[i_ind]
-                    norm2_cols_X[j] += sample_weight[i] * (
-                        (X_data[i_ind] - X_mean[j]) ** 2 - X_mean[j] ** 2
-                    )
-                if center:
-                    for i in range(n_samples):
-                        norm2_cols_X[j] += sample_weight[i] * X_mean[j] ** 2
+        R_sum = np.sum(R, axis=0)
+    # Note: No need to update R_sum from here on because the update terms cancel each
+    # other: w_j[t] * np.sum(X[:,j] - X_mean[j]) = 0. R_sum is only ever needed and
+    # calculated if X_mean is provided.
 
     with nogil:
-        # R = Y - X @ W.T
-        # R = Y was already set above.
-        for j in range(n_features):
-            for t in range(n_tasks):
-                if W[t, j] != 0:
-                    if not X_is_sparse:
-                        _axpy(n_samples, -W[t, j], &X[0, j], 1, &R[0, t], 1)
-                    else:
-                        if no_sample_weights:
-                            sparse_axpy(j, -W[t, j], X_data, X_indices, X_indptr, R[:, t])
-                        else:
-                            startptr = X_indptr[j]
-                            endptr = X_indptr[j + 1]
-                            for i_ind in range(startptr, endptr):
-                                i = X_indices[i_ind]
-                                R[i, t] -= sample_weight[i] * X_data[i_ind] * W[t, j]
-
-            if X_is_sparse and center:
-                # R = Y - (X - X_mean) @ W.T
-                if no_sample_weights:
-                    for i in range(n_samples):
-                        for t in range(n_tasks):
-                            R[i, t] += X_mean[j] * W[t, j]
-                            R_sum[t] += R[i, t]
-                else:
-                    for i in range(n_samples):
-                        for t in range(n_tasks):
-                            R[i, t] += sample_weight[i] * X_mean[j] * W[t, j]
-                            R_sum[t] += R[i, t]
-
-        # Note: No need to update R_sum from here on because the update terms cancel
-        # each other: w_j[t] * np.sum(X[:,j] - X_mean[j]) = 0. R_sum is only ever
-        # needed and calculated if X_mean is provided.
 
         # tol = tol * linalg.norm(Y, ord='fro') ** 2
         # with sample weights: tol *= y @ (sw * y)

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -151,7 +151,7 @@ def R_and_X_colnorm2(
     R : memoryview of shape (n_samples,)
         Residuals: R = y - X @ w
 
-    norm2_cols_X : memoryview of shape (n_samples,)
+    norm2_cols_X : memoryview of shape (n_features,)
         Column norms of X: norm2_cols_X = np.sum(X**2, axis=0)
     """
     if floating is float:

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -372,6 +372,8 @@ def enet_coordinate_descent(
 
     Further Parameters
     ------------------
+    random : bint, default=0 (False)
+        If False, uses cyclic coordinate descent. If True, pick features at random.
     positive : bint, default=0 (False)
         If set to True, forces coefficients w to be positive.
     do_screening : bint, default=1 (True)
@@ -380,6 +382,10 @@ def enet_coordinate_descent(
     early_stopping : bint, default=1 (True)
         If set to True, check for convergence (with the dual gap) before entering the
         main iteration loop.
+    R : memoryview or ndarray of shape (n_samples,) or None, default=None
+        Initial value of the residual `R = y - X @ w`. If None, it will be computed.
+    norm2_cols_X : memoryview or ndarray of shape (n_features,) or None, default=None
+        Squared column norms of X. If None, it will be computed.
 
     Returns
     -------
@@ -450,6 +456,7 @@ def enet_coordinate_descent(
         excluded_set = np.empty(n_features, dtype=np.uint8)
 
     if R is None:
+        # Initial value of the residuals. Will be kept up to date in the iterations.
         R, norm2_cols_X = R_and_X_colnorm2(w=w, X=X, y=y)
 
     with nogil:
@@ -861,6 +868,25 @@ def enet_coordinate_descent_sparse(
 
     The rest is the same as enet_coordinate_descent, but for sparse X.
 
+    Further Parameters
+    ------------------
+    random : bint, default=0 (False)
+        If False, uses cyclic coordinate descent. If True, pick features at random.
+    positive : bint, default=0 (False)
+        If set to True, forces coefficients w to be positive.
+    do_screening : bint, default=1 (True)
+        If set to True, use gap safe screening rules to screen coefficients
+        (exclude early based on dual gap).
+    early_stopping : bint, default=1 (True)
+        If set to True, check for convergence (with the dual gap) before entering the
+        main iteration loop.
+    R : memoryview or ndarray of shape (n_samples,) or None, default=None
+        Initial value of the residual `R = y - X @ w`. If None, it will be computed.
+        See `R_and_X_colnorm2_sparse` for how sample_weight and X_mean are taken
+        into account.
+    norm2_cols_X : memoryview or ndarray of shape (n_features,) or None, default=None
+        Squared column norms of X. If None, it will be computed.
+
     Returns
     -------
     w : ndarray of shape (n_features,)
@@ -942,6 +968,7 @@ def enet_coordinate_descent_sparse(
                 break
 
     if R is None:
+        # Initial value of the residuals. Will be kept up to date in the iterations.
         R, norm2_cols_X = R_and_X_colnorm2_sparse(
             w=w,
             X_data=X_data,
@@ -1284,6 +1311,21 @@ def enet_coordinate_descent_gram(
         Q = X^T X (Gram matrix)
         q = X^T y
 
+    Further Parameters
+    ------------------
+    random : bint, default=0 (False)
+        If False, uses cyclic coordinate descent. If True, pick features at random.
+    positive : bint, default=0 (False)
+        If set to True, forces coefficients w to be positive.
+    do_screening : bint, default=1 (True)
+        If set to True, use gap safe screening rules to screen coefficients
+        (exclude early based on dual gap).
+    early_stopping : bint, default=1 (True)
+        If set to True, check for convergence (with the dual gap) before entering the
+        main iteration loop.
+    Qw : memoryview or ndarray of shape (n_features,) or None, default=None
+        Initial value of `Q @ w`. If None, it will be computed.
+
     Returns
     -------
     w : ndarray of shape (n_features,)
@@ -1337,7 +1379,7 @@ def enet_coordinate_descent_gram(
         excluded_set = np.empty(n_features, dtype=np.uint8)
 
     if Qw is None:
-        # initial value "Q w" which will be kept of up to date in the iterations
+        # Initial value of Qw. Will be kept up to date in the iterations.
         Qw = np.dot(Q, w)
 
     with nogil:
@@ -1492,8 +1534,8 @@ def R_and_X_colnorm2_multi_task(
     -------
     R : memoryview of shape (n_samples, n_tasks)
         Residuals:
-        - unweighted: R = Y - Z @ W
-        - weighted:   R = sw * (Y - Z @ W)
+        - unweighted: R = Y - Z @ W.T
+        - weighted:   R = sw * (Y - Z @ W.T)
 
     norm2_cols_X : memoryview of shape (n_samples,)
         Column norms of X:
@@ -1606,7 +1648,7 @@ cdef (floating, floating) gap_enet_multi_task(
     bint no_sample_weights,
     const floating[::1] X_mean,
     bint center,
-    const floating[::1, :] R,  # current residuals = y - X @ w
+    const floating[::1, :] R,  # current residuals = y - X @ W.T
     const floating[::1] R_sum,
     floating[:, ::1] XtA,  # out
     floating[::1] XtA_row_norms,  # out
@@ -1757,6 +1799,23 @@ def enet_coordinate_descent_multi_task(
     Regression
     https://doi.org/10.48550/arXiv.1311.6529
 
+    Further Parameters
+    ------------------
+    random : bint, default=0 (False)
+        If False, uses cyclic coordinate descent. If True, pick features at random.
+    do_screening : bint, default=1 (True)
+        If set to True, use gap safe screening rules to screen coefficients
+        (exclude early based on dual gap).
+    early_stopping : bint, default=1 (True)
+        If set to True, check for convergence (with the dual gap) before entering the
+        main iteration loop.
+    R : memoryview or ndarray of shape (n_samples, n_tasks) or None, default=None
+        Initial value of the residual `R = y - X @ W.T`. If None, it will be computed.
+        See `R_and_X_colnorm2_multi_task` for how sample_weight and X_mean are taken
+        into account.
+    norm2_cols_X : memoryview or ndarray of shape (n_features,) or None, default=None
+        Squared column norms of X. If None, it will be computed.
+
     Returns
     -------
     W : ndarray of shape (n_tasks, n_features)
@@ -1832,6 +1891,7 @@ def enet_coordinate_descent_multi_task(
         Yw = np.multiply(sample_weight[:, None], Y)
 
     if R is None:
+        # Initial value of the residuals. Will be kept up to date in the iterations.
         R, norm2_cols_X = R_and_X_colnorm2_multi_task(
             W=W,
             X=X,

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -551,6 +551,96 @@ def enet_coordinate_descent(
     return np.asarray(w), gap, tol, n_iter + 1
 
 
+def R_and_X_colnorm2_sparse(
+    const floating[::1] w,
+    const floating[::1] X_data,
+    const int32_t[::1] X_indices,
+    const int32_t[::1] X_indptr,
+    const floating[::1] y,
+    const floating[::1] sample_weight,
+    const floating[::1] X_mean,
+):
+    """Compute residuals and squared column norms of X.
+
+    Z = X - X_mean
+    sw = sample_weight
+
+    Returns
+    -------
+    R : memoryview of shape (n_samples,)
+        Residuals:
+        - unweighted: R = y - Z @ w
+        - weighted:   R = sw * (y - Z @ w)
+
+    norm2_cols_X : memoryview of shape (n_samples,)
+        Column norms of X:
+        - unweighted: norm2_cols_X = np.sum((X - X_mean)**2, axis=0)
+        - weighted:   norm2_cols_X = np.sum(sw * (X - X_mean)**2, axis=0)
+    """
+    cdef unsigned int n_samples = y.shape[0]
+    cdef unsigned int n_features = w.shape[0]
+    cdef floating tmp
+    cdef floating w_j
+    cdef floating X_mean_j
+    cdef floating normalize_sum
+    cdef int32_t i, i_ind
+    cdef unsigned int j
+    cdef int32_t startptr = X_indptr[0]
+    cdef int32_t endptr
+    cdef bint center = False
+    cdef bint no_sample_weights = sample_weight is None
+
+    cdef floating[::1] R = np.empty_like(y)
+    cdef floating[::1] norm2_cols_X = np.empty_like(w)
+
+    if X_mean is not None:
+        # center = (X_mean != 0).any()
+        for j in range(n_features):
+            if X_mean[j]:
+                center = True
+                break
+
+    _copy(n_samples, &y[0], 1, &R[0], 1)
+    if not no_sample_weights:
+        for i in range(n_samples):
+            R[i] *= sample_weight[i]
+
+    for j in range(n_features):
+        endptr = X_indptr[j + 1]
+        normalize_sum = 0.0
+        w_j = w[j]
+        X_mean_j = X_mean[j]
+
+        if no_sample_weights:
+            for i_ind in range(startptr, endptr):
+                i = X_indices[i_ind]
+                normalize_sum += (X_data[i_ind] - X_mean_j) ** 2
+                R[i] -= X_data[i_ind] * w_j
+            norm2_cols_X[j] = normalize_sum
+            if center:
+                norm2_cols_X[j] += (n_samples - endptr + startptr) * X_mean_j ** 2
+                for i in range(n_samples):
+                    R[i] += X_mean_j * w_j
+        else:
+            # R = sw * (y - np.dot(X, w))
+            for i_ind in range(startptr, endptr):
+                i = X_indices[i_ind]
+                tmp = sample_weight[i]
+                # second term will be subtracted by loop over range(n_samples)
+                normalize_sum += (
+                    tmp * (X_data[i_ind] - X_mean_j) ** 2 - tmp * X_mean_j ** 2
+                )
+                R[i] -= tmp * X_data[i_ind] * w_j
+            if center:
+                for i in range(n_samples):
+                    normalize_sum += sample_weight[i] * X_mean_j ** 2
+                    R[i] += sample_weight[i] * X_mean_j * w_j
+            norm2_cols_X[j] = normalize_sum
+        startptr = endptr
+
+    return R, norm2_cols_X
+
+
 cdef inline void R_plus_wj_Xj(
     unsigned int n_samples,
     floating[::1] R,  # out
@@ -722,6 +812,8 @@ def enet_coordinate_descent_sparse(
     bint positive=0,
     bint do_screening=1,
     bint early_stopping=1,
+    floating[::1] R=None,
+    floating[::1] norm2_cols_X=None,
 ):
     """Cython version of the coordinate descent algorithm for Elastic-Net
 
@@ -769,12 +861,6 @@ def enet_coordinate_descent_sparse(
     cdef unsigned int n_samples = y.shape[0]
     cdef unsigned int n_features = w.shape[0]
 
-    # compute squared norms of the columns of X
-    cdef floating[::1] norm2_cols_X = np.zeros(n_features, dtype=dtype)
-
-    # initial value of the residuals
-    # R = y - Zw, weighted version R = sample_weight * (y - Zw)
-    cdef floating[::1] R
     cdef floating[::1] XtA = np.empty(n_features, dtype=dtype)
     cdef const floating[::1] yw
 
@@ -790,7 +876,6 @@ def enet_coordinate_descent_sparse(
     cdef floating dual_norm_XtA
     cdef floating X_mean_j
     cdef floating R_sum = 0.0
-    cdef floating normalize_sum
     cdef unsigned int n_active = n_features
     cdef uint32_t[::1] active_set
     # TODO: use binset instead of array of bools
@@ -816,56 +901,32 @@ def enet_coordinate_descent_sparse(
 
     if no_sample_weights:
         yw = y
-        R = y.copy()
     else:
         yw = np.multiply(sample_weight, y)
-        R = yw.copy()
 
-    with nogil:
-        # center = (X_mean != 0).any()
+    # center = (X_mean != 0).any()
+    if X_mean is not None:
         for j in range(n_features):
             if X_mean[j]:
                 center = True
                 break
 
-        # R = y - np.dot(X, w)
-        for j in range(n_features):
-            X_mean_j = X_mean[j]
-            endptr = X_indptr[j + 1]
-            normalize_sum = 0.0
-            w_j = w[j]
+    if R is None:
+        R, norm2_cols_X = R_and_X_colnorm2_sparse(
+            w=w,
+            X_data=X_data,
+            X_indices=X_indices,
+            X_indptr=X_indptr,
+            y=y,
+            sample_weight=sample_weight,
+            X_mean=X_mean,
+        )
+    R_sum = np.sum(R)
+    # Note: No need to update R_sum from here on because the update terms cancel each
+    # other: w_j * np.sum(X[:,j] - X_mean[j]) = 0. R_sum is only ever needed and
+    # calculated if X_mean is provided.
 
-            if no_sample_weights:
-                for i_ind in range(startptr, endptr):
-                    i = X_indices[i_ind]
-                    normalize_sum += (X_data[i_ind] - X_mean_j) ** 2
-                    R[i] -= X_data[i_ind] * w_j
-                norm2_cols_X[j] = normalize_sum
-                if center:
-                    norm2_cols_X[j] += (n_samples - endptr + startptr) * X_mean_j ** 2
-                    for i in range(n_samples):
-                        R[i] += X_mean_j * w_j
-                        R_sum += R[i]
-            else:
-                # R = sw * (y - np.dot(X, w))
-                for i_ind in range(startptr, endptr):
-                    i = X_indices[i_ind]
-                    tmp = sample_weight[i]
-                    # second term will be subtracted by loop over range(n_samples)
-                    normalize_sum += (tmp * (X_data[i_ind] - X_mean_j) ** 2
-                                      - tmp * X_mean_j ** 2)
-                    R[i] -= tmp * X_data[i_ind] * w_j
-                if center:
-                    for i in range(n_samples):
-                        normalize_sum += sample_weight[i] * X_mean_j ** 2
-                        R[i] += sample_weight[i] * X_mean_j * w_j
-                        R_sum += R[i]
-                norm2_cols_X[j] = normalize_sum
-            startptr = endptr
-
-        # Note: No need to update R_sum from here on because the update terms cancel
-        # each other: w_j * np.sum(X[:,j] - X_mean[j]) = 0. R_sum is only ever
-        # needed and calculated if X_mean is provided.
+    with nogil:
 
         # tol *= np.dot(y, y)
         # with sample weights: tol *= y @ (sw * y)

--- a/sklearn/linear_model/_cd_fast.pyx
+++ b/sklearn/linear_model/_cd_fast.pyx
@@ -610,6 +610,7 @@ def R_and_X_colnorm2_sparse(
     cdef floating w_j
     cdef floating X_mean_j
     cdef floating normalize_sum
+    cdef floating sw_sum
     cdef int32_t i, i_ind
     cdef unsigned int j
     cdef int32_t startptr = X_indptr[0]
@@ -626,6 +627,8 @@ def R_and_X_colnorm2_sparse(
             if X_mean[j]:
                 center = True
                 break
+        if center and not no_sample_weights:
+            sw_sum = np.sum(sample_weight)
 
     _copy(n_samples, &y[0], 1, &R[0], 1)
     if not no_sample_weights:
@@ -659,8 +662,8 @@ def R_and_X_colnorm2_sparse(
                 )
                 R[i] -= tmp * X_data[i_ind] * w_j
             if center:
+                normalize_sum += sw_sum * X_mean_j ** 2
                 for i in range(n_samples):
-                    normalize_sum += sample_weight[i] * X_mean_j ** 2
                     R[i] += sample_weight[i] * X_mean_j * w_j
             norm2_cols_X[j] = normalize_sum
         startptr = endptr
@@ -1506,9 +1509,10 @@ def R_and_X_colnorm2_multi_task(
     cdef unsigned int n_tasks = Y.shape[1]
     cdef floating X_mean_j
     cdef floating normalize_sum
+    cdef floating sw_sum
     cdef int32_t i, i_ind
     cdef unsigned int j
-    cdef int32_t startptr = X_indptr[0]
+    cdef int32_t startptr
     cdef int32_t endptr
     cdef bint center = False
     cdef bint no_sample_weights = sample_weight is None
@@ -1523,6 +1527,8 @@ def R_and_X_colnorm2_multi_task(
             if X_mean[j]:
                 center = True
                 break
+        if center and not no_sample_weights:
+            sw_sum = np.sum(sample_weight)
 
     if not X_is_sparse:
         np.einsum("ij,ij->j", X, X, dtype=dtype, out=norm2_cols_X_array)
@@ -1545,8 +1551,7 @@ def R_and_X_colnorm2_multi_task(
                         (X_data[i_ind] - X_mean_j) ** 2 - X_mean_j ** 2
                     )
                 if center:
-                    for i in range(n_samples):
-                        normalize_sum += sample_weight[i] * X_mean_j ** 2
+                    normalize_sum += sw_sum * X_mean_j ** 2
             norm2_cols_X[j] = normalize_sum
 
     _copy(n_samples * n_tasks, &Y[0, 0], 1, &R[0, 0], 1)

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -674,8 +674,8 @@ def enet_path(
     else:
         _alphas = alphas
 
-    X_offset_param = params.pop("X_offset", None)
-    X_scale_param = params.pop("X_scale", None)
+    X_offset = params.pop("X_offset", None)
+    X_scale = params.pop("X_scale", None)
     sample_weight = params.pop("sample_weight", None)
     tol = params.pop("tol", 1e-4)
     max_iter = params.pop("max_iter", 1000)
@@ -723,11 +723,10 @@ def enet_path(
 
     X_is_sparse = sparse.issparse(X)
     if X_is_sparse:
-        if X_offset_param is not None:
+        if X_offset is not None:
             # As sparse matrices are not actually centered we need this to be passed to
             # the CD solver.
-            X_sparse_scaling = X_offset_param / X_scale_param
-            X_sparse_scaling = np.asarray(X_sparse_scaling, dtype=X.dtype)
+            X_sparse_scaling = np.asarray(X_offset / X_scale, dtype=X.dtype)
         else:
             X_sparse_scaling = np.zeros(n_features, dtype=X.dtype)
     else:
@@ -793,6 +792,15 @@ def enet_path(
         algo = CD_Algo.ENET_CD_MULTITASK
     elif X_is_sparse:
         algo = CD_Algo.ENET_CD_SPARSE
+        R, norm2_cols_X = cd_fast.R_and_X_colnorm2_sparse(
+            w=coef_,
+            X_data=X_data,
+            X_indices=X_indices,
+            X_indptr=X_indptr,
+            y=y,
+            sample_weight=sample_weight,
+            X_mean=X_sparse_scaling,
+        )
     elif isinstance(precompute, np.ndarray):
         algo = CD_Algo.ENET_CD_GRAM
         # We expect precompute to be already Fortran ordered when bypassing checks
@@ -847,6 +855,8 @@ def enet_path(
                 sample_weight=sample_weight,
                 X_mean=X_sparse_scaling,
                 positive=positive,
+                R=R,
+                norm2_cols_X=norm2_cols_X,
                 **params,
             )
         elif algo == CD_Algo.ENET_CD_MULTITASK:

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -790,6 +790,17 @@ def enet_path(
 
     if multi_output:
         algo = CD_Algo.ENET_CD_MULTITASK
+        R, norm2_cols_X = cd_fast.R_and_X_colnorm2_multi_task(
+            W=coef_,
+            X=None if X_is_sparse else X,
+            X_is_sparse=X_is_sparse,
+            X_data=X_data,
+            X_indices=X_indices,
+            X_indptr=X_indptr,
+            Y=y,
+            sample_weight=sample_weight,
+            X_mean=X_sparse_scaling,
+        )
     elif X_is_sparse:
         algo = CD_Algo.ENET_CD_SPARSE
         R, norm2_cols_X = cd_fast.R_and_X_colnorm2_sparse(
@@ -806,8 +817,10 @@ def enet_path(
         # We expect precompute to be already Fortran ordered when bypassing checks
         if check_input:
             precompute = check_array(precompute, dtype=X.dtype.type, order="C")
+        Qw = precompute @ coef_
     else:  # precompute is False
         algo = CD_Algo.ENET_CD
+        R, norm2_cols_X = cd_fast.R_and_X_colnorm2(w=coef_, X=X, y=y)
 
     params = dict(
         max_iter=max_iter,
@@ -830,6 +843,8 @@ def enet_path(
                 X=X,
                 y=y,
                 positive=positive,
+                R=R,
+                norm2_cols_X=norm2_cols_X,
                 **params,
             )
         elif algo == CD_Algo.ENET_CD_GRAM:
@@ -841,6 +856,7 @@ def enet_path(
                 q=Xy,
                 y=y,
                 positive=positive,
+                Qw=Qw,
                 **params,
             )
         elif algo == CD_Algo.ENET_CD_SPARSE:
@@ -872,6 +888,8 @@ def enet_path(
                 Y=y,
                 sample_weight=sample_weight,
                 X_mean=X_sparse_scaling,
+                R=R,
+                norm2_cols_X=norm2_cols_X,
                 **params,
             )
 


### PR DESCRIPTION
#### Reference Issues/PRs
None.
This PR needed #34514 as preparation.


#### What does this implement/fix? Explain your changes.
This PR adds precomputing of
- residuals: `R = y - X @ coef`
- squared column norms of X: `norm2_cols_X = np.sum(X ** 2, axis=0)`

in the coordinate descent solvers (Cython). The main impact is when computing paths with `enet_path` or `ElasticNetCV` because then, except for the very first path value, the initialization (memory) and computation of residuals and column norms is avoided.

Note the at the end of a coordinate descent algo, residuals are always up to date. 


#### AI usage disclosure
None

#### Any other comments?
**No** public API change.
