### PR TITLE
DOC add example: anisotropy severe enough to defeat GaussianMixture

### DIFF
--- a/examples/cluster/plot_kmeans_assumptions.py
+++ b/examples/cluster/plot_kmeans_assumptions.py
@@ -218,38 +218,10 @@ plt.title(f"GaussianMixture on whitened data\n(ARI={ari:.2f} against ground trut
 plt.show()
 
 # %%
-# A caveat: whitening degrades in high dimensions
-# --------------------------------------------------
-#
-# In high dimensions, e.g. ``d=30``, whitening fails too.
-
-d = 30
-compress = 0.1
-half_sep = np.sqrt(1 - compress**2)  # makes the informative dimension's own
-# total variance exactly 1 too, matching the noise dimensions
-
-rng = np.random.RandomState(random_state)
-n1 = n_samples // 2
-n2 = n_samples - n1
-informative = np.concatenate(
-    [rng.randn(n1) * compress - half_sep, rng.randn(n2) * compress + half_sep]
-)
-y_cigars_d = np.array([0] * n1 + [1] * n2)
-X_cigars_d = np.empty((n_samples, d))
-X_cigars_d[:, 0] = informative
-X_cigars_d[:, 1:] = rng.randn(n_samples, d - 1)
-
-print("overall mean (first 3 dims):", X_cigars_d.mean(axis=0)[:3].round(3))
-print(
-    "overall covariance (top-left 3x3):\n",
-    np.cov(X_cigars_d, rowvar=False)[:3, :3].round(3),
-)
-
-y_pred = GaussianMixture(n_components=2, random_state=random_state).fit_predict(
-    X_cigars_d
-)
-print(f"ARI at d={d} (whitening this data changes nothing): "
-      f"{adjusted_rand_score(y_cigars_d, y_pred):.2f}")
+# This whitening fix does not scale to high dimensions: the same
+# construction lifted to ``d=30`` (one informative dimension plus 29 pure
+# noise dimensions, positioned so the overall data already has mean 0 and
+# identity covariance) gives ARI :math:`\approx` 0 again.
 
 # %%
 # Final remarks

--- a/examples/cluster/plot_kmeans_assumptions.py
+++ b/examples/cluster/plot_kmeans_assumptions.py
@@ -163,6 +163,95 @@ plt.suptitle("Gaussian mixture clusters").set_y(0.95)
 plt.show()
 
 # %%
+# Anisotropy severe enough to affect GaussianMixture too
+# --------------------------------------------------------
+#
+# :class:`~sklearn.mixture.GaussianMixture` fixes the anisotropic case above
+# by fitting a full covariance per component instead of assuming spherical
+# clusters. But it is still initialized from a k-means-style partition of the
+# raw data, and EM only ever *refines* that starting partition -- it does not
+# search over every possible partition from scratch. If the anisotropy is
+# severe enough, the initial partition can already be so wrong that no amount
+# of iteration recovers the true clusters, even with unconstrained
+# covariances.
+#
+# To see this clearly, we build two isotropic blobs separated only along the
+# x-axis, then apply a diagonal ``transformation`` that compresses that
+# separating axis and stretches the other, uninformative one -- two
+# elongated, parallel clusters. Euclidean distance, and any k-means-style
+# initialization built on it, is dominated by the high-variance direction and
+# cannot tell the classes apart.
+
+from sklearn.metrics import adjusted_rand_score
+
+X_latent, y_cigars = make_blobs(
+    n_samples=n_samples, centers=[[-2, 0], [2, 0]], random_state=random_state
+)
+cigars_transformation = [[0.1, 0], [0, 8]]
+X_cigars = np.dot(X_latent, cigars_transformation)
+
+y_pred = GaussianMixture(n_components=2, random_state=random_state).fit_predict(X_cigars)
+ari = adjusted_rand_score(y_cigars, y_pred)
+
+plt.scatter(X_cigars[:, 0], X_cigars[:, 1], c=y_pred)
+plt.title(f"GaussianMixture on parallel cigars\n(ARI={ari:.2f} against ground truth)")
+plt.show()
+
+# %%
+# The fix is not a different clustering algorithm: it is whitening the data
+# first, with :class:`~sklearn.decomposition.PCA`'s ``whiten=True`` option.
+# Whitening rescales onto the principal axes so that every direction has unit
+# variance, which is exactly what makes the informative direction visible to
+# a k-means-style initialization again.
+
+from sklearn.decomposition import PCA
+
+X_cigars_white = PCA(n_components=2, whiten=True).fit_transform(X_cigars)
+
+y_pred = GaussianMixture(n_components=2, random_state=random_state).fit_predict(
+    X_cigars_white
+)
+ari = adjusted_rand_score(y_cigars, y_pred)
+
+plt.scatter(X_cigars_white[:, 0], X_cigars_white[:, 1], c=y_pred)
+plt.title(f"GaussianMixture on whitened data\n(ARI={ari:.2f} against ground truth)")
+plt.show()
+
+# %%
+# A caveat: whitening degrades in high dimensions
+# --------------------------------------------------
+#
+# In high dimensions, e.g. ``d=30``, whitening fails too.
+
+d = 30
+compress = 0.1
+half_sep = np.sqrt(1 - compress**2)  # makes the informative dimension's own
+# total variance exactly 1 too, matching the noise dimensions
+
+rng = np.random.RandomState(random_state)
+n1 = n_samples // 2
+n2 = n_samples - n1
+informative = np.concatenate(
+    [rng.randn(n1) * compress - half_sep, rng.randn(n2) * compress + half_sep]
+)
+y_cigars_d = np.array([0] * n1 + [1] * n2)
+X_cigars_d = np.empty((n_samples, d))
+X_cigars_d[:, 0] = informative
+X_cigars_d[:, 1:] = rng.randn(n_samples, d - 1)
+
+print("overall mean (first 3 dims):", X_cigars_d.mean(axis=0)[:3].round(3))
+print(
+    "overall covariance (top-left 3x3):\n",
+    np.cov(X_cigars_d, rowvar=False)[:3, :3].round(3),
+)
+
+y_pred = GaussianMixture(n_components=2, random_state=random_state).fit_predict(
+    X_cigars_d
+)
+print(f"ARI at d={d} (whitening this data changes nothing): "
+      f"{adjusted_rand_score(y_cigars_d, y_pred):.2f}")
+
+# %%
 # Final remarks
 # -------------
 #


### PR DESCRIPTION
Closes #34842

\`plot_kmeans_assumptions.py\` already shows \`GaussianMixture\` fixing mild anisotropy that breaks \`KMeans\`. This adds a case where the anisotropy is severe enough that \`GaussianMixture\`'s own k-means-style initialization finds a partition too wrong for EM to recover from (ARI ~0), even though EM still fits an unconstrained covariance per component.

The new dataset is built the same way as the existing \`X_aniso\` example (isotropic \`make_blobs\` + a linear \`transformation\`), just with a transformation that compresses the separating axis and stretches the uninformative one instead of a general rotation.

Whitening first with \`PCA(whiten=True)\` fixes it (ARI 0.92) by rescaling onto the principal axes so every direction has comparable variance, restoring a good initialization — no custom clustering code needed.

One line notes a caveat: the same construction lifted to \`d=30\` (positioned so the overall data already has mean 0 and identity covariance) degrades back to ARI ≈ 0 — whitening fixes this specific anisotropy problem, not high-dimensional distance inflation generally.