### PR TITLE
CI Use Auth.Token for remaining PyGithub scripts

### DIFF
--- a/.github/scripts/first-time-contributor.py
+++ b/.github/scripts/first-time-contributor.py
@@ -5,7 +5,7 @@ Called from .github/workflows/first-time-contributor.yml.
 
 import os
 
-from github import Auth, Github
+from github import Github
 
 GITHUB_REPO = os.getenv("GITHUB_REPO")
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")

--- a/.github/scripts/first-time-contributor.py
+++ b/.github/scripts/first-time-contributor.py
@@ -5,7 +5,7 @@ Called from .github/workflows/first-time-contributor.yml.
 
 import os
 
-from github import Github
+from github import Auth, Github
 
 GITHUB_REPO = os.getenv("GITHUB_REPO")
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
@@ -52,7 +52,7 @@ def is_not_ready(issue):
     )
 
 
-gh = Github(GITHUB_TOKEN)
+gh = Github(autAuth.Token(GITHUB_TOKEN))
 repo = gh.get_repo(GITHUB_REPO)
 pr = repo.get_pull(PR_NUMBER)
 

--- a/.github/scripts/first-time-contributor.py
+++ b/.github/scripts/first-time-contributor.py
@@ -5,7 +5,7 @@ Called from .github/workflows/first-time-contributor.yml.
 
 import os
 
-from github import Github
+from github import Auth, Github
 
 GITHUB_REPO = os.getenv("GITHUB_REPO")
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
@@ -52,7 +52,7 @@ def is_not_ready(issue):
     )
 
 
-gh = Github(autAuth.Token(GITHUB_TOKEN))
+gh = Github(auth=Auth.Token(GITHUB_TOKEN))
 repo = gh.get_repo(GITHUB_REPO)
 pr = repo.get_pull(PR_NUMBER)
 

--- a/.github/scripts/label_title_regex.py
+++ b/.github/scripts/label_title_regex.py
@@ -5,12 +5,12 @@ import json
 import os
 import re
 
-from github import Github
+from github import Auth, Github
 
 context_dict = json.loads(os.getenv("CONTEXT_GITHUB"))
 
 repo = context_dict["repository"]
-g = Github(context_dict["token"])
+g = Github(auth=Auth.Token(context_dict["token"]))
 repo = g.get_repo(repo)
 pr_number = context_dict["event"]["number"]
 issue = repo.get_issue(number=pr_number)


### PR DESCRIPTION
#### Reference Issues/PRs
Follow up to #34787, see lesteve's comment: https://github.com/scikit-learn/scikit-learn/pull/34787#issuecomment-5390366476

#### What does this implement/fix? Explain your changes.
This is a follow up to my previous PR. lesteve pointed out two more scripts still using the old deprecated Github(token) constructor: .github/scripts/first-time-contributor.py and .github/scripts/label_title_regex.py. This PR updates both to use auth=Auth.Token(token) instead, same as before.

#### Introduce yourself
Hi again, it's Luke, same person from the last PR. Just cleaning up the remaining spots lesteve flagged.

#### AI usage disclosure
None for this one, it's a direct copy of the already approved fix.

#### Any other comments?
Happy to make any adjustments needed.