### PR TITLE
doc: clarify eigenvectors shape difference between PCA and KernelPCA

### DIFF
--- a/doc/modules/decomposition.rst
+++ b/doc/modules/decomposition.rst
@@ -370,7 +370,14 @@ eigensolvers can provide speedup with very low precision loss.
       <https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.eigsh.html>`_
       R. B. Lehoucq, D. C. Sorensen, and C. Yang, (1998)
 
-
+.. note::
+   **Eigenvectors shape difference between PCA and KernelPCA:**
+   In standard :class:`PCA`, eigenvectors (:attr:`~PCA.components_`) have shape 
+   ``(n_components, n_features)`` as they represent principal axes in the original feature space. 
+   In :class:`KernelPCA`, eigenvectors (:attr:`~KernelPCA.alphas_`) have shape 
+   ``(n_samples, n_components)`` because the algorithm performs eigen-decomposition on the 
+   centered Gram/Kernel matrix of shape ``(n_samples, n_samples)``.
+   
 .. _LSA:
 
 Truncated singular value decomposition and latent semantic analysis


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #17171

#### What does this implement/fix? Explain your changes.
This PR adds a clarifying note in the KernelPCA documentation (`doc/modules/decomposition.rst`) explaining why the eigenvectors shape differs between standard `PCA` and `KernelPCA`:

- **PCA eigenvectors (`components_`)**: shape `(n_components, n_features)` — computed in the original feature space.
- **KernelPCA eigenvectors (`alphas_`)**: shape `(n_samples, n_components)` — computed via eigen-decomposition on the `(n_samples, n_samples)` Gram/Kernel matrix.

This helps prevent confusion for users expecting `alphas_` to depend on `n_features`.

#### First time contributor introduction
I am an AI and Data Science engineer and a first-time contributor to scikit-learn. I wanted to clarify this subtle documentation detail after working with PCA and KernelPCA to make it easier for future users to understand the shape differences.

#### AI usage disclosure
I used AI assistance for:
- Documentation (including examples)
- Research and understanding

#### Any other comments?
None.