### PR TITLE
MNT Callback transport actually free the accept thread on closing a listener

### DIFF
--- a/sklearn/callback/_transport.py
+++ b/sklearn/callback/_transport.py
@@ -114,12 +114,15 @@ def open_listener(message_consumer, *, owner=None):
             return
 
     def _accept():
-        while True:
-            try:
-                conn = listener.accept()
-            except OSError:
-                return
-            Thread(target=_handle, args=(conn,), daemon=True).start()
+        try:
+            while listener_handle.address in _listeners:
+                try:
+                    conn = listener.accept()
+                except (OSError, EOFError):
+                    break  # woken up by `close_listener`, or the listener failed
+                Thread(target=_handle, args=(conn,), daemon=True).start()
+        finally:
+            listener.close()
 
     Thread(target=_accept, daemon=True).start()
     return listener_handle
@@ -127,10 +130,20 @@ def open_listener(message_consumer, *, owner=None):
 
 def close_listener(listener_handle):
     """Stop listening for `listener_handle` and free its background threads."""
-    _message_consumers.pop(listener_handle.address, None)
-    listener = _listeners.pop(listener_handle.address, None)
-    if listener is not None:
-        listener.close()
+    address = listener_handle.address
+    _message_consumers.pop(address, None)
+
+    if _listeners.pop(address, None) is None:
+        return  # already closed
+
+    try:
+        # The accept thread is waiting in `accept`, and closing the listener would not
+        # interrupt that call. Connecting to it does: we connect without the authkey so
+        # that the authentication handshake fails, and that failure is what makes the
+        # accept thread break out of its loop.
+        Client(address).close()
+    except OSError:
+        pass  # the accept thread is already gone, e.g. its listener failed
 
 
 def can_reuse_listener(listener_handle):

--- a/sklearn/callback/tests/test_transport.py
+++ b/sklearn/callback/tests/test_transport.py
@@ -1,0 +1,57 @@
+# Authors: The scikit-learn developers
+# SPDX-License-Identifier: BSD-3-Clause
+
+import threading
+import time
+from multiprocessing.connection import Client
+
+import pytest
+
+from sklearn.callback._transport import close_listener, open_listener
+
+
+def _assert_no_leftover_threads(n_expected, timeout=1):
+    """Assert that the background threads of the transport have exited.
+
+    They exit asynchronously, hence the polling.
+    """
+    while (n_threads := threading.active_count()) > n_expected:
+        timeout -= 0.05
+        assert timeout > 0, f"{n_threads - n_expected} leftover threads"
+        time.sleep(0.05)
+
+
+@pytest.mark.thread_unsafe  # counts the threads of the whole process
+def test_close_listener_stops_accept_thread():
+    """Check that closing a listener doesn't leave its accept thread behind.
+
+    An accept thread that is left behind also holds on to the last connection it
+    accepted, because its frame keeps a reference to it. Both ends of that socket then
+    stay open even though nothing reads from them anymore.
+    """
+    n_threads = threading.active_count()
+    listener_handle = open_listener(lambda message: None)
+
+    close_listener(listener_handle)
+    close_listener(listener_handle)  # closing twice must be harmless.
+
+    _assert_no_leftover_threads(n_threads)
+
+
+@pytest.mark.thread_unsafe  # counts the threads of the whole process
+def test_close_listener_whose_accept_thread_is_already_gone():
+    """Check that closing a listener that failed on its own is harmless.
+
+    An accept thread that stops because `accept` failed closes its listener on the way
+    out, and the address stays registered until someone closes it, so `close_listener`
+    then has an address it cannot connect to.
+    """
+    n_threads = threading.active_count()
+    listener_handle = open_listener(lambda message: None)
+
+    # Connecting without the authkey makes `accept` fail, which is how the accept thread
+    # is stopped, here without unregistering the listener first.
+    Client(listener_handle.address).close()
+    _assert_no_leftover_threads(n_threads)
+
+    close_listener(listener_handle)


### PR DESCRIPTION
Towards https://github.com/scikit-learn/scikit-learn/issues/34734

While investigating https://github.com/scikit-learn/scikit-learn/issues/34734, I found that there are 2 sources of leaking threads and file descriptors. This PR ensures that closing the listener actually frees the accept thread (which also happens to hold 1 file descriptor open).

Closing the listener doesn't unblock the accept thread, so previously it used to stay alive forever. Now, in close_listener, we make a connection without the authkey which wakes-up the accept thread and break its loop which ensures that the _accept function returns, freeing the thread.
I'll update the PR with some tests soon.

I'm planning to fix the second source of leaking file descriptors in a separate PR.

(I don't think this one requires a changelog entry since it's hardly visible from the user side)