### PR TITLE
BUG Fix mutual information computation

### DIFF
--- a/sklearn/feature_selection/_mutual_info.py
+++ b/sklearn/feature_selection/_mutual_info.py
@@ -307,7 +307,8 @@ def _estimate_mi(
         )
 
     if not discrete_target:
-        y = scale(y, with_mean=False)
+        y = y.astype(np.float64, copy=copy)
+        y = scale(y, with_mean=False, copy=False)
         y += (
             1e-10
             * np.maximum(1, np.mean(np.abs(y)))


### PR DESCRIPTION
Reference Issues/PRs

Fixes #34800

What does this implement/fix? Explain your changes.

This fixes the handling of the `copy` parameter in `_estimate_mi` when the target `y` is continuous.

Previously, `y` could be modified in place during scaling even when `copy=False` was not intended to allow modification of the original input. The implementation now explicitly converts `y` to `float64` with the appropriate copy behavior before scaling, and performs the scaling in place on the converted array.

This ensures that the input is not unexpectedly modified while preserving the intended `copy` semantics.

Introduce yourself

Hi! I'm Shaunak Nagvenkar, a Computer Science graduate and software engineer interested in machine learning, data engineering, and AI.

I use scikit-learn regularly for machine learning projects, and this contribution was motivated by a desire to understand and improve the behavior of scikit-learn's mutual information feature selection implementation.

This is my first contribution to the scikit-learn community, and I'm looking forward to learning from the review process and contributing further.

AI usage disclosure

I used AI assistance for:

Research and understanding
Code generation (e.g., when writing an implementation or fixing a bug)
Test/benchmark generation

Any other comments?

I tested the changes with the relevant mutual information tests and the complete feature selection test suite.

Relevant tests:

14 passed, 8 skipped for test_mutual_info.py
293 passed, 13 skipped for sklearn/feature_selection/tests

All relevant tests pass with 0 failures. 8 tests are skipped as expected
