### PR TITLE
DOC Fix parameter names in private function docstrings

### DIFF
--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -772,10 +772,6 @@ def _labels_inertia(X, sample_weight, centers, n_threads=1, return_inertia=True)
     sample_weight : ndarray of shape (n_samples,)
         The weights for each observation in X.
 
-    x_squared_norms : ndarray of shape (n_samples,)
-        Precomputed squared euclidean norm of each data point, to speed up
-        computations.
-
     centers : ndarray of shape (n_clusters, n_features)
         The cluster centers.
 
@@ -1582,9 +1578,6 @@ def _mini_batch_step(
 
     X : {ndarray, sparse matrix} of shape (n_samples, n_features)
         The original data array. If sparse, must be in CSR format.
-
-    x_squared_norms : ndarray of shape (n_samples,)
-        Squared euclidean norm of each data point.
 
     sample_weight : ndarray of shape (n_samples,)
         The weights for each observation in `X`.

--- a/sklearn/datasets/_arff_parser.py
+++ b/sklearn/datasets/_arff_parser.py
@@ -133,7 +133,7 @@ def _liac_arff_parser(
         - `"pandas"`: `X` will be a pandas DataFrame and `y` will be either a
           pandas Series or DataFrame.
 
-    columns_info : dict
+    openml_columns_info : dict
         The information provided by OpenML regarding the columns of the ARFF
         file.
 

--- a/sklearn/mixture/_bayesian_mixture.py
+++ b/sklearn/mixture/_bayesian_mixture.py
@@ -596,8 +596,6 @@ class BayesianGaussianMixture(BaseMixture):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-
         nk : array-like of shape (n_components,)
 
         xk : array-like of shape (n_components, n_features)
@@ -632,8 +630,6 @@ class BayesianGaussianMixture(BaseMixture):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-
         nk : array-like of shape (n_components,)
 
         xk : array-like of shape (n_components, n_features)
@@ -666,8 +662,6 @@ class BayesianGaussianMixture(BaseMixture):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-
         nk : array-like of shape (n_components,)
 
         xk : array-like of shape (n_components, n_features)
@@ -696,8 +690,6 @@ class BayesianGaussianMixture(BaseMixture):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-
         nk : array-like of shape (n_components,)
 
         xk : array-like of shape (n_components, n_features)
@@ -787,8 +779,6 @@ class BayesianGaussianMixture(BaseMixture):
 
         Parameters
         ----------
-        X : array-like of shape (n_samples, n_features)
-
         log_resp : array, shape (n_samples, n_components)
             Logarithm of the posterior probabilities (or responsibilities) of
             the point of each sample in X.

--- a/sklearn/mixture/_gaussian_mixture.py
+++ b/sklearn/mixture/_gaussian_mixture.py
@@ -231,7 +231,7 @@ def _estimate_gaussian_covariances_diag(resp, X, nk, means, reg_covar, xp=None):
 
     Parameters
     ----------
-    responsibilities : array-like of shape (n_samples, n_components)
+    resp : array-like of shape (n_samples, n_components)
 
     X : array-like of shape (n_samples, n_features)
 
@@ -257,7 +257,7 @@ def _estimate_gaussian_covariances_spherical(resp, X, nk, means, reg_covar, xp=N
 
     Parameters
     ----------
-    responsibilities : array-like of shape (n_samples, n_components)
+    resp : array-like of shape (n_samples, n_components)
 
     X : array-like of shape (n_samples, n_features)
 

--- a/sklearn/utils/_set_output.py
+++ b/sklearn/utils/_set_output.py
@@ -60,8 +60,8 @@ class ContainerAdapterProtocol(Protocol):
 
         Parameters
         ----------
-        Xs: container
-            Containers to be checked.
+        X : container
+            Container to be checked.
 
         Returns
         -------


### PR DESCRIPTION
#### Reference Issues/PRs

None

#### What does this implement/fix? Explain your changes.

`test_docstring_parameters` skips anything whose name starts with an underscore:

```python
if fname.startswith("_"):
    # Don't test private methods / functions
```

So private helpers are never checked, and eleven of them document a parameter that is not in the signature

| where | the docstring says | the signature says |
|---|---|---|
| `_kmeans.py` `_labels_inertia` | `x_squared_norms` | no such argument |
| `_kmeans.py` `_mini_batch_step` | `x_squared_norms` | no such argument |
| `_bayesian_mixture.py` `_estimate_wishart_full` | `X` | `nk, xk, sk` |
| `_bayesian_mixture.py` `_estimate_wishart_tied` | `X` | `nk, xk, sk` |
| `_bayesian_mixture.py` `_estimate_wishart_diag` | `X` | `nk, xk, sk` |
| `_bayesian_mixture.py` `_estimate_wishart_spherical` | `X` | `nk, xk, sk` |
| `_bayesian_mixture.py` `_compute_lower_bound` | `X` | `log_resp, log_prob_norm` |
| `_gaussian_mixture.py` `_estimate_gaussian_covariances_diag` | `responsibilities` | `resp` |
| `_gaussian_mixture.py` `_estimate_gaussian_covariances_spherical` | `responsibilities` | `resp` |
| `_arff_parser.py` `_liac_arff_parser` | `columns_info` | `openml_columns_info` |
| `_set_output.py` `is_supported_container` | `Xs`, "Containers to be checked" | `X`, and the summary line right above says `X` too |

The stale entries are dropped and the renamed ones are corrected. Docstrings only, nothing else touched

btw the sibling helpers in the same files are fine, so this is drift rather than a convention: `_initialize` and `_m_step` in `_bayesian_mixture.py` do take `X` and document it correctly, and I left those alone

#### First time contributor introduction

I use scikit-learn for ordinary work with data rather than for research. This one came out of a side project: I write small checkers that compare what a project says about itself against what its code does, run them over libraries I use, and send back what survives reading by hand

#### AI usage disclosure

I used AI assistance for:
- Documentation (including examples)

Btw the finding came from a checker I wrote with help from Claude Opus 5. Every one of the eleven was opened and read by hand before it went into this PR, and two more that the checker flagged turned out to be wrong and were dropped

#### Any other comments?

None