### PR TITLE
MNT Add tickboxes for AI disclosure in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,11 +39,11 @@ Keep the ones that apply, delete the rest.
 Make sure that you adhere to our Automated Contributions Policy:
 https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
 -->
-I used AI assistance for:
-- Code generation (e.g., when writing an implementation or fixing a bug)
-- Test/benchmark generation
-- Documentation (including examples)
-- Research and understanding
+I used AI assistance for (untick boxes below where applicable):
+- [X] Code generation (e.g., when writing an implementation or fixing a bug)
+- [X] Test/benchmark generation
+- [X] Documentation (including examples)
+- [X] Research and understanding
 
 
 #### Any other comments?


### PR DESCRIPTION
Maybe a conscious decision, maybe not, but I think it makes sense to have this as tickboxes and not bullet points, which looks a bit weird to me. Are you supposed to remove the non-applicable lines from the bullet points?

Now the semi-controversial part: by default all the boxes are ticked, so that if someone ignores this section, it is assumed that AI was used for everything.