### PR TITLE
FIX Avoid race condition in fetch_20newsgroups cache write

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.datasets/34650.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.datasets/34650.fix.rst
@@ -1,0 +1,4 @@
+- :func:`datasets.fetch_20newsgroups` no longer raises a race condition
+  when called concurrently from multiple processes or threads (for example
+  under pytest-xdist), by downloading and caching the dataset atomically.
+  By :user:`Tirth <tirthfx>`.

--- a/sklearn/datasets/_twenty_newsgroups.py
+++ b/sklearn/datasets/_twenty_newsgroups.py
@@ -30,10 +30,10 @@ import logging
 import os
 import pickle
 import re
-import shutil
 import tarfile
 from contextlib import suppress
 from numbers import Integral, Real
+from tempfile import TemporaryDirectory
 
 import joblib
 import numpy as np
@@ -68,35 +68,48 @@ TRAIN_FOLDER = "20news-bydate-train"
 TEST_FOLDER = "20news-bydate-test"
 
 
-def _download_20newsgroups(target_dir, cache_path, n_retries, delay):
+def _download_20newsgroups(cache_path, n_retries, delay):
     """Download the 20 newsgroups data and stored it as a zipped pickle."""
-    train_path = os.path.join(target_dir, TRAIN_FOLDER)
-    test_path = os.path.join(target_dir, TEST_FOLDER)
+    data_home = os.path.dirname(cache_path)
+    os.makedirs(data_home, exist_ok=True)
 
-    os.makedirs(target_dir, exist_ok=True)
+    # Download, extract and build the cache in an isolated, uniquely-named
+    # temporary directory, then atomically move the finished cache file into
+    # place. This way, concurrent callers (e.g. separate pytest-xdist
+    # workers fetching the same dataset at the same time) never step on each
+    # other's working files, and a reader of cache_path either sees no cache
+    # file yet or a fully written one, never a partial one. Creating the
+    # temporary directory inside data_home guarantees it is on the same
+    # filesystem as cache_path, which os.replace requires to be atomic.
+    with TemporaryDirectory(dir=data_home) as temp_dir:
+        train_path = os.path.join(temp_dir, TRAIN_FOLDER)
+        test_path = os.path.join(temp_dir, TEST_FOLDER)
 
-    logger.info("Downloading dataset from %s (14 MB)", ARCHIVE.url)
-    archive_path = _fetch_remote(
-        ARCHIVE, dirname=target_dir, n_retries=n_retries, delay=delay
-    )
+        logger.info("Downloading dataset from %s (14 MB)", ARCHIVE.url)
+        archive_path = _fetch_remote(
+            ARCHIVE, dirname=temp_dir, n_retries=n_retries, delay=delay
+        )
 
-    logger.debug("Decompressing %s", archive_path)
-    with tarfile.open(archive_path, "r:gz") as fp:
-        tarfile_extractall(fp, path=target_dir)
+        logger.debug("Decompressing %s", archive_path)
+        with tarfile.open(archive_path, "r:gz") as fp:
+            tarfile_extractall(fp, path=temp_dir)
 
-    with suppress(FileNotFoundError):
-        os.remove(archive_path)
+        with suppress(FileNotFoundError):
+            os.remove(archive_path)
 
-    # Store a zipped pickle
-    cache = dict(
-        train=load_files(train_path, encoding="latin1"),
-        test=load_files(test_path, encoding="latin1"),
-    )
-    compressed_content = codecs.encode(pickle.dumps(cache), "zlib_codec")
-    with open(cache_path, "wb") as f:
-        f.write(compressed_content)
+        # Store a zipped pickle
+        cache = dict(
+            train=load_files(train_path, encoding="latin1"),
+            test=load_files(test_path, encoding="latin1"),
+        )
+        compressed_content = codecs.encode(pickle.dumps(cache), "zlib_codec")
+        cache_tmp_path = os.path.join(temp_dir, os.path.basename(cache_path))
+        with open(cache_tmp_path, "wb") as f:
+            f.write(compressed_content)
+        # os.replace is atomic on POSIX and, unlike os.rename, also succeeds
+        # on Windows when the destination already exists.
+        os.replace(cache_tmp_path, cache_path)
 
-    shutil.rmtree(target_dir)
     return cache
 
 
@@ -300,7 +313,6 @@ def fetch_20newsgroups(
 
     data_home = get_data_home(data_home=data_home)
     cache_path = _pkl_filepath(data_home, CACHE_NAME)
-    twenty_home = os.path.join(data_home, "20news_home")
     cache = None
     if os.path.exists(cache_path):
         try:
@@ -318,7 +330,6 @@ def fetch_20newsgroups(
         if download_if_missing:
             logger.info("Downloading 20news dataset. This may take a few minutes.")
             cache = _download_20newsgroups(
-                target_dir=twenty_home,
                 cache_path=cache_path,
                 n_retries=n_retries,
                 delay=delay,

--- a/sklearn/datasets/tests/test_20news.py
+++ b/sklearn/datasets/tests/test_20news.py
@@ -2,6 +2,9 @@
 or if specifically requested via environment variable
 (e.g. for CI jobs)."""
 
+import codecs
+import os
+import pickle
 from functools import partial
 from unittest.mock import patch
 
@@ -9,12 +12,16 @@ import numpy as np
 import pytest
 import scipy.sparse as sp
 
+from sklearn.datasets import fetch_20newsgroups
+from sklearn.datasets._base import _pkl_filepath
+from sklearn.datasets._twenty_newsgroups import CACHE_NAME, _download_20newsgroups
 from sklearn.datasets.tests.test_common import (
     check_as_frame,
     check_pandas_dependency_message,
     check_return_X_y,
 )
 from sklearn.preprocessing import normalize
+from sklearn.utils import Bunch
 from sklearn.utils._testing import assert_allclose_dense_sparse
 
 
@@ -141,3 +148,124 @@ def test_outdated_pickle(fetch_20newsgroups_vectorized_fxt):
             err_msg = "The cached dataset located in"
             with pytest.raises(ValueError, match=err_msg):
                 fetch_20newsgroups_vectorized_fxt(as_frame=True)
+
+
+def _write_fake_20newsgroups_cache(data_home):
+    """Write a minimal but structurally valid 20newsgroups cache to disk.
+
+    This lets tests exercise `fetch_20newsgroups`'s post-processing (e.g. the
+    `subset="all"` merging logic) without requiring network access.
+    """
+    cache = {
+        "train": Bunch(
+            data=["train doc 0", "train doc 1"],
+            target=np.array([0, 1]),
+            filenames=np.array(["train0", "train1"]),
+            target_names=["alt.atheism", "sci.space"],
+        ),
+        "test": Bunch(
+            data=["test doc 0"],
+            target=np.array([1]),
+            filenames=np.array(["test0"]),
+            target_names=["alt.atheism", "sci.space"],
+        ),
+    }
+    cache_path = _pkl_filepath(data_home, CACHE_NAME)
+    compressed_content = codecs.encode(pickle.dumps(cache), "zlib_codec")
+    with open(cache_path, "wb") as f:
+        f.write(compressed_content)
+    return cache
+
+
+def test_20news_subset_all_merges_train_and_test(tmp_path):
+    """Non-regression test for `fetch_20newsgroups(subset="all")`.
+
+    A previous change to the `subset == "all"` branch introduced a loop
+    variable that shadowed, without updating, a reference to the outer
+    `subset` parameter, which made every `subset="all"` call raise
+    `KeyError: 'all'`. This avoids the network dependency of `test_20news`
+    so it always runs in CI.
+    """
+    _write_fake_20newsgroups_cache(tmp_path)
+
+    data = fetch_20newsgroups(
+        data_home=tmp_path,
+        subset="all",
+        shuffle=False,
+        download_if_missing=False,
+    )
+
+    assert len(data.data) == 3
+    assert list(data.data) == ["train doc 0", "train doc 1", "test doc 0"]
+    assert_allclose_dense_sparse(data.target, np.array([0, 1, 1]))
+    assert list(data.filenames) == ["train0", "train1", "test0"]
+
+
+def test_download_20newsgroups_atomic_write(tmp_path, monkeypatch):
+    """`_download_20newsgroups` must never leave a partially written cache.
+
+    Non-regression test for a race condition (gh-32095) where concurrent
+    callers (e.g. separate pytest-xdist workers) could observe a partially
+    written cache file. The fix downloads and builds the cache in an
+    isolated temporary directory and finalizes it with an atomic
+    `os.replace`, mirroring the pattern already used by `fetch_openml` and
+    `fetch_covtype`.
+    """
+    cache_path = _pkl_filepath(str(tmp_path), CACHE_NAME)
+
+    fake_cache = {
+        "train": Bunch(data=["doc"], target=np.array([0]), filenames=np.array(["f"])),
+        "test": Bunch(data=["doc"], target=np.array([0]), filenames=np.array(["f"])),
+    }
+
+    def fake_fetch_remote(archive, dirname, n_retries, delay):
+        # Simulate a downloaded archive without touching the network.
+        archive_path = os.path.join(dirname, archive.filename)
+        with open(archive_path, "wb") as f:
+            f.write(b"not a real tar.gz, extraction is mocked below")
+        return archive_path
+
+    class _FakeTarfile:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def fake_tarfile_open(*args, **kwargs):
+        return _FakeTarfile()
+
+    def fake_tarfile_extractall(fp, path):
+        # Create the train/test folders that load_files below expects.
+        os.makedirs(os.path.join(path, "20news-bydate-train"), exist_ok=True)
+        os.makedirs(os.path.join(path, "20news-bydate-test"), exist_ok=True)
+
+    def fake_load_files(path, encoding=None):
+        return fake_cache["train"] if "train" in path else fake_cache["test"]
+
+    monkeypatch.setattr(
+        "sklearn.datasets._twenty_newsgroups._fetch_remote", fake_fetch_remote
+    )
+    monkeypatch.setattr(
+        "sklearn.datasets._twenty_newsgroups.tarfile.open", fake_tarfile_open
+    )
+    monkeypatch.setattr(
+        "sklearn.datasets._twenty_newsgroups.tarfile_extractall",
+        fake_tarfile_extractall,
+    )
+    monkeypatch.setattr(
+        "sklearn.datasets._twenty_newsgroups.load_files", fake_load_files
+    )
+
+    result = _download_20newsgroups(cache_path=cache_path, n_retries=3, delay=1)
+
+    assert result["train"] is fake_cache["train"]
+    assert os.path.exists(cache_path)
+    # No leftover temporary directories or files should remain in data_home.
+    assert os.listdir(tmp_path) == [os.path.basename(cache_path)]
+
+    # The cache file that was written is a valid, fully-formed pickle.
+    with open(cache_path, "rb") as f:
+        uncompressed = codecs.decode(f.read(), "zlib_codec")
+    reloaded = pickle.loads(uncompressed)
+    assert set(reloaded) == {"train", "test"}


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #32095. Supersedes/builds on the approach from #34309, which had the right idea but shipped a regression (see review comment on that PR) — this is a from-scratch corrected implementation, not a rebase of that branch.

#### What does this implement/fix? Explain your changes.
`fetch_20newsgroups` wrote its zipped-pickle cache directly with `open(cache_path, "wb")`, and downloaded/extracted the archive into a shared `target_dir`. Concurrent callers (e.g. separate `pytest-xdist` workers fetching the dataset at the same time) could therefore observe a partially written cache file, or interfere with each other's extraction, leading to inconsistent dataset sizes being returned to different workers.

This follows the same pattern already used by `fetch_openml` (#21833) and `fetch_covtype` (#23113): download, extract, and build the cache inside an isolated `TemporaryDirectory` created under `data_home`, then finalize the cache file with an atomic `os.replace` (chosen over `os.rename` since it also succeeds on Windows when the destination already exists). Concurrent callers now either see no cache file yet, or a fully written one — never a partial one.

Also drops the now-unused `target_dir`/`twenty_home` plumbing, since the temporary directory replaces it.

#### Testing
- `sklearn/datasets/tests/test_20news.py::test_download_20newsgroups_atomic_write` — exercises `_download_20newsgroups` directly with the network calls (`_fetch_remote`, `tarfile`, `load_files`) mocked out, and asserts the final cache file is valid and no temporary files are left behind in `data_home`.
- `sklearn/datasets/tests/test_20news.py::test_20news_subset_all_merges_train_and_test` — exercises `fetch_20newsgroups(subset="all")` against a pre-populated fake cache (no network needed), so it always runs in CI rather than being skipped like the existing `test_20news`/`test_20news_length_consistency`.
- Ran the full non-network `sklearn/datasets/tests/` suite (155 passed, 254 skipped — the skips are all real-network-download tests gated by `SKLEARN_SKIP_NETWORK_TESTS`).
- `ruff check` / `ruff format --check` pass with the repo's pinned `ruff==0.12.2`.

#### First time contributor introduction
Not a first-time contributor to open source generally, but this is my first contribution to scikit-learn. I found this while reviewing #34309 (which correctly diagnosed and attempted to fix #32095, but introduced a `KeyError: 'all'` regression via an unrelated variable-shadowing cleanup, left debug `print()` statements in `_download_20newsgroups` — one of which broke the function's docstring — and shipped without a regression test). I left review comments on that PR and am opening this as a corrected implementation of the same fix.

#### AI usage disclosure
I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Research and understanding

#### Any other comments?
None of the debug prints, the `subset="all"` regression, or the missing test from #34309 are present here — see the diff and the two new tests, which I verified would have caught the regression by temporarily reintroducing it locally and confirming the test failed with the exact `KeyError: 'all'` reported.
