### PR TITLE
DOC Mention PyTorch XPU instability and latest version recommendation (#34648)

### DIFF
--- a/doc/modules/array_api.rst
+++ b/doc/modules/array_api.rst
@@ -445,3 +445,7 @@ Note on Intel GPU support
 PyTorch XPU support is only available in PyTorch >= 2.12. For detailed compatibility
 information and setup instructions, see the `PyTorch XPU documentation
 <https://docs.pytorch.org/docs/2.12/notes/get_start_xpu.html>`__.
+
+.. note::
+  
+   PyTorch support for Intel GPU (XPU) devices is under active development and may exhibit instability or unexpected performance slowdowns. Users targeting Intel GPUs are strongly encouraged to use the latest versions of PyTorch where fixes and optimizations are regularly released or to consider using `dpnp <https://intelpython.github.io/dpnp/>`__ as an alternative backend.


### PR DESCRIPTION
Fixes #34648

### Proposed Changes
Added a note `doc/modules/array_api.rst` under the Intel GPU support section mentioning that: 
-PyTorch support for Intel GPU (XPU) devices is under active development and may exhibit instability or unexpected performance slowdowns.

-Users targeting Intel GPUs are strongly encouraged to use the latest versions of PyTorch where fixes and optimizations are regularly released or to consider using [dpnp](https://intelpython.github.io/dpnp/) as an alternative backend.