### PR TITLE
FIX prevent catastrophic cancellation in r_regression (#11395)

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.feature_selection/34834.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.feature_selection/34834.fix.rst
@@ -1,0 +1,4 @@
+- Fix catastrophic cancellation in :func:`feature_selection.r_regression` when
+  computing centered feature norms for constant or near-constant columns under
+  floating-point precision.
+  By :user:`FinalSunFlower <FinalSunFlower>`.

--- a/sklearn/feature_selection/_univariate_selection.py
+++ b/sklearn/feature_selection/_univariate_selection.py
@@ -377,7 +377,9 @@ def r_regression(X, y, *, center=True, force_finite=True):
         X_means = X.mean(axis=0)
         X_means = X_means.getA1() if isinstance(X_means, np.matrix) else X_means
         # Compute the scaled standard deviations via moments
-        X_norms = np.sqrt(row_norms(X.T, squared=True) - n_samples * X_means**2)
+        X_norms_squared = row_norms(X.T, squared=True) - n_samples * X_means**2
+        # Roundoff can make the centered sum of squares slightly negative.
+        X_norms = np.sqrt(np.maximum(X_norms_squared, 0.0))
     else:
         X_norms = row_norms(X.T)
 

--- a/sklearn/feature_selection/tests/test_univariate_selection.py
+++ b/sklearn/feature_selection/tests/test_univariate_selection.py
@@ -1,0 +1,83 @@
+import warnings
+
+import numpy as np
+import pytest
+from scipy import sparse
+
+from sklearn.feature_selection import f_regression, r_regression
+
+
+@pytest.mark.parametrize(
+    "container", [lambda X: X, sparse.csr_matrix, sparse.csc_matrix]
+)
+def test_r_regression_constant_features_no_runtime_warning(container):
+    X = np.array([[2.0, 1.0], [2.0, 0.0], [2.0, 10.0], [2.0, 4.0]])
+    y = np.array([0.0, 1.0, 1.0, 0.0])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        correlation = r_regression(container(X), y)
+
+    assert correlation[0] == 0.0
+    assert correlation[1] == pytest.approx(0.32075015)
+
+
+@pytest.mark.parametrize(
+    "container", [lambda X: X, sparse.csr_matrix, sparse.csc_matrix]
+)
+def test_f_regression_constant_features_no_runtime_warning(container):
+    X = np.array([[2.0, 1.0], [2.0, 0.0], [2.0, 10.0], [2.0, 4.0]])
+    y = np.array([0.0, 1.0, 1.0, 0.0])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        f_statistic, p_values = f_regression(container(X), y)
+
+    assert f_statistic[0] == 0.0
+    assert p_values[0] == 1.0
+    assert f_statistic[1] == pytest.approx(0.2293578)
+
+
+@pytest.mark.parametrize(
+    "container", [lambda X: X, sparse.csr_matrix, sparse.csc_matrix]
+)
+def test_r_regression_constant_features_force_finite_false(container):
+    X = np.array([[2.0, 1.0], [2.0, 0.0], [2.0, 10.0], [2.0, 4.0]])
+    y = np.array([0.0, 1.0, 1.0, 0.0])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        correlation = r_regression(container(X), y, force_finite=False)
+
+    assert np.isnan(correlation[0])
+    assert correlation[1] == pytest.approx(0.32075015)
+
+
+def test_r_regression_cancellation_is_clamped():
+    X = np.column_stack(
+        [
+            # The perturbation is below the ULP at this magnitude, so the
+            # represented values are constant while the moment subtraction
+            # still suffers cancellation.
+            np.full(20, 1e12) + np.arange(20) * 1e-8,
+            np.arange(20, dtype=float),
+        ]
+    )
+    y = np.arange(20, dtype=float)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        correlation = r_regression(X, y)
+
+    assert correlation[0] == 0.0
+    assert correlation[1] == 1.0
+
+
+def test_r_regression_active_features_are_unchanged():
+    X = np.array([[2.0, 1.0], [2.0, 0.0], [2.0, 10.0], [2.0, 4.0]])
+    y = np.array([0.0, 1.0, 1.0, 0.0])
+    expected = r_regression(X[:, 1:], y)[0]
+
+    actual = r_regression(X, y)[1]
+
+    assert actual == expected


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #11395.

#### What does this implement/fix? Explain your changes.

`r_regression` computes centered feature norms using a moment-based expression. Floating-point cancellation can make the mathematically non-negative centered sum of squares slightly negative for constant or near-constant columns, causing an invalid square root and propagating invalid correlations. This change clamps the intermediate squared norms to zero before `sqrt`, preserving existing results for active non-constant features and keeping dense, CSR, and CSC inputs consistent. Regression tests cover constant features, `force_finite=False`, sparse formats, high-magnitude cancellation, and active-feature preservation.

#### Introduce yourself

I am FinalSunFlower, contributing a numerically focused bug fix to scikit-learn's feature-selection utilities. I use scikit-learn for classical machine-learning workflows and was prompted by issue #11395 to improve the stability of `r_regression` on degenerate inputs.

#### AI usage disclosure

I used AI assistance for:
- Research and understanding
- Code generation (implementation and tests)
- Test/benchmark generation
- Documentation (including examples)

#### Any other comments?

Local CPU validation passed for the targeted regression tests, the complete feature-selection test module, Ruff checks, and formatting checks. The changelog entry is included in `doc/whats_new/upcoming_changes/sklearn.feature_selection/34834.fix.rst`.