### PR TITLE
FIX accurate unknown category warning in OneHotEncoder with infrequent_if_exist

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -226,12 +226,42 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
 
         if columns_with_unknown:
             if handle_unknown == "infrequent_if_exist":
-                msg = (
-                    "Found unknown categories in columns "
-                    f"{columns_with_unknown} during transform. These "
-                    "unknown categories will be encoded as the "
-                    "infrequent category."
-                )
+                infrequent_indices = getattr(self, "_infrequent_indices", None)
+                infrequent_cols = [
+                    i
+                    for i in columns_with_unknown
+                    if infrequent_indices is not None
+                    and infrequent_indices[i] is not None
+                ]
+                zeros_cols = [
+                    i
+                    for i in columns_with_unknown
+                    if infrequent_indices is None
+                    or infrequent_indices[i] is None
+                ]
+                if infrequent_cols and zeros_cols:
+                    msg = (
+                        "Found unknown categories in columns "
+                        f"{columns_with_unknown} during transform. The unknown "
+                        f"categories in columns {infrequent_cols} will be "
+                        "encoded as the infrequent category. Those in columns "
+                        f"{zeros_cols} will be encoded as all zeros, because "
+                        "these columns have no infrequent category."
+                    )
+                elif infrequent_cols:
+                    msg = (
+                        "Found unknown categories in columns "
+                        f"{infrequent_cols} during transform. These "
+                        "unknown categories will be encoded as the "
+                        "infrequent category."
+                    )
+                else:
+                    msg = (
+                        "Found unknown categories in columns "
+                        f"{zeros_cols} during transform. These "
+                        "unknown categories will be encoded as all zeros, "
+                        "because these columns have no infrequent category."
+                    )
             else:
                 msg = (
                     "Found unknown categories in columns "

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -1622,12 +1622,33 @@ def test_ohe_drop_first_explicit_categories(handle_unknown):
     else:
         warn_msg = (
             r"Found unknown categories in columns \[0\] during transform. "
-            r"These unknown categories will be encoded as the "
-            r"infrequent category."
+            r"These unknown categories will be encoded as all zeros, "
+            r"because these columns have no infrequent category."
         )
     with pytest.warns(UserWarning, match=warn_msg):
         X_trans = ohe.transform(X_test)
     assert_allclose(X_trans, X_expected)
+
+
+def test_ohe_unknown_category_warning_mixed_infrequent():
+    """Check warning accurately describes mixed infrequent and zero-encoded columns."""
+    X = [["a", "x"], ["a", "x"], ["b", "x"], ["b", "y"]]
+
+    encoder = OneHotEncoder(
+        drop="first",
+        sparse_output=False,
+        handle_unknown="infrequent_if_exist",
+        min_frequency=2,
+    ).fit(X)
+
+    warn_msg = (
+        r"Found unknown categories in columns \[0, 1\] during transform\. "
+        r"The unknown categories in columns \[1\] will be encoded as the infrequent category\. "
+        r"Those in columns \[0\] will be encoded as all zeros, because these columns have no infrequent category\."
+    )
+    with pytest.warns(UserWarning, match=warn_msg):
+        X_trans = encoder.transform([["c", "z"]])
+    assert_allclose(X_trans, np.array([[0.0, 1.0]]))
 
 
 def test_ohe_more_informative_error_message():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://scikit-learn.org/dev/developers/index.html
-->

#### Reference Issues/PRs
Fixes #34822

#### What does this implement/fix? Explain your changes.
When `handle_unknown="infrequent_if_exist"` is set on `OneHotEncoder`, unknown categories encountered during `transform()` across multiple columns triggered a warning claiming all `columns_with_unknown` would be encoded as the infrequent category.

However, if any of those columns do not have an infrequent category (i.e. `_infrequent_indices[i] is None`), their unknown values are actually encoded as all zeros (per documented `handle_unknown='ignore'` fallback semantics).

This PR:
1. Partitions `columns_with_unknown` into columns that have an infrequent category (`infrequent_cols`) and columns that fall back to all zeros (`zeros_cols`).
2. Constructs a precise warning message accurately describing the handling for each column group.
3. Updates `test_ohe_drop_first_explicit_categories` and adds `test_ohe_unknown_category_warning_mixed_infrequent` regression test in `sklearn/preprocessing/tests/test_encoders.py`.

#### Any other comments?
All changes are self-contained in `sklearn/preprocessing/_encoders.py` and tests.