### PR TITLE
DOC Fix wikipedia principal eigenvector example references

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -511,6 +511,9 @@ redirects = {
     "auto_examples/miscellaneous/plot_partial_dependence_visualization_api": (
         "auto_examples/inspection/plot_partial_dependence_visualization_api"
     ),
+    "auto_examples/applications/wikipedia_principal_eigenvector": (
+        "auto_examples/applications/plot_wikipedia_principal_eigenvector"
+    ),
 }
 html_context["redirects"] = redirects
 for old_link in redirects:

--- a/doc/whats_new/older_versions.rst
+++ b/doc/whats_new/older_versions.rst
@@ -1153,7 +1153,7 @@ Changelog
   datasets was created. These include:
   :ref:`sphx_glr_auto_examples_applications_plot_face_recognition.py`,
   :ref:`sphx_glr_auto_examples_applications_plot_species_distribution_modeling.py`,
-  :ref:`sphx_glr_auto_examples_applications_wikipedia_principal_eigenvector.py` and
+  :ref:`sphx_glr_auto_examples_applications_plot_wikipedia_principal_eigenvector.py` and
   others.
 
 - Faster :ref:`least_angle_regression` algorithm. It is now 2x

--- a/sklearn/utils/extmath.py
+++ b/sklearn/utils/extmath.py
@@ -416,7 +416,7 @@ def randomized_svd(
     (problem (1.5), p5).
 
     Refer to
-    :ref:`sphx_glr_auto_examples_applications_wikipedia_principal_eigenvector.py`
+    :ref:`sphx_glr_auto_examples_applications_plot_wikipedia_principal_eigenvector.py`
     for a typical example where the power iteration algorithm is used to rank web pages.
     This algorithm is also known to be used as a building block in Google's PageRank
     algorithm.


### PR DESCRIPTION
(caught in the release branch https://github.com/scikit-learn/scikit-learn/pull/34905)

Follow-up of #34266. That PR renamed the example without updating its references. I also added a redirection as we usually do when we rename examples.

ping @lesteve @ArturoAmorQ 