### PR TITLE
TST Add array API scorer and cross_validate integration tests

### DIFF
--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1834,7 +1834,7 @@ def test_regression_scorer_array_api_compliance(
     """
     estimator = clone(estimator)
     scorer = check_scoring(estimator=estimator, scoring=scoring)
-    xp, device_ = _array_api_for_tests(namespace, device_name)
+    xp, device = _array_api_for_tests(namespace, device_name)
 
     # Check compliance of the scorer API for regression tasks.
     X_np, y_np = make_regression(
@@ -1845,10 +1845,10 @@ def test_regression_scorer_array_api_compliance(
         random_state=0,
     )
     X_np = X_np.astype(dtype_name)
-    X_xp = xp.asarray(X_np, device=device_)
+    X_xp = xp.asarray(X_np, device=device)
 
     if target_namespace_dtype == "xp_float32":
-        y = xp.asarray(y_np, device=device_, dtype=xp.float32)
+        y = xp.asarray(y_np, device=device, dtype=xp.float32)
     else:  # np_float64
         y = y_np
 

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -11,7 +11,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 from sklearn import config_context
-from sklearn.base import BaseEstimator, ClassifierMixin
+from sklearn.base import BaseEstimator, ClassifierMixin, clone
 from sklearn.cluster import KMeans
 from sklearn.datasets import (
     load_diabetes,
@@ -21,8 +21,9 @@ from sklearn.datasets import (
     make_multilabel_classification,
     make_regression,
 )
+from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
 from sklearn.exceptions import UnsetMetadataPassedError
-from sklearn.linear_model import LogisticRegression, Perceptron, Ridge
+from sklearn.linear_model import LogisticRegression, Perceptron, Ridge, RidgeClassifier
 from sklearn.metrics import (
     accuracy_score,
     average_precision_score,
@@ -60,7 +61,12 @@ from sklearn.tests.metadata_routing_common import (
     assert_request_is_empty,
 )
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
+from sklearn.utils._array_api import (
+    _atol_for_type,
+    yield_namespace_device_dtype_combinations,
+)
 from sklearn.utils._testing import (
+    _array_api_for_tests,
     assert_almost_equal,
     assert_array_equal,
     ignore_warnings,
@@ -1721,3 +1727,137 @@ def test_Pipeline_in_PassthroughScorer():
     )
     search = GridSearchCV(pipe, {"logistic__C": [0.1, 1]}, n_jobs=1, cv=3)
     search.fit(X, y, sample_weight=sample_weight)
+
+
+@pytest.mark.parametrize(
+    "namespace, device_name, dtype_name", yield_namespace_device_dtype_combinations()
+)
+@pytest.mark.parametrize(
+    "target_namespace_dtype", ["xp_int32", "np_int32", "np_str_object"]
+)
+@pytest.mark.parametrize(
+    "estimator, scoring",
+    [
+        (
+            RidgeClassifier(solver="svd"),
+            "accuracy",
+        ),  # TODO: add "roc_auc" when supported
+        (LinearDiscriminantAnalysis(), "d2_brier_score"),  # has predict_proba
+    ],
+)
+@pytest.mark.parametrize("n_classes", [2, 3])
+def test_classification_scorer_array_api_compliance(
+    namespace,
+    device_name,
+    dtype_name,
+    estimator,
+    scoring,
+    target_namespace_dtype,
+    n_classes,
+):
+    """Test that scorers work with array API compliant arrays.
+
+    The purpose of this test is to check that the scorer API works with
+    array API compliant arrays from different namespaces.
+
+    We do not exhaustively test all scorers here since the array compliance
+    of the metrics functions are tested in a common test. Similarly, the
+    estimators' array API compliance is also tested in a dedicated test.
+    """
+    estimator = clone(estimator)
+    scorer = check_scoring(estimator=estimator, scoring=scoring)
+    xp, device_ = _array_api_for_tests(namespace, device_name)
+
+    # Check compliance of the scorer API for binary classification tasks.
+    X_np, y_np = make_classification(
+        n_samples=100,
+        n_classes=n_classes,
+        n_features=20,
+        n_informative=10,
+        random_state=0,
+    )
+    X_np = X_np.astype(dtype_name)
+    X_xp = xp.asarray(X_np, device=device_)
+
+    if target_namespace_dtype == "np_str_object":
+        y_np = np.array(
+            ["class_" + str(class_idx + 1) for class_idx in y_np],
+            dtype=object,
+        )
+        y = y_np
+        # XXX: there is no public API to build a classification scoring object
+        # from the combination of a scoring name and string labels.
+        if n_classes == 2 and scoring in ["d2_brier_score"]:
+            scorer._kwargs["labels"] = np.unique(y)
+            scorer._kwargs["pos_label"] = "class_1"
+    else:
+        y_np = y_np.astype("int32")
+        if target_namespace_dtype == "xp_int32":
+            y = xp.asarray(y_np, device=device_)
+        else:  # np_int32
+            y = y_np
+
+    score_np = scorer(estimator.fit(X_np, y_np), X_np, y_np)
+    with config_context(array_api_dispatch=True):
+        score_xp = scorer(estimator.fit(X_xp, y), X_xp, y)
+
+    assert score_np == pytest.approx(
+        score_xp,
+        rel=1e-4 if dtype_name == "float32" else 1e-6,
+        abs=_atol_for_type(dtype_name),
+    )
+
+
+@pytest.mark.parametrize(
+    "namespace, device_name, dtype_name", yield_namespace_device_dtype_combinations()
+)
+@pytest.mark.parametrize("target_namespace_dtype", ["xp_float32", "np_float64"])
+@pytest.mark.parametrize(
+    "estimator, scoring",
+    [
+        (Ridge(solver="svd"), "r2"),
+    ],
+)
+@pytest.mark.parametrize("n_targets", [1, 3])
+def test_regression_scorer_array_api_compliance(
+    namespace,
+    device_name,
+    dtype_name,
+    estimator,
+    scoring,
+    target_namespace_dtype,
+    n_targets,
+):
+    """Test that scorers work with array API compliant arrays.
+
+    Similar comment as in `test_classification_scorer_array_api_compliance`.
+    """
+    estimator = clone(estimator)
+    scorer = check_scoring(estimator=estimator, scoring=scoring)
+    xp, device_ = _array_api_for_tests(namespace, device_name)
+
+    # Check compliance of the scorer API for regression tasks.
+    X_np, y_np = make_regression(
+        n_samples=100,
+        n_features=20,
+        n_targets=n_targets,
+        n_informative=10,
+        random_state=0,
+    )
+    X_np = X_np.astype(dtype_name)
+    X_xp = xp.asarray(X_np, device=device_)
+
+    if target_namespace_dtype == "xp_float32":
+        y = xp.asarray(y_np, device=device_, dtype=xp.float32)
+    else:  # np_float64
+        y = y_np
+
+    score_np = scorer(estimator.fit(X_np, y_np), X_np, y_np)
+    with config_context(array_api_dispatch=True):
+        score_xp = scorer(estimator.fit(X_xp, y), X_xp, y)
+
+    assert score_np == pytest.approx(
+        score_xp,
+        rel=1e-4 if dtype_name == "float32" else 1e-6,
+        abs=_atol_for_type(dtype_name),
+    )

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1766,7 +1766,7 @@ def test_classification_scorer_array_api_compliance(
     """
     estimator = clone(estimator)
     scorer = check_scoring(estimator=estimator, scoring=scoring)
-    xp, device_ = _array_api_for_tests(namespace, device_name)
+    xp, device = _array_api_for_tests(namespace, device_name)
 
     # Check compliance of the scorer API for binary classification tasks.
     X_np, y_np = make_classification(
@@ -1777,7 +1777,7 @@ def test_classification_scorer_array_api_compliance(
         random_state=0,
     )
     X_np = X_np.astype(dtype_name)
-    X_xp = xp.asarray(X_np, device=device_)
+    X_xp = xp.asarray(X_np, device=device)
 
     if target_namespace_dtype == "np_str_object":
         y_np = np.array(
@@ -1793,7 +1793,7 @@ def test_classification_scorer_array_api_compliance(
     else:
         y_np = y_np.astype("int32")
         if target_namespace_dtype == "xp_int32":
-            y = xp.asarray(y_np, device=device_)
+            y = xp.asarray(y_np, device=device)
         else:  # np_int32
             y = y_np
 

--- a/sklearn/metrics/tests/test_score_objects.py
+++ b/sklearn/metrics/tests/test_score_objects.py
@@ -1852,7 +1852,8 @@ def test_regression_scorer_array_api_compliance(
     else:  # np_float64
         y = y_np
 
-    score_np = scorer(estimator.fit(X_np, y_np), X_np, y_np)
+    with config_context(array_api_dispatch=False):
+        score_np = scorer(estimator.fit(X_np, y_np), X_np, y_np)
     with config_context(array_api_dispatch=True):
         score_xp = scorer(estimator.fit(X_xp, y), X_xp, y)
 

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -1139,18 +1139,32 @@ def test_cross_validate_array_api_pipeline(
         expected_device = array_device(X_xp)
         expected_dtype = X_xp.dtype
 
-    for est_xp in cv_results_xp["estimator"]:
+    for est_xp, est_np in zip(
+        cv_results_xp["estimator"], cv_results_np["estimator"], strict=True
+    ):
         # Ensure that the estimators returned can predict when fed with the
         # same kind of array API inputs they were trained on and that their
-        # predictions are consistent.
+        # predictions are consistent with the NumPy baseline.
+        preds_np = est_np.predict(X_np)
         with config_context(array_api_dispatch=True):
             if is_classifier(est_xp):
                 preds_xp = est_xp.predict(X_np)
-                # XXX: which namespace, dtype and device is expected for
-                # preds_xp? If we use string labels, this will be numpy arrays
-                # of object dtype and CPU device. But what about integer
-                # classes? Should this be the namespace/device of X_train or
-                # y_train?
+                # Classifier `predict` returns class labels. String labels
+                # cannot be represented by array API namespaces, so they stay
+                # as NumPy arrays on CPU (namespace/device of `y`, typically
+                # unicode or object dtype). Integer class ids follow `X`
+                # (same library and device).
+                if target_dtype is str:
+                    assert _is_numpy_namespace(get_namespace(preds_xp)[0])
+                    assert array_device(preds_xp) == array_device(y_np)
+                    assert preds_xp.dtype.kind in ("U", "S", "O")
+                else:
+                    assert (
+                        get_namespace(preds_xp)[0].__name__
+                        == get_namespace(X_xp)[0].__name__
+                    )
+                    assert array_device(preds_xp) == expected_device
+                assert_array_equal(move_to(preds_xp, xp=numpy, device="cpu"), preds_np)
 
                 if hasattr(est_xp, "predict_proba"):
                     proba_xp = est_xp.predict_proba(X_np)
@@ -1166,6 +1180,12 @@ def test_cross_validate_array_api_pipeline(
                 preds_xp = est_xp.predict(X_np)
                 assert preds_xp.dtype == expected_dtype
                 assert array_device(preds_xp) == expected_device
+                assert_allclose(
+                    move_to(preds_xp, xp=numpy, device="cpu"),
+                    preds_np,
+                    rtol=1e-4 if dtype_name == "float32" else 1e-6,
+                    atol=_atol_for_type(dtype_name),
+                )
 
     for score_name in cv_params["scoring"]:
         for key in [f"test_{score_name}", f"train_{score_name}"]:

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -1145,7 +1145,8 @@ def test_cross_validate_array_api_pipeline(
         # Ensure that the estimators returned can predict when fed with the
         # same kind of array API inputs they were trained on and that their
         # predictions are consistent with the NumPy baseline.
-        preds_np = est_np.predict(X_np)
+        with config_context(array_api_dispatch=False):
+            preds_np = est_np.predict(X_np)
         with config_context(array_api_dispatch=True):
             if is_classifier(est_xp):
                 preds_xp = est_xp.predict(X_np)

--- a/sklearn/utils/tests/test_array_api.py
+++ b/sklearn/utils/tests/test_array_api.py
@@ -9,7 +9,12 @@ from numpy.testing import assert_allclose
 from scipy.special import expit, logit
 
 from sklearn._config import config_context
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, is_classifier
+from sklearn.datasets import make_classification, make_regression
+from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
+from sklearn.linear_model import Ridge, RidgeClassifier
+from sklearn.model_selection import cross_validate
+from sklearn.pipeline import FunctionTransformer, make_pipeline
 from sklearn.utils._array_api import (
     _add_to_diagonal,
     _asarray_with_order,
@@ -1057,3 +1062,117 @@ def test_swapaxes(namespace, device_name, dtype_name):
     with config_context(array_api_dispatch=True):
         result_xp = _swapaxes(X_xp, 0, 1)
     assert_array_equal(move_to(result_xp, xp=numpy, device="cpu"), result_np)
+
+
+@pytest.mark.parametrize(
+    "estimator, n_classes, scoring, target_dtype",
+    [
+        (Ridge(), None, ["r2", "neg_mean_absolute_error"], numpy.float32),
+        (
+            LinearDiscriminantAnalysis(),
+            2,
+            ["d2_brier_score", "d2_log_loss_score", "accuracy"],
+            numpy.int32,
+        ),
+        (
+            RidgeClassifier(),
+            3,
+            ["accuracy", "average_precision"],
+            str,
+        ),
+    ],
+    ids=["Ridge", "LinearDiscriminantAnalysis", "RidgeClassifier"],
+)
+@pytest.mark.parametrize("cv", [None, 3, 5])
+@pytest.mark.parametrize(
+    "namespace, device_name, dtype_name", yield_namespace_device_dtype_combinations()
+)
+def test_cross_validate_array_api_pipeline(
+    estimator, n_classes, scoring, target_dtype, cv, namespace, device_name, dtype_name
+):
+    """Integration test for `cross_validate` with array API arrays.
+
+    The goal of this test is to ensure that `cross_validate` works as expected
+    when using array API compatible estimators and multiple scorers at once.
+
+    It is a bit redundant with individual tests for array API compliance of
+    estimators and scorers but the purpose is to check that array API
+    compatibility is preserved when composing these building blocks together,
+    in particular when only X is moved to the array API namespace via the
+    pipeline usage pattern.
+    """
+
+    xp, device_ = _array_api_for_tests(namespace, device_name)
+    if is_classifier(estimator):
+        X_np, y_np = make_classification(
+            n_samples=100,
+            n_features=5,
+            n_classes=n_classes,
+            n_informative=3,
+            random_state=42,
+        )
+    else:
+        X_np, y_np = make_regression(
+            n_samples=100, n_features=5, n_informative=3, random_state=42
+        )
+
+    X_np = X_np.astype(dtype_name)
+    y_np = y_np.astype(target_dtype)
+    X_xp = xp.asarray(X_np, device=device_)
+
+    xp_pipeline = make_pipeline(
+        FunctionTransformer(partial(xp.asarray, device=device_)),
+        estimator,
+    )
+
+    cv_params = {
+        "cv": cv,
+        "return_estimator": True,
+        "return_train_score": True,
+        "error_score": "raise",
+        "scoring": scoring,
+    }
+
+    cv_results_np = cross_validate(estimator, X_np, y_np, **cv_params)
+    with config_context(array_api_dispatch=True):
+        cv_results_xp = cross_validate(xp_pipeline, X_np, y_np, **cv_params)
+        expected_device = array_device(X_xp)
+        expected_dtype = X_xp.dtype
+
+    for est_xp in cv_results_xp["estimator"]:
+        # Ensure that the estimators returned can predict when fed with the
+        # same kind of array API inputs they were trained on and that their
+        # predictions are consistent.
+        with config_context(array_api_dispatch=True):
+            if is_classifier(est_xp):
+                preds_xp = est_xp.predict(X_np)
+                # XXX: which namespace, dtype and device is expected for
+                # preds_xp? If we use string labels, this will be numpy arrays
+                # of object dtype and CPU device. But what about integer
+                # classes? Should this be the namespace/device of X_train or
+                # y_train?
+
+                if hasattr(est_xp, "predict_proba"):
+                    proba_xp = est_xp.predict_proba(X_np)
+                    assert array_device(proba_xp) == expected_device
+                    assert proba_xp.dtype == expected_dtype
+
+                raw_preds_xp = est_xp.decision_function(X_np)
+                assert array_device(raw_preds_xp) == expected_device
+                assert raw_preds_xp.dtype == expected_dtype
+            else:
+                # For regressors, also check that the prediction dtype is
+                # preserved.
+                preds_xp = est_xp.predict(X_np)
+                assert preds_xp.dtype == expected_dtype
+                assert array_device(preds_xp) == expected_device
+
+    for score_name in cv_params["scoring"]:
+        for key in [f"test_{score_name}", f"train_{score_name}"]:
+            assert_allclose(
+                cv_results_xp[key],
+                cv_results_np[key],
+                rtol=1e-4 if dtype_name == "float32" else 1e-6,
+                atol=_atol_for_type(dtype_name),
+                err_msg=key,
+            )

--- a/sklearn/utils/tests/test_response.py
+++ b/sklearn/utils/tests/test_response.py
@@ -242,6 +242,22 @@ def test_get_response_error(estimator, X, y, err_msg, params):
         _get_response_values_binary(estimator, X, **params)
 
 
+def test_get_response_no_pos_label_validation_for_multiclass():
+    X, y = make_classification(
+        n_samples=10, n_classes=3, n_informative=3, random_state=0
+    )
+    classifier = DecisionTreeClassifier().fit(X, y)
+    y_pred, pos_label = _get_response_values(
+        classifier,
+        X,
+        response_method="predict_proba",
+        # pos_label should be ignored even if invalid for multiclass problems.
+        pos_label="invalid",
+    )
+    assert y_pred.shape == (X.shape[0], len(classifier.classes_))
+    assert pos_label == "invalid"  # does not matter.
+
+
 @pytest.mark.parametrize("return_response_method_used", [True, False])
 def test_get_response_predict_proba(return_response_method_used):
     """Check the behaviour of `_get_response_values_binary` using `predict_proba`."""

--- a/sklearn/utils/tests/test_response.py
+++ b/sklearn/utils/tests/test_response.py
@@ -242,22 +242,6 @@ def test_get_response_error(estimator, X, y, err_msg, params):
         _get_response_values_binary(estimator, X, **params)
 
 
-def test_get_response_no_pos_label_validation_for_multiclass():
-    X, y = make_classification(
-        n_samples=10, n_classes=3, n_informative=3, random_state=0
-    )
-    classifier = DecisionTreeClassifier().fit(X, y)
-    y_pred, pos_label = _get_response_values(
-        classifier,
-        X,
-        response_method="predict_proba",
-        # pos_label should be ignored even if invalid for multiclass problems.
-        pos_label="invalid",
-    )
-    assert y_pred.shape == (X.shape[0], len(classifier.classes_))
-    assert pos_label == "invalid"  # does not matter.
-
-
 @pytest.mark.parametrize("return_response_method_used", [True, False])
 def test_get_response_predict_proba(return_response_method_used):
     """Check the behaviour of `_get_response_values_binary` using `predict_proba`."""
@@ -324,7 +308,9 @@ def test_get_response_decision_function(return_response_method_used):
 )
 def test_get_response_values_multiclass(estimator, response_method):
     """Check that we can call `_get_response_values` with a multiclass estimator.
-    It should return the predictions untouched.
+
+    Predictions should be returned untouched. `pos_label` is ignored for
+    multiclass problems, including when it is not a valid class label.
     """
     estimator = clone(estimator).fit(X, y)  # clone to make test execution thread-safe
     predictions, pos_label = _get_response_values(
@@ -337,6 +323,16 @@ def test_get_response_values_multiclass(estimator, response_method):
         assert np.logical_and(predictions >= 0, predictions <= 1).all()
     elif response_method == "predict_log_proba":
         assert (predictions <= 0.0).all()
+
+    predictions_invalid, pos_label_invalid = _get_response_values(
+        estimator,
+        X,
+        response_method=response_method,
+        pos_label="invalid",
+    )
+    assert pos_label_invalid == "invalid"
+    assert predictions_invalid.shape == (X.shape[0], len(estimator.classes_))
+    assert_allclose(predictions_invalid, predictions)
 
 
 def test_get_response_values_with_response_list():


### PR DESCRIPTION
Towards: #33444.

This is an extraction from the previously stalled #32873 PR.

The purpose is to complement the existing unit tests for array API compliance (for estimators and metrics) to check that everything still works as expected when all used in conjunction (e.g. when wrapped in cross-validation pipelines that exercise the scoring infrastructure).