### PR TITLE
Fix LogisticRegressionCV TypeError with string scoring on binary classification

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/34531.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/34531.fix.rst
@@ -1,0 +1,6 @@
+- :class:`linear_model.LogisticRegressionCV` no longer raises a
+  :class:`TypeError` when using a string scoring parameter (e.g.
+  ``scoring="f1_macro"``) on a binary classification problem. The
+  ``pos_label`` keyword argument was being passed twice to
+  :func:`metrics.make_scorer`.
+  By :user:`Abhishek Shivakumar <abhishekshivakumar>`.

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1008,13 +1008,18 @@ def _log_reg_scoring_path(
             if is_binary and "pos_label" in sig:
                 # see _logistic_regression_path
                 pos_label_kwarg["pos_label"] = n_classes - 1  # classes[-1]
+            # Avoid passing pos_label twice: if the scorer's _kwargs already
+            # contains pos_label, remove it to prevent a TypeError from
+            # make_scorer getting duplicate keyword arguments.
+            scorer_kwargs = dict(getattr(scoring, "_kwargs", {}))
+            scorer_kwargs.pop("pos_label", None)
             scoring = make_scorer(
                 scoring._score_func,
                 greater_is_better=True if scoring._sign == 1 else False,
                 response_method=scoring._response_method,
                 labels=log_reg.classes_,
                 **pos_label_kwarg,
-                **getattr(scoring, "_kwargs", {}),
+                **scorer_kwargs,
             )
 
         def calc_score(log_reg):


### PR DESCRIPTION
## Reference Issue

Fixes #34531

## What does this implement/fix?

`LogisticRegressionCV` with `scoring="f1_macro"` raised `TypeError: make_scorer() got multiple values for keyword argument pos_label` on binary classification problems. This is a regression in sklearn 1.9.

The root cause: macro-averaged scorers (e.g. `f1_macro`) are created with `make_scorer(metric, pos_label=None, average="macro")`, so their `_kwargs` contains `pos_label=None`. In `_log_reg_scoring_path`, when `is_binary and "pos_label" in sig`, `pos_label_kwarg["pos_label"]` is also set. Both are passed to `make_scorer`, causing the duplicate keyword argument error.

Fix: remove `pos_label` from the scorer `_kwargs` before merging with `pos_label_kwarg`.

## Reproducer

```python
from sklearn.linear_model import LogisticRegressionCV
from sklearn.datasets import make_classification

X, y = make_classification(n_samples=100, n_features=20, n_classes=2, random_state=0)
clf = LogisticRegressionCV(cv=3, random_state=0, scoring="f1_macro")
clf.fit(X, y)  # raised TypeError in 1.9
```

This pull request includes code written with the assistance of AI.
The code has not yet been reviewed by a human.