### PR TITLE
Fix accessibility: add alt text to sponsor images

### DIFF
--- a/doc/templates/funding_links.html
+++ b/doc/templates/funding_links.html
@@ -7,7 +7,7 @@
         <div class="text-center">
             <a href="https://probabl.ai/lp/scikit-learn">
                 <div class="sk-funding-logos">
-                    <img src="{{ pathto('_static/probabl.png', 1) }}" title="Probabl">
+                    <img src="{{ pathto('_static/probabl.png', 1) }}" alt="Probabl" title="Probabl">
                 </div>
                 <p>Enterprise-grade solutions and services</p>
             </a>

--- a/doc/templates/index.html
+++ b/doc/templates/index.html
@@ -212,7 +212,7 @@
         <a class="sk-funding-link" href="https://probabl.ai/lp/scikit-learn">
           <div class="text-center">
             <div class="sk-funding-logos">
-              <img src="_static/probabl.png" title="Probabl">
+              <img src="_static/probabl.png" alt="Probabl" title="Probabl">
             </div>
             <p>Probabl: Enterprise-grade solutions and services</p>
         </div>
@@ -222,15 +222,15 @@
         <a class="sk-funding-link" href="institutional_support.html#funding">
           <div class="text-center">
             <div class="sk-funding-logos">
-              <img src="_static/inria-small.png" title="Inria">
-              <img src="_static/czi-small.png" title="Chan Zuckerberg Initiative">
-              <img src="_static/wellcome-trust-small.png" title="Wellcome Trust">
-              <img src="_static/nvidia-small.png" title="NVIDIA">
-              <img src="_static/nasa-small.png" title="NASA">
-              <img src="_static/quansight-labs-small.png" title="Quansight Labs">
-              <img src="_static/chanel-small.png" title="Chanel">
-              <img src="_static/bnp-paribas-small.png" title="BNP Paribas Group">
-              <img src="_static/michelin-small.png" title="Michelin">
+              <img src="_static/inria-small.png" alt="Inria" title="Inria">
+              <img src="_static/czi-small.png" alt="Chan Zuckerberg Initiative" title="Chan Zuckerberg Initiative">
+              <img src="_static/wellcome-trust-small.png" alt="Wellcome Trust" title="Wellcome Trust">
+              <img src="_static/nvidia-small.png" alt="NVIDIA" title="NVIDIA">
+              <img src="_static/nasa-small.png" alt="NASA" title="NASA">
+              <img src="_static/quansight-labs-small.png" alt="Quansight Labs" title="Quansight Labs">
+              <img src="_static/chanel-small.png" alt="Chanel" title="Chanel">
+              <img src="_static/bnp-paribas-small.png" alt="BNP Paribas Group" title="BNP Paribas Group">
+              <img src="_static/michelin-small.png" alt="Michelin" title="Michelin">
             </div>
             <p>Learn more about scikit-learn's financial support.</p>
         </div>


### PR DESCRIPTION
## Reference Issue

References #34366

## What does this implement/fix?

Several sponsor/funding images on the documentation home page (`doc/templates/index.html`) and funding side panel (`doc/templates/funding_links.html`) used `title` attributes but were missing `alt` text. WAVE (web accessibility evaluation tool) flags these as accessibility errors.

This PR adds `alt` attributes to all 11 images that were missing them.

This pull request includes code written with the assistance of AI.
The code has not yet been reviewed by a human.