### PR TITLE
CI Upgrade `cython-lint` version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
 -   repo: https://github.com/MarcoGorelli/cython-lint
     # NOTE if you update the cython-lint version here, remember to update
     # sklearn/_min_dependencies.py as well
-    rev: v0.21.0
+    rev: v0.21.1
     hooks:
     # TODO: add the double-quote-cython-strings hook when it's usability has improved:
     # possibility to pass a directory and use it as a check instead of auto-formatter.

--- a/build_tools/github/lint_lock.txt
+++ b/build_tools/github/lint_lock.txt
@@ -6,7 +6,7 @@
 #
 codespell==2.4.1
     # via -r build_tools/github/lint_requirements.txt
-cython==3.2.9
+cython==3.3.0
     # via cython-lint
 cython-lint==0.21.0
     # via -r build_tools/github/lint_requirements.txt
@@ -26,7 +26,7 @@ pyrefly==1.2.0
     # via -r build_tools/github/lint_requirements.txt
 pytest==9.1.0
     # via -r build_tools/github/lint_requirements.txt
-regex==2026.7.19
+regex==2026.9.3
     # via sphinx-lint
 ruff==0.12.2
     # via -r build_tools/github/lint_requirements.txt

--- a/build_tools/github/lint_lock.txt
+++ b/build_tools/github/lint_lock.txt
@@ -8,7 +8,7 @@ codespell==2.4.1
     # via -r build_tools/github/lint_requirements.txt
 cython==3.3.0
     # via cython-lint
-cython-lint==0.21.0
+cython-lint==0.21.1
     # via -r build_tools/github/lint_requirements.txt
 iniconfig==2.3.0
     # via pytest
@@ -26,7 +26,7 @@ pyrefly==1.2.0
     # via -r build_tools/github/lint_requirements.txt
 pytest==9.1.0
     # via -r build_tools/github/lint_requirements.txt
-regex==2026.9.3
+regex==2026.9.10
     # via sphinx-lint
 ruff==0.12.2
     # via -r build_tools/github/lint_requirements.txt

--- a/build_tools/github/lint_requirements.txt
+++ b/build_tools/github/lint_requirements.txt
@@ -4,6 +4,6 @@
 pytest==9.1.0
 ruff==0.12.2  # min
 pyrefly==1.2.0  # min
-cython-lint==0.21  # min
+cython-lint==0.21.1  # min
 sphinx-lint==1.0.2  # min
 codespell==2.4.1  # min

--- a/sklearn/_min_dependencies.py
+++ b/sklearn/_min_dependencies.py
@@ -39,7 +39,7 @@ dependent_packages = {
     # here, remember to update .pre-commit-config.yaml as well
     "ruff": ("0.12.2", "tests"),
     "pyrefly": ("1.2.0", "tests"),
-    "cython-lint": ("0.21", "tests"),
+    "cython-lint": ("0.21.1", "tests"),
     "sphinx-lint": ("1.0.2", "tests"),
     "codespell": ("2.4.1", "tests"),
     "pyamg": ("5.0.0", "tests"),


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes the linting issue as discussed in #34802

#### What does this implement/fix? Explain your changes.
Upgrades `cython-lint` to the newest version, which is now compatible with `cython` 3.3.0 (the upgrade that broke the linting step).

I updated `_min_dependencies.py` and `.pre-commit-config.yaml` manually and ran 
```
python build_tools/update_environments_and_lock_files.py --select-tag lint
``` 
to update the lock files.

@lesteve