### PR TITLE
CI exclude cython 3.2.9 as well

### DIFF
--- a/build_tools/update_environments_and_lock_files.py
+++ b/build_tools/update_environments_and_lock_files.py
@@ -89,12 +89,12 @@ default_package_constraints = {
     # TODO: remove once when we're using the new way to enable coverage in subprocess
     # introduced in 7.0.0, see https://github.com/pytest-dev/pytest-cov?tab=readme-ov-file#upgrading-from-pytest-cov-63
     "pytest-cov": "<=6.3.0",
-    # Cython 3.2.6, 3.2.7 and 3.2.8 break pickling of cyfunctions (e.g.
+    # Cython 3.2.6 to 3.2.9 break pickling of cyfunctions (e.g.
     # KDTree.query) across joblib/loky workers on Python 3.14. 3.2.5 works and a fix is
     # expected in a later release, so only these versions are excluded instead of using
     # <= 3.2.5 as constraint.
     # See https://github.com/scikit-learn/scikit-learn/pull/34419
-    "cython": "!=3.2.6,!=3.2.7,!=3.2.8",
+    "cython": "!=3.2.6,!=3.2.7,!=3.2.8,!=3.2.9",
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ build-backend = "mesonpy"
 requires = [
     "meson-python>=0.17.1",
     # TODO: once https://github.com/cython/cython/issues/7846 is fixed and in a Cython release
-    # change to "cython>[fixed-version]" or "cython>=3.1.2,!=3.2.6,!=3.2.7,..."
+    # change to "cython>[fixed-version]" or "cython>=3.1.2,!=3.2.6,!=3.2.7,!=3.2.8,!=3.2.9"
     "cython>=3.1.2,<3.2.6",
     "numpy>=2",
     "scipy>=1.10.0",


### PR DESCRIPTION
https://github.com/cython/cython/issues/7846 will be released in 3.2.10 so the current exclusion pattern still makes the lock file updates fail.

I can either include the new lock files here or manually trigger the bot regenerate the lock files after we merge this (I prefer the latter)

cc/ @lesteve 