### PR TITLE
FIX Reference-count BLAS thread limit in pairwise distance reductions

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.metrics/34878.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.metrics/34878.fix.rst
@@ -1,0 +1,3 @@
+Fix race condition and silent data corruption in :class:`~sklearn.metrics.pairwise_distances_argmin_min`
+and neighborhood reductions when called concurrently from multiple threads with OpenBLAS and OpenMP.
+

--- a/sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_argkmin.pyx.tp
@@ -14,7 +14,7 @@ from numbers import Integral
 from scipy.sparse import issparse
 from sklearn.utils import check_array, check_scalar
 from sklearn.utils.fixes import _in_unstable_openblas_configuration
-from sklearn.utils.parallel import _get_threadpool_controller
+from sklearn.utils.parallel import _get_threadpool_controller, _shared_blas_limit
 
 {{for name_suffix in ['64', '32']}}
 
@@ -58,7 +58,7 @@ cdef class ArgKmin{{name_suffix}}(BaseDistancesReduction{{name_suffix}}):
         """
         # Limit the number of threads in second level of nested parallelism for BLAS
         # to avoid threads over-subscription (in DOT or GEMM for instance).
-        with _get_threadpool_controller().limit(limits=1, user_api='blas'):
+        with _shared_blas_limit:
           if metric in ("euclidean", "sqeuclidean"):
               # Specialized implementation of ArgKmin for the Euclidean distance
               # for the dense-dense and sparse-sparse cases.

--- a/sklearn/metrics/_pairwise_distances_reduction/_argkmin_classmode.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_argkmin_classmode.pyx.tp
@@ -4,7 +4,7 @@ from libcpp.map cimport map as cpp_map, pair as cpp_pair
 from libc.stdlib cimport free
 
 from sklearn.utils._typedefs cimport intp_t, float64_t
-from sklearn.utils.parallel import _get_threadpool_controller
+from sklearn.utils.parallel import _get_threadpool_controller, _shared_blas_limit
 
 import numpy as np
 from scipy.sparse import issparse
@@ -66,7 +66,7 @@ cdef class ArgKminClassMode{{name_suffix}}(ArgKmin{{name_suffix}}):
 
         # Limit the number of threads in second level of nested parallelism for BLAS
         # to avoid threads over-subscription (in GEMM for instance).
-        with _get_threadpool_controller().limit(limits=1, user_api="blas"):
+        with _shared_blas_limit:
             if pda.execute_in_parallel_on_Y:
                 pda._parallel_on_Y()
             else:

--- a/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors.pyx.tp
@@ -17,7 +17,7 @@ from numbers import Real
 from scipy.sparse import issparse
 from sklearn.utils import check_array, check_scalar
 from sklearn.utils.fixes import _in_unstable_openblas_configuration
-from sklearn.utils.parallel import _get_threadpool_controller
+from sklearn.utils.parallel import _get_threadpool_controller, _shared_blas_limit
 
 cnp.import_array()
 
@@ -110,7 +110,7 @@ cdef class RadiusNeighbors{{name_suffix}}(BaseDistancesReduction{{name_suffix}})
 
         # Limit the number of threads in second level of nested parallelism for BLAS
         # to avoid threads over-subscription (in GEMM for instance).
-        with _get_threadpool_controller().limit(limits=1, user_api="blas"):
+        with _shared_blas_limit:
             if pda.execute_in_parallel_on_Y:
                 pda._parallel_on_Y()
             else:

--- a/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors_classmode.pyx.tp
+++ b/sklearn/metrics/_pairwise_distances_reduction/_radius_neighbors_classmode.pyx.tp
@@ -8,7 +8,7 @@ from sklearn.utils._typedefs cimport intp_t, float64_t, uint8_t
 
 import numpy as np
 from scipy.sparse import issparse
-from sklearn.utils.parallel import _get_threadpool_controller
+from sklearn.utils.parallel import _get_threadpool_controller, _shared_blas_limit
 
 
 {{for name_suffix in ["32", "64"]}}
@@ -60,7 +60,7 @@ cdef class RadiusNeighborsClassMode{{name_suffix}}(RadiusNeighbors{{name_suffix}
 
         # Limit the number of threads in second level of nested parallelism for BLAS
         # to avoid threads over-subscription (in GEMM for instance).
-        with _get_threadpool_controller().limit(limits=1, user_api="blas"):
+        with _shared_blas_limit:
             if pda.execute_in_parallel_on_Y:
                 pda._parallel_on_Y()
             else:

--- a/sklearn/metrics/tests/test_pairwise_distances_reduction.py
+++ b/sklearn/metrics/tests/test_pairwise_distances_reduction.py
@@ -16,13 +16,14 @@ from sklearn.metrics._pairwise_distances_reduction import (
     RadiusNeighborsClassMode,
     sqeuclidean_row_norms,
 )
+from sklearn.metrics._pairwise_distances_reduction._argkmin import ArgKmin64
 from sklearn.utils._testing import (
     assert_allclose,
     assert_array_equal,
     create_memmap_backed_data,
 )
 from sklearn.utils.fixes import CSR_CONTAINERS
-from sklearn.utils.parallel import _get_threadpool_controller
+from sklearn.utils.parallel import Parallel, _get_threadpool_controller, delayed
 
 # Common supported metric between scipy.spatial.distance.cdist
 # and BaseDistanceReductionDispatcher.
@@ -1641,3 +1642,32 @@ def test_radius_neighbors_classmode_strategy_consistent(outlier_label):
         strategy="parallel_on_Y",
     )
     assert_allclose(results_X, results_Y)
+
+
+def test_argkmin_multithreaded_reentrancy():
+    """Non-regression test for OpenBLAS/OpenMP GEMM race condition.
+
+    Concurrent calls to ArgKmin64.compute from multiple Python threads
+    must produce identical results to a single-threaded reference,
+    even when linked against OpenBLAS compiled with the OpenMP threading
+    layer.
+    """
+    rng = np.random.RandomState(0)
+    X = rng.randn(97, 100)
+    Y = rng.randn(111, 100)
+
+    kwargs = {
+        "k": 1,
+        "metric": "euclidean",
+        "strategy": "parallel_on_X",
+        "return_distance": True,
+    }
+    ref_dists, ref_indices = ArgKmin64.compute(X, Y, **kwargs)
+
+    results = Parallel(n_jobs=4, backend="threading")(
+        delayed(ArgKmin64.compute)(X, Y, **kwargs) for _ in range(40)
+    )
+
+    for dists, indices in results:
+        assert_allclose(dists, ref_dists)
+        assert_array_equal(indices, ref_indices)

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -6,6 +6,7 @@ usage.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import functools
+import threading
 import warnings
 from functools import update_wrapper
 
@@ -212,3 +213,41 @@ def _threadpool_controller_decorator(limits=1, user_api="blas"):
         return wrapper
 
     return decorator
+
+
+class _RefcountedBLASLimit:
+    """Thread-safe reference-counted context manager for BLAS thread limits.
+
+    Ensures BLAS is pegged to limits=1 as long as at least one thread is
+    executing, and only restores the original thread count when the last
+    concurrent thread exits. Prevents overlapping context managers from
+    prematurely restoring multi-threading during concurrent GEMM operations.
+    """
+
+    def __init__(self, limits=1):
+        self.limits = limits
+        self._lock = threading.Lock()
+        self._count = 0
+        self._cm = None
+
+    def __enter__(self):
+        with self._lock:
+            if self._count == 0:
+                self._cm = _get_threadpool_controller().limit(
+                    limits=self.limits, user_api="blas"
+                )
+                self._cm.__enter__()
+            self._count += 1
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        with self._lock:
+            self._count -= 1
+            if self._count == 0 and self._cm is not None:
+                cm = self._cm
+                self._cm = None
+                return cm.__exit__(exc_type, exc_val, exc_tb)
+        return False
+
+
+_shared_blas_limit = _RefcountedBLASLimit(limits=1)

--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -17,7 +17,12 @@ from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils.fixes import _IS_WASM
-from sklearn.utils.parallel import Parallel, delayed
+from sklearn.utils.parallel import (
+    Parallel,
+    _get_threadpool_controller,
+    _RefcountedBLASLimit,
+    delayed,
+)
 
 
 def get_working_memory():
@@ -195,3 +200,41 @@ def test_filter_warning_propagates_no_side_effect_with_loky_backend():
             joblib.delayed(warnings.warn)("Convergence warning", ConvergenceWarning)
             for _ in range(10)
         )
+
+
+def test_refcounted_blas_limit():
+    """Check that _RefcountedBLASLimit correctly reference-counts entries."""
+    controller = _get_threadpool_controller()
+    ref_limit = _RefcountedBLASLimit(limits=1)
+
+    # Initial state
+    assert ref_limit._count == 0
+    assert ref_limit._cm is None
+
+    # Nested / concurrent enters
+    with ref_limit:
+        assert ref_limit._count == 1
+        assert ref_limit._cm is not None
+
+        with ref_limit:
+            assert ref_limit._count == 2
+
+        assert ref_limit._count == 1
+
+    # Final restore
+    assert ref_limit._count == 0
+    assert ref_limit._cm is None
+
+
+def test_refcounted_blas_limit_exception_safety():
+    """Check that _RefcountedBLASLimit cleans up after exceptions."""
+    ref_limit = _RefcountedBLASLimit(limits=1)
+
+    try:
+        with ref_limit:
+            raise RuntimeError("Testing exception unwind")
+    except RuntimeError:
+        pass
+
+    assert ref_limit._count == 0
+    assert ref_limit._cm is None


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://scikit-learn.org/dev/developers/index.html
-->

#### Reference Issues/PRs
Fixes #31884

#### What does this implement/fix? Explain your changes.
When calling `ArgKmin64.compute()` or `RadiusNeighbors64.compute()` concurrently across threads (e.g. using `joblib.Parallel(backend="threading")`), numerical corruption occurs in environments running OpenBLAS compiled with the OpenMP threading layer.

The root cause is overlapping `threadpoolctl` context manager lifecycles: `threadpoolctl` changes process-global C state (`openblas_set_num_threads`). When Thread A exits its `compute()` block, it prematurely restores the thread limit back to default (e.g. 12) while concurrent threads are still running `_gemm` operations, corrupting OpenBLAS's non-reentrant static packing buffers.

This PR introduces `_RefcountedBLASLimit` in `sklearn.utils.parallel`. It reference-counts concurrent entries across threads so the BLAS thread limit stays pinned to 1 as long as any reduction is active, and only restores the original thread count once the last concurrent thread exits.

#### Any other comments?
- Added unit tests for `_RefcountedBLASLimit` in `test_parallel.py`.
- Added a multithreaded regression test in `test_pairwise_distances_reduction.py`.
- Included a towncrier news entry.