### PR TITLE
FIX Use uniform probabilities for zero-affinity rows

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.semi_supervised/34835.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.semi_supervised/34835.fix.rst
@@ -1,0 +1,5 @@
+- :class:`semi_supervised.LabelPropagation` and
+  :class:`semi_supervised.LabelSpreading` now use uniform class probabilities
+  for samples with zero affinity, ensuring that probability distributions from
+  both ``fit`` and ``predict_proba`` sum to one.
+  By :user:`Sudam Ranasinghe <sudam802>`.

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -74,6 +74,18 @@ from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_is_fitted, validate_data
 
 
+def _normalize_probabilities(probabilities):
+    """Normalize probabilities, using a uniform distribution for zero-sum rows."""
+    normalizer = np.sum(probabilities, axis=1)[:, np.newaxis]
+    uniform_probabilities = np.full_like(probabilities, 1 / probabilities.shape[1])
+    return np.divide(
+        probabilities,
+        normalizer,
+        out=uniform_probabilities,
+        where=normalizer != 0,
+    )
+
+
 class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
     """Base class for label propagation module.
 
@@ -228,9 +240,7 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
         else:
             weight_matrices = weight_matrices.T
             probabilities = safe_sparse_dot(weight_matrices, self.label_distributions_)
-        normalizer = np.atleast_2d(np.sum(probabilities, axis=1)).T
-        probabilities /= normalizer
-        return probabilities
+        return _normalize_probabilities(probabilities)
 
     @_fit_context(prefer_skip_nested_validation=True)
     def fit(self, X, y):
@@ -310,9 +320,9 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
             )
 
             if self._variant == "propagation":
-                normalizer = np.sum(self.label_distributions_, axis=1)[:, np.newaxis]
-                normalizer[normalizer == 0] = 1
-                self.label_distributions_ /= normalizer
+                self.label_distributions_ = _normalize_probabilities(
+                    self.label_distributions_
+                )
                 self.label_distributions_ = np.where(
                     unlabeled, self.label_distributions_, y_static
                 )
@@ -328,9 +338,7 @@ class BaseLabelPropagation(ClassifierMixin, BaseEstimator, metaclass=ABCMeta):
             )
             self.n_iter_ += 1
 
-        normalizer = np.sum(self.label_distributions_, axis=1)[:, np.newaxis]
-        normalizer[normalizer == 0] = 1
-        self.label_distributions_ /= normalizer
+        self.label_distributions_ = _normalize_probabilities(self.label_distributions_)
 
         # set the transduction item
         transduction = self.classes_[np.argmax(self.label_distributions_, axis=1)]

--- a/sklearn/semi_supervised/tests/test_label_propagation.py
+++ b/sklearn/semi_supervised/tests/test_label_propagation.py
@@ -79,6 +79,20 @@ def test_predict_proba(global_dtype, Estimator, parameters):
     assert_allclose(clf.predict_proba([[1.0, 1.0]]), np.array([[0.5, 0.5]]))
 
 
+@pytest.mark.parametrize(
+    "Estimator",
+    [label_propagation.LabelPropagation, label_propagation.LabelSpreading],
+)
+def test_predict_proba_uniform_for_zero_affinity(global_dtype, Estimator):
+    X = np.asarray([[1.0, 0.0], [0.0, 1.0], [1.0, 2.5]], dtype=global_dtype)
+    y = np.array([0, 1, -1])
+    clf = Estimator(kernel="rbf").fit(X, y)
+
+    probabilities = clf.predict_proba([[1e6, 1e6]])
+
+    assert_allclose(probabilities, [[0.5, 0.5]])
+
+
 @pytest.mark.parametrize("alpha", [0.1, 0.3, 0.5, 0.7, 0.9])
 @pytest.mark.parametrize("Estimator, parameters", ESTIMATORS)
 def test_label_spreading_closed_form(global_dtype, Estimator, parameters, alpha):
@@ -217,7 +231,7 @@ def test_convergence_warning():
     [label_propagation.LabelSpreading, label_propagation.LabelPropagation],
 )
 def test_label_propagation_non_zero_normalizer(LabelPropagationCls):
-    # check that we don't divide by zero in case of null normalizer
+    # Check that a null normalizer produces a valid probability distribution.
     # non-regression test for
     # https://github.com/scikit-learn/scikit-learn/pull/15946
     # https://github.com/scikit-learn/scikit-learn/issues/9292
@@ -227,6 +241,7 @@ def test_label_propagation_non_zero_normalizer(LabelPropagationCls):
     with warnings.catch_warnings():
         warnings.simplefilter("error", RuntimeWarning)
         mdl.fit(X, y)
+    assert_allclose(mdl.label_distributions_[2:], 0.5)
 
 
 def test_predict_sparse_callable_kernel(global_dtype):


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #34351. Related to #34350.

#### What does this implement/fix? Explain your changes.

Zero-affinity rows currently normalize to all-zero values during fit and can produce NaN values in predict_proba. Neither result is a valid categorical probability distribution.

This change introduces one private normalization helper shared by fit and predict_proba. Rows with a nonzero sum retain the existing normalization, while zero-sum rows receive uniform probabilities. The uniform fallback represents the absence of class information without preferring a class and follows the direction agreed in #34351.

Regression tests cover disconnected training samples and far-away prediction samples for both LabelPropagation and LabelSpreading.

Tests:
- python -m pytest sklearn/semi_supervised/tests/test_label_propagation.py -q (175 passed, 60 skipped)
- python -m ruff check sklearn/semi_supervised/_label_propagation.py sklearn/semi_supervised/tests/test_label_propagation.py
- python -m ruff format --check sklearn/semi_supervised/_label_propagation.py sklearn/semi_supervised/tests/test_label_propagation.py

#### Introduce yourself

I am contributing this focused numerical correctness fix after following the maintainer-approved direction in #34351.

#### AI usage disclosure

I used AI assistance for:
- Code generation
- Test generation
- Research and understanding

#### Any other comments?

The main review point is applying the uniform fallback during LabelPropagation iterations as well as final normalization. This keeps disconnected rows valid throughout fitting and is covered by the existing closed-form and convergence tests.

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.