### PR TITLE
FIX fowlkes_mallows_score returns 0 for identical singleton clusterings

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/34625.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/34625.fix.rst
@@ -1,0 +1,6 @@
+- :func:`metrics.fowlkes_mallows_score` no longer returns 0.0 for two identical
+  labelings that consist only of singleton clusters. Such labelings share no
+  pair of co-clustered points, which was previously reported as the worst
+  possible score instead of a perfect match, unlike the other supervised
+  clustering metrics.
+  By :user:`Pranav Achar <PranavAchar01>`.

--- a/sklearn/metrics/cluster/_supervised.py
+++ b/sklearn/metrics/cluster/_supervised.py
@@ -1265,7 +1265,13 @@ def fowlkes_mallows_score(labels_true, labels_pred):
     tk = np.dot(c.data, c.data) - n_samples
     pk = np.sum(np.asarray(c.sum(axis=0)).ravel() ** 2) - n_samples
     qk = np.sum(np.asarray(c.sum(axis=1)).ravel() ** 2) - n_samples
-    return float(np.sqrt(tk / pk) * np.sqrt(tk / qk)) if tk != 0.0 else 0.0
+    if tk == 0.0:
+        # No pair of points is co-clustered in both labelings. When neither
+        # labeling co-clusters any pair either (pk == qk == 0), both consist
+        # only of singletons, so the two labelings agree and the score is 1.0.
+        # Otherwise one of them does group points together and they disagree.
+        return 1.0 if pk == 0.0 and qk == 0.0 else 0.0
+    return float(np.sqrt(tk / pk) * np.sqrt(tk / qk))
 
 
 def _entropy(labels):

--- a/sklearn/metrics/cluster/tests/test_supervised.py
+++ b/sklearn/metrics/cluster/tests/test_supervised.py
@@ -40,6 +40,7 @@ score_funcs = [
     v_measure_score,
     adjusted_mutual_info_score,
     normalized_mutual_info_score,
+    fowlkes_mallows_score,
 ]
 
 


### PR DESCRIPTION
#### Reference Issues/PRs

None, found while comparing the supervised clustering metrics on degenerate
inputs. Happy to open an issue first if you'd prefer to discuss it separately.

#### What does this implement/fix? Explain your changes.

`fowlkes_mallows_score` returns `0.0`, the worst possible score, for two
**identical** labelings whenever those labelings consist only of singletons:

```python
>>> from sklearn.metrics import fowlkes_mallows_score, adjusted_rand_score
>>> fowlkes_mallows_score([0, 1, 2], [0, 1, 2])
0.0
>>> adjusted_rand_score([0, 1, 2], [0, 1, 2])
1.0
```

The index is built from pair counts, so all-singleton labelings give `tk == 0`
and the implementation had a single fallback for that case:

```python
return float(np.sqrt(tk / pk) * np.sqrt(tk / qk)) if tk != 0.0 else 0.0
```

That conflates two different situations. `tk == 0` because one labeling groups
points that the other separates is genuine disagreement and should score `0.0`.
`tk == 0` because *neither* labeling groups anything (`pk == qk == 0`) means both
are all singletons, so they are the same partition and should score `1.0`.

This is also what the rest of the module already does: the shared
`test_perfect_matches` asserts `score_func([0, 1, 2], [42, 7, 2]) == 1.0` for all
seven metrics in `score_funcs`, and `fowlkes_mallows_score` is simply absent from
that list.

#### Any other comments?

- The existing `test_fowlkes_mallows_score` assertions are unchanged, including
  the worst case `fowlkes_mallows_score([0]*6, [0, 1, 2, 3, 4, 5]) == 0.0`, which
  still has `qk > 0` and so still returns `0.0`.
- `fowlkes_mallows_score` is added to `score_funcs`, so it is now covered by both
  `test_perfect_matches` and `test_error_messages_on_wrong_input`. I checked it
  already satisfies the latter's three expectations.
- Opened as a draft since this changes a returned value; happy to rework if you
  consider `0.0` the intended reading of "no pairs to agree on".
