### PR TITLE
PERF New parallelism API with lower overhead

### DIFF
--- a/benchmarks/bench_isolation_forest_predict.py
+++ b/benchmarks/bench_isolation_forest_predict.py
@@ -149,6 +149,7 @@ def bench(args):
     # Loop over all datasets for fitting and scoring the estimator:
     n_samples_train = 1000
     for n_samples_test in [
+        100,
         1000,
         10000,
         50000,

--- a/sklearn/ensemble/_iforest.py
+++ b/sklearn/ensemble/_iforest.py
@@ -15,7 +15,7 @@ from sklearn.tree import ExtraTreeRegressor
 from sklearn.utils import check_array, check_random_state, gen_batches
 from sklearn.utils._chunking import get_chunk_n_rows
 from sklearn.utils._param_validation import Interval, RealNotInt, StrOptions
-from sklearn.utils.parallel import Parallel, delayed
+from sklearn.utils.parallel import _parallel_thread_map
 from sklearn.utils.validation import (
     _check_sample_weight,
     _num_samples,
@@ -610,23 +610,25 @@ class IsolationForest(OutlierMixin, BaseBagging):
         # https://github.com/scikit-learn/scikit-learn/pull/28622 for more
         # details.
         lock = threading.Lock()
-        Parallel(
-            verbose=self.verbose,
-            require="sharedmem",
-        )(
-            delayed(_parallel_compute_tree_depths)(
-                tree,
-                X,
-                features if subsample_features else None,
-                self._decision_path_lengths[tree_idx],
-                self._average_path_length_per_tree[tree_idx],
-                depths,
-                lock,
-            )
-            for tree_idx, (tree, features) in enumerate(
-                zip(self.estimators_, self.estimators_features_)
-            )
+        results = _parallel_thread_map(
+            None,
+            lambda args: _parallel_compute_tree_depths(*args),
+            (
+                (
+                    tree,
+                    X,
+                    features if subsample_features else None,
+                    self._decision_path_lengths[tree_idx],
+                    self._average_path_length_per_tree[tree_idx],
+                    depths,
+                    lock,
+                )
+                for tree_idx, (tree, features) in enumerate(
+                    zip(self.estimators_, self.estimators_features_)
+                )
+            ),
         )
+        list(results)
 
         denominator = len(self.estimators_) * average_path_length_max_samples
         scores = 2 ** (

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -6,7 +6,6 @@ usage.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import functools
-import sys
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from functools import update_wrapper
@@ -258,15 +257,3 @@ def _threadpool_controller_decorator(limits=1, user_api="blas"):
         return wrapper
 
     return decorator
-
-
-def _is_gil_enabled() -> bool:
-    """Return whether Python has the GIL enabled.
-
-    Returns
-    -------
-    bool
-        Whether the GIL is enabled.
-    """
-    _is_gil_enabled = getattr(sys, "_is_gil_enabled", lambda: True)
-    return _is_gil_enabled()

--- a/sklearn/utils/parallel.py
+++ b/sklearn/utils/parallel.py
@@ -6,13 +6,15 @@ usage.
 # SPDX-License-Identifier: BSD-3-Clause
 
 import functools
+import sys
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from functools import update_wrapper
 
 import joblib
 from threadpoolctl import ThreadpoolController
 
-from sklearn._config import config_context, get_config
+from sklearn._config import config_context, get_config, set_config
 
 # Global threadpool controller instance that can be used to locally limit the number of
 # threads without looping through all shared libraries every time.
@@ -184,6 +186,50 @@ class _FuncWrapper:
             return self.function(*args, **kwargs)
 
 
+def _parallel_thread_map(n_jobs, func, *iterables):
+    """
+    Like ``map()``, but uses threads to run in parallel.
+
+    Aims for minimal overhead, to maximize the cases where it improves
+    performance.
+
+    .. versionadded:: 1.10
+
+    Parameters
+    ----------
+    n_jobs : int or None
+        The maximum number of concurrently running jobs.
+        See :class:`joblib.Parallel` for details.
+
+    func : callable function
+        Called with each value in the iterable.
+
+    *iterables : iterables of values
+        Each value will be passed to func.
+
+    Returns
+    -------
+    results : Iterable
+        Results of calling ``func(*values)`` for each set of values
+        from the input iterables.
+    """
+    n_jobs = joblib.effective_n_jobs(n_jobs)
+    if n_jobs == 1:
+        # Run sequentially:
+        return map(func, *iterables)
+
+    # Create pool here, so it copies contextvars:
+    config = get_config()
+    pool = ThreadPoolExecutor(n_jobs, initializer=lambda: set_config(**config))
+
+    # Make sure pool doesn't get garbage collected prematurely:
+    def gen():
+        with pool:
+            yield from pool.map(func, *iterables)
+
+    return gen()
+
+
 def _get_threadpool_controller():
     """Return the global threadpool controller instance."""
     global _threadpool_controller
@@ -212,3 +258,15 @@ def _threadpool_controller_decorator(limits=1, user_api="blas"):
         return wrapper
 
     return decorator
+
+
+def _is_gil_enabled() -> bool:
+    """Return whether Python has the GIL enabled.
+
+    Returns
+    -------
+    bool
+        Whether the GIL is enabled.
+    """
+    _is_gil_enabled = getattr(sys, "_is_gil_enabled", lambda: True)
+    return _is_gil_enabled()

--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -2,6 +2,8 @@ import itertools
 import re
 import time
 import warnings
+from threading import current_thread
+from typing import Callable, Iterable
 
 import joblib
 import numpy as np
@@ -17,7 +19,11 @@ from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils.fixes import _IS_WASM
-from sklearn.utils.parallel import Parallel, delayed
+from sklearn.utils.parallel import (
+    Parallel,
+    _parallel_thread_map,
+    delayed,
+)
 
 
 def get_working_memory():
@@ -195,3 +201,61 @@ def test_filter_warning_propagates_no_side_effect_with_loky_backend():
             joblib.delayed(warnings.warn)("Convergence warning", ConvergenceWarning)
             for _ in range(10)
         )
+
+
+@pytest.mark.parametrize(
+    "func,arguments",
+    [
+        (lambda x: x + 1, [range(1000)]),
+        (lambda a, b: a + b, [range(1, 1001), range(2, 1002)]),
+    ],
+)
+def test_parallel_thread_map_results(func: Callable, arguments: list[Iterable]) -> None:
+    """``_parallel_thread_map()`` gives the same results as ``map()``."""
+    for n_jobs in [None, 1, 2, -1]:
+        expected = list(map(func, *arguments))
+        actual = _parallel_thread_map(n_jobs, func, *arguments)
+        assert not isinstance(actual, list)
+        assert expected == list(actual)
+
+
+def test_parallel_thread_map_parallelism() -> None:
+    """
+    ``_parallel_thread_map()`` uses parallelism only on free-threaded Python.
+    """
+    idents = set()
+
+    def add_ident(_):
+        idents.add(current_thread().ident)
+
+    list(_parallel_thread_map(-1, add_ident, range(1000)))
+
+    if joblib.effective_n_jobs(-1) == 1:
+        assert idents == {current_thread().ident}
+    else:
+        assert current_thread().ident not in idents
+        assert len(idents) > 1
+
+
+def test_parallel_thread_map_preserves_config() -> None:
+    """
+    The scikit-learn config is passed on to threads by
+    ``_parallel_thread_map()``.
+    """
+    with config_context(working_memory=123):
+        results = set(
+            _parallel_thread_map(-1, lambda _: get_working_memory(), range(100))
+        )
+
+    assert_array_equal(results, {123})
+
+
+def test_parallel_thread_map_warnings_settings() -> None:
+    """
+    Warning settings are propagated on to threads by ``_parallel_thread_map()``.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category=ConvergenceWarning)
+
+        with pytest.raises(ConvergenceWarning):
+            list(_parallel_thread_map(-1, lambda _: raise_warning(), range(2)))

--- a/sklearn/utils/tests/test_parallel.py
+++ b/sklearn/utils/tests/test_parallel.py
@@ -221,7 +221,7 @@ def test_parallel_thread_map_results(func: Callable, arguments: list[Iterable]) 
 
 def test_parallel_thread_map_parallelism() -> None:
     """
-    ``_parallel_thread_map()`` uses parallelism only on free-threaded Python.
+    ``_parallel_thread_map()`` uses parallelism only when ``n_jobs`` > 1.
     """
     idents = set()
 


### PR DESCRIPTION
`joblib.Parallel` has significant performance overhead. `sklearn.utils.parallel.Parallel` has even more. That means parallelism becomes pointless in some cases, because the overhead of using these APIs drowns out the benefits of parallelism.

This PR introduces a new parallelism API with lower overhead, and switches the IsolationForest prediction algorithm to use it instead of `Parallel()` as a demonstration of the benefits.

### Background

https://github.com/scikit-learn/scikit-learn/pull/28622 introduced parallelism for IsolationForest prediction. However, it did _not_ enable parallelism by default, because for smaller samples the overhead made the parallel version slower.

### Speed-up of `IsolationForest` enabled by this PR

With this PR, the speed of predicting large number of samples is essentially the same (so I omitted this from the plots below because it obscures the improvements on small numbers of samples). However, because of lower overhead:

* Parallelism is now almost always faster than parallelism. Even in the worst case, previously it was much faster in the 100 samples case, now it's only slightly worse given how much faster all of this is for 100 samples.
* For smaller number of samples, the lower overhead speeds up results.

Here's a plot of before and after using this API, generated with `bench_plot_isolation_forest_predict.py` (with the 50,000 sample case disabled; for that value there's no benefit in the new API):

<img width="1762" height="566" alt="out" src="https://github.com/user-attachments/assets/064985a7-2bcb-4029-a223-f6f40bf5ba4d" />

### Question for reviewers

Since parallelism is now useful in almost all cases, and less harmful when it's not, it is worth turning it on by default?

### AI: None

### Future work

* New APIs can now be parallelized, e.g. on free-threading; see #34747 which I will update and resubmit if/when this PR gets merged.
* Swapping out `ThreadPoolExecutor` for a faster thread pool (e.g. https://github.com/Quansight/spinningjenny/) can reduce parallelism overhead even more. See numbers in #34747 for an example.