### PR TITLE
FIX indexable with dataframes

### DIFF
--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -658,10 +658,10 @@ def test_cross_val_and_permutation_test_on_dataframe(input_type, target_type):
     target_type = type(y_ser)
 
     def check_df(x):
-        return isinstance(x, input_type) or isinstance(x.to_native(), input_type)
+        return isinstance(x, input_type)
 
     def check_series(x):
-        return isinstance(x, target_type) or isinstance(x.to_native(), target_type)
+        return isinstance(x, target_type)
 
     clf = CheckingClassifier(check_X=check_df, check_y=check_series)
     cross_val_predict(clf, X_df, y_ser, cv=3)

--- a/sklearn/utils/tests/test_validation.py
+++ b/sklearn/utils/tests/test_validation.py
@@ -32,6 +32,7 @@ from sklearn.utils import (
     check_symmetric,
     check_X_y,
     deprecated,
+    indexable,
 )
 from sklearn.utils._array_api import (
     _is_numpy_namespace,
@@ -2538,3 +2539,31 @@ def test_num_samples_pa_chunked_array():
 
     result = _num_samples(chunked_array([[0.1, 0.2, 0.3]]))
     assert result == 3
+
+
+@pytest.mark.parametrize(
+    "constructor_name",
+    [
+        "list",
+        "tuple",
+        "array",
+        "series",
+        "polars_series",
+        "pyarrow_array",
+        "sparse_csr",
+        "sparse_csc_array",
+        "pandas",
+        "polars",
+        "pyarrow",
+        "index",
+    ],
+)
+def test_indexable_return_type(constructor_name):
+    """Test that indexable returns objects of expected type."""
+    X = _convert_container(list(range(3)), constructor_name)
+    if constructor_name == "sparse_csc_array":
+        expected_type = sp.csr_array
+    else:
+        expected_type = type(X)
+    X = indexable(X)[0]
+    assert isinstance(X, expected_type)

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -478,7 +478,7 @@ def _make_indexable(iterable):
         # Even if dataframe has __getitem__, semantics are quite different, examples:
         # pandas: df[0] -> KeyError if 0 is not a column name
         # polars: df[0] -> returns the 0th row
-        return nw.from_native(iterable, allow_series=True)
+        return iterable
     elif hasattr(iterable, "__getitem__"):
         return iterable
     elif iterable is None:


### PR DESCRIPTION
#### Reference Issues/PRs
Fix bug introduced in #33959.

#### What does this implement/fix? Explain your changes.
Keep input type = output type for dataframes in indexable, i.e. no conversion to narwhals.


#### AI usage disclosure
None

#### Any other comments?
@jeremiedbb You were right in #33959. It is not so much the public `indexable` but its use in CV tools that would then pass narwhals df to estimators which have no control over.