### PR TITLE
FIX split_sign inconsistencies in DictionaryLearning, MiniBatchDictionaryLearning and SparseCoder

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.decomposition/34768.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.decomposition/34768.fix.rst
@@ -1,0 +1,7 @@
+- :class:`decomposition.DictionaryLearning`, :class:`decomposition.MiniBatchDictionaryLearning`
+  and :class:`decomposition.SparseCoder` now correctly report the number of output
+  features from :meth:`get_feature_names_out` when `split_sign=True`, preserve the
+  input dtype in the split code, and :meth:`decomposition.DictionaryLearning.fit_transform`
+  now consistently applies the sign-splitting so that its output matches
+  :meth:`decomposition.DictionaryLearning.transform`.
+  By :user:`Sahil Mangla <sahil-mangla>`.

--- a/sklearn/decomposition/_dict_learning.py
+++ b/sklearn/decomposition/_dict_learning.py
@@ -1089,6 +1089,16 @@ class _BaseSparseCoding(ClassNamePrefixFeaturesOutMixin, TransformerMixin):
         self.n_jobs = n_jobs
         self.positive_code = positive_code
 
+    def _apply_split_sign(self, code):
+        """Split the code into a positive and negative side, if requested."""
+        if not self.split_sign:
+            return code
+        n_samples, n_features = code.shape
+        split_code = np.empty((n_samples, 2 * n_features), dtype=code.dtype)
+        split_code[:, :n_features] = np.maximum(code, 0)
+        split_code[:, n_features:] = -np.minimum(code, 0)
+        return split_code
+
     def _transform(self, X, dictionary):
         """Private method allowing to accommodate both DictionaryLearning and
         SparseCoder."""
@@ -1110,15 +1120,7 @@ class _BaseSparseCoding(ClassNamePrefixFeaturesOutMixin, TransformerMixin):
             positive=self.positive_code,
         )
 
-        if self.split_sign:
-            # feature vector is split into a positive and negative side
-            n_samples, n_features = code.shape
-            split_code = np.empty((n_samples, 2 * n_features))
-            split_code[:, :n_features] = np.maximum(code, 0)
-            split_code[:, n_features:] = -np.minimum(code, 0)
-            code = split_code
-
-        return code
+        return self._apply_split_sign(code)
 
     def transform(self, X):
         """Encode the data as a sparse combination of the dictionary atoms.
@@ -1411,7 +1413,10 @@ class SparseCoder(_BaseSparseCoding, BaseEstimator):
     @property
     def _n_features_out(self):
         """Number of transformed output features."""
-        return self.n_components_
+        n_features_out = self.n_components_
+        if self.split_sign:
+            n_features_out *= 2
+        return n_features_out
 
 
 class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
@@ -1744,12 +1749,15 @@ class DictionaryLearning(_BaseSparseCoding, BaseEstimator):
         self.components_ = U
         self.error_ = E
 
-        return V
+        return self._apply_split_sign(V)
 
     @property
     def _n_features_out(self):
         """Number of transformed output features."""
-        return self.components_.shape[0]
+        n_features_out = self.components_.shape[0]
+        if self.split_sign:
+            n_features_out *= 2
+        return n_features_out
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
@@ -2333,7 +2341,10 @@ class MiniBatchDictionaryLearning(_BaseSparseCoding, BaseEstimator):
     @property
     def _n_features_out(self):
         """Number of transformed output features."""
-        return self.components_.shape[0]
+        n_features_out = self.components_.shape[0]
+        if self.split_sign:
+            n_features_out *= 2
+        return n_features_out
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()

--- a/sklearn/decomposition/tests/test_dict_learning.py
+++ b/sklearn/decomposition/tests/test_dict_learning.py
@@ -296,6 +296,52 @@ def test_dict_learning_split():
     assert_array_almost_equal(Xr, Xr2)
 
 
+@pytest.mark.parametrize(
+    "estimator_class", [DictionaryLearning, MiniBatchDictionaryLearning]
+)
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_dict_learning_split_sign_n_features_out(estimator_class, dtype):
+    """Check that split_sign is consistently reflected in the number of
+    output features, the output dtype, and that fit_transform and transform
+    produce outputs of matching shape.
+
+    Non-regression test for gh-34768.
+    """
+    n_components = 4
+    Xd = X.astype(dtype)
+    est = estimator_class(
+        n_components,
+        split_sign=True,
+        transform_algorithm="threshold",
+        random_state=0,
+    )
+
+    Xt_fit = est.fit_transform(Xd)
+    Xt_transform = est.transform(Xd)
+
+    assert Xt_fit.shape == Xt_transform.shape == (Xd.shape[0], 2 * n_components)
+    assert Xt_fit.dtype == dtype
+    assert Xt_transform.dtype == dtype
+
+    feature_names = est.get_feature_names_out()
+    assert len(feature_names) == 2 * n_components
+
+
+def test_sparse_coder_split_sign_n_features_out():
+    """Non-regression test for gh-34768."""
+    n_components = 4
+    dictionary = rng_global.randn(n_components, n_features)
+    coder = SparseCoder(
+        dictionary=dictionary, split_sign=True, transform_algorithm="threshold"
+    ).fit(X)
+
+    Xt = coder.transform(X)
+    assert Xt.shape == (X.shape[0], 2 * n_components)
+
+    feature_names = coder.get_feature_names_out()
+    assert len(feature_names) == 2 * n_components
+
+
 def test_dict_learning_online_shapes():
     rng = np.random.RandomState(0)
     n_components = 8


### PR DESCRIPTION
## Summary
Fixes #34768. With `split_sign=True`, the sparse-coding transformers
(`DictionaryLearning`, `MiniBatchDictionaryLearning`, `SparseCoder`) double
the number of output columns, but three things didn't account for it:

- `_n_features_out` (used by `get_feature_names_out()` and
  `set_output(transform="pandas")`) still returned the un-doubled count.
- The array allocated for the split code (`np.empty((n_samples, 2 * n_features))`)
  didn't specify a dtype, so float32 inputs were silently upcast to float64.
- `DictionaryLearning.fit_transform` returned the raw sparse codes without
  applying the sign-splitting at all, so its output shape disagreed with a
  subsequent call to `.transform()`, breaking `Pipeline.predict` (fit-time
  and predict-time feature counts mismatched).

## Fix
- Added a shared `_apply_split_sign` helper on `_BaseSparseCoding` that
  preserves the input dtype, used by `transform()` and by
  `DictionaryLearning.fit_transform`.
- Updated the `_n_features_out` property on all three classes to double the
  count when `split_sign=True`.

## Test plan
- [x] Added regression tests in `test_dict_learning.py` covering
      feature-name count, dtype preservation, and `fit_transform`/`transform`
      shape consistency, for float32 and float64, across
      `DictionaryLearning`, `MiniBatchDictionaryLearning`, and `SparseCoder`.
- [x] Full `sklearn/decomposition/tests/test_dict_learning.py` suite passes
      (204 passed).
- [x] Relevant `test_common.py` checks for these estimators pass.
- [x] Manually verified `Pipeline.predict` and `set_output(transform="pandas")`
      now work with `split_sign=True`.
