### PR TITLE
MNT Don't ship RecordingCallback.record to the workers

### DIFF
--- a/sklearn/callback/tests/_common/callbacks.py
+++ b/sklearn/callback/tests/_common/callbacks.py
@@ -19,6 +19,12 @@ class RecordingCallback:
         self.record = []
         self._listener_handle = open_listener(self.record.append, owner=self)
 
+    def __getstate__(self):
+        # We never access the record from a worker so there's no need to ship it.
+        # Emptying it avoids nesting the record, callback and context in each other
+        # which would grow the pickle size exponentially.
+        return {**self.__dict__, "record": []}
+
     def setup(self, estimator, context):
         send(
             self._listener_handle,


### PR DESCRIPTION
For public callbacks we make sure to only store plain data on the callback instances. But ``RecordingCallback`` is there for testing purpose, to check the context tree or the passed estimator for instance so we want to store whole objects.

The thing is that the context holds a reference to the callback which itself holds a reference to the record. So we end up nesting the record into the record which makes it grow exponentially.

We assumed that since it would only be used it tests it would be fine but as we grow and strengthen the tests, it looks like it's not fine anymore.

The solution is to not ship the record when the callback is serialized and sent to the workers, because we never need to read the full record from a worker, only from the callback instance in the main process.

This should fix the issue from https://github.com/scikit-learn/scikit-learn/pull/34806, https://github.com/scikit-learn/scikit-learn/pull/34804
It should also fix https://github.com/scikit-learn/scikit-learn/issues/34792
(It already makes the callback test suite twice as fast so worth merging anyway)

ping @lesteve @FrancoisPgm 