### PR TITLE
Fix radius_neighbors with array radius and n_jobs > 1

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.neighbors/34338.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.neighbors/34338.fix.rst
@@ -1,0 +1,6 @@
+- :meth:`neighbors.NearestNeighbors.radius_neighbors` now correctly
+  handles per-sample array radius with ``n_jobs > 1`` for ball_tree and
+  kd_tree algorithms. Previously, the full radius array was passed to
+  each parallel worker instead of the slice corresponding to its data
+  chunk.
+  By :user:`Abhishek Shivakumar <abhishekshivakumar>`.

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -1267,10 +1267,18 @@ class RadiusNeighborsMixin:
 
             n_jobs = effective_n_jobs(self.n_jobs)
             delayed_query = delayed(self._tree.query_radius)
-            chunked_results = Parallel(n_jobs, prefer="threads")(
-                delayed_query(X[s], radius, return_distance, sort_results=sort_results)
-                for s in gen_even_slices(X.shape[0], n_jobs)
-            )
+            if np.isscalar(radius):
+                chunked_results = Parallel(n_jobs, prefer="threads")(
+                    delayed_query(X[s], radius, return_distance, sort_results=sort_results)
+                    for s in gen_even_slices(X.shape[0], n_jobs)
+                )
+            else:
+                # When radius is an array (per-sample), each slice must get
+                # the corresponding subset of the radius array.
+                chunked_results = Parallel(n_jobs, prefer="threads")(
+                    delayed_query(X[s], radius[s], return_distance, sort_results=sort_results)
+                    for s in gen_even_slices(X.shape[0], n_jobs)
+                )
             if return_distance:
                 neigh_ind, neigh_dist = tuple(zip(*chunked_results))
                 results = np.hstack(neigh_dist), np.hstack(neigh_ind)

--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -1269,14 +1269,18 @@ class RadiusNeighborsMixin:
             delayed_query = delayed(self._tree.query_radius)
             if np.isscalar(radius):
                 chunked_results = Parallel(n_jobs, prefer="threads")(
-                    delayed_query(X[s], radius, return_distance, sort_results=sort_results)
+                    delayed_query(
+                        X[s], radius, return_distance, sort_results=sort_results
+                    )
                     for s in gen_even_slices(X.shape[0], n_jobs)
                 )
             else:
                 # When radius is an array (per-sample), each slice must get
                 # the corresponding subset of the radius array.
                 chunked_results = Parallel(n_jobs, prefer="threads")(
-                    delayed_query(X[s], radius[s], return_distance, sort_results=sort_results)
+                    delayed_query(
+                        X[s], radius[s], return_distance, sort_results=sort_results
+                    )
                     for s in gen_even_slices(X.shape[0], n_jobs)
                 )
             if return_distance:


### PR DESCRIPTION
## Reference Issue

Fixes #34338

## What does this implement/fix?

When `radius` is passed as a per-sample array to `radius_neighbors` with `ball_tree` or `kd_tree` and `n_jobs > 1`, the full radius array was passed to each parallel worker instead of the slice corresponding to its data chunk. This caused a `ValueError` because the radius array length did not match the number of query points in the slice.

Fix: slice the radius array alongside X when dispatching to parallel workers, using `radius[s]` instead of `radius` for each slice `s`.

## Reproducer

```python
import numpy as np
from sklearn.neighbors import NearestNeighbors

X = np.random.RandomState(0).rand(10, 3)
r = np.full(len(X), 0.4)

# Works with n_jobs=1:
NearestNeighbors(algorithm="ball_tree", n_jobs=1).fit(X).radius_neighbors(X, radius=r)

# Failed with n_jobs=2, now fixed:
NearestNeighbors(algorithm="ball_tree", n_jobs=2).fit(X).radius_neighbors(X, radius=r)
```

This pull request includes code written with the assistance of AI.
The code has not yet been reviewed by a human.