### PR TITLE
DOC Fix docstring defaults that do not match the signature

### DIFF
--- a/sklearn/cluster/_spectral.py
+++ b/sklearn/cluster/_spectral.py
@@ -227,11 +227,12 @@ def spectral_clustering(
           - heat kernel of the pairwise distance matrix of the samples,
           - symmetric k-nearest neighbours connectivity matrix of the samples.
 
-    n_clusters : int, default=None
+    n_clusters : int, default=8
         Number of clusters to extract.
 
-    n_components : int, default=n_clusters
-        Number of eigenvectors to use for the spectral embedding.
+    n_components : int, default=None
+        Number of eigenvectors to use for the spectral embedding. If None,
+        defaults to `n_clusters`.
 
     eigen_solver : {None, 'arpack', 'lobpcg', or 'amg'}
         The eigenvalue decomposition method. If None then ``'arpack'`` is used.

--- a/sklearn/datasets/_lfw.py
+++ b/sklearn/datasets/_lfw.py
@@ -306,7 +306,7 @@ def fetch_lfw_people(
         Ratio used to resize the each face picture. If `None`, no resizing is
         performed.
 
-    min_faces_per_person : int, default=None
+    min_faces_per_person : int, default=0
         The extracted dataset will only retain pictures of people that have at
         least `min_faces_per_person` different pictures.
 

--- a/sklearn/decomposition/_nmf.py
+++ b/sklearn/decomposition/_nmf.py
@@ -1900,7 +1900,7 @@ class MiniBatchNMF(_BaseNMF):
         results across multiple function calls.
         See :term:`Glossary <random_state>`.
 
-    verbose : bool, default=False
+    verbose : int, default=0
         Whether to be verbose.
 
     Attributes

--- a/sklearn/feature_selection/_sequential.py
+++ b/sklearn/feature_selection/_sequential.py
@@ -92,7 +92,7 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
         - `None`: the `estimator`'s
           :ref:`default evaluation criterion <scoring_api_overview>` is used.
 
-    cv : int, cross-validation generator or an iterable, default=None
+    cv : int, cross-validation generator or an iterable, default=5
         Determines the cross-validation splitting strategy.
         Possible inputs for cv are:
 

--- a/sklearn/model_selection/_search_successive_halving.py
+++ b/sklearn/model_selection/_search_successive_halving.py
@@ -565,7 +565,7 @@ class HalvingGridSearchCV(BaseSuccessiveHalving):
         FitFailedWarning is raised. This parameter does not affect the refit
         step, which will always raise the error. Default is ``np.nan``.
 
-    return_train_score : bool, default=False
+    return_train_score : bool, default=True
         If ``False``, the ``cv_results_`` attribute will not include training
         scores.
         Computing training scores is used to get insights on how different
@@ -935,7 +935,7 @@ class HalvingRandomSearchCV(BaseSuccessiveHalving):
         FitFailedWarning is raised. This parameter does not affect the refit
         step, which will always raise the error. Default is ``np.nan``.
 
-    return_train_score : bool, default=False
+    return_train_score : bool, default=True
         If ``False``, the ``cv_results_`` attribute will not include training
         scores.
         Computing training scores is used to get insights on how different

--- a/sklearn/preprocessing/_target_encoder.py
+++ b/sklearn/preprocessing/_target_encoder.py
@@ -104,7 +104,7 @@ class TargetEncoder(OneToOneFeatureMixin, _BaseEncoder):
         more weight on the global target mean.
         If `"auto"`, then `smooth` is set to an empirical Bayes estimate.
 
-    cv : int, cross-validation generator or an iterable, default=None
+    cv : int, cross-validation generator or an iterable, default=5
         Determines the splitting strategy used in the internal :term:`cross fitting`
         during :meth:`fit_transform`. Splitters where each sample index doesn't appear
         in the validation fold exactly once, raise a `ValueError`.

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -480,7 +480,7 @@ def randomized_svd(
         set to `True`, the sign ambiguity is resolved by making the largest
         loadings for each component in the left singular vectors positive.
 
-    random_state : int, RandomState instance or None, default='warn'
+    random_state : int, RandomState instance or None, default=None
         The seed of the pseudo random number generator to use when
         shuffling the data, i.e. getting the random vectors to initialize
         the algorithm. Pass an int for reproducible results across multiple


### PR DESCRIPTION
#### Reference Issues/PRs

  None. These are docstring-only corrections where the documented default contradicts
  the signature, which the Documentation section of the pull request checklist exempts
  from needing an issue ("typos or obvious inconsistencies in the documentation").
  
  
---

#### What does this implement/fix? Explain your changes.

  Nine parameters in seven files documented a default value that the function or
  class signature contradicts. This PR corrects the docstrings to match the code. No
  behaviour is changed.

  | function / class | parameter | docstring said | signature says |
  |---|---|---|---|
  | `HalvingGridSearchCV` | `return_train_score` | `default=False` | `True` (`_search_successive_halving.py:758`) |
  | `HalvingRandomSearchCV` | `return_train_score` | `default=False` | `True` (`_search_successive_halving.py:1139`) |
  | `randomized_svd` | `random_state` | `default='warn'` | `None` (`extmath.py:411`) |
  | `spectral_clustering` | `n_clusters` | `default=None` | `8` (`_spectral.py:197`) |
  | `spectral_clustering` | `n_components` | `default=n_clusters` | `None` (`_spectral.py:198`) |
  | `fetch_lfw_people` | `min_faces_per_person` | `default=None` | `0` (`_lfw.py:271`) |
  | `SequentialFeatureSelector` | `cv` | `default=None` | `5` (`_sequential.py:191`) |
  | `TargetEncoder` | `cv` | `default=None` | `5` (`_target_encoder.py:245`) |
  | `MiniBatchNMF` | `verbose` | `bool, default=False` | `0` (`_nmf.py:1993`) |

  Two of these are settled by the codebase itself:

  - `SpectralClustering` the class already documents `n_clusters : int, default=8`
    (`_spectral.py:407`) and `n_components : int, default=None ... If None, defaults to
    n_clusters`. The `spectral_clustering` function in the same module disagrees with
    both. These changes make the function match the class.
  - `NMF` documents `verbose : int, default=0` (`_nmf.py:1458`), so do the three private helpers
    in that module (lines 453, 788, 1069). `MiniBatchNMF` is the only one
    documenting it as `bool` / `False`.

  `randomized_svd`'s `default='warn'` is left over from a deprecation cycle that ended
  in 1.2; the signature has been `None` since then.

  ---
  
  
#### Introduce yourself

I am saikrishna working as a senior data engineer I have bachelors degree in computer science with data analytics specialization where I have worked on wide variety of tools like numpy, pandas, scikit-learn,... Where I have done various projects using various tools. Now I was reading the source looking for a bug to fix. So I wanted to contribute and help tool perform better.


---

  #### AI usage disclosure

  I used AI assistance for:
  - Documentation (including examples)
  - Research and understanding

  This pull request includes code written with the assistance of AI.
  The code has **not yet been reviewed** by a human.

  ---

  #### Any other comments?


  On `return_train_score`: `BaseSearchCV` defaults this to `False` (`_search.py:1696`,
  `_search.py:2095`), while both halving classes override it to `True`. I have documented
  the behaviour as it currently is. Whether the `True` override was intended is a
  behaviour question and I did not want to fold it into a documentation PR; happy to open
  a separate issue if that is worth looking at. If reviewers would rather not touch that
  one here, it can be dropped and the other eight are unaffected.

  No changelog entry: `check-changelog.yml` only requires one when a file matching
  `sklearn/.+test_.+\.py` changes, and this PR touches no test files.

  Checks run locally: `sklearn/tests/test_docstrings.py`,
  `sklearn/tests/test_docstring_parameters.py` and
  `sklearn/tests/test_docstring_parameters_consistency.py` (2939 passed), the test modules
  for all seven touched files (826 passed), and `ruff` 0.12.2 check and format.


