### PR TITLE
MAINT use Auth.Token for PyGithub in tracking issue tool

### DIFF
--- a/maint_tools/update_tracking_issue.py
+++ b/maint_tools/update_tracking_issue.py
@@ -18,7 +18,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import defusedxml.ElementTree as ET
-from github import Github
+from github import Auth, Github
 
 parser = argparse.ArgumentParser(
     description="Create or update issue from JUnit test results from pytest"
@@ -65,7 +65,7 @@ if args.junit_file is None and args.tests_passed is None:
     print("Either --junit-file or --test-passed must be passed in")
     sys.exit(1)
 
-gh = Github(args.bot_github_token)
+gh = Github(auth=Auth.Token(args.bot_github_token))
 issue_repo = gh.get_repo(args.issue_repo)
 dt_now = datetime.now(tz=timezone.utc)
 date_str = dt_now.strftime("%b %d, %Y")


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #34639

#### What does this implement/fix?

Replace the deprecated positional PyGithub token construction with `Auth.Token` passed through the supported `auth=` parameter. This removes the CI `DeprecationWarning` without changing the tracking tool’s behavior.

#### Testing

- `python3 -m compileall -q maint_tools/update_tracking_issue.py`
- PyGithub `Auth.Token` import check

#### AI usage disclosure

I used AI assistance for:
- Code generation
- Research and understanding

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.