### PR TITLE
FIX Don't send ScoringMonitor._log to the pickler

### DIFF
--- a/doc/whats_new/upcoming_changes/callback/34821.fix.rst
+++ b/doc/whats_new/upcoming_changes/callback/34821.fix.rst
@@ -1,0 +1,4 @@
+- Fixed a bug where fitting an estimator with a :class:`callback.ScoringMonitor` and a
+  parallel backend using multi-processing could fail with "Could not pickle the task to
+  send it to the workers".
+  By :user:`Jérémie du Boisberranger <jeremiedbb>`.

--- a/sklearn/callback/_scoring_monitor.py
+++ b/sklearn/callback/_scoring_monitor.py
@@ -170,6 +170,12 @@ class ScoringMonitor:
 
         send(self._listener_handle, (run_id, run_info, task_info_path, scores))
 
+    def __getstate__(self):
+        # `_log` is grown by the listener thread, which can run while this callback is
+        # being pickled by another thread, e.g. loky's queue feeder when a task is
+        # dispatched to a worker. The pickler must therefore never walk the live list.
+        return {**self.__dict__, "_log": list(self._log)}
+
     def __setstate__(self, state):
         """Restore state, opening a fresh listener if the inherited one is unusable."""
         self.__dict__.update(state)

--- a/sklearn/callback/tests/test_pickle.py
+++ b/sklearn/callback/tests/test_pickle.py
@@ -145,24 +145,20 @@ def test_callbacks_refit_after_load_in_fresh_process(tmp_path, capsys):
 
 
 class _TraversalRecorder(pickle.Pickler):
-    """A pickler that records which of the `watched` objects it walks through.
+    """A pickler that records the id of every object it walks through.
 
     `persistent_id` is called for every object the pickler encounters, so an object is
-    detected whichever path leads to it, not only when it is a direct attribute of the
+    recorded whichever path leads to it, not only when it is a direct attribute of the
     object being pickled,
     see https://docs.python.org/3/library/pickle.html#pickle.Pickler.persistent_id.
     """
 
-    def __init__(self, watched):
+    def __init__(self):
         super().__init__(io.BytesIO(), protocol=pickle.HIGHEST_PROTOCOL)
-        # Keyed by id because a watched container need not be hashable and because a
-        # match must mean "this very object", not "an object that compares equal to it".
-        self._watched = {id(obj): obj for obj in watched}
         self.walked_through = set()
 
     def persistent_id(self, obj):
-        if id(obj) in self._watched:
-            self.walked_through.add(obj.__class__.__name__)
+        self.walked_through.add(id(obj))
         return None  # pickle `obj` as usual
 
 
@@ -180,20 +176,20 @@ def _checked(hook):
     # preserve the signature of the hook because callbacks are validated against it
     @functools.wraps(hook)
     def checked_hook(self, *args, **kwargs):
-        watched = []
-        for consumer in list(_message_consumers.values()):
-            target = getattr(consumer, "__self__", None)
-            if target is not None:
-                watched.append(target)
+        # snapshot because another thread may register a listener concurrently
+        consumers = list(_message_consumers.values())
+        # the containers are held, not just their ids, which could be reused once freed
+        watched = [c.__self__ for c in consumers if hasattr(c, "__self__")]
 
-        recorder = _TraversalRecorder(watched)
+        recorder = _TraversalRecorder()
         recorder.dump(self)
 
-        assert not recorder.walked_through, (
-            f"Pickling {self.__class__.__name__} walks through "
-            f"{recorder.walked_through}, which a listener thread mutates "
-            "concurrently. Exclude it in the callback's `__getstate__`, e.g. by "
-            "replacing it with a copy or an empty container."
+        offenders = recorder.walked_through & {id(container) for container in watched}
+        assert not offenders, (
+            f"Pickling {self.__class__.__name__} walks through a container that a"
+            " listener thread mutates concurrently. Keep it away from the pickler,"
+            " either by handing over a copy of it in the callback's `__getstate__`, or"
+            " by storing it outside of the callback instance."
         )
 
         return hook(self, *args, **kwargs)
@@ -203,12 +199,21 @@ def _checked(hook):
 
 @pytest.mark.parametrize("factory", CALLBACK_FACTORIES)
 def test_listener_state_is_not_walked_by_the_pickler(factory, monkeypatch):
-    """Check that pickling a callback never traverses state its listener mutates."""
+    """Check that pickling a callback never traverses state its listener mutates.
+
+    An estimator carrying a callback can be pickled by a background thread, e.g. loky's
+    queue feeder dispatching a task to a worker, while the listener thread of that same
+    callback mutates the callback's state as messages come in. Pickling a container that
+    another thread mutates breaks the dump, which joblib reports as "Could not pickle
+    the task to send it to the workers".
+
+    The check runs from a hook, i.e. while the listeners are up, which is when such a
+    dispatch would happen.
+    """
     callback = factory()
-    X, y = make_regression(n_samples=30, n_features=2, random_state=0)
 
     for hook_name in ("on_fit_task_begin", "on_fit_task_end"):
         hook = getattr(callback.__class__, hook_name)
         monkeypatch.setattr(callback.__class__, hook_name, _checked(hook))
 
-    MaxIterEstimator(max_iter=3).set_callbacks(callback).fit(X=X, y=y)
+    MaxIterEstimator(max_iter=3).set_callbacks(callback).fit()

--- a/sklearn/callback/tests/test_pickle.py
+++ b/sklearn/callback/tests/test_pickle.py
@@ -8,6 +8,8 @@ must be picklable, and that an estimator pickled after a successful fit can be
 unpickled in a fresh Python interpreter.
 """
 
+import functools
+import io
 import pickle
 import re
 import subprocess
@@ -17,6 +19,7 @@ import textwrap
 import pytest
 
 from sklearn.callback import ProgressBar, ScoringMonitor
+from sklearn.callback._transport import _message_consumers
 from sklearn.callback.tests._common.estimators import MaxIterEstimator
 from sklearn.datasets import make_regression
 
@@ -139,3 +142,73 @@ def test_callbacks_refit_after_load_in_fresh_process(tmp_path, capsys):
     stdout = result.stdout.decode()
     assert re.search(r"MaxIterEstimator - fit", stdout)
     assert re.search(r"100%", stdout)
+
+
+class _TraversalRecorder(pickle.Pickler):
+    """A pickler that records which of the `watched` objects it walks through.
+
+    `persistent_id` is called for every object the pickler encounters, so an object is
+    detected whichever path leads to it, not only when it is a direct attribute of the
+    object being pickled,
+    see https://docs.python.org/3/library/pickle.html#pickle.Pickler.persistent_id.
+    """
+
+    def __init__(self, watched):
+        super().__init__(io.BytesIO(), protocol=pickle.HIGHEST_PROTOCOL)
+        # Keyed by id because a watched container need not be hashable and because a
+        # match must mean "this very object", not "an object that compares equal to it".
+        self._watched = {id(obj): obj for obj in watched}
+        self.walked_through = set()
+
+    def persistent_id(self, obj):
+        if id(obj) in self._watched:
+            self.walked_through.add(obj.__class__.__name__)
+        return None  # pickle `obj` as usual
+
+
+def _checked(hook):
+    """Wrap a callback hook so that it first checks the callback it is called on.
+
+    The check is that the pickler does not walk through the objects that listener
+    threads mutate. They are found through the registered consumers: a consumer is
+    normally a method bound to the container it fills, e.g. `self._log.append` for
+    ScoringMonitor or `queue.put` for ProgressBar, so the container is what it is bound
+    to. A consumer bound to nothing, e.g. a closure, is skipped, since there is then no
+    way to tell what it mutates.
+    """
+
+    # preserve the signature of the hook because callbacks are validated against it
+    @functools.wraps(hook)
+    def checked_hook(self, *args, **kwargs):
+        watched = []
+        for consumer in list(_message_consumers.values()):
+            target = getattr(consumer, "__self__", None)
+            if target is not None:
+                watched.append(target)
+
+        recorder = _TraversalRecorder(watched)
+        recorder.dump(self)
+
+        assert not recorder.walked_through, (
+            f"Pickling {self.__class__.__name__} walks through "
+            f"{recorder.walked_through}, which a listener thread mutates "
+            "concurrently. Exclude it in the callback's `__getstate__`, e.g. by "
+            "replacing it with a copy or an empty container."
+        )
+
+        return hook(self, *args, **kwargs)
+
+    return checked_hook
+
+
+@pytest.mark.parametrize("factory", CALLBACK_FACTORIES)
+def test_listener_state_is_not_walked_by_the_pickler(factory, monkeypatch):
+    """Check that pickling a callback never traverses state its listener mutates."""
+    callback = factory()
+    X, y = make_regression(n_samples=30, n_features=2, random_state=0)
+
+    for hook_name in ("on_fit_task_begin", "on_fit_task_end"):
+        hook = getattr(callback.__class__, hook_name)
+        monkeypatch.setattr(callback.__class__, hook_name, _checked(hook))
+
+    MaxIterEstimator(max_iter=3).set_callbacks(callback).fit(X=X, y=y)


### PR DESCRIPTION
Fixes https://github.com/scikit-learn/scikit-learn/issues/34816
It should also fix the main CI.

Sending the `_log`, that is being mutated by threads or subprocesses, to the pickler raises a pickling error, as seen in https://github.com/scikit-learn/scikit-learn/issues/34816. The error was added in Python 3.14.7 but the bug was already there silently before. This is why it was caught by #34806: the doc build bumped python version to 3.14.7.

The issue and the fix is very similar to the one for RecordingCallback, see https://github.com/scikit-learn/scikit-learn/pull/34811, except that here we can't send an empty log since we want to be able to pickle and unpickle the callback and retrieve the log. So we send a snapshot of the log instead of the live log being mutated.

I wrote a test, heavily helped by claude, to ensure that we don't send to the pickler the live containers that the listener threads mutate. This way it should prevent us to do the same error for future callbacks. (note that progressbar is not impacted since the queue lives at the module level and is thus not sent to the pickler)