### PR TITLE
FIX compute_class_weight coerces string labels to int (#34883)

### DIFF
--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -102,10 +102,7 @@ def compute_class_weight(class_weight, *, classes, y, sample_weight=None):
         weight = xp.ones(size(classes), device=device)
         unweighted_classes = []
         for i, c in enumerate(classes):
-            try:
-                c = int(c)
-            except ValueError:  # `classes` contains strings
-                c = str(c)
+            c = c.item() if hasattr(c, "item") else c
             if c in class_weight:
                 weight[i] = class_weight[c]
             else:

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -91,6 +91,19 @@ def test_compute_class_weight_dict():
     assert_allclose([4.0, 2.0, 3.0], cw)
 
 
+def test_compute_class_weight_dict_numeric_string_labels():
+    """Non-regression test for #34883.
+
+    String labels that parse as integers (e.g. "1", "2") must not be
+    coerced to int during the dict lookup.
+    """
+    classes = np.array(["1", "2"])
+    class_weights = {"1": 0.5, "2": 2.0}
+    y = np.array(["1", "1", "2"])
+    cw = compute_class_weight(class_weights, classes=classes, y=y)
+    assert_allclose(cw, [0.5, 2.0])
+
+
 def test_compute_class_weight_invariance():
     # Test that results with class_weight="balanced" is invariant wrt
     # class imbalance if the number of samples is identical.


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #34883.

#### What does this implement/fix? Explain your changes.

`compute_class_weight` with a user-supplied dict fails when class labels are strings that parse as integers (e.g. `"1"`, `"2"`). The `try: c = int(c)` block added in #32644 converts `np.str_("1")` to `int(1)`, which then fails the dict lookup because the key is `"1"`.

The fix replaces the `int`/`str` coercion with `.item()`, which converts numpy scalars to their native Python type without altering the dtype: `np.str_("1").item()` returns `"1"`, `np.int64(0).item()` returns `0`.

A regression test is included for the string-label case.

#### Introduce yourself

Hi, I'm Gaurav, a CS grad student from UIC working in the AI/ML space. I use scikit-learn regularly for preprocessing and model evaluation in my projects, and this bug caught my eye because it's a clean regression with a straightforward fix.

#### AI usage disclosure

I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation

#### Any other comments?

The changelog entry will be added once I have the PR number for the filename.