### PR TITLE
FIX Clarify OneHotEncoder unknown category warning for mixed infrequent columns

### DIFF
--- a/sklearn/preprocessing/_encoders.py
+++ b/sklearn/preprocessing/_encoders.py
@@ -225,13 +225,52 @@ class _BaseEncoder(TransformerMixin, BaseEstimator):
                     columns_with_unknown.append(i)
 
         if columns_with_unknown:
-            if handle_unknown == "infrequent_if_exist":
-                msg = (
-                    "Found unknown categories in columns "
-                    f"{columns_with_unknown} during transform. These "
-                    "unknown categories will be encoded as the "
-                    "infrequent category."
-                )
+            if handle_unknown in ("infrequent_if_exist", "warn"):
+                infrequent_cols = [
+                    i
+                    for i in columns_with_unknown
+                    if self._infrequent_enabled
+                    and self._infrequent_indices[i] is not None
+                ]
+                zeros_cols = [
+                    i
+                    for i in columns_with_unknown
+                    if not (
+                        self._infrequent_enabled
+                        and self._infrequent_indices[i] is not None
+                    )
+                ]
+
+                if infrequent_cols and not zeros_cols:
+                    msg = (
+                        "Found unknown categories in columns "
+                        f"{infrequent_cols} during transform. These "
+                        "unknown categories will be encoded as the "
+                        "infrequent category."
+                    )
+                elif zeros_cols and not infrequent_cols:
+                    if self._infrequent_enabled:
+                        msg = (
+                            "Found unknown categories in columns "
+                            f"{zeros_cols} during transform. These "
+                            "unknown categories will be encoded as all zeros, "
+                            "because these columns have no infrequent category."
+                        )
+                    else:
+                        msg = (
+                            "Found unknown categories in columns "
+                            f"{zeros_cols} during transform. These "
+                            "unknown categories will be encoded as all zeros"
+                        )
+                else:
+                    msg = (
+                        "Found unknown categories in columns "
+                        f"{columns_with_unknown} during transform. "
+                        f"The unknown categories in columns {infrequent_cols} "
+                        "will be encoded as the infrequent category. "
+                        f"Those in columns {zeros_cols} will be encoded as all zeros, "
+                        "because these columns have no infrequent category."
+                    )
             else:
                 msg = (
                     "Found unknown categories in columns "

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -2433,3 +2433,26 @@ def test_onehotencoder_handle_unknown_warn_maps_to_infrequent():
         result_warn = encoder_warn.transform(test_data)
 
     assert_allclose(result_warn[2], result_infreq[2])
+
+
+def test_ohe_unknown_category_warning_mixed_infrequent():
+    """Test that OneHotEncoder warns accurately when some columns have infrequent
+    categories and others do not."""
+    X = [["a", "x"], ["a", "x"], ["b", "x"], ["b", "y"]]
+    encoder = OneHotEncoder(
+        drop="first",
+        sparse_output=False,
+        handle_unknown="infrequent_if_exist",
+        min_frequency=2,
+    ).fit(X)
+
+    # Column 0 has no infrequent category, column 1 has an infrequent category ('y')
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        encoder.transform([["c", "z"]])
+
+    assert len(caught) == 1
+    msg = str(caught[0].message)
+    assert "columns [1] will be encoded as the infrequent category" in msg
+    assert "columns [0] will be encoded as all zeros" in msg
+

--- a/sklearn/preprocessing/tests/test_encoders.py
+++ b/sklearn/preprocessing/tests/test_encoders.py
@@ -2455,4 +2455,3 @@ def test_ohe_unknown_category_warning_mixed_infrequent():
     msg = str(caught[0].message)
     assert "columns [1] will be encoded as the infrequent category" in msg
     assert "columns [0] will be encoded as all zeros" in msg
-


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #34822

#### What does this implement/fix? Explain your changes.
When `handle_unknown="infrequent_if_exist"`, the previous warning message uniformly stated that all unknown categories would be mapped to the infrequent category. However, columns where `infrequent_categories_[i] is None` actually fall back to an all-zeros encoding (equivalent to `handle_unknown="ignore"`).

This PR:
1. Partitions `columns_with_unknown` into `infrequent_cols` (having an infrequent category) and `zeros_cols` (falling back to all zeros).
2. Generates an accurate warning message distinguishing between these cases:
   - If all affected columns have infrequent categories: `"These unknown categories will be encoded as the infrequent category."`
   - If all affected columns lack infrequent categories: `"These unknown categories will be encoded as all zeros, because these columns have no infrequent category."`
   - If mixed: `"The unknown categories in columns [...] will be encoded as the infrequent category. Those in columns [...] will be encoded as all zeros, because these columns have no infrequent category."`
3. Adds regression test `test_ohe_unknown_category_warning_mixed_infrequent` in `sklearn/preprocessing/tests/test_encoders.py`.
