### PR TITLE
Improve clarity of error message in validation utilities

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -119,7 +119,7 @@ def _assert_all_finite(
     # for object dtype data, we only check for NaNs (GH-13254)
     if not is_array_api and X.dtype == np.dtype("object") and not allow_nan:
         if _object_dtype_isnan(X).any():
-            raise ValueError("Input contains NaN")
+            raise ValueError("Input contains NaN values. Please handle missing values (e.g., imputation or removal) before passing data to the estimator.")
 
     # We need only consider float arrays, hence can early return for all else.
     if not xp.isdtype(X.dtype, ("real floating", "complex floating")):


### PR DESCRIPTION
#### Reference Issues/PRs

This PR fixes the documentation issue reported in #33904: corrects `Input contains NaN` to `Input contains NaN values. Please handle missing values (e.g., imputation or removal) before passing data to the estimator.` in `sklearn/utils/validation.py`.

Fixes #33904

#### What does this implement/fix? Explain your changes.

#### First time contributor introduction

#### AI usage disclosure

I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Documentation (including examples)
- Research and understanding

#### Any other comments?

Fixes #33904