### PR TITLE
FIX Fix OpenML dataset parsing with pandas>=3.1.0.dev0

### DIFF
--- a/build_tools/github/pylatest_pip_scipy_dev_linux-64_conda.lock
+++ b/build_tools/github/pylatest_pip_scipy_dev_linux-64_conda.lock
@@ -2,7 +2,7 @@
 # platform: linux-64
 # input_hash: 24ef416e2330a91ab0f9ebe316ec9431025e1b63eab146a1ce2e60f14fcf4caa
 @EXPLICIT
-https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda#0539938c55b6b1a59b560e843ad864a4
+https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-9_cp314.conda#350d89b50d7de805abf2e63e29dee451
 https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda#fcb489df604d100968b737f2cb6076c6
 https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda#0f51e2391ade309db462a55611263e9c
 https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda#89d2c1231f47bd818f5d624b9411459d
@@ -17,18 +17,18 @@ https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda#65
 https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda#1390b7c5ac0b1d8e447bc5efa6d3c8c2
 https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda#fcfed1dc5053eb1901b66e7b1fc32588
 https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda#2f2ef0d96de5bdd8c1270ff22fdf9352
-https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda#01bb81d12c957de066ea7362007df642
+https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda#74a0a409d9f4561265d36b789d3f398a
 https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda#ee6c0cd80a60961a1f48aa3e0b91f986
 https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda#16e3034a330cc625f2c685edec60cf4e
 https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda#676a2f9b1c4fcf57b70aa5c65f6c60d0
 https://conda.anaconda.org/conda-forge/linux-64/xxhash-0.8.3-hec8ed23_1.conda#72ab4ea51529ec63ff010ae9fb62b02f
 https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda#72a381cbad04f24b1c2a43ef707f45b4
 https://conda.anaconda.org/conda-forge/linux-64/libhiredis-1.3.0-h5888daf_1.conda#aa342fcf3bc583660dbfdb2eae6be48e
-https://conda.anaconda.org/conda-forge/linux-64/libpython-3.14.7-hdc7f604_103_cp314.conda#27f0da75a79c7bea2e29335f7a87cbc1
+https://conda.anaconda.org/conda-forge/linux-64/libpython-3.14.7-hdc7f604_106_cp314.conda#28af2158bb8dbb62e55b0af3b44f9d4a
 https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda#69c01c781e7c8190bbdaf79e3848c5ca
 https://conda.anaconda.org/conda-forge/linux-64/ccache-4.14-h420ae53_0.conda#4a06ca30c8f0c68207c1ab0f25efef03
 https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda#e72bbec309c2b0f37823ee7d4fabfcd3
-https://conda.anaconda.org/conda-forge/linux-64/python-3.14.7-hcd007b5_103_cp314.conda#fe53375d62a48f09b5ffdfa78ea3ca4b
+https://conda.anaconda.org/conda-forge/linux-64/python-3.14.7-hcd007b5_106_cp314.conda#56ee91e118243e46bfc0c41e4030d354
 https://conda.anaconda.org/conda-forge/noarch/pip-26.2.1-pyh145f28c_0.conda#573cb3ed111004230ed3de650653cd4d
 # pip alabaster @ https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl#sha256=fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b
 # pip babel @ https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl#sha256=e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35
@@ -44,7 +44,7 @@ https://conda.anaconda.org/conda-forge/noarch/pip-26.2.1-pyh145f28c_0.conda#573c
 # pip meson @ https://files.pythonhosted.org/packages/07/68/b0117422eb0a46d9d8d9e328f0c5b5c835179bfc058688bca35c90c89eba/meson-1.12.0-py3-none-any.whl#sha256=71f133147fa0fcfe8f4df49fa1045771064947834538409e5d97b3613aac8b4e
 # pip ninja @ https://files.pythonhosted.org/packages/6e/53/ebfed7b689c338dd8ebeec9c0730c8d56821292f14e2536e5f3ef1a05744/ninja-1.13.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl#sha256=65a24341b5ac09fcadcc37082660be40a94174e51a937fabf6e2cae26225fa2c
 # pip packaging @ https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl#sha256=d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c
-# pip platformdirs @ https://files.pythonhosted.org/packages/c7/12/6f3fcd5067a9cbf4f8664b32957973498da8b083455203c8d9cab83a725c/platformdirs-4.11.5-py3-none-any.whl#sha256=89f8d42695853b89c7170bd49bc3dc593f98a71e695ede88e06a3b247bc4563b
+# pip platformdirs @ https://files.pythonhosted.org/packages/27/6e/80993e10a0482f630cef528635789233224f36b1ffd11592aa15d13ff9ce/platformdirs-4.11.7-py3-none-any.whl#sha256=8a02cb259042c79d1cd0450facc2fe6dc9d303ae7901afbe33bf8ea0b188cef6
 # pip pluggy @ https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl#sha256=e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
 # pip pygments @ https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl#sha256=2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9
 # pip roman-numerals @ https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl#sha256=647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7
@@ -63,7 +63,7 @@ https://conda.anaconda.org/conda-forge/noarch/pip-26.2.1-pyh145f28c_0.conda#573c
 # pip pytest @ https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl#sha256=37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c
 # pip python-dateutil @ https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl#sha256=a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
 # pip requests @ https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl#sha256=2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
-# pip meson-python @ https://files.pythonhosted.org/packages/90/ad/77f9483e180cabab2772ac222aedd3dfab858e60d992f40414a3f08e7494/meson_python-0.20.0-py3-none-any.whl#sha256=6a744cf0c09e76ecbdc58cfa374b48c8902dac1b74479628238634efbf36aec9
+# pip meson-python @ https://files.pythonhosted.org/packages/bc/64/28280d983512b8d13efac5cc841e1ed05dd6e0bbc71e0daf8c9c0c028609/meson_python-0.21.0-py3-none-any.whl#sha256=b5d93fc66c80874c28916f6cb55a912fcd92a699563a4047158c50216867ad94
 # pip pooch @ https://files.pythonhosted.org/packages/2a/2d/d4bf65e47cea8ff2c794a600c4fd1273a7902f268757c531e0ee9f18aa58/pooch-1.9.0-py3-none-any.whl#sha256=f265597baa9f760d25ceb29d0beb8186c243d6607b0f60b83ecf14078dbc703b
 # pip pytest-cov @ https://files.pythonhosted.org/packages/80/b4/bb7263e12aade3842b938bc5c6958cae79c5ee18992f9b9349019579da0f/pytest_cov-6.3.0-py3-none-any.whl#sha256=440db28156d2468cafc0415b4f8e50856a0d11faefa38f30906048fe490f1749
 # pip pytest-xdist @ https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl#sha256=202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88

--- a/doc/whats_new/upcoming_changes/sklearn.datasets/34902.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.datasets/34902.fix.rst
@@ -1,0 +1,4 @@
+- :func:`datasets.fetch_openml` with `parser="pandas"` no longer raises a
+  `TypeError` when a nominal column's values are inferred by pandas as numeric
+  or boolean categories instead of strings.
+  By :user:`Dea María Léon <DeaMariaLeon>`.

--- a/sklearn/datasets/_arff_parser.py
+++ b/sklearn/datasets/_arff_parser.py
@@ -432,6 +432,9 @@ def _pandas_arff_parser(
     single_quote_pattern = re.compile(r"^'(?P<contents>.*)'$")
 
     def strip_single_quotes(input_string):
+        if not isinstance(input_string, str):
+            return input_string
+
         match = re.search(single_quote_pattern, input_string)
         if match is None:
             return input_string

--- a/sklearn/datasets/tests/test_arff_parser.py
+++ b/sklearn/datasets/tests/test_arff_parser.py
@@ -149,8 +149,8 @@ def test_pandas_arff_parser_strip_single_quotes(parser_func):
     pd.testing.assert_series_equal(frame.iloc[0], pd.Series(expected_values, name=0))
 
 
-def test_pandas_arff_parser_strip_single_quotes_non_string_categories():
-    """Check that non-string categories are left untouched by quote stripping."""
+def test_pandas_arff_parser_numeric_nominal_categories():
+    """Check that a nominal column with unquoted numeric values is parsed."""
     pd = pytest.importorskip("pandas")
 
     arff_file = BytesIO(
@@ -160,6 +160,8 @@ def test_pandas_arff_parser_strip_single_quotes_non_string_categories():
             @attribute 'cat_int' {1, 2, 3}
             @data
             1
+            2
+            3
             """
         ).encode("utf-8")
     )
@@ -171,10 +173,10 @@ def test_pandas_arff_parser_strip_single_quotes_non_string_categories():
         openml_columns_info=columns_info,
         feature_names_to_select=["cat_int"],
         target_names_to_select=[],
-        read_csv_kwargs={"dtype": {0: pd.CategoricalDtype([1, 2, 3])}},
     )
 
-    assert frame["cat_int"].cat.categories.tolist() == [1, 2, 3]
+    assert isinstance(frame["cat_int"].dtype, pd.CategoricalDtype)
+    assert len(frame["cat_int"].cat.categories) == 3
 
 
 @pytest.mark.parametrize("parser_func", [_liac_arff_parser, _pandas_arff_parser])

--- a/sklearn/datasets/tests/test_arff_parser.py
+++ b/sklearn/datasets/tests/test_arff_parser.py
@@ -149,6 +149,34 @@ def test_pandas_arff_parser_strip_single_quotes(parser_func):
     pd.testing.assert_series_equal(frame.iloc[0], pd.Series(expected_values, name=0))
 
 
+def test_pandas_arff_parser_strip_single_quotes_non_string_categories():
+    """Check that non-string categories are left untouched by quote stripping."""
+    pd = pytest.importorskip("pandas")
+
+    arff_file = BytesIO(
+        textwrap.dedent(
+            """
+            @relation 'toy'
+            @attribute 'cat_int' {1, 2, 3}
+            @data
+            1
+            """
+        ).encode("utf-8")
+    )
+    columns_info = {"cat_int": {"data_type": "nominal", "name": "cat_int"}}
+
+    _, _, frame, _ = _pandas_arff_parser(
+        arff_file,
+        output_arrays_type="pandas",
+        openml_columns_info=columns_info,
+        feature_names_to_select=["cat_int"],
+        target_names_to_select=[],
+        read_csv_kwargs={"dtype": {0: pd.CategoricalDtype([1, 2, 3])}},
+    )
+
+    assert frame["cat_int"].cat.categories.tolist() == [1, 2, 3]
+
+
 @pytest.mark.parametrize("parser_func", [_liac_arff_parser, _pandas_arff_parser])
 def test_pandas_arff_parser_strip_double_quotes(parser_func):
     """Check that we properly strip double quotes from the data."""

--- a/sklearn/datasets/tests/test_arff_parser.py
+++ b/sklearn/datasets/tests/test_arff_parser.py
@@ -149,15 +149,15 @@ def test_pandas_arff_parser_strip_single_quotes(parser_func):
     pd.testing.assert_series_equal(frame.iloc[0], pd.Series(expected_values, name=0))
 
 
-def test_pandas_arff_parser_numeric_nominal_categories():
-    """Check that a nominal column with unquoted numeric values is parsed."""
+@pytest.mark.parametrize("force_int_categories", [False, True])
+def test_pandas_arff_parser_numeric_nominal_categories(force_int_categories):
+    """Check that a nominal column with numeric values is parsed."""
     pd = pytest.importorskip("pandas")
 
     arff_file = BytesIO(
         textwrap.dedent(
             """
             @relation 'toy'
-            @attribute 'cat_int' {1, 2, 3}
             @data
             1
             2
@@ -167,16 +167,28 @@ def test_pandas_arff_parser_numeric_nominal_categories():
     )
     columns_info = {"cat_int": {"data_type": "nominal", "name": "cat_int"}}
 
+    # pandas only infers the categories as integers from recent versions onwards,
+    # so force it to cover the case on any supported version.
+    read_csv_kwargs = (
+        {"dtype": {0: pd.CategoricalDtype([1, 2, 3])}} if force_int_categories else None
+    )
+
     _, _, frame, _ = _pandas_arff_parser(
         arff_file,
         output_arrays_type="pandas",
         openml_columns_info=columns_info,
         feature_names_to_select=["cat_int"],
         target_names_to_select=[],
+        read_csv_kwargs=read_csv_kwargs,
     )
 
     assert isinstance(frame["cat_int"].dtype, pd.CategoricalDtype)
-    assert len(frame["cat_int"].cat.categories) == 3
+    categories = frame["cat_int"].cat.categories
+    if force_int_categories:
+        assert categories.tolist() == [1, 2, 3]
+    else:
+        # the inferred categories are integers or strings depending on the version
+        assert categories.astype(str).tolist() == ["1", "2", "3"]
 
 
 @pytest.mark.parametrize("parser_func", [_liac_arff_parser, _pandas_arff_parser])


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Closes https://github.com/scikit-learn/scikit-learn/pull/34894
Fixes https://github.com/scikit-learn/scikit-learn/issues/34892 

#### What does this implement/fix? Explain your changes.
The bug that was found by the CI failure is in sklearn/datasets/_arff_parser.py line 435-447:

 `_pandas_arff_parser` strips single quotes on categories as a post-processing steps if needed.
This part of the code (on the main branch) assumes that every categorical value is a `str`.

But ` pd.read_csv(..., dtype="category")` on unquoted numeric values yields `object` with pandas 2.3.3. 
And it yields `int64` with pandas 3.1.0.dev0.

The pandas' PR that seems to have changed the behaviour: https://github.com/pandas-dev/pandas/pull/64659

One can verify that with:
```
for env in ~/mambaforge/envs/sklearn-dev ~/venvs/sklearn-scipy-dev; do
  "$env/bin/python" -c "
import io, pandas as pd
col = pd.read_csv(io.StringIO('1\n2\n3\n'), header=None, dtype={0: 'category'})[0]
print(f'pandas {pd.__version__}: {col.cat.categories.dtype}')"
done
``` 
Where `sklearn-scipy-dev` was my local environment with the nightly builds.
The output of the block above is:
```
pandas 2.3.3: object
pandas 3.1.0.dev0+1803.gc26625d6e7: int64
```

The test that I added fails without this check on `_pandas_arff_parser`: `if not isinstance(input_string, str)`

For this PR I run this command and committed the generated files:
```
python build_tools/update_environments_and_lock_files.py --select-tag scipy-dev
```

#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test generation
- Research and understanding

#### Any other comments?
~~Not ready to review - I want to see if there are other failures~~

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
