### PR TITLE
Fix pandas output path skipping finite value validation

### DIFF
--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -3042,6 +3042,18 @@ def validate_data(
             out = y
         else:
             out = X, y
+
+        # When skip_check_array is True (e.g., pandas output path), we still
+        # need to check for NaN and infinity if ensure_all_finite is requested.
+        ensure_all_finite = check_params.get("ensure_all_finite", True)
+        if not no_val_X and ensure_all_finite:
+            X_to_check = np.asarray(X) if not sp.issparse(X) else X
+            _assert_all_finite(
+                X_to_check,
+                allow_nan=ensure_all_finite == "allow-nan",
+                estimator_name=_check_estimator_name(_estimator),
+                input_name="X",
+            )
     elif not no_val_X and no_val_y:
         out = check_array(X, input_name="X", **check_params)
     elif no_val_X and not no_val_y:


### PR DESCRIPTION
## Reference Issue

Fixes #34500

## What does this implement/fix?

When `set_output(transform="pandas")` is used, `validate_data` is called with `skip_check_array=True` to preserve the DataFrame. This also skips the `check_array` finite value validation, allowing infinity and NaN values through `transform` without raising an error.

This PR adds a finite value check in `validate_data` when `skip_check_array` is True and `ensure_all_finite` is requested. The check converts the input to a numpy array first (if not sparse) before calling `_assert_all_finite`.

## Reproducer

```python
import numpy as np
import pandas as pd
from sklearn.feature_selection import SelectKBest, f_classif

X_train = pd.DataFrame({"a": [0.0, 1.0, 0.0, 1.0], "b": [1.0, 2.0, 1.0, 2.0]})
y = [0, 0, 1, 1]
selector = SelectKBest(f_classif, k=1).set_output(transform="pandas")
selector.fit(X_train, y)

X_bad = X_train.copy()
X_bad.loc[0, "a"] = np.inf
selector.transform(X_bad)  # currently succeeds, should raise ValueError
```

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.