### PR TITLE
CI Use lint lock-file from merging main into PR branch in lint.yml workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          # We want to check out the PR branch to report linting errors with
+          # lines that match the contributor PR branch. GHA checkout behavior
+          # by default is to merge main into the PR branch
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Python
@@ -32,7 +35,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r build_tools/github/lint_lock.txt
+          # We want to use the linting tools from main and not the PR branch,
+          # so we download the linting lock-file from main and pip install from it
+          curl https://raw.githubusercontent.com/scikit-learn/scikit-learn/main/build_tools/github/lint_lock.txt \
+            --retry 5 -o ./build_tools/main_lint_lock.txt
+          pip install -r build_tools/github/main_lint_lock.txt
+
           # we save the versions of the linters to be used in the error message later.
           python -c "from importlib.metadata import version; print(f\"pytest={version('pytest')}\")" >> /tmp/versions.txt
           python -c "from importlib.metadata import version; print(f\"ruff={version('ruff')}\")" >> /tmp/versions.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,13 +20,22 @@ jobs:
       pull-requests: none
 
     steps:
-      - name: Checkout code
+      - name: Checkout code from PR branch
         uses: actions/checkout@v7
         with:
           # We want to check out the PR branch to report linting errors with
-          # lines that match the contributor PR branch. GHA checkout behavior
-          # by default is to merge main into the PR branch
+          # lines that match the PR branch. GHA checkout behavior by default is
+          # to merge main into the PR branch
           ref: ${{ github.event.pull_request.head.sha }}
+
+      # We want to use the lint lock-file from merging main into the PR branch
+      # (default checkout behavior)
+      - name: Checkout lint lock-file from merging main into the PR branch
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: build_tools/github/lint_lock.txt
+          sparse-checkout-cone-mode: false
+          path: merge-main-into-pr-branch
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -35,11 +44,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          # We want to use the linting tools from main and not the PR branch,
-          # so we download the linting lock-file from main and pip install from it
-          curl https://raw.githubusercontent.com/scikit-learn/scikit-learn/main/build_tools/github/lint_lock.txt \
-            --retry 5 -o main_lint_lock.txt
-          pip install -r main_lint_lock.txt
+          # We want to install the lint lock-file from merging main into the PR branch
+          pip install -r merge-main-into-pr-branch/build_tools/github/lint_lock.txt
 
           # we save the versions of the linters to be used in the error message later.
           python -c "from importlib.metadata import version; print(f\"pytest={version('pytest')}\")" >> /tmp/versions.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,8 +38,8 @@ jobs:
           # We want to use the linting tools from main and not the PR branch,
           # so we download the linting lock-file from main and pip install from it
           curl https://raw.githubusercontent.com/scikit-learn/scikit-learn/main/build_tools/github/lint_lock.txt \
-            --retry 5 -o ./build_tools/main_lint_lock.txt
-          pip install -r build_tools/github/main_lint_lock.txt
+            --retry 5 -o main_lint_lock.txt
+          pip install -r main_lint_lock.txt
 
           # we save the versions of the linters to be used in the error message later.
           python -c "from importlib.metadata import version; print(f\"pytest={version('pytest')}\")" >> /tmp/versions.txt


### PR DESCRIPTION
So the `lint.yml` workflow that is used for the bot comment should use the linting tools from merging `main` into the PR branch (default GHA `checkout` behaviour) since this is the source of truth for the tools we use.

Because in the `lint.yml` workflow we explicitly check-out the PR branch (not the result of merging `main` into the PR branch which is the default GHA checkout behavior), the lint lock-file from the PR is used which seems wrong.

See https://github.com/scikit-learn/scikit-learn/issues/34719#issuecomment-5254892182 for context.

cc @betatim @AnneBeyer 
