### PR TITLE
TST add missing coverage for the D^2 single-sample guards

### DIFF
--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -3694,14 +3694,17 @@ def test_d2_brier_score_raises(y_true, y_pred, labels, error_msg):
         d2_brier_score(y_true, y_pred, labels=labels)
 
 
-def test_d2_brier_score_warning_on_less_than_two_samples():
-    """Test that d2_brier_score emits a warning when there are less than
+@pytest.mark.parametrize(
+    "metric, y_proba",
+    [(d2_brier_score, np.array([0.8])), (d2_log_loss_score, np.array([[0.2, 0.8]]))],
+)
+def test_d2_score_warning_on_less_than_two_samples(metric, y_proba):
+    """Test that the D^2 scores emit a warning when there are less than
     two samples"""
     y_true = np.array([1])
-    y_pred = np.array([0.8])
     warning_message = "not well-defined with less than two samples"
     with pytest.warns(UndefinedMetricWarning, match=warning_message):
-        d2_brier_score(y_true, y_pred)
+        assert np.isnan(metric(y_true, y_proba))
 
 
 @pytest.mark.parametrize(

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -492,7 +492,9 @@ def test_regression_custom_weights():
     assert_almost_equal(msle, msle2, decimal=2)
 
 
-@pytest.mark.parametrize("metric", [r2_score, d2_tweedie_score, d2_pinball_score])
+@pytest.mark.parametrize(
+    "metric", [r2_score, d2_tweedie_score, d2_pinball_score, d2_absolute_error_score]
+)
 def test_regression_single_sample(metric):
     y_true = [0]
     y_pred = [1]


### PR DESCRIPTION
#### Reference Issues/PRs

Related to #11435. While auditing the unchecked entries on that checklist I found that two of the four `D^2` metrics have the `n_samples < 2` guard but nothing pinning it.

#### What does this implement/fix? Explain your changes.

`d2_pinball_score`, `d2_log_loss_score` and `d2_brier_score` all warn with `UndefinedMetricWarning` and return `nan` below two samples, and `d2_absolute_error_score` inherits that by delegating to `d2_pinball_score`. Only `d2_brier_score` had a test covering it.

`d2_log_loss_score` is the notable gap: it is subtracted out of the generic single-sample check in `test_common.py` via `CONTINUOUS_CLASSIFICATION_METRICS` (`test_common.py:310`, applied at `:1271`), so its guard was entirely untested.

Two changes, both test-only:

- add `d2_absolute_error_score` to the `test_regression_single_sample` parametrize;
- parametrize `test_d2_brier_score_warning_on_less_than_two_samples` to cover `d2_log_loss_score` as well, and assert the returned value is `nan` rather than only checking that a warning fires.

**No behaviour change** — no source file is touched.

#### Any other comments?

Both new cases fail if the corresponding guard is removed, so they cover real code paths rather than restating passing behaviour:

```
FAILED test_regression_single_sample[d2_absolute_error_score]                  - Failed: DID NOT WARN.
FAILED test_d2_score_warning_on_less_than_two_samples[d2_log_loss_score-...]   - Failed: DID NOT WARN.
```

`sklearn/metrics/tests/test_regression.py` + `test_classification.py`: `284 passed, 15 skipped`. `test_common.py`: `1797 passed, 3412 skipped`.

Renaming `test_d2_brier_score_warning_on_less_than_two_samples` to `test_d2_score_warning_on_less_than_two_samples` keeps one parametrized test instead of two near-identical ones, matching how `test_regression_single_sample` is structured. Happy to add a sibling test instead if you would rather not rename.

No changelog entry, since this is test-only — let me know if you would like one anyway.
