### PR TITLE
PERF Faster random sampling without replacement

### DIFF
--- a/sklearn/utils/_random.pyx
+++ b/sklearn/utils/_random.pyx
@@ -10,6 +10,10 @@ The module contains:
     * Several algorithms to sample integers without replacement.
     * Fast rand_r alternative based on xor shifts
 """
+
+from libcpp.set cimport set as cppset
+from libcpp.random cimport mt19937, uniform_int_distribution
+
 import numpy as np
 from sklearn.utils.validation import check_random_state
 
@@ -87,18 +91,24 @@ cpdef _sample_without_replacement_with_tracking_selection(
     cdef default_int[::1] out = np.empty((n_samples, ), dtype=int)
 
     rng = check_random_state(random_state)
-    rng_randint = rng.randint
+    cdef mt19937 random_gen
+    random_gen = mt19937(rng.randint(2 ** 20))
+    cdef uniform_int_distribution[default_int] int_dist = uniform_int_distribution[default_int](0, n_population - 1)
 
     # The following line of code are heavily inspired from python core,
     # more precisely of random.sample.
-    cdef set selected = set()
+    cdef cppset[default_int] selected
 
-    for i in range(n_samples):
-        j = rng_randint(n_population)
-        while j in selected:
-            j = rng_randint(n_population)
-        selected.add(j)
-        out[i] = j
+    with nogil:
+        for i in range(n_samples):
+            while True:
+                j = int_dist(random_gen)
+                # set.contains is only in C++20, so do it the annoying way.
+                if selected.find(j) == selected.end():
+                    # Not found.
+                    break
+            selected.insert(j)
+            out[i] = j
 
     return np.asarray(out)
 
@@ -202,7 +212,9 @@ cpdef _sample_without_replacement_with_reservoir_sampling(
     cdef default_int[::1] out = np.empty((n_samples, ), dtype=int)
 
     rng = check_random_state(random_state)
-    rng_randint = rng.randint
+    cdef mt19937 random_gen
+    cdef uniform_int_distribution[default_int] int_dist
+    random_gen = mt19937(rng.randint(2 ** 20))
 
     # This cython implementation is based on the one of Robert Kern:
     # http://mail.scipy.org/pipermail/numpy-discussion/2010-December/
@@ -212,7 +224,8 @@ cpdef _sample_without_replacement_with_reservoir_sampling(
         out[i] = i
 
     for i from n_samples <= i < n_population:
-        j = rng_randint(0, i + 1)
+        int_dist = uniform_int_distribution[default_int](0, i)
+        j = int_dist(random_gen)
         if j < n_samples:
             out[j] = i
 

--- a/sklearn/utils/meson.build
+++ b/sklearn/utils/meson.build
@@ -46,7 +46,7 @@ utils_extension_metadata = {
   '_fast_dict':
     {'sources': [cython_gen_cpp.process('_fast_dict.pyx')]},
   '_openmp_helpers': {'sources': [cython_gen.process('_openmp_helpers.pyx')], 'dependencies': [openmp_dep]},
-  '_random': {'sources': [cython_gen.process('_random.pyx')]},
+  '_random': {'sources': [cython_gen_cpp.process('_random.pyx')]},
   '_typedefs': {'sources': [cython_gen.process('_typedefs.pyx')]},
   '_sorting': {'sources': [cython_gen.process('_sorting.pyx')]},
   '_vector_sentinel':


### PR DESCRIPTION
Switches calls to NumPy's Python API (slow) with calls to C++'s random number generator (fast).

Running `DISPLAY= time python benchmarks/bench_sample_without_replacement.py `—

* Before: `9.55user 0.08system 0:08.04elapsed 119%CPU`
* After: `5.53user 0.08system 0:04.02elapsed 139%CPU`

No AI.
