### PR TITLE
Document tie-breaking behavior for max_categories in encoders

### DIFF
--- a/doc/modules/preprocessing.rst
+++ b/doc/modules/preprocessing.rst
@@ -863,10 +863,11 @@ infrequent::
           [0., 0., 1.]])
 
 If there are infrequent categories with the same cardinality at the cutoff of
-`max_categories`, then the first `max_categories` are taken based on lexicon
-ordering. In the following example, "b", "c", and "d", have the same cardinality
-and with `max_categories=2`, "b" and "c" are infrequent because they have a higher
-lexicon order.
+`max_categories`, then the first `max_categories` are taken based on the sort
+order of the categories (via a stable sort). For `categories='auto'`, this is
+lexicographic or numeric sort order. In the following example, "b", "c", and "d"
+have the same cardinality and with `max_categories=3`, "b" and "c" are infrequent
+because they have a higher sort order.
 
    >>> X = np.asarray([["a"] * 20 + ["b"] * 10 + ["c"] * 10 + ["d"] * 10], dtype=object).T
    >>> enc = preprocessing.OneHotEncoder(max_categories=3).fit(X)

--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -584,6 +584,11 @@ class OneHotEncoder(_BaseEncoder):
         infrequent categories along with the frequent categories. If `None`,
         there is no limit to the number of output features.
 
+        When multiple categories have the same count at the cutoff boundary,
+        ties are broken using the sort order of the categories (via a stable
+        sort). For `categories='auto'`, this is lexicographic or numeric sort
+        order.
+
         .. versionadded:: 1.1
             Read more in the :ref:`User Guide <encoder_infrequent_categories>`.
 
@@ -1317,6 +1322,11 @@ class OrdinalEncoder(OneToOneFeatureMixin, _BaseEncoder):
         categories. Setting `unknown_value` or `encoded_missing_value` to an
         integer will increase the number of unique integer codes by one each.
         This can result in up to `max_categories + 2` integer codes.
+
+        When multiple categories have the same count at the cutoff boundary,
+        ties are broken using the sort order of the categories (via a stable
+        sort). For `categories='auto'`, this is lexicographic or numeric sort
+        order.
 
         .. versionadded:: 1.3
             Read more in the :ref:`User Guide <encoder_infrequent_categories>`.


### PR DESCRIPTION
## Reference Issue

Fixes #34669

## What does this implement/fix?

When `max_categories` forces categories into the infrequent group and multiple categories are tied in count at the cutoff boundary, the docs did not specify which tied category is kept as frequent vs. grouped as infrequent. The tie-break is done via `np.argsort(category_count, kind="mergesort")` (a stable sort), so ties resolve by the sort order of categories in `categories_[i]`.

This PR documents this behavior in:
- `OneHotEncoder.max_categories` docstring
- `OrdinalEncoder.max_categories` docstring
- User Guide section on infrequent categories

Also corrected the User Guide example text to say `max_categories=3` (matching the actual code example, which previously said `max_categories=2`).

This pull request includes code written with the assistance of AI.
The code has not yet been reviewed by a human.