### PR TITLE
CI Speed up doc (sphinx gallery in parallel)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,11 @@ jobs:
     docker:
       - image: cimg/base:current-22.04
     environment:
-      - MKL_NUM_THREADS: 2
-      - OPENBLAS_NUM_THREADS: 2
+      - MKL_NUM_THREADS: 1
+      - OPENBLAS_NUM_THREADS: 1
+      - OMP_NUM_THREADS: 1
+      # 2 vcpus with the medium (default) resource class
+      - SPHINX_GALLERY_PARALLEL: 2
       - CONDA_ENV_NAME: testenv
       - LOCK_FILE: build_tools/circle/doc_min_dependencies_linux-64_conda.lock
       # Do not fail if the documentation build generates warnings with minimum
@@ -68,8 +71,11 @@ jobs:
       - image: cimg/base:current-22.04
     resource_class: medium+
     environment:
-      - MKL_NUM_THREADS: 2
-      - OPENBLAS_NUM_THREADS: 2
+      - MKL_NUM_THREADS: 1
+      - OPENBLAS_NUM_THREADS: 1
+      - OMP_NUM_THREADS: 1
+      # 3 vcpus with the medium+ resource class
+      - SPHINX_GALLERY_PARALLEL: 3
       - CONDA_ENV_NAME: testenv
       - LOCK_FILE: build_tools/circle/doc_linux-64_conda.lock
       # Make sure that we fail if the documentation build generates warnings with

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,18 @@
 version: 2.1
 
+executors:
+  doc-linux:
+    docker:
+      - image: cimg/base:current-22.04
+    resource_class: medium+
+    environment:
+      - MKL_NUM_THREADS: 1
+      - OPENBLAS_NUM_THREADS: 1
+      - OMP_NUM_THREADS: 1
+      # 3 vcpus with the medium+ resource class
+      - SPHINX_GALLERY_PARALLEL: 3
+      - CONDA_ENV_NAME: testenv
+
 jobs:
   lint:
     docker:
@@ -15,15 +28,8 @@ jobs:
           command: ./build_tools/linting.sh
 
   doc-min-dependencies:
-    docker:
-      - image: cimg/base:current-22.04
+    executor: doc-linux
     environment:
-      - MKL_NUM_THREADS: 1
-      - OPENBLAS_NUM_THREADS: 1
-      - OMP_NUM_THREADS: 1
-      # 2 vcpus with the medium (default) resource class
-      - SPHINX_GALLERY_PARALLEL: 2
-      - CONDA_ENV_NAME: testenv
       - LOCK_FILE: build_tools/circle/doc_min_dependencies_linux-64_conda.lock
       # Do not fail if the documentation build generates warnings with minimum
       # dependencies as long as we can avoid raising warnings with more recent
@@ -67,16 +73,8 @@ jobs:
           destination: log.txt
 
   doc:
-    docker:
-      - image: cimg/base:current-22.04
-    resource_class: medium+
+    executor: doc-linux
     environment:
-      - MKL_NUM_THREADS: 1
-      - OPENBLAS_NUM_THREADS: 1
-      - OMP_NUM_THREADS: 1
-      # 3 vcpus with the medium+ resource class
-      - SPHINX_GALLERY_PARALLEL: 3
-      - CONDA_ENV_NAME: testenv
       - LOCK_FILE: build_tools/circle/doc_linux-64_conda.lock
       # Make sure that we fail if the documentation build generates warnings with
       # recent versions of the dependencies.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -738,6 +738,7 @@ sphinx_gallery_conf = {
     "gallery_dirs": [sg_gallery_dir],
     "subsection_order": SubSectionTitleOrder(sg_examples_dir),
     "within_subsection_order": SKExampleTitleSortKey,
+    "parallel": int(os.environ.get("SPHINX_GALLERY_PARALLEL", "0")),
     "binder": {
         "org": "scikit-learn",
         "repo": "scikit-learn",


### PR DESCRIPTION
Closes #29614

Another attempt at speeding-up the doc jobs after https://github.com/scikit-learn/scikit-learn/pull/34936.
This time by running sphinx gallery in parallel:
- 2 workers for the min dep job because it uses the default medium resource class that has 2 vcpus
- 3 workers for the doc job because it uses the medium+ resource class that has 3 vcpus

Make sure to set BLAS/OpenMP num threads to 1 to prevent oversubscription.