### PR TITLE
ENH improve X validation in coordinate descent CV classes

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/34613.enhancement.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/34613.enhancement.rst
@@ -1,0 +1,6 @@
+- :class:`linear_model.ElasticNetCV`, :class:`linear_model.LassoCV` and
+  :class:`linear_model.MultiTaskElasticNetCV` now avoid prematurely converting `X` to
+  F-contiguous array or sparse CSC because the inner cross validation take subsamples
+  of `X` which then need the same conversion again, anyway. So this PR can avoid memory
+  copies of `X`.
+  By :user:`Christian Lorentzen <lorentzenchr>`.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2280,8 +2280,7 @@ class LassoCV(RegressorMixin, LinearModelCV):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            Training data. Pass directly as Fortran-contiguous data
-            to avoid unnecessary memory duplication. If y is mono-output,
+            Training data. If y is mono-output,
             X can be sparse. Note that large sparse matrices and arrays
             requiring `int64` indices are not accepted.
 
@@ -2558,8 +2557,7 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            Training data. Pass directly as Fortran-contiguous data
-            to avoid unnecessary memory duplication. If y is mono-output,
+            Training data. If y is mono-output,
             X can be sparse. Note that large sparse matrices and arrays
             requiring `int64` indices are not accepted.
 

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -13,6 +13,7 @@ import numpy as np
 from joblib import effective_n_jobs
 from scipy import sparse
 
+import sklearn
 from sklearn.base import RegressorMixin, _fit_context
 
 # mypy error: Module 'sklearn.linear_model' has no attribute '_cd_fast'
@@ -1567,7 +1568,6 @@ def _path_residuals(
     path_params,
     alphas=None,
     l1_ratio=1,
-    X_order=None,
     dtype=None,
 ):
     """Returns the MSE for the models computed by 'path'.
@@ -1605,10 +1605,6 @@ def _path_residuals(
         l1 and l2 penalties). For ``l1_ratio = 0`` the penalty is an
         L2 penalty. For ``l1_ratio = 1`` it is an L1 penalty. For ``0
         < l1_ratio < 1``, the penalty is a combination of L1 and L2.
-
-    X_order : {'F', 'C'}, default=None
-        The order of the arrays expected by the path function to
-        avoid memory copies.
 
     dtype : a numpy dtype, default=None
         The dtype of the arrays expected by the path function to
@@ -1676,7 +1672,7 @@ def _path_residuals(
 
     # Do the ordering and type casting here, as if it is done in the path,
     # X is copied and a reference is kept here
-    X_train = check_array(X_train, accept_sparse="csc", dtype=dtype, order=X_order)
+    X_train = check_array(X_train, accept_sparse="csc", dtype=dtype, order="F")
     alphas, coefs, _ = path(X_train, y_train, **path_params)
     del X_train, y_train
 
@@ -1773,8 +1769,7 @@ class LinearModelCV(MultiOutputLinearModel, ABC):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            Training data. Pass directly as Fortran-contiguous data
-            to avoid unnecessary memory duplication. If y is mono-output,
+            Training data. If y is mono-output,
             X can be sparse. Note that large sparse matrices and arrays
             requiring `int64` indices are not accepted.
 
@@ -1827,7 +1822,7 @@ class LinearModelCV(MultiOutputLinearModel, ABC):
             # csr. We also want to allow y to be 64 or 32 but check_X_y only
             # allows to convert for 64.
             check_X_params = dict(
-                accept_sparse="csc",
+                accept_sparse="csr",
                 dtype=[np.float64, np.float32],
                 force_writeable=True,
                 copy=False,
@@ -1852,9 +1847,9 @@ class LinearModelCV(MultiOutputLinearModel, ABC):
             # csr. We also want to allow y to be 64 or 32 but check_X_y only
             # allows to convert for 64.
             check_X_params = dict(
-                accept_sparse="csc",
+                accept_sparse="csr",
                 dtype=[np.float64, np.float32],
-                order="F",
+                order=None,
                 force_writeable=True,
                 copy=copy_X,
             )
@@ -1969,7 +1964,6 @@ class LinearModelCV(MultiOutputLinearModel, ABC):
                 path_params,
                 alphas=this_alphas,
                 l1_ratio=this_l1_ratio,
-                X_order="F",
                 dtype=X.dtype.type,
             )
             for this_l1_ratio, this_alphas in zip(l1_ratios, alphas)
@@ -2003,6 +1997,7 @@ class LinearModelCV(MultiOutputLinearModel, ABC):
             self.alphas_ = np.asarray(alphas[0])
 
         # Refit the model with the parameters selected
+        X, y = _set_order(X, y, order="F")
         common_params = {
             name: value
             for name, value in self.get_params().items()
@@ -2016,12 +2011,13 @@ class LinearModelCV(MultiOutputLinearModel, ABC):
         if isinstance(precompute, str) and precompute == "auto":
             model.precompute = False
 
-        if sample_weight is None:
-            # MultiTaskElasticNetCV does not (yet) support sample_weight, even
-            # not sample_weight=None.
-            model.fit(X, y)
-        else:
-            model.fit(X, y, sample_weight=sample_weight)
+        with sklearn.config_context(skip_parameter_validation=True):
+            if sample_weight is None:
+                # MultiTaskElasticNetCV does not (yet) support sample_weight, even
+                # not sample_weight=None.
+                model.fit(X, y)
+            else:
+                model.fit(X, y, sample_weight=sample_weight)
         if not hasattr(self, "l1_ratio"):
             del self.l1_ratio_
         self.coef_ = model.coef_

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -13,7 +13,6 @@ import numpy as np
 from joblib import effective_n_jobs
 from scipy import sparse
 
-import sklearn
 from sklearn.base import RegressorMixin, _fit_context
 
 # mypy error: Module 'sklearn.linear_model' has no attribute '_cd_fast'
@@ -2011,13 +2010,12 @@ class LinearModelCV(MultiOutputLinearModel, ABC):
         if isinstance(precompute, str) and precompute == "auto":
             model.precompute = False
 
-        with sklearn.config_context(skip_parameter_validation=True):
-            if sample_weight is None:
-                # MultiTaskElasticNetCV does not (yet) support sample_weight, even
-                # not sample_weight=None.
-                model.fit(X, y)
-            else:
-                model.fit(X, y, sample_weight=sample_weight)
+        if sample_weight is None:
+            # MultiTaskElasticNetCV does not (yet) support sample_weight, even
+            # not sample_weight=None.
+            model.fit(X, y)
+        else:
+            model.fit(X, y, sample_weight=sample_weight)
         if not hasattr(self, "l1_ratio"):
             del self.l1_ratio_
         self.coef_ = model.coef_


### PR DESCRIPTION
#### Reference Issues/PRs
None


#### What does this implement/fix? Explain your changes.
For `LassoCV`, `ElasticNetCV` and so on, the validation of `X` is bad. Currently it forces X to be F ordered (csc or F-contiguous), but then X is indexed on the first dimension for the cross validation part, the indexed subsets then need again to be F-ordered.

This PR avoids the first conversion to F.

#### AI usage disclosure
None

#### Any other comments?
