### PR TITLE
docs: DOC: Array API - mention torch XPU is a bit unstable

### DIFF
--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -442,6 +442,7 @@ with `float64` support.
 Note on Intel GPU support
 -------------------------
 
-PyTorch XPU support is only available in PyTorch >= 2.12. For detailed compatibility
-information and setup instructions, see the `PyTorch XPU documentation
+PyTorch XPU support is only available in PyTorch >= 2.12. This backend is still
+evolving, so using the latest PyTorch release is recommended. For detailed
+compatibility information and setup instructions, see the `PyTorch XPU documentation
 <https://docs.pytorch.org/docs/2.12/notes/get_start_xpu.html>`__.


### PR DESCRIPTION
## Summary

Addresses #34648: DOC: Array API - mention torch XPU is a bit unstable

## Changed files

- `doc/modules/array_api.rst`

## Validation

- `git diff --check`: passed

Fixes #34648
