### PR TITLE
RidgeClassifier binary coef_ shape does not match documented shape

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1500,7 +1500,7 @@ class RidgeClassifier(_RidgeClassifierMixin, _BaseRidge):
 
     Attributes
     ----------
-    coef_ : ndarray of shape (1, n_features) or (n_classes, n_features)
+    coef_ : ndarray of shape (n_features,) or (n_classes, n_features)
         Coefficient of the features in the decision function.
 
         ``coef_`` is of shape (1, n_features) when the given problem is binary.


### PR DESCRIPTION
#### Reference Issues/PRs

This PR fixes the documentation issue reported in #34170: corrects `coef_ : ndarray of shape (1, n_features) or (n_classes, n_features)` to `coef_ : ndarray of shape (n_features,) or (n_classes, n_features)` in `sklearn/linear_model/_ridge.py`.

Fixes #34170

#### What does this implement/fix? Explain your changes.

#### First time contributor introduction

#### AI usage disclosure

I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Documentation (including examples)
- Research and understanding

#### Any other comments?

Fixes #34170