### PR TITLE
CI Improve dataset caching for docs builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,8 @@ jobs:
       # The third key uses the cache created by _any_ previous build. This is
       # a useful fallback for PRs from contributors who don't have a cache
       # for `main`.
-      # Caches are not shared across repositories.
+      # Caches are not shared across repositories. This means that the
+      # scikit-learn/scikit-learn cache is used by PRs from <user>/scikit-learn.
       - restore_cache:
           keys:
             - v1-doc-min-deps-datasets-{{ .Branch }}
@@ -83,7 +84,8 @@ jobs:
       # The third key uses the cache created by _any_ previous build. This is
       # a useful fallback for PRs from contributors who don't have a cache
       # for `main`.
-      # Caches are not shared across repositories.
+      # Caches are not shared across repositories. This means that the
+      # scikit-learn/scikit-learn cache is used by PRs from <user>/scikit-learn.
       - restore_cache:
           keys:
             - v1-doc-datasets-{{ .Branch }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,18 @@ jobs:
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh
+      # Cache keys are matched by prefix. The second key makes a build that has
+      # no cache of its own, e.g. the first build of a branch, start from the
+      # datasets downloaded by the last build of main instead of from scratch.
+      # The third key uses the cache created by _any_ previous build. This is
+      # a useful fallback for PRs from contributors who don't have a cache
+      # for `main`.
+      # Caches are not shared across repositories.
       - restore_cache:
-          key: v1-doc-min-deps-datasets-{{ .Branch }}
+          keys:
+            - v1-doc-min-deps-datasets-{{ .Branch }}
+            - v1-doc-min-deps-datasets-main
+            - v1-doc-min-deps-datasets
       - restore_cache:
           keys:
             - doc-min-deps-ccache-{{ .Branch }}
@@ -67,8 +77,18 @@ jobs:
     steps:
       - checkout
       - run: ./build_tools/circle/checkout_merge_commit.sh
+      # Cache keys are matched by prefix. The second key makes a build that has
+      # no cache of its own, e.g. the first build of a branch, start from the
+      # datasets downloaded by the last build of main instead of from scratch.
+      # The third key uses the cache created by _any_ previous build. This is
+      # a useful fallback for PRs from contributors who don't have a cache
+      # for `main`.
+      # Caches are not shared across repositories.
       - restore_cache:
-          key: v1-doc-datasets-{{ .Branch }}
+          keys:
+            - v1-doc-datasets-{{ .Branch }}
+            - v1-doc-datasets-main
+            - v1-doc-datasets
       - restore_cache:
           keys:
             - doc-ccache-{{ .Branch }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       # a useful fallback for PRs from contributors who don't have a cache
       # for `main`.
       # Caches are not shared across repositories. This means that the
-      # scikit-learn/scikit-learn cache is used by PRs from <user>/scikit-learn.
+      # scikit-learn/scikit-learn cache is not used by PRs from <user>/scikit-learn.
       - restore_cache:
           keys:
             - v1-doc-min-deps-datasets-{{ .Branch }}
@@ -85,7 +85,7 @@ jobs:
       # a useful fallback for PRs from contributors who don't have a cache
       # for `main`.
       # Caches are not shared across repositories. This means that the
-      # scikit-learn/scikit-learn cache is used by PRs from <user>/scikit-learn.
+      # scikit-learn/scikit-learn cache is not used by PRs from <user>/scikit-learn.
       - restore_cache:
           keys:
             - v1-doc-datasets-{{ .Branch }}


### PR DESCRIPTION

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to #34763

#### What does this implement/fix? Explain your changes.
This allows a CI job to re-use the cache from `main` or other branches from the same repository.

There is one cache used for branches within the upstream repo and then a separate cache per fork. So my fork has its own cache, and so does Loic's, etc. This means my fork can't poison the upstream repository. It also means it can't use a cache from the upstream repository. This is why I think it makes sense to have fallback keys configured. It increases the chances that a contributor's repo has some form of cache for the datasets that it can use.