### PR TITLE
MAINT enable `check_array_api_mixed_inputs` for PCA

### DIFF
--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -1168,7 +1168,6 @@ PER_ESTIMATOR_XFAIL_CHECKS: dict[type, dict[str, str]] = {
         ),
     },
     PCA: {
-        "check_array_api_mixed_inputs": "mixed array API input support not added yet",
         # TODO: see gh-33205 for details
         "check_array_api_input": "`linalg.inv` fails because input is singular",
     },


### PR DESCRIPTION
xref: #28668.

Locally the check passes (and this is not surprising since PCA is unsupervised and our current implementation does not support `sample_weight`). I think we should not have marked this as XFAIL when introducing the PR for this new check.