### PR TITLE
FIX Handle zero-weight samples in regression scores

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/34798.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/34798.fix.rst
@@ -1,0 +1,6 @@
+- :func:`metrics.r2_score`, :func:`metrics.d2_tweedie_score`,
+  :func:`metrics.d2_pinball_score`, and :func:`metrics.d2_absolute_error_score` now
+  return a NaN score with an :class:`exceptions.UndefinedMetricWarning` when zero
+  sample weights leave fewer than two observations, instead of returning a finite
+  score or raising a ``ZeroDivisionError``.
+  By :user:`A Aswanth Raj <aswanth-07>`.

--- a/sklearn/metrics/_regression.py
+++ b/sklearn/metrics/_regression.py
@@ -245,6 +245,12 @@ def _check_reg_targets_with_floating_dtype(
     return y_type, y_true, y_pred, sample_weight, multioutput
 
 
+def _num_effective_samples(y, sample_weight, xp):
+    if sample_weight is None:
+        return _num_samples(y)
+    return int(xp.count_nonzero(sample_weight))
+
+
 @validate_params(
     {
         "y_true": ["array-like"],
@@ -1310,7 +1316,7 @@ def r2_score(
         )
     )
 
-    if _num_samples(y_pred) < 2:
+    if _num_effective_samples(y_pred, sample_weight, xp) < 2:
         msg = "R^2 score is not well-defined with less than two samples."
         warnings.warn(msg, UndefinedMetricWarning)
         return float("nan")
@@ -1694,7 +1700,7 @@ def d2_tweedie_score(y_true, y_pred, *, sample_weight=None, power=0):
     if y_type == "continuous-multioutput":
         raise ValueError("Multioutput not supported in d2_tweedie_score")
 
-    if _num_samples(y_pred) < 2:
+    if _num_effective_samples(y_pred, sample_weight, xp) < 2:
         msg = "D^2 score is not well-defined with less than two samples."
         warnings.warn(msg, UndefinedMetricWarning)
         return float("nan")
@@ -1837,7 +1843,7 @@ def d2_pinball_score(
         )
     )
 
-    if _num_samples(y_pred) < 2:
+    if _num_effective_samples(y_pred, sample_weight, xp) < 2:
         msg = "D^2 score is not well-defined with less than two samples."
         warnings.warn(msg, UndefinedMetricWarning)
         return float("nan")

--- a/sklearn/metrics/tests/test_regression.py
+++ b/sklearn/metrics/tests/test_regression.py
@@ -492,7 +492,10 @@ def test_regression_custom_weights():
     assert_almost_equal(msle, msle2, decimal=2)
 
 
-@pytest.mark.parametrize("metric", [r2_score, d2_tweedie_score, d2_pinball_score])
+@pytest.mark.parametrize(
+    "metric",
+    [r2_score, d2_tweedie_score, d2_pinball_score, d2_absolute_error_score],
+)
 def test_regression_single_sample(metric):
     y_true = [0]
     y_pred = [1]
@@ -502,6 +505,21 @@ def test_regression_single_sample(metric):
     with pytest.warns(UndefinedMetricWarning, match=warning_msg):
         score = metric(y_true, y_pred)
         assert np.isnan(score)
+
+
+@pytest.mark.parametrize(
+    "metric",
+    [r2_score, d2_tweedie_score, d2_pinball_score, d2_absolute_error_score],
+)
+def test_regression_single_effective_sample(metric):
+    y_true = [0, 100]
+    y_pred = [1, -999]
+    sample_weight = [1, 0]
+
+    warning_msg = "not well-defined with less than two samples."
+    with pytest.warns(UndefinedMetricWarning, match=warning_msg):
+        score = metric(y_true, y_pred, sample_weight=sample_weight)
+    assert np.isnan(score)
 
 
 def test_tweedie_deviance_continuity(global_random_seed):


### PR DESCRIPTION
#### Reference Issues/PRs

No existing issue. I reproduced this on current `main` and found no matching open or closed issue or pull request.

#### What does this implement/fix? Explain your changes.

Regression scores document that they are undefined for fewer than two samples, and scikit-learn's common metric contract treats zero-weight samples as equivalent to removing them. The existing guards counted the raw input length, so one nonzero-weight sample plus any number of zero-weight samples bypassed the guard. In particular, `d2_tweedie_score` could then raise `ZeroDivisionError`, while the other affected scores returned a misleading finite value.

This change counts nonzero sample weights after validation when deciding whether `r2_score`, `d2_tweedie_score`, and `d2_pinball_score` have enough observations. `d2_absolute_error_score` inherits the corrected behavior through `d2_pinball_score`. All four now follow the existing single-sample path: emit `UndefinedMetricWarning` and return `NaN`.

Validation:

- `python -m pytest sklearn/metrics/tests/test_regression.py -q` — 33 passed
- common regression sample-weight invariance tests — 20 passed
- focused Array API compliance tests with `SCIPY_ARRAY_API=1` — 12 passed (optional backends skipped)
- Ruff lint and format checks — passed

#### Introduce yourself

I'm Aswanth. I focus on machine learning and deep learning and contribute bug fixes to scientific Python and ML libraries.

#### AI usage disclosure

I used AI assistance for:
- Code generation
- Test generation
- Research and understanding

#### Any other comments?

The permanent regression test fails for all four score functions on pristine `main`; `d2_tweedie_score` fails with `ZeroDivisionError` and the others fail because they do not emit the documented warning.

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.
