### PR TITLE
CI Fix argument in `get_comment.py` on failed linting

### DIFF
--- a/build_tools/get_comment.py
+++ b/build_tools/get_comment.py
@@ -332,7 +332,7 @@ if __name__ == "__main__":
             # try again without the details.
             message = get_message(
                 log_file,
-                repo=repo_str,
+                repo_str=repo_str,
                 pr_number=pr_number,
                 sha=sha,
                 run_id=run_id,

--- a/build_tools/get_comment.py
+++ b/build_tools/get_comment.py
@@ -332,7 +332,7 @@ if __name__ == "__main__":
             # try again without the details.
             message = get_message(
                 log_file,
-                repo=repo,
+                repo=repo_str,
                 pr_number=pr_number,
                 sha=sha,
                 run_id=run_id,


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
While adding sphinx-lint I noticed

#### What does this implement/fix? Explain your changes.

Line 333 calls `get_message` using a keyword argument `repo=`, but the function signature at line 75 defines the parameter as `repo_str`. So, if there is a long comment that exceeds the limit, this would fail. 

Original PR https://github.com/scikit-learn/scikit-learn/pull/32804
