### PR TITLE
TST use global_random_seed in sklearn/ensemble/_hist_gradient_boostin…

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_binning.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_binning.py
@@ -164,19 +164,18 @@ def test_bin_mapper_random_data(max_bins):
 
 
 @pytest.mark.parametrize("n_samples, max_bins", [(5, 5), (5, 10), (5, 11), (42, 255)])
-def test_bin_mapper_small_random_data(n_samples, max_bins):
-    data = np.random.RandomState(42).normal(size=n_samples).reshape(-1, 1)
+def test_bin_mapper_small_random_data(n_samples, max_bins, global_random_seed):
+    data = np.random.RandomState(global_random_seed).normal(size=n_samples).reshape(-1, 1)
     assert len(np.unique(data)) == n_samples
 
     # max_bins is the number of bins for non-missing values
     n_bins = max_bins + 1
-    mapper = _BinMapper(n_bins=n_bins, random_state=42)
+    mapper = _BinMapper(n_bins=n_bins, random_state=global_random_seed)
     binned = mapper.fit_transform(data)
 
     assert binned.shape == data.shape
     assert binned.dtype == np.uint8
     assert_array_equal(binned.ravel()[np.argsort(data.ravel())], np.arange(n_samples))
-
 
 @pytest.mark.parametrize(
     "max_bins, n_distinct, multiplier",
@@ -195,8 +194,8 @@ def test_bin_mapper_identity_repeated_values(max_bins, n_distinct, multiplier):
 
 
 @pytest.mark.parametrize("n_distinct", [2, 7, 42])
-def test_bin_mapper_repeated_values_invariance(n_distinct):
-    rng = np.random.RandomState(42)
+def test_bin_mapper_repeated_values_invariance(n_distinct, global_random_seed):
+    rng = np.random.RandomState(global_random_seed)
     distinct_values = rng.normal(size=n_distinct)
     assert len(np.unique(distinct_values)) == n_distinct
 
@@ -320,15 +319,14 @@ def test_bin_mapper_identity_small(max_bins, scale, offset):
         (42, 255),
     ],
 )
-def test_bin_mapper_idempotence(max_bins_small, max_bins_large):
+def test_bin_mapper_idempotence(max_bins_small, max_bins_large, global_random_seed):
     assert max_bins_large >= max_bins_small
-    data = np.random.RandomState(42).normal(size=30000).reshape(-1, 1)
+    data = np.random.RandomState(global_random_seed).normal(size=30000).reshape(-1, 1)
     mapper_small = _BinMapper(n_bins=max_bins_small + 1)
     mapper_large = _BinMapper(n_bins=max_bins_large + 1)
     binned_small = mapper_small.fit_transform(data)
     binned_large = mapper_large.fit_transform(binned_small)
     assert_array_equal(binned_small, binned_large)
-
 
 @pytest.mark.parametrize("n_bins", [10, 100, 256])
 @pytest.mark.parametrize("diff", [-5, 0, 5])
@@ -343,10 +341,10 @@ def test_n_bins_non_missing(n_bins, diff):
     assert np.all(mapper.n_bins_non_missing_ == min(n_bins - 1, n_unique_values))
 
 
-def test_subsample():
+def test_subsample(global_random_seed):
     # Make sure bin thresholds are different when applying subsampling
-    mapper_no_subsample = _BinMapper(subsample=None, random_state=0).fit(DATA)
-    mapper_subsample = _BinMapper(subsample=256, random_state=0).fit(DATA)
+    mapper_no_subsample = _BinMapper(subsample=None, random_state=global_random_seed).fit(DATA)
+    mapper_subsample = _BinMapper(subsample=256, random_state=global_random_seed).fit(DATA)
 
     for feature in range(DATA.shape[1]):
         assert not np.allclose(

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_binning.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_binning.py
@@ -165,7 +165,9 @@ def test_bin_mapper_random_data(max_bins):
 
 @pytest.mark.parametrize("n_samples, max_bins", [(5, 5), (5, 10), (5, 11), (42, 255)])
 def test_bin_mapper_small_random_data(n_samples, max_bins, global_random_seed):
-    data = np.random.RandomState(global_random_seed).normal(size=n_samples).reshape(-1, 1)
+    data = (
+        np.random.RandomState(global_random_seed).normal(size=n_samples).reshape(-1, 1)
+    )
     assert len(np.unique(data)) == n_samples
 
     # max_bins is the number of bins for non-missing values
@@ -176,6 +178,7 @@ def test_bin_mapper_small_random_data(n_samples, max_bins, global_random_seed):
     assert binned.shape == data.shape
     assert binned.dtype == np.uint8
     assert_array_equal(binned.ravel()[np.argsort(data.ravel())], np.arange(n_samples))
+
 
 @pytest.mark.parametrize(
     "max_bins, n_distinct, multiplier",
@@ -328,6 +331,7 @@ def test_bin_mapper_idempotence(max_bins_small, max_bins_large, global_random_se
     binned_large = mapper_large.fit_transform(binned_small)
     assert_array_equal(binned_small, binned_large)
 
+
 @pytest.mark.parametrize("n_bins", [10, 100, 256])
 @pytest.mark.parametrize("diff", [-5, 0, 5])
 def test_n_bins_non_missing(n_bins, diff):
@@ -343,8 +347,12 @@ def test_n_bins_non_missing(n_bins, diff):
 
 def test_subsample(global_random_seed):
     # Make sure bin thresholds are different when applying subsampling
-    mapper_no_subsample = _BinMapper(subsample=None, random_state=global_random_seed).fit(DATA)
-    mapper_subsample = _BinMapper(subsample=256, random_state=global_random_seed).fit(DATA)
+    mapper_no_subsample = _BinMapper(
+        subsample=None, random_state=global_random_seed
+    ).fit(DATA)
+    mapper_subsample = _BinMapper(subsample=256, random_state=global_random_seed).fit(
+        DATA
+    )
 
     for feature in range(DATA.shape[1]):
         assert not np.allclose(


### PR DESCRIPTION
#### Reference Issues/PRs
Towards #22827

#### What does this implement/fix?
Converted 4 test functions in `test_binning.py` to use the `global_random_seed` fixture instead of a hardcoded seed:
- `test_bin_mapper_small_random_data`
- `test_bin_mapper_repeated_values_invariance`
- `test_bin_mapper_idempotence`
- `test_subsample`

Left `test_bin_mapper_random_data` and the module-level `DATA` fixture unchanged, since several tests assert exact numeric values computed from that fixed seed, and `test_bin_mapper_random_data` only exercises the mapper on that shared fixed input — converting it wouldn't add real seed-sensitivity coverage.

All converted tests pass across the full seed range (`SKLEARN_TESTS_GLOBAL_RANDOM_SEED=all`).

#### AI usage disclosure
I used AI assistance for:
- Research and understanding