### PR TITLE
FIX Fix sample_weight with zero values when bootstrap=False in Bagging and IsolationForest (#34673)

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.ensemble/34720.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.ensemble/34720.fix.rst
@@ -1,0 +1,2 @@
+- Fixes a bug in :class:`ensemble.BaggingClassifier`, :class:`ensemble.BaggingRegressor`, and :class:`ensemble.IsolationForest` where passing a ``sample_weight`` with zero values raised a ``ValueError`` when ``bootstrap=False``.
+  By :user:`Azhar Hussain <azharhussaincs>`.

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -462,13 +462,21 @@ class BaseBagging(BaseEnsemble, metaclass=ABCMeta):
 
         # Validate max_samples
         if max_samples is None:
-            max_samples = self.max_samples
+            if not self.bootstrap and sample_weight is not None:
+                max_samples = np.count_nonzero(sample_weight)
+            else:
+                max_samples = self.max_samples
 
         max_samples = _get_n_samples_bootstrap(X.shape[0], max_samples, sample_weight)
-        if not self.bootstrap and max_samples > X.shape[0]:
+        n_effective_samples = (
+            np.count_nonzero(sample_weight)
+            if (sample_weight is not None and not self.bootstrap)
+            else X.shape[0]
+        )
+        if not self.bootstrap and max_samples > n_effective_samples:
             raise ValueError(
                 f"Effective max_samples={max_samples} must be <= n_samples="
-                f"{X.shape[0]} to be able to sample without replacement."
+                f"{n_effective_samples} to be able to sample without replacement."
             )
 
         # Store validated integer row sampling value

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -333,7 +333,11 @@ class IsolationForest(OutlierMixin, BaseBagging):
         y = rnd.uniform(size=X.shape[0])
 
         # ensure that max_sample is in [1, n_samples]:
-        n_samples = X.shape[0]
+        n_samples = (
+            np.count_nonzero(sample_weight)
+            if (sample_weight is not None and not self.bootstrap)
+            else X.shape[0]
+        )
 
         if isinstance(self.max_samples, str) and self.max_samples == "auto":
             max_samples = min(256, n_samples)
@@ -350,7 +354,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
             else:
                 max_samples = self.max_samples
         else:  # max_samples is float
-            max_samples = int(self.max_samples * X.shape[0])
+            max_samples = int(self.max_samples * n_samples)
 
         self.max_samples_ = max_samples
         max_depth = int(np.ceil(np.log2(max(max_samples, 2))))

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -1171,3 +1171,18 @@ def test_bagging_without_support_metadata_routing(model):
     """Make sure that we still can use an estimator that does not implement the
     metadata routing."""
     model.fit(iris.data, iris.target)
+
+
+@pytest.mark.parametrize("bagging_class", [BaggingClassifier, BaggingRegressor])
+def test_zero_sample_weight_bootstrap_false(bagging_class):
+    """Check that zero sample_weight with bootstrap=False does not raise error."""
+    X = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+    y = np.array([0, 0, 1, 1])
+    sample_weight = np.array([1.0, 0.0, 1.0, 0.0])
+
+    clf = bagging_class(bootstrap=False, random_state=0)
+    clf.fit(X, y, sample_weight=sample_weight)
+
+    for samples in clf.estimators_samples_:
+        assert np.isin(samples, [0, 2]).all()
+        assert len(samples) == 2

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -393,3 +393,17 @@ def test_iforest_predict_parallel(global_random_seed, contamination, n_jobs):
 
     # assert the same results as non-parallel
     assert_array_equal(pred, pred_parallel)
+
+
+def test_iforest_zero_sample_weight_bootstrap_false():
+    """Check that zero sample_weight with bootstrap=False does not raise error."""
+    X = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+    sample_weight = np.array([1.0, 0.0, 1.0, 0.0])
+
+    iso = IsolationForest(bootstrap=False, random_state=0)
+    iso.fit(X, sample_weight=sample_weight)
+
+    assert iso.max_samples_ == 2
+    for samples in iso.estimators_samples_:
+        assert np.isin(samples, [0, 2]).all()
+        assert len(samples) == 2


### PR DESCRIPTION
Fixes #34673

### Summary of Changes
When fitting `BaggingClassifier`, `BaggingRegressor`, or `IsolationForest` with `bootstrap=False` and a `sample_weight` array containing zero values (`0.0`), `np.random.choice(..., replace=False)` raised an unhandled `ValueError: Fewer non-zero entries in p than size`. 

This occurs because zero-weighted samples have probability $0.0$ of being selected, capping the maximum draw count at $N_{\text{non\_zero}}$.

1. **`sklearn/ensemble/_bagging.py`**: Updated `_fit` to calculate the effective maximum samples using `np.count_nonzero(sample_weight)` when `bootstrap=False` and `sample_weight` is present.
2. **`sklearn/ensemble/_iforest.py`**: Updated `fit` to calculate effective sample capacity based on non-zero `sample_weight` entries under `bootstrap=False`.
3. **Tests**: Added regression unit tests in `test_bagging.py` and `test_iforest.py` verifying estimators fit without raising `ValueError` when `sample_weight` contains zeros under `bootstrap=False`.

### Verification
- Executed `pytest sklearn/ensemble/tests/test_bagging.py sklearn/ensemble/tests/test_iforest.py`
- All 162 ensemble unit tests passed cleanly.