### PR TITLE
FIX sparse convergence check in _bistochastic_normalize

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.cluster/34871.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.cluster/34871.fix.rst
@@ -1,0 +1,7 @@
+- :class:`cluster.SpectralBiclustering` with `method="bistochastic"` now returns the
+  same result for sparse and dense input. The convergence check of the underlying
+  bistochastic normalization compared the current iterate against the original
+  input rather than against the newly scaled matrix, so for sparse input the
+  distance was zero on the first pass and the loop always stopped after a single
+  scaling pass.
+  By :user:`Dylan Pulver <dylanpulver>`.

--- a/sklearn/cluster/_bicluster.py
+++ b/sklearn/cluster/_bicluster.py
@@ -54,11 +54,13 @@ def _bistochastic_normalize(X, max_iter=1000, tol=1e-5):
     for _ in range(max_iter):
         X_new, _, _ = _scale_normalize(X_scaled)
         if issparse(X):
-            dist = norm(X_scaled.data - X.data)
+            # X_new has the same sparsity pattern as X_scaled, so the
+            # difference of the data arrays is the change in this iteration
+            dist = norm(X_scaled.data - X_new.data)
         else:
             dist = norm(X_scaled - X_new)
         X_scaled = X_new
-        if dist is not None and dist < tol:
+        if dist < tol:
             break
     return X_scaled
 

--- a/sklearn/cluster/tests/test_bicluster.py
+++ b/sklearn/cluster/tests/test_bicluster.py
@@ -15,6 +15,7 @@ from sklearn.datasets import make_biclusters, make_checkerboard
 from sklearn.metrics import consensus_score, v_measure_score
 from sklearn.model_selection import ParameterGrid
 from sklearn.utils._testing import (
+    assert_allclose,
     assert_almost_equal,
     assert_array_almost_equal,
     assert_array_equal,
@@ -169,6 +170,28 @@ def test_bistochastic_normalize(global_random_seed, csr_container):
         _do_bistochastic_test(scaled)
         if issparse(mat):
             assert issparse(scaled)
+
+
+@pytest.mark.parametrize("csr_container", CSR_CONTAINERS)
+def test_bistochastic_normalize_sparse_matches_dense(global_random_seed, csr_container):
+    # non-regression: the sparse convergence check compared the current
+    # iterate against the original input rather than against the new one, so
+    # it stopped after a single scaling pass and the result was not
+    # bistochastic.
+    generator = np.random.RandomState(global_random_seed)
+    X = generator.rand(60, 40) + 0.1
+
+    dense = _bistochastic_normalize(X)
+    sparse = _bistochastic_normalize(csr_container(X)).toarray()
+    assert_allclose(sparse, dense, atol=1e-12)
+
+    # every row sums to one constant and every column to another; checking
+    # the spread rather than the mean, which a single scaling pass already
+    # gets right
+    row_sums = sparse.sum(axis=1)
+    col_sums = sparse.sum(axis=0)
+    assert row_sums.max() - row_sums.min() < 1e-3
+    assert col_sums.max() - col_sums.min() < 1e-3
 
 
 def test_log_normalize(global_random_seed):


### PR DESCRIPTION
#### Reference Issues/PRs

None — found by audit, no existing issue.

#### What does this implement/fix? Explain your changes.

In `_bistochastic_normalize` the sparse convergence check compares the current iterate against the **original input** instead of against the newly scaled matrix:

```python
X_scaled = X
for _ in range(max_iter):
    X_new, _, _ = _scale_normalize(X_scaled)
    if issparse(X):
        dist = norm(X_scaled.data - X.data)   # X_scaled *is* X on the first pass
    else:
        dist = norm(X_scaled - X_new)
```

On the first pass `X_scaled is X`, so `dist` is exactly `0.0` and the loop always breaks after one scaling pass. Sparse input never gets the iterative normalization the function exists to perform.

Measured on `main`, 60x50, `tol=1e-5`: the sparse result has row-sum spread `2.3e-01` and column-sum spread `2.7e-01` against `2.0e-05` / `3.3e-05` dense. `SpectralBiclustering(method="bistochastic")` gives different row/column labels for dense vs CSR input on **40 of 60** checkerboard and random matrices. With this change the two agree to `5.6e-17` and 0 of 60 differ.

- **The sparse branch is load-bearing.** The obvious simplification — drop the branch and use `norm(X_scaled - X_new)` for both — *fails*: `scipy.linalg.norm` on a sparse operand raises `ValueError: matmul: dimension mismatch`, and it breaks 4 tests in `test_bicluster.py`. So the fix stays inside `issparse` and compares `.data`, which is valid because diagonal scaling preserves the sparsity pattern. I also checked a matrix with an all-zero row (where `row_diag` becomes 0) — pattern still matches, no length mismatch.
- **Why CI was green for 12 years.** `test_bistochastic_normalize` never compares the dense and sparse results against each other. All 21 existing tests pass on unmodified `main`. The added test fails on `main` and passes here.
- `git log -S` puts the expression in 268b7ee29 (2013), which added the sparse branch next to the already-correct dense line. The `dist is not None` guard has been dead since 5af272ac6 removed the `dist = None` initializer in 2018, so I dropped it.

Ran: `pytest sklearn/cluster` → 726 passed, 99 skipped.

#### Introduce yourself

I'm not a regular scikit-learn user and did not hit this in an analysis. I found it by auditing functions where a dense and a sparse code path are meant to compute the same quantity, on the theory that usually only one of the two gets updated. Please weigh it accordingly.

#### AI usage disclosure

I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Research and understanding

Tool: Claude Code, model Claude Opus 5 (`claude-opus-5`).

> This pull request includes code written with the assistance of AI.
> The code has **not yet been reviewed** by a human.
