### PR TITLE
DOC stabilize SpectralCoclustering doctest

### DIFF
--- a/sklearn/cluster/_bicluster.py
+++ b/sklearn/cluster/_bicluster.py
@@ -298,13 +298,17 @@ class SpectralCoclustering(BaseSpectral):
     --------
     >>> from sklearn.cluster import SpectralCoclustering
     >>> import numpy as np
-    >>> X = np.array([[1, 1], [2, 1], [1, 0],
-    ...               [4, 7], [3, 5], [3, 6]])
+    >>> X = np.array([[3, 3, 0, 0], [3, 3, 0, 0],
+    ...               [0, 0, 1, 1], [0, 0, 1, 1]])
     >>> clustering = SpectralCoclustering(n_clusters=2, random_state=0).fit(X)
-    >>> clustering.row_labels_ #doctest: +SKIP
-    array([0, 1, 1, 0, 0, 0], dtype=int32)
-    >>> clustering.column_labels_ #doctest: +SKIP
-    array([0, 0], dtype=int32)
+    >>> same_cluster = (
+    ...     clustering.row_labels_[:, np.newaxis] == clustering.column_labels_
+    ... )
+    >>> same_cluster.astype(int)
+    array([[1, 1, 0, 0],
+           [1, 1, 0, 0],
+           [0, 0, 1, 1],
+           [0, 0, 1, 1]])
     >>> clustering
     SpectralCoclustering(n_clusters=2, random_state=0)
 


### PR DESCRIPTION
Fixes #13762

### Description
This PR fixes an architecture-sensitive `SpectralCoclustering` doctest by replacing it with a label-permutation-invariant example. 

**Why the previous doctest was fragile:**
The original doctest asserted exact numeric row and column labels. However, cluster labels are essentially arbitrary. Even with a fixed `random_state=0`, equivalent clustering results can produce a completely different label permutation depending on the numerical backend or CPU architecture (e.g., ARM vs. x86). 

**Implementation Details:**
- Replaced the input with a strongly separated 4-by-4 block matrix.
- Instead of checking the exact numeric label values, the assertion now verifies the actual row-to-column co-cluster relationship.
- This preserves the core semantic assertion of the doctest while making it robust and independent of arbitrary label numbering across different platforms.

**Local Verification:**
- Current source docstring doctest: 7/7 passed.
- `sklearn/cluster/tests/test_bicluster.py`: 21 passed.
- Exploratory matrix: 20/20 combinations passed across the `randomized` and `arpack` SVD backends with seeds 0–9.
- Ruff check, Ruff format, and `git diff --check` all passed.

*(Note: I will add the required changelog fragment once this PR is assigned a number.)*

**Declaration:**
This pull request includes code written with the assistance of AI. The code has been reviewed and tested by a human.