### PR TITLE
PRF Don't force X to C-order for LogisticRegression's lbfgs solver

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.linear_model/34903.efficiency.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.linear_model/34903.efficiency.rst
@@ -1,0 +1,4 @@
+- :class:`linear_model.LogisticRegression` with `solver="lbfgs"` no longer forces
+  the input `X` to C-order. If `X` is already Fortran-contiguous, this avoids an
+  unnecessary copy and lets the gradient computation use a better-parallelizing
+  BLAS kernel. By :user:`Arthur Lacote <cakedev0>`.

--- a/sklearn/linear_model/_logistic.py
+++ b/sklearn/linear_model/_logistic.py
@@ -1517,10 +1517,11 @@ class LogisticRegression(
             y,
             accept_sparse="csc" if solver == "newton-cd" else "csr",
             dtype=[xp.float64, xp.float32],
-            order="F" if solver == "newton-cd" else "C",
+            order=(
+                "F" if solver == "newton-cd" else None if solver == "lbfgs" else "C"
+            ),
             accept_large_sparse=solver not in ("liblinear", "newton-cd", "sag", "saga"),
         )
-        n_samples, n_features = X.shape
         check_classification_targets(y)
         le = LabelEncoder().fit(y)
         self.classes_ = le.classes_


### PR DESCRIPTION
#### Reference Issues/PRs

Related to #32162 (that one's about OpenMP threads in the loss kernel; this is about BLAS threads in the GEMV calls around it).

#### What does this implement/fix? Explain your changes.

While investigating why `LogisticRegression(solver="lbfgs")` doesn't benefit from (and sometimes gets hurt by) multithreaded OpenBLAS, I traced it down to the backward-pass gradient computation (`X.T @ grad_pointwise` in `LinearModelLoss.loss_gradient`). For `n_samples >> n_features` (the common shape), that GEMV parallelizes much better for the F-order (for the C-order, on my machine, parallelization is usually neutral / slightly counter-productive)

Turns out `LogisticRegression.fit()` unconditionally forces `X` to C-order for `solver="lbfgs"`, even though `X` is only read (never mutated) throughout all L-BFGS iterations. So if a caller already had F-order `X`, we were silently paying for a full copy *and* throwing away the layout that would've made BLAS threading actually work.

This PR just changes that to `order=None` (preserve caller's layout) for `solver="lbfgs"`. This gives a nice speed-up and saves memory for users passing a F-ordered `X`.

#### AI usage disclosure

- Research and understanding
- Early benchmarks generation (the numbers below, and a scratch benchmark script I'm not including in the PR)

#### Benchmarks

`LogisticRegression(max_iter=200).fit(X, y)` on synthetic binary data, 9 fits, median, 14 BLAS threads (this machine's core count).

For X already Fortran-ordered:
```
n_samples=100,000,  n_features=200: before 0.24s -> after 0.17s
n_samples=500,000,  n_features=200: before 1.00s -> after 0.71s  (~1.4x)
n_samples=1,000,000, n_features=200: before 1.53s -> after 1.04s  (~1.5x)
```

Peak memory (1M x 200 float64, X is ~1.6GB):
```
before (forced C-order copy): 3.16 GB peak RSS
after  (layout preserved):    1.60 GB peak RSS
```
