### PR TITLE
FIX roc_auc_score one-vs-one warns with UndefinedMetricWarning when y_true has a single class

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/34631.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/34631.fix.rst
@@ -1,0 +1,6 @@
+- :func:`metrics.roc_auc_score` with `multi_class="ovo"` now warns with
+  :class:`exceptions.UndefinedMetricWarning` when `y_true` contains a single class,
+  matching the binary case. Previously no class pair could be formed and averaging the
+  empty array of pairwise scores surfaced a bare numpy `RuntimeWarning` instead. The
+  returned value is unchanged (`nan`).
+  By :user:`Shivam Lalakiya <shivamlalakiya>`.

--- a/sklearn/metrics/_base.py
+++ b/sklearn/metrics/_base.py
@@ -6,11 +6,13 @@ Common code for all metrics.
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import warnings
 from itertools import combinations
 
 import numpy as np
 
 import sklearn.externals.array_api_extra as xpx
+from sklearn.exceptions import UndefinedMetricWarning
 from sklearn.utils import check_array, check_consistent_length
 from sklearn.utils._array_api import (
     _average,
@@ -184,6 +186,17 @@ def _average_multiclass_ovo_score(binary_metric, y_true, y_score, average="macro
     y_true_unique = np.unique(y_true)
     n_classes = y_true_unique.shape[0]
     n_pairs = n_classes * (n_classes - 1) // 2
+
+    if n_pairs == 0:
+        warnings.warn(
+            (
+                "Only one class is present in y_true. The one-vs-one multiclass "
+                "score is not defined in that case."
+            ),
+            UndefinedMetricWarning,
+        )
+        return np.nan
+
     pair_scores = np.empty(n_pairs)
 
     is_weighted = average == "weighted"

--- a/sklearn/metrics/tests/test_ranking.py
+++ b/sklearn/metrics/tests/test_ranking.py
@@ -848,6 +848,26 @@ def test_auc_score_non_binary_class():
         roc_auc_score(y_true, y_pred)
 
 
+@pytest.mark.parametrize("average", ["macro", "weighted"])
+@pytest.mark.parametrize("n_samples", [1, 3])
+def test_auc_score_multiclass_ovo_single_class(average, n_samples):
+    # Test that the one-vs-one path warns with UndefinedMetricWarning when
+    # y_true holds a single class, instead of averaging an empty array of
+    # pairwise scores and letting a bare numpy RuntimeWarning reach the user.
+    y_true = np.ones(n_samples, dtype="int")
+    y_score = np.tile([0.2, 0.5, 0.3], (n_samples, 1))
+    warn_message = (
+        "Only one class is present in y_true. The one-vs-one multiclass "
+        "score is not defined in that case."
+    )
+    with pytest.warns(UndefinedMetricWarning, match=warn_message) as record:
+        score = roc_auc_score(
+            y_true, y_score, multi_class="ovo", average=average, labels=[0, 1, 2]
+        )
+    assert np.isnan(score)
+    assert not [w for w in record if issubclass(w.category, RuntimeWarning)]
+
+
 def test_sort_inputs_and_compute_classification_thresholds_input_validation():
     """Test `_sort_inputs_and_compute_classification_thresholds` input validation."""
     # Inconsistent lengths


### PR DESCRIPTION
#### Reference Issues/PRs

Related to #11435 (metrics that are degenerate with a single sample). Found while auditing the unchecked entries on that checklist — this is the one-vs-one half of the `roc_auc_score` row.

#### What does this implement/fix? Explain your changes.

When `y_true` holds a single distinct class, the one-vs-one scheme forms no class pairs, so `_average_multiclass_ovo_score` calls `np.average` on an empty array. The result is `nan`, but it arrives via a bare numpy warning instead of the `UndefinedMetricWarning` that the binary path already emits for the same degenerate input:

```python
>>> roc_auc_score([1], [[0.2, 0.5, 0.3]], multi_class="ovo", labels=[0, 1, 2])
nan   # RuntimeWarning: Mean of empty slice
      # RuntimeWarning: invalid value encountered in scalar divide

>>> roc_auc_score([0, 0], [0.1, 0.9])
nan   # UndefinedMetricWarning: Only one class is present in y_true. ...
```

This guards `n_pairs == 0` in the helper and warns with `UndefinedMetricWarning`, mirroring `_binary_roc_auc_score`.

The **returned value is unchanged** (`nan` before and after), so no numeric behaviour is affected.

To be precise about the type, since the original wording here was too loose: it narrows from `np.float64` to `float`. Previously the `nan` came out of `np.average` on an empty array; now it comes from the `np.nan` literal. `np.float64` is a subclass of `float`, and every other `roc_auc_score` return path already gives a plain `float` — the binary path (one-class and healthy), `ovr`, and the `n < 2` guards in `r2_score` / `d2_log_loss_score` / `d2_brier_score`. The `np.float64` was the odd one out, leaking from an unwrapped `np.average` in the healthy `ovo` path, so this moves towards the convention rather than away from it.

`_average_multiclass_ovo_score` has a single caller (`roc_auc_score`, `_ranking.py:865`), so the guard sits in the helper rather than at the call site.

Note the case is not specific to a single sample: any `y_true` with one distinct class reaches it, so the test covers `n_samples` of both 1 and 3.

#### Any other comments?

The new test also asserts that no `RuntimeWarning` leaks out, which is the actual regression being pinned. It fails without the guard:

```
FAILED test_auc_score_multiclass_ovo_single_class[1-macro]    - Failed: DID NOT WARN.
FAILED test_auc_score_multiclass_ovo_single_class[1-weighted] - Failed: DID NOT WARN.
FAILED test_auc_score_multiclass_ovo_single_class[3-macro]    - Failed: DID NOT WARN.
FAILED test_auc_score_multiclass_ovo_single_class[3-weighted] - Failed: DID NOT WARN.
```

Full `sklearn/metrics/` suite passes locally: `3981 passed, 3782 skipped, 2 xfailed`.

A changelog entry is included now that the PR has a number.
