### PR TITLE
CI: Add `continue-on-error` in linting comment action

### DIFF
--- a/.github/workflows/bot-lint-comment.yml
+++ b/.github/workflows/bot-lint-comment.yml
@@ -23,6 +23,9 @@ jobs:
         run: mkdir -p "$ARTIFACTS_DIR"
 
       - name: Download artifact
+        # If nothing was uploaded in the linting step, this will error, but we still
+        # want to continue and post a generic comment in that case.
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: lint-log


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md

✅ In particular following the pull request checklist will increase the likelihood
of having maintainers review your PR:
https://scikit-learn.org/dev/developers/contributing.html#pull-request-checklist

📋 If your PR is likely to affect users, you will need to add a changelog entry
describing your PR changes, see:
https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Small follow-up from #34726

#### What does this implement/fix? Explain your changes.
The bot comment relies on logs created in the linting step. If nothing was uploaded due to an early failure in that step, the download will error (the upload will only throw a warning), so we need to set `continue-on-error: true` here to post a generic comment in that case.
See https://github.com/scikit-learn/scikit-learn/pull/34726#issuecomment-5278386629 for details.

<!--
Thank you for your patience. Changes to scikit-learn require careful
attention, but with limited maintainer time, not every contribution can be reviewed
quickly.
For more information and tips on improving your pull request, see:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
