### PR TITLE
CI Fix scipy-dev remaining failures due to scipy sparse DeprecationWarning

### DIFF
--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -33,7 +33,12 @@ from sklearn.utils._testing import (
     assert_almost_equal,
     skip_if_32bit,
 )
-from sklearn.utils.fixes import _IS_WASM, CSC_CONTAINERS, CSR_CONTAINERS
+from sklearn.utils.fixes import (
+    _IS_WASM,
+    CSC_CONTAINERS,
+    CSR_CONTAINERS,
+    _sparse_random_array,
+)
 
 JUNK_FOOD_DOCS = (
     "the pizza pizza beer copyright",
@@ -1239,7 +1244,7 @@ def test_vectorizer_string_object_as_input(Vectorizer):
 
 @pytest.mark.parametrize("X_dtype", [np.float32, np.float64])
 def test_tfidf_transformer_type(X_dtype):
-    X = sparse.rand(10, 20000, dtype=X_dtype, random_state=42)
+    X = _sparse_random_array((10, 20000), dtype=X_dtype, random_state=42)
     X_trans = TfidfTransformer().fit_transform(X)
     assert X_trans.dtype == X.dtype
 
@@ -1248,7 +1253,7 @@ def test_tfidf_transformer_type(X_dtype):
     "csc_container, csr_container", product(CSC_CONTAINERS, CSR_CONTAINERS)
 )
 def test_tfidf_transformer_sparse(csc_container, csr_container):
-    X = sparse.rand(10, 20000, dtype=np.float64, random_state=42)
+    X = _sparse_random_array((10, 20000), dtype=np.float64, random_state=42)
     X_csc = csc_container(X)
     X_csr = csr_container(X)
 
@@ -1600,7 +1605,7 @@ def test_vectorizers_do_not_have_set_output(Estimator):
 @pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
 def test_tfidf_transformer_copy(csr_container):
     """Check the behaviour of TfidfTransformer.transform with the copy parameter."""
-    X = sparse.rand(10, 20000, dtype=np.float64, random_state=42)
+    X = _sparse_random_array((10, 20000), dtype=np.float64, random_state=42)
     X_csr = csr_container(X)
 
     # keep a copy of the original matrix for later comparison

--- a/sklearn/linear_model/tests/test_base.py
+++ b/sklearn/linear_model/tests/test_base.py
@@ -30,6 +30,7 @@ from sklearn.utils.fixes import (
     CSR_CONTAINERS,
     LIL_CONTAINERS,
     _sparse_eye_array,
+    _sparse_random_array,
 )
 
 rtol = 1e-6
@@ -502,7 +503,7 @@ def test_sparse_preprocess_data_offsets(global_random_seed, lil_container):
     rng = np.random.RandomState(global_random_seed)
     n_samples = 200
     n_features = 2
-    X = sparse.rand(n_samples, n_features, density=0.5, random_state=rng)
+    X = _sparse_random_array((n_samples, n_features), density=0.5, random_state=rng)
     X = lil_container(X)
     y = rng.rand(n_samples)
     XA = X.toarray()

--- a/sklearn/linear_model/tests/test_logistic.py
+++ b/sklearn/linear_model/tests/test_logistic.py
@@ -49,7 +49,12 @@ from sklearn.utils._array_api import (
     yield_namespace_device_dtype_combinations,
 )
 from sklearn.utils._testing import _array_api_for_tests, ignore_warnings
-from sklearn.utils.fixes import _IS_32BIT, COO_CONTAINERS, CSR_CONTAINERS
+from sklearn.utils.fixes import (
+    _IS_32BIT,
+    COO_CONTAINERS,
+    CSR_CONTAINERS,
+    _sparse_random_array,
+)
 
 pytestmark = pytest.mark.filterwarnings(
     "error::sklearn.exceptions.ConvergenceWarning:sklearn.*"
@@ -2511,7 +2516,7 @@ def test_large_sparse_matrix(solver, csr_container):
     # Non-regression test for pull-request #21093.
 
     # generate sparse matrix with int64 indices
-    X = csr_container(sparse.rand(20, 10, random_state=42))
+    X = csr_container(_sparse_random_array((20, 10), random_state=42))
     for attr in ["indices", "indptr"]:
         setattr(X, attr, getattr(X, attr).astype("int64"))
     rng = np.random.RandomState(42)

--- a/sklearn/manifold/tests/test_isomap.py
+++ b/sklearn/manifold/tests/test_isomap.py
@@ -3,7 +3,6 @@ from itertools import product
 
 import numpy as np
 import pytest
-from scipy.sparse import rand as sparse_rand
 
 from sklearn import clone, datasets, manifold, neighbors, pipeline, preprocessing
 from sklearn.datasets import make_blobs
@@ -13,7 +12,7 @@ from sklearn.utils._testing import (
     assert_allclose_dense_sparse,
     assert_array_equal,
 )
-from sklearn.utils.fixes import CSR_CONTAINERS
+from sklearn.utils.fixes import CSR_CONTAINERS, _sparse_random_array
 
 eigen_solvers = ["auto", "dense", "arpack"]
 path_methods = ["auto", "FW", "D"]
@@ -234,9 +233,8 @@ def test_sparse_input(
     # TODO: compare results on dense and sparse data as proposed in:
     # https://github.com/scikit-learn/scikit-learn/pull/23585#discussion_r968388186
     X = csr_container(
-        sparse_rand(
-            100,
-            3,
+        _sparse_random_array(
+            (100, 3),
             density=0.1,
             format="csr",
             dtype=global_dtype,

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -1619,97 +1619,107 @@ def test_multilabel_hamming_loss():
 
 
 def test_jaccard_score_validation():
-    y_true = np.array([0, 1, 0, 1, 1])
-    y_pred = np.array([0, 1, 0, 1, 1])
-    err_msg = re.escape("pos_label=2 is not a valid label. It should be one of [0 1]")
-    with pytest.raises(ValueError, match=err_msg):
-        jaccard_score(y_true, y_pred, average="binary", pos_label=2)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=UndefinedMetricWarning)
 
-    y_true = np.array([[0, 1, 1], [1, 0, 0]])
-    y_pred = np.array([[1, 1, 1], [1, 0, 1]])
-    msg1 = (
-        r"Target is multilabel-indicator but average='binary'. "
-        r"Please choose another average setting, one of \[None, "
-        r"'micro', 'macro', 'weighted', 'samples'\]."
-    )
-    with pytest.raises(ValueError, match=msg1):
-        jaccard_score(y_true, y_pred, average="binary", pos_label=-1)
+        y_true = np.array([0, 1, 0, 1, 1])
+        y_pred = np.array([0, 1, 0, 1, 1])
+        err_msg = re.escape(
+            "pos_label=2 is not a valid label. It should be one of [0 1]"
+        )
+        with pytest.raises(ValueError, match=err_msg):
+            jaccard_score(y_true, y_pred, average="binary", pos_label=2)
 
-    y_true = np.array([0, 1, 1, 0, 2])
-    y_pred = np.array([1, 1, 1, 1, 0])
-    msg2 = (
-        r"Target is multiclass but average='binary'. Please choose "
-        r"another average setting, one of \[None, 'micro', 'macro', "
-        r"'weighted'\]."
-    )
-    with pytest.raises(ValueError, match=msg2):
-        jaccard_score(y_true, y_pred, average="binary")
-    msg3 = "Samplewise metrics are not available outside of multilabel classification."
-    with pytest.raises(ValueError, match=msg3):
-        jaccard_score(y_true, y_pred, average="samples")
+        y_true = np.array([[0, 1, 1], [1, 0, 0]])
+        y_pred = np.array([[1, 1, 1], [1, 0, 1]])
+        msg1 = (
+            r"Target is multilabel-indicator but average='binary'. "
+            r"Please choose another average setting, one of \[None, "
+            r"'micro', 'macro', 'weighted', 'samples'\]."
+        )
+        with pytest.raises(ValueError, match=msg1):
+            jaccard_score(y_true, y_pred, average="binary", pos_label=-1)
 
-    msg = (
-        r"Note that pos_label \(set to 3\) is ignored when "
-        r"average != 'binary' \(got 'micro'\). You may use "
-        r"labels=\[pos_label\] to specify a single positive "
-        "class."
-    )
-    with pytest.warns(UserWarning, match=msg):
-        jaccard_score(y_true, y_pred, average="micro", pos_label=3)
+        y_true = np.array([0, 1, 1, 0, 2])
+        y_pred = np.array([1, 1, 1, 1, 0])
+        msg2 = (
+            r"Target is multiclass but average='binary'. Please choose "
+            r"another average setting, one of \[None, 'micro', 'macro', "
+            r"'weighted'\]."
+        )
+        with pytest.raises(ValueError, match=msg2):
+            jaccard_score(y_true, y_pred, average="binary")
+        msg3 = (
+            "Samplewise metrics are not available outside of multilabel classification."
+        )
+        with pytest.raises(ValueError, match=msg3):
+            jaccard_score(y_true, y_pred, average="samples")
+
+        msg = (
+            r"Note that pos_label \(set to 3\) is ignored when "
+            r"average != 'binary' \(got 'micro'\). You may use "
+            r"labels=\[pos_label\] to specify a single positive "
+            "class."
+        )
+        with pytest.warns(UserWarning, match=msg):
+            jaccard_score(y_true, y_pred, average="micro", pos_label=3)
 
 
-def test_multilabel_jaccard_score(recwarn):
-    # Dense label indicator matrix format
-    y1 = np.array([[0, 1, 1], [1, 0, 1]])
-    y2 = np.array([[0, 0, 1], [1, 0, 1]])
+def test_multilabel_jaccard_score():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=UndefinedMetricWarning)
+        # Dense label indicator matrix format
+        y1 = np.array([[0, 1, 1], [1, 0, 1]])
+        y2 = np.array([[0, 0, 1], [1, 0, 1]])
 
-    # size(y1 \inter y2) = [1, 2]
-    # size(y1 \union y2) = [2, 2]
+        # size(y1 \inter y2) = [1, 2]
+        # size(y1 \union y2) = [2, 2]
 
-    assert jaccard_score(y1, y2, average="samples") == 0.75
-    assert jaccard_score(y1, y1, average="samples") == 1
-    assert jaccard_score(y2, y2, average="samples") == 1
-    assert jaccard_score(y2, np.logical_not(y2), average="samples") == 0
-    assert jaccard_score(y1, np.logical_not(y1), average="samples") == 0
-    assert jaccard_score(y1, np.zeros(y1.shape), average="samples") == 0
-    assert jaccard_score(y2, np.zeros(y1.shape), average="samples") == 0
+        assert jaccard_score(y1, y2, average="samples") == 0.75
+        assert jaccard_score(y1, y1, average="samples") == 1
+        assert jaccard_score(y2, y2, average="samples") == 1
+        assert jaccard_score(y2, np.logical_not(y2), average="samples") == 0
+        assert jaccard_score(y1, np.logical_not(y1), average="samples") == 0
+        assert jaccard_score(y1, np.zeros(y1.shape), average="samples") == 0
+        assert jaccard_score(y2, np.zeros(y1.shape), average="samples") == 0
 
-    y_true = np.array([[0, 1, 1], [1, 0, 0]])
-    y_pred = np.array([[1, 1, 1], [1, 0, 1]])
-    # average='macro'
-    assert_almost_equal(jaccard_score(y_true, y_pred, average="macro"), 2.0 / 3)
-    # average='micro'
-    assert_almost_equal(jaccard_score(y_true, y_pred, average="micro"), 3.0 / 5)
-    # average='samples'
-    assert_almost_equal(jaccard_score(y_true, y_pred, average="samples"), 7.0 / 12)
-    assert_almost_equal(
-        jaccard_score(y_true, y_pred, average="samples", labels=[0, 2]), 1.0 / 2
-    )
-    assert_almost_equal(
-        jaccard_score(y_true, y_pred, average="samples", labels=[1, 2]), 1.0 / 2
-    )
-    # average=None
-    assert_array_equal(
-        jaccard_score(y_true, y_pred, average=None), np.array([1.0 / 2, 1.0, 1.0 / 2])
-    )
+        y_true = np.array([[0, 1, 1], [1, 0, 0]])
+        y_pred = np.array([[1, 1, 1], [1, 0, 1]])
+        # average='macro'
+        assert_almost_equal(jaccard_score(y_true, y_pred, average="macro"), 2.0 / 3)
+        # average='micro'
+        assert_almost_equal(jaccard_score(y_true, y_pred, average="micro"), 3.0 / 5)
+        # average='samples'
+        assert_almost_equal(jaccard_score(y_true, y_pred, average="samples"), 7.0 / 12)
+        assert_almost_equal(
+            jaccard_score(y_true, y_pred, average="samples", labels=[0, 2]), 1.0 / 2
+        )
+        assert_almost_equal(
+            jaccard_score(y_true, y_pred, average="samples", labels=[1, 2]), 1.0 / 2
+        )
+        # average=None
+        assert_array_equal(
+            jaccard_score(y_true, y_pred, average=None),
+            np.array([1.0 / 2, 1.0, 1.0 / 2]),
+        )
 
-    y_true = np.array([[0, 1, 1], [1, 0, 1]])
-    y_pred = np.array([[1, 1, 1], [1, 0, 1]])
-    assert_almost_equal(jaccard_score(y_true, y_pred, average="macro"), 5.0 / 6)
-    # average='weighted'
-    assert_almost_equal(jaccard_score(y_true, y_pred, average="weighted"), 7.0 / 8)
+        y_true = np.array([[0, 1, 1], [1, 0, 1]])
+        y_pred = np.array([[1, 1, 1], [1, 0, 1]])
+        assert_almost_equal(jaccard_score(y_true, y_pred, average="macro"), 5.0 / 6)
+        # average='weighted'
+        assert_almost_equal(jaccard_score(y_true, y_pred, average="weighted"), 7.0 / 8)
 
-    msg2 = "Got 4 > 2"
-    with pytest.raises(ValueError, match=msg2):
-        jaccard_score(y_true, y_pred, labels=[4], average="macro")
-    msg3 = "Got -1 < 0"
-    with pytest.raises(ValueError, match=msg3):
-        jaccard_score(y_true, y_pred, labels=[-1], average="macro")
+        msg2 = "Got 4 > 2"
+        with pytest.raises(ValueError, match=msg2):
+            jaccard_score(y_true, y_pred, labels=[4], average="macro")
+        msg3 = "Got -1 < 0"
+        with pytest.raises(ValueError, match=msg3):
+            jaccard_score(y_true, y_pred, labels=[-1], average="macro")
 
-    msg = (
-        "Jaccard is ill-defined and being set to 0.0 in labels "
-        "with no true or predicted samples."
-    )
+        msg = (
+            "Jaccard is ill-defined and being set to 0.0 in labels "
+            "with no true or predicted samples."
+        )
 
     with pytest.warns(UndefinedMetricWarning, match=msg):
         assert (
@@ -1732,67 +1742,71 @@ def test_multilabel_jaccard_score(recwarn):
             == 0.5
         )
 
-    assert not list(recwarn)
+
+def test_multiclass_jaccard_score():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=UndefinedMetricWarning)
+
+        y_true = ["ant", "ant", "cat", "cat", "ant", "cat", "bird", "bird"]
+        y_pred = ["cat", "ant", "cat", "cat", "ant", "bird", "bird", "cat"]
+        labels = ["ant", "bird", "cat"]
+        lb = LabelBinarizer()
+        lb.fit(labels)
+        y_true_bin = lb.transform(y_true)
+        y_pred_bin = lb.transform(y_pred)
+        multi_jaccard_score = partial(jaccard_score, y_true, y_pred)
+        bin_jaccard_score = partial(jaccard_score, y_true_bin, y_pred_bin)
+        multi_labels_list = [
+            ["ant", "bird"],
+            ["ant", "cat"],
+            ["cat", "bird"],
+            ["ant"],
+            ["bird"],
+            ["cat"],
+            None,
+        ]
+        bin_labels_list = [[0, 1], [0, 2], [2, 1], [0], [1], [2], None]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", category=UndefinedMetricWarning)
+            # other than average='samples'/'none-samples', test everything else here
+            for average in ("macro", "weighted", "micro", None):
+                for m_label, b_label in zip(multi_labels_list, bin_labels_list):
+                    assert_almost_equal(
+                        multi_jaccard_score(average=average, labels=m_label),
+                        bin_jaccard_score(average=average, labels=b_label),
+                    )
+
+            y_true = np.array([[0, 0], [0, 0], [0, 0]])
+            y_pred = np.array([[0, 0], [0, 0], [0, 0]])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UndefinedMetricWarning)
+        jaccard_score(y_true, y_pred, average="weighted") == 0
 
 
-def test_multiclass_jaccard_score(recwarn):
-    y_true = ["ant", "ant", "cat", "cat", "ant", "cat", "bird", "bird"]
-    y_pred = ["cat", "ant", "cat", "cat", "ant", "bird", "bird", "cat"]
-    labels = ["ant", "bird", "cat"]
-    lb = LabelBinarizer()
-    lb.fit(labels)
-    y_true_bin = lb.transform(y_true)
-    y_pred_bin = lb.transform(y_pred)
-    multi_jaccard_score = partial(jaccard_score, y_true, y_pred)
-    bin_jaccard_score = partial(jaccard_score, y_true_bin, y_pred_bin)
-    multi_labels_list = [
-        ["ant", "bird"],
-        ["ant", "cat"],
-        ["cat", "bird"],
-        ["ant"],
-        ["bird"],
-        ["cat"],
-        None,
-    ]
-    bin_labels_list = [[0, 1], [0, 2], [2, 1], [0], [1], [2], None]
+def test_average_binary_jaccard_score():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=UndefinedMetricWarning)
 
-    # other than average='samples'/'none-samples', test everything else here
-    for average in ("macro", "weighted", "micro", None):
-        for m_label, b_label in zip(multi_labels_list, bin_labels_list):
-            assert_almost_equal(
-                multi_jaccard_score(average=average, labels=m_label),
-                bin_jaccard_score(average=average, labels=b_label),
-            )
+        # tp=0, fp=0, fn=1, tn=0
+        assert jaccard_score([1], [0], average="binary") == 0.0
+        # tp=0, fp=0, fn=0, tn=1
+        msg = (
+            "Jaccard is ill-defined and being set to 0.0 due to "
+            "no true or predicted samples"
+        )
+        with pytest.warns(UndefinedMetricWarning, match=msg):
+            assert jaccard_score([0, 0], [0, 0], average="binary") == 0.0
 
-    y_true = np.array([[0, 0], [0, 0], [0, 0]])
-    y_pred = np.array([[0, 0], [0, 0], [0, 0]])
-    with ignore_warnings():
-        assert jaccard_score(y_true, y_pred, average="weighted") == 0
-
-    assert not list(recwarn)
-
-
-def test_average_binary_jaccard_score(recwarn):
-    # tp=0, fp=0, fn=1, tn=0
-    assert jaccard_score([1], [0], average="binary") == 0.0
-    # tp=0, fp=0, fn=0, tn=1
-    msg = (
-        "Jaccard is ill-defined and being set to 0.0 due to "
-        "no true or predicted samples"
-    )
-    with pytest.warns(UndefinedMetricWarning, match=msg):
-        assert jaccard_score([0, 0], [0, 0], average="binary") == 0.0
-
-    # tp=1, fp=0, fn=0, tn=0 (pos_label=0)
-    assert jaccard_score([0], [0], pos_label=0, average="binary") == 1.0
-    y_true = np.array([1, 0, 1, 1, 0])
-    y_pred = np.array([1, 0, 1, 1, 1])
-    assert_almost_equal(jaccard_score(y_true, y_pred, average="binary"), 3.0 / 4)
-    assert_almost_equal(
-        jaccard_score(y_true, y_pred, average="binary", pos_label=0), 1.0 / 2
-    )
-
-    assert not list(recwarn)
+        # tp=1, fp=0, fn=0, tn=0 (pos_label=0)
+        assert jaccard_score([0], [0], pos_label=0, average="binary") == 1.0
+        y_true = np.array([1, 0, 1, 1, 0])
+        y_pred = np.array([1, 0, 1, 1, 1])
+        assert_almost_equal(jaccard_score(y_true, y_pred, average="binary"), 3.0 / 4)
+        assert_almost_equal(
+            jaccard_score(y_true, y_pred, average="binary", pos_label=0), 1.0 / 2
+        )
 
 
 def test_jaccard_score_zero_division_warning():
@@ -2062,7 +2076,7 @@ def test_precision_recall_f1_no_labels(beta, average, zero_division):
     y_pred = np.zeros_like(y_true)
 
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        warnings.simplefilter("error", category=UndefinedMetricWarning)
 
         p, r, f, s = precision_recall_fscore_support(
             y_true,
@@ -2128,7 +2142,7 @@ def test_precision_recall_f1_no_labels_average_none(zero_division):
     # |y_hat_i| = [0, 0, 0]
 
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        warnings.simplefilter("error", category=UndefinedMetricWarning)
 
         p, r, f, s = precision_recall_fscore_support(
             y_true,
@@ -2285,7 +2299,7 @@ def test_prf_warnings():
 @pytest.mark.parametrize("zero_division", [0, 1, np.nan])
 def test_prf_no_warnings_if_zero_division_set(zero_division):
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        warnings.simplefilter("error", category=UndefinedMetricWarning)
 
         # average of per-label scores
         for average in [None, "weighted", "macro"]:
@@ -2337,7 +2351,7 @@ def test_prf_no_warnings_if_zero_division_set(zero_division):
         )
 
     with warnings.catch_warnings(record=True) as record:
-        warnings.simplefilter("always")
+        warnings.simplefilter("always", category=UndefinedMetricWarning)
         precision_recall_fscore_support(
             [0, 0], [0, 0], average="binary", zero_division=zero_division
         )
@@ -2347,7 +2361,7 @@ def test_prf_no_warnings_if_zero_division_set(zero_division):
 @pytest.mark.parametrize("zero_division", ["warn", 0, 1, np.nan])
 def test_recall_warnings(zero_division):
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        warnings.simplefilter("error", category=UndefinedMetricWarning)
 
         recall_score(
             np.array([[1, 1], [1, 1]]),
@@ -2357,7 +2371,7 @@ def test_recall_warnings(zero_division):
         )
 
     with warnings.catch_warnings(record=True) as record:
-        warnings.simplefilter("always")
+        warnings.simplefilter("always", category=UndefinedMetricWarning)
         recall_score(
             np.array([[0, 0], [0, 0]]),
             np.array([[1, 1], [1, 1]]),
@@ -2387,7 +2401,7 @@ def test_recall_warnings(zero_division):
 @pytest.mark.parametrize("zero_division", ["warn", 0, 1, np.nan])
 def test_precision_warnings(zero_division):
     with warnings.catch_warnings(record=True) as record:
-        warnings.simplefilter("always")
+        warnings.simplefilter("always", category=UndefinedMetricWarning)
         precision_score(
             np.array([[1, 1], [1, 1]]),
             np.array([[0, 0], [0, 0]]),
@@ -2414,7 +2428,7 @@ def test_precision_warnings(zero_division):
             )
 
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        warnings.simplefilter("error", category=UndefinedMetricWarning)
 
         precision_score(
             np.array([[0, 0], [0, 0]]),
@@ -2427,7 +2441,7 @@ def test_precision_warnings(zero_division):
 @pytest.mark.parametrize("zero_division", ["warn", 0, 1, np.nan])
 def test_fscore_warnings(zero_division):
     with warnings.catch_warnings(record=True) as record:
-        warnings.simplefilter("always")
+        warnings.simplefilter("always", category=UndefinedMetricWarning)
 
         for score in [f1_score, partial(fbeta_score, beta=2)]:
             score(

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -565,7 +565,7 @@ def test_sort_graph_by_row_values_warning(csr_container):
 
     # no warning
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        warnings.simplefilter("error", category=EfficiencyWarning)
         sort_graph_by_row_values(X, copy=True, warn_when_not_sorted=False)
 
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -1192,7 +1192,7 @@ def test_scale_input_finiteness_validation():
 
 
 def test_robust_scaler_error_sparse():
-    X_sparse = sparse.rand(1000, 10)
+    X_sparse = _sparse_random_array((1000, 10))
     scaler = RobustScaler(with_centering=True)
     err_msg = "Cannot center sparse matrices"
     with pytest.raises(ValueError, match=err_msg):
@@ -1201,7 +1201,9 @@ def test_robust_scaler_error_sparse():
 
 @pytest.mark.parametrize("with_centering", [True, False])
 @pytest.mark.parametrize("with_scaling", [True, False])
-@pytest.mark.parametrize("X", [np.random.randn(10, 3), sparse.rand(10, 3, density=0.5)])
+@pytest.mark.parametrize(
+    "X", [np.random.randn(10, 3), _sparse_random_array((10, 3), density=0.5)]
+)
 def test_robust_scaler_attributes(X, with_centering, with_scaling):
     # check consistent type of attributes
     if with_centering and sparse.issparse(X):
@@ -1253,7 +1255,7 @@ def test_robust_scaler_2d_arrays():
 @pytest.mark.parametrize("strictly_signed", ["positive", "negative", "zeros", None])
 def test_robust_scaler_equivalence_dense_sparse(density, strictly_signed):
     # Check the equivalence of the fitting with dense and sparse matrices
-    X_sparse = sparse.rand(1000, 5, density=density).tocsc()
+    X_sparse = _sparse_random_array((1000, 5), density=density).tocsc()
     if strictly_signed == "positive":
         X_sparse.data = np.abs(X_sparse.data)
     elif strictly_signed == "negative":
@@ -1516,7 +1518,7 @@ def test_quantile_transform_subsampling():
 
     # sparse support
 
-    X = sparse.rand(n_samples, 1, density=0.99, format="csc", random_state=0)
+    X = _sparse_random_array((n_samples, 1), density=0.99, format="csc", random_state=0)
     inf_norm_arr = []
     for random_state in range(ROUND):
         transformer = QuantileTransformer(

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -808,7 +808,7 @@ def test_one_hot_encoder_warning():
     enc = OneHotEncoder()
     X = [["Male", 1], ["Female", 3]]
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        warnings.simplefilter("error", category=UserWarning)
         enc.fit_transform(X)
 
 

--- a/sklearn/preprocessing/tests/test_polynomial.py
+++ b/sklearn/preprocessing/tests/test_polynomial.py
@@ -6,7 +6,6 @@ import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 from scipy import sparse
 from scipy.interpolate import BSpline
-from scipy.sparse import random as sparse_random
 
 from sklearn._config import config_context
 from sklearn.linear_model import LinearRegression
@@ -35,6 +34,7 @@ from sklearn.utils._testing import (
 from sklearn.utils.fixes import (
     CSC_CONTAINERS,
     CSR_CONTAINERS,
+    _sparse_random_array,
 )
 
 
@@ -905,7 +905,9 @@ def test_num_combinations(
 def test_polynomial_features_csr_X_floats(
     deg, include_bias, interaction_only, dtype, csr_container, global_random_seed
 ):
-    X_csr = csr_container(sparse_random(1000, 10, 0.5, random_state=global_random_seed))
+    X_csr = csr_container(
+        _sparse_random_array((1000, 10), density=0.5, random_state=global_random_seed)
+    )
     X = X_csr.toarray()
 
     est = PolynomialFeatures(
@@ -940,7 +942,9 @@ def test_polynomial_features_csr_X_floats(
 def test_polynomial_features_csr_X_zero_row(
     zero_row_index, deg, interaction_only, csr_container, global_random_seed
 ):
-    X_csr = csr_container(sparse_random(3, 10, 1.0, random_state=global_random_seed))
+    X_csr = csr_container(
+        _sparse_random_array((3, 10), density=1.0, random_state=global_random_seed)
+    )
     X_csr[zero_row_index, :] = 0.0
     X = X_csr.toarray()
 
@@ -963,7 +967,9 @@ def test_polynomial_features_csr_X_zero_row(
 def test_polynomial_features_csr_X_degree_4(
     include_bias, interaction_only, csr_container, global_random_seed
 ):
-    X_csr = csr_container(sparse_random(1000, 10, 0.5, random_state=global_random_seed))
+    X_csr = csr_container(
+        _sparse_random_array((1000, 10), density=0.5, random_state=global_random_seed)
+    )
     X = X_csr.toarray()
 
     est = PolynomialFeatures(
@@ -997,7 +1003,7 @@ def test_polynomial_features_csr_X_dim_edges(
     deg, dim, interaction_only, csr_container, global_random_seed
 ):
     X_csr = csr_container(
-        sparse_random(1000, dim, 0.5, random_state=global_random_seed)
+        _sparse_random_array((1000, dim), density=0.5, random_state=global_random_seed)
     )
     X = X_csr.toarray()
 

--- a/sklearn/utils/_testing.py
+++ b/sklearn/utils/_testing.py
@@ -1529,7 +1529,7 @@ def _get_warnings_filters_info_list():
         # will happen, only that it won't be earlier than v2.2.
         WarningInfo(
             "ignore",
-            message=r"(?s).*All sparse matrix classes",
+            message=r"(?s).*All sparse matrix classes.+deprecated",
             category=DeprecationWarning,
         ),
     ]

--- a/sklearn/utils/tests/test_sparsefuncs.py
+++ b/sklearn/utils/tests/test_sparsefuncs.py
@@ -11,6 +11,7 @@ from sklearn.utils.fixes import (
     CSC_CONTAINERS,
     CSR_CONTAINERS,
     LIL_CONTAINERS,
+    _sparse_eye_array,
     _sparse_random_array,
 )
 from sklearn.utils.sparsefuncs import (
@@ -1007,19 +1008,39 @@ def test_implit_center_rmatvec(global_random_seed, centered_matrices):
 @pytest.mark.parametrize(
     ["A", "B", "out", "msg"],
     [
-        (sp.eye(3, format="csr"), sp.eye(2, format="csr"), None, "Shapes must fulfil"),
-        (sp.eye(2, format="csr"), sp.eye(2, format="csr"), np.eye(3), "Shape of out"),
-        (sp.eye(2, format="coo"), sp.eye(2, format="csr"), None, "Input 'A' must"),
-        (sp.eye(2, format="csr"), sp.eye(2, format="coo"), None, "Input 'B' must"),
         (
-            sp.eye(2, format="csr", dtype=np.int32),
-            sp.eye(2, format="csr"),
+            _sparse_eye_array(3, format="csr"),
+            _sparse_eye_array(2, format="csr"),
+            None,
+            "Shapes must fulfil",
+        ),
+        (
+            _sparse_eye_array(2, format="csr"),
+            _sparse_eye_array(2, format="csr"),
+            np.eye(3),
+            "Shape of out",
+        ),
+        (
+            _sparse_eye_array(2, format="coo"),
+            _sparse_eye_array(2, format="csr"),
+            None,
+            "Input 'A' must",
+        ),
+        (
+            _sparse_eye_array(2, format="csr"),
+            _sparse_eye_array(2, format="coo"),
+            None,
+            "Input 'B' must",
+        ),
+        (
+            _sparse_eye_array(2, format="csr", dtype=np.int32),
+            _sparse_eye_array(2, format="csr"),
             None,
             "Dtype of A and B",
         ),
         (
-            sp.eye(2, format="csr", dtype=np.float32),
-            sp.eye(2, format="csr", dtype=np.float64),
+            _sparse_eye_array(2, format="csr", dtype=np.float32),
+            _sparse_eye_array(2, format="csr", dtype=np.float64),
             None,
             "Dtype of A and B",
         ),


### PR DESCRIPTION
Fix https://github.com/scikit-learn/scikit-learn/issues/34621.

Here are the issues that remained after #34614:
- `recwarn` doesn't seem to take into account our warnings filters set through `SKLEARN_WARNINGS_AS_ERRORS`, which AFAICT this is not really documented and slightly surprising (`pytest.warns` on the other hand does use our warnings filters). I used `warnings.catch_warnings` + `warnings.simplefilter` on top with some explicit warning class to test that no warnings of a particular class was emitted.
- some lingering uses of `scipy.sparse.random`, `scipy.sparse.eye` were replaced by the `sklearn.utils.fixes` equivalent.