### PR TITLE
FIX drop_intermediate in roc_curve keeps redundant collinear points

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/34599.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/34599.fix.rst
@@ -1,0 +1,9 @@
+- :func:`metrics.roc_curve` with ``drop_intermediate=True`` (the default) no longer
+  keeps redundant points on the ROC curve. Previously, thresholds could be dropped
+  before the ``(0, 0)`` origin point was prepended, and the collinearity check itself
+  only detected points that were exactly midway between their neighbors, so many
+  collinear points on longer flat or diagonal segments were incorrectly kept. Both
+  issues are fixed by prepending the origin first and using a general geometric
+  collinearity test. This does not affect the ROC AUC or the visual shape of the
+  curve, only the number of points returned.
+  By :user:`Tharun Billuri <Tharunbilluri>`.

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1322,33 +1322,6 @@ def roc_curve(
         y_true, y_score, pos_label=pos_label, sample_weight=sample_weight
     )
 
-    # Attempt to drop thresholds corresponding to points in between and
-    # collinear with other points. These are always suboptimal and do not
-    # appear on a plotted ROC curve (and thus do not affect the AUC).
-    # Here np.diff(_, 2) is used as a "second derivative" to tell if there
-    # is a corner at the point. Both fps and tps must be tested to handle
-    # thresholds with multiple data points (which are combined in
-    # confusion_matrix_at_thresholds). This keeps all cases where the point should be
-    # kept, but does not drop more complicated cases like fps = [1, 3, 7],
-    # tps = [1, 2, 4]; there is no harm in keeping too many thresholds.
-    if drop_intermediate and fps.shape[0] > 2:
-        optimal_idxs = xp.nonzero(
-            xp.concat(
-                [
-                    xp.asarray([True], device=device),
-                    # Array API spec recommends `logical_or` only accepts bool input
-                    xp.logical_or(
-                        xp.astype(xp.diff(fps, n=2), xp.bool),
-                        xp.astype(xp.diff(tps, n=2), xp.bool),
-                    ),
-                    xp.asarray([True], device=device),
-                ]
-            )
-        )[0]
-        fps = fps[optimal_idxs]
-        tps = tps[optimal_idxs]
-        thresholds = thresholds[optimal_idxs]
-
     # Add an extra threshold position
     # to make sure that the curve starts at (0, 0)
     tps = xp.concat([xp.asarray([0.0], device=device), tps])
@@ -1356,6 +1329,59 @@ def roc_curve(
     # get dtype of `y_score` even if it is an array-like
     thresholds = xp.astype(thresholds, _max_precision_float_dtype(xp, device))
     thresholds = xp.concat([xp.asarray([xp.inf], device=device), thresholds])
+
+    # Attempt to drop thresholds corresponding to points in between and
+    # collinear with their neighbors in ROC space. These are always
+    # suboptimal and do not appear on a plotted ROC curve (and thus do not
+    # affect the AUC). This must happen *after* the (0, 0) origin point above
+    # has been prepended, otherwise points that are only redundant once the
+    # origin is taken into account would incorrectly be kept.
+    #
+    # Collinearity of three consecutive points (x0, y0), (x1, y1), (x2, y2)
+    # is tested with the cross product of the two vectors they form:
+    # (x1 - x0) * (y2 - y1) - (y1 - y0) * (x2 - x1). This is (numerically)
+    # zero iff the middle point lies on the straight line through its
+    # neighbors, regardless of how far apart the points are. This is more
+    # general than only checking points that are exactly midway between
+    # their neighbors (e.g. via a second-order finite difference), which
+    # misses many redundant points on longer collinear segments.
+    if drop_intermediate and fps.shape[0] > 2:
+        dx0 = fps[1:-1] - fps[:-2]
+        dy0 = tps[1:-1] - tps[:-2]
+        dx1 = fps[2:] - fps[1:-1]
+        dy1 = tps[2:] - tps[1:-1]
+        cross_product = dx0 * dy1 - dy0 * dx1
+        # fps and tps hold (possibly weighted) sample counts, so exactly
+        # collinear points yield an exactly zero cross product up to
+        # floating-point rounding error. Scale the tolerance with the
+        # magnitude of the coordinates (the cross product is a difference of
+        # two such products) to remain robust for large or float-weighted
+        # counts while not being too lax for small ones.
+        max_coord = xp.maximum(xp.max(fps), xp.max(tps))
+        max_coord = xp.where(
+            max_coord > 0,
+            max_coord,
+            xp.asarray(1.0, dtype=max_coord.dtype, device=device),
+        )
+        eps = xp.asarray(
+            xp.finfo(cross_product.dtype).eps,
+            dtype=cross_product.dtype,
+            device=device,
+        )
+        tolerance = 10 * eps * max_coord * max_coord
+        is_collinear = xp.abs(cross_product) <= tolerance
+        optimal_idxs = xp.nonzero(
+            xp.concat(
+                [
+                    xp.asarray([True], device=device),
+                    ~is_collinear,
+                    xp.asarray([True], device=device),
+                ]
+            )
+        )[0]
+        fps = fps[optimal_idxs]
+        tps = tps[optimal_idxs]
+        thresholds = thresholds[optimal_idxs]
 
     if fps[-1] <= 0:
         warnings.warn(

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -374,8 +374,11 @@ def test_roc_curve_toydata():
     )
     with pytest.warns(UndefinedMetricWarning, match=expected_message):
         tpr, fpr, _ = roc_curve(y_true, y_score)
-    assert_array_almost_equal(tpr, [0.0, 0.5, 1.0])
-    assert_array_almost_equal(fpr, [np.nan, np.nan, np.nan])
+    # All 3 points (the prepended origin and the 2 data points) are collinear
+    # (fpr is constant at 0 tp throughout), so the middle point is correctly
+    # dropped by `drop_intermediate` (the default). See gh-31635.
+    assert_array_almost_equal(tpr, [0.0, 1.0])
+    assert_array_almost_equal(fpr, [np.nan, np.nan])
     expected_message = (
         "Only one class is present in y_true. "
         "ROC AUC score is not defined in that case."
@@ -393,8 +396,10 @@ def test_roc_curve_toydata():
     )
     with pytest.warns(UndefinedMetricWarning, match=expected_message):
         tpr, fpr, _ = roc_curve(y_true, y_score)
-    assert_array_almost_equal(tpr, [np.nan, np.nan, np.nan])
-    assert_array_almost_equal(fpr, [0.0, 0.5, 1.0])
+    # Same reasoning as above (mirrored): all 3 points are collinear, so the
+    # middle point is dropped. See gh-31635.
+    assert_array_almost_equal(tpr, [np.nan, np.nan])
+    assert_array_almost_equal(fpr, [0.0, 1.0])
     expected_message = (
         "Only one class is present in y_true. "
         "ROC AUC score is not defined in that case."
@@ -442,13 +447,77 @@ def test_roc_curve_drop_intermediate():
     y_true = [0, 0, 0, 0, 1, 1]
     y_score = [0.0, 0.2, 0.5, 0.6, 0.7, 1.0]
     tpr, fpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=True)
-    assert_array_almost_equal(thresholds, [np.inf, 1.0, 0.7, 0.0])
+    # The point at threshold 1.0, i.e. (fpr=0, tpr=0.5), is collinear with the
+    # prepended origin (fpr=0, tpr=0) and the next point (fpr=0, tpr=1) since
+    # all three lie on the vertical line fpr=0, so it is correctly dropped.
+    # See gh-31635.
+    assert_array_almost_equal(thresholds, [np.inf, 0.7, 0.0])
 
     # Test dropping thresholds with repeating scores
     y_true = [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1]
     y_score = [0.0, 0.1, 0.6, 0.6, 0.7, 0.8, 0.9, 0.6, 0.7, 0.8, 0.9, 0.9, 1.0]
     tpr, fpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=True)
     assert_array_almost_equal(thresholds, [np.inf, 1.0, 0.9, 0.7, 0.6, 0.0])
+
+
+@pytest.mark.parametrize(
+    "y_true, y_score, expected_fpr, expected_tpr, expected_thresholds",
+    [
+        # Perfect separator: everything strictly above the threshold of 4 is
+        # positive. The minimal ROC curve should have a single interior point.
+        (
+            [0, 0, 0, 0, 1, 1, 1, 1],
+            [0, 1, 2, 3, 4, 5, 6, 7],
+            [0.0, 0.0, 1.0],
+            [0.0, 1.0, 1.0],
+            [np.inf, 4.0, 0.0],
+        ),
+        # Same perfect separator, but with several tied/repeated scores below
+        # the decision boundary: all of those points lie on the same flat
+        # segment of the curve and should all be dropped as collinear.
+        (
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 1, 1, 1, 2, 2, 3, 4],
+            [0.0, 0.0, 1.0],
+            [0.0, 1.0, 1.0],
+            [np.inf, 4.0, 0.0],
+        ),
+        # A non-informative classifier: fpr == tpr at every threshold, so the
+        # whole curve lies on the diagonal and should collapse to 2 points.
+        (
+            [0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1],
+            [0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3],
+            [0.0, 1.0],
+            [0.0, 1.0],
+            [np.inf, 0.0],
+        ),
+    ],
+)
+def test_roc_curve_drop_intermediate_collinear_points(
+    y_true, y_score, expected_fpr, expected_tpr, expected_thresholds
+):
+    """Non-regression test for gh-31635.
+
+    `drop_intermediate=True` (the default) must remove *all* points that are
+    collinear with their neighbors in ROC space, including:
+
+    - points that are only redundant once the prepended (0, 0) origin point
+      is taken into account (bug 1 in the report), and
+    - points on longer flat/diagonal segments that are not exactly midway
+      between their neighbors (bug 2 in the report).
+    """
+    fpr, tpr, thresholds = roc_curve(y_true, y_score, drop_intermediate=True)
+    assert_array_almost_equal(fpr, expected_fpr)
+    assert_array_almost_equal(tpr, expected_tpr)
+    assert_array_almost_equal(thresholds, expected_thresholds)
+
+    # Sanity check: dropping intermediate, collinear points must never change
+    # the AUC nor discard a point that is not actually on the straight line
+    # connecting its neighbors in the non-dropped curve.
+    fpr_full, tpr_full, _ = roc_curve(y_true, y_score, drop_intermediate=False)
+    assert_almost_equal(auc(fpr, tpr), auc(fpr_full, tpr_full))
+    for x, y in zip(fpr, tpr):
+        assert np.any(np.isclose(fpr_full, x) & np.isclose(tpr_full, y))
 
 
 def test_roc_curve_fpr_tpr_increasing():


### PR DESCRIPTION
## Summary

Fixes #31635.

`roc_curve(..., drop_intermediate=True)` (the default) is meant to drop ROC
points that are collinear with their neighbors, since they don't affect the
AUC or the visual shape of the curve. Two bugs prevented it from doing so
correctly:

1. **Ordering bug**: intermediate points were identified for dropping
   *before* the `(0, 0)` origin point and the `inf` threshold were
   prepended to `fps`/`tps`/`thresholds`. This means a point that is only
   redundant once the origin is taken into account (e.g. it lies on the
   straight line from the origin to the next point) was never recognized as
   such, and was incorrectly kept.

2. **Heuristic bug**: the collinearity test compared the second-order finite
   difference (`np.diff(_, 2)`) of `fps`/`tps`, which is zero only for a
   point that lies *exactly midway* between its neighbors. It does not
   generalize to longer flat/diagonal segments (e.g. several tied scores in
   a row, or a completely non-informative classifier), so many redundant
   points on such segments were kept.

### Fix

- Move the "prepend `(0, 0)` / `inf`" step before the `drop_intermediate`
  block, so the origin is available when identifying collinear points.
- Replace the second-difference heuristic with a general geometric
  collinearity test: for three consecutive points, compute the cross
  product of the vectors formed by consecutive differences
  (`dx0 * dy1 - dy0 * dx1`). This is (numerically) zero exactly when the
  middle point lies on the straight line through its neighbors, regardless
  of spacing. The zero-tolerance is scaled with the magnitude of the
  `fps`/`tps` coordinates so it remains robust for large counts or
  float-weighted (`sample_weight`) data.

This does not change the ROC AUC or the visual shape of the curve — only
the number of points/thresholds returned when `drop_intermediate=True`
(the default).

### Example (from the issue)

```python
import numpy as np
from sklearn.metrics import roc_curve

y_true = np.array([0, 0, 0, 0, 1, 1, 1, 1])
y_score = np.array([0, 1, 2, 3, 4, 5, 6, 7])
roc_curve(y_true, y_score)
```

Before:
```
(array([0., 0., 0., 1.]), array([0.  , 0.25, 1.  , 1.  ]), array([inf, 7., 4., 0.]))
```

After:
```
(array([0., 0., 1.]), array([0., 1., 1.]), array([inf, 4., 0.]))
```

## Test plan

- Added `test_roc_curve_drop_intermediate_collinear_points`, a
  parametrized non-regression test covering the three reproducer cases
  from the issue (perfect separator, perfect separator with tied scores,
  and a fully non-informative classifier), including an invariant check
  that dropping intermediate points never changes the AUC and never drops a
  point that isn't actually collinear in the full (non-dropped) curve.
- Updated the two pre-existing tests whose hardcoded expectations
  reflected the buggy behavior (`test_roc_curve_drop_intermediate` and the
  no-positive/no-negative-samples cases in `test_roc_curve_toydata`), with
  comments explaining why the new, smaller point counts are correct.
- Ran the full `sklearn/metrics/` test suite locally against a fresh
  editable build: 3404 passed, 0 failed (4356 skipped are optional
  array-API backends not installed locally, e.g. torch/cupy).
- Verified `ruff check`/`ruff format` report no new issues introduced by
  this diff (confirmed the pre-existing warning count on `_ranking.py` and
  `test_ranking.py` is unchanged before/after this patch).
- Added a changelog entry under `doc/whats_new/upcoming_changes/sklearn.metrics/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)