### PR TITLE
DOC Remove redundant paragraph about opening issues

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -179,13 +179,9 @@ PRs that appear to violate this policy will be closed without review.
 Submitting a bug report or a feature request
 ============================================
 
-We use GitHub issues to track all bugs and feature requests; feel free to open
-an issue if you have found a bug or wish to see a feature implemented.
-
-In case you experience issues using this package, do not hesitate to submit a
-ticket to the
-`Bug Tracker <https://github.com/scikit-learn/scikit-learn/issues>`_. You are
-also welcome to post feature requests or pull requests.
+We use `GitHub issues <https://github.com/scikit-learn/scikit-learn/issues>`_ to
+track all bugs and feature requests; feel free to open an issue if you have found a bug
+or wish to see a feature implemented.
 
 It is recommended to check that your issue complies with the
 following rules before submitting:


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Follows up from [this discussion](https://github.com/scikit-learn/scikit-learn/pull/34239/changes/BASE..27773374f0b6b299afdea22a25dd3a5adcbfb0c1#r3512828721) in a review of #34239.

#### What does this implement/fix? Explain your changes.
Removes a paragraph which only repeats the information about opening issues or PRs from the previous paragraph, using confusing vocabulary : "submit a ticket to the bug tracker" to say "open an issue".

Also add a link to the issue tracker in the previous paragraph.




#### Any other comments?
ping @AnneBeyer 

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
