### PR TITLE
MAINT Remove unused _find_smallest_angle helper in _ridge.py

### DIFF
--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -1642,25 +1642,6 @@ def _check_gcv_mode(X, gcv_mode):
     return "gram" if n <= p else "cov"
 
 
-def _find_smallest_angle(query, vectors):
-    """Find the column of vectors that is most aligned with the query.
-
-    Both query and the columns of vectors must have their l2 norm equal to 1.
-
-    Parameters
-    ----------
-    query : ndarray of shape (n_samples,)
-        Normalized query vector.
-
-    vectors : ndarray of shape (n_samples, n_features)
-        Vectors to which we compare query, as columns. Must be normalized.
-    """
-    xp, _ = get_namespace(query)
-    abs_cosine = xp.abs(query @ vectors)
-    index = xp.argmax(abs_cosine)
-    return index
-
-
 class _X_CenterStackOp(sparse.linalg.LinearOperator):
     """Behaves as centered and scaled X with an added intercept column.
 


### PR DESCRIPTION
#### Reference Issues/PRs

No issue - small dead-code cleanup. The helper was left behind when the eigen-GCV
intercept path moved to an explicit `G^-1` correction in `_solve_eigen_gram` (#33020).

#### What does this implement/fix? Explain your changes.

`_find_smallest_angle` used to find the intercept eigenvector in `_RidgeGCV`'s
eigen-GCV path. Once that path switched to computing the intercept correction
directly in `_solve_eigen_gram`, nothing called it anymore. It's private,
unexported, and grep finds it only at its own definition - no callers in the code,
tests, or docs.

So this just deletes the function (19 lines). Ridge and RidgeCV behave exactly the
same; there's no API with a caller to break.

#### Introduce yourself

I'm Anshul, working on [Vinv](https://vinv.ai/) - it traces running Python services to find dead code,
hotspots, and runtime errors without changing the source. scikit-learn is a
dependency in our own pipeline, so it goes through the same analysis. Vinv's
dead-code pass flagged `_find_smallest_angle`: no callers in the traces we captured,
no static references. I went and read the code, saw the eigen-GCV caller was already
gone, and sent this.

#### AI usage disclosure

Models: Composer 2.5 (via Cursor + [VinvAI](https://vinv.ai/))

Prompt (paraphrased): act on Vinv's dead-code finding for `_find_smallest_angle`, 
confirm it's genuinely unreferenced (no static references anywhere in code, tests,
or docs; not exported; no dynamic lookup by name; and its former eigen-GCV caller
was replaced by the `_solve_eigen_gram` intercept correction), then delete it.

<details>
<summary>AI transcript</summary>

* Vinv's dead-code sweep flagged `_find_smallest_angle` in
  `sklearn/linear_model/_ridge.py` as unreferenced.
* Verified before deleting:
   * Repo-wide grep for `_find_smallest_angle` → only the definition site matched
     (code, tests, and docs).
   * Confirmed it is private, not in any `__all__`, and not re-exported.
   * Confirmed the only symbol it used (`get_namespace`) is still used elsewhere in
     the module, so its import stays.
* Deleted the function.
* Ran `python -m py_compile sklearn/linear_model/_ridge.py` → compiles clean.

</details>

#### Any other comments?

No changelog entry - it's an internal helper with no callers, so nothing user-facing
changes. I can add one if you'd rather. Verified locally that the module still
compiles and `get_namespace` is still used elsewhere.