### PR TITLE
FIX Fix UnionFind.fast_find path compression to correctly compress nodes to root

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.cluster/34722.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.cluster/34722.fix.rst
@@ -1,0 +1,4 @@
+- Hierarchical clustering UnionFind path compression
+  (``fast_find``) now correctly compresses intermediate nodes to the root
+  (previously path compression could leave stale parent links).
+  By :user:`Vedant Madane <VedantMadane>`.

--- a/sklearn/cluster/_hierarchical_fast.pyx
+++ b/sklearn/cluster/_hierarchical_fast.pyx
@@ -338,15 +338,17 @@ cdef class UnionFind(object):
 
     @cython.wraparound(True)
     cdef intp_t fast_find(self, intp_t n) noexcept:
-        cdef intp_t p
-        p = n
+        cdef intp_t root, nxt
+        root = n
         # find the highest node in the linkage graph so far
-        while self.parent[n] != -1:
-            n = self.parent[n]
+        while self.parent[root] != -1:
+            root = self.parent[root]
         # provide a shortcut up to the highest node
-        while self.parent[p] != n:
-            p, self.parent[p] = self.parent[p], n
-        return n
+        while self.parent[n] != -1 and self.parent[n] != root:
+            nxt = self.parent[n]
+            self.parent[n] = root
+            n = nxt
+        return root
 
 
 def _single_linkage_label(const float64_t[:, :] L):

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -916,3 +916,24 @@ def test_agglomeration_ward_euclidean(Clustering, metric):
         linkage="ward",
     )
     clustering.fit(X)
+
+
+def test_union_find_fast_find_path_compression():
+    """Test that UnionFind.fast_find correctly compresses paths to the root (#34626)."""
+    from sklearn.cluster._hierarchical_fast import single_linkage_label
+
+    K = 100
+    rows = []
+    w = 0.0
+    for i in range(K - 1):
+        rows.append((i, i + 1, w))
+        w += 1.0
+    for i in range(K):
+        rows.append((i, K + i, w))
+        w += 1.0
+    L = np.array(rows, dtype=np.float64)
+
+    # Should run quickly and return valid tree structure without error
+    result = single_linkage_label(L)
+    assert result.shape[0] == 2 * K - 1
+

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -936,4 +936,3 @@ def test_union_find_fast_find_path_compression():
     # Should run quickly and return valid tree structure without error
     result = single_linkage_label(L)
     assert result.shape[0] == 2 * K - 1
-


### PR DESCRIPTION
### Summary

Fixes #34626

In sklearn/cluster/_hierarchical_fast.pyx, UnionFind.fast_find previously used a chained tuple assignment p, self.parent[p] = self.parent[p], n to perform path compression.

In Cython/Python, chained tuple assignments evaluate the right-hand side first and perform target assignments left-to-right (p is rebound to self.parent[p] first, so self.parent[p] = n indexes with the already-updated p). As a result, the node originally passed to ast_find(n) was never repointed at the root, causing repeated lookups to take O(N^2) time in single-linkage clustering and HDBSCAN.

### Details
- Refactored ast_find to use explicit two-pass root finding and path compression loop without tuple assignment aliasing.
- Added unit test 	est_union_find_fast_find_path_compression in sklearn/cluster/tests/test_hierarchical.py.