### PR TITLE
fix: reshape dataset arrays

### DIFF
--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1003,8 +1003,7 @@ def load_digits(*, n_class=10, return_X_y=False, as_frame=False):
 
     target = data[:, -1].astype(int, copy=False)
     flat_data = data[:, :-1]
-    images = flat_data.view()
-    images.shape = (-1, 8, 8)
+    images = flat_data.reshape(-1, 8, 8)
 
     if n_class < 10:
         idx = target < n_class

--- a/sklearn/datasets/_lfw.py
+++ b/sklearn/datasets/_lfw.py
@@ -476,7 +476,7 @@ def _fetch_lfw_pairs(
     n_faces = shape.pop(0)
     shape.insert(0, 2)
     shape.insert(0, n_faces // 2)
-    pairs.shape = shape
+    pairs = pairs.reshape(shape)
 
     return pairs, target, np.array(["Different persons", "Same person"])
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

NumPy 2.5 deprecated assignment to `ndarray.shape`.

This change replaces direct assignment to `ndarray.shape` with `reshape` in 2 files.

#### Benchmark

ASV measured `load_digits` at 20.434 milliseconds before the change and 19.970 milliseconds after the change.  
ASV measured `_fetch_lfw_pairs` at 0.545 milliseconds before the change and 0.503 milliseconds after the change.

The reported times are medians from 31 repeats for each case on each revision.

Each ASV checksum matched. Each result shared memory with its input.

The [ASV benchmark on my fork](https://github.com/stanbot8/scikit-learn/tree/238947b3b390591ca3ac6a436ec89c94be143f42/benchmarks/shape-to-reshape) is AI generated.
