### PR TITLE
FIX SimpleImputer.inverse_transform column shift with empty features …

### DIFF
--- a/doc/whats_new/upcoming_changes/sklearn.impute/34949.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.impute/34949.fix.rst
@@ -1,0 +1,6 @@
+- :meth:`impute.SimpleImputer.inverse_transform` now correctly preserves
+  the order of output columns when a feature is entirely missing during
+  :meth:`impute.SimpleImputer.fit` but has observed values during
+  :meth:`impute.SimpleImputer.transform`. Previously, non-empty columns
+  were shifted left, overwriting the wrong positions.
+  :issue:`27012` by :user:`Abhisek Kundu <abhisekkundu-DS>`.

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -733,20 +733,32 @@ class SimpleImputer(_BaseImputer):
 
         n_features_original = len(self.statistics_)
         shape_original = (X.shape[0], n_features_original)
-        X_original = np.zeros(shape_original)
-        X_original[:, self.indicator_.features_] = missing_mask
-        full_mask = X_original.astype(bool)
 
-        imputed_idx, original_idx = 0, 0
-        while imputed_idx < len(array_imputed.T):
-            if not np.all(X_original[:, original_idx]):
-                X_original[:, original_idx] = array_imputed.T[imputed_idx]
-                imputed_idx += 1
-                original_idx += 1
+        # Determine which features were kept during fit (not dropped as empty)
+        if hasattr(self, "_valid_mask") and self._valid_mask is not None:
+            valid_mask = self._valid_mask
+        else:
+            if isinstance(self.missing_values, float) and np.isnan(self.missing_values):
+                valid_mask = ~np.isnan(self.statistics_)
             else:
-                original_idx += 1
+                valid_mask = self.statistics_ != self.missing_values
 
-        X_original[full_mask] = self.missing_values
+        # Initialize output array with missing_values (preserves empty feature cols)
+        if isinstance(self.missing_values, float) and np.isnan(self.missing_values):
+            X_original = np.full(shape_original, np.nan)
+        else:
+            X_original = np.full(shape_original, self.missing_values)
+
+        # Direct index mapping: avoids heuristic while-loop column drift
+        valid_indices = np.flatnonzero(valid_mask)
+        X_original[:, valid_indices] = array_imputed
+
+        # Restore missing values for features tracked by missing indicator
+        indicator_features = self.indicator_.features_
+        for idx, feat_idx in enumerate(indicator_features):
+            is_missing = missing_mask[:, idx]
+            X_original[is_missing, feat_idx] = self.missing_values
+
         return X_original
 
     def __sklearn_tags__(self):

--- a/sklearn/impute/_base.py
+++ b/sklearn/impute/_base.py
@@ -734,20 +734,19 @@ class SimpleImputer(_BaseImputer):
         n_features_original = len(self.statistics_)
         shape_original = (X.shape[0], n_features_original)
 
-        # Determine which features were kept during fit (not dropped as empty)
-        if hasattr(self, "_valid_mask") and self._valid_mask is not None:
-            valid_mask = self._valid_mask
+        if self.keep_empty_features:
+            valid_mask = np.ones(n_features_original, dtype=bool)
         else:
-            if isinstance(self.missing_values, float) and np.isnan(self.missing_values):
-                valid_mask = ~np.isnan(self.statistics_)
-            else:
-                valid_mask = self.statistics_ != self.missing_values
+            invalid_mask = _get_mask(self.statistics_, np.nan)
+            valid_mask = np.logical_not(invalid_mask)
 
         # Initialize output array with missing_values (preserves empty feature cols)
-        if isinstance(self.missing_values, float) and np.isnan(self.missing_values):
-            X_original = np.full(shape_original, np.nan)
+        if is_scalar_nan(self.missing_values) or is_pandas_na(self.missing_values):
+            X_original = np.full(shape_original, np.nan, dtype=array_imputed.dtype)
         else:
-            X_original = np.full(shape_original, self.missing_values)
+            X_original = np.full(
+                shape_original, self.missing_values, dtype=array_imputed.dtype
+            )
 
         # Direct index mapping: avoids heuristic while-loop column drift
         valid_indices = np.flatnonzero(valid_mask)

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1560,7 +1560,6 @@ def test_simple_imputer_inverse_transform_empty_last_feature():
     assert np.isnan(X_inv[:, 2]).all()
 
 
-
 @pytest.mark.parametrize(
     "expected,array,dtype,extra_value,n_repeat",
     [

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1505,6 +1505,62 @@ def test_simple_imputation_inverse_transform_exceptions(missing_value):
         imputer.inverse_transform(X_1_trans)
 
 
+def test_simple_imputer_inverse_transform_empty_first_feature():
+    """Non-regression test for gh-27012.
+
+    inverse_transform must preserve column order when the first feature is
+    completely empty during fit but has values during transform.
+    """
+    X1 = np.array([[np.nan, 2.0, 3.0], [np.nan, 2.0, 3.0]])
+    X2 = np.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]])
+
+    imputer = SimpleImputer(add_indicator=True)
+    imputer.fit(X1)
+    X_inv = imputer.inverse_transform(imputer.transform(X2))
+
+    # Column 0 must be NaN (fully empty during fit), rest preserved
+    assert np.isnan(X_inv[:, 0]).all()
+    assert_array_equal(X_inv[:, 1:], X2[:, 1:])
+
+
+def test_simple_imputer_inverse_transform_empty_middle_feature():
+    """Non-regression test for gh-27012.
+
+    inverse_transform must preserve column order when a middle feature is
+    completely empty during fit but has values during transform.
+    """
+    X1 = np.array([[1.0, np.nan, 3.0], [1.0, np.nan, 3.0]])
+    X2 = np.array([[1.0, 5.0, 3.0], [1.0, 5.0, 3.0]])
+
+    imputer = SimpleImputer(add_indicator=True)
+    imputer.fit(X1)
+    X_inv = imputer.inverse_transform(imputer.transform(X2))
+
+    assert_array_equal(X_inv[:, 0], X2[:, 0])
+    # Column 1 must be NaN (fully empty during fit)
+    assert np.isnan(X_inv[:, 1]).all()
+    assert_array_equal(X_inv[:, 2], X2[:, 2])
+
+
+def test_simple_imputer_inverse_transform_empty_last_feature():
+    """Non-regression test for gh-27012.
+
+    inverse_transform must preserve column order when the last feature is
+    completely empty during fit but has values during transform.
+    """
+    X1 = np.array([[1.0, 2.0, np.nan], [1.0, 2.0, np.nan]])
+    X2 = np.array([[1.0, 2.0, 9.0], [1.0, 2.0, 9.0]])
+
+    imputer = SimpleImputer(add_indicator=True)
+    imputer.fit(X1)
+    X_inv = imputer.inverse_transform(imputer.transform(X2))
+
+    assert_array_equal(X_inv[:, :2], X2[:, :2])
+    # Last column must be NaN (fully empty during fit)
+    assert np.isnan(X_inv[:, 2]).all()
+
+
+
 @pytest.mark.parametrize(
     "expected,array,dtype,extra_value,n_repeat",
     [

--- a/sklearn/impute/tests/test_impute.py
+++ b/sklearn/impute/tests/test_impute.py
@@ -1560,6 +1560,31 @@ def test_simple_imputer_inverse_transform_empty_last_feature():
     assert np.isnan(X_inv[:, 2]).all()
 
 
+@pytest.mark.parametrize("missing_value", [-1, np.nan])
+def test_simple_imputer_inverse_transform_empty_feature_non_default_missing(
+    missing_value,
+):
+    """Non-regression test for gh-27012 with various missing_values types.
+
+    inverse_transform must preserve column order when a feature is
+    completely empty during fit, for both NaN and integer missing values.
+    """
+    # Build X where col 1 is entirely missing during fit
+    fv = missing_value
+    X1 = np.array([[1.0, fv, 3.0], [1.0, fv, 3.0]], dtype=float)
+    X2 = np.array([[1.0, 5.0, 3.0], [1.0, 5.0, 3.0]], dtype=float)
+
+    imputer = SimpleImputer(missing_values=missing_value, add_indicator=True)
+    imputer.fit(X1)
+    X_inv = imputer.inverse_transform(imputer.transform(X2))
+
+    assert_array_equal(X_inv[:, 0], X2[:, 0])
+    # Column 1 was entirely missing during fit; its value in X_inv should
+    # equal the missing_values sentinel (not a shifted data column)
+    assert_array_equal(X_inv[:, 1], np.full(2, fv))
+    assert_array_equal(X_inv[:, 2], X2[:, 2])
+
+
 @pytest.mark.parametrize(
     "expected,array,dtype,extra_value,n_repeat",
     [


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #27012.

#### What does this implement/fix? Explain your changes.

This PR fixes a column-shifting issue in `SimpleImputer.inverse_transform` when the transformed data contains features that were empty during fitting.

The existing implementation could incorrectly identify valid features during `inverse_transform`, causing the reconstructed output columns to be shifted when empty features were present.

This PR:

* Correctly detects valid features in `SimpleImputer.inverse_transform`.
* Fixes the column-shifting behavior when empty features are present.
* Adds regression tests covering `inverse_transform` with empty features.
* Adds test coverage for non-NaN `missing_values`.
* Adds the corresponding changelog entry.
* Fixes a Ruff formatting issue in the tests.

#### Introduce yourself

Hi, I'm Abhisek Kundu. I currently work as an AI Engineer and have experience working with Python, machine learning, deep learning, and computer vision.

I use Python and machine learning libraries such as scikit-learn in my development and experimentation work. I wanted to contribute to scikit-learn because it is an important open-source project in the machine-learning ecosystem, and I wanted to gain experience contributing to a large production-quality codebase.

This is my first contribution to the scikit-learn community, and I'm looking forward to learning from the maintainers and improving the implementation based on their feedback.

#### AI usage disclosure

I used AI assistance for:

* Code generation (e.g., when writing an implementation or fixing a bug)
* Test/benchmark generation
* Documentation (including examples)
* Research and understanding

I reviewed the generated suggestions, adapted them to the scikit-learn codebase, and tested the resulting changes.

#### Any other comments?

Thank you for reviewing this contribution. I am happy to make any changes or improvements requested during the review process.
