### PR TITLE
DOC clarify random_state recommendations

### DIFF
--- a/doc/common_pitfalls.rst
+++ b/doc/common_pitfalls.rst
@@ -244,14 +244,14 @@ subtle parameter.
 .. note:: Recommendation summary
 
     For an optimal robustness of cross-validation (CV) results, pass
-    `RandomState` instances when creating estimators, or leave `random_state`
-    to `None`. Passing integers to CV splitters is usually the safest option
-    and is preferable; passing `RandomState` instances to splitters may
-    sometimes be useful to achieve very specific use-cases.
-    For both estimators and splitters, passing an integer vs passing an
-    instance (or `None`) leads to subtle but significant differences,
-    especially for CV procedures. These differences are important to
-    understand when reporting results.
+    `RandomState` instances when creating estimators. Pass integers to CV
+    splitters.
+
+    Passing `RandomState` instances to splitters may sometimes be useful to
+    achieve very specific use-cases. For both estimators and splitters,
+    passing an integer vs passing an instance (or `None`) leads to subtle but
+    significant differences, especially for CV procedures. These differences
+    are important to understand when reporting results.
 
     For reproducible results across executions, remove any use of
     `random_state=None`.


### PR DESCRIPTION
Fixes #34641.

Rephrase the Recommendation Summary in Common Pitfalls to clearly distinguish integer and `RandomState` behavior for estimators and cross-validation splitters, following the maintainer direction in the issue discussion.

Validation:
- `sphinx-lint doc/common_pitfalls.rst` passed
- `git diff --check` passed
- Full Sphinx build was not available in the preparation environment because `sphinx-build` was not installed.
