### PR TITLE
DOC: inconsistent estimators_ shape documentation in GradientBoostingClassifier

### DIFF
--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1992,7 +1992,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         The estimator that provides the initial predictions. Set via the ``init``
         argument.
 
-    estimators_ : ndarray of DecisionTreeRegressor of shape (n_estimators, 1)
+    estimators_ : ndarray of DecisionTreeRegressor of shape (n_estimators, ``n_trees_per_iteration_``)
         The collection of fitted sub-estimators.
 
     n_features_in_ : int


### PR DESCRIPTION
#### Reference Issues/PRs

This PR fixes the documentation issue reported in #34279: corrects `estimators_ : ndarray of DecisionTreeRegressor of shape (n_estimators, 1)` to `estimators_ : ndarray of DecisionTreeRegressor of shape (n_estimators, ``n_trees_per_iteration_``)` in `sklearn/ensemble/_gb.py`.

Fixes #34279

#### What does this implement/fix? Explain your changes.

#### First time contributor introduction

#### AI usage disclosure

I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Documentation (including examples)
- Research and understanding

#### Any other comments?

Fixes #34279