### PR TITLE
FIX Have progressbar timers stop when task is finished in meta-estimators.

### DIFF
--- a/sklearn/callback/_progressbar.py
+++ b/sklearn/callback/_progressbar.py
@@ -124,7 +124,7 @@ try:
 
         def render(self, task):
             if self.elapsed_when_finished and task.finished:
-                seconds = task.elapsed
+                seconds = task.finished_time
             else:
                 seconds = task.time_remaining
 


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
N/A

#### What does this implement/fix? Explain your changes.

When using a `ProgressBar` with `max_propagation_depth` > 0 in a meta-estimators, the timer of bars that are full continue to run while the following bars are filling up (see GIF below). This PR fixes this behaviour simply by using `task.finished_time` rather than `task.elapsed` when updating the finished tasks' timer.


<img width="871" height="259" alt="output5" src="https://github.com/user-attachments/assets/91e5fb09-4442-4150-bfd1-c90ccf1ae5eb" />


#### Any other comments?
ping @jeremiedbb 

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
