### PR TITLE
DOC clarify GradientBoostingRegressor estimators_ shape

### DIFF
--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1992,7 +1992,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         The estimator that provides the initial predictions. Set via the ``init``
         argument.
 
-    estimators_ : ndarray of DecisionTreeRegressor of shape (n_estimators, 1)
+    estimators_ : ndarray of DecisionTreeRegressor of shape (n_estimators, ``n_trees_per_iteration_``)
         The collection of fitted sub-estimators.
 
     n_features_in_ : int

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1992,7 +1992,8 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         The estimator that provides the initial predictions. Set via the ``init``
         argument.
 
-    estimators_ : ndarray of DecisionTreeRegressor of shape (n_estimators, ``n_trees_per_iteration_``)
+    estimators_ : ndarray of DecisionTreeRegressor of 
+            shape (n_estimators, ``n_trees_per_iteration_``)
         The collection of fitted sub-estimators.
 
     n_features_in_ : int

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1377,7 +1377,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         The estimator that provides the initial predictions. Set via the ``init``
         argument.
 
-    estimators_ : ndarray of DecisionTreeRegressor of \
+    estimators_ : ndarray of DecisionTreeRegressor of \\
             shape (n_estimators, ``n_trees_per_iteration_``)
         The collection of fitted sub-estimators. ``n_trees_per_iteration_`` is 1 for
         binary classification, otherwise ``n_classes``.
@@ -1992,7 +1992,7 @@ class GradientBoostingRegressor(RegressorMixin, BaseGradientBoosting):
         The estimator that provides the initial predictions. Set via the ``init``
         argument.
 
-    estimators_ : ndarray of DecisionTreeRegressor of 
+    estimators_ : ndarray of DecisionTreeRegressor of \
             shape (n_estimators, ``n_trees_per_iteration_``)
         The collection of fitted sub-estimators.
 

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -1377,7 +1377,7 @@ class GradientBoostingClassifier(ClassifierMixin, BaseGradientBoosting):
         The estimator that provides the initial predictions. Set via the ``init``
         argument.
 
-    estimators_ : ndarray of DecisionTreeRegressor of \\
+    estimators_ : ndarray of DecisionTreeRegressor of \
             shape (n_estimators, ``n_trees_per_iteration_``)
         The collection of fitted sub-estimators. ``n_trees_per_iteration_`` is 1 for
         binary classification, otherwise ``n_classes``.


### PR DESCRIPTION
Fixes #34279.

The GradientBoostingRegressor estimators_ documentation now uses the shared n_trees_per_iteration_ terminology, matching the classifier documentation and the attribute documented behavior.