### PR TITLE
FIX preserve string class labels in compute_class_weight dictionary branch

### DIFF
--- a/sklearn/utils/class_weight.py
+++ b/sklearn/utils/class_weight.py
@@ -102,10 +102,15 @@ def compute_class_weight(class_weight, *, classes, y, sample_weight=None):
         weight = xp.ones(size(classes), device=device)
         unweighted_classes = []
         for i, c in enumerate(classes):
-            try:
-                c = int(c)
-            except ValueError:  # `classes` contains strings
-                c = str(c)
+            # Normalize array scalars to Python scalars for dict lookup, but
+            # do not coerce strings that happen to parse as integers: the
+            # class_weight dict may be keyed by those strings (e.g. produced
+            # by _validate_y_class_weight round-tripping "balanced").
+            if not isinstance(c, (str, int, float, bool, type(None))):
+                try:
+                    c = int(c)
+                except (ValueError, TypeError):
+                    c = str(c)
             if c in class_weight:
                 weight[i] = class_weight[c]
             else:

--- a/sklearn/utils/tests/test_class_weight.py
+++ b/sklearn/utils/tests/test_class_weight.py
@@ -4,6 +4,7 @@ from numpy.testing import assert_allclose
 
 from sklearn.datasets import make_blobs
 from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestClassifier
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.utils._testing import assert_almost_equal, assert_array_almost_equal
 from sklearn.utils.class_weight import compute_class_weight, compute_sample_weight
@@ -332,3 +333,31 @@ def test_compute_sample_weight_sparse(csc_container):
     y = csc_container(np.asarray([[0], [1], [1]]))
     sample_weight = compute_sample_weight("balanced", y)
     assert_allclose(sample_weight, [1.5, 0.75, 0.75])
+
+def test_compute_class_weight_dict_string_integer_labels():
+    """Check that string class labels that parse as integers are not coerced.
+
+    Non-regression test for #34883: the array-API normalization in the
+    dictionary branch called int(c) on every class, so string labels like
+    "1"/"2" were silently converted to integers and the dict lookup with
+    string keys failed. The forest ensemble's "balanced" round-trip produces
+    exactly this shape.
+    """
+    # Direct compute_class_weight with string keys and string classes
+    weight = compute_class_weight(
+        {"1": 2.0, "2": 1.0}, classes=np.array(["1", "2"]), y=np.array(["1", "2", "1"])
+    )
+    assert_allclose(weight, [2.0, 1.0])
+
+    # Integer keys and integer classes still work
+    weight = compute_class_weight(
+        {1: 2.0, 2: 1.0}, classes=np.array([1, 2]), y=np.array([1, 2, 1])
+    )
+    assert_allclose(weight, [2.0, 1.0])
+
+    # RandomForestClassifier with class_weight="balanced" and string labels
+    # that happen to parse as integers
+    X = np.random.RandomState(0).rand(20, 5)
+    y = np.array(["1"] * 10 + ["2"] * 10)
+    clf = RandomForestClassifier(n_estimators=5, class_weight="balanced").fit(X, y)
+    assert clf.classes_.tolist() == ["1", "2"]


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #34883

#### What does this implement/fix? Explain your changes.

The array-API normalization added in #32644 coerced every class label in the `compute_class_weight` dictionary branch with `int(c)`, so string labels that happen to parse as integers (`"1"`, `"2"`) were silently converted to integers and the dict lookup with string keys failed with:

```
ValueError: The classes, [1, 2], are not in class_weight
```

This broke `RandomForestClassifier` and `ExtraTreesClassifier` with `class_weight="balanced"` for string labels that look like integers — a regression from 1.8. The forest ensemble round-trips `"balanced"` through an explicit dict keyed by the original labels (strings), and that dict then hits the coercion.

The fix only normalizes to Python scalars when the value is **not already a Python builtin type** (`str`/`int`/`float`/`bool`/`None`), which is the actual goal of the array-API compatibility code — converting array scalars like `np.int64(1)` to `int(1)` for dict lookup.

#### Any other comments?

Verification: the new regression test fails on unpatched `main` with the exact error from the issue; with this change all 22 tests in `test_class_weight.py` pass, and the 328 forest ensemble tests are unaffected.