### PR TITLE
DOC: Add table to Recommendation Summary in Common Pitfalls

### DIFF
--- a/doc/common_pitfalls.rst
+++ b/doc/common_pitfalls.rst
@@ -256,6 +256,25 @@ subtle parameter.
     For reproducible results across executions, remove any use of
     `random_state=None`.
 
+    .. list-table::
+       :header-rows: 1
+
+       * - Goal
+         - Estimator
+         - CV Splitter
+       * - Same results every fit/split call
+         - int
+         - int
+       * - Robust CV of a randomized estimator (fresh RNG per fold)
+         - RandomState or None
+         - int
+       * - Comparable fold-to-fold scores across separate runs
+         - (any)
+         - int
+       * - Reproducible across program executions
+         - fixed RandomState or int
+         - int
+
 Using `None` or `RandomState` instances, and repeated calls to `fit` and `split`
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Reference Issue

Fixes #34641

## What does this implement/fix?

Add a quick-reference list-table to the Recommendation Summary note in the Common Pitfalls page. The table maps common goals to recommended `random_state` values for estimators and CV splitters.

| Goal | Estimator | CV Splitter |
|------|-----------|-------------|
| Same results every fit/split call | int | int |
| Robust CV of a randomized estimator | RandomState or None | int |
| Comparable fold-to-fold scores | (any) | int |
| Reproducible across program executions | fixed RandomState or int | int |

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.