### PR TITLE
MNT Avoid numpy array shape DeprecationWarnings in datasets

### DIFF
--- a/sklearn/datasets/_base.py
+++ b/sklearn/datasets/_base.py
@@ -1003,8 +1003,7 @@ def load_digits(*, n_class=10, return_X_y=False, as_frame=False):
 
     target = data[:, -1].astype(int, copy=False)
     flat_data = data[:, :-1]
-    images = flat_data.view()
-    images.shape = (-1, 8, 8)
+    images = flat_data.reshape(-1, 8, 8)
 
     if n_class < 10:
         idx = target < n_class

--- a/sklearn/datasets/_lfw.py
+++ b/sklearn/datasets/_lfw.py
@@ -476,7 +476,7 @@ def _fetch_lfw_pairs(
     n_faces = shape.pop(0)
     shape.insert(0, 2)
     shape.insert(0, n_faces // 2)
-    pairs.shape = shape
+    pairs = pairs.reshape(shape)
 
     return pairs, target, np.array(["Different persons", "Same person"])
 


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
N/A


#### What does this implement/fix? Explain your changes.
Scikit-learn suppresses DeprecationWarnings, but in downstream examples in scikit-learn-intelex we run examples with `-W error` to keep user-facing examples clean. With numpy 2.5+, setting shape on numpy array was deprecated. Simplest reproducer (py3.12+):
```
pip install scikit-learn==1.9.0 numpy==2.5.2
python -W error -c "from sklearn.datasets import load_digits; load_digits()"

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/mnt/cached_oses/eglaser/miniforge3/envs/sklearn_bug/lib/python3.12/site-packages/sklearn/utils/_param_validation.py", line 218, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/cached_oses/eglaser/miniforge3/envs/sklearn_bug/lib/python3.12/site-packages/sklearn/datasets/_base.py", line 1007, in load_digits
    images.shape = (-1, 8, 8)
    ^^^^^^^^^^^^
DeprecationWarning: Setting the shape on a NumPy array has been deprecated in NumPy 2.5.
As an alternative, you can create a new view using np.reshape (with copy=False if needed).
```

#### First time contributor introduction
I am a developer working on https://github.com/uxlfoundation/scikit-learn-intelex


#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Research and understanding


#### Any other comments?
N/A

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
