### PR TITLE
FIX Raise a clear error when text vectorizers receive 2D input

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.feature_extraction/34603.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.feature_extraction/34603.fix.rst
@@ -1,0 +1,7 @@
+- :class:`feature_extraction.text.CountVectorizer`,
+  :class:`feature_extraction.text.HashingVectorizer` and
+  :class:`feature_extraction.text.TfidfVectorizer` now raise a clear error
+  message when given a 2-dimensional array-like (e.g. a single-column
+  ``DataFrame``) instead of an iterable of raw documents, rather than
+  silently producing a nonsensical result.
+  By :user:`Arthur Lacote <cakedev0>`.

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1237,6 +1237,76 @@ def test_vectorizer_string_object_as_input(Vectorizer):
         vec.transform("hello world!")
 
 
+@pytest.mark.parametrize(
+    "Vectorizer", (CountVectorizer, TfidfVectorizer, HashingVectorizer)
+)
+def test_vectorizer_2d_array_like_as_input(Vectorizer):
+    # A 2D array-like (e.g. a single-column DataFrame) used to silently
+    # produce a nonsensical result instead of raising: iterating over it does
+    # not yield one document per sample.
+    message = "Iterable over raw text documents expected, 2-dimensional array-like"
+    docs = ["one two", "three four", "five six"]
+    X_2d = np.array(docs, dtype=object).reshape(-1, 1)
+    vec = Vectorizer()
+
+    with pytest.raises(ValueError, match=message):
+        vec.fit_transform(X_2d)
+
+    with pytest.raises(ValueError, match=message):
+        vec.fit(X_2d)
+    vec.fit(docs)
+
+    with pytest.raises(ValueError, match=message):
+        vec.transform(X_2d)
+
+
+@pytest.mark.parametrize(
+    "Vectorizer", (CountVectorizer, TfidfVectorizer, HashingVectorizer)
+)
+def test_vectorizer_pandas_dataframe_as_input(Vectorizer):
+    # A single-column (or wider) DataFrame is a common and easy mistake: unlike
+    # a Series, iterating over a DataFrame yields its column names rather than
+    # its rows, so passing `df[["col"]]` instead of `df["col"]` used to
+    # silently vectorize the column name as if it were the only document.
+    pd = pytest.importorskip("pandas")
+    message = "Iterable over raw text documents expected, 2-dimensional array-like"
+    df = pd.DataFrame({"text": ["one two", "three four", "five six"]})
+    vec = Vectorizer()
+
+    with pytest.raises(ValueError, match=message):
+        vec.fit_transform(df[["text"]])
+
+    vec.fit_transform(df["text"])  # a Series is fine: one document per row
+
+
+def test_column_transformer_list_selector_with_vectorizer_raises():
+    # Non-regression test illustrating another common way to hit the 2D input
+    # error above: selecting columns by list (even a single-element list) in
+    # a ColumnTransformer passes a DataFrame down to the transformer, whereas
+    # a scalar (bare string) selector passes a 1D Series as documented in
+    # :class:`~sklearn.compose.ColumnTransformer`.
+    pd = pytest.importorskip("pandas")
+    from sklearn.compose import ColumnTransformer
+
+    df = pd.DataFrame(
+        {
+            "Heating": ["Forced Air", "Central, Gas"],
+            "Cooling": ["Central Air", None],
+        }
+    )
+    message = "Iterable over raw text documents expected, 2-dimensional array-like"
+
+    ct = ColumnTransformer(
+        [("heating", CountVectorizer(), ["Heating", "Cooling"])],
+    )
+    with pytest.raises(ValueError, match=message):
+        ct.fit_transform(df)
+
+    # Using a scalar column selector instead extracts a 1D Series and works.
+    ct = ColumnTransformer([("heating", CountVectorizer(), "Heating")])
+    ct.fit_transform(df)
+
+
 @pytest.mark.parametrize("X_dtype", [np.float32, np.float64])
 def test_tfidf_transformer_type(X_dtype):
     X = sparse.rand(10, 20000, dtype=X_dtype, random_state=42)

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -29,6 +29,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.svm import LinearSVC
 from sklearn.utils import _align_api_if_sparse
 from sklearn.utils._testing import (
+    _convert_container,
     assert_allclose_dense_sparse,
     assert_almost_equal,
     skip_if_32bit,
@@ -1240,13 +1241,14 @@ def test_vectorizer_string_object_as_input(Vectorizer):
 @pytest.mark.parametrize(
     "Vectorizer", (CountVectorizer, TfidfVectorizer, HashingVectorizer)
 )
-def test_vectorizer_2d_array_like_as_input(Vectorizer):
+@pytest.mark.parametrize("container", ("list", "array", "pandas"))
+def test_vectorizer_2d_array_like_as_input(Vectorizer, container):
     # A 2D array-like (e.g. a single-column DataFrame) used to silently
-    # produce a nonsensical result instead of raising: iterating over it does
-    # not yield one document per sample.
+    # produce a nonsensical result instead of raising, or hard to comprehend erros:
+    # iterating over it does not yield one document per sample.
     message = "Iterable over raw text documents expected, 2-dimensional array-like"
     docs = ["one two", "three four", "five six"]
-    X_2d = np.array(docs, dtype=object).reshape(-1, 1)
+    X_2d = _convert_container([[d] for d in docs], container)
     vec = Vectorizer()
 
     with pytest.raises(ValueError, match=message):
@@ -1258,53 +1260,6 @@ def test_vectorizer_2d_array_like_as_input(Vectorizer):
 
     with pytest.raises(ValueError, match=message):
         vec.transform(X_2d)
-
-
-@pytest.mark.parametrize(
-    "Vectorizer", (CountVectorizer, TfidfVectorizer, HashingVectorizer)
-)
-def test_vectorizer_pandas_dataframe_as_input(Vectorizer):
-    # A single-column (or wider) DataFrame is a common and easy mistake: unlike
-    # a Series, iterating over a DataFrame yields its column names rather than
-    # its rows, so passing `df[["col"]]` instead of `df["col"]` used to
-    # silently vectorize the column name as if it were the only document.
-    pd = pytest.importorskip("pandas")
-    message = "Iterable over raw text documents expected, 2-dimensional array-like"
-    df = pd.DataFrame({"text": ["one two", "three four", "five six"]})
-    vec = Vectorizer()
-
-    with pytest.raises(ValueError, match=message):
-        vec.fit_transform(df[["text"]])
-
-    vec.fit_transform(df["text"])  # a Series is fine: one document per row
-
-
-def test_column_transformer_list_selector_with_vectorizer_raises():
-    # Non-regression test illustrating another common way to hit the 2D input
-    # error above: selecting columns by list (even a single-element list) in
-    # a ColumnTransformer passes a DataFrame down to the transformer, whereas
-    # a scalar (bare string) selector passes a 1D Series as documented in
-    # :class:`~sklearn.compose.ColumnTransformer`.
-    pd = pytest.importorskip("pandas")
-    from sklearn.compose import ColumnTransformer
-
-    df = pd.DataFrame(
-        {
-            "Heating": ["Forced Air", "Central, Gas"],
-            "Cooling": ["Central Air", None],
-        }
-    )
-    message = "Iterable over raw text documents expected, 2-dimensional array-like"
-
-    ct = ColumnTransformer(
-        [("heating", CountVectorizer(), ["Heating", "Cooling"])],
-    )
-    with pytest.raises(ValueError, match=message):
-        ct.fit_transform(df)
-
-    # Using a scalar column selector instead extracts a 1D Series and works.
-    ct = ColumnTransformer([("heating", CountVectorizer(), "Heating")])
-    ct.fit_transform(df)
 
 
 @pytest.mark.parametrize("X_dtype", [np.float32, np.float64])

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1241,7 +1241,7 @@ def test_vectorizer_string_object_as_input(Vectorizer):
 @pytest.mark.parametrize(
     "Vectorizer", (CountVectorizer, TfidfVectorizer, HashingVectorizer)
 )
-@pytest.mark.parametrize("container", ("list", "array", "pandas"))
+@pytest.mark.parametrize("container", ("array", "pandas"))
 def test_vectorizer_2d_array_like_as_input(Vectorizer, container):
     # A 2D array-like (e.g. a single-column DataFrame) used to silently
     # produce a nonsensical result instead of raising, or hard to comprehend erros:

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -197,6 +197,31 @@ def strip_tags(s):
     return re.compile(r"<([^>]+)>", flags=re.UNICODE).sub(" ", s)
 
 
+def _validate_raw_documents(raw_documents):
+    """Raise a helpful error for common misuses of the ``raw_documents`` API.
+
+    ``raw_documents`` must be a 1D iterable of documents (or file-like
+    objects), one per sample. Passing a single string, or a 2D array-like
+    such as a pandas/polars DataFrame or a 2D numpy array, does not raise:
+    Python happily iterates over such objects, but over the wrong axis
+    (characters of the string, or column labels/rows of the 2D structure),
+    silently producing a nonsensical result instead of the expected error.
+    """
+    if isinstance(raw_documents, str):
+        raise ValueError(
+            "Iterable over raw text documents expected, string object received."
+        )
+    shape = getattr(raw_documents, "shape", None)
+    if shape is not None and len(shape) == 2:
+        raise ValueError(
+            "Iterable over raw text documents expected, 2-dimensional "
+            f"array-like with shape {shape} received. A vectorizer expects "
+            "one document per sample, e.g. a single DataFrame column "
+            "(`df['column_name']`, not `df[['column_name']]`), or a scalar "
+            "(not list) column selector when used inside a ColumnTransformer."
+        )
+
+
 def _check_stop_list(stop):
     if stop == "english":
         return ENGLISH_STOP_WORDS
@@ -851,10 +876,7 @@ class HashingVectorizer(
             HashingVectorizer instance.
         """
         # triggers a parameter validation
-        if isinstance(X, str):
-            raise ValueError(
-                "Iterable over raw text documents expected, string object received."
-            )
+        _validate_raw_documents(X)
 
         self._warn_for_unused_params()
         self._validate_ngram_range()
@@ -877,10 +899,7 @@ class HashingVectorizer(
         X : sparse matrix of shape (n_samples, n_features)
             Document-term matrix.
         """
-        if isinstance(X, str):
-            raise ValueError(
-                "Iterable over raw text documents expected, string object received."
-            )
+        _validate_raw_documents(X)
 
         self._validate_ngram_range()
 
@@ -1361,10 +1380,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         # We intentionally don't call the transform method to make
         # fit_transform overridable without unwanted side effects in
         # TfidfVectorizer.
-        if isinstance(raw_documents, str):
-            raise ValueError(
-                "Iterable over raw text documents expected, string object received."
-            )
+        _validate_raw_documents(raw_documents)
 
         self._validate_ngram_range()
         self._warn_for_unused_params()
@@ -1422,10 +1438,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         X : sparse matrix of shape (n_samples, n_features)
             Document-term matrix.
         """
-        if isinstance(raw_documents, str):
-            raise ValueError(
-                "Iterable over raw text documents expected, string object received."
-            )
+        _validate_raw_documents(raw_documents)
         self._check_vocabulary()
 
         # use the same matrix-building strategy as fit_transform

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -10,6 +10,7 @@ import warnings
 from collections import defaultdict
 from collections.abc import Mapping
 from functools import partial
+from itertools import chain
 from numbers import Integral
 from operator import itemgetter
 
@@ -206,18 +207,59 @@ def _validate_raw_documents(raw_documents):
     nonsensical results instead.
 
     This function checks for this kind of wrong input and raises a clear error.
+
+    Returns
+    -------
+    raw_documents : iterable
+        Equivalent to the input, to be used in place of it (peeking at the
+        first element to validate it consumes it from a one-shot iterator).
     """
     if isinstance(raw_documents, str):
         raise ValueError(
             "Iterable over raw text documents expected, string object received."
         )
+
     shape = getattr(raw_documents, "shape", None)
     if shape is not None and len(shape) == 2:
         raise ValueError(
-            "Iterable over raw text documents expected, 2-dimensional array-like"
-            f"with shape {shape} received. A vectorizer expects one document"
-            "per sample, e.g. a single DataFrame column `df['column_name']`"
+            "Iterable over raw text documents expected, 2-dimensional "
+            f"array-like with shape {shape} received. A vectorizer expects "
+            "one document per sample, e.g. a single DataFrame column "
+            "(`df['column_name']`, not `df[['column_name']]`), or a scalar "
+            "(not list) column selector when used inside a ColumnTransformer."
         )
+
+    if iter(raw_documents) is raw_documents:
+        # A one-shot iterator/generator: peeking at its first element below
+        # would consume it, which some callers cannot afford (e.g.
+        # `HashingVectorizer.fit_transform` iterates the same object twice,
+        # once through `fit` and once through `transform`). Skip the deeper
+        # check in that case: the per-document decoding/analysis code will
+        # still surface a (less friendly) error for genuinely invalid content.
+        return raw_documents
+
+    raw_documents = iter(raw_documents)
+    try:
+        first_doc = next(raw_documents)
+    except StopIteration:
+        return iter(())
+
+    if isinstance(first_doc, (list, tuple, np.ndarray)):
+        # A document can legitimately be something other than a string, bytes
+        # or file-like object (e.g. a dict, when using a custom
+        # ``preprocessor``), so we don't validate its type in general. But a
+        # first "document" that is itself a list/tuple/array is an unambiguous
+        # sign of a 2-dimensional structure such as a list of lists.
+        raise ValueError(
+            "Iterable over raw text documents expected, 2-dimensional "
+            "array-like received: its first element is itself a "
+            f"{type(first_doc).__name__}. A vectorizer expects one document "
+            "per sample: did you mean to pass a 1D sequence of strings "
+            "rather than a 2-dimensional structure, e.g. a list of lists, or "
+            "a DataFrame column selected as a list "
+            "(`df[['column_name']]` instead of `df['column_name']`)?"
+        )
+    return chain([first_doc], raw_documents)
 
 
 def _check_stop_list(stop):
@@ -897,7 +939,7 @@ class HashingVectorizer(
         X : sparse matrix of shape (n_samples, n_features)
             Document-term matrix.
         """
-        _validate_raw_documents(X)
+        X = _validate_raw_documents(X)
 
         self._validate_ngram_range()
 
@@ -1378,7 +1420,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         # We intentionally don't call the transform method to make
         # fit_transform overridable without unwanted side effects in
         # TfidfVectorizer.
-        _validate_raw_documents(raw_documents)
+        raw_documents = _validate_raw_documents(raw_documents)
 
         self._validate_ngram_range()
         self._warn_for_unused_params()
@@ -1436,7 +1478,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         X : sparse matrix of shape (n_samples, n_features)
             Document-term matrix.
         """
-        _validate_raw_documents(raw_documents)
+        raw_documents = _validate_raw_documents(raw_documents)
         self._check_vocabulary()
 
         # use the same matrix-building strategy as fit_transform

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -198,14 +198,14 @@ def strip_tags(s):
 
 
 def _validate_raw_documents(raw_documents):
-    """Raise a helpful error for common misuses of the ``raw_documents`` API.
+    """Raise a helpful error for common misuses of the raw_documents API.
 
-    ``raw_documents`` must be a 1D iterable of documents (or file-like
-    objects), one per sample. Passing a single string, or a 2D array-like
-    such as a pandas/polars DataFrame or a 2D numpy array, does not raise:
-    Python happily iterates over such objects, but over the wrong axis
-    (characters of the string, or column labels/rows of the 2D structure),
-    silently producing a nonsensical result instead of the expected error.
+    raw_documents must be a 1D iterable of documents (or file-like objects).
+    But Python can iterate over a single string or a 2D array-like, so
+    raw_documents-consuming code don't raise for such inputs but produces
+    nonsensical results instead.
+
+    This function checks for this kind of wrong input and raises a clear error.
     """
     if isinstance(raw_documents, str):
         raise ValueError(
@@ -214,11 +214,9 @@ def _validate_raw_documents(raw_documents):
     shape = getattr(raw_documents, "shape", None)
     if shape is not None and len(shape) == 2:
         raise ValueError(
-            "Iterable over raw text documents expected, 2-dimensional "
-            f"array-like with shape {shape} received. A vectorizer expects "
-            "one document per sample, e.g. a single DataFrame column "
-            "(`df['column_name']`, not `df[['column_name']]`), or a scalar "
-            "(not list) column selector when used inside a ColumnTransformer."
+            "Iterable over raw text documents expected, 2-dimensional array-like"
+            f"with shape {shape} received. A vectorizer expects one document"
+            "per sample, e.g. a single DataFrame column `df['column_name']`"
         )
 
 

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -10,7 +10,6 @@ import warnings
 from collections import defaultdict
 from collections.abc import Mapping
 from functools import partial
-from itertools import chain
 from numbers import Integral
 from operator import itemgetter
 
@@ -207,59 +206,18 @@ def _validate_raw_documents(raw_documents):
     nonsensical results instead.
 
     This function checks for this kind of wrong input and raises a clear error.
-
-    Returns
-    -------
-    raw_documents : iterable
-        Equivalent to the input, to be used in place of it (peeking at the
-        first element to validate it consumes it from a one-shot iterator).
     """
     if isinstance(raw_documents, str):
         raise ValueError(
             "Iterable over raw text documents expected, string object received."
         )
-
     shape = getattr(raw_documents, "shape", None)
     if shape is not None and len(shape) == 2:
         raise ValueError(
-            "Iterable over raw text documents expected, 2-dimensional "
-            f"array-like with shape {shape} received. A vectorizer expects "
-            "one document per sample, e.g. a single DataFrame column "
-            "(`df['column_name']`, not `df[['column_name']]`), or a scalar "
-            "(not list) column selector when used inside a ColumnTransformer."
+            "Iterable over raw text documents expected, 2-dimensional array-like"
+            f"with shape {shape} received. A vectorizer expects one document"
+            "per sample, e.g. a single DataFrame column `df['column_name']`"
         )
-
-    if iter(raw_documents) is raw_documents:
-        # A one-shot iterator/generator: peeking at its first element below
-        # would consume it, which some callers cannot afford (e.g.
-        # `HashingVectorizer.fit_transform` iterates the same object twice,
-        # once through `fit` and once through `transform`). Skip the deeper
-        # check in that case: the per-document decoding/analysis code will
-        # still surface a (less friendly) error for genuinely invalid content.
-        return raw_documents
-
-    raw_documents = iter(raw_documents)
-    try:
-        first_doc = next(raw_documents)
-    except StopIteration:
-        return iter(())
-
-    if isinstance(first_doc, (list, tuple, np.ndarray)):
-        # A document can legitimately be something other than a string, bytes
-        # or file-like object (e.g. a dict, when using a custom
-        # ``preprocessor``), so we don't validate its type in general. But a
-        # first "document" that is itself a list/tuple/array is an unambiguous
-        # sign of a 2-dimensional structure such as a list of lists.
-        raise ValueError(
-            "Iterable over raw text documents expected, 2-dimensional "
-            "array-like received: its first element is itself a "
-            f"{type(first_doc).__name__}. A vectorizer expects one document "
-            "per sample: did you mean to pass a 1D sequence of strings "
-            "rather than a 2-dimensional structure, e.g. a list of lists, or "
-            "a DataFrame column selected as a list "
-            "(`df[['column_name']]` instead of `df['column_name']`)?"
-        )
-    return chain([first_doc], raw_documents)
 
 
 def _check_stop_list(stop):
@@ -939,7 +897,7 @@ class HashingVectorizer(
         X : sparse matrix of shape (n_samples, n_features)
             Document-term matrix.
         """
-        X = _validate_raw_documents(X)
+        _validate_raw_documents(X)
 
         self._validate_ngram_range()
 
@@ -1420,7 +1378,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         # We intentionally don't call the transform method to make
         # fit_transform overridable without unwanted side effects in
         # TfidfVectorizer.
-        raw_documents = _validate_raw_documents(raw_documents)
+        _validate_raw_documents(raw_documents)
 
         self._validate_ngram_range()
         self._warn_for_unused_params()
@@ -1478,7 +1436,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         X : sparse matrix of shape (n_samples, n_features)
             Document-term matrix.
         """
-        raw_documents = _validate_raw_documents(raw_documents)
+        _validate_raw_documents(raw_documents)
         self._check_vocabulary()
 
         # use the same matrix-building strategy as fit_transform


### PR DESCRIPTION

#### Context

Being used to encoders API, I tried to do: `CountVectorizer(...).fit_transform(df[["Heating", "Cooling"]])` and got very surprising results: 1x2 sparse matrix. Because the underlying code iterates on the dataframe which yields column names... Because `CountVectorizer` feels conceptually close to `OneHotEncoder`, it took me some time to figure out wtf was happening ^^ I propose to have a clear error message instead.

You would have similarly hard to comprehend behavior in a `ColumnTransformer` like this:
`ColumnTransformer([("vect", CountVectorizer(), ["Heating", "Cooling"])])`

#### Reference Issues/PRs

None

#### What does this implement/fix? Explain your changes.

This adds a `_validate_raw_documents` helper (mirroring the existing check that already rejects a bare string, which is the same class of bug: iterable, but along the wrong axis) that also rejects anything with a 2D `.shape`.

#### AI usage disclosure

I used AI assistance for code & test generation. Then rewrote some of it.

