### PR TITLE
DOC Correct the description of `tol` in the k-means estimators

### DIFF
--- a/sklearn/cluster/_bisect_k_means.py
+++ b/sklearn/cluster/_bisect_k_means.py
@@ -127,10 +127,15 @@ class BisectingKMeans(_BaseKMeans):
         Verbosity mode.
 
     tol : float, default=1e-4
-        Relative tolerance with regards to Frobenius norm of the difference
-        in the cluster centers of two consecutive iterations  to declare
-        convergence. Used in inner k-means algorithm at each bisection to pick
-        best possible clusters.
+        Tolerance on the squared change of the cluster centers between two
+        consecutive iterations to declare convergence, i.e. convergence is
+        declared when ``(center_shift ** 2).sum() <= tol``. Used in inner
+        k-means algorithm at each bisection to pick best possible clusters.
+
+        .. note::
+            Unlike :class:`KMeans`, `tol` is used here as an absolute
+            threshold: it is not rescaled by the mean variance of the
+            features, so a suitable value depends on the scale of the data.
 
     copy_x : bool, default=True
         When pre-computing distances it is more numerically accurate to center

--- a/sklearn/cluster/_kmeans.py
+++ b/sklearn/cluster/_kmeans.py
@@ -372,9 +372,15 @@ def k_means(
         Verbosity mode.
 
     tol : float, default=1e-4
-        Relative tolerance with regards to Frobenius norm of the difference
-        in the cluster centers of two consecutive iterations to declare
-        convergence.
+        Tolerance on the squared change of the cluster centers between two
+        consecutive iterations to declare convergence. Convergence is declared
+        when::
+
+            (center_shift ** 2).sum() <= tol * mean(var(X, axis=0))
+
+        that is, `tol` is scaled by the mean variance of the features, so that
+        it is interpreted relative to the scale of the data rather than as an
+        absolute distance.
 
     random_state : int, RandomState instance or None, default=None
         Determines random number generation for centroid initialization. Use
@@ -488,9 +494,12 @@ def _kmeans_single_elkan(
         Verbosity mode.
 
     tol : float, default=1e-4
-        Relative tolerance with regards to Frobenius norm of the difference
-        in the cluster centers of two consecutive iterations to declare
-        convergence.
+        Tolerance on the squared change of the cluster centers between two
+        consecutive iterations to declare convergence, i.e. convergence is
+        declared when ``(center_shift ** 2).sum() <= tol``. Unlike the `tol`
+        parameter of :class:`KMeans`, this is an absolute threshold: it is
+        expected to have already been scaled by the mean feature variance of
+        the data by the caller.
         It's not advised to set `tol=0` since convergence might never be
         declared due to rounding errors. Use a very small number instead.
 
@@ -656,9 +665,12 @@ def _kmeans_single_lloyd(
         Verbosity mode
 
     tol : float, default=1e-4
-        Relative tolerance with regards to Frobenius norm of the difference
-        in the cluster centers of two consecutive iterations to declare
-        convergence.
+        Tolerance on the squared change of the cluster centers between two
+        consecutive iterations to declare convergence, i.e. convergence is
+        declared when ``(center_shift ** 2).sum() <= tol``. Unlike the `tol`
+        parameter of :class:`KMeans`, this is an absolute threshold: it is
+        expected to have already been scaled by the mean feature variance of
+        the data by the caller.
         It's not advised to set `tol=0` since convergence might never be
         declared due to rounding errors. Use a very small number instead.
 
@@ -1250,9 +1262,15 @@ class KMeans(_BaseKMeans):
         single run.
 
     tol : float, default=1e-4
-        Relative tolerance with regards to Frobenius norm of the difference
-        in the cluster centers of two consecutive iterations to declare
-        convergence.
+        Tolerance on the squared change of the cluster centers between two
+        consecutive iterations to declare convergence. Convergence is declared
+        when::
+
+            (center_shift ** 2).sum() <= tol * mean(var(X, axis=0))
+
+        that is, `tol` is scaled by the mean variance of the features, so that
+        it is interpreted relative to the scale of the data rather than as an
+        absolute distance.
 
     verbose : int, default=0
         Verbosity mode.


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses the documentation half of #22519. Does not close it: that issue also
carries a proposal to *change* the convergence criterion, which is left open.

#### What does this implement/fix? Explain your changes.
`tol` is documented across the k-means estimators as:

> Relative tolerance with regards to Frobenius norm of the difference in the
> cluster centers of two consecutive iterations to declare convergence.

That sentence appears in five places and is inaccurate in all of them, in three
different ways. It also reads as if the normalisation were relative to the
centers themselves, which is what the reporter of #22519 originally expected.

**1. `KMeans` and `k_means` — scaled by the feature variance.**
`fit` sets `self._tol = _tolerance(X, self.tol)`, i.e. `mean(var(X, axis=0)) * tol`,
so convergence is declared when

```
(center_shift ** 2).sum() <= tol * mean(var(X, axis=0))
```

```
mean(var(X))        : 0.0839
_tolerance(X, 1e-4) : 8.39e-06     # actual threshold
mean(var(10*X))     : 8.388
_tolerance(10X,1e-4): 8.39e-04     # 100x larger
```

`MiniBatchKMeans` already documents this correctly ("a smoothed,
variance-normalized ... mean center squared position changes"), so `KMeans` was
inconsistent with its own sibling.

**2. `_kmeans_single_lloyd` / `_kmeans_single_elkan` — absolute.**
These are called with `tol=self._tol`, a value that has *already* been scaled,
so for them the threshold is absolute. Calling it "relative" is wrong in the
opposite direction.

**3. `BisectingKMeans` — absolute, unlike `KMeans`.**
It passes the raw `self.tol` to the inner k-means; `self._tol` is computed by
the inherited `_check_params_vs_input` but never used on that path:

```
user tol              : 0.0001
_tol (variance-scaled): 0.0820
tol passed to inner k-means: 0.0001      # raw value
```

So a `tol` that works for `KMeans` does not mean the same thing for
`BisectingKMeans`. This one surprised me, and it is the reason the wording is
not shared between the two classes.

This PR describes each of the three cases explicitly. Documentation only;
there is no behaviour change, and no changelog fragment since no behaviour
changed.

I deliberately scoped this to documentation. #22519 also contains a 2022
suggestion by @jeremiedbb to make the criterion a genuinely relative center
shift, with a deprecation cycle; that is a behaviour change and I did not want
to assume a four-year-old plan is still current, so I left it for a separate
discussion. Happy to adjust the wording, or to fold in the user guide if you
think `modules/clustering.rst` should say something too.

#### Introduce yourself
I use scikit-learn for general ML work. I came across #22519 while reading
around the k-means implementation and noticed the `tol` docstring didn't
match what the code actually does in any of the three cases described above.

#### AI usage disclosure
I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Research and understanding

#### Any other comments?
- `pytest sklearn/cluster/tests/test_k_means.py sklearn/cluster/tests/test_bisect_k_means.py` → 280 passed
- `pytest --doctest-modules sklearn/cluster/_kmeans.py sklearn/cluster/_bisect_k_means.py` → 5 passed
- `pytest sklearn/tests/test_docstrings.py` (numpydoc validation) → 2723 passed
- `ruff check` / `ruff format --check` clean with the pinned `ruff==0.12.2`
