### PR TITLE
Fix AdaBoost feature_importances_ dead error-handling code

### DIFF
--- a/sklearn/ensemble/_weight_boosting.py
+++ b/sklearn/ensemble/_weight_boosting.py
@@ -290,10 +290,7 @@ class BaseWeightBoosting(BaseEnsemble, metaclass=ABCMeta):
         feature_importances_ : ndarray of shape (n_features,)
             The feature importances.
         """
-        if self.estimators_ is None or len(self.estimators_) == 0:
-            raise ValueError(
-                "Estimator not fitted, call `fit` before `feature_importances_`."
-            )
+        check_is_fitted(self)
 
         try:
             norm = self.estimator_weights_.sum()


### PR DESCRIPTION
## Reference Issue

Fixes #34472

## What does this implement/fix?

The `feature_importances_` property in `BaseWeightBoosting` had a check for `self.estimators_ is None or len(self.estimators_) == 0` that was dead code. Accessing `estimators_` before fitting raises `AttributeError` before the check runs, and after fitting `estimators_` is never `None` or empty.

Replace the dead `ValueError` with `check_is_fitted(self)`, which gives a proper `NotFittedError`, matching the pattern used by other ensemble methods like `RandomForestClassifier`.

## Reproducer

```python
from sklearn.ensemble import AdaBoostClassifier
AdaBoostClassifier().feature_importances_
# Before: AttributeError: 'AdaBoostClassifier' object has no attribute 'estimators_'
# After:  NotFittedError: This AdaBoostClassifier instance is not fitted yet.
```

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.