### PR TITLE
DOC Mark dev index as orphan

### DIFF
--- a/doc/developers/index.rst
+++ b/doc/developers/index.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _developers_guide:
 
 =================


### PR DESCRIPTION
(caught in the release branch https://github.com/scikit-learn/scikit-learn/pull/34905)

doc/developers/index.rst is only included in a toc tree when building the dev doc (so in PRs targeting main). Otherwise it's replaced by an external link so this page is not included in any toc tree, see https://github.com/scikit-learn/scikit-learn/blob/2cc7893a2097be891426ca6a4d9ea2e14cf82b9c/doc/conf.py#L1024-L1029

The issue only surfaces in PRs not targeting main and that modify this file (happens right now in the release PR), which explains why it didn't happen so far. Marking it as orphan says that it's fine if it's not in any toc tree, but still includes it in the toc tree when targeting main.

ping @lesteve 