### PR TITLE
CI Use Auth.Token to avoid PyGithub DeprecationWarning

### DIFF
--- a/maint_tools/update_tracking_issue.py
+++ b/maint_tools/update_tracking_issue.py
@@ -18,7 +18,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import defusedxml.ElementTree as ET
-from github import Github
+from github import Auth, Github
 
 parser = argparse.ArgumentParser(
     description="Create or update issue from JUnit test results from pytest"
@@ -65,7 +65,7 @@ if args.junit_file is None and args.tests_passed is None:
     print("Either --junit-file or --test-passed must be passed in")
     sys.exit(1)
 
-gh = Github(args.bot_github_token)
+gh = Github(auth=Auth.Token(args.bot_github_token))
 issue_repo = gh.get_repo(args.issue_repo)
 dt_now = datetime.now(tz=timezone.utc)
 date_str = dt_now.strftime("%b %d, %Y")


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #34639

#### What does this implement/fix? Explain your changes.
Updates `maint_tools/update_tracking_issue.py` to use PyGithub's current
authentication API. The script was still using the deprecated
`Github(token)` constructor, which raises a `DeprecationWarning` in CI.
This switches to the `auth=Auth.Token(token)` pattern, matching what
other scripts in the repo already use.

#### Introduce yourself
Hi, I'm Luke, a CS student at Swansea University working towards a career
in cyber/ML for defence. This is one of my first contributions to
scikit-learn, thanks for the pointer to a good first issue, lesteve!

#### AI usage disclosure
I used AI assistance for:
- Documentation (including examples)

The AI use was limited to reorganising and titling sections in my personal
university notes/project files in Word, for easier reference, not for
generating or researching this specific fix. The fix itself came from my
own prior notes and was implemented directly by me.

#### Any other comments?
Happy to make any adjustments needed.