### PR TITLE
fix(ci): align workflow Python version with requires-python

### DIFF
--- a/.github/workflows/labeler-title-regex.yml
+++ b/.github/workflows/labeler-title-regex.yml
@@ -20,7 +20,7 @@ jobs:
         persist-credentials: false
     - uses: actions/setup-python@v6
       with:
-        python-version: '3.9'
+        python-version: '3.11'
     - name: Install PyGithub
       run: pip install -Uq PyGithub
     - name: Label pull request

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v7
     - uses: actions/setup-python@v6
       with:
-        python-version: '3.8'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         pip install -U wheelhouse_uploader pyyaml

--- a/.github/workflows/update_tracking_issue.yml
+++ b/.github/workflows/update_tracking_issue.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Update tracking issue on GitHub
         run: |
           set -ex


### PR DESCRIPTION
## Why
Package metadata declares `requires-python` / `.python-version` as `>=3.11`, but CI workflows still pin `python-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `python-version` pins so they satisfy `>=3.11` (using `3.11` where a concrete pin is needed).

- `.github/workflows/labeler-title-regex.yml`
  - `python-version: '3.9'` → `python-version: '3.11'`
- `.github/workflows/publish_pypi.yml`
  - `python-version: '3.8'` → `python-version: '3.11'`
- `.github/workflows/update_tracking_issue.yml`
  - `python-version: '3.9'` → `python-version: '3.11'`

## Test plan
- [ ] Package `requires-python` / `.python-version` is still `>=3.11`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
