### PR TITLE
DOC Add recommendation summary table for random_state usage

### DIFF
--- a/doc/common_pitfalls.rst
+++ b/doc/common_pitfalls.rst
@@ -264,17 +264,17 @@ subtle parameter.
          - Estimator
          - CV splitter
        * - Identical results for repeated calls to `fit`/`split`
-         - int
-         - int
+         - `int`
+         - `int`
        * - Robust CV results, with fresh randomness for each fold
          - `RandomState` instance or `None`
-         - int
-       * - Comparable per-fold scores across separate runs
-         - any
-         - int
+         - `int`
+       * - Comparable per-fold scores across different models/configurations
+         - `any`
+         - `int`
        * - Reproducible results across different program executions
-         - int, or a fixed `RandomState` instance
-         - int
+         - `int`, or a fixed `RandomState` instance
+         - `int`
 
 Using `None` or `RandomState` instances, and repeated calls to `fit` and `split`
 --------------------------------------------------------------------------------

--- a/doc/common_pitfalls.rst
+++ b/doc/common_pitfalls.rst
@@ -256,6 +256,26 @@ subtle parameter.
     For reproducible results across executions, remove any use of
     `random_state=None`.
 
+    .. list-table::
+       :widths: 40 30 20
+       :header-rows: 1
+
+       * - Goal
+         - Estimator
+         - CV splitter
+       * - Identical results for repeated calls to `fit`/`split`
+         - int
+         - int
+       * - Robust CV results, with fresh randomness for each fold
+         - `RandomState` instance or `None`
+         - int
+       * - Comparable per-fold scores across separate runs
+         - any
+         - int
+       * - Reproducible results across different program executions
+         - int, or a fixed `RandomState` instance
+         - int
+
 Using `None` or `RandomState` instances, and repeated calls to `fit` and `split`
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #34641

#### What does this implement/fix? Explain your changes.
The "Controlling randomness" section of the Common Pitfalls guide has a
paragraph recommending how to set `random_state` for estimators vs. CV
splitters, but it's easy to miss which combination applies to which goal.
This adds a quick-reference table right after that paragraph, listing four
common goals (identical results on repeated fit/split calls, robust CV with
fresh randomness per fold, comparable fold scores across runs, full
reproducibility across executions) and the recommended `random_state`
value for the estimator and the CV splitter in each case.

#### Introduce yourself
I'm using scikit-learn to learn ML. This is my first time contributing to
open source, so I picked a small, well-scoped documentation issue to start
with and learn the contribution workflow.

#### AI usage disclosure
I used AI assistance for:
- Documentation (including examples)
- Research and understanding

#### Any other comments?