### PR TITLE
DOC fix broken link to git tutorial in contributing guide

### DIFF
--- a/doc/developers/contributing.rst
+++ b/doc/developers/contributing.rst
@@ -359,8 +359,9 @@ line
 .. topic:: Learning Git
 
     The `Git documentation <https://git-scm.com/doc>`_ and
-    https://try.github.io are excellent resources to get started with git,
-    and understanding all of the commands shown here.
+    `Learn Git Branching <https://learngitbranching.js.org/>`_ are excellent
+    resources to get started with git, and understanding all of the commands
+    shown here.
 
 .. _pr_checklist:
 


### PR DESCRIPTION
#### Reference Issues/PRs

None -- this is a trivial link fix.

#### What does this implement/fix? Explain your changes.

`try.github.io` (referenced in `doc/developers/contributing.rst`) now 301-redirects to a GitHub Docs page about setting up git. It used to be an interactive git tutorial, but that no longer exists. The sentence says the link is for "understanding all of the commands shown here" which doesn't match a setup page.

Replaced it with learngitbranching.js.org, which is an interactive git tutorial that actually fits the described purpose.

#### Introduce yourself

Hi, I'm Soham. I use scikit-learn for ML coursework and personal projects. This is my first contribution here -- figured I'd start small with a doc fix I noticed while reading the contributing guide.

#### AI usage disclosure

I used AI assistance for:
- Research and understanding (verifying the redirect behavior of the old link)

#### Any other comments?

One-line change, no changelog needed since it doesn't affect users.