### PR TITLE
Add Export dict #20051

### DIFF
--- a/doc/modules/tree.rst
+++ b/doc/modules/tree.rst
@@ -213,6 +213,16 @@ Once trained, you can plot the tree with the :func:`plot_tree` function::
       |   |   |--- class: 2
       <BLANKLINE>
 
+  Alternatively, the tree can be exported as a nested dict with the
+  function :func:`export_dict`::
+
+      >>> from sklearn.tree import export_dict
+      >>> tree_dict = export_dict(decision_tree, feature_names=iris['feature_names'])
+      >>> sorted(tree_dict.keys())
+      ['feature', 'feature_name', 'impurity', 'left', 'n_node_samples', 'node_id', 'right', 'threshold', 'weighted_n_node_samples']
+      >>> tree_dict['feature_name']
+      'petal width (cm)'
+
 .. rubric:: Examples
 
 * :ref:`sphx_glr_auto_examples_tree_plot_iris_dtc.py`

--- a/doc/whats_new/upcoming_changes/sklearn.tree/34809.feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.tree/34809.feature.rst
@@ -1,0 +1,3 @@
+- :func:`tree.export_dict`, which exports a fitted :class:`tree.DecisionTreeClassifier`
+  or :class:`tree.DecisionTreeRegressor` as a nested dict, optionally writing it to
+  `out_file` as JSON. By :user:`lcrmorin`.

--- a/sklearn/tree/__init__.py
+++ b/sklearn/tree/__init__.py
@@ -10,7 +10,7 @@ from sklearn.tree._classes import (
     ExtraTreeClassifier,
     ExtraTreeRegressor,
 )
-from sklearn.tree._export import export_graphviz, export_text, plot_tree
+from sklearn.tree._export import export_dict, export_graphviz, export_text, plot_tree
 
 __all__ = [
     "BaseDecisionTree",
@@ -18,6 +18,7 @@ __all__ = [
     "DecisionTreeRegressor",
     "ExtraTreeClassifier",
     "ExtraTreeRegressor",
+    "export_dict",
     "export_graphviz",
     "export_text",
     "plot_tree",

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -1338,8 +1338,7 @@ def export_dict(
     if class_names is not None:
         if not single_output_clf:
             raise ValueError(
-                "class_names is only supported for single-output "
-                "classification trees."
+                "class_names is only supported for single-output classification trees."
             )
         class_names = check_array(
             class_names, ensure_2d=False, dtype=None, ensure_min_samples=0

--- a/sklearn/tree/_export.py
+++ b/sklearn/tree/_export.py
@@ -5,6 +5,7 @@ This module defines export functions for decision trees.
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import json
 from collections.abc import Iterable
 from io import StringIO
 from numbers import Integral
@@ -1232,3 +1233,180 @@ def export_text(
 
     print_tree_recurse(report, 0, 1)
     return report.getvalue()
+
+
+@validate_params(
+    {
+        "decision_tree": [DecisionTreeClassifier, DecisionTreeRegressor],
+        "out_file": [str, None, HasMethods("write")],
+        "feature_names": ["array-like", None],
+        "class_names": ["array-like", None],
+        "max_depth": [Interval(Integral, 0, None, closed="left"), None],
+        "decimals": [Interval(Integral, 0, None, closed="left"), None],
+    },
+    prefer_skip_nested_validation=True,
+)
+def export_dict(
+    decision_tree,
+    out_file=None,
+    *,
+    feature_names=None,
+    class_names=None,
+    max_depth=None,
+    decimals=None,
+):
+    """Build a nested dict representation of a decision tree.
+
+    Note that backwards compatibility may not be supported.
+
+    Parameters
+    ----------
+    decision_tree : object
+        The decision tree estimator to be exported.
+        It can be an instance of
+        DecisionTreeClassifier or DecisionTreeRegressor.
+
+    out_file : object or str, default=None
+        Handle or name of the file to additionally write the result to, as
+        JSON. If None, nothing is written to a file. The dict is returned
+        either way.
+
+    feature_names : array-like of shape (n_features,), default=None
+        An array containing the feature names.
+        If None generic names will be used ("feature_0", "feature_1", ...).
+
+    class_names : array-like of shape (n_classes,), default=None
+        Names of each of the target classes in ascending numerical order.
+        Only relevant for classification and not supported for multi-output.
+
+        - if `None`, the class names are delegated to `decision_tree.classes_`;
+        - otherwise, `class_names` will be used as class names instead of
+          `decision_tree.classes_`. The length of `class_names` must match
+          the length of `decision_tree.classes_`.
+
+    max_depth : int, default=None
+        Only the first max_depth levels of the tree are exported. Nodes
+        beyond this depth are exported as leaves, with a ``"truncated"``
+        key set to `True`. If None, the full tree is exported.
+
+    decimals : int, default=None
+        Number of decimal digits `threshold`, `impurity` and `value` are
+        rounded to. If None, no rounding is applied and values are exported
+        at full floating-point precision. Rounding `threshold` can change
+        which branch a value near the boundary is routed to, so the default
+        should be kept when the output is used to reproduce
+        `decision_tree.predict`.
+
+    Returns
+    -------
+    tree_dict : dict
+        Nested dict representation of the decision tree, rooted at node 0.
+        Every node has the keys ``"node_id"``, ``"n_node_samples"``,
+        ``"weighted_n_node_samples"`` and ``"impurity"``. An internal node
+        additionally has ``"feature"``, ``"feature_name"`` (only if
+        `feature_names` was provided), ``"threshold"``, ``"left"`` and
+        ``"right"``. A leaf, or a node truncated by `max_depth`,
+        additionally has ``"value"`` and, for single-output classifiers,
+        ``"class"``.
+
+    Examples
+    --------
+    >>> from sklearn.datasets import load_iris
+    >>> from sklearn.tree import DecisionTreeClassifier, export_dict
+    >>> iris = load_iris()
+    >>> clf = DecisionTreeClassifier(random_state=0, max_depth=1)
+    >>> clf = clf.fit(iris.data, iris.target)
+    >>> tree_dict = export_dict(clf, feature_names=iris.feature_names)
+    >>> tree_dict["feature_name"]
+    'petal width (cm)'
+    """
+    check_is_fitted(decision_tree)
+    tree_ = decision_tree.tree_
+
+    if feature_names is not None:
+        feature_names = check_array(
+            feature_names, ensure_2d=False, dtype=None, ensure_min_samples=0
+        )
+        if len(feature_names) != tree_.n_features:
+            raise ValueError(
+                "feature_names must contain %d elements, got %d"
+                % (tree_.n_features, len(feature_names))
+            )
+
+    single_output_clf = is_classifier(decision_tree) and tree_.n_outputs == 1
+
+    if class_names is not None:
+        if not single_output_clf:
+            raise ValueError(
+                "class_names is only supported for single-output "
+                "classification trees."
+            )
+        class_names = check_array(
+            class_names, ensure_2d=False, dtype=None, ensure_min_samples=0
+        )
+        if len(class_names) != len(decision_tree.classes_):
+            raise ValueError(
+                "When `class_names` is an array, it should contain as"
+                " many items as `decision_tree.classes_`. Got"
+                f" {len(class_names)} while the tree was fitted with"
+                f" {len(decision_tree.classes_)} classes."
+            )
+    elif single_output_clf:
+        class_names = decision_tree.classes_
+
+    def _round(value):
+        value = float(value)
+        return value if decimals is None else round(value, decimals)
+
+    def _native(value):
+        return value.item() if hasattr(value, "item") else value
+
+    def _value(node_id):
+        value = tree_.value[node_id]
+        if tree_.n_outputs == 1:
+            return [_round(v) for v in value[0]]
+        return [[_round(v) for v in output] for output in value]
+
+    def _recurse(node_id, depth):
+        node = {
+            "node_id": int(node_id),
+            "n_node_samples": int(tree_.n_node_samples[node_id]),
+            "weighted_n_node_samples": _round(tree_.weighted_n_node_samples[node_id]),
+            "impurity": _round(tree_.impurity[node_id]),
+        }
+
+        is_leaf = tree_.feature[node_id] == _tree.TREE_UNDEFINED
+        truncated = max_depth is not None and depth > max_depth
+
+        if is_leaf or truncated:
+            node["value"] = _value(node_id)
+            if single_output_clf:
+                class_idx = int(np.argmax(tree_.value[node_id][0]))
+                node["class"] = _native(class_names[class_idx])
+            if truncated and not is_leaf:
+                node["truncated"] = True
+            return node
+
+        feature = int(tree_.feature[node_id])
+        node["feature"] = feature
+        if feature_names is not None:
+            node["feature_name"] = _native(feature_names[feature])
+        node["threshold"] = _round(tree_.threshold[node_id])
+        node["left"] = _recurse(tree_.children_left[node_id], depth + 1)
+        node["right"] = _recurse(tree_.children_right[node_id], depth + 1)
+        return node
+
+    tree_dict = _recurse(0, 0)
+
+    if out_file is not None:
+        own_file = False
+        if isinstance(out_file, str):
+            out_file = open(out_file, "w", encoding="utf-8")
+            own_file = True
+        try:
+            json.dump(tree_dict, out_file)
+        finally:
+            if own_file:
+                out_file.close()
+
+    return tree_dict

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -2,6 +2,7 @@
 Testing for export functions of decision trees (sklearn.tree.export).
 """
 
+import json
 from io import StringIO
 from re import finditer, search
 from textwrap import dedent
@@ -15,6 +16,7 @@ from sklearn.exceptions import NotFittedError
 from sklearn.tree import (
     DecisionTreeClassifier,
     DecisionTreeRegressor,
+    export_dict,
     export_graphviz,
     export_text,
     plot_tree,
@@ -771,3 +773,186 @@ def test_not_fitted_tree(pyplot):
     clf = DecisionTreeRegressor()
     with pytest.raises(NotFittedError):
         plot_tree(clf)
+
+
+def test_export_dict():
+    clf = DecisionTreeClassifier(max_depth=2, random_state=0)
+    clf.fit(X, y)
+    tree_dict = export_dict(clf)
+
+    assert tree_dict["node_id"] == 0
+    assert tree_dict["feature"] == 1
+    assert tree_dict["threshold"] == 0.0
+    assert tree_dict["left"]["class"] == -1
+    assert tree_dict["right"]["class"] == 1
+    assert "feature" not in tree_dict["left"]
+    assert "left" not in tree_dict["left"]
+
+    tree_dict = export_dict(
+        clf, feature_names=["a", "b"], class_names=["neg", "pos"]
+    )
+    assert tree_dict["feature_name"] == "b"
+    assert tree_dict["left"]["class"] == "neg"
+    assert tree_dict["right"]["class"] == "pos"
+
+    X_mo = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]]
+    y_mo = [[-1, -1], [-1, -1], [-1, -1], [1, 1], [1, 1], [1, 1]]
+    reg = DecisionTreeRegressor(max_depth=2, random_state=0)
+    reg.fit(X_mo, y_mo)
+    tree_dict = export_dict(reg, decimals=1)
+    assert "class" not in tree_dict["left"]
+    assert tree_dict["left"]["value"] == [[-1.0], [-1.0]]
+    assert tree_dict["right"]["value"] == [[1.0], [1.0]]
+
+
+def test_export_dict_max_depth():
+    X_l = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1], [-1, 1]]
+    y_l = [-1, -1, -1, 1, 1, 1, 2]
+    clf = DecisionTreeClassifier(max_depth=4, random_state=0)
+    clf.fit(X_l, y_l)
+
+    full = export_dict(clf)
+    truncated = export_dict(clf, max_depth=0)
+
+    assert "left" in full["right"]
+    assert truncated["right"]["truncated"] is True
+    assert "left" not in truncated["right"]
+    assert "value" in truncated["right"]
+    assert "class" in truncated["right"]
+
+
+def test_export_dict_json_round_trip():
+    clf = DecisionTreeClassifier(max_depth=2, random_state=0)
+    clf.fit(X, y)
+    tree_dict = export_dict(clf, feature_names=["a", "b"])
+
+    assert json.loads(json.dumps(tree_dict)) == tree_dict
+
+
+def test_export_dict_matches_export_text():
+    X_l = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1], [-1, 1]]
+    y_l = [-1, -1, -1, 1, 1, 1, 2]
+    clf = DecisionTreeClassifier(max_depth=4, random_state=0)
+    clf.fit(X_l, y_l)
+    tree_dict = export_dict(clf)
+    text_report = export_text(clf, max_depth=10)
+
+    leaves = []
+
+    def collect_leaves(node):
+        if "left" in node:
+            collect_leaves(node["left"])
+            collect_leaves(node["right"])
+        else:
+            leaves.append(node["class"])
+
+    collect_leaves(tree_dict)
+    expected = [
+        int(line.rsplit(":", 1)[1])
+        for line in text_report.splitlines()
+        if "class:" in line
+    ]
+    assert leaves == expected
+
+
+def test_export_dict_default_decimals_matches_predict():
+    X_l = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1], [-1, 1]]
+    y_l = [-1, -1, -1, 1, 1, 1, 2]
+    clf = DecisionTreeClassifier(max_depth=4, random_state=0)
+    clf.fit(X_l, y_l)
+    tree_dict = export_dict(clf)
+
+    def route(node, x):
+        while "left" in node:
+            v = x[node["feature"]]
+            node = node["left"] if v <= node["threshold"] else node["right"]
+        return node["class"]
+
+    thresholds = []
+
+    def collect(node):
+        if "left" in node:
+            thresholds.append((node["feature"], node["threshold"]))
+            collect(node["left"])
+            collect(node["right"])
+
+    collect(tree_dict)
+
+    for feature, threshold in thresholds:
+        for sign in (-1, 1):
+            x = np.array(X_l[0], dtype=float)
+            x[feature] = threshold + sign * 1e-6
+            assert route(tree_dict, x) == clf.predict([x])[0]
+
+
+def test_export_dict_rounding_changes_routing():
+    X_r = np.array([[0.0], [1.0], [1.75], [1.751], [3.0], [3.5]])
+    y_r = [0, 0, 0, 1, 1, 1]
+    clf = DecisionTreeClassifier(max_depth=1, random_state=0).fit(X_r, y_r)
+
+    x_boundary = np.array([1.76])
+    true_pred = clf.predict([x_boundary])[0]
+
+    def route(node, x):
+        while "left" in node:
+            v = x[node["feature"]]
+            node = node["left"] if v <= node["threshold"] else node["right"]
+        return node["class"]
+
+    assert route(export_dict(clf), x_boundary) == true_pred
+    rounded = export_dict(clf, decimals=1)
+    assert rounded["threshold"] == 1.8
+    assert route(rounded, x_boundary) != true_pred
+
+
+def test_export_dict_string_class_labels():
+    y_str = ["neg", "neg", "neg", "pos", "pos", "pos"]
+    clf = DecisionTreeClassifier(max_depth=2, random_state=0).fit(X, y_str)
+    tree_dict = export_dict(clf)
+
+    assert tree_dict["left"]["class"] == "neg"
+    assert isinstance(tree_dict["left"]["class"], str)
+    json.dumps(tree_dict)
+
+
+def test_export_dict_out_file(tmp_path):
+    clf = DecisionTreeClassifier(max_depth=2, random_state=0)
+    clf.fit(X, y)
+    tree_dict = export_dict(clf)
+
+    path = tmp_path / "tree.json"
+    result = export_dict(clf, str(path))
+    assert result == tree_dict
+    with open(path) as f:
+        assert json.load(f) == tree_dict
+
+    buf = StringIO()
+    result = export_dict(clf, out_file=buf)
+    assert result == tree_dict
+    assert json.loads(buf.getvalue()) == tree_dict
+    assert not buf.closed
+
+
+def test_export_dict_errors():
+    clf = DecisionTreeClassifier(max_depth=2, random_state=0)
+    clf.fit(X, y)
+
+    err_msg = "feature_names must contain 2 elements, got 1"
+    with pytest.raises(ValueError, match=err_msg):
+        export_dict(clf, feature_names=["a"])
+
+    err_msg = (
+        "When `class_names` is an array, it should contain as"
+        " many items as `decision_tree.classes_`. Got 1 while"
+        " the tree was fitted with 2 classes."
+    )
+    with pytest.raises(ValueError, match=err_msg):
+        export_dict(clf, class_names=["a"])
+
+    reg = DecisionTreeRegressor(max_depth=2, random_state=0)
+    reg.fit(X, y)
+    with pytest.raises(ValueError, match="only supported for single-output"):
+        export_dict(reg, class_names=["a"])
+
+    with pytest.raises(NotFittedError):
+        export_dict(DecisionTreeClassifier())

--- a/sklearn/tree/tests/test_export.py
+++ b/sklearn/tree/tests/test_export.py
@@ -788,9 +788,7 @@ def test_export_dict():
     assert "feature" not in tree_dict["left"]
     assert "left" not in tree_dict["left"]
 
-    tree_dict = export_dict(
-        clf, feature_names=["a", "b"], class_names=["neg", "pos"]
-    )
+    tree_dict = export_dict(clf, feature_names=["a", "b"], class_names=["neg", "pos"])
     assert tree_dict["feature_name"] == "b"
     assert tree_dict["left"]["class"] == "neg"
     assert tree_dict["right"]["class"] == "pos"


### PR DESCRIPTION
Reference Issues/PRs:
#20051 

Adds `tree.export_dict`, which returns a fitted `DecisionTreeClassifier` or `DecisionTreeRegressor` as a nested dict. An optional `out_file` (str path or file-like object, handled the same way as in `export_graphviz`) additionally writes the dict as JSON; the dict is always returned regardless of whether `out_file` is given.

## Why this shape
- Functionally very close to export_text, to the point that I am concerned this could be factored. 

Closes #20051.

The code has been mostly copy-pasted, edited, then reviewed by AI. AI use for installation / tests.