### PR TITLE
FIX StratifiedGroupKFold returns an empty fold when n_groups == n_splits

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.model_selection/34829.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.model_selection/34829.fix.rst
@@ -1,0 +1,6 @@
+- :class:`model_selection.StratifiedGroupKFold` no longer returns an empty fold when
+  the number of groups equals `n_splits`. Fold evaluations that are mathematically
+  tied can differ by a few ULP, and a strict comparison let that floating-point noise
+  decide the assignment, bypassing the heuristic that sends a group to the least
+  populated fold. This changes the fold assignment for some inputs.
+  By :user:`Akshath <akshath-raj>`.

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -956,20 +956,20 @@ class StratifiedGroupKFold(GroupsConsumerMixin, _BaseKFold):
     ...     print(f"  Test:  index={test_index}")
     ...     print(f"         group={groups[test_index]}")
     Fold 0:
-      Train: index=[ 0  1  2  3  7  8  9 10 11 15 16]
-             group=[1 1 2 2 4 5 5 5 5 8 8]
-      Test:  index=[ 4  5  6 12 13 14]
-             group=[3 3 3 6 6 7]
-    Fold 1:
-      Train: index=[ 4  5  6  7  8  9 10 11 12 13 14]
-             group=[3 3 3 4 5 5 5 5 6 6 7]
-      Test:  index=[ 0  1  2  3 15 16]
-             group=[1 1 2 2 8 8]
-    Fold 2:
       Train: index=[ 0  1  2  3  4  5  6 12 13 14 15 16]
              group=[1 1 2 2 3 3 3 6 6 7 8 8]
       Test:  index=[ 7  8  9 10 11]
              group=[4 5 5 5 5]
+    Fold 1:
+      Train: index=[ 0  1  2  3  7  8  9 10 11 15 16]
+             group=[1 1 2 2 4 5 5 5 5 8 8]
+      Test:  index=[ 4  5  6 12 13 14]
+             group=[3 3 3 6 6 7]
+    Fold 2:
+      Train: index=[ 4  5  6  7  8  9 10 11 12 13 14]
+             group=[3 3 3 4 5 5 5 5 6 6 7]
+      Test:  index=[ 0  1  2  3 15 16]
+             group=[1 1 2 2 8 8]
 
     Notes
     -----

--- a/sklearn/model_selection/_split.py
+++ b/sklearn/model_selection/_split.py
@@ -1102,9 +1102,13 @@ class StratifiedGroupKFold(GroupsConsumerMixin, _BaseKFold):
             y_counts_per_fold[i] -= group_y_counts
             fold_eval = np.mean(std_per_class)
             samples_in_fold = np.sum(y_counts_per_fold[i])
-            is_current_fold_better = fold_eval < min_eval or (
-                np.isclose(fold_eval, min_eval)
-                and samples_in_fold < min_samples_in_fold
+            # `fold_eval` values that are mathematically equal can still differ
+            # by a few ULP. Comparing them with a strict `<` would let that noise
+            # decide the assignment and bypass the tiebreak below, which can leave
+            # a fold empty when there is no slack (`n_groups == n_splits`).
+            is_tied = np.isclose(fold_eval, min_eval)
+            is_current_fold_better = (fold_eval < min_eval and not is_tied) or (
+                is_tied and samples_in_fold < min_samples_in_fold
             )
             if is_current_fold_better:
                 min_eval = fold_eval

--- a/sklearn/model_selection/tests/test_split.py
+++ b/sklearn/model_selection/tests/test_split.py
@@ -781,6 +781,47 @@ def test_stratified_group_kfold_against_group_kfold(cls_distr, n_groups):
     assert sgkf_entr <= gkf_entr
 
 
+@pytest.mark.parametrize(
+    "n_splits, y, groups",
+    [
+        (
+            4,
+            [0, 1, 1, 2, 2, 2, 1, 1, 0, 2, 0, 2, 0, 2, 1, 0, 1, 0],
+            [0, 3, 3, 3, 3, 3, 0, 1, 3, 1, 2, 1, 0, 0, 3, 3, 0, 2],
+        ),
+        (
+            4,
+            [0, 3, 3, 2, 2, 0, 2, 0, 1, 1, 1, 3, 3, 0, 1, 2, 3, 0, 0, 2, 2, 3],
+            [3, 3, 0, 3, 1, 0, 0, 3, 3, 0, 3, 3, 3, 0, 0, 3, 2, 1, 3, 3, 1, 2],
+        ),
+        (
+            6,
+            [0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 1],
+            [5, 1, 2, 0, 3, 5, 1, 2, 4, 4, 4, 1, 5, 1, 5, 1, 5, 5, 1, 0, 2, 4, 0, 0],
+        ),
+        (
+            4,
+            [1, 0, 0, 1, 0, 0, 2, 2, 0, 1, 1, 1, 0, 2, 2, 2, 2, 0, 1, 0],
+            [0, 3, 1, 1, 1, 0, 3, 1, 1, 2, 0, 1, 3, 1, 3, 3, 3, 1, 1, 0],
+        ),
+        (
+            5,
+            [1, 1, 1, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1],
+            [4, 2, 2, 3, 0, 1, 2, 0, 3, 4, 0, 2, 3],
+        ),
+    ],
+)
+def test_stratified_group_kfold_no_empty_fold(n_splits, y, groups):
+    # Non-regression test for gh-34828: fold evaluations that are mathematically
+    # tied can still differ by a few ULP. A strict `<` comparison let that noise
+    # pick the fold and bypass the least-populated-fold tiebreak, which could
+    # leave a fold empty when there was no slack (`n_groups == n_splits`).
+    X = np.ones((len(y), 1))
+    sgkf = StratifiedGroupKFold(n_splits=n_splits)
+    test_sizes = [len(test) for _, test in sgkf.split(X, y, groups=groups)]
+    assert min(test_sizes) > 0
+
+
 def test_shuffle_split():
     ss1 = ShuffleSplit(test_size=0.2, random_state=0).split(X)
     ss2 = ShuffleSplit(test_size=2, random_state=0).split(X)


### PR DESCRIPTION
Closes #34828

#### Reference Issues/PRs

Fixes #34828. Related to #33085 / #33176, which addressed the *other* cause of degenerate splits (`n_groups < n_splits`); this is an independent one.

#### What does this implement/fix? Explain your changes.

`StratifiedGroupKFold` can return an empty test fold even when `n_groups >= n_splits`.

`_find_best_fold` picks a fold with:

```python
is_current_fold_better = fold_eval < min_eval or (
    np.isclose(fold_eval, min_eval)
    and samples_in_fold < min_samples_in_fold
)
```

The first branch uses an exact `<`. When two candidate folds are *mathematically* tied, `np.std` still returns values differing by an ULP or two, so `fold_eval < min_eval` fires and that fold wins outright — the `samples_in_fold` comparison never runs. That comparison is the "heuristic for assigning group to the least populated fold in cases when all other criteria are equal" documented in the changelist comment at the top of `_iter_test_indices`, so the intent is clear; it is simply unreachable in those cases.

Tracing the reproducer, the second assignment is decisive:

```
-- group 1 counts=[0, 1, 2]
     fold 0: eval=0.12028130608117205  samples_before=0
     fold 1: eval=0.12028130608117205  samples_before=0
     fold 2: eval=0.12028130608117205  samples_before=0
     fold 3: eval=0.12028130608117203  samples_before=2   <- 1 ULP lower
     -> chose fold 3
```

Three folds are empty, fold 3 already holds a group, all four evaluations are mathematically identical, and fold 3 wins on a 1-ULP artefact. With `n_groups == n_splits` there is no slack, so a fold is left empty and `cross_val_score` silently returns `nan` for it.

This PR requires a strictly-better evaluation to be better by more than noise, making the tiebreak reachable:

```python
is_tied = np.isclose(fold_eval, min_eval)
is_current_fold_better = (fold_eval < min_eval and not is_tied) or (
    is_tied and samples_in_fold < min_samples_in_fold
)
```

#### Any other comments?

Scale of the underlying problem, measured over 15898 group-assignment decisions from randomised configurations:

- 7.0% of decisions have two or more mathematically tied folds whose winner is decided by floating-point noise (median deciding difference **1 ULP**, max 3).
- In 6.9% of all decisions the intended least-populated-fold tiebreak would have chosen a *different* fold.

Verification:

- Empty folds in a sweep of the sensitive regime (`n_splits` 2-6, `n_classes` 2-4, `n < 40`): **4/73401 → 0/73401**. Every failing case found is at `n_groups == n_splits`.
- The 5 parametrised cases in the new test all fail on `main` and pass with this change.
- `pytest --pyargs sklearn.model_selection`: 642 passed / 238 skipped before, 647 passed / 238 skipped after (the 5 new cases), no regressions.
- Reproduced identically on released 1.9.0 (numpy 2.5.2) and 1.10.dev0 (numpy 2.6.0.dev0), so it is not a single-build floating-point artefact.

Two things reviewers should weigh:

1. **This changes roughly 21% of splits.** That is the size of the latent defect rather than an over-aggressive tolerance — tightening `np.isclose` to `rtol=1e-9` or `1e-12` yields the same 21%, because these are true ties; exact equality drops churn to 0.3% but does not fix the bug. It will still change existing users' fold assignments, so it may warrant a `changed-models` note in addition to the changelog entry.
2. **Stratification quality is unchanged** — mean fold-size CV 0.2393 both ways, mean per-fold class-proportion deviation 0.10618 vs 0.10620 over 4000 configurations. This is a correctness fix for the degenerate case, not a stratification improvement (cf. #24656).

Changelog fragment added. Happy to adjust the approach if maintainers prefer a different tolerance or a more targeted guard.
