### PR TITLE
MNT Use triage bot token in CUDA update-lock-file workflow

### DIFF
--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Trigger additional tests
         if: steps.cpr.outputs.pull-request-number != '' && matrix.name == 'array-api'
         env:
-          GH_TOKEN: ${{ secrets.SKLEARN_CI_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.TRIAGE_BOT_GITHUB_TOKEN }}
           PR_NUMBER: ${{steps.cpr.outputs.pull-request-number}}
         run: |
           curl -L \

--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Trigger additional tests
         if: steps.cpr.outputs.pull-request-number != '' && matrix.name == 'array-api'
         env:
-          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SKLEARN_CI_GITHUB_TOKEN }}
           PR_NUMBER: ${{steps.cpr.outputs.pull-request-number}}
         run: |
           curl -L \


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Maintainers can see: https://github.com/scikit-learn/scikit-learn/security/advisories/GHSA-874x-968x-x9wp

#### What does this implement/fix? Explain your changes.
We need to add a bot with Triage role only, in order to set CUDA CI label

#### Any other comments?
@lesteve 

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
