### PR TITLE
PERF Faster text processing with parallelism

### DIFF
--- a/benchmarks/bench_text_vectorizer.py
+++ b/benchmarks/bench_text_vectorizer.py
@@ -1,0 +1,40 @@
+import sys
+from time import time
+
+from sklearn.datasets import fetch_20newsgroups
+from sklearn.feature_extraction.text import CountVectorizer, HashingVectorizer
+
+categories = [
+    "alt.atheism",
+    "comp.graphics",
+    "comp.sys.ibm.pc.hardware",
+    "misc.forsale",
+    "rec.autos",
+    "sci.space",
+    "talk.religion.misc",
+]
+
+print("Loading 20 newsgroups training data")
+raw_data, _ = fetch_20newsgroups(categories=categories, return_X_y=True)
+data_size_mb = sum(len(s.encode("utf-8")) for s in raw_data) / 1e6
+print(f"{len(raw_data)} documents - {data_size_mb:.3f}MB")
+
+if len(sys.argv) > 1:
+    n_jobs = {"n_jobs": int(sys.argv[1])}
+else:
+    n_jobs = {}
+
+t0 = time()
+vectorizer = CountVectorizer(**n_jobs)
+vectorizer.fit_transform(raw_data)
+duration = time() - t0
+print(f"CountVectorizer done in {duration:.3f} s at {data_size_mb / duration:.1f} MB/s")
+print(f"Found {len(vectorizer.get_feature_names_out())} unique terms")
+
+t0 = time()
+vectorizer = HashingVectorizer(n_features=2 * 18, **n_jobs)
+vectorizer.fit_transform(raw_data)
+duration = time() - t0
+print(
+    f"HashingVectorizer done in {duration:.3f} s at {data_size_mb / duration:.1f} MB/s"
+)

--- a/examples/text/plot_hashing_vs_dict_vectorizer.py
+++ b/examples/text/plot_hashing_vs_dict_vectorizer.py
@@ -128,8 +128,9 @@ duration = time() - t0
 dict_count_vectorizers["vectorizer"].append(
     vectorizer.__class__.__name__ + "\non freq dicts"
 )
-dict_count_vectorizers["speed"].append(data_size_mb / duration)
-print(f"done in {duration:.3f} s at {data_size_mb / duration:.1f} MB/s")
+speed = data_size_mb / duration
+dict_count_vectorizers["speed"].append(speed)
+print(f"DictVectorizer done in {duration:.3f} s at {speed:.1f} MB/s")
 print(f"Found {len(vectorizer.get_feature_names_out())} unique terms")
 
 # %%
@@ -190,8 +191,9 @@ duration = time() - t0
 dict_count_vectorizers["vectorizer"].append(
     hasher.__class__.__name__ + "\non freq dicts"
 )
-dict_count_vectorizers["speed"].append(data_size_mb / duration)
-print(f"done in {duration:.3f} s at {data_size_mb / duration:.1f} MB/s")
+speed = data_size_mb / duration
+dict_count_vectorizers["speed"].append(speed)
+print(f"FeatureHasher(2**18) done in {duration:.3f} s at {speed:.1f} MB/s")
 print(f"Found {n_nonzero_columns(X)} unique tokens")
 
 # %%
@@ -210,8 +212,8 @@ t0 = time()
 hasher = FeatureHasher(n_features=2**22)
 X = hasher.transform(token_freqs(d) for d in raw_data)
 duration = time() - t0
-
-print(f"done in {duration:.3f} s at {data_size_mb / duration:.1f} MB/s")
+speed = data_size_mb / duration
+print(f"FeatureHasher(2**22) done in {duration:.3f} s at {speed:.1f} MB/s")
 print(f"Found {n_nonzero_columns(X)} unique tokens")
 
 # %%
@@ -232,8 +234,9 @@ duration = time() - t0
 dict_count_vectorizers["vectorizer"].append(
     hasher.__class__.__name__ + "\non raw tokens"
 )
-dict_count_vectorizers["speed"].append(data_size_mb / duration)
-print(f"done in {duration:.3f} s at {data_size_mb / duration:.1f} MB/s")
+speed = data_size_mb / duration
+dict_count_vectorizers["speed"].append(speed)
+print(f"FeatureHasher(2**18) raw done in {duration:.3f} s at {speed:.1f} MB/s")
 print(f"Found {n_nonzero_columns(X)} unique tokens")
 
 # %%
@@ -282,8 +285,9 @@ vectorizer = CountVectorizer()
 vectorizer.fit_transform(raw_data)
 duration = time() - t0
 dict_count_vectorizers["vectorizer"].append(vectorizer.__class__.__name__)
-dict_count_vectorizers["speed"].append(data_size_mb / duration)
-print(f"done in {duration:.3f} s at {data_size_mb / duration:.1f} MB/s")
+speed = data_size_mb / duration
+dict_count_vectorizers["speed"].append(speed)
+print(f"CountVectorizer done in {duration:.3f} s at {speed:.1f} MB/s")
 print(f"Found {len(vectorizer.get_feature_names_out())} unique terms")
 
 # %%
@@ -309,8 +313,9 @@ vectorizer = HashingVectorizer(n_features=2**18)
 vectorizer.fit_transform(raw_data)
 duration = time() - t0
 dict_count_vectorizers["vectorizer"].append(vectorizer.__class__.__name__)
-dict_count_vectorizers["speed"].append(data_size_mb / duration)
-print(f"done in {duration:.3f} s at {data_size_mb / duration:.1f} MB/s")
+speed = data_size_mb / duration
+dict_count_vectorizers["speed"].append(speed)
+print(f"HashingVectorizer done in {duration:.3f} s at {speed:.1f} MB/s")
 
 # %%
 # We can observe that this is the fastest text tokenization strategy so far,
@@ -344,8 +349,9 @@ vectorizer = TfidfVectorizer()
 vectorizer.fit_transform(raw_data)
 duration = time() - t0
 dict_count_vectorizers["vectorizer"].append(vectorizer.__class__.__name__)
-dict_count_vectorizers["speed"].append(data_size_mb / duration)
-print(f"done in {duration:.3f} s at {data_size_mb / duration:.1f} MB/s")
+speed = data_size_mb / duration
+dict_count_vectorizers["speed"].append(speed)
+print(f"TfidfVectorizer done in {duration:.3f} s at {speed:.1f} MB/s")
 print(f"Found {len(vectorizer.get_feature_names_out())} unique terms")
 
 # %%

--- a/sklearn/feature_extraction/tests/test_text.py
+++ b/sklearn/feature_extraction/tests/test_text.py
@@ -1657,3 +1657,47 @@ def test_hashing_vectorizer_transform_without_fit():
     corpus = ["This is test", "Another test"]
     result = vectorizer.transform(corpus)
     assert result.shape == (2, 10)
+
+
+def _newsgroups_raw_data(fetch_20newsgroups_fxt):
+    categories = [
+        "alt.atheism",
+        "comp.graphics",
+        "comp.sys.ibm.pc.hardware",
+        "misc.forsale",
+        "rec.autos",
+        "sci.space",
+        "talk.religion.misc",
+    ]
+    raw_data, _ = fetch_20newsgroups_fxt(
+        subset="train", categories=categories, return_X_y=True
+    )
+    return raw_data
+
+
+def test_hashing_vectorizer_parallelism(fetch_20newsgroups_fxt):
+    """Parallelism doesn't affect the result of HashingVectorizer."""
+    raw_data = _newsgroups_raw_data(fetch_20newsgroups_fxt)
+    results = []
+    for n_jobs in [1, -1]:
+        vectorizer = HashingVectorizer(n_features=2**18, n_jobs=n_jobs)
+        results.append(vectorizer.fit_transform(raw_data))
+    first = results[0]
+    for other in results[1:]:
+        assert (
+            np.all(first.indices == other.indices)
+            and np.all(first.indptr == other.indptr)
+            and np.array_equal(first.data, other.data)
+        )
+
+
+def test_count_vectorizer_parallelism(fetch_20newsgroups_fxt):
+    """Parallelism doesn't affect the result of CountVectorizer."""
+    raw_data = _newsgroups_raw_data(fetch_20newsgroups_fxt)
+    results = []
+    for n_jobs in [1, -1]:
+        vectorizer = CountVectorizer(n_jobs=n_jobs)
+        results.append(vectorizer.fit(raw_data))
+    first = results[0]
+    for other in results[1:]:
+        assert first.vocabulary_ == other.vocabulary_

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -30,6 +30,7 @@ from sklearn.utils import metadata_routing
 from sklearn.utils._param_validation import HasMethods, Interval, RealNotInt, StrOptions
 from sklearn.utils._sparse import _align_api_if_sparse
 from sklearn.utils.fixes import _IS_32BIT, SCIPY_VERSION_BELOW_1_12
+from sklearn.utils.parallel import parallel_thread_map
 from sklearn.utils.validation import (
     FLOAT_DTYPES,
     check_array,
@@ -790,6 +791,7 @@ class HashingVectorizer(
         norm="l2",
         alternate_sign=True,
         dtype=np.float64,
+        n_jobs=None,
     ):
         self.input = input
         self.encoding = encoding
@@ -807,6 +809,7 @@ class HashingVectorizer(
         self.norm = norm
         self.alternate_sign = alternate_sign
         self.dtype = dtype
+        self.n_jobs = n_jobs
 
     @_fit_context(prefer_skip_nested_validation=True)
     def partial_fit(self, X, y=None):
@@ -885,7 +888,7 @@ class HashingVectorizer(
         self._validate_ngram_range()
 
         analyzer = self.build_analyzer()
-        X = self._get_hasher().transform(analyzer(doc) for doc in X)
+        X = self._get_hasher().transform(parallel_thread_map(self.n_jobs, analyzer, X))
         if self.binary:
             X.data.fill(1)
         if self.norm is not None:
@@ -1182,6 +1185,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         vocabulary=None,
         binary=False,
         dtype=np.int64,
+        n_jobs=None,
     ):
         self.input = input
         self.encoding = encoding
@@ -1200,6 +1204,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         self.vocabulary = vocabulary
         self.binary = binary
         self.dtype = dtype
+        self.n_jobs = n_jobs
 
     def _sort_features(self, X, vocabulary):
         """Sort features by name
@@ -1269,9 +1274,9 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
 
         values = _make_int_array()
         indptr.append(0)
-        for doc in raw_documents:
+        for doc in parallel_thread_map(self.n_jobs, analyze, raw_documents):
             feature_counter = {}
-            for feature in analyze(doc):
+            for feature in doc:
                 try:
                     feature_idx = vocabulary[feature]
                     if feature_idx not in feature_counter:

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -724,11 +724,14 @@ class HashingVectorizer(
     dtype : type, default=np.float64
         Type of the matrix returned by fit_transform() or transform().
 
-        n_jobs : int or None
-        The maximum number of concurrently running jobs.
-        See :class:`joblib.Parallel` for details.
+    n_jobs : int, default=None
+        The number of parallel jobs to use for the computation.
 
-        ..versionadded:: 1.10
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
+        for more details.
+
+        .. versionadded:: 1.10
 
     See Also
     --------
@@ -1091,11 +1094,14 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
     dtype : dtype, default=np.int64
         Type of the matrix returned by fit_transform() or transform().
 
-    n_jobs : int or None
-        The maximum number of concurrently running jobs.
-        See :class:`joblib.Parallel` for details.
+    n_jobs : int, default=None
+        The number of parallel jobs to use for the computation.
 
-        ..versionadded:: 1.10
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
+        for more details.
+
+        .. versionadded:: 1.10
 
     Attributes
     ----------

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -30,7 +30,7 @@ from sklearn.utils import metadata_routing
 from sklearn.utils._param_validation import HasMethods, Interval, RealNotInt, StrOptions
 from sklearn.utils._sparse import _align_api_if_sparse
 from sklearn.utils.fixes import _IS_32BIT, SCIPY_VERSION_BELOW_1_12
-from sklearn.utils.parallel import is_free_threaded, parallel_thread_map
+from sklearn.utils.parallel import _is_gil_enabled, parallel_thread_map
 from sklearn.utils.validation import (
     FLOAT_DTYPES,
     check_array,
@@ -900,7 +900,7 @@ class HashingVectorizer(
         analyzer = self.build_analyzer()
         # The analyze() callable doesn't release the GIL, so there's no point
         # in using parallelism if there's a GIL.
-        n_jobs = self.n_jobs if is_free_threaded() else 1
+        n_jobs = 1 if _is_gil_enabled() else self.n_jobs
         X = self._get_hasher().transform(parallel_thread_map(n_jobs, analyzer, X))
         if self.binary:
             X.data.fill(1)
@@ -1299,7 +1299,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         indptr.append(0)
         # The analyze() callable doesn't release the GIL, so there's no point
         # in using parallelism if there's a GIL.
-        n_jobs = self.n_jobs if is_free_threaded() else 1
+        n_jobs = 1 if _is_gil_enabled() else self.n_jobs
         for doc in parallel_thread_map(n_jobs, analyze, raw_documents):
             feature_counter = {}
             for feature in doc:

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -779,6 +779,7 @@ class HashingVectorizer(
         "norm": [StrOptions({"l1", "l2"}), None],
         "alternate_sign": ["boolean"],
         "dtype": "no_validation",  # delegate to numpy
+        "n_jobs": [Integral, None],
     }
 
     def __init__(
@@ -1184,6 +1185,7 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
         "vocabulary": [Mapping, HasMethods("__iter__"), None],
         "binary": ["boolean"],
         "dtype": "no_validation",  # delegate to numpy
+        "n_jobs": [Integral, None],
     }
 
     def __init__(
@@ -1935,6 +1937,15 @@ class TfidfVectorizer(CountVectorizer):
     sublinear_tf : bool, default=False
         Apply sublinear tf scaling, i.e. replace tf with 1 + log(tf).
 
+    n_jobs : int, default=None
+        The number of parallel jobs to use for the computation.
+
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
+        for more details.
+
+        .. versionadded:: 1.10
+
     Attributes
     ----------
     vocabulary_ : dict
@@ -2007,6 +2018,7 @@ class TfidfVectorizer(CountVectorizer):
         use_idf=True,
         smooth_idf=True,
         sublinear_tf=False,
+        n_jobs=None,
     ):
         super().__init__(
             input=input,
@@ -2026,6 +2038,7 @@ class TfidfVectorizer(CountVectorizer):
             vocabulary=vocabulary,
             binary=binary,
             dtype=dtype,
+            n_jobs=n_jobs,
         )
         self.norm = norm
         self.use_idf = use_idf

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -30,7 +30,7 @@ from sklearn.utils import metadata_routing
 from sklearn.utils._param_validation import HasMethods, Interval, RealNotInt, StrOptions
 from sklearn.utils._sparse import _align_api_if_sparse
 from sklearn.utils.fixes import _IS_32BIT, SCIPY_VERSION_BELOW_1_12
-from sklearn.utils.parallel import parallel_thread_map
+from sklearn.utils.parallel import is_free_threaded, parallel_thread_map
 from sklearn.utils.validation import (
     FLOAT_DTYPES,
     check_array,
@@ -897,7 +897,10 @@ class HashingVectorizer(
         self._validate_ngram_range()
 
         analyzer = self.build_analyzer()
-        X = self._get_hasher().transform(parallel_thread_map(self.n_jobs, analyzer, X))
+        # The analyze() callable doesn't release the GIL, so there's no point
+        # in using parallelism if there's a GIL.
+        n_jobs = self.n_jobs if is_free_threaded() else 1
+        X = self._get_hasher().transform(parallel_thread_map(n_jobs, analyzer, X))
         if self.binary:
             X.data.fill(1)
         if self.norm is not None:
@@ -1292,7 +1295,10 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
 
         values = _make_int_array()
         indptr.append(0)
-        for doc in parallel_thread_map(self.n_jobs, analyze, raw_documents):
+        # The analyze() callable doesn't release the GIL, so there's no point
+        # in using parallelism if there's a GIL.
+        n_jobs = self.n_jobs if is_free_threaded() else 1
+        for doc in parallel_thread_map(n_jobs, analyze, raw_documents):
             feature_counter = {}
             for feature in doc:
                 try:

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -724,6 +724,12 @@ class HashingVectorizer(
     dtype : type, default=np.float64
         Type of the matrix returned by fit_transform() or transform().
 
+        n_jobs : int or None
+        The maximum number of concurrently running jobs.
+        See :class:`joblib.Parallel` for details.
+
+        ..versionadded:: 1.10
+
     See Also
     --------
     CountVectorizer : Convert a collection of text documents to a matrix of
@@ -1084,6 +1090,12 @@ class CountVectorizer(_VectorizerMixin, BaseEstimator):
 
     dtype : dtype, default=np.int64
         Type of the matrix returned by fit_transform() or transform().
+
+    n_jobs : int or None
+        The maximum number of concurrently running jobs.
+        See :class:`joblib.Parallel` for details.
+
+        ..versionadded:: 1.10
 
     Attributes
     ----------

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -188,7 +188,7 @@ class _FuncWrapper:
 
 def parallel_thread_map(n_jobs, func, *iterables):
     """
-    Like ``map()``, but on free-threaded Python runs in parallel.
+    Like ``map()``, but uses threads to run in parallel.
 
     Aims for minimal overhead, to maximize the cases where it improves
     performance.
@@ -213,11 +213,7 @@ def parallel_thread_map(n_jobs, func, *iterables):
         Results of calling ``func(*values)`` for each set of values
         from the input iterables.
     """
-    if is_free_threaded():
-        n_jobs = joblib.effective_n_jobs(n_jobs)
-    else:
-        # If we're not free-threaded, don't bother with parallelism:
-        n_jobs = 1
+    n_jobs = joblib.effective_n_jobs(n_jobs)
     if n_jobs == 1:
         # Run sequentially:
         return map(func, *iterables)

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -268,5 +268,5 @@ def _is_gil_enabled() -> bool:
     bool
         Whether the GIL is enabled.
     """
-    _is_gil_enabled = getattr(sys, "_is_gil_enabled", lambda: False)
+    _is_gil_enabled = getattr(sys, "_is_gil_enabled", lambda: True)
     return _is_gil_enabled()

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -8,12 +8,13 @@ usage.
 import functools
 import sys
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from functools import update_wrapper
 
 import joblib
 from threadpoolctl import ThreadpoolController
 
-from sklearn._config import config_context, get_config
+from sklearn._config import config_context, get_config, set_config
 
 # Global threadpool controller instance that can be used to locally limit the number of
 # threads without looping through all shared libraries every time.
@@ -190,6 +191,8 @@ def parallel_thread_map(n_jobs, func, *iterables):
     Like ``map()``, but runs using a thread pool on free-threaded Python, and
     aims for minimal overhead.
 
+    .. versionadded:: 1.10
+
     Parameters
     ----------
     n_jobs : int or None
@@ -199,8 +202,6 @@ def parallel_thread_map(n_jobs, func, *iterables):
         Called with each value in the iterable.
     iterables : iterables of values
         Each value will be passed to func.
-
-    .. versionadded:: 1.10
 
     Returns
     -------
@@ -216,13 +217,17 @@ def parallel_thread_map(n_jobs, func, *iterables):
     if n_jobs == 1:
         # Run sequentially:
         return map(func, *iterables)
-    # Future implementations may switch to alternatives with less overhead,
-    # e.g. concurrent.futures.ThreadPoolExecutor. If that happens, add some
-    # tests to ensure warnings and sklearn config get propagated.
-    func = delayed(func)
-    return Parallel(n_jobs, require="sharedmem", return_as="generator")(
-        func(*values) for values in zip(*iterables)
-    )
+
+    # Create pool here, so it copies contextvars:
+    config = get_config()
+    pool = ThreadPoolExecutor(n_jobs, initializer=lambda: set_config(**config))
+
+    # Make sure pool doesn't get garbage collected prematurely:
+    def gen():
+        with pool:
+            yield from pool.map(func, *iterables)
+
+    return gen()
 
 
 def _get_threadpool_controller():

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -188,8 +188,10 @@ class _FuncWrapper:
 
 def parallel_thread_map(n_jobs, func, *iterables):
     """
-    Like ``map()``, but runs using a thread pool on free-threaded Python, and
-    aims for minimal overhead.
+    Like ``map()``, but on free-threaded Python runs in parallel.
+
+    Aims for minimal overhead, to maximize the cases where it improves
+    performance.
 
     .. versionadded:: 1.10
 
@@ -198,9 +200,11 @@ def parallel_thread_map(n_jobs, func, *iterables):
     n_jobs : int or None
         The maximum number of concurrently running jobs.
         See :class:`joblib.Parallel` for details.
+
     func : callable function
         Called with each value in the iterable.
-    iterables : iterables of values
+
+    *iterables : iterables of values
         Each value will be passed to func.
 
     Returns

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -260,15 +260,13 @@ def _threadpool_controller_decorator(limits=1, user_api="blas"):
     return decorator
 
 
-def is_free_threaded() -> bool:
-    """Return whether the current Python has no GIL.
-
-    .. versionadded:: 1.10
+def _is_gil_enabled() -> bool:
+    """Return whether Python has the GIL enabled.
 
     Returns
     -------
     bool
-        Whether the Python interpreter is free-threaded, i.e. has no GIL.
+        Whether the GIL is enabled.
     """
-    is_gil_enabled = getattr(sys, "_is_gil_enabled", lambda: True)
-    return not is_gil_enabled()
+    _is_gil_enabled = getattr(sys, "_is_gil_enabled", lambda: False)
+    return _is_gil_enabled()

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -6,6 +6,7 @@ usage.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import functools
+import sys
 import warnings
 from functools import update_wrapper
 
@@ -184,6 +185,46 @@ class _FuncWrapper:
             return self.function(*args, **kwargs)
 
 
+def parallel_thread_map(n_jobs, func, *iterables):
+    """
+    Like ``map()``, but runs using a thread pool on free-threaded Python, and
+    aims for minimal overhead.
+
+    Parameters
+    ----------
+    n_jobs : int or None
+        The maximum number of concurrently running jobs.
+        See :class:`joblib.Parallel` for details.
+    func : callable function
+        Called with each value in the iterable.
+    iterables : iterables of values
+        Each value will be passed to func.
+
+    .. versionadded:: 1.10
+
+    Returns
+    -------
+    results : Iterable
+        Results of calling ``func(*values)`` for each set of values
+        from the input iterables.
+    """
+    if is_free_threaded():
+        n_jobs = joblib.effective_n_jobs(n_jobs)
+    else:
+        # If we're not free-threaded, don't bother with parallelism:
+        n_jobs = 1
+    if n_jobs == 1:
+        # Run sequentially:
+        return map(func, *iterables)
+    # Future implementations may switch to alternatives with less overhead,
+    # e.g. concurrent.futures.ThreadPoolExecutor. If that happens, add some
+    # tests to ensure warnings and sklearn config get propagated.
+    func = delayed(func)
+    return Parallel(n_jobs, require="sharedmem", return_as="generator")(
+        func(*values) for values in zip(*iterables)
+    )
+
+
 def _get_threadpool_controller():
     """Return the global threadpool controller instance."""
     global _threadpool_controller
@@ -212,3 +253,17 @@ def _threadpool_controller_decorator(limits=1, user_api="blas"):
         return wrapper
 
     return decorator
+
+
+def is_free_threaded() -> bool:
+    """Return whether the current Python has no GIL.
+
+    .. versionadded:: 1.10
+
+    Returns
+    -------
+    bool
+        Whether the Python interpreter is free-threaded, i.e. has no GIL.
+    """
+    is_gil_enabled = getattr(sys, "_is_gil_enabled", lambda: True)
+    return not is_gil_enabled()

--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -22,7 +22,6 @@ from sklearn.utils.fixes import _IS_WASM
 from sklearn.utils.parallel import (
     Parallel,
     delayed,
-    is_free_threaded,
     parallel_thread_map,
 )
 
@@ -231,7 +230,7 @@ def test_parallel_thread_map_parallelism() -> None:
 
     list(parallel_thread_map(-1, add_ident, range(1000)))
 
-    if not is_free_threaded() or joblib.effective_n_jobs(-1) == 1:
+    if joblib.effective_n_jobs(-1) == 1:
         assert idents == {current_thread().ident}
     else:
         assert current_thread().ident not in idents

--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -236,3 +236,27 @@ def test_parallel_thread_map_parallelism() -> None:
     else:
         assert current_thread().ident not in idents
         assert len(idents) > 1
+
+
+def test_parallel_thread_map_preserves_config() -> None:
+    """
+    The scikit-learn config is passed on to threads by
+    ``parallel_thread_map()``.
+    """
+    with config_context(working_memory=123):
+        results = set(
+            parallel_thread_map(-1, lambda _: get_working_memory(), range(100))
+        )
+
+    assert_array_equal(results, {123})
+
+
+def test_parallel_thread_map_warnings_settings() -> None:
+    """
+    Warning settings are propagated on to threads by ``parallel_thread_map()``.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=ConvergenceWarning)
+
+        with pytest.raises(ConvergenceWarning):
+            list(parallel_thread_map(-1, lambda _: raise_warning(), range(2)))

--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -2,6 +2,8 @@ import itertools
 import re
 import time
 import warnings
+from threading import current_thread
+from typing import Callable, Iterable
 
 import joblib
 import numpy as np
@@ -17,7 +19,12 @@ from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils.fixes import _IS_WASM
-from sklearn.utils.parallel import Parallel, delayed
+from sklearn.utils.parallel import (
+    Parallel,
+    delayed,
+    is_free_threaded,
+    parallel_thread_map,
+)
 
 
 def get_working_memory():
@@ -195,3 +202,37 @@ def test_filter_warning_propagates_no_side_effect_with_loky_backend():
             joblib.delayed(warnings.warn)("Convergence warning", ConvergenceWarning)
             for _ in range(10)
         )
+
+
+@pytest.mark.parametrize(
+    "func,arguments",
+    [
+        (lambda x: x + 1, [range(1000)]),
+        (lambda a, b: a + b, [range(1, 1001), range(2, 1002)]),
+    ],
+)
+def test_parallel_thread_map_results(func: Callable, arguments: list[Iterable]) -> None:
+    """``parallel_thread_map()`` gives the same results as ``map()``."""
+    for n_jobs in [None, 1, 2, -1]:
+        expected = list(map(func, *arguments))
+        actual = parallel_thread_map(n_jobs, func, *arguments)
+        assert not isinstance(actual, list)
+        assert expected == list(actual)
+
+
+def test_parallel_thread_map_parallelism() -> None:
+    """
+    ``parallel_thread_map()`` uses parallelism only on free-threaded Python.
+    """
+    idents = set()
+
+    def add_ident(_):
+        idents.add(current_thread().ident)
+
+    list(parallel_thread_map(-1, add_ident, range(1000)))
+
+    if not is_free_threaded() or joblib.effective_n_jobs(-1) == 1:
+        assert idents == {current_thread().ident}
+    else:
+        assert current_thread().ident not in idents
+        assert len(idents) > 1


### PR DESCRIPTION
This PR does two things:

* Introduces a new API for parallelism for threads. The motivation is speed: `joblib.Parallel` has very significant per-operation overhead, which is fine for the usual use case of a few large chunks of work, but becomes a problem if you have lots of small fast functions to call. See the benchmark results for numbers.
* Uses this new API to demonstrate how with free-threaded Python, new code paths can be parallelized.

Note that much of the code in both CountVectorizer and HashingVectorizer is still single-threaded, so in theory more could be done to speed these up.

All benchmarks were run with 12 cores, on Python 3.14 free-threaded.

**Questions for reviewer:**

* This code now assumes that the analyzer is thread-safe; this was not previously a constraint. How should this be approached? Documentation? Disallowing parallelism if anything is changed from scikit-learn's base classes? Just assuming that it will be thread-safe?

# Benchmarks

## Baseline on `main` branch

```
Loading 20 newsgroups training data
3803 documents - 6.245MB
CountVectorizer done in 0.433 s at 14.4 MB/s
Found 47885 unique terms
HashingVectorizer done in 0.333 s at 18.7 MB/s
```

## `parallel_thread_map()` in this PR

`concurrent.futures.ThreadPoolExecutor` is faster:

```
CountVectorizer done in 0.355 s at 17.6 MB/s
HashingVectorizer done in 0.229 s at 27.3 MB/s
```

## Other alternative thread pool benchmarks

### Way too slow: sklearn.utils.parallel.Parallel

This actually makes things worse, because the overhead is so high:

```
CountVectorizer done in 0.484 s at 12.9 MB/s
HashingVectorizer done in 0.374 s at 16.7 MB/s
```

### Faster, but not yet ready for real-world usage: `spinningjenny`

`spinningjenny` is a faster alternative to stdlib `ThreadPoolExecutor`. Still just a prototype, so missing features and not quite ready to use, but just to give an example of what is possible:

```
CountVectorizer done in 0.309 s at 20.2 MB/s
HashingVectorizer done in 0.190 s at 32.9 MB/s
```

