### PR TITLE
FIX Remove dead error-handling check in AdaBoost.feature_importances_…

### DIFF
--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -239,7 +239,6 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
             The classification error for the current boost.
             If None then boosting has terminated early.
         """
-        pass
 
     def staged_score(self, X, y, sample_weight=None):
         """Return staged scores for X, y.

--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -290,10 +290,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         feature_importances_ : ndarray of shape (n_features,)
             The feature importances.
         """
-        if self.estimators_ is None or len(self.estimators_) == 0:
-            raise ValueError(
-                "Estimator not fitted, call `fit` before `feature_importances_`."
-            )
+        check_is_fitted(self)
 
         try:
             norm = self.estimator_weights_.sum()


### PR DESCRIPTION
## Reference Issues/PRs
Fixes #34472

#### What does this implement/fix? 

Removes dead/unreachable error-handling check in `BaseWeightBoosting.feature_importances_` that checks if `self.estimators_` is `None` or empty. Since `check_is_fitted(self)` is called immediately before this block, an unfitted estimator will always raise `NotFittedError` before reaching this check.


- Clean refactor removing redundant defensive check.