### PR TITLE
FIX use averaged inverted CDF in DummyRegressor median and quantile

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.dummy/34776.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.dummy/34776.fix.rst
@@ -1,0 +1,7 @@
+- :class:`dummy.DummyRegressor` with `strategy="median"` or
+  `strategy="quantile"` now uses the `averaged_inverted_cdf` percentile when
+  `sample_weight` is passed. Previously the weighted path used
+  `inverted_cdf` while the unweighted path used `np.median` / `np.percentile`,
+  so passing unit weights could return a different constant than passing no
+  weights at all.
+  By :user:`Selim <CodingSelim>`.

--- a/sklearn/dummy.py
+++ b/sklearn/dummy.py
@@ -582,7 +582,7 @@ class DummyRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                 self.constant_ = np.median(y, axis=0)
             else:
                 self.constant_ = _weighted_percentile(
-                    y, sample_weight, percentile_rank=50.0
+                    y, sample_weight, percentile_rank=50.0, average=True
                 )
 
         elif self.strategy == "quantile":
@@ -596,7 +596,7 @@ class DummyRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                 self.constant_ = np.percentile(y, axis=0, q=percentile_rank)
             else:
                 self.constant_ = _weighted_percentile(
-                    y, sample_weight, percentile_rank=percentile_rank
+                    y, sample_weight, percentile_rank=percentile_rank, average=True
                 )
 
         elif self.strategy == "constant":

--- a/sklearn/tests/test_dummy.py
+++ b/sklearn/tests/test_dummy.py
@@ -8,6 +8,7 @@ from sklearn.base import clone
 from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.exceptions import NotFittedError
 from sklearn.utils._testing import (
+    assert_allclose,
     assert_almost_equal,
     assert_array_almost_equal,
     assert_array_equal,
@@ -632,10 +633,31 @@ def test_dummy_regressor_sample_weight(global_random_seed, n_samples=10):
     assert est.constant_ == np.average(y, weights=sample_weight)
 
     est = DummyRegressor(strategy="median").fit(X, y, sample_weight)
-    assert est.constant_ == _weighted_percentile(y, sample_weight, 50.0)
+    assert est.constant_ == _weighted_percentile(y, sample_weight, 50.0, average=True)
 
     est = DummyRegressor(strategy="quantile", quantile=0.95).fit(X, y, sample_weight)
-    assert est.constant_ == _weighted_percentile(y, sample_weight, 95.0)
+    assert est.constant_ == _weighted_percentile(y, sample_weight, 95.0, average=True)
+
+
+@pytest.mark.parametrize(
+    "strategy, quantile",
+    [("mean", None), ("median", None), ("quantile", 0.5)],
+)
+def test_dummy_regressor_unit_sample_weight(strategy, quantile):
+    """Passing unit weights must be the same as passing no weights.
+
+    Non-regression test for the `median` and `quantile=0.5` strategies, which used
+    the `inverted_cdf` percentile while the unweighted branch uses `np.median` /
+    `np.percentile`. The two disagree when the number of samples is even.
+    """
+    y = np.array([0.0, 1.0, 2.0, 4.0, 8.0, 16.0])
+    X = [[0]] * len(y)
+
+    est = DummyRegressor(strategy=strategy, quantile=quantile)
+    unweighted = est.fit(X, y).constant_
+    weighted = est.fit(X, y, sample_weight=np.ones(len(y))).constant_
+
+    assert_allclose(unweighted, weighted)
 
 
 def test_dummy_regressor_on_3D_array():


### PR DESCRIPTION
#### Reference Issues/PRs

Related to #16298. `DummyRegressor` isn't on that list and isn't in `PER_ESTIMATOR_XFAIL_CHECKS` either, so it's meant to pass `check_sample_weight_equivalence`. Follows on from #17370 and the `averaged_inverted_cdf` default change in #33763.

#### What does this implement/fix? Explain your changes.

`DummyRegressor` picks a different quantile definition depending on whether you passed weights. the unweighted branch uses `np.median` / `np.percentile`, the weighted one uses `_weighted_percentile`, which defaults to `inverted_cdf`. those two disagree when the sample count is even, so unit weights aren't a no-op:

```python
import numpy as np
from sklearn.dummy import DummyRegressor

y = np.array([0., 1., 2., 4., 8., 16.])
X = [[0]] * len(y)

DummyRegressor(strategy="median").fit(X, y).constant_                 # 3.0
DummyRegressor(strategy="median").fit(X, y, np.ones(6)).constant_     # 2.0
```

fix is to pass `average=True` so the weighted path uses `averaged_inverted_cdf`, which is what `median_absolute_error` already does and what `KBinsDiscretizer` moved to in #33763. at `percentile_rank=50` that matches `np.median` exactly, over a few hundred random seeds the mismatch count against the replicated median goes from 80/300 to 0/300.

i changed the quantile branch as well, not just median, because `strategy="median"` and `strategy="quantile", quantile=0.5` need to keep agreeing with each other. they do in the unweighted path since `np.median` is `np.percentile(50)`, and fixing only median would have split them.

one thing this doesn't close: for `quantile` at q != 0.5 the weighted result still won't match `np.percentile`, since numpy defaults to `linear` and there's no weighted `linear`. `average=True` lands closer below the median and slightly further above it. so this fully fixes median and quantile=0.5 and leaves the general quantile case where it was. can look at exposing a `quantile_method` there the way `KBinsDiscretizer` does if that's the direction you want.

on why the existing tests missed it, `test_dummy_regressor_sample_weight` uses `random_state.rand(n)` weights, and with continuous weights the cumulative weight essentially never lands exactly on the 50% boundary, which is the only place the averaging changes anything. and the common checks only ever construct `DummyRegressor()` with the default `strategy="mean"`, which is weight correct, so median and quantile aren't exercised there at all.

added `test_dummy_regressor_unit_sample_weight` with fixed data so it doesn't lean on a seed. it fails on main (median returns 2.0 instead of 3.0) and passes here. also switched the two assertions in `test_dummy_regressor_sample_weight` to `average=True` so they document the intended behaviour, they passed either way for the reason above.

#### Introduce yourself

i'm Selim. i use scikit-learn mostly for regression baselines and preprocessing on small data projects. i was checking `sample_weight` handling across a handful of estimators and this one looked like a clean contract violation rather than a definitional argument, so i wanted to send the fix.

#### AI usage disclosure

I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Research and understanding

i reviewed every line myself, ran the tests, and checked the behaviour against `np.median` and `np.percentile` before sending this. happy to explain any part of it.

#### Any other comments?

building scikit-learn from source didn't work out on this machine, so i verified by applying the same two line change to my installed 1.8.0 and running the suites against that. `sklearn.tests.test_dummy` gives 64 passed, and `test_common -k Dummy` gives 159 passed / 3 skipped / 2 xfailed / 2 xpassed, same counts as before the change. relying on CI for the full run.

changelog entry to follow once this has a PR number.
