### PR TITLE
FIX validate multilabel target shape in dump_svmlight_file (#34661)

### DIFF
--- a/sklearn/datasets/_svmlight_format_io.py
+++ b/sklearn/datasets/_svmlight_format_io.py
@@ -544,6 +544,18 @@ def dump_svmlight_file(
     else:
         if yval.ndim != 1 and not multilabel:
             raise ValueError("expected y of shape (n_samples,), got %r" % (yval.shape,))
+        # Multilabel requires a 2D target: one row per sample holding its set of
+        # labels, which is what the Cython dumper indexes as `y[i, j]`. A 1D y
+        # (scalar label per sample) slips through the shape check above when
+        # multilabel=True and then reaches that 2D index as a 1D array — reading
+        # out of bounds and terminating the interpreter with SIGSEGV (issue
+        # #34661). Reject it up front with a clear error instead of crashing.
+        if multilabel and yval.ndim != 2:
+            raise ValueError(
+                "When multilabel=True, y must be a 2D array of shape "
+                "(n_samples, n_labels), got %r. Pass an array-like of label "
+                "sequences such as [[0, 1], [2]]." % (yval.shape,)
+            )
 
     Xval = check_array(X, accept_sparse="csr")
     if Xval.shape[0] != yval.shape[0]:

--- a/sklearn/datasets/tests/test_svmlight_format.py
+++ b/sklearn/datasets/tests/test_svmlight_format.py
@@ -417,6 +417,20 @@ def test_dump_invalid():
         dump_svmlight_file(X, y[:-1], f)
 
 
+def test_dump_invalid_multilabel_1d_y():
+    # Multilabel needs a 2D target (one label-set row per sample); a 1D y is
+    # incompatible and previously reached the Cython dumper as a 1D array,
+    # whose 2D `y[i, j]` indexing read out of bounds and segfaulted the whole
+    # interpreter (issue #34661). It must raise a clear ValueError, not crash.
+    X = np.zeros((2, 2))
+    y_1d = np.array([0, 1])
+    f = BytesIO()
+    with pytest.raises(ValueError, match="multilabel"):
+        dump_svmlight_file(X, y_1d, f, multilabel=True)
+    # Can't return here: a segfault kills the process rather than raising, so an
+    # exception reaching this line already proves the interpreter survived.
+
+
 def test_dump_query_id():
     # test dumping a file with query_id
     X, y = _load_svmlight_local_test_file(datafile)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! The PR body below follows
scikit-learn's contributing guidelines (describe the why, highlight areas
needing careful review, no filler).
-->

#### Reference Issues/PRs
Fixes #34661

#### What does this implement/fix?
`dump_svmlight_file(X, y, f, multilabel=True)` with a 1D `y` terminates the
interpreter with SIGSEGV. The public API validation lets a 1D `y` through when
`multilabel=True`, and the low-level Cython dumper then indexes `y` as 2D
(`y[i, j]`), reading out of bounds on a 1D array and killing the process with
no Python traceback.

This adds an up-front validation guard in `dump_svmlight_file`: when
`multilabel=True`, `y` must be a 2D array of shape `(n_samples, n_labels)`.
A 1D target now raises a clear `ValueError` ("When multilabel=True, y must be a
2D array of shape (n_samples, n_labels) ...") instead of crashing the notebook
or pipeline.

#### Why is this the right fix?
A 1D `y` is genuinely incompatible with multilabel semantics (each sample needs
a collection of labels), so rejecting it is correct — and the guard lives in the
same dense/shape validation block as the existing single-label shape checks,
mirroring their style. The Cython dumper needs no changes and keeps its current
contract (2D dense or a sparse matrix of labels).

#### Any other changes?
- Added `test_dump_invalid_multilabel_1d_y` asserting a 1D `y` + `multilabel=True`
  raises `ValueError` (and that the process survives, which is the failure mode).
- Existing `test_dump`, `test_dump_multilabel`, and `test_dump_invalid` still pass.

#### Release note
Fix `dump_svmlight_file` segfault when `multilabel=True` is combined with a
1-dimensional target.

---

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.
