### PR TITLE
DOC add BayesHalvingSearchCV and PatternSearchCV to related_projects.rst

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -54,7 +54,7 @@ enhance the functionality of scikit-learn's estimators.
   Two scikit-learn-compatible hyperparameter search estimators, a Bayesian
   (Gaussian Process) search and a Hooke-Jeeves pattern search, that grow
   their data budget as the search converges; drop-in replacements for
-  ``GridSearchCV``/``RandomizedSearchCV``.
+  `GridSearchCV`/`RandomizedSearchCV`.
 
 **Experimentation and model registry frameworks**
 

--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -50,6 +50,12 @@ enhance the functionality of scikit-learn's estimators.
   A Python package for AutoML on Tabular Data with Feature Engineering,
   Hyper-Parameters Tuning, Explanations and Automatic Documentation.
 
+- `BayesHalvingSearchCV <https://github.com/rpcoelho17/PatternSearch_HyperParam_Opt__V2>`_
+  Two scikit-learn-compatible hyperparameter search estimators, a Bayesian
+  (Gaussian Process) search and a Hooke-Jeeves pattern search, that grow
+  their data budget as the search converges; drop-in replacements for
+  ``GridSearchCV``/``RandomizedSearchCV``.
+
 **Experimentation and model registry frameworks**
 
 - `MLFlow <https://mlflow.org/>`_ An open source platform to manage the ML


### PR DESCRIPTION
Reference Issues/PRs
This isn't related to an existing issue. This PR adds a new entry for a hyperparameter search method that could be useful to the community for work on large datasets. Comments and improvements are welcome.

What does this implement/fix? Explain your changes.
Adds BayesHalvingSearchCV / PatternSearchCV to the Auto-ML section, the closest existing fit — these are specifically HalvingGridSearchCV/HalvingRandomSearchCV-style hyperparameter search estimators (not full pipeline automation like the other entries in this section). Implements the scikit-learn estimator API and passes check_estimator (see tests/test_sklearn_compat.py in the repo). I'm adding it here because it didn't fit cleanly anywhere else in the existing sections — happy to move it if maintainers think a different placement makes more sense.

I am calling these HalvingGridSearchCV/HalvingRandomSearchCV-"style" algorithms because they share the same idea of testing the hyperparameters with a small sample of the dataset and increasing the sample size as the solution approaches the optimum.

Where they differ is what decides when to add more data.

scikit-learn's halving works like a bracket tournament: every candidate starts on the same small slice of data, gets ranked against every other candidate at that checkpoint, and only the top third (by default) survives to the next round, where they're all given more data together. The candidates that get more data are the ones that scored well relative to the others, at a fixed, pre-scheduled checkpoint — nothing about an individual candidate's own progress matters, only its rank in that round's field. A genuinely good candidate that happens to score poorly on a noisy small sample can be knocked out permanently and never get a chance at more data.

My mechanism works differently: there's no bracket, no ranking against other candidates, and nothing gets eliminated. Instead, each search path watches its own trajectory — specifically, how far it moves each time it finds an improvement. Early on, those moves tend to be large as the search is still exploring. As it homes in on a local optimum, the moves naturally get smaller. My algorithm measures that shrinking step size directly (calibrated from the search's own behavior on this specific run, not a fixed formula) and uses it as the trigger: once the moves get small enough to cross a threshold, that path "earns" the next, bigger slice of data. It's not "you beat your peers," it's "you're converging" — and since nothing is ever eliminated, every path always gets to run to its own conclusion and gets independently confirmed on 100% of the data before its result is trusted.

On my primary benchmark — a 523K-row retail regression task, tuning an ExtraTreesRegressor over a 3-parameter grid — this paid off concretely. BayesHalvingSearchCV reached the same optimum as Optuna's own GP-based sampler using 3.125 full-fit-equivalent evaluations, compared to Optuna's 15 (every Optuna trial evaluates on 100% of the data, since it has no multi-fidelity mechanism of its own) — a 4.8x reduction in compute for an identical answer. PatternSearchCV, the Hooke-Jeeves variant built on the same convergence-triggered data growth, reached that same optimum at 5.04 full-fit equivalents — a 2.98x reduction relative to Optuna. Full methodology, every run, and the complete experiment log are public in the repository (EXPERIMENTS.md). On a different, smaller dataset, BayesHalvingSearchCV and PatternSearchCV took more evaluations but found better minima than Optuna.

The algorithm also has a novel way of picking the sample. It takes the dataset in the order given by the user (if the user wants to prioritize the sorting of a specific column, they must do that sorting first before handing it to the algorithm), and performs a kind of stratified sampling, but only considering the features (target variable changes are not considered, only changes in the categories of the features).

The algorithm starts by picking the first row (since it is obviously a boundary row); when the first feature changes, rather than picking the boundary row again, it picks the midpoint for that whole group that has the new feature value. Then, when that feature changes again, it picks the first row of the change (the boundary row) and keeps alternating like that until it reaches the end of the dataset. If the sample size requires more rows than this first pass, it starts filling in the midpoint or the boundary that was skipped in the first pass.

In the case that every single row is different from the one before it, instead of walking through the rows in the order they appear, it picks rows by repeatedly splitting the dataset in half. The very first row it picks lands right in the middle of the whole dataset; the next pick lands in the middle of whichever half hasn't been touched yet; and it keeps halving the remaining gaps like that with every new pick. The result is that no matter how small the sample ends up being, the rows it contains are never clustered together in one region — they're spread out evenly across the entire dataset from the very first pick onward, which is the same evenness guarantee the boundary/midpoint trick was providing when there was repeating structure to actually exploit.

Introduce yourself
My name is Rodrigo Coelho, and I came across these ideas while doing my post-graduate degree in Data Science at Università della Svizzera italiana (USI) in Switzerland. I regularly use scikit-learn's model_selection tools — GridSearchCV, RandomizedSearchCV — to tune ensemble models like ExtraTreesRegressor on large tabular datasets, and I kept running into the same wall: grid/random search was too slow to iterate on at that scale. So I explored the pattern search idea, building PatternSearchCV, and later added a halving-style multi-fidelity mechanism on top of it, then adapted that same idea onto a from-scratch Bayesian optimization search as well — giving BayesHalvingSearchCV — all while staying compatible with scikit-learn's own search-CV interface. I recently published both on PyPI, and I'm submitting this PR to make them discoverable to others who might be in the same spot I was.

AI usage disclosure
I used AI assistance for this PR specifically:
Documentation (including examples)
Research (where to add the PR)

Any other comments?
One thing I noticed while working on this: scikit-optimize and hyperopt aren't listed anywhere in this document either, despite being well-known in the hyperparameter-search space. I placed my entry in Auto-ML since it was the closest existing fit, but a dedicated "Hyperparameter Search" section might be worth considering if others want a home there too — happy to help with that if it'd be useful, but I'll leave that call to the maintainers.

I hope this is as useful to the community as it's been for me.
