### PR TITLE
DOC Fix documented defaults that disagree with signatures

### DIFF
--- a/sklearn/_config.py
+++ b/sklearn/_config.py
@@ -196,13 +196,16 @@ def set_config(
 
         .. versionadded:: 1.3
 
-    sparse_interface : str, default="spmatrix"
+    sparse_interface : str, default=None
 
         The sparse interface used for every sparse object that scikit-learn produces,
         e.g., function returns, estimator attributes, estimator properties, etc.
 
         - `"sparray"`: Return sparse as SciPy sparse array
         - `"spmatrix"`: Return sparse as SciPy sparse matrix
+        - `None`: Configuration is unchanged
+
+        Global default: "spmatrix".
 
         .. versionadded:: 1.9
 
@@ -377,13 +380,16 @@ def config_context(
 
         .. versionadded:: 1.3
 
-    sparse_interface : str, default="spmatrix"
+    sparse_interface : str, default=None
 
         The sparse interface used for every sparse object that scikit-learn produces,
         e.g., function returns, estimator attributes, estimator properties, etc.
 
         - `"sparray"`: Return sparse as SciPy sparse array
         - `"spmatrix"`: Return sparse as SciPy sparse matrix
+        - `None`: Configuration is unchanged
+
+        Global default: "spmatrix".
 
         .. versionadded:: 1.8
 

--- a/sklearn/utils/validation.py
+++ b/sklearn/utils/validation.py
@@ -2958,7 +2958,7 @@ def validate_data(
         The estimator to validate the input for.
 
     X : {array-like, sparse matrix, dataframe} of shape \
-            (n_samples, n_features), default='no validation'
+            (n_samples, n_features), default='no_validation'
         The input samples.
         If `'no_validation'`, no validation is performed on `X`. This is
         useful for meta-estimator which can delegate input validation to


### PR DESCRIPTION
- validate_data: X documented as default='no validation' (space) but the sentinel compared at runtime is 'no_validation' (underscore). Users copying the documented value hit silent misbehaviour because the equality check on line 3029 fails and the string is validated as data. The y parameter directly below already documents it correctly.

- set_config/config_context: sparse_interface documented as default="spmatrix" but the signature default is None. "spmatrix" is the global config value, not the parameter default; None means 'unchanged'. Aligned with the other ten parameters, which all use default=None plus a 'Global default:' note.

<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Introduce yourself
<!-- Especially if you are new to the scikit-learn community, please introduce yourself.
How do you use scikit-learn, what prompted you to make this contribution?
Getting to know you helps us build trust in your judgement and welcome you into the
community.
-->


#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance for:
- Code generation (e.g., when writing an implementation or fixing a bug)
- Test/benchmark generation
- Documentation (including examples)
- Research and understanding

#### Any other comments?


<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
