### PR TITLE
Fix spurious EfficiencyWarning in OPTICS with precomputed sparse input

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.cluster/34647.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.cluster/34647.fix.rst
@@ -1,0 +1,4 @@
+- :class:`cluster.OPTICS` no longer raises a spurious
+  :class:`~sklearn.exceptions.EfficiencyWarning` when given a precomputed
+  sparse distance matrix.
+  By :user:`Abhishek Shivakumar <abhishekshivakumar>`.

--- a/sklearn/cluster/_optics.py
+++ b/sklearn/cluster/_optics.py
@@ -17,7 +17,7 @@ from sklearn.base import BaseEstimator, ClusterMixin, _fit_context
 from sklearn.exceptions import DataConversionWarning
 from sklearn.metrics import pairwise_distances
 from sklearn.metrics.pairwise import _VALID_METRICS, PAIRWISE_BOOLEAN_FUNCTIONS
-from sklearn.neighbors import NearestNeighbors
+from sklearn.neighbors import NearestNeighbors, sort_graph_by_row_values
 from sklearn.utils import gen_batches
 from sklearn.utils._chunking import get_chunk_n_rows
 from sklearn.utils._param_validation import (
@@ -341,6 +341,8 @@ class OPTICS(ClusterMixin, BaseEstimator):
                 # Set each diagonal to an explicit value so each point is its
                 # own neighbor
                 X.setdiag(X.diagonal())
+                # Sorting could be undone by .setdiag(), make sure it's sorted
+                X = sort_graph_by_row_values(X, warn_when_not_sorted=False)
         memory = check_memory(self.memory)
 
         (


### PR DESCRIPTION
## Reference Issue

Fixes #34647

## What does this implement/fix?

OPTICS.fit with `metric="precomputed"` calls `X.setdiag()` which can unsort the sparse graph data. When `NearestNeighbors.fit` later calls `_check_precomputed`, it finds the graph unsorted and raises an `EfficiencyWarning`, even when the user already sorted the graph with `sort_graph_by_row_values`.

Fix: sort the graph with `sort_graph_by_row_values(warn_when_not_sorted=False)` after `setdiag()`, matching the approach used in DBSCAN (PR #34399).

## Reproducer

```python
import numpy as np
from sklearn.cluster import OPTICS
from sklearn.neighbors import kneighbors_graph, sort_graph_by_row_values

X = np.random.RandomState(0).randn(1000, 5)
graph = kneighbors_graph(X, n_neighbors=5, mode="distance")

# Both of these should work without EfficiencyWarning:
OPTICS(metric="precomputed", min_samples=5).fit(graph)

graph = sort_graph_by_row_values(graph, warn_when_not_sorted=False)
OPTICS(metric="precomputed", min_samples=5).fit(graph)
```

This pull request includes code written with the assistance of AI.
The code has not yet been reviewed by a human.