### PR TITLE
TST: run the array API test with a `float32` only device

### DIFF
--- a/sklearn/utils/_array_api.py
+++ b/sklearn/utils/_array_api.py
@@ -113,6 +113,7 @@ def yield_namespace_device_dtype_combinations(include_numpy_namespaces=True):
             # creates Device objects when needed.
             yield array_namespace, "CPU_DEVICE", "float64"
             yield array_namespace, "device1", "float32"
+            yield array_namespace, "no_float64", "float32"
         else:
             yield array_namespace, None, None
 
@@ -1315,10 +1316,12 @@ def _bincount(array, weights=None, minlength=0, xp=None):
     array_np = move_to(array, xp=numpy, device="cpu")
     if weights is not None:
         weights_np = move_to(weights, xp=numpy, device="cpu")
+        dtype = weights.dtype
     else:
         weights_np = None
+        dtype = None
     bin_out = numpy.bincount(array_np, weights=weights_np, minlength=minlength)
-    return xp.asarray(bin_out, device=array_device(array))
+    return xp.asarray(bin_out, device=array_device(array), dtype=dtype)
 
 
 def _logsumexp(array, axis=None, xp=None):


### PR DESCRIPTION
This is a draft PR to leverage array-api-strict's newly introduced `no_float64` device that should allow us to discover dtype handling bugs in our code.

This device is meant to emulate devices such as torch MPS or torch XPU on some GPU that have a floating point arithmetic capabilities limited to float32 precision.

I added the test and fixed what looks like a bug in our bincount fallback code.

However there are many other failures that need to be investigated. This is curious that those tests pass with the torch MPS device though.

Related: https://github.com/scikit-learn/scikit-learn/issues/34813