### PR TITLE
Request for comment: Reduce parallel overhead for threads

### DIFF
--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -7,9 +7,12 @@ usage.
 
 import functools
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from functools import update_wrapper
+from inspect import Signature
 
 import joblib
+import joblib.parallel
 from threadpoolctl import ThreadpoolController
 
 from sklearn._config import config_context, get_config
@@ -38,7 +41,27 @@ def _with_config_and_warning_filters(delayed_func, config, warning_filters):
         return delayed_func
 
 
-class Parallel(joblib.Parallel):
+class _FastThreadedParallel:
+    """Similar interface to :class:`joblib.Parallel`, but with lower overhead."""
+
+    def __init__(self, n_jobs):
+        # TODO support return_as="generator"
+        self._n_threads = joblib.parallel.effective_n_jobs(n_jobs)
+
+    def __call__(self, iterable):
+        # TODO warnings config
+        config = get_config()
+        with ThreadPoolExecutor(self._n_threads) as pool:
+
+            def run(params):
+                f, args, kwargs = params
+                with config_context(**config):
+                    return f(*args, *kwargs)
+
+            return list(pool.map(run, iterable))
+
+
+class _JoblibParallel(joblib.Parallel):
     """Tweak of :class:`joblib.Parallel` that propagates the scikit-learn configuration.
 
     This subclass of :class:`joblib.Parallel` ensures that the active configuration
@@ -89,6 +112,47 @@ class Parallel(joblib.Parallel):
             for delayed_func, args, kwargs in iterable
         )
         return super().__call__(iterable_with_config_and_warning_filters)
+
+
+def Parallel(*args, **kwargs) -> _FastThreadedParallel | _JoblibParallel:
+    """Like :class:`joblib.Parallel` but propagates the scikit-learn configuration.
+
+    May also use a faster implementation when using a threaded backend.
+
+    .. versionadded:: 1.3
+    """
+    signature = Signature.from_callable(joblib.Parallel.__init__).bind(
+        None, *args, **kwargs
+    )
+    signature.apply_defaults()
+    arguments = {
+        key: value.default_value if hasattr(value, "default_value") else value
+        for (key, value) in signature.arguments.items()
+    }
+
+    # TODO expose current config in joblib as semi-public API, so we don't rely
+    # on implementation details.
+    default_parallel_config = {
+        key: value.default_value if hasattr(value, "default_value") else value
+        for (key, value) in joblib.parallel.default_parallel_config.items()
+    }
+    config = getattr(joblib.parallel._backend, "config", default_parallel_config)
+
+    backend = arguments["backend"] or config["backend"]
+    is_threaded = (
+        backend == "threading"
+        or arguments["prefer"] == "threads"
+        or arguments["require"] == "shared_mem"
+    )
+    if (
+        is_threaded
+        # TODO can support generator too
+        and arguments["return_as"] == "list"
+        and arguments["timeout"] is None
+    ):
+        return _FastThreadedParallel(arguments["n_jobs"])
+    else:
+        return _JoblibParallel(*args, **kwargs)
 
 
 # remove when https://github.com/joblib/joblib/issues/1071 is fixed

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -13,7 +13,7 @@ from inspect import Signature
 from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Iterable
+    from typing import Any, Callable, Iterable, Literal
 
 import joblib
 import joblib.parallel
@@ -51,10 +51,10 @@ def _with_config_and_warning_filters(delayed_func, config, warning_filters):
 class _FastThreadedParallel:
     """Similar interface to :class:`joblib.Parallel`, but with lower overhead."""
 
-    def __init__(self, n_jobs, return_as="list"):
-        # TODO shouldn't be used if _n_threads == 1
+    def __init__(self, n_jobs, return_as: Literal["list", "generator"]):
+        assert n_jobs > 1
         self._return_as = return_as
-        self._n_threads = joblib.parallel.effective_n_jobs(n_jobs)
+        self._n_jobs = n_jobs
 
     def _map(self, func: Callable[[T], Any], iterable: Iterable[T]) -> Iterable[R]:
         """Similar to built-in ``map()``, but parallel.
@@ -68,7 +68,7 @@ class _FastThreadedParallel:
             with config_context(**config):
                 return func(arg)
 
-        with ThreadPoolExecutor(self._n_threads) as pool:
+        with ThreadPoolExecutor(self._n_jobs) as pool:
             yield from pool.map(run, iterable)
 
     def __call__(self, iterable, _unwrap=False):
@@ -85,7 +85,7 @@ class _FastThreadedParallel:
         # For warnings, on free-threaded Python this already copies contextvars
         # on thread startup which is how that is controlled, so it works
         # automatically.
-        pool = ThreadPoolExecutor(self._n_threads)
+        pool = ThreadPoolExecutor(self._n_jobs)
         result = pool.map(run, iterable)
         if self._return_as == "list":
             with pool:
@@ -190,6 +190,12 @@ def Parallel(*args, **kwargs) -> _FastThreadedParallel | _JoblibParallel:
     config = getattr(joblib.parallel._backend, "config", default_parallel_config)
 
     backend = arguments["backend"] or config["backend"]
+
+    n_jobs = arguments["n_jobs"]
+    if n_jobs is None:
+        n_jobs = config["n_jobs"]
+    n_jobs = joblib.parallel.effective_n_jobs(arguments["n_jobs"])
+
     is_threaded = (
         backend == "threading"
         or arguments["prefer"] == "threads"
@@ -197,8 +203,12 @@ def Parallel(*args, **kwargs) -> _FastThreadedParallel | _JoblibParallel:
     )
     if (
         is_threaded
+        # Make sure only supported arguments are being passed in:
         and arguments["return_as"] in ("list", "generator")
         and arguments["timeout"] is None
+        # No point in threading if there is only one thread, joblib will handle
+        # this by using sequential backend.
+        and n_jobs > 1
     ):
         return _FastThreadedParallel(arguments["n_jobs"], arguments["return_as"])
     else:

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -223,7 +223,7 @@ def Parallel(*args, **kwargs) -> _FastThreadedParallel | _JoblibParallel:
         # this by using sequential backend.
         and n_jobs > 1
     ):
-        return _FastThreadedParallel(arguments["n_jobs"], arguments["return_as"])
+        return _FastThreadedParallel(n_jobs, arguments["return_as"])
     else:
         return _JoblibParallel(*args, **kwargs)
 

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -69,7 +69,7 @@ class _FastThreadedParallel:
                     # thread when it is created. However, we might later want
                     # to reuse ThreadPoolExecutor, so better to just do the
                     # right thing.
-                    return ctx.run(f, *args, *kwargs)
+                    return ctx.run(f, *args, **kwargs)
 
             return list(pool.map(run, iterable))
 

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -22,7 +22,7 @@ from threadpoolctl import ThreadpoolController
 from sklearn._config import config_context, get_config
 
 T = TypeVar("T")
-
+R = TypeVar("R")
 
 # Global threadpool controller instance that can be used to locally limit the number of
 # threads without looping through all shared libraries every time.
@@ -56,11 +56,12 @@ class _FastThreadedParallel:
         self._return_as = return_as
         self._n_threads = joblib.parallel.effective_n_jobs(n_jobs)
 
-    def map(self, func: Callable[[T], Any], iterable: Iterable[T]):
+    def _map(self, func: Callable[[T], Any], iterable: Iterable[T]) -> Iterable[R]:
         """Similar to built-in ``map()``, but parallel.
 
         There is no need to wrap in a ``delayed()``.
         """
+        assert self._return_as == "generator"
         config = get_config()
 
         def run(arg):
@@ -99,7 +100,7 @@ class _FastThreadedParallel:
 
             return _gen()
         else:
-            assert False, "shouldn't be reached"
+            assert False, "shouldn't be reached"  # pragma: nocover
 
 
 class _JoblibParallel(joblib.Parallel):
@@ -115,11 +116,12 @@ class _JoblibParallel(joblib.Parallel):
     .. versionadded:: 1.3
     """
 
-    def map(self, func: Callable[[T], Any], iterable: Iterable[T]):
+    def _map(self, func: Callable[[T], R], iterable: Iterable[T]) -> Iterable[R]:
         """Similar to built-in ``map()``, but parallel.
 
         There is no need to wrap in a ``delayed()``.
         """
+        assert self.return_as == "generator"
         delayed_func = delayed(func)
         return self(delayed_func(args) for args in iterable)
 
@@ -166,7 +168,7 @@ class _JoblibParallel(joblib.Parallel):
 def Parallel(*args, **kwargs) -> _FastThreadedParallel | _JoblibParallel:
     """Like :class:`joblib.Parallel` but propagates the scikit-learn configuration.
 
-    May also use a faster implementation when using a threaded backend.
+    May use a faster implementation when a threaded backend is requested.
 
     .. versionadded:: 1.3
     """
@@ -191,16 +193,32 @@ def Parallel(*args, **kwargs) -> _FastThreadedParallel | _JoblibParallel:
     is_threaded = (
         backend == "threading"
         or arguments["prefer"] == "threads"
-        or arguments["require"] == "shared_mem"
+        or arguments["require"] == "sharedmem"
     )
     if (
         is_threaded
         and arguments["return_as"] in ("list", "generator")
         and arguments["timeout"] is None
     ):
-        return _FastThreadedParallel(arguments["n_jobs"])
+        return _FastThreadedParallel(arguments["n_jobs"], arguments["return_as"])
     else:
         return _JoblibParallel(*args, **kwargs)
+
+
+def parallel_map(
+    func: Callable[[T], R],
+    iterable: Iterable[T],
+    n_jobs=None,
+    backend=None,
+    requires=None,
+) -> Iterable[R]:
+    """Similar to built-in ``map()``, but parallel.
+
+    There is no need to wrap in a ``delayed()``.
+    """
+    return Parallel(
+        n_jobs=n_jobs, backend=backend, requires=requires, return_as="generator"
+    )._map(func, iterable)
 
 
 # remove when https://github.com/joblib/joblib/issues/1071 is fixed

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -10,12 +10,19 @@ import warnings
 from concurrent.futures import ThreadPoolExecutor
 from functools import update_wrapper
 from inspect import Signature
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from typing import Any, Callable, Iterable
 
 import joblib
 import joblib.parallel
 from threadpoolctl import ThreadpoolController
 
 from sklearn._config import config_context, get_config
+
+T = TypeVar("T")
+
 
 # Global threadpool controller instance that can be used to locally limit the number of
 # threads without looping through all shared libraries every time.
@@ -44,27 +51,55 @@ def _with_config_and_warning_filters(delayed_func, config, warning_filters):
 class _FastThreadedParallel:
     """Similar interface to :class:`joblib.Parallel`, but with lower overhead."""
 
-    def __init__(self, n_jobs):
-        # TODO support return_as="generator"
+    def __init__(self, n_jobs, return_as="list"):
         # TODO shouldn't be used if _n_threads == 1
+        self._return_as = return_as
         self._n_threads = joblib.parallel.effective_n_jobs(n_jobs)
 
-    def __call__(self, iterable):
+    def map(self, func: Callable[[T], Any], iterable: Iterable[T]):
+        """Similar to built-in ``map()``, but parallel.
+
+        There is no need to wrap in a ``delayed()``.
+        """
         config = get_config()
+
+        def run(arg):
+            with config_context(**config):
+                return func(arg)
+
+        with ThreadPoolExecutor(self._n_threads) as pool:
+            yield from pool.map(run, iterable)
+
+    def __call__(self, iterable, _unwrap=False):
+        config = get_config()
+
+        def run(params):
+            f, args, kwargs = params
+            with config_context(**config):
+                # Undo unnecessary wrapping done by delayed():
+                f = f.function
+
+                return f(*args, **kwargs)
+
         # For warnings, on free-threaded Python this already copies contextvars
         # on thread startup which is how that is controlled, so it works
         # automatically.
-        with ThreadPoolExecutor(self._n_threads) as pool:
+        pool = ThreadPoolExecutor(self._n_threads)
+        result = pool.map(run, iterable)
+        if self._return_as == "list":
+            with pool:
+                return list(result)
+        elif self._return_as == "generator":
 
-            def run(params):
-                f, args, kwargs = params
-                with config_context(**config):
-                    # Undo unnecessary wrapping done by delayed():
-                    f = f.function
+            def _gen():
+                try:
+                    yield from result
+                finally:
+                    pool.shutdown()
 
-                    return f(*args, **kwargs)
-
-            return list(pool.map(run, iterable))
+            return _gen()
+        else:
+            assert False, "shouldn't be reached"
 
 
 class _JoblibParallel(joblib.Parallel):
@@ -79,6 +114,14 @@ class _JoblibParallel(joblib.Parallel):
 
     .. versionadded:: 1.3
     """
+
+    def map(self, func: Callable[[T], Any], iterable: Iterable[T]):
+        """Similar to built-in ``map()``, but parallel.
+
+        There is no need to wrap in a ``delayed()``.
+        """
+        delayed_func = delayed(func)
+        return self(delayed_func(args) for args in iterable)
 
     def __call__(self, iterable):
         """Dispatch the tasks and return the results.
@@ -152,8 +195,7 @@ def Parallel(*args, **kwargs) -> _FastThreadedParallel | _JoblibParallel:
     )
     if (
         is_threaded
-        # TODO can support generator too
-        and arguments["return_as"] == "list"
+        and arguments["return_as"] in ("list", "generator")
         and arguments["timeout"] is None
     ):
         return _FastThreadedParallel(arguments["n_jobs"])

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -5,7 +5,6 @@ usage.
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
-import contextvars
 import functools
 import warnings
 from concurrent.futures import ThreadPoolExecutor
@@ -52,10 +51,9 @@ class _FastThreadedParallel:
 
     def __call__(self, iterable):
         config = get_config()
-        # Used for warnings configuration for versions of Python (notably
-        # free-threaded Python) that rely on contextvars for that information:
-        ctx = contextvars.copy_context()
-
+        # For warnings, on free-threaded Python this already copies contextvars
+        # on thread startup which is how that is controlled, so it works
+        # automatically.
         with ThreadPoolExecutor(self._n_threads) as pool:
 
             def run(params):
@@ -63,13 +61,8 @@ class _FastThreadedParallel:
                 with config_context(**config):
                     # Undo unnecessary wrapping done by delayed():
                     f = f.function
-                    # Technically you don't need the ctx.run() in some cases:
-                    # ThreadPoolExecutor has unexpected behavior on
-                    # free-threaded Python where the context gets copied to the
-                    # thread when it is created. However, we might later want
-                    # to reuse ThreadPoolExecutor, so better to just do the
-                    # right thing.
-                    return ctx.run(f, *args, **kwargs)
+
+                    return f(*args, **kwargs)
 
             return list(pool.map(run, iterable))
 

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -48,9 +48,7 @@ def _with_config_and_warning_filters(delayed_func, config, warning_filters):
 class _FastThreadedParallel:
     """Similar interface to :class:`joblib.Parallel`, but with lower overhead."""
 
-    def __init__(self, n_jobs, return_as: Literal["list", "generator"]):
-        if n_jobs is None:
-            n_jobs = joblib.parallel.effective_n_jobs(-1)
+    def __init__(self, n_jobs: int, return_as: Literal["list", "generator"]):
         self._return_as = return_as
         self._n_jobs = n_jobs
 

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -10,10 +10,7 @@ import warnings
 from concurrent.futures import ThreadPoolExecutor
 from functools import update_wrapper
 from inspect import Signature
-from typing import TYPE_CHECKING, TypeVar
-
-if TYPE_CHECKING:
-    from typing import Any, Callable, Iterable, Literal
+from typing import Any, Callable, Iterable, Literal, TypeVar
 
 import joblib
 import joblib.parallel
@@ -52,7 +49,8 @@ class _FastThreadedParallel:
     """Similar interface to :class:`joblib.Parallel`, but with lower overhead."""
 
     def __init__(self, n_jobs, return_as: Literal["list", "generator"]):
-        assert n_jobs > 1
+        if n_jobs is None:
+            n_jobs = joblib.parallel.effective_n_jobs(-1)
         self._return_as = return_as
         self._n_jobs = n_jobs
 
@@ -171,6 +169,24 @@ def Parallel(*args, **kwargs) -> _FastThreadedParallel | _JoblibParallel:
     May use a faster implementation when a threaded backend is requested.
 
     .. versionadded:: 1.3
+
+    .. versionchanged:: 1.10
+       Now a function, can return a fast-path implementation for threaded use.
+
+    Parameters
+    ----------
+
+    *args : params
+        Constructor parameters for :class:`joblib.Parallel`.
+
+    **kwargs : params
+        Constructor parameters for :class:`joblib.Parallel`.
+
+    Returns
+    -------
+    object similar to :class:`joblib.Parallel`
+        Might be actual :class:`joblib.Parallel`, or a faster implementation
+        for threaded usage.
     """
     signature = Signature.from_callable(joblib.Parallel.__init__).bind(
         None, *args, **kwargs
@@ -196,10 +212,9 @@ def Parallel(*args, **kwargs) -> _FastThreadedParallel | _JoblibParallel:
         n_jobs = config["n_jobs"]
     n_jobs = joblib.parallel.effective_n_jobs(arguments["n_jobs"])
 
-    is_threaded = (
-        backend == "threading"
-        or arguments["prefer"] == "threads"
-        or arguments["require"] == "sharedmem"
+    is_threaded = backend == "threading" or (
+        backend is None
+        and (arguments["prefer"] == "threads" or arguments["require"] == "sharedmem")
     )
     if (
         is_threaded
@@ -220,14 +235,39 @@ def parallel_map(
     iterable: Iterable[T],
     n_jobs=None,
     backend=None,
-    requires=None,
+    prefer=None,
+    require=None,
 ) -> Iterable[R]:
     """Similar to built-in ``map()``, but parallel.
 
     There is no need to wrap in a ``delayed()``.
+
+    .. versionadded:: 1.10
+
+    Parameters
+    ----------
+    func : callable function
+        Called with each value in the iterable.
+    iterable : an iterable of values
+        Each value will be passed to func.
+    n_jobs : int, default=None
+        The maximum number of concurrently running jobs.
+        See :class:`joblib.Parallel` for details.
+    backend : str, ParallelBackendBase instance or None, default='loky'
+        Specify the parallelization backend implementation.
+        See :class:`joblib.Parallel` for details.
+    prefer : str in {'processes', 'threads'} or None, default=None
+        See :class:`joblib.Parallel` for details.
+    require : 'sharedmem' or None, default=None
+        See :class:`joblib.Parallel` for details.
+
+    Returns
+    -------
+    results : Iterable
+        Results of calling ``func(value)`` for value in the input iterable.
     """
     return Parallel(
-        n_jobs=n_jobs, backend=backend, requires=requires, return_as="generator"
+        n_jobs=n_jobs, backend=backend, require=require, return_as="generator"
     )._map(func, iterable)
 
 

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -5,6 +5,7 @@ usage.
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import contextvars
 import functools
 import warnings
 from concurrent.futures import ThreadPoolExecutor
@@ -46,17 +47,29 @@ class _FastThreadedParallel:
 
     def __init__(self, n_jobs):
         # TODO support return_as="generator"
+        # TODO shouldn't be used if _n_threads == 1
         self._n_threads = joblib.parallel.effective_n_jobs(n_jobs)
 
     def __call__(self, iterable):
-        # TODO warnings config
         config = get_config()
+        # Used for warnings configuration for versions of Python (notably
+        # free-threaded Python) that rely on contextvars for that information:
+        ctx = contextvars.copy_context()
+
         with ThreadPoolExecutor(self._n_threads) as pool:
 
             def run(params):
                 f, args, kwargs = params
                 with config_context(**config):
-                    return f(*args, *kwargs)
+                    # Undo unnecessary wrapping done by delayed():
+                    f = f.function
+                    # Technically you don't need the ctx.run() in some cases:
+                    # ThreadPoolExecutor has unexpected behavior on
+                    # free-threaded Python where the context gets copied to the
+                    # thread when it is created. However, we might later want
+                    # to reuse ThreadPoolExecutor, so better to just do the
+                    # right thing.
+                    return ctx.run(f, *args, *kwargs)
 
             return list(pool.map(run, iterable))
 

--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -271,3 +271,6 @@ def test_map(backend: str) -> None:
     result = parallel_map(square, [1, 2, 3], 2, backend=backend)
     assert not isinstance(result, list)
     assert list(result) == [1, 4, 9]
+
+
+# TODO test n_jobs for threads - set by config, passing -1, etc

--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -206,9 +206,16 @@ def square(x: int) -> int:
     return x * x
 
 
+_THREADING_PARAMS = [
+    {"backend": "threading"},
+    {"require": "sharedmem"},
+    {"prefer": "threads"},
+]
+
+
 @pytest.mark.parametrize(
     "backend_params",
-    [{"backend": "threading"}, {"require": "sharedmem"}, {"prefer": "threads"}],
+    _THREADING_PARAMS,
 )
 @pytest.mark.parametrize(
     "return_as_params", [{}, {"return_as": "list"}, {"return_as": "generator"}]
@@ -227,6 +234,20 @@ def test_thread_fast_path(
         assert isinstance(result, list)
         list_result = result
     assert list_result == [9, 25]
+
+
+@pytest.mark.parametrize(
+    "backend_params",
+    _THREADING_PARAMS,
+)
+def test_thread_no_fast_path_single_threaded(backend_params: dict[str, str]):
+    """
+    When ``n_jobs == 1``, normal ``joblib.Parallel`` is used since that gives
+    us fast sequential execution.
+    """
+    par = Parallel(1, **backend_params)
+    assert not isinstance(par, _FastThreadedParallel)
+    assert par(delayed(square)(x) for x in [1, 3]) == [1, 9]
 
 
 @pytest.mark.parametrize("backend", ["loky", "threading"])

--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -250,6 +250,22 @@ def test_thread_no_fast_path_single_threaded(backend_params: dict[str, str]):
     assert par(delayed(square)(x) for x in [1, 3]) == [1, 9]
 
 
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"backend": "somebackend", "require": "sharedmem"},
+        {"backend": "somebackend", "prefer": "threads"},
+    ],
+)
+def test_thread_no_fast_path_explicit_backend(params: dict[str, str]):
+    """
+    When an explicit non-threading backend is given, the fast path is not used.
+    """
+    # If fast path was used, it wouldn't raise a ValueError...
+    with pytest.raises(ValueError, match="Invalid backend"):
+        Parallel(2, **params)
+
+
 @pytest.mark.parametrize("backend", ["loky", "threading"])
 def test_map(backend: str) -> None:
     result = parallel_map(square, [1, 2, 3], 2, backend=backend)

--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -17,7 +17,12 @@ from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils.fixes import _IS_WASM
-from sklearn.utils.parallel import Parallel, delayed
+from sklearn.utils.parallel import (
+    Parallel,
+    _FastThreadedParallel,
+    delayed,
+    parallel_map,
+)
 
 
 def get_working_memory():
@@ -195,3 +200,37 @@ def test_filter_warning_propagates_no_side_effect_with_loky_backend():
             joblib.delayed(warnings.warn)("Convergence warning", ConvergenceWarning)
             for _ in range(10)
         )
+
+
+def square(x: int) -> int:
+    return x * x
+
+
+@pytest.mark.parametrize(
+    "backend_params",
+    [{"backend": "threading"}, {"require": "sharedmem"}, {"prefer": "threads"}],
+)
+@pytest.mark.parametrize(
+    "return_as_params", [{}, {"return_as": "list"}, {"return_as": "generator"}]
+)
+def test_thread_fast_path(
+    backend_params: dict[str, str], return_as_params: dict[str, str]
+) -> None:
+    """When backend is threaded, and ``n_jobs > 1``, use fast path."""
+    par = Parallel(2, **backend_params, **return_as_params)
+    assert isinstance(par, _FastThreadedParallel)
+    result = par(delayed(square)(x) for x in [3, 5])
+    if return_as_params.get("return_as") == "generator":
+        assert not isinstance(result, list)
+        list_result = list(result)
+    else:
+        assert isinstance(result, list)
+        list_result = result
+    assert list_result == [9, 25]
+
+
+@pytest.mark.parametrize("backend", ["loky", "threading"])
+def test_map(backend: str) -> None:
+    result = parallel_map(square, [1, 2, 3], 2, backend=backend)
+    assert not isinstance(result, list)
+    assert list(result) == [1, 4, 9]


### PR DESCRIPTION
This PR is work-in-progress, most importantly would require adding a public API to joblib. I implemented some of it because I wanted to provide a reasonably shaped API, and because performance benchmarks are important to prove it's worth doing.

The summary: `joblib.Parallel` has high overhead, making threaded parallelism less usable in many cases. This sets out to fix that. Possibly this should be done here, possibly in `joblib`.

### Motivation

With the advent of free-threading, there are code paths where parallelism probably wasn't worth it before, but where it is worth it now. I started by looking at CountVectorizer: tokenizing documents seemed like it could be parallelized without any major code changes.

There is a problem, however: joblib was designed for a world with a few heavy computational tasks.
It therefore has lots of overhead per task. But this code path involved many, pretty fast tasks.

The result was that the overhead from `joblib.Parallel` was enough to cancel out the gains from parallelism. However, with `ThreadPoolExecutor` there is a gain from parallelism, since its overhead is significantly lower.

### What I tried first

My initial thought was to speed up `joblib.Parallel`. However:

* It's _very_ complicated internally, probably unnecessarily so in some places, but backwards compatibility is critical.
* scikit-learn doesn't actually use most of these features.
* scikit-learn's `Parallel/delayed` wrappers add extra performance overhead!

I am open to ideas on how to integrate this back into `joblib`; possibly the core code, now that it's working, should be moved to `joblib`, and then a follow-up PR can deal with reducing overhead here. Or maybe `joblib`'s backwards compatibility concerns are too pressing.

### The proposal in this PR

I implemented two things:

* A compatible API for parallelism, to be used only for threading backends.
  I didn't bother implementing APIs that scikit-learn doesn't use.
  This will make any existing threading-based `Parallel()` calls in scikit-learn have less overhead.
* An alternative API that reduces the overhead even more (`map()`).

Next step if merged: start using this, conditional on use of free-threading, in e.g. text parsing code like `CountVectorizer`.
(In normal GIL Python it's actually slower to use threads since you get overhead but no paralellism.)
The benchmark has a demonstration of what this would look like.

### Benchmark code

For my benchmark, I implemented the parallelism I originally intended to add to `CountVectorizer`, and would add as later PR if this is merged:

```python
from concurrent.futures import ThreadPoolExecutor
from time import time

from joblib import cpu_count
from sklearn.datasets import fetch_20newsgroups
from sklearn.utils import parallel

categories = [
    "alt.atheism",
    "comp.graphics",
    "comp.sys.ibm.pc.hardware",
    "misc.forsale",
    "rec.autos",
    "sci.space",
    "talk.religion.misc",
]

raw_data, _ = fetch_20newsgroups(subset="train", categories=categories, return_X_y=True)


# A motivating example: we want to parallelize the part of CountVectorizer that
# tokenizes text:
from sklearn.feature_extraction.text import CountVectorizer

analyze = CountVectorizer().build_analyzer()


def sequential():
    return [analyze(doc) for doc in raw_data]


def parallel_default():
    return parallel._JoblibParallel(cpu_count(), backend="threading")(
        parallel.delayed(analyze)(doc) for doc in raw_data
    )


def parallel_fast_path():
    return parallel._FastThreadedParallel(cpu_count(), return_as="list")(
        parallel.delayed(analyze)(doc) for doc in raw_data
    )


def parallel_fast_path_map():
    return list(
        parallel.parallel_map(analyze, raw_data, n_jobs=-1, backend="threading")
    )


def threadpoolexecutor():
    with ThreadPoolExecutor(cpu_count()) as pool:
        return list(pool.map(analyze, raw_data))


def timeit(f):
    start = time()
    for _ in range(10):
        f()
    print(f"{f.__name__:>30}", (time() - start) / 10)


def go():
    expected = sequential()
    for f in (
        sequential,
        parallel_default,
        parallel_fast_path,
        parallel_fast_path_map,
        threadpoolexecutor,
    ):
        assert expected == f()
        timeit(f)


if __name__ == "__main__":
    go()
```

### Benchmark results

Notice that the status quo usage of `Parallel` (`parallel_default`) is actually _slower_ than running sequentially. So right now using parallelism is a waste of time. With the fastest API, `parallel_fast_path_map`, parallelism gives a 2× speed-up. 

2× is still pretty sad given I have 12 cores, but at this point we're bottlenecked on `ThreadPoolExecutor` (and perhaps cost of starting threads). Both of these are solvable with follow-up work; a faster replacement for `ThreadPoolExecutor` is likely useful for the broader ecosystem.

```
                    sequential 0.15275838375091552
              parallel_default 0.19093468189239501
            parallel_fast_path 0.09387767314910889
        parallel_fast_path_map 0.07617080211639404
            threadpoolexecutor 0.07242515087127685
```
