### PR TITLE
FIX HGBT sample_weight zero-weight and integer equivalence

### DIFF
--- a/doc/modules/ensemble.rst
+++ b/doc/modules/ensemble.rst
@@ -247,9 +247,14 @@ As you can see, the `[1, 0]` is comfortably classified as `1` since the first
 two samples are ignored due to their sample weights.
 
 Implementation detail: taking sample weights into account amounts to
-multiplying the gradients (and the hessians) by the sample weights. Note that
-the binning stage (specifically the quantiles computation) does not take the
-weights into account.
+multiplying the gradients (and the hessians) by the sample weights.
+Furthermore, the tree grower excludes splits that would lead to a zero-weight
+leaf (consistently to what is done in
+:class:`~sklearn.tree.DecisionTreeClassifier`).
+
+``min_samples_leaf`` is applied to the unweighted sample count, so the
+repeated/weighted equivalence described in :term:`sample_weight` only holds
+when ``min_samples_leaf=1``.
 
 .. _categorical_support_gbdt:
 

--- a/doc/whats_new/upcoming_changes/sklearn.ensemble/27.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.ensemble/27.fix.rst
@@ -1,0 +1,9 @@
+- :class:`ensemble.HistGradientBoostingClassifier` and
+  :class:`ensemble.HistGradientBoostingRegressor` now exclude zero-weight
+  samples from the tree grower partition so they do not inflate unweighted
+  histogram counts and cannot form a zero-weight leaf. As a consequence, the
+  repeated/weighted equivalence described in :term:`sample_weight` holds when
+  fitting with ``min_samples_leaf=1``. In particular, weight 0 matches removing
+  the sample even for deep trees. Furthermore, fitting on a dataset with many
+  zero-weight samples is now faster.
+  By :user:`Antoine Baker <antoinebaker>` and :user:`Olivier Grisel <ogrisel>`.

--- a/doc/whats_new/upcoming_changes/sklearn.ensemble/27.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.ensemble/27.fix.rst
@@ -1,9 +1,0 @@
-- :class:`ensemble.HistGradientBoostingClassifier` and
-  :class:`ensemble.HistGradientBoostingRegressor` now exclude zero-weight
-  samples from the tree grower partition so they do not inflate unweighted
-  histogram counts and cannot form a zero-weight leaf. As a consequence, the
-  repeated/weighted equivalence described in :term:`sample_weight` holds when
-  fitting with ``min_samples_leaf=1``. In particular, weight 0 matches removing
-  the sample even for deep trees. Furthermore, fitting on a dataset with many
-  zero-weight samples is now faster.
-  By :user:`Antoine Baker <antoinebaker>` and :user:`Olivier Grisel <ogrisel>`.

--- a/doc/whats_new/upcoming_changes/sklearn.ensemble/34885.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.ensemble/34885.fix.rst
@@ -1,10 +1,6 @@
 - :class:`ensemble.HistGradientBoostingClassifier` and
-  :class:`ensemble.HistGradientBoostingRegressor` now exclude zero-weight
-  samples from the tree grower partition so they do not inflate unweighted
-  histogram counts and cannot form a zero-weight leaf. The
-  repeated/weighted equivalence described in :term:`sample_weight` therefore
-  holds when fitting with ``min_samples_leaf=1``: weight 0 matches removing
-  the sample even for deep trees, and datasets with many zero-weight samples
-  fit faster. Split selection also treats gain differences within float32
-  rounding as ties, so near-tied features are not swapped by numerical noise.
+  :class:`ensemble.HistGradientBoostingRegressor` now exclude samples with
+  zero `sample_weight` from the tree grower.
+  The repeated/weighted equivalence described in :term:`sample_weight` therefore
+  holds when fitting with `min_samples_leaf=1`.
   By :user:`Antoine Baker <antoinebaker>` and :user:`Olivier Grisel <ogrisel>`.

--- a/doc/whats_new/upcoming_changes/sklearn.ensemble/34885.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.ensemble/34885.fix.rst
@@ -1,0 +1,10 @@
+- :class:`ensemble.HistGradientBoostingClassifier` and
+  :class:`ensemble.HistGradientBoostingRegressor` now exclude zero-weight
+  samples from the tree grower partition so they do not inflate unweighted
+  histogram counts and cannot form a zero-weight leaf. The
+  repeated/weighted equivalence described in :term:`sample_weight` therefore
+  holds when fitting with ``min_samples_leaf=1``: weight 0 matches removing
+  the sample even for deep trees, and datasets with many zero-weight samples
+  fit faster. Split selection also treats gain differences within float32
+  rounding as ties, so near-tied features are not swapped by numerical noise.
+  By :user:`Antoine Baker <antoinebaker>` and :user:`Olivier Grisel <ogrisel>`.

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -837,6 +837,7 @@ class BaseHistGradientBoosting(BaseEstimator, ABC):
                     rng=self._feature_subsample_rng,
                     shrinkage=self.learning_rate,
                     n_threads=n_threads,
+                    sample_weight=sample_weight_train,
                 )
                 grower.grow()
 
@@ -1422,6 +1423,11 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         The minimum number of samples per leaf. For small datasets with less
         than a few hundred samples, it is recommended to lower this value
         since only very shallow trees would be built.
+
+        This constraint is applied to the unweighted sample count, not the
+        sum of sample weights. Therefore the repeated/weighted equivalence
+        described in :term:`sample_weight` only holds when
+        ``min_samples_leaf=1``.
     l2_regularization : float, default=0
         The L2 regularization parameter penalizing leaves with small hessians.
         Use ``0`` for no regularization (default).
@@ -1814,6 +1820,11 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
         The minimum number of samples per leaf. For small datasets with less
         than a few hundred samples, it is recommended to lower this value
         since only very shallow trees would be built.
+
+        This constraint is applied to the unweighted sample count, not the
+        sum of sample weights. Therefore the repeated/weighted equivalence
+        described in :term:`sample_weight` only holds when
+        ``min_samples_leaf=1``.
     l2_regularization : float, default=0
         The L2 regularization parameter penalizing leaves with small hessians.
         Use ``0`` for no regularization (default).

--- a/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py
@@ -1424,9 +1424,9 @@ class HistGradientBoostingRegressor(RegressorMixin, BaseHistGradientBoosting):
         than a few hundred samples, it is recommended to lower this value
         since only very shallow trees would be built.
 
-        This constraint is applied to the unweighted sample count, not the
-        sum of sample weights. Therefore the repeated/weighted equivalence
-        described in :term:`sample_weight` only holds when
+        This constraint is applied to the sample count based on number of data
+        rows, not the sum of sample weights. Therefore the repeated/weighted
+        equivalence described in :term:`sample_weight` only holds when
         ``min_samples_leaf=1``.
     l2_regularization : float, default=0
         The L2 regularization parameter penalizing leaves with small hessians.
@@ -1821,9 +1821,9 @@ class HistGradientBoostingClassifier(ClassifierMixin, BaseHistGradientBoosting):
         than a few hundred samples, it is recommended to lower this value
         since only very shallow trees would be built.
 
-        This constraint is applied to the unweighted sample count, not the
-        sum of sample weights. Therefore the repeated/weighted equivalence
-        described in :term:`sample_weight` only holds when
+        This constraint is applied to the sample count based on number of data
+        rows, not the sum of sample weights. Therefore the repeated/weighted
+        equivalence described in :term:`sample_weight` only holds when
         ``min_samples_leaf=1``.
     l2_regularization : float, default=0
         The L2 regularization parameter penalizing leaves with small hessians.

--- a/sklearn/ensemble/_hist_gradient_boosting/grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/grower.py
@@ -217,6 +217,9 @@ class TreeGrower:
         to determine the effective number of threads use, which takes cgroups CPU
         quotes into account. See the docstring of `_openmp_effective_n_threads`
         for details.
+    sample_weight : ndarray of shape (n_samples,), dtype=float64, default=None
+        Optional sample weights. Zero-weight samples are excluded from the
+        splitter partition so they never enter a leaf.
 
     Attributes
     ----------
@@ -262,6 +265,7 @@ class TreeGrower:
         rng=np.random.default_rng(),
         shrinkage=1.0,
         n_threads=None,
+        sample_weight=None,
     ):
         self._validate_parameters(
             X_binned,
@@ -329,6 +333,7 @@ class TreeGrower:
             feature_fraction_per_split=feature_fraction_per_split,
             rng=rng,
             n_threads=n_threads,
+            sample_weight=sample_weight,
         )
         self.X_binned = X_binned
         self.max_leaf_nodes = max_leaf_nodes
@@ -423,7 +428,8 @@ class TreeGrower:
         self.total_compute_hist_time += time() - tic
 
         tic = time()
-        n_samples = self.X_binned.shape[0]
+        # Use the splitter partition length (positively weighted samples only).
+        n_samples = self.splitter.partition.shape[0]
         depth = 0
         histogram_array = np.asarray(histograms[arbitrary_feature])
         sum_gradients = histogram_array["sum_gradients"].sum()

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -162,6 +162,13 @@ cdef class Splitter:
     rng : Generator
     n_threads : int, default=1
         Number of OpenMP threads to use.
+    sample_weight : ndarray of shape (n_samples,), dtype=float64, default=None
+        Optional sample weights. Zero-weight samples are excluded from
+        ``partition`` so they never enter a leaf (same approach as
+        :class:`~sklearn.tree.DecisionTreeClassifier`). That prevents
+        unweighted histogram ``count`` / ``min_samples_leaf`` from being
+        inflated by ignored rows, and avoids splits that would create a
+        zero-weight leaf.
     """
     cdef public:
         const X_BINNED_DTYPE_C [::1, :] X_binned
@@ -198,7 +205,8 @@ cdef class Splitter:
                  uint8_t hessians_are_constant=False,
                  Y_DTYPE_C feature_fraction_per_split=1.0,
                  rng=np.random.RandomState(),
-                 unsigned int n_threads=1):
+                 unsigned int n_threads=1,
+                 sample_weight=None):
 
         self.X_binned = X_binned
         self.n_features = X_binned.shape[1]
@@ -219,13 +227,21 @@ cdef class Splitter:
         # The partition array maps each sample index into the leaves of the
         # tree (a leaf in this context is a node that isn't split yet, not
         # necessarily a 'finalized' leaf). Initially, the root contains all
-        # the indices, e.g.:
+        # positively weighted indices, e.g.:
         # partition = [abcdefghijkl]
         # After a call to split_indices, it may look e.g. like this:
         # partition = [cef|abdghijkl]
         # we have 2 leaves, the left one is at position 0 and the second one at
         # position 3. The order of the samples is irrelevant.
-        self.partition = np.arange(X_binned.shape[0], dtype=np.uint32)
+        #
+        # Zero-weight samples are omitted so they do not inflate hist.count /
+        # min_samples_leaf and cannot form a leaf alone.
+        if sample_weight is None:
+            self.partition = np.arange(X_binned.shape[0], dtype=np.uint32)
+        else:
+            self.partition = np.flatnonzero(sample_weight).astype(
+                np.uint32, copy=False
+            )
         # buffers used in split_indices to support parallel splitting.
         self.left_indices_buffer = np.empty_like(self.partition)
         self.right_indices_buffer = np.empty_like(self.partition)

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -12,8 +12,8 @@
 cimport cython
 from cython.parallel import prange
 import numpy as np
-from libc.float cimport FLT_EPSILON
-from libc.math cimport INFINITY, ceil, sqrt
+from libc.float cimport DBL_EPSILON, FLT_EPSILON
+from libc.math cimport INFINITY, ceil
 from libc.stdlib cimport malloc, free, qsort
 from libc.string cimport memcpy
 
@@ -625,7 +625,10 @@ cdef class Splitter:
             int best_split_info_idx = 0
 
         for split_info_idx in range(1, n_allowed_features):
-            if (split_infos[split_info_idx].gain > split_infos[best_split_info_idx].gain):
+            if _gain_is_better(
+                split_infos[split_info_idx].gain,
+                split_infos[best_split_info_idx].gain,
+            ):
                 best_split_info_idx = split_info_idx
         return best_split_info_idx
 
@@ -734,7 +737,10 @@ cdef class Splitter:
                                upper_bound,
                                self.l2_regularization)
 
-            if gain > best_gain and gain > self.min_gain_to_split:
+            if (
+                _gain_is_better(gain, best_gain)
+                and gain > self.min_gain_to_split
+            ):
                 found_better_split = True
                 best_gain = gain
                 best_bin_idx = bin_idx
@@ -944,7 +950,10 @@ cdef class Splitter:
                                    loss_current_node, monotonic_cst,
                                    lower_bound, upper_bound,
                                    self.l2_regularization)
-                if gain > best_gain and gain > self.min_gain_to_split:
+                if (
+                    _gain_is_better(gain, best_gain)
+                    and gain > self.min_gain_to_split
+                ):
                     found_better_split = True
                     best_gain = gain
                     best_cat_infos_thresh = sorted_cat_idx
@@ -996,6 +1005,20 @@ cdef class Splitter:
 
 cdef int compare_cat_infos(const void * a, const void * b) noexcept nogil:
     return -1 if (<categorical_info *>a).value < (<categorical_info *>b).value else 1
+
+
+cdef inline uint8_t _gain_is_better(
+        Y_DTYPE_C gain,
+        Y_DTYPE_C best_gain) noexcept nogil:
+    """Return whether gain is meaningfully greater than the current best gain."""
+    cdef Y_DTYPE_C tolerance
+
+    # Histogram statistics accumulate float32 gradients and hessians over at
+    # most 256 bins. Keep the first candidate when gains differ only within the
+    # corresponding error bound, making tie-breaking stable.
+    tolerance = 256 * FLT_EPSILON * max(abs(gain), abs(best_gain))
+    return gain > best_gain + tolerance
+
 
 cdef inline Y_DTYPE_C _split_gain(
         Y_DTYPE_C sum_gradient_left,
@@ -1049,10 +1072,9 @@ cdef inline Y_DTYPE_C _split_gain(
 
     # Computing the gain involves subtracting loss values of similar magnitude.
     # Ignore positive values that are within the floating-point error of this
-    # cancellation. Gradients and hessians are stored as float32, hence the use
-    # of FLT_EPSILON. Otherwise a theoretically zero-gain split can be selected
+    # cancellation. Otherwise a theoretically zero-gain split can be selected
     # and alter subsequent trees.
-    gain_tolerance = sqrt(FLT_EPSILON) * (
+    gain_tolerance = 10 * DBL_EPSILON * (
         abs(loss_current_node) + abs(loss_left) + abs(loss_right)
     )
     if gain > 0 and gain <= gain_tolerance:

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -12,6 +12,7 @@
 cimport cython
 from cython.parallel import prange
 import numpy as np
+from libc.float cimport DBL_EPSILON
 from libc.math cimport INFINITY, ceil
 from libc.stdlib cimport malloc, free, qsort
 from libc.string cimport memcpy
@@ -1017,6 +1018,9 @@ cdef inline Y_DTYPE_C _split_gain(
     """
     cdef:
         Y_DTYPE_C gain
+        Y_DTYPE_C gain_tolerance
+        Y_DTYPE_C loss_left
+        Y_DTYPE_C loss_right
         Y_DTYPE_C value_left
         Y_DTYPE_C value_right
 
@@ -1036,12 +1040,22 @@ cdef inline Y_DTYPE_C _split_gain(
         # account (if any).
         return -1
 
-    gain = loss_current_node
-    gain -= _loss_from_value(value_left, sum_gradient_left)
-    gain -= _loss_from_value(value_right, sum_gradient_right)
+    loss_left = _loss_from_value(value_left, sum_gradient_left)
+    loss_right = _loss_from_value(value_right, sum_gradient_right)
+    gain = loss_current_node - loss_left - loss_right
     # Note that for the gain to be correct (and for min_gain_to_split to work
     # as expected), we need all values to be bounded (current node, left child
     # and right child).
+
+    # Computing the gain involves subtracting loss values of similar magnitude.
+    # Ignore positive values that are within the floating-point error of this
+    # cancellation. Otherwise a theoretically zero-gain split can be selected
+    # and alter subsequent trees.
+    gain_tolerance = 10 * DBL_EPSILON * (
+        abs(loss_current_node) + abs(loss_left) + abs(loss_right)
+    )
+    if gain > 0 and gain <= gain_tolerance:
+        return 0
 
     return gain
 

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -12,7 +12,7 @@
 cimport cython
 from cython.parallel import prange
 import numpy as np
-from libc.float cimport DBL_EPSILON, FLT_EPSILON
+from libc.float cimport FLT_EPSILON
 from libc.math cimport INFINITY, ceil
 from libc.stdlib cimport malloc, free, qsort
 from libc.string cimport memcpy
@@ -24,6 +24,13 @@ from sklearn.ensemble._hist_gradient_boosting.common cimport X_BINNED_DTYPE_C
 from sklearn.ensemble._hist_gradient_boosting.common cimport Y_DTYPE_C
 from sklearn.ensemble._hist_gradient_boosting.common cimport hist_struct
 from sklearn.ensemble._hist_gradient_boosting.common cimport MonotonicConstraint
+
+# Positive gains below this are ignored. Cancellation in the gain formula can
+# produce ~1e-15 dust for a theoretically zero-gain split.
+cdef Y_DTYPE_C GAIN_NUMERICAL_ZERO = 1e-12
+# Feature gains that differ only within float32 histogram accumulation error
+# are treated as ties. Applied once per feature, not per bin.
+cdef Y_DTYPE_C GAIN_FEATURE_TIE_SCALE = 256 * FLT_EPSILON
 
 
 cdef struct split_info_struct:
@@ -623,12 +630,15 @@ cdef class Splitter:
         cdef:
             int split_info_idx
             int best_split_info_idx = 0
+            Y_DTYPE_C gain
+            Y_DTYPE_C best_gain
 
         for split_info_idx in range(1, n_allowed_features):
-            if _gain_is_better(
-                split_infos[split_info_idx].gain,
-                split_infos[best_split_info_idx].gain,
-            ):
+            # O(n_features) per node. Keep the first feature when gains differ
+            # only by float32 histogram accumulation error.
+            gain = split_infos[split_info_idx].gain
+            best_gain = split_infos[best_split_info_idx].gain
+            if gain > best_gain + GAIN_FEATURE_TIE_SCALE * max(abs(gain), abs(best_gain)):
                 best_split_info_idx = split_info_idx
         return best_split_info_idx
 
@@ -738,8 +748,9 @@ cdef class Splitter:
                                self.l2_regularization)
 
             if (
-                _gain_is_better(gain, best_gain)
+                gain > best_gain
                 and gain > self.min_gain_to_split
+                and gain > GAIN_NUMERICAL_ZERO
             ):
                 found_better_split = True
                 best_gain = gain
@@ -951,8 +962,9 @@ cdef class Splitter:
                                    lower_bound, upper_bound,
                                    self.l2_regularization)
                 if (
-                    _gain_is_better(gain, best_gain)
+                    gain > best_gain
                     and gain > self.min_gain_to_split
+                    and gain > GAIN_NUMERICAL_ZERO
                 ):
                     found_better_split = True
                     best_gain = gain
@@ -1006,20 +1018,6 @@ cdef class Splitter:
 cdef int compare_cat_infos(const void * a, const void * b) noexcept nogil:
     return -1 if (<categorical_info *>a).value < (<categorical_info *>b).value else 1
 
-
-cdef inline uint8_t _gain_is_better(
-        Y_DTYPE_C gain,
-        Y_DTYPE_C best_gain) noexcept nogil:
-    """Return whether gain is meaningfully greater than the current best gain."""
-    cdef Y_DTYPE_C tolerance
-
-    # Histogram statistics accumulate float32 gradients and hessians over at
-    # most 256 bins. Keep the first candidate when gains differ only within the
-    # corresponding error bound, making tie-breaking stable.
-    tolerance = 256 * FLT_EPSILON * max(abs(gain), abs(best_gain))
-    return gain > best_gain + tolerance
-
-
 cdef inline Y_DTYPE_C _split_gain(
         Y_DTYPE_C sum_gradient_left,
         Y_DTYPE_C sum_hessian_left,
@@ -1041,9 +1039,6 @@ cdef inline Y_DTYPE_C _split_gain(
     """
     cdef:
         Y_DTYPE_C gain
-        Y_DTYPE_C gain_tolerance
-        Y_DTYPE_C loss_left
-        Y_DTYPE_C loss_right
         Y_DTYPE_C value_left
         Y_DTYPE_C value_right
 
@@ -1063,22 +1058,12 @@ cdef inline Y_DTYPE_C _split_gain(
         # account (if any).
         return -1
 
-    loss_left = _loss_from_value(value_left, sum_gradient_left)
-    loss_right = _loss_from_value(value_right, sum_gradient_right)
-    gain = loss_current_node - loss_left - loss_right
+    gain = loss_current_node
+    gain -= _loss_from_value(value_left, sum_gradient_left)
+    gain -= _loss_from_value(value_right, sum_gradient_right)
     # Note that for the gain to be correct (and for min_gain_to_split to work
     # as expected), we need all values to be bounded (current node, left child
     # and right child).
-
-    # Computing the gain involves subtracting loss values of similar magnitude.
-    # Ignore positive values that are within the floating-point error of this
-    # cancellation. Otherwise a theoretically zero-gain split can be selected
-    # and alter subsequent trees.
-    gain_tolerance = 10 * DBL_EPSILON * (
-        abs(loss_current_node) + abs(loss_left) + abs(loss_right)
-    )
-    if gain > 0 and gain <= gain_tolerance:
-        return 0
 
     return gain
 

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -13,7 +13,7 @@ cimport cython
 from cython.parallel import prange
 import numpy as np
 from libc.float cimport FLT_EPSILON
-from libc.math cimport INFINITY, ceil
+from libc.math cimport INFINITY, ceil, sqrt
 from libc.stdlib cimport malloc, free, qsort
 from libc.string cimport memcpy
 
@@ -1052,7 +1052,7 @@ cdef inline Y_DTYPE_C _split_gain(
     # cancellation. Gradients and hessians are stored as float32, hence the use
     # of FLT_EPSILON. Otherwise a theoretically zero-gain split can be selected
     # and alter subsequent trees.
-    gain_tolerance = 100 * FLT_EPSILON * (
+    gain_tolerance = sqrt(FLT_EPSILON) * (
         abs(loss_current_node) + abs(loss_left) + abs(loss_right)
     )
     if gain > 0 and gain <= gain_tolerance:

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -1052,7 +1052,7 @@ cdef inline Y_DTYPE_C _split_gain(
     # cancellation. Gradients and hessians are stored as float32, hence the use
     # of FLT_EPSILON. Otherwise a theoretically zero-gain split can be selected
     # and alter subsequent trees.
-    gain_tolerance = 10 * FLT_EPSILON * (
+    gain_tolerance = 100 * FLT_EPSILON * (
         abs(loss_current_node) + abs(loss_left) + abs(loss_right)
     )
     if gain > 0 and gain <= gain_tolerance:

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -12,7 +12,7 @@
 cimport cython
 from cython.parallel import prange
 import numpy as np
-from libc.float cimport DBL_EPSILON
+from libc.float cimport FLT_EPSILON
 from libc.math cimport INFINITY, ceil
 from libc.stdlib cimport malloc, free, qsort
 from libc.string cimport memcpy
@@ -1049,9 +1049,10 @@ cdef inline Y_DTYPE_C _split_gain(
 
     # Computing the gain involves subtracting loss values of similar magnitude.
     # Ignore positive values that are within the floating-point error of this
-    # cancellation. Otherwise a theoretically zero-gain split can be selected
+    # cancellation. Gradients and hessians are stored as float32, hence the use
+    # of FLT_EPSILON. Otherwise a theoretically zero-gain split can be selected
     # and alter subsequent trees.
-    gain_tolerance = 10 * DBL_EPSILON * (
+    gain_tolerance = 10 * FLT_EPSILON * (
         abs(loss_current_node) + abs(loss_left) + abs(loss_right)
     )
     if gain > 0 and gain <= gain_tolerance:

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -28,8 +28,10 @@ from sklearn.ensemble._hist_gradient_boosting.common cimport MonotonicConstraint
 # Positive gains below this are ignored. Cancellation in the gain formula can
 # produce ~1e-15 dust for a theoretically zero-gain split.
 cdef Y_DTYPE_C GAIN_NUMERICAL_ZERO = 1e-12
-# Feature gains that differ only within float32 histogram accumulation error
-# are treated as ties. Applied once per feature, not per bin.
+# Relative gain gap treated as a tie when comparing features. 256 is the
+# maximum histogram size (uint8 bins, i.e. max_bins + the missing-value bin).
+# n_bins float32 ulps (~3e-5) is a heuristic: large enough for G/H rounding
+# (integer weights vs repeated rows), not a bound on histogram summation.
 cdef Y_DTYPE_C GAIN_FEATURE_TIE_SCALE = 256 * FLT_EPSILON
 
 
@@ -634,8 +636,7 @@ cdef class Splitter:
             Y_DTYPE_C best_gain
 
         for split_info_idx in range(1, n_allowed_features):
-            # O(n_features) per node. Keep the first feature when gains differ
-            # only by float32 histogram accumulation error.
+            # O(n_features) per node. Keep the first feature on a relative tie.
             gain = split_infos[split_info_idx].gain
             best_gain = split_infos[best_split_info_idx].gain
             if gain > best_gain + GAIN_FEATURE_TIE_SCALE * max(abs(gain), abs(best_gain)):

--- a/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
+++ b/sklearn/ensemble/_hist_gradient_boosting/splitting.pyx
@@ -30,8 +30,9 @@ from sklearn.ensemble._hist_gradient_boosting.common cimport MonotonicConstraint
 cdef Y_DTYPE_C GAIN_NUMERICAL_ZERO = 1e-12
 # Relative gain gap treated as a tie when comparing features. 256 is the
 # maximum histogram size (uint8 bins, i.e. max_bins + the missing-value bin).
-# n_bins float32 ulps (~3e-5) is a heuristic: large enough for G/H rounding
-# (integer weights vs repeated rows), not a bound on histogram summation.
+# n_bins float32 ulps (~3e-5) is a heuristic for G/H rounding, not a bound
+# on histogram summation. Without it, tiny float32 noise can swap near-tied
+# features and change the rest of the tree.
 cdef Y_DTYPE_C GAIN_FEATURE_TIE_SCALE = 256 * FLT_EPSILON
 
 

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -781,9 +781,7 @@ def test_integer_sample_weight_equivalence_many_features():
     y = rng.randint(0, 3, size=n_samples)
     sample_weight = rng.randint(0, 5, size=n_samples)
 
-    est = HistGradientBoostingClassifier(
-        max_iter=5, min_samples_leaf=1, random_state=0
-    )
+    est = HistGradientBoostingClassifier(max_iter=5, min_samples_leaf=1, random_state=0)
     est_weighted = clone(est).fit(X, y, sample_weight=sample_weight)
     est_repeated = clone(est).fit(
         np.repeat(X, sample_weight, axis=0),

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -790,7 +790,7 @@ def test_integer_sample_weight_equivalence_many_features():
         np.repeat(y, sample_weight),
     )
 
-    assert_allclose(est_weighted._raw_predict(X), est_repeated._raw_predict(X))
+    assert_allclose(est_weighted.predict_proba(X), est_repeated.predict_proba(X))
 
 
 @pytest.mark.parametrize("Loss", (HalfSquaredError, AbsoluteError))

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_gradient_boosting.py
@@ -772,6 +772,27 @@ def test_sample_weight_effect(problem, global_random_seed):
     assert_allclose(est_weighted._raw_predict(X), est_repeated._raw_predict(X))
 
 
+def test_integer_sample_weight_equivalence_many_features():
+    # Many features make zero-gain candidate splits likely. Numerical noise in
+    # their gain must not make the weighted and repeated fits diverge.
+    rng = np.random.RandomState(42)
+    n_samples = 15
+    X = rng.rand(n_samples, 2 * n_samples)
+    y = rng.randint(0, 3, size=n_samples)
+    sample_weight = rng.randint(0, 5, size=n_samples)
+
+    est = HistGradientBoostingClassifier(
+        max_iter=5, min_samples_leaf=1, random_state=0
+    )
+    est_weighted = clone(est).fit(X, y, sample_weight=sample_weight)
+    est_repeated = clone(est).fit(
+        np.repeat(X, sample_weight, axis=0),
+        np.repeat(y, sample_weight),
+    )
+
+    assert_allclose(est_weighted._raw_predict(X), est_repeated._raw_predict(X))
+
+
 @pytest.mark.parametrize("Loss", (HalfSquaredError, AbsoluteError))
 def test_sum_hessians_are_sample_weight(Loss):
     # For losses with constant hessians, the sum_hessians field of the

--- a/sklearn/ensemble/_hist_gradient_boosting/tests/test_grower.py
+++ b/sklearn/ensemble/_hist_gradient_boosting/tests/test_grower.py
@@ -337,6 +337,37 @@ def test_input_validation():
         TreeGrower(X_binned_C_array, all_gradients, all_hessians)
 
 
+def test_sample_weight_excludes_zero_weight_from_partition():
+    # Zero-weight samples must not enter the grower partition, otherwise they
+    # inflate hist.count / min_samples_leaf and can produce zero-weight leaves.
+    rng = np.random.RandomState(0)
+    n_samples = 20
+    X_binned = np.asfortranarray(
+        rng.randint(0, 10, size=(n_samples, 2), dtype=X_BINNED_DTYPE)
+    )
+    gradients = rng.randn(n_samples).astype(G_H_DTYPE)
+    hessians = np.ones(n_samples, dtype=G_H_DTYPE)
+    sample_weight = np.ones(n_samples, dtype=np.float64)
+    sample_weight[:5] = 0.0
+    gradients[:5] = 0.0
+    hessians[:5] = 0.0
+
+    grower = TreeGrower(
+        X_binned,
+        gradients,
+        hessians,
+        min_samples_leaf=1,
+        sample_weight=sample_weight,
+    )
+    expected = np.flatnonzero(sample_weight).astype(np.uint32)
+    assert_array_equal(np.sort(grower.root.sample_indices), expected)
+    grower.grow()
+    leaf_indices = np.concatenate(
+        [leaf.sample_indices for leaf in grower.finalized_leaves]
+    )
+    assert_array_equal(np.sort(leaf_indices), expected)
+
+
 def test_init_parameters_validation():
     X_binned, all_gradients, all_hessians = _make_training_data()
     with pytest.raises(ValueError, match="min_gain_to_split=-1 must be positive"):

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -583,6 +583,14 @@ PER_ESTIMATOR_CHECK_PARAMS: dict = {
     },
     GaussianRandomProjection: {"check_dict_unchanged": dict(n_components=1)},
     GraphicalLasso: {"check_array_api_input": dict(max_iter=5, alpha=1.0)},
+    # min_samples_leaf uses unweighted counts; zero-weight samples are excluded
+    # from the grower partition.
+    HistGradientBoostingClassifier: {
+        "check_sample_weight_equivalence_on_dense_data": dict(min_samples_leaf=1),
+    },
+    HistGradientBoostingRegressor: {
+        "check_sample_weight_equivalence_on_dense_data": dict(min_samples_leaf=1),
+    },
     IncrementalPCA: {"check_dict_unchanged": dict(batch_size=10, n_components=1)},
     Isomap: {"check_dict_unchanged": dict(n_components=1)},
     KBinsDiscretizer: {
@@ -1032,24 +1040,6 @@ PER_ESTIMATOR_XFAIL_CHECKS: dict[type, dict[str, str]] = {
         "check_fit2d_1feature": "FIXME",
         "check_supervised_y_2d": "DataConversionWarning not caught",
         "check_requires_y_none": "Doesn't fail gracefully",
-    },
-    HistGradientBoostingClassifier: {
-        # TODO: replace by a statistical test, see meta-issue #16298
-        "check_sample_weight_equivalence_on_dense_data": (
-            "sample_weight is not equivalent to removing/repeating samples."
-        ),
-        "check_sample_weight_equivalence_on_sparse_data": (
-            "sample_weight is not equivalent to removing/repeating samples."
-        ),
-    },
-    HistGradientBoostingRegressor: {
-        # TODO: replace by a statistical test, see meta-issue #16298
-        "check_sample_weight_equivalence_on_dense_data": (
-            "sample_weight is not equivalent to removing/repeating samples."
-        ),
-        "check_sample_weight_equivalence_on_sparse_data": (
-            "sample_weight is not equivalent to removing/repeating samples."
-        ),
     },
     IsolationForest: {
         # TODO: replace by a statistical test, see meta-issue #16298

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -584,8 +584,8 @@ PER_ESTIMATOR_CHECK_PARAMS: dict = {
     GaussianRandomProjection: {"check_dict_unchanged": dict(n_components=1)},
     GraphicalLasso: {"check_array_api_input": dict(max_iter=5, alpha=1.0)},
     # min_samples_leaf uses unweighted counts; zero-weight samples are excluded
-    # from the grower partition. Regularization keeps the classifier's raw
-    # decision values away from the float32 precision limit of the check.
+    # from the grower partition. A little L2 keeps the classifier's raw
+    # decision values away from the float32 rounding limit of the check.
     HistGradientBoostingClassifier: {
         "check_sample_weight_equivalence_on_dense_data": dict(
             min_samples_leaf=1, l2_regularization=1.0

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -584,9 +584,12 @@ PER_ESTIMATOR_CHECK_PARAMS: dict = {
     GaussianRandomProjection: {"check_dict_unchanged": dict(n_components=1)},
     GraphicalLasso: {"check_array_api_input": dict(max_iter=5, alpha=1.0)},
     # min_samples_leaf uses unweighted counts; zero-weight samples are excluded
-    # from the grower partition.
+    # from the grower partition. Regularization keeps the classifier's raw
+    # decision values away from the float32 precision limit of the check.
     HistGradientBoostingClassifier: {
-        "check_sample_weight_equivalence_on_dense_data": dict(min_samples_leaf=1),
+        "check_sample_weight_equivalence_on_dense_data": dict(
+            min_samples_leaf=1, l2_regularization=1.0
+        ),
     },
     HistGradientBoostingRegressor: {
         "check_sample_weight_equivalence_on_dense_data": dict(min_samples_leaf=1),

--- a/sklearn/utils/_test_common/instance_generator.py
+++ b/sklearn/utils/_test_common/instance_generator.py
@@ -588,7 +588,7 @@ PER_ESTIMATOR_CHECK_PARAMS: dict = {
     # decision values away from the float32 rounding limit of the check.
     HistGradientBoostingClassifier: {
         "check_sample_weight_equivalence_on_dense_data": dict(
-            min_samples_leaf=1, l2_regularization=1.0
+            min_samples_leaf=1, l2_regularization=1e-2
         ),
     },
     HistGradientBoostingRegressor: {


### PR DESCRIPTION
Fixes #34745.

This is an alternative/continuation of the work stated in #34838.

It still needs some investigation to understand the exact cause of the failure of the equivalence check for classifier.

Note: this is based on cursor-based iteration that I iteratively cleaned up but I still need to self review more to be satisfied.

Also, for some reason, cursor started of off main rather than the #34838 branch so I will need to amend for co-authorship rather than stealing @antoinebaker's credit for the initial doc updates :)