### PR TITLE
FIX radius_neighbors ignores per-sample radius slicing under n_jobs>1 (ball_tree/kd_tree)

### DIFF
--- a/sklearn/neighbors/_base.py
+++ b/sklearn/neighbors/_base.py
@@ -1268,7 +1268,12 @@ class RadiusNeighborsMixin:
             n_jobs = effective_n_jobs(self.n_jobs)
             delayed_query = delayed(self._tree.query_radius)
             chunked_results = Parallel(n_jobs, prefer="threads")(
-                delayed_query(X[s], radius, return_distance, sort_results=sort_results)
+                delayed_query(
+                    X[s],
+                    radius[s] if np.ndim(radius) > 0 else radius,
+                    return_distance,
+                    sort_results=sort_results,
+                )
                 for s in gen_even_slices(X.shape[0], n_jobs)
             )
             if return_distance:

--- a/sklearn/neighbors/tests/test_neighbors.py
+++ b/sklearn/neighbors/tests/test_neighbors.py
@@ -1105,6 +1105,28 @@ def test_radius_neighbors_sort_results(algorithm, metric):
     assert _is_sorted_by_data(graph)
 
 
+@pytest.mark.parametrize("algorithm", ["ball_tree", "kd_tree"])
+def test_radius_neighbors_array_radius_multiple_jobs(algorithm):
+    # Non-regression test for gh-34338: passing a per-sample array of radii
+    # to `radius_neighbors` used to raise a ValueError when `n_jobs > 1`
+    # because the whole (unsliced) radius array was passed to every worker
+    # chunk instead of only the radii for that chunk's query points.
+    n_samples = 10
+    rng = np.random.RandomState(0)
+    X = rng.rand(n_samples, 3)
+    radius = np.full(n_samples, 0.4)
+
+    model = neighbors.NearestNeighbors(algorithm=algorithm, n_jobs=1).fit(X)
+    dist_1job, ind_1job = model.radius_neighbors(X, radius=radius)
+
+    model_n_jobs = neighbors.NearestNeighbors(algorithm=algorithm, n_jobs=2).fit(X)
+    dist_n_jobs, ind_n_jobs = model_n_jobs.radius_neighbors(X, radius=radius)
+
+    for i in range(n_samples):
+        assert_array_equal(np.sort(ind_1job[i]), np.sort(ind_n_jobs[i]))
+        assert_allclose(np.sort(dist_1job[i]), np.sort(dist_n_jobs[i]))
+
+
 def test_RadiusNeighborsClassifier_multioutput():
     # Test k-NN classifier on multioutput data
     rng = check_random_state(0)


### PR DESCRIPTION
Fixes #34338

`radius_neighbors()` raises `ValueError: r must be broadcastable to X.shape` when an array-like `radius` is used together with `n_jobs > 1` for the `ball_tree`/`kd_tree` algorithms.

**Root cause:** the parallel branch in `sklearn/neighbors/_base.py` slices the query points `X[s]` per worker chunk via `gen_even_slices`, but always passes the full, unsliced `radius` array to every worker, causing a shape mismatch inside `query_radius`.

**Fix:** slice `radius` the same way as `X` when it is array-like (`radius[s] if np.ndim(radius) > 0 else radius`), leaving scalar radii unchanged.

Added `test_radius_neighbors_array_radius_multiple_jobs`, parametrized over `ball_tree`/`kd_tree`, verifying `n_jobs=1` and `n_jobs=2` return identical neighbor sets/distances for an array radius.
