### PR TITLE
BUG: clamp max_samples to non-zero weight count when bootstrap=False and sample_weight has zeros (gh-34673)

### DIFF
--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -85,6 +85,12 @@ def _generate_bagging_indices(
         )
     else:
         normalized_sample_weight = sample_weight / np.sum(sample_weight)
+        if not bootstrap_samples:
+            # Without replacement, numpy.choice requires at least max_samples
+            # non-zero entries in p. Clamp to the available support so that
+            # zero-weighted rows (the documented way to exclude a sample) are
+            # simply excluded rather than raising ValueError (gh-34673).
+            max_samples = min(max_samples, np.count_nonzero(sample_weight))
         sample_indices = random_state.choice(
             n_samples,
             max_samples,

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -1171,3 +1171,32 @@ def test_bagging_without_support_metadata_routing(model):
     """Make sure that we still can use an estimator that does not implement the
     metadata routing."""
     model.fit(iris.data, iris.target)
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        BaggingClassifier(bootstrap=False, random_state=0),
+        BaggingRegressor(bootstrap=False, random_state=0),
+    ],
+)
+def test_bagging_zero_sample_weight_no_bootstrap(model):
+    """Regression test for gh-34673.
+
+    Zero sample_weight with bootstrap=False used to raise
+    ``ValueError: Fewer non-zero entries in p than size`` because
+    numpy.choice cannot draw without-replacement more samples than there
+    are non-zero probability entries.  Zero-weighting a row is the
+    documented way to exclude it from the fit, so this must not crash.
+    """
+    rng = np.random.RandomState(0)
+    X = rng.uniform(size=(80, 4))
+    y = rng.randint(0, 2, size=80)
+    w = np.ones(80)
+    w[0] = 0.0  # exclude the first sample
+
+    model.fit(X, y, sample_weight=w)
+
+    # Zero-weighted row must never appear in any estimator's training set.
+    for sample_indices in model.estimators_samples_:
+        assert 0 not in sample_indices

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -393,3 +393,29 @@ def test_iforest_predict_parallel(global_random_seed, contamination, n_jobs):
 
     # assert the same results as non-parallel
     assert_array_equal(pred, pred_parallel)
+
+
+def test_iforest_zero_sample_weight():
+    """Regression test for gh-34673.
+
+    IsolationForest (bootstrap=False by default) used to raise
+    ``ValueError: Fewer non-zero entries in p than size`` when any
+    sample_weight entry was zero.  Zero-weighting a row is the documented
+    way to exclude it, so this must not crash.
+    """
+    rng = np.random.RandomState(0)
+    X = rng.uniform(size=(80, 4))
+    w = np.ones(80)
+    w[0] = 0.0  # exclude the first sample
+
+    clf = IsolationForest(random_state=0)
+    clf.fit(X, sample_weight=w)
+
+    # Must produce valid scores — the zero-weighted row should score normally.
+    scores = clf.decision_function(X)
+    assert scores.shape == (80,)
+    assert np.isfinite(scores).all()
+
+    # The zero-weighted row must never be selected in any estimator's sample.
+    for sample_indices in clf.estimators_samples_:
+        assert 0 not in sample_indices


### PR DESCRIPTION
## Summary

Fixes #34673. Regression from #31414 (first released in 1.8.0).

When `bootstrap=False` and `sample_weight` contains zeros, `_generate_bagging_indices`
calls `numpy.random.choice(..., replace=False, p=normalized_weight)`.
NumPy requires at least `max_samples` non-zero entries in `p` for without-replacement
sampling, so any `sample_weight` with enough zeros raises:

```
ValueError: Fewer non-zero entries in p than size
```

`IsolationForest` is affected on its **defaults** (`bootstrap=False`,
`max_samples=auto` → `min(256, n_samples)`): a single zero weight crashes
any dataset with ≤ 256 rows. `BaggingClassifier` / `BaggingRegressor` with
`bootstrap=False` are equally affected.

Zero-weighting a row is the documented way to exclude it from the fit everywhere
else in scikit-learn. The fix clamps `max_samples` to `np.count_nonzero(sample_weight)`
before the `choice` call in the `not bootstrap_samples` branch. The `bootstrap=True`
path is unchanged.

## Changes

- `sklearn/ensemble/_bagging.py`: one guard before `random_state.choice` in the
  weighted, without-replacement path.
- `sklearn/ensemble/tests/test_bagging.py`: regression test for `BaggingClassifier`
  and `BaggingRegressor` — fits without raising and never selects zero-weighted rows.
- `sklearn/ensemble/tests/test_iforest.py`: regression test for `IsolationForest` —
  fits without raising, produces finite scores, never selects zero-weighted rows.

## Verification

```python
import numpy as np
from sklearn.ensemble import IsolationForest

X = np.random.RandomState(0).uniform(size=(80, 4))
w = np.ones(80)
w[0] = 0.0

IsolationForest(random_state=0).fit(X, sample_weight=w)  # no longer raises
```

---

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.

[This is Claude Code on behalf of Venkateswarlu Nagineni]