### PR TITLE
fix: set timeout on OpenML urlopen calls to avoid indefinite hangs

### DIFF
--- a/sklearn/datasets/_openml.py
+++ b/sklearn/datasets/_openml.py
@@ -39,6 +39,11 @@ _DATA_INFO = "https://www.openml.org/api/v1/json/data/{}"
 _DATA_FEATURES = "https://www.openml.org/api/v1/json/data/features/{}"
 _DATA_QUALITIES = "https://www.openml.org/api/v1/json/data/qualities/{}"
 
+# Default socket timeout (in seconds) for OpenML network requests. Without an
+# explicit timeout, urlopen() can block indefinitely on a slow or unresponsive
+# server, and the TimeoutError retry handling below would never trigger.
+_OPENML_URLOPEN_TIMEOUT = 60
+
 OpenmlQualitiesType = List[Dict[str, str]]
 OpenmlFeaturesType = List[Dict[str, str]]
 
@@ -180,7 +185,9 @@ def _open_openml_url(
     req.add_header("Accept-encoding", "gzip")
 
     if data_home is None:
-        fsrc = _retry_on_network_error(n_retries, delay, req.full_url)(urlopen)(req)
+        fsrc = _retry_on_network_error(n_retries, delay, req.full_url)(urlopen)(
+            req, timeout=_OPENML_URLOPEN_TIMEOUT
+        )
         if is_gzip_encoded(fsrc):
             return gzip.GzipFile(fileobj=fsrc, mode="rb")
         return fsrc
@@ -198,7 +205,7 @@ def _open_openml_url(
             with TemporaryDirectory(dir=dir_name) as tmpdir:
                 with closing(
                     _retry_on_network_error(n_retries, delay, req.full_url)(urlopen)(
-                        req
+                        req, timeout=_OPENML_URLOPEN_TIMEOUT
                     )
                 ) as fsrc:
                     opener: Callable


### PR DESCRIPTION
## What

`_open_openml_url` in `sklearn/datasets/_openml.py` opens network connections with `urlopen(req)` and never passes a `timeout`. With the default (`timeout=None`), the call blocks indefinitely if the server accepts the connection but stops sending data (a slow-loris / stalled response).

## Why it matters

`fetch_openml(...)` is the public entry point that drives these downloads. The surrounding retry helper `_retry_on_network_error` explicitly catches `TimeoutError`:

```python
except (URLError, TimeoutError) as e:
    ...
```

but because no `timeout` is ever set on `urlopen`, a socket read timeout can never be raised, so that retry branch is effectively dead code and a stalled or unresponsive host hangs the caller forever (a denial-of-service / resource-exhaustion condition, CWE-400). A user calling `fetch_openml` in an automated pipeline against a slow or misbehaving mirror has no way to recover short of killing the process.

## Fix

Add a module-level default timeout (`_OPENML_URLOPEN_TIMEOUT = 60`) and pass it to both `urlopen` calls in `_open_openml_url`. This bounds each network read and makes the existing `TimeoutError` retry logic actually reachable. The change is internal only and does not alter the public API.

## Test

The existing OpenML test mocks use the signature `def _mock_urlopen(request, *args, **kwargs)`, so the added `timeout=` keyword is accepted without changes. Run:

```
pytest sklearn/datasets/tests/test_openml.py
```
