### PR TITLE
DOC Add nightly install link to dev warning banner

### DIFF
--- a/doc/js/scripts/version-switcher.js
+++ b/doc/js/scripts/version-switcher.js
@@ -38,3 +38,54 @@ function addVersionSwitcherAvailDocsLink() {
 }
 
 document.addEventListener("DOMContentLoaded", addVersionSwitcherAvailDocsLink);
+
+function addVersionWarningNightlyLink() {
+  var version = DOCUMENTATION_OPTIONS.VERSION || "";
+  var isDevelopmentVersion = version.includes("dev");
+
+  if (!isDevelopmentVersion) {
+    return;
+  }
+
+  var banner = document.querySelector("#bd-header-version-warning");
+
+  if (!banner) {
+    return;
+  }
+
+  function addNightlyLink() {
+    if (
+      banner.classList.contains("d-none") ||
+      banner.querySelector(".sk-nightly-install-link")
+    ) {
+      return;
+    }
+
+    var stableLink = banner.querySelector(".pst-button-link-to-stable-version");
+
+    if (!stableLink) {
+      return;
+    }
+
+    var nightlyLink = document.createElement("a");
+    nightlyLink.href =
+      "https://scikit-learn.org/dev/install.html#installing-nightly-builds";
+    nightlyLink.innerText = "Install nightly build";
+    nightlyLink.className = stableLink.className;
+    nightlyLink.classList.add("sk-nightly-install-link");
+
+    stableLink.insertAdjacentElement("afterend", nightlyLink);
+  }
+
+  addNightlyLink();
+
+  var observer = new MutationObserver(addNightlyLink);
+  observer.observe(banner, {
+    attributes: true,
+    attributeFilter: ["class"],
+    childList: true,
+    subtree: true,
+  });
+}
+
+document.addEventListener("DOMContentLoaded", addVersionWarningNightlyLink);

--- a/doc/whats_new/upcoming_changes/custom-top-level/34850.other.rst
+++ b/doc/whats_new/upcoming_changes/custom-top-level/34850.other.rst
@@ -1,0 +1,3 @@
+- The development documentation version warning banner now links to the
+  nightly build installation instructions.
+  By :user:`Bhushan Asati <bhushanasati25>`.


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #30242.

#### What does this implement/fix? Explain your changes.

This restores a discoverable path from the development documentation banner to the nightly build installation instructions.

The PyData Sphinx Theme version-warning banner is populated asynchronously, so `doc/js/scripts/version-switcher.js` now watches `#bd-header-version-warning` and appends an `Install nightly build` link after the existing `Switch to stable version` button once the dev-version banner is available.

The link is only added for documentation versions containing `dev`; it is not added for stable or release-candidate docs. It reuses the theme's stable-version button classes and adds `sk-nightly-install-link` so the link is styled consistently and not duplicated.

A changelog fragment was added in `doc/whats_new/upcoming_changes/custom-top-level/34850.other.rst`.

#### Introduce yourself

Hi, I’m Bhushan Asati (`bhushanasati25`). This is a small documentation/UI contribution to make the development docs easier to use for people trying nightly builds.

#### AI usage disclosure

I used AI assistance for:
- Code generation (writing the JavaScript helper)
- Test generation (creating the local simulated-DOM behavior check)
- Documentation (drafting the changelog fragment and PR description)
- Research and understanding (checking the PyData Sphinx Theme banner behavior and existing scikit-learn docs links)

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.

#### Any other comments?

Checks run locally:
- `node --check doc/js/scripts/version-switcher.js`
- `PRE_COMMIT_HOME=/Users/ihack-pc/Documents/Codex/2026-08-31/scikit-learn-scikit-learn-git-https/work/.pre-commit-cache npm_config_cache=/Users/ihack-pc/Documents/Codex/2026-08-31/scikit-learn-scikit-learn-git-https/work/.npm-cache pre-commit run prettier --files doc/js/scripts/version-switcher.js`
- `PRE_COMMIT_HOME=/Users/ihack-pc/Documents/Codex/2026-08-31/scikit-learn-scikit-learn-git-https/work/.pre-commit-cache npm_config_cache=/Users/ihack-pc/Documents/Codex/2026-08-31/scikit-learn-scikit-learn-git-https/work/.npm-cache pre-commit run sphinx-lint --files doc/whats_new/upcoming_changes/custom-top-level/34850.other.rst`
- `git diff --check`
- local Node simulated-DOM check that verifies the link is added for `1.10.dev0` and not for stable or rc versions

Not run locally: full Sphinx docs build. This fresh checkout is not built and the local environment is missing several docs dependencies such as `pydata_sphinx_theme` and `sphinx_gallery`.
