### PR TITLE
Fix .score() with array API and pandas y

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.utils/33822.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.utils/33822.fix.rst
@@ -1,0 +1,6 @@
+- :func:`utils._array_api.move_to` now converts pandas Series and
+  DataFrame inputs to NumPy arrays before moving them to the target
+  array API namespace. This fixes errors in ``ClassifierMixin.score``
+  and other methods when ``y`` is a pandas object and array API
+  dispatch is enabled.
+  By :user:`Abhishek Shivakumar <abhishekshivakumar>`.

--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -563,6 +563,13 @@ def move_to(*arrays, xp, device):
             "namespace is Numpy"
         )
 
+    # Convert pandas Series/DataFrame to numpy arrays so that they can be
+    # moved to the target namespace via DLPack or asarray.
+    arrays = [
+        numpy.asarray(array) if (not is_none and is_df_or_series(array)) else array
+        for array, is_none in zip(arrays, none_mask)
+    ]
+
     arrays_ = arrays
     # Down cast float64 `arrays` when highest precision of `xp`/`device` is float32
     if _max_precision_float_dtype(xp, device) == xp.float32:


### PR DESCRIPTION
## Reference Issue

Fixes #33822

## What does this implement/fix?

`move_to` in `sklearn/utils/_array_api.py` failed when passed a pandas `Series` or `DataFrame` because those objects do not support the DLPack protocol. The fallback path also failed because `get_namespace_and_device` does not recognize pandas objects as array API arrays.

This caused `ClassifierMixin.score` (and other methods that call `accuracy_score` or similar metrics) to fail when `y` was a pandas object and array API dispatch was enabled.

Fix: convert pandas `Series`/`DataFrame` to NumPy arrays at the start of `move_to`, before the namespace detection and DLPack transfer logic.

## Reproducer

```python
import numpy as np
import pandas as pd
import torch
from sklearn.linear_model import RidgeClassifier
from sklearn import config_context

rng = np.random.default_rng(seed=123)
X = rng.standard_normal(size=(100, 10))
y = rng.integers(2, size=X.shape[0])
Xt = torch.tensor(X)
ys = pd.Series(y)

with config_context(array_api_dispatch=True):
    model = RidgeClassifier(solver="svd").fit(Xt, ys)
    score = model.score(Xt, ys)  # failed before, now works
```

This pull request includes code written with the assistance of AI.
The code has not yet been reviewed by a human.