### PR TITLE
FIX explained_variance_score is not well-defined with a single sample

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/34622.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/34622.fix.rst
@@ -1,0 +1,5 @@
+- :func:`metrics.explained_variance_score` no longer silently returns ``1.0``
+  for a single-sample input regardless of prediction correctness. It now
+  raises an :class:`~sklearn.exceptions.UndefinedMetricWarning` and returns
+  ``nan``, matching the existing behavior of :func:`metrics.r2_score`.
+  By :user:`agu2347 <agu2347>`.

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -1141,6 +1141,11 @@ def explained_variance_score(
         )
     )
 
+    if _num_samples(y_pred) < 2:
+        msg = "Explained variance score is not well-defined with less than two samples."
+        warnings.warn(msg, UndefinedMetricWarning)
+        return float("nan")
+
     y_diff_avg = _average(y_true - y_pred, weights=sample_weight, axis=0, xp=xp)
     numerator = _average(
         (y_true - y_pred - y_diff_avg) ** 2, weights=sample_weight, axis=0, xp=xp

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -222,7 +222,12 @@ def test_multioutput_regression():
 
 def test_regression_metrics_at_limits():
     # Single-sample case
-    # Note: for r2 and d2_tweedie see also test_regression_single_sample
+    # Note: for r2, explained_variance and d2_tweedie see also
+    # test_regression_single_sample. explained_variance_score's numerator is
+    # always exactly 0 for a single sample (the mean-residual centering
+    # cancels it out regardless of whether the prediction is correct), so it
+    # cannot distinguish a perfect prediction from a wrong one at n=1 and,
+    # like r2_score, is not well-defined there.
     assert_almost_equal(mean_squared_error([0.0], [0.0]), 0.0)
     assert_almost_equal(root_mean_squared_error([0.0], [0.0]), 0.0)
     assert_almost_equal(mean_squared_log_error([0.0], [0.0]), 0.0)
@@ -231,7 +236,6 @@ def test_regression_metrics_at_limits():
     assert_almost_equal(mean_absolute_percentage_error([0.0], [0.0]), 0.0)
     assert_almost_equal(median_absolute_error([0.0], [0.0]), 0.0)
     assert_almost_equal(max_error([0.0], [0.0]), 0.0)
-    assert_almost_equal(explained_variance_score([0.0], [0.0]), 1.0)
 
     # Perfect cases
     assert_almost_equal(r2_score([0.0, 1], [0.0, 1]), 1.0)
@@ -492,7 +496,9 @@ def test_regression_custom_weights():
     assert_almost_equal(msle, msle2, decimal=2)
 
 
-@pytest.mark.parametrize("metric", [r2_score, d2_tweedie_score, d2_pinball_score])
+@pytest.mark.parametrize(
+    "metric", [r2_score, explained_variance_score, d2_tweedie_score, d2_pinball_score]
+)
 def test_regression_single_sample(metric):
     y_true = [0]
     y_pred = [1]


### PR DESCRIPTION
## Summary

`explained_variance_score` returns a perfect `1.0` for a single sample no matter how wrong the prediction is, and emits no warning. `r2_score`, its documented sibling, guards the same degenerate case with an `UndefinedMetricWarning` and returns `nan`.

```python
import numpy as np
from sklearn.linear_model import LinearRegression
from sklearn.metrics import explained_variance_score, r2_score
from sklearn.model_selection import LeaveOneOut, cross_val_score

# 1) single sample, clearly wrong prediction
print(explained_variance_score([1.0], [2.0]))  # 1.0, no warning
print(r2_score([1.0], [2.0]))                  # nan + UndefinedMetricWarning

# 2) the practical impact: LeaveOneOut on pure noise
rng = np.random.RandomState(0)
X, y = rng.normal(size=(12, 3)), rng.normal(size=12)

ev = cross_val_score(LinearRegression(), X, y, cv=LeaveOneOut(), scoring="explained_variance")
r2 = cross_val_score(LinearRegression(), X, y, cv=LeaveOneOut(), scoring="r2")
print(ev.mean())  # 1.0   <- perfect score on noise, silently
print(r2.mean())  # nan   <- correctly undefined
```

## Root cause

`explained_variance_score` centers the residual before squaring it (`y_diff_avg = mean(y_true - y_pred)`, then `numerator = mean((y_true - y_pred - y_diff_avg) ** 2)`). For a single sample, `y_diff_avg` *is* the single residual, so `numerator` is **always exactly 0** regardless of whether the prediction is right or wrong. `denominator` is also always 0 (no variance with one point). The `force_finite` logic then maps `0/0` to `1.0` ("perfect predictions"), even when the prediction is arbitrarily wrong.

This is a real mathematical degeneracy of the explained-variance formula at `n=1`, not merely a missing edge-case check — `explained_variance_score` cannot distinguish a perfect single-sample prediction from a wrong one, unlike `r2_score` (which doesn't do this residual-centering and computes `numerator = (y_true - y_pred) ** 2` directly).

## Fix

Add the same `n_samples < 2` guard that `r2_score` already has to `explained_variance_score`: warn with `UndefinedMetricWarning` and return `nan`.

This does change the previously-documented behavior of `explained_variance_score([0.0], [0.0]) == 1.0` (asserted in the existing `test_regression_metrics_at_limits`). That assertion encoded exactly the buggy degenerate behavior described above — a single perfect-prediction sample is computationally indistinguishable from a single wrong-prediction sample for this metric, so keeping the old "perfect" result for one case necessarily keeps the misleading "perfect" result for the other. I removed that assertion and added `explained_variance_score` to the existing parametrized `test_regression_single_sample` test alongside `r2_score`, `d2_tweedie_score`, and `d2_pinball_score`, which already test this "not well-defined with less than two samples" contract.

## Testing

- `sklearn/metrics/tests/test_regression.py`: 29 passed (including the updated `test_regression_metrics_at_limits` and the extended `test_regression_single_sample[explained_variance_score]`).
- Reverting only `sklearn/metrics/_regression.py` (keeping the test changes) reproduces the exact reported behavior: `test_regression_single_sample[explained_variance_score]` fails with `Failed: DID NOT WARN`.
- `sklearn/metrics/tests/test_common.py -k explained_variance`: 17 passed, 38 skipped (unrelated/environment-gated), 0 failed.
- Manually re-ran both reproduction snippets from the issue against the fix; both now report `nan` with the expected `UndefinedMetricWarning`.
- Spot-checked other real (non-degenerate, `n>=2`) usages of `explained_variance_score` elsewhere in the test suite (`ensemble/tests/test_forest.py`, `model_selection/tests/test_validation.py::test_cross_val_score_with_score_func_regression`) — all pass unaffected.
- `ruff check` / `ruff format --check` clean on both changed files.

Fixes #34622
