### PR TITLE
FIX RadiusNeighborsRegressor silently returns a sentinel for empty neighborhoods with integer targets

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.neighbors/34716.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.neighbors/34716.fix.rst
@@ -1,0 +1,7 @@
+- :class:`neighbors.RadiusNeighborsRegressor` now returns `nan` and warns when a
+  query point has no neighbors within `radius` and `y` has a non-floating point
+  dtype. Previously the `nan` was cast to the target dtype, which produced an
+  implementation defined value and suppressed the warning. Predictions for such
+  targets are now floating point, as is already the case when the neighborhood
+  is non-empty.
+  By :user:`Kayvan Zahiri <Kayvan-Zahiri>`.

--- a/sklearn/neighbors/_regression.py
+++ b/sklearn/neighbors/_regression.py
@@ -486,7 +486,16 @@ class RadiusNeighborsRegressor(RadiusNeighborsMixin, RegressorMixin, NeighborsBa
         if _y.ndim == 1:
             _y = _y.reshape((-1, 1))
 
-        empty_obs = np.full_like(_y[0], np.nan)
+        # `np.full_like` would inherit the target dtype, and casting NaN into an
+        # integer or boolean target is undefined: it silently yields a sentinel
+        # (0 or -2**63 depending on platform) that is indistinguishable from a
+        # real prediction. It also defeats the `np.isnan` check below, so the
+        # "no neighbors" warning never fired for such targets. Promote to a
+        # float dtype so NaN is representable, matching what `np.mean` returns
+        # for the non-empty rows.
+        empty_obs = np.full_like(
+            _y[0], np.nan, dtype=np.promote_types(_y.dtype, np.float16)
+        )
 
         if weights is None:
             y_pred = np.array(

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -999,6 +999,47 @@ def test_neighbors_regressors_zero_distance():
             assert_allclose(corr_labels, knn.predict(z))
 
 
+@pytest.mark.parametrize("y_dtype", [np.int32, np.int64, np.float32, np.float64])
+@pytest.mark.parametrize("weights", ["uniform", "distance"])
+def test_radius_neighbors_regressor_empty_neighborhood_dtype(y_dtype, weights):
+    """Empty neighborhoods must predict NaN and warn for any target dtype.
+
+    Non-regression test for #12960: the placeholder was built with
+    `np.full_like` on the target, so casting NaN into an integer target
+    produced a platform-dependent sentinel (0 or -2**63) that looked like a
+    real prediction. That also defeated the `np.isnan` check guarding the
+    "no neighbors" warning, so integer targets failed silently.
+    """
+    X = np.array([[0.0], [1.0], [2.0]])
+    y = np.array([0, 1, 2], dtype=y_dtype)
+
+    est = neighbors.RadiusNeighborsRegressor(radius=0.5, weights=weights).fit(X, y)
+    with pytest.warns(UserWarning, match="no neighbors"):
+        y_pred = est.predict(np.array([[100.0]]))
+
+    assert np.issubdtype(y_pred.dtype, np.floating)
+    assert np.isnan(y_pred).all()
+
+
+@pytest.mark.parametrize("y_dtype", [np.int64, np.float64])
+def test_radius_neighbors_regressor_partially_empty_neighborhood(y_dtype):
+    """A sample with neighbors and one without must not contaminate each other.
+
+    Non-regression test for #12960: with an integer target the empty row came
+    back as 0 rather than NaN, so the caller could not tell it apart from a
+    genuine zero prediction.
+    """
+    X = np.array([[0.0], [1.0], [2.0]])
+    y = np.array([0, 1, 2], dtype=y_dtype)
+
+    est = neighbors.RadiusNeighborsRegressor(radius=0.6).fit(X, y)
+    with pytest.warns(UserWarning, match="no neighbors"):
+        y_pred = est.predict(np.array([[1.0], [100.0]]))
+
+    assert y_pred[0] == pytest.approx(1.0)
+    assert np.isnan(y_pred[1])
+
+
 def test_radius_neighbors_boundary_handling():
     """Test whether points lying on boundary are handled consistently
 


### PR DESCRIPTION
Reference Issues/PRs
--------------------
Fixes #12960.

What does this implement/fix? Explain your changes.
---------------------------------------------------

`RadiusNeighborsRegressor` builds the placeholder for samples with no neighbors
inside `radius` with:

```python
empty_obs = np.full_like(_y[0], np.nan)
```

`np.full_like` inherits the target dtype, and casting NaN into an integer target
is undefined. The result is a sentinel that is indistinguishable from a real
prediction:

```python
X = np.array([[0.0], [1.0], [2.0]])
est = RadiusNeighborsRegressor(radius=0.5).fit(X, np.array([0, 1, 2]))
est.predict([[100.0]])
# main: array([0])          <- 0 is a plausible prediction here
# this PR: array([nan]) + UserWarning
```

The reported value was `-9223372036854775808` in the original issue and is `0`
on numpy 2.x; either way it is platform-dependent garbage.

There is a second, worse consequence. The "no neighbors" warning is guarded by:

```python
if np.any(np.isnan(y_pred)):
```

`np.isnan` on an integer array is always `False`, so once the NaN had been cast
away the warning could never fire. Integer targets therefore failed silently in
both directions: wrong value *and* no warning. Float targets were unaffected,
which is why this went unnoticed.

Mixed batches were also affected, and this is the case most likely to reach a
user unnoticed:

```python
est = RadiusNeighborsRegressor(radius=0.6).fit(X, np.array([0, 1, 2]))
est.predict([[1.0], [100.0]])
# main:    array([1., 0.])    <- second entry is not a prediction
# this PR: array([ 1., nan]) + UserWarning
```

The fix promotes the placeholder to a float dtype so NaN is representable:

```python
empty_obs = np.full_like(
    _y[0], np.nan, dtype=np.promote_types(_y.dtype, np.float16)
)
```

`np.promote_types(dtype, np.float16)` reproduces the dtype `np.mean` already
returns for the non-empty rows (`int32/int64 -> float64`, `float32 -> float32`,
`float64 -> float64`), so predictions are unchanged wherever neighbors exist and
`float32` targets keep their precision rather than being widened.

Any other comments?
-------------------

**Tests.** Two non-regression tests, ten parametrised cases: empty
neighborhoods across `int32/int64/float32/float64` and both weightings, and a
partially-empty batch. Each asserts NaN, a floating result dtype, and that the
`UserWarning` actually fires. Against `main` five of the ten fail (every integer
case); all ten pass with this change.

**Validation caveat, stated plainly.** I could not build scikit-learn from source
on this machine; the C++ toolchain fails on the macOS SDK headers, unrelated to
this change. I validated by applying the patched `_regression.py` over an
installed 1.8.0 and running `sklearn.neighbors.tests.test_neighbors`:

```
pristine 1.8.0, its own tests                     585 passed, 436 skipped
patched _regression.py, its own tests             585 passed, 436 skipped
```

identical, so no regression in the released test suite. Running `main`'s test
file against installed 1.8.0 produces 10 pre-existing failures purely from the
version skew (confirmed with none of my changes applied), and the same 10 with
this change plus my 10 new tests passing. CI here is authoritative over my local
numbers.

One incidental effect: the fix removes roughly 185 spurious
`RuntimeWarning: invalid value encountered in cast` warnings from that test run.

**One design question for the reviewer.** I kept the existing contract of
NaN-plus-`UserWarning` rather than raising, since that is what float targets have
always done and changing it would be a behaviour break for them. Integer targets
now simply behave like float ones. If the preference is to raise on empty
neighborhoods, that is a different and larger change and I am happy to take it
instead.


#### AI usage disclosure

I used AI assistance for:
- Code generation (fixing the bug)
- Test/benchmark generation
- Drafting this PR description

Per the Automated Contributions Policy, the change was reviewed, run and verified before
submission rather than submitted unread.
