### PR TITLE
FIX MLP squared_error loss now matches the gradient for multi-output targets

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.neural_network/34830.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.neural_network/34830.fix.rst
@@ -1,0 +1,8 @@
+- :class:`neural_network.MLPRegressor` with `loss="squared_error"` and more than one
+  output now computes a loss that matches the gradient used to minimise it. The loss
+  was averaged over outputs while the gradient was not, so it was `n_outputs` times
+  smaller than the objective the optimiser was actually following. Only `solver="lbfgs"`
+  is affected, as it is the only solver that consumes the loss value; `sgd` and `adam`
+  are unchanged. Note that `loss_`, `loss_curve_` and `best_loss_` now scale with
+  `n_outputs`, which makes the `tol` convergence check correspondingly stricter.
+  By :user:`Akshath <akshath-raj>`.

--- a/sklearn/neural_network/_base.py
+++ b/sklearn/neural_network/_base.py
@@ -184,9 +184,13 @@ def squared_loss(y_true, y_pred, sample_weight=None):
     loss : float
         The degree to which the samples are correctly predicted.
     """
-    return (
-        0.5 * np.average((y_true - y_pred) ** 2, weights=sample_weight, axis=0).mean()
-    )
+    # The average is taken over samples and the result summed over outputs, so
+    # that the returned loss matches the gradient computed in `_backprop`, where
+    # `deltas[last] = activations[-1] - y` is the canonical loss-link derivative
+    # of a per-sample squared error summed over outputs. Using `.mean()` here
+    # would divide the loss, but not the gradient, by `n_outputs`. This also
+    # matches the reduction used by the other loss functions below.
+    return 0.5 * np.average((y_true - y_pred) ** 2, weights=sample_weight, axis=0).sum()
 
 
 def poisson_loss(y_true, y_pred, sample_weight=None):

--- a/sklearn/neural_network/tests/test_mlp.py
+++ b/sklearn/neural_network/tests/test_mlp.py
@@ -246,6 +246,66 @@ def test_gradient():
             assert_almost_equal(numgrad, grad)
 
 
+@pytest.mark.parametrize("loss", ["squared_error", "poisson"])
+@pytest.mark.parametrize("n_outputs", [1, 2, 3])
+def test_gradient_regressor(loss, n_outputs):
+    # Non-regression test for gh-8349.
+    # The loss returned by `_loss_grad_lbfgs` must be the loss whose gradient is
+    # returned alongside it, otherwise lbfgs line-searches on one function while
+    # following the gradient of another. `squared_error` used to average over
+    # outputs while the gradient did not, which made the analytical gradient
+    # `n_outputs` times too large for multi-output regression.
+    n_samples, n_features = 5, 10
+    rng = np.random.RandomState(42)
+    X = rng.rand(n_samples, n_features)
+    y = rng.rand(n_samples, n_outputs)
+    if loss == "poisson":
+        y += 0.5
+    if n_outputs == 1:
+        y = y.ravel()
+
+    mlp = MLPRegressor(
+        hidden_layer_sizes=10,
+        solver="lbfgs",
+        alpha=1e-5,
+        loss=loss,
+        max_iter=1,
+        random_state=1,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ConvergenceWarning)
+        mlp.fit(X, y)
+
+    Y = y.reshape(-1, 1) if y.ndim == 1 else y
+    theta = np.hstack([l.ravel() for l in mlp.coefs_ + mlp.intercepts_])
+    layer_units = [X.shape[1]] + [mlp.hidden_layer_sizes] + [mlp.n_outputs_]
+
+    activations = [X]
+    deltas, coef_grads, intercept_grads = [], [], []
+    for i in range(mlp.n_layers_ - 1):
+        activations.append(np.empty((X.shape[0], layer_units[i + 1])))
+        deltas.append(np.empty((X.shape[0], layer_units[i + 1])))
+        coef_grads.append(np.empty((layer_units[i], layer_units[i + 1])))
+        intercept_grads.append(np.empty(layer_units[i + 1]))
+
+    def loss_grad_fun(t):
+        return mlp._loss_grad_lbfgs(
+            t, X, Y, None, activations, deltas, coef_grads, intercept_grads
+        )
+
+    _, grad = loss_grad_fun(theta)
+    grad = grad.copy()
+    numgrad = np.zeros_like(theta)
+    epsilon = 1e-5
+    E = np.eye(theta.size)
+    for i in range(theta.size):
+        dtheta = E[:, i] * epsilon
+        numgrad[i] = (
+            loss_grad_fun(theta + dtheta)[0] - loss_grad_fun(theta - dtheta)[0]
+        ) / (epsilon * 2.0)
+    assert_allclose(numgrad, grad, rtol=1e-5, atol=1e-8)
+
+
 @pytest.mark.parametrize("X,y", classification_datasets)
 def test_lbfgs_classification(X, y):
     # Test lbfgs on classification.


### PR DESCRIPTION
#### Reference Issues/PRs

Closes #8349. Detailed evidence and the comparison of the two candidate fixes are in [this comment](https://github.com/scikit-learn/scikit-learn/issues/8349#issuecomment-5443257996).

#### What does this implement/fix? Explain your changes.

`_loss_grad_lbfgs` returns a `(loss, grad)` pair, and lbfgs line-searches on the loss while stepping along the gradient. For multi-output regression with `squared_error` these are not the same function.

`squared_loss` reduces over outputs with `.mean()`, while `_backprop` computes `deltas[last] = activations[-1] - y` and divides only by `sw_sum`. That is the canonical loss-link derivative of a per-sample squared error summed over outputs, so the loss is `n_outputs` times smaller than the function the gradient belongs to.

Central-difference check of the returned pair against itself:

| `n_outputs` | analytic/numeric | `‖g − num‖ / ‖num‖` |
|---|---|---|
| 1 | 1.000000 | 5.7e-10 |
| 2 | 2.000000 | 1.000 |
| 3 | 3.000000 | 2.000 |
| 5 | 5.000000 | 4.000 |

The factor is exact in all 24 configurations I tried (`hidden_layer_sizes` `(5,)` and `(6, 4)`, `alpha` 0 and 1e-3, 3 seeds), so it is not a conditioning artefact.

`squared_loss` is the only loss that does this. `poisson_loss`, `log_loss` and `binary_log_loss` all reduce with `.sum()`, and all of them pass the same check. This PR makes `squared_loss` use `.sum()` too.

The gradient is not touched, so `sgd` and `adam` produce bit-for-bit identical coefficients. Only `lbfgs`, which actually consumes the loss, is affected. The alternative fix, scaling `deltas[last]` down by `n_outputs`, also restores consistency, but it changes the effective learning rate for every solver and needs loss-specific special-casing inside `_backprop`, so I did not take it. Happy to switch if maintainers prefer it.

#### Introduce yourself

I have been using scikit-learn for several years. It was one of the first libraries I worked with when I started doing AI and data analysis work, and I have kept using it since. Over that time I have made a point of understanding the libraries I depend on rather than treating them as black boxes, and I decided I would like to help with development instead of only consuming it. This is my first contribution here. I went through the open issues looking for numerical correctness bugs, found that this one still reproduces on `main` nine years after it was reported, and worked it up.

#### AI usage disclosure

I used AI assistance for:
- Code generation
- Test/benchmark generation
- Documentation
- Research and understanding

I reviewed all of it before pushing. I have read the change, the test and the changelog entry, I understand why summing over outputs is the correct reduction here, and I can explain any part of it on request. Every number quoted in this description came from running the code against a build of `main` rather than being asserted, and all of it is reproducible from what is written above.

#### Any other comments?

This does not improve predictive accuracy, and I would rather say so than oversell it. Over 12 seeds on multi-output regression, test MSE improved on 6 of 12. Excluding one outlier seed the mean is marginally worse, 0.03258 against 0.03369. The case for the change is correctness: right now the optimiser follows a gradient that does not belong to the objective it is evaluating.

There is one behaviour change to weigh. `loss_`, `loss_curve_` and `best_loss_` scale by `n_outputs` for multi-output `squared_error`. Since `tol` is compared against loss changes, convergence becomes effectively `n_outputs` times stricter, so lbfgs tends to run longer, median 536 against 594 iterations over 15 seeds. A changelog entry is included. Let me know if this also warrants a `changed-models` note.

On testing: `test_gradient` only exercises `MLPClassifier`, whose loss already uses `.sum()`, which is why the regressor path went unchecked for so long. This PR adds `test_gradient_regressor`, parametrised over `loss` and `n_outputs`.

- The new test fails on `main` for `squared_error` with `n_outputs` 2 and 3, and passes for `poisson` and for single output, so it is specific to the defect.
- `pytest --pyargs sklearn.neural_network`: 91 to 97 passed (6 new cases), 2 skipped, no regressions.
- Common estimator checks for MLP: 124 passed, 13 skipped.
- Everything matching `mlp or MLP or neural`: 222 passed, 18 skipped.
- `MLPRegressor` and `MLPClassifier` doctests are unchanged, verified against a pristine control, since the regressor example is single output and the two reductions coincide there.
