### PR TITLE
BUG: fix crash on zero sample_weight with bootstrap=False in bagging estimators

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.ensemble/34884.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.ensemble/34884.fix.rst
@@ -1,0 +1,6 @@
+- :class:`ensemble.BaggingClassifier`, :class:`ensemble.BaggingRegressor` and
+  :class:`ensemble.IsolationForest` no longer raise when fitted with
+  `sample_weight` containing zeros and `bootstrap=False` (the default):
+  zero-weighted samples are now excluded from the sampling, as with
+  `bootstrap=True`.
+  By :user:`istoolsfox`.

--- a/sklearn/ensemble/_bagging.py
+++ b/sklearn/ensemble/_bagging.py
@@ -85,6 +85,12 @@ def _generate_bagging_indices(
         )
     else:
         normalized_sample_weight = sample_weight / np.sum(sample_weight)
+        if not bootstrap_samples:
+            # Sampling without replacement requires at least `max_samples`
+            # entries of `p` to be non-zero. Zero-weighted samples are meant
+            # to be excluded from the fit, so cap `max_samples` at the number
+            # of non-zero weights, i.e. draw all non-zero-weighted samples.
+            max_samples = min(max_samples, np.count_nonzero(sample_weight))
         sample_indices = random_state.choice(
             n_samples,
             max_samples,

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -743,6 +743,42 @@ def test_invalid_sample_weight_max_samples_bootstrap_combinations():
             clf.fit(X, y, sample_weight=sample_weight)
 
 
+def test_zero_sample_weight_without_bootstrap():
+    # Non-regression test for https://github.com/scikit-learn/scikit-learn/issues/34673
+    # Sampling without replacement must not raise when the number of
+    # non-zero-weighted samples is below `max_samples`; zero-weighted samples
+    # are excluded from the fit.
+    X, y = iris.data, iris.target
+    sample_weight = np.ones(X.shape[0])
+    sample_weight[:30] = 0.0
+    n_nonzero = X.shape[0] - 30
+    non_zero_indices = np.flatnonzero(sample_weight)
+
+    # Integer `max_samples` above the number of non-zero weights: the draw is
+    # capped at the number of non-zero-weighted samples instead of raising.
+    clf = BaggingClassifier(
+        DecisionTreeClassifier(),
+        n_estimators=2,
+        bootstrap=False,
+        max_samples=n_nonzero + 20,
+        random_state=0,
+    )
+    clf.fit(X, y, sample_weight=sample_weight)
+    for samples in clf.estimators_samples_:
+        assert samples.shape[0] == n_nonzero
+        assert np.isin(samples, non_zero_indices).all()
+
+    # Default `max_samples=1.0` is interpreted against the sum of the weights,
+    # hence exactly the non-zero-weighted samples are drawn in every estimator.
+    clf = BaggingClassifier(
+        DecisionTreeClassifier(), n_estimators=2, bootstrap=False, random_state=0
+    )
+    clf.fit(X, y, sample_weight=sample_weight)
+    for samples in clf.estimators_samples_:
+        assert samples.shape[0] == n_nonzero
+        assert np.isin(samples, non_zero_indices).all()
+
+
 class EstimatorAcceptingSampleWeight(BaseEstimator):
     """Fake estimator accepting sample_weight"""
 

--- a/sklearn/ensemble/tests/test_bagging.py
+++ b/sklearn/ensemble/tests/test_bagging.py
@@ -779,6 +779,51 @@ def test_zero_sample_weight_without_bootstrap():
         assert np.isin(samples, non_zero_indices).all()
 
 
+def test_zero_sample_weight_fractional_max_samples_without_bootstrap():
+    # Non-regression test for https://github.com/scikit-learn/scikit-learn/issues/34673
+    # Fractional `max_samples` is interpreted against the sum of the weights,
+    # which can exceed the number of non-zero weights when weights are greater
+    # than one; the draw must be capped at the non-zero count.
+    X, y = iris.data, iris.target
+    sample_weight = np.zeros(X.shape[0])
+    sample_weight[:10] = 3.0  # sum of weights = 30, 0.8 * 30 = 24 > 10 non-zero
+
+    clf = BaggingClassifier(
+        DecisionTreeClassifier(),
+        n_estimators=2,
+        bootstrap=False,
+        max_samples=0.8,
+        random_state=0,
+    )
+    clf.fit(X, y, sample_weight=sample_weight)
+    for samples in clf.estimators_samples_:
+        assert samples.shape[0] == 10
+        assert np.isin(samples, np.arange(10)).all()
+
+
+def test_zero_sample_weight_without_bootstrap_regressor():
+    # Non-regression test for https://github.com/scikit-learn/scikit-learn/issues/34673
+    # `BaggingRegressor` shares the sampling path with `BaggingClassifier`;
+    # zero-weighted samples must be excluded there as well.
+    X, y = diabetes.data, diabetes.target
+    sample_weight = np.ones(X.shape[0])
+    sample_weight[:30] = 0.0
+    n_nonzero = X.shape[0] - 30
+    non_zero_indices = np.flatnonzero(sample_weight)
+
+    reg = BaggingRegressor(
+        DecisionTreeRegressor(),
+        n_estimators=2,
+        bootstrap=False,
+        max_samples=n_nonzero + 10,
+        random_state=0,
+    )
+    reg.fit(X, y, sample_weight=sample_weight)
+    for samples in reg.estimators_samples_:
+        assert samples.shape[0] == n_nonzero
+        assert np.isin(samples, non_zero_indices).all()
+
+
 class EstimatorAcceptingSampleWeight(BaseEstimator):
     """Fake estimator accepting sample_weight"""
 

--- a/sklearn/ensemble/tests/test_iforest.py
+++ b/sklearn/ensemble/tests/test_iforest.py
@@ -393,3 +393,18 @@ def test_iforest_predict_parallel(global_random_seed, contamination, n_jobs):
 
     # assert the same results as non-parallel
     assert_array_equal(pred, pred_parallel)
+
+
+def test_iforest_zero_sample_weight_without_bootstrap():
+    # Non-regression test for https://github.com/scikit-learn/scikit-learn/issues/34673
+    # Zero weights are the documented way to exclude samples from the fit, and
+    # `IsolationForest` uses `bootstrap=False` by default: a single zero weight
+    # must not raise "Fewer non-zero entries in p than size".
+    X = iris.data
+    sample_weight = np.ones(X.shape[0])
+    sample_weight[0] = 0.0
+
+    model = IsolationForest(random_state=0)
+    model.fit(X, sample_weight=sample_weight)
+
+    assert model.score_samples(X).shape[0] == X.shape[0]


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #34673.

#### What does this implement/fix?
Since #31414 (released in 1.8.0), fitting `BaggingClassifier`, `BaggingRegressor` or `IsolationForest` with a `sample_weight` containing zeros raises `ValueError: Fewer non-zero entries in p than size` whenever the number of non-zero weights is below `max_samples`. `bootstrap` defaults to `False` in all three estimators, and zero-weighting a row is the documented way to exclude it from a fit, so this regression hits ordinary input — on `IsolationForest` defaults, a single zero weight is enough for datasets of 256 rows or fewer.

The root cause is in `_generate_bagging_indices`: with `replace=False`, `random_state.choice` requires at least `max_samples` non-zero entries in `p`, which fails when zero-weighted samples push the non-zero count below `max_samples`.

The fix caps `max_samples` at `np.count_nonzero(sample_weight)` on the non-bootstrap path, i.e. the draw selects all non-zero-weighted samples instead of raising. This matches the documented semantics — the fit becomes equivalent to fitting on the non-zero-weighted samples only — and is the same behavior the `bootstrap=True` path already has. Note that with fractional `max_samples`, the effective count is `max_samples * sample_weight.sum()` (see `_get_n_samples_bootstrap`), so weights greater than one can push it above the non-zero count even when `max_samples < 1.0`; the cap covers that case too.

Boundary note: an all-zero `sample_weight` remains an error (as before, via the normalization producing NaN probabilities) — there are no samples left to draw from, so this is unchanged, invalid input.

Estimators such as `DecisionTreeClassifier` or `SVC` are unaffected: they never call `_generate_bagging_indices`, so the reported `class_weight="balanced"` failures on string labels are a separate path from this fix.

Tests (all fail on `main` with the exact reported error and pass with the fix, verified by temporarily reverting the fix):
- `test_zero_sample_weight_without_bootstrap`: integer `max_samples` above the non-zero count (capped), and default `max_samples=1.0` (all non-zero drawn)
- `test_zero_sample_weight_fractional_max_samples_without_bootstrap`: fractional `max_samples` with weights > 1
- `test_zero_sample_weight_without_bootstrap_regressor`: `BaggingRegressor` on the same capped path
- `test_iforest_zero_sample_weight_without_bootstrap`: `IsolationForest` default-parameter crash

Full `test_bagging.py`, `test_iforest.py` and `test_forest.py` suites pass locally (160 + 332 tests).

#### Introduce yourself
Hi, I'm istoolsfox, a developer contributing to open source in my spare time. I maintain several personal projects built on the scientific Python stack and hit this class of weighted-sampling issue while working with tree ensembles; happy to iterate on review feedback.

#### AI usage disclosure
I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Research and understanding

I reviewed, tested and understood every change before submitting. Tool: ZCode (GLM coding plan, model GLM-5.3-Flash).

#### Any other comments?
A changelog fragment is included (`doc/whats_new/upcoming_changes/sklearn.ensemble/34884.fix.rst`).