### PR TITLE
FIX force -O3 on hot-loop Cython extensions regardless of CFLAGS

### DIFF
--- a/doc/whats_new/upcoming_changes/many-modules/34864.efficiency.rst
+++ b/doc/whats_new/upcoming_changes/many-modules/34864.efficiency.rst
@@ -1,0 +1,9 @@
+- Cython extensions in :mod:`sklearn.tree`, :mod:`sklearn.ensemble` (histogram
+  gradient boosting) and :mod:`sklearn.metrics` (pairwise distances reduction)
+  are now reliably compiled with `-O3`, fixing a build configuration issue
+  where distributions injecting their own optimization flags (e.g.
+  conda-forge's default `-O2`) would silently override scikit-learn's
+  intended optimization level for these performance-critical, branch-heavy
+  loops, most noticeably affecting :class:`ensemble.ExtraTreesClassifier` and
+  :class:`ensemble.ExtraTreesRegressor`.
+  By :user:`Arthur Lacote <cakedev0>`.

--- a/sklearn/ensemble/_hist_gradient_boosting/meson.build
+++ b/sklearn/ensemble/_hist_gradient_boosting/meson.build
@@ -20,6 +20,14 @@ foreach ext_name, ext_dict : hist_gradient_boosting_extension_metadata
     ext_name,
     [ext_dict.get('sources'), hist_gradient_boosting_cython_tree],
     dependencies: ext_dict.get('dependencies', []),
+    override_options : ['optimization=3'],
+    # See sklearn/tree/meson.build for why c_args is needed on top of
+    # override_options: environments such as conda-forge inject their own
+    # `-O2` through CFLAGS, which is appended after Meson's optimization
+    # flag and silently wins. c_args is added after environment flags, so
+    # it is what actually guarantees -O3 for these histogram/splitting hot
+    # loops. See https://github.com/mesonbuild/meson/issues/15055.
+    c_args: ['-O3'],
     subdir: 'sklearn/ensemble/_hist_gradient_boosting',
     install: true
   )

--- a/sklearn/metrics/_pairwise_distances_reduction/meson.build
+++ b/sklearn/metrics/_pairwise_distances_reduction/meson.build
@@ -40,6 +40,13 @@ _datasets_pair = py.extension_module(
   '_datasets_pair',
   cython_gen_cpp.process(_datasets_pair_pyx),
   dependencies: [np_dep],
+  # Force -O3 regardless of the build environment: distributions such as
+  # conda-forge inject their own `-O2` through CXXFLAGS, which is appended
+  # after Meson's own optimization flag and silently wins (GCC/Clang use
+  # the last -O flag on the command line). cpp_args is added after
+  # environment flags by Meson, so this is what actually guarantees -O3
+  # for these hot loops. See https://github.com/mesonbuild/meson/issues/15055.
+  cpp_args: ['-O3'],
   subdir: 'sklearn/metrics/_pairwise_distances_reduction',
   install: true
 )
@@ -65,6 +72,8 @@ _base = py.extension_module(
   '_base',
   cython_gen_cpp.process(_base_pyx),
   dependencies: [np_dep, openmp_dep],
+  # See _datasets_pair above for why this is needed.
+  cpp_args: ['-O3'],
   subdir: 'sklearn/metrics/_pairwise_distances_reduction',
   install: true
 )
@@ -91,6 +100,8 @@ _middle_term_computer = py.extension_module(
   '_middle_term_computer',
   cython_gen_cpp.process(_middle_term_computer_pyx),
   dependencies: [np_dep],
+  # See _datasets_pair above for why this is needed.
+  cpp_args: ['-O3'],
   subdir: 'sklearn/metrics/_pairwise_distances_reduction',
   install: true
 )
@@ -117,6 +128,8 @@ _argkmin = py.extension_module(
     '_argkmin',
     cython_gen_cpp.process(_argkmin_pyx),
     dependencies: [np_dep, openmp_dep],
+    # See _datasets_pair above for why this is needed.
+    cpp_args: ['-O3'],
     subdir: 'sklearn/metrics/_pairwise_distances_reduction',
     install: true
 )
@@ -143,6 +156,8 @@ _radius_neighbors = py.extension_module(
     '_radius_neighbors',
     cython_gen_cpp.process(_radius_neighbors_pyx),
     dependencies: [np_dep, openmp_dep],
+    # See _datasets_pair above for why this is needed.
+    cpp_args: ['-O3'],
     subdir: 'sklearn/metrics/_pairwise_distances_reduction',
     install: true
 )
@@ -166,7 +181,8 @@ _argkmin_classmode = py.extension_module(
   # XXX: for some reason -fno-sized-deallocation is needed otherwise there is
   # an error with undefined symbol _ZdlPv at import time in manylinux wheels.
   # See https://github.com/scikit-learn/scikit-learn/issues/28596 for more details.
-  cpp_args: ['-fno-sized-deallocation'],
+  # -O3 is added on top for the same reason as _datasets_pair above.
+  cpp_args: ['-fno-sized-deallocation', '-O3'],
   subdir: 'sklearn/metrics/_pairwise_distances_reduction',
   install: true
 )
@@ -188,6 +204,8 @@ _radius_neighbors_classmode = py.extension_module(
   '_radius_neighbors_classmode',
   cython_gen_cpp.process(_radius_neighbors_classmode_pyx),
   dependencies: [np_dep, openmp_dep],
+  # See _datasets_pair above for why this is needed.
+  cpp_args: ['-O3'],
   subdir: 'sklearn/metrics/_pairwise_distances_reduction',
   install: true
 )

--- a/sklearn/metrics/_pairwise_distances_reduction/meson.build
+++ b/sklearn/metrics/_pairwise_distances_reduction/meson.build
@@ -72,7 +72,6 @@ _base = py.extension_module(
   '_base',
   cython_gen_cpp.process(_base_pyx),
   dependencies: [np_dep, openmp_dep],
-  # See _datasets_pair above for why this is needed.
   cpp_args: ['-O3'],
   subdir: 'sklearn/metrics/_pairwise_distances_reduction',
   install: true
@@ -100,7 +99,6 @@ _middle_term_computer = py.extension_module(
   '_middle_term_computer',
   cython_gen_cpp.process(_middle_term_computer_pyx),
   dependencies: [np_dep],
-  # See _datasets_pair above for why this is needed.
   cpp_args: ['-O3'],
   subdir: 'sklearn/metrics/_pairwise_distances_reduction',
   install: true
@@ -128,7 +126,6 @@ _argkmin = py.extension_module(
     '_argkmin',
     cython_gen_cpp.process(_argkmin_pyx),
     dependencies: [np_dep, openmp_dep],
-    # See _datasets_pair above for why this is needed.
     cpp_args: ['-O3'],
     subdir: 'sklearn/metrics/_pairwise_distances_reduction',
     install: true
@@ -156,7 +153,6 @@ _radius_neighbors = py.extension_module(
     '_radius_neighbors',
     cython_gen_cpp.process(_radius_neighbors_pyx),
     dependencies: [np_dep, openmp_dep],
-    # See _datasets_pair above for why this is needed.
     cpp_args: ['-O3'],
     subdir: 'sklearn/metrics/_pairwise_distances_reduction',
     install: true
@@ -181,7 +177,6 @@ _argkmin_classmode = py.extension_module(
   # XXX: for some reason -fno-sized-deallocation is needed otherwise there is
   # an error with undefined symbol _ZdlPv at import time in manylinux wheels.
   # See https://github.com/scikit-learn/scikit-learn/issues/28596 for more details.
-  # -O3 is added on top for the same reason as _datasets_pair above.
   cpp_args: ['-fno-sized-deallocation', '-O3'],
   subdir: 'sklearn/metrics/_pairwise_distances_reduction',
   install: true
@@ -204,7 +199,6 @@ _radius_neighbors_classmode = py.extension_module(
   '_radius_neighbors_classmode',
   cython_gen_cpp.process(_radius_neighbors_classmode_pyx),
   dependencies: [np_dep, openmp_dep],
-  # See _datasets_pair above for why this is needed.
   cpp_args: ['-O3'],
   subdir: 'sklearn/metrics/_pairwise_distances_reduction',
   install: true

--- a/sklearn/tree/meson.build
+++ b/sklearn/tree/meson.build
@@ -22,6 +22,15 @@ foreach ext_name, ext_dict : tree_extension_metadata
     [ext_dict.get('sources'), utils_cython_tree],
     dependencies: [np_dep],
     override_options : ext_dict.get('override_options', []),
+    # `override_options` above is not enough: distributions such as
+    # conda-forge inject their own `-O2` through CFLAGS/CXXFLAGS, which is
+    # appended after Meson's own optimization flag on the compiler command
+    # line, so it silently wins (GCC/Clang use the last -O flag). Per-target
+    # c_args/cpp_args are added after environment flags by Meson, so this is
+    # what actually guarantees -O3 for these hot loops regardless of the
+    # build environment. See https://github.com/mesonbuild/meson/issues/15055.
+    c_args: ['-O3'],
+    cpp_args: ['-O3'],
     subdir: 'sklearn/tree',
     install: true
   )


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #34865

#### What does this implement/fix? Explain your changes.

Meson's per-target `c_args`/`cpp_args` kwargs are appended after environment flags and are documented to override everything else, so this switches from `override_options` to `c_args`/`cpp_args: ['-O3']`, which actually guarantees `-O3` regardless of the build environment (including conda-forge recipe)

Applied to `sklearn.tree` (keeping `override_options` alongside, for Meson's own introspection), `sklearn.ensemble._hist_gradient_boosting` (histogram/splitting are the same kind of branch-heavy tight loop as tree's splitter), and `sklearn.metrics._pairwise_distances_reduction` (already flagged in-file as one of the most involved modules in the codebase, heavily loop-bound C++ code).
Scope is limited to these three families rather than every extension, since they're the ones already treated as performance-critical / directly analogous to the reported issue, but maybe we could extend further?

No-op for anyone not injecting their own optimization flags via `CFLAGS`/`CXXFLAGS` (PyPI wheels, plain source builds): `-O3 ... -O3` is redundant but harmless.

#### AI usage disclosure

I used AI assistance for everything, except noticing the initial slowdown of the build pulled from conda-forge.

