### PR TITLE
Fix PyGitHub deprecation and check_array empty dtype list

### DIFF
--- a/maint_tools/update_tracking_issue.py
+++ b/maint_tools/update_tracking_issue.py
@@ -18,7 +18,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import defusedxml.ElementTree as ET
-from github import Github
+from github import Auth, Github
 
 parser = argparse.ArgumentParser(
     description="Create or update issue from JUnit test results from pytest"
@@ -65,7 +65,7 @@ if args.junit_file is None and args.tests_passed is None:
     print("Either --junit-file or --test-passed must be passed in")
     sys.exit(1)
 
-gh = Github(args.bot_github_token)
+gh = Github(auth=Auth.Token(args.bot_github_token))
 issue_repo = gh.get_repo(args.issue_repo)
 dt_now = datetime.now(tz=timezone.utc)
 date_str = dt_now.strftime("%b %d, %Y")

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -962,6 +962,8 @@ def check_array(
             dtype = None
 
     if isinstance(dtype, (list, tuple)):
+        if len(dtype) == 0:
+            raise ValueError("dtype is an empty list, please provide a non-empty list.")
         if dtype_orig is not None and dtype_orig in dtype:
             # no dtype conversion required
             dtype = None


### PR DESCRIPTION
## Reference Issues

Fixes #34639
Fixes #33582

## What does this implement/fix?

Two small fixes:

1. **#34639**: `maint_tools/update_tracking_issue.py` used the deprecated `Github(login_or_token=...)` API. Replaced with `Github(auth=Auth.Token(...))` to fix the PyGitHub DeprecationWarning.

2. **#33582**: `check_array` in `sklearn/utils/validation.py` raises `IndexError` when `dtype` is an empty list or tuple, because it does `dtype[0]` without checking. Added a guard that raises `ValueError("dtype is an empty list, please provide a non-empty list.")` before the indexing.

This pull request includes code written with the assistance of AI.
The code has not yet been reviewed by a human.