### PR TITLE
Perf: algorithmic improvement to `PCA(n_components="mle")`

### DIFF
--- a/sklearn/decomposition/_pca.py
+++ b/sklearn/decomposition/_pca.py
@@ -22,28 +22,29 @@ from sklearn.utils.sparsefuncs import _implicit_column_offset, mean_variance_axi
 from sklearn.utils.validation import check_is_fitted, validate_data
 
 
-def _assess_dimension(spectrum, rank, n_samples):
-    """Compute the log-likelihood of a rank ``rank`` dataset.
+def _infer_dimension(spectrum, n_samples):
+    """Infers the dimension of a dataset with a given spectrum.
 
-    The dataset is assumed to be embedded in gaussian noise of shape(n,
-    dimf) having spectrum ``spectrum``. This implements the method of
-    T. P. Minka.
+    The dataset is assumed to be a low-rank signal embedded in isotropic
+    gaussian noise, with ``spectrum`` holding the eigenvalues of its sample
+    covariance. This implements the method of T. P. Minka, sometimes referred
+    to as a "Laplace approximation" in the literature.
+
+    In the original paper, the algorithm runs in O(n_features^3); Minka
+    has an accompanying laplace_pca.m that provides an O(n_features^2)
+    reformulation, which has been partially adapted here.
 
     Parameters
     ----------
     spectrum : ndarray of shape (n_features,)
-        Data spectrum.
-    rank : int
-        Tested rank value. It should be strictly lower than n_features,
-        otherwise the method isn't specified (division by zero in equation
-        (31) from the paper).
+        Data spectrum, in non-increasing order.
     n_samples : int
         Number of samples.
 
     Returns
     -------
-    ll : float
-        The log-likelihood.
+    n_components : int
+        The rank with the highest likelihood, in [1, n_features - 1].
 
     References
     ----------
@@ -52,62 +53,88 @@ def _assess_dimension(spectrum, rank, n_samples):
     <https://proceedings.neurips.cc/paper/2000/file/7503cfacd12053d309b6bed5c89de212-Paper.pdf>`_
     """
     xp, _ = get_namespace(spectrum)
-
     n_features = spectrum.shape[0]
-    if not 1 <= rank < n_features:
-        raise ValueError("the tested rank should be in [1, n_features - 1]")
-
     eps = 1e-15
 
-    if spectrum[rank - 1] < eps:
-        # When the tested rank is associated with a small eigenvalue, there's
-        # no point in computing the log-likelihood: it's going to be very
-        # small and won't be the max anyway. Also, it can lead to numerical
-        # issues below when computing pa, in particular in log((spectrum[i] -
-        # spectrum[j]) because this will take the log of something very small.
-        return -xp.inf
+    # Running argmax of log likelihood. Rank 0 is never a candidate (per the
+    # documented return range).
+    best_ll = -xp.inf
+    best_rank = 1
 
-    pu = -rank * log(2.0)
-    for i in range(1, rank + 1):
-        pu += (
-            lgamma((n_features - i + 1) / 2.0) - log(xp.pi) * (n_features - i + 1) / 2.0
-        )
+    # Below, l = spectrum (non-increasing) and d = n_features. At rank k the
+    # retained block is l(0:k) and lambda_hat(j) = v for j >= k.
+    #
+    # log_diff_sum(k) = sum_{i<k} sum_{j>i} log(l(i) - l(j))
+    # inv_pair_sum(k) = sum_{i<j<k} log(1/l(j) - 1/l(i))
+    # pu_terms(k) = sum_{i<=k} gammaln((d-i+1)/2) - (d-i+1)/2 log(pi), so that
+    #               -k log(2) + pu_terms(k) = log p(U)
+    log_diff_sum = 0.0
+    inv_pair_sum = 0.0
+    pu_terms = 0.0
 
-    pl = xp.sum(xp.log(spectrum[:rank]))
-    pl = -pl * n_samples / 2.0
+    with np.errstate(divide="ignore", invalid="ignore"):
+        # cum_log_spec(k-1) = sum_{i<k} log(l(i)). A spectrum with trailing
+        # zeros makes the tail of this -inf, but the loop breaks at the noise
+        # floor and so only ever reads entries above it.
+        cum_log_spec = xp.cumulative_sum(xp.log(spectrum))
 
-    v = max(eps, xp.sum(spectrum[rank:]) / (n_features - rank))
-    pv = -log(v) * n_samples * (n_features - rank) / 2.0
+        for rank in range(1, n_features):
+            if spectrum[rank - 1] < eps:
+                # When the tested rank is associated with a small eigenvalue,
+                # there's no point in computing the log-likelihood: it's going
+                # to be very small and won't be the max anyway. Also, it can
+                # lead to numerical issues below when computing pa, in
+                # particular in log(spectrum[i] - spectrum[j]) because this
+                # will take the log of something very small. The spectrum is
+                # non-increasing, so every remaining rank is below the floor
+                # too and keeps its -inf.
+                break
 
-    m = n_features * rank - rank * (rank + 1.0) / 2.0
-    pp = log(2.0 * xp.pi) * (m + rank) / 2.0
+            pu_terms += (
+                lgamma((n_features - rank + 1) / 2.0)
+                - log(xp.pi) * (n_features - rank + 1) / 2.0
+            )
+            pu = -rank * log(2.0) + pu_terms
 
-    pa = 0.0
-    spectrum_ = xp.asarray(spectrum, copy=True)
-    spectrum_[rank:n_features] = v
-    for i in range(rank):
-        for j in range(i + 1, spectrum.shape[0]):
-            pa += log(
-                (spectrum[i] - spectrum[j]) * (1.0 / spectrum_[j] - 1.0 / spectrum_[i])
-            ) + log(n_samples)
+            pl = -cum_log_spec[rank - 1] * n_samples / 2.0
 
-    ll = pu + pl + pv + pp - pa / 2.0 - rank * log(n_samples) / 2.0
+            # v = mean of the discarded eigenvalues, the noise variance MLE
+            v = max(eps, xp.sum(spectrum[rank:]) / (n_features - rank))
+            pv = -log(v) * n_samples * (n_features - rank) / 2.0
 
-    return ll
+            # m = #{(i, j) : i < k, j > i}, the dimension of the Stiefel
+            # manifold U lives on, so m log(n_samples) is the whole log N
+            # contribution to pa
+            m = n_features * rank - rank * (rank + 1.0) / 2.0
+            pp = log(2.0 * xp.pi) * (m + rank) / 2.0
 
+            # pa = logdet(A_Z). Each rank appends one row to each pair sum:
+            #   log_diff_sum += sum_{j>=k} log(l(k-1) - l(j))
+            #   inv_pair_sum += sum_{i<k-1} log(1/l(k-1) - 1/l(i))
+            # Tied eigenvalues make these log(0); the guard on `ll` below
+            # deals with the -inf that propagates from there.
+            last = spectrum[rank - 1]
+            log_diff_sum += xp.sum(xp.log(last - spectrum[rank:]))
+            inv_pair_sum += xp.sum(xp.log(1.0 / last - 1.0 / spectrum[: rank - 1]))
 
-def _infer_dimension(spectrum, n_samples):
-    """Infers the dimension of a dataset with a given spectrum.
+            # lambda_hat(j) = v for j >= k, so the k(d-k) signal-noise pairs
+            # share one value per i and collapse to a (d-k)-weighted sum
+            inv_v_sum = xp.sum(xp.log(1.0 / v - 1.0 / spectrum[:rank]))
+            pa = (
+                log_diff_sum
+                + inv_pair_sum
+                + (n_features - rank) * inv_v_sum
+                + m * log(n_samples)
+            )
 
-    The returned value will be in [1, n_features - 1].
-    """
-    xp, _ = get_namespace(spectrum)
+            ll = pu + pl + pv + pp - pa / 2.0 - rank * log(n_samples) / 2.0
 
-    ll = xp.empty_like(spectrum)
-    ll[0] = -xp.inf  # we don't want to return n_components = 0
-    for rank in range(1, spectrum.shape[0]):
-        ll[rank] = _assess_dimension(spectrum, rank, n_samples)
-    return xp.argmax(ll)
+            # Reject +inf or nan
+            if ll < xp.inf and ll > best_ll:
+                best_ll = ll
+                best_rank = rank
+
+    return best_rank
 
 
 class PCA(_BasePCA):

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -10,7 +10,7 @@ from sklearn import config_context, datasets
 from sklearn.base import clone
 from sklearn.datasets import load_iris, make_classification, make_low_rank_matrix
 from sklearn.decomposition import PCA
-from sklearn.decomposition._pca import _assess_dimension, _infer_dimension
+from sklearn.decomposition._pca import _infer_dimension
 from sklearn.utils._array_api import (
     _atol_for_type,
     array_device,
@@ -577,20 +577,19 @@ def test_pca_dim():
 
 
 def test_infer_dim_1():
-    # TODO: explain what this is testing
-    # Or at least use explicit variable names...
-    n, p = 1000, 5
+    # A single latent factor (one randn column times a fixed loading vector)
+    # buried in isotropic noise an order of magnitude smaller, so the true
+    # latent dimension is 1 and that is what should be inferred.
+    n_samples, n_features = 1000, 5
     rng = np.random.RandomState(0)
     X = (
-        rng.randn(n, p) * 0.1
-        + rng.randn(n, 1) * np.array([3, 4, 5, 1, 2])
+        rng.randn(n_samples, n_features) * 0.1
+        + rng.randn(n_samples, 1) * np.array([3, 4, 5, 1, 2])
         + np.array([1, 0, 7, 4, 6])
     )
-    pca = PCA(n_components=p, svd_solver="full")
+    pca = PCA(n_components=n_features, svd_solver="full")
     pca.fit(X)
-    spect = pca.explained_variance_
-    ll = np.array([_assess_dimension(spect, k, n) for k in range(1, p)])
-    assert ll[1] > ll.max() - 0.01 * n
+    assert _infer_dimension(pca.explained_variance_, n_samples) == 1
 
 
 def test_infer_dim_2():
@@ -816,25 +815,10 @@ def test_pca_n_components_mostly_explained_variance_ratio():
     assert pca2.n_components_ == X.shape[1]
 
 
-def test_assess_dimension_bad_rank():
-    # Test error when tested rank not in [1, n_features - 1]
-    spectrum = np.array([1, 1e-30, 1e-30, 1e-30])
-    n_samples = 10
-    for rank in (0, 5):
-        with pytest.raises(ValueError, match=r"should be in \[1, n_features - 1\]"):
-            _assess_dimension(spectrum, rank, n_samples)
-
-
 def test_small_eigenvalues_mle():
-    # Test rank associated with tiny eigenvalues are given a log-likelihood of
-    # -inf. The inferred rank will be 1
+    # Ranks resting on eigenvalues below the noise floor must never be chosen,
+    # however many of them there are.
     spectrum = np.array([1, 1e-30, 1e-30, 1e-30])
-
-    assert _assess_dimension(spectrum, rank=1, n_samples=10) > -np.inf
-
-    for rank in (2, 3):
-        assert _assess_dimension(spectrum, rank, 10) == -np.inf
-
     assert _infer_dimension(spectrum, 10) == 1
 
 
@@ -877,17 +861,42 @@ def test_mle_simple_case():
     assert pca_skl.n_components_ == n_dim - 1
 
 
-def test_assess_dimension_rank_one():
-    # Make sure assess_dimension works properly on a matrix of rank 1
+def test_infer_dimension_rank_one():
+    # Make sure inference works properly on a matrix of rank 1
     n_samples, n_features = 9, 6
     X = np.ones((n_samples, n_features))  # rank 1 matrix
     _, s, _ = np.linalg.svd(X, full_matrices=True)
     # except for rank 1, all eigenvalues are 0 resp. close to 0 (FP)
     assert_allclose(s[1:], np.zeros(n_features - 1), atol=1e-12)
 
-    assert np.isfinite(_assess_dimension(s, rank=1, n_samples=n_samples))
-    for rank in range(2, n_features):
-        assert _assess_dimension(s, rank, n_samples) == -np.inf
+    assert _infer_dimension(s, n_samples) == 1
+
+
+# Spectra whose selected rank is sensitive to every term of Minka's
+# log-likelihood. Picked by mutation testing: perturbing any single term (the
+# pu/pl/pv/pp pieces, either pair sum, the noise variance, the pair count, or
+# the rank penalty) changes the chosen rank of at least one of these. A shallow
+# likelihood maximum is what makes a spectrum sensitive, so these are gentle
+# decays rather than clean factor models.
+@pytest.mark.parametrize(
+    "spectrum, n_samples, expected",
+    [
+        (np.exp(-0.05 * np.arange(12.0)), 60, 8),
+        (np.exp(-0.3 * np.arange(30.0)), 60, 22),
+        (np.exp(-0.1 * np.arange(50.0)), 200, 36),
+        (np.linspace(50, 0.5, 20), 100, 19),
+    ],
+)
+def test_infer_dimension_sensitive_spectra(spectrum, n_samples, expected):
+    assert _infer_dimension(spectrum, n_samples) == expected
+
+
+def test_infer_dimension_tied_eigenvalues_is_not_an_error():
+    # An exactly isotropic spectrum makes every gap log(0), so no rank has a
+    # meaningful likelihood. _infer_dimension still has to return a rank in
+    # [1, n_features - 1] rather than propagating a math domain error.
+    spectrum = np.ones(8)
+    assert _infer_dimension(spectrum, 100) == 1
 
 
 def test_pca_randomized_svd_n_oversamples():


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

Before, `_infer_dimension` was O(d^3), where d = min(samples, features) = n_features (we need more samples than features by construction). This PR adapts Minka's O(d^2) implementation of his laplace approximation, which he originally implemented in matlab.  **`sklearn.PCA(n_components="mle").fit(X)` with `X.shape = (3000, 3000)` used to take an hour just to infer the dimension, now it takes less than a second**.

<details><summary>laplace_pca.m</summary>

```matlab
function [k,p] = laplace_pca(data, e, d, n, alpha, beta)
% LAPLACE_PCA   Estimate latent dimensionality by Laplace approximation.
%
% k = LAPLACE_PCA([],e,d,n) returns an estimate of the latent dimensionality
% of a dataset with eigenvalues e, original dimensionality d, and size n.
% LAPLACE_PCA(data) computes (e,d,n) from the matrix data 
% (data points are rows)
% [k,p] = LAPLACE_PCA(...) also returns the log-probability of each 
% dimensionality, starting at 1.  k is the argmax of p.

% Written by Tom Minka

if ~isempty(data)
  [n,d] = size(data);
  m = mean(data);
  data0 = data - repmat(m, n, 1);
  e = svd(data0,0).^2/n;
end
if nargin < 5
  alpha = 0;
  beta = 0;
end
e = e(:);
% break off the eigenvalues which are identically zero
i = find(e < eps);
e(i) = [];

% logediff(i) = sum_{j>i} log(e(i) - e(j))
logediff = zeros(1,length(e));
for i = 1:(length(e)-1)
  j = (i+1):length(e);
  logediff(i) = sum(log(e(i) - e(j))) + (d-length(e))*log(e(i));
end
cumsum_logediff = cumsum(logediff);

n1 = n-1+alpha;
ehat = (e + beta/n)*n/n1;
inve = 1./ehat;
% invediff(i,j) = log(inve(i) - inve(j))  (if i > j)
%               = 0                       (if i <= j)
invediff = repmat(inve,1,length(e)) - repmat(inve',length(e),1);
invediff(invediff <= 0) = 1;
invediff = log(invediff);
% cumsum_invediff(i,j) = sum_{t=(j+1):i} log(inve(t) - inve(j))
cumsum_invediff = cumsum(invediff,1);
% row_invediff(i) = sum_{j=1:(i-1)} sum_{t=(j+1):i} log(inve(t) - inve(j))
row_invediff = row_sum(cumsum_invediff);
% row_invediff(k) = sum_{i=1:(k-1)} sum_{j=(i+1):k} log(inve(j) - inve(i))

loge = log(ehat);
cumsum_loge = cumsum(loge);

cumsum_e = cumsum(ehat);

dn = length(e);
kmax = length(e)-1;
%dn = d;
%kmax = min([kmax 15]);
ks = 1:kmax;
% the normalizing constant for the prior (from James)
% sum(z(1:k)) is -log(p(U))
z = log(2) + (d-ks+1)/2*log(pi) - gammaln((d-ks+1)/2);
cumsum_z = cumsum(z);
for i = 1:length(ks)
  k = ks(i);
  %e1 = e(1:k);
  %e2 = e((k+1):length(e));
  %v = sum(e2)/(d-k);
  %v = (cumsum_e(end) - cumsum_e(k))/(length(cumsum_e)-k);
  v = (cumsum_e(end) - cumsum_e(k))/(d-k);
  p(i) = -n1/2*cumsum_loge(k) + (-n1*(d-k)/2)*log(v);
  p(i) = p(i) - cumsum_z(k) - k/2*log(n1);
  % compute h = logdet(A_Z)
  h = row_invediff(k) + cumsum_logediff(k);
  % lambda_hat(i)=1/v for i>k
  h = h + (d-k)*sum(log(1/v - inve(1:k)));
  m = d*k-k*(k+1)/2;
  h = h + m*log(n);
  p(i) = p(i) + (m+k)/2*log(2*pi) - h/2;
  % missing terms added August 21 2008
  p(i) = p(i) + 1.5*k*log(2);
  p(i) = p(i) - 0.5*log(d-k);
  if alpha > 0
    ck = alpha*(d-k)/2*log(beta*(d-k)/2) - gammaln(alpha*(d-k)/2) + ...
	k*(alpha/2*log(beta/2) - gammaln(alpha/2));
    p(i) = p(i) - n1*d/2 - 0.5*log(n1) + ck;
  end
end
[pmax,i] = max(p);
k = ks(i);
  
v0 = cumsum_e(end)/length(cumsum_e);
p0 = -n1*d/2*log(v0) - 0.5*log(d);
%p0 = -n1*d/2*log(v0)
%p0 = -alpha*d/2*log(beta/alpha);
%p0 = -alpha*d/2*log(beta*d/2) + alpha*d/2*log(alpha*d/2);
if alpha > 0
  % must inline ck and put at end
  p0 = p0 - n1*d/2 - 0.5*log(n1) + alpha*d/2*log(beta*d/2) - gammaln(alpha*d/2);
end
if p0 >= pmax
  k = 0;
end
p = [p0 p];

%p(3)
%figure(1)
%plot(p)

```

</details>

My goal here was to port the algorithmic improvement without making any changes that would affect the selected rank. To that end, I left out a few things that we should possibly add in at some point in the future:
- the "missing terms added August 21 2008" (not in the original paper)
- `n-1` in place of `n`
- returning rank 0 when there is no discernible signal (we always return at least `1`)
- considering up to the number of eigenvalues above the floor minus one, which is one fewer than we do

Also Minka materialized a full O(d^2) `invediff` matrix; I wanted to keep memory usage at `O(d)`, so didn't do that. Not much practical impact on runtime anyway.

#### Math

<details><summary> Expand me to see how the math works! </summary>

The math equivalence was not intuitive to me at first, but really just rests on decomposing sums and recognizing which parts actually depend on which dimensions. Writing it up here to reinforce my own understanding and help any future readers as well.

Anyway, `pa` is the runtime culprit in the original formulation. Note the double product (or double sum in log space), which is what was written as a literal double `for` loop in the original implementation:

$$|A_Z| = \prod_{i=1}^{k} \prod_{j=i+1}^{d} N \left( \hat\lambda_j^{-1} - \hat\lambda_i^{-1} \right) \left( \lambda_i - \lambda_j \right)$$

$$\mathrm{pa}(k) = \log|A_Z| = \sum_{i=1}^{k}\sum_{j=i+1}^{d} \left[ \log(\lambda_i - \lambda_j) + \log\left(\hat\lambda_j^{-1} - \hat\lambda_i^{-1}\right) + \log N \right]$$

For a candidate rank $k \in [1, d-1]$ the PPCA maximum-likelihood estimates of the eigenvalues are

$$\hat\lambda_i^{(k)} = \begin{cases} \lambda_i & i \le k \text{ (signal)} \\ v_k & i > k \text{ (noise)} \end{cases}$$

$$v_k = \frac{1}{d-k}\sum_{j=k+1}^{d}\lambda_j$$

The set of pairs under consideration is

$$\mathcal{P}_k = \lbrace (i,j) : 1 \le i \le k, \ i < j \le d \rbrace$$

And the trick is to split on whether $j$ is inside the retained block:

$$\mathcal{S}_k = \lbrace (i,j) \in \mathcal{P}_k : j \le k \rbrace$$ (signal-signal pairs)

$$\mathcal{C}_k = \lbrace (i,j) \in \mathcal{P}_k : j > k \rbrace$$ (signal-noise pairs)

The former is an upper triangle with k choose 2 pairs; the latter is a rectangle; the total number of pairs is given by
$$|\mathcal{P}_k| = \frac{k(k-1)}{2} + k(d-k) = dk - \frac{k(k+1)}{2} = m_k$$

and we can use $$m_k$$ for the $$log N$$ term to avoid a loop there entirely. Back to the interesting stuff, let's consider the eigenvalue-gap factor (which only sees the raw eigenvalues and does not depend on the noise estimate or k in any way):

$$R(i) = \sum_{j=i+1}^{d} \log(\lambda_i - \lambda_j)$$

and its running total

$$D(k) = \sum_{i=1}^{k} R(i)$$

The inner sum $R(i)$ runs to $d$ regardless of $k$, so $D$ is a plain prefix sum:

$$D(k) = D(k-1) + R(k), \qquad D(0) = 0$$

The second factor does depend on the partition, because $\hat\lambda_j$ differs
between the two regions.

**On $\mathcal{S}_k$** (that is, $j \le k$): here $\hat\lambda_i = \lambda_i$
and $\hat\lambda_j = \lambda_j$, so the contribution is

$$P(k) = \sum_{1 \le i < j \le k} \log\left(\frac{1}{\lambda_j} - \frac{1}{\lambda_i}\right)$$

Grouping by the larger index $j$ makes this a prefix sum too:

$$P(k) = P(k-1) + \sum_{i=1}^{k-1}\log\left(\frac{1}{\lambda_k} - \frac{1}{\lambda_i}\right), \qquad P(0) = P(1) = 0$$

**On $\mathcal{C}_k$** (that is, $j > k$): every such $j$ has
$\hat\lambda_j = v_k$, so the summand $\log(v_k^{-1} - \lambda_i^{-1})$ **does
not depend on $j$**. Writing

$$Q(k) = \sum_{i=1}^{k}\log\left(\frac{1}{v_k} - \frac{1}{\lambda_i}\right)$$

the inner sum is that one value repeated $d-k$ times:

$$\sum_{(i,j) \in \mathcal{C}_k} \log\left(\hat\lambda_j^{-1} - \hat\lambda_i^{-1}\right) = (d-k) Q(k)$$

$Q(k)$ is the one piece that cannot be accumulated, because $v_k$ moves with
$k$. It is recomputed each rank at $O(k)$.

**Putting it together**:

$$\mathrm{pa}(k) = D(k) + P(k) + (d-k) Q(k) + m_k \log N$$

No more double loops! Each component is at most O(k).

</details>

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Previously I had just vectorized the implementation without changing the algorithm: https://github.com/scikit-learn/scikit-learn/pull/33602

This version is much faster!

#### PERFORMANCE

Running this benchmark script on my branch versus main:

```python
import time
import numpy as np
from sklearn.decomposition import PCA

rng = np.random.default_rng(0)

# Warm up
PCA(n_components="mle", svd_solver="full").fit(rng.standard_normal((32, 16)))

for n_features in [64, 128, 256, 512, 1024]:
    n_samples = 2 * n_features
    signal = rng.standard_normal((n_samples, 10)) @ rng.standard_normal((10, n_features))
    X = signal + rng.standard_normal((n_samples, n_features))

    pca = PCA(n_components="mle", svd_solver="full")
    start = time.perf_counter()
    pca.fit(X)
    elapsed = time.perf_counter() - start

    print(
        f"n_features={n_features:5d}  n_samples={n_samples:5d}  "
        f"n_components_={pca.n_components_:4d}  {elapsed:9.3f}s"
    )
```

Had claude turn that into a nice table after running on my m3 mac:

```
┌────────────┬───────────┬─────────────┬─────────┐
│ n_features │   main    │ this branch │ speedup │
├────────────┼───────────┼─────────────┼─────────┤
│         64 │   0.038 s │     0.002 s │     20x │
├────────────┼───────────┼─────────────┼─────────┤
│        128 │   0.305 s │     0.005 s │     61x │
├────────────┼───────────┼─────────────┼─────────┤
│        256 │   2.376 s │     0.020 s │    119x │
├────────────┼───────────┼─────────────┼─────────┤
│        512 │  19.057 s │     0.084 s │    227x │
├────────────┼───────────┼─────────────┼─────────┤
│       1024 │ 152.786 s │     0.420 s │    364x │
└────────────┴───────────┴─────────────┴─────────┘
```

Now the cost is pretty much *only* the SVD. Extrapolating, previously `_infer_dimension` would have taken more than a day on my hardware to crunch n_features=10000; now it takes less than a second.

#### What does this implement/fix? Explain your changes.
Fixes https://github.com/scikit-learn/scikit-learn/issues/34618


#### First time contributor introduction
<!-- If you are new to the scikit-learn community, please introduce yourself. How do you
 use scikit-learn, what prompted you to make this contribution? Getting to know you
 helps us build trust in your judgement and welcome you into the community.
-->

Hi! I'm just some guy. I write a lot of Python professionally and make open source contributions in my spare time.


#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Documentation (including examples)
- Research and understanding

All of the above, although I can vouch for every line of code in this. Opus 5 is outstanding at exactly this task: given a reference implementation in another language, translate it to Python. In particular, I used it for fuzz testing, and some of the more "interesting" spectra have been preserved in the new `test_infer_dimension_sensitive_spectra` test case.


#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->




