### PR TITLE
MNT Don't cache the signature of the bound callback hook

### DIFF
--- a/sklearn/callback/_callback_context.py
+++ b/sklearn/callback/_callback_context.py
@@ -318,7 +318,11 @@ class CallbackContext:
                 # sub-estimator's root context (both represent the same task).
                 continue
 
-            signature = _cached_signature(getattr(callback, hook_name))
+            hook = getattr(callback, hook_name)
+            # Cache the signature of the underlying function rather than that of the
+            # bound method, which would make the cache hold references to the callbacks
+            # themselves and keep the resources they own alive.
+            signature = _cached_signature(getattr(hook, "__func__", hook))
             params_names = {
                 p.name
                 for p in signature.parameters.values()
@@ -347,9 +351,7 @@ class CallbackContext:
 
                 args_to_pass[param_name] = evaluated_args[param_name]
 
-            result |= bool(
-                getattr(callback, hook_name)(estimator, self, **args_to_pass)
-            )
+            result |= bool(hook(estimator, self, **args_to_pass))
 
         return result
 

--- a/sklearn/callback/tests/test_scoring_monitor.py
+++ b/sklearn/callback/tests/test_scoring_monitor.py
@@ -1,6 +1,8 @@
 # Authors: The scikit-learn developers
 # SPDX-License-Identifier: BSD-3-Clause
 
+import gc
+
 import numpy as np
 import pytest
 
@@ -415,6 +417,10 @@ def test_scoring_monitor_listener_closed_on_gc():
     assert listener_address in _listeners
     assert listener_address in _message_consumers
 
+    MaxIterEstimator().set_callbacks(callback).fit()
+
     del callback
+    gc.collect()
+
     assert listener_address not in _listeners
     assert listener_address not in _message_consumers

--- a/sklearn/callback/tests/test_scoring_monitor.py
+++ b/sklearn/callback/tests/test_scoring_monitor.py
@@ -9,6 +9,7 @@ import pytest
 from sklearn.base import clone
 from sklearn.callback import ScoringMonitor
 from sklearn.callback._scoring_monitor import ScoringMonitorLog
+from sklearn.callback._transport import _listeners, _message_consumers
 from sklearn.callback.tests._common.estimators import (
     MaxIterEstimator,
     MetaEstimator,
@@ -410,8 +411,6 @@ def test_scoring_monitor_no_callback_support(backend):
 
 def test_scoring_monitor_listener_closed_on_gc():
     """Check that listener is closed when callback is garbage collected."""
-    from sklearn.callback._transport import _listeners, _message_consumers
-
     callback = ScoringMonitor(scoring="r2")
     listener_address = callback._listener_handle.address
     assert listener_address in _listeners


### PR DESCRIPTION
We cache the signatures of the callback hooks for performance reasons (see https://github.com/scikit-learn/scikit-learn/pull/34099).

However we cache the bound method (the hook of the callback instance) so there's one entry per callback instance.
Besides growing the cache more than necessary (we really need an entry per callback class, not instance), the bound method holds a strong reference to the instance it's bound to. So this means that we keep the callback objects, and the resources they hold, even after they are not used anymore.

The test that was updated in this PR didn't show it because it was missing a `fit` call (which triggers the signature caching). Now it fails on main and passes on this branch.

This PR is also a prerequisite for a fix I'm working on for https://github.com/scikit-learn/scikit-learn/issues/34734. Indeed, holding strong refs to the callbacks will prevent freeing the resources and terminating the threads that are currently leftover.

I don't believe it needs a changelog entry as it doesn't surface to the user.

ping @FrancoisPgm 