### PR TITLE
Fix PCA namespace checking in transform and inverse_transform

### DIFF
--- a/sklearn/decomposition/_base.py
+++ b/sklearn/decomposition/_base.py
@@ -13,7 +13,12 @@ from sklearn.base import (
     ClassNamePrefixFeaturesOutMixin,
     TransformerMixin,
 )
-from sklearn.utils._array_api import _add_to_diagonal, array_device, get_namespace
+from sklearn.utils._array_api import (
+    _add_to_diagonal,
+    array_device,
+    check_same_namespace,
+    get_namespace,
+)
 from sklearn.utils.validation import check_array, check_is_fitted, validate_data
 
 
@@ -139,6 +144,8 @@ class _BasePCA(
 
         check_is_fitted(self)
 
+        check_same_namespace(X, self, attribute="components_", method="transform")
+
         X = validate_data(
             self,
             X,
@@ -193,6 +200,8 @@ class _BasePCA(
         xp, _ = get_namespace(X, self.components_, self.explained_variance_)
 
         check_is_fitted(self)
+
+        check_same_namespace(X, self, attribute="components_", method="inverse_transform")
 
         X = check_array(X, input_name="X", dtype=[xp.float64, xp.float32])
 

--- a/sklearn/decomposition/_base.py
+++ b/sklearn/decomposition/_base.py
@@ -201,7 +201,9 @@ class _BasePCA(
 
         check_is_fitted(self)
 
-        check_same_namespace(X, self, attribute="components_", method="inverse_transform")
+        check_same_namespace(
+            X, self, attribute="components_", method="inverse_transform"
+        )
 
         X = check_array(X, input_name="X", dtype=[xp.float64, xp.float32])
 


### PR DESCRIPTION
## Reference Issue

Fixes #34483

## What does this implement/fix?

`PCA.transform` and `PCA.inverse_transform` used `get_namespace` instead of `check_same_namespace`, resulting in a less informative `TypeError` instead of the standard `ValueError` with guidance message when the input array namespace differs from the fitted attributes.

This PR adds `check_same_namespace` calls to both methods, matching the pattern used by other array API estimators like `Ridge` and `LogisticRegression`. Users now get the standard error message with guidance on how to move the estimator to the right namespace.