### PR TITLE
FIX restore UnionFind path compression in single-linkage clustering

### DIFF
--- a/asv_benchmarks/benchmarks/cluster.py
+++ b/asv_benchmarks/benchmarks/cluster.py
@@ -1,8 +1,35 @@
+import numpy as np
+from sklearn.cluster._hierarchical_fast import _single_linkage_label
+
 from sklearn.cluster import KMeans, MiniBatchKMeans
 
 from .common import Benchmark, Estimator, Predictor, Transformer
 from .datasets import _20newsgroups_highdim_dataset, _blobs_dataset
 from .utils import neg_mean_inertia
+
+
+class SingleLinkageLabelBenchmark(Benchmark):
+    """Benchmark conversion of an adversarial MST to single linkage."""
+
+    param_names = ["n_samples"]
+    params = ([2_000, 16_000],)
+
+    def setup(self, n_samples):
+        half_n_samples = n_samples // 2
+        self.mst = np.empty((n_samples - 1, 3), dtype=np.float64)
+
+        indices = np.arange(half_n_samples - 1)
+        self.mst[: half_n_samples - 1, 0] = indices
+        self.mst[: half_n_samples - 1, 1] = indices + 1
+
+        indices = np.arange(half_n_samples)
+        self.mst[half_n_samples - 1 :, 0] = indices
+        self.mst[half_n_samples - 1 :, 1] = half_n_samples + indices
+
+        self.mst[:, 2] = np.arange(n_samples - 1)
+
+    def time_single_linkage_label(self, n_samples):
+        _single_linkage_label(self.mst)
 
 
 class KMeansBenchmark(Predictor, Transformer, Estimator, Benchmark):

--- a/doc/whats_new/upcoming_changes/sklearn.cluster/34626.efficiency.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.cluster/34626.efficiency.rst
@@ -1,0 +1,4 @@
+- Single-linkage clustering (including :class:`cluster.AgglomerativeClustering`
+  with ``linkage="single"`` and HDBSCAN) is now faster on large datasets by
+  restoring path compression in the internal ``UnionFind`` structure.
+  By :user:`Shamik Basu <ShamikOfficial>`.

--- a/sklearn/cluster/_hierarchical_fast.pyx
+++ b/sklearn/cluster/_hierarchical_fast.pyx
@@ -336,17 +336,34 @@ cdef class UnionFind(object):
         self.next_label += 1
         return
 
-    @cython.wraparound(True)
     cdef intp_t fast_find(self, intp_t n) noexcept:
-        cdef intp_t p
-        p = n
+        cdef intp_t root = n
+        cdef intp_t next_parent
+
         # find the highest node in the linkage graph so far
-        while self.parent[n] != -1:
-            n = self.parent[n]
-        # provide a shortcut up to the highest node
-        while self.parent[p] != n:
-            p, self.parent[p] = self.parent[p], n
-        return n
+        while self.parent[root] != -1:
+            root = self.parent[root]
+        # compress the path to the highest node
+        while n != root and self.parent[n] != root:
+            next_parent = self.parent[n]
+            self.parent[n] = root
+            n = next_parent
+        return root
+
+
+cdef class PytestUnionFind(UnionFind):
+    """Used for testing only."""
+
+    def py_union(self, intp_t m, intp_t n):
+        cdef intp_t new_label = self.next_label
+        self.union(m, n)
+        return new_label
+
+    def py_fast_find(self, intp_t n):
+        return self.fast_find(n)
+
+    def py_get_parent(self):
+        return np.asarray(self.parent).copy()
 
 
 def _single_linkage_label(const float64_t[:, :] L):

--- a/sklearn/cluster/tests/test_hierarchical.py
+++ b/sklearn/cluster/tests/test_hierarchical.py
@@ -24,6 +24,7 @@ from sklearn.cluster._agglomerative import (
     linkage_tree,
 )
 from sklearn.cluster._hierarchical_fast import (
+    PytestUnionFind,
     average_merge,
     max_merge,
     mst_linkage_core,
@@ -385,6 +386,36 @@ def test_vector_scikit_single_vs_scipy_single(global_random_seed):
     cut = _hc_cut(n_clusters, children, n_leaves)
     cut_scipy = _hc_cut(n_clusters, children_scipy, n_leaves)
     assess_same_labelling(cut, cut_scipy)
+
+
+def test_union_find_fast_find_compresses_path():
+    """Check that fast_find compresses the queried path to its root."""
+    union_find = PytestUnionFind(5)
+
+    node_5 = union_find.py_union(0, 1)
+    node_6 = union_find.py_union(node_5, 2)
+    root = union_find.py_union(node_6, 3)
+
+    assert union_find.py_fast_find(0) == root
+
+    parent = union_find.py_get_parent()
+    assert_array_equal(
+        parent[[0, node_5, node_6]],
+        np.full(3, root, dtype=np.intp),
+    )
+    assert parent[root] == -1
+
+
+def test_union_find_fast_find_on_root_is_noop():
+    """Check that fast_find does not mutate state when called on a root.
+
+    Non-regression test for issue #34626.
+    """
+    union_find = PytestUnionFind(3)
+    parent_before = union_find.py_get_parent()
+
+    assert union_find.py_fast_find(0) == 0
+    assert_array_equal(union_find.py_get_parent(), parent_before)
 
 
 @pytest.mark.parametrize("metric_param_grid", METRICS_DEFAULT_PARAMS)


### PR DESCRIPTION
## What

`UnionFind.fast_find` in `_hierarchical_fast.pyx` was supposed to do path compression, but the Cython tuple assignment on the compression loop doesn't actually update `self.parent[p]` — it just rebinds a local variable. On adversarial MST inputs this degrades single-linkage to roughly O(n²) instead of the expected near-linear behavior.

This affects `AgglomerativeClustering(linkage="single")`, HDBSCAN, and anything else that goes through `_single_linkage_label`.

## Fix

Replaced the broken loop with an explicit two-pass compression (find root, then walk back and point nodes directly at the root). Also removed `@cython.wraparound(True)` from `fast_find` since negative indexing isn't used there.

## Tests

- `test_union_find_fast_find_compresses_path` — verifies parent pointers get flattened after a find
- `test_union_find_fast_find_on_root_is_noop` — calling find on a root shouldn't mutate the structure
- Added an ASV benchmark with the adversarial MST from the issue

Fixes #34626
