### PR TITLE
Always enable array API support when using `move_to`

### DIFF
--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -14,7 +14,7 @@ import numpy
 import scipy
 import scipy.sparse as sp
 
-from sklearn._config import get_config
+from sklearn import config_context, get_config
 from sklearn.externals import array_api_compat
 from sklearn.externals import array_api_extra as xpx
 from sklearn.externals.array_api_compat import numpy as np_compat
@@ -558,76 +558,82 @@ def move_to(*arrays, xp, device):
             "namespace is Numpy"
         )
 
-    arrays_ = arrays
-    # Down cast float64 `arrays` when highest precision of `xp`/`device` is float32
-    if _max_precision_float_dtype(xp, device) == xp.float32:
-        arrays_ = []
-        for array in arrays:
-            xp_array, _ = get_namespace(array)
-            if getattr(array, "dtype", None) == xp_array.float64:
-                arrays_.append(xp_array.astype(array, xp_array.float32))
-            else:
-                arrays_.append(array)
+    with config_context(array_api_dispatch=True):
+        arrays_ = arrays
+        # Down cast float64 `arrays` when highest precision of `xp`/`device` is float32
+        if _max_precision_float_dtype(xp, device) == xp.float32:
+            arrays_ = []
+            for array in arrays:
+                xp_array, _ = get_namespace(array)
+                if getattr(array, "dtype", None) == xp_array.float64:
+                    arrays_.append(xp_array.astype(array, xp_array.float32))
+                else:
+                    arrays_.append(array)
 
-    converted_arrays = []
-    for array, is_sparse, is_none in zip(arrays_, sparse_mask, none_mask):
-        if is_none:
-            converted_arrays.append(None)
-        elif is_sparse:
-            converted_arrays.append(array)
-        else:
-            xp_array, _, device_array = get_namespace_and_device(array)
-            if xp == xp_array and device == device_array:
+        converted_arrays = []
+        for array, is_sparse, is_none in zip(arrays_, sparse_mask, none_mask):
+            if is_none:
+                converted_arrays.append(None)
+            elif is_sparse:
                 converted_arrays.append(array)
             else:
-                if _is_xp_namespace(xp, "torch") and _is_numpy_namespace(xp_array):
-                    if any(stride < 0 for stride in array.strides):
-                        # Work around PyTorch aborting the process when importing
-                        # negative-strided NumPy arrays with DLPack. Remove this once
-                        # https://github.com/pytorch/pytorch/issues/188023 is fixed.
-                        # See also https://github.com/scikit-learn/scikit-learn/issues/34307
-                        array = numpy.ascontiguousarray(array)
-                try:
-                    # The dlpack protocol is the future proof and library agnostic
-                    # method to transfer arrays across namespace and device boundaries
-                    # hence this method is attempted first and going through NumPy is
-                    # only used as fallback in case of failure.
-                    # Note: copy=None is the default since array-api 2023.12. Namespace
-                    # libraries should only trigger a copy automatically if needed.
-                    array_converted = xp.from_dlpack(array, device=device)
-                    # `AttributeError` occurs when `__dlpack__` and `__dlpack_device__`
-                    # methods are not present on the input array
-                    # `TypeError` and `NotImplementedError` for packages that do not
-                    # yet support dlpack 1.0
-                    # (i.e. the `device`/`copy` kwargs, e.g., torch <= 2.8.0)
-                    # See https://github.com/data-apis/array-api/pull/741 for
-                    # more details about the introduction of the `copy` and `device`
-                    # kwargs in the from_dlpack method and their expected
-                    # meaning by namespaces implementing the array API spec.
-                    # TODO: try removing this once DLPack v1 more widely supported
-                    # TODO: ValueError not needed once min NumPy >=2.4.0:
-                    # https://github.com/numpy/numpy/issues/30341
-                except (
-                    AttributeError,
-                    TypeError,
-                    NotImplementedError,
-                    BufferError,
-                    ValueError,
-                ):
-                    # Converting to numpy is tricky, handle this via dedicated function
-                    if _is_numpy_namespace(xp):
-                        array_converted = _convert_to_numpy(array, xp_array)
-                    # Convert from numpy, all array libraries can do this
-                    elif _is_numpy_namespace(xp_array):
-                        array_converted = xp.asarray(array, device=device)
-                    else:
-                        # There is no generic way to convert from namespace A to B
-                        # So we first convert from A to numpy and then from numpy to B
-                        # The way to avoid this round trip is to lobby for DLpack
-                        # support in libraries A and B
-                        array_np = _convert_to_numpy(array, xp_array)
-                        array_converted = xp.asarray(array_np, device=device)
-                converted_arrays.append(array_converted)
+                xp_array, _, device_array = get_namespace_and_device(array)
+                if xp == xp_array and device == device_array:
+                    converted_arrays.append(array)
+                else:
+                    if _is_xp_namespace(xp, "torch") and _is_numpy_namespace(xp_array):
+                        if any(stride < 0 for stride in array.strides):
+                            # Work around PyTorch aborting the process when importing
+                            # negative-strided NumPy arrays with DLPack. Remove this
+                            # once https://github.com/pytorch/pytorch/issues/188023 is
+                            # fixed. See also
+                            # https://github.com/scikit-learn/scikit-learn/issues/34307
+                            array = numpy.ascontiguousarray(array)
+                    try:
+                        # The dlpack protocol is the future proof and library agnostic
+                        # method to transfer arrays across namespace and device
+                        # boundaries hence this method is attempted first and going
+                        # through NumPy is only used as fallback in case of failure.
+                        # Note: copy=None is the default since array-api 2023.12.
+                        # Namespace libraries should only trigger a copy automatically
+                        # if needed.
+                        array_converted = xp.from_dlpack(array, device=device)
+                        # `AttributeError` occurs when `__dlpack__` and
+                        # `__dlpack_device__` methods are not present on the input
+                        # array `TypeError` and `NotImplementedError` for packages
+                        # that do not yet support dlpack 1.0
+                        # (i.e. the `device`/`copy` kwargs, e.g., torch <= 2.8.0)
+                        # See https://github.com/data-apis/array-api/pull/741 for
+                        # more details about the introduction of the `copy` and
+                        # `device` kwargs in the from_dlpack method and their expected
+                        # meaning by namespaces implementing the array API spec.
+                        # TODO: try removing this once DLPack v1 more widely
+                        # TODO: supported ValueError not needed once min
+                        # TODO: NumPy >=2.4.0:
+                        # TODO: https://github.com/numpy/numpy/issues/30341
+                    except (
+                        AttributeError,
+                        TypeError,
+                        NotImplementedError,
+                        BufferError,
+                        ValueError,
+                    ):
+                        # Converting to numpy is tricky, handle this via dedicated
+                        # function
+                        if _is_numpy_namespace(xp):
+                            array_converted = _convert_to_numpy(array, xp_array)
+                        # Convert from numpy, all array libraries can do this
+                        elif _is_numpy_namespace(xp_array):
+                            array_converted = xp.asarray(array, device=device)
+                        else:
+                            # There is no generic way to convert from namespace A to B
+                            # So we first convert from A to numpy and then from
+                            # numpy to B.
+                            # The way to avoid this round trip is to lobby for DLpack
+                            # support in libraries A and B
+                            array_np = _convert_to_numpy(array, xp_array)
+                            array_converted = xp.asarray(array_np, device=device)
+                    converted_arrays.append(array_converted)
 
     return (
         converted_arrays[0] if len(converted_arrays) == 1 else tuple(converted_arrays)
@@ -1057,14 +1063,15 @@ def _convert_to_numpy(array, xp):
     This function is not meant to be called directly and
     `move_to(array, xp=np, device="cpu")` should be used instead.
     """
-    if _is_xp_namespace(xp, "torch"):
-        return array.cpu().numpy()
-    elif _is_xp_namespace(xp, "cupy"):  # pragma: nocover
-        return array.get()
-    elif _is_xp_namespace(xp, "array_api_strict"):
-        return numpy.asarray(xp.asarray(array, device=xp.Device("CPU_DEVICE")))
-    elif _is_xp_namespace(xp, "dpnp"):  # pragma: nocover
-        return array.asnumpy()
+    with config_context(array_api_dispatch=True):
+        if _is_xp_namespace(xp, "torch"):
+            return array.cpu().numpy()
+        elif _is_xp_namespace(xp, "cupy"):  # pragma: nocover
+            return array.get()
+        elif _is_xp_namespace(xp, "array_api_strict"):
+            return numpy.asarray(xp.asarray(array, device=xp.Device("CPU_DEVICE")))
+        elif _is_xp_namespace(xp, "dpnp"):  # pragma: nocover
+            return array.asnumpy()
 
     return numpy.asarray(array)
 

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -641,33 +641,30 @@ def move_to(*arrays, xp, device):
                 if _is_xp_namespace(xp, "torch") and _is_numpy_namespace(xp_array):
                     if any(stride < 0 for stride in array.strides):
                         # Work around PyTorch aborting the process when importing
-                        # negative-strided NumPy arrays with DLPack. Remove this
-                        # once https://github.com/pytorch/pytorch/issues/188023 is
-                        # fixed. See also
-                        # https://github.com/scikit-learn/scikit-learn/issues/34307
+                        # negative-strided NumPy arrays with DLPack. Remove this once
+                        # https://github.com/pytorch/pytorch/issues/188023 is fixed.
+                        # See also https://github.com/scikit-learn/scikit-learn/issues/34307
                         array = numpy.ascontiguousarray(array)
                 try:
                     # The dlpack protocol is the future proof and library agnostic
-                    # method to transfer arrays across namespace and device
-                    # boundaries hence this method is attempted first and going
-                    # through NumPy is only used as fallback in case of failure.
-                    # Note: copy=None is the default since array-api 2023.12.
-                    # Namespace libraries should only trigger a copy automatically
-                    # if needed.
+                    # method to transfer arrays across namespace and device boundaries
+                    # hence this method is attempted first and going through NumPy is
+                    # only used as fallback in case of failure.
+                    # Note: copy=None is the default since array-api 2023.12. Namespace
+                    # libraries should only trigger a copy automatically if needed.
                     array_converted = xp.from_dlpack(array, device=device)
-                    # `AttributeError` occurs when `__dlpack__` and
-                    # `__dlpack_device__` methods are not present on the input
-                    # array `TypeError` and `NotImplementedError` for packages
-                    # that do not yet support dlpack 1.0
+                    # `AttributeError` occurs when `__dlpack__` and `__dlpack_device__`
+                    # methods are not present on the input array
+                    # `TypeError` and `NotImplementedError` for packages that do not
+                    # yet support dlpack 1.0
                     # (i.e. the `device`/`copy` kwargs, e.g., torch <= 2.8.0)
                     # See https://github.com/data-apis/array-api/pull/741 for
-                    # more details about the introduction of the `copy` and
-                    # `device` kwargs in the from_dlpack method and their expected
+                    # more details about the introduction of the `copy` and `device`
+                    # kwargs in the from_dlpack method and their expected
                     # meaning by namespaces implementing the array API spec.
-                    # TODO: try removing this once DLPack v1 more widely
-                    # TODO: supported ValueError not needed once min
-                    # TODO: NumPy >=2.4.0:
-                    # TODO: https://github.com/numpy/numpy/issues/30341
+                    # TODO: try removing this once DLPack v1 more widely supported
+                    # TODO: ValueError not needed once min NumPy >=2.4.0:
+                    # https://github.com/numpy/numpy/issues/30341
                 except (
                     AttributeError,
                     TypeError,
@@ -675,8 +672,7 @@ def move_to(*arrays, xp, device):
                     BufferError,
                     ValueError,
                 ):
-                    # Converting to numpy is tricky, handle this via dedicated
-                    # function
+                    # Converting to numpy is tricky, handle this via dedicated function
                     if _is_numpy_namespace(xp):
                         array_converted = _convert_to_numpy(array, xp_array)
                     # Convert from numpy, all array libraries can do this
@@ -684,8 +680,7 @@ def move_to(*arrays, xp, device):
                         array_converted = xp.asarray(array, device=device)
                     else:
                         # There is no generic way to convert from namespace A to B
-                        # So we first convert from A to numpy and then from
-                        # numpy to B.
+                        # So we first convert from A to numpy and then from numpy to B
                         # The way to avoid this round trip is to lobby for DLpack
                         # support in libraries A and B
                         array_np = _convert_to_numpy(array, xp_array)

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -14,7 +14,7 @@ import numpy
 import scipy
 import scipy.sparse as sp
 
-from sklearn import config_context, get_config
+from sklearn._config import get_config
 from sklearn.externals import array_api_compat
 from sklearn.externals import array_api_extra as xpx
 from sklearn.externals.array_api_compat import numpy as np_compat
@@ -187,8 +187,10 @@ def _check_array_api_dispatch(array_api_dispatch):
         )
 
 
-def _single_array_device(array):
+def _single_array_device(array, array_api_dispatch=None):
     """Hardware device where the array data resides on."""
+    if array_api_dispatch is None:
+        array_api_dispatch = get_config()["array_api_dispatch"]
     if (
         not hasattr(array, "device")
         # When array API dispatch is disabled, we expect the scikit-learn code
@@ -196,14 +198,19 @@ def _single_array_device(array):
         # CPU. In this case, scikit-learn should stay as device neutral as possible,
         # hence the use of `device=None` which is accepted by all libraries, before
         # and after the expected conversion to NumPy via np.asarray.
-        or not get_config()["array_api_dispatch"]
+        or not array_api_dispatch
     ):
         return None
     else:
         return array.device
 
 
-def array_device(*array_list, remove_none=True, remove_types=REMOVE_TYPES_DEFAULT):
+def array_device(
+    *array_list,
+    remove_none=True,
+    remove_types=REMOVE_TYPES_DEFAULT,
+    array_api_dispatch=None,
+):
     """Hardware device where the array data resides on.
 
     If the hardware device is not the same for all arrays, an error is raised.
@@ -219,6 +226,12 @@ def array_device(*array_list, remove_none=True, remove_types=REMOVE_TYPES_DEFAUL
     remove_types : tuple or list, default=(str, list, tuple)
         Types to ignore in array_list.
 
+    array_api_dispatch : bool, default=None
+        Override for the ``array_api_dispatch`` configuration flag. When left as
+        None, the value is read from the global configuration. Internal callers
+        can force introspection of the true device regardless of the global
+        configuration.
+
     Returns
     -------
     out : device
@@ -231,14 +244,16 @@ def array_device(*array_list, remove_none=True, remove_types=REMOVE_TYPES_DEFAUL
     if not array_list:
         return None
 
-    device = _single_array_device(array_list[0])
+    device = _single_array_device(array_list[0], array_api_dispatch=array_api_dispatch)
 
     # Note: here we cannot simply use a Python `set` as it requires
     # hashable members which is not guaranteed for Array API device
     # objects. In particular, CuPy devices are not hashable at the
     # time of writing.
     for array in array_list[1:]:
-        device_other = _single_array_device(array)
+        device_other = _single_array_device(
+            array, array_api_dispatch=array_api_dispatch
+        )
         if device != device_other:
             raise ValueError(
                 f"Input arrays use different devices: {device}, {device_other}"
@@ -372,7 +387,11 @@ def _unwrap_memoryviewslices(*arrays):
 
 
 def get_namespace(
-    *arrays, remove_none=True, remove_types=REMOVE_TYPES_DEFAULT, xp=None
+    *arrays,
+    remove_none=True,
+    remove_types=REMOVE_TYPES_DEFAULT,
+    xp=None,
+    array_api_dispatch=None,
 ):
     """Get namespace of arrays.
 
@@ -417,6 +436,12 @@ def get_namespace(
         that has already performed inspection of its own inputs, skips array
         namespace inspection.
 
+    array_api_dispatch : bool, default=None
+        Override for the ``array_api_dispatch`` configuration flag. When left as
+        None, the value is read from the global configuration. Internal callers
+        can force introspection of the true namespace regardless of the global
+        configuration.
+
     Returns
     -------
     namespace : module
@@ -428,7 +453,12 @@ def get_namespace(
         https://data-apis.org/array-api/latest/index.html).
         Always False when array_api_dispatch=False.
     """
-    array_api_dispatch = get_config()["array_api_dispatch"]
+    if array_api_dispatch is None:
+        array_api_dispatch = get_config()["array_api_dispatch"]
+        validate_dispatch = True
+    else:
+        validate_dispatch = False
+
     if not array_api_dispatch:
         if xp is not None:
             return xp, False
@@ -453,7 +483,8 @@ def get_namespace(
     if not arrays:
         return np_compat, False
 
-    _check_array_api_dispatch(array_api_dispatch)
+    if validate_dispatch:
+        _check_array_api_dispatch(array_api_dispatch)
 
     namespace = array_api_compat.get_namespace(*arrays)
     is_array_api_compliant = True
@@ -467,7 +498,11 @@ def get_namespace(
 
 
 def get_namespace_and_device(
-    *array_list, remove_none=True, remove_types=REMOVE_TYPES_DEFAULT, xp=None
+    *array_list,
+    remove_none=True,
+    remove_types=REMOVE_TYPES_DEFAULT,
+    xp=None,
+    array_api_dispatch=None,
 ):
     """Combination into one single function of `get_namespace` and `device`.
 
@@ -483,6 +518,11 @@ def get_namespace_and_device(
         Precomputed array namespace module. When passed, typically from a caller
         that has already performed inspection of its own inputs, skips array
         namespace inspection.
+    array_api_dispatch : bool, default=None
+        Override for the ``array_api_dispatch`` configuration flag. When left as
+        None, the value is read from the global configuration. Internal callers
+        can force introspection of the true namespace and device regardless of
+        the global configuration.
 
     Returns
     -------
@@ -502,10 +542,14 @@ def get_namespace_and_device(
         remove_none=remove_none,
         remove_types=remove_types,
     )
-    arrays_device = array_device(*array_list, **skip_remove_kwargs)
+    arrays_device = array_device(
+        *array_list, array_api_dispatch=array_api_dispatch, **skip_remove_kwargs
+    )
 
     if xp is None:
-        xp, is_array_api = get_namespace(*array_list, **skip_remove_kwargs)
+        xp, is_array_api = get_namespace(
+            *array_list, array_api_dispatch=array_api_dispatch, **skip_remove_kwargs
+        )
     else:
         xp, is_array_api = xp, True
 
@@ -558,93 +602,95 @@ def move_to(*arrays, xp, device):
             "namespace is Numpy"
         )
 
-    with config_context(array_api_dispatch=True):
-        arrays_ = arrays
-        # Down cast float64 `arrays` when highest precision of `xp`/`device` is float32
-        if _max_precision_float_dtype(xp, device) == xp.float32:
-            arrays_ = []
-            for array in arrays:
-                try:
-                    xp_array, _ = get_namespace(array)
-                except (TypeError, ValueError):
-                    # Not an Array API array (e.g. a Python/NumPy scalar). Treat it as
-                    # NumPy, matching the behavior when array_api_dispatch is disabled.
-                    xp_array = np_compat
-                if getattr(array, "dtype", None) == xp_array.float64:
-                    arrays_.append(xp_array.astype(array, xp_array.float32))
-                else:
-                    arrays_.append(array)
+    arrays_ = arrays
+    # Down cast float64 `arrays` when highest precision of `xp`/`device` is float32
+    if _max_precision_float_dtype(xp, device) == xp.float32:
+        arrays_ = []
+        for array in arrays:
+            try:
+                xp_array, _ = get_namespace(array, array_api_dispatch=True)
+            except (TypeError, ValueError):
+                # Not an Array API array (e.g. a Python/NumPy scalar). Treat it as
+                # NumPy, matching the behavior when array_api_dispatch is disabled.
+                xp_array = np_compat
+            if getattr(array, "dtype", None) == xp_array.float64:
+                arrays_.append(xp_array.astype(array, xp_array.float32))
+            else:
+                arrays_.append(array)
 
-        converted_arrays = []
-        for array, is_sparse, is_none in zip(arrays_, sparse_mask, none_mask):
-            if is_none:
-                converted_arrays.append(None)
-            elif is_sparse:
+    converted_arrays = []
+    for array, is_sparse, is_none in zip(arrays_, sparse_mask, none_mask):
+        if is_none:
+            converted_arrays.append(None)
+        elif is_sparse:
+            converted_arrays.append(array)
+        else:
+            try:
+                xp_array, _, device_array = get_namespace_and_device(
+                    array, array_api_dispatch=True
+                )
+            except (TypeError, ValueError):
+                # Not an Array API array (e.g. a Python/NumPy scalar). Treat it as
+                # NumPy, matching the behavior when array_api_dispatch is disabled.
+                xp_array = np_compat
+                device_array = array_device(array, array_api_dispatch=True)
+
+            if xp == xp_array and device == device_array:
                 converted_arrays.append(array)
             else:
+                if _is_xp_namespace(xp, "torch") and _is_numpy_namespace(xp_array):
+                    if any(stride < 0 for stride in array.strides):
+                        # Work around PyTorch aborting the process when importing
+                        # negative-strided NumPy arrays with DLPack. Remove this
+                        # once https://github.com/pytorch/pytorch/issues/188023 is
+                        # fixed. See also
+                        # https://github.com/scikit-learn/scikit-learn/issues/34307
+                        array = numpy.ascontiguousarray(array)
                 try:
-                    xp_array, _, device_array = get_namespace_and_device(array)
-                except (TypeError, ValueError):
-                    # Not an Array API array (e.g. a Python/NumPy scalar). Treat it as
-                    # NumPy, matching the behavior when array_api_dispatch is disabled.
-                    xp_array, device_array = np_compat, array_device(array)
-
-                if xp == xp_array and device == device_array:
-                    converted_arrays.append(array)
-                else:
-                    if _is_xp_namespace(xp, "torch") and _is_numpy_namespace(xp_array):
-                        if any(stride < 0 for stride in array.strides):
-                            # Work around PyTorch aborting the process when importing
-                            # negative-strided NumPy arrays with DLPack. Remove this
-                            # once https://github.com/pytorch/pytorch/issues/188023 is
-                            # fixed. See also
-                            # https://github.com/scikit-learn/scikit-learn/issues/34307
-                            array = numpy.ascontiguousarray(array)
-                    try:
-                        # The dlpack protocol is the future proof and library agnostic
-                        # method to transfer arrays across namespace and device
-                        # boundaries hence this method is attempted first and going
-                        # through NumPy is only used as fallback in case of failure.
-                        # Note: copy=None is the default since array-api 2023.12.
-                        # Namespace libraries should only trigger a copy automatically
-                        # if needed.
-                        array_converted = xp.from_dlpack(array, device=device)
-                        # `AttributeError` occurs when `__dlpack__` and
-                        # `__dlpack_device__` methods are not present on the input
-                        # array `TypeError` and `NotImplementedError` for packages
-                        # that do not yet support dlpack 1.0
-                        # (i.e. the `device`/`copy` kwargs, e.g., torch <= 2.8.0)
-                        # See https://github.com/data-apis/array-api/pull/741 for
-                        # more details about the introduction of the `copy` and
-                        # `device` kwargs in the from_dlpack method and their expected
-                        # meaning by namespaces implementing the array API spec.
-                        # TODO: try removing this once DLPack v1 more widely
-                        # TODO: supported ValueError not needed once min
-                        # TODO: NumPy >=2.4.0:
-                        # TODO: https://github.com/numpy/numpy/issues/30341
-                    except (
-                        AttributeError,
-                        TypeError,
-                        NotImplementedError,
-                        BufferError,
-                        ValueError,
-                    ):
-                        # Converting to numpy is tricky, handle this via dedicated
-                        # function
-                        if _is_numpy_namespace(xp):
-                            array_converted = _convert_to_numpy(array, xp_array)
-                        # Convert from numpy, all array libraries can do this
-                        elif _is_numpy_namespace(xp_array):
-                            array_converted = xp.asarray(array, device=device)
-                        else:
-                            # There is no generic way to convert from namespace A to B
-                            # So we first convert from A to numpy and then from
-                            # numpy to B.
-                            # The way to avoid this round trip is to lobby for DLpack
-                            # support in libraries A and B
-                            array_np = _convert_to_numpy(array, xp_array)
-                            array_converted = xp.asarray(array_np, device=device)
-                    converted_arrays.append(array_converted)
+                    # The dlpack protocol is the future proof and library agnostic
+                    # method to transfer arrays across namespace and device
+                    # boundaries hence this method is attempted first and going
+                    # through NumPy is only used as fallback in case of failure.
+                    # Note: copy=None is the default since array-api 2023.12.
+                    # Namespace libraries should only trigger a copy automatically
+                    # if needed.
+                    array_converted = xp.from_dlpack(array, device=device)
+                    # `AttributeError` occurs when `__dlpack__` and
+                    # `__dlpack_device__` methods are not present on the input
+                    # array `TypeError` and `NotImplementedError` for packages
+                    # that do not yet support dlpack 1.0
+                    # (i.e. the `device`/`copy` kwargs, e.g., torch <= 2.8.0)
+                    # See https://github.com/data-apis/array-api/pull/741 for
+                    # more details about the introduction of the `copy` and
+                    # `device` kwargs in the from_dlpack method and their expected
+                    # meaning by namespaces implementing the array API spec.
+                    # TODO: try removing this once DLPack v1 more widely
+                    # TODO: supported ValueError not needed once min
+                    # TODO: NumPy >=2.4.0:
+                    # TODO: https://github.com/numpy/numpy/issues/30341
+                except (
+                    AttributeError,
+                    TypeError,
+                    NotImplementedError,
+                    BufferError,
+                    ValueError,
+                ):
+                    # Converting to numpy is tricky, handle this via dedicated
+                    # function
+                    if _is_numpy_namespace(xp):
+                        array_converted = _convert_to_numpy(array, xp_array)
+                    # Convert from numpy, all array libraries can do this
+                    elif _is_numpy_namespace(xp_array):
+                        array_converted = xp.asarray(array, device=device)
+                    else:
+                        # There is no generic way to convert from namespace A to B
+                        # So we first convert from A to numpy and then from
+                        # numpy to B.
+                        # The way to avoid this round trip is to lobby for DLpack
+                        # support in libraries A and B
+                        array_np = _convert_to_numpy(array, xp_array)
+                        array_converted = xp.asarray(array_np, device=device)
+                converted_arrays.append(array_converted)
 
     return (
         converted_arrays[0] if len(converted_arrays) == 1 else tuple(converted_arrays)
@@ -1074,15 +1120,14 @@ def _convert_to_numpy(array, xp):
     This function is not meant to be called directly and
     `move_to(array, xp=np, device="cpu")` should be used instead.
     """
-    with config_context(array_api_dispatch=True):
-        if _is_xp_namespace(xp, "torch"):
-            return array.cpu().numpy()
-        elif _is_xp_namespace(xp, "cupy"):  # pragma: nocover
-            return array.get()
-        elif _is_xp_namespace(xp, "array_api_strict"):
-            return numpy.asarray(xp.asarray(array, device=xp.Device("CPU_DEVICE")))
-        elif _is_xp_namespace(xp, "dpnp"):  # pragma: nocover
-            return array.asnumpy()
+    if _is_xp_namespace(xp, "torch"):
+        return array.cpu().numpy()
+    elif _is_xp_namespace(xp, "cupy"):  # pragma: nocover
+        return array.get()
+    elif _is_xp_namespace(xp, "array_api_strict"):
+        return numpy.asarray(xp.asarray(array, device=xp.Device("CPU_DEVICE")))
+    elif _is_xp_namespace(xp, "dpnp"):  # pragma: nocover
+        return array.asnumpy()
 
     return numpy.asarray(array)
 

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -564,7 +564,12 @@ def move_to(*arrays, xp, device):
         if _max_precision_float_dtype(xp, device) == xp.float32:
             arrays_ = []
             for array in arrays:
-                xp_array, _ = get_namespace(array)
+                try:
+                    xp_array, _ = get_namespace(array)
+                except (TypeError, ValueError):
+                    # Not an Array API array (e.g. a Python/NumPy scalar). Treat it as
+                    # NumPy, matching the behavior when array_api_dispatch is disabled.
+                    xp_array = np_compat
                 if getattr(array, "dtype", None) == xp_array.float64:
                     arrays_.append(xp_array.astype(array, xp_array.float32))
                 else:
@@ -577,7 +582,13 @@ def move_to(*arrays, xp, device):
             elif is_sparse:
                 converted_arrays.append(array)
             else:
-                xp_array, _, device_array = get_namespace_and_device(array)
+                try:
+                    xp_array, _, device_array = get_namespace_and_device(array)
+                except (TypeError, ValueError):
+                    # Not an Array API array (e.g. a Python/NumPy scalar). Treat it as
+                    # NumPy, matching the behavior when array_api_dispatch is disabled.
+                    xp_array, device_array = np_compat, array_device(array)
+
                 if xp == xp_array and device == device_array:
                     converted_arrays.append(array)
                 else:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Without array API support enabled the namespace determination does not work properly. Which means we incorrectly determine that the namespace of an array is numpy, even if it is not.

In many of our tests we call `move_to` outside the config context in which array API support is enabled.

I think `move_to` can't work properly if array API support is not enabled because it calls `get_namespace` on the array(s) that are to be moved. But `get_namespace` always returns numpy when array API support is disabled. I considered the option of asserting that array API support is enabled at the start of `move_to` but I think I prefer this option. We'd have to move a lot of `move_to` calls around in the tests, and sometimes the `move_to` call is in a good place in the test, but a long way away from where we use the context manager to enable array API. So you'd have to move it a long way, which imho would make it less readable. That is why I think enabling it inside `move_to` is the better choice.

I noticed this when running the scikit-learn test suite with https://github.com/data-apis/array-api-strict/pull/233 which improves the DLPack emulation in array-api-strict.

#### First time contributor introduction
<!-- If you are new to the scikit-learn community, please introduce yourself. How do you
 use scikit-learn, what prompted you to make this contribution? Getting to know you
 helps us build trust in your judgement and welcome you into the community.
-->


#### AI usage disclosure

All my own thinking, reasoning and work :-o


