### PR TITLE
[32161] Added frequency option to ordinaryEncoder 

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -89,7 +89,7 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
         )
         self.n_features_in_ = n_features
 
-        if self.categories != "auto":
+        if self.categories != "auto" and self.categories != "frequency":
             if len(self.categories) != n_features:
                 raise ValueError(
                     "Shape mismatch: if categories is an array,"
@@ -110,6 +110,20 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
                     category_counts.append(counts)
                 else:
                     cats = result
+            elif self.categories == "frequency":
+                unique_vals, counts = _unique(X_list[i], return_counts=True)
+                local_decoder = {}
+                count_sort_idx = np.argsort(counts)
+                sorted_unique_vals = unique_vals[count_sort_idx]
+                encoder_mapping = dict()
+                for idx, val in enumerate(sorted_unique_vals):
+                    encoder_mapping[val] = idx
+                    local_decoder[idx] = val
+                if compute_counts:
+                    cats =  np.array(list(encoder_mapping.keys()))
+                    category_counts.append(counts)
+                else:
+                    cats = np.array(list(encoder_mapping.keys()))
             else:
                 if np.issubdtype(Xi.dtype, np.str_):
                     # Always convert string categories to objects to avoid
@@ -1281,6 +1295,9 @@ class OrdinalEncoder(OneToOneFeatureMixin, _BaseEncoder):
         Categories (unique values) per feature:
 
         - 'auto' : Determine categories automatically from the training data.
+        - 'frequency' : Determine categories automatically based on the most
+          frequency of the samples.The least frequent is encoded 0 the second
+          lest frequent is encoded 1 and so on. 
         - list : ``categories[i]`` holds the categories expected in the ith
           column. The passed categories should not mix strings and numeric
           values, and should be sorted in case of numeric values.
@@ -1440,7 +1457,7 @@ class OrdinalEncoder(OneToOneFeatureMixin, _BaseEncoder):
     """
 
     _parameter_constraints: dict = {
-        "categories": [StrOptions({"auto"}), list],
+        "categories": [StrOptions({"auto","frequency"}), list],
         "dtype": "no_validation",  # validation delegated to numpy
         "encoded_missing_value": [Integral, type(np.nan)],
         "handle_unknown": [StrOptions({"error", "use_encoded_value"})],

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -628,13 +628,13 @@ def test_one_hot_encoder_drop_equals_if_binary():
     ],
     ids=["mixed", "numeric", "object"],
 )
-
 def test_ordinal_encoder(X):
     enc = OrdinalEncoder()
     exp = np.array([[0, 1, 0], [1, 0, 0]], dtype="int64")
     assert_array_equal(enc.fit_transform(X), exp.astype("float64"))
     enc = OrdinalEncoder(dtype="int64")
     assert_array_equal(enc.fit_transform(X), exp)
+
 
 @pytest.mark.parametrize(
     "kwargs",
@@ -686,6 +686,7 @@ def test_ordinal_encoder_frequency(kwargs):
     X_trans_inv = enc.inverse_transform(X_trans_enc)
     assert_array_equal(X_trans_inv, X_decoded)
 
+
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -704,7 +705,6 @@ def test_ordinal_encoder_all_infrequent_frequency(kwargs):
 
     X_test = [["a"], ["b"], ["c"], ["d"], ["e"]]
     assert_allclose(encoder.transform(X_test), [[0], [0], [0], [0], [-1]])
-
 
 
 @pytest.mark.parametrize(

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -628,12 +628,83 @@ def test_one_hot_encoder_drop_equals_if_binary():
     ],
     ids=["mixed", "numeric", "object"],
 )
+
 def test_ordinal_encoder(X):
     enc = OrdinalEncoder()
     exp = np.array([[0, 1, 0], [1, 0, 0]], dtype="int64")
     assert_array_equal(enc.fit_transform(X), exp.astype("float64"))
     enc = OrdinalEncoder(dtype="int64")
     assert_array_equal(enc.fit_transform(X), exp)
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [   
+        #missing values
+        {"fit":  [["a", "x"],["a", "x"]] + [["b", "y"],["b", "y"]],
+            "X":[["a", "x"]] + [["ab", "x"]] + [["b", "y"],["b", "y"]],
+            "X_decoded":[["a", "x"]] + [[None, "x"]] + [["b", "y"],["b", "y"]],
+            "X_encoded":[[ 0.0,  0.0]] + [[ -2.0,  0.0]]+[[ 1.0,  1.0],[ 1.0,  1.0]]},
+        #nan
+         {"fit":  [["aa", "xx"],["aa", "xx"]] + [["bb", "yy"],["bb", "yy"]],
+            "X":[[np.nan, "xx"]] + [["bb", "yy"],["bb", "yy"]],#x
+            "X_decoded":[[None, "xx"]] + [["bb", "yy"],["bb", "yy"]],
+            "X_encoded":[[-2.0,  0.0]] + [[ 1.0,  1.0],[ 1.0,  1.0]]},
+        #
+         {"fit":  [["aa", "xx"],["aa", "xx"]] + [["bb", "yy"],["bb", "yy"]],
+            "X":[["aa", "xx"]] + [["bb", "yy"],["bb", "yy"]],
+            "X_decoded":[["aa", "xx"]] + [["bb", "yy"],["bb", "yy"]],
+            "X_encoded":[[ 0.0,  0.0]] + [[ 1.0,  1.0],[ 1.0,  1.0]]},
+        #numeric
+         {"fit":  [[2, 7]] + [[1, 5],[1, 5]],
+            "X": [[2, 7]] + [[1, 5],[1, 5]],
+            "X_decoded":[[2, 7]] + [[1, 5],[1, 5]],
+            "X_encoded":[[ 0.0,  0.0]] + [[ 1.0,  1.0],[ 1.0,  1.0]]}
+    ],
+)
+def test_ordinal_encoder_frequency(kwargs):    
+    print("kwargs",list(kwargs.keys()))
+    enc = OrdinalEncoder(
+        handle_unknown="use_encoded_value", unknown_value=-2,categories='frequency',
+    )
+    X_fit = np.array(
+        kwargs['fit'] ,
+        dtype=object,
+    )
+    X = np.array(
+        kwargs['X'], 
+        dtype=object,
+    )
+    X_decoded = np.array(
+        kwargs['X_decoded'],
+        dtype=object,
+    )
+    X_encoded = np.array(kwargs['X_encoded'])
+
+    enc.fit(X_fit)
+    X_trans_enc = enc.transform(X)
+    assert_array_equal(X_trans_enc, X_encoded)
+    X_trans_inv = enc.inverse_transform(X_trans_enc)
+    assert_array_equal(X_trans_inv, X_decoded)
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"max_categories": 1},
+        {"min_frequency": 100},
+    ],
+)
+def test_ordinal_encoder_all_infrequent_frequency(kwargs):
+    """When all categories are infrequent, they are all encoded as zero."""
+    X_train = np.array(
+        [["a"] * 5 + ["b"] * 20 + ["c"] * 10 + ["d"] * 3], dtype=object
+    ).T
+    encoder = OrdinalEncoder(
+        **kwargs, handle_unknown="use_encoded_value", unknown_value=-1,categories='frequency',
+    ).fit(X_train)
+
+    X_test = [["a"], ["b"], ["c"], ["d"], ["e"]]
+    assert_allclose(encoder.transform(X_test), [[0], [0], [0], [0], [-1]])
+
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Reference Issues/PRs

closes https://github.com/scikit-learn/scikit-learn/issues/32161
What does this implement/fix? Explain your changes.

I have added an option for encoding of the inputs based on their frequency instead of their alphabetical order
AI usage disclosure

None
Any other comments?

No