### PR TITLE
MNT Refactor/Improve features sampling in HGB splitting

### DIFF
--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -479,6 +479,7 @@ cdef class Splitter:
             int split_info_idx
             int best_split_info_idx
             int n_allowed_features
+            int n_split_candidates
             split_info_struct split_info
             split_info_struct * split_infos
             const uint8_t [::1] has_missing_values = self.has_missing_values
@@ -487,8 +488,8 @@ cdef class Splitter:
             int n_threads = self.n_threads
             bint has_interaction_cst = False
             Y_DTYPE_C feature_fraction_per_split = self.feature_fraction_per_split
-            uint8_t [:] subsample_mask  # same as npy_bool
-            int n_subsampled_features
+            bint is_subsampled
+            const unsigned int [:] split_features
             uint8_t missing_go_to_left
 
         has_interaction_cst = allowed_features is not None
@@ -497,30 +498,39 @@ cdef class Splitter:
         else:
             n_allowed_features = self.n_features
 
-        if feature_fraction_per_split < 1.0:
+        is_subsampled = feature_fraction_per_split < 1.0
+        if is_subsampled:
             # We do all random sampling before the nogil and make sure that we sample
-            # exactly n_subsampled_features >= 1 features.
-            n_subsampled_features = max(
+            # exactly n_split_candidates >= 1 features.
+            n_split_candidates = max(
                 1,
                 int(ceil(feature_fraction_per_split * n_allowed_features)),
             )
-            subsample_mask_arr = np.full(n_allowed_features, False)
-            subsample_mask_arr[:n_subsampled_features] = True
-            self.rng.shuffle(subsample_mask_arr)
-            # https://github.com/numpy/numpy/issues/18273
-            subsample_mask = subsample_mask_arr
+
+            if has_interaction_cst:
+                split_features = self.rng.choice(
+                    allowed_features, n_split_candidates, replace=False,
+                )
+            else:
+                split_features = self.rng.choice(
+                    self.n_features, n_split_candidates, replace=False,
+                ).astype(np.uint32)
+        else:
+            n_split_candidates = n_allowed_features
+            if has_interaction_cst:
+                split_features = allowed_features
 
         with nogil:
 
             split_infos = <split_info_struct *> malloc(
-                n_allowed_features * sizeof(split_info_struct))
+                n_split_candidates * sizeof(split_info_struct))
 
-            # split_info_idx is index of split_infos of size n_allowed_features.
+            # split_info_idx is index of split_infos of size n_split_candidates.
             # features_idx is the index of the feature column in X.
-            for split_info_idx in prange(n_allowed_features, schedule='static',
+            for split_info_idx in prange(n_split_candidates, schedule='static',
                                          num_threads=n_threads):
-                if has_interaction_cst:
-                    feature_idx = allowed_features[split_info_idx]
+                if has_interaction_cst or is_subsampled:
+                    feature_idx = split_features[split_info_idx]
                 else:
                     feature_idx = split_info_idx
 
@@ -533,13 +543,6 @@ cdef class Splitter:
                 # node into a leaf.
                 split_infos[split_info_idx].gain = -1
                 split_infos[split_info_idx].is_categorical = is_categorical[feature_idx]
-
-                # Note that subsample_mask is indexed by split_info_idx and not by
-                # feature_idx because we only need to exclude the same features again
-                # and again. We do NOT need to access the features directly by using
-                # allowed_features.
-                if feature_fraction_per_split < 1.0 and not subsample_mask[split_info_idx]:
-                    continue
 
                 if is_categorical[feature_idx]:
                     self._find_best_bin_to_split_category(
@@ -570,7 +573,7 @@ cdef class Splitter:
             # then compute best possible split among all features
             # split_info is set to the best of split_infos
             best_split_info_idx = self._find_best_feature_to_split_helper(
-                split_infos, n_allowed_features
+                split_infos, n_split_candidates
             )
             split_info = split_infos[best_split_info_idx]
 


### PR DESCRIPTION
#### Reference Issues/PRs

Will help in implementing strategy 4 described in https://github.com/scikit-learn/scikit-learn/issues/34764#issuecomment-5343004000

#### What does this implement/fix? Explain your changes.

It changes the features subsampling of HGB (when `max_features < 1.0`): instead of a boolean mask, it samples without replacement. 

It has two benefits:
- no "no-op" iteration inside the `prange(..., schedule="static")`, which will help for future scalability heuristic I'm working on
- unbiased tie breaking behavior (but only for `max_features < 1.0`), as it randomized the order in which features are split (and we use > in the loop). 

The effect on runtime is not visible as far as I could experiment, even in extreme cases where split time is dominant. But I think it should be visible in some (relatively rare) cases once combine with the "use_threads_if" heuristic as it allow having a more accurate estimate of the work to do.

There is no added complexity so it's worth the PR/merge I'd say.

#### AI usage disclosure

Very guided session, I had a precise idea of what I wanted.

