### PR TITLE
FIX warn instead of raising on lbfgs line search failure in HuberRegressor

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/27777.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/27777.fix.rst
@@ -1,0 +1,6 @@
+- :class:`linear_model.HuberRegressor` now raises a
+  :class:`exceptions.ConvergenceWarning` instead of a `ValueError` when the
+  L-BFGS-B solver reports a line search failure, which is consistent with the
+  other estimators relying on this solver. The coefficients of the last
+  iteration are returned instead of discarding the fitted model.
+  By :user:`Tirth Shendage <tirthfx>`.

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/27777.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/27777.fix.rst
@@ -1,6 +1,0 @@
-- :class:`linear_model.HuberRegressor` now raises a
-  :class:`exceptions.ConvergenceWarning` instead of a `ValueError` when the
-  L-BFGS-B solver reports a line search failure, which is consistent with the
-  other estimators relying on this solver. The coefficients of the last
-  iteration are returned instead of discarding the fitted model.
-  By :user:`Tirth Shendage <tirthfx>`.

--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/34644.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/34644.fix.rst
@@ -1,0 +1,6 @@
+- :class:`linear_model.HuberRegressor` now warns with a
+  :class:`exceptions.ConvergenceWarning` instead of raising a `ValueError` when
+  the L-BFGS-B solver reports a line search failure, which is consistent with the
+  other estimators relying on this solver. The coefficients of the last
+  iteration are returned instead of discarding the fitted model.
+  By :user:`Tirth Shendage <tirthfx>`.

--- a/sklearn/linear_model/_huber.py
+++ b/sklearn/linear_model/_huber.py
@@ -340,11 +340,6 @@ class HuberRegressor(LinearModel, RegressorMixin, BaseEstimator):
 
         parameters = opt_res.x
 
-        if opt_res.status == 2:
-            raise ValueError(
-                "HuberRegressor convergence failed: l-BFGS-b solver terminated with %s"
-                % opt_res.message
-            )
         self.n_iter_ = _check_optimize_result("lbfgs", opt_res, self.max_iter)
         self.scale_ = parameters[-1]
         if self.fit_intercept:

--- a/sklearn/linear_model/tests/test_huber.py
+++ b/sklearn/linear_model/tests/test_huber.py
@@ -6,6 +6,7 @@ import pytest
 from scipy import optimize
 
 from sklearn.datasets import make_regression
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import HuberRegressor, LinearRegression, Ridge, SGDRegressor
 from sklearn.linear_model._huber import _huber_loss_and_gradient
 from sklearn.utils._testing import (
@@ -214,3 +215,29 @@ def test_huber_bool():
     X, y = make_regression(n_samples=200, n_features=2, noise=4.0, random_state=0)
     X_bool = X > 0
     HuberRegressor().fit(X_bool, y)
+
+
+def test_huber_lbfgs_line_search_failure_warns(monkeypatch):
+    # Non-regression test for #27777: a line search failure reported by L-BFGS-B
+    # (status=2) should emit a ConvergenceWarning like for the other lbfgs based
+    # estimators instead of raising a ValueError, and still expose the parameters
+    # of the last iteration.
+    # The status is forced here because the datasets triggering it naturally are
+    # too sensitive to platform specific floating point differences.
+    X, y = make_regression_with_outliers()
+
+    minimize = optimize.minimize
+
+    def minimize_with_line_search_failure(*args, **kwargs):
+        opt_res = minimize(*args, **kwargs)
+        opt_res.status = 2
+        opt_res.message = "ABNORMAL_TERMINATION_IN_LNSRCH"
+        return opt_res
+
+    monkeypatch.setattr(optimize, "minimize", minimize_with_line_search_failure)
+
+    huber = HuberRegressor()
+    with pytest.warns(ConvergenceWarning, match="ABNORMAL_TERMINATION_IN_LNSRCH"):
+        huber.fit(X, y)
+
+    assert huber.coef_.shape == (X.shape[1],)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #27777. See also #27888 and #33641 (earlier attempts, both closed).

#### What does this implement/fix? Explain your changes.

`HuberRegressor.fit` raises a `ValueError` when L-BFGS-B reports a line search
failure (`status=2`) instead of emitting a `ConvergenceWarning` like the other
lbfgs based estimators. This makes it the only such estimator that discards a
fitted model rather than returning the parameters of the last iteration.

**Root cause.** The `if opt_res.status == 2: raise ValueError(...)` block predates
#14250, which introduced the shared `_check_optimize_result` helper that is called
on the very next line. That helper already emits a `ConvergenceWarning` for every
non-zero status, so the raise only shadowed it. Removing it restores consistency
with `LogisticRegression`, as suggested by @lorentzenchr and @glemaitre in the
issue discussion.

**Changes**
- `sklearn/linear_model/_huber.py`: remove the vestigial `ValueError`.
- `sklearn/linear_model/tests/test_huber.py`: non-regression test.
- `doc/whats_new/upcoming_changes/sklearn.linear_model/27777.fix.rst`: changelog entry.

**On the test.** The dataset in the issue no longer reproduces on all platforms —
on my machine (arm64, scipy 1.18) it converges cleanly. This is the same platform
sensitivity that led to #27888 being closed by its author. The test therefore forces
`status=2` via `monkeypatch` so that it is deterministic everywhere. It tests the
status-handling contract rather than a specific numerical failure; happy to revisit
if you would prefer a different approach.

**Prior attempts.** #27888 and #33641 both proposed the same fix. Neither was
rejected on the approach — #27888 was closed by its author over the
platform-dependent test, and #33641 was closed without review. This PR addresses
the test-determinism problem that blocked the first.

**Behavior change.** Code catching `ValueError` from `HuberRegressor.fit` will no
longer catch it. The exception was not documented in the class docstring, and the
new behavior matches the other lbfgs based estimators.

**Testing**
- `sklearn/linear_model/tests/test_huber.py`: 13 passed
- `sklearn/linear_model/`: 3339 passed, 0 failed
- `sklearn/tests/test_common.py -k HuberRegressor`: 59 passed
- `ruff check` / `ruff format --check` (v0.12.2): clean
- Verified the new test fails without the fix (`ValueError` at `_huber.py:344`).

#### First time contributor introduction

I use scikit-learn for performing predictive data analysis.

I found this issue while looking for a bug I could fix in the linear models
code. It looked like a good fit because the problem was small and two
maintainers had already agreed on what the fix should be.

#### AI usage disclosure

I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Documentation (including examples)
- Research and understanding

I have reviewed, run and understood all of the changes.

