### PR TITLE
ENH Add categorical support for the forests

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.ensemble/34832.major-feature.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.ensemble/34832.major-feature.rst
@@ -1,0 +1,8 @@
+- :class:`ensemble.RandomForestClassifier`, :class:`ensemble.RandomForestRegressor`,
+  :class:`ensemble.ExtraTreesClassifier`, :class:`ensemble.ExtraTreesRegressor`, and
+  :class:`ensemble.IsolationForest` now accept the `categorical_features` parameter.
+  Random forests support binary classification and single-output regression with up to
+  255 categories per feature. Extra trees and isolation forests support up to
+  ``2**24 - 1`` categories per feature, including multi-class and multi-output targets
+  for extra trees.
+  By :user:`Adam Li <adam2392>`.

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -159,14 +159,17 @@ def _parallel_build_estimators(
             sample_weight,
         )
 
-        if (
-            requires_feature_indexing
-            and getattr(ensemble, "is_categorical_", None) is not None
-        ):
-            cat_subset = ensemble.is_categorical_[features]
-            estimator.set_params(
-                categorical_features=None if not np.any(cat_subset) else cat_subset
-            )
+        # Pass the resolved categorical mask from the ensemble. Trees only see the
+        # already-encoded float ndarray, so user values like "from_dtype" or
+        # feature-name lists would otherwise silently resolve to None.
+        if getattr(ensemble, "is_categorical_", None) is not None:
+            if requires_feature_indexing:
+                cat_subset = ensemble.is_categorical_[features]
+                estimator.set_params(
+                    categorical_features=None if not np.any(cat_subset) else cat_subset
+                )
+            else:
+                estimator.set_params(categorical_features=ensemble.is_categorical_)
 
         fit_params_ = fit_params.copy()
 

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -159,6 +159,15 @@ def _parallel_build_estimators(
             sample_weight,
         )
 
+        if (
+            requires_feature_indexing
+            and getattr(ensemble, "is_categorical_", None) is not None
+        ):
+            cat_subset = ensemble.is_categorical_[features]
+            estimator.set_params(
+                categorical_features=None if not np.any(cat_subset) else cat_subset
+            )
+
         fit_params_ = fit_params.copy()
 
         # Note: Row sampling can be achieved either through setting sample_weight or

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -497,6 +497,12 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
                 self._make_estimator(append=False, random_state=random_state)
                 for i in range(n_more_estimators)
             ]
+            # Pass the resolved categorical mask, not the user parameter. After the
+            # forest encodes X, trees only see a float ndarray so values like
+            # "from_dtype" or feature-name lists would silently resolve to None.
+            if self.is_categorical_ is not None:
+                for tree in trees:
+                    tree.set_params(categorical_features=self.is_categorical_)
 
             # Parallel loop: we prefer the threading backend as the Cython code
             # for fitting the trees is internally releasing the Python GIL

--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -74,9 +74,12 @@ from sklearn.utils._tags import get_tags
 from sklearn.utils.multiclass import check_classification_targets, type_of_target
 from sklearn.utils.parallel import Parallel, delayed
 from sklearn.utils.validation import (
+    _check_categorical_features,
     _check_feature_names_in,
+    _check_n_features,
     _check_sample_weight,
     _num_samples,
+    check_array,
     check_is_fitted,
     validate_data,
 )
@@ -331,15 +334,51 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         if issparse(y):
             raise ValueError("sparse multilabel-indicator for y is not supported.")
 
-        X, y = validate_data(
-            self,
-            X,
-            y,
-            multi_output=True,
-            accept_sparse="csc",
-            dtype=np.float32,
-            ensure_all_finite=False,
-        )
+        categorical_features = getattr(self, "categorical_features", None)
+        self.is_categorical_ = _check_categorical_features(X, categorical_features)
+        has_categorical = self.is_categorical_ is not None
+
+        if has_categorical:
+            if issparse(X):
+                raise NotImplementedError(
+                    "Categorical features not supported with sparse inputs"
+                )
+            # Capture feature names on the original dataframe-like input before
+            # categorical encoding converts X to a NumPy array.
+            validate_data(
+                self,
+                X,
+                y,
+                multi_output=True,
+                reset=True,
+                skip_check_array=True,
+            )
+            X = self._preprocess_X(X, reset=True)
+            # X has already been encoded to a numeric array. Do not call
+            # validate_data(reset=True) again here because ndarray input would
+            # remove feature_names_in_ captured from the original container.
+            X, y = validate_data(
+                self,
+                X,
+                y,
+                multi_output=True,
+                accept_sparse="csc",
+                dtype=np.float32,
+                ensure_all_finite=False,
+                reset=False,
+            )
+        else:
+            self._categorical_encoder = None
+            self._preprocessor = None
+            X, y = validate_data(
+                self,
+                X,
+                y,
+                multi_output=True,
+                accept_sparse="csc",
+                dtype=np.float32,
+                ensure_all_finite=False,
+            )
         # _compute_missing_values_in_feature_mask checks if X has missing values and
         # will raise an error if the underlying tree base estimator can't handle missing
         # values. Only the criterion is required to determine if the tree supports
@@ -603,6 +642,15 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         # Default implementation
         return y, None
 
+    def _preprocess_X(self, X, *, reset):
+        """Encode categorical features and cast numerical features to float32.
+
+        Reuses the tree implementation so forests stay aligned with
+        :class:`~sklearn.tree.DecisionTreeClassifier` /
+        :class:`~sklearn.tree.DecisionTreeRegressor` preprocessing.
+        """
+        return BaseDecisionTree._preprocess_X(self, X, reset=reset)
+
     def _validate_X_predict(self, X):
         """
         Validate X whenever one tries to predict, apply, predict_proba."""
@@ -612,14 +660,34 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         else:
             ensure_all_finite = True
 
-        X = validate_data(
-            self,
-            X,
-            dtype=np.float32,
-            accept_sparse="csr",
-            reset=False,
-            ensure_all_finite=ensure_all_finite,
-        )
+        has_categorical = self.is_categorical_ is not None
+        if has_categorical:
+            if issparse(X):
+                raise NotImplementedError(
+                    "Categorical features not supported with sparse inputs"
+                )
+            # Check feature names on the original input before categorical
+            # encoding converts it to a NumPy array and drops dataframe metadata.
+            validate_data(self, X, reset=False, skip_check_array=True)
+            X = self._preprocess_X(X, reset=False)
+            X = check_array(
+                X,
+                input_name="X",
+                estimator=self,
+                dtype=np.float32,
+                accept_sparse="csr",
+                ensure_all_finite=ensure_all_finite,
+            )
+            _check_n_features(self, X, reset=False)
+        else:
+            X = validate_data(
+                self,
+                X,
+                dtype=np.float32,
+                accept_sparse="csr",
+                reset=False,
+                ensure_all_finite=ensure_all_finite,
+            )
         if issparse(X) and (X.indices.dtype != np.intc or X.indptr.dtype != np.intc):
             raise ValueError("No support for np.int64 index based sparse matrices")
         return X
@@ -1394,6 +1462,32 @@ class RandomForestClassifier(ForestClassifier):
 
         .. versionadded:: 1.4
 
+    categorical_features : array-like of {bool, int, str} of shape (n_features,) or \
+        (n_categorical_features,), or "from_dtype", default=None
+        Indicates which features are treated as categorical.
+
+        - None : no feature will be considered categorical.
+        - boolean array-like : boolean mask indicating categorical features.
+        - integer array-like : integer indices indicating categorical
+          features.
+        - str array-like: names of categorical features (assuming the training
+          data has feature names).
+        - `"from_dtype"`: dataframe columns with dtype "Categorical" and "Enum" are
+          considered to be categorical features. The input must be a dataframe that
+          is supported by narwhals (or supports it): :func:`narwhals.from_native` must
+          work. This is the case, for instance, for pandas and polars DataFrames.
+
+        For each categorical feature, there must be at most 255 unique
+        categories. Missing values for categorical features should be
+        represented by ``np.nan``; unknown categories at prediction time are
+        also treated as missing values.
+
+        Trees in the forest use the best split strategy, so categorical
+        features are only supported for binary classification and
+        single-output regression.
+
+        .. versionadded:: 1.11
+
     Attributes
     ----------
     estimator_ : :class:`~sklearn.tree.DecisionTreeClassifier`
@@ -1418,6 +1512,12 @@ class RandomForestClassifier(ForestClassifier):
         Number of features seen during :term:`fit`.
 
         .. versionadded:: 0.24
+
+    is_categorical_ : ndarray of shape (n_features,) or None
+        Boolean mask indicating which features are treated as categorical.
+        ``None`` if no categorical features are used.
+
+        .. versionadded:: 1.11
 
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of features seen during :term:`fit`. Defined only when `X`
@@ -1511,7 +1611,6 @@ class RandomForestClassifier(ForestClassifier):
         ],
     }
     _parameter_constraints.pop("splitter")
-    _parameter_constraints.pop("categorical_features")
 
     def __init__(
         self,
@@ -1535,6 +1634,7 @@ class RandomForestClassifier(ForestClassifier):
         ccp_alpha=0.0,
         max_samples=None,
         monotonic_cst=None,
+        categorical_features=None,
     ):
         super().__init__(
             estimator=DecisionTreeClassifier(),
@@ -1551,6 +1651,7 @@ class RandomForestClassifier(ForestClassifier):
                 "random_state",
                 "ccp_alpha",
                 "monotonic_cst",
+                "categorical_features",
             ),
             bootstrap=bootstrap,
             oob_score=oob_score,
@@ -1572,6 +1673,7 @@ class RandomForestClassifier(ForestClassifier):
         self.min_impurity_decrease = min_impurity_decrease
         self.monotonic_cst = monotonic_cst
         self.ccp_alpha = ccp_alpha
+        self.categorical_features = categorical_features
 
 
 class RandomForestRegressor(ForestRegressor):
@@ -1784,6 +1886,32 @@ class RandomForestRegressor(ForestRegressor):
 
         .. versionadded:: 1.4
 
+    categorical_features : array-like of {bool, int, str} of shape (n_features,) or \
+        (n_categorical_features,), or "from_dtype", default=None
+        Indicates which features are treated as categorical.
+
+        - None : no feature will be considered categorical.
+        - boolean array-like : boolean mask indicating categorical features.
+        - integer array-like : integer indices indicating categorical
+          features.
+        - str array-like: names of categorical features (assuming the training
+          data has feature names).
+        - `"from_dtype"`: dataframe columns with dtype "Categorical" and "Enum" are
+          considered to be categorical features. The input must be a dataframe that
+          is supported by narwhals (or supports it): :func:`narwhals.from_native` must
+          work. This is the case, for instance, for pandas and polars DataFrames.
+
+        For each categorical feature, there must be at most 255 unique
+        categories. Missing values for categorical features should be
+        represented by ``np.nan``; unknown categories at prediction time are
+        also treated as missing values.
+
+        Trees in the forest use the best split strategy, so categorical
+        features are only supported for binary classification and
+        single-output regression.
+
+        .. versionadded:: 1.11
+
     Attributes
     ----------
     estimator_ : :class:`~sklearn.tree.DecisionTreeRegressor`
@@ -1889,7 +2017,6 @@ class RandomForestRegressor(ForestRegressor):
         **DecisionTreeRegressor._parameter_constraints,
     }
     _parameter_constraints.pop("splitter")
-    _parameter_constraints.pop("categorical_features")
 
     def __init__(
         self,
@@ -1912,6 +2039,7 @@ class RandomForestRegressor(ForestRegressor):
         ccp_alpha=0.0,
         max_samples=None,
         monotonic_cst=None,
+        categorical_features=None,
     ):
         super().__init__(
             estimator=DecisionTreeRegressor(),
@@ -1928,6 +2056,7 @@ class RandomForestRegressor(ForestRegressor):
                 "random_state",
                 "ccp_alpha",
                 "monotonic_cst",
+                "categorical_features",
             ),
             bootstrap=bootstrap,
             oob_score=oob_score,
@@ -1958,6 +2087,7 @@ class RandomForestRegressor(ForestRegressor):
         self.min_impurity_decrease = min_impurity_decrease
         self.ccp_alpha = ccp_alpha
         self.monotonic_cst = monotonic_cst
+        self.categorical_features = categorical_features
 
 
 class ExtraTreesClassifier(ForestClassifier):
@@ -2181,6 +2311,31 @@ class ExtraTreesClassifier(ForestClassifier):
 
         .. versionadded:: 1.4
 
+    categorical_features : array-like of {bool, int, str} of shape (n_features,) or \
+        (n_categorical_features,), or "from_dtype", default=None
+        Indicates which features are treated as categorical.
+
+        - None : no feature will be considered categorical.
+        - boolean array-like : boolean mask indicating categorical features.
+        - integer array-like : integer indices indicating categorical
+          features.
+        - str array-like: names of categorical features (assuming the training
+          data has feature names).
+        - `"from_dtype"`: dataframe columns with dtype "Categorical" and "Enum" are
+          considered to be categorical features. The input must be a dataframe that
+          is supported by narwhals (or supports it): :func:`narwhals.from_native` must
+          work. This is the case, for instance, for pandas and polars DataFrames.
+
+        For each categorical feature, about 16 million unique categories are
+        supported. Missing values for categorical features should be represented
+        by ``np.nan``; unknown categories at prediction time are also treated as
+        missing values.
+
+        Trees in the forest use the random split strategy, including multi-class
+        classification and multi-output targets.
+
+        .. versionadded:: 1.11
+
     Attributes
     ----------
     estimator_ : :class:`~sklearn.tree.ExtraTreeClassifier`
@@ -2286,8 +2441,6 @@ class ExtraTreesClassifier(ForestClassifier):
         ],
     }
     _parameter_constraints.pop("splitter")
-    # TODO: remove once randomsplitter supports categorical features
-    _parameter_constraints.pop("categorical_features")
 
     def __init__(
         self,
@@ -2311,6 +2464,7 @@ class ExtraTreesClassifier(ForestClassifier):
         ccp_alpha=0.0,
         max_samples=None,
         monotonic_cst=None,
+        categorical_features=None,
     ):
         super().__init__(
             estimator=ExtraTreeClassifier(),
@@ -2327,6 +2481,7 @@ class ExtraTreesClassifier(ForestClassifier):
                 "random_state",
                 "ccp_alpha",
                 "monotonic_cst",
+                "categorical_features",
             ),
             bootstrap=bootstrap,
             oob_score=oob_score,
@@ -2348,6 +2503,7 @@ class ExtraTreesClassifier(ForestClassifier):
         self.min_impurity_decrease = min_impurity_decrease
         self.ccp_alpha = ccp_alpha
         self.monotonic_cst = monotonic_cst
+        self.categorical_features = categorical_features
 
 
 class ExtraTreesRegressor(ForestRegressor):
@@ -2555,6 +2711,31 @@ class ExtraTreesRegressor(ForestRegressor):
 
         .. versionadded:: 1.4
 
+    categorical_features : array-like of {bool, int, str} of shape (n_features,) or \
+        (n_categorical_features,), or "from_dtype", default=None
+        Indicates which features are treated as categorical.
+
+        - None : no feature will be considered categorical.
+        - boolean array-like : boolean mask indicating categorical features.
+        - integer array-like : integer indices indicating categorical
+          features.
+        - str array-like: names of categorical features (assuming the training
+          data has feature names).
+        - `"from_dtype"`: dataframe columns with dtype "Categorical" and "Enum" are
+          considered to be categorical features. The input must be a dataframe that
+          is supported by narwhals (or supports it): :func:`narwhals.from_native` must
+          work. This is the case, for instance, for pandas and polars DataFrames.
+
+        For each categorical feature, about 16 million unique categories are
+        supported. Missing values for categorical features should be represented
+        by ``np.nan``; unknown categories at prediction time are also treated as
+        missing values.
+
+        Trees in the forest use the random split strategy, including multi-class
+        classification and multi-output targets.
+
+        .. versionadded:: 1.11
+
     Attributes
     ----------
     estimator_ : :class:`~sklearn.tree.ExtraTreeRegressor`
@@ -2644,8 +2825,6 @@ class ExtraTreesRegressor(ForestRegressor):
         **DecisionTreeRegressor._parameter_constraints,
     }
     _parameter_constraints.pop("splitter")
-    # TODO: remove once randomsplitter supports categorical features
-    _parameter_constraints.pop("categorical_features")
 
     def __init__(
         self,
@@ -2668,6 +2847,7 @@ class ExtraTreesRegressor(ForestRegressor):
         ccp_alpha=0.0,
         max_samples=None,
         monotonic_cst=None,
+        categorical_features=None,
     ):
         super().__init__(
             estimator=ExtraTreeRegressor(),
@@ -2684,6 +2864,7 @@ class ExtraTreesRegressor(ForestRegressor):
                 "random_state",
                 "ccp_alpha",
                 "monotonic_cst",
+                "categorical_features",
             ),
             bootstrap=bootstrap,
             oob_score=oob_score,
@@ -2714,6 +2895,7 @@ class ExtraTreesRegressor(ForestRegressor):
         self.min_impurity_decrease = min_impurity_decrease
         self.ccp_alpha = ccp_alpha
         self.monotonic_cst = monotonic_cst
+        self.categorical_features = categorical_features
 
 
 class RandomTreesEmbedding(TransformerMixin, BaseForest):

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -11,14 +11,17 @@ from scipy.sparse import issparse
 
 from sklearn.base import OutlierMixin, _fit_context
 from sklearn.ensemble._bagging import BaseBagging
-from sklearn.tree import ExtraTreeRegressor
-from sklearn.utils import check_array, check_random_state, gen_batches
+from sklearn.tree import BaseDecisionTree, ExtraTreeRegressor
+from sklearn.utils import check_random_state, gen_batches
 from sklearn.utils._chunking import get_chunk_n_rows
 from sklearn.utils._param_validation import Interval, RealNotInt, StrOptions
 from sklearn.utils.parallel import Parallel, delayed
 from sklearn.utils.validation import (
+    _check_categorical_features,
+    _check_n_features,
     _check_sample_weight,
     _num_samples,
+    check_array,
     check_is_fitted,
     validate_data,
 )
@@ -140,6 +143,28 @@ class IsolationForest(OutlierMixin, BaseBagging):
 
         .. versionadded:: 0.21
 
+    categorical_features : array-like of {bool, int, str} of shape (n_features,) or \
+        (n_categorical_features,), or "from_dtype", default=None
+        Indicates which features are treated as categorical.
+
+        - None : no feature will be considered categorical.
+        - boolean array-like : boolean mask indicating categorical features.
+        - integer array-like : integer indices indicating categorical
+          features.
+        - str array-like: names of categorical features (assuming the training
+          data has feature names).
+        - `"from_dtype"`: dataframe columns with dtype "Categorical" and "Enum" are
+          considered to be categorical features. The input must be a dataframe that
+          is supported by narwhals (or supports it): :func:`narwhals.from_native` must
+          work. This is the case, for instance, for pandas and polars DataFrames.
+
+        For each categorical feature, about 16 million unique categories are
+        supported. Missing values for categorical features should be represented
+        by ``np.nan``; unknown categories at prediction time are also treated as
+        missing values.
+
+        .. versionadded:: 1.11
+
     Attributes
     ----------
     estimator_ : :class:`~sklearn.tree.ExtraTreeRegressor` instance
@@ -184,6 +209,12 @@ class IsolationForest(OutlierMixin, BaseBagging):
         has feature names that are all strings.
 
         .. versionadded:: 1.0
+
+    is_categorical_ : ndarray of shape (n_features,) or None
+        Boolean mask indicating which features are treated as categorical.
+        ``None`` if no categorical features are used.
+
+        .. versionadded:: 1.11
 
     See Also
     --------
@@ -245,6 +276,9 @@ class IsolationForest(OutlierMixin, BaseBagging):
         "random_state": ["random_state"],
         "verbose": ["verbose"],
         "warm_start": ["boolean"],
+        "categorical_features": BaseDecisionTree._parameter_constraints[
+            "categorical_features"
+        ],
     }
 
     def __init__(
@@ -259,6 +293,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
         random_state=None,
         verbose=0,
         warm_start=False,
+        categorical_features=None,
     ):
         super().__init__(
             estimator=None,
@@ -275,6 +310,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
         )
 
         self.contamination = contamination
+        self.categorical_features = categorical_features
 
     def _get_estimator(self):
         return ExtraTreeRegressor(
@@ -282,7 +318,46 @@ class IsolationForest(OutlierMixin, BaseBagging):
             max_features=1,
             splitter="random",
             random_state=self.random_state,
+            categorical_features=self.categorical_features,
         )
+
+    def _preprocess_X(self, X, *, reset):
+        """Encode categorical features and cast numerical features to float32.
+
+        Reuses the tree implementation so IsolationForest stays aligned with
+        :class:`~sklearn.tree.ExtraTreeRegressor` preprocessing.
+        """
+        return BaseDecisionTree._preprocess_X(self, X, reset=reset)
+
+    def _validate_X_predict(self, X):
+        check_is_fitted(self)
+        has_categorical = self.is_categorical_ is not None
+        if has_categorical:
+            if issparse(X):
+                raise NotImplementedError(
+                    "Categorical features not supported with sparse inputs"
+                )
+            validate_data(self, X, reset=False, skip_check_array=True)
+            X = self._preprocess_X(X, reset=False)
+            X = check_array(
+                X,
+                input_name="X",
+                estimator=self,
+                dtype=np.float32,
+                accept_sparse="csr",
+                ensure_all_finite="allow-nan",
+            )
+            _check_n_features(self, X, reset=False)
+        else:
+            X = validate_data(
+                self,
+                X,
+                accept_sparse="csr",
+                dtype=np.float32,
+                reset=False,
+                ensure_all_finite=False,
+            )
+        return X
 
     def _set_oob_score(self, X, y):
         raise NotImplementedError("OOB score not supported by iforest")
@@ -317,9 +392,34 @@ class IsolationForest(OutlierMixin, BaseBagging):
         self : object
             Fitted estimator.
         """
-        X = validate_data(
-            self, X, accept_sparse=["csc"], dtype=np.float32, ensure_all_finite=False
-        )
+        self.is_categorical_ = _check_categorical_features(X, self.categorical_features)
+        has_categorical = self.is_categorical_ is not None
+
+        if has_categorical:
+            if issparse(X):
+                raise NotImplementedError(
+                    "Categorical features not supported with sparse inputs"
+                )
+            validate_data(self, X, reset=True, skip_check_array=True)
+            X = self._preprocess_X(X, reset=True)
+            X = validate_data(
+                self,
+                X,
+                accept_sparse=["csc"],
+                dtype=np.float32,
+                ensure_all_finite=False,
+                reset=False,
+            )
+        else:
+            self._categorical_encoder = None
+            self._preprocessor = None
+            X = validate_data(
+                self,
+                X,
+                accept_sparse=["csc"],
+                dtype=np.float32,
+                ensure_all_finite=False,
+            )
 
         if sample_weight is not None:
             sample_weight = _check_sample_weight(sample_weight, X, dtype=None)
@@ -523,14 +623,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
                 model.score(X)
         """
         # Check data
-        X = validate_data(
-            self,
-            X,
-            accept_sparse="csr",
-            dtype=np.float32,
-            reset=False,
-            ensure_all_finite=False,
-        )
+        X = self._validate_X_predict(X)
 
         return self._score_samples(X)
 

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -345,7 +345,7 @@ class IsolationForest(OutlierMixin, BaseBagging):
                 estimator=self,
                 dtype=np.float32,
                 accept_sparse="csr",
-                ensure_all_finite="allow-nan",
+                ensure_all_finite=False,
             )
             _check_n_features(self, X, reset=False)
         else:

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 import joblib
 import numpy as np
 import pytest
+import scipy.sparse
 from scipy.special import comb
 
 import sklearn
@@ -1932,3 +1933,121 @@ def test_missing_value_is_predictive(Forest, criterion, global_random_seed):
 def test_friedman_mse_deprecation(Forest):
     with pytest.warns(FutureWarning, match="friedman_mse"):
         _ = Forest(criterion="friedman_mse")
+
+
+@pytest.mark.parametrize("name", FOREST_CLASSIFIERS_REGRESSORS)
+def test_fit_categorical_raw_labels_are_reencoded(name):
+    """Forest encodes raw labels once and forwards the mask to base trees."""
+    Forest = FOREST_CLASSIFIERS_REGRESSORS[name]
+    X = np.array([["a"], ["a"], ["b"], ["b"]], dtype=object)
+    y = np.array([0, 0, 1, 1])
+    est = Forest(categorical_features=[0], n_estimators=5, random_state=0).fit(X, y)
+
+    assert_array_equal(est.is_categorical_, [True])
+    assert_array_equal(est._categorical_encoder.categories_[0], ["a", "b"])
+    assert_array_equal(est.estimators_[0].is_categorical_, [True])
+    assert_array_equal(est.predict(X), y)
+
+
+@pytest.mark.parametrize("name", FOREST_CLASSIFIERS_REGRESSORS)
+def test_no_sparse_with_categorical(name):
+    """Sparse matrices are rejected at fit and at predict when categoricals are used."""
+    rng = np.random.RandomState(0)
+    n_samples = 50
+    X = np.hstack(
+        [
+            rng.randn(n_samples, 3),
+            rng.randint(0, 3, size=(n_samples, 2)).astype(np.float64),
+        ]
+    )
+    y = rng.randint(0, 2, size=n_samples)
+    X_sparse = scipy.sparse.csc_array(X)
+    Forest = FOREST_CLASSIFIERS_REGRESSORS[name]
+
+    with pytest.raises(
+        NotImplementedError, match="Categorical features not supported with sparse"
+    ):
+        Forest(categorical_features=[3, 4], n_estimators=5, random_state=0).fit(
+            X_sparse, y
+        )
+
+    with pytest.raises(
+        NotImplementedError, match="Categorical features not supported with sparse"
+    ):
+        Forest(categorical_features=[3, 4], n_estimators=5, random_state=0).fit(
+            X, y
+        ).predict(X_sparse)
+
+
+@pytest.mark.parametrize("name", FOREST_CLASSIFIERS_REGRESSORS)
+def test_fit_categorical_missing_and_unknown_values(name):
+    """Missing and unseen categories share the same prediction path."""
+    Forest = FOREST_CLASSIFIERS_REGRESSORS[name]
+    X = np.array([["a"], ["a"], ["b"], ["b"], [np.nan], [np.nan]], dtype=object)
+    y = np.array([0, 0, 0, 0, 1, 1])
+    est = Forest(
+        categorical_features=[0], max_depth=2, n_estimators=5, random_state=0
+    ).fit(X, y)
+
+    non_missing_prediction = est.predict(X[:1])
+    missing_prediction = est.predict(np.array([[np.nan]], dtype=object))
+    unknown_prediction = est.predict(np.array([["c"]], dtype=object))
+
+    assert_array_equal(non_missing_prediction, [0])
+    assert missing_prediction[0] != non_missing_prediction[0]
+    assert_array_equal(unknown_prediction, missing_prediction)
+
+
+@pytest.mark.parametrize("name", FOREST_CLASSIFIERS_REGRESSORS)
+@pytest.mark.parametrize(
+    "categorical_features, match",
+    [
+        ([0.5, 1.5], "must be an array-like of bool, int or str"),
+        ([False, False, False], "boolean mask must have shape"),
+        ([5], "must be in \\[0, n_features - 1\\]"),
+        ([-3], "must be in \\[0, n_features - 1\\]"),
+    ],
+)
+def test_invalid_categorical(name, categorical_features, match):
+    """Forest fit surfaces invalid categorical_features the same way trees do."""
+    Forest = FOREST_CLASSIFIERS_REGRESSORS[name]
+    with pytest.raises(ValueError, match=match):
+        Forest(categorical_features=categorical_features, random_state=0).fit(
+            np.asarray(X), y
+        )
+
+
+@pytest.mark.parametrize("Forest", [RandomForestRegressor, ExtraTreesRegressor])
+def test_categorical_absolute_error_unsupported(Forest):
+    """absolute_error categorical splits are rejected (same limit as trees)."""
+    X = np.array([[0.0], [1.0], [0.0], [1.0]], dtype=np.float64)
+    y = np.array([0.0, 1.0, 0.0, 1.0])
+
+    with pytest.raises(
+        ValueError,
+        match="Categorical features are not supported with criterion='absolute_error'",
+    ):
+        Forest(
+            categorical_features=[0], criterion="absolute_error", random_state=0
+        ).fit(X, y)
+
+
+@pytest.mark.parametrize("Forest", [ExtraTreesClassifier, ExtraTreesRegressor])
+def test_extratrees_high_cardinality_categorical(Forest):
+    """ExtraTrees accept >255 categories; RandomForest best-splits do not."""
+    # Include every level so cardinality is deterministic (>255), not sampled.
+    n_categories = 500
+    X = np.arange(n_categories).reshape(-1, 1)
+    y = X[:, 0] % 2
+
+    Forest(categorical_features=[0], n_estimators=5, random_state=0).fit(X, y)
+
+    RF = (
+        RandomForestClassifier
+        if issubclass(Forest, ExtraTreesClassifier)
+        else RandomForestRegressor
+    )
+    with pytest.raises(
+        ValueError, match=r"Values for categorical features.*\[0, 255\]"
+    ):
+        RF(categorical_features=[0], n_estimators=5, random_state=0).fit(X, y)

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1946,7 +1946,42 @@ def test_fit_categorical_raw_labels_are_reencoded(name):
     assert_array_equal(est.is_categorical_, [True])
     assert_array_equal(est._categorical_encoder.categories_[0], ["a", "b"])
     assert_array_equal(est.estimators_[0].is_categorical_, [True])
+    # Forest owns encoding; trees must not re-fit their own preprocessor.
+    assert est.estimators_[0]._preprocessor is None
     assert_array_equal(est.predict(X), y)
+
+
+@pytest.mark.parametrize("name", FOREST_CLASSIFIERS_REGRESSORS)
+@pytest.mark.parametrize("constructor_name", ["pandas", "polars"])
+def test_categorical_from_dtype_propagated_to_trees(name, constructor_name):
+    """``categorical_features="from_dtype"`` must survive down to each tree.
+
+    Trees only ever see the forest's already-encoded ndarray, so
+    ``_check_categorical_features`` on the tree side can no longer see the
+    original dataframe dtypes and would silently resolve to "no categorical
+    features" unless the forest passes the resolved bool mask.
+    """
+    pytest.importorskip(constructor_name)
+    Forest = FOREST_CLASSIFIERS_REGRESSORS[name]
+    X = _convert_container(
+        np.array(
+            [[0.0, "low"], [1.0, "high"], [2.0, "low"], [3.0, "high"]], dtype=object
+        ),
+        constructor_name,
+        column_names=["f_num", "f_cat"],
+        dtype=object,
+        categorical_feature_names=["f_cat"],
+    )
+    y = np.array([0, 1, 0, 1])
+
+    est = Forest(
+        categorical_features="from_dtype", n_estimators=3, random_state=0
+    ).fit(X, y)
+
+    assert_array_equal(est.is_categorical_, [False, True])
+    for tree in est.estimators_:
+        assert_array_equal(tree.is_categorical_, [False, True])
+        assert tree._preprocessor is None
 
 
 @pytest.mark.parametrize("name", FOREST_CLASSIFIERS_REGRESSORS)

--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1974,9 +1974,9 @@ def test_categorical_from_dtype_propagated_to_trees(name, constructor_name):
     )
     y = np.array([0, 1, 0, 1])
 
-    est = Forest(
-        categorical_features="from_dtype", n_estimators=3, random_state=0
-    ).fit(X, y)
+    est = Forest(categorical_features="from_dtype", n_estimators=3, random_state=0).fit(
+        X, y
+    )
 
     assert_array_equal(est.is_categorical_, [False, True])
     for tree in est.estimators_:

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -393,3 +393,44 @@ def test_iforest_predict_parallel(global_random_seed, contamination, n_jobs):
 
     # assert the same results as non-parallel
     assert_array_equal(pred, pred_parallel)
+
+
+def test_iforest_categorical_fit_predict(global_random_seed):
+    """IsolationForest encodes string categories and scores them end-to-end."""
+    X = np.array([["a"], ["b"], ["a"], ["b"], ["c"], ["c"]], dtype=object)
+    clf = IsolationForest(
+        n_estimators=10, random_state=global_random_seed, categorical_features=[0]
+    ).fit(X)
+
+    assert_array_equal(clf.is_categorical_, [True])
+    pred = clf.predict(X)
+    assert pred.shape == (X.shape[0],)
+    assert set(np.unique(pred)).issubset({-1, 1})
+    assert clf.score_samples(X).shape == (X.shape[0],)
+
+
+def test_iforest_categorical_feature_subsampling(global_random_seed):
+    """Feature bagging subsets is_categorical_ to match each tree's columns."""
+    rng = np.random.RandomState(global_random_seed)
+    X = np.column_stack(
+        [
+            rng.randn(50),
+            rng.choice(["a", "b", "c"], size=50),
+        ]
+    )
+    clf = IsolationForest(
+        n_estimators=10,
+        max_features=0.5,
+        random_state=global_random_seed,
+        categorical_features=[1],
+    ).fit(X)
+
+    assert_array_equal(clf.is_categorical_, [False, True])
+    # max_features=0.5 on 2 columns yields 1 feature per tree.
+    for tree, features in zip(clf.estimators_, clf.estimators_features_):
+        cat_subset = clf.is_categorical_[features]
+        if np.any(cat_subset):
+            assert_array_equal(tree.is_categorical_, cat_subset)
+        else:
+            assert tree.is_categorical_ is None
+    assert clf.score_samples(X).shape == (X.shape[0],)

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -19,6 +19,7 @@ from sklearn.metrics import roc_auc_score
 from sklearn.model_selection import ParameterGrid, train_test_split
 from sklearn.utils import check_random_state
 from sklearn.utils._testing import (
+    _convert_container,
     assert_allclose,
     assert_array_almost_equal,
     assert_array_equal,
@@ -403,6 +404,7 @@ def test_iforest_categorical_fit_predict(global_random_seed):
     ).fit(X)
 
     assert_array_equal(clf.is_categorical_, [True])
+    assert clf.estimators_[0]._preprocessor is None
     pred = clf.predict(X)
     assert pred.shape == (X.shape[0],)
     assert set(np.unique(pred)).issubset({-1, 1})
@@ -433,4 +435,33 @@ def test_iforest_categorical_feature_subsampling(global_random_seed):
             assert_array_equal(tree.is_categorical_, cat_subset)
         else:
             assert tree.is_categorical_ is None
+        assert tree._preprocessor is None
+    assert clf.score_samples(X).shape == (X.shape[0],)
+
+
+@pytest.mark.parametrize("constructor_name", ["pandas", "polars"])
+def test_iforest_categorical_from_dtype_propagated_to_trees(
+    constructor_name, global_random_seed
+):
+    """``categorical_features="from_dtype"`` must reach each IsolationForest tree."""
+    pytest.importorskip(constructor_name)
+    X = _convert_container(
+        np.array(
+            [[0.0, "low"], [1.0, "high"], [2.0, "low"], [3.0, "high"]], dtype=object
+        ),
+        constructor_name,
+        column_names=["f_num", "f_cat"],
+        dtype=object,
+        categorical_feature_names=["f_cat"],
+    )
+    clf = IsolationForest(
+        categorical_features="from_dtype",
+        n_estimators=3,
+        random_state=global_random_seed,
+    ).fit(X)
+
+    assert_array_equal(clf.is_categorical_, [False, True])
+    for tree in clf.estimators_:
+        assert_array_equal(tree.is_categorical_, [False, True])
+        assert tree._preprocessor is None
     assert clf.score_samples(X).shape == (X.shape[0],)

--- a/sklearn/tree/_classes.py
+++ b/sklearn/tree/_classes.py
@@ -249,27 +249,47 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         missing_values_in_feature_mask=None,
     ):
         random_state = check_random_state(self.random_state)
-        self.is_categorical_ = _check_categorical_features(X, self.categorical_features)
-        has_categorical = self.is_categorical_ is not None
-
-        if has_categorical:
-            if issparse(X):
-                raise NotImplementedError(
-                    "Categorical features not supported with sparse inputs"
-                )
-
-            if check_input:
-                # Capture feature names on the original dataframe-like input before
-                # categorical encoding converts X to a NumPy array.
-                validate_data(self, X, reset=True, skip_check_array=True)
-
-            # Categorical feature selection must see the original container for
-            # names/dtypes, but tree fitting needs numeric values. Encode selected
-            # columns before numeric validation, preserving column order.
-            X = self._preprocess_X(X, reset=True)
-        else:
+        # Ensembles may pass an already-resolved bool mask and already-encoded X
+        # with check_input=False. Skip re-encoding to avoid a per-tree copy and
+        # OrdinalEncoder under n_jobs.
+        categorical_features = self.categorical_features
+        already_encoded = (
+            not check_input
+            and isinstance(categorical_features, np.ndarray)
+            and categorical_features.dtype == bool
+            and categorical_features.shape == (X.shape[1],)
+        )
+        if already_encoded:
+            self.is_categorical_ = (
+                categorical_features if np.any(categorical_features) else None
+            )
             self._categorical_encoder = None
             self._preprocessor = None
+            has_categorical = self.is_categorical_ is not None
+        else:
+            self.is_categorical_ = _check_categorical_features(
+                X, self.categorical_features
+            )
+            has_categorical = self.is_categorical_ is not None
+
+            if has_categorical:
+                if issparse(X):
+                    raise NotImplementedError(
+                        "Categorical features not supported with sparse inputs"
+                    )
+
+                if check_input:
+                    # Capture feature names on the original dataframe-like input before
+                    # categorical encoding converts X to a NumPy array.
+                    validate_data(self, X, reset=True, skip_check_array=True)
+
+                # Categorical feature selection must see the original container for
+                # names/dtypes, but tree fitting needs numeric values. Encode selected
+                # columns before numeric validation, preserving column order.
+                X = self._preprocess_X(X, reset=True)
+            else:
+                self._categorical_encoder = None
+                self._preprocessor = None
 
         if check_input:
             # Need to validate separately here.
@@ -493,17 +513,33 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
                 f"[0, {max_n_categories - 1}]."
             )
 
-            for idx, categories in zip(
-                np.flatnonzero(self.is_categorical_),
-                self._categorical_encoder.categories_,
-            ):
-                # OrdinalEncoder places np.nan last if missing values reach fit.
-                if len(categories) and is_scalar_nan(categories[-1]):
-                    n_categories[idx] = len(categories) - 1
-                else:
-                    n_categories[idx] = len(categories)
+            if self._categorical_encoder is not None:
+                category_counts = []
+                for categories in self._categorical_encoder.categories_:
+                    # OrdinalEncoder places np.nan last if missing values reach fit.
+                    if len(categories) and is_scalar_nan(categories[-1]):
+                        category_counts.append(len(categories) - 1)
+                    else:
+                        category_counts.append(len(categories))
+            else:
+                # Already-encoded ensemble input: category codes are dense in
+                # [0, n_categories - 1] with missing values as NaN.
+                category_counts = []
+                for idx in np.flatnonzero(self.is_categorical_):
+                    col = X[:, idx]
+                    if issparse(X):
+                        col = col.toarray().ravel()
+                    finite = col[np.isfinite(col)]
+                    if finite.size == 0:
+                        category_counts.append(0)
+                    else:
+                        category_counts.append(int(np.max(finite)) + 1)
 
-                max_encoded_value = n_categories[idx] - 1
+            for idx, n_cats in zip(
+                np.flatnonzero(self.is_categorical_), category_counts
+            ):
+                n_categories[idx] = n_cats
+                max_encoded_value = n_cats - 1
                 if max_encoded_value >= max_n_categories:
                     raise ValueError(f"{base_msg} Found {max_encoded_value}.")
 
@@ -675,7 +711,10 @@ class BaseDecisionTree(MultiOutputMixin, BaseEstimator, metaclass=ABCMeta):
         else:
             # The number of features is checked regardless of `check_input`
             _check_n_features(self, X, reset=False)
-            if has_categorical:
+            # Ensembles that already encoded X leave `_preprocessor` unset and pass
+            # check_input=False; skip transform so prediction stays on the encoded
+            # float array.
+            if has_categorical and getattr(self, "_preprocessor", None) is not None:
                 X = self._preprocess_X(X, reset=False)
         return X
 


### PR DESCRIPTION
#### Reference Issues/PRs
Towards: https://github.com/scikit-learn/scikit-learn/issues/33965

#### What does this implement/fix? Explain your changes.
Adds native categorical support to `RandomForest*`, `ExtraTrees*`, and `IsolationForest` via `categorical_features`, same idea as decision trees, and HGBT.

The forest encodes once, then passes the resolved bool mask into each tree so `"from_dtype"` / feature names are not dropped after `X` becomes a NumPy array. Trees fitted through the forest skip a second OrdinalEncoder pass when they already get that mask (`check_input=False`), which avoids an extra copy per tree under `n_jobs`.For forest categorical_features, default is `"from_dtype"` (aligned with HGBT). 

This PR adds mostly documentation copy/pasted across RandomForest*, ExtraTrees*, and IsoluationForest classes within `sklearn/ensemble/`.

#### AI usage disclosure

I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Documentation (including examples)
- ~Research and understanding~


#### Any other comments?
n/a