### PR TITLE
FIX Use weighted hessian counts for min_samples_leaf in HGBDT

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.ensemble/34818.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.ensemble/34818.fix.rst
@@ -1,0 +1,6 @@
+- |Fix| :class:`ensemble.HistGradientBoostingClassifier` and
+  :class:`ensemble.HistGradientBoostingRegressor` now correctly apply
+  `min_samples_leaf` using the sum of sample weights instead of the
+  unweighted sample count when `sample_weight` is provided. This makes the
+  constraint consistent with the equivalent repeated-sample training.
+  By :user:`Amarnath S <Amarnath10i>`.

--- a/sklearn/ensemble/_hist_gradient_boosting/common.pxd
+++ b/sklearn/ensemble/_hist_gradient_boosting/common.pxd
@@ -16,6 +16,7 @@ cdef packed struct hist_struct:
     # to be packed since by default numpy dtypes aren't aligned
     Y_DTYPE_C sum_gradients
     Y_DTYPE_C sum_hessians
+    Y_DTYPE_C sum_weights
     unsigned int count
 
 

--- a/sklearn/ensemble/_hist_gradient_boosting/common.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/common.pyx
@@ -23,6 +23,7 @@ X_BITSET_INNER_DTYPE = np.uint32
 HISTOGRAM_DTYPE = np.dtype([
     ('sum_gradients', Y_DTYPE),  # sum of sample gradients in bin
     ('sum_hessians', Y_DTYPE),  # sum of sample hessians in bin
+    ('sum_weights', Y_DTYPE),  # sum of sample weights in bin
     ('count', np.uint32),  # number of samples in bin
 ])
 

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -837,6 +837,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                     rng=self._feature_subsample_rng,
                     shrinkage=self.learning_rate,
                     n_threads=n_threads,
+                    sample_weight=sample_weight_train,
                 )
                 grower.grow()
 

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -91,6 +91,7 @@ class TreeNode:
         partition_stop,
         sum_gradients,
         sum_hessians,
+        sum_weights,
         value=None,
     ):
         self.depth = depth
@@ -98,6 +99,7 @@ class TreeNode:
         self.n_samples = sample_indices.shape[0]
         self.sum_gradients = sum_gradients
         self.sum_hessians = sum_hessians
+        self.sum_weights = sum_weights
         self.value = value
         self.is_leaf = False
         self.allowed_features = None
@@ -262,6 +264,7 @@ class TreeGrower:
         rng=np.random.default_rng(),
         shrinkage=1.0,
         n_threads=None,
+        sample_weight=None,
     ):
         self._validate_parameters(
             X_binned,
@@ -311,7 +314,13 @@ class TreeGrower:
 
         hessians_are_constant = hessians.shape[0] == 1
         self.histogram_builder = HistogramBuilder(
-            X_binned, n_bins, gradients, hessians, hessians_are_constant, n_threads
+            X_binned,
+            n_bins,
+            gradients,
+            hessians,
+            hessians_are_constant,
+            n_threads,
+            sample_weights=sample_weight,
         )
         missing_values_bin_idx = n_bins - 1
         self.splitter = Splitter(
@@ -431,6 +440,7 @@ class TreeGrower:
             sum_hessians = self.histogram_builder.hessians[0] * n_samples
         else:
             sum_hessians = histogram_array["sum_hessians"].sum()
+        sum_weights = histogram_array["sum_weights"].sum()
         self.root = TreeNode(
             depth=depth,
             sample_indices=self.splitter.partition,
@@ -438,10 +448,11 @@ class TreeGrower:
             partition_stop=n_samples,
             sum_gradients=sum_gradients,
             sum_hessians=sum_hessians,
+            sum_weights=sum_weights,
             value=0,
         )
 
-        if self.root.n_samples < 2 * self.min_samples_leaf:
+        if self.root.sum_weights < 2 * self.min_samples_leaf:
             # Do not even bother computing any splitting statistics.
             self._finalize_leaf(self.root)
             return
@@ -472,6 +483,7 @@ class TreeGrower:
             histograms=node.histograms,
             sum_gradients=node.sum_gradients,
             sum_hessians=node.sum_hessians,
+            sum_weights=node.sum_weights,
             value=node.value,
             lower_bound=node.children_lower_bound,
             upper_bound=node.children_upper_bound,
@@ -515,6 +527,7 @@ class TreeGrower:
             partition_stop=node.partition_start + right_child_pos,
             sum_gradients=node.split_info.sum_gradient_left,
             sum_hessians=node.split_info.sum_hessian_left,
+            sum_weights=node.split_info.sum_weight_left,
             value=node.split_info.value_left,
         )
         right_child_node = TreeNode(
@@ -524,6 +537,7 @@ class TreeGrower:
             partition_stop=node.partition_stop,
             sum_gradients=node.split_info.sum_gradient_right,
             sum_hessians=node.split_info.sum_hessian_right,
+            sum_weights=node.split_info.sum_weight_right,
             value=node.split_info.value_right,
         )
 
@@ -565,9 +579,9 @@ class TreeGrower:
             self._finalize_leaf(right_child_node)
             return left_child_node, right_child_node
 
-        if left_child_node.n_samples < self.min_samples_leaf * 2:
+        if left_child_node.sum_weights < self.min_samples_leaf * 2:
             self._finalize_leaf(left_child_node)
-        if right_child_node.n_samples < self.min_samples_leaf * 2:
+        if right_child_node.sum_weights < self.min_samples_leaf * 2:
             self._finalize_leaf(right_child_node)
 
         if self.with_monotonic_cst:

--- a/sklearn/ensemble/_hist_gradient_boosting/histogram.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/histogram.pyx
@@ -9,10 +9,11 @@ from libc.string cimport memset
 
 import numpy as np
 
-from sklearn.ensemble._hist_gradient_boosting.common import HISTOGRAM_DTYPE
+from sklearn.ensemble._hist_gradient_boosting.common import HISTOGRAM_DTYPE, Y_DTYPE
 from sklearn.ensemble._hist_gradient_boosting.common cimport hist_struct
 from sklearn.ensemble._hist_gradient_boosting.common cimport X_BINNED_DTYPE_C
 from sklearn.ensemble._hist_gradient_boosting.common cimport G_H_DTYPE_C
+from sklearn.ensemble._hist_gradient_boosting.common cimport Y_DTYPE_C
 from sklearn.utils._typedefs cimport uint8_t
 
 
@@ -81,6 +82,8 @@ cdef class HistogramBuilder:
         G_H_DTYPE_C [::1] hessians
         G_H_DTYPE_C [::1] ordered_gradients
         G_H_DTYPE_C [::1] ordered_hessians
+        Y_DTYPE_C [::1] sample_weights
+        Y_DTYPE_C [::1] ordered_weights
         uint8_t hessians_are_constant
         int n_threads
 
@@ -88,7 +91,8 @@ cdef class HistogramBuilder:
                  unsigned int n_bins, G_H_DTYPE_C [::1] gradients,
                  G_H_DTYPE_C [::1] hessians,
                  uint8_t hessians_are_constant,
-                 int n_threads):
+                 int n_threads,
+                 Y_DTYPE_C [::1] sample_weights=None):
 
         self.X_binned = X_binned
         self.n_features = X_binned.shape[1]
@@ -102,6 +106,10 @@ cdef class HistogramBuilder:
         self.ordered_hessians = hessians.copy()
         self.hessians_are_constant = hessians_are_constant
         self.n_threads = n_threads
+        if sample_weights is None:
+            sample_weights = np.ones(gradients.shape[0], dtype=Y_DTYPE)
+        self.sample_weights = sample_weights
+        self.ordered_weights = sample_weights.copy()
 
     def compute_histograms_brute(
         HistogramBuilder self,
@@ -138,6 +146,8 @@ cdef class HistogramBuilder:
             G_H_DTYPE_C [::1] gradients = self.gradients
             G_H_DTYPE_C [::1] ordered_hessians = self.ordered_hessians
             G_H_DTYPE_C [::1] hessians = self.hessians
+            Y_DTYPE_C [::1] ordered_weights = self.ordered_weights
+            Y_DTYPE_C [::1] sample_weights = self.sample_weights
             # Histograms will be initialized to zero later within a prange
             hist_struct [:, ::1] histograms = np.empty(
                 shape=(self.n_features, self.n_bins),
@@ -160,11 +170,13 @@ cdef class HistogramBuilder:
                     for i in prange(n_samples, schedule='static',
                                     num_threads=n_threads):
                         ordered_gradients[i] = gradients[sample_indices[i]]
+                        ordered_weights[i] = sample_weights[sample_indices[i]]
                 else:
                     for i in prange(n_samples, schedule='static',
                                     num_threads=n_threads):
                         ordered_gradients[i] = gradients[sample_indices[i]]
                         ordered_hessians[i] = hessians[sample_indices[i]]
+                        ordered_weights[i] = sample_weights[sample_indices[i]]
 
             # Compute histogram of each feature
             for f_idx in prange(
@@ -176,7 +188,7 @@ cdef class HistogramBuilder:
                     feature_idx = f_idx
 
                 self._compute_histogram_brute_single_feature(
-                    feature_idx, sample_indices, histograms
+                    feature_idx, sample_indices, ordered_weights, histograms
                 )
 
         return histograms
@@ -185,6 +197,7 @@ cdef class HistogramBuilder:
             HistogramBuilder self,
             const int feature_idx,
             const unsigned int [::1] sample_indices,  # IN
+            const Y_DTYPE_C [::1] ordered_weights,     # IN
             hist_struct [:, ::1] histograms) noexcept nogil:  # OUT
         """Compute the histogram for a given feature."""
 
@@ -197,6 +210,8 @@ cdef class HistogramBuilder:
                 self.ordered_gradients[:n_samples]
             G_H_DTYPE_C [::1] ordered_hessians = \
                 self.ordered_hessians[:n_samples]
+            const Y_DTYPE_C [::1] ordered_weights_view = \
+                ordered_weights[:n_samples]
             uint8_t hessians_are_constant = \
                 self.hessians_are_constant
 
@@ -207,20 +222,24 @@ cdef class HistogramBuilder:
             if hessians_are_constant:
                 _build_histogram_root_no_hessian(feature_idx, X_binned,
                                                  ordered_gradients,
+                                                 ordered_weights_view,
                                                  histograms)
             else:
                 _build_histogram_root(feature_idx, X_binned,
                                       ordered_gradients, ordered_hessians,
-                                      histograms)
+                                      ordered_weights_view, histograms)
         else:
             if hessians_are_constant:
                 _build_histogram_no_hessian(feature_idx,
                                             sample_indices, X_binned,
-                                            ordered_gradients, histograms)
+                                            ordered_gradients,
+                                            ordered_weights_view,
+                                            histograms)
             else:
                 _build_histogram(feature_idx, sample_indices,
                                  X_binned, ordered_gradients,
-                                 ordered_hessians, histograms)
+                                 ordered_hessians,
+                                 ordered_weights_view, histograms)
 
     def compute_histograms_subtraction(
         HistogramBuilder self,
@@ -289,6 +308,7 @@ cpdef void _build_histogram_naive(
         X_BINNED_DTYPE_C [:] binned_feature,  # IN
         G_H_DTYPE_C [:] ordered_gradients,  # IN
         G_H_DTYPE_C [:] ordered_hessians,  # IN
+        Y_DTYPE_C [:] ordered_weights,  # IN
         hist_struct [:, :] out) noexcept nogil:  # OUT
     """Build histogram in a naive way, without optimizing for cache hit.
 
@@ -304,6 +324,7 @@ cpdef void _build_histogram_naive(
         bin_idx = binned_feature[sample_idx]
         out[feature_idx, bin_idx].sum_gradients += ordered_gradients[i]
         out[feature_idx, bin_idx].sum_hessians += ordered_hessians[i]
+        out[feature_idx, bin_idx].sum_weights += ordered_weights[i]
         out[feature_idx, bin_idx].count += 1
 
 
@@ -330,6 +351,7 @@ cpdef void _subtract_histograms(
     for i in range(n_bins):
         hist_a[feature_idx, i].sum_gradients -= hist_b[feature_idx, i].sum_gradients
         hist_a[feature_idx, i].sum_hessians -= hist_b[feature_idx, i].sum_hessians
+        hist_a[feature_idx, i].sum_weights -= hist_b[feature_idx, i].sum_weights
         hist_a[feature_idx, i].count -= hist_b[feature_idx, i].count
 
 
@@ -339,6 +361,7 @@ cpdef void _build_histogram(
         const X_BINNED_DTYPE_C [::1] binned_feature,  # IN
         const G_H_DTYPE_C [::1] ordered_gradients,  # IN
         const G_H_DTYPE_C [::1] ordered_hessians,  # IN
+        const Y_DTYPE_C [::1] ordered_weights,  # IN
         hist_struct [:, ::1] out) noexcept nogil:  # OUT
     """Return histogram for a given feature."""
     cdef:
@@ -368,6 +391,11 @@ cpdef void _build_histogram(
         out[feature_idx, bin_2].sum_hessians += ordered_hessians[i + 2]
         out[feature_idx, bin_3].sum_hessians += ordered_hessians[i + 3]
 
+        out[feature_idx, bin_0].sum_weights += ordered_weights[i]
+        out[feature_idx, bin_1].sum_weights += ordered_weights[i + 1]
+        out[feature_idx, bin_2].sum_weights += ordered_weights[i + 2]
+        out[feature_idx, bin_3].sum_weights += ordered_weights[i + 3]
+
         out[feature_idx, bin_0].count += 1
         out[feature_idx, bin_1].count += 1
         out[feature_idx, bin_2].count += 1
@@ -377,6 +405,7 @@ cpdef void _build_histogram(
         bin_idx = binned_feature[sample_indices[i]]
         out[feature_idx, bin_idx].sum_gradients += ordered_gradients[i]
         out[feature_idx, bin_idx].sum_hessians += ordered_hessians[i]
+        out[feature_idx, bin_idx].sum_weights += ordered_weights[i]
         out[feature_idx, bin_idx].count += 1
 
 
@@ -385,6 +414,7 @@ cpdef void _build_histogram_no_hessian(
         const unsigned int [::1] sample_indices,  # IN
         const X_BINNED_DTYPE_C [::1] binned_feature,  # IN
         const G_H_DTYPE_C [::1] ordered_gradients,  # IN
+        const Y_DTYPE_C [::1] ordered_weights,  # IN
         hist_struct [:, ::1] out) noexcept nogil:  # OUT
     """Return histogram for a given feature, not updating hessians.
 
@@ -413,6 +443,11 @@ cpdef void _build_histogram_no_hessian(
         out[feature_idx, bin_2].sum_gradients += ordered_gradients[i + 2]
         out[feature_idx, bin_3].sum_gradients += ordered_gradients[i + 3]
 
+        out[feature_idx, bin_0].sum_weights += ordered_weights[i]
+        out[feature_idx, bin_1].sum_weights += ordered_weights[i + 1]
+        out[feature_idx, bin_2].sum_weights += ordered_weights[i + 2]
+        out[feature_idx, bin_3].sum_weights += ordered_weights[i + 3]
+
         out[feature_idx, bin_0].count += 1
         out[feature_idx, bin_1].count += 1
         out[feature_idx, bin_2].count += 1
@@ -421,14 +456,15 @@ cpdef void _build_histogram_no_hessian(
     for i in range(unrolled_upper, n_node_samples):
         bin_idx = binned_feature[sample_indices[i]]
         out[feature_idx, bin_idx].sum_gradients += ordered_gradients[i]
+        out[feature_idx, bin_idx].sum_weights += ordered_weights[i]
         out[feature_idx, bin_idx].count += 1
-
 
 cpdef void _build_histogram_root(
         const int feature_idx,
         const X_BINNED_DTYPE_C [::1] binned_feature,  # IN
         const G_H_DTYPE_C [::1] all_gradients,  # IN
         const G_H_DTYPE_C [::1] all_hessians,  # IN
+        const Y_DTYPE_C [::1] all_weights,  # IN
         hist_struct [:, ::1] out) noexcept nogil:  # OUT
     """Compute histogram of the root node.
 
@@ -465,6 +501,11 @@ cpdef void _build_histogram_root(
         out[feature_idx, bin_2].sum_hessians += all_hessians[i + 2]
         out[feature_idx, bin_3].sum_hessians += all_hessians[i + 3]
 
+        out[feature_idx, bin_0].sum_weights += all_weights[i]
+        out[feature_idx, bin_1].sum_weights += all_weights[i + 1]
+        out[feature_idx, bin_2].sum_weights += all_weights[i + 2]
+        out[feature_idx, bin_3].sum_weights += all_weights[i + 3]
+
         out[feature_idx, bin_0].count += 1
         out[feature_idx, bin_1].count += 1
         out[feature_idx, bin_2].count += 1
@@ -474,6 +515,7 @@ cpdef void _build_histogram_root(
         bin_idx = binned_feature[i]
         out[feature_idx, bin_idx].sum_gradients += all_gradients[i]
         out[feature_idx, bin_idx].sum_hessians += all_hessians[i]
+        out[feature_idx, bin_idx].sum_weights += all_weights[i]
         out[feature_idx, bin_idx].count += 1
 
 
@@ -481,6 +523,7 @@ cpdef void _build_histogram_root_no_hessian(
         const int feature_idx,
         const X_BINNED_DTYPE_C [::1] binned_feature,  # IN
         const G_H_DTYPE_C [::1] all_gradients,  # IN
+        const Y_DTYPE_C [::1] all_weights,  # IN
         hist_struct [:, ::1] out) noexcept nogil:  # OUT
     """Compute histogram of the root node, not updating hessians.
 
@@ -499,6 +542,7 @@ cpdef void _build_histogram_root_no_hessian(
         unsigned int bin_idx
 
     for i in range(0, unrolled_upper, 4):
+
         bin_0 = binned_feature[i]
         bin_1 = binned_feature[i + 1]
         bin_2 = binned_feature[i + 2]
@@ -509,6 +553,11 @@ cpdef void _build_histogram_root_no_hessian(
         out[feature_idx, bin_2].sum_gradients += all_gradients[i + 2]
         out[feature_idx, bin_3].sum_gradients += all_gradients[i + 3]
 
+        out[feature_idx, bin_0].sum_weights += all_weights[i]
+        out[feature_idx, bin_1].sum_weights += all_weights[i + 1]
+        out[feature_idx, bin_2].sum_weights += all_weights[i + 2]
+        out[feature_idx, bin_3].sum_weights += all_weights[i + 3]
+
         out[feature_idx, bin_0].count += 1
         out[feature_idx, bin_1].count += 1
         out[feature_idx, bin_2].count += 1
@@ -517,4 +566,5 @@ cpdef void _build_histogram_root_no_hessian(
     for i in range(unrolled_upper, n_samples):
         bin_idx = binned_feature[i]
         out[feature_idx, bin_idx].sum_gradients += all_gradients[i]
+        out[feature_idx, bin_idx].sum_weights += all_weights[i]
         out[feature_idx, bin_idx].count += 1

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -38,6 +38,8 @@ cdef struct split_info_struct:
     Y_DTYPE_C sum_hessian_right
     unsigned int n_samples_left
     unsigned int n_samples_right
+    Y_DTYPE_C sum_weight_left
+    Y_DTYPE_C sum_weight_right
     Y_DTYPE_C value_left
     Y_DTYPE_C value_right
     uint8_t is_categorical
@@ -79,6 +81,10 @@ class SplitInfo:
         The number of samples in the left child.
     n_samples_right : int
         The number of samples in the right child.
+    sum_weight_left : float
+        The sum of the sample weights of all the samples in the left child.
+    sum_weight_right : float
+        The sum of the sample weights of all the samples in the right child.
     is_categorical : bool
         Whether the split is done on a categorical feature.
     left_cat_bitset : ndarray of shape=(8,), dtype=uint32 or None
@@ -92,7 +98,8 @@ class SplitInfo:
     def __init__(self, gain, feature_idx, bin_idx,
                  missing_go_to_left, sum_gradient_left, sum_hessian_left,
                  sum_gradient_right, sum_hessian_right, n_samples_left,
-                 n_samples_right, value_left, value_right,
+                 n_samples_right, sum_weight_left, sum_weight_right,
+                 value_left, value_right,
                  is_categorical, left_cat_bitset):
         self.gain = gain
         self.feature_idx = feature_idx
@@ -104,6 +111,8 @@ class SplitInfo:
         self.sum_hessian_right = sum_hessian_right
         self.n_samples_left = n_samples_left
         self.n_samples_right = n_samples_right
+        self.sum_weight_left = sum_weight_left
+        self.sum_weight_right = sum_weight_right
         self.value_left = value_left
         self.value_right = value_right
         self.is_categorical = is_categorical
@@ -433,6 +442,7 @@ cdef class Splitter:
             const Y_DTYPE_C lower_bound=-INFINITY,
             const Y_DTYPE_C upper_bound=INFINITY,
             const unsigned int [:] allowed_features=None,
+            sum_weights=None,
             ):
         """For each feature, find the best bin to split on at a given node.
 
@@ -487,9 +497,21 @@ cdef class Splitter:
             int n_threads = self.n_threads
             bint has_interaction_cst = False
             Y_DTYPE_C feature_fraction_per_split = self.feature_fraction_per_split
+            Y_DTYPE_C sum_weights_total
             uint8_t [:] subsample_mask  # same as npy_bool
             int n_subsampled_features
             uint8_t missing_go_to_left
+
+        # When not provided (e.g. direct calls in tests), derive the node's
+        # total sum of sample weights from the histograms. The sum over the
+        # bins of a single feature equals the node total, since each sample
+        # contributes to exactly one bin per feature.
+        if sum_weights is None:
+            sum_weights_total = 0.
+            for _b in range(histograms.shape[1]):
+                sum_weights_total += histograms[0, _b].sum_weights
+        else:
+            sum_weights_total = sum_weights
 
         has_interaction_cst = allowed_features is not None
         if has_interaction_cst:
@@ -545,8 +567,8 @@ cdef class Splitter:
                     self._find_best_bin_to_split_category(
                         feature_idx, has_missing_values[feature_idx],
                         histograms, n_samples, sum_gradients, sum_hessians,
-                        value, monotonic_cst[feature_idx], lower_bound,
-                        upper_bound, &split_infos[split_info_idx])
+                        sum_weights_total, value, monotonic_cst[feature_idx],
+                        lower_bound, upper_bound, &split_infos[split_info_idx])
                 else:
                     # We scan bins from left to right and, if there are any
                     # missing values, we scan a second time with missing
@@ -563,7 +585,7 @@ cdef class Splitter:
                         self._find_best_bin_to_split_numerical(
                             feature_idx, has_missing_values[feature_idx],
                             histograms, n_samples, sum_gradients, sum_hessians,
-                            value, monotonic_cst[feature_idx],
+                            sum_weights_total, value, monotonic_cst[feature_idx],
                             lower_bound, upper_bound, missing_go_to_left,
                             &split_infos[split_info_idx])
 
@@ -585,6 +607,8 @@ cdef class Splitter:
             split_info.sum_hessian_right,
             split_info.n_samples_left,
             split_info.n_samples_right,
+            split_info.sum_weight_left,
+            split_info.sum_weight_right,
             split_info.value_left,
             split_info.value_right,
             split_info.is_categorical,
@@ -620,6 +644,7 @@ cdef class Splitter:
             unsigned int n_samples,
             Y_DTYPE_C sum_gradients,
             Y_DTYPE_C sum_hessians,
+            Y_DTYPE_C sum_weights,
             Y_DTYPE_C value,
             signed char monotonic_cst,
             Y_DTYPE_C lower_bound,
@@ -640,12 +665,12 @@ cdef class Splitter:
             unsigned int hist_bin_idx
             int n_bins_non_missing = self.n_bins_non_missing[feature_idx]
             unsigned int n_samples_left
-            unsigned int n_samples_right
-            unsigned int n_samples_ = n_samples
             int start
             int end
             Y_DTYPE_C sum_hessian_left
             Y_DTYPE_C sum_hessian_right
+            Y_DTYPE_C sum_weight_left
+            Y_DTYPE_C sum_weight_right
             Y_DTYPE_C sum_gradient_left
             Y_DTYPE_C sum_gradient_right
             Y_DTYPE_C loss_current_node
@@ -654,6 +679,7 @@ cdef class Splitter:
 
             Y_DTYPE_C best_sum_hessian_left
             Y_DTYPE_C best_sum_gradient_left
+            Y_DTYPE_C best_sum_weight_left
             unsigned int best_bin_idx
             unsigned int best_n_samples_left
             Y_DTYPE_C best_gain = split_info.gain
@@ -661,6 +687,7 @@ cdef class Splitter:
 
         sum_gradient_left, sum_hessian_left = 0., 0.
         n_samples_left = 0
+        sum_weight_left = 0.
 
         loss_current_node = _loss_from_value(value, sum_gradients)
 
@@ -679,7 +706,8 @@ cdef class Splitter:
 
             hist = histograms[feature_idx, hist_bin_idx]
             n_samples_left += hist.count
-            n_samples_right = n_samples_ - n_samples_left
+            sum_weight_left += hist.sum_weights
+            sum_weight_right = sum_weights - sum_weight_left
 
             if self.hessians_are_constant:
                 sum_hessian_left += hist.count
@@ -697,9 +725,9 @@ cdef class Splitter:
                 # is already considered when missing_go_to_left is False.
                 continue
 
-            if n_samples_left < self.min_samples_leaf:
+            if sum_weight_left < self.min_samples_leaf:
                 continue
-            if n_samples_right < self.min_samples_leaf:
+            if sum_weight_right < self.min_samples_leaf:
                 # won't get any better
                 break
 
@@ -723,6 +751,7 @@ cdef class Splitter:
                 best_bin_idx = bin_idx
                 best_sum_gradient_left = sum_gradient_left
                 best_sum_hessian_left = sum_hessian_left
+                best_sum_weight_left = sum_weight_left
                 best_n_samples_left = n_samples_left
 
         if found_better_split:
@@ -735,6 +764,8 @@ cdef class Splitter:
             split_info.sum_hessian_right = sum_hessians - best_sum_hessian_left
             split_info.n_samples_left = best_n_samples_left
             split_info.n_samples_right = n_samples - best_n_samples_left
+            split_info.sum_weight_left = best_sum_weight_left
+            split_info.sum_weight_right = sum_weights - best_sum_weight_left
 
             # We recompute best values here but it's cheap
             split_info.value_left = compute_node_value(
@@ -753,6 +784,7 @@ cdef class Splitter:
             unsigned int n_samples,
             Y_DTYPE_C sum_gradients,
             Y_DTYPE_C sum_hessians,
+            Y_DTYPE_C sum_weights,
             Y_DTYPE_C value,
             char monotonic_cst,
             Y_DTYPE_C lower_bound,
@@ -785,12 +817,14 @@ cdef class Splitter:
             Y_DTYPE_C loss_current_node
             Y_DTYPE_C sum_gradient_left, sum_hessian_left
             Y_DTYPE_C sum_gradient_right, sum_hessian_right
-            unsigned int n_samples_left, n_samples_right
+            Y_DTYPE_C sum_weight_left, sum_weight_right
+            unsigned int n_samples_left
             Y_DTYPE_C gain
             Y_DTYPE_C best_gain = -1.0
             uint8_t found_better_split = False
             Y_DTYPE_C best_sum_hessian_left
             Y_DTYPE_C best_sum_gradient_left
+            Y_DTYPE_C best_sum_weight_left
             unsigned int best_n_samples_left
             unsigned int best_cat_infos_thresh
             # Reduces the effect of noises in categorical features,
@@ -892,6 +926,7 @@ cdef class Splitter:
 
             # The categories we'll consider will go to the left child
             sum_gradient_left, sum_hessian_left = 0., 0.
+            sum_weight_left = 0.
             n_samples_left = 0
 
             for i in range(middle):
@@ -900,7 +935,8 @@ cdef class Splitter:
                 hist = feature_hist[bin_idx]
 
                 n_samples_left += hist.count
-                n_samples_right = n_samples - n_samples_left
+                sum_weight_left += hist.sum_weights
+                sum_weight_right = sum_weights - sum_weight_left
 
                 if self.hessians_are_constant:
                     sum_hessian_left += hist.count
@@ -912,12 +948,12 @@ cdef class Splitter:
                 sum_gradient_right = sum_gradients - sum_gradient_left
 
                 if (
-                    n_samples_left < self.min_samples_leaf or
+                    sum_weight_left < self.min_samples_leaf or
                     sum_hessian_left < self.min_hessian_to_split
                 ):
                     continue
                 if (
-                    n_samples_right < self.min_samples_leaf or
+                    sum_weight_right < self.min_samples_leaf or
                     sum_hessian_right < self.min_hessian_to_split
                 ):
                     break
@@ -933,6 +969,7 @@ cdef class Splitter:
                     best_cat_infos_thresh = sorted_cat_idx
                     best_sum_gradient_left = sum_gradient_left
                     best_sum_hessian_left = sum_hessian_left
+                    best_sum_weight_left = sum_weight_left
                     best_n_samples_left = n_samples_left
                     best_direction = direction
 
@@ -949,6 +986,8 @@ cdef class Splitter:
             split_info.sum_hessian_right = sum_hessians - best_sum_hessian_left
             split_info.n_samples_left = best_n_samples_left
             split_info.n_samples_right = n_samples - best_n_samples_left
+            split_info.sum_weight_left = best_sum_weight_left
+            split_info.sum_weight_right = sum_weights - best_sum_weight_left
 
             # We recompute best values here but it's cheap
             split_info.value_left = compute_node_value(

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -652,6 +652,35 @@ def test_consistent_lengths():
         gbdt.fit(X, y[1:])
 
 
+@pytest.mark.parametrize(
+    "Klass", [HistGradientBoostingRegressor, HistGradientBoostingClassifier]
+)
+def test_min_samples_leaf_with_sample_weight(Klass):
+    # min_samples_leaf must be applied to the sum of sample weights, not to the
+    # number of samples. Training with integer sample weights must therefore be
+    # equivalent to training on data where each sample is repeated according to
+    # its weight (no sample_weight passed). See #34745.
+    rng = np.random.RandomState(0)
+    n_samples = 50
+    X = rng.randn(n_samples, 3)
+    if Klass is HistGradientBoostingClassifier:
+        y = (X[:, 0] > 0).astype(int)
+    else:
+        y = X[:, 0]
+    sample_weight = rng.randint(1, 4, size=n_samples).astype(float)
+
+    est_weighted = Klass(min_samples_leaf=5, max_iter=50, learning_rate=1.0)
+    est_weighted.fit(X, y, sample_weight=sample_weight)
+
+    repeats = sample_weight.astype(int)
+    X_rep = np.repeat(X, repeats, axis=0)
+    y_rep = np.repeat(y, repeats, axis=0)
+    est_repeated = Klass(min_samples_leaf=5, max_iter=50, learning_rate=1.0)
+    est_repeated.fit(X_rep, y_rep)
+
+    assert_allclose(est_weighted.predict(X), est_repeated.predict(X), atol=1e-3)
+
+
 def test_infinite_values_missing_values():
     # High level test making sure that inf and nan values are properly handled
     # when both are present. This is similar to

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_histogram.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_histogram.py
@@ -26,23 +26,38 @@ def test_build_histogram(build_func):
     ordered_hessians = np.array([1, 1, 2], dtype=G_H_DTYPE)
 
     sample_indices = np.array([0, 2, 3], dtype=np.uint32)
+    weights = np.ones(len(sample_indices), dtype=np.float64)
     hist = np.zeros((1, 3), dtype=HISTOGRAM_DTYPE)
     build_func(
-        0, sample_indices, binned_feature, ordered_gradients, ordered_hessians, hist
+        0,
+        sample_indices,
+        binned_feature,
+        ordered_gradients,
+        ordered_hessians,
+        weights,
+        hist,
     )
     hist = hist[0]
     assert_array_equal(hist["count"], [2, 1, 0])
     assert_allclose(hist["sum_gradients"], [1, 3, 0])
     assert_allclose(hist["sum_hessians"], [2, 2, 0])
+    assert_allclose(hist["sum_weights"], [2, 1, 0])
 
     # Larger sample_indices (above unrolling threshold)
     sample_indices = np.array([0, 2, 3, 6, 7], dtype=np.uint32)
     ordered_gradients = np.array([0, 1, 3, 0, 1], dtype=G_H_DTYPE)
     ordered_hessians = np.array([1, 1, 2, 1, 0], dtype=G_H_DTYPE)
 
+    weights = np.ones(len(sample_indices), dtype=np.float64)
     hist = np.zeros((1, 3), dtype=HISTOGRAM_DTYPE)
     build_func(
-        0, sample_indices, binned_feature, ordered_gradients, ordered_hessians, hist
+        0,
+        sample_indices,
+        binned_feature,
+        ordered_gradients,
+        ordered_hessians,
+        weights,
+        hist,
     )
     hist = hist[0]
     assert_array_equal(hist["count"], [2, 2, 1])
@@ -63,15 +78,22 @@ def test_histogram_sample_order_independence():
         np.arange(n_samples, dtype=np.uint32), n_sub_samples, replace=False
     )
     ordered_gradients = rng.randn(n_sub_samples).astype(G_H_DTYPE)
+    ordered_weights = np.ones(n_sub_samples, dtype=np.float64)
     hist_gc = np.zeros((1, n_bins), dtype=HISTOGRAM_DTYPE)
     _build_histogram_no_hessian(
-        0, sample_indices, binned_feature, ordered_gradients, hist_gc
+        0, sample_indices, binned_feature, ordered_gradients, ordered_weights, hist_gc
     )
 
     ordered_hessians = rng.exponential(size=n_sub_samples).astype(G_H_DTYPE)
     hist_ghc = np.zeros((1, n_bins), dtype=HISTOGRAM_DTYPE)
     _build_histogram(
-        0, sample_indices, binned_feature, ordered_gradients, ordered_hessians, hist_ghc
+        0,
+        sample_indices,
+        binned_feature,
+        ordered_gradients,
+        ordered_hessians,
+        ordered_weights,
+        hist_ghc,
     )
 
     permutation = rng.permutation(n_sub_samples)
@@ -127,16 +149,31 @@ def test_unrolled_equivalent_to_naive(constant_hessian):
     hist_gc = np.zeros((1, n_bins), dtype=HISTOGRAM_DTYPE)
     hist_ghc = np.zeros((1, n_bins), dtype=HISTOGRAM_DTYPE)
     hist_naive = np.zeros((1, n_bins), dtype=HISTOGRAM_DTYPE)
+    all_weights = np.ones(n_samples, dtype=np.float64)
+    ordered_weights = np.ones(n_samples, dtype=np.float64)
 
-    _build_histogram_root_no_hessian(0, binned_feature, ordered_gradients, hist_gc_root)
+    _build_histogram_root_no_hessian(
+        0, binned_feature, ordered_gradients, all_weights, hist_gc_root
+    )
     _build_histogram_root(
-        0, binned_feature, ordered_gradients, ordered_hessians, hist_ghc_root
+        0,
+        binned_feature,
+        ordered_gradients,
+        ordered_hessians,
+        all_weights,
+        hist_ghc_root,
     )
     _build_histogram_no_hessian(
-        0, sample_indices, binned_feature, ordered_gradients, hist_gc
+        0, sample_indices, binned_feature, ordered_gradients, ordered_weights, hist_gc
     )
     _build_histogram(
-        0, sample_indices, binned_feature, ordered_gradients, ordered_hessians, hist_ghc
+        0,
+        sample_indices,
+        binned_feature,
+        ordered_gradients,
+        ordered_hessians,
+        ordered_weights,
+        hist_ghc,
     )
     _build_histogram_naive(
         0,
@@ -144,6 +181,7 @@ def test_unrolled_equivalent_to_naive(constant_hessian):
         binned_feature,
         ordered_gradients,
         ordered_hessians,
+        ordered_weights,
         hist_naive,
     )
 
@@ -175,11 +213,17 @@ def test_hist_subtraction(constant_hessian):
         ordered_hessians = np.ones(n_samples, dtype=G_H_DTYPE)
     else:
         ordered_hessians = rng.lognormal(size=n_samples).astype(G_H_DTYPE)
+    ordered_weights = np.ones(n_samples, dtype=np.float64)
 
     hist_parent = np.zeros((1, n_bins), dtype=HISTOGRAM_DTYPE)
     if constant_hessian:
         _build_histogram_no_hessian(
-            0, sample_indices, binned_feature, ordered_gradients, hist_parent
+            0,
+            sample_indices,
+            binned_feature,
+            ordered_gradients,
+            ordered_weights,
+            hist_parent,
         )
     else:
         _build_histogram(
@@ -188,6 +232,7 @@ def test_hist_subtraction(constant_hessian):
             binned_feature,
             ordered_gradients,
             ordered_hessians,
+            ordered_weights,
             hist_parent,
         )
 
@@ -196,10 +241,16 @@ def test_hist_subtraction(constant_hessian):
     sample_indices_left = sample_indices[mask]
     ordered_gradients_left = ordered_gradients[mask]
     ordered_hessians_left = ordered_hessians[mask]
+    ordered_weights_left = ordered_weights[mask]
     hist_left = np.zeros((1, n_bins), dtype=HISTOGRAM_DTYPE)
     if constant_hessian:
         _build_histogram_no_hessian(
-            0, sample_indices_left, binned_feature, ordered_gradients_left, hist_left
+            0,
+            sample_indices_left,
+            binned_feature,
+            ordered_gradients_left,
+            ordered_weights_left,
+            hist_left,
         )
     else:
         _build_histogram(
@@ -208,16 +259,23 @@ def test_hist_subtraction(constant_hessian):
             binned_feature,
             ordered_gradients_left,
             ordered_hessians_left,
+            ordered_weights_left,
             hist_left,
         )
 
     sample_indices_right = sample_indices[~mask]
     ordered_gradients_right = ordered_gradients[~mask]
     ordered_hessians_right = ordered_hessians[~mask]
+    ordered_weights_right = ordered_weights[~mask]
     hist_right = np.zeros((1, n_bins), dtype=HISTOGRAM_DTYPE)
     if constant_hessian:
         _build_histogram_no_hessian(
-            0, sample_indices_right, binned_feature, ordered_gradients_right, hist_right
+            0,
+            sample_indices_right,
+            binned_feature,
+            ordered_gradients_right,
+            ordered_weights_right,
+            hist_right,
         )
     else:
         _build_histogram(
@@ -226,6 +284,7 @@ def test_hist_subtraction(constant_hessian):
             binned_feature,
             ordered_gradients_right,
             ordered_hessians_right,
+            ordered_weights_right,
             hist_right,
         )
 
@@ -234,6 +293,6 @@ def test_hist_subtraction(constant_hessian):
     _subtract_histograms(0, n_bins, hist_left_sub, hist_right)
     _subtract_histograms(0, n_bins, hist_right_sub, hist_left)
 
-    for key in ("count", "sum_hessians", "sum_gradients"):
+    for key in ("count", "sum_hessians", "sum_gradients", "sum_weights"):
         assert_allclose(hist_left[key], hist_left_sub[key], rtol=1e-6)
         assert_allclose(hist_right[key], hist_right_sub[key], rtol=1e-6)


### PR DESCRIPTION
## Summary

Fixes #34745

`HistGradientBoostingClassifier` / `HistGradientBoostingRegressor` applied the
`min_samples_leaf` constraint to the unweighted number of samples in each child,
ignoring `sample_weight`. This made training with sample weights inconsistent
with the equivalent repeated-sample training (a weighted sample of weight `w`
should count as `w` samples for `min_samples_leaf`).

## Changes

We now track the **sum of sample weights** inside the histograms and use it for
the `min_samples_leaf` checks:

1. Added a `sum_weights` field to `hist_struct` / `HISTOGRAM_DTYPE`
   (`common.pxd`, `common.pyx`).
2. `HistogramBuilder` now accepts the raw `sample_weights` (defaulting to ones
   when none are provided) and the histogram build functions accumulate
   `sum_weights` per bin, both for the brute-force and subtraction paths
   (`histogram.pyx`).
3. The splitter (`splitting.pyx`) compares `min_samples_leaf` against
   `sum_weight_left` / `sum_weight_right` instead of `n_samples_left` /
   `n_samples_right`, for both numerical and categorical splits. The
   `split_info` carries the new `sum_weight_left` / `sum_weight_right` fields.
4. The grower (`grower.py`) threads `sample_weight` into the `HistogramBuilder`
   and uses the weighted sums for the node-finalization heuristics, and
   `gradient_boosting.py` passes `sample_weight_train` to `TreeGrower`.

When no sample weights are provided, `sum_weights` equals the sample count, so
the previous behavior is fully preserved.

## Testing

- Updated `test_histogram.py` to pass/expect the new `sum_weights` field.
- Added `test_min_samples_leaf_with_sample_weight` (regression test for #34745):
  training with integer sample weights is equivalent to training on the
  corresponding repeated data.

---

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.
