### PR TITLE
DOC: Add payment fraud example to precision_recall_curve

### DIFF
--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1170,7 +1170,6 @@ def precision_recall_curve(
     >>> scores = clf.predict_proba(X_test)[:, 1]
     >>> precision, recall, thresholds = precision_recall_curve(y_test, scores)
         """
-    
     xp, _, device = get_namespace_and_device(y_score)
 
     _, fps, _, tps, thresholds = confusion_matrix_at_thresholds(

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1169,7 +1169,8 @@ def precision_recall_curve(
     >>> clf = LogisticRegression().fit(X_train, y_train)
     >>> scores = clf.predict_proba(X_test)[:, 1]
     >>> precision, recall, thresholds = precision_recall_curve(y_test, scores)
-        """
+    """
+    
     xp, _, device = get_namespace_and_device(y_score)
 
     _, fps, _, tps, thresholds = confusion_matrix_at_thresholds(

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1157,7 +1157,7 @@ def precision_recall_curve(
     array([1. , 1. , 0.5, 0.5, 0. ])
     >>> thresholds
     array([0.1 , 0.35, 0.4 , 0.8 ])
-    >>> # FinTech example: payment fraud detection with imbalanced classes
+   >>> # FinTech example: payment fraud detection with imbalanced classes
     >>> from sklearn.datasets import make_classification
     >>> from sklearn.linear_model import LogisticRegression
     >>> from sklearn.metrics import precision_recall_curve
@@ -1170,7 +1170,6 @@ def precision_recall_curve(
     >>> scores = clf.predict_proba(X_test)[:, 1]
     >>> precision, recall, thresholds = precision_recall_curve(y_test, scores)
     """
-    
     xp, _, device = get_namespace_and_device(y_score)
 
     _, fps, _, tps, thresholds = confusion_matrix_at_thresholds(

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1157,7 +1157,7 @@ def precision_recall_curve(
     array([1. , 1. , 0.5, 0.5, 0. ])
     >>> thresholds
     array([0.1 , 0.35, 0.4 , 0.8 ])
-   >>> # FinTech example: payment fraud detection with imbalanced classes
+    >>> # FinTech example: payment fraud detection with imbalanced classes
     >>> from sklearn.datasets import make_classification
     >>> from sklearn.linear_model import LogisticRegression
     >>> from sklearn.metrics import precision_recall_curve

--- a/sklearn/metrics/_ranking.py
+++ b/sklearn/metrics/_ranking.py
@@ -1157,7 +1157,20 @@ def precision_recall_curve(
     array([1. , 1. , 0.5, 0.5, 0. ])
     >>> thresholds
     array([0.1 , 0.35, 0.4 , 0.8 ])
-    """
+    >>> # FinTech example: payment fraud detection with imbalanced classes
+    >>> from sklearn.datasets import make_classification
+    >>> from sklearn.linear_model import LogisticRegression
+    >>> from sklearn.metrics import precision_recall_curve
+    >>> X, y = make_classification(
+    ...     n_samples=10000, weights=[0.9828, 0.0172], n_informative=5, random_state=42
+    ... )
+    >>> X_train, X_test = X[:8000], X[8000:]
+    >>> y_train, y_test = y[:8000], y[8000:]
+    >>> clf = LogisticRegression().fit(X_train, y_train)
+    >>> scores = clf.predict_proba(X_test)[:, 1]
+    >>> precision, recall, thresholds = precision_recall_curve(y_test, scores)
+        """
+    
     xp, _, device = get_namespace_and_device(y_score)
 
     _, fps, _, tps, thresholds = confusion_matrix_at_thresholds(


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix?
DOC: Adds an imbalanced classification example (payment fraud detection) to the `precision_recall_curve` docstring.

- Adds a realistic imbalanced dataset example (1.72% fraud rate) using `make_classification`.
- Demonstrates training a `LogisticRegression` classifier and extracting precision-recall scores.
- Formatted to comply with docstring standard and passing doctests.

#### First time contributor introduction
Hi! I'm Mitali, a Senior Business Analyst and ML practitioner working with imbalanced data systems in financial contexts. I wanted to contribute a realistic example to scikit-learn's docstring to assist developers working with imbalanced target distributions.

#### AI usage disclosure
I used AI assistance for:
- Documentation (including examples)

#### Any other comments?
N/A