### PR TITLE
FIX IsolationForest: floor a small float max_samples to 1 instead of crashing

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.ensemble/34859.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.ensemble/34859.fix.rst
@@ -1,0 +1,5 @@
+- :class:`sklearn.ensemble.IsolationForest` no longer raises a confusing error
+  when ``max_samples`` is a small float that rounds down to zero. It now floors
+  the number of drawn samples to 1 and warns, matching
+  :class:`sklearn.ensemble.BaggingClassifier`.
+  By :user:`Alejandro Coronado <AlejandroCoronadoN>`.

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -11,6 +11,7 @@ from scipy.sparse import issparse
 
 from sklearn.base import OutlierMixin, _fit_context
 from sklearn.ensemble._bagging import BaseBagging
+from sklearn.ensemble._bootstrap import _get_n_samples_bootstrap
 from sklearn.tree import ExtraTreeRegressor
 from sklearn.utils import check_array, check_random_state, gen_batches
 from sklearn.utils._chunking import get_chunk_n_rows
@@ -350,7 +351,11 @@ class IsolationForest(OutlierMixin, BaseBagging):
             else:
                 max_samples = self.max_samples
         else:  # max_samples is float
-            max_samples = int(self.max_samples * X.shape[0])
+            max_samples = _get_n_samples_bootstrap(
+                n_samples=X.shape[0],
+                max_samples=self.max_samples,
+                sample_weight=None,
+            )
 
         self.max_samples_ = max_samples
         max_depth = int(np.ceil(np.log2(max(max_samples, 2))))

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -95,6 +95,16 @@ def test_iforest_error():
         IsolationForest().fit(X).predict(X[:, 1:])
 
 
+def test_max_samples_small_float_floors_to_one():
+    # A small float `max_samples` must floor the drawn sample count to 1 and
+    # warn, like BaggingClassifier, instead of truncating to 0 and raising a
+    # confusing "Sample weights must contain at least one non-zero number."
+    X = np.random.RandomState(0).randn(100, 3)
+    with pytest.warns(UserWarning, match="low number"):
+        clf = IsolationForest(max_samples=0.005, random_state=0).fit(X)
+    assert clf.max_samples_ == 1
+
+
 def test_recalculate_max_depth():
     """Check max_depth recalculation when max_samples is reset to n_samples"""
     X = iris.data


### PR DESCRIPTION
#### Reference Issues/PRs

None found in a search of open/closed issues and PRs.

#### What does this implement/fix?

`IsolationForest(max_samples=<small float>)` truncates to `max_samples=0` and crashes with a misleading, unrelated error, even though a float in `(0, 1]` is documented and validated as legal input. The sibling `BaggingClassifier`/`BaggingRegressor` handle the same case by flooring to 1 and warning.

Repro:

```python
from sklearn.ensemble import IsolationForest
import numpy as np

X = np.random.RandomState(0).randn(100, 3)
IsolationForest(max_samples=0.005, random_state=0).fit(X)
# ValueError: Sample weights must contain at least one non-zero number.
```

`IsolationForest._fit` reimplements the float-to-count conversion inline (`int(self.max_samples * X.shape[0])`), dropping the `max(..., 1)` floor and the low-sample warning that `sklearn.ensemble._bootstrap._get_n_samples_bootstrap` already provides (and that `BaggingClassifier` uses). This delegates to that helper, so a small fraction floors to 1 and emits the same warning, matching the Bagging estimators:

```python
BaggingClassifier(max_samples=0.005)  # warns and fits
IsolationForest(max_samples=0.005)    # now warns and fits too
```

`sample_weight=None` is passed so the drawn count stays relative to `n_samples`, preserving the previous (unweighted) semantics while adding the floor and the warning.

Added a non-regression test.
