### PR TITLE
DOC Clarify primal and dual formulations in Ridge solvers

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -189,13 +189,31 @@ a linear kernel.
 Ridge Complexity
 ----------------
 
-This method has the same order of complexity as
-:ref:`ordinary_least_squares`.
+The computational cost of :class:`Ridge` depends on the solver and the shape of
+``X``. The ``"cholesky"`` and ``"sparse_cg"`` solvers use the primal formulation
+when ``n_samples >= n_features``, solving a system with ``n_features`` unknowns:
 
-.. FIXME:
-.. Not completely true: OLS is solved by an SVD, while Ridge is solved by
-.. the method of normal equations (Cholesky), there is a big flop difference
-.. between these
+.. math::
+
+   (X^T X + \alpha I) w = X^T y.
+
+When ``n_samples < n_features``, they use the dual formulation, solving a system
+with ``n_samples`` unknowns and recovering the coefficients as follows:
+
+.. math::
+
+   (X X^T + \alpha I) c = y, \qquad w = X^T c.
+
+Here, :math:`I` is the identity matrix of the appropriate size, and :math:`X` and
+:math:`y` denote the data after centering and sample-weight rescaling, when
+applicable. Using the dual formulation can be more efficient when there are many
+more features than samples.
+
+The ``"cholesky"`` solver explicitly forms the corresponding Gram matrix.
+Storing the Gram matrix requires memory proportional to
+:math:`n_{\text{features}}^2` in the primal formulation and
+:math:`n_{\text{samples}}^2` in the dual formulation. In contrast, ``"sparse_cg"`` uses
+matrix-vector products without forming it.
 
 
 Setting the regularization parameter: leave-one-out Cross-Validation

--- a/sklearn/linear_model/_ridge.py
+++ b/sklearn/linear_model/_ridge.py
@@ -474,13 +474,16 @@ def ridge_regression(
           for singular matrices than 'cholesky' at the cost of being slower.
 
         - 'cholesky' uses the standard scipy.linalg.solve function to
-          obtain a closed-form solution via a Cholesky decomposition of
-          dot(X.T, X)
+          obtain a closed-form solution via a Cholesky decomposition. It solves
+          the primal problem involving `X.T @ X` when `n_samples >= n_features`,
+          and the dual problem involving `X @ X.T` otherwise.
 
         - 'sparse_cg' uses the conjugate gradient solver as found in
-          scipy.sparse.linalg.cg. As an iterative algorithm, this solver is
-          more appropriate than 'cholesky' for large-scale data
-          (possibility to set `tol` and `max_iter`).
+          scipy.sparse.linalg.cg. It solves the same primal or dual problem
+          as 'cholesky', without explicitly forming `X.T @ X` or `X @ X.T`.
+          As an iterative algorithm, this solver is more appropriate than
+          'cholesky' for large-scale data (possibility to set `tol` and
+          `max_iter`).
 
         - 'lsqr' uses the dedicated regularized least-squares routine
           scipy.sparse.linalg.lsqr. It is the fastest and uses an iterative
@@ -1099,12 +1102,16 @@ class Ridge(MultiOutputMixin, RegressorMixin, _BaseRidge):
           for singular matrices than 'cholesky' at the cost of being slower.
 
         - 'cholesky' uses the standard :func:`scipy.linalg.solve` function to
-          obtain a closed-form solution.
+          obtain a closed-form solution via a Cholesky decomposition. It solves
+          the primal problem involving `X.T @ X` when `n_samples >= n_features`,
+          and the dual problem involving `X @ X.T` otherwise.
 
         - 'sparse_cg' uses the conjugate gradient solver as found in
-          :func:`scipy.sparse.linalg.cg`. As an iterative algorithm, this solver is
-          more appropriate than 'cholesky' for large-scale data
-          (possibility to set `tol` and `max_iter`).
+          :func:`scipy.sparse.linalg.cg`. It solves the same primal or dual problem
+          as 'cholesky', without explicitly forming `X.T @ X` or `X @ X.T`.
+          As an iterative algorithm, this solver is more appropriate than
+          'cholesky' for large-scale data (possibility to set `tol` and
+          `max_iter`).
 
         - 'lsqr' uses the dedicated regularized least-squares routine
           :func:`scipy.sparse.linalg.lsqr`. It is the fastest and uses an iterative
@@ -1462,12 +1469,16 @@ class RidgeClassifier(_RidgeClassifierMixin, _BaseRidge):
           for singular matrices than 'cholesky' at the cost of being slower.
 
         - 'cholesky' uses the standard :func:`scipy.linalg.solve` function to
-          obtain a closed-form solution.
+          obtain a closed-form solution via a Cholesky decomposition. It solves
+          the primal problem involving `X.T @ X` when `n_samples >= n_features`,
+          and the dual problem involving `X @ X.T` otherwise.
 
         - 'sparse_cg' uses the conjugate gradient solver as found in
-          :func:`scipy.sparse.linalg.cg`. As an iterative algorithm, this solver is
-          more appropriate than 'cholesky' for large-scale data
-          (possibility to set `tol` and `max_iter`).
+          :func:`scipy.sparse.linalg.cg`. It solves the same primal or dual problem
+          as 'cholesky', without explicitly forming `X.T @ X` or `X @ X.T`.
+          As an iterative algorithm, this solver is more appropriate than
+          'cholesky' for large-scale data (possibility to set `tol` and
+          `max_iter`).
 
         - 'lsqr' uses the dedicated regularized least-squares routine
           :func:`scipy.sparse.linalg.lsqr`. It is the fastest and uses an iterative


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #34807.

#### What does this implement/fix? Explain your changes.
Document primal/dual selection for `cholesky` and `sparse_cg` across the Ridge APIs. Explain the equations and Cholesky memory costs in the user guide, distinguishing matrix-free `sparse_cg`. No runtime changes.

#### Introduce yourself
I am a student in CS and Math. I regularly use scikit-learn for my side projects and partime job. I enjoy the community and want to contribute a bit.

#### AI usage disclosure
I used AI assistance for:
- grammar and spelling
- research on the methods and doc writing best practices