### PR TITLE
DOC fix MaxAbsScaler fit parameter descriptions

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1299,7 +1299,7 @@ class MaxAbsScaler(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            The data used to compute the per-feature minimum and maximum
+            The data used to compute the per-feature maximum absolute value
             used for later scaling along the features axis.
 
         y : None
@@ -1325,7 +1325,7 @@ class MaxAbsScaler(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
         Parameters
         ----------
         X : {array-like, sparse matrix} of shape (n_samples, n_features)
-            The data used to compute the mean and standard deviation
+            The data used to compute the maximum absolute value
             used for later scaling along the features axis.
 
         y : None


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #34900

#### What does this implement/fix? Explain your changes.

The `fit` and `partial_fit` docstrings for `MaxAbsScaler` contained incorrect descriptions of the statistics computed from `X`.

This change updates the documentation to correctly describe the maximum absolute value computed for each feature.

No functional changes are made.