### PR TITLE
ENH Add huber loss to HistGradientBoostingRegressor

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -102,6 +102,8 @@ Available losses for **regression** are:
 
 - 'squared_error', which is the default loss;
 - 'absolute_error', which is less sensitive to outliers than the squared error;
+- 'huber', which combines the squared error for small residuals and the
+  absolute error for large residuals, making it robust to outliers;
 - 'gamma', which is well suited to model strictly positive outcomes;
 - 'poisson', which is well suited to model counts and frequencies;
 - 'quantile', which allows for estimating a conditional quantile that can later
@@ -132,8 +134,8 @@ in [XGBoost]_):
 .. dropdown:: Details on l2 regularization
 
   It is important to notice that the loss term :math:`l(\hat{y}_i, y_i)` describes
-  only half of the actual loss function except for the pinball loss and absolute
-  error.
+  only half of the actual loss function except for the pinball loss, the absolute
+  error and the huber loss.
 
   The index :math:`k` refers to the k-th tree in the ensemble of trees. In the
   case of regression and binary classification, gradient boosting models grow one

--- a/doc/whats_new/upcoming_changes/sklearn.ensemble/34617.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.ensemble/34617.feature.rst
@@ -1,0 +1,5 @@
+- :class:`ensemble.HistGradientBoostingRegressor` now supports the Huber loss
+  with ``loss="huber"``, which is robust to outliers in the target. The
+  breakpoint between the quadratic and the linear part of the loss is
+  controlled by the ``quantile`` parameter (0.9 by default).
+  By :user:`Abduselam Tesfaye <abudi47>`.

--- a/sklearn/_loss/_loss.pyx.tp
+++ b/sklearn/_loss/_loss.pyx.tp
@@ -423,10 +423,13 @@ cdef inline double_pair cgrad_hess_huber_loss(
     gh.val2 = raw_prediction - y_true               # used as temporary
     if fabs(gh.val2) <= delta:
         gh.val1 = gh.val2                           # gradient
-        gh.val2 = 1                                 # hessian
     else:
         gh.val1 = delta if gh.val2 >=0 else -delta  # gradient
-        gh.val2 = 0                                 # hessian
+    # The exact hessian is 1 inside the quadratic region and 0 outside of it.
+    # Optimization routines like HGBT, however, need a hessian > 0. Therefore,
+    # we use the constant approximation 1 everywhere, which is an upper bound
+    # of the exact hessian.
+    gh.val2 = 1                                     # hessian
     return gh
 
 

--- a/sklearn/_loss/loss.py
+++ b/sklearn/_loss/loss.py
@@ -694,6 +694,10 @@ class HuberLoss(BaseLoss):
     Note: HuberLoss(quantile=1) equals HalfSquaredError and HuberLoss(quantile=0)
     equals delta * (AbsoluteError() - delta/2).
 
+    Note that the exact hessian = 1 for ``abserr <= delta`` and = 0 elsewhere.
+    Optimization routines like in HGBT, however, need a hessian > 0. Therefore,
+    we assign 1 everywhere, which is an upper bound of the exact hessian.
+
     Additional Attributes
     ---------------------
     quantile : float
@@ -728,7 +732,7 @@ class HuberLoss(BaseLoss):
             device=device,
         )
         self.approx_hessian = True
-        self.constant_hessian = False
+        self.constant_hessian = sample_weight is None
 
     def fit_intercept_only(self, y_true, sample_weight=None):
         """Compute raw_prediction of an intercept-only model.

--- a/sklearn/ensemble/_gb.py
+++ b/sklearn/ensemble/_gb.py
@@ -255,8 +255,10 @@ def _update_terminal_regions(
 def set_huber_delta(loss, y_true, raw_prediction, sample_weight=None):
     """Calculate and set self.closs.delta based on self.quantile."""
     abserr = np.abs(y_true - raw_prediction.squeeze())
-    # sample_weight is always an ndarray, never None.
-    delta = _weighted_percentile(abserr, sample_weight, 100 * loss.quantile)
+    if sample_weight is None:
+        delta = np.percentile(abserr, 100 * loss.quantile)
+    else:
+        delta = _weighted_percentile(abserr, sample_weight, 100 * loss.quantile)
     loss.closs.delta = float(delta)
 
 

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -19,6 +19,7 @@ from sklearn._loss.loss import (
     HalfGammaLoss,
     HalfMultinomialLoss,
     HalfPoissonLoss,
+    HuberLoss,
     PinballLoss,
 )
 from sklearn.base import (
@@ -29,6 +30,7 @@ from sklearn.base import (
     is_classifier,
 )
 from sklearn.compose import ColumnTransformer
+from sklearn.ensemble._gb import set_huber_delta
 from sklearn.ensemble._hist_gradient_boosting._gradient_boosting import (
     _update_raw_predictions,
 )
@@ -44,6 +46,7 @@ from sklearn.utils._missing import is_scalar_nan
 from sklearn.utils._openmp_helpers import _openmp_effective_n_threads
 from sklearn.utils._param_validation import Interval, RealNotInt, StrOptions
 from sklearn.utils.multiclass import check_classification_targets
+from sklearn.utils.stats import _weighted_percentile
 from sklearn.utils.validation import (
     _check_categorical_features,
     _check_monotonic_cst,
@@ -61,6 +64,7 @@ _LOSSES.update(
         "poisson": HalfPoissonLoss,
         "gamma": HalfGammaLoss,
         "quantile": PinballLoss,
+        "huber": HuberLoss,
     }
 )
 
@@ -73,10 +77,13 @@ def _update_leaves_values(loss, grower, y_true, raw_prediction, sample_weight):
 
     This is only applied if loss.differentiable is False.
     Note: It only works, if the loss is a function of the residual, as is the
-    case for AbsoluteError and PinballLoss. Otherwise, one would need to get
-    the minimum of loss(y_true, raw_prediction + x) in x. A few examples:
+    case for AbsoluteError, PinballLoss and HuberLoss. Otherwise, one would
+    need to get the minimum of loss(y_true, raw_prediction + x) in x. A few
+    examples:
       - AbsoluteError: median(y_true - raw_prediction).
       - PinballLoss: quantile(y_true - raw_prediction).
+      - HuberLoss: median + mean of clipped residuals, see formula before
+        algo 4 in Friedman (2001).
 
     More background:
     For the standard gradient descent method according to "Greedy Function
@@ -635,6 +642,22 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
             # shape (n_samples, n_trees_per_iteration) where
             # n_trees_per_iterations is n_classes in multiclass classification,
             # else 1.
+            if isinstance(self._loss, HuberLoss):
+                # Initialize the delta breakpoint of the Huber loss as the
+                # quantile of the absolute residuals w.r.t. the (weighted)
+                # median of y, which is the robust location estimate that the
+                # Huber loss intercept-only fit is based on.
+                if sample_weight_train is None:
+                    median = np.median(y_train)
+                else:
+                    median = _weighted_percentile(y_train, sample_weight_train, 50)
+                set_huber_delta(
+                    loss=self._loss,
+                    y_true=y_train,
+                    raw_prediction=np.full(y_train.shape, median),
+                    sample_weight=sample_weight_train,
+                )
+
             # self._baseline_prediction has shape (1, n_trees_per_iteration)
             self._baseline_prediction = self._loss.fit_intercept_only(
                 y_true=y_train, sample_weight=sample_weight_train
@@ -782,6 +805,17 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                 iteration_start_time = time()
                 print(
                     "[{}/{}] ".format(iteration + 1, self.max_iter), end="", flush=True
+                )
+
+            if isinstance(self._loss, HuberLoss):
+                # Recompute the delta breakpoint of the Huber loss as the
+                # quantile of the absolute residuals of the current model,
+                # see algo 4 in Friedman (2001).
+                set_huber_delta(
+                    loss=self._loss,
+                    y_true=y_train,
+                    raw_prediction=raw_predictions[:, 0],
+                    sample_weight=sample_weight_train,
                 )
 
             # Update gradients and hessians, inplace
@@ -1382,8 +1416,8 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
 
     Parameters
     ----------
-    loss : {'squared_error', 'absolute_error', 'gamma', 'poisson', 'quantile'}, \
-            default='squared_error'
+    loss : {'squared_error', 'absolute_error', 'gamma', 'poisson', 'quantile', \
+            'huber'}, default='squared_error'
         The loss function to use in the boosting process. Note that the
         "squared error", "gamma" and "poisson" losses actually implement
         "half least squares loss", "half gamma deviance" and "half poisson
@@ -1391,6 +1425,8 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         "gamma" and "poisson" losses internally use a log-link, "gamma"
         requires ``y > 0`` and "poisson" requires ``y >= 0``.
         "quantile" uses the pinball loss.
+        "huber" uses the Huber loss, a combination of squared error and
+        absolute error that is robust to outliers in ``y``.
 
         .. versionchanged:: 0.23
            Added option 'poisson'.
@@ -1401,9 +1437,14 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         .. versionchanged:: 1.3
            Added option 'gamma'.
 
+        .. versionchanged:: 1.10
+           Added option 'huber'.
+
     quantile : float, default=None
         If loss is "quantile", this parameter specifies which quantile to be estimated
-        and must be between 0 and 1.
+        and must be between 0 and 1. If loss is "huber", this parameter specifies the
+        quantile of the absolute residuals that defines the breakpoint between the
+        quadratic and the linear part of the loss; if None, it defaults to 0.9.
     learning_rate : float, default=0.1
         The learning rate, also known as *shrinkage*. This is used as a
         multiplicative factor for the leaves values. Use ``1`` for no
@@ -1635,6 +1676,7 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
                     "poisson",
                     "gamma",
                     "quantile",
+                    "huber",
                 }
             ),
             BaseLoss,
@@ -1754,6 +1796,9 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
             return _LOSSES[self.loss](
                 sample_weight=sample_weight, quantile=self.quantile
             )
+        elif self.loss == "huber":
+            quantile = 0.9 if self.quantile is None else self.quantile
+            return _LOSSES[self.loss](sample_weight=sample_weight, quantile=quantile)
         else:
             return _LOSSES[self.loss](sample_weight=sample_weight)
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -242,6 +242,117 @@ def test_absolute_error_sample_weight():
     gbdt.fit(X, y, sample_weight=sample_weight)
 
 
+def test_huber():
+    # For coverage and basic fit quality.
+    X, y = make_regression(n_samples=500, random_state=0)
+    gbdt = HistGradientBoostingRegressor(loss="huber", random_state=0)
+    gbdt.fit(X, y)
+    assert gbdt.score(X, y) > 0.9
+
+
+@pytest.mark.parametrize("quantile", [None, 0.1, 0.5, 0.9])
+def test_huber_quantile_values(quantile):
+    # The huber loss works for all allowed values of the quantile parameter.
+    X, y = make_regression(n_samples=200, random_state=0)
+    gbdt = HistGradientBoostingRegressor(
+        loss="huber", quantile=quantile, max_iter=10, random_state=0
+    )
+    gbdt.fit(X, y)
+    assert np.all(np.isfinite(gbdt.predict(X)))
+
+
+def test_huber_default_quantile():
+    # The quantile parameter of the huber loss defaults to 0.9.
+    gbdt = HistGradientBoostingRegressor(loss="huber", max_iter=2, random_state=0)
+    gbdt.fit(X_regression, y_regression)
+    assert gbdt._loss.quantile == 0.9
+
+
+def test_huber_sample_weight():
+    # Make sure no error is thrown during fit of
+    # HistGradientBoostingRegressor with huber loss function
+    # and passing sample_weight
+    rng = np.random.RandomState(0)
+    n_samples = 100
+    X = rng.uniform(-1, 1, size=(n_samples, 2))
+    y = rng.uniform(-1, 1, size=n_samples)
+    sample_weight = rng.uniform(0, 1, size=n_samples)
+    gbdt = HistGradientBoostingRegressor(loss="huber")
+    gbdt.fit(X, y, sample_weight=sample_weight)
+
+
+def test_huber_delta_updated_each_iteration(monkeypatch):
+    # The breakpoint delta of the huber loss must be recomputed as the
+    # quantile of the absolute residuals once before the first tree (for the
+    # baseline prediction) and then at each iteration, see algo 4 in
+    # Friedman (2001).
+    max_iter = 3
+    quantile = 0.8
+    deltas = []
+    set_huber_delta_orig = hgb_module.set_huber_delta
+
+    def set_huber_delta_spy(loss, y_true, raw_prediction, sample_weight=None):
+        set_huber_delta_orig(loss, y_true, raw_prediction, sample_weight)
+        deltas.append(loss.closs.delta)
+
+    monkeypatch.setattr(hgb_module, "set_huber_delta", set_huber_delta_spy)
+
+    X, y = make_regression(n_samples=200, noise=10, random_state=0)
+    gbdt = HistGradientBoostingRegressor(
+        loss="huber", quantile=quantile, max_iter=max_iter, random_state=0
+    )
+    gbdt.fit(X, y)
+
+    # one call for the baseline prediction, then one call per iteration
+    assert len(deltas) == 1 + max_iter
+
+    # the first delta is computed on the residuals w.r.t. the median of y
+    expected_first = np.percentile(np.abs(y - np.median(y)), 100 * quantile)
+    assert_allclose(deltas[0], expected_first)
+
+    # residuals shrink during boosting, hence delta decreases
+    assert deltas[-1] < deltas[0]
+
+
+@pytest.mark.parametrize(
+    "quantile, err_msg",
+    [
+        (0, "quantile == 0, must be > 0."),
+        (1, "quantile == 1, must be < 1."),
+    ],
+)
+def test_huber_invalid_quantile(quantile, err_msg):
+    gbdt = HistGradientBoostingRegressor(loss="huber", quantile=quantile)
+    with pytest.raises(ValueError, match=err_msg):
+        gbdt.fit(X_regression, y_regression)
+
+
+def test_huber_outlier_robustness():
+    # The huber loss should be less affected by outliers in y than the
+    # squared error.
+    rng = np.random.RandomState(42)
+    n_samples = 2000
+    X = rng.uniform(-1, 1, size=(n_samples, 2))
+    y = X[:, 0] + 2 * X[:, 1] + rng.normal(scale=0.1, size=n_samples)
+    # contaminate 5% of the targets with large outliers
+    outlier_idx = rng.choice(n_samples, size=n_samples // 20, replace=False)
+    y[outlier_idx] += rng.choice([-50, 50], size=outlier_idx.size)
+
+    huber = HistGradientBoostingRegressor(loss="huber", random_state=0).fit(X, y)
+    squared_error = HistGradientBoostingRegressor(
+        loss="squared_error", random_state=0
+    ).fit(X, y)
+
+    # compare robust median absolute errors on the non-contaminated samples
+    clean_mask = np.ones(n_samples, dtype=bool)
+    clean_mask[outlier_idx] = False
+    err_huber = np.median(np.abs(huber.predict(X[clean_mask]) - y[clean_mask]))
+    err_squared_error = np.median(
+        np.abs(squared_error.predict(X[clean_mask]) - y[clean_mask])
+    )
+    assert err_huber < err_squared_error
+
+
 @pytest.mark.parametrize("y", [([1.0, -2.0, 0.0]), ([0.0, 1.0, 2.0])])
 def test_gamma_y_positive(y):
     # Test that ValueError is raised if any y_i <= 0.


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #31542.

#### What does this implement/fix? Explain your changes.

This PR adds the Huber loss as a new `loss="huber"` option for `HistGradientBoostingRegressor`, following Friedman (2001), algo 4. The Huber loss combines the squared error for small residuals with the absolute error for large residuals, making the estimator robust to outliers in `y` — the same loss that has long been available in the exact `GradientBoostingRegressor` but was missing for the histogram-based implementation.

Implementation details:

- The existing `HuberLoss` class from `sklearn._loss.loss` is registered under the name `"huber"` in the HGBT loss registry.
- The breakpoint `delta` is recomputed at each iteration as the `quantile` of the absolute residuals via `set_huber_delta`, which is shared with the classic `GradientBoostingRegressor` and now also supports `sample_weight=None`. For the baseline prediction, `delta` is initialized from the residuals w.r.t. the (weighted) median of `y`.
- The existing `quantile` parameter of `HistGradientBoostingRegressor` is reused for `loss="huber"`, defaulting to 0.9 (mirroring the `alpha=0.9` default of `GradientBoostingRegressor`).
- Since the Huber loss is piecewise quadratic/linear, its exact hessian is 1 inside the quadratic region and 0 outside of it. The Newton boosting split finding of HGBT requires positive hessians, so the approximate hessian is the constant 1 everywhere (an upper bound of the exact hessian), consistent with the `absolute_error` and `quantile` losses. This also gives `constant_hessian=True` when no sample weights are passed, enabling the faster gradient-only path.
- Leaf values are updated with the Friedman line search (`fit_intercept_only`) as for the other non-differentiable losses.

Tests added in `sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py`:

- fit/score coverage, allowed `quantile` values, invalid `quantile` validation, default quantile (0.9), `sample_weight` support
- `test_huber_delta_updated_each_iteration`: checks that `delta` is set once for the baseline prediction and then recomputed at each iteration, and that it decreases as the residuals shrink
- `test_huber_outlier_robustness`: checks that `loss="huber"` achieves a lower median absolute error than `loss="squared_error"` on outlier-contaminated targets

I also verified that the full test files of `sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py`, `sklearn/ensemble/tests/test_gradient_boosting.py`, `sklearn/_loss/tests/test_loss.py`, the warm start / monotonic constraints tests and the SGD huber tests still pass.

#### First time contributor introduction

This is my first contribution to scikit-learn. I was looking for a meaningful way to contribute to the project and found #31542 labeled "help wanted", which seemed like a well-scoped but interesting feature to work on.

#### AI usage disclosure

I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Documentation (including examples)
- Research and understanding

#### Any other comments?

Happy to adjust the choice of the default quantile or the documentation wording if reviewers prefer a different approach.
