### PR TITLE
FIX Use exact expected path length in IsolationForest

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.ensemble/34629.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.ensemble/34629.fix.rst
@@ -1,0 +1,7 @@
+- :class:`ensemble.IsolationForest` now computes the exact expected path length
+  ``c(n) = 2 H(n-1) - 2 (n-1)/n`` (using ``scipy.special.digamma``) instead of the
+  logarithmic approximation from the original paper, which was inaccurate for small
+  subsample sizes (about 30% too low at ``n = 3``). This slightly changes the anomaly
+  scores, and can change the predicted label of points that lie on the decision
+  boundary.
+  By :user:`Jayesh Suryavanshi <JayeshSuryavanshi>`.

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -8,6 +8,7 @@ from warnings import warn
 
 import numpy as np
 from scipy.sparse import issparse
+from scipy.special import digamma
 
 from sklearn.base import OutlierMixin, _fit_context
 from sklearn.ensemble._bagging import BaseBagging
@@ -649,6 +650,17 @@ def _average_path_length(n_samples_leaf):
     The average path length in an n_samples iTree, which is equal to
     the average path length of an unsuccessful BST search since the
     latter has the same structure as an isolation tree.
+
+    This uses the exact expected path length
+
+        c(n) = 2 H(n - 1) - 2 (n - 1) / n = 2 (psi(n + 1) + gamma - 1),
+
+    where H is the harmonic number, psi the digamma function and gamma the
+    Euler-Mascheroni constant. The original Isolation Forest paper approximates
+    H(n - 1) by ``log(n - 1) + gamma``, which is inaccurate for small n (about
+    30% too low at n = 3) and biases the anomaly scores. The closed form above
+    is exact to machine precision.
+
     Parameters
     ----------
     n_samples_leaf : array-like of shape (n_samples,)
@@ -666,15 +678,10 @@ def _average_path_length(n_samples_leaf):
     n_samples_leaf = n_samples_leaf.reshape((1, -1))
     average_path_length = np.zeros(n_samples_leaf.shape)
 
-    mask_1 = n_samples_leaf <= 1
-    mask_2 = n_samples_leaf == 2
-    not_mask = ~np.logical_or(mask_1, mask_2)
-
-    average_path_length[mask_1] = 0.0
-    average_path_length[mask_2] = 1.0
-    average_path_length[not_mask] = (
-        2.0 * (np.log(n_samples_leaf[not_mask] - 1.0) + np.euler_gamma)
-        - 2.0 * (n_samples_leaf[not_mask] - 1.0) / n_samples_leaf[not_mask]
+    mask = n_samples_leaf > 1
+    average_path_length[mask] = 2.0 * (
+        digamma(n_samples_leaf[mask] + 1.0) + np.euler_gamma - 1.0
     )
+    # n_samples_leaf <= 1 keeps the initialised value of 0.
 
     return average_path_length.reshape(n_samples_leaf_shape)

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -199,11 +199,22 @@ def test_iforest_average_path_length():
     # It tests non-regression for #8549 which used the wrong formula
     # for average path length, strictly for the integer case
     # Updated to check average path length when input is <= 2 (issue #11839)
-    result_one = 2.0 * (np.log(4.0) + np.euler_gamma) - 2.0 * 4.0 / 5.0
-    result_two = 2.0 * (np.log(998.0) + np.euler_gamma) - 2.0 * 998.0 / 999.0
+    # and to use the exact expected path length c(n) = 2 H(n-1) - 2 (n-1)/n
+    # instead of the paper's logarithmic approximation, which is ~30% too low
+    # for small n (issue #15724).
+    def exact_average_path_length(n):
+        # 2 H(n - 1) - 2 (n - 1) / n, straight from the definition of the
+        # harmonic number H, as an implementation-independent reference.
+        harmonic = np.sum(1.0 / np.arange(1, n))
+        return 2.0 * harmonic - 2.0 * (n - 1) / n
+
+    result_one = exact_average_path_length(5)  # 77 / 30
+    result_two = exact_average_path_length(999)
     assert_allclose(_average_path_length([0]), [0.0])
     assert_allclose(_average_path_length([1]), [0.0])
     assert_allclose(_average_path_length([2]), [1.0])
+    # Exact small-n value; the old approximation returned ~1.207 (issue #15724).
+    assert_allclose(_average_path_length([3]), [5.0 / 3.0])
     assert_allclose(_average_path_length([5]), [result_one])
     assert_allclose(_average_path_length([999]), [result_two])
     assert_allclose(
@@ -283,7 +294,22 @@ def test_iforest_chunks_works2(
 
 
 def test_iforest_with_uniform_data():
-    """Test whether iforest predicts inliers when using uniform data"""
+    """Test that iforest does not flag uniform / degenerate data as anomalies.
+
+    On perfectly uniform training data no split is possible, so every tree is a
+    single node holding all ``max_samples`` samples. Each point's path length
+    then equals the normalisation constant, so its anomaly score sits exactly on
+    the inlier/outlier decision boundary (``decision_function == 0``). Whether
+    that boundary rounds to a +1 or -1 label is governed by sub-ULP
+    floating-point error, so we assert the meaningful invariant: no point is
+    scored as a genuine anomaly (``decision_function >= 0`` up to floating-point
+    tolerance).
+    """
+    # A few ULPs of slack around the exact-boundary score of the degenerate fit.
+    tol = 1e-12
+
+    def assert_not_flagged_as_outlier(clf, X):
+        assert np.all(clf.decision_function(X) >= -tol)
 
     # 2-d array of all 1s
     X = np.ones((100, 10))
@@ -292,28 +318,28 @@ def test_iforest_with_uniform_data():
 
     rng = np.random.RandomState(0)
 
-    assert all(iforest.predict(X) == 1)
-    assert all(iforest.predict(rng.randn(100, 10)) == 1)
-    assert all(iforest.predict(X + 1) == 1)
-    assert all(iforest.predict(X - 1) == 1)
+    assert_not_flagged_as_outlier(iforest, X)
+    assert_not_flagged_as_outlier(iforest, rng.randn(100, 10))
+    assert_not_flagged_as_outlier(iforest, X + 1)
+    assert_not_flagged_as_outlier(iforest, X - 1)
 
     # 2-d array where columns contain the same value across rows
     X = np.repeat(rng.randn(1, 10), 100, 0)
     iforest = IsolationForest()
     iforest.fit(X)
 
-    assert all(iforest.predict(X) == 1)
-    assert all(iforest.predict(rng.randn(100, 10)) == 1)
-    assert all(iforest.predict(np.ones((100, 10))) == 1)
+    assert_not_flagged_as_outlier(iforest, X)
+    assert_not_flagged_as_outlier(iforest, rng.randn(100, 10))
+    assert_not_flagged_as_outlier(iforest, np.ones((100, 10)))
 
     # Single row
     X = rng.randn(1, 10)
     iforest = IsolationForest()
     iforest.fit(X)
 
-    assert all(iforest.predict(X) == 1)
-    assert all(iforest.predict(rng.randn(100, 10)) == 1)
-    assert all(iforest.predict(np.ones((100, 10))) == 1)
+    assert_not_flagged_as_outlier(iforest, X)
+    assert_not_flagged_as_outlier(iforest, rng.randn(100, 10))
+    assert_not_flagged_as_outlier(iforest, np.ones((100, 10)))
 
 
 @pytest.mark.parametrize("csc_container", CSC_CONTAINERS)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please make sure that your code passes
the tests. If your change is related to an open issue, please link it.
-->

#### Reference Issues/PRs

Closes #15724. Supersedes the stale #16721 (last updated Jan 2024), which took a lookup-table approach.

#### What does this implement/fix? Explain your changes.

`_average_path_length` used the Isolation Forest paper's logarithmic approximation of the harmonic number,

```
c(n) = 2 (ln(n - 1) + gamma) - 2 (n - 1) / n,
```

which is only accurate for large `n`. For small leaf sizes it is quite far off (about **30% too low at `n = 3`**, ~9% at `n = 5`, ~3% at `n = 10`), and this feeds directly into the anomaly scores through the path-length normalisation.

This PR replaces it with the **exact** expected path length

```
c(n) = 2 H(n - 1) - 2 (n - 1) / n = 2 (psi(n + 1) + gamma - 1),
```

where `H` is the harmonic number and `psi` the digamma function (`H(n) = psi(n + 1) + gamma`). It is computed with `scipy.special.digamma`, which is already used elsewhere in scikit-learn (`feature_selection._mutual_info`, `mixture._bayesian_mixture`), so no new dependency. The closed form is exact to machine precision and, as a bonus, subsumes the previous `n <= 1` and `n == 2` special cases into a single expression.

`_average_path_length` is computed once per tree at fit time and cached (`_average_path_length_per_tree`), so it is not on the per-sample scoring hot path and `digamma` has no meaningful performance cost here.

Accuracy after the change (exact vs the old approximation):

| n | exact | old approx | old error |
|---|-------|------------|-----------|
| 3 | 1.6667 | 1.2074 | 27.6% |
| 5 | 2.5667 | 2.3270 | 9.3% |
| 10 | 3.8579 | 3.7489 | 2.8% |
| 100 | 8.3748 | 8.3647 | 0.12% |

Impact on the anomaly score itself, from the issue: at `n = 3`, `E(h) = 1`, the score `s = -2**(-E(h)/c(n))` goes from `-0.563` (approx) to `-0.660` (exact), a ~15% difference.

#### Any other comments?

- `test_iforest_average_path_length` previously hard-coded the old approximation as its expected values, so it now (correctly) fails on `main`. I updated it to compare against an implementation-independent harmonic-number reference and added an explicit `n = 3 -> 5/3` assertion, which is the case the issue highlights (the old code returned ~1.207 there).
- `test_iforest_with_uniform_data` needed a small robustness change and I want to flag it explicitly. On perfectly uniform/degenerate training data no split is possible, so every leaf holds all `max_samples` samples and each point's path length equals the normalisation constant. Its anomaly score therefore sits **exactly** on the inlier/outlier decision boundary (`decision_function == 0`), and whether it rounds to a `+1` or `-1` label is decided by sub-ULP floating-point error. The old approximation happened to round to the inlier side; the exact value rounds one ULP (`2.2e-16`) the other way. Rather than depend on that coincidence, the test now asserts the meaningful invariant: degenerate data is never scored as a genuine anomaly (`decision_function >= 0` up to floating-point tolerance). Happy to adjust the framing if you'd prefer a different assertion.
