### PR TITLE
DOC add neural-trees to related projects

### DIFF
--- a/doc/related_projects.rst
+++ b/doc/related_projects.rst
@@ -211,6 +211,11 @@ Note scikit-learn own modern gradient boosting estimators
 - `gplearn <https://github.com/trevorstephens/gplearn>`_ Genetic Programming
   for symbolic regression tasks.
 
+- `neural-trees <https://github.com/cgrtml/neural-trees>`_ Differentiable and
+  constructive classifiers with a PyTorch backend: soft decision trees,
+  omnivariate trees, hierarchical mixtures of experts and a grow-and-prune
+  network, together with the combined 5x2cv F test for comparing classifiers.
+
 - `scikit-multilearn <https://github.com/scikit-multilearn/scikit-multilearn>`_
   Multi-label classification with focus on label space manipulation.
 


### PR DESCRIPTION
Adds `neural-trees` under **Other regression and classification**.

It is a scikit-learn compatible library of differentiable and constructive tree-structured classifiers with a PyTorch backend: soft decision trees (İrsoy, Yıldız & Alpaydın, ICPR 2012), multivariate and omnivariate trees (Yıldız & Alpaydın, 2001), hierarchical mixtures of experts with subtree dropout (İrsoy & Alpaydın, 2021), and a grow-and-prune network (Alpaydın, 1994). It also ships the combined 5x2cv F test (Alpaydın, 1999) alongside McNemar's test for comparing classifiers.

Checking against the requirements suggested for listed projects:

| | |
|---|---|
| `check_estimator` | Four of the seven estimators pass all 55 checks. The three that accept `sample_weight` are held to 63 and pass 62, failing only `check_sample_weight_equivalence_on_dense_data`, which no stochastic mini-batch learner can satisfy. |
| Tests | 283, 95% coverage, gated in CI |
| Python | 3.9 – 3.13 |
| Lint | ruff and mypy in CI |
| License | MIT |
| Packaging | On PyPI as `neural-trees` |
| Archive | DOI [10.5281/zenodo.22718897](https://doi.org/10.5281/zenodo.22718897) |
| Demo | https://neural-trees.streamlit.app |

Documentation is hosted at https://cagritemel.com/neural-trees/ (API reference, design decisions, and a runnable example gallery), alongside the README and notebooks in the repository.

Happy to reword the entry or move it to a different subsection if another one fits better.
