### PR TITLE
DOC Improve jaccard score docstring

### DIFF
--- a/doc/computing/parallelism.rst
+++ b/doc/computing/parallelism.rst
@@ -25,7 +25,7 @@ is always controlled by environment variables or `threadpoolctl` as explained be
 Note that some estimators can leverage all three kinds of parallelism at different
 points of their training and prediction methods.
 
-We describe these 3 types of parallelism in the following subsections in more details.
+We describe these 3 types of parallelism in the following subsections in more detail.
 
 Higher-level parallelism with joblib
 ....................................

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1133,9 +1133,9 @@ def jaccard_score(
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights.
 
-    zero_division : "warn", {0.0, 1.0}, default="warn"
+    zero_division : {"warn", 0.0, 1.0, np.nan}, default="warn"
         Sets the value to return when there is a zero division, i.e. when there
-        there are no negative values in predictions and labels. If set to
+        are no negative values in predictions and labels. If set to
         "warn", this acts like 0, but a warning is also raised.
 
         .. versionadded:: 0.24


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
No Issues to reference, since these are typos/corrections

#### What does this implement/fix? Explain your changes.

---
In `doc/computing/parallelism.rst` on line 28, we have:
> We describe these 3 types of parallelism in the following subsections in more details.

The correct grammar is to use "in more detail." and that is the change:

```
# old
We describe these 3 types of parallelism in the following subsections in more details.

# new
We describe these 3 types of parallelism in the following subsections in more detail.
```
---
In the docstring for [`jaccard_score`](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.jaccard_score.html) (in `sklearn/metrics/_classification.py` line 1136), the `zero_division` parameters state: `"warn", {0.0, 1.0}`. The rest of the metrics have format of `{"warn", 0.0, 1.0, np.nan}` (example is [`f1_score`](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html)). 

This fix aligns the docstring with the standard for other metrics:
```
# old
zero_division : "warn", {0.0, 1.0}, np.nan, default="warn"

# new
zero_division : {"warn", 0.0, 1.0, np.nan}, default="warn"
```
---
In the docstring for [`jaccard_score`](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.jaccard_score.html) (in `sklearn/metrics/_classification.py` line 1138), there are two "there"s under `zero_division`.

> Sets the value to return when there is a zero division, i.e. when **there there** are no negative values in predictions and labels. If set to “warn”, this acts like 0, but a warning is also raised.

Removes one **there**.

#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Research and understanding


#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
