### PR TITLE
added changes to n_jobs_docs

### DIFF
--- a/sklearn/cluster/_dbscan.py
+++ b/sklearn/cluster/_dbscan.py
@@ -269,10 +269,10 @@ class DBSCAN(ClusterMixin, BaseEstimator):
         distance). When p=1, this is equivalent to Manhattan distance.
 
     n_jobs : int, default=None
-        The number of parallel jobs to run.
-        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
-        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
-        for more details.
+        The number of parallel jobs to run for the radius-neighbor queries used
+        to compute the neighborhoods. ``None`` means 1 unless in a
+        :obj:`joblib.parallel_backend` context. ``-1`` means using all
+        processors. See :term:`Glossary <n_jobs>` for more details.
 
     Attributes
     ----------

--- a/sklearn/compose/_column_transformer.py
+++ b/sklearn/compose/_column_transformer.py
@@ -124,7 +124,8 @@ class ColumnTransformer(TransformerMixin, _BaseComposition):
         stacked result will be dense, and this keyword will be ignored.
 
     n_jobs : int, default=None
-        Number of jobs to run in parallel.
+        Number of jobs to run in parallel when fitting and transforming the
+        transformers.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -1369,7 +1370,8 @@ def make_column_transformer(
         keyword will be ignored.
 
     n_jobs : int, default=None
-        Number of jobs to run in parallel.
+        Number of jobs to run in parallel when fitting and transforming the
+        transformers.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/covariance/_graph_lasso.py
+++ b/sklearn/covariance/_graph_lasso.py
@@ -777,7 +777,8 @@ class GraphicalLassoCV(BaseGraphicalLasso):
         stable.
 
     n_jobs : int, default=None
-        Number of jobs to run in parallel.
+        Number of jobs to run in parallel when evaluating the cross-validation
+        splits.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/decomposition/_kernel_pca.py
+++ b/sklearn/decomposition/_kernel_pca.py
@@ -154,7 +154,7 @@ class KernelPCA(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator
         .. versionadded:: 0.18
 
     n_jobs : int, default=None
-        The number of parallel jobs to run.
+        The number of parallel jobs to run when computing the kernel matrix.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -2126,7 +2126,8 @@ class LassoCV(RegressorMixin, LinearModelCV):
         Amount of verbosity.
 
     n_jobs : int, default=None
-        Number of CPUs to use during the cross validation.
+        Number of CPUs to use during cross-validation. The fits for the
+        different folds are run in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -2385,7 +2386,8 @@ class ElasticNetCV(RegressorMixin, LinearModelCV):
         Amount of verbosity.
 
     n_jobs : int, default=None
-        Number of CPUs to use during the cross validation.
+        Number of CPUs to use during cross-validation. The fits for the
+        different folds are run in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -3118,7 +3120,8 @@ class MultiTaskElasticNetCV(RegressorMixin, LinearModelCV):
         Amount of verbosity.
 
     n_jobs : int, default=None
-        Number of CPUs to use during the cross validation. Note that this is
+        Number of CPUs to use during cross-validation. The fits for the
+        different ``l1_ratio`` values are run in parallel. Note that this is
         used only if multiple values for l1_ratio are given.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
@@ -3324,7 +3327,8 @@ class MultiTaskLassoCV(RegressorMixin, LinearModelCV):
         Amount of verbosity.
 
     n_jobs : int, default=None
-        Number of CPUs to use during the cross validation. Note that this is
+        Number of CPUs to use during cross-validation. The fits for the
+        different ``l1_ratio`` values are run in parallel. Note that this is
         used only if multiple values for l1_ratio are given.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`

--- a/sklearn/linear_model/_least_angle.py
+++ b/sklearn/linear_model/_least_angle.py
@@ -1562,7 +1562,8 @@ class LarsCV(Lars):
         residuals in the cross-validation.
 
     n_jobs : int or None, default=None
-        Number of CPUs to use during the cross validation.
+        Number of CPUs to use during cross-validation. The fits for the
+        different folds are run in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -1882,7 +1883,8 @@ class LassoLarsCV(LarsCV):
         residuals in the cross-validation.
 
     n_jobs : int or None, default=None
-        Number of CPUs to use during the cross validation.
+        Number of CPUs to use during cross-validation. The fits for the
+        different folds are run in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/linear_model/_omp.py
+++ b/sklearn/linear_model/_omp.py
@@ -965,7 +965,8 @@ class OrthogonalMatchingPursuitCV(RegressorMixin, LinearModel):
             ``cv`` default value if None changed from 3-fold to 5-fold.
 
     n_jobs : int, default=None
-        Number of CPUs to use during the cross validation.
+        Number of CPUs to use during cross-validation. The fits for the
+        different folds are run in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/linear_model/_theil_sen.py
+++ b/sklearn/linear_model/_theil_sen.py
@@ -256,7 +256,8 @@ class TheilSenRegressor(RegressorMixin, LinearModel):
         See :term:`Glossary <random_state>`.
 
     n_jobs : int, default=None
-        Number of CPUs to use during the cross validation.
+        Number of CPUs to use when fitting the independent least-squares
+        problems used to compute the regression estimate.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/manifold/_isomap.py
+++ b/sklearn/manifold/_isomap.py
@@ -81,7 +81,7 @@ class Isomap(ClassNamePrefixFeaturesOutMixin, TransformerMixin, BaseEstimator):
         passed to neighbors.NearestNeighbors instance.
 
     n_jobs : int or None, default=None
-        The number of parallel jobs to run.
+        The number of parallel jobs to run for neighbor searches.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/manifold/_locally_linear.py
+++ b/sklearn/manifold/_locally_linear.py
@@ -681,7 +681,7 @@ class LocallyLinearEmbedding(
         across multiple function calls. See :term:`Glossary <random_state>`.
 
     n_jobs : int or None, default=None
-        The number of parallel jobs to run.
+        The number of parallel jobs to run for the nearest-neighbor search.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/manifold/_spectral_embedding.py
+++ b/sklearn/manifold/_spectral_embedding.py
@@ -555,7 +555,8 @@ class SpectralEmbedding(BaseEstimator):
         If None, n_neighbors will be set to max(n_samples/10, 1).
 
     n_jobs : int, default=None
-        The number of parallel jobs to run.
+        The number of parallel jobs to run for nearest-neighbor graph
+        construction.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -1393,7 +1393,8 @@ class GridSearchCV(BaseSearchCV):
         See :ref:`multimetric_grid_search` for an example.
 
     n_jobs : int, default=None
-        Number of jobs to run in parallel.
+        Number of jobs to run in parallel. Fitting and scoring are performed
+        in parallel for the parameter candidates and cross-validation splits.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -1792,7 +1793,8 @@ class RandomizedSearchCV(BaseSearchCV):
         If None, the estimator's score method is used.
 
     n_jobs : int, default=None
-        Number of jobs to run in parallel.
+        Number of jobs to run in parallel. Fitting and scoring are performed
+        in parallel for the parameter candidates and cross-validation splits.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/model_selection/_search_successive_halving.py
+++ b/sklearn/model_selection/_search_successive_halving.py
@@ -581,7 +581,8 @@ class HalvingGridSearchCV(BaseSuccessiveHalving):
         See :term:`Glossary <random_state>`.
 
     n_jobs : int or None, default=None
-        Number of jobs to run in parallel.
+        Number of jobs to run in parallel. Fitting and scoring are performed
+        in parallel for the parameter candidates and cross-validation splits.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -953,7 +954,8 @@ class HalvingRandomSearchCV(BaseSuccessiveHalving):
         See :term:`Glossary <random_state>`.
 
     n_jobs : int or None, default=None
-        Number of jobs to run in parallel.
+        Number of jobs to run in parallel. Fitting and scoring are performed
+        in parallel for the parameter candidates and cross-validation splits.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/pipeline.py
+++ b/sklearn/pipeline.py
@@ -1655,7 +1655,8 @@ class FeatureUnion(TransformerMixin, _BaseComposition):
            Deprecated `None` as a transformer in favor of 'drop'.
 
     n_jobs : int, default=None
-        Number of jobs to run in parallel.
+        Number of jobs to run in parallel when fitting and transforming the
+        transformers.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.

--- a/sklearn/semi_supervised/_label_propagation.py
+++ b/sklearn/semi_supervised/_label_propagation.py
@@ -370,7 +370,9 @@ class LabelPropagation(BaseLabelPropagation):
         state.
 
     n_jobs : int, default=None
-        The number of parallel jobs to run.
+        The number of parallel jobs to run when constructing the
+        nearest-neighbor graph for ``kernel='knn'``. This parameter has no
+        effect when ``kernel='rbf'``.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
@@ -535,7 +537,9 @@ class LabelSpreading(BaseLabelPropagation):
       state.
 
     n_jobs : int, default=None
-        The number of parallel jobs to run.
+        The number of parallel jobs to run when constructing the
+        nearest-neighbor graph for ``kernel='knn'``. This parameter has no
+        effect when ``kernel='rbf'``.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.


#### Introduce yourself
<!-- Especially if you are new to the scikit-learn community, please introduce yourself.
How do you use scikit-learn, what prompted you to make this contribution?
Hi, I have made contributions before ~2 years ago, looking to keeping myself active, so I am currently in the process of ramping up contributions again. 
-->


#### AI usage disclosure
<!--
Edit the list below to show when/how you used AI tools to create this PR.
Keep the ones that apply, delete the rest.
Make sure that you adhere to our Automated Contributions Policy:
https://scikit-learn.org/dev/developers/contributing.html#automated-contributions-policy
-->
I used AI assistance to:
use keyword search to mass-change relevant n_job entries in sklearn.
For efficiency purposes, I gave AI discretion to choose which jobs were still relevant to the PR and which are not. To the discretion of AI, ~25% of the 101 mentions still had a vague reference to n_jobs.

I will be manually verifying the function of n_jobs to ensure everything is up to par
