### PR TITLE
DOC Clarify sample_weight semantics in forest split criteria

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -1245,7 +1245,9 @@ class RandomForestClassifier(ForestClassifier):
     min_weight_fraction_leaf : float, default=0.0
         The minimum weighted fraction of the sum total of weights (of all
         the input samples) required to be at a leaf node. Samples have
-        equal weight when sample_weight is not provided.
+        equal weight when sample_weight is not provided. If ``bootstrap=True``,
+        the weights are those of the bootstrap sample of each tree, i.e. the
+        number of times each sample was drawn, rather than ``sample_weight``.
 
     max_features : {"sqrt", "log2", None}, int or float, default="sqrt"
         The number of features to consider when looking for the best split:
@@ -1284,9 +1286,16 @@ class RandomForestClassifier(ForestClassifier):
         left child, and ``N_t_R`` is the number of samples in the right child.
 
         ``N``, ``N_t``, ``N_t_R`` and ``N_t_L`` all refer to the weighted sum,
-        if ``sample_weight`` is passed.
+        if ``sample_weight`` is passed and ``bootstrap=False``. If
+        ``bootstrap=True``, ``sample_weight`` is instead used to draw the
+        bootstrap sample of each tree, and these quantities refer to the number
+        of times each sample was drawn for that tree.
 
         .. versionadded:: 0.19
+
+        .. versionchanged:: 1.9
+            When ``bootstrap=True``, ``sample_weight`` is used for the weighted
+            bootstrap instead of being passed to the underlying tree.
 
     bootstrap : bool, default=True
         Whether bootstrap samples are used when building trees. If False, the
@@ -1660,7 +1669,9 @@ class RandomForestRegressor(ForestRegressor):
     min_weight_fraction_leaf : float, default=0.0
         The minimum weighted fraction of the sum total of weights (of all
         the input samples) required to be at a leaf node. Samples have
-        equal weight when sample_weight is not provided.
+        equal weight when sample_weight is not provided. If ``bootstrap=True``,
+        the weights are those of the bootstrap sample of each tree, i.e. the
+        number of times each sample was drawn, rather than ``sample_weight``.
 
     max_features : {"sqrt", "log2", None}, int or float, default=1.0
         The number of features to consider when looking for the best split:
@@ -1703,9 +1714,16 @@ class RandomForestRegressor(ForestRegressor):
         left child, and ``N_t_R`` is the number of samples in the right child.
 
         ``N``, ``N_t``, ``N_t_R`` and ``N_t_L`` all refer to the weighted sum,
-        if ``sample_weight`` is passed.
+        if ``sample_weight`` is passed and ``bootstrap=False``. If
+        ``bootstrap=True``, ``sample_weight`` is instead used to draw the
+        bootstrap sample of each tree, and these quantities refer to the number
+        of times each sample was drawn for that tree.
 
         .. versionadded:: 0.19
+
+        .. versionchanged:: 1.9
+            When ``bootstrap=True``, ``sample_weight`` is used for the weighted
+            bootstrap instead of being passed to the underlying tree.
 
     bootstrap : bool, default=True
         Whether bootstrap samples are used when building trees. If False, the
@@ -2028,7 +2046,9 @@ class ExtraTreesClassifier(ForestClassifier):
     min_weight_fraction_leaf : float, default=0.0
         The minimum weighted fraction of the sum total of weights (of all
         the input samples) required to be at a leaf node. Samples have
-        equal weight when sample_weight is not provided.
+        equal weight when sample_weight is not provided. If ``bootstrap=True``,
+        the weights are those of the bootstrap sample of each tree, i.e. the
+        number of times each sample was drawn, rather than ``sample_weight``.
 
     max_features : {"sqrt", "log2", None}, int or float, default="sqrt"
         The number of features to consider when looking for the best split:
@@ -2067,9 +2087,16 @@ class ExtraTreesClassifier(ForestClassifier):
         left child, and ``N_t_R`` is the number of samples in the right child.
 
         ``N``, ``N_t``, ``N_t_R`` and ``N_t_L`` all refer to the weighted sum,
-        if ``sample_weight`` is passed.
+        if ``sample_weight`` is passed and ``bootstrap=False``. If
+        ``bootstrap=True``, ``sample_weight`` is instead used to draw the
+        bootstrap sample of each tree, and these quantities refer to the number
+        of times each sample was drawn for that tree.
 
         .. versionadded:: 0.19
+
+        .. versionchanged:: 1.9
+            When ``bootstrap=True``, ``sample_weight`` is used for the weighted
+            bootstrap instead of being passed to the underlying tree.
 
     bootstrap : bool, default=False
         Whether bootstrap samples are used when building trees. If False, the
@@ -2427,7 +2454,9 @@ class ExtraTreesRegressor(ForestRegressor):
     min_weight_fraction_leaf : float, default=0.0
         The minimum weighted fraction of the sum total of weights (of all
         the input samples) required to be at a leaf node. Samples have
-        equal weight when sample_weight is not provided.
+        equal weight when sample_weight is not provided. If ``bootstrap=True``,
+        the weights are those of the bootstrap sample of each tree, i.e. the
+        number of times each sample was drawn, rather than ``sample_weight``.
 
     max_features : {"sqrt", "log2", None}, int or float, default=1.0
         The number of features to consider when looking for the best split:
@@ -2470,9 +2499,16 @@ class ExtraTreesRegressor(ForestRegressor):
         left child, and ``N_t_R`` is the number of samples in the right child.
 
         ``N``, ``N_t``, ``N_t_R`` and ``N_t_L`` all refer to the weighted sum,
-        if ``sample_weight`` is passed.
+        if ``sample_weight`` is passed and ``bootstrap=False``. If
+        ``bootstrap=True``, ``sample_weight`` is instead used to draw the
+        bootstrap sample of each tree, and these quantities refer to the number
+        of times each sample was drawn for that tree.
 
         .. versionadded:: 0.19
+
+        .. versionchanged:: 1.9
+            When ``bootstrap=True``, ``sample_weight`` is used for the weighted
+            bootstrap instead of being passed to the underlying tree.
 
     bootstrap : bool, default=False
         Whether bootstrap samples are used when building trees. If False, the
@@ -2779,7 +2815,9 @@ class RandomTreesEmbedding(TransformerMixin, BaseForest):
     min_weight_fraction_leaf : float, default=0.0
         The minimum weighted fraction of the sum total of weights (of all
         the input samples) required to be at a leaf node. Samples have
-        equal weight when sample_weight is not provided.
+        equal weight when sample_weight is not provided. If ``bootstrap=True``,
+        the weights are those of the bootstrap sample of each tree, i.e. the
+        number of times each sample was drawn, rather than ``sample_weight``.
 
     max_leaf_nodes : int, default=None
         Grow trees with ``max_leaf_nodes`` in best-first fashion.
@@ -2800,9 +2838,16 @@ class RandomTreesEmbedding(TransformerMixin, BaseForest):
         left child, and ``N_t_R`` is the number of samples in the right child.
 
         ``N``, ``N_t``, ``N_t_R`` and ``N_t_L`` all refer to the weighted sum,
-        if ``sample_weight`` is passed.
+        if ``sample_weight`` is passed and ``bootstrap=False``. If
+        ``bootstrap=True``, ``sample_weight`` is instead used to draw the
+        bootstrap sample of each tree, and these quantities refer to the number
+        of times each sample was drawn for that tree.
 
         .. versionadded:: 0.19
+
+        .. versionchanged:: 1.9
+            When ``bootstrap=True``, ``sample_weight`` is used for the weighted
+            bootstrap instead of being passed to the underlying tree.
 
     sparse_output : bool, default=True
         Whether or not to return a sparse CSR matrix, as default behavior,


### PR DESCRIPTION
Reference Issues/PRs
--------------------
Fixes #34825.

What does this implement/fix? Explain your changes.
------------------------------------------------
Since #31529 (released in 1.9), `sample_weight` is used to draw the bootstrap
sample of each tree when `bootstrap=True`. In `_parallel_build_trees`, the tree
is then fit with `np.bincount(indices)` — the number of times each sample was
drawn — rather than with the user-supplied `sample_weight`:

```python
indices = _generate_sample_indices(
    tree.random_state, n_samples, n_samples_bootstrap, sample_weight
)
# Simulate row-wise sampling by passing counts as sample_weight in trees.
sample_weight_tree = np.bincount(indices, minlength=n_samples)
```

The docstrings of `min_impurity_decrease` and `min_weight_fraction_leaf` still
described the weighted-sum behaviour unconditionally, so they are only accurate
for `bootstrap=False` — which is not the default for the random forests.

Quick check of what the underlying tree actually receives:

```
user sample_weight : [100.   1.   1.   1.   1.   1.   1.   1.   1.   1.]
bootstrap=True  -> tree sees: [9 0 0 0 0 0 1 0 0 0]   # integer draw counts
bootstrap=False -> tree sees: [100.   1.   1.   1.   1.   1.   1.   1.   1.   1.]
```

This PR qualifies both docstrings for the five bootstrapping estimators in
`sklearn/ensemble/_forest.py` (`RandomForestClassifier`, `RandomForestRegressor`,
`ExtraTreesClassifier`, `ExtraTreesRegressor`, `RandomTreesEmbedding`) and adds a
`.. versionchanged:: 1.9` note pointing at the weighted-bootstrap change.

`sklearn/tree/_classes.py` and `sklearn/ensemble/_gb.py` carry the same sentence
but are intentionally left untouched, since they do not resample by weight.

This is a documentation-only change; there is no behaviour change.

Per @antoinebaker's comment on the issue, `min_weight_fraction_leaf` is updated
alongside `min_impurity_decrease`. Happy to adjust the wording — in particular
whether the `versionchanged` note is wanted on every one of the five classes.

Any other comments?
-------------------
- `pytest sklearn/ensemble/tests/test_forest.py --doctest-modules` → 332 passed
- `pytest sklearn/tests/test_docstrings.py` (numpydoc validation) → 2723 passed
- `ruff check` / `ruff format --check` clean with the pinned `ruff==0.12.2`

I have not added a changelog fragment, since this only corrects documentation of
existing behaviour and the underlying change is already described in the 1.9
changelog. Glad to add one if you would prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiDamr4ZkXUuQ74bbL6qi3