### PR TITLE
FIX prevent overflow in StandardScaler.partial_fit for large values

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.preprocessing/34874.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.preprocessing/34874.fix.rst
@@ -1,4 +1,4 @@
-- :func:`preprocessing.StandardScaler.partial_fit` no longer overflows when
+- :meth:`preprocessing.StandardScaler.partial_fit` no longer overflows when
   the accumulated sum exceeds the float64 range for features with large values
   or long streams, by falling back to a delta-based update (Chan, Golub &
   LeVeque 1979) where the sum-based result is not finite.

--- a/doc/whats_new/upcoming_changes/sklearn.preprocessing/5602.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.preprocessing/5602.fix.rst
@@ -1,0 +1,5 @@
+- :func:`preprocessing.StandardScaler.partial_fit` no longer overflows when
+  the accumulated sum exceeds the float64 range for features with large values
+  or long streams, by falling back to a delta-based update (Chan, Golub &
+  LeVeque 1979) where the sum-based result is not finite.
+  By :user:`Shamik Basu <ShamikOfficial>`.

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -95,7 +95,12 @@ def _is_constant_feature(var, mean, n_samples):
     max_float_dtype = _max_precision_float_dtype(xp=xp, device=device)
     eps = xp.finfo(max_float_dtype).eps
 
-    upper_bound = n_samples * eps * var + (n_samples * mean * eps) ** 2
+    # The upper bound can overflow to inf for very large means. The
+    # comparison below remains meaningful: no finite variance can exceed an
+    # infinite bound and such a feature is indeed indistinguishable from a
+    # constant feature.
+    with np.errstate(over="ignore"):
+        upper_bound = n_samples * eps * var + (n_samples * mean * eps) ** 2
     return var <= upper_bound
 
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -681,6 +681,24 @@ def test_standard_scaler_partial_fit_numerical_stability(sparse_container):
     assert_allclose(scaler_incr.scale_, scaler.scale_, rtol=tol)
 
 
+def test_standard_scaler_partial_fit_large_values_no_overflow():
+    # Non-regression test for gh-5602: repeated calls to partial_fit on data
+    # with a large mean used to overflow the accumulated sum, turning the
+    # fitted statistics into inf or nan. A power of two keeps the expected
+    # statistics exactly representable.
+    big = 2.0**1020
+    X = np.full((10, 2), big)
+
+    scaler = StandardScaler()
+    with np.errstate(over="raise", invalid="raise"):
+        for _ in range(100):
+            scaler.partial_fit(X)
+
+    assert_allclose(scaler.mean_, [big, big])
+    assert_allclose(scaler.var_, [0.0, 0.0])
+    assert scaler.n_samples_seen_ == 1000
+
+
 @pytest.mark.parametrize("sample_weight", [True, None])
 @pytest.mark.parametrize("sparse_container", CSC_CONTAINERS + CSR_CONTAINERS)
 def test_partial_fit_sparse_input(sample_weight, sparse_container):

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -1179,7 +1179,6 @@ def _incremental_mean_and_var(
     last_sample_count = xp.asarray(
         last_sample_count, dtype=max_float_dtype, device=X_device
     )
-    last_sum = last_mean * last_sample_count
     X_nan_mask = xp.isnan(X)
     if xp.any(X_nan_mask):
         sum_op = xpx.nansum
@@ -1207,13 +1206,38 @@ def _incremental_mean_and_var(
 
     updated_sample_count = last_sample_count + new_sample_count
 
-    updated_mean = (last_sum + new_sum) / updated_sample_count
+    # There is no errstate equivalent for warning/error management in array API
+    if _is_numpy_namespace(xp):
+        context_manager = partial(
+            np.errstate, divide="ignore", invalid="ignore", over="ignore"
+        )
+    else:
+        context_manager = nullcontext
+
+    with context_manager():
+        new_mean = new_sum / new_sample_count
+    # new_sample_count is 0 for features holding only NaN values in this
+    # batch: mask their meaningless batch mean so that the fallback updates
+    # below stay free of spurious non-finite values.
+    new_mean = xp.where(new_sample_count == 0, xp.zeros_like(new_mean), new_mean)
+    delta_mean = new_mean - last_mean
+
+    # The mean update based on the accumulated sum is the most accurate, but
+    # the sum of a long stream (or of very large values) can exceed the
+    # floating point range while the mean cannot, as it is bounded by the
+    # largest absolute value observed. Where the accumulated sum overflows,
+    # fall back to an algebraically equivalent update expressed with the
+    # bounded batch means, following Chan et al.
+    with context_manager():
+        last_sum = last_mean * last_sample_count
+        sum_mean = (last_sum + new_sum) / updated_sample_count
+        shift_mean = last_mean + delta_mean * (new_sample_count / updated_sample_count)
+    updated_mean = xp.where(xp.isfinite(sum_mean), sum_mean, shift_mean)
 
     if last_variance is None:
         updated_variance = None
     else:
-        T = new_sum / new_sample_count
-        temp = X - T
+        temp = X - new_mean
         if sample_weight is not None:
             # equivalent to np.nansum((X-T)**2 * sample_weight, axis=0)
             # safer because np.float64(X*W) != np.float64(X)*np.float64(W)
@@ -1240,23 +1264,36 @@ def _incremental_mean_and_var(
 
         last_unnormalized_variance = last_variance * last_sample_count
 
-        # There is no errstate equivalent for warning/error management in array API
-        context_manager = (
-            np.errstate(divide="ignore", invalid="ignore")
-            if _is_numpy_namespace(xp)
-            else nullcontext()
-        )
-        with context_manager:
+        zeros = last_sample_count == 0
+        with context_manager():
+            # Correction term of the corrected 2 pass algorithm of Chan et
+            # al. in its most accurate form, based on the accumulated sum.
             last_over_new_count = last_sample_count / new_sample_count
-            updated_unnormalized_variance = (
-                last_unnormalized_variance
-                + new_unnormalized_variance
-                + last_over_new_count
+            sum_correction_term = (
+                last_over_new_count
                 / updated_sample_count
                 * (last_sum / last_over_new_count - new_sum) ** 2
             )
+            # The same term expressed with the bounded batch means, used as
+            # a fallback where the accumulated sum overflows (see the mean
+            # update above). delta_mean is masked where last_sample_count
+            # is 0: the term is 0 there but squaring an unmasked delta_mean
+            # could overflow.
+            delta_var = xp.where(zeros, xp.zeros_like(delta_mean), delta_mean)
+            shift_correction_term = (
+                delta_var**2
+                * last_sample_count
+                * (new_sample_count / updated_sample_count)
+            )
+            correction_term = xp.where(
+                xp.isfinite(sum_correction_term),
+                sum_correction_term,
+                shift_correction_term,
+            )
+            updated_unnormalized_variance = (
+                last_unnormalized_variance + new_unnormalized_variance + correction_term
+            )
 
-        zeros = last_sample_count == 0
         updated_unnormalized_variance[zeros] = new_unnormalized_variance[zeros]
         updated_variance = updated_unnormalized_variance / updated_sample_count
 

--- a/sklearn/utils/tests/test_extmath.py
+++ b/sklearn/utils/tests/test_extmath.py
@@ -945,6 +945,28 @@ def test_incremental_variance_numerical_stability():
     assert tol > np.abs(np_var(A) - var).max()
 
 
+@pytest.mark.parametrize("sample_weight", [None, np.ones(10)])
+def test_incremental_mean_and_var_no_overflow(sample_weight):
+    # Non-regression test for gh-5602: the accumulated sum of a long stream
+    # of large values used to exceed the floating point range, returning
+    # inf or nan statistics even though the mean and the variance of the
+    # stream are representable. Using a power of two makes the expected
+    # statistics exactly representable.
+    big = 2.0**1020
+    X = np.full((10, 2), big)
+
+    mean, var, count = np.zeros(2), np.zeros(2), np.zeros(2)
+    with np.errstate(over="raise", invalid="raise"):
+        for _ in range(100):
+            mean, var, count = _incremental_mean_and_var(
+                X, mean, var, count, sample_weight=sample_weight
+            )
+
+    assert_allclose(mean, np.full(2, big))
+    assert_allclose(var, np.zeros(2))
+    assert_array_equal(count, np.full(2, 1000))
+
+
 def test_incremental_variance_ddof():
     # Test that degrees of freedom parameter for calculations are correct.
     rng = np.random.RandomState(1999)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #5602.

#### What does this implement/fix? Explain your changes.

`_incremental_mean_and_var` updates running statistics with
`last_sum = last_mean * last_sample_count`. For features with very large
values or long incremental streams, that product can overflow to `inf`,
which then poisons the mean and variance used by
`StandardScaler.partial_fit`.

This keeps the sum-based update as the primary path (more accurate in the
normal case), but falls back to an algebraically equivalent delta-based
update from Chan, Golub & LeVeque (1979) whenever the sum-based result is
not finite. The same idea is applied to the variance correction term.

Constant-feature detection also wraps its upper-bound check in
`np.errstate(over="ignore")` so it does not spuriously warn when the
mean itself is huge.

#### Introduce yourself

I use scikit-learn for applied ML and numerical/data pipelines. I picked
#5602 because it is a long-standing numerical correctness bug in a
widely used estimator, with a clear overflow mechanism and a standard
fallback algorithm.

This is among my first scikit-learn pull requests.

#### AI usage disclosure

I used AI assistance for:
- Research and understanding
- Test/benchmark generation
- Drafting parts of the implementation

I reviewed, ran, and understand all of the changes in this PR.

#### Any other comments?

- Changelog fragment is named `34874.fix.rst` (PR number).
- Local coverage includes overflow regression tests for
  `_incremental_mean_and_var` and end-to-end `StandardScaler.partial_fit`.