### PR TITLE
MNT Ignore DepecationWarning for sparse_matrix removal in scipy

### DIFF
--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1524,6 +1524,14 @@ def _get_warnings_filters_info_list():
             message="Class PassiveAggressive.+is deprecated",
             category=FutureWarning,
         ),
+        # TODO: remove once the version where scipy has removed all the sparse matrix
+        # classes is our min version; note that scipy did not yet announce when this
+        # will happen, only that it won't be earlier than v2.2.
+        WarningInfo(
+            "ignore",
+            message=r"(?s).*All sparse matrix classes",
+            category=DeprecationWarning,
+        ),
     ]
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
closes #34608

#### What does this implement/fix? Explain your changes.
This ignores the scipy DepecationWarning on deprecation all sparse_matrix classes that pops up on the nightly build.

#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Research and understanding
