### PR TITLE
FIX explained_variance_score is undefined with a single sample

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/34623.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/34623.fix.rst
@@ -1,0 +1,7 @@
+- :func:`metrics.explained_variance_score` now warns with
+  :class:`exceptions.UndefinedMetricWarning` and returns `nan` when called with
+  a single sample, instead of silently reporting a perfect score of 1.0. This
+  matches :func:`metrics.r2_score` and makes `LeaveOneOut` cross-validation
+  scored with `explained_variance` no longer report a perfect score for every
+  model.
+  By :user:`Pranav Achar <PranavAchar01>`.

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1141,6 +1141,14 @@ def explained_variance_score(
         )
     )
 
+    if _num_samples(y_pred) < 2:
+        msg = (
+            "Explained variance score is not well-defined with less than two "
+            "samples."
+        )
+        warnings.warn(msg, UndefinedMetricWarning)
+        return float("nan")
+
     y_diff_avg = _average(y_true - y_pred, weights=sample_weight, axis=0, xp=xp)
     numerator = _average(
         (y_true - y_pred - y_diff_avg) ** 2, weights=sample_weight, axis=0, xp=xp

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1142,10 +1142,7 @@ def explained_variance_score(
     )
 
     if _num_samples(y_pred) < 2:
-        msg = (
-            "Explained variance score is not well-defined with less than two "
-            "samples."
-        )
+        msg = "Explained variance score is not well-defined with less than two samples."
         warnings.warn(msg, UndefinedMetricWarning)
         return float("nan")
 

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -222,7 +222,8 @@ def test_multioutput_regression():
 
 def test_regression_metrics_at_limits():
     # Single-sample case
-    # Note: for r2 and d2_tweedie see also test_regression_single_sample
+    # Note: for r2, d2_tweedie and explained_variance see also
+    # test_regression_single_sample
     assert_almost_equal(mean_squared_error([0.0], [0.0]), 0.0)
     assert_almost_equal(root_mean_squared_error([0.0], [0.0]), 0.0)
     assert_almost_equal(mean_squared_log_error([0.0], [0.0]), 0.0)
@@ -231,7 +232,6 @@ def test_regression_metrics_at_limits():
     assert_almost_equal(mean_absolute_percentage_error([0.0], [0.0]), 0.0)
     assert_almost_equal(median_absolute_error([0.0], [0.0]), 0.0)
     assert_almost_equal(max_error([0.0], [0.0]), 0.0)
-    assert_almost_equal(explained_variance_score([0.0], [0.0]), 1.0)
 
     # Perfect cases
     assert_almost_equal(r2_score([0.0, 1], [0.0, 1]), 1.0)
@@ -492,7 +492,10 @@ def test_regression_custom_weights():
     assert_almost_equal(msle, msle2, decimal=2)
 
 
-@pytest.mark.parametrize("metric", [r2_score, d2_tweedie_score, d2_pinball_score])
+@pytest.mark.parametrize(
+    "metric",
+    [r2_score, d2_tweedie_score, d2_pinball_score, explained_variance_score],
+)
 def test_regression_single_sample(metric):
     y_true = [0]
     y_pred = [1]


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #34622.

#### What does this implement/fix? Explain your changes.

With a single sample there is no variance to explain: the residual variance and
`Var(y_true)` are both `0`, so `force_finite` maps `0/0` to `1.0` — documented as
"perfect predictions" — regardless of how wrong the prediction is, and without a
warning:

```python
explained_variance_score([1.0], [2.0])   # 1.0, silently
r2_score([1.0], [2.0])                   # nan + UndefinedMetricWarning
```

The practical consequence is that `LeaveOneOut` cross-validation scored with
`explained_variance` reports a perfect `1.0` for any model, including one fit on
pure noise, while `r2` correctly reports `nan`.

This adds the same `n_samples < 2` guard that `r2_score`, `d2_tweedie_score` and
`d2_pinball_score` already use: warn with `UndefinedMetricWarning` and return
`nan`. Scores for two or more samples are untouched.

#### Any other comments?

This changes a currently asserted behaviour, so I've opened it as a draft for
discussion rather than as a merge-ready PR.

`test_regression_metrics_at_limits` pinned `explained_variance_score([0.0], [0.0]) == 1.0`
in its single-sample block. That assertion only covered a *perfect* single-sample
prediction; the incorrect one was untested. Since both collapse to the same `0/0`
under `force_finite`, separating them would need an explicit branch anyway, so
this moves `explained_variance_score` into `test_regression_single_sample`
alongside the other three metrics — which is what the existing comment in that
block already pointed at ("for r2 and d2_tweedie see also
test_regression_single_sample").

If you'd rather keep the perfect single-sample case returning `1.0` and only warn
when the residual is non-zero, or prefer to document the caveat instead of
changing behaviour, I'm happy to rework it.
